### PR TITLE
Use ss filter to match TCP connections on Linux

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1328,17 +1328,18 @@ def active_tcp():
     '''
     ret = {}
     for statf in ['/proc/net/tcp', '/proc/net/tcp6']:
-        if os.path.isfile(statf):
-            with salt.utils.files.fopen(statf, 'rb') as fp_:
-                for line in fp_:
-                    line = salt.utils.stringutils.to_unicode(line)
-                    if line.strip().startswith('sl'):
-                        continue
-                    iret = _parse_tcp_line(line)
-                    slot = next(iter(iret))
-                    if iret[slot]['state'] == 1:  # 1 is ESTABLISHED
-                        del iret[slot]['state']
-                        ret[len(ret)] = iret[slot]
+        if not os.path.isfile(statf):
+            continue
+        with salt.utils.files.fopen(statf, 'rb') as fp_:
+            for line in fp_:
+                line = salt.utils.stringutils.to_unicode(line)
+                if line.strip().startswith('sl'):
+                    continue
+                iret = _parse_tcp_line(line)
+                slot = next(iter(iret))
+                if iret[slot]['state'] == 1:  # 1 is ESTABLISHED
+                    del iret[slot]['state']
+                    ret[len(ret)] = iret[slot]
     return ret
 
 
@@ -1371,17 +1372,18 @@ def _remotes_on(port, which_end):
     ret = set()
     proc_available = False
     for statf in ['/proc/net/tcp', '/proc/net/tcp6']:
-        if os.path.isfile(statf):
-            proc_available = True
-            with salt.utils.files.fopen(statf, 'r') as fp_:
-                for line in fp_:
-                    line = salt.utils.stringutils.to_unicode(line)
-                    if line.strip().startswith('sl'):
-                        continue
-                    iret = _parse_tcp_line(line)
-                    slot = next(iter(iret))
-                    if iret[slot][which_end] == port and iret[slot]['state'] == 1:  # 1 is ESTABLISHED
-                        ret.add(iret[slot]['remote_addr'])
+        if not os.path.isfile(statf):
+            continue
+        proc_available = True
+        with salt.utils.files.fopen(statf, 'r') as fp_:
+            for line in fp_:
+                line = salt.utils.stringutils.to_unicode(line)
+                if line.strip().startswith('sl'):
+                    continue
+                iret = _parse_tcp_line(line)
+                slot = next(iter(iret))
+                if iret[slot][which_end] == port and iret[slot]['state'] == 1:  # 1 is ESTABLISHED
+                    ret.add(iret[slot]['remote_addr'])
 
     if not proc_available:  # Fallback to use OS specific tools
         if salt.utils.platform.is_sunos():

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1434,8 +1434,9 @@ def _netlink_tool_remote_on(port, which_end):
     '''
     remotes = set()
     valid = False
+    tcp_end = 'dst' if which_end == 'remote_port' else 'src'
     try:
-        data = subprocess.check_output(['ss', '-ant'])  # pylint: disable=minimum-python-version
+        data = subprocess.check_output(['ss', '-ant', tcp_end, ':{0}'.format(port)])  # pylint: disable=minimum-python-version
     except subprocess.CalledProcessError:
         log.error('Failed ss')
         raise
@@ -1450,13 +1451,8 @@ def _netlink_tool_remote_on(port, which_end):
         elif 'ESTAB' not in line:
             continue
         chunks = line.split()
-        local_host, local_port = chunks[3].rsplit(':', 1)
         remote_host, remote_port = chunks[4].rsplit(':', 1)
 
-        if which_end == 'remote_port' and int(remote_port) != port:
-            continue
-        if which_end == 'local_port' and int(local_port) != port:
-            continue
         remotes.add(remote_host)
 
     if valid is False:

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -680,5 +680,5 @@ class NetworkTestCase(TestCase):
 
     def test_netlink_tool_remote_on(self):
         with patch('subprocess.check_output', return_value=NETLINK_SS):
-            remotes = network._netlink_tool_remote_on('4505', 'remote')
+            remotes = network._netlink_tool_remote_on('4505', 'remote_port')
             self.assertEqual(remotes, set(['127.0.0.1', '::ffff:1.2.3.4']))


### PR DESCRIPTION
### What does this PR do?
The current implementation of `_netlink_tool_remote_on` cause high CPU usage and is slow if the number of TCP connection is high. This patch address the problem by using the filtering options available in `ss` to reduce the output returned to just the TCP connection we are interested in.

### What issues does this PR fix or reference?
Fixes #53580 

### Previous Behavior
`salt-minion` or `salt-call` are slow and CPU intesive when using `status.master`

### New Behavior
The response of the call is immediate, low CPU usage

### Tests written?
A test was written for the function but was not correct. A parameter has been fixed.