### PR TITLE
War Room Skip WinSystemModuleTest.test_get_system_time

### DIFF
--- a/tests/integration/modules/test_system.py
+++ b/tests/integration/modules/test_system.py
@@ -409,6 +409,7 @@ class WinSystemModuleTest(ModuleCase):
         finally:
             self.run_function('system.set_computer_desc', [current_desc])
 
+    @skipIf(True, 'WAR ROOM 7/26/2019')
     def test_get_system_time(self):
         '''
         Test getting the system time


### PR DESCRIPTION
### What does this PR do?
War Room Skip for test: integration.modules.test_system.WinSystemModuleTest.test_get_system_time

### Tests written?
No - skips test temporarily 

### Commits signed with GPG?

Yes