### PR TITLE
Avoid exception when minion does not respond

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -32,7 +32,7 @@ def get_bnum(opts, minions, quiet):
     '''
     partition = lambda x: float(x) / 100.0 * len(minions)
     try:
-        if '%' in opts['batch']:
+        if isinstance(opts['batch'], basestring) and '%' in opts['batch']:
             res = partition(float(opts['batch'].strip('%')))
             if res < 1:
                 return int(math.ceil(res))

--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -32,7 +32,7 @@ def get_bnum(opts, minions, quiet):
     '''
     partition = lambda x: float(x) / 100.0 * len(minions)
     try:
-        if isinstance(opts['batch'], basestring) and '%' in opts['batch']:
+        if isinstance(opts['batch'], str) and '%' in opts['batch']:
             res = partition(float(opts['batch'].strip('%')))
             if res < 1:
                 return int(math.ceil(res))

--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -312,6 +312,15 @@ class Batch(object):
                     if self.opts.get('failhard') and data['ret']['retcode'] > 0:
                         failhard = True
 
+                # avoid an exception if the minion does not respond.
+                if data.get("failed") is True:
+                    log.debug('Minion %s failed to respond: data=%s', minion, data)
+                    data = {
+                        'out': 'no_return',
+                        'ret': 'Minion did not return. [Failed]',
+                        'retcode': salt.defaults.exitcodes.EX_GENERIC
+                    }
+
                 if self.opts.get('raw'):
                     ret[minion] = data
                     yield data

--- a/tests/integration/cli/test_batch.py
+++ b/tests/integration/cli/test_batch.py
@@ -75,3 +75,15 @@ class BatchTest(ShellCase):
             timeout=self.run_timeout,
         )
         self.assertEqual(cmd[-1], 2)
+
+    def test_batch_no_response(self):
+        '''
+        Tests executing a simple batch command using a number division instead of
+        a percentage with full batch CLI call.
+        '''
+        ret = 'Minion did not return. [Failed]'
+        cmd = self.run_salt(
+            '"badminion" test.ping --batch-size 2',
+            timeout=self.run_timeout,
+        )
+        self.assertIn(ret, cmd)

--- a/tests/integration/cli/test_batch.py
+++ b/tests/integration/cli/test_batch.py
@@ -83,7 +83,7 @@ class BatchTest(ShellCase):
         '''
         ret = 'Minion did not return. [Failed]'
         cmd = self.run_salt(
-            '"badminion" test.ping --batch-size 2',
-            timeout=self.run_timeout,
+            ' "*" test.ping --batch-size 2',
+            timeout=1,
         )
         self.assertIn(ret, cmd)


### PR DESCRIPTION
### What does this PR do?
We have several issues reporting that salt is throwing exception when the minion does not respond. This change avoid the exception adding a default data to the minion when it fails to respond. This patch is based on the changes that @jvanz submitted in https://github.com/saltstack/salt/pull/53159 with a few minor changes made in response to the requested comments. 

### What issues does this PR fix or reference?
Issues #46876 #48509 #50238
bsc#1135507
Also PR https://github.com/saltstack/salt/pull/53159

### Previous Behavior
```
salt -b 50 -L server1.domain.com,fake.domain.com test.ping
```

Fail with
```
[ERROR ] An un-handled exception was caught by salt's global exception handler:
KeyError: u'ret'
Traceback (most recent call last):
File "/usr/bin/salt", line 10, in
salt_main()
File "/usr/lib/python2.7/site-packages/salt/scripts.py", line 485, in salt_main
client.run()
File "/usr/lib/python2.7/site-packages/salt/cli/salt.py", line 65, in run
self._run_batch()
File "/usr/lib/python2.7/site-packages/salt/cli/salt.py", line 283, in _run_batch
for res in batch.run():
File "/usr/lib/python2.7/site-packages/salt/cli/batch.py", line 322, in run
ret[minion] = data['ret']
KeyError: u'ret'
Traceback (most recent call last):
File "/usr/bin/salt", line 10, in
salt_main()
File "/usr/lib/python2.7/site-packages/salt/scripts.py", line 485, in salt_main
client.run()
File "/usr/lib/python2.7/site-packages/salt/cli/salt.py", line 65, in run
self._run_batch()
File "/usr/lib/python2.7/site-packages/salt/cli/salt.py", line 283, in _run_batch
for res in batch.run():
File "/usr/lib/python2.7/site-packages/salt/cli/batch.py", line 322, in run
ret[minion] = data['ret']
KeyError: u'ret'
```
### New Behavior

```
salt --out=raw -L germ109.suse.cz,fake.domain.cz test.ping
{u'germ109.suse.cz': True}
{u'fake.domain.cz': u'Minion did not return. [Failed]'}
```

### Tests written?

No

### Commits signed with GPG?

No
