### PR TITLE
#53931 never fail on codecov curls

### DIFF
--- a/.ci/kitchen-centos6-py2
+++ b/.ci/kitchen-centos6-py2
@@ -140,7 +140,7 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                             withCredentials([[$class: 'StringBinding', credentialsId: 'codecov-upload-token-salt', variable: 'CODECOV_TOKEN']]) {
                               sh '''
                               if [ -n "${FORCE_FULL}" -a "${FORCE_FULL}" = "true" -a -f artifacts/coverage/coverage.xml ]; then
-                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}") || true
+                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}" || true) || true
                               fi
                               '''
                             }

--- a/.ci/kitchen-centos7-py2
+++ b/.ci/kitchen-centos7-py2
@@ -140,7 +140,7 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                             withCredentials([[$class: 'StringBinding', credentialsId: 'codecov-upload-token-salt', variable: 'CODECOV_TOKEN']]) {
                               sh '''
                               if [ -n "${FORCE_FULL}" -a "${FORCE_FULL}" = "true" -a -f artifacts/coverage/coverage.xml ]; then
-                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}") || true
+                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}" || true) || true
                               fi
                               '''
                             }

--- a/.ci/kitchen-centos7-py2-tcp
+++ b/.ci/kitchen-centos7-py2-tcp
@@ -140,7 +140,7 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                             withCredentials([[$class: 'StringBinding', credentialsId: 'codecov-upload-token-salt', variable: 'CODECOV_TOKEN']]) {
                               sh '''
                               if [ -n "${FORCE_FULL}" -a "${FORCE_FULL}" = "true" -a -f artifacts/coverage/coverage.xml ]; then
-                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}") || true
+                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}" || true) || true
                               fi
                               '''
                             }

--- a/.ci/kitchen-centos7-py3
+++ b/.ci/kitchen-centos7-py3
@@ -140,7 +140,7 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                             withCredentials([[$class: 'StringBinding', credentialsId: 'codecov-upload-token-salt', variable: 'CODECOV_TOKEN']]) {
                               sh '''
                               if [ -n "${FORCE_FULL}" -a "${FORCE_FULL}" = "true" -a -f artifacts/coverage/coverage.xml ]; then
-                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}") || true
+                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}" || true) || true
                               fi
                               '''
                             }

--- a/.ci/kitchen-debian10-py2
+++ b/.ci/kitchen-debian10-py2
@@ -140,7 +140,7 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                             withCredentials([[$class: 'StringBinding', credentialsId: 'codecov-upload-token-salt', variable: 'CODECOV_TOKEN']]) {
                               sh '''
                               if [ -n "${FORCE_FULL}" -a "${FORCE_FULL}" = "true" -a -f artifacts/coverage/coverage.xml ]; then
-                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}") || true
+                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}" || true) || true
                               fi
                               '''
                             }

--- a/.ci/kitchen-debian10-py3
+++ b/.ci/kitchen-debian10-py3
@@ -140,7 +140,7 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                             withCredentials([[$class: 'StringBinding', credentialsId: 'codecov-upload-token-salt', variable: 'CODECOV_TOKEN']]) {
                               sh '''
                               if [ -n "${FORCE_FULL}" -a "${FORCE_FULL}" = "true" -a -f artifacts/coverage/coverage.xml ]; then
-                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}") || true
+                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}" || true) || true
                               fi
                               '''
                             }

--- a/.ci/kitchen-debian8-py2
+++ b/.ci/kitchen-debian8-py2
@@ -140,7 +140,7 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                             withCredentials([[$class: 'StringBinding', credentialsId: 'codecov-upload-token-salt', variable: 'CODECOV_TOKEN']]) {
                               sh '''
                               if [ -n "${FORCE_FULL}" -a "${FORCE_FULL}" = "true" -a -f artifacts/coverage/coverage.xml ]; then
-                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}") || true
+                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}" || true) || true
                               fi
                               '''
                             }

--- a/.ci/kitchen-debian8-py3
+++ b/.ci/kitchen-debian8-py3
@@ -140,7 +140,7 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                             withCredentials([[$class: 'StringBinding', credentialsId: 'codecov-upload-token-salt', variable: 'CODECOV_TOKEN']]) {
                               sh '''
                               if [ -n "${FORCE_FULL}" -a "${FORCE_FULL}" = "true" -a -f artifacts/coverage/coverage.xml ]; then
-                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}") || true
+                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}" || true) || true
                               fi
                               '''
                             }

--- a/.ci/kitchen-debian9-py2
+++ b/.ci/kitchen-debian9-py2
@@ -140,7 +140,7 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                             withCredentials([[$class: 'StringBinding', credentialsId: 'codecov-upload-token-salt', variable: 'CODECOV_TOKEN']]) {
                               sh '''
                               if [ -n "${FORCE_FULL}" -a "${FORCE_FULL}" = "true" -a -f artifacts/coverage/coverage.xml ]; then
-                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}") || true
+                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}" || true) || true
                               fi
                               '''
                             }

--- a/.ci/kitchen-debian9-py3
+++ b/.ci/kitchen-debian9-py3
@@ -140,7 +140,7 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                             withCredentials([[$class: 'StringBinding', credentialsId: 'codecov-upload-token-salt', variable: 'CODECOV_TOKEN']]) {
                               sh '''
                               if [ -n "${FORCE_FULL}" -a "${FORCE_FULL}" = "true" -a -f artifacts/coverage/coverage.xml ]; then
-                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}") || true
+                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}" || true) || true
                               fi
                               '''
                             }

