### PR TITLE
Test verify logs without a whole minion

### DIFF
--- a/salt/cli/api.py
+++ b/salt/cli/api.py
@@ -15,7 +15,7 @@ import logging
 import salt.client.netapi
 import salt.utils.files
 import salt.utils.parsers as parsers
-from salt.utils.verify import check_user, verify_files, verify_log
+from salt.utils.verify import check_user, verify_log_files, verify_log
 
 log = logging.getLogger(__name__)
 
@@ -38,12 +38,10 @@ class SaltAPI(parsers.SaltAPIParser):
         try:
             if self.config['verify_env']:
                 logfile = self.config['log_file']
-                if logfile is not None and not logfile.startswith(('tcp://',
-                                                                   'udp://',
-                                                                   'file://')):
+                if logfile is not None:
                     # Logfile is not using Syslog, verify
                     with salt.utils.files.set_umask(0o027):
-                        verify_files([logfile], self.config['user'])
+                        verify_log_files([logfile], self.config['user'])
         except OSError as err:
             log.exception('Failed to prepare salt environment')
             self.shutdown(err.errno)

--- a/salt/cloud/cli.py
+++ b/salt/cloud/cli.py
@@ -28,7 +28,7 @@ import salt.utils.cloud
 import salt.utils.parsers
 import salt.utils.user
 from salt.exceptions import SaltCloudException, SaltCloudSystemExit
-from salt.utils.verify import check_user, verify_env, verify_files, verify_log
+from salt.utils.verify import check_user, verify_env, verify_log_files, verify_log
 
 # Import 3rd-party libs
 from salt.ext import six
@@ -70,11 +70,9 @@ class SaltCloud(salt.utils.parsers.SaltCloudParser):
                     root_dir=self.config['root_dir'],
                 )
                 logfile = self.config['log_file']
-                if logfile is not None and not logfile.startswith('tcp://') \
-                        and not logfile.startswith('udp://') \
-                        and not logfile.startswith('file://'):
+                if logfile is not None:
                     # Logfile is not using Syslog, verify
-                    verify_files([logfile], salt_master_user)
+                    verify_log_files([logfile], salt_master_user)
         except (IOError, OSError) as err:
             log.error('Error while verifying the environment: %s', err)
             sys.exit(err.errno)

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -43,7 +43,7 @@ import salt.utils.xdg
 import salt.utils.yaml
 from salt.defaults import DEFAULT_TARGET_DELIM
 from salt.utils.validate.path import is_writeable
-from salt.utils.verify import verify_files
+from salt.utils.verify import verify_log_files
 import salt.exceptions
 from salt.ext import six
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
@@ -723,10 +723,10 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
         if self.config['verify_env'] and self.config['log_level'] not in ('quiet', ):
             # Verify the logfile if it was explicitly set but do not try to
             # verify the default
-            if logfile is not None and not logfile.startswith(('tcp://', 'udp://', 'file://')):
+            if logfile is not None:
                 # Logfile is not using Syslog, verify
                 with salt.utils.files.set_umask(0o027):
-                    verify_files([logfile], self.config['user'])
+                    verify_log_files([logfile], self.config['user'])
 
         if logfile is None:
             # Use the default setting if the logfile wasn't explicity set

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -35,7 +35,7 @@ import salt.utils.user
 log = logging.getLogger(__name__)
 
 ROOT_DIR = 'c:\\salt' if salt.utils.platform.is_windows() else '/'
-
+DEFAULT_SCHEMES = ['tcp://', 'udp://', 'file://',]
 
 def zmq_version():
     '''
@@ -144,6 +144,28 @@ def verify_socket(interface, pub_port, ret_port):
             sock.close()
 
     return True
+
+
+def verify_logs_filter(files):
+    to_verify = []
+    for filename in files:
+        verify_file = True
+        for scheme in DEFAULT_SCHEMES:
+            if filename.startswith(scheme):
+                verify_file = False
+                break
+        if verify_file:
+            to_verify.append(filename)
+    return to_verify
+
+
+def verify_log_files(files, user):
+    '''
+    Verify the log files exist and are owned by the named user.  Filenames that
+    begin with tcp:// and udp:// will be filtered out. Filenames that begin
+    with file:// are handled correctly
+    '''
+    return verify_files(verify_logs_filter(files), user)
 
 
 def verify_files(files, user):

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -35,7 +35,8 @@ import salt.utils.user
 log = logging.getLogger(__name__)
 
 ROOT_DIR = 'c:\\salt' if salt.utils.platform.is_windows() else '/'
-DEFAULT_SCHEMES = ['tcp://', 'udp://', 'file://',]
+DEFAULT_SCHEMES = ['tcp://', 'udp://', 'file://']
+
 
 def zmq_version():
     '''

