### PR TITLE
ip_bracket can now accept ipv6 addresses with brackets

### DIFF
--- a/salt/utils/zeromq.py
+++ b/salt/utils/zeromq.py
@@ -80,8 +80,11 @@ def check_ipc_path_max_len(uri):
 
 def ip_bracket(addr):
     '''
-    Convert IP address representation to ZMQ (URL) format. ZMQ expects
-    brackets around IPv6 literals, since they are used in URLs.
+    Ensure IP addresses are URI-compatible - specifically, add brackets
+    around IPv6 literals if they are not already present.
     '''
+    addr = str(addr)
+    addr = addr.lstrip('[')
+    addr = addr.rstrip(']')
     addr = ipaddress.ip_address(addr)
     return ('[{}]' if addr.version == 6 else '{}').format(addr)

--- a/tests/unit/utils/test_zeromq.py
+++ b/tests/unit/utils/test_zeromq.py
@@ -6,6 +6,7 @@ Test salt.utils.zeromq
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
 import zmq
+from salt._compat import ipaddress
 
 # Import Salt Testing libs
 from tests.support.unit import TestCase, skipIf
@@ -24,8 +25,13 @@ class UtilsTestCase(TestCase):
     def test_ip_bracket(self):
         test_ipv4 = '127.0.0.1'
         test_ipv6 = '::1'
+        test_ipv6_uri = '[::1]'
         self.assertEqual(test_ipv4, salt.utils.zeromq.ip_bracket(test_ipv4))
         self.assertEqual('[{0}]'.format(test_ipv6), salt.utils.zeromq.ip_bracket(test_ipv6))
+        self.assertEqual('[{0}]'.format(test_ipv6), salt.utils.zeromq.ip_bracket(test_ipv6_uri))
+
+        ip_addr_obj = ipaddress.ip_address(test_ipv4)
+        self.assertEqual(test_ipv4, salt.utils.zeromq.ip_bracket(ip_addr_obj))
 
     @skipIf(NO_MOCK, NO_MOCK_REASON)
     @skipIf(not hasattr(zmq, 'IPC_PATH_MAX_LEN'), "ZMQ does not have max length support.")


### PR DESCRIPTION
### What does this PR do?
`ip_bracket` is now more liberal in its input - attempting to add brackets to an IPv6 address that already has brackets is not fatal.

### What issues does this PR fix or reference?
#54762

### Tests written?
Yes

### Commits signed with GPG?

Yes
