### PR TITLE
Fix webutil.user_exists grep error on first run

### DIFF
--- a/changelog/53977.fixed
+++ b/changelog/53977.fixed
@@ -1,0 +1,1 @@
+Fix error in webutil state module when attempting to grep a file that does not exist.

--- a/doc/_themes/saltstack2/static/js/webhelp.min_v1.4.4.js
+++ b/doc/_themes/saltstack2/static/js/webhelp.min_v1.4.4.js
@@ -274,4 +274,3 @@ function getMetaStatus() {
 
     $(document).ready($.proxy(anchorScrolls, 'init'));
 })(window.document, window.history, window.location);
-

--- a/salt/states/webutil.py
+++ b/salt/states/webutil.py
@@ -66,7 +66,10 @@ def user_exists(
     """
     ret = {"name": name, "changes": {}, "comment": "", "result": None}
 
-    exists = __salt__["file.grep"](htpasswd_file, "^{}:".format(name))["retcode"] == 0
+    if __salt__["file.file_exists"](htpasswd_file):
+        exists = __salt__["file.grep"](htpasswd_file, "^{}:".format(name))["retcode"] == 0
+    else:
+        exists = False
 
     # If user exists, but we're supposed to update the password, find out if
     # it's changed, but not if we're forced to update the file regardless.

--- a/salt/states/webutil.py
+++ b/salt/states/webutil.py
@@ -67,7 +67,9 @@ def user_exists(
     ret = {"name": name, "changes": {}, "comment": "", "result": None}
 
     if __salt__["file.file_exists"](htpasswd_file):
-        exists = __salt__["file.grep"](htpasswd_file, "^{}:".format(name))["retcode"] == 0
+        exists = (
+            __salt__["file.grep"](htpasswd_file, "^{}:".format(name))["retcode"] == 0
+        )
     else:
         exists = False
 

--- a/tests/pytests/unit/states/test_webutil.py
+++ b/tests/pytests/unit/states/test_webutil.py
@@ -19,8 +19,11 @@ def test_user_exists_already():
     """
 
     mock = MagicMock(return_value={"retcode": 0})
+    mock_file_exists = MagicMock(return_value={"retcode": 1})
 
-    with patch.dict(htpasswd.__salt__, {"file.grep": mock}):
+    with patch.dict(
+        htpasswd.__salt__, {"file.grep": mock, "file.file_exists": mock_file_exists}
+    ):
         ret = htpasswd.user_exists("larry", "badpass", "/etc/httpd/htpasswd")
         expected = {
             "name": "larry",
@@ -36,11 +39,17 @@ def test_new_user_success():
     Test if it returns True when new user is added to htpasswd file
     """
 
+    mock_file_exists = MagicMock(return_value={"retcode": 1})
     mock_grep = MagicMock(return_value={"retcode": 1})
     mock_useradd = MagicMock(return_value={"retcode": 0, "stderr": "Success"})
 
     with patch.dict(
-        htpasswd.__salt__, {"file.grep": mock_grep, "webutil.useradd": mock_useradd}
+        htpasswd.__salt__,
+        {
+            "file.grep": mock_grep,
+            "file.file_exists": mock_file_exists,
+            "webutil.useradd": mock_useradd,
+        },
     ):
         ret = htpasswd.user_exists("larry", "badpass", "/etc/httpd/htpasswd")
         expected = {
@@ -57,11 +66,17 @@ def test_new_user_error():
     Test if it returns False when adding user to htpasswd failed
     """
 
+    mock_file_exists = MagicMock(return_value={"retcode": 1})
     mock_grep = MagicMock(return_value={"retcode": 1})
     mock_useradd = MagicMock(return_value={"retcode": 1, "stderr": "Error"})
 
     with patch.dict(
-        htpasswd.__salt__, {"file.grep": mock_grep, "webutil.useradd": mock_useradd}
+        htpasswd.__salt__,
+        {
+            "file.grep": mock_grep,
+            "file.file_exists": mock_file_exists,
+            "webutil.useradd": mock_useradd,
+        },
     ):
         ret = htpasswd.user_exists("larry", "badpass", "/etc/httpd/htpasswd")
         expected = {
@@ -69,5 +84,35 @@ def test_new_user_error():
             "result": False,
             "comment": "Error",
             "changes": {},
+        }
+        assert ret == expected
+
+
+def test_no_htpasswd_file_and_user_doesnt_exist(tmp_path):
+    """
+    Test if .htpasswd does not exist, it returns that the user does not
+    exist as opposed to erroring out
+    """
+    htpasswd_file = tmp_path / ".htpasswd"
+    assert not htpasswd_file.is_file()
+
+    mock_file_exists = MagicMock(return_value={"retcode": 1})
+    mock_grep = MagicMock(return_value={"retcode": 1})
+    mock_useradd = MagicMock(return_value={"retcode": 0, "stderr": "Success"})
+
+    with patch.dict(
+        htpasswd.__salt__,
+        {
+            "file.grep": mock_grep,
+            "file.file_exists": mock_file_exists,
+            "webutil.useradd": mock_useradd,
+        },
+    ):
+        ret = htpasswd.user_exists("larry", "badpass", "/etc/httpd/htpasswd")
+        expected = {
+            "name": "larry",
+            "result": True,
+            "comment": "Success",
+            "changes": {"larry": True},
         }
         assert ret == expected


### PR DESCRIPTION
Fixes #53977

### What does this PR do?

Checks for the existence of /etc/nginx/.htpasswd before grepping it to avoid error messages in the minion log.

### What issues does this PR fix or reference?

#53977 
