### PR TITLE
Backport #53311 to 2019.2.1

### DIFF
--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -14,6 +14,7 @@ import time
 
 # Import Salt libs
 import salt.utils.platform
+import salt.utils.path
 from salt.exceptions import CommandExecutionError
 
 # Import 3rd party libs
@@ -581,7 +582,8 @@ def create_win_salt_restart_task():
 
         salt '*' service.create_win_salt_restart_task()
     '''
-    cmd = 'cmd'
+    # Updated to use full name for Nessus agent
+    cmd = salt.utils.path.which('cmd')
     args = '/c ping -n 3 127.0.0.1 && net stop salt-minion && net start ' \
            'salt-minion'
     return __salt__['task.create_task'](name='restart-salt-minion',

--- a/tests/unit/modules/test_win_service.py
+++ b/tests/unit/modules/test_win_service.py
@@ -18,6 +18,7 @@ from tests.support.mock import (
 
 # Import Salt Libs
 import salt.modules.win_service as win_service
+import salt.utils.path
 
 # Import 3rd Party Libs
 try:
@@ -209,9 +210,22 @@ class WinServiceTestCase(TestCase, LoaderModuleMockMixin):
             Test to create a task in Windows task
             scheduler to enable restarting the salt-minion
         '''
-        mock_true = MagicMock(return_value=True)
-        with patch.dict(win_service.__salt__, {'task.create_task': mock_true}):
-            self.assertTrue(win_service.create_win_salt_restart_task())
+        cmd = salt.utils.path.which('cmd')
+        mock = MagicMock()
+        with patch.dict(win_service.__salt__, {'task.create_task': mock}):
+            win_service.create_win_salt_restart_task()
+            mock.assert_called_once_with(
+                action_type='Execute',
+                arguments='/c ping -n 3 127.0.0.1 && net stop salt-minion && '
+                          'net start salt-minion',
+                cmd=cmd,
+                force=True,
+                name='restart-salt-minion',
+                start_date='1975-01-01',
+                start_time='01:00',
+                trigger_type='Once',
+                user_name='System'
+            )
 
     def test_execute_salt_restart_task(self):
         '''


### PR DESCRIPTION
### What does this PR do?
Add full path to the CMD.exe call when creating a scheduled task to restart the Salt minion on Windows

### What issues does this PR fix or reference?
Fixes #53306 

### Previous Behavior
Full path to the CMD command was not used causing some vulnerability scanners to list the Salt minion as a potential threat.

### Tests written?
Yes

### Commits signed with GPG?
Yes