### PR TITLE
Fix deprecation warnings for msgpack > 0.5.2

### DIFF
--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -265,7 +265,12 @@ class IPCClient(object):
             encoding = None
         else:
             encoding = 'utf-8'
-        self.unpacker = msgpack.Unpacker(encoding=encoding)
+        unpack_args = {}
+        if msgpack.version >= (0, 5, 2):
+            unpack_args['raw'] = False
+        else:
+            unpack_args['encoding'] = encoding
+        self.unpacker = msgpack.Unpacker(**unpack_args)
 
     def connected(self):
         return self.stream is not None and not self.stream.closed()


### PR DESCRIPTION
I am getting the following warnings
```
09:58:35,223 [WARNING ] /usr/local/lib/python3.6/site-packages/salt/transport/ipc.py:280: DeprecationWarning: encoding is deprecated, Use raw=False instead.
  self.unpacker = msgpack.Unpacker(encoding=encoding)
```
This commit fixed the problem