### PR TITLE
replace pycrypto with pycryptodomex [develop]

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ PyYAML = "*"
 MarkupSafe = "*"
 requests = ">=1.0.0"
 tornado = ">=4.2.1,<5.0"
-pycrypto = ">=2.6.1"
+pycryptodomex = "*"
 pyzmq = ">=2.2.0"
 
 [dev-packages]

--- a/pkg/arch/PKGBUILD-local
+++ b/pkg/arch/PKGBUILD-local
@@ -13,7 +13,7 @@ depends=('python2'
          'python2-pyzmq'
          'python-m2crypto'
          'python2-yaml'
-         'pycrypto'
+         'pycryptodomex'
          'python2-psutil')
 makedepends=('git')
 provides=()

--- a/pkg/smartos/esky/zeromq_requirements.txt
+++ b/pkg/smartos/esky/zeromq_requirements.txt
@@ -1,6 +1,6 @@
 # Need to set a specific version of pyzmq, so can't use the main project's requirements file... have to copy it in and modify...
 #-r ../../../requirements/zeromq.txt
 -r ../../../requirements/base.txt
-pycrypto>=2.6.1
+pycryptodomex
 pyzmq
 -r requirements.txt

--- a/pkg/suse/salt.spec
+++ b/pkg/suse/salt.spec
@@ -74,7 +74,7 @@ BuildRequires:  python-ioflo >= 1.1.7
 BuildRequires:  python-raet >= 0.6.0
 %endif
 # requirements/zeromq.txt
-BuildRequires:  python-pycrypto >= 2.6.1
+BuildRequires:  python-pycryptodomex
 BuildRequires:  python-pyzmq >= 2.2.0
 %if %{with test}
 # requirements/dev_python27.txt
@@ -121,7 +121,7 @@ Recommends:     python-gnupg
 # Recommends:     salt-raet
 # requirements/zeromq.txt
 %endif
-Requires:       python-pycrypto >= 2.6.1
+Requires:       python-pycryptodomex
 Requires:       python-pyzmq >= 2.2.0
 #
 %if 0%{?suse_version}

--- a/requirements/zeromq.txt
+++ b/requirements/zeromq.txt
@@ -1,7 +1,5 @@
 -r base.txt
 
-# PyCrypto has issues on Windows, while pycryptodomex does not
-pycrypto>=2.6.1; sys.platform != 'win32'
-pycryptodomex; sys.platform == 'win32'
+pycryptodomex
 pyzmq>=2.2.0,<17.1.0; python_version == '3.4'  # pyzmq 17.1.0 stopped building wheels for python3.4
 pyzmq>=2.2.0; python_version != '3.4'


### PR DESCRIPTION
pycrypto is unmaintained and has open security issues.

Fixes: #54115

Forward port of https://github.com/saltstack/salt/pull/54119

### What does this PR do?
replace pycrypto with pycryptodomex, like it already is on many platforms

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/54115

### Previous Behavior
require pycrpto

### New Behavior
require pycryptodomex

### Tests written?
No, drop in replacement of functionality.

### Commits signed with GPG?
Yes
