### PR TITLE
Fix Issue #54459

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -984,8 +984,12 @@ def _parse_conf(conf_file=None, in_mem=False, family='ipv4'):
 
     rules = ''
     if conf_file:
-        with salt.utils.files.fopen(conf_file, 'r') as ifile:
-            rules = ifile.read()
+        try:
+            with salt.utils.files.fopen(conf_file, 'r') as ifile:
+                rules = ifile.read()
+        except IOError:
+            # Fix GitHub Issue #54459
+            return _parse_conf(conf_file=None, in_mem=True, family=family)
     elif in_mem:
         cmd = '{0}-save' . format(_iptables_cmd(family))
         rules = __salt__['cmd.run'](cmd)


### PR DESCRIPTION
### What does this PR do?
When a minion doesn't have the default file where
iptables stores it's current state, iptables.insert
will throw an exception. This change makes it so if
that file is not found, the current state is read
from memory instead of hard failing.

### What issues does this PR fix or reference?
#54459 
### Previous Behavior
Exception thrown during `iptables.insert` when the default saved configuration file (/etc/sysconfig/iptables on Fedora) didn't exist.

### New Behavior
Iptables state is read from memory (`iptables-save`) when the file is not found.

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
