### PR TITLE
Contents newline fix

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2362,8 +2362,10 @@ def managed(name,
 
         If ``True``, files managed using ``contents``, ``contents_pillar``, or
         ``contents_grains`` will have a newline added to the end of the file if
-        one is not present. Setting this option to ``False`` will omit this
-        final newline.
+        one is not present. Setting this option to ``False`` will ensure the
+        final line, or entry, does not contain a new line. If the last line, or
+        entry in the file does contain a new line already, this option will not
+        remove it.
 
     contents_delimiter
         .. versionadded:: 2015.8.4

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2712,9 +2712,18 @@ def managed(name,
             contents = ''
             for part in validated_contents:
                 for line in part.splitlines():
-                    contents += line.rstrip('\n').rstrip('\r') + os.linesep
-            if contents_newline and not contents.endswith(os.linesep):
-                contents += os.linesep
+                    if not (line == validated_contents[-1]):
+                        # So long as we havent reached the end strip out the
+                        # newline and carriage return and add a platform
+                        # specific line ending with os.linesep
+                        contents += line.rstrip('\n').rstrip('\r') + os.linesep
+                    else:
+                        # Were at the last line decide if a newline needs to
+                        # go in or not
+                        contents += line.rstrip('\n').rstrip('\r')
+                        if contents_newline:
+                            contents += os.linesep
+
         except UnicodeDecodeError:
             # Either something terrible happened, or we have binary data.
             if template:

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -565,6 +565,34 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
             for typ in managed_files:
                 os.remove(managed_files[typ])
 
+    def test_managed_contents_with_contents_newline(self):
+        '''
+        test file.managed with contents by using the default content_newline
+        flag.
+        '''
+        contents = r'test_managed_contents_with_newline_one'
+        name = os.path.join(RUNTIME_VARS.TMP, 'foo')
+
+        # Create a file named foo with contents as above but with a \n at EOF
+        self.run_state('file.managed', name=name, contents=contents, contents_newline=True)
+        with salt.utils.files.fopen(name, 'r') as fp_:
+            last_line = fp_.read()
+            self.assertEqual((contents + os.linesep), last_line)
+
+    def test_managed_contents_with_contents_newline_false(self):
+        '''
+        test file.managed with contents by using the non default content_newline
+        flag.
+        '''
+        contents = 'test_managed_contents_with_newline_one'
+        name = os.path.join(RUNTIME_VARS.TMP, 'bar')
+
+        # Create a file named foo with contents as above but with a \n at EOF
+        self.run_state('file.managed', name=name, contents=contents, contents_newline=False)
+        with salt.utils.files.fopen(name, 'r') as fp_:
+            last_line = fp_.read()
+            self.assertEqual((contents), last_line)
+
     @skip_if_not_root
     @skipIf(IS_WINDOWS, 'Windows does not support "mode" kwarg. Skipping.')
     @skipIf(not salt.utils.path.which('visudo'), 'sudo is missing')

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -574,7 +574,8 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         name = os.path.join(RUNTIME_VARS.TMP, 'foo')
 
         # Create a file named foo with contents as above but with a \n at EOF
-        self.run_state('file.managed', name=name, contents=contents, contents_newline=True)
+        self.run_state('file.managed', name=name, contents=contents,
+                       contents_newline=True)
         with salt.utils.files.fopen(name, 'r') as fp_:
             last_line = fp_.read()
             self.assertEqual((contents + os.linesep), last_line)
@@ -588,10 +589,11 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
         name = os.path.join(RUNTIME_VARS.TMP, 'bar')
 
         # Create a file named foo with contents as above but with a \n at EOF
-        self.run_state('file.managed', name=name, contents=contents, contents_newline=False)
+        self.run_state('file.managed', name=name, contents=contents,
+                       contents_newline=False)
         with salt.utils.files.fopen(name, 'r') as fp_:
             last_line = fp_.read()
-            self.assertEqual((contents), last_line)
+            self.assertEqual(contents, last_line)
 
     @skip_if_not_root
     @skipIf(IS_WINDOWS, 'Windows does not support "mode" kwarg. Skipping.')


### PR DESCRIPTION
### What does this PR do?
Address the issue of the file.managed state not using contents_newline correctly.

### What issues does this PR fix or reference?
Issue https://github.com/saltstack/salt/issues/54177

### Previous Behavior
```
            for part in validated_contents:
                for line in part.splitlines():
                    contents += line.rstrip('\n').rstrip('\r') + os.linesep
            if contents_newline and not contents.endswith(os.linesep):
                contents += os.linesep
```
Because of the `for` loop EOF would contain a platform-specific line-ending, even if the user set
`contents_newline = False`. According to the documentation, contents_newline should allow the user
to specify that they _don't_ want the file to end with a newline.

### New Behavior
Setting `contents_newline = False` will now determine if the last entry in the file should end with
a newline character

### Tests written?
Yes

### Commits signed with GPG?

No