### PR TITLE
auth: log details in case of user auth issue

### DIFF
--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -330,7 +330,7 @@ class LoadAuth(object):
                 return auth_user.sudo_name()
             elif load['user'] == self.opts.get('user', 'root') or load['user'] == 'root':
                 if auth_key != key[self.opts.get('user', 'root')]:
-                    log.warning('Master runs as "{}", but user in payload is "{}"'.format(self.opts.get('user', 'root'), load['user']))
+                    log.warning('Master runs as %r, but user in payload is %r', self.opts.get('user', 'root'), load['user'])
                     log.warning(error_msg)
                     return False
             elif auth_user.is_running_user():

--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -330,6 +330,7 @@ class LoadAuth(object):
                 return auth_user.sudo_name()
             elif load['user'] == self.opts.get('user', 'root') or load['user'] == 'root':
                 if auth_key != key[self.opts.get('user', 'root')]:
+                    log.warning('Master runs as "{}", but user in payload is "{}"'.format(self.opts.get('user', 'root'), load['user']))
                     log.warning(error_msg)
                     return False
             elif auth_user.is_running_user():


### PR DESCRIPTION
When a local SaltClient sends a job as "root" while the Master runs as a non-root user, make it more clear why the message `Authentication failure of type "user" occurred.` is logged.

### What does this PR do?

Improve logging, to save the next one affected a few hours of debugging 😄 

### What issues does this PR fix or reference?

None

### Previous Behavior

When the Master runs as non-root user, but `root` is used locally on the CLI for any kind of operations (`salt \* test.ping`, ...), no Job could be created. The only message that was logged without any further indication what might cause the failure was `Authentication failure of type "user" occurred.`

### New Behavior
An additional log message (level: `warning`) was added which states:
```
Master runs as "some-other-user", but user in payload is "root"
```

### Tests written?

No - doesn't really apply, as it's just an added log message.

### Commits signed with GPG?

Yes