### PR TITLE
Do not dup2 things without fileno

### DIFF
--- a/tests/unit/utils/test_process.py
+++ b/tests/unit/utils/test_process.py
@@ -415,4 +415,4 @@ class TestDup2(TestCase):
                 salt.utils.process.dup2(f1, f2)
             except io.UnsupportedOperation:
                 assert False, 'io.UnsupportedOperation was raised'
-        assert dup_mock.called == False
+        assert not dup_mock.called

--- a/tests/unit/utils/test_process.py
+++ b/tests/unit/utils/test_process.py
@@ -2,6 +2,7 @@
 
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
+import io
 import os
 import sys
 import time
@@ -399,3 +400,19 @@ class TestSignalHandlingMultiprocessingProcess(TestCase):
             evt.set()
             proc2.join(30)
             proc.join(30)
+
+
+class TestDup2(TestCase):
+
+    def test_dup2_no_fileno(self):
+        'The dup2 method does not fail on streams without fileno support'
+        f1 = io.StringIO("some initial text data")
+        f2 = io.StringIO("some initial other text data")
+        with self.assertRaises(io.UnsupportedOperation):
+            f1.fileno()
+        with patch('os.dup2') as dup_mock:
+            try:
+                salt.utils.process.dup2(f1, f2)
+            except io.UnsupportedOperation:
+                assert False, 'io.UnsupportedOperation was raised'
+        assert dup_mock.called == False


### PR DESCRIPTION
### What does this PR do?

Skip trying to call `os.dup2` on streams that do not support the `fileno` method. This comes up in the test suite and is noisy.

### Tests written?

Yes

### Commits signed with GPG?

Yes