### PR TITLE
Fix to scheduler when job without a time element is run with schedule.run_job

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -475,8 +475,7 @@ class Schedule(object):
                                            datetime.datetime.now())
 
         # Grab run, assume True
-        run = data.get('run', True)
-        if run:
+        if data.get('run'):
             log.info('Running Job: %s', name)
             self._run_job(func, data)
 

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -214,7 +214,7 @@ class Schedule(object):
         # dict we treat it like it was there and is True
 
         # Check if we're able to run
-        if not data['run']:
+        if 'run' not in data or not data['run']:
             return data
         if 'jid_include' not in data or data['jid_include']:
             jobcount = 0
@@ -463,7 +463,10 @@ class Schedule(object):
 
         if 'name' not in data:
             data['name'] = name
-        log.info('Running Job: %s', name)
+
+        # Assume run should be True until we check max_running
+        if 'run' not in data:
+            data['run'] = True
 
         if not self.standalone:
             data = self._check_max_running(func,
@@ -474,6 +477,7 @@ class Schedule(object):
         # Grab run, assume True
         run = data.get('run', True)
         if run:
+            log.info('Running Job: %s', name)
             self._run_job(func, data)
 
     def enable_schedule(self):

--- a/tests/integration/scheduler/test_run_job.py
+++ b/tests/integration/scheduler/test_run_job.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+# Import Python libs
+from __future__ import absolute_import
+import copy
+import datetime
+import logging
+import os
+import random
+import time
+
+import dateutil.parser as dateutil_parser
+import datetime
+
+# Import Salt Testing libs
+from tests.support.case import ModuleCase
+from tests.support.mixins import SaltReturnAssertsMixin
+
+# Import Salt Testing Libs
+from tests.support.mock import MagicMock, patch
+from tests.support.unit import skipIf
+import tests.integration as integration
+
+# Import Salt libs
+import salt.utils.schedule
+import salt.utils.platform
+
+from salt.modules.test import ping as ping
+
+try:
+    import croniter  # pylint: disable=W0611
+    HAS_CRONITER = True
+except ImportError:
+    HAS_CRONITER = False
+
+log = logging.getLogger(__name__)
+ROOT_DIR = os.path.join(integration.TMP, 'schedule-unit-tests')
+SOCK_DIR = os.path.join(ROOT_DIR, 'test-socks')
+
+DEFAULT_CONFIG = salt.config.minion_config(None)
+DEFAULT_CONFIG['conf_dir'] = ROOT_DIR
+DEFAULT_CONFIG['root_dir'] = ROOT_DIR
+DEFAULT_CONFIG['sock_dir'] = SOCK_DIR
+DEFAULT_CONFIG['pki_dir'] = os.path.join(ROOT_DIR, 'pki')
+DEFAULT_CONFIG['cachedir'] = os.path.join(ROOT_DIR, 'cache')
+
+
+class SchedulerRunJobTest(ModuleCase, SaltReturnAssertsMixin):
+    '''
+    Validate the pkg module
+    '''
+    def setUp(self):
+        with patch('salt.utils.schedule.clean_proc_dir', MagicMock(return_value=None)):
+            functions = {'test.ping': ping}
+            self.schedule = salt.utils.schedule.Schedule(copy.deepcopy(DEFAULT_CONFIG), functions, returners={})
+        self.schedule.opts['loop_interval'] = 1
+
+    def tearDown(self):
+        self.schedule.reset()
+
+    def test_run_job(self):
+        '''
+        verify that scheduled job runs
+        '''
+        job_name = 'test_run_job'
+        job = {
+          'schedule': {
+            job_name: {
+              'function': 'test.ping',
+            }
+          }
+        }
+        # Add the job to the scheduler
+        self.schedule.opts.update(job)
+
+        # Run job
+        self.schedule.run_job(job_name)
+        ret = self.schedule.job_status(job_name)
+        expected = {'function': 'test.ping', u'name': 'test_run_job'}
+        self.assertEqual(ret, expected)

--- a/tests/integration/scheduler/test_run_job.py
+++ b/tests/integration/scheduler/test_run_job.py
@@ -3,14 +3,8 @@
 # Import Python libs
 from __future__ import absolute_import
 import copy
-import datetime
 import logging
 import os
-import random
-import time
-
-import dateutil.parser as dateutil_parser
-import datetime
 
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
@@ -18,7 +12,6 @@ from tests.support.mixins import SaltReturnAssertsMixin
 
 # Import Salt Testing Libs
 from tests.support.mock import MagicMock, patch
-from tests.support.unit import skipIf
 import tests.integration as integration
 
 # Import Salt libs

--- a/tests/integration/scheduler/test_run_job.py
+++ b/tests/integration/scheduler/test_run_job.py
@@ -69,5 +69,5 @@ class SchedulerRunJobTest(ModuleCase, SaltReturnAssertsMixin):
         # Run job
         self.schedule.run_job(job_name)
         ret = self.schedule.job_status(job_name)
-        expected = {'function': 'test.ping', u'name': 'test_run_job'}
+        expected = {'function': 'test.ping', 'run': True, 'name': 'test_run_job'}
         self.assertEqual(ret, expected)

--- a/tests/unit/modules/test_schedule.py
+++ b/tests/unit/modules/test_schedule.py
@@ -150,14 +150,14 @@ class ScheduleTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test if it run a scheduled job on the minion immediately.
         '''
-        with patch.dict(schedule.__opts__, {'schedule': {}, 'sock_dir': SOCK_DIR}):
+        with patch.dict(schedule.__opts__, {'schedule': {'job1': JOB1}, 'sock_dir': SOCK_DIR}):
             mock = MagicMock(return_value=True)
             with patch.dict(schedule.__salt__, {'event.fire': mock}):
-                _ret_value = {'complete': True, 'schedule': {}}
+                _ret_value = {'complete': True, 'schedule': {'job1': JOB1}}
                 with patch.object(SaltEvent, 'get_event', return_value=_ret_value):
                     self.assertDictEqual(schedule.run_job('job1'),
-                                         {'comment': 'Job job1 does not exist.',
-                                          'result': False})
+                                         {'comment': 'Scheduling Job job1 on minion.',
+                                          'result': True})
 
     # 'enable_job' function tests: 1
 

--- a/tests/unit/test_module_names.py
+++ b/tests/unit/test_module_names.py
@@ -156,6 +156,7 @@ class BadTestModuleNamesTestCase(TestCase):
             'integration.scheduler.test_skip',
             'integration.scheduler.test_maxrunning',
             'integration.scheduler.test_helpers',
+            'integration.scheduler.test_run_job',
             'integration.shell.test_spm',
             'integration.shell.test_cp',
             'integration.shell.test_syndic',


### PR DESCRIPTION
### What does this PR do?
If a scheduled job does not contains a time element parameter, running that job with schedule.run_job fails and causes a traceback because data['run'] does not exist.

### What issues does this PR fix or reference?
#54741 

### Previous Behavior
Jobs without time elements when run with "schedule.run_job" failed with traceback.

### New Behavior
Ensure data['run'] exists and handle situations when it does not.  Jobs run as expected.

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
