### PR TITLE
Fix flaky set_computer_name in mac_system module

### DIFF
--- a/salt/modules/mac_system.py
+++ b/salt/modules/mac_system.py
@@ -311,7 +311,7 @@ def get_computer_name():
         salt '*' system.get_computer_name
     '''
     ret = __utils__['mac_utils.execute_return_result'](
-        'systemsetup -getcomputername')
+        'scutil --get ComputerName')
 
     return __utils__['mac_utils.parse_return'](ret)
 
@@ -331,7 +331,7 @@ def set_computer_name(name):
 
         salt '*' system.set_computer_name "Mike's Mac"
     '''
-    cmd = 'systemsetup -setcomputername "{0}"'.format(name)
+    cmd = 'scutil --set ComputerName "{0}"'.format(name)
     __utils__['mac_utils.execute_return_success'](cmd)
 
     return __utils__['mac_utils.confirm_updated'](

--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -154,6 +154,7 @@ def execute_return_success(cmd):
     '''
 
     ret = _run_all(cmd)
+    log.debug('Execute return success %s: %r', cmd, ret)
 
     if ret['retcode'] != 0 or 'not supported' in ret['stdout'].lower():
         msg = 'Command Failed: {0}\n'.format(cmd)
@@ -254,6 +255,10 @@ def confirm_updated(value, check_fun, normalize_ret=False, wait=5):
     '''
     for i in range(wait):
         state = validate_enabled(check_fun()) if normalize_ret else check_fun()
+        log.debug(
+            'Confirm update try: %d func:%r state:%s value:%s',
+            i, check_fun, state, value,
+        )
         if value in state:
             return True
         time.sleep(1)

--- a/tests/integration/modules/test_mac_system.py
+++ b/tests/integration/modules/test_mac_system.py
@@ -39,6 +39,7 @@ SET_SUBNET_NAME = __random_string()
 
 
 @skip_if_not_root
+@flaky(attempts=10)
 @skipIf(not salt.utils.platform.is_darwin(), 'Test only available on macOS')
 @skipIf(not salt.utils.path.which('systemsetup'), '\'systemsetup\' binary not found in $PATH')
 class MacSystemModuleTest(ModuleCase):

--- a/tests/integration/modules/test_mac_system.py
+++ b/tests/integration/modules/test_mac_system.py
@@ -238,6 +238,7 @@ class MacSystemModuleTest(ModuleCase):
 
 
 @skip_if_not_root
+@skipIf(not salt.utils.platform.is_darwin(), 'Test only available on macOS')
 class MacSystemComputerNameTest(ModuleCase):
 
     def setUp(self):

--- a/tests/integration/modules/test_mac_system.py
+++ b/tests/integration/modules/test_mac_system.py
@@ -7,6 +7,7 @@ integration tests for mac_system
 from __future__ import absolute_import, unicode_literals, print_function
 import random
 import string
+import logging
 
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
@@ -18,6 +19,9 @@ import salt.utils.path
 import salt.utils.platform
 import salt.ext.six as six
 from salt.ext.six.moves import range
+
+
+log = logging.getLogger(__name__)
 
 
 def __random_string(size=6):
@@ -35,7 +39,6 @@ SET_SUBNET_NAME = __random_string()
 
 
 @skip_if_not_root
-@flaky(attempts=10)
 @skipIf(not salt.utils.platform.is_darwin(), 'Test only available on macOS')
 @skipIf(not salt.utils.path.which('systemsetup'), '\'systemsetup\' binary not found in $PATH')
 class MacSystemModuleTest(ModuleCase):
@@ -45,7 +48,6 @@ class MacSystemModuleTest(ModuleCase):
     ATRUN_ENABLED = False
     REMOTE_LOGIN_ENABLED = False
     REMOTE_EVENTS_ENABLED = False
-    COMPUTER_NAME = ''
     SUBNET_NAME = ''
     KEYBOARD_DISABLED = False
 
@@ -56,7 +58,6 @@ class MacSystemModuleTest(ModuleCase):
         self.ATRUN_ENABLED = self.run_function('service.enabled', ['com.apple.atrun'])
         self.REMOTE_LOGIN_ENABLED = self.run_function('system.get_remote_login')
         self.REMOTE_EVENTS_ENABLED = self.run_function('system.get_remote_events')
-        self.COMPUTER_NAME = self.run_function('system.get_computer_name')
         self.SUBNET_NAME = self.run_function('system.get_subnet_name')
         self.KEYBOARD_DISABLED = self.run_function('system.get_disable_keyboard_on_lock')
 
@@ -70,7 +71,6 @@ class MacSystemModuleTest(ModuleCase):
 
         self.run_function('system.set_remote_login', [self.REMOTE_LOGIN_ENABLED])
         self.run_function('system.set_remote_events', [self.REMOTE_EVENTS_ENABLED])
-        self.run_function('system.set_computer_name', [self.COMPUTER_NAME])
         self.run_function('system.set_subnet_name', [self.SUBNET_NAME])
         self.run_function('system.set_disable_keyboard_on_lock',
                           [self.KEYBOARD_DISABLED])
@@ -128,19 +128,6 @@ class MacSystemModuleTest(ModuleCase):
         self.assertIn(
             'Invalid String Value for Enabled',
             self.run_function('system.set_remote_events', ['spongebob']))
-
-    @skipIf(salt.utils.platform.is_darwin() and six.PY3, 'This test hangs on OS X on Py3.  Skipping until #53566 is merged.')
-    @destructiveTest
-    def test_get_set_computer_name(self):
-        '''
-        Test system.get_computer_name
-        Test system.set_computer_name
-        '''
-        self.assertTrue(
-            self.run_function('system.set_computer_name', [SET_COMPUTER_NAME]))
-        self.assertEqual(
-            self.run_function('system.get_computer_name'),
-            SET_COMPUTER_NAME)
 
     @destructiveTest
     def test_get_set_subnet_name(self):
@@ -248,3 +235,32 @@ class MacSystemModuleTest(ModuleCase):
         self.assertIn(
             'Invalid value passed for arch',
             self.run_function('system.set_boot_arch', ['spongebob']))
+
+
+@skip_if_not_root
+class MacSystemComputerNameTest(ModuleCase):
+
+    def setUp(self):
+        self.COMPUTER_NAME = self.run_function('system.get_computer_name')
+        self.wait_for_all_jobs()
+
+    def tearDown(self):
+        self.run_function('system.set_computer_name', [self.COMPUTER_NAME])
+        self.wait_for_all_jobs()
+
+    # A similar test used to be skipped on py3 due to 'hanging', if we see
+    # something similar again we may want to skip this gain until we
+    # investigate
+    #@skipIf(salt.utils.platform.is_darwin() and six.PY3, 'This test hangs on OS X on Py3.  Skipping until #53566 is merged.')
+    @destructiveTest
+    def test_get_set_computer_name(self):
+        '''
+        Test system.get_computer_name
+        Test system.set_computer_name
+        '''
+        log.debug("Set name is %s", SET_COMPUTER_NAME)
+        self.assertTrue(
+            self.run_function('system.set_computer_name', [SET_COMPUTER_NAME]))
+        self.assertEqual(
+            self.run_function('system.get_computer_name'),
+            SET_COMPUTER_NAME)

--- a/tests/integration/modules/test_mac_system.py
+++ b/tests/integration/modules/test_mac_system.py
@@ -17,7 +17,6 @@ from tests.support.helpers import destructiveTest, skip_if_not_root, flaky
 # Import salt libs
 import salt.utils.path
 import salt.utils.platform
-import salt.ext.six as six
 from salt.ext.six.moves import range
 
 


### PR DESCRIPTION
### What does this PR do?

Use `scutil` instead of `systemsetup` to set and get the computer name on MacOS. `systemsetup` is from 2002 and is not reliable at setting the computer name.

```
(venv) root@carbon:~/src/salt-forge/2019.2.1-tests/salt# systemsetup -setcomputername "RS-KFQZY1"
setcomputername: RS-KFQZY1
(venv) root@carbon:~/src/salt-forge/2019.2.1-tests/salt# systemsetup -getcomputername
Computer Name: RS-KFQZYP
(venv) root@carbon:~/src/salt-forge/2019.2.1-tests/salt# systemsetup -getcomputername
Computer Name: RS-KFQZYP
(venv) root@carbon:~/src/salt-forge/2019.2.1-tests/salt# systemsetup -getcomputername
Computer Name: RS-KFQZYP
(venv) root@carbon:~/src/salt-forge/2019.2.1-tests/salt# systemsetup -getcomputername
Computer Name: RS-KFQZYP
(venv) root@carbon:~/src/salt-forge/2019.2.1-tests/salt# systemsetup -getcomputername
Computer Name: RS-KFQZYP
(venv) root@carbon:~/src/salt-forge/2019.2.1-tests/salt# systemsetup -setcomputername "RS-KFQZY1"
setcomputername: RS-KFQZY1
(venv) root@carbon:~/src/salt-forge/2019.2.1-tests/salt# systemsetup -getcomputername
Computer Name: RS-KFQZYP
(venv) root@carbon:~/src/salt-forge/2019.2.1-tests/salt# systemsetup -getcomputername
Computer Name: RS-KFQZYP
(venv) root@carbon:~/src/salt-forge/2019.2.1-tests/salt# systemsetup -getcomputername
Computer Name: RS-KFQZYP
```

`scutil` is from 2008 and `scutil --set ComputerName "RS-KFQZY1"` works reliably.

### Tests written?

No - Has existing test coverage that was failing

### Commits signed with GPG?

Yes