### PR TITLE
[2019.2.1] Addition logging in testprogram used by integration.shell.test_minion.MinionTest.test_exit_status_correct_usage

### DIFF
--- a/tests/integration/utils/testprogram.py
+++ b/tests/integration/utils/testprogram.py
@@ -828,6 +828,10 @@ class TestDaemon(TestProgram):
                 except psutils.AccessDenied:
                     # We might get access denied if not running as root
                     if not salt.utils.platform.is_windows():
+                        pinfo = proc.as_dict(attrs=['pid', 'name', 'username'])
+                        log.error('Unable to access process %s, '
+                                  'running command %s as user %s',
+                                  pinfo['pid'], pinfo['name'], pinfo['username'])
                         raise
                 if any((cmdline == proc_cmdline[n:n + cmd_len])
                         for n in range(len(proc_cmdline) - cmd_len + 1)):


### PR DESCRIPTION
### What does this PR do?
Adding some additional logging when the call to "proc_cmdline = proc.cmdline()" reults in a AccessDenied exception, so we can see what the process is and who the process is running as.

### What issues does this PR fix or reference?
N/A

### Previous Behavior
The test `integration.shell.test_minion.MinionTest.test_exit_status_correct_usage` occasionally fails on MacOS.

### New Behavior
Adding some additional logging to see what process is cause the failure.

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.
No.  Attempting to fix a failing test.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
