### PR TITLE
virt.full_info fixes

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -458,7 +458,7 @@ def _get_disks(dom):
             if driver is not None and driver.get('type') == 'qcow2':
                 try:
                     stdout = subprocess.Popen(
-                                ['qemu-img', 'info', '--output', 'json', '--backing-chain', disk['file']],
+                                ['qemu-img', 'info', '-U', '--output', 'json', '--backing-chain', disk['file']],
                                 shell=False,
                                 stdout=subprocess.PIPE).communicate()[0]
                     qemu_output = salt.utils.stringutils.to_str(stdout)


### PR DESCRIPTION
### What does this PR do?

While running `virt.full_info` module function, several errors happened:

    'ERROR: The VM "<libvirt.virDomain object at 0x7fad04208650>" is not present'

and

        The minion function caused an exception: Traceback (most recent call last):
      File "/usr/lib/python3.6/site-packages/salt/minion.py", line 1673, in _thread_return
        return_data = minion_instance.executors[fname](opts, data, func, args, kwargs)
      File "/usr/lib/python3.6/site-packages/salt/executors/direct_call.py", line 12, in execute
        return func(*args, **kwargs)
      File "/usr/lib/python3.6/site-packages/salt/modules/virt.py", line 2411, in full_info
        'vm_info': vm_info()}
      File "/usr/lib/python3.6/site-packages/salt/modules/virt.py", line 2020, in vm_info
        info[domain.name()] = _info(domain)
      File "/usr/lib/python3.6/site-packages/salt/modules/virt.py", line 2004, in _info
        'disks': _get_disks(dom),
      File "/usr/lib/python3.6/site-packages/salt/modules/virt.py", line 465, in _get_disks
        output = _parse_qemu_img_info(qemu_output)
      File "/usr/lib/python3.6/site-packages/salt/modules/virt.py", line 287, in _parse_qemu_img_info
        raw_infos = salt.utils.json.loads(info)
      File "/usr/lib/python3.6/site-packages/salt/utils/json.py", line 92, in loads
        return json_module.loads(s, **kwargs)
      File "/usr/lib64/python3.6/json/__init__.py", line 354, in loads
        return _default_decoder.decode(s)
      File "/usr/lib64/python3.6/json/decoder.py", line 339, in decode
        obj, end = self.raw_decode(s, idx=_w(s, 0).end())
      File "/usr/lib64/python3.6/json/decoder.py", line 357, in raw_decode
        raise JSONDecodeError("Expecting value", s, err.value) from None
    json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

This PR fixes both of these issues.

### What issues does this PR fix or reference?

### Previous Behavior

Run `virt.full_info` on a KVM minion with at least a running VM. You will see the first error. Once fixed you will see the second one.

### New Behavior

Run `virt.full_info` on a KVM minion displays the expected data

### Tests written?

Yes, merged some scattered unit tests into a `full_info` test covering it all.

### Commits signed with GPG?

Yes