### PR TITLE
updating git repo where rbenv is hosted

### DIFF
--- a/salt/modules/rbenv.py
+++ b/salt/modules/rbenv.py
@@ -121,7 +121,7 @@ def _install_rbenv(path, runas=None):
     if os.path.isdir(path):
         return True
 
-    cmd = ['git', 'clone', 'https://github.com/sstephenson/rbenv.git', path]
+    cmd = ['git', 'clone', 'https://github.com/rbenv/rbenv.git', path]
     return __salt__['cmd.retcode'](cmd, runas=runas, python_shell=False) == 0
 
 
@@ -131,7 +131,7 @@ def _install_ruby_build(path, runas=None):
         return True
 
     cmd = ['git', 'clone',
-           'https://github.com/sstephenson/ruby-build.git', path]
+           'https://github.com/rbenv/ruby-build.git', path]
     return __salt__['cmd.retcode'](cmd, runas=runas, python_shell=False) == 0
 
 

--- a/salt/states/rbenv.py
+++ b/salt/states/rbenv.py
@@ -9,7 +9,7 @@ Rbenv will be installed automatically the first time it is needed and can be
 updated later. This module will *not* automatically install packages which rbenv
 will need to compile the versions of ruby. If your version of ruby fails to
 install, refer to the ruby-build documentation to verify you are not missing any
-dependencies: https://github.com/sstephenson/ruby-build/wiki
+dependencies: https://github.com/rbenv/ruby-build/wiki
 
 If rbenv is run as the root user then it will be installed to /usr/local/rbenv,
 otherwise it will be installed to the users ~/.rbenv directory. To make


### PR DESCRIPTION
### What does this PR do?
It changes the url where rbenv is cloned from

### What issues does this PR fix or reference?
None
### Previous Behavior
Github redirects the clone to rbenv's repos

### New Behavior
We go directly to rbenv's repos

### Commits signed with GPG?

Yes