### PR TITLE
(Backport 53992) cmdmod: fix runas and group in run_chroot

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -3264,13 +3264,19 @@ def run_chroot(root,
 
     if isinstance(cmd, (list, tuple)):
         cmd = ' '.join([six.text_type(i) for i in cmd])
-    cmd = 'chroot {0} {1} -c {2}'.format(root, sh_, _cmd_quote(cmd))
+
+    # If runas and group are provided, we expect that the user lives
+    # inside the chroot, not outside.
+    if runas:
+        userspec = '--userspec {}:{}'.format(runas, group if group else '')
+    else:
+        userspec = ''
+
+    cmd = 'chroot {} {} {} -c {}'.format(userspec, root, sh_, _cmd_quote(cmd))
 
     run_func = __context__.pop('cmd.run_chroot.func', run_all)
 
     ret = run_func(cmd,
-                   runas=runas,
-                   group=group,
                    cwd=cwd,
                    stdin=stdin,
                    shell=shell,

--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -365,10 +365,10 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
         '''
         cmd = 'pwd'
         cwd = '/tmp'
-        runas = 'foobar'
+        runas = os.getlogin()
 
-        with patch('pwd.getpwnam') as getpwnam_mock, \
-                patch.dict(cmdmod.__grains__, {'os': 'Darwin', 'os_family': 'Solaris'}):
+        with patch.dict(cmdmod.__grains__, {'os': 'Darwin',
+                                            'os_family': 'Solaris'}):
             stdout = cmdmod._run(cmd, cwd=cwd, runas=runas).get('stdout')
         self.assertEqual(stdout, cwd)
 

--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -461,3 +461,37 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
             ret = cmdmod.run_all('some command', output_encoding='latin1')
 
         self.assertEqual(ret['stdout'], stdout)
+
+    def test_run_chroot_runas(self):
+        '''
+        Test run_chroot when a runas parameter is provided
+        '''
+        with patch.dict(cmdmod.__salt__, {'mount.mount': MagicMock(),
+                                          'mount.umount': MagicMock()}):
+            with patch('salt.modules.cmdmod.run_all') as run_all_mock:
+                cmdmod.run_chroot('/mnt', 'ls', runas='foobar')
+        run_all_mock.assert_called_with(
+            'chroot --userspec foobar: /mnt /bin/sh -c ls',
+            bg=False,
+            clean_env=False,
+            cwd=None,
+            env=None,
+            ignore_retcode=False,
+            log_callback=None,
+            output_encoding=None,
+            output_loglevel='quiet',
+            pillar=None,
+            pillarenv=None,
+            python_shell=True,
+            reset_system_locale=True,
+            rstrip=True,
+            saltenv='base',
+            shell='/bin/bash',
+            stdin=None,
+            success_retcodes=None,
+            success_stderr=None,
+            success_stdout=None,
+            template=None,
+            timeout=None,
+            umask=None,
+            use_vt=False)


### PR DESCRIPTION
The parameters runas and group for cmdmod.run() will change the efective
user and group before executing the command. But in a chroot environment is
expected that the change happends inside the chroot, not outside, as the
user and groups are refering to objects that can only exist inside the
environment.

This patch add the userspec parameter to the chroot command, to change
the user in the correct place.

(backport #53992)
