### PR TITLE
Fix minion schedue when using pillar

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -404,6 +404,7 @@ class Schedule(object):
     # an init for the singleton instance to call
     def __singleton_init__(self, opts, functions, returners=None, intervals=None, cleanup=None, proxy=None, utils=None):
         self.opts = opts
+        self.schedule = {}
         self.proxy = proxy
         self.functions = functions
         self.utils = utils
@@ -452,7 +453,17 @@ class Schedule(object):
             if not isinstance(opts_schedule, dict):
                 raise ValueError('Schedule must be of type dict.')
             schedule.update(opts_schedule)
-        return schedule
+
+        for job, data in six.iteritems(schedule):
+            if not isinstance(data, dict):
+                self.schedule.update({job: data})
+                continue
+            if job not in self.schedule:
+                self.schedule.update({job: data})
+                continue
+            if not all([self.schedule.get(job, {}).get(k) == v for k, v in six.iteritems(data)]):
+                self.schedule.update({job: data})
+        return self.schedule
 
     def persist(self):
         '''


### PR DESCRIPTION
### What does this PR do?

When a minion schedule is added via a pillar it is stored in the
`Schedule` class under `self.opts['pillar']['schedule']`. When the
schedule runs it adds keys to the job dict under
`self.opts['pillar']['schedule']`, one of which is `_next_fire_time`,
this indicates when the job should next run. When the minion pillar is
refreshed `self.opts['pillar']['schedule']` is set back to exactly what
appears in the pillar, therefore removing the `_next_fire_time` along
with the others added by the `eval` function. This means that if you
have a job scheduled to run every 10 minutes, and you refresh your
pillars every 9 minutes, then the job will never run. Also if you have
`run_on_start` set for a job then this will run every time the pillar is
refreshed.

To fix this I have copied the jobs from both the pillar and the opts
into `self.schedule` and return this object for use by other functions.
If the schedule config is updated then the new details are copied to
`self.schedule`.

### Tests written?
No

### Commits signed with GPG?

No
