### PR TITLE
Add a global lock when processing git_pillar

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -362,7 +362,7 @@ import salt.utils.gitfs
 import salt.utils.dictupdate
 import salt.utils.stringutils
 import salt.utils.versions
-from salt.exceptions import ( FileserverConfigError, GitLockError )
+from salt.exceptions import (FileserverConfigError, GitLockError)
 from salt.pillar import Pillar
 
 # Import third party libs
@@ -481,6 +481,7 @@ def ext_pillar(minion_id, pillar, *repos):  # pylint: disable=unused-argument
     except GitLockError:
         log.error("Could not obtain the global lock for pillar procssing")
     return False
+
 
 def _extract_key_val(kv, delimiter='='):
     '''Extract key and value from key=val string.

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -362,7 +362,7 @@ import salt.utils.gitfs
 import salt.utils.dictupdate
 import salt.utils.stringutils
 import salt.utils.versions
-from salt.exceptions import FileserverConfigError
+from salt.exceptions import ( FileserverConfigError, GitLockError )
 from salt.pillar import Pillar
 
 # Import third party libs

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -415,6 +415,7 @@ def ext_pillar(minion_id, pillar, *repos):  # pylint: disable=unused-argument
         # If masterless, fetch the remotes. We'll need to remove this once
         # we make the minion daemon able to run standalone.
         git_pillar.fetch_remotes()
+    git_pillar.global_lock()
     git_pillar.checkout()
     ret = {}
     merge_strategy = __opts__.get(

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -3046,7 +3046,7 @@ class GitPillar(GitBase):
                     self.pillar_dirs[cachedir] = env
 
     @contextlib.contextmanager
-    def global_lock(self, timeout=0, poll_interval=0.5):
+    def global_lock(self, timeout=60, poll_interval=0.5):
         '''
         Set and automatically clear a lock on all the repos
         '''
@@ -3087,7 +3087,7 @@ class GitPillar(GitBase):
                             log.debug(
                                 'A global lock is already present for %s remote '
                                 '\'%s\', sleeping %f second(s)',
-                                self.role, self.id, poll_interval
+                                self.role, remote.id, poll_interval
                             )
                             time.sleep(poll_interval)
                             continue

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -831,7 +831,7 @@ class GitProvider(object):
                                     'using multi-master with shared gitfs '
                                     'cache, the lock may have been obtained '
                                     'by another master.')
-                    log.warning(msg)
+                    log.debug(msg)
                     if failhard:
                         six.reraise(*sys.exc_info())
                     return

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -3050,11 +3050,6 @@ class GitPillar(GitBase):
         '''
         Set and automatically clear a lock on all the repos
         '''
-        if not isinstance(lock_type, six.string_types):
-            raise GitLockError(
-                errno.EINVAL,
-                'Invalid lock_type \'{0}\''.format(lock_type)
-            )
 
         # Make sure that we have a positive integer timeout, otherwise just set
         # it to zero.
@@ -3090,9 +3085,9 @@ class GitPillar(GitBase):
                             raise GitLockError(exc.errno, exc.strerror)
                         else:
                             log.debug(
-                                'A %s lock is already present for %s remote '
+                                'A global lock is already present for %s remote '
                                 '\'%s\', sleeping %f second(s)',
-                                lock_type, self.role, self.id, poll_interval
+                                self.role, self.id, poll_interval
                             )
                             time.sleep(poll_interval)
                             continue


### PR DESCRIPTION
### What does this PR do?

This PR introduces a global lock on git pillars to make sure that the checkout and the processing operation are done atomically.

### What issues does this PR fix or reference?

As per #39420, there is a race condition when processing git_pillar and using __env__.

The race exists in pillar/pillar.py:ext_pillar() :

```
Process 1               |  Process 2 
checkout  branch devel  |
                        | checkout branch master
read files from tree    |
                        | read files from tree
```

This occurs when the salt master is processing pillars from different branches no matter what host.


### Previous Behavior

state.apply would randomly fail. For example a file not present in the master branch but present in the devel branch would be reported as missing even if pillarenv=devel.

### New Behavior

It works !

### Tests written?

No

### Commits signed with GPG?

No
