### PR TITLE
Fix potential recursion/duplicate object detection

### DIFF
--- a/salt/payload.py
+++ b/salt/payload.py
@@ -249,10 +249,15 @@ class Serial(object):
             def verylong_encoder(obj, context):
                 # Make sure we catch recursion here.
                 objid = id(obj)
-                if objid in context:
+                # This instance list needs to correspond to the types recursed
+                # in the below if/elif chain. Also update
+                # tests/unit/test_payload.py
+                if objid in context and isinstance(obj, (dict, list, tuple)):
                     return '<Recursion on {} with id={}>'.format(type(obj).__name__, id(obj))
                 context.add(objid)
 
+                # The isinstance checks in this if/elif chain need to be
+                # kept in sync with the above recursion check.
                 if isinstance(obj, dict):
                     for key, value in six.iteritems(obj.copy()):
                         obj[key] = verylong_encoder(value, context)


### PR DESCRIPTION
### What does this PR do?

It's unlikely, but possible, that we could get a problem with over-eager
detection of recursion. Especially in the cases of short interned
strings or small numbers on CPython, since those are cached. Instead
we'll just check of it's a type that we're going to recurse on.


### What issues does this PR fix or reference?

previous PR #51322
#37646 

### Previous Behavior

In the extremely unlikely event that we were setting the same object multiple places, or the incredibly unlikely event that we were returning a short string, or the potential case where we were returning two of the same number, it's possible that we could be overeager in our recursion detection.

This stops that.

### New Behavior

Only detect recursion on objects that we're going to recurse on.

### Tests written?

Yes

### Commits signed with GPG?

Yes