--- a/tests/integration/shell/test_call.py
+++ b/tests/integration/shell/test_call.py
@@ -151,43 +151,6 @@ class CallTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin
         self.assertTrue(True in ['returnTOmaster' in a for a in master_out])
 
     @skipIf(salt.utils.platform.is_windows(), 'Skip on Windows')
-    def test_issue_7754(self):
-        old_cwd = os.getcwd()
-        config_dir = os.path.join(TMP, 'issue-7754')
-        if not os.path.isdir(config_dir):
-            os.makedirs(config_dir)
-
-        os.chdir(config_dir)
-
-        with salt.utils.files.fopen(self.get_config_file_path('minion'), 'r') as fh_:
-            minion_config = salt.utils.yaml.safe_load(fh_)
-            minion_config['log_file'] = 'file:///dev/log/LOG_LOCAL3'
-            with salt.utils.files.fopen(os.path.join(config_dir, 'minion'), 'w') as fh_:
-                salt.utils.yaml.safe_dump(minion_config, fh_, default_flow_style=False)
-        ret = self.run_script(
-            'salt-call',
-            '--config-dir {0} cmd.run "echo foo"'.format(
-                config_dir
-            ),
-            timeout=60,
-            catch_stderr=True,
-            with_retcode=True
-        )
-        try:
-            self.assertIn('local:', ret[0])
-            self.assertFalse(os.path.isdir(os.path.join(config_dir, 'file:')))
-        except AssertionError:
-            # We now fail when we're unable to properly set the syslog logger
-            self.assertIn(
-                'Failed to setup the Syslog logging handler', '\n'.join(ret[1])
-            )
-            self.assertEqual(ret[2], 2)
-        finally:
-            self.chdir(old_cwd)
-            if os.path.isdir(config_dir):
-                shutil.rmtree(config_dir)
-
-    @skipIf(salt.utils.platform.is_windows(), 'Skip on Windows')
     def test_syslog_file_not_found(self):
         '''
         test when log_file is set to a syslog file that does not exist

--- a/tests/integration/shell/test_cp.py
+++ b/tests/integration/shell/test_cp.py
@@ -9,18 +9,14 @@
 
 # Import python libs
 from __future__ import absolute_import
-import errno
 import os
 import pipes
-import shutil
-import tempfile
 import logging
 
 # Import Salt Testing libs
 from tests.support.case import ShellCase
 from tests.support.paths import TMP
 from tests.support.mixins import ShellCaseCommonTestsMixin
-from tests.support.unit import skipIf
 
 # Import salt libs
 import salt.utils.platform

--- a/tests/integration/shell/test_cp.py
+++ b/tests/integration/shell/test_cp.py
@@ -36,8 +36,6 @@ log = logging.getLogger(__name__)
 
 class CopyTest(ShellCase, ShellCaseCommonTestsMixin):
 
-    _call_binary_ = 'salt-cp'
-
     def test_cp_testfile(self):
         '''
         test salt-cp
@@ -126,59 +124,3 @@ class CopyTest(ShellCase, ShellCaseCommonTestsMixin):
             )
             data = salt.utils.yaml.safe_load('\n'.join(ret))
             self.assertTrue(data[minion])
