### PR TITLE
Remove unnecessary logging from minion.py

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -3308,7 +3308,6 @@ class ProxyMinionManager(MinionManager):
 
 
 def _metaproxy_call(opts, fn_name):
-    log.debug('=== here ====')
     metaproxy = salt.loader.metaproxy(opts)
     try:
         metaproxy_name = opts['metaproxy']


### PR DESCRIPTION
Remove unnecessary logging from minion.py. Looks like this was possibly left over from debugging an issue.