### PR TITLE
War room temporary skip of flaky cloud tests

### DIFF
--- a/tests/integration/cloud/clouds/test_ec2.py
+++ b/tests/integration/cloud/clouds/test_ec2.py
@@ -65,7 +65,6 @@ class EC2Test(ShellCase):
             return name
         return self._fetch_latest_installer()
 
-    @skipIf(True, 'WAR ROOM 8/1/2019, flaky cloud test')
     @expensiveTest
     def setUp(self):
         '''

--- a/tests/integration/cloud/clouds/test_ec2.py
+++ b/tests/integration/cloud/clouds/test_ec2.py
@@ -65,6 +65,7 @@ class EC2Test(ShellCase):
             return name
         return self._fetch_latest_installer()
 
+    @skipIf(True, 'WAR ROOM 8/1/2019, flaky cloud test')
     @expensiveTest
     def setUp(self):
         '''

--- a/tests/integration/cloud/clouds/test_msazure.py
+++ b/tests/integration/cloud/clouds/test_msazure.py
@@ -50,6 +50,7 @@ def __has_required_azure():
     return False
 
 
+@skipIf(True, 'WAR ROOM 8/1/2019, flaky cloud test')
 @skipIf(HAS_AZURE is False, 'These tests require the Azure Python SDK to be installed.')
 @skipIf(__has_required_azure() is False, 'The Azure Python SDK must be >= 0.11.1.')
 class AzureTest(ShellCase):


### PR DESCRIPTION
### What does this PR do?
War room skip flaky EC2 Cloud test

### What issues does this PR fix or reference 

