### PR TITLE
[WIP] Added clean_top argument for the archive state

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -1247,7 +1247,7 @@ def extracted(name,
                     'removed', "Directory {} was removed prior to the extraction".format(name))
             except OSError as exc:
                 if exc.errno != errno.ENOENT:
-                        errors.append(exc.__str__())
+                    errors.append(exc.__str__())
             if errors:
                 msg = (
                     'Unable to remove the directory {}. The following '

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -528,7 +528,7 @@ def extracted(name,
         .. versionadded:: 2016.11.1
 
     clean_top : False
-        Set this to ``True`` to remove a top level directory defore the extration.
+        Set this to ``True`` to remove a top level directory before the extration.
 
     user
         The user to own each extracted file. Not available on Windows.


### PR DESCRIPTION
### What does this PR do?

Adding new argument `clean_top` to the archive state. This allows the state to remove top level directory before the extraction.

### What issues does this PR fix or reference?

#54012 

### Previous Behavior
archive state was unable to do so by itself.

### New Behavior
archive state now able to remove top level directory if requested

### Tests written?


No(yet) - RFC required first

### Commits signed with GPG?

Yes