### PR TITLE
Virt states: Allow configuration of hidden state for KVM hypervisors

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -568,6 +568,12 @@ def _gen_xml(
         # TODO: make bus and model parameterized, this works for 64-bit Linux
         context["controller_model"] = "lsilogic"
 
+    if hypervisor in ["qemu", "kvm"]:
+        if "hidden" in kwargs:
+            context["hidden"] = kwargs["hidden"]
+        else:
+            context["hidden"] = False
+
     # By default, set the graphics to listen to all addresses
     if graphics:
         if "listen" not in graphics:
@@ -1252,6 +1258,8 @@ def init(
     :param serial_type: Serial device type. One of ``'pty'``, ``'tcp'`` (Default: ``None``)
     :param telnet_port: Telnet port to use for serial device of type ``tcp``.
     :param console: ``True`` to add a console device along with serial one (Default: ``True``)
+    :param hidden: ``True`` to hide the KVM hypervisor from standard MSR based discovery.
+        (Default: ``False``)
     :param connection: libvirt connection URI, overriding defaults
 
                        .. versionadded:: 2019.2.0

--- a/salt/states/virt.py
+++ b/salt/states/virt.py
@@ -288,6 +288,7 @@ def running(
     connection=None,
     username=None,
     password=None,
+    hidden=None,
     os_type=None,
     arch=None,
     boot=None,
@@ -367,6 +368,10 @@ def running(
         Only used when creating a new virtual machine.
 
         .. versionadded:: 3000
+    :param hidden: ``True`` to hide the KVM hypervisor from standard MSR based discovery.
+        (Default: ``False``)
+
+        .. versionadded:: 3001
     :param arch:
         architecture of the virtual machine. The default value is taken from the host capabilities,
         but ``x86_64`` is prefed over ``i686``. Only used when creating a new virtual machine.
@@ -510,6 +515,8 @@ def running(
                 nic=nic_profile,
                 interfaces=interfaces,
                 graphics=graphics,
+                hidden=hidden,
+                loader=loader,
                 seed=seed,
                 install=install,
                 pub_key=pub_key,

--- a/salt/templates/virt/libvirt_domain.jinja
+++ b/salt/templates/virt/libvirt_domain.jinja
@@ -100,5 +100,10 @@
         </devices>
         <features>
                 <acpi />
+                {% if hidden %}
+                <kvm>
+                        <hidden state='on'/>
+                </kvm>
+                {% endif %}
         </features>
 </domain>


### PR DESCRIPTION
### What does this PR do?
Allow configuration of hidden state for KVM/QEMU hypervisors managed by libvirt. It permits to hide the KVM hypervisor from standard MSR based discovery : [libvirt](https://libvirt.org/formatdomain.html#elementsFeatures)

This setting is used with "PCI passthrough via OVMF" when we have "Error 43: Driver failed to load" on Nvidia GPUs passed to Windows VMs

### What issues does this PR fix or reference?
[PCI_passthrough_via_OVMF](https://wiki.archlinux.org/index.php/PCI_passthrough_via_OVMF)

### Previous Behavior
No "hidden" setting on virt states and module

### New Behavior
We can select "hidden" setting with boolean

### Tests written?
No

### Commits signed with GPG?
No