### PR TITLE
cmdmod: fix runas and group in run_chroot

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -3132,14 +3132,20 @@ def run_chroot(
 
     if isinstance(cmd, (list, tuple)):
         cmd = " ".join([six.text_type(i) for i in cmd])
-    cmd = "chroot {0} {1} -c {2}".format(root, sh_, _cmd_quote(cmd))
+
+    # If runas and group are provided, we expect that the user lives
+    # inside the chroot, not outside.
+    if runas:
+        userspec = "--userspec {}:{}".format(runas, group if group else "")
+    else:
+        userspec = ""
+
+    cmd = "chroot {} {} {} -c {}".format(userspec, root, sh_, _cmd_quote(cmd))
 
     run_func = __context__.pop("cmd.run_chroot.func", run_all)
 
     ret = run_func(
         cmd,
-        runas=runas,
-        group=group,
         cwd=cwd,
         stdin=stdin,
         shell=shell,

--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -452,6 +452,22 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
         else:
             raise RuntimeError
 
+    @skipIf(salt.utils.platform.is_windows(), 'Do not run on Windows')
+    @skipIf(salt.utils.platform.is_darwin(), 'Do not run on MacOS')
+    def test_run_cwd_in_combination_with_runas(self):
+        '''
+        cmd.run executes command in the cwd directory
+        when the runas parameter is specified
+        '''
+        cmd = 'pwd'
+        cwd = '/tmp'
+        runas = os.getlogin()
+
+        with patch.dict(cmdmod.__grains__, {'os': 'Darwin',
+                                            'os_family': 'Solaris'}):
+            stdout = cmdmod._run(cmd, cwd=cwd, runas=runas).get('stdout')
+        self.assertEqual(stdout, cwd)
+
     def test_run_all_binary_replace(self):
         """
         Test for failed decoding of binary data, for instance when doing


### PR DESCRIPTION
The parameters runas and group for cmdmod.run() will change the efective
user and group before executing the command. But in a chroot environment is
expected that the change happends inside the chroot, not outside, as the
user and groups are refering to objects that can only exist inside the
environment.

This patch add the userspec parameter to the chroot command, to change
the user in the correct place.
