### PR TITLE
54256 re fix empty api token 2019.2.1

### DIFF
--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -351,6 +351,12 @@ class TokenAuthenticationError(SaltException):
     '''
 
 
+class SaltDeserializationError(SaltException):
+    '''
+    Thrown when salt cannot deserialize data.
+    '''
+
+
 class AuthorizationError(SaltException):
     '''
     Thrown when runner or wheel execution fails due to permissions

--- a/salt/payload.py
+++ b/salt/payload.py
@@ -17,7 +17,7 @@ import salt.log
 import salt.transport.frame
 import salt.utils.immutabletypes as immutabletypes
 import salt.utils.stringutils
-from salt.exceptions import SaltReqTimeoutError
+from salt.exceptions import SaltReqTimeoutError, SaltDeserializationError
 from salt.utils.data import CaseInsensitiveDict
 
 # Import third party libs
@@ -174,7 +174,13 @@ class Serial(object):
             )
             log.debug('Msgpack deserialization failure on message: %s', msg)
             gc.collect()
-            raise
+            raise six.raise_from(
+                SaltDeserializationError(
+                    'Could not deserialize msgpack message.'
+                    ' See log for more info.'
+                ),
+                exc,
+            )
         finally:
             gc.enable()
         return ret

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -6,6 +6,8 @@
 # Import pytohn libs
 from __future__ import absolute_import, print_function, unicode_literals
 
+import time
+
 # Import Salt Testing libs
 from tests.support.unit import TestCase, skipIf
 from tests.support.mock import patch, call, NO_MOCK, NO_MOCK_REASON, MagicMock
@@ -14,6 +16,7 @@ from tests.support.mock import patch, call, NO_MOCK, NO_MOCK_REASON, MagicMock
 import salt.master
 from tests.support.case import ModuleCase
 from salt import auth
+from salt.exceptions import SaltDeserializationError
 import salt.utils.platform
 
 
@@ -36,6 +39,72 @@ class LoadAuthTestCase(TestCase):
             patcher.start()
             self.addCleanup(patcher.stop)
         self.lauth = auth.LoadAuth({})  # Load with empty opts
+
+    def test_get_tok_with_broken_file_will_remove_bad_token(self):
+        fake_get_token = MagicMock(side_effect=SaltDeserializationError('hi'))
+        patch_opts = patch.dict(self.lauth.opts, {'eauth_tokens': 'testfs'})
+        patch_get_token = patch.dict(
+            self.lauth.tokens,
+            {
+                'testfs.get_token': fake_get_token
+            },
+        )
+        mock_rm_token = MagicMock()
+        patch_rm_token = patch.object(self.lauth, 'rm_token', mock_rm_token)
+        with patch_opts, patch_get_token, patch_rm_token:
+            expected_token = 'fnord'
+            self.lauth.get_tok(expected_token)
+            mock_rm_token.assert_called_with(expected_token)
+
+    def test_get_tok_with_no_expiration_should_remove_bad_token(self):
+        fake_get_token = MagicMock(return_value={'no_expire_here': 'Nope'})
+        patch_opts = patch.dict(self.lauth.opts, {'eauth_tokens': 'testfs'})
+        patch_get_token = patch.dict(
+            self.lauth.tokens,
+            {
+                'testfs.get_token': fake_get_token
+            },
+        )
+        mock_rm_token = MagicMock()
+        patch_rm_token = patch.object(self.lauth, 'rm_token', mock_rm_token)
+        with patch_opts, patch_get_token, patch_rm_token:
+            expected_token = 'fnord'
+            self.lauth.get_tok(expected_token)
+            mock_rm_token.assert_called_with(expected_token)
+
+    def test_get_tok_with_expire_before_current_time_should_remove_token(self):
+        fake_get_token = MagicMock(return_value={'expire': time.time()-1})
+        patch_opts = patch.dict(self.lauth.opts, {'eauth_tokens': 'testfs'})
+        patch_get_token = patch.dict(
+            self.lauth.tokens,
+            {
+                'testfs.get_token': fake_get_token
+            },
+        )
+        mock_rm_token = MagicMock()
+        patch_rm_token = patch.object(self.lauth, 'rm_token', mock_rm_token)
+        with patch_opts, patch_get_token, patch_rm_token:
+            expected_token = 'fnord'
+            self.lauth.get_tok(expected_token)
+            mock_rm_token.assert_called_with(expected_token)
+
+    def test_get_tok_with_valid_expiration_should_return_token(self):
+        expected_token = {'expire': time.time()+1}
+        fake_get_token = MagicMock(return_value=expected_token)
+        patch_opts = patch.dict(self.lauth.opts, {'eauth_tokens': 'testfs'})
+        patch_get_token = patch.dict(
+            self.lauth.tokens,
+            {
+                'testfs.get_token': fake_get_token
+            },
+        )
+        mock_rm_token = MagicMock()
+        patch_rm_token = patch.object(self.lauth, 'rm_token', mock_rm_token)
+        with patch_opts, patch_get_token, patch_rm_token:
+            token_name = 'fnord'
+            actual_token = self.lauth.get_tok(token_name)
+            mock_rm_token.assert_not_called()
+            assert expected_token is actual_token, 'Token was not returned'
 
     def test_load_name(self):
         valid_eauth_load = {'username': 'test_user',

--- a/tests/unit/tokens/test_localfs.py
+++ b/tests/unit/tokens/test_localfs.py
@@ -57,7 +57,7 @@ class WriteTokenTest(TestCase):
         ], rename.called_with
 
 
-class TestLocalFS(unittest.TestCase):
+class TestLocalFS(TestCase):
     def setUp(self):
         # Default expected data
         self.expected_data = {'this': 'is', 'some': 'token data'}
@@ -79,7 +79,7 @@ class TestLocalFS(unittest.TestCase):
             opts=opts,
             tdata=self.expected_data,
         )['token']
-        with open(os.path.join(tempdir, tok), 'w') as f:
+        with salt.utils.files.fopen(os.path.join(tempdir, tok), 'w') as f:
             f.truncate()
         with self.assertRaises(salt.exceptions.SaltDeserializationError) as e:
             salt.tokens.localfs.get_token(opts=opts, tok=tok)
@@ -91,7 +91,7 @@ class TestLocalFS(unittest.TestCase):
             opts=opts,
             tdata=self.expected_data,
         )['token']
-        with open(os.path.join(tempdir, tok), 'w') as f:
+        with salt.utils.files.fopen(os.path.join(tempdir, tok), 'w') as f:
             f.truncate()
             f.write('this is not valid msgpack data')
         with self.assertRaises(salt.exceptions.SaltDeserializationError) as e:


### PR DESCRIPTION
Rebased #54325 and fixed linter errors.

What does this PR do?
#54324 to 2019.2.1 - Deletes eauth token files if they're empty (or otherwise fail to be read)

What issues does this PR fix or reference?
#54256
#37945

Previous Behavior
If the token file was empty or we otherwise failed to deserialize the token it would cause an exception. This was a regression.

New Behavior
If the token file is empty or we otherwise fail to deserialize the token we delete the invalid token file.

Tests written?
Yes - not just ones to cover this regression, but also added a couple more to cover this whole function.

Commits signed with GPG?
Yes
