### PR TITLE
Fix up transport tests and bugs in process utils

### DIFF
--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -613,10 +613,17 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
                     raise exc
             self._socket.close()
             self._socket = None
-        if hasattr(self.req_server, 'stop'):
+        if hasattr(self.req_server, 'shutdown'):
+            try:
+                self.req_server.shutdown()
+            except Exception as exc:
+                log.exception('TCPReqServerChannel close generated an exception: %s', str(exc))
+        elif hasattr(self.req_server, 'stop'):
             try:
                 self.req_server.stop()
-            except Exception as exc:
+            except socket.error as exc:
+                if exc.errno != 9:
+                    raise
                 log.exception('TCPReqServerChannel close generated an exception: %s', str(exc))
 
     def __del__(self):
@@ -662,7 +669,8 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
                     self._socket.setblocking(0)
                     self._socket.bind((self.opts['interface'], int(self.opts['ret_port'])))
                 self.req_server = SaltMessageServer(self.handle_message,
-                                                    ssl_options=self.opts.get('ssl'))
+                                                    ssl_options=self.opts.get('ssl'),
+                                                    io_loop=self.io_loop)
                 self.req_server.add_socket(self._socket)
                 self._socket.listen(self.backlog)
         salt.transport.mixins.auth.AESReqServerMixin.post_fork(self, payload_handler, io_loop)
