### PR TITLE
zypperpkg: fix pkg.list_pkgs cache

### DIFF
--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -448,8 +448,14 @@ def _clean_cache():
     '''
     Clean cached results
     '''
+    keys = []
     for cache_name in ['pkg.list_pkgs', 'pkg.list_provides']:
-        __context__.pop(cache_name, None)
+        for contextkey in __context__:
+            if contextkey.startswith(cache_name):
+                keys.append(contextkey)
+
+    for key in keys:
+        __context__.pop(key, None)
 
 
 def list_upgrades(refresh=True, root=None, **kwargs):
@@ -784,9 +790,10 @@ def list_pkgs(versions_as_list=False, root=None, includes=None, **kwargs):
 
     includes = includes if includes else []
 
-    contextkey = 'pkg.list_pkgs'
+    # Results can be different if a different root or a different
+    # inclusion types are passed
+    contextkey = 'pkg.list_pkgs_{}_{}'.format(root, includes)
 
-    # TODO(aplanas): this cached value depends on the parameters
     if contextkey not in __context__:
         ret = {}
         cmd = ['rpm']

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -570,6 +570,7 @@ Repository 'DUMMY' not found by its alias, number, or URI.
              patch.dict(zypper.__salt__, {'pkg_resource.stringify': MagicMock()}):
             pkgs = zypper.list_pkgs(versions_as_list=True)
             self.assertFalse(pkgs.get('gpg-pubkey', False))
+            self.assertTrue('pkg.list_pkgs_None_[]' in zypper.__context__)
             for pkg_name, pkg_version in {
                 'jakarta-commons-discovery': ['0.4-129.686'],
                 'yast2-ftp-server': ['3.1.8-8.1'],
@@ -611,6 +612,7 @@ Repository 'DUMMY' not found by its alias, number, or URI.
              patch.dict(zypper.__salt__, {'pkg_resource.stringify': MagicMock()}):
             pkgs = zypper.list_pkgs(attr=['epoch', 'release', 'arch', 'install_date_time_t'])
             self.assertFalse(pkgs.get('gpg-pubkey', False))
+            self.assertTrue('pkg.list_pkgs_None_[]' in zypper.__context__)
             for pkg_name, pkg_attr in {
                 'jakarta-commons-discovery': [{
                     'version': '0.4',
@@ -1355,3 +1357,22 @@ pattern() = package-c'''),
                 'summary': 'description b',
             },
         }
+
+    def test__clean_cache_empty(self):
+        '''Test that an empty cached can be cleaned'''
+        context = {}
+        with patch.dict(zypper.__context__, context):
+            zypper._clean_cache()
+            assert context == {}
+
+    def test__clean_cache_filled(self):
+        '''Test that a filled cached can be cleaned'''
+        context = {
+            'pkg.list_pkgs_/mnt_[]': None,
+            'pkg.list_pkgs_/mnt_[patterns]': None,
+            'pkg.list_provides': None,
+            'pkg.other_data': None,
+        }
+        with patch.dict(zypper.__context__, context):
+            zypper._clean_cache()
+            self.assertEqual(zypper.__context__, {'pkg.other_data': None})


### PR DESCRIPTION
### What does this PR do?

The cache from pkg.list_pkgs for the zypper installer is too aggresive.
Some parameters will deliver different package lists, like root and
includes. The current cache do not take those parameters into
consideration, so the next time that this function is called, the last
list of packages will be returned, without checking if the current
parameters match the old one.

This patch create a different cache key for each parameter combination,
so the cached data will be separated too.

### Tests written?

Yes
