### PR TITLE
[develop] Mount module fixes

### DIFF
--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -727,7 +727,6 @@ def set_fstab(
         salt '*' mount.set_fstab /mnt/foo /dev/sdz1 ext4
     '''
 
-    log.debug('=== here ===')
     # Fix the opts type if it is a list
     if isinstance(opts, list):
         opts = ','.join(opts)

--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -727,6 +727,7 @@ def set_fstab(
         salt '*' mount.set_fstab /mnt/foo /dev/sdz1 ext4
     '''
 
+    log.debug('=== here ===')
     # Fix the opts type if it is a list
     if isinstance(opts, list):
         opts = ','.join(opts)
@@ -763,6 +764,9 @@ def set_fstab(
             'securityfs',
             'devtmpfs',
             'cgroup',
+            'nfs',
+            'nfs4',
+            'glusterfs',
             'btrfs'])
 
         if fstype in specialFSes:

--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -329,6 +329,8 @@ def mounted(name,
             if label_device and label_device not in device_list:
                 device_list.append(label_device)
             if opts:
+                opts.sort()
+
                 mount_invisible_options = [
                     '_netdev',
                     'actimeo',
@@ -594,6 +596,7 @@ def mounted(name,
             else:
                 ret['comment'] = '{0} not mounted'.format(name)
 
+    log.debug('=== here ===')
     if persist:
         if '/etc/fstab' == config:
             # Override default for Mac OS

--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -596,7 +596,6 @@ def mounted(name,
             else:
                 ret['comment'] = '{0} not mounted'.format(name)
 
-    log.debug('=== here ===')
     if persist:
         if '/etc/fstab' == config:
             # Override default for Mac OS

--- a/tests/unit/states/test_mount.py
+++ b/tests/unit/states/test_mount.py
@@ -53,14 +53,6 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
         superopts3 = ['uid=510', 'gid=100', 'username=jfs2user',
                       'domain=jfs2sdomain']
 
-        name4 = os.path.realpath('/mnt/nfs1')
-        device = os.path.realpath('localhost:/mnt/nfsshare')
-        fstype = 'nfs4'
-
-        name5 = os.path.realpath('/mnt/nfs2')
-        device = os.path.realpath('localhost:/mnt/nfsshare')
-        fstype = 'nfs4'
-
         ret = {'name': name,
                'result': False,
                'comment': '',
@@ -1070,15 +1062,15 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
         Test to verify that a device is mounted.
         '''
         name = os.path.realpath('/mnt/nfs1')
-        device = os.path.realpath('localhost:/mnt/nfsshare')
+        device = 'localhost:/mnt/nfsshare'
         fstype = 'nfs4'
 
         name2 = os.path.realpath('/mnt/nfs2')
-        device2 = os.path.realpath('localhost:/mnt/nfsshare')
+        device2 = 'localhost:/mnt/nfsshare'
         fstype2 = 'nfs4'
 
         name3 = os.path.realpath('/mnt/glusterfs1')
-        device3 = os.path.realpath('localhost:/mnt/gluster_share')
+        device3 = 'localhost:/mnt/gluster_share'
         fstype3 = 'glusterfs'
 
         ret = {'name': name,
@@ -1102,14 +1094,14 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
 
         # Test no change for uid provided as a name #25293
         with patch.dict(mount.__grains__, {'os': 'CentOS'}):
-            with patch.dict(mount.__salt__, {'mount.active': mock_mnt,
-                                             'mount.mount': mock_str,
-                                             'mount.umount': mock_f,
-                                             'mount.read_mount_cache': mock_read_cache,
-                                             'mount.write_mount_cache': mock_write_cache,
-                                             'user.info': mock_user,
-                                             'group.info': mock_group}):
-                with patch.dict(mount.__opts__, {'test': False}):
+            with patch.dict(mount.__opts__, {'test': True}):
+                with patch.dict(mount.__salt__, {'mount.active': mock_mnt,
+                                                 'mount.mount': mock_str,
+                                                 'mount.umount': mock_f,
+                                                 'mount.read_mount_cache': mock_read_cache,
+                                                 'mount.write_mount_cache': mock_write_cache,
+                                                 'user.info': mock_user,
+                                                 'group.info': mock_group}):
                     with patch.object(os.path, 'exists', mock_t):
                        comt = '/mnt/nfs2 would be mounted'
                        ret.update({'name': name2, 'result': None})

--- a/tests/unit/states/test_mount.py
+++ b/tests/unit/states/test_mount.py
@@ -13,12 +13,10 @@ from tests.support.mock import (
     NO_MOCK,
     NO_MOCK_REASON,
     MagicMock,
-    mock_open,
     patch)
 
 # Import Salt Libs
 import salt.states.mount as mount
-import salt.utils.files
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -1103,10 +1101,10 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                                                  'user.info': mock_user,
                                                  'group.info': mock_group}):
                     with patch.object(os.path, 'exists', mock_t):
-                       comt = '/mnt/nfs2 would be mounted'
-                       ret.update({'name': name2, 'result': None})
-                       ret.update({'comment': comt, 'changes': {}})
-                       self.assertDictEqual(mount.mounted(name2, device2,
-                                                          fstype2,
-                                                          opts=[]),
+                        comt = '/mnt/nfs2 would be mounted'
+                        ret.update({'name': name2, 'result': None})
+                        ret.update({'comment': comt, 'changes': {}})
+                        self.assertDictEqual(mount.mounted(name2, device2,
+                                                           fstype2,
+                                                           opts=[]),
                                             ret)


### PR DESCRIPTION
### What does this PR do?
Fixes a regression that was introduced to in 2019.2.1 and also an issue when mounting devices under multiple mount points where supports, eg. NFS and GlusterFS.  TBD back port to other branches.

### What issues does this PR fix or reference?
#54084
#48280

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
