### PR TITLE
Call os.fork less to avoid race conditions

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -331,6 +331,7 @@ class Maintenance(salt.utils.process.SignalHandlingMultiprocessingProcess):
                 self.loop_interval = self.schedule.loop_interval
         except Exception as exc:
             log.error('Exception %s occurred in scheduled job', exc)
+        self.schedule.cleanup_subprocesses()
 
     def handle_presence(self, old_present):
         '''

--- a/salt/metaproxy/proxy.py
+++ b/salt/metaproxy/proxy.py
@@ -69,7 +69,6 @@ log = logging.getLogger(__name__)
 
 
 def post_master_init(self, master):
-
     log.debug("subclassed LazyLoaded _post_master_init")
     if self.connected:
         self.opts['master'] = master
@@ -336,15 +335,6 @@ def thread_return(cls, minion_instance, opts, data):
     '''
     fn_ = os.path.join(minion_instance.proc_dir, data['jid'])
 
-    if opts['multiprocessing'] and not salt.utils.platform.is_windows():
-        # Shutdown the multiprocessing before daemonizing
-        salt.log.setup.shutdown_multiprocessing_logging()
-
-        salt.utils.process.daemonize_if(opts)
-
-        # Reconfigure multiprocessing logging after daemonizing
-        salt.log.setup.setup_multiprocessing_logging()
-
     salt.utils.process.appendproctitle('{0}._thread_return {1}'.format(cls.__name__, data['jid']))
 
     sdata = {'pid': os.getpid()}
@@ -559,15 +549,6 @@ def thread_multi_return(cls, minion_instance, opts, data):
     '''
     fn_ = os.path.join(minion_instance.proc_dir, data['jid'])
 
-    if opts['multiprocessing'] and not salt.utils.platform.is_windows():
-        # Shutdown the multiprocessing before daemonizing
-        salt.log.setup.shutdown_multiprocessing_logging()
-
-        salt.utils.process.daemonize_if(opts)
-
-        # Reconfigure multiprocessing logging after daemonizing
-        salt.log.setup.setup_multiprocessing_logging()
-
     salt.utils.process.appendproctitle('{0}._thread_multi_return {1}'.format(cls.__name__, data['jid']))
 
     sdata = {'pid': os.getpid()}
@@ -761,13 +742,8 @@ def handle_decoded_payload(self, data):
             process.start()
     else:
         process.start()
-
-    # TODO: remove the windows specific check?
-    if multiprocessing_enabled and not salt.utils.platform.is_windows():
-        # we only want to join() immediately if we are daemonizing a process
-        process.join()
-    else:
-        self.win_proc.append(process)
+    process.name = '{}-Job-{}'.format(process.name, data['jid'])
+    self.subprocess_list.add(process)
 
 
 def target_load(self, load):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -422,6 +422,41 @@ class MinionBase(object):
     def __init__(self, opts):
         self.opts = opts
 
+    def gen_modules(self, initial_load=False):
+        '''
+        Tell the minion to reload the execution modules
+
+        CLI Example:
+
+        .. code-block:: bash
+
+            salt '*' sys.reload_modules
+        '''
+        self.opts['pillar'] = salt.pillar.get_pillar(
+            self.opts,
+            self.opts['grains'],
+            self.opts['id'],
+            self.opts['saltenv'],
+            pillarenv=self.opts.get('pillarenv'),
+        ).compile_pillar()
+
+        self.utils = salt.loader.utils(self.opts)
+        self.functions = salt.loader.minion_mods(self.opts, utils=self.utils)
+        self.serializers = salt.loader.serializers(self.opts)
+        self.returners = salt.loader.returners(self.opts, self.functions)
+        self.proxy = salt.loader.proxy(self.opts, self.functions, self.returners, None)
+        # TODO: remove
+        self.function_errors = {}  # Keep the funcs clean
+        self.states = salt.loader.states(self.opts,
+                self.functions,
+                self.utils,
+                self.serializers)
+        self.rend = salt.loader.render(self.opts, self.functions)
+#        self.matcher = Matcher(self.opts, self.functions)
+        self.matchers = salt.loader.matchers(self.opts)
+        self.functions['sys.reload_modules'] = self.gen_modules
+        self.executors = salt.loader.executors(self.opts)
+
     @staticmethod
     def process_schedule(minion, loop_interval):
         try:
@@ -828,41 +863,6 @@ class SMinion(MinionBase):
                 salt.utils.yaml.safe_dump(self.opts['pillar'], fp_)
                 os.chmod(cache_sls, 0o600)
 
-    def gen_modules(self, initial_load=False):
-        '''
-        Tell the minion to reload the execution modules
-
-        CLI Example:
-
-        .. code-block:: bash
-
-            salt '*' sys.reload_modules
-        '''
-        self.opts['pillar'] = salt.pillar.get_pillar(
-            self.opts,
-            self.opts['grains'],
-            self.opts['id'],
-            self.opts['saltenv'],
-            pillarenv=self.opts.get('pillarenv'),
-        ).compile_pillar()
-
-        self.utils = salt.loader.utils(self.opts)
-        self.functions = salt.loader.minion_mods(self.opts, utils=self.utils)
-        self.serializers = salt.loader.serializers(self.opts)
-        self.returners = salt.loader.returners(self.opts, self.functions)
-        self.proxy = salt.loader.proxy(self.opts, self.functions, self.returners, None)
-        # TODO: remove
-        self.function_errors = {}  # Keep the funcs clean
-        self.states = salt.loader.states(self.opts,
-                self.functions,
-                self.utils,
-                self.serializers)
-        self.rend = salt.loader.render(self.opts, self.functions)
-#        self.matcher = Matcher(self.opts, self.functions)
-        self.matchers = salt.loader.matchers(self.opts)
-        self.functions['sys.reload_modules'] = self.gen_modules
-        self.executors = salt.loader.executors(self.opts)
-
 
 class MasterMinion(object):
     '''
