### PR TITLE
Fix for file module test

### DIFF
--- a/tests/unit/modules/test_file.py
+++ b/tests/unit/modules/test_file.py
@@ -1128,9 +1128,9 @@ class FilemodLineTests(TestCase, LoaderModuleMockMixin):
         :return:
         '''
         for mode, err_msg in [(None, 'How to process the file'), ('nonsense', 'Unknown mode')]:
-            with pytest.raises(CommandExecutionError) as cmd_err:
+            with pytest.raises(CommandExecutionError) as exc_info:
                 filemod.line('foo', mode=mode)
-            self.assertIn(err_msg, six.text_type(cmd_err))
+            self.assertIn(err_msg, six.text_type(exc_info.value))
 
     @patch('os.path.realpath', MagicMock(wraps=lambda x: x))
     @patch('os.path.isfile', MagicMock(return_value=True))
@@ -1140,10 +1140,10 @@ class FilemodLineTests(TestCase, LoaderModuleMockMixin):
         :return:
         '''
         for mode in ['insert', 'ensure', 'replace']:
-            with pytest.raises(CommandExecutionError) as cmd_err:
+            with pytest.raises(CommandExecutionError) as exc_info:
                 filemod.line('foo', mode=mode)
             self.assertIn('Content can only be empty if mode is "delete"',
-                          six.text_type(cmd_err))
+                          six.text_type(exc_info.value))
 
     @patch('os.path.realpath', MagicMock(wraps=lambda x: x))
     @patch('os.path.isfile', MagicMock(return_value=True))
@@ -1155,10 +1155,10 @@ class FilemodLineTests(TestCase, LoaderModuleMockMixin):
         '''
         files_fopen = mock_open(read_data='test data')
         with patch('salt.utils.files.fopen', files_fopen):
-            with pytest.raises(CommandExecutionError) as cmd_err:
+            with pytest.raises(CommandExecutionError) as exc_info:
                 filemod.line('foo', content='test content', mode='insert')
             self.assertIn('"location" or "before/after"',
-                          six.text_type(cmd_err))
+                          six.text_type(exc_info.value))
 
     def test_util_starts_till(self):
         '''
@@ -1764,11 +1764,11 @@ class FilemodLineTests(TestCase, LoaderModuleMockMixin):
             with patch('salt.utils.files.fopen', files_fopen):
                 atomic_opener = mock_open()
                 with patch('salt.utils.atomicfile.atomic_open', atomic_opener):
-                    with pytest.raises(CommandExecutionError) as cmd_err:
+                    with pytest.raises(CommandExecutionError) as exc_info:
                         filemod.line('foo', content=cfg_content, after=_after, before=_before, mode='ensure')
             self.assertIn(
                 'Found more than one line between boundaries "before" and "after"',
-                six.text_type(cmd_err))
+                six.text_type(exc_info))
 
     @with_tempfile()
     def test_line_delete(self, name):

--- a/tests/unit/modules/test_localemod.py
+++ b/tests/unit/modules/test_localemod.py
@@ -160,24 +160,24 @@ class LocalemodTestCase(TestCase, LoaderModuleMockMixin):
         Test localectl status parser raises an exception if no systemd installed.
         :return:
         '''
-        with pytest.raises(CommandExecutionError) as err:
+        with pytest.raises(CommandExecutionError) as exc_info:
             localemod._localectl_status()
-        assert 'Unable to find "localectl"' in six.text_type(err)
+        assert 'Unable to find "localectl"' in six.text_type(exc_info.value)
         assert not localemod.log.debug.called
 
     @patch('salt.utils.path.which', MagicMock(return_value="/usr/bin/localctl"))
     @patch('salt.modules.localemod.__salt__', {'cmd.run': MagicMock(return_value=locale_ctl_out_empty)})
     def test_localectl_status_parser_empty(self):
-        with pytest.raises(CommandExecutionError) as err:
+        with pytest.raises(CommandExecutionError) as exc_info:
             localemod._localectl_status()
-        assert 'Unable to parse result of "localectl"' in six.text_type(err)
+        assert 'Unable to parse result of "localectl"' in six.text_type(exc_info.value)
 
     @patch('salt.utils.path.which', MagicMock(return_value="/usr/bin/localctl"))
     @patch('salt.modules.localemod.__salt__', {'cmd.run': MagicMock(return_value=locale_ctl_out_broken)})
     def test_localectl_status_parser_broken(self):
-        with pytest.raises(CommandExecutionError) as err:
+        with pytest.raises(CommandExecutionError) as exc_info:
             localemod._localectl_status()
-        assert 'Unable to parse result of "localectl"' in six.text_type(err)
+        assert 'Unable to parse result of "localectl"' in six.text_type(exc_info.value)
 
     @patch('salt.utils.path.which', MagicMock(return_value="/usr/bin/localctl"))
     @patch('salt.modules.localemod.__salt__', {'cmd.run': MagicMock(return_value=locale_ctl_out_structure)})
@@ -293,9 +293,9 @@ class LocalemodTestCase(TestCase, LoaderModuleMockMixin):
         Test getting current system locale with systemd and dbus available on Gentoo.
         :return:
         '''
