### PR TITLE
Pass grains in minion start event

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -548,6 +548,11 @@
 #  - edit.vim
 #  - hyper
 #
+# List of grains to pass in start event when minion starts up:
+#start_event_grains:
+#  - machine_id
+#  - id
+#
 # Top file to execute if startup_states is 'top':
 #top_file: ''
 

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -2066,6 +2066,21 @@ List of states to run when the minion starts up if ``startup_states`` is set to 
       - edit.vim
       - hyper
 
+.. conf_minion:: start_event_grains
+
+``start_event_grains``
+----------------------
+
+Default: ``[]``
+
+List of grains to pass in start event when minion starts up.
+
+.. code-block:: yaml
+
+    start_event_grains:
+      - machine_id
+      - id
+
 .. conf_minion:: top_file
 
 ``top_file``

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1283,6 +1283,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze({
     'state_top_saltenv': None,
     'startup_states': '',
     'sls_list': [],
+    'start_event_grains': [],
     'top_file': '',
     'thoriumenv': None,
     'thorium_top': 'top.sls',

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1475,6 +1475,11 @@ class Minion(MinionBase):
         else:
             return
 
+        if self.opts['start_event_grains']:
+            grains_to_add = dict(
+                [(k, v) for k, v in six.iteritems(self.opts.get('grains', {})) if k in self.opts['start_event_grains']])
+            load['grains'] = grains_to_add
+
         if sync:
             try:
                 self._send_req_sync(load, timeout)


### PR DESCRIPTION
### What does this PR do?
Adds a configuration option to have a selection of grains in the minion start event.

Reason behind this is better integration with [Uyuni]( https://github.com/uyuni-project/uyuni), especially when a lot of minions are starting in a short time frame - we need to get some minimal data (at least the `machine_id`) and getting it separately as a reaction to the minion start event (via a separate call or a startup state) generates considerable load on the master.

By default, there will be no grains passed to the event.

### Previous Behavior
```
salt/minion/abid-minion.tf.local/start	{
    "_stamp": "2019-08-01T10:46:22.840597", 
    "cmd": "_minion_event", 
    "data": "Minion abid-minion.tf.local started at Thu Aug  1 12:46:22 2019", 
    "id": "abid-minion.tf.local", 
    "pretag": null, 
    "tag": "salt/minion/abid-minion.tf.local/start"
}
```

### New Behavior
```
salt/minion/abid-minion.tf.local/start	{
    "_stamp": "2019-08-01T10:46:58.696390", 
    "cmd": "_minion_event", 
    "data": "Minion abid-minion.tf.local started at Thu Aug  1 12:46:58 2019", 
    "grains": {
        "id": "abid-minion.tf.local", 
        "machine_id": "21ee22c6906887c2dd6adeed5d404145"
    }, 
    "id": "abid-minion.tf.local", 
    "pretag": null, 
    "tag": "salt/minion/abid-minion.tf.local/start"
}
```

### Tests written?

_Tests will be provided once upstream agreed to approach, this draft PR was opened to make sure the overall approach is OK_



Yes/No

### Commits signed with GPG?

Yes