@@ -1096,6 +1096,7 @@ class Minion(MinionBase):
 
         self._running = None
         self.win_proc = []
+        self.subprocess_list = salt.utils.process.SubprocessList()
         self.loaded_base_name = loaded_base_name
         self.connected = False
         self.restart = False
@@ -1533,13 +1534,8 @@ class Minion(MinionBase):
                 process.start()
         else:
             process.start()
-
-        # TODO: remove the windows specific check?
-        if multiprocessing_enabled and not salt.utils.platform.is_windows():
-            # we only want to join() immediately if we are daemonizing a process
-            process.join()
-        else:
-            self.win_proc.append(process)
+        process.name = '{}-Job-{}'.format(process.name, data['jid'])
+        self.subprocess_list.add(process)
 
     def ctx(self):
         '''
@@ -1596,16 +1592,8 @@ class Minion(MinionBase):
         This method should be used as a threading target, start the actual
         minion side execution.
         '''
+        minion_instance.gen_modules()
         fn_ = os.path.join(minion_instance.proc_dir, data['jid'])
-
-        if opts['multiprocessing'] and not salt.utils.platform.is_windows():
-            # Shutdown the multiprocessing before daemonizing
-            salt.log.setup.shutdown_multiprocessing_logging()
-
-            salt.utils.process.daemonize_if(opts)
-
-            # Reconfigure multiprocessing logging after daemonizing
-            salt.log.setup.setup_multiprocessing_logging()
 
         salt.utils.process.appendproctitle('{0}._thread_return {1}'.format(cls.__name__, data['jid']))
 
