### PR TITLE
Fix for test test_present_with_subnets

### DIFF
--- a/tests/unit/states/test_boto_vpc.py
+++ b/tests/unit/states/test_boto_vpc.py
@@ -321,8 +321,8 @@ class BotoVpcRouteTableTestCase(BotoVpcStateTestCaseBase, BotoVpcResourceTestCas
     @mock_ec2_deprecated
     def test_present_with_subnets(self):
         vpc = self._create_vpc(name='test')
-        subnet1 = self._create_subnet(vpc_id=vpc.id, name='test1')
-        subnet2 = self._create_subnet(vpc_id=vpc.id, name='test2')
+        subnet1 = self._create_subnet(vpc_id=vpc.id, cidr_block='10.0.0.0/25', name='test1')
+        subnet2 = self._create_subnet(vpc_id=vpc.id, cidr_block='10.0.0.128/25', name='test2')
 
         route_table_present_result = self.salt_states['boto_vpc.route_table_present'](
                 name='test', vpc_name='test', subnet_names=['test1'], subnet_ids=[subnet2.id])


### PR DESCRIPTION
### What does this PR do?
Fixes the `unit.states.test_boto_vpc.BotoVpcRouteTableTestCase.test_present_with_subnets` test error.
```
Traceback (most recent call last):
  File "/tmp/kitchen/testing/.nox/runtests-parametrized-2-7-coverage-true-crypto-none-transport-zeromq/lib/python2.7/site-packages/moto/core/models.py", line 80, in wrapper
    result = func(*args, **kwargs)
  File "/tmp/kitchen/testing/tests/unit/states/test_boto_vpc.py", line 325, in test_present_with_subnets
    subnet2 = self._create_subnet(vpc_id=vpc.id, name='test2')
  File "/tmp/kitchen/testing/tests/unit/modules/test_boto_vpc.py", line 193, in _create_subnet
    subnet = self.conn.create_subnet(vpc_id, cidr_block, availability_zone=availability_zone)
  File "/tmp/kitchen/testing/.nox/runtests-parametrized-2-7-coverage-true-crypto-none-transport-zeromq/lib/python2.7/site-packages/boto/vpc/__init__.py", line 1180, in create_subnet
    return self.get_object('CreateSubnet', params, Subnet)
  File "/tmp/kitchen/testing/.nox/runtests-parametrized-2-7-coverage-true-crypto-none-transport-zeromq/lib/python2.7/site-packages/boto/connection.py", line 1208, in get_object
    raise self.ResponseError(response.status, response.reason, body)
EC2ResponseError: EC2ResponseError: 400 Bad Request
<?xml version="1.0" encoding="UTF-8"?>
  <Response>
    <Errors>
      <Error>
        <Code>InvalidSubnet.Conflict</Code>
        <Message>The CIDR '10.0.0.0/25' conflicts with another subnet</Message>
        
      </Error>
    </Errors>
  <RequestID>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</RequestID>
</Response>
```

The original test code tries to create 2 subnets in a VPC with the same CIDR block when documentation says:
> The CIDR block must not overlap with any existing CIDR block that's associated with the VPC.

https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Subnets.html#vpc-resize

### What issues does this PR fix or reference?
No particular issue.
This fixes the test for merge forward #53841

### Tests written?
No, test fix.

### Commits signed with GPG?
Yes