### PR TITLE
flat roster: copy options before passing them to apply_sb

### DIFF
--- a/salt/roster/flat.py
+++ b/salt/roster/flat.py
@@ -32,5 +32,5 @@ def targets(tgt, tgt_type='glob', **kwargs):
                            **kwargs)
     conditioned_raw = {}
     for minion in raw:
-        conditioned_raw[six.text_type(minion)] = salt.config.apply_sdb(raw[minion])
+        conditioned_raw[six.text_type(minion)] = salt.config.apply_sdb(raw[minion].copy())
     return __utils__['roster_matcher.targets'](conditioned_raw, tgt, tgt_type, 'ipv4')


### PR DESCRIPTION
### What does this PR do?

`apply_sdb` actually modifies the passed options. This messes up the outer hash-table
in `raw`, leading to wrong key accesses in subsequent iterations

I feel like there must be a better fix to this, something like
```py
for minion in raw.keys():
  apply_sdb(raw[minion])
  raw.deeprehash()
return roster_target(raw, ...)
```

but apparently Python has no support for rehashing any of its dictionary structures? No Python dev here :D

`copy` fixed it for my usecase, but perhaps a deep copy would be better. 
Or perhaps an `apply_sdb` variant that doesn't act on the  passed argument but passes a copy instead,  in case it actually changed something.

### Previous Behavior
when applying sdb the flat roster hash table got messed up

### New Behavior
when applying sdb the flat roster hash table is no longer messed up

### Tests written?
No, I couldn't find any existing tests for this and writing an entire suite for this feature 
is a bit beyond my experience with this project