### PR TITLE
pillar_stack: add *fetch* method as an alias to salt.utils.data.traverse_dict_and_list

### DIFF
--- a/salt/pillar/stack.py
+++ b/salt/pillar/stack.py
@@ -438,6 +438,7 @@ def _process_stack_cfg(cfg, stack, minion_id, pillar):
             },
         "minion_id": minion_id,
         "pillar": pillar,
+        "fetch": salt.utils.data.traverse_dict_and_list,
         })
     for item in _parse_stack_cfg(
             jenv.get_template(filename).render(stack=stack)):


### PR DESCRIPTION
### What does this PR do?

Add *fetch* method as an alias to salt.utils.data.traverse_dict_and_list in pillar stack.

### Tests written?

No

### Commits signed with GPG?

No
