### PR TITLE
Acme state fixup 2018.3

### DIFF
--- a/doc/topics/jinja/index.rst
+++ b/doc/topics/jinja/index.rst
@@ -1019,6 +1019,137 @@ Returns:
   d94a45acd81f8e3107d237dbc0d5d195f6a52a0d188bc0284c0763ece1eac9f9496fb6a531a296074c87b3540398dace1222b42e150e67c9301383fde3d66ae5
 
 
+.. jinja_ref:: set_dict_key_value
+
+``set_dict_key_value``
+----------------------
+
+..versionadded:: Neon
+
+Allows you to set a value in a nested dictionary without having to worry if all the nested keys actually exist.
+Missing keys will be automatically created if they do not exist.
+The default delimiter for the keys is ':', however, with the `delimiter`-parameter, a different delimiter can be specified.
+
+Examples:
+
+.. code-block:: jinja
+
+Example 1:
+  {%- set foo = {} %}
+  {{ foo | set_dict_key_value('bar:baz', 42) }}
+
+Example 2:
+  {{ {} | set_dict_key_value('bar.baz.qux', 42, delimiter='.') }}
+
+Returns:
+
+.. code-block:: text
+
+Example 1:
+  {'bar': {'baz': 42}}
+
+Example 2:
+  {'bar': {'baz': {'qux': 42}}}
+
+
+.. jinja_ref:: append_dict_key_value
+
+``append_dict_key_value``
+-------------------------
+
+..versionadded:: Neon
+
+Allows you to append to a list nested (deep) in a dictionary without having to worry if all the nested keys (or the list itself) actually exist.
+Missing keys will automatically be created if they do not exist.
+The default delimiter for the keys is ':', however, with the `delimiter`-parameter, a different delimiter can be specified.
+
+Examples:
+
+.. code-block:: jinja
+
+Example 1:
+  {%- set foo = {'bar': {'baz': [1, 2]}} %}
+  {{ foo | append_dict_key_value('bar:baz', 42) }}
+
+Example 2:
+  {%- set foo = {} %}
+  {{ foo | append_dict_key_value('bar:baz:qux', 42) }}
+
+Returns:
+
+.. code-block:: text
+
+Example 1:
+  {'bar': {'baz': [1, 2, 42]}}
+
+Example 2:
+  {'bar': {'baz': {'qux': [42]}}}
+
+
+.. jinja_ref:: extend_dict_key_value
+
+``extend_dict_key_value``
+-------------------------
+
+..versionadded:: Neon
+
+Allows you to extend a list nested (deep) in a dictionary without having to worry if all the nested keys (or the list itself) actually exist.
+Missing keys will automatically be created if they do not exist.
+The default delimiter for the keys is ':', however, with the `delimiter`-parameter, a different delimiter can be specified.
+
+Examples:
+
+.. code-block:: jinja
+
+Example 1:
+  {%- set foo = {'bar': {'baz': [1, 2]}} %}
+  {{ foo | extend_dict_key_value('bar:baz', [42, 42]) }}
+
+Example 2:
+  {{ {} | extend_dict_key_value('bar:baz:qux', [42]) }}
+
+Returns:
+
+.. code-block:: text
+
+Example 1:
+  {'bar': {'baz': [1, 2, 42, 42]}}
+
+Example 2:
+  {'bar': {'baz': {'qux': [42]}}}
+
+
+.. jinja_ref:: update_dict_key_value
+
+``update_dict_key_value``
+-------------------------
+
+..versionadded:: Neon
+
+Allows you to update a dictionary nested (deep) in another dictionary without having to worry if all the nested keys actually exist.
+Missing keys will automatically be created if they do not exist.
+The default delimiter for the keys is ':', however, with the `delimiter`-parameter, a different delimiter can be specified.
+
+Examples:
+
+.. code-block:: jinja
+
+Example 1:
+  {%- set foo = {'bar': {'baz': {'qux': 1}}} %}
+  {{ foo | update_dict_key_value('bar:baz', {'quux': 3}) }}
+
+Example 2:
+  {{ {} | update_dict_key_value('bar:baz:qux', {'quux': 3}) }}
+
+.. code-block:: text
+
+Example 1:
+  {'bar': {'baz': {'qux': 1, 'quux': 3}}}
+
+Example 2:
+  {'bar': {'baz': {'qux': {'quux': 3}}}}
+
+
 .. jinja_ref:: md5
 
 ``md5``

--- a/salt/modules/acme.py
+++ b/salt/modules/acme.py
@@ -232,7 +232,7 @@ def info(name):
     cert_file = _cert_file(name, 'cert')
     # Use the tls salt module if available
     if 'tls.cert_info' in __salt__:
-        info = __salt__['tls.cert_info'](cert_file)
+        cert_info = __salt__['tls.cert_info'](cert_file)
         # Strip out the extensions object contents;
         # these trip over our poor state output
         # and they serve no real purpose here anyway

--- a/salt/states/acme.py
+++ b/salt/states/acme.py
@@ -31,7 +31,6 @@ import logging
 
 # Import salt libs
 import salt.utils.dictdiffer
-import salt.ext.six as six
 
 log = logging.getLogger(__name__)
 

--- a/salt/states/acme.py
+++ b/salt/states/acme.py
@@ -53,7 +53,14 @@ def cert(name,
          owner='root',
          group='root',
          mode='0640',
-         certname=None):
+         certname=None,
+         preferred_challenges=None,
+         tls_sni_01_port=None,
+         tls_sni_01_address=None,
+         http_01_port=None,
+         http_01_address=None,
+         dns_plugin=None,
+         dns_plugin_credentials=None):
     '''
     Obtain/renew a certificate from an ACME CA, probably Let's Encrypt.
 
@@ -69,6 +76,20 @@ def cert(name,
     :param group: group of the private key file
     :param mode: mode of the private key file
     :param certname: Name of the certificate to save
+    :param preferred_challenges: A sorted, comma delimited list of the preferred
+                                 challenge to use during authorization with the
+                                 most preferred challenge listed first.
+    :param tls_sni_01_port: Port used during tls-sni-01 challenge. This only affects
+                            the port Certbot listens on. A conforming ACME server
+                            will still attempt to connect on port 443.
+    :param tls_sni_01_address: The address the server listens to during tls-sni-01
+                               challenge.
+    :param http_01_port: Port used in the http-01 challenge. This only affects
+                         the port Certbot listens on. A conforming ACME server
+                         will still attempt to connect on port 80.
+    :param https_01_address: The address the server listens to during http-01 challenge.
+    :param dns_plugin: Name of a DNS plugin to use (currently only 'cloudflare')
+    :param dns_plugin_credentials: Path to the credentials file if required by the specified DNS plugin
     '''
     ret = {'name': name, 'result': 'changeme', 'comment': [], 'changes': {}}
     action = None

--- a/salt/utils/dictupdate.py
+++ b/salt/utils/dictupdate.py
@@ -15,7 +15,14 @@ except ImportError:
 # Import 3rd-party libs
 import copy
 import logging
+
+# Import salt libs
 import salt.ext.six as six
+from salt.defaults import DEFAULT_TARGET_DELIM
+import salt.utils.data
+from salt.exceptions import SaltInvocationError
+from salt.utils.odict import OrderedDict
+from salt.utils.decorators.jinja import jinja_filter
 
 log = logging.getLogger(__name__)
 
