### PR TITLE
Don't remove one directory level from slspath

### DIFF
--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -122,8 +122,6 @@ def wrap_tmpl_func(render_str):
             slspath = context['sls'].replace('.', '/')
             if tmplpath is not None:
                 context['tplpath'] = tmplpath
-                if not tmplpath.lower().replace('\\', '/').endswith('/init.sls'):
-                    slspath = os.path.dirname(slspath)
                 template = tmplpath.replace('\\', '/')
                 i = template.rfind(slspath.replace('.', '/'))
                 if i != -1:


### PR DESCRIPTION
This breaks the `tpldir` jinja context variable for the cases where there
is an SLS path in the format `X.X` (e.g. `foo.foo`, `bar.bar`, etc.).

It also conflicts with the stated documentation for this parameter in
`doc/rev/states/vars.rst`, which states that this variable should be the
path to the SLS target. In reality this is passed in via
`context['sls']` and already has the correct path.

If I were to wager a guess, I would say that it's likely that the way
`context['sls']` is formulated has changed at some point since these two
lines were added in 2014, making these two lines unnecessary.