@@ -1819,16 +1807,8 @@ class Minion(MinionBase):
         This method should be used as a threading target, start the actual
         minion side execution.
         '''
+        minion_instance.gen_modules()
         fn_ = os.path.join(minion_instance.proc_dir, data['jid'])
-
-        if opts['multiprocessing'] and not salt.utils.platform.is_windows():
-            # Shutdown the multiprocessing before daemonizing
-            salt.log.setup.shutdown_multiprocessing_logging()
-
-            salt.utils.process.daemonize_if(opts)
-
-            # Reconfigure multiprocessing logging after daemonizing
-            salt.log.setup.setup_multiprocessing_logging()
 
         salt.utils.process.appendproctitle('{0}._thread_multi_return {1}'.format(cls.__name__, data['jid']))
 
@@ -2546,24 +2526,15 @@ class Minion(MinionBase):
             )
             salt.crypt.AsyncAuth.creds_map[tuple(data['key'])] = data['creds']
 
-    def _fallback_cleanups(self):
+    def cleanup_subprocesses(self):
         '''
-        Fallback cleanup routines, attempting to fix leaked processes, threads, etc.
+        Clean up subprocesses and spawned threads.
         '''
         # Add an extra fallback in case a forked process leaks through
         multiprocessing.active_children()
-
-        # Cleanup Windows threads
-        if not salt.utils.platform.is_windows():
-            return
-        for thread in self.win_proc:
-            if not thread.is_alive():
-                thread.join()
-                try:
-                    self.win_proc.remove(thread)
-                    del thread
-                except (ValueError, NameError):
-                    pass
+        self.subprocess_list.cleanup()
+        if self.schedule:
+            self.schedule.cleanup_subprocesses()
 
     def _setup_core(self):
         '''
@@ -2589,10 +2560,7 @@ class Minion(MinionBase):
         This is safe to call multiple times.
         '''
         self._setup_core()
-
         loop_interval = self.opts['loop_interval']
-        new_periodic_callbacks = {}
-
         if 'beacons' not in self.periodic_callbacks:
             self.beacons = salt.beacons.Beacon(self.opts, self.functions)
 
@@ -2606,21 +2574,11 @@ class Minion(MinionBase):
                 if beacons and self.connected:
                     self._fire_master(events=beacons)
 
-            new_periodic_callbacks['beacons'] = tornado.ioloop.PeriodicCallback(
-                    handle_beacons, loop_interval * 1000)
             if before_connect:
                 # Make sure there is a chance for one iteration to occur before connect
                 handle_beacons()
 
-        if 'cleanup' not in self.periodic_callbacks:
-            new_periodic_callbacks['cleanup'] = tornado.ioloop.PeriodicCallback(
-                    self._fallback_cleanups, loop_interval * 1000)
-
-        # start all the other callbacks
-        for periodic_cb in six.itervalues(new_periodic_callbacks):
-            periodic_cb.start()
-
-        self.periodic_callbacks.update(new_periodic_callbacks)
+            self.add_periodic_callback('beacons', handle_beacons)
 
     def setup_scheduler(self, before_connect=False):
         '''
@@ -2630,7 +2588,6 @@ class Minion(MinionBase):
         self._setup_core()
 
         loop_interval = self.opts['loop_interval']
-        new_periodic_callbacks = {}
 
         if 'schedule' not in self.periodic_callbacks:
             if 'schedule' not in self.opts:
@@ -2659,21 +2616,36 @@ class Minion(MinionBase):
             # TODO: actually listen to the return and change period
             def handle_schedule():
                 self.process_schedule(self, loop_interval)
-            new_periodic_callbacks['schedule'] = tornado.ioloop.PeriodicCallback(handle_schedule, 1000)
 
             if before_connect:
                 # Make sure there is a chance for one iteration to occur before connect
                 handle_schedule()
 
-        if 'cleanup' not in self.periodic_callbacks:
-            new_periodic_callbacks['cleanup'] = tornado.ioloop.PeriodicCallback(
-                    self._fallback_cleanups, loop_interval * 1000)
+            self.add_periodic_callback('schedue', handle_schedule)
 
