### PR TITLE
Skip pygit2 fileserver tests on Windows

### DIFF
--- a/tests/unit/fileserver/test_gitfs.py
+++ b/tests/unit/fileserver/test_gitfs.py
@@ -500,6 +500,7 @@ class GitPythonTest(GitFSTestBase, GitFSTestFuncs, TestCase, LoaderModuleMockMix
 
 @skipIf(not HAS_GITPYTHON, 'GitPython >= {0} required for temp repo setup'.format(GITPYTHON_MINVER))
 @skipIf(not HAS_PYGIT2, 'pygit2 >= {0} and libgit2 >= {1} required'.format(PYGIT2_MINVER, LIBGIT2_MINVER))
+@skipIf(salt.utils.platform.is_windows(), 'Skip Pygit2 on windows, due to pygit2 access error on windows')
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class Pygit2Test(GitFSTestBase, GitFSTestFuncs, TestCase, LoaderModuleMockMixin):
 


### PR DESCRIPTION
### What does this PR do?
Skips the pygit2 fileserver tests on Windows due to issues with file locks not being released by git.

### What issues does this PR fix or reference?
This is being done on 2019.2.1 via https://github.com/saltstack/salt/pull/53974

### Tests written?
Yes

### Commits signed with GPG?
Yes