### PR TITLE
[2018.3] Pytest 5.0 contextmanager str: call value on ExceptionInfo objects

### DIFF
--- a/tests/unit/modules/test_file.py
+++ b/tests/unit/modules/test_file.py
@@ -1768,7 +1768,7 @@ class FilemodLineTests(TestCase, LoaderModuleMockMixin):
                         filemod.line('foo', content=cfg_content, after=_after, before=_before, mode='ensure')
             self.assertIn(
                 'Found more than one line between boundaries "before" and "after"',
-                six.text_type(exc_info))
+                six.text_type(exc_info.value))
 
     @with_tempfile()
     def test_line_delete(self, name):


### PR DESCRIPTION
this test is failing on 2018.3 amazon2 py3: `unit.modules.test_file.FilemodLineTests.test_line_insert_ensure_beforeafter_rangelines`

bringing in similar fix from https://github.com/saltstack/salt/pull/53680 into 2018.3