-        # start all the other callbacks
-        for periodic_cb in six.itervalues(new_periodic_callbacks):
-            periodic_cb.start()
+    def add_periodic_callback(self, name, method, interval=1000):
+        '''
+        Add a periodic callback to the event loop and call it's start method.
+        If a callback by the given name exists this method returns False
+        '''
+        if name in self.periodic_callbacks:
+            return False
+        self.periodic_callbacks[name] = tornado.ioloop.PeriodicCallback(
+            method, interval * 1000,
+        )
+        self.periodic_callbacks[name].start()
+        return True
 
-        self.periodic_callbacks.update(new_periodic_callbacks)
+    def remove_periodic_callback(self, name):
+        '''
+        Remove a periodic callback.
+        If a callback by the given name does not exist this method returns False
+        '''
+        callback = self.periodic_callbacks.pop(name, None)
+        if callbback is None:
+            return False
+        callback.stop()
+        return True
 
     # Main Minion Tune In
     def tune_in(self, start=True):
@@ -2707,6 +2679,7 @@ class Minion(MinionBase):
 
         self.setup_beacons()
         self.setup_scheduler()
+        self.add_periodic_callback('cleanup', self.cleanup_subprocesses)
 
         # schedule the stuff that runs every interval
         ping_interval = self.opts.get('ping_interval', 0) * 60
@@ -2733,8 +2706,8 @@ class Minion(MinionBase):
                     self._fire_master('ping', 'minion_ping', sync=False, timeout_handler=ping_timeout_handler)
                 except Exception:
                     log.warning('Attempt to ping master failed.', exc_on_loglevel=logging.DEBUG)
-            self.periodic_callbacks['ping'] = tornado.ioloop.PeriodicCallback(ping_master, ping_interval * 1000)
-            self.periodic_callbacks['ping'].start()
+            self.remove_periodic_callbback('ping', ping_master)
+            self.add_periodic_callback('ping', ping_master, ping_interval)
 
         # add handler to subscriber
         if hasattr(self, 'pub_channel') and self.pub_channel is not None:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2621,7 +2621,7 @@ class Minion(MinionBase):
                 # Make sure there is a chance for one iteration to occur before connect
                 handle_schedule()
 
-            self.add_periodic_callback('schedue', handle_schedule)
+            self.add_periodic_callback('schedule', handle_schedule)
 
     def add_periodic_callback(self, name, method, interval=1000):
         '''
@@ -2642,7 +2642,7 @@ class Minion(MinionBase):
         If a callback by the given name does not exist this method returns False
         '''
         callback = self.periodic_callbacks.pop(name, None)
-        if callbback is None:
+        if callback is None:
             return False
         callback.stop()
         return True

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -857,7 +857,7 @@ class SubprocessList(object):
     def add(self, proc):
         with self.lock:
             self.processes.append(proc)
-            log.warning('Subprocess %s added', proc.name)
+            log.debug('Subprocess %s added', proc.name)
 
     def cleanup(self):
         with self.lock:
@@ -866,4 +866,4 @@ class SubprocessList(object):
                     continue
                 proc.join()
                 self.processes.remove(proc)
-                log.warning('Subprocess %s cleaned up', proc.name)
+                log.debug('Subprocess %s cleaned up', proc.name)

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -664,10 +664,6 @@ class Schedule(object):
             # Reconfigure multiprocessing logging after daemonizing
             log_setup.setup_multiprocessing_logging()
 
-        #if multiprocessing_enabled:
-        #    # Don't *BEFORE* to go into try to don't let it triple execute the finally section.
-        #    salt.utils.process.daemonize_if(self.opts)
-
         # TODO: Make it readable! Splt to funcs, remove nested try-except-finally sections.
         try:
 

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -44,7 +44,6 @@ import salt.minion
 import salt.payload
 import salt.syspaths
 import salt.exceptions