-
-    @skipIf(salt.utils.platform.is_windows(), 'Skip on Windows OS')
-    def test_issue_7754(self):
-        config_dir = os.path.join(TMP, 'issue-7754')
-
-        try:
-            os.makedirs(config_dir)
-        except OSError as exc:
-            if exc.errno != errno.EEXIST:
-                raise
-
-        config_file_name = 'master'
-        with salt.utils.files.fopen(self.get_config_file_path(config_file_name), 'r') as fhr:
-            config = salt.utils.yaml.safe_load(fhr)
-            config['log_file'] = 'file:///dev/log/LOG_LOCAL3'
-            with salt.utils.files.fopen(os.path.join(config_dir, config_file_name), 'w') as fhw:
-                salt.utils.yaml.safe_dump(config, fhw, default_flow_style=False)
-
-        try:
-            fd_, fn_ = tempfile.mkstemp()
-            os.close(fd_)
-
-            with salt.utils.files.fopen(fn_, 'w') as fp_:
-                fp_.write('Hello world!\n')
-
-            ret = self.run_script(
-                self._call_binary_,
-                '--out pprint --config-dir {0} \'*minion\' {1} {0}/{2}'.format(
-                    config_dir,
-                    fn_,
-                    os.path.basename(fn_),
-                ),
-                catch_stderr=True,
-                with_retcode=True
-            )
-
-            self.assertIn('minion', '\n'.join(ret[0]))
-            self.assertIn('sub_minion', '\n'.join(ret[0]))
-            self.assertFalse(os.path.isdir(os.path.join(config_dir, 'file:')))
-        except AssertionError:
-            if os.path.exists('/dev/log') and ret[2] != 2:
-                # If there's a syslog device and the exit code was not 2, 'No
-                # such file or directory', raise the error
-                raise
-            self.assertIn(
-                'Failed to setup the Syslog logging handler', '\n'.join(ret[1])
-            )
-            self.assertEqual(ret[2], 2)
-        finally:
-            try:
-                os.remove(fn_)
-            except OSError as exc:
-                if exc.errno != errno.ENOENT:
-                    raise
-            if os.path.isdir(config_dir):
-                shutil.rmtree(config_dir)

--- a/tests/integration/shell/test_key.py
+++ b/tests/integration/shell/test_key.py
@@ -281,32 +281,3 @@ class KeyTest(ShellCase, ShellCaseCommonTestsMixin):
             )
         finally:
             shutil.rmtree(tempdir)
-
-    def test_issue_7754(self):
-        old_cwd = os.getcwd()
-        config_dir = os.path.join(TMP, 'issue-7754')
-        if not os.path.isdir(config_dir):
-            os.makedirs(config_dir)
-
-        os.chdir(config_dir)
-
-        config_file_name = 'master'
-        with salt.utils.files.fopen(self.get_config_file_path(config_file_name), 'r') as fhr:
-            config = salt.utils.yaml.safe_load(fhr)
-            config['log_file'] = 'file:///dev/log/LOG_LOCAL3'
-            with salt.utils.files.fopen(os.path.join(config_dir, config_file_name), 'w') as fhw:
-                salt.utils.yaml.safe_dump(config, fhw, default_flow_style=False)
-        ret = self.run_script(
-            self._call_binary_,
-            '--config-dir {0} -L'.format(
-                config_dir
-            ),
-            timeout=60
-        )
-        try:
-            self.assertIn('minion', '\n'.join(ret))
-            self.assertFalse(os.path.isdir(os.path.join(config_dir, 'file:')))
-        finally:
-            self.chdir(old_cwd)
-            if os.path.isdir(config_dir):
-                shutil.rmtree(config_dir)

--- a/tests/integration/shell/test_master.py
+++ b/tests/integration/shell/test_master.py
@@ -29,53 +29,6 @@ from tests.integration.utils import testprogram
 @skipIf(True, 'This test file should be in an isolated test space.')
 class MasterTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin):
 
