### PR TITLE
clean up renamed instances in the teardown

### DIFF
--- a/tests/integration/cloud/clouds/test_ec2.py
+++ b/tests/integration/cloud/clouds/test_ec2.py
@@ -115,20 +115,19 @@ class EC2Test(CloudTest):
         '''
         Tests creating and renaming an instance on EC2 (classic)
         '''
-        # Start with a name that is different from usual so that it will get deleted normally after the test
-        changed_name = self.instance_name + '-changed'
         # create the instance
-        ret_val = self.run_cloud('-p ec2-test {0} --no-deploy'.format(changed_name), timeout=TIMEOUT)
-
+        ret_val = self.run_cloud('-p ec2-test {0} --no-deploy'.format(self.instance_name), timeout=TIMEOUT)
         # check if instance returned
-        self.assertInstanceExists(ret_val, changed_name)
+        self.assertInstanceExists(ret_val)
 
-        rename_result = self.run_cloud('-a rename {0} newname={1} --assume-yes'.format(changed_name, self.instance_name),
-                       timeout=TIMEOUT)
-        self.assertFalse(self._instance_exists(changed_name), 'Instance wasn\'t renamed: |\n{}'.format(rename_result))
-        self.assertInstanceExists()
+        changed_name = self.instance_name + '-changed'
 
-        self.assertDestroyInstance()
+        rename_result = self.run_cloud(
+            '-a rename {0} newname={1} --assume-yes'.format(self.instance_name, changed_name), timeout=TIMEOUT)
+        self.assertFalse(self._instance_exists(), 'Instance wasn\'t renamed: |\n{}'.format(rename_result))
+        self.assertInstanceExists(instance_name=changed_name)
+
+        self.assertDestroyInstance(changed_name)
 
     def test_instance(self):
         '''

--- a/tests/integration/cloud/clouds/test_ec2.py
+++ b/tests/integration/cloud/clouds/test_ec2.py
@@ -123,14 +123,10 @@ class EC2Test(CloudTest):
         # check if instance returned
         self.assertInstanceExists(ret_val, changed_name)
 
-        change_name = self.run_cloud('-a rename {0} newname={1} --assume-yes'.format(changed_name, self.instance_name),
-                                     timeout=TIMEOUT)
-
-        check_rename = self.run_cloud('-a show_instance {0} --assume-yes'.format(self.instance_name), [self.instance_name])
-        exp_results = ['        {0}:'.format(self.instance_name), '            size:',
-                       '            architecture:']
-        for result in exp_results:
-            self.assertIn(result, check_rename[0])
+        rename_result = self.run_cloud('-a rename {0} newname={1} --assume-yes'.format(changed_name, self.instance_name),
+                       timeout=TIMEOUT)
+        self.assertFalse(self._instance_exists(changed_name), 'Instance wasn\'t renamed: |\n{}'.format(rename_result))
+        self.assertInstanceExists()
 
         self.assertDestroyInstance()
 

--- a/tests/integration/cloud/helpers/cloud_test_base.py
+++ b/tests/integration/cloud/helpers/cloud_test_base.py
@@ -210,7 +210,9 @@ class CloudTest(ShellCase):
         '''
         query = self.query_instances()
         for q in query:
-            if q.startswith(self.instance_name) and not q == self.instance_name:
+            # Verify but this is a new name and not a shutting down ec2 instance
+            if q.startswith(self.instance_name) and not (q == self.instance_name) \
+               and not (q.split('-')[-1].startswith('DEL')):
                 return q
 
     def _ensure_deletion(self, instance_name=None):

--- a/tests/integration/cloud/helpers/cloud_test_base.py
+++ b/tests/integration/cloud/helpers/cloud_test_base.py
@@ -212,7 +212,7 @@ class CloudTest(ShellCase):
         for q in query:
             # Verify but this is a new name and not a shutting down ec2 instance
             if q.startswith(self.instance_name) and not (q == self.instance_name) \
-               and not (q.split('-')[-1].startswith('DEL')):
+               and not q.split('-')[-1].startswith('DEL'):
                 return q
 
     def _ensure_deletion(self, instance_name=None):

--- a/tests/integration/cloud/helpers/cloud_test_base.py
+++ b/tests/integration/cloud/helpers/cloud_test_base.py
@@ -213,7 +213,7 @@ class CloudTest(ShellCase):
             if q.startswith(self.instance_name) and not q == self.instance_name:
                 return q
 
-    def __ensure_deletion(self, instance_name=None):
+    def _ensure_deletion(self, instance_name=None):
         '''
         Make sure that the instance absolutely gets deleted, but fail the test if it happens in the tearDown
         :return True if an instance was deleted, False if no instance was deleted; and a message
@@ -249,10 +249,10 @@ class CloudTest(ShellCase):
         one time in a test for each instance created.  This is a failSafe and something went wrong
         if the tearDown is where an instance is destroyed.
         '''
-        instance_destroyed, destroy_message = self.__ensure_deletion()
-        alt_name = self._alt_name_exists()
+        instance_destroyed, destroy_message = self._ensure_deletion()
+        alt_name = self._alt_name()
         if alt_name:
-            alt_destroyed, alt_destroy_message = self.__ensure_deletion(alt_name)
+            alt_destroyed, alt_destroy_message = self._ensure_deletion(alt_name)
             self.assertTrue(instance_destroyed and alt_destroyed, destroy_message + ' :: ' + alt_destroy_message)
         else:
             self.assertTrue(instance_destroyed, destroy_message)


### PR DESCRIPTION
### What does this PR do?
Clean up renamed cloud instances, check that renamed instances exist the same way normal instances are checked