### PR TITLE
[2019.2.1] Porting #50622 to 2019.2.1

### DIFF
--- a/salt/modules/openvswitch.py
+++ b/salt/modules/openvswitch.py
@@ -184,7 +184,7 @@ def bridge_delete(br, if_exists=True):
     return _retcode_to_bool(retcode)
 
 
-def port_add(br, port, may_exist=False):
+def port_add(br, port, may_exist=False, internal=False):
     '''
     Creates on bridge a new port named port.
 
@@ -195,6 +195,7 @@ def port_add(br, port, may_exist=False):
         br: A string - bridge name
         port: A string - port name
         may_exist: Bool, if False - attempting to create a port that exists returns False.
+        internal: A boolean to create an internal interface if one does not exist.
 
     .. versionadded:: 2016.3.0
 
@@ -205,6 +206,8 @@ def port_add(br, port, may_exist=False):
     '''
     param_may_exist = _param_may_exist(may_exist)
     cmd = 'ovs-vsctl {2}add-port {0} {1}'.format(br, port, param_may_exist)
+    if internal:
+        cmd += ' -- set interface {0} type=internal'.format(port)
     result = __salt__['cmd.run_all'](cmd)
     retcode = result['retcode']
     return _retcode_to_bool(retcode)

--- a/salt/serializers/yaml.py
+++ b/salt/serializers/yaml.py
@@ -20,6 +20,7 @@ from yaml.scanner import ScannerError
 from salt.serializers import DeserializationError, SerializationError
 from salt.ext import six
 from salt.utils.odict import OrderedDict
+from salt.utils.thread_local_proxy import ThreadLocalProxy
 
 __all__ = ['deserialize', 'serialize', 'available']
 
@@ -140,3 +141,7 @@ Dumper.add_multi_representer(datetime.date, Dumper.represent_date)
 Dumper.add_multi_representer(datetime.datetime, Dumper.represent_datetime)
 Dumper.add_multi_representer(None, Dumper.represent_undefined)
 Dumper.add_multi_representer(OrderedDict, Dumper.represent_dict)
+Dumper.add_representer(
+    ThreadLocalProxy,
+    lambda dumper, proxy:
+        dumper.represent_data(ThreadLocalProxy.unproxy(proxy)))

--- a/salt/serializers/yamlex.py
+++ b/salt/serializers/yamlex.py
@@ -113,6 +113,7 @@ import logging
 from salt.serializers import DeserializationError, SerializationError
 from salt.utils.aggregation import aggregate, Map, Sequence
 from salt.utils.odict import OrderedDict
+from salt.utils.thread_local_proxy import ThreadLocalProxy
 
 # Import 3rd-party libs
 import yaml
@@ -418,6 +419,10 @@ Dumper.add_multi_representer(set, Dumper.represent_set)
 Dumper.add_multi_representer(datetime.date, Dumper.represent_date)
 Dumper.add_multi_representer(datetime.datetime, Dumper.represent_datetime)
 Dumper.add_multi_representer(None, Dumper.represent_undefined)
+Dumper.add_representer(
+    ThreadLocalProxy,
+    lambda dumper, proxy:
+        dumper.represent_data(ThreadLocalProxy.unproxy(proxy)))
 
 
 def merge_recursive(obj_a, obj_b, level=False):

--- a/tests/unit/states/test_openvswitch_port.py
+++ b/tests/unit/states/test_openvswitch_port.py
@@ -42,6 +42,7 @@ class OpenvswitchPortTestCase(TestCase, LoaderModuleMockMixin):
         mock_n = MagicMock(return_value=[])
 
         with patch.dict(openvswitch_port.__salt__, {'openvswitch.bridge_exists': mock,
+                                                    'openvswitch.interface_get_type': MagicMock(return_value='""'),
                                                     'openvswitch.port_list': mock_l
                                                     }):
             comt = 'Port salt already exists.'
@@ -49,6 +50,7 @@ class OpenvswitchPortTestCase(TestCase, LoaderModuleMockMixin):
             self.assertDictEqual(openvswitch_port.present(name, bridge), ret)
 
         with patch.dict(openvswitch_port.__salt__, {'openvswitch.bridge_exists': mock,
+                                                    'openvswitch.interface_get_type': MagicMock(return_value='""'),
                                                     'openvswitch.port_list': mock_n,
                                                     'openvswitch.port_add': mock
                                                     }):


### PR DESCRIPTION
Porting #50622 to 2019.2.1