### PR TITLE
Use "checksums" args when calling "postgres.datadir_init"

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -3151,6 +3151,7 @@ def datadir_init(name,
         password=password,
         encoding=encoding,
         locale=locale,
+        checksums=checksums,
         runas=runas)
     return ret['retcode'] == 0
 

--- a/tests/unit/modules/test_postgres.py
+++ b/tests/unit/modules/test_postgres.py
@@ -1467,6 +1467,7 @@ class PostgresTestCase(TestCase, LoaderModuleMockMixin):
                     locale=None,
                     password='test',
                     runas='postgres',
+                    checksums=False,
                     user='postgres',
                 )
                 self.assertTrue(ret)


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue inside `postgres.datadir_init` that is causing the accepted argument `checksums` is not being taken into account.

Therefore, without this PR, when you execute `postgres.datadir_init` or `postgres_initdb.present` state, the `checksums` argument is not used.

### Previous Behavior
Given the following state:
```yaml
pgsql-data-dir:
  postgres_initdb.present:
    - name: /var/lib/pgsql/data
    - auth: password
    - user: postgres
    - password: xxxxxx
    - encoding: UTF8
    - locale: C
    - runas: postgres
    - checksums: true
```
After applying it, the created DB is not created properly:

```console
# su - postgres
postgres@postgres:~> psql
Password:
psql (10.10)
Type "help" for help.

postgres=# show data_checksums;
 data_checksums
----------------
 off                                                                                                                                                                                                 
(1 row)

postgres=#
```

### New Behavior
Applying the same state produces a DB created successfully:
```console
# su - postgres
postgres@postgres:~> psql
Password:
psql (10.10)
Type "help" for help.

postgres=# show data_checksums;
 data_checksums
----------------
 on                                                                                                                                                                                                 
(1 row)

postgres=#
```


### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

Yes

### Commits signed with GPG?

Yes