### PR TITLE
[2019.2] Fix to thin.generate runner function

### DIFF
--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -553,7 +553,7 @@ def gen_thin(cachedir, extra_mods='', overwrite=False, so_mods='',
     for fname in ['version', '.thin-gen-py-version', 'salt-call', 'supported-versions', 'code-checksum']:
         tfp.add(fname)
 
-    if start_dir:
+    if start_dir and os.access(start_dir, os.R_OK) and os.access(start_dir, os.X_OK):
         os.chdir(start_dir)
     tfp.close()
 


### PR DESCRIPTION
### What does this PR do?
Verify that the user running thin.generate has read and execute permissions before attempting to chdir back to start_dir.

### What issues does this PR fix or reference?
#54317 

### Previous Behavior
If Salt was configured to run as a non-root user and the thin.generate runner was executed in a directory that the user did not have access to an exception would be triggered.

### New Behavior
Check that the user has read and execute permissions before attempting the chdir.

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
