### PR TITLE
Fix state.show_states when sls file missing in top file

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -1634,6 +1634,9 @@ def show_states(queue=False, **kwargs):
             raise Exception(result)
 
         for s in result:
+            if not isinstance(s, dict):
+                _set_retcode(result)
+                return result
             states[s['__sls__']] = True
     finally:
         st_.pop_active()

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -890,10 +890,10 @@ class TestDaemon(object):
         }
         master_opts['file_roots'] = syndic_master_opts['file_roots'] = {
             'base': [
-                os.path.join(FILES, 'file', 'base'),
                 # Let's support runtime created files that can be used like:
                 #   salt://my-temp-file.txt
-                RUNTIME_VARS.TMP_STATE_TREE
+                RUNTIME_VARS.TMP_STATE_TREE,
+                os.path.join(FILES, 'file', 'base'),
             ],
             # Alternate root to test __env__ choices
             'prod': [
@@ -903,10 +903,10 @@ class TestDaemon(object):
         }
         minion_opts['file_roots'] = {
             'base': [
-                os.path.join(FILES, 'file', 'base'),
                 # Let's support runtime created files that can be used like:
                 #   salt://my-temp-file.txt
-                RUNTIME_VARS.TMP_STATE_TREE
+                RUNTIME_VARS.TMP_STATE_TREE,
+                os.path.join(FILES, 'file', 'base'),
             ],
             # Alternate root to test __env__ choices
             'prod': [

--- a/tests/integration/modules/test_state.py
+++ b/tests/integration/modules/test_state.py
@@ -2080,25 +2080,20 @@ class StateModuleTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(_expected, ret[key]['changes']['stdout'])
 
     def tearDown(self):
-        nonbase_file = os.path.join(TMP, 'nonbase_env')
-        if os.path.isfile(nonbase_file):
-            os.remove(nonbase_file)
+        rm_files = [os.path.join(TMP, 'nonbase_env'),
+                    os.path.join(TMP, 'testfile'),
+                    os.path.join(TMP, 'test.txt'),
+                    os.path.join(TMP_STATE_TREE, 'top.sls')]
+
+        for file_ in rm_files:
+            if os.path.isfile(file_):
+                os.remove(file_)
 
         # remove old pillar data
         for filename in os.listdir(TMP_PILLAR_TREE):
             os.remove(os.path.join(TMP_PILLAR_TREE, filename))
         self.run_function('saltutil.refresh_pillar')
         self.run_function('test.sleep', [5])
-
-        # remove testfile added in core.sls state file
-        state_file = os.path.join(TMP, 'testfile')
-        if os.path.isfile(state_file):
-            os.remove(state_file)
-
-        # remove testfile added in issue-30161.sls state file
-        state_file = os.path.join(TMP, 'test.txt')
-        if os.path.isfile(state_file):
-            os.remove(state_file)
 
     def test_state_sls_integer_name(self):
         '''

--- a/tests/integration/modules/test_state.py
+++ b/tests/integration/modules/test_state.py
@@ -15,7 +15,7 @@ import time
 from tests.support.case import ModuleCase
 from tests.support.helpers import with_tempdir, flaky
 from tests.support.unit import skipIf
-from tests.support.paths import BASE_FILES, TMP, TMP_PILLAR_TREE
+from tests.support.paths import BASE_FILES, TMP, TMP_PILLAR_TREE, TMP_STATE_TREE
 from tests.support.mixins import SaltReturnAssertsMixin
 
 # Import Salt libs
@@ -117,6 +117,21 @@ class StateModuleTest(ModuleCase, SaltReturnAssertsMixin):
         states = self.run_function('state.show_states', sorted=False)
         self.assertTrue(isinstance(states, list))
         self.assertTrue(isinstance(states[0], six.string_types))
+
+    def test_show_states_missing_sls(self):
+        '''
+        Test state.show_states with a sls file
+        defined in a top file is missing
+        '''
+        with salt.utils.files.fopen(os.path.join(TMP_STATE_TREE, 'top.sls'), 'w') as top_file:
+            top_file.write(textwrap.dedent('''\
+                                           base:
+                                             '*':
+                                               - doesnotexist
+                                           '''))
+        states = self.run_function('state.show_states')
+        assert isinstance(states, list)
+        assert states == ["No matching sls found for 'doesnotexist' in env 'base'"]
 
     def test_catch_recurse(self):
         '''

--- a/tests/unit/modules/test_state.py
+++ b/tests/unit/modules/test_state.py
@@ -632,6 +632,19 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
             self.assertEqual(state.show_low_sls("foo"), "A")
             self.assertListEqual(state.show_states("foo"), ['abc'])
 
+    def test_show_states_missing_sls(self):
+        '''
+        Test state.show_states when a sls file defined
+        in a top.sls file is missing
+        '''
+        msg = ["No matching sls found for 'cloud' in evn 'base'"]
+        chunks_mock = MagicMock(side_effect=[msg])
+        mock = MagicMock(side_effect=["A", None])
+        with patch.object(state, '_check_queue', mock),\
+            patch('salt.state.HighState.compile_low_chunks', chunks_mock):
+            self.assertEqual(state.show_low_sls("foo"), "A")
+            self.assertListEqual(state.show_states("foo"), [msg[0]])
+
     def test_sls_id(self):
         '''
             Test to call a single ID from the


### PR DESCRIPTION
### What does this PR do?
When a sls file is defined in a top.sls file that is missing a TypeError was raised when using `state.show_states`. This PR ensures we do not stacktrace and handle this situation

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/54758

### Previous Behavior

```
Passed invalid arguments: string indices must be integers.

Usage:

    Returns the list of states that will be applied on highstate.

    CLI Example:

    .. code-block:: bash

        salt '*' state.show_states

    .. versionadded:: 2019.2.0
```

### New Behavior

```
local:
       - No matching sls found for 'cloud' in env 'base'
```

### Tests written?

Yes

### Commits signed with GPG?

Yes