@@ -55,8 +62,7 @@ def update(dest, upd, recursive_update=True, merge_lists=False):
                     and isinstance(val, Mapping):
                 ret = update(dest_subkey, val, merge_lists=merge_lists)
                 dest[key] = ret
-            elif isinstance(dest_subkey, list) \
-                     and isinstance(val, list):
+            elif isinstance(dest_subkey, list) and isinstance(val, list):
                 if merge_lists:
                     merged = copy.deepcopy(dest_subkey)
                     merged.extend([x for x in val if x not in merged])
@@ -66,15 +72,14 @@ def update(dest, upd, recursive_update=True, merge_lists=False):
             else:
                 dest[key] = upd[key]
         return dest
-    else:
-        try:
-            for k in upd:
-                dest[k] = upd[k]
-        except AttributeError:
-            # this mapping is not a dict
-            for k in upd:
-                dest[k] = upd[k]
-        return dest
+    try:
+        for k in upd:
+            dest[k] = upd[k]
+    except AttributeError:
+        # this mapping is not a dict
+        for k in upd:
+            dest[k] = upd[k]
+    return dest
 
 
 def merge_list(obj_a, obj_b):
@@ -132,3 +137,204 @@ def merge(obj_a, obj_b, strategy='smart', renderer='yaml', merge_lists=False):
         merged = merge_recurse(obj_a, obj_b)
 
     return merged
+
+
+def ensure_dict_key(
+        in_dict,
+        keys,
+        delimiter=DEFAULT_TARGET_DELIM,
+        ordered_dict=False):
+    '''
+    Ensures that in_dict contains the series of recursive keys defined in keys.
+
+    :param dict in_dict: The dict to work with.
+    :param str keys: The delimited string with one or more keys.
+    :param str delimiter: The delimiter to use in `keys`. Defaults to ':'.
+    :param bool ordered_dict: Create OrderedDicts if keys are missing.
+                              Default: create regular dicts.
+    '''
+    if delimiter in keys:
+        a_keys = keys.split(delimiter)
+    else:
+        a_keys = [keys]
+    dict_pointer = in_dict
+    while a_keys:
+        current_key = a_keys.pop(0)
+        if current_key not in dict_pointer or not isinstance(dict_pointer[current_key], dict):
+            dict_pointer[current_key] = OrderedDict() if ordered_dict else {}
+        dict_pointer = dict_pointer[current_key]
+    return in_dict
+
+
+def _dict_rpartition(
+        in_dict,
+        keys,
+        delimiter=DEFAULT_TARGET_DELIM,
+        ordered_dict=False):
+    '''
+    Helper function to:
+    - Ensure all but the last key in `keys` exist recursively in `in_dict`.
+    - Return the dict at the one-to-last key, and the last key
+
+    :param dict in_dict: The dict to work with.
+    :param str keys: The delimited string with one or more keys.
+    :param str delimiter: The delimiter to use in `keys`. Defaults to ':'.
+    :param bool ordered_dict: Create OrderedDicts if keys are missing.
+                              Default: create regular dicts.
+
+    :return tuple(dict, str)
+    '''
+    if delimiter in keys:
+        all_but_last_keys, _, last_key = keys.rpartition(delimiter)
+        ensure_dict_key(in_dict,
+                        all_but_last_keys,
+                        delimiter=delimiter,
+                        ordered_dict=ordered_dict)
+        dict_pointer = salt.utils.data.traverse_dict(in_dict,
+                                                     all_but_last_keys,
+                                                     default=None,
+                                                     delimiter=delimiter)
+    else:
+        dict_pointer = in_dict
+        last_key = keys
+    return dict_pointer, last_key
+
+
+@jinja_filter('set_dict_key_value')
+def set_dict_key_value(
+        in_dict,
+        keys,
+        value,
+        delimiter=DEFAULT_TARGET_DELIM,
+        ordered_dict=False):
+    '''
+    Ensures that in_dict contains the series of recursive keys defined in keys.
+    Also sets whatever is at the end of `in_dict` traversed with `keys` to `value`.
+
+    :param dict in_dict: The dictionary to work with
+    :param str keys: The delimited string with one or more keys.
+    :param any value: The value to assign to the nested dict-key.
+    :param str delimiter: The delimiter to use in `keys`. Defaults to ':'.
+    :param bool ordered_dict: Create OrderedDicts if keys are missing.
+                              Default: create regular dicts.
+
+    :return dict: Though it updates in_dict in-place.
+    '''
+    dict_pointer, last_key = _dict_rpartition(in_dict,
+                                              keys,
+                                              delimiter=delimiter,
+                                              ordered_dict=ordered_dict)
+    dict_pointer[last_key] = value
+    return in_dict
+
+
+@jinja_filter('update_dict_key_value')
+def update_dict_key_value(
+        in_dict,
+        keys,
+        value,
+        delimiter=DEFAULT_TARGET_DELIM,
+        ordered_dict=False):
+    '''
+    Ensures that in_dict contains the series of recursive keys defined in keys.
+    Also updates the dict, that is at the end of `in_dict` traversed with `keys`,
+    with `value`.
+
+    :param dict in_dict: The dictionary to work with
+    :param str keys: The delimited string with one or more keys.
+    :param any value: The value to update the nested dict-key with.
+    :param str delimiter: The delimiter to use in `keys`. Defaults to ':'.
+    :param bool ordered_dict: Create OrderedDicts if keys are missing.
+                              Default: create regular dicts.
+
+    :return dict: Though it updates in_dict in-place.
+    '''
+    dict_pointer, last_key = _dict_rpartition(in_dict,
+                                              keys,
+                                              delimiter=delimiter,
+                                              ordered_dict=ordered_dict)
+    if last_key not in dict_pointer or dict_pointer[last_key] is None:
+        dict_pointer[last_key] = OrderedDict() if ordered_dict else {}
+    try:
+        dict_pointer[last_key].update(value)
+    except AttributeError:
+        raise SaltInvocationError('The last key contains a {}, which cannot update.'
+                                  ''.format(type(dict_pointer[last_key])))
+    except (ValueError, TypeError):
+        raise SaltInvocationError('Cannot update {} with a {}.'
+                                  ''.format(type(dict_pointer[last_key]), type(value)))
+    return in_dict
+
+
+@jinja_filter('append_dict_key_value')
+def append_dict_key_value(
+        in_dict,
+        keys,
+        value,
+        delimiter=DEFAULT_TARGET_DELIM,
+        ordered_dict=False):
+    '''
+    Ensures that in_dict contains the series of recursive keys defined in keys.
+    Also appends `value` to the list that is at the end of `in_dict` traversed
+    with `keys`.
+
+    :param dict in_dict: The dictionary to work with
+    :param str keys: The delimited string with one or more keys.
+    :param any value: The value to append to the nested dict-key.
+    :param str delimiter: The delimiter to use in `keys`. Defaults to ':'.
+    :param bool ordered_dict: Create OrderedDicts if keys are missing.
+                              Default: create regular dicts.
+
+    :return dict: Though it updates in_dict in-place.
+    '''
+    dict_pointer, last_key = _dict_rpartition(in_dict,
+                                              keys,
+                                              delimiter=delimiter,
+                                              ordered_dict=ordered_dict)
+    if last_key not in dict_pointer or dict_pointer[last_key] is None:
+        dict_pointer[last_key] = []
+    try:
+        dict_pointer[last_key].append(value)
+    except AttributeError:
+        raise SaltInvocationError('The last key contains a {}, which cannot append.'
+                                  ''.format(type(dict_pointer[last_key])))
+    return in_dict
+
+
+@jinja_filter('extend_dict_key_value')
+def extend_dict_key_value(
+        in_dict,
+        keys,
+        value,
+        delimiter=DEFAULT_TARGET_DELIM,
+        ordered_dict=False):
+    '''
+    Ensures that in_dict contains the series of recursive keys defined in keys.
+    Also extends the list, that is at the end of `in_dict` traversed with `keys`,
+    with `value`.
+
+    :param dict in_dict: The dictionary to work with
+    :param str keys: The delimited string with one or more keys.
+    :param any value: The value to extend the nested dict-key with.
+    :param str delimiter: The delimiter to use in `keys`. Defaults to ':'.
+    :param bool ordered_dict: Create OrderedDicts if keys are missing.
+                              Default: create regular dicts.
+
+    :return dict: Though it updates in_dict in-place.
+    '''
+    dict_pointer, last_key = _dict_rpartition(
+        in_dict,
+        keys,
+        delimiter=delimiter,
+        ordered_dict=ordered_dict)
+    if last_key not in dict_pointer or dict_pointer[last_key] is None:
+        dict_pointer[last_key] = []
+    try:
+        dict_pointer[last_key].extend(value)
+    except AttributeError:
+        raise SaltInvocationError('The last key contains a {}, which cannot extend.'
+                                  ''.format(type(dict_pointer[last_key])))
+    except TypeError:
+        raise SaltInvocationError('Cannot extend {} with a {}.'
+                                  ''.format(type(dict_pointer[last_key]), type(value)))
+    return in_dict

