### PR TITLE
Add minion config option for default apt cache_valid_time

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -3556,3 +3556,17 @@ global pillar data.
 
 If set to ``False`` only the overriding pillar data will be available
 to the ``showpillar`` state.
+
+Pkg Configuration
+====================
+
+.. conf_minion:: pkg.cache_valid_time
+
+``pkg.cache_valid_time``
+----------------------
+.. versionadded:: TBD
+
+Default: ``0``
+
+This parameter sets the default value in seconds after which the pkg cache is
+marked as invalid, and a cache update is necessary.

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1220,6 +1220,9 @@ VALID_OPTS = immutabletypes.freeze({
 
     # Disable requisites during State runs
     'disabled_requisites': (six.string_types, list),
+
+    # pkg cache_valid_lifetime default
+    'pkg.cache_valid_time': int,
 })
 
 # default configurations
@@ -1523,6 +1526,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze({
     'ssh_merge_pillar': True,
     'server_id_use_crc': False,
     'disabled_requisites': [],
+    'pkg.cache_valid_time': 0,
 })
 
 DEFAULT_MASTER_OPTS = immutabletypes.freeze({

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -201,7 +201,7 @@ def latest_version(*names, **kwargs):
         .. versionadded:: 2016.11.0
 
         Skip refreshing the package database if refresh has already occurred within
-        <value> seconds
+        <value> seconds. Default is pkg.cache_valid_time in minion config.
 
     CLI Example:
 
@@ -218,7 +218,6 @@ def latest_version(*names, **kwargs):
             'The \'repo\' argument is invalid, use \'fromrepo\' instead'
         )
     fromrepo = kwargs.pop('fromrepo', None)
-    cache_valid_time = kwargs.pop('cache_valid_time', 0)
 
     if not names:
         return ''
@@ -232,7 +231,7 @@ def latest_version(*names, **kwargs):
 
     # Refresh before looking for the latest version available
     if refresh:
-        refresh_db(cache_valid_time)
+        refresh_db(kwargs.pop('cache_valid_time'))
 
     for name in names:
         cmd = ['apt-cache', '-q', 'policy', name]
@@ -294,7 +293,7 @@ def version(*names, **kwargs):
     return __salt__['pkg_resource.version'](*names, **kwargs)
 
 
-def refresh_db(cache_valid_time=0, failhard=False, **kwargs):
+def refresh_db(cache_valid_time=None, failhard=False, **kwargs):
     '''
     Updates the APT database to latest packages based upon repositories
 
@@ -310,7 +309,7 @@ def refresh_db(cache_valid_time=0, failhard=False, **kwargs):
         .. versionadded:: 2016.11.0
 
         Skip refreshing the package database if refresh has already occurred within
-        <value> seconds
+        <value> seconds. Default is pkg.cache_valid_time in minion config.
 
     failhard
 
@@ -330,6 +329,9 @@ def refresh_db(cache_valid_time=0, failhard=False, **kwargs):
     failhard = salt.utils.data.is_true(failhard)
     ret = {}
     error_repos = list()
+
+    if cache_valid_time is None:
+        cache_valid_time = __opts__['pkg.cache_valid_time']
 
     if cache_valid_time:
         try:
@@ -428,7 +430,7 @@ def install(name=None,
         .. versionadded:: 2016.11.0
 
         Skip refreshing the package database if refresh has already occurred within
-        <value> seconds
+        <value> seconds. Default is pkg.cache_valid_time in minion config.
 
     fromrepo
         Specify a package repository to install from
@@ -741,9 +743,8 @@ def install(name=None,
     if not cmds:
         ret = {}
     else:
-        cache_valid_time = kwargs.pop('cache_valid_time', 0)
         if _refresh_db:
-            refresh_db(cache_valid_time)
+            refresh_db(kwargs.pop('cache_valid_time'))
 
         env = _parse_env(kwargs.get('env'))
         env.update(DPKG_ENV_VARS.copy())
@@ -1014,7 +1015,7 @@ def upgrade(refresh=True, dist_upgrade=False, **kwargs):
         .. versionadded:: 2016.11.0
 
         Skip refreshing the package database if refresh has already occurred within
-        <value> seconds
+        <value> seconds. Default is pkg.cache_valid_time in minion config.
 
     download_only
         Only download the packages, don't unpack or install them
@@ -1032,9 +1033,8 @@ def upgrade(refresh=True, dist_upgrade=False, **kwargs):
 
         salt '*' pkg.upgrade
     '''
-    cache_valid_time = kwargs.pop('cache_valid_time', 0)
     if salt.utils.data.is_true(refresh):
-        refresh_db(cache_valid_time)
+        refresh_db(kwargs.pop('cache_valid_time'))
 
     old = list_pkgs()
     if 'force_conf_new' in kwargs and kwargs['force_conf_new']:
@@ -1374,7 +1374,7 @@ def list_upgrades(refresh=True, dist_upgrade=True, **kwargs):
         .. versionadded:: 2016.11.0
 
         Skip refreshing the package database if refresh has already occurred within
-        <value> seconds
+        <value> seconds. Default is pkg.cache_valid_time in minion config.
 
     dist_upgrade
         Whether to list the upgrades using dist-upgrade vs upgrade.  Default is
@@ -1386,9 +1386,8 @@ def list_upgrades(refresh=True, dist_upgrade=True, **kwargs):
 
         salt '*' pkg.list_upgrades
     '''
-    cache_valid_time = kwargs.pop('cache_valid_time', 0)
     if salt.utils.data.is_true(refresh):
-        refresh_db(cache_valid_time)
+        refresh_db(kwargs.pop('cache_valid_time'))
     return _get_upgradable(dist_upgrade, **kwargs)
 
 


### PR DESCRIPTION
Signed-off-by: Clint Armstrong <clint@clintarmstrong.net>

### What does this PR do?

Adds a minion config option that sets the default cache_valid_time for the apt module.

### Previous Behavior

To use cache_valid_time every single apt state must specify the cache_valid_time option. This change allows a default to be set in the minion config.

### New Behavior


### Tests written?
No. This is a draft PR while I try to understand the apt unit tests. Currently there are no unit tests for cache_valid_time.

### Commits signed with GPG?

Yes