### PR TITLE
Fix plugin in user_chpass with unix_socket True

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -1559,7 +1559,7 @@ def user_chpass(user,
     if salt.utils.data.is_true(allow_passwordless) and \
             salt.utils.data.is_true(unix_socket):
         if host == 'localhost':
-            args['unix_socket'] = 'auth_socket'
+            args['unix_socket'] = 'unix_socket'
             if salt.utils.versions.version_cmp(server_version, compare_version) >= 0:
                 qry = "ALTER USER %(user)s@%(host)s IDENTIFIED WITH %(unix_socket)s AS %(user)s;"
             else:


### PR DESCRIPTION
### What does this PR do?

Plugin should be set to unix_socket, as user_create does.
user_exists and user_create checks/sets plugin as unix_socket

### Previous Behavior

user_chpass is setting 'auth_socket', which fails to login with error:

ERROR 1524 (HY000): Plugin 'auth_socket' is not loaded

### New Behavior

user_chpass sets 'unix_socket' plugin, then login works.

### Tests written?

No
