### PR TITLE
Dont include vm_ information in cloud debug log

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -616,6 +616,7 @@ def bootstrap(vm_, opts=None):
     del event_kwargs['minion_pem']
     del event_kwargs['minion_pub']
     del event_kwargs['sudo_password']
+    del event_kwargs['vm_']
     if 'password' in event_kwargs:
         del event_kwargs['password']
     ret['deploy_kwargs'] = event_kwargs

--- a/tests/integration/cloud/clouds/test_ec2.py
+++ b/tests/integration/cloud/clouds/test_ec2.py
@@ -94,15 +94,13 @@ class EC2Test(CloudTest):
                 dfp.write(sfp.read())
         return dst
 
-    def _test_instance(self, profile, debug):
+    def _test_instance(self, profile):
         '''
         Tests creating and deleting an instance on EC2 (classic)
         '''
 
         # create the instance
         cmd = ['-p', profile]
-        if debug:
-            cmd.extend(['-l', 'debug'])
         cmd.append(self.instance_name)
         ret_val = self.run_cloud(' '.join(cmd), timeout=TIMEOUT)
 
@@ -133,7 +131,7 @@ class EC2Test(CloudTest):
         '''
         Tests creating and deleting an instance on EC2 (classic)
         '''
-        self._test_instance('ec2-test', debug=False)
+        self._test_instance('ec2-test')
 
     def test_win2012r2_psexec(self):
         '''
@@ -151,7 +149,7 @@ class EC2Test(CloudTest):
                 'win_installer': self.copy_file(self.installer),
             },
         )
-        self._test_instance('ec2-win2012r2-test', debug=True)
+        self._test_instance('ec2-win2012r2-test')
 
     @skipIf(not HAS_WINRM, 'Skip when winrm dependencies are missing')
     def test_win2012r2_winrm(self):
@@ -169,7 +167,7 @@ class EC2Test(CloudTest):
             }
 
         )
-        self._test_instance('ec2-win2012r2-test', debug=True)
+        self._test_instance('ec2-win2012r2-test')
 
     def test_win2016_psexec(self):
         '''
@@ -186,7 +184,7 @@ class EC2Test(CloudTest):
                 'win_installer': self.copy_file(self.installer),
             },
         )
-        self._test_instance('ec2-win2016-test', debug=True)
+        self._test_instance('ec2-win2016-test')
 
     @skipIf(not HAS_WINRM, 'Skip when winrm dependencies are missing')
     def test_win2016_winrm(self):
@@ -204,4 +202,4 @@ class EC2Test(CloudTest):
             }
 
         )
-        self._test_instance('ec2-win2016-test', debug=True)
+        self._test_instance('ec2-win2016-test')

--- a/tests/support/case.py
+++ b/tests/support/case.py
@@ -235,11 +235,11 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
 
         return self.run_script('salt-call', arg_str, with_retcode=with_retcode, catch_stderr=catch_stderr)
 
-    def run_cloud(self, arg_str, catch_stderr=False, timeout=None):
+    def run_cloud(self, arg_str, catch_stderr=False, timeout=None, cloud_log='debug'):
         '''
         Execute salt-cloud
         '''
-        arg_str = '-c {0} {1}'.format(self.config_dir, arg_str)
+        arg_str = '-c {0} {1} -l{2}'.format(self.config_dir, arg_str, cloud_log)
         return self.run_script('salt-cloud', arg_str, catch_stderr, timeout)
 
     def run_script(self,
@@ -645,11 +645,11 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
         log.debug('Result of run_call for command \'%s\': %s', arg_str, ret)
         return ret
 
-    def run_cloud(self, arg_str, catch_stderr=False, timeout=RUN_TIMEOUT):
+    def run_cloud(self, arg_str, catch_stderr=False, timeout=RUN_TIMEOUT, cloud_log='debug'):
         '''
         Execute salt-cloud
         '''
-        arg_str = '-c {0} {1}'.format(self.config_dir, arg_str)
+        arg_str = '-c {0} {1} -l{2}'.format(self.config_dir, arg_str, cloud_log)
         ret = self.run_script('salt-cloud',
                               arg_str,
                               catch_stderr,

--- a/tests/unit/utils/test_cloud.py
+++ b/tests/unit/utils/test_cloud.py
@@ -17,7 +17,6 @@ import tempfile
 # Import Salt Testing libs
 from tests.support.unit import TestCase, skipIf
 from tests.support.paths import TMP, CODE_DIR
-from tests.support.helpers import TestsLoggingHandler
 from tests.support.mock import patch, MagicMock
 from tests.support.mixins import LoaderModuleMockMixin
 import tests.integration as integration
@@ -175,11 +174,10 @@ class CloudUtilsTestCase(TestCase, LoaderModuleMockMixin):
                 'start_action': 'start', 'parallel': False, 'sock_dir':
                 '/tmp/sock_dir', 'conf_file': '/tmp/conf_file', 'keep_tmp': False,
                 'sudo_password': 'passwd'}
-        with TestsLoggingHandler() as handler:
-            with patch.dict(cloud.__opts__, {'sock_dir': os.path.join(integration.TMP, 'test-socks')}):
-                cloud.bootstrap(vm_, opts)
-                for ret in events.call_args_list:
-                    arg, kwarg = ret
-                    event_kwargs = kwarg['args']['kwargs']
-                    assert 'vm_' not in event_kwargs
-                    assert 'sudo_password' not in event_kwargs
+        with patch.dict(cloud.__opts__, {'sock_dir': os.path.join(integration.TMP, 'test-socks')}):
+            cloud.bootstrap(vm_, opts)
+            for ret in events.call_args_list:
+                arg, kwarg = ret
+                event_kwargs = kwarg['args']['kwargs']
+                assert 'vm_' not in event_kwargs
+                assert 'sudo_password' not in event_kwargs


### PR DESCRIPTION
### What does this PR do?
We include sensitive information in `vm_` including, the key,id,ssh key info, passwords, etc. We do not need to include this in the debug log.

This also enables debug on other cloud tests so we can see if there are other creds in the debug logs.

### What issues does this PR fix or reference?

### Previous Behavior
sensitive information logged in debug mode

### New Behavior
sensitive information not logged

### Tests written?
Yes

### Commits signed with GPG?

Yes