### PR TITLE
[Regression] Batch with failhard fix 

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -254,6 +254,9 @@ class Batch(object):
                     data['ret']['retcode'] = data['retcode']
                     if self.opts.get('failhard') and data['ret']['retcode'] > 0:
                         failhard = True
+                else:
+                    if self.opts.get('failhard') and data['retcode'] > 0:
+                        failhard = True
 
                 if self.opts.get('raw'):
                     ret[minion] = data

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -547,7 +547,7 @@ class LocalClient(object):
                 'tgt_type': tgt_type,
                 'ret': ret,
                 'batch': batch,
-                'failhard': kwargs.get('failhard', False),
+                'failhard': kwargs.get('failhard', self.opts.get('failhard', False)),
                 'raw': kwargs.get('raw', False)}
 
         if 'timeout' in kwargs:

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -128,6 +128,7 @@ def state(name,
         queue=False,
         subset=None,
         orchestration_jid=None,
+        failhard=None,
         **kwargs):
     '''
     Invoke a state run on a given target
@@ -221,6 +222,11 @@ def state(name,
 
         .. versionadded:: 2017.7.0
 
+    failhard
+        pass failhard down to the executing state
+
+        .. versionadded:: 2019.2.2
+
     Examples:
 
     Run a list of sls files via :py:func:`state.sls <salt.state.sls>` on target
@@ -311,8 +317,12 @@ def state(name,
 
     if batch is not None:
         cmd_kw['batch'] = six.text_type(batch)
+
     if subset is not None:
         cmd_kw['subset'] = subset
+
+    if failhard is True or __opts__.get('failhard'):
+        cmd_kw['failhard'] = True
 
     masterless = __opts__['__role'] == 'minion' and \
                  __opts__['file_client'] == 'local'
@@ -428,6 +438,7 @@ def function(
         timeout=None,
         batch=None,
         subset=None,
+        failhard=None,
         **kwargs):  # pylint: disable=unused-argument
     '''
     Execute a single module function on a remote minion via salt or salt-ssh
@@ -477,6 +488,11 @@ def function(
 
         .. versionadded:: 2017.7.0
 
+    failhard
+        pass failhard down to the executing state
+
+        .. versionadded:: 2019.2.2
+
     '''
     func_ret = {'name': name,
                 'changes': {},
@@ -501,6 +517,9 @@ def function(
     cmd_kw['ssh'] = ssh
     cmd_kw['expect_minions'] = expect_minions
     cmd_kw['_cmd_meta'] = True
+
+    if failhard is True or __opts__.get('failhard'):
+        cmd_kw['failhard'] = True
 
     if ret_config:
         cmd_kw['ret_config'] = ret_config

--- a/tests/integration/files/file/base/orch/batch.sls
+++ b/tests/integration/files/file/base/orch/batch.sls
@@ -1,0 +1,6 @@
+call_fail_state:
+  salt.state:
+    - tgt: '*minion'
+    - batch: 1
+    - failhard: True
+    - sls: fail


### PR DESCRIPTION
### What does this PR do?
Added proper detection of `failhard` during the orchestration\cli batch logic.

This is backport of the https://github.com/saltstack/salt/pull/54700, huge thanks to @mattp- for the original patch.

### What issues does this PR fix or reference?
#54521

### Previous Behavior
batch didn't stop upon encountering the error with `failhard` set to `True`

### New Behavior
batch stops upon encountering the error with `failhard` set to `True`

### Tests written?

Yes

### Commits signed with GPG?

Yes