### PR TITLE
Avoid traceback on "http.query" when there are errors with the requested URL

### DIFF
--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -568,7 +568,7 @@ def query(url,
             ret['status'] = exc.code
             ret['error'] = six.text_type(exc)
             return ret
-        except socket.gaierror as exc:
+        except (socket.herror, socket.error, socket.timeout, socket.gaierror) as exc:
             if status is True:
                 ret['status'] = 0
             ret['error'] = six.text_type(exc)

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -567,11 +567,13 @@ def query(url,
         except tornado.httpclient.HTTPError as exc:
             ret['status'] = exc.code
             ret['error'] = six.text_type(exc)
+            log.error("Cannot perform 'http.query': {0} - {1}".format(url_full, ret['error']))
             return ret
         except (socket.herror, socket.error, socket.timeout, socket.gaierror) as exc:
             if status is True:
                 ret['status'] = 0
             ret['error'] = six.text_type(exc)
+            log.error("Cannot perform 'http.query': {0} - {1}".format(url_full, ret['error']))
             return ret
 
         if stream is True or handle is True:

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -567,7 +567,6 @@ def query(url,
         except tornado.httpclient.HTTPError as exc:
             ret['status'] = exc.code
             ret['error'] = six.text_type(exc)
-            log.error("Cannot perform 'http.query': {0} - {1}".format(url_full, ret['error']))
             return ret
         except (socket.herror, socket.error, socket.timeout, socket.gaierror) as exc:
             if status is True:

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -572,7 +572,7 @@ def query(url,
             if status is True:
                 ret['status'] = 0
             ret['error'] = six.text_type(exc)
-            log.error("Cannot perform 'http.query': {0} - {1}".format(url_full, ret['error']))
+            log.debug("Cannot perform 'http.query': {0} - {1}".format(url_full, ret['error']))
             return ret
 
         if stream is True or handle is True:


### PR DESCRIPTION
### What does this PR do?
This PR prevents traceback on `http.query` and improves error logging in cases where there are errors with the requested URL:

- Connection refused
- No route to host
- Errors with DNS servers

### Previous Behavior
In cases where the requested URL refuses the connection:

```
# salt-call --local http.query http://127.0.0.1/
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
Traceback (most recent call last):
  File "salt-call", line 27, in <module>
    salt_call()
  File "pyall/salt/scripts.py", line 431, in salt_call
    client.run()
  File "pyall/salt/cli/call.py", line 57, in run
    caller.run()
  File "pyall/salt/cli/caller.py", line 138, in run
    ret = self.call()
  File "pyall/salt/cli/caller.py", line 237, in call
    ret['return'] = self.minion.executors[fname](self.opts, data, func, args, kwargs)
  File "/var/tmp/.root_fc9778_salt/pyall/salt/executors/direct_call.py", line 12, in execute
    return func(*args, **kwargs)
  File "/var/tmp/.root_fc9778_salt/pyall/salt/modules/http.py", line 41, in query
    return salt.utils.http.query(url=url, opts=opts, **kwargs)
  File "pyall/salt/utils/http.py", line 566, in query
    result = download_client.fetch(url_full, **req_kwargs)
  File "py2/tornado/httpclient.py", line 102, in fetch
    self._async_client.fetch, request, **kwargs))
  File "py2/tornado/ioloop.py", line 457, in run_sync
    return future_cell[0].result()
  File "py2/tornado/concurrent.py", line 237, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 3, in raise_exc_info
error: [Errno 111] Connection refused
```

### New Behavior
```
# salt-call --local http.query http://127.0.0.1/
[ERROR   ] Cannot perform 'http.query': http://127.0.0.1/ - [Errno 111] Connection refused
local:
    ----------
    error:
        [Errno 111] Connection refused
```

### Tests written?

No - This PR doesn't include unit tests to cover this small issue since the whole `utils.http.query` is currently not being tested and complexity is really high (function is bigger than 500 LOC).

### Commits signed with GPG?

Yes