### PR TITLE
FIX: Make vault kv module compatible with v2

### DIFF
--- a/salt/modules/vault.py
+++ b/salt/modules/vault.py
@@ -156,6 +156,9 @@ def read_secret(path, key=None):
             first: {{ supersecret.first }}
             second: {{ supersecret.second }}
     '''
+    version2 = is_v2(path)
+    if version2['v2']:
+        path = version2['data']
     log.debug('Reading Vault secret for %s at %s', __grains__['id'], path)
     try:
         url = 'v1/{0}'.format(path)
@@ -184,6 +187,10 @@ def write_secret(path, **kwargs):
     '''
     log.debug('Writing vault secrets for %s at %s', __grains__['id'], path)
     data = dict([(x, y) for x, y in kwargs.items() if not x.startswith('__')])
+    version2 = is_v2(path)
+    if version2['v2']:
+        path = version2['data']
+        data = {'data': data}
     try:
         url = 'v1/{0}'.format(path)
         response = __utils__['vault.make_request']('POST', url, json=data)
@@ -208,6 +215,10 @@ def write_raw(path, raw):
             salt '*' vault.write_raw "secret/my/secret" '{"user":"foo","password": "bar"}'
     '''
     log.debug('Writing vault secrets for %s at %s', __grains__['id'], path)
+    version2 = is_v2(path)
+    if version2['v2']:
+        path = version2['data']
+        raw = {'data': raw}
     try:
         url = 'v1/{0}'.format(path)
         response = __utils__['vault.make_request']('POST', url, json=raw)
@@ -232,6 +243,9 @@ def delete_secret(path):
         salt '*' vault.delete_secret "secret/my/secret"
     '''
     log.debug('Deleting vault secrets for %s in %s', __grains__['id'], path)
+    version2 = is_v2(path)
+    if version2['v2']:
+        path = version2['data']
     try:
         url = 'v1/{0}'.format(path)
         response = __utils__['vault.make_request']('DELETE', url)
