### PR TITLE
fix #54521; failhard not being respected in batch/orch

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -309,8 +309,8 @@ class Batch(object):
                 failhard = False
                 if 'retcode' in data and isinstance(data['ret'], dict) and 'retcode' not in data['ret']:
                     data['ret']['retcode'] = data['retcode']
-                    if self.opts.get('failhard') and data['ret']['retcode'] > 0:
-                        failhard = True
+                if self.opts.get('failhard') and data['ret']['retcode'] > 0:
+                    failhard = True
 
                 if self.opts.get('raw'):
                     ret[minion] = data

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -543,7 +543,7 @@ class LocalClient(object):
                 'tgt_type': tgt_type,
                 'ret': ret,
                 'batch': batch,
-                'failhard': kwargs.get('failhard', False),
+                'failhard': kwargs.get('failhard', self.opts.get('failhard', False)),
                 'raw': kwargs.get('raw', False)}
 
         if 'timeout' in kwargs:

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -340,8 +340,12 @@ def state(name,
 
     if batch is not None:
         cmd_kw['batch'] = six.text_type(batch)
+
     if subset is not None:
         cmd_kw['subset'] = subset
+
+    if failhard is True or __opts__.get('failhard'):
+        cmd_kw['failhard'] = True
 
     masterless = __opts__['__role'] == 'minion' and \
                  __opts__['file_client'] == 'local'
@@ -547,6 +551,9 @@ def function(
     cmd_kw['expect_minions'] = expect_minions
     cmd_kw['_cmd_meta'] = True
     cmd_kw['asynchronous'] = kwargs.pop('asynchronous', False)
+
+    if failhard is True or __opts__.get('failhard'):
+        cmd_kw['failhard'] = True
 
     if ret_config:
         cmd_kw['ret_config'] = ret_config

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -129,6 +129,7 @@ def state(name,
         queue=False,
         subset=None,
         orchestration_jid=None,
+        failhard=None,
         **kwargs):
     '''
     Invoke a state run on a given target
@@ -233,6 +234,10 @@ def state(name,
 
         .. versionadded:: neon
 
+    failhard
+        pass failhard down to the executing state
+
+        .. versionadded:: develop
 
     Examples:
 
@@ -472,6 +477,7 @@ def function(
         timeout=None,
         batch=None,
         subset=None,
+        failhard=None,
         **kwargs):  # pylint: disable=unused-argument
     '''
     Execute a single module function on a remote minion via salt or salt-ssh
@@ -525,6 +531,11 @@ def function(
         Run the salt command but don't wait for a reply.
 
         .. versionadded:: neon
+
+    failhard
+        pass failhard down to the executing state
+
+        .. versionadded:: develop
 
     '''
     func_ret = {'name': name,


### PR DESCRIPTION
also noticed a bug in cli.batch itself, probably from backport mistake.
fixed that as well with the unindent.

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