-    _call_binary_ = 'salt-master'
-
-    def test_issue_7754(self):
-        old_cwd = os.getcwd()
-        config_dir = os.path.join(TMP, 'issue-7754')
-        if not os.path.isdir(config_dir):
-            os.makedirs(config_dir)
-
-        os.chdir(config_dir)
-
-        config_file_name = 'master'
-        pid_path = os.path.join(config_dir, '{0}.pid'.format(config_file_name))
-        with salt.utils.files.fopen(self.get_config_file_path(config_file_name), 'r') as fhr:
-            config = salt.utils.yaml.safe_load(fhr)
-            config['root_dir'] = config_dir
-            config['log_file'] = 'file:///tmp/log/LOG_LOCAL3'
-            config['ret_port'] = config['ret_port'] + 10
-            config['publish_port'] = config['publish_port'] + 10
-
-            with salt.utils.files.fopen(os.path.join(config_dir, config_file_name), 'w') as fhw:
-                salt.utils.yaml.safe_dump(config, fhw, default_flow_style=False)
-
-        ret = self.run_script(
-            self._call_binary_,
-            '--config-dir {0} --pid-file {1} -l debug'.format(
-                config_dir,
-                pid_path
-            ),
-            timeout=5,
-            catch_stderr=True,
-            with_retcode=True
-        )
-
-        # Now kill it if still running
-        if os.path.exists(pid_path):
-            with salt.utils.files.fopen(pid_path) as fhr:
-                try:
-                    os.kill(int(fhr.read()), signal.SIGKILL)
-                except OSError:
-                    pass
-        try:
-            self.assertFalse(os.path.isdir(os.path.join(config_dir, 'file:')))
-        finally:
-            self.chdir(old_cwd)
-            if os.path.isdir(config_dir):
-                shutil.rmtree(config_dir)
-
     def test_exit_status_unknown_user(self):
         '''
         Ensure correct exit status when the master is configured to run as an unknown user.

--- a/tests/integration/shell/test_master.py
+++ b/tests/integration/shell/test_master.py
@@ -9,18 +9,10 @@
 
 # Import python libs
 from __future__ import absolute_import
-import os
-import signal
-import shutil
-
-# Import salt libs
-import salt.utils.files
-import salt.utils.yaml
 
 # Import salt test libs
 import tests.integration.utils
 from tests.support.case import ShellCase
-from tests.support.paths import TMP
 from tests.support.mixins import ShellCaseCommonTestsMixin
 from tests.support.unit import skipIf
 from tests.integration.utils import testprogram

--- a/tests/integration/shell/test_matcher.py
+++ b/tests/integration/shell/test_matcher.py
@@ -2,15 +2,12 @@
 
 # Import python libs
 from __future__ import absolute_import
-import os
-import shutil
 import time
 
 # Import Salt Testing libs
 from tests.support.case import ShellCase
 from tests.support.helpers import flaky
 from tests.support.mixins import ShellCaseCommonTestsMixin
-from tests.support.paths import TMP
 from tests.support.unit import skipIf
 
 # Import salt libs

--- a/tests/integration/shell/test_matcher.py
+++ b/tests/integration/shell/test_matcher.py
@@ -26,7 +26,6 @@ class MatchTest(ShellCase, ShellCaseCommonTestsMixin):
     '''
     Test salt matchers
     '''
-    _call_binary_ = 'salt'
 
     def test_list(self):
         '''
