### PR TITLE
Delete bad API token files

### DIFF
--- a/salt/tokens/localfs.py
+++ b/salt/tokens/localfs.py
@@ -10,9 +10,10 @@ import hashlib
 import os
 import logging
 
+import salt.exceptions
+import salt.payload
 import salt.utils.files
 import salt.utils.path
-import salt.payload
 
 from salt.ext import six
 


### PR DESCRIPTION
### What does this PR do?

Deletes eauth token files if they're empty (or otherwise fail to be read)

### What issues does this PR fix or reference?

#54256 
#37945

### Previous Behavior

If the token file was empty or we otherwise failed to deserialize the token it would cause an exception. This was a regression.

### New Behavior

If the token file is empty or we otherwise fail to deserialize the token we delete the invalid token file.

### Tests written?

Yes - not just ones to cover this regression, but also added a couple more to cover this whole function.

### Commits signed with GPG?

Yes

---

I have one question about this, though - right now I'm capturing `Exception` when trying to load the token file. This seems like it *could* be overly broad - OTOH, it's also probably accurate. For an IOError or OSError it will end out taking a different path (i.e. that load will just return an empty dict that gets returned, which bypasses the file removal process).

Any thoughts?