-#import salt.log.setup as log_setup
 import salt.defaults.exitcodes
 from salt.utils.odict import OrderedDict
 
@@ -659,10 +658,6 @@ class Schedule(object):
                 salt.minion.get_proc_dir(self.opts['cachedir']),
                 ret['jid']
             )
-
-        # if multiprocessing_enabled and not salt.utils.platform.is_windows():
-        #     # Reconfigure multiprocessing logging after daemonizing
-        #     log_setup.setup_multiprocessing_logging()
 
         # TODO: Make it readable! Splt to funcs, remove nested try-except-finally sections.
         try:

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -44,7 +44,7 @@ import salt.minion
 import salt.payload
 import salt.syspaths
 import salt.exceptions
-import salt.log.setup as log_setup
+#import salt.log.setup as log_setup
 import salt.defaults.exitcodes
 from salt.utils.odict import OrderedDict
 
@@ -660,9 +660,9 @@ class Schedule(object):
                 ret['jid']
             )
 
-        if multiprocessing_enabled and not salt.utils.platform.is_windows():
-            # Reconfigure multiprocessing logging after daemonizing
-            log_setup.setup_multiprocessing_logging()
+        # if multiprocessing_enabled and not salt.utils.platform.is_windows():
+        #     # Reconfigure multiprocessing logging after daemonizing
+        #     log_setup.setup_multiprocessing_logging()
 
         # TODO: Make it readable! Splt to funcs, remove nested try-except-finally sections.
         try:
@@ -1727,6 +1727,7 @@ class Schedule(object):
 
     def cleanup_subprocesses(self):
         self._subprocess_list.cleanup()
+
 
 def clean_proc_dir(opts):
 

--- a/tests/integration/shell/test_call.py
+++ b/tests/integration/shell/test_call.py
@@ -174,7 +174,7 @@ class CallTest(ShellCase, testprogram.TestProgramCase, ShellCaseCommonTestsMixin
             '--config-dir {0} cmd.run "echo foo"'.format(
                 config_dir
             ),
-            timeout=60,
+            timeout=120,
             catch_stderr=True,
             with_retcode=True
         )

--- a/tests/unit/utils/test_process.py
+++ b/tests/unit/utils/test_process.py
@@ -433,7 +433,7 @@ class TestProcessList(TestCase):
         start = time.time()
         while proc.is_alive():
             if time.time() - start > timeout:
-                raise TimeoutError("Process did not finishe before timeout")
+                raise Exception("Process did not finishe before timeout")
             time.sleep(.3)
 
     def test_process_list_process(self):

--- a/tests/unit/utils/test_process.py
+++ b/tests/unit/utils/test_process.py
@@ -421,15 +421,18 @@ class TestDup2(TestCase):
 
 class TestProcessList(TestCase):
 
-    def null_target(self):
+    @staticmethod
+    def null_target():
         pass
 
-    def event_target(self, event):
+    @staticmethod
+    def event_target(event):
         while True:
             if event.wait(5):
                 break
 
-    def wait_for_proc(self, proc, timeout=10):
+    @staticmethod
+    def wait_for_proc(proc, timeout=10):
         start = time.time()
         while proc.is_alive():
             if time.time() - start > timeout:


### PR DESCRIPTION
### What issues does this PR fix or reference?

#54153
#54219

### Previous Behavior

- The minions' `_threaded_return` and `_threaded_multi_return` methods did a double fork so that we could join the parent process immediately, not blocking anything. 
- Schedules run by masters and minions did a double fork so that we could join the parent process immediately, not blocking anything.

### New Behavior

- The minions do not call join right away on job subprocesses instead they track and reap them when they are finished.
- Masters and minions do not join schedule processes right away, instead the Schedule class tracks it's subprocesses and provide a method for the users of this class to call periodically to reap them.

### Tests written?

Yes - Unit tests added for new classes

### Commits signed with GPG?

Yes