### PR TITLE
S3 pillar cache file should be opened 'wb' on python3

### DIFF
--- a/salt/pillar/s3.py
+++ b/salt/pillar/s3.py
@@ -343,7 +343,7 @@ def _refresh_buckets_cache_file(creds, cache_file, multiple_env, environment, pr
 
     log.debug('Writing S3 buckets pillar cache file')
 
-    with salt.utils.files.fopen(cache_file, 'w') as fp_:
+    with salt.utils.files.fopen(cache_file, 'wb') as fp_:
         pickle.dump(metadata, fp_)
 
     return metadata


### PR DESCRIPTION
### What does this PR do?

This fixes the S3 pillar on python3. In python3 the file that is written to with pickle.dump needs to be opened in binary write mode. The fix should be backwards compatible to python2 AFAIK.

### What issues does this PR fix or reference?

Fixes #54696 

### Previous Behavior

Previously fetching the pillar data would fail on python3 due to the writing of the cache throwing an exception.

### New Behavior

It works.

### Tests written?

No. I'd not mind giving a stab at it if someone can point me at test fixtures for EC2.

### Commits signed with GPG?

Yes.
