### PR TITLE
rest_tornado set session_id cookie

### DIFF
--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -740,6 +740,7 @@ class SaltAuthHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
             self.send_error(401)
             # return since we don't want to execute any more
             return
+        self.set_cookie(AUTH_COOKIE_NAME, token['token'])
 
         # Grab eauth config for the current backend for the current user
         try:

--- a/tests/unit/netapi/test_rest_tornado.py
+++ b/tests/unit/netapi/test_rest_tornado.py
@@ -527,17 +527,17 @@ class TestSaltAuthHandler(SaltnadoTestCase):
         '''
         Test valid logins
         '''
-
         # Test in form encoded
         response = self.fetch('/login',
                                method='POST',
                                body=urlencode(self.auth_creds),
                                headers={'Content-Type': self.content_type_map['form']})
 
+        cookies = response.headers['Set-Cookie']
         self.assertEqual(response.code, 200)
         response_obj = salt.utils.json.loads(response.body)['return'][0]
         token = response_obj['token']
-        self.assertEqual(response.cookies['session_id'], token)
+        self.assertIn('session_id={0}'.format(token), cookies)
         self.assertEqual(sorted(response_obj['perms']), sorted(self.opts['external_auth']['auto'][self.auth_creds_dict['username']]))
         self.assertIn('token', response_obj)  # TODO: verify that its valid?
         self.assertEqual(response_obj['user'], self.auth_creds_dict['username'])
@@ -549,10 +549,11 @@ class TestSaltAuthHandler(SaltnadoTestCase):
                                body=salt.utils.json.dumps(self.auth_creds_dict),
                                headers={'Content-Type': self.content_type_map['json']})
 
+        cookies = response.headers['Set-Cookie']
         self.assertEqual(response.code, 200)
         response_obj = salt.utils.json.loads(response.body)['return'][0]
         token = response_obj['token']
-        self.assertEqual(response.cookies['session_id'], token)
+        self.assertIn('session_id={0}'.format(token), cookies)
         self.assertEqual(sorted(response_obj['perms']), sorted(self.opts['external_auth']['auto'][self.auth_creds_dict['username']]))
         self.assertIn('token', response_obj)  # TODO: verify that its valid?
         self.assertEqual(response_obj['user'], self.auth_creds_dict['username'])
@@ -564,10 +565,11 @@ class TestSaltAuthHandler(SaltnadoTestCase):
                                body=salt.utils.yaml.safe_dump(self.auth_creds_dict),
                                headers={'Content-Type': self.content_type_map['yaml']})
 
+        cookies = response.headers['Set-Cookie']
         self.assertEqual(response.code, 200)
         response_obj = salt.utils.json.loads(response.body)['return'][0]
         token = response_obj['token']
-        self.assertEqual(response.cookies['session_id'], token)
+        self.assertIn('session_id={0}'.format(token), cookies)
         self.assertEqual(sorted(response_obj['perms']), sorted(self.opts['external_auth']['auto'][self.auth_creds_dict['username']]))
         self.assertIn('token', response_obj)  # TODO: verify that its valid?
         self.assertEqual(response_obj['user'], self.auth_creds_dict['username'])

--- a/tests/unit/netapi/test_rest_tornado.py
+++ b/tests/unit/netapi/test_rest_tornado.py
@@ -536,6 +536,8 @@ class TestSaltAuthHandler(SaltnadoTestCase):
 
         self.assertEqual(response.code, 200)
         response_obj = salt.utils.json.loads(response.body)['return'][0]
+        token = response_obj['token']
+        self.assertEqual(response.cookies['session_id'], token)
         self.assertEqual(sorted(response_obj['perms']), sorted(self.opts['external_auth']['auto'][self.auth_creds_dict['username']]))
         self.assertIn('token', response_obj)  # TODO: verify that its valid?
         self.assertEqual(response_obj['user'], self.auth_creds_dict['username'])
@@ -549,6 +551,8 @@ class TestSaltAuthHandler(SaltnadoTestCase):
 
         self.assertEqual(response.code, 200)
         response_obj = salt.utils.json.loads(response.body)['return'][0]
+        token = response_obj['token']
+        self.assertEqual(response.cookies['session_id'], token)
         self.assertEqual(sorted(response_obj['perms']), sorted(self.opts['external_auth']['auto'][self.auth_creds_dict['username']]))
         self.assertIn('token', response_obj)  # TODO: verify that its valid?
         self.assertEqual(response_obj['user'], self.auth_creds_dict['username'])
@@ -562,6 +566,8 @@ class TestSaltAuthHandler(SaltnadoTestCase):
 
         self.assertEqual(response.code, 200)
         response_obj = salt.utils.json.loads(response.body)['return'][0]
+        token = response_obj['token']
+        self.assertEqual(response.cookies['session_id'], token)
         self.assertEqual(sorted(response_obj['perms']), sorted(self.opts['external_auth']['auto'][self.auth_creds_dict['username']]))
         self.assertIn('token', response_obj)  # TODO: verify that its valid?
         self.assertEqual(response_obj['user'], self.auth_creds_dict['username'])


### PR DESCRIPTION
### What does this PR do?

This PR sets the `session_id` cookie when a user is authenticated against the rest_tornado backend. This allows clients such as `requests` to work with cookies as expected.

### What issues does this PR fix or reference?

This is to bring rest_tornado up to parity with rest_cherrypy with respect to cookies.

### Previous Behavior

No cookies set.

### New Behavior

`session_id` cookie is set.

### Tests written?

Yes

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
