### PR TITLE
Add optional warnings to test.configurable_test_state

### DIFF
--- a/salt/states/test.py
+++ b/salt/states/test.py
@@ -197,7 +197,7 @@ def configurable_test_state(name, changes=True, result=True, comment='', warning
         String to fill the comment field with.
         Default is ''
 
-    .. versionadded:: 2018.3.5
+    .. versionadded:: Neon
 
     warnings:
         A string (or a list of strings) to fill the warnings field with.

--- a/salt/states/test.py
+++ b/salt/states/test.py
@@ -201,7 +201,7 @@ def configurable_test_state(name, changes=True, result=True, comment='', warning
 
     warnings:
         A string (or a list of strings) to fill the warnings field with.
-        Default is False
+        Default is None
     '''
     ret = {
         'name': name,

--- a/salt/states/test.py
+++ b/salt/states/test.py
@@ -36,6 +36,7 @@ calls, e.g. running, calling, logging, output filtering etc.
         - changes: True
         - result: False
         - comment: bar.baz
+        - warnings: A warning
 
     is-pillar-foo-present-and-bar-is-int:
       test.check_pillar:
@@ -174,7 +175,7 @@ def fail_with_changes(name, **kwargs):  # pylint: disable=unused-argument
     return ret
 
 
-def configurable_test_state(name, changes=True, result=True, comment=''):
+def configurable_test_state(name, changes=True, result=True, comment='', warnings=None):
     '''
     A configurable test state which determines its output based on the inputs.
 
@@ -195,6 +196,12 @@ def configurable_test_state(name, changes=True, result=True, comment=''):
     comment:
         String to fill the comment field with.
         Default is ''
+
+    .. versionadded:: 2018.3.5
+
+    warnings:
+        A string (or a list of strings) to fill the warnings field with.
+        Default is False
     '''
     ret = {
         'name': name,
@@ -239,6 +246,17 @@ def configurable_test_state(name, changes=True, result=True, comment=''):
                                   '\'Result\' with invalid arguments. It must '
                                   'be either \'True\', \'False\', or '
                                   '\'Random\'')
+
+    if warnings is None:
+        pass
+    elif isinstance(warnings, six.string_types):
+        ret['warnings'] = [warnings]
+    elif isinstance(warnings, list):
+        ret['warnings'] = warnings
+    else:
+        raise SaltInvocationError('You have specified the state option '
+                                  '\'Warnings\' with invalid arguments. It must '
+                                  'be a string or a list of strings')
 
     if __opts__['test']:
         ret['result'] = True if changes is False else None

--- a/tests/unit/states/test_test.py
+++ b/tests/unit/states/test_test.py
@@ -224,6 +224,57 @@ class TestTestCase(TestCase, LoaderModuleMockMixin):
                               mock_name,
                               result='Cheese')
 
+    def test_configurable_test_state_warnings(self):
+        '''
+        Test test.configurable_test_state with and without warnings
+        '''
+        # Configure mock parameters
+        mock_name = 'cheese_shop'
+        mock_comment = "I'm afraid we're fresh out of Red Leicester sir."
+        mock_warning = 'Today the van broke down.'
+        mock_warning_list = [
+            mock_warning,
+            "Oooooooooohhh........!"
+        ]
+        mock_changes = {
+            'testing': {
+                'old': 'Unchanged',
+                'new': 'Something pretended to change'
+            }
+        }
+
+        # Test default state without warnings
+        with patch.dict(test.__opts__, {'test': False}):
+            mock_ret = {'name': mock_name,
+                        'changes': mock_changes,
+                        'result': True,
+                        'comment': ''}
+            ret = test.configurable_test_state(mock_name)
+            self.assertDictEqual(ret, mock_ret)
+
+        # Test default state with warnings (string)
+        with patch.dict(test.__opts__, {'test': False}):
+            mock_ret = {'name': mock_name,
+                        'changes': mock_changes,
+                        'result': True,
+                        'comment': '',
+                        'warnings': mock_warning_list}
+            ret = test.configurable_test_state(mock_name,
+                                               warnings=mock_warning_list)
+            self.assertDictEqual(ret, mock_ret)
+
+        # Test default state with warnings (list)
+        with patch.dict(test.__opts__, {'test': False}):
+            mock_ret = {'name': mock_name,
+                        'changes': mock_changes,
+                        'result': True,
+                        'comment': '',
+                        'warnings': ['Today the van broke down.']}
+            ret = test.configurable_test_state(mock_name,
+                                               warnings=mock_warning)
+
+            self.assertDictEqual(ret, mock_ret)
+
     def test_configurable_test_state_test(self):
         '''
         Test test.configurable_test_state with test=True with and without


### PR DESCRIPTION
### What does this PR do?

Add optional `warnings` argument to `test.configurable_test_state`.

The PR is backward-compatible, non-intrusive and involves a test module (shouldn't be very mission-critical). Please consider merging it into the oldest supported branch, so it won't be necessary to wait for another six months.

### What issues does this PR fix or reference?

This is useful to inject warnings into a highstate process. Unlike the `salt.log.warning` jinja function, the warnings are propagated back to a master.

As per the mailing list request: https://groups.google.com/forum/#!topic/salt-users/4yrxKtNycsk

### Tests written?

Yes

### Commits signed with GPG?

No