### PR TITLE
Only run one filter test

### DIFF
--- a/tests/integration/ssh/test_jinja_filters.py
+++ b/tests/integration/ssh/test_jinja_filters.py
@@ -5,11 +5,20 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Testing Libs
 from tests.support.case import SSHCase
-from tests.support.jinja_filters import JinjaFiltersTest
 
 
-class SSHJinjaFiltersTest(SSHCase, JinjaFiltersTest):
+class SSHJinjaFiltersTest(SSHCase):
     '''
     testing Jinja filters are available via state system & salt-ssh
     '''
-    pass
+
+    def test_dateutils_strftime(self):
+        '''
+        test jinja filter datautils.strftime
+        '''
+        arg = self._arg_str('state.sls', ['jinja_filters.dateutils_strftime'])
+        ret = self.run_ssh(arg)
+        import salt.utils.json
+        ret = salt.utils.json.loads(ret)['localhost']
+        self.assertIn('module_|-test_|-test.echo_|-run', ret)
+        self.assertIn('ret', ret['module_|-test_|-test.echo_|-run']['changes'])


### PR DESCRIPTION
### What does this PR do?

We're already running jinja filter tests elsewhere, running them all
on ssh takes 30 minutes. 

### What issues does this PR fix or reference?

### Previous Behavior

SSH tests take extra long

### New Behavior

SSH tests don't take nearly as long

### Tests written?

Improving tests