### PR TITLE
Remove noisy debug logging from config.get

### DIFF
--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -480,7 +480,6 @@ def get(
         ret = salt.utils.data.traverse_dict_and_list(
             DEFAULTS, key, "_|-", delimiter=delimiter
         )
-        log.debug("key: %s, ret: %s", key, ret)
         if ret != "_|-":
             return sdb.sdb_get(ret, __opts__)
     else:


### PR DESCRIPTION
This is not helpful and results in a bunch of noise in debug logging, since config.get is used in a lot of places.