### PR TITLE
Fix TypeError python3 in get_image_id ec2 cloud

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -77,6 +77,7 @@ To use the EC2 cloud module, set up the cloud configuration at
 
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
+from functools import cmp_to_key
 import os
 import sys
 import stat
@@ -1226,7 +1227,7 @@ def get_imageid(vm_):
     _t = lambda x: datetime.datetime.strptime(x['creationDate'], '%Y-%m-%dT%H:%M:%S.%fZ')
     image_id = sorted(aws.query(params, location=get_location(),
                                  provider=get_provider(), opts=__opts__, sigver='4'),
-                      lambda i, j: salt.utils.compat.cmp(_t(i), _t(j))
+                      key=cmp_to_key(lambda i, j: salt.utils.compat.cmp(_t(i), _t(j)))
                       )[-1]['imageId']
     get_imageid.images[image] = image_id
     return image_id

--- a/tests/integration/files/conf/cloud.profiles.d/ec2.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/ec2.conf
@@ -1,6 +1,6 @@
 ec2-test:
   provider: ec2-config
-  image: ami-3ecc8f46
+  image: ''
   size: c5.large
   sh_username: centos
   script_args: '-P'
@@ -8,7 +8,7 @@ ec2-test:
 ec2-win2012r2-test:
   provider: ec2-config
   size: c5.large
-  image: ami-004d6bbd25fdba500
+  image: ''
   smb_port: 445
   win_installer: ''
   win_username: Administrator
@@ -22,7 +22,7 @@ ec2-win2012r2-test:
 ec2-win2016-test:
   provider: ec2-config
   size: c5.large
-  image: ami-013c9f19b48ddfd08
+  image: ''
   smb_port: 445
   win_installer: ''
   win_username: Administrator

--- a/tests/unit/cloud/clouds/test_ec2.py
+++ b/tests/unit/cloud/clouds/test_ec2.py
@@ -87,3 +87,28 @@ class EC2TestCase(TestCase, LoaderModuleMockMixin):
         )
         assert ret['passwordData'] == PASS_DATA
         assert ret['password'] == 'testp4ss!'
+
+    @patch('salt.cloud.clouds.ec2.config.get_cloud_config_value')
+    @patch('salt.cloud.clouds.ec2.get_location')
+    @patch('salt.cloud.clouds.ec2.get_provider')
+    @patch('salt.cloud.clouds.ec2.aws.query')
+    def test_get_imageid(self, aws_query, get_provider, get_location, config):
+        '''
+        test querying imageid function
+        '''
+        vm = {}
+        ami = 'ami-1234'
+        config.return_value = 'test/*'
+        get_location.return_value = 'us-west2'
+        get_provider.return_value = 'ec2'
+        aws_query.return_value = [{'imageId': ami}]
+
+        # test image filter
+        self.assertEqual(ec2.get_imageid(vm), ami)
+
+        # test ami-image
+        config.return_value = 'ami-1234'
+        self.assertEqual(ec2.get_imageid(vm), ami)
+
+        # we should have only ran aws.query once when testing the aws filter
+        aws_query.assert_called_once()

--- a/tests/unit/cloud/clouds/test_ec2.py
+++ b/tests/unit/cloud/clouds/test_ec2.py
@@ -107,7 +107,7 @@ class EC2TestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(ec2.get_imageid(vm), ami)
 
         # test ami-image
-        config.return_value = 'ami-1234'
+        config.return_value = ami
         self.assertEqual(ec2.get_imageid(vm), ami)
 
         # we should have only ran aws.query once when testing the aws filter


### PR DESCRIPTION
### What does this PR do?
Fixes issue when using an aws filter for the image like so:

```
amazon:
  provider: amazon
  image: 'salt/test/*'
```

When you try to build the vm with `salt-cloud -p profile_name ch3ll-vm` you see this error on python3:

```
Traceback (most recent call last):
  File "/tmp/kitchen/testing/salt/cloud/cli.py", line 281, in run
    self.config.get('names')
  File "/tmp/kitchen/testing/salt/cloud/__init__.py", line 1432, in run_profile
    ret[name] = self.create(vm_)
  File "/tmp/kitchen/testing/salt/cloud/__init__.py", line 1253, in create
    output = self.clouds[func](vm_)
  File "/tmp/kitchen/testing/salt/cloud/clouds/ec2.py", line 2634, in create
    data, vm_ = request_instance(vm_, location)
  File "/tmp/kitchen/testing/salt/cloud/clouds/ec2.py", line 1803, in request_instance
    image_id = get_imageid(vm_)
  File "/tmp/kitchen/testing/salt/cloud/clouds/ec2.py", line 1231, in get_imageid
    lambda i, j: salt.utils.compat.cmp(_t(i), _t(j))
TypeError: must use keyword argument for key function
```

This is because sorted requires the key argument in python3. The functools library has the ability to make this python2/python3 compatible included in this PR.

### Previous Behavior
Could not create a VM with an image using an AWS filter.

### New Behavior
Create a VM with an image using an AWS filter.

### Tests written?
Yes

### Commits signed with GPG?

Yes