### PR TITLE
Fix grains.core pylint error

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -43,6 +43,7 @@ _supported_dists += ('arch', 'mageia', 'meego', 'vmware', 'bluewhite64',
 
 # linux_distribution deprecated in py3.7
 try:
+    #pylint: disable=W1505
     from platform import linux_distribution as _deprecated_linux_distribution
 
     def linux_distribution(**kwargs):


### PR DESCRIPTION
### What does this PR do?
Ignore the pylint warning for salt/grains/core.py `Using deprecated method _deprecated_linux_distribution()`

ignoring error since we still support python3.4 and it was not deprecated until later.