### PR TITLE
Fix Vault Request Amplification and Latency

### DIFF
--- a/salt/runners/vault.py
+++ b/salt/runners/vault.py
@@ -14,6 +14,7 @@ import json
 import logging
 import string
 import requests
+import time
 
 # Import Salt libs
 import salt.crypt
@@ -25,7 +26,7 @@ from salt.ext import six
 log = logging.getLogger(__name__)
 
 
-def generate_token(minion_id, signature, impersonated_by_master=False):
+def generate_token(minion_id, signature, impersonated_by_master=False, ttl=None, uses=None):
     '''
     Generate a Vault token for minion minion_id
 
@@ -39,6 +40,12 @@ def generate_token(minion_id, signature, impersonated_by_master=False):
     impersonated_by_master
         If the master needs to create a token on behalf of the minion, this is
         True. This happens when the master generates minion pillars.
+
+    ttl
+        time to live in seconds, 1m minutes, or 2h hrs
+
+    uses
+        number of times a token can be use
     '''
     log.debug(
         'Token generation request for %s (impersonated by master: %s)',
@@ -47,8 +54,15 @@ def generate_token(minion_id, signature, impersonated_by_master=False):
     _validate_signature(minion_id, signature, impersonated_by_master)
 
     try:
-        config = __opts__['vault']
+        config = __opts__.get('vault', {})
         verify = config.get('verify', None)
+        # Allow disabling of minion provided values via the master
+        amo = config.get('minion_auth', {}).get('allow_minion_override', True)
+        # This preserves the previous behavior of default TTL and 1 use
+        if not amo or uses is None:
+            uses = config.get('minion_auth', {}).get('uses', 1)
+        if not amo or ttl is None:
+            ttl = config.get('minion_auth', {}).get('ttl', None)
 
         if config['auth']['method'] == 'approle':
             if _selftoken_expired():
@@ -73,9 +87,12 @@ def generate_token(minion_id, signature, impersonated_by_master=False):
         }
         payload = {
                     'policies': _get_policies(minion_id, config),
-                    'num_uses': 1,
+                    'num_uses': uses,
                     'meta': audit_data
                   }
+
+        if ttl is not None:
+            payload['ttl'] = str(ttl)
 
         if payload['policies'] == []:
             return {'error': 'No policies matched minion'}
@@ -87,11 +104,18 @@ def generate_token(minion_id, signature, impersonated_by_master=False):
             return {'error': response.reason}
 
         auth_data = response.json()['auth']
-        return {
-            'token': auth_data['client_token'],
-            'url': config['url'],
-            'verify': verify,
-        }
+        ret =  {
+                'token': auth_data['client_token'],
+                'lease_duration': authData['lease_duration'],
+                'renewable': authData['renewable'],
+                'issued': int(round(time.time())),
+                'url': config['url'],
+                'verify': verify,
+                }
+        if uses > 0:
+            ret['uses'] = uses
+
+        return ret
     except Exception as e:
         return {'error': six.text_type(e)}
 


### PR DESCRIPTION
### What does this PR do?
This patch does the following:
 1. Allows you set set minion or master configuration values for the TTL and Number of uses of the generated vault auth tokens.
 2. Updates the token generation function to utilize those values
 3. Updates the make_request function to appropriately cache/monitor the life cycles.
 4. Defaults to the old inefficient way of doing things

### What issues does this PR fix or reference?
Two related issues currently exist with the design of the vault token generate/make request functionality.

Currently when a minion requests a secret the following occurs
 1. Minion generates a signature and contacts the Master for a new token, blocking while it does so
 2. Salt-master verifies the signature and sends a request to the vault server for a new, **1 use** token,
 3. Vault server generates the token, returns it to the salt-master
 4. Salt-master returns the new token to the salt-minion
 5. Salt-minion uses token and contacts the vault server, **1 use** token is now dead
 6. Vault returns secret to salt-minion.

This results in two issues:
 1. Latency - every secret lookup involves multiple network hops.  Which can quickly add up, over the course of just 10 secrets in testing, this processed averaged 42.65 seconds.
 2. Licensing/Amplification - Vault enterprise is licensed on a [per-request basis](https://medium.com/@rmolsen/monitoring-hashicorp-vault-requests-with-datadog-fa73ae53229d) With the current design you are doubling the number of requests needed to take any action.  Maybe the original author secretly had stock in hashicorp....the truth is out there 👽

### Previous Behavior
Slow salt run's and paying twice as much as you should.  See above for description of how Salt interacts with Vault

### New Behavior
716.80% speed increase of salt runs (using the 10 secret test above) and paying way less than you do now.  

Default behavior will remain the same as described above.

If uses/ttl is specified, the salt-master will generate a longer lived token.  The salt-minion will then cache that token and utilize it until the TTL or uses are exhausted.  At which point it removes the token from cache and requests a new one.

### Tests written?
No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.