### PR TITLE
Fix pyenv installation into the state.pyenv.install_pyenv

### DIFF
--- a/salt/states/pyenv.py
+++ b/salt/states/pyenv.py
@@ -61,6 +61,9 @@ def _check_pyenv(ret, user=None):
     if not __salt__['pyenv.is_installed'](user):
         ret['result'] = False
         ret['comment'] = 'pyenv is not installed.'
+    else:
+        ret['result'] = True
+        ret['comment'] = 'pyenv is installed.'
     return ret
 
 

--- a/salt/states/pyenv.py
+++ b/salt/states/pyenv.py
@@ -216,4 +216,10 @@ def install_pyenv(name, user=None):
         ret['comment'] = 'pyenv is set to be installed'
         return ret
 
-    return _check_and_install_python(ret, user)
+    ret =  _check_pyenv(ret, user)
+    if not ret['result'] is True:
+        if __salt__['pyenv.install'](user):
+            ret['result'] = True
+            ret['comment'] = 'Successfully installed pyenv'
+
+    return ret

--- a/salt/states/pyenv.py
+++ b/salt/states/pyenv.py
@@ -220,7 +220,7 @@ def install_pyenv(name, user=None):
         return ret
 
     ret =  _check_pyenv(ret, user)
-    if not ret['result'] is True:
+    if not ret['result']:
         if __salt__['pyenv.install'](user):
             ret['result'] = True
             ret['comment'] = 'Successfully installed pyenv'


### PR DESCRIPTION
### What does this PR do?
Add real request for pyenv installation inside then states.pyenv.install_pyenv

### What issues does this PR fix or reference?
Fixes #37648

### Previous Behavior
The function states.pyenv.install_pyenv just requested an installation of python with the username for pyenv instead of a real python version. So when it was called it always returns error.

### New Behavior
if pyenv is not installed the function requests the installation

### Tests written?
No

### Commits signed with GPG?
Yes