### PR TITLE
Do not include unresponsive minions in subset

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -387,7 +387,7 @@ class LocalClient(object):
         random.shuffle(minions)
         f_tgt = []
         for minion in minions:
-            if fun in minion_ret[minion]:
+            if minion_ret[minion] and fun in minion_ret[minion]:
                 f_tgt.append(minion)
             if len(f_tgt) >= sub:
                 break


### PR DESCRIPTION
### What does this PR do?

If there is an accepted key for a minion but it does not respond to the `sys.list_functions` then its return value in `minion_ret` (https://github.com/saltstack/salt/compare/develop...bloomberg:subset-fix?expand=1#diff-afe7362c6e0817c26aaf1e3c4351ba97R385) will be `False`. If a minion does not respond to `sys.list_functions` then we should not consider it for inclusion in the subset.

### What issues does this PR fix or reference?

### Previous Behavior
test.sls
```
test:
  salt.function:
    - name: cmd.run
    - tgt: 'id:minion'
    - tgt_type: grain
    - kwarg:
        cmd: uptime
    - subset: 1
```

Shutdown one minion which has an accepted key on the master and run the above orch.

```
# salt-run state.orch test

master:
----------
          ID: test
    Function: salt.function
        Name: cmd.run
      Result: False
     Comment: argument of type 'bool' is not iterable
     Started: 15:54:53.206709
    Duration: 45169.086 ms
     Changes:
```

### New Behavior

Works as expected

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
