### PR TITLE
fix: pam exception on Windows

### DIFF
--- a/salt/auth/pam.py
+++ b/salt/auth/pam.py
@@ -49,15 +49,19 @@ from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-b
 from salt.ext import six
 
 try:
-    LIBC = CDLL(find_library('c'))
+    LIBCPATH = find_library('c')
+    if LIBCPATH is None:
+        HAS_LIBC = False
+    else:
+        LIBC = CDLL(LIBCPATH)
 
-    CALLOC = LIBC.calloc
-    CALLOC.restype = c_void_p
-    CALLOC.argtypes = [c_uint, c_uint]
+        CALLOC = LIBC.calloc
+        CALLOC.restype = c_void_p
+        CALLOC.argtypes = [c_uint, c_uint]
 
-    STRDUP = LIBC.strdup
-    STRDUP.argstypes = [c_char_p]
-    STRDUP.restype = POINTER(c_char)  # NOT c_char_p !!!!
+        STRDUP = LIBC.strdup
+        STRDUP.argstypes = [c_char_p]
+        STRDUP.restype = POINTER(c_char)  # NOT c_char_p !!!!
 except AttributeError:
     HAS_LIBC = False
 else:


### PR DESCRIPTION
fix: pam exception on Windows

Using salt-api was triggering the loader to
load all auth modules, and trying to load
pam on Windows failed because find_library('C')
returns None, and when it tries to create a handle
out of it it expects a string.

Signed-off-by: Rares POP <rares.pop@ni.com>

### What does this PR do?
check against find_library failing to locate clib, which is the case on Windows platforms

### What issues does this PR fix or reference?
N/A

### Previous Behavior
The following error was in the master log each time when I started salt-api on Windows:
```
Traceback (most recent call last):
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\lib\site-packages\salt\loader.py", line 1531, in _load_module
    mod = spec.loader.load_module()
  File "<frozen importlib._bootstrap_external>", line 399, in _check_name_wrapper
  File "<frozen importlib._bootstrap_external>", line 823, in load_module
  File "<frozen importlib._bootstrap_external>", line 682, in load_module
  File "<frozen importlib._bootstrap>", line 265, in _load_module_shim
  File "<frozen importlib._bootstrap>", line 684, in _load
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\lib\site-packages\salt\auth\pam.py", line 52, in <module>
    LIBC = CDLL(find_library('c'))
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\lib\ctypes\__init__.py", line 348, in __init__
    self._handle = _dlopen(self._name, mode)
TypeError: LoadLibrary() argument 1 must be str, not None
```

### New Behavior
There's no more errors in the log

### Tests written?
No

### Commits signed with GPG?

Yes
