### PR TITLE
alter sql was only considering password and not password_hash

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -1552,7 +1552,7 @@ def user_chpass(user,
     args['user'] = user
     args['host'] = host
     if salt.utils.versions.version_cmp(server_version, compare_version) >= 0:
-        qry = "ALTER USER %(user)s@%(host)s IDENTIFIED BY %(password)s;"
+        qry = "ALTER USER %(user)s@%(host)s IDENTIFIED BY %(password_sql)s;"
     else:
         qry = ('UPDATE mysql.user SET ' + password_column + '=' + password_sql +
                ' WHERE User=%(user)s AND Host = %(host)s;')


### PR DESCRIPTION
### What does this PR do?
 Fixes password updates in versions that support `ALTER USER....`
### What issues does this PR fix or reference?
A second run of the highstate is not idempotent b/c of the variable used.
### Previous Behavior
Remove this section if not relevant
```2019-08-23 20:56:14,318 [salt.state       :322 ][ERROR   ][16287] An exception occurred in this state: Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1933, in call
    **cdata['kwargs'])
  File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1939, in wrapper
    return f(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/states/mysql_user.py", line 174, in present
    **connection_args):
  File "/usr/lib/python2.7/dist-packages/salt/modules/mysql.py", line 1475, in user_chpass
    " IDENTIFIED BY '" + password + "';")
TypeError: coercing to Unicode: need string or buffer, NoneType found
```
**this prevented idempotency from subsequent runs and i don't it may have double encoded (which i will try to prove in another PR) the hash b/c i saw that my local users password was the PASSWORD_HASH hashed.
### New Behavior
None of the above occurs
Remove this section if not relevant

### Tests written?
no - I'll write tests, but clearly test were not written for this use case, i'm not saying that to in adversity, just let me know where i can add this specific one, i would really appreciate that.
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

Yes/No

### Commits signed with GPG?
No
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
