### PR TITLE
Fix using password hashes with MariaDB

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -1437,7 +1437,10 @@ def user_create(user,
         args['password'] = six.text_type(password)
     elif password_hash is not None:
         if salt.utils.versions.version_cmp(server_version, compare_version) >= 0:
-            qry += ' IDENTIFIED BY %(password)s'
+            if 'MariaDB' in server_version:
+                qry += ' IDENTIFIED BY PASSWORD %(password)s'
+            else:
+                qry += ' IDENTIFIED BY %(password)s'
         else:
             qry += ' IDENTIFIED BY PASSWORD %(password)s'
         args['password'] = password_hash
@@ -1554,7 +1557,10 @@ def user_chpass(user,
     args['user'] = user
     args['host'] = host
     if salt.utils.versions.version_cmp(server_version, compare_version) >= 0:
-        qry = "ALTER USER %(user)s@%(host)s IDENTIFIED BY %(password)s;"
+        if 'MariaDB' in server_version and password_hash is not None:
+            qry = "ALTER USER %(user)s@%(host)s IDENTIFIED BY PASSWORD %(password)s;"
+        else:
+            qry = "ALTER USER %(user)s@%(host)s IDENTIFIED BY %(password)s;"
     else:
         qry = ('UPDATE mysql.user SET ' + password_column + '=' + password_sql +
                ' WHERE User=%(user)s AND Host = %(host)s;')


### PR DESCRIPTION
MariaDB 10.2.0 introduced the 'ALTER USER' statement, but it did NOT remove the need to denote password hashes with the PASSWORD keyword.
Both [CREATE USER](https://mariadb.com/kb/en/library/create-user/) as well as [ALTER USER](https://mariadb.com/kb/en/library/alter-user/) still need `IDENTIFIED BY PASSWORD`

This should be a more complete fix compared to previous attempts in #53861 and #54299 