### PR TITLE
Fix 46034 2019.2.1

### DIFF
--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -200,12 +200,15 @@ def yamlify_arg(arg):
 
         elif arg is None \
                 or isinstance(arg, (list, float, six.integer_types, six.string_types)):
-            # yaml.safe_load will load '|' as '', don't let it do that.
+            # yaml.safe_load will load '|' and '!' as '', don't let it do that.
             if arg == '' and original_arg in ('|', '!'):
                 return original_arg
             # yaml.safe_load will treat '#' as a comment, so a value of '#'
             # will become None. Keep this value from being stomped as well.
             elif arg is None and original_arg.strip().startswith('#'):
+                return original_arg
+            # Other times, yaml.safe_load will load '!' as None. Prevent that.
+            elif arg is None and original_arg == '!':
                 return original_arg
             else:
                 return arg

--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -201,7 +201,7 @@ def yamlify_arg(arg):
         elif arg is None \
                 or isinstance(arg, (list, float, six.integer_types, six.string_types)):
             # yaml.safe_load will load '|' as '', don't let it do that.
-            if arg == '' and original_arg in ('|',):
+            if arg == '' and original_arg in ('|', '!'):
                 return original_arg
             # yaml.safe_load will treat '#' as a comment, so a value of '#'
             # will become None. Keep this value from being stomped as well.

--- a/tests/unit/utils/test_args.py
+++ b/tests/unit/utils/test_args.py
@@ -256,6 +256,10 @@ class ArgsTestCase(TestCase):
         item = '|'
         self.assertIs(_yamlify_arg(item), item)
 
+        # Make sure we don't load '!' as something else (None in 2018.3, '' in newer)
+        item = '!'
+        self.assertIs(_yamlify_arg(item), item)
+
         # Make sure we load ints, floats, and strings correctly
         self.assertEqual(_yamlify_arg('123'), 123)
         self.assertEqual(_yamlify_arg('45.67'), 45.67)


### PR DESCRIPTION
### What does this PR do?
This PR prevents `salt.utils.yaml.safe_load` from stomping arguments that only consist of a single exclamation mark.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/46034

### Previous Behavior
When using `!` as an argument, like in 46034, `safe_load` changes this to `''` (empty string).

### New Behavior
The argument `!` is kept as is.

### Tests written?
Yes

### Commits signed with GPG?
Yes