### PR TITLE
Replace use of mkdir with makedirs to ensure all directories in path created

### DIFF
--- a/tests/integration/modules/test_cp.py
+++ b/tests/integration/modules/test_cp.py
@@ -502,7 +502,7 @@ class CPModuleTest(ModuleCase):
         file_contents = 'Hello world!'
 
         for dirname in (nginx_root_dir, nginx_conf_dir):
-            os.mkdir(dirname)
+            os.makedirs(dirname)
 
         # Write the temp file
         with salt.utils.files.fopen(os.path.join(nginx_root_dir, 'actual_file'), 'w') as fp_:


### PR DESCRIPTION
### What does this PR do?
Ensure that all directories in test directory path are created

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/54130

### Previous Behavior
Occasional failure in test due to non-existent path 
https://jenkinsci.saltstack.com/job/neon/job/salt-debian-8-py2/110/testReport/junit/tests.integration.modules.test_cp/CPModuleTest/test_cache_remote_file/

### New Behavior
Use of makedirs should ensure all directories in path are created

### Tests written?
Yes

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
