### PR TITLE
2018.3 fix 46034

### DIFF
--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -201,6 +201,9 @@ def yamlify_arg(arg):
             # will become None. Keep this value from being stomped as well.
             elif arg is None and original_arg.strip().startswith('#'):
                 return original_arg
+            # The condition below happens in 2018.3 only. Do not merge-forward.
+            elif arg is None and original_arg == '!':
+                return original_arg
             else:
                 return arg
         else:

--- a/tests/unit/utils/test_args.py
+++ b/tests/unit/utils/test_args.py
@@ -257,7 +257,7 @@ class ArgsTestCase(TestCase):
         item = '|'
         self.assertIs(_yamlify_arg(item), item)
 
-        # Make sure we don't load '!' as None (only happens in 2018.3)
+        # Make sure we don't load '!' as something else (None in 2018.3, '' in newer)
         item = '!'
         self.assertIs(_yamlify_arg(item), item)
 

--- a/tests/unit/utils/test_args.py
+++ b/tests/unit/utils/test_args.py
@@ -257,6 +257,10 @@ class ArgsTestCase(TestCase):
         item = '|'
         self.assertIs(_yamlify_arg(item), item)
 
+        # Make sure we don't load '!' as None (only happens in 2018.3)
+        item = '!'
+        self.assertIs(_yamlify_arg(item), item)
+
         # Make sure we load ints, floats, and strings correctly
         self.assertEqual(_yamlify_arg('123'), 123)
         self.assertEqual(_yamlify_arg('45.67'), 45.67)


### PR DESCRIPTION
### What does this PR do?
This PR prevents `salt.utils.yaml.safe_load` from stomping arguments that only consist of a single exclamation mark.
Note that this behavior is different between 2018.3 on one side and 2019.2 and newer on the other. This PR should not be merged-forward. Different PR's will be created for newer versions of salt.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/46034

### Previous Behavior
When using `!` as an argument, like in 46034, `safe_load` changes this to `None` (NoneType), which gets coerced into the string `None` in `file.comment`.

### New Behavior
The argument `!` is kept as is.

### Tests written?
Yes

### Commits signed with GPG?
Yes