### PR TITLE
[2018.3] Skip unit.modules.test_file.ChattrTests tests on windows

### DIFF
--- a/tests/unit/modules/test_file.py
+++ b/tests/unit/modules/test_file.py
@@ -2217,6 +2217,10 @@ class ChattrTests(TestCase, LoaderModuleMockMixin):
             actual = filemod._chattr_has_extended_attrs()
             assert actual, actual
 
+    # We're skipping this on Windows as it tests the check_perms function in
+    # file.py which is specifically for Linux. The Windows version resides in
+    # win_file.py
+    @skipIf(salt.utils.platform.is_windows(), 'Skip on Windows')
     def test_check_perms_should_report_no_attr_changes_if_there_are_none(self):
         filename = '/path/to/fnord'
         attrs = 'aAcCdDeijPsStTu'
@@ -2254,6 +2258,10 @@ class ChattrTests(TestCase, LoaderModuleMockMixin):
             )
             assert actual_ret.get('changes', {}).get('attrs')is None, actual_ret
 
+    # We're skipping this on Windows as it tests the check_perms function in
+    # file.py which is specifically for Linux. The Windows version resides in
+    # win_file.py
+    @skipIf(salt.utils.platform.is_windows(), 'Skip on Windows')
     def test_check_perms_should_report_attrs_new_and_old_if_they_changed(self):
         filename = '/path/to/fnord'
         attrs = 'aAcCdDeijPsStTu'


### PR DESCRIPTION
### What does this PR do?
The tests 

```
unit.modules.test_file.ChattrTests.test_check_perms_should_report_attrs_new_and_old_if_they_changed
unit.modules.test_file.ChattrTests.test_check_perms_should_report_no_attr_changes_if_there_are_none
```

are failing on windows. We're skipping this on Windows as it tests the check_perms function in file.py which is specifically for Linux. The Windows version resides in win_file.py

### What issues does this PR fix or reference?
brings in the changes from PR: https://github.com/saltstack/salt/pull/53467/commits/31ce1fb0feee26e14e55b8d7127db5ab329ac7f7#diff-f5f4309ab655cd2b5ab09240bff340c4R2400

### Previous Behavior
tests fail

### New Behavior
tests are skipped

### Tests written?
No - fixes tests
### Commits signed with GPG?

Yes