### PR TITLE
mongodb_user.present aplying changes on existing mongodb user even if Test=true

### DIFF
--- a/salt/states/mongodb_user.py
+++ b/salt/states/mongodb_user.py
@@ -105,6 +105,12 @@ def present(name,
             ret['comment'] = "Mongo Err: {0}".format(users[1])
             return ret
 
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = ('User {0} is already present and should be updated if neccesary.'
+                    ).format(name)
+            return ret
+
         # check each user occurrence
         for usr in users:
             # prepare empty list for current roles

--- a/tests/unit/states/test_mongodb_user.py
+++ b/tests/unit/states/test_mongodb_user.py
@@ -26,11 +26,11 @@ class MongodbUserTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         return {mongodb_user: {'__opts__': {'test': True}}}
 
-    # 'present' function tests: 1
+    # 'present' function tests: 2
 
-    def test_present(self):
+    def test_present_new_user(self):
         '''
-        Test to ensure that the user is present with the specified properties.
+        Test to ensure that the user is present with the specified properties for a new account.
         '''
         name = 'myapp'
         passwd = 'password-of-myapp'
@@ -67,6 +67,50 @@ class MongodbUserTestCase(TestCase, LoaderModuleMockMixin):
                 ret.update({'comment': comt, 'result': True,
                             'changes': {name: 'Present'}})
                 self.assertDictEqual(mongodb_user.present(name, passwd), ret)
+
+    def test_present_existing_user(self):
+        '''
+        Test to ensure that the user is present with the specified properties for an existing account.
+        '''
+        name = 'myapp'
+        passwd = 'password-of-myapp'
+        db = 'myapp-database'
+        current_role = 'mongodb-role'
+        current_role_as_dict = ['mongodb-role']
+        new_role = 'new-mongodb-role'
+
+        ret = {'name': name,
+               'result': False,
+               'comment': '',
+               'changes': {}}
+
+        comt = ('Port ({}) is not an integer.')
+        ret.update({'comment': comt})
+        self.assertDictEqual(mongodb_user.present(name, passwd, port={}), ret)
+
+        mock_t = MagicMock(return_value=True)
+        mock = MagicMock(return_value=[{'user': name, 'roles':[{'db':db,'role': current_role}]}])
+        with patch.dict(mongodb_user.__salt__,
+                        {
+                         'mongodb.user_create': mock_t,
+                         'mongodb.user_find': mock
+                        }):
+            comt = ('User {0} is already present and should be updated if neccesary.'
+                ).format(name)
+            ret.update({'comment': comt, 'result': None})
+            self.assertDictEqual(mongodb_user.present(name, passwd, database=db,roles=new_role), ret)
+
+            with patch.dict(mongodb_user.__opts__, {'test': True}):
+                comt = ('User {0} is already present and should be updated if neccesary.'
+                        .format(name))
+                ret.update({'comment': comt, 'result': None})
+                self.assertDictEqual(mongodb_user.present(name, passwd, database=db,roles=new_role), ret)
+
+            with patch.dict(mongodb_user.__opts__, {'test': False}):
+                comt = ('User {0} is already present'.format(name))
+                ret.update({'comment': comt, 'result': True,
+                            'changes': {name: {'database': db, 'roles': {'old': current_role_as_dict, 'new': new_role}}}})
+                self.assertDictEqual(mongodb_user.present(name, passwd, database=db,roles=new_role), ret)
 
     # 'absent' function tests: 1
 

--- a/tests/unit/states/test_mongodb_user.py
+++ b/tests/unit/states/test_mongodb_user.py
@@ -89,7 +89,7 @@ class MongodbUserTestCase(TestCase, LoaderModuleMockMixin):
         self.assertDictEqual(mongodb_user.present(name, passwd, port={}), ret)
 
         mock_t = MagicMock(return_value=True)
-        mock = MagicMock(return_value=[{'user': name, 'roles':[{'db':db,'role': current_role}]}])
+        mock = MagicMock(return_value=[{'user': name, 'roles':[{'db':db, 'role': current_role}]}])
         with patch.dict(mongodb_user.__salt__,
                         {
                          'mongodb.user_create': mock_t,
@@ -98,19 +98,19 @@ class MongodbUserTestCase(TestCase, LoaderModuleMockMixin):
             comt = ('User {0} is already present and should be updated if neccesary.'
                 ).format(name)
             ret.update({'comment': comt, 'result': None})
-            self.assertDictEqual(mongodb_user.present(name, passwd, database=db,roles=new_role), ret)
+            self.assertDictEqual(mongodb_user.present(name, passwd, database=db, roles=new_role), ret)
 
             with patch.dict(mongodb_user.__opts__, {'test': True}):
                 comt = ('User {0} is already present and should be updated if neccesary.'
                         .format(name))
                 ret.update({'comment': comt, 'result': None})
-                self.assertDictEqual(mongodb_user.present(name, passwd, database=db,roles=new_role), ret)
+                self.assertDictEqual(mongodb_user.present(name, passwd, database=db, roles=new_role), ret)
 
             with patch.dict(mongodb_user.__opts__, {'test': False}):
                 comt = ('User {0} is already present'.format(name))
                 ret.update({'comment': comt, 'result': True,
                             'changes': {name: {'database': db, 'roles': {'old': current_role_as_dict, 'new': new_role}}}})
-                self.assertDictEqual(mongodb_user.present(name, passwd, database=db,roles=new_role), ret)
+                self.assertDictEqual(mongodb_user.present(name, passwd, database=db, roles=new_role), ret)
 
     # 'absent' function tests: 1
 


### PR DESCRIPTION
### What does this PR do?
- Fixes bug at mongodb_user.present modifying state to avoid apply changes when Test=true on an existing MongoDb user.
- Add a new mongodb_user.present test for an existing MongoDb user
### What issues does this PR fix or reference?
Fixes #53962 
### Previous Behavior
Apply changes to mongodb user when Test=true

### New Behavior
Doesn't apply changes to mongodb user when Test=true, and shows a new debug message to notify that user is already present and it's going to be modified.

### Tests written?
Yes

### Commits signed with GPG?
No
