### PR TITLE
adding multipart/form-data file posting to http.query util

### DIFF
--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -70,6 +70,11 @@ import tornado.httputil
 import tornado.simple_httpclient
 from tornado.httpclient import HTTPClient
 
+if six.PY2:
+    from StringIO import StringIO
+elif six.PY3:
+    from io import StringIO
+
 try:
     import tornado.curl_httpclient
     HAS_CURL_HTTPCLIENT = True
@@ -175,6 +180,9 @@ def query(url,
           agent=USERAGENT,
           hide_fields=None,
           raise_error=True,
+          formdata=False,
+          formdata_fieldname=None,
+          formdata_filename=None,
           **kwargs):
     '''
     Query a resource, and decode the return data
@@ -348,9 +356,22 @@ def query(url,
                 log.error('The client-side certificate path that'
                           ' was passed is not valid: %s', cert)
 
-        result = sess.request(
-            method, url, params=params, data=data, **req_kwargs
-        )
+        if formdata:
+            if not formdata_fieldname:
+                ret['error'] = ('formdata_fieldname is required when formdata=True')
+                log.error(ret['error'])
+                return ret
+            result = sess.request(
+                method,
+                url,
+                params=params,
+                files={formdata_fieldname: (formdata_filename, StringIO(data))},
+                **req_kwargs
+            )
+        else:
+            result = sess.request(
+                method, url, params=params, data=data, **req_kwargs
+            )
         result.raise_for_status()
         if stream is True:
             # fake a HTTP response header

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -1553,8 +1553,18 @@ class MirrorPostHandler(tornado.web.RequestHandler):
     Mirror a POST body back to the client
     '''
     def post(self, *args):
+        '''
+        Handle the post
+        '''
         body = self.request.body
+        log.debug('Incoming body: %s  Incoming args: %s', body, args)
         self.write(body)
+
+    def data_received(self):
+        '''
+        Streaming not used for testing
+        '''
+        raise NotImplementedError()
 
 
 def win32_kill_process_tree(pid, sig=signal.SIGTERM, include_parent=True,

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -1552,7 +1552,7 @@ class MirrorPostHandler(tornado.web.RequestHandler):
     '''
     Mirror a POST body back to the client
     '''
-    def post(self, *args):
+    def post(self, *args):  # pylint: disable=arguments-differ
         '''
         Handle the post
         '''
@@ -1560,7 +1560,7 @@ class MirrorPostHandler(tornado.web.RequestHandler):
         log.debug('Incoming body: %s  Incoming args: %s', body, args)
         self.write(body)
 
-    def data_received(self):
+    def data_received(self):  # pylint: disable=arguments-differ
         '''
         Streaming not used for testing
         '''

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -1480,8 +1480,12 @@ class Webserver(object):
         '''
         self.ioloop = tornado.ioloop.IOLoop()
         self.ioloop.make_current()
-        self.application = tornado.web.Application(
-            [(r'/(.*)', self.handler, {'path': self.root})])
+        if self.handler == tornado.web.StaticFileHandler:
+            self.application = tornado.web.Application(
+                [(r'/(.*)', self.handler, {'path': self.root})])
+        else:
+            self.application = tornado.web.Application(
+                [(r'/(.*)', self.handler)])
         self.application.listen(self.port)
         self.ioloop.start()
 
@@ -1542,6 +1546,15 @@ class Webserver(object):
         '''
         self.ioloop.add_callback(self.ioloop.stop)
         self.server_thread.join()
+
+
+class MirrorPostHandler(tornado.web.RequestHandler):
+    '''
+    Mirror a POST body back to the client
+    '''
+    def post(self, *args):
+        body = self.request.body
+        self.write(body)
 
 
 def win32_kill_process_tree(pid, sig=signal.SIGTERM, include_parent=True,


### PR DESCRIPTION
### What does this PR do?
This PR adds the ability for the requests backend to post files as multipart/form-data. I'm not really familiar with tornado, or else I'd add that too... updates welcome!

### What issues does this PR fix or reference?
N/A

### Previous Behavior
The http.query utility could not handle multipart/form-data, which is commonly used in file uploads to web servers.

### New Behavior
Now the http.query utility supports that capability in the requests backend.

### Tests written?
Yes

### Commits signed with GPG?
Yes