### PR TITLE
Added support for is_fedora and skip Minion test test_issue_7754 on Fedora

### DIFF
--- a/salt/utils/platform.py
+++ b/salt/utils/platform.py
@@ -8,6 +8,18 @@ import os
 import subprocess
 import sys
 
+import warnings
+# linux_distribution deprecated in py3.7
+try:
+    from platform import linux_distribution as _deprecated_linux_distribution
+
+    def linux_distribution(**kwargs):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return _deprecated_linux_distribution(**kwargs)
+except ImportError:
+    from distro import linux_distribution
+
 # Import Salt libs
 from salt.utils.decorators import memoize as real_memoize
 
@@ -159,3 +171,13 @@ def is_aix():
     Simple function to return if host is AIX or not
     '''
     return sys.platform.startswith('aix')
+
+
+@real_memoize
+def is_fedora():
+    '''
+    Simple function to return if host is Fedora or not
+    '''
+    (osname, osrelease, oscodename) = \
+        [x.strip('"').strip("'") for x in linux_distribution()]
+    return osname == 'Fedora'

--- a/tests/integration/shell/test_minion.py
+++ b/tests/integration/shell/test_minion.py
@@ -50,6 +50,7 @@ class MinionTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMix
     )
 
     @skipIf(salt.utils.platform.is_darwin(), 'Test is flaky on macosx')
+    @skipIf(salt.utils.platform.is_fedora(), 'Test is flaky on fedora')
     def test_issue_7754(self):
         old_cwd = os.getcwd()
         config_dir = os.path.join(TMP, 'issue-7754')


### PR DESCRIPTION
### What does this PR do?
Skips Minion's test_issue_7754 if Fedora  since flaky
https://github.com/saltstack/salt/issues/54054


### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
