### PR TITLE
[2019.2.1] Catch the AccessDenied exception and continue when running under Py3.

### DIFF
--- a/tests/integration/utils/testprogram.py
+++ b/tests/integration/utils/testprogram.py
@@ -816,6 +816,14 @@ class TestDaemon(TestProgram):
                     # Process exited between when process_iter was invoked and
                     # when we tried to invoke this instance's cmdline() func.
                     continue
+                except psutils.AccessDenied:
+                    # We might get access denied if not running as root
+                    if not salt.utils.platform.is_windows():
+                        pinfo = proc.as_dict(attrs=['pid', 'name', 'username'])
+                        log.error('Unable to access process %s, '
+                                  'running command %s as user %s',
+                                  pinfo['pid'], pinfo['name'], pinfo['username'])
+                        continue
         else:
             cmd_len = len(cmdline)
             for proc in psutils.process_iter():


### PR DESCRIPTION
### What does this PR do?
Catch the AccessDenied exception and continue when running under Py3.

### What issues does this PR fix or reference?
N/A

### Previous Behavior
Same behavior we saw under Python2 happening under Python3 because of different code for Python3.

### New Behavior
Catch the AccessDenied exception and continue.

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.
No

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
