### PR TITLE
Localemod test fix

### DIFF
--- a/tests/unit/modules/test_localemod.py
+++ b/tests/unit/modules/test_localemod.py
@@ -160,24 +160,24 @@ class LocalemodTestCase(TestCase, LoaderModuleMockMixin):
         Test localectl status parser raises an exception if no systemd installed.
         :return:
         '''
-        with pytest.raises(CommandExecutionError) as err:
+        with pytest.raises(CommandExecutionError) as exc_info:
             localemod._localectl_status()
-        assert 'Unable to find "localectl"' in six.text_type(err)
+        assert 'Unable to find "localectl"' in six.text_type(exc_info.value)
         assert not localemod.log.debug.called
 
     @patch('salt.utils.path.which', MagicMock(return_value="/usr/bin/localctl"))
     @patch('salt.modules.localemod.__salt__', {'cmd.run': MagicMock(return_value=locale_ctl_out_empty)})
     def test_localectl_status_parser_empty(self):
-        with pytest.raises(CommandExecutionError) as err:
+        with pytest.raises(CommandExecutionError) as exc_info:
             localemod._localectl_status()
-        assert 'Unable to parse result of "localectl"' in six.text_type(err)
+        assert 'Unable to parse result of "localectl"' in six.text_type(exc_info.value)
 
     @patch('salt.utils.path.which', MagicMock(return_value="/usr/bin/localctl"))
     @patch('salt.modules.localemod.__salt__', {'cmd.run': MagicMock(return_value=locale_ctl_out_broken)})
     def test_localectl_status_parser_broken(self):
-        with pytest.raises(CommandExecutionError) as err:
+        with pytest.raises(CommandExecutionError) as exc_info:
             localemod._localectl_status()
-        assert 'Unable to parse result of "localectl"' in six.text_type(err)
+        assert 'Unable to parse result of "localectl"' in six.text_type(exc_info.value)
 
     @patch('salt.utils.path.which', MagicMock(return_value="/usr/bin/localctl"))
     @patch('salt.modules.localemod.__salt__', {'cmd.run': MagicMock(return_value=locale_ctl_out_structure)})
@@ -293,9 +293,9 @@ class LocalemodTestCase(TestCase, LoaderModuleMockMixin):
         Test getting current system locale with systemd and dbus available on Gentoo.
         :return:
         '''
-        with pytest.raises(CommandExecutionError) as err:
+        with pytest.raises(CommandExecutionError) as exc_info:
             localemod.get_locale()
-        assert '"DrunkDragon" is unsupported' in six.text_type(err)
+        assert '"DrunkDragon" is unsupported' in six.text_type(exc_info.value)
 
     @patch('salt.utils.path.which', MagicMock(return_value="/usr/bin/localctl"))
     @patch('salt.modules.localemod.__grains__', {'os_family': 'Ubuntu', 'osmajorrelease': 42})
@@ -395,10 +395,10 @@ class LocalemodTestCase(TestCase, LoaderModuleMockMixin):
         :return:
         '''
         loc = 'de_DE.utf8'
-        with pytest.raises(CommandExecutionError) as err:
+        with pytest.raises(CommandExecutionError) as exc_info:
             localemod.set_locale(loc)
         assert not localemod._localectl_set.called
-        assert 'Cannot set locale: "update-locale" was not found.' in six.text_type(err)
+        assert 'Cannot set locale: "update-locale" was not found.' in six.text_type(exc_info.value)
 
     @patch('salt.utils.path.which', MagicMock(return_value=None))
     @patch('salt.modules.localemod.__grains__', {'os_family': 'Gentoo', 'osmajorrelease': 42})
@@ -467,9 +467,9 @@ class LocalemodTestCase(TestCase, LoaderModuleMockMixin):
         Test setting current system locale without systemd on unknown system.
         :return:
         '''
-        with pytest.raises(CommandExecutionError) as err:
+        with pytest.raises(CommandExecutionError) as exc_info:
             localemod.set_locale('de_DE.utf8')
-        assert 'Unsupported platform' in six.text_type(err)
+        assert 'Unsupported platform' in six.text_type(exc_info.value)
 
     @patch('salt.utils.locales.normalize_locale', MagicMock(return_value='en_US.UTF-8 UTF-8'))
     @patch('salt.modules.localemod.__salt__', {'locale.list_avail': MagicMock(return_value=['A', 'B'])})
@@ -537,9 +537,9 @@ class LocalemodTestCase(TestCase, LoaderModuleMockMixin):
         Tests the location where gen_locale is handling error while calling not installed localedef on Suse os-family.
         :return:
         '''
-        with pytest.raises(CommandExecutionError) as err:
+        with pytest.raises(CommandExecutionError) as exc_info:
             localemod.gen_locale('de_DE.utf8')
-        assert 'Command "locale-gen" or "localedef" was not found on this system.' in six.text_type(err)
+        assert 'Command "locale-gen" or "localedef" was not found on this system.' in six.text_type(exc_info.value)
 
     def test_gen_locale_debian(self):
         '''


### PR DESCRIPTION
### What does this PR do?
Fixes localetest errors:
```
Traceback (most recent call last):
  File "/tmp/kitchen/testing/.nox/runtests-parametrized-3-coverage-true-crypto-none-transport-zeromq/lib/python3.7/site-packages/mock/mock.py", line 1330, in patched
    return func(*args, **keywargs)
  File "/tmp/kitchen/testing/tests/unit/modules/test_localemod.py", line 542, in test_gen_locale_suse_localedef_error_handling
    assert 'Command "locale-gen" or "localedef" was not found on this system.' in six.text_type(err)
AssertionError
```

It's in progress. I'm just trying to understand what's happening.

### What issues does this PR fix or reference?
Fix tests for merge forward #53841

### Tests written?
No, test fix

### Commits signed with GPG?
Yes