--- a/tests/unit/modules/test_acme.py
+++ b/tests/unit/modules/test_acme.py
@@ -88,7 +88,7 @@ class AcmeTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test certificate information retrieval.
         '''
-        certinfo_result = {
+        certinfo_tls_result = {
             "not_after": 1559471377,
             "signature_algorithm": "sha256WithRSAEncryption",
             "extensions": {},
@@ -99,16 +99,46 @@ class AcmeTestCase(TestCase, LoaderModuleMockMixin):
             "not_before": 1559557777,
             "subject": {},
         }
+        certinfo_x509_result = {
+            "Not After": "2019-06-02 10:29:37",
+            "Subject Hash": "54:3B:6C:A4",
+            "Serial Number": "59:AB:CB:A0:FB:90:E8:4B",
+            "SHA1 Finger Print": "F1:8D:F3:26:1B:D3:88:32:CD:B6:FA:3B:85:58:DA:C7:6F:62:BE:7E",
+            "SHA-256 Finger Print": ("FB:A4:5F:71:D6:5D:6C:B6:1D:2C:FD:91:09:2C:1C:52:"
+                                     "3C:EC:B6:4D:1A:95:65:37:04:D0:E2:5E:C7:64:0C:9C"),
+            "MD5 Finger Print": "95:B5:96:9B:42:A5:9E:20:78:FD:99:09:4B:21:1E:97",
+            "Version": 3,
+            "Key Size": 2048,
+            "Public Key": ("-----BEGIN PUBLIC KEY-----\n"
+                           "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsVO2vwQPKU92PSBnuGid\n"
+                           "k8t6KWVE2jEBM10u7CgqQmD/JCnYflEHAo1nOsD7wxdhBrxhf5Qs+pEX1HOsh8VA\n"
+                           "HDTim0iE8nQVJ0Iuen2SrwaWMhwKmZTSJRYMgd46oCMi2RdlCvcgF2Hw6RTwF7FT\n"
+                           "hnksc4HBT91XddnP32N558tOT3YejafQNvClz5WcR+E0JzqGrV/+wfe3o+j/q5eK\n"
+                           "UowttWazeSMvuROtqj/fEk0rop4D14pgzZqWi30tjwhJNl6fSPFWBrLEHGNyDJ+O\n"
+                           "zfov0B2MRLJibH7GMkOCwsP2g1lVOReqcml+ju6zAKW8nHBTRg0iXB18Ifxef57Y\n"
+                           "AQIDAQAB\n"
+                           "-----END PUBLIC KEY-----\n"),
+            "Issuer": {},
+            "Issuer Hash": "54:3B:6C:A4",
+            "Not Before": "2019-06-03 10:29:37",
+            "Subject": {}
+        }
+
         with patch.dict(acme.__salt__, {  # pylint: disable=no-member
-                    'tls.cert_info': MagicMock(return_value=certinfo_result),
-                    'file.file_exists': MagicMock(return_value=True)
+                    'file.file_exists': MagicMock(return_value=True),
+                    'tls.cert_info': MagicMock(return_value=certinfo_tls_result),
                 }):
-            self.assertEqual(acme.info('test'), certinfo_result)
+            self.assertEqual(acme.info('test'), certinfo_tls_result)
         with patch.dict(acme.__salt__, {  # pylint: disable=no-member
+                    'file.file_exists': MagicMock(return_value=True),
+                    'x509.read_certificate': MagicMock(return_value=certinfo_x509_result),
+                }):
+            self.assertEqual(acme.info('test'), certinfo_x509_result)
+        with patch.dict(acme.__salt__, {  # pylint: disable=no-member
+                    'file.file_exists': MagicMock(return_value=True),
                     'cmd.run': MagicMock(return_value='foo'),
-                    'file.file_exists': MagicMock(return_value=True)
                 }):
-            self.assertEqual(acme.info('test'), 'foo')
+            self.assertEqual(acme.info('test'), {'text': 'foo'})
 
     def test_cert(self):
         '''
