### PR TITLE
Fix pip state pip >=10.0 and <=18.0

### DIFF
--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -60,14 +60,35 @@ except ImportError:
     if sys_modules_pip is not None:
         del sys_modules_pip
 
+
+def pip_has_internal_exceptions_mod(ver):
+    '''
+    True when the pip version has the `pip._internal.exceptions` module
+    '''
+    return salt.utils.versions.compare(
+        ver1=ver,
+        oper='>=',
+        ver2='10.0',
+    )
+
+
+def pip_has_exceptions_mod(ver):
+    '''
+    True when the pip version has the `pip.exceptions` module
+    '''
+    if pip_has_internal_exceptions_mod(ver):
+        return False
+    return salt.utils.versions.compare(
+        ver1=ver,
+        oper='>=',
+        ver2='1.0'
+    )
+
+
 if HAS_PIP is True:
-    if salt.utils.versions.compare(ver1=pip.__version__,
-                                   oper='>=',
-                                   ver2='10.0'):
+    if pip_has_internal_exceptions_mod(pip.__version__):
         from pip._internal.exceptions import InstallationError  # pylint: disable=E0611,E0401
-    elif salt.utils.versions.compare(ver1=pip.__version__,
-                                     oper='>=',
-                                     ver2='1.0'):
+    elif pip_has_exceptions_mod(pip.__version__):
         from pip.exceptions import InstallationError  # pylint: disable=E0611,E0401
     else:
         InstallationError = ValueError

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -85,7 +85,7 @@ def _from_line(*args, **kwargs):
     import pip
     if salt.utils.versions.compare(ver1=pip.__version__,
                                    oper='>=',
-                                   ver2='10.0'):
+                                   ver2='18.1'):
         import pip._internal.req.constructors  # pylint: disable=E0611,E0401
         return pip._internal.req.constructors.install_req_from_line(*args, **kwargs)
     elif salt.utils.versions.compare(ver1=pip.__version__,

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -63,7 +63,7 @@ except ImportError:
 if HAS_PIP is True:
     if salt.utils.versions.compare(ver1=pip.__version__,
                                    oper='>=',
-                                   ver2='18.1'):
+                                   ver2='10.0'):
         from pip._internal.exceptions import InstallationError  # pylint: disable=E0611,E0401
     elif salt.utils.versions.compare(ver1=pip.__version__,
                                      oper='>=',
@@ -85,7 +85,7 @@ def _from_line(*args, **kwargs):
     import pip
     if salt.utils.versions.compare(ver1=pip.__version__,
                                    oper='>=',
-                                   ver2='18.1'):
+                                   ver2='10.0'):
         import pip._internal.req.constructors  # pylint: disable=E0611,E0401
         return pip._internal.req.constructors.install_req_from_line(*args, **kwargs)
     elif salt.utils.versions.compare(ver1=pip.__version__,

--- a/tests/unit/states/test_pip_state.py
+++ b/tests/unit/states/test_pip_state.py
@@ -282,3 +282,13 @@ class PipStateTest(TestCase, SaltReturnAssertsMixin, LoaderModuleMockMixin):
                 'successfully installed',
                 {'test': ret}
             )
+
+    def test_has_internal_exceptions_mod_function(self):
+        assert pip_state.pip_has_internal_exceptions_mod('10.0')
+        assert pip_state.pip_has_internal_exceptions_mod('18.1')
+        assert not pip_state.pip_has_internal_exceptions_mod('9.99')
+
+    def test_has_exceptions_mod_function(self):
+        assert pip_state.pip_has_exceptions_mod('1.0')
+        assert not pip_state.pip_has_exceptions_mod('0.1')
+        assert not pip_state.pip_has_exceptions_mod('10.0')


### PR DESCRIPTION
This PR takes the work from #54772 and adds tests

### What does this PR do?

When using pip versions between 10.0 and 18.0, the import of the pip.exceptions modules in pip_state will fail, as it was moved to pip._internal.exceptions in pip version 10.0.

Ref pip 10.0.0b1 release notes:
https://pip.pypa.io/en/stable/news/#b1-2018-03-31

### What issues does this PR fix or reference?

#54762

### Previous Behavior

pip.installed state will fail to load with pip >=10.0 and <=18.0

### New Behavior

pip.installed state will load with pip >=10.0 and <=18.0

### Tests written?

Yes

### Commits signed with GPG?

Yes