### PR TITLE
Allow for main thread having terminated pid, before ThreadPoolExecutor threads

### DIFF
--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -807,15 +807,15 @@ class SignalHandlingMultiprocessingProcess(MultiprocessingProcess):
         msg += '. Exiting'
         log.debug(msg)
         if HAS_PSUTIL:
-            for process in psutil.process_iter():
-                if process == self.pid and hasattr(process, 'children'):
+            if psutil.pid_exists(self.pid):
+                process = psutil.Process(self.pid)
+                if hasattr(process, 'children'):
                     try:
                         for child in process.children(recursive=True):
                             if child.is_running():
                                 child.terminate()
                     except psutil.NoSuchProcess:
                         pass
-                    break
         sys.exit(salt.defaults.exitcodes.EX_OK)
 
     def start(self):

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# ndle-*- coding: utf-8 -*-
 '''
 Functions for daemonizing and otherwise modifying running processes
 '''
@@ -807,11 +807,15 @@ class SignalHandlingMultiprocessingProcess(MultiprocessingProcess):
         msg += '. Exiting'
         log.debug(msg)
         if HAS_PSUTIL:
-            process = psutil.Process(self.pid)
-            if hasattr(process, 'children'):
-                for child in process.children(recursive=True):
-                    if child.is_running():
-                        child.terminate()
+            for process in psutil.process_iter():
+                if process == self.pid and hasattr(process, 'children'):
+                    try:
+                        for child in process.children(recursive=True):
+                            if child.is_running():
+                                child.terminate()
+                    except psutil.NoSuchProcess:
+                        pass
+                    break
         sys.exit(salt.defaults.exitcodes.EX_OK)
 
     def start(self):

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -815,9 +815,17 @@ class SignalHandlingMultiprocessingProcess(MultiprocessingProcess):
                             if child.is_running():
                                 child.terminate()
                         except psutil.NoSuchProcess:
-                            pass
+                            log.warn(
+                                'Unable to kill child of process %d, it does '
+                                'not exist. My pid is %d',
+                                self.pid, os.getpid()
+                            )
             except psutil.NoSuchProcess:
-                pass
+                log.warn(
+                    'Unable to kill children of process %d, it does not exist.'
+                    'My pid is %d',
+                    self.pid, os.getpid()
+                )
         sys.exit(salt.defaults.exitcodes.EX_OK)
 
     def start(self):

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -808,14 +808,14 @@ class SignalHandlingMultiprocessingProcess(MultiprocessingProcess):
         log.debug(msg)
         if HAS_PSUTIL:
             if psutil.pid_exists(self.pid):
-                process = psutil.Process(self.pid)
-                if hasattr(process, 'children'):
-                    try:
+                try:
+                    process = psutil.Process(self.pid)
+                    if hasattr(process, 'children'):
                         for child in process.children(recursive=True):
                             if child.is_running():
                                 child.terminate()
-                    except psutil.NoSuchProcess:
-                        pass
+                except psutil.NoSuchProcess:
+                    pass
         sys.exit(salt.defaults.exitcodes.EX_OK)
 
     def start(self):

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -807,15 +807,17 @@ class SignalHandlingMultiprocessingProcess(MultiprocessingProcess):
         msg += '. Exiting'
         log.debug(msg)
         if HAS_PSUTIL:
-            if psutil.pid_exists(self.pid):
-                try:
-                    process = psutil.Process(self.pid)
-                    if hasattr(process, 'children'):
-                        for child in process.children(recursive=True):
+            try:
+                process = psutil.Process(self.pid)
+                if hasattr(process, 'children'):
+                    for child in process.children(recursive=True):
+                        try:
                             if child.is_running():
                                 child.terminate()
