### PR TITLE
Wrong isinstance in ini options absent

### DIFF
--- a/salt/states/ini_manage.py
+++ b/salt/states/ini_manage.py
@@ -180,7 +180,7 @@ def options_absent(name, sections=None, separator='='):
                 return ret
             except AttributeError:
                 cur_section = section
-            if isinstance(sections[section], (dict, OrderedDict)):
+            if isinstance(sections[section], list):
                 for key in sections[section]:
                     cur_value = cur_section.get(key)
                     if not cur_value:
@@ -213,7 +213,7 @@ def options_absent(name, sections=None, separator='='):
             if section not in ret['changes']:
                 ret['changes'].update({section: {}})
             ret['changes'][section].update({key: current_value})
-            if not isinstance(sections[section], (dict, OrderedDict)):
+            if not isinstance(sections[section], list):
                 ret['changes'].update({section: current_value})
                 # break
             ret['comment'] = 'Changes take effect'

--- a/tests/unit/states/test_ini_manage.py
+++ b/tests/unit/states/test_ini_manage.py
@@ -94,6 +94,19 @@ class IniManageTestCase(TestCase, LoaderModuleMockMixin):
             comt = ('No anomaly detected')
             ret.update({'comment': comt, 'result': True})
             self.assertDictEqual(ini_manage.options_absent(name), ret)
+        original = {'Tables': {'key1': '1',
+                               'key2': '2',
+                               'key3': '3',
+                               'key4': '4'}}
+        sections = {'Tables': ['key2',
+                               'key3']}
+        changes = {'Tables': {'key2': '2',
+                              'key3': '3'}}
+        with patch.dict(ini_manage.__salt__, {'ini.remove_option': MagicMock(side_effect=['2', '3'])}):
+            with patch.dict(ini_manage.__opts__, {'test': False}):
+                comt = ('Changes take effect')
+                ret.update({'comment': comt, 'result': True, 'changes': changes})
+                self.assertDictEqual(ini_manage.options_absent(name, sections), ret)
 
     # 'sections_present' function tests: 1
 


### PR DESCRIPTION
### What does this PR do?
In ini.options_absent, sections are supposed to be lists of keys to delete but the code is checking for dicts (the correct type for options_present). This means the code path for deleting entire sections is always followed and causes several problems, one of which is described in #53874.

### What issues does this PR fix or reference?
#53874

### Previous Behavior
AttributeError when more than one key to delete.

### New Behavior
No error.

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

Yes, added one test to unit.states.test_ini_manage.IniManageTestCase.test_options_absent

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
