### PR TITLE
Fix `integration.states.test_cmd` on Windows (2018.3)

### DIFF
--- a/tests/integration/states/test_cmd.py
+++ b/tests/integration/states/test_cmd.py
@@ -30,20 +30,29 @@ class CMDTest(ModuleCase, SaltReturnAssertsMixin):
     '''
     Validate the cmd state
     '''
+    @classmethod
+    def setUpClass(cls):
+        cls.cmd = 'dir' if IS_WINDOWS else 'ls'
+
     def test_run_simple(self):
         '''
         cmd.run
         '''
-        cmd = 'dir' if IS_WINDOWS else 'ls'
-        ret = self.run_state('cmd.run', name=cmd, cwd=tempfile.gettempdir())
+        ret = self.run_state(
+            'cmd.run',
+            name=self.cmd,
+            cwd=tempfile.gettempdir())
         self.assertSaltTrueReturn(ret)
 
-    def test_test_run_simple(self):
+    def test_run_simple_test_true(self):
         '''
         cmd.run test interface
         '''
-        ret = self.run_state('cmd.run', name='ls',
-                             cwd=tempfile.gettempdir(), test=True)
+        ret = self.run_state(
+            'cmd.run',
+            name=self.cmd,
+            cwd=tempfile.gettempdir(),
+            test=True)
         self.assertSaltNoneReturn(ret)
 
     def test_run_hide_output(self):
@@ -52,7 +61,7 @@ class CMDTest(ModuleCase, SaltReturnAssertsMixin):
         '''
         ret = self.run_state(
             u'cmd.run',
-            name=u'ls',
+            name=self.cmd,
             hide_output=True)
         self.assertSaltTrueReturn(ret)
         ret = ret[next(iter(ret))]


### PR DESCRIPTION
### What does this PR do?
Uses `dir` on Windows

### What issues does this PR fix or reference?
Found while creating golden images

### Tests written?
Yes

### Commits signed with GPG?
Yes