### PR TITLE
address runner race condition in saltnado

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1937,9 +1937,19 @@ class ClearFuncs(object):
         try:
             fun = clear_load.pop('fun')
             runner_client = salt.runner.RunnerClient(self.opts)
+
+            # if runner is pre-subscribed from ie salt-api, honor it
+            if 'jid' in clear_load:
+                jid = clear_load['jid']
+                tag = 'salt/run/' + jid
+                pub = {'tag': tag, 'jid': jid}
+            else:
+                pub = None
+
             return runner_client.asynchronous(fun,
                                               clear_load.get('kwarg', {}),
-                                              username)
+                                              username,
+                                              pub=pub)
         except Exception as exc:
             log.error('Exception occurred while introspecting %s: %s', fun, exc)
             return {'error': {'name': exc.__class__.__name__,

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -78,7 +78,7 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
         verify_fun(self.functions, fun)
 
         eauth_creds = dict([(i, low.pop(i)) for i in [
-            'username', 'password', 'eauth', 'token', 'client', 'user', 'key',
+            'username', 'password', 'eauth', 'token', 'client', 'user', 'key', 'jid'
         ] if i in low])
 
         # Run name=value args through parse_input. We don't need to run kwargs


### PR DESCRIPTION
### What does this PR do?
Although unlikely, if a runner is sufficiently fast or things are
blocked for whatever reason api side, we can miss the result on the bus
before subscribing. This pre-gens the jid for subscription before
sending the runner request off to the master.

### What issues does this PR fix or reference?
n/a

### Tests written?
n/a

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
