### PR TITLE
Fix unit.utils.test_win_dacl (neon)

### DIFF
--- a/salt/utils/win_dacl.py
+++ b/salt/utils/win_dacl.py
@@ -931,6 +931,7 @@ def dacl(obj_name=None, obj_type='file'):
                     if ace[1] & perm == perm:
                         ace_perms.append(
                             self.ace_perms[obj_type]['advanced'][perm])
+                ace_perms.sort()
 
             # If still nothing, it must be undefined
             if not ace_perms:

--- a/tests/unit/utils/test_win_dacl.py
+++ b/tests/unit/utils/test_win_dacl.py
@@ -295,10 +295,10 @@ class WinDaclRegTestCase(TestCase, LoaderModuleMockMixin):
                 'NETWORK SERVICE': {
                     'deny': {
                         'applies to': 'This key and subkeys',
-                        'permissions': ['Set Value',
-                                        'Delete',
-                                        'Write Owner',
-                                        'Write DAC']}}}}
+                        'permissions': ['Delete',
+                                        'Set Value',
+                                        'Write DAC',
+                                        'Write Owner']}}}}
         self.assertDictEqual(
             win_dacl.get_permissions(
                 obj_name=self.obj_name,
@@ -595,10 +595,10 @@ class WinDaclFileTestCase(TestCase, LoaderModuleMockMixin):
                 'NETWORK SERVICE': {
                     'deny': {
                         'applies to': 'Not Inherited (file)',
-                        'permissions': ['Delete',
+                        'permissions': ['Change permissions',
                                         'Create files / write data',
-                                        'Write attributes',
-                                        'Change permissions']}}}}
+                                        'Delete',
+                                        'Write attributes']}}}}
         self.assertDictEqual(
             win_dacl.get_permissions(
                 obj_name=self.obj_name,


### PR DESCRIPTION
### What does this PR do?
Fixes a failing test. The test was failing because the list of permissions isn't always in the same order. This adds a `.sort()` so that the permissions come back sorted.

### What issues does this PR fix or reference?
jenkins

### Tests written?
Yes

### Commits signed with GPG?
Yes