### PR TITLE
Fix zpool state's return values for test mode

### DIFF
--- a/salt/states/zpool.py
+++ b/salt/states/zpool.py
@@ -295,11 +295,9 @@ def present(name, properties=None, filesystem_properties=None, layout=None, conf
     # don't do anything because this is a test
     if __opts__['test']:
         ret['result'] = True
-        if __salt__['zpool.exists'](name):
-            ret['changes'][name] = 'uptodate'
-        else:
-            ret['changes'][name] = 'imported' if config['import'] else 'created'
-        ret['comment'] = 'storage pool {0} was {1}'.format(name, ret['changes'][name])
+        if not __salt__['zpool.exists'](name):
+            ret['result'] = None
+            ret['comment'] = 'zpool "{0}" will be created'.format(name)
 
     # update pool
     elif __salt__['zpool.exists'](name):
@@ -409,7 +407,8 @@ def absent(name, export=False, force=False):
 
         # NOTE: handle test
         if __opts__['test']:
-            ret['result'] = True
+            ret['result'] = None
+            ret['comment'] = 'zpool "{}" will be destroyed'.format(name)
 
         # NOTE: try to export the pool
         elif export:


### PR DESCRIPTION
## What does this PR do?

Fix test mode for `zpool.present` and `zpool.absent`.

### What issues does this PR fix or reference?

(None)

### Previous Behavior

The `zpool` state would return changes when executed in test mode when no changes are pending and return ``result=True` in test mode when changes were pending.

### New Behavior

- `result` should be `None` for pending changes
- `changes` should be empty when run in test mode.
- Tweak test `comment` for present/absent

### Tests written?

No - I tried to get tests setup but something appears awry on `develop` when I try to run them. Rather than delay this PR, I'll open it and try to get tests in-place if they are required for this change.

### Commits signed with GPG?

Yes