@@ -748,11 +756,12 @@ class SaltMessageServer(tornado.tcpserver.TCPServer, object):
     messages that are sent through to us
     '''
     def __init__(self, message_handler, *args, **kwargs):
+        io_loop = kwargs.pop('io_loop', None) or tornado.ioloop.IOLoop.current()
         super(SaltMessageServer, self).__init__(*args, **kwargs)
-        self.io_loop = tornado.ioloop.IOLoop.current()
-
+        self.io_loop = io_loop
         self.clients = []
         self.message_handler = message_handler
+        self._shutting_down = False
 
     @tornado.gen.coroutine
     def handle_stream(self, stream, address):
@@ -776,20 +785,33 @@ class SaltMessageServer(tornado.tcpserver.TCPServer, object):
 
         except tornado.iostream.StreamClosedError:
             log.trace('req client disconnected %s', address)
-            self.clients.remove((stream, address))
+            self.remove_client((stream, address))
         except Exception as e:
             log.trace('other master-side exception: %s', e)
-            self.clients.remove((stream, address))
+            self.remove_client((stream, address))
             stream.close()
+
+    def remove_client(self, client):
+        try:
+            self.clients.remove(client)
+        except ValueError:
+            log.trace("Message server client was not in list to remove")
 
     def shutdown(self):
         '''
         Shutdown the whole server
         '''
-        for item in self.clients:
-            client, address = item
-            client.close()
-            self.clients.remove(item)
+        if not self._shutting_down:
+            self._shutting_down = True
+            for item in self.clients:
+                client, address = item
+                client.close()
+                self.remove_client(item)
+        try:
+            self.stop()
+        except socket.error as exc:
+            if exc.errno != 9:
+                raise
 
 
 if USE_LOAD_BALANCER:

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -801,12 +801,13 @@ class SaltMessageServer(tornado.tcpserver.TCPServer, object):
         '''
         Shutdown the whole server
         '''
-        if not self._shutting_down:
-            self._shutting_down = True
-            for item in self.clients:
-                client, address = item
-                client.close()
-                self.remove_client(item)
+        if self._shutting_down:
+            return
+        self._shutting_down = True
+        for item in self.clients:
+            client, address = item
+            client.close()
+            self.remove_client(item)
         try:
             self.stop()
         except socket.error as exc:

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -669,22 +669,9 @@ class MultiprocessingProcess(multiprocessing.Process, NewStyleClassMixIn):
         return instance
 
     def __init__(self, *args, **kwargs):
-        if (salt.utils.platform.is_windows() and
-                not hasattr(self, '_is_child') and
-                self.__setstate__.__code__ is
-                MultiprocessingProcess.__setstate__.__code__):
-            # On Windows, if a derived class hasn't defined __setstate__, that
-            # means the 'MultiprocessingProcess' version will be used. For this
-            # version, save a copy of the args and kwargs to use with its
-            # __setstate__ and __getstate__.
-            # We do this so that __init__ will be invoked on Windows in the
-            # child process so that a register_after_fork() equivalent will
-            # work on Windows. Note that this will only work if the derived
-            # class uses the exact same args and kwargs as this class. Hence
-            # this will also work for 'SignalHandlingMultiprocessingProcess'.
-            # However, many derived classes take params that they don't pass
-            # down (eg opts). Those classes need to override __setstate__ and
-            # __getstate__ themselves.
+        if salt.utils.platform.is_windows():
+            # On Windows, subclasses should call super if they define
+            # __setstate__ and/or __getstate__
             self._args_for_getstate = copy.copy(args)
             self._kwargs_for_getstate = copy.copy(kwargs)
 
@@ -706,42 +693,21 @@ class MultiprocessingProcess(multiprocessing.Process, NewStyleClassMixIn):
         # 'log_queue' and 'log_queue_level' from kwargs.
         super(MultiprocessingProcess, self).__init__(*args, **kwargs)
 
-        if salt.utils.platform.is_windows():
-            # On Windows, the multiprocessing.Process object is reinitialized
-            # in the child process via the constructor. Due to this, methods
-            # such as ident() and is_alive() won't work properly. So we use
-            # our own creation '_is_child' for this purpose.
-            if hasattr(self, '_is_child'):
-                # On Windows, no need to call register_after_fork().
-                # register_after_fork() would only work on Windows if called
-                # from the child process anyway. Since we know this is the
-                # child process, call __setup_process_logging() directly.
-                self.__setup_process_logging()
-                multiprocessing.util.Finalize(
-                    self,
-                    salt.log.setup.shutdown_multiprocessing_logging,
-                    exitpriority=16
-                )
-        else:
-            multiprocessing.util.register_after_fork(
-                self,
-                MultiprocessingProcess.__setup_process_logging
-            )
-            multiprocessing.util.Finalize(
-                self,
-                salt.log.setup.shutdown_multiprocessing_logging,
-                exitpriority=16
-            )
+        self._after_fork_methods = [
+            (MultiprocessingProcess._setup_process_logging, [self], {}),
+        ]
+        self._finalize_methods = [
+            (salt.log.setup.shutdown_multiprocessing_logging, [], {})
+        ]
 
     # __setstate__ and __getstate__ are only used on Windows.
-    # We do this so that __init__ will be invoked on Windows in the child
-    # process so that a register_after_fork() equivalent will work on Windows.
     def __setstate__(self, state):
-        self._is_child = True
         args = state['args']
         kwargs = state['kwargs']
         # This will invoke __init__ of the most derived class.
         self.__init__(*args, **kwargs)
+        self._after_fork_methods = self._after_fork_methods
+        self._finalize_methods = self._finalize_methods
 
     def __getstate__(self):
         args = self._args_for_getstate
@@ -755,12 +721,17 @@ class MultiprocessingProcess(multiprocessing.Process, NewStyleClassMixIn):
         del self._args_for_getstate
         del self._kwargs_for_getstate
         return {'args': args,
-                'kwargs': kwargs}
+                'kwargs': kwargs,
+                '_after_fork_methods': self._after_fork_methods,
+                '_finalize_methods': self._finalize_methods,
+                }
 
-    def __setup_process_logging(self):
+    def _setup_process_logging(self):
         salt.log.setup.setup_multiprocessing_logging(self.log_queue)
 
     def _run(self):
+        for method, args, kwargs in self._after_fork_methods:
+            method(*args, **kwargs)
         try:
             return self._original_run()
         except SystemExit:
@@ -774,31 +745,32 @@ class MultiprocessingProcess(multiprocessing.Process, NewStyleClassMixIn):
             # sys.stderr and set the proper exitcode and we have already logged
             # it above.
             raise
+        finally:
+            for method, args, kwargs in self._finalize_methods:
+                method(*args, **kwargs)
 
 
 class SignalHandlingMultiprocessingProcess(MultiprocessingProcess):
     def __init__(self, *args, **kwargs):
         super(SignalHandlingMultiprocessingProcess, self).__init__(*args, **kwargs)
-        if salt.utils.platform.is_windows():
-            if hasattr(self, '_is_child'):
-                # On Windows, no need to call register_after_fork().
-                # register_after_fork() would only work on Windows if called
-                # from the child process anyway. Since we know this is the
-                # child process, call __setup_signals() directly.
-                self.__setup_signals()
-        else:
-            multiprocessing.util.register_after_fork(
-                self,
-                SignalHandlingMultiprocessingProcess.__setup_signals
-            )
+        self._signal_handled = multiprocessing.Value('i', 0)
+        self._signal_handled.value = 0
+        self._after_fork_methods.append(
+            (SignalHandlingMultiprocessingProcess._setup_signals, [self], {})
+        )
 
-    def __setup_signals(self):
+    def signal_handled(self):
+        if self._signal_handled.value == 1:
+            return True
+        return False
+
+    def _setup_signals(self):
         signal.signal(signal.SIGINT, self._handle_signals)
         signal.signal(signal.SIGTERM, self._handle_signals)
 
     def _handle_signals(self, signum, sigframe):
-        signal.signal(signal.SIGTERM, signal.SIG_IGN)
-        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        if self._signal_handled.value == 0:
+            self._signal_handled.value = 1
         msg = '{0} received a '.format(self.__class__.__name__)
         if signum == signal.SIGINT:
             msg += 'SIGINT'
@@ -808,7 +780,7 @@ class SignalHandlingMultiprocessingProcess(MultiprocessingProcess):
         log.debug(msg)
         if HAS_PSUTIL:
             try:
-                process = psutil.Process(self.pid)
+                process = psutil.Process(os.getpid())
                 if hasattr(process, 'children'):
                     for child in process.children(recursive=True):
                         try:

--- a/tests/unit/transport/mixins.py
+++ b/tests/unit/transport/mixins.py
@@ -10,7 +10,27 @@ import salt.transport.client
 from salt.ext import six
 
 
+def run_loop_in_thread(loop, evt):
+    '''
+    Run the provided loop until an event is set
+    '''
+    loop.make_current()
+    @tornado.gen.coroutine
+    def stopper():
+        while True:
+            if evt.is_set():
+                loop.stop()
+                break
+            yield tornado.gen.sleep(.3)
+    loop.add_callback(stopper)
+    try:
+        loop.start()
+    finally:
+        loop.close()
+
+
 class ReqChannelMixin(object):
+
     def test_basic(self):
         '''
         Test a variety of messages, make sure we get the expected responses

