### PR TITLE
Loop until no eval

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -394,6 +394,35 @@ Restart the Minion from the command line:
     salt -G kernel:Windows cmd.run_bg 'C:\salt\salt-call.bat service.restart salt-minion'
     salt -C 'not G@kernel:Windows' cmd.run_bg 'salt-call service.restart salt-minion'
 
+Waiting for minions to come back online
+***************************************
+
+A common issue in performing automated restarts of a salt minion, for example during
+an orchestration run, is that it will break the orchestration since the next statement
+is likely to be attempted before the minion is back online. This can be remedied
+by inserting a blocking waiting state that only returns when the selected minions
+are back up (note: this will only work in orchestration states since `manage.up`
+needs to run on the master):
+
+.. code-block:: jinja
+
+    Wait for salt minion:
+      loop.until_no_eval:
+        - name: saltutil.runner
+        - expected:
+            - my_minion
+        - args:
+            - manage.up
+        - kwargs:
+            tgt: my_minion
+        - period: 3
+        - init_wait: 3
+
+This will, after an initial delay of 3 seconds, execute the `manage.up`-runner
+targeted specifically for `my_minion`. It will do this every `period` seconds
+until the `expected` data is returned. The default timeout is 60s but can be configured
+as well.
+
 Salting the Salt Master
 -----------------------
 

--- a/salt/states/loop.py
+++ b/salt/states/loop.py
@@ -28,21 +28,27 @@ Allows for looping over execution modules.
 
 .. versionchanged:: Neon
 
+A version that does not use eval is now available. It uses either the python ``operator``
+to compare the result of the function called in ``name``, which can be one of the
+following: lt, le, eq (default), ne, ge, gt.
+Alternatively, `compare_operator` can be filled with a function from an execution
+module in `__salt__` or `__utils__` like the example below.
+
 .. code-block:: yaml
 
     Wait for service to be healthy:
       loop.until_no_eval:
-      - name: boto_elb.get_instance_health
-      - expected: '0:state:InService'
-      - compare_operator: data.subdict_match
-      - period: 5
-      - timeout: 20
-      - args:
-        - {{ elb }}
-      - kwargs:
-          keyid: {{ access_key }}
-          key: {{ secret_key }}
-          instances: "{{ instance }}"
+        - name: boto_elb.get_instance_health
+        - expected: '0:state:InService'
+        - compare_operator: data.subdict_match
+        - period: 5
+        - timeout: 20
+        - args:
+          - {{ elb }}
+        - kwargs:
+            keyid: {{ access_key }}
+            key: {{ secret_key }}
+            instances: "{{ instance }}"
 '''
 
 # Import python libs

--- a/salt/states/loop.py
+++ b/salt/states/loop.py
@@ -83,8 +83,10 @@ def until(name,
     :param dict m_kwargs: The execution module's keyword arguments
     :param str condition: The condition which must be met for the loop to break.
         This should contain ``m_ret`` which is the return from the execution module.
-    :param int period: The number of seconds to wait between executions
-    :param int timeout: The timeout in seconds
+    :param period: The number of seconds to wait between executions
+    :type period: int or float
+    :param timeout: The timeout in seconds
+    :type timeout: int or float
     '''
     ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
 