-        with pytest.raises(CommandExecutionError) as err:
+        with pytest.raises(CommandExecutionError) as exc_info:
             localemod.get_locale()
-        assert '"DrunkDragon" is unsupported' in six.text_type(err)
+        assert '"DrunkDragon" is unsupported' in six.text_type(exc_info.value)
 
     @patch('salt.utils.path.which', MagicMock(return_value="/usr/bin/localctl"))
     @patch('salt.modules.localemod.__grains__', {'os_family': 'Ubuntu', 'osmajorrelease': 42})
@@ -395,10 +395,10 @@ class LocalemodTestCase(TestCase, LoaderModuleMockMixin):
         :return:
         '''
         loc = 'de_DE.utf8'
-        with pytest.raises(CommandExecutionError) as err:
+        with pytest.raises(CommandExecutionError) as exc_info:
             localemod.set_locale(loc)
         assert not localemod._localectl_set.called
-        assert 'Cannot set locale: "update-locale" was not found.' in six.text_type(err)
+        assert 'Cannot set locale: "update-locale" was not found.' in six.text_type(exc_info.value)
 
     @patch('salt.utils.path.which', MagicMock(return_value=None))
     @patch('salt.modules.localemod.__grains__', {'os_family': 'Gentoo', 'osmajorrelease': 42})
@@ -467,9 +467,9 @@ class LocalemodTestCase(TestCase, LoaderModuleMockMixin):
         Test setting current system locale without systemd on unknown system.
         :return:
         '''
-        with pytest.raises(CommandExecutionError) as err:
+        with pytest.raises(CommandExecutionError) as exc_info:
             localemod.set_locale('de_DE.utf8')
-        assert 'Unsupported platform' in six.text_type(err)
+        assert 'Unsupported platform' in six.text_type(exc_info.value)
 
     @patch('salt.utils.locales.normalize_locale', MagicMock(return_value='en_US.UTF-8 UTF-8'))
     @patch('salt.modules.localemod.__salt__', {'locale.list_avail': MagicMock(return_value=['A', 'B'])})
@@ -537,9 +537,9 @@ class LocalemodTestCase(TestCase, LoaderModuleMockMixin):
         Tests the location where gen_locale is handling error while calling not installed localedef on Suse os-family.
         :return:
         '''
-        with pytest.raises(CommandExecutionError) as err:
+        with pytest.raises(CommandExecutionError) as exc_info:
             localemod.gen_locale('de_DE.utf8')
-        assert 'Command "locale-gen" or "localedef" was not found on this system.' in six.text_type(err)
+        assert 'Command "locale-gen" or "localedef" was not found on this system.' in six.text_type(exc_info.value)
 
     def test_gen_locale_debian(self):
         '''


### PR DESCRIPTION
### What does this PR do?
Fixes errors like
```
AssertionError: 'Found more than one line between boundaries "before" and "after"' not found in '<ExceptionInfo CommandExecutionError tblen=2>'
```
in `unit.modules.test_file` tests.

I've actually didn't got why it gets `repr` string instead of `str` string there. But what I've found is: `with raises(Exc) as exc` puts an `ExceptionInfo` value to the `exc` variable instead of the caught exception. So if we want to assert something in the exception we have to use `exc.value` instead of `exc`. It'd be more correct.

So I've made the least change let's see what will happen.

### What issues does this PR fix or reference?
New failure. No issue.
A part of tests fixes for #53841 

### Tests written?
No, Tests fix.

### Commits signed with GPG?
Yes
