### PR TITLE
change to saltstack version of kitchen-salt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 
 gem 'test-kitchen', '~>1.23.3'
-gem 'kitchen-salt', :git => 'https://github.com/s0undt3ch/kitchen-salt.git', :branch => 'features/nox'
+gem 'kitchen-salt', :git => 'https://github.com/saltstack/kitchen-salt.git'
 gem 'kitchen-sync'
 gem 'git'
 


### PR DESCRIPTION
### What does this PR do?
change to using saltstack version of kitchen-salt as they are the same now.
