### PR TITLE
Skip sync_all test- causing slow downs

### DIFF
--- a/tests/integration/runners/test_saltutil.py
+++ b/tests/integration/runners/test_saltutil.py
@@ -10,6 +10,7 @@ import os
 
 # Import Salt Testing Libs
 from tests.support.case import ShellCase
+from tests.support.unit import skipIf
 
 log = logging.getLogger(__name__)
 
@@ -26,6 +27,7 @@ class SyncRunnerTest(ShellCase):
         # Clean up?
         os.unlink(os.path.join(self.master_opts['root_dir'], 'extension_modules', 'auth', 'nullauth.py'))
 
+    @skipIf(True, 'WAR ROOM - this test is causing slow downs, skip until we find out why')
     def test_sync_all_includes_auth(self):
         '''
         '''

--- a/tests/integration/runners/test_saltutil.py
+++ b/tests/integration/runners/test_saltutil.py
@@ -10,7 +10,7 @@ import os
 
 # Import Salt Testing Libs
 from tests.support.case import ShellCase
-from tests.support.unit import skipIf
+from tests.support.unit import skipIf, WAR_ROOM_SKIP
 
 log = logging.getLogger(__name__)
 
@@ -27,7 +27,7 @@ class SyncRunnerTest(ShellCase):
         # Clean up?
         os.unlink(os.path.join(self.master_opts['root_dir'], 'extension_modules', 'auth', 'nullauth.py'))
 
-    @skipIf(True, 'WAR ROOM - this test is causing slow downs, skip until we find out why')
+    @skipIf(WAR_ROOM_SKIP, 'WAR ROOM - this test is causing slow downs, skip until we find out why')
     def test_sync_all_includes_auth(self):
         '''
         '''


### PR DESCRIPTION
### What does this PR do?
Skips the sync_all runner command in the tests as we found out this is causing our slow down.

### What issues does this PR fix or reference?
We have this issue open to track down why this test is causing the slow down:

https://github.com/saltstack/salt/issues/54090

### Previous Behavior
tests run for 6 hours

### New Behavior
test runs for about 2-3 hours depending on OS

### Tests written?
Skipping tests

### Commits signed with GPG?

Yes