--- a/.ci/kitchen-fedora29-py2
+++ b/.ci/kitchen-fedora29-py2
@@ -140,7 +140,7 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                             withCredentials([[$class: 'StringBinding', credentialsId: 'codecov-upload-token-salt', variable: 'CODECOV_TOKEN']]) {
                               sh '''
                               if [ -n "${FORCE_FULL}" -a "${FORCE_FULL}" = "true" -a -f artifacts/coverage/coverage.xml ]; then
-                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}") || true
+                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}" || true) || true
                               fi
                               '''
                             }

--- a/.ci/kitchen-fedora29-py3
+++ b/.ci/kitchen-fedora29-py3
@@ -140,7 +140,7 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                             withCredentials([[$class: 'StringBinding', credentialsId: 'codecov-upload-token-salt', variable: 'CODECOV_TOKEN']]) {
                               sh '''
                               if [ -n "${FORCE_FULL}" -a "${FORCE_FULL}" = "true" -a -f artifacts/coverage/coverage.xml ]; then
-                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}") || true
+                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}" || true) || true
                               fi
                               '''
                             }

--- a/.ci/kitchen-ubuntu1604-py2
+++ b/.ci/kitchen-ubuntu1604-py2
@@ -140,7 +140,7 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                             withCredentials([[$class: 'StringBinding', credentialsId: 'codecov-upload-token-salt', variable: 'CODECOV_TOKEN']]) {
                               sh '''
                               if [ -n "${FORCE_FULL}" -a "${FORCE_FULL}" = "true" -a -f artifacts/coverage/coverage.xml ]; then
-                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}") || true
+                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}" || true) || true
                               fi
                               '''
                             }

--- a/.ci/kitchen-ubuntu1604-py2-tcp
+++ b/.ci/kitchen-ubuntu1604-py2-tcp
@@ -140,7 +140,7 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                             withCredentials([[$class: 'StringBinding', credentialsId: 'codecov-upload-token-salt', variable: 'CODECOV_TOKEN']]) {
                               sh '''
                               if [ -n "${FORCE_FULL}" -a "${FORCE_FULL}" = "true" -a -f artifacts/coverage/coverage.xml ]; then
-                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}") || true
+                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}" || true) || true
                               fi
                               '''
                             }

--- a/.ci/kitchen-ubuntu1604-py3
+++ b/.ci/kitchen-ubuntu1604-py3
@@ -140,7 +140,7 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                             withCredentials([[$class: 'StringBinding', credentialsId: 'codecov-upload-token-salt', variable: 'CODECOV_TOKEN']]) {
                               sh '''
                               if [ -n "${FORCE_FULL}" -a "${FORCE_FULL}" = "true" -a -f artifacts/coverage/coverage.xml ]; then
-                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}") || true
+                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}" || true) || true
                               fi
                               '''
                             }

--- a/.ci/kitchen-ubuntu1804-py2
+++ b/.ci/kitchen-ubuntu1804-py2
@@ -140,7 +140,7 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                             withCredentials([[$class: 'StringBinding', credentialsId: 'codecov-upload-token-salt', variable: 'CODECOV_TOKEN']]) {
                               sh '''
                               if [ -n "${FORCE_FULL}" -a "${FORCE_FULL}" = "true" -a -f artifacts/coverage/coverage.xml ]; then
-                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}") || true
+                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}" || true) || true
                               fi
                               '''
                             }

--- a/.ci/kitchen-ubuntu1804-py3
+++ b/.ci/kitchen-ubuntu1804-py3
@@ -140,7 +140,7 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                             withCredentials([[$class: 'StringBinding', credentialsId: 'codecov-upload-token-salt', variable: 'CODECOV_TOKEN']]) {
                               sh '''
                               if [ -n "${FORCE_FULL}" -a "${FORCE_FULL}" = "true" -a -f artifacts/coverage/coverage.xml ]; then
-                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}") || true
+                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}" || true) || true
                               fi
                               '''
                             }

--- a/.ci/kitchen-windows2016-py2
+++ b/.ci/kitchen-windows2016-py2
@@ -149,7 +149,7 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                             withCredentials([[$class: 'StringBinding', credentialsId: 'codecov-upload-token-salt', variable: 'CODECOV_TOKEN']]) {
                               sh '''
                               if [ -n "${FORCE_FULL}" -a "${FORCE_FULL}" = "true" -a -f artifacts/coverage/coverage.xml ]; then
-                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}") || true
+                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}" || true) || true
                               fi
                               '''
                             }

--- a/.ci/kitchen-windows2016-py3
+++ b/.ci/kitchen-windows2016-py3
@@ -149,7 +149,7 @@ wrappedNode('kitchen-slave', global_timeout, '#jenkins-prod-pr') {
                             withCredentials([[$class: 'StringBinding', credentialsId: 'codecov-upload-token-salt', variable: 'CODECOV_TOKEN']]) {
                               sh '''
                               if [ -n "${FORCE_FULL}" -a "${FORCE_FULL}" = "true" -a -f artifacts/coverage/coverage.xml ]; then
-                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}") || true
+                                  (curl -L https://codecov.io/bash | /bin/sh -s -- -R $(pwd) -s artifacts/coverage/ -F "${CODECOV_FLAGS}" || true) || true
                               fi
                               '''
                             }


### PR DESCRIPTION
What does this PR do?

adds || true to codecov curls so we don't fail if they are down.
What issues does this PR fix or reference?

#53931
Previous Behavior

codecov curl statements could cause a test run to fail if codecov is down
New Behavior

bash will now return 0 for this curl even if codecov is down
Tests written?

[NOTICE] Bug fixes or features added to Salt require tests.
Please review the test documentation for details on how to implement tests into Salt's test suite.

No
Commits signed with GPG?

Yes

Please review Salt's Contributing Guide for best practices.

See GitHub's page on GPG signing for more information about signing commits with GPG.