### PR TITLE
file.drectory should return True instead of None in test mode

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -798,7 +798,7 @@ def _check_directory(name,
         for fn_ in changes:
             for key, val in six.iteritems(changes[fn_]):
                 comments.append('{0}: {1} - {2}\n'.format(fn_, key, val))
-        return None, ''.join(comments), changes
+        return True, ''.join(comments), changes
     return True, 'The directory {0} is in the correct state'.format(name), changes
 
 


### PR DESCRIPTION
I think all states should return a dict with `result: True` unless they run into errors.
Returning `result: None` in test mode will break requisites like `prereq`.