### PR TITLE
[2019.2.1] Do not raise the exception in testprogram.py

### DIFF
--- a/tests/integration/utils/testprogram.py
+++ b/tests/integration/utils/testprogram.py
@@ -832,7 +832,7 @@ class TestDaemon(TestProgram):
                         log.error('Unable to access process %s, '
                                   'running command %s as user %s',
                                   pinfo['pid'], pinfo['name'], pinfo['username'])
-                        raise
+                        continue
                 if any((cmdline == proc_cmdline[n:n + cmd_len])
                         for n in range(len(proc_cmdline) - cmd_len + 1)):
                     ret.append(proc)


### PR DESCRIPTION
### What does this PR do?
Do not raise the exception if a process can not be access, just continue

### What issues does this PR fix or reference?
N/A

### Previous Behavior
If we receive an AccessDenied exception when looking for zombie processes the exception is raseid.

### New Behavior
If we receive an AccessDenied exception when looking for zombie processes just continue.

### Tests written?
No.  Updating existing tests.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