@@ -119,7 +149,8 @@ class AcmeTestCase(TestCase, LoaderModuleMockMixin):
         expired_timestamp = (datetime.datetime.now() - datetime.timedelta(days=3) -
                              datetime.datetime(1970, 1, 1, 0, 0, 0, 0)).total_seconds()
         cmd_new_cert = {
-            'stdout': textwrap.dedent('''IMPORTANT NOTES:
+            'stdout': textwrap.dedent('''
+                IMPORTANT NOTES:
                  - Congratulations! Your certificate and chain have been saved at:
                    /etc/letsencrypt/live/test/fullchain.pem
                    Your key file has been saved at:
@@ -133,7 +164,8 @@ class AcmeTestCase(TestCase, LoaderModuleMockMixin):
                    Donating to ISRG / Let's Encrypt:   https://letsencrypt.org/donate
                    Donating to EFF:                    https://eff.org/donate-le
                 '''),
-            'stderr': textwrap.dedent('''Saving debug log to /var/log/letsencrypt/letsencrypt.log
+            'stderr': textwrap.dedent('''
+                Saving debug log to /var/log/letsencrypt/letsencrypt.log
                 Plugins selected: Authenticator standalone, Installer None
                 Starting new HTTPS connection (1): acme-v02.api.letsencrypt.org
                 Obtaining a new certificate

--- a/tests/unit/modules/test_acme.py
+++ b/tests/unit/modules/test_acme.py
@@ -1,0 +1,221 @@
+# -*- coding: utf-8 -*-
+'''
+:codeauthor: Herbert Buurman <herbert.buurman@ogd.nl>
+'''
+
+# Import future libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import Python libs
+import textwrap
+import datetime
+
+# Import Salt Testing libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import skipIf, TestCase
+from tests.support.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
+
+# Import Salt Module
+import salt.modules.acme as acme
+import salt.utils.dictupdate
+from salt.exceptions import SaltInvocationError
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class AcmeTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    Test cases for salt.modules.acme
+    '''
+
+    def setup_loader_modules(self):
+        return {acme: {}}
+
+    def test_certs(self):
+        '''
+        Test listing certs
+        '''
+        with patch.dict(acme.__salt__, {  # pylint: disable=no-member
+                    'file.readdir': MagicMock(return_value=['.', '..', 'README', 'test_expired', 'test_valid'])
+                }), \
+                patch('os.path.isdir', side_effect=[False, True, True]):
+            self.assertEqual(acme.certs(), ['test_expired', 'test_valid'])
+
+    def test_has(self):
+        '''
+        Test checking if certificate (does not) exist.
+        '''
+        with patch.dict(acme.__salt__, {'file.file_exists': MagicMock(return_value=True)}):  # pylint: disable=no-member
+            self.assertTrue(acme.has('test_expired'))
+        with patch.dict(acme.__salt__, {'file.file_exists': MagicMock(return_value=False)}):  # pylint: disable=no-member
+            self.assertFalse(acme.has('test_invalid'))
+
+    def test_needs_renewal(self):
+        '''
+        Test if expired certs do indeed need renewal.
+        '''
+        expired = datetime.date.today() - datetime.timedelta(days=3) - datetime.date(1970, 1, 1)
+        valid = datetime.date.today() + datetime.timedelta(days=3) - datetime.date(1970, 1, 1)
+        with patch.dict(acme.__salt__, {  # pylint: disable=no-member
+                    'tls.cert_info': MagicMock(return_value={'not_after': expired.total_seconds()})
+                }):
+            self.assertTrue(acme.needs_renewal('test_expired'))
+        with patch.dict(acme.__salt__, {  # pylint: disable=no-member
+                    'tls.cert_info': MagicMock(return_value={'not_after': valid.total_seconds()})
+                }):
+            self.assertFalse(acme.needs_renewal('test_valid'))
+            # Test with integer window parameter
+            self.assertTrue(acme.needs_renewal('test_valid', window=5))
+            # Test with string-like window parameter
+            self.assertTrue(acme.needs_renewal('test_valid', window='5'))
+            # Test with invalid window parameter
+            self.assertRaises(SaltInvocationError, acme.needs_renewal, 'test_valid', window='foo')
+
+    def test_expires(self):
+        '''
+        Test if expires function functions properly.
+        '''
+        test_value = datetime.datetime.today() - datetime.timedelta(days=3)
+        test_stamp = test_value - datetime.datetime(1970, 1, 1)
+        with patch.dict(acme.__salt__, {  # pylint: disable=no-member
+                    'tls.cert_info': MagicMock(return_value={'not_after': test_stamp.total_seconds()})
+                }):
+            self.assertEqual(
+                acme.expires('test_expired'),
+                datetime.datetime.fromtimestamp(test_stamp.total_seconds()).isoformat()
+            )
+
+    def test_info(self):
+        '''
+        Test certificate information retrieval.
+        '''
+        certinfo_result = {
+            "not_after": 1559471377,
+            "signature_algorithm": "sha256WithRSAEncryption",
+            "extensions": {},
+            "fingerprint": ("FB:A4:5F:71:D6:5D:6C:B6:1D:2C:FD:91:09:2C:1C:52:"
+                            "3C:EC:B6:4D:1A:95:65:37:04:D0:E2:5E:C7:64:0C:9C"),
+            "serial_number": 6461481982668892235,
+            "issuer": {},
+            "not_before": 1559557777,
+            "subject": {},
+        }
+        with patch.dict(acme.__salt__, {  # pylint: disable=no-member
+                    'tls.cert_info': MagicMock(return_value=certinfo_result),
+                    'file.file_exists': MagicMock(return_value=True)
+                }):
+            self.assertEqual(acme.info('test'), certinfo_result)
+        with patch.dict(acme.__salt__, {  # pylint: disable=no-member
+                    'cmd.run': MagicMock(return_value='foo'),
+                    'file.file_exists': MagicMock(return_value=True)
+                }):
+            self.assertEqual(acme.info('test'), 'foo')
+
+    def test_cert(self):
+        '''
+        Test certificate retrieval/renewal
+        '''
+        valid_timestamp = (datetime.datetime.now() + datetime.timedelta(days=30) -
+                           datetime.datetime(1970, 1, 1, 0, 0, 0, 0)).total_seconds()
+        expired_timestamp = (datetime.datetime.now() - datetime.timedelta(days=3) -
+                             datetime.datetime(1970, 1, 1, 0, 0, 0, 0)).total_seconds()
+        cmd_new_cert = {
+            'stdout': textwrap.dedent('''IMPORTANT NOTES:
+                 - Congratulations! Your certificate and chain have been saved at:
+                   /etc/letsencrypt/live/test/fullchain.pem
+                   Your key file has been saved at:
+                   /etc/letsencrypt/live/test/privkey.pem
+                   Your cert will expire on 2019-08-07. To obtain a new or tweaked
+                   version of this certificate in the future, simply run certbot
+                   again. To non-interactively renew *all* of your certificates, run
+                   "certbot renew"
+                 - If you like Certbot, please consider supporting our work by:
+                
+                   Donating to ISRG / Let's Encrypt:   https://letsencrypt.org/donate
+                   Donating to EFF:                    https://eff.org/donate-le
+                '''),
+            'stderr': textwrap.dedent('''Saving debug log to /var/log/letsencrypt/letsencrypt.log
+                Plugins selected: Authenticator standalone, Installer None
+                Starting new HTTPS connection (1): acme-v02.api.letsencrypt.org
+                Obtaining a new certificate
+                Resetting dropped connection: acme-v02.api.letsencrypt.org
+                '''),
+            'retcode': 0,
+        }
+        result_new_cert = {
+            "comment": "Certificate test obtained",
+            "not_after": datetime.datetime.fromtimestamp(valid_timestamp).isoformat(),
+            "changes": {
+                "mode": "0640"
+            },
+            "result": True
+        }
+
+        cmd_no_renew = {
+            'stdout': textwrap.dedent('''
+                - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+                Certificate not yet due for renewal; no action taken.
+                - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+                '''),
+            'stderr': textwrap.dedent('''Saving debug log to /var/log/letsencrypt/letsencrypt.log
+                Plugins selected: Authenticator standalone, Installer None
+                Starting new HTTPS connection (1): acme-v02.api.letsencrypt.org
+                Cert not yet due for renewal
+                Keeping the existing certificate
+                '''),
+            'retcode': 0
+        }
+        result_no_renew = {
+            "comment": "Certificate /etc/letsencrypt/live/test/cert.pem unchanged",
+            "not_after": datetime.datetime.fromtimestamp(valid_timestamp).isoformat(),
+            "changes": {},
+            "result": True
+        }
+        result_renew = {
+            "comment": "Certificate test renewed",
+            "not_after": datetime.datetime.fromtimestamp(expired_timestamp).isoformat(),
+            "changes": {},
+            "result": True
+        }
+
+        # Test fetching new certificate
+        with patch('salt.modules.acme.LEA', 'certbot'), \
+                patch.dict(acme.__salt__, {  # pylint: disable=no-member
+                    'cmd.run_all': MagicMock(return_value=cmd_new_cert),
+                    'file.file_exists': MagicMock(return_value=False),
+                    'tls.cert_info': MagicMock(return_value={'not_after': valid_timestamp}),
+                    'file.check_perms': MagicMock(
+                        side_effect=lambda a, x, b, c, d, follow_symlinks: (
+                            salt.utils.dictupdate.set_dict_key_value(x, 'changes:mode', '0640'),
+                            None
+                        )
+                    )
+                }):
+            self.assertEqual(acme.cert('test'), result_new_cert)
+        # Test not renewing a valid certificate
+        with patch('salt.modules.acme.LEA', 'certbot'), \
+                patch.dict(acme.__salt__, {  # pylint: disable=no-member
+                    'cmd.run_all': MagicMock(return_value=cmd_no_renew),
+                    'file.file_exists': MagicMock(return_value=True),
+                    'tls.cert_info': MagicMock(return_value={'not_after': valid_timestamp}),
+                    'file.check_perms': MagicMock(
+                        side_effect=lambda a, x, b, c, d, follow_symlinks: (
+                            salt.utils.dictupdate.set_dict_key_value(x, 'result', True),
+                            None
+                        )
+                    )
+                }):
+            self.assertEqual(acme.cert('test'), result_no_renew)
+        # Test renewing an expired certificate
+        with patch('salt.modules.acme.LEA', 'certbot'), \
+                patch.dict(acme.__salt__, {  # pylint: disable=no-member
+                    'cmd.run_all': MagicMock(return_value=cmd_new_cert),
+                    'file.file_exists': MagicMock(return_value=True),
+                    'tls.cert_info': MagicMock(return_value={'not_after': expired_timestamp}),
+                    'file.check_perms': MagicMock(
+                        side_effect=lambda a, x, b, c, d, follow_symlinks: (
+                            salt.utils.dictupdate.set_dict_key_value(x, 'result', True),
+                            None
+                        )
+                    )
+                }):
+            self.assertEqual(acme.cert('test'), result_renew)

--- a/tests/unit/states/test_acme.py
+++ b/tests/unit/states/test_acme.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+'''
+:codeauthor: Herbert Buurman <herbert.buurman@ogd.nl>
+'''
+
+# Import future libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import Salt Testing libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import skipIf, TestCase
+from tests.support.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
+
+# Import Salt Module
+import salt.states.acme as acme
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class AcmeTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    Test cases for salt.modules.acme
+    '''
+
+    def setup_loader_modules(self):
+        return {acme: {'__opts__': {'test': False}}}
+
+    def test_cert_no_changes_t(self):
+        '''
+        Test cert state with no needed changes. (test=True)
+        '''
+        # With test=True
+        with patch.dict(acme.__salt__, {  # pylint: disable=no-member
+                   'acme.has': MagicMock(return_value=True),
+                   'acme.needs_renewal': MagicMock(return_value=False),
+                }), \
+                patch.dict(acme.__opts__, {'test': True}):  # pylint: disable=no-member
+            self.assertEqual(acme.cert('test'), {
+                'name': 'test',
+                'result': True,
+                'comment': ['Certificate test exists and does not need renewal.'],
+                'changes': {},
+            })
+
+    def test_cert_no_changes(self):
+        '''
+        Test cert state with no needed changes. (test=False)
+        '''
+        # With test=False
+        with patch.dict(acme.__salt__, {  # pylint: disable=no-member
+                   'acme.has': MagicMock(return_value=True),
+                   'acme.needs_renewal': MagicMock(return_value=False),
+                }):
+            self.assertEqual(acme.cert('test'), {
+                'name': 'test',
+                'result': True,
+                'comment': ['Certificate test exists and does not need renewal.'],
+                'changes': {},
+            })
+
+    def test_cert_fresh_certificate_t(self):
+        '''
+        Test cert state fetching a new certificate. (test=True)
+        '''
+        # With test=True
+        with patch.dict(acme.__salt__, {  # pylint: disable=no-member
+                    'acme.has': MagicMock(return_value=False),
+                    # 'acme.cert': MagicMock(return_value={'result': True, 'comment': 'Mockery'}),
+                    'acme.info': MagicMock(return_value={'foo': 'bar'}),
+                }), \
+                patch.dict(acme.__opts__, {'test': True}):  # pylint: disable=no-member
+            self.assertEqual(acme.cert('test'), {
+                'name': 'test',
+                'result': None,
+                'comment': ['Certificate test would have been obtained.'],
+                'changes': {'old': 'current certificate', 'new': 'new certificate'},
+            })
+
+    def test_cert_fresh_certificate(self):
+        '''
+        Test cert state fetching a new certificate. (test=False)
+        '''
+        # With test=False
+        with patch.dict(acme.__salt__, {  # pylint: disable=no-member
+                    'acme.has': MagicMock(return_value=False),
+                    'acme.cert': MagicMock(return_value={'result': True, 'comment': 'Mockery'}),
+                    'acme.info': MagicMock(return_value={'foo': 'bar'}),
+                }):
+            self.assertEqual(acme.cert('test'), {
+                'name': 'test',
+                'result': True,
+                'comment': ['Mockery'],
+                'changes': {'new': {'foo': 'bar'}},
+            })
+
+    def test_cert_renew_certificate_t(self):
+        '''
+        Test cert state renewing a certificate. (test=True)
+        '''
+        with patch.dict(acme.__salt__, {  # pylint: disable=no-member
+                    'acme.has': MagicMock(return_value=True),
+                    'acme.needs_renewal': MagicMock(return_value=True),
+                    'acme.info': MagicMock(side_effect=[{'name': 'old cert'}, {'name': 'new cert'}]),
+                    'acme.cert': MagicMock(return_value={'result': True, 'comment': 'Mockery'}),
+                }), \
+                patch.dict(acme.__opts__, {'test': True}):  # pylint: disable=no-member
+            self.assertEqual(acme.cert('test'), {
+                'name': 'test',
+                'result': None,
+                'comment': ['Certificate test would have been renewed.'],
+                'changes': {'old': 'current certificate', 'new': 'new certificate'},
+            })
+
+    def test_cert_renew_certificate(self):
+        '''
+        Test cert state renewing a certificate. (test=False)
+        '''
+        with patch.dict(acme.__salt__, {  # pylint: disable=no-member
+                    'acme.has': MagicMock(return_value=True),
+                    'acme.needs_renewal': MagicMock(return_value=True),
+                    'acme.info': MagicMock(side_effect=[{'name': 'old cert'}, {'name': 'new cert'}]),
+                    'acme.cert': MagicMock(return_value={'result': True, 'comment': 'Mockery'}),
+                }):
+            self.assertEqual(acme.cert('test'), {
+                'name': 'test',
+                'result': True,
+                'comment': ['Mockery'],
+                'changes': {'old': {'name': 'old cert'}, 'new': {'name': 'new cert'}},
+            })

--- a/tests/unit/utils/test_dictupdate.py
+++ b/tests/unit/utils/test_dictupdate.py
@@ -9,6 +9,8 @@ from tests.support.unit import TestCase
 
 # Import Salt libs
 import salt.utils.dictupdate as dictupdate
+from salt.utils.odict import OrderedDict
+from salt.exceptions import SaltInvocationError
 
 
 class UtilDictupdateTestCase(TestCase):
@@ -91,7 +93,8 @@ class UtilDictupdateTestCase(TestCase):
         mdict = copy.deepcopy(self.dict1)
         mdict['C']['F']['G'] = ['a', 'b']
         res = dictupdate.update(copy.deepcopy(mdict),
-            {'C': {'F': {'G': ['c', 'd']}}}, merge_lists=False)
+                                {'C': {'F': {'G': ['c', 'd']}}},
+                                merge_lists=False)
         mdict['C']['F']['G'] = ['c', 'd']
         self.assertEqual(res, mdict)
 
@@ -99,7 +102,8 @@ class UtilDictupdateTestCase(TestCase):
         mdict = copy.deepcopy(self.dict1)
         mdict['C']['F']['G'] = ['a', 'b']
         res = dictupdate.update(copy.deepcopy(mdict),
-            {'C': {'F': {'G': ['c', 'd']}}}, merge_lists=True)
+                                {'C': {'F': {'G': ['c', 'd']}}},
+                                merge_lists=True)
         mdict['C']['F']['G'] = ['a', 'b', 'c', 'd']
         self.assertEqual(res, mdict)
 
@@ -107,7 +111,8 @@ class UtilDictupdateTestCase(TestCase):
         mdict = copy.deepcopy(self.dict1)
         mdict['C']['F']['G'] = ['a', 'b']
         res = dictupdate.update(copy.deepcopy(mdict),
-            {'C': {'F': {'G': ['d', 'c', 'b', 'a']}}}, merge_lists=True)
+                                {'C': {'F': {'G': ['d', 'c', 'b', 'a']}}},
+                                merge_lists=True)
         mdict['C']['F']['G'] = ['a', 'b', 'd', 'c']
         self.assertEqual(res, mdict)
 
@@ -195,3 +200,127 @@ class UtilDictMergeTestCase(TestCase):
         mdict1['A'] = ['B']
         ret = dictupdate.merge_list(mdict1, {'A': ['b', 'c']})
         self.assertEqual({'A': [['B'], ['b', 'c']], 'C': {'D': 'E', 'F': {'I': 'J', 'G': 'H'}}}, ret)
+
+
+class UtilDeepDictUpdateTestCase(TestCase):
+
+    dict1 = {'A': 'B', 'C': {'D': 'E', 'F': {'G': 'H', 'I': 'J'}}}
+
+    def test_deep_set_overwrite(self):
+        '''
+        Test overwriting an existing value.
+        '''
+        mdict = copy.deepcopy(self.dict1)
+        res = dictupdate.set_dict_key_value(mdict, 'C:F', 'foo')
+        self.assertEqual({'A': 'B', 'C': {'D': 'E', 'F': 'foo'}}, res)
+        # Verify modify-in-place
+        self.assertEqual({'A': 'B', 'C': {'D': 'E', 'F': 'foo'}}, mdict)
+
+        # Test using alternative delimiter
+        res = dictupdate.set_dict_key_value(mdict, 'C/F', {'G': 'H', 'I': 'J'}, delimiter='/')
+        self.assertEqual(self.dict1, res)
+
+        # Test without using a delimiter in the keys
+        res = dictupdate.set_dict_key_value(mdict, 'C', None)
+        self.assertEqual({'A': 'B', 'C': None}, res)
+
+    def test_deep_set_create(self):
+        '''
+        Test creating new nested keys.
+        '''
+        mdict = copy.deepcopy(self.dict1)
+        res = dictupdate.set_dict_key_value(mdict, 'K:L:M', 'Q')
+        self.assertEqual({'A': 'B', 'C': {'D': 'E', 'F': {'G': 'H', 'I': 'J'}}, 'K': {'L': {'M': 'Q'}}}, res)
+
+    def test_deep_set_ordered_dicts(self):
+        '''
+        Test creating new nested ordereddicts.
+        '''
+        res = dictupdate.set_dict_key_value({}, 'A:B', 'foo', ordered_dict=True)
+        self.assertEqual({'A': OrderedDict([('B', 'foo')])}, res)
+
+    def test_deep_append(self):
+        '''
+        Test appending to a list.
+        '''
+        sdict = {'bar': {'baz': [1, 2]}}
+        res = dictupdate.append_dict_key_value(sdict, 'bar:baz', 42)
+        self.assertEqual({'bar': {'baz': [1, 2, 42]}}, res)
+        # Append with alternate delimiter
+        res = dictupdate.append_dict_key_value(sdict, 'bar~baz', 43, delimiter='~')
+        self.assertEqual({'bar': {'baz': [1, 2, 42, 43]}}, res)
+        # Append to a not-yet existing list
+        res = dictupdate.append_dict_key_value({}, 'foo:bar:baz', 42)
+        self.assertEqual({'foo': {'bar': {'baz': [42]}}}, res)
+
+    def test_deep_extend(self):
+        '''
+        Test extending a list.
+        Note that the provided value (to extend with) will be coerced to a list
+        if this is not already a list. This can cause unexpected behaviour.
+        '''
+        sdict = {'bar': {'baz': [1, 2]}}
+        res = dictupdate.extend_dict_key_value(sdict, 'bar:baz', [42, 42])
+        self.assertEqual({'bar': {'baz': [1, 2, 42, 42]}}, res)
+
+        # Extend a not-yet existing list
+        res = dictupdate.extend_dict_key_value({}, 'bar:baz:qux', [42])
+        self.assertEqual({'bar': {'baz': {'qux': [42]}}}, res)
+
+        # Extend with a dict (remember, foo has been updated in the first test)
+        res = dictupdate.extend_dict_key_value(sdict, 'bar:baz', {'qux': 'quux'})
+        self.assertEqual({'bar': {'baz': [1, 2, 42, 42, 'qux']}}, res)
+
+    def test_deep_extend_illegal_addition(self):
+        '''
+        Test errorhandling extending lists with illegal types.
+        '''
+        # Extend with an illegal type
+        for extend_with in [42, None]:
+            with self.assertRaisesRegex(SaltInvocationError,
+                                        r"Cannot extend {} with a {}."
+                                        "".format(type([]), type(extend_with))):
+                dictupdate.extend_dict_key_value({}, 'foo', extend_with)
+
+    def test_deep_extend_illegal_source(self):
+        '''
+        Test errorhandling extending things that are not a list.
+        '''
+        # Extend an illegal type
+        for extend_this in [{}, 42, 'bar']:
+            with self.assertRaisesRegex(SaltInvocationError,
+                                        r"The last key contains a {}, which cannot extend."
+                                        "".format(type(extend_this))):
+                dictupdate.extend_dict_key_value({'foo': extend_this}, 'foo', [42])
+
+    def test_deep_update(self):
+        '''
+        Test updating a (sub)dict.
+        '''
+        mdict = copy.deepcopy(self.dict1)
+        res = dictupdate.update_dict_key_value(mdict, 'C:F', {'foo': 'bar', 'qux': 'quux'})
+        self.assertEqual({'A': 'B', 'C': {'D': 'E', 'F': {'G': 'H', 'I': 'J', 'foo': 'bar', 'qux': 'quux'}}}, res)
+
+        # Test updating a non-existing subkey
+        res = dictupdate.update_dict_key_value({}, 'foo:bar:baz', {'qux': 'quux'})
+        self.assertEqual({'foo': {'bar': {'baz': {'qux': 'quux'}}}}, res)
+        # Test updating a non-existing subkey, with a different delimiter
+        res = dictupdate.update_dict_key_value({}, 'foo bar baz', {'qux': 'quux'}, delimiter=' ')
+        self.assertEqual({'foo': {'bar': {'baz': {'qux': 'quux'}}}}, res)
+
+    def test_deep_update_illegal_update(self):
+        '''
+        Test errorhandling updating a (sub)dict with illegal types.
+        '''
+        # Update with an illegal type
+        for update_with in [42, None, [42], 'bar']:
+            with self.assertRaisesRegex(SaltInvocationError,
+                                        r"Cannot update {} with a {}."
+                                        "".format(type({}), type(update_with))):
+                dictupdate.update_dict_key_value({}, 'foo', update_with)
+        # Again, but now using OrderedDicts
+        for update_with in [42, None, [42], 'bar']:
+            with self.assertRaisesRegex(SaltInvocationError,
+                                        r"Cannot update {} with a {}."
+                                        "".format(type(OrderedDict()), type(update_with))):
+                dictupdate.update_dict_key_value({}, 'foo', update_with, ordered_dict=True)

--- a/tests/unit/utils/test_jinja.py
+++ b/tests/unit/utils/test_jinja.py
@@ -51,12 +51,6 @@ try:
 except ImportError:
     HAS_TIMELIB = False
 
-try:
-    import jmespath  # pylint: disable=W0611
-    HAS_JMESPATH = True
-except ImportError:
-    HAS_JMESPATH = False
-
 CACHEDIR = os.path.join(TMP, 'jinja-template-cache')
 BLINESEP = salt.utils.stringutils.to_bytes(os.linesep)
 
@@ -1382,17 +1376,6 @@ class TestCustomExtensions(TestCase):
         rendered = render_jinja_tmpl("{{ 'cmFuZG9t' | base64_decode }}",
                                      dict(opts=self.local_opts, saltenv='test', salt=self.local_salt))
         self.assertEqual(rendered, 'random')
-
-    @skipIf(HAS_JMESPATH is False, 'The `jmespath` library is not installed.')
-    def test_json_query(self):
-        '''
-        Test the `json_query` Jinja filter.
-        '''
-        rendered = render_jinja_tmpl(
-            "{{ [1, 2, 3] | json_query('[1]')}}",
-            dict(opts=self.local_opts, saltenv='test', salt=self.local_salt)
-        )
-        self.assertEqual(rendered, '2')
 
     # def test_print(self):
     #     env = Environment(extensions=[SerializerExtension])

--- a/tests/unit/utils/test_jinja.py
+++ b/tests/unit/utils/test_jinja.py
@@ -51,6 +51,12 @@ try:
 except ImportError:
     HAS_TIMELIB = False
 
+try:
+    import jmespath  # pylint: disable=W0611
+    HAS_JMESPATH = True
+except ImportError:
+    HAS_JMESPATH = False
+
 CACHEDIR = os.path.join(TMP, 'jinja-template-cache')
 BLINESEP = salt.utils.stringutils.to_bytes(os.linesep)
 
@@ -63,7 +69,9 @@ class JinjaTestCase(TestCase):
         '''
         data = {'Non-ascii words': ['süß', 'спам', 'яйца']}
         result = tojson(data)
-        expected = '{"Non-ascii words": ["s\\u00fc\\u00df", "\\u0441\\u043f\\u0430\\u043c", "\\u044f\\u0439\\u0446\\u0430"]}'
+        expected = ('{"Non-ascii words": ["s\\u00fc\\u00df", '
+                    '"\\u0441\\u043f\\u0430\\u043c", '
+                    '"\\u044f\\u0439\\u0446\\u0430"]}')
         assert result == expected, result
 
 
@@ -749,20 +757,20 @@ class TestCustomExtensions(TestCase):
 
         with self.assertRaises(exceptions.TemplateRuntimeError):
             env.from_string('{% set document = document|load_yaml %}'
-                                       '{{ document.foo }}').render(document={"foo": "it works"})
+                            '{{ document.foo }}').render(document={"foo": "it works"})
 
     def test_load_tag(self):
         env = Environment(extensions=[SerializerExtension])
 
         source = '{{ bar }}, ' + \
                  '{% load_yaml as docu %}{foo: it works, {{ bar }}: baz}{% endload %}' + \
-                                        '{{ docu.foo }}'
+                 '{{ docu.foo }}'
 
         rendered = env.from_string(source).render(bar="barred")
         self.assertEqual(rendered, "barred, it works")
 
         source = '{{ bar }}, {% load_json as docu %}{"foo": "it works", "{{ bar }}": "baz"}{% endload %}' + \
-                                        '{{ docu.foo }}'
+                 '{{ docu.foo }}'
 
         rendered = env.from_string(source).render(bar="barred")
         self.assertEqual(rendered, "barred, it works")
@@ -877,15 +885,14 @@ class TestCustomExtensions(TestCase):
             ('foo', OrderedDict([
                         ('bar', 'baz'),
                         ('qux', 42)
-                    ])
-            )
+            ]))
         ])
 
         rendered = env.from_string('{{ data }}').render(data=data)
         self.assertEqual(
             rendered,
             "{u'foo': {u'bar': u'baz', u'qux': 42}}" if six.PY2
-                else "{'foo': {'bar': 'baz', 'qux': 42}}"
+            else "{'foo': {'bar': 'baz', 'qux': 42}}"
         )
 
         rendered = env.from_string('{{ data }}').render(data=[
@@ -899,7 +906,117 @@ class TestCustomExtensions(TestCase):
         self.assertEqual(
             rendered,
             "[{'foo': u'bar'}, {'baz': 42}]" if six.PY2
-                else "[{'foo': 'bar'}, {'baz': 42}]"
+            else "[{'foo': 'bar'}, {'baz': 42}]"
+        )
+
+    def test_set_dict_key_value(self):
+        '''
+        Test the `set_dict_key_value` Jinja filter.
+        '''
+        rendered = render_jinja_tmpl("{{ {} | set_dict_key_value('foo:bar:baz', 42) }}",
+                                     dict(opts=self.local_opts,
+                                          saltenv='test',
+                                          salt=self.local_salt))
+        self.assertEqual(rendered, "{'foo': {'bar': {'baz': 42}}}")
+
+        rendered = render_jinja_tmpl("{{ {} | set_dict_key_value('foo.bar.baz', 42, delimiter='.') }}",
+                                     dict(opts=self.local_opts,
+                                          saltenv='test',
+                                          salt=self.local_salt))
+        self.assertEqual(rendered, "{'foo': {'bar': {'baz': 42}}}")
+
+    def test_update_dict_key_value(self):
+        '''
+        Test the `update_dict_key_value` Jinja filter.
+        '''
+        # Use OrderedDicts to avoid random key-order-switches in the rendered string.
+        expected = OrderedDict([('bar', OrderedDict([('baz', OrderedDict([('qux', 1), ('quux', 3)]))]))])
+        dataset = OrderedDict([('bar', OrderedDict([('baz', OrderedDict([('qux', 1)]))]))])
+        dataset_exp = OrderedDict([('quux', 3)])
+        rendered = render_jinja_tmpl("{{ foo | update_dict_key_value('bar:baz', exp) }}",
+                                     dict(foo=dataset,
+                                          exp=dataset_exp,
+                                          opts=self.local_opts,
+                                          saltenv='test',
+                                          salt=self.local_salt))
+        self.assertEqual(
+            rendered,
+            "{u'bar': {u'baz': {u'qux': 1, u'quux': 3}}}" if six.PY2
+            else "{'bar': {'baz': {'qux': 1, 'quux': 3}}}")
+
+        # Test incorrect usage
+        for update_with in [42, 'foo', [42]]:
+            template = "{{ {} | update_dict_key_value('bar:baz', update_with) }}"
+            expected = r"Cannot update {} with a {}.".format(type({}), type(update_with))
+            self.assertRaisesRegex(
+                SaltRenderError,
+                expected,
+                render_jinja_tmpl,
+                template,
+                dict(update_with=update_with,
+                     opts=self.local_opts,
+                     saltenv='test',
+                     salt=self.local_salt)
+            )
+
+    def test_append_dict_key_value(self):
+        '''
+        Test the `append_dict_key_value` Jinja filter.
+        '''
+        rendered = render_jinja_tmpl("{{ {} | append_dict_key_value('foo:bar:baz', 42) }}",
+                                     dict(opts=self.local_opts,
+                                          saltenv='test',
+                                          salt=self.local_salt))
+        self.assertEqual(rendered, "{'foo': {'bar': {'baz': [42]}}}")
+
+        rendered = render_jinja_tmpl("{{ foo | append_dict_key_value('bar:baz', 42) }}",
+                                     dict(foo={'bar': {'baz': [1, 2]}},
+                                          opts=self.local_opts,
+                                          saltenv='test',
+                                          salt=self.local_salt))
+        self.assertEqual(
+            rendered,
+            "{u'bar': {u'baz': [1, 2, 42]}}" if six.PY2
+            else "{'bar': {'baz': [1, 2, 42]}}"
+        )
+
+    def test_extend_dict_key_value(self):
+        '''
+        Test the `extend_dict_key_value` Jinja filter.
+        '''
+        rendered = render_jinja_tmpl("{{ {} | extend_dict_key_value('foo:bar:baz', [42]) }}",
+                                     dict(opts=self.local_opts, saltenv='test', salt=self.local_salt))
+        self.assertEqual(rendered, "{'foo': {'bar': {'baz': [42]}}}")
+
+        rendered = render_jinja_tmpl("{{ foo | extend_dict_key_value('bar:baz', [42, 43]) }}",
+                                     dict(foo={'bar': {'baz': [1, 2]}},
+                                          opts=self.local_opts,
+                                          saltenv='test',
+                                          salt=self.local_salt))
+        self.assertEqual(
+            rendered,
+            "{u'bar': {u'baz': [1, 2, 42, 43]}}" if six.PY2
+            else "{'bar': {'baz': [1, 2, 42, 43]}}"
+        )
+        # Edge cases
+        rendered = render_jinja_tmpl("{{ {} | extend_dict_key_value('foo:bar:baz', 'quux') }}",
+                                     dict(opts=self.local_opts, saltenv='test', salt=self.local_salt))
+        self.assertEqual(rendered, "{'foo': {'bar': {'baz': ['q', 'u', 'u', 'x']}}}")
+        # Beware! When supplying a dict, the list gets extended with the dict coerced to a list,
+        # which will only contain the keys of the dict.
+        rendered = render_jinja_tmpl("{{ {} | extend_dict_key_value('foo:bar:baz', {'foo': 'bar'}) }}",
+                                     dict(opts=self.local_opts, saltenv='test', salt=self.local_salt))
+        self.assertEqual(rendered, "{'foo': {'bar': {'baz': ['foo']}}}")
+
+        # Test incorrect usage
+        template = "{{ {} | extend_dict_key_value('bar:baz', 42) }}"
+        expected = r"Cannot extend {} with a {}.".format(type([]), type(42))
+        self.assertRaisesRegex(
+            SaltRenderError,
+            expected,
+            render_jinja_tmpl,
+            template,
+            dict(opts=self.local_opts, saltenv='test', salt=self.local_salt)
         )
 
     def test_sequence(self):
@@ -1265,6 +1382,17 @@ class TestCustomExtensions(TestCase):
         rendered = render_jinja_tmpl("{{ 'cmFuZG9t' | base64_decode }}",
                                      dict(opts=self.local_opts, saltenv='test', salt=self.local_salt))
         self.assertEqual(rendered, 'random')
+
+    @skipIf(HAS_JMESPATH is False, 'The `jmespath` library is not installed.')
+    def test_json_query(self):
+        '''
+        Test the `json_query` Jinja filter.
+        '''
+        rendered = render_jinja_tmpl(
+            "{{ [1, 2, 3] | json_query('[1]')}}",
+            dict(opts=self.local_opts, saltenv='test', salt=self.local_salt)
+        )
+        self.assertEqual(rendered, '2')
 
     # def test_print(self):
     #     env = Environment(extensions=[SerializerExtension])


### PR DESCRIPTION
### What does this PR do?
(2018.3 version of https://github.com/saltstack/salt/pull/53366)
Edit: Expanded on the changes in this PR. Clarified the changes to behaviour in test-mode. I earlier stated that test-mode is blatantly ignored, which was incorrect.

It fixes the state `acme` by implementing correct handling of `__opts__['test']` and also properly detecting if a change is needed or not. It also fixes the returned changes (i.e. no changes returned if no changes were made, and only the changed items returned when there were changes.). Also now returns expected changes in test-mode.
Fixed handling of the `window`-parameter in `salt.modules.acme.needs_renewal` and thereby removing the broad `Exception` catching in `acme.cert`.
Moved check if certificate file actually exists into `salt.modules.acme.info`, removing 
Pylint now scores both the module and the state, as well as the unittest files with a 10 :)

### What issues does this PR fix or reference?
None that I'm aware of.

### Previous Behavior
`acme.cert` always starts `salt.modules.acme.cert` regardless of whether a certificate renewal is needed.
No expected changes are reported in testmode, even when this is the case.
`acme.cert` always returns changes, even when no changes have been made (i.e. when a certificate was not due for renewal and no renewal had been forced).

### New Behavior
`acme.cert` does not start `salt.modules.acme.cert` when the certificate specified does not need renewal and no renewal has been forced. It also now properly returns actual changes instead of always dumping the entire certificate information for both the certificate prior to the call to `salt.modules.acme.cert` and after.
Running `acme.cert` with `__opts__['test'] == True` returns changes when a certificate would have been fetched or renewed.

### Tests written?
Yes

### Commits signed with GPG?
Yes