@@ -138,15 +140,22 @@ def until_no_eval(
     :param str compare_operator: Operator to use to compare the result of the
         module.function call with the expected value. This can be anything present
         in __salt__ or __utils__. Will be called with 2 args: result, expected.
-    :param int timeout: Abort after this amount of seconds (excluding init_wait).
-    :param float period: Time (in seconds) to wait between attempts.
-    :param float init_wait: Time (in seconds) to wait before trying anything.
+    :param timeout: Abort after this amount of seconds (excluding init_wait).
+    :type timeout: int or float
+    :param period: Time (in seconds) to wait between attempts.
+    :type period: int or float
+    :param init_wait: Time (in seconds) to wait before trying anything.
+    :type init_wait: int or float
     :param list args: args to pass to the salt module.function.
     :param dict kwargs: kwargs to pass to the salt module.function.
     '''
     ret = {'name': name, 'comment': '', 'changes': {}, 'result': False}
     if name not in __salt__:
         ret['comment'] = 'Module.function "{}" is unavailable.'.format(name)
+    elif not isinstance(period, (int, float)):
+        ret['comment'] = 'Period must be specified as a float in seconds'
+    elif not isinstance(timeout, (int, float)):
+        ret['comment'] = 'Timeout must be specified as a float in seconds'
     elif compare_operator in __salt__:
         comparator = __salt__[compare_operator]
     elif compare_operator in __utils__:

--- a/salt/states/loop.py
+++ b/salt/states/loop.py
@@ -6,6 +6,10 @@ Allows for looping over execution modules.
 
 .. versionadded:: 2017.7.0
 
+In both examples below, the execution module function ``boto_elb.get_instance_health``
+returns a list of dicts. The condition checks the ``state``-key of the first dict
+in the returned list and compares its value to the string `InService`.
+
 .. code-block:: yaml
 
     wait_for_service_to_be_healthy:
@@ -32,7 +36,10 @@ A version that does not use eval is now available. It uses either the python ``o
 to compare the result of the function called in ``name``, which can be one of the
 following: lt, le, eq (default), ne, ge, gt.
 Alternatively, `compare_operator` can be filled with a function from an execution
-module in `__salt__` or `__utils__` like the example below.
+module in ``__salt__`` or ``__utils__`` like the example below.
+The function :py:func:`data.subdict_match <salt.utils.data.subdict_match>` checks if the
+``expected`` expression matches the data returned by calling the ``name`` function
+(with passed ``args`` and ``kwargs``).
 
 .. code-block:: yaml
 

--- a/salt/states/loop.py
+++ b/salt/states/loop.py
@@ -26,7 +26,7 @@ Allows for looping over execution modules.
     This state allows arbitrary python code to be executed through the condition
     parameter which is literally evaluated within the state. Please use caution.
 
-.. versionchanged:: Neon
+.. versionchanged:: Natrium
 
 A version that does not use eval is now available. It uses either the python ``operator``
 to compare the result of the function called in ``name``, which can be one of the
@@ -148,6 +148,9 @@ def until_no_eval(
     :type init_wait: int or float
     :param list args: args to pass to the salt module.function.
     :param dict kwargs: kwargs to pass to the salt module.function.
+
+    .. versionadded:: Natrium
+
     '''
     ret = {'name': name, 'comment': '', 'changes': {}, 'result': False}
     if name not in __salt__:

--- a/tests/unit/states/test_loop.py
+++ b/tests/unit/states/test_loop.py
@@ -1,0 +1,245 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: Herbert Buurman <herbert.buurman@ogd.nl>
+'''
+# Import Python libs
+from __future__ import absolute_import, unicode_literals, print_function
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import skipIf, TestCase
+from tests.support.mock import (
+    NO_MOCK,
+    NO_MOCK_REASON,
+    MagicMock,
+    patch)
+
+# Import Salt Libs
+import salt.states.loop
+from salt.ext.six.moves import range
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class LoopTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    Test cases for salt.states.loop
+    '''
+    def setup_loader_modules(self):
+        self.opts = opts = salt.config.DEFAULT_MINION_OPTS.copy()
+        utils = salt.loader.utils(opts)
+        return {salt.states.loop: {
+            '__opts__': opts,
+            '__utils__': utils,
+        }}
+
+    def test_test_mode(self):
+        '''
+        Test response when test_mode is enabled.
+        '''
+        with \
+                patch.dict(salt.states.loop.__salt__, {
+                    'foo.foo': True,
+                }), \
+                patch.dict(salt.states.loop.__opts__, {
+                    'test': True,
+                }):
+            self.assertDictEqual(
+                salt.states.loop.until(
+                    name='foo.foo',
+                    condition='m_ret'),
+                {'name': 'foo.foo', 'result': None, 'changes': {},
+                 'comment': 'The execution module foo.foo will be run'}
+            )
+            self.assertDictEqual(
+                salt.states.loop.until_no_eval(
+                    name='foo.foo',
+                    expected=2),
+                {'name': 'foo.foo', 'result': None, 'changes': {},
+                 'comment': 'Would have waited for "foo.foo" to produce "2".'}
+            )
+
+    def test_immediate_success(self):
+        '''
+        Test for an immediate success.
+        '''
+        with \
+                patch.dict(salt.states.loop.__salt__, {
+                    'foo.foo': lambda: 2,
+                    'foo.baz': lambda x, y: True,
+                }), \
+                patch.dict(salt.states.loop.__utils__, {
+                    'foo.baz': lambda x, y: True,
+                }):
+            self.assertDictEqual(
+                salt.states.loop.until(
+                    name='foo.foo',
+                    condition='m_ret'),
+                {'name': 'foo.foo', 'result': True, 'changes': {},
+                 'comment': 'Condition m_ret was met'}
+            )
+            # Using default compare_operator 'eq'
+            self.assertDictEqual(
+                salt.states.loop.until_no_eval(
+                    name='foo.foo',
+                    expected=2),
+                {'name': 'foo.foo', 'result': True, 'changes': {},
+                 'comment': 'Call provided the expected results in 1 attempts'}
+            )
+            # Using compare_operator 'gt'
+            self.assertDictEqual(
+                salt.states.loop.until_no_eval(
+                    name='foo.foo',  # Returns 2
+                    expected=1,
+                    compare_operator='gt'),
+                {'name': 'foo.foo', 'result': True, 'changes': {},
+                 'comment': 'Call provided the expected results in 1 attempts'}
+            )
+            # Using compare_operator 'ne'
+            self.assertDictEqual(
+                salt.states.loop.until_no_eval(
+                    name='foo.foo',  # Returns 2
+                    expected=3,
+                    compare_operator='ne'),
+                {'name': 'foo.foo', 'result': True, 'changes': {},
+                 'comment': 'Call provided the expected results in 1 attempts'}
+            )
+            # Using __utils__['foo.baz'] as compare_operator
+            self.assertDictEqual(
+                salt.states.loop.until_no_eval(
+                    name='foo.foo',
+                    expected='anything, mocked compare_operator returns True anyway',
+                    compare_operator='foo.baz'),
+                {'name': 'foo.foo', 'result': True, 'changes': {},
+                 'comment': 'Call provided the expected results in 1 attempts'}
+            )
+            # Using __salt__['foo.baz]' as compare_operator
+            self.assertDictEqual(
+                salt.states.loop.until_no_eval(
+                    name='foo.foo',
+                    expected='anything, mocked compare_operator returns True anyway',
+                    compare_operator='foo.baz'),
+                {'name': 'foo.foo', 'result': True, 'changes': {},
+                 'comment': 'Call provided the expected results in 1 attempts'}
+            )
+
+    def test_immediate_failure(self):
+        '''
+        Test for an immediate failure.
+        Period and timeout will be set to 0.01 to assume one attempt.
+        '''
+        with patch.dict(salt.states.loop.__salt__, {'foo.bar': lambda: False}):
+            self.assertDictEqual(
+                salt.states.loop.until(
+                    name='foo.bar',
+                    condition='m_ret',
+                    period=0.01,
+                    timeout=0.01),
+                {'name': 'foo.bar', 'result': False, 'changes': {},
+                 'comment': 'Timed out while waiting for condition m_ret'}
+            )
+
+            self.assertDictEqual(
+                salt.states.loop.until_no_eval(
+                    name='foo.bar',
+                    expected=True,
+                    period=0.01,
+                    timeout=0.01),
+                {'name': 'foo.bar', 'result': False, 'changes': {},
+                 'comment': 'Call did not produce the expected result after 1 attempts'}
+            )
+
+    def test_eval_exceptions(self):
+        '''
+        Test a couple of eval exceptions.
+        '''
+        with patch.dict(salt.states.loop.__salt__, {'foo.bar': lambda: None}):
+            self.assertRaises(
+                SyntaxError,
+                salt.states.loop.until,
+                name='foo.bar',
+                condition='raise NameError("FOO")'
+            )
+            self.assertRaises(
+                NameError,
+                salt.states.loop.until,
+                name='foo.bar',
+                condition='foo'
+            )
+
+    def test_no_eval_exceptions(self):
+        '''
+        Test exception handling in until_no_eval.
+        '''
+        with patch.dict(salt.states.loop.__salt__,
+                    {'foo.bar': MagicMock(side_effect=KeyError(str('FOO')))}
+                ):
+            self.assertDictEqual(
+                salt.states.loop.until_no_eval(
+                    name='foo.bar',
+                    expected=True),
+                {'name': 'foo.bar', 'result': False, 'changes': {},
+                 'comment': 'Exception occurred while executing foo.bar: {}:{}'.format(type(KeyError()), "'FOO'")}
+            )
+
+    def test_retried_success(self):
+        '''
+        Test if the function does indeed return after a fixed amount of retries.
+
+        Note: Do not merge these two tests in one with-block, as the side_effect
+        iterator is shared.
+        '''
+        with patch.dict(salt.states.loop.__salt__,
+                    {'foo.bar': MagicMock(side_effect=range(1, 7))}
+                ):
+            self.assertDictEqual(
+                salt.states.loop.until(
+                    name='foo.bar',
+                    condition='m_ret == 5',
+                    period=0,
+                    timeout=1),
+                {'name': 'foo.bar', 'result': True, 'changes': {},
+                 'comment': 'Condition m_ret == 5 was met'}
+            )
+
+        with patch.dict(salt.states.loop.__salt__,
+                    {'foo.bar': MagicMock(side_effect=range(1, 7))}
+                ):
+            self.assertDictEqual(
+                salt.states.loop.until_no_eval(
+                    name='foo.bar',
+                    expected=5,
+                    period=0,
+                    timeout=1),
+                {'name': 'foo.bar', 'result': True, 'changes': {},
+                 'comment': 'Call provided the expected results in 5 attempts'}
+            )
+
+    def test_retried_failure(self):
+        '''
+        Test if the function fails after the designated timeout.
+        '''
+        with patch.dict(salt.states.loop.__salt__,
+                    {'foo.bar': MagicMock(side_effect=range(1, 7))}
+                ):
+            self.assertDictEqual(
+                salt.states.loop.until(
+                    name='foo.bar',
+                    condition='m_ret == 5',
+                    period=0.01,
+                    timeout=0.03),
+                {'name': 'foo.bar', 'result': False, 'changes': {},
+                 'comment': 'Timed out while waiting for condition m_ret == 5'}
+            )
+
+        with patch.dict(salt.states.loop.__salt__,
+                    {'foo.bar': MagicMock(side_effect=range(1, 7))}
+                ):
+            self.assertDictEqual(
+                salt.states.loop.until_no_eval(
+                    name='foo.bar',
+                    expected=5,
+                    period=0.01,
+                    timeout=0.03),
+                {'name': 'foo.bar', 'result': False, 'changes': {},
+                 'comment': 'Call did not produce the expected result after 3 attempts'}
+            )


### PR DESCRIPTION
### What does this PR do?
It provides an alternative to `loop.until` that does not use `eval`.
Added example for using this in the faq. Made some pylint-inspired changes.
I'm not entirely sure that the name of the new state `until_no_eval` is good enough (even though it is accurate), since it feels wrong to name a function with something that it does *not* have. I'm open to suggestions on this.

### What issues does this PR fix or reference?
None

### Previous Behavior
The generic state that allows you to (blockingly) execute a salt function until it produces a desired output hinged on using `eval` with user-input. Since this is potentially very dangerous, an alternative has been supplied.

### New Behavior
A state exists (`loop.until_no_eval`) that will block execution until a specific salt execution module function returns an expected result. This produced result is passed together with the expected result to a function (either a method of python's `operator`, a function from `__salt__` or `__utils__`) to produce a boolean indicating success (or failure).
Additionally, a parameter `init_wait` is available to configure a waiting period before the 1st call of the salt function is made.

### Tests written?
Yes

### Commits signed with GPG?
Yes