@@ -365,44 +364,3 @@ class MatchTest(ShellCase, ShellCaseCommonTestsMixin):
         '''
         data = self.run_salt('-d minion salt ldap.search "filter=ou=People"', catch_stderr=True)
         self.assertIn('You can only get documentation for one method at one time', '\n'.join(data[1]))
-
-    @skipIf(salt.utils.platform.is_windows(), 'Skip on Windows OS')
-    def test_issue_7754(self):
-        '''
-        Skip on Windows because Syslog is not installed
-        '''
-        old_cwd = os.getcwd()
-        config_dir = os.path.join(TMP, 'issue-7754')
-        if not os.path.isdir(config_dir):
-            os.makedirs(config_dir)
-
-        os.chdir(config_dir)
-
-        config_file_name = 'master'
-        with salt.utils.files.fopen(self.get_config_file_path(config_file_name), 'r') as fhr:
-            config = salt.utils.yaml.safe_load(fhr)
-            config['log_file'] = 'file:///dev/log/LOG_LOCAL3'
-            with salt.utils.files.fopen(os.path.join(config_dir, config_file_name), 'w') as fhw:
-                salt.utils.yaml.safe_dump(config, fhw, default_flow_style=False)
-        ret = self.run_script(
-            self._call_binary_,
-            '--config-dir {0} minion test.ping'.format(
-                config_dir
-            ),
-            timeout=60,
-            catch_stderr=True,
-            with_retcode=True
-        )
-        try:
-            self.assertIn('minion', '\n'.join(ret[0]))
-            self.assertFalse(os.path.isdir(os.path.join(config_dir, 'file:')))
-        except AssertionError:
-            # We now fail when we're unable to properly set the syslog logger
-            self.assertIn(
-                'Failed to setup the Syslog logging handler', '\n'.join(ret[1])
-            )
-            self.assertEqual(ret[2], 2)
-        finally:
-            self.chdir(old_cwd)
-            if os.path.isdir(config_dir):
-                shutil.rmtree(config_dir)

--- a/tests/integration/shell/test_minion.py
+++ b/tests/integration/shell/test_minion.py
@@ -13,15 +13,13 @@ import getpass
 import os
 import sys
 import platform
-import signal
-import shutil
 import logging
 
 # Import Salt Testing libs
 import tests.integration.utils
 from tests.support.case import ShellCase
 from tests.support.unit import skipIf
-from tests.support.paths import CODE_DIR, TMP
+from tests.support.paths import CODE_DIR
 from tests.support.mixins import ShellCaseCommonTestsMixin
 from tests.integration.utils import testprogram
 

--- a/tests/integration/shell/test_minion.py
+++ b/tests/integration/shell/test_minion.py
@@ -49,51 +49,6 @@ class MinionTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMix
         'subminion',
     )
 
-    @skipIf(salt.utils.platform.is_darwin(), 'Test is flaky on macosx')
-    @skipIf(salt.utils.platform.is_fedora(), 'Test is flaky on fedora')
-    def test_issue_7754(self):
-        old_cwd = os.getcwd()
-        config_dir = os.path.join(TMP, 'issue-7754')
-        if not os.path.isdir(config_dir):
-            os.makedirs(config_dir)
-
-        os.chdir(config_dir)
-
-        config_file_name = 'minion'
-        pid_path = os.path.join(config_dir, '{0}.pid'.format(config_file_name))
-        with salt.utils.files.fopen(self.get_config_file_path(config_file_name), 'r') as fhr:
-            config = salt.utils.yaml.safe_load(fhr)
-            config['log_file'] = 'file:///tmp/log/LOG_LOCAL3'
-            config['id'] = 'issue-7754'
-
-            with salt.utils.files.fopen(os.path.join(config_dir, config_file_name), 'w') as fhw:
-                salt.utils.yaml.safe_dump(config, fhw, default_flow_style=False)
-
-        ret = self.run_script(
-            self._call_binary_,
-            '--disable-keepalive --config-dir {0} --pid-file {1} -l debug'.format(
-                config_dir,
-                pid_path
-            ),
-            timeout=5,
-            catch_stderr=True,
-            with_retcode=True
-        )
-
-        # Now kill it if still running
-        if os.path.exists(pid_path):
-            with salt.utils.files.fopen(pid_path) as fhr:
-                try:
-                    os.kill(int(fhr.read()), signal.SIGKILL)
-                except OSError:
-                    pass
-        try:
-            self.assertFalse(os.path.isdir(os.path.join(config_dir, 'file:')))
-        finally:
-            self.chdir(old_cwd)
-            if os.path.isdir(config_dir):
-                shutil.rmtree(config_dir)
-
     def _run_initscript(
         self,
         init_script,

--- a/tests/integration/shell/test_minion.py
+++ b/tests/integration/shell/test_minion.py
@@ -42,7 +42,6 @@ class MinionTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMix
     '''
     Various integration tests for the salt-minion executable.
     '''
-    _call_binary_ = 'salt-minion'
 
     _test_minions = (
         'minion',

--- a/tests/integration/shell/test_runner.py
+++ b/tests/integration/shell/test_runner.py
@@ -6,16 +6,12 @@ Tests for the salt-run command
 
 # Import Python libs
 from __future__ import absolute_import
-import os
-import shutil
 
 # Import Salt Testing libs
 from tests.integration.utils import testprogram
 from tests.support.case import ShellCase
-from tests.support.paths import TMP
 from tests.support.mixins import ShellCaseCommonTestsMixin
 from tests.support.helpers import skip_if_not_root
-from tests.support.unit import skipIf
 
 # Import Salt libs
 import salt.utils.files

--- a/tests/integration/shell/test_runner.py
+++ b/tests/integration/shell/test_runner.py
@@ -33,8 +33,6 @@ class RunTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin)
     Test the salt-run command
     '''
 
-    _call_binary_ = 'salt-run'
-
     def _add_user(self):
         '''
         helper method to add user
@@ -91,51 +89,6 @@ class RunTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin)
         '''
         data = self.run_run('-d virt.list foo', catch_stderr=True)
         self.assertIn('You can only get documentation for one method at one time', '\n'.join(data[1]))
