### PR TITLE
Backport #53311 to Neon

### DIFF
--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -14,6 +14,7 @@ import time
 
 # Import Salt libs
 import salt.utils.platform
+import salt.utils.path
 from salt.exceptions import CommandExecutionError
 
 # Import 3rd party libs
@@ -773,7 +774,8 @@ def create_win_salt_restart_task():
 
         salt '*' service.create_win_salt_restart_task()
     '''
-    cmd = 'cmd'
+    # Updated to use full name for Nessus agent
+    cmd = salt.utils.path.which('cmd')
     args = '/c ping -n 3 127.0.0.1 && net stop salt-minion && net start ' \
            'salt-minion'
     return __salt__['task.create_task'](name='restart-salt-minion',


### PR DESCRIPTION
### What does this PR do?
Add full path to the CMD.exe call when creating a scheduled task to restart the Salt minion on Windows

### What issues does this PR fix or reference?
Fixes #53306 

### Previous Behavior
Full path to the CMD command was not used causing some vulnerability scanners to list the Salt minion as a potential threat.

### Tests written?
Yes

### Commits signed with GPG?
Yes