### PR TITLE
(Backport 54022) Some improvements and fixes to the freezer module

### DIFF
--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -396,6 +396,10 @@ Module Changes
 - The :py:func:`chocolatey.unbootstrap <salt.modules.chocolatey.unbootstrap>` function
   has been added to uninstall Chocolatey.
 
+- The :py:func:`freezer.restore <salt.modules.freezer.restore>` function provides a
+  new parameter, `clean`, that will remove the frozen data after a successful recovery.
+
+
 Runner Changes
 ==============
 

--- a/salt/modules/freezer.py
+++ b/salt/modules/freezer.py
@@ -151,7 +151,8 @@ def freeze(name=None, force=False, **kwargs):
     states_path = _states_path()
 
     try:
-        os.makedirs(states_path)
+        if not os.path.exists(states_path):
+            os.makedirs(states_path)
     except OSError as e:
         msg = 'Error when trying to create the freezer storage %s: %s'
         log.error(msg, states_path, e)

--- a/tests/unit/modules/test_freezer.py
+++ b/tests/unit/modules/test_freezer.py
@@ -296,3 +296,29 @@ class FreezerTestCase(TestCase, LoaderModuleMockMixin):
             salt_mock['pkg.del_repo'].assert_called_once()
             fopen.assert_called()
             load.assert_called()
+
+    @patch('os.remove')
+    @patch('salt.utils.json.load')
+    @patch('salt.modules.freezer.fopen')
+    @patch('salt.modules.freezer.status')
+    def test_restore_clean_yml(self, status, fopen, load, remove):
+        '''
+        Test to restore an old state
+        '''
+        status.return_value = True
+        salt_mock = {
+            'pkg.list_pkgs': MagicMock(return_value={}),
+            'pkg.list_repos': MagicMock(return_value={}),
+            'pkg.install': MagicMock(),
+        }
+        with patch.dict(freezer.__salt__, salt_mock):
+            self.assertEqual(freezer.restore(clean=True), {
+                'pkgs': {'add': [], 'remove': []},
+                'repos': {'add': [], 'remove': []},
+                'comment': [],
+            })
+            salt_mock['pkg.list_pkgs'].assert_called()
+            salt_mock['pkg.list_repos'].assert_called()
+            fopen.assert_called()
+            load.assert_called()
+            self.assertEqual(remove.call_count, 2)

--- a/tests/unit/modules/test_freezer.py
+++ b/tests/unit/modules/test_freezer.py
@@ -116,6 +116,30 @@ class FreezerTestCase(TestCase, LoaderModuleMockMixin):
     @patch('salt.modules.freezer.fopen')
     @patch('salt.modules.freezer.status')
     @patch('os.makedirs')
+    def test_freeze_success_two_freeze(self, makedirs, status, fopen, dump):
+        '''
+        Test to freeze a current installation
+        '''
+        # Freeze the current new state
+        status.return_value = False
+        salt_mock = {
+            'pkg.list_pkgs': MagicMock(return_value={}),
+            'pkg.list_repos': MagicMock(return_value={}),
+        }
+        with patch.dict(freezer.__salt__, salt_mock):
+            self.assertTrue(freezer.freeze('one'))
+            self.assertTrue(freezer.freeze('two'))
+
+            self.assertEqual(makedirs.call_count, 2)
+            self.assertEqual(salt_mock['pkg.list_pkgs'].call_count, 2)
+            self.assertEqual(salt_mock['pkg.list_repos'].call_count, 2)
+            fopen.assert_called()
+            dump.assert_called()
+
+    @patch('salt.utils.json.dump')
+    @patch('salt.modules.freezer.fopen')
+    @patch('salt.modules.freezer.status')
+    @patch('os.makedirs')
     def test_freeze_success_new_state(self, makedirs, status, fopen, dump):
         '''
         Test to freeze a current installation
@@ -132,7 +156,7 @@ class FreezerTestCase(TestCase, LoaderModuleMockMixin):
             salt_mock['pkg.list_pkgs'].assert_called_once()
             salt_mock['pkg.list_repos'].assert_called_once()
             fopen.assert_called()
-            dump.asster_called()
+            dump.assert_called()
 
     @patch('salt.utils.json.dump')
     @patch('salt.modules.freezer.fopen')
@@ -154,7 +178,7 @@ class FreezerTestCase(TestCase, LoaderModuleMockMixin):
             salt_mock['pkg.list_pkgs'].assert_called_once()
             salt_mock['pkg.list_repos'].assert_called_once()
             fopen.assert_called()
-            dump.asster_called()
+            dump.assert_called()
 
     @patch('salt.modules.freezer.status')
     def test_restore_fails_missing_state(self, status):
@@ -190,7 +214,7 @@ class FreezerTestCase(TestCase, LoaderModuleMockMixin):
             salt_mock['pkg.list_repos'].assert_called()
             salt_mock['pkg.mod_repo'].assert_called_once()
             fopen.assert_called()
-            load.asster_called()
+            load.assert_called()
 
     @patch('salt.utils.json.load')
     @patch('salt.modules.freezer.fopen')
@@ -217,7 +241,7 @@ class FreezerTestCase(TestCase, LoaderModuleMockMixin):
             salt_mock['pkg.list_repos'].assert_called()
             salt_mock['pkg.install'].assert_called_once()
             fopen.assert_called()
-            load.asster_called()
+            load.assert_called()
 
     @patch('salt.utils.json.load')
     @patch('salt.modules.freezer.fopen')
@@ -244,7 +268,7 @@ class FreezerTestCase(TestCase, LoaderModuleMockMixin):
             salt_mock['pkg.list_repos'].assert_called()
             salt_mock['pkg.remove'].assert_called_once()
             fopen.assert_called()
-            load.asster_called()
+            load.assert_called()
 
     @patch('salt.utils.json.load')
     @patch('salt.modules.freezer.fopen')
@@ -271,4 +295,4 @@ class FreezerTestCase(TestCase, LoaderModuleMockMixin):
             salt_mock['pkg.list_repos'].assert_called()
             salt_mock['pkg.del_repo'].assert_called_once()
             fopen.assert_called()
-            load.asster_called()
+            load.assert_called()


### PR DESCRIPTION
### What does this PR do?

Fix a bug when the module try to re-create the directory where the package information is stored, and add a new parameter in the restore function to clean the YAML document that contain this information after a successful recovery.

### Tests written?

Yes/No

(backport #54022)