--- a/tests/unit/transport/mixins.py
+++ b/tests/unit/transport/mixins.py
@@ -8,6 +8,7 @@ import salt.transport.client
 
 # Import 3rd-party libs
 from salt.ext import six
+import tornado.gen
 
 
 def run_loop_in_thread(loop, evt):

--- a/tests/unit/transport/test_tcp.py
+++ b/tests/unit/transport/test_tcp.py
@@ -188,10 +188,9 @@ class BaseTCPPubCase(AsyncTestCase, AdaptedConfigurationTestCaseMixin):
         # we also require req server for auth
         cls.req_server_channel = salt.transport.server.ReqServerChannel.factory(cls.master_config)
         cls.req_server_channel.pre_fork(cls.process_manager)
-        cls.req_server_channel.post_fork(cls._handle_payload, io_loop=cls.io_loop)
-
         cls.io_loop = tornado.ioloop.IOLoop()
         cls.stop = threading.Event()
+        cls.req_server_channel.post_fork(cls._handle_payload, io_loop=cls.io_loop)
         cls.server_thread = threading.Thread(
             target=run_loop_in_thread,
             args=(cls.io_loop, cls.stop,),

--- a/tests/unit/transport/test_tcp.py
+++ b/tests/unit/transport/test_tcp.py
@@ -27,9 +27,9 @@ from salt.transport.tcp import SaltMessageClientPool, SaltMessageClient
 # Import Salt Testing libs
 from tests.support.unit import TestCase, skipIf
 from tests.support.helpers import get_unused_localhost_port, flaky
-from tests.support.mixins import AdaptedConfigurationTestCaseMixin, run_loop_in_thread
+from tests.support.mixins import AdaptedConfigurationTestCaseMixin
 from tests.support.mock import MagicMock, patch
-from tests.unit.transport.mixins import PubChannelMixin, ReqChannelMixin
+from tests.unit.transport.mixins import PubChannelMixin, ReqChannelMixin, run_loop_in_thread
 
 log = logging.getLogger(__name__)
 

--- a/tests/unit/transport/test_tcp.py
+++ b/tests/unit/transport/test_tcp.py
@@ -27,7 +27,7 @@ from salt.transport.tcp import SaltMessageClientPool, SaltMessageClient
 # Import Salt Testing libs
 from tests.support.unit import TestCase, skipIf
 from tests.support.helpers import get_unused_localhost_port, flaky
-from tests.support.mixins import AdaptedConfigurationTestCaseMixin
+from tests.support.mixins import AdaptedConfigurationTestCaseMixin, run_loop_in_thread
 from tests.support.mock import MagicMock, patch
 from tests.unit.transport.mixins import PubChannelMixin, ReqChannelMixin
 
@@ -72,29 +72,22 @@ class BaseTCPReqCase(TestCase, AdaptedConfigurationTestCaseMixin):
 
         cls.server_channel = salt.transport.server.ReqServerChannel.factory(cls.master_config)
         cls.server_channel.pre_fork(cls.process_manager)
-
         cls.io_loop = tornado.ioloop.IOLoop()
-
-        def run_loop_in_thread(loop):
-            loop.make_current()
-            loop.start()
-
+        cls.stop = threading.Event()
         cls.server_channel.post_fork(cls._handle_payload, io_loop=cls.io_loop)
-
-        cls.server_thread = threading.Thread(target=run_loop_in_thread, args=(cls.io_loop,))
-        cls.server_thread.daemon = True
+        cls.server_thread = threading.Thread(
+            target=run_loop_in_thread,
+            args=(cls.io_loop, cls.stop,),
+        )
         cls.server_thread.start()
 
     @classmethod
     def tearDownClass(cls):
-        if not hasattr(cls, '_handle_payload'):
-            return
-        if hasattr(cls, 'io_loop'):
-            cls.io_loop.add_callback(cls.io_loop.stop)
-            cls.server_thread.join()
-            cls.process_manager.kill_children()
-            cls.server_channel.close()
-            del cls.server_channel
+        cls.server_channel.close()
+        cls.stop.set()
+        cls.server_thread.join()
+        cls.process_manager.kill_children()
+        del cls.server_channel
 
     @classmethod
     @tornado.gen.coroutine
@@ -195,16 +188,14 @@ class BaseTCPPubCase(AsyncTestCase, AdaptedConfigurationTestCaseMixin):
         # we also require req server for auth
         cls.req_server_channel = salt.transport.server.ReqServerChannel.factory(cls.master_config)
         cls.req_server_channel.pre_fork(cls.process_manager)
+        cls.req_server_channel.post_fork(cls._handle_payload, io_loop=cls.io_loop)
 
-        cls._server_io_loop = tornado.ioloop.IOLoop()
-        cls.req_server_channel.post_fork(cls._handle_payload, io_loop=cls._server_io_loop)
-
-        def run_loop_in_thread(loop):
-            loop.make_current()
-            loop.start()
-
-        cls.server_thread = threading.Thread(target=run_loop_in_thread, args=(cls._server_io_loop,))
-        cls.server_thread.daemon = True
+        cls.io_loop = tornado.ioloop.IOLoop()
+        cls.stop = threading.Event()
+        cls.server_thread = threading.Thread(
+            target=run_loop_in_thread,
+            args=(cls.io_loop, cls.stop,),
+        )
         cls.server_thread.start()
 
     @classmethod
@@ -216,10 +207,11 @@ class BaseTCPPubCase(AsyncTestCase, AdaptedConfigurationTestCaseMixin):
 
     @classmethod
     def tearDownClass(cls):
-        cls._server_io_loop.add_callback(cls._server_io_loop.stop)
+        cls.req_server_channel.close()
+        cls.server_channel.close()
+        cls.stop.set()
         cls.server_thread.join()
         cls.process_manager.kill_children()
-        cls.req_server_channel.close()
         del cls.req_server_channel
 
     def setUp(self):

--- a/tests/unit/utils/test_process.py
+++ b/tests/unit/utils/test_process.py
@@ -336,9 +336,12 @@ class TestSignalHandlingMultiprocessingProcess(TestCase):
         evt = multiprocessing.Event()
         teardown_to_mock = 'salt.log.setup.shutdown_multiprocessing_logging'
         log_to_mock = 'salt.utils.process.MultiprocessingProcess._setup_process_logging'
-        with patch(teardown_to_mock) as ma, patch(log_to_mock) as mb:
-            self.sh_proc = salt.utils.process.SignalHandlingMultiprocessingProcess(target=self.no_op_target)
-            self.sh_proc._run()
+        sig_to_mock = 'salt.utils.process.SignalHandlingMultiprocessingProcess._setup_signals'
+        # Mock _setup_signals so we do not register one for this process.
+        with patch(sig_to_mock):
+            with patch(teardown_to_mock) as ma, patch(log_to_mock) as mb:
+                self.sh_proc = salt.utils.process.SignalHandlingMultiprocessingProcess(target=self.no_op_target)
+                self.sh_proc._run()
         ma.assert_called()
         mb.assert_called()
 

--- a/tests/unit/utils/test_process.py
+++ b/tests/unit/utils/test_process.py
@@ -236,7 +236,6 @@ class TestProcess(TestCase):
         # pylint: enable=assignment-from-none
 
 
-#@skipIf(sys.platform.startswith('win'), 'pickling nested function errors on Windows')
 class TestSignalHandlingMultiprocessingProcess(TestCase):
 
     @classmethod

--- a/tests/unit/utils/test_process.py
+++ b/tests/unit/utils/test_process.py
@@ -236,35 +236,158 @@ class TestProcess(TestCase):
         # pylint: enable=assignment-from-none
 
 
-@skipIf(sys.platform.startswith('win'), 'pickling nested function errors on Windows')
+#@skipIf(sys.platform.startswith('win'), 'pickling nested function errors on Windows')
 class TestSignalHandlingMultiprocessingProcess(TestCase):
+
+    @classmethod
+    def Process(cls, pid):
+        raise psutil.NoSuchProcess(pid)
+
+    @classmethod
+    def target(cls):
+        os.kill(os.getpid(), signal.SIGTERM)
+
+    @classmethod
+    def children(*args, **kwargs):
+        raise psutil.NoSuchProcess(1)
 
     @skipIf(NO_MOCK, NO_MOCK_REASON)
     def test_process_does_not_exist(self):
-        def Process(pid):
-            raise psutil.NoSuchProcess(pid)
-
-        def target():
-            os.kill(os.getpid(), signal.SIGTERM)
-
         try:
-            with patch('psutil.Process', Process):
-                proc = salt.utils.process.SignalHandlingMultiprocessingProcess(target=target)
+            with patch('psutil.Process', self.Process):
+                proc = salt.utils.process.SignalHandlingMultiprocessingProcess(target=self.target)
                 proc.start()
         except psutil.NoSuchProcess:
             assert False, "psutil.NoSuchProcess raised"
 
     @skipIf(NO_MOCK, NO_MOCK_REASON)
     def test_process_children_do_not_exist(self):
-        def children(*args, **kwargs):
-            raise psutil.NoSuchProcess(1)
-
-        def target():
-            os.kill(os.getpid(), signal.SIGTERM)
-
         try:
-            with patch('psutil.Process.children', children):
-                proc = salt.utils.process.SignalHandlingMultiprocessingProcess(target=target)
+            with patch('psutil.Process.children', self.children):
+                proc = salt.utils.process.SignalHandlingMultiprocessingProcess(target=self.target)
                 proc.start()
         except psutil.NoSuchProcess:
             assert False, "psutil.NoSuchProcess raised"
+
+    @staticmethod
+    def run_forever_sub_target(evt):
+        'Used by run_forever_target to create a sub-process'
+        while not evt.is_set():
+            time.sleep(1)
+
+    @staticmethod
+    def run_forever_target(sub_target, evt):
+        'A target that will run forever or until an event is set'
+        p = multiprocessing.Process(target=sub_target, args=(evt,))
+        p.start()
+        p.join()
+
+    @staticmethod
+    def kill_target_sub_proc():
+        pid = os.fork()
+        if pid == 0:
+            return
+        pid = os.fork()
+        if pid == 0:
+            return
+        time.sleep(.1)
+        try:
+            os.kill(os.getpid(), signal.SIGINT)
+        except KeyboardInterrupt:
+            pass
+
+    @skipIf(sys.platform.startswith('win'), 'No os.fork on Windows')
+    def test_signal_processing_regression_test(self):
+        evt = multiprocessing.Event()
+        sh_proc = salt.utils.process.SignalHandlingMultiprocessingProcess(
+            target=self.run_forever_target,
+            args=(self.run_forever_sub_target, evt)
+        )
+        sh_proc.start()
+        proc = multiprocessing.Process(target=self.kill_target_sub_proc)
+        proc.start()
+        proc.join()
+        # When the bug exists, the kill_target_sub_proc signal will kill both
+        # processes. sh_proc will be alive if the bug is fixed
+        assert sh_proc.is_alive()
+        evt.set()
+        sh_proc.join()
+
+    @staticmethod
+    def no_op_target():
+        pass
+
+    @skipIf(NO_MOCK, NO_MOCK_REASON)
+    def test_signal_processing_test_after_fork_called(self):
+        'Validate MultiprocessingProcess and sub classes call after fork methods'
+        evt = multiprocessing.Event()
+        sig_to_mock = 'salt.utils.process.SignalHandlingMultiprocessingProcess._setup_signals'
+        log_to_mock = 'salt.utils.process.MultiprocessingProcess._setup_process_logging'
+        with patch(sig_to_mock) as ma, patch(log_to_mock) as mb:
+            self.sh_proc = salt.utils.process.SignalHandlingMultiprocessingProcess(target=self.no_op_target)
+            self.sh_proc._run()
+        ma.assert_called()
+        mb.assert_called()
+
+    @skipIf(NO_MOCK, NO_MOCK_REASON)
+    def test_signal_processing_test_final_methods_called(self):
+        'Validate MultiprocessingProcess and sub classes call finalize methods'
+        evt = multiprocessing.Event()
+        teardown_to_mock = 'salt.log.setup.shutdown_multiprocessing_logging'
+        log_to_mock = 'salt.utils.process.MultiprocessingProcess._setup_process_logging'
+        with patch(teardown_to_mock) as ma, patch(log_to_mock) as mb:
+            self.sh_proc = salt.utils.process.SignalHandlingMultiprocessingProcess(target=self.no_op_target)
+            self.sh_proc._run()
+        ma.assert_called()
+        mb.assert_called()
+
+    @staticmethod
+    def pid_setting_target(sub_target, val, evt):
+        val.value = os.getpid()
+        p = multiprocessing.Process(target=sub_target, args=(evt,))
+        p.start()
+        p.join()
+
+    @skipIf(sys.platform.startswith('win'), 'Required signals not supported on windows')
+    def test_signal_processing_handle_signals_called(self):
+        'Validate SignalHandlingMultiprocessingProcess handles signals'
+        # Gloobal event to stop all processes we're creating
+        evt = multiprocessing.Event()
+
+        # Create a process to test signal handler
+        val = multiprocessing.Value('i', 0)
+        proc = salt.utils.process.SignalHandlingMultiprocessingProcess(
+            target=self.pid_setting_target,
+            args=(self.run_forever_sub_target, val, evt),
+        )
+        proc.start()
+
+        # Create a second process that should not respond to SIGINT or SIGTERM
+        proc2 = multiprocessing.Process(
+            target=self.run_forever_target,
+            args=(self.run_forever_sub_target, evt),
+        )
+        proc2.start()
+
+        # Wait for the sub process to set it's pid
+        while not val.value:
+            time.sleep(.3)
+
+        assert not proc.signal_handled()
+
+        # Send a signal that should get handled by the subprocess
+        os.kill(val.value, signal.SIGTERM)
+
+        # wait up to 10 seconds for signal handler:
+        start = time.time()
+        while time.time() - start < 10:
+            if proc.signal_handled():
+                break
+            time.sleep(.3)
+
+        assert proc.signal_handled()
+        # Reap the signaled process
+        proc.join(1)
+        assert psutil.pid_exists(proc2.pid)
+        evt.set()
+        proc2.join()

--- a/tests/unit/utils/test_process.py
+++ b/tests/unit/utils/test_process.py
@@ -389,12 +389,13 @@ class TestSignalHandlingMultiprocessingProcess(TestCase):
                 break
             time.sleep(.3)
 
-        assert not proc.is_alive()
-        assert proc.signal_handled()
-        # Reap the signaled process
-        proc.join(1)
         try:
+            # Allow some time for the signal handler to do it's thing
+            assert proc.signal_handled()
+            # Reap the signaled process
+            proc.join(1)
             assert proc2.is_alive()
         finally:
             evt.set()
-            proc2.join()
+            proc2.join(30)
+            proc.join(30)

--- a/tests/unit/utils/test_process.py
+++ b/tests/unit/utils/test_process.py
@@ -308,9 +308,11 @@ class TestSignalHandlingMultiprocessingProcess(TestCase):
         proc.join()
         # When the bug exists, the kill_target_sub_proc signal will kill both
         # processes. sh_proc will be alive if the bug is fixed
-        assert sh_proc.is_alive()
-        evt.set()
-        sh_proc.join()
+        try:
+            assert sh_proc.is_alive()
+        finally:
+            evt.set()
+            sh_proc.join()
 
     @staticmethod
     def no_op_target():

--- a/tests/unit/utils/test_process.py
+++ b/tests/unit/utils/test_process.py
@@ -385,9 +385,12 @@ class TestSignalHandlingMultiprocessingProcess(TestCase):
                 break
             time.sleep(.3)
 
+        assert not proc.is_alive()
         assert proc.signal_handled()
         # Reap the signaled process
         proc.join(1)
-        assert psutil.pid_exists(proc2.pid)
-        evt.set()
-        proc2.join()
+        try:
+            assert proc2.is_alive()
+        finally:
+            evt.set()
+            proc2.join()

--- a/tests/unit/utils/test_process.py
+++ b/tests/unit/utils/test_process.py
@@ -248,7 +248,7 @@ class TestSignalHandlingMultiprocessingProcess(TestCase):
         os.kill(os.getpid(), signal.SIGTERM)
 
     @classmethod
-    def children(*args, **kwargs):
+    def children(cls, *args, **kwargs):
         raise psutil.NoSuchProcess(1)
 
     @skipIf(NO_MOCK, NO_MOCK_REASON)


### PR DESCRIPTION
### What does this PR do?

- Run loops in a single thread during transport unit tests
- Fix bugs in `salt/utils/process.py` caused by the use of `multiprocessing.utils.register_after_fork`

### What issues does this PR fix or reference?

#54174

### Tests written?

Yes

### Commits signed with GPG?

Yes