-
-    @skipIf(salt.utils.platform.is_windows(), 'Skip on Windows OS')
-    def test_issue_7754(self):
-        '''
-        Skip on windows because syslog not available
-        '''
-        old_cwd = os.getcwd()
-        config_dir = os.path.join(TMP, 'issue-7754')
-        if not os.path.isdir(config_dir):
-            os.makedirs(config_dir)
-
-        os.chdir(config_dir)
-
-        config_file_name = 'master'
-        with salt.utils.files.fopen(self.get_config_file_path(config_file_name), 'r') as fhr:
-            config = salt.utils.yaml.safe_load(fhr)
-            config['log_file'] = 'file:///dev/log/LOG_LOCAL3'
-            with salt.utils.files.fopen(os.path.join(config_dir, config_file_name), 'w') as fhw:
-                salt.utils.yaml.safe_dump(config, fhw, default_flow_style=False)
-        ret = self.run_script(
-            self._call_binary_,
-            '--config-dir {0} -d'.format(
-                config_dir
-            ),
-            timeout=60,
-            catch_stderr=True,
-            with_retcode=True
-        )
-        try:
-            self.assertIn('doc.runner:', ret[0])
-            self.assertFalse(os.path.isdir(os.path.join(config_dir, 'file:')))
-        except AssertionError:
-            if os.path.exists('/dev/log') and ret[2] != 2:
-                # If there's a syslog device and the exit code was not 2,
-                # 'No such file or directory', raise the error
-                raise
-            self.assertIn(
-                'Failed to setup the Syslog logging handler',
-                '\n'.join(ret[1])
-            )
-            self.assertEqual(ret[2], 2)
-        finally:
-            self.chdir(old_cwd)
-            if os.path.isdir(config_dir):
-                shutil.rmtree(config_dir)
 
     def test_exit_status_unknown_argument(self):
         '''

--- a/tests/integration/shell/test_syndic.py
+++ b/tests/integration/shell/test_syndic.py
@@ -36,54 +36,6 @@ class SyndicTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMix
     Test the salt-syndic command
     '''
 
-    _call_binary_ = 'salt-syndic'
-
-    def test_issue_7754(self):
-        old_cwd = os.getcwd()
-        config_dir = os.path.join(TMP, 'issue-7754')
-        if not os.path.isdir(config_dir):
-            os.makedirs(config_dir)
-
-        os.chdir(config_dir)
-
-        for fname in ('master', 'minion'):
-            pid_path = os.path.join(config_dir, '{0}.pid'.format(fname))
-            with salt.utils.files.fopen(self.get_config_file_path(fname), 'r') as fhr:
-                config = salt.utils.yaml.safe_load(fhr)
-                config['log_file'] = config['syndic_log_file'] = 'file:///tmp/log/LOG_LOCAL3'
-                config['root_dir'] = config_dir
-                if 'ret_port' in config:
-                    config['ret_port'] = int(config['ret_port']) + 10
-                    config['publish_port'] = int(config['publish_port']) + 10
-
-                with salt.utils.files.fopen(os.path.join(config_dir, fname), 'w') as fhw:
-                    salt.utils.yaml.safe_dump(config, fhw, default_flow_style=False)
-
-        ret = self.run_script(
-            self._call_binary_,
-            '--config-dir={0} --pid-file={1} -l debug'.format(
-                config_dir,
-                pid_path
-            ),
-            timeout=5,
-            catch_stderr=True,
-            with_retcode=True
-        )
-
-        # Now kill it if still running
-        if os.path.exists(pid_path):
-            with salt.utils.files.fopen(pid_path) as fhr:
-                try:
-                    os.kill(int(fhr.read()), SIGKILL)
-                except OSError:
-                    pass
-        try:
-            self.assertFalse(os.path.isdir(os.path.join(config_dir, 'file:')))
-        finally:
-            self.chdir(old_cwd)
-            if os.path.isdir(config_dir):
-                shutil.rmtree(config_dir)
-
     @skipIf(salt.utils.platform.is_windows(), 'Skip on Windows OS')
     def test_exit_status_unknown_user(self):
         '''

--- a/tests/integration/shell/test_syndic.py
+++ b/tests/integration/shell/test_syndic.py
@@ -9,13 +9,10 @@
 
 # Import python libs
 from __future__ import absolute_import
-import os
-import shutil
 import logging
 
 # Import Salt Testing libs
 from tests.support.case import ShellCase
-from tests.support.paths import TMP
 from tests.support.mixins import ShellCaseCommonTestsMixin
 from tests.support.unit import skipIf
 from tests.integration.utils import testprogram


### PR DESCRIPTION
### What does this PR do?

Refactor and simplify tests that verify we don't create directories from schemes (eg `file://foo/bar`)

The test `integration.shell.test_minion.MinionTest.test_issue_7754` is hanging on python 3.6. We don't need a whole minion to test such a small case so remove `integration.shell.test_minion.MinionTest.test_issue_7754` and simplify how we are testing for the issue.

### What issues does this PR fix or reference?

#7745

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

Yes

### Commits signed with GPG?

Yes