-                except psutil.NoSuchProcess:
-                    pass
+                        except psutil.NoSuchProcess:
+                            pass
+            except psutil.NoSuchProcess:
+                pass
         sys.exit(salt.defaults.exitcodes.EX_OK)
 
     def start(self):

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -1,4 +1,4 @@
-# ndle-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 '''
 Functions for daemonizing and otherwise modifying running processes
 '''

--- a/tests/unit/utils/test_process.py
+++ b/tests/unit/utils/test_process.py
@@ -24,6 +24,7 @@ import salt.utils.process
 # Import 3rd-party libs
 from salt.ext import six
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
+import psutil
 
 
 def die(func):
@@ -233,3 +234,32 @@ class TestProcess(TestCase):
             salt.utils.process.daemonize_if({})
             self.assertTrue(salt.utils.process.daemonize.called)
         # pylint: enable=assignment-from-none
+
+
+class TestSignalHandlingMultiprocessingProcess(TestCase):
+
+    @skipIf(NO_MOCK, NO_MOCK_REASON)
+    def test_process_does_not_exist(self):
+        def Process(pid):
+            raise psutil.NoSuchProcess(pid)
+        def target():
+            os.kill(os.getpid(), signal.SIGTERM)
+        try:
+            with patch('psutil.Process', Process):
+                proc = salt.utils.process.SignalHandlingMultiprocessingProcess(target=target)
+                proc.start()
+        except psutil.NoSuchProcess:
+            assert False, "psutil.NoSuchProcess raised"
+
+    @skipIf(NO_MOCK, NO_MOCK_REASON)
+    def test_process_children_do_not_exist(self):
+        def children(*args, **kwargs):
+            raise psutil.NoSuchProcess(1)
+        def target():
+            os.kill(os.getpid(), signal.SIGTERM)
+        try:
+            with patch('psutil.Process.children', children):
+                proc = salt.utils.process.SignalHandlingMultiprocessingProcess(target=target)
+                proc.start()
+        except psutil.NoSuchProcess:
+            assert False, "psutil.NoSuchProcess raised"

--- a/tests/unit/utils/test_process.py
+++ b/tests/unit/utils/test_process.py
@@ -242,8 +242,10 @@ class TestSignalHandlingMultiprocessingProcess(TestCase):
     def test_process_does_not_exist(self):
         def Process(pid):
             raise psutil.NoSuchProcess(pid)
+
         def target():
             os.kill(os.getpid(), signal.SIGTERM)
+
         try:
             with patch('psutil.Process', Process):
                 proc = salt.utils.process.SignalHandlingMultiprocessingProcess(target=target)
@@ -255,8 +257,10 @@ class TestSignalHandlingMultiprocessingProcess(TestCase):
     def test_process_children_do_not_exist(self):
         def children(*args, **kwargs):
             raise psutil.NoSuchProcess(1)
+
         def target():
             os.kill(os.getpid(), signal.SIGTERM)
+
         try:
             with patch('psutil.Process.children', children):
                 proc = salt.utils.process.SignalHandlingMultiprocessingProcess(target=target)

--- a/tests/unit/utils/test_process.py
+++ b/tests/unit/utils/test_process.py
@@ -236,6 +236,7 @@ class TestProcess(TestCase):
         # pylint: enable=assignment-from-none
 
 
+@skipIf(sys.platform.startswith('win'), 'pickling nested function errors on Windows')
 class TestSignalHandlingMultiprocessingProcess(TestCase):
 
     @skipIf(NO_MOCK, NO_MOCK_REASON)


### PR DESCRIPTION
### What does this PR do?
Checks if pid exists before using psutil to kill any children of the pid

### What issues does this PR fix or reference?
https://jenkinsci.saltstack.com/job/2019.2.1/job/salt-debian-9-py2/90/testReport/junit/unit.transport.test_zeromq/PubServerChannel/test_publish_to_pubserv_tcp

### Previous Behavior
Test would fail.

### New Behavior
test should pass.  The problem was that the ThreadExecutorPool executor.submit (4 of them) are handling the signal for the main thread too, which by the time they are called, is terminated.  Fix is to check if the pid exists before having psutil attempt to use it and kill any existing children.

### Tests written?
Yes, using existing tests, e.g. unit/transport/test_zeromq.py

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