```integration.cloud.clouds.test_virtualbox.VirtualboxProviderHeavyTests.test_network_addresses                  -&gt;  salt-cloud requires virtualbox to be installed
 integration.cloud.clouds.test_virtualbox.VirtualboxProviderHeavyTests.test_restart_action                     -&gt;  salt-cloud requires virtualbox to be installed
 integration.cloud.clouds.test_virtualbox.VirtualboxProviderHeavyTests.test_start_stop_action                  -&gt;  salt-cloud requires virtualbox to be installed
 integration.cloud.clouds.test_virtualbox.VirtualboxProviderTest.test_cloud_create                             -&gt;  salt-cloud requires virtualbox to be installed
 integration.cloud.clouds.test_virtualbox.VirtualboxProviderTest.test_cloud_destroy                            -&gt;  salt-cloud requires virtualbox to be installed
 integration.cloud.clouds.test_virtualbox.VirtualboxProviderTest.test_cloud_list                               -&gt;  salt-cloud requires virtualbox to be installed
 integration.cloud.clouds.test_virtualbox.VirtualboxProviderTest.test_cloud_list_full                          -&gt;  salt-cloud requires virtualbox to be installed
 integration.cloud.clouds.test_virtualbox.VirtualboxProviderTest.test_cloud_list_select                        -&gt;  salt-cloud requires virtualbox to be installed
 integration.cloud.clouds.test_virtualbox.VirtualboxProviderTest.test_function_show_instance                   -&gt;  salt-cloud requires virtualbox to be installed
 integration.cloud.clouds.test_vultrpy.VultrTest.test_instance                                                 -&gt;  Skipped temporarily
  -----------------------------------------------------------------------------------------------------------------------
  --------  Failed Tests  -----------------------------------------------------------------------------------------------
 integration.cloud.clouds.test_ec2.EC2Test.test_instance  .........................................................
 Traceback (most recent call last):
   File "/tmp/kitchen/testing/tests/integration/cloud/clouds/test_ec2.py", line 212, in test_instance
     self._test_instance('ec2-test')
   File "/tmp/kitchen/testing/tests/integration/cloud/clouds/test_ec2.py", line 158, in _test_instance
     self.assertIn(ret_str, instance)
 AssertionError: 'CLOUD-TEST-WWHKI9:' not found in []
    .....................................................................................................................
 integration.cloud.clouds.test_ec2.EC2Test.test_instance_rename  ..................................................
 Traceback (most recent call last):
   File "/tmp/kitchen/testing/tests/integration/cloud/clouds/test_ec2.py", line 184, in test_instance_rename
     self.assertIn(ret_str, instance)
 AssertionError: 'CLOUD-TEST-WWHKI9:' not found in []
    .....................................................................................................................
 integration.cloud.clouds.test_ec2.EC2Test.test_win2012r2_psexec  .................................................
 Traceback (most recent call last):
   File "/tmp/kitchen/testing/tests/integration/cloud/clouds/test_ec2.py", line 229, in test_win2012r2_psexec
     self._test_instance('ec2-win2012r2-test', debug=True, timeout=TIMEOUT)
   File "/tmp/kitchen/testing/tests/integration/cloud/clouds/test_ec2.py", line 158, in _test_instance
     self.assertIn(ret_str, instance)
 AssertionError: 'CLOUD-TEST-WWHKI9:' not found in []
    .....................................................................................................................
 integration.cloud.clouds.test_ec2.EC2Test.test_win2012r2_winrm  ..................................................
 Traceback (most recent call last):
   File "/tmp/kitchen/testing/tests/integration/cloud/clouds/test_ec2.py", line 247, in test_win2012r2_winrm
     self._test_instance('ec2-win2012r2-test', debug=True, timeout=TIMEOUT)
   File "/tmp/kitchen/testing/tests/integration/cloud/clouds/test_ec2.py", line 158, in _test_instance
     self.assertIn(ret_str, instance)
 AssertionError: 'CLOUD-TEST-WWHKI9:' not found in []
    .....................................................................................................................
 integration.cloud.clouds.test_ec2.EC2Test.test_win2016_psexec  ...................................................
 Traceback (most recent call last):
   File "/tmp/kitchen/testing/tests/integration/cloud/clouds/test_ec2.py", line 264, in test_win2016_psexec
     self._test_instance('ec2-win2016-test', debug=True, timeout=TIMEOUT)
   File "/tmp/kitchen/testing/tests/integration/cloud/clouds/test_ec2.py", line 158, in _test_instance
     self.assertIn(ret_str, instance)
 AssertionError: 'CLOUD-TEST-WWHKI9:' not found in []
    .....................................................................................................................
 integration.cloud.clouds.test_ec2.EC2Test.test_win2016_winrm  ....................................................
 Traceback (most recent call last):
   File "/tmp/kitchen/testing/tests/integration/cloud/clouds/test_ec2.py", line 282, in test_win2016_winrm
     self._test_instance('ec2-win2016-test', debug=True, timeout=TIMEOUT)
   File "/tmp/kitchen/testing/tests/integration/cloud/clouds/test_ec2.py", line 158, in _test_instance
     self.assertIn(ret_str, instance)
 AssertionError: 'CLOUD-TEST-WWHKI9:' not found in []
    .....................................................................................................................
 integration.cloud.clouds.test_msazure.AzureTest.test_instance  ...................................................
 Traceback (most recent call last):
   File "/tmp/kitchen/testing/tests/integration/cloud/clouds/test_msazure.py", line 139, in test_instance
     ), timeout=TIMEOUT
 AssertionError: 'CLOUD-TEST-XKZ7MJ:' not found in ['No machines were found to be destroyed']
    .....................................................................................................................
  -----------------------------------------------------------------------------------------------------------------------
 ========================================================================================================================
 FAILED (total=61, skipped=34, passed=20, failures=7, errors=0) 
 ================================================  Overall Tests Report  ================================================
Command coverage run tests/runtests.py --tests-logfile=/tmp/kitchen/testing/artifacts/logs/runtests.log --cloud-provider-tests --output-columns=120 --sysinfo --xml=/tmp/kitchen/testing/artifacts/xml-unittests-output -v --run-destructive failed with exit code 1
coverage xml -o /tmp/kitchen/testing/artifacts/coverage/coverage.xml
Session runtests-cloud-3(coverage=True) failed.
------Exception-------
Class: Kitchen::ActionFailed
Message: 1 actions failed.
    Failed to complete #verify action: [SSH exited (1) for command: [sudo -E env CI=1 nox -f /tmp/kitchen/testing/noxfile.py -e 'runtests-cloud-3(coverage=True)' -- --output-columns=120  --sysinfo --xml=/tmp/kitchen/testing/artifacts/xml-unittests-output -v --run-destructive   ]] on py3-centos-7
----------------------
Please see .kitchen/logs/kitchen.log for more details
Also try running `kitchen diagnose --all` for configuration```
