### PR TITLE
Fix kwargs iteration for chroot.call

### DIFF
--- a/salt/modules/chroot.py
+++ b/salt/modules/chroot.py
@@ -56,7 +56,8 @@ def exist(name):
     '''
     dev = os.path.join(name, 'dev')
     proc = os.path.join(name, 'proc')
-    return all(os.path.isdir(i) for i in (name, dev, proc))
+    sys = os.path.join(name, 'sys')
+    return all(os.path.isdir(i) for i in (name, dev, proc, sys))
 
 
 def create(name):
@@ -80,9 +81,11 @@ def create(name):
     if not exist(name):
         dev = os.path.join(name, 'dev')
         proc = os.path.join(name, 'proc')
+        sys = os.path.join(name, 'sys')
         try:
             os.makedirs(dev, mode=0o755)
             os.makedirs(proc, mode=0o555)
+            os.makedirs(sys, mode=0o555)
         except OSError as e:
             log.error('Error when trying to create chroot directories: %s', e)
             return False

--- a/salt/modules/chroot.py
+++ b/salt/modules/chroot.py
@@ -110,6 +110,7 @@ def call(root, function, *args, **kwargs):
     .. code-block:: bash
 
         salt myminion chroot.call /chroot test.ping
+        salt myminion chroot.call /chroot ssh.set_auth_key user key=mykey
 
     '''
 
@@ -147,7 +148,7 @@ def call(root, function, *args, **kwargs):
             '-l', 'quiet',
             '--',
             function
-        ] + list(args) + ['{}={}'.format(k, v) for (k, v) in safe_kwargs]
+        ] + list(args) + ['{}={}'.format(k, v) for (k, v) in safe_kwargs.items()]
         ret = __salt__['cmd.run_chroot'](root, [str(x) for x in salt_argv])
         if ret['retcode'] != EX_OK:
             raise CommandExecutionError(ret['stderr'])

--- a/tests/unit/modules/test_chroot.py
+++ b/tests/unit/modules/test_chroot.py
@@ -150,7 +150,12 @@ class ChrootTestCase(TestCase, LoaderModuleMockMixin):
             utils_mock['thin.gen_thin'].assert_called_once()
             salt_mock['config.option'].assert_called()
             salt_mock['archive.tar'].assert_called_once()
-            salt_mock['cmd.run_chroot'].assert_called_once()
+            salt_mock['cmd.run_chroot'].assert_called_with(
+                '/chroot',
+                ['python{}'.format(sys.version_info[0]), '/tmp01/salt-call',
+                 '--metadata', '--local',
+                 '--log-file', '/tmp01/log', '--cachedir', '/tmp01/cache',
+                 '--out', 'json', '-l', 'quiet', '--', 'test.ping'])
             utils_mock['files.rm_rf'].assert_called_once()
 
     @patch('salt.modules.chroot.exist')
@@ -181,7 +186,12 @@ class ChrootTestCase(TestCase, LoaderModuleMockMixin):
             utils_mock['thin.gen_thin'].assert_called_once()
             salt_mock['config.option'].assert_called()
             salt_mock['archive.tar'].assert_called_once()
-            salt_mock['cmd.run_chroot'].assert_called_once()
+            salt_mock['cmd.run_chroot'].assert_called_with(
+                '/chroot',
+                ['python{}'.format(sys.version_info[0]), '/tmp01/salt-call',
+                 '--metadata', '--local',
+                 '--log-file', '/tmp01/log', '--cachedir', '/tmp01/cache',
+                 '--out', 'json', '-l', 'quiet', '--', 'test.ping'])
             utils_mock['files.rm_rf'].assert_called_once()
 
     @patch('salt.modules.chroot.exist')

--- a/tests/unit/modules/test_chroot.py
+++ b/tests/unit/modules/test_chroot.py
@@ -63,10 +63,10 @@ class ChrootTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test if the chroot environment exist.
         '''
-        isdir.side_effect = (True, True, True)
+        isdir.side_effect = (True, True, True, True)
         self.assertTrue(chroot.exist('/chroot'))
 
-        isdir.side_effect = (True, True, False)
+        isdir.side_effect = (True, True, True, False)
         self.assertFalse(chroot.exist('/chroot'))
 
     @patch('os.makedirs')


### PR DESCRIPTION
### What does this PR do?

Fix a bug during the call of the kwargs parameters for chroot.call(). In the original code the iteration was done only on the keys, but the code expect the key and the value too. Simply adding `.items()` fix the issue.

### Tests written?

Yes
