### PR TITLE
Pyton3 digitial ocean test fix: to_str on key

### DIFF
--- a/tests/integration/cloud/clouds/test_digitalocean.py
+++ b/tests/integration/cloud/clouds/test_digitalocean.py
@@ -18,6 +18,7 @@ from tests.support.helpers import expensiveTest, generate_random_name
 # Import Salt Libs
 from salt.config import cloud_providers_config
 from salt.ext.six.moves import range
+import salt.utils.stringutils
 
 
 # Create the cloud instance name to be used throughout the tests
@@ -107,7 +108,7 @@ class DigitalOceanTest(ShellCase):
 
         # generate key and fingerprint
         ssh_key = RSA.generate(4096)
-        pub = ssh_key.publickey().exportKey("OpenSSH")
+        pub = salt.utils.stringutils.to_str(ssh_key.publickey().exportKey("OpenSSH"))
         key_hex = hashlib.md5(base64.b64decode(pub.strip().split()[1].encode())).hexdigest()
         finger_print = ':'.join([key_hex[x:x+2] for x in range(0, len(key_hex), 2)])
 


### PR DESCRIPTION
### What does this PR do?
Fixes the test failure: integration.cloud.clouds.test_digitalocean.DigitalOceanTest.test_key_management

on python3 cloud tests by ensuring the key is a string type.

### What issues does this PR fix or reference?
NA

### Previous Behavior
Test was failing on python3:

```
Traceback (most recent call last):
  File "/tmp/kitchen/testing/tests/integration/cloud/clouds/test_digitalocean.py", line 111, in test_key_management
    key_hex = hashlib.md5(base64.b64decode(pub.strip().split()[1].encode())).hexdigest()
AttributeError: 'bytes' object has no attribute 'encode'
```

### New Behavior
Test passes on python2 and python3

### Tests written?
No - Fixing a test

### Commits signed with GPG?

Yes