@@ -255,6 +269,9 @@ def list_secrets(path):
             salt '*' vault.list_secrets "secret/my/"
     '''
     log.debug('Listing vault secret keys for %s in %s', __grains__['id'], path)
+    version2 = is_v2(path)
+    if version2['v2']:
+        path = version2['metadata']
     try:
         url = 'v1/{0}'.format(path)
         response = __utils__['vault.make_request']('LIST', url)
@@ -264,3 +281,80 @@ def list_secrets(path):
     except Exception as err:
         log.error('Failed to list secrets! %s: %s', type(err).__name__, err)
         return None
+
+
+def is_v2(path):
+    '''
+    Determines if a given secret path is kv version 1 or 2
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' vault.is_v2 "secret/my/secret"
+    '''
+    ret = {'v2': False, 'data': path, 'metadata': path, 'type': 'kv'}
+    path_metadata = _get_secret_path_metadata(path)
+    if path_metadata.get('options', {}).get('version', '1') in ['2']:
+        ret['v2'] = True
+        ret['data'] = _v2_the_path(path, path_metadata.get('path', path))
+        ret['metadata'] = _v2_the_path(path, path_metadata.get('path', path), 'metadata')
+    return ret
+
+
+def _v2_the_path(path, pfilter, ptype='data'):
+    '''
+    Given a path, a filter, and a path type, properly inject 'data' or 'metadata' into the path
+
+    CLI Example:
+
+    .. code-block:: python
+
+        _v2_the_path('dev/secrets/fu/bar', 'dev/secrets', 'data') => 'dev/secrets/data/fu/bar'
+    '''
+    possible_types = ['data', 'metadata']
+    assert ptype in possible_types
+    msg = "Path {} already contains {} in the right place - saltstack duct tape?".format(path, ptype)
+
+    path = path.rstrip('/').lstrip('/')
+    pfilter = pfilter.rstrip('/').lstrip('/')
+
+    together = pfilter + '/' + ptype
+
+    otype = possible_types[0] if possible_types[0] != ptype else possible_types[1]
+    other = pfilter + '/' + otype
+    if other in path:
+        path = path.replace(other, together, 1)
+        msg = 'Path is a "{}" type but "{}" type requested - Flipping: {}'.format(otype, ptype, path)
+    elif together not in path:
+        msg = "Converting path to v2 {} => {}".format(path, path.replace(pfilter, together, 1))
+        path = path.replace(pfilter, together, 1)
+
+    log.debug(msg)
+    return path
+
+
+def _get_secret_path_metadata(path):
+    '''
+    Given a path query vault to determine where the mount point is, it's type and version
+
+    CLI Example:
+
+    .. code-block:: python
+
+        _get_secret_path_metadata('dev/secrets/fu/bar')
+    '''
+    ret = None
+    log.debug('Fetching metadata for %s in %s', __grains__['id'], path)
+    try:
+        url = 'v1/sys/internal/ui/mounts/{0}'.format(path)
+        response = __utils__['vault.make_request']('GET', url)
+        if response.ok:
+            response.raise_for_status()
+        if response.json().get('data', False):
+            ret = response.json()['data']
+        else:
+            raise response.json()
+    except Exception as err:
+        log.error('Failed to list secrets! %s: %s', type(err).__name__, err)
+    return ret

--- a/salt/pillar/vault.py
+++ b/salt/pillar/vault.py
@@ -158,6 +158,10 @@ def ext_pillar(minion_id,  # pylint: disable=W0613
     try:
         path = paths[0].replace('path=', '')
         path = path.format(**{'minion': minion_id})
+        version2 = __utils__['vault.is_v2'](path)
+        if version2['v2']:
+            path = version2['data']
+
         url = 'v1/{0}'.format(path)
         response = __utils__['vault.make_request']('GET', url)
         if response.status_code == 200:

--- a/salt/sdb/vault.py
+++ b/salt/sdb/vault.py
@@ -68,6 +68,10 @@ def set_(key, value, profile=None):
     else:
         path, key = key.rsplit('/', 1)
 
+    version2 = __utils__['vault.is_v2'](path)
+    if version2['v2']:
+        path = version2['data']
+
     try:
         url = 'v1/{0}'.format(path)
         data = {key: value}
@@ -100,6 +104,10 @@ def get(key, profile=None):
         path, key = key.split('?')
     else:
         path, key = key.rsplit('/', 1)
+
+    version2 = __utils__['vault.is_v2'](path)
+    if version2['v2']:
+        path = version2['data']
 
     try:
         url = 'v1/{0}'.format(path)


### PR DESCRIPTION
### What does this PR do?
Hashicorp vault introduced 'Key Value Store Version 2.0' which dramatically modified the path/structure of the KV secrets.  However both are accessed using the same calls.

This changes makes the vault module compatible with both version 1 and version 2 of the vault KV secret store

This module uses the same method/calls that the vault client does to determine if the requested path is v1 or v2 (validated via vault audit logs).

Note: Some blog posts and the GitHub issue below suggest adding extra `data` or `metadata` to your path manually.  Which "worked" but was super not user friendly and could lead to interesting results if you needed both the data and metadata.

### What issues does this PR fix or reference?
Some of the "modify the path" suggestions where here....though looks like I need to port the v2 logic over to the sub module as well. https://github.com/saltstack/salt/issues/50186

### Previous Behavior
When attempting to access a KV2 secret, you would receive a 403 because the path was incorrect.

```
sudo salt-call vault.read_secret secrets/test 
.......
ERROR   ] Failed to read secret! HTTPError: 403 Client Error: Forbidden for url: https://example.com:8200/v1/secrets/test
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/cli/caller.py", line 204, in call
    ret['return'] = func(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/modules/vault.py", line 113, in read_secret
    raise salt.exceptions.CommandExecutionError(e)
CommandExecutionError: 403 Client Error: Forbidden for url: https://example.com:8200/v1/secrets/test
Error running 'vault.read_secret': 403 Client Error: Forbidden for url: https://example.com:8200/v1/secrets/test
```

### New Behavior
You can actually read v2 secrets!

```
sudo salt-call vault.read_secret secrets/test 
....
[DEBUG   ] Converting path to v2 secrets/test => secrets/data/test
[DEBUG   ] Converting path to v2 secrets/test => secrets/metadata/test
[DEBUG   ] Reading Vault secret for example.com at secrets/data/test
....
[DEBUG   ] Starting new HTTPS connection (1): example.com:8200
[DEBUG   ] https://example.com:8200 "GET /v1/secrets/data/test HTTP/1.1" 200 312

[DEBUG   ] LazyLoaded nested.output
local:
    ----------
    data:
        ----------
        i am a teapot:
            short and stout
    metadata:
        ----------
        created_time:
            2019-04-25T04:46:01.903118162Z
        deletion_time:
        destroyed:
            False
        version:
            1
```

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.