### PR TITLE
fix broken salt-cloud openstack query

### DIFF
--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -280,8 +280,8 @@ def get_dependencies():
         log.warning(HAS_SHADE[1])
         return False
     deps = {
-        'shade': shade[0],
-        'os_client_config': shade[0],
+        'shade': HAS_SHADE[0],
+        'os_client_config': HAS_SHADE[0],
     }
     return config.check_driver_dependencies(
         __virtualname__,


### PR DESCRIPTION
This PR fixes `salt-cloud -Q` breaking for the openstack driver after upgrading from 2019.2.0 to 2019.2.1. 

see https://github.com/saltstack/salt/issues/54760

```py
def get_dependencies():
    '''
    Warn if dependencies aren't met.
    '''
    if not HAS_SHADE:
        log.warning('"shade" not found')
        return False
    elif hasattr(HAS_SHADE, '__len__') and not HAS_SHADE[0]:
        log.warning(HAS_SHADE[1])
        return False
    import ipdb; ipdb.set_trace()
    deps = {
        'shade': shade[0],
        'os_client_config': shade[0],
    }
    return config.check_driver_dependencies(
        __virtualname__,
        deps
    )
```

```
$ salt-cloud -Q -l debug

[INFO    ] salt-cloud starting
> /usr/local/venv/saltyparrot/lib/python3.5/site-packages/salt/cloud/clouds/openstack.py(284)get_dependencies()
    283     deps = {
--> 284         'shade': shade[0],
    285         'os_client_config': shade[0],
ipdb> shade[0]                                                                                                                                 
*** TypeError: 'module' object is not subscriptable
ipdb> HAS_SHADE[0]                                                                                                                             
True
```

The version of get_dependencies that was in salt-2019.2.0 looked like:
```py
def get_dependencies():
    '''
    Warn if dependencies aren't met.
    '''
    deps = {
        'shade': HAS_SHADE,
        'os_client_config': HAS_SHADE,
    }
    return config.check_driver_dependencies(
        __virtualname__,
        deps
    )
```

