### PR TITLE
Use iptables.check to ensure that the rule is removed.

### DIFF
--- a/tests/multimaster/minion/test_event.py
+++ b/tests/multimaster/minion/test_event.py
@@ -2,6 +2,7 @@
 
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
+import logging
 
 # Import Salt Testing libs
 from tests.support.case import MultimasterModuleCase, ShellTestCase
@@ -13,6 +14,8 @@ import salt.modules.iptables
 HAS_IPTABLES = salt.modules.iptables.__virtual__()
 if isinstance(HAS_IPTABLES, tuple):
     HAS_IPTABLES = HAS_IPTABLES[0]
+
+log = logging.getLogger(__name__)
 
 
 @destructiveTest
@@ -64,8 +67,30 @@ class TestHandleEvents(MultimasterModuleCase, ShellTestCase, AdaptedConfiguratio
             # Remove the firewall rule taking master online back.
             # Since minion could be not responsive now use `salt-call --local` for this.
             res = self.run_call(
+                    "iptables.get_rules",
+                    local=True)
+            log.debug('TEST IPTABLES rules after the test pass: %s', res)
+
+            res = self.run_call(
                     "iptables.delete filter INPUT rule='{0}'".format(disconnect_master_rule),
                     local=True)
+            log.debug('TEST IPTABLES salt-call iptables.delete reutrned: %s', res)
+
+            res = self.run_call(
+                    "iptables.get_rules",
+                    local=True)
+            log.debug('TEST IPTABLES rules after the rule removed: %s', res)
+
+            res = self.run_call(
+                    "iptables.delete filter INPUT rule='{0}'".format(disconnect_master_rule),
+                    local=True)
+            log.debug('TEST IPTABLES salt-call iptables.delete 2 reutrned: %s', res)
+
+            res = self.run_call(
+                    "iptables.get_rules",
+                    local=True)
+            log.debug('TEST IPTABLES rules after the rule removed 2: %s', res)
+
             res = self.run_call(
                     "iptables.check filter INPUT rule='{0}'".format(disconnect_master_rule),
                     local=True)

--- a/tests/multimaster/minion/test_event.py
+++ b/tests/multimaster/minion/test_event.py
@@ -66,7 +66,13 @@ class TestHandleEvents(MultimasterModuleCase, ShellTestCase, AdaptedConfiguratio
             res = self.run_call(
                     "iptables.delete filter INPUT rule='{0}'".format(disconnect_master_rule),
                     local=True)
-            self.assertEqual(res, ['local:'])
+            res = self.run_call(
+                    "iptables.check filter INPUT rule='{0}'".format(disconnect_master_rule),
+                    local=True)
+            self.assertEqual(
+                    res,
+                    ['local:',
+                     '    iptables: Bad rule (does a matching rule exist in that chain?).'])
             # Ensure the master is back.
             res = self.run_function(
                     'event.send',


### PR DESCRIPTION
### What does this PR do?
This is a try to workaround a flaky issues with the event multimaster test.
Here I'm using `iptables.check` after the rule should be removed with `iptables.delete` to ensure there is no that rule in the table.

### What issues does this PR fix or reference?
Fixes #54361

### Previous Behavior
The tests failed on the last step that is clearing the iptables rules that imitates master is down. For some reason `salt-call` returns an empty output.

### New Behavior
Should work if the rule is actually removed and the issue is just in the wrong return.

### Tests written?
No, fix for a test.

### Commits signed with GPG?
Yes