### PR TITLE
Update relasenotes 2019.2.2

### DIFF
--- a/doc/topics/releases/2019.2.2.rst
+++ b/doc/topics/releases/2019.2.2.rst
@@ -25,6 +25,7 @@ URIs with IPv6 addresses are broken, preventing master-minion communication in I
 
 * `#54763`_
 .. _`#54763`: https://github.com/saltstack/salt/issues/54763
+
 * `#54762`_
 .. _`#54762`: https://github.com/saltstack/salt/issues/54762
 

--- a/doc/topics/releases/2019.2.2.rst
+++ b/doc/topics/releases/2019.2.2.rst
@@ -28,10 +28,10 @@ URIs with IPv6 addresses are broken, preventing master-minion communication in I
 
 Minion fails to start when it contains below values in minion configuration file. Fix planned in 2019.2.2 release.
 .. code-block:: jinja
-  auth_tries: 2
-  master_tries: -1
-  auth_safemode: false
-  ping_interval: 5
+    auth_tries: 2
+    master_tries: -1
+    auth_safemode: false
+    ping_interval: 5
 * `#54776`_
 .. _`#54776`: https://github.com/saltstack/salt/issues/54776
 

--- a/doc/topics/releases/2019.2.2.rst
+++ b/doc/topics/releases/2019.2.2.rst
@@ -16,12 +16,10 @@ https://github.com/saltstack/salt/issues/54763
 https://github.com/saltstack/salt/issues/54762
 
 Minion fails to start when it contains below values in minion configuration file.Fix planned in 2019.2.2 release.
-cat > /etc/salt/minion.d/test.conf << EOF
 auth_tries: 2
 master_tries: -1
 auth_safemode: false
 ping_interval: 5
-EOF
 https://github.com/saltstack/salt/issues/54776
 
 Returners (except for default salt master returner) not loading properly in Py3. Fix planned in 2019.2.2 release.

--- a/doc/topics/releases/2019.2.2.rst
+++ b/doc/topics/releases/2019.2.2.rst
@@ -17,11 +17,14 @@ Known Issues
 ============
 
 Proxy minion fails to start. Fix planned in 2019.2.2 release.
-https://github.com/saltstack/salt/issues/54751
+* `#54751`_
+.. _`#54751`: https://github.com/saltstack/salt/issues/54751
 
 URIs with IPv6 addresses are broken, preventing master-minion communication in IPv6-only environments. Fix planned in 2019.2.2 release.
-https://github.com/saltstack/salt/issues/54763
-https://github.com/saltstack/salt/issues/54762
+* `#54763`_
+.. _`#54763`: https://github.com/saltstack/salt/issues/54763
+* `#54762`_
+.. _`#54762`: https://github.com/saltstack/salt/issues/54762
 
 Minion fails to start when it contains below values in minion configuration file. Fix planned in 2019.2.2 release.
 .. code-block:: jinja
@@ -29,19 +32,25 @@ Minion fails to start when it contains below values in minion configuration file
   master_tries: -1
   auth_safemode: false
   ping_interval: 5
-https://github.com/saltstack/salt/issues/54776
+* `#54776`_
+.. _`#54776`: https://github.com/saltstack/salt/issues/54776
 
 Returners (except for default salt master returner) not loading properly in Py3. Fix planned in 2019.2.2 release.
-https://github.com/saltstack/salt/pull/54731
+* `#54731`_
+.. _`#54731`: https://github.com/saltstack/salt/pull/54731
 
 salt-call state.show_states gives  "Passed invalid arguments" error when a sls defined in top.sls file is missing. Fix planned in 2019.2.2 release.
-https://github.com/saltstack/salt/issues/54758
+* `#54758`_
+.. _`#54758`: https://github.com/saltstack/salt/issues/54758
 
 Jinja from import is broken. Fix planned in 2019.2.2 release.
-https://github.com/saltstack/salt/issues/54765
+* `#54765`_
+.. _`#54765`: https://github.com/saltstack/salt/issues/54765
 
 Affects only Debian 10. pkgrepo.managed does not work if used with proxy (configured at salt-minion). No fix date available yet.
-https://github.com/saltstack/salt/issues/54771
+* `#54771`_
+.. _`#54771`: https://github.com/saltstack/salt/issues/54771
 
 Deprecation warnings for pyzmq. No fix date available yet.
-https://github.com/saltstack/salt/issues/54759
+* `#54759`_
+.. _`#54759`: https://github.com/saltstack/salt/issues/54759

--- a/doc/topics/releases/2019.2.2.rst
+++ b/doc/topics/releases/2019.2.2.rst
@@ -19,14 +19,17 @@ Known Issues
 Proxy minion fails to start. Fix planned in 2019.2.2 release.
 
 * `#54751`_
+
 .. _`#54751`: https://github.com/saltstack/salt/issues/54751
 
 URIs with IPv6 addresses are broken, preventing master-minion communication in IPv6-only environments. Fix planned in 2019.2.2 release.
 
 * `#54763`_
+
 .. _`#54763`: https://github.com/saltstack/salt/issues/54763
 
 * `#54762`_
+
 .. _`#54762`: https://github.com/saltstack/salt/issues/54762
 
 Minion fails to start when it contains below values in minion configuration file. Fix planned in 2019.2.2 release.
@@ -38,29 +41,35 @@ Minion fails to start when it contains below values in minion configuration file
     ping_interval: 5
 
 * `#54776`_
+
 .. _`#54776`: https://github.com/saltstack/salt/issues/54776
 
 Returners (except for default salt master returner) not loading properly in Py3. Fix planned in 2019.2.2 release.
 
 * `#54731`_
+
 .. _`#54731`: https://github.com/saltstack/salt/pull/54731
 
 salt-call state.show_states gives  "Passed invalid arguments" error when a sls defined in top.sls file is missing. Fix planned in 2019.2.2 release.
 
 * `#54758`_
+
 .. _`#54758`: https://github.com/saltstack/salt/issues/54758
 
 Jinja from import is broken. Fix planned in 2019.2.2 release.
 
 * `#54765`_
+
 .. _`#54765`: https://github.com/saltstack/salt/issues/54765
 
 Affects only Debian 10. pkgrepo.managed does not work if used with proxy (configured at salt-minion). No fix date available yet.
 
 * `#54771`_
+
 .. _`#54771`: https://github.com/saltstack/salt/issues/54771
 
 Deprecation warnings for pyzmq. No fix date available yet.
 
 * `#54759`_
+
 .. _`#54759`: https://github.com/saltstack/salt/issues/54759

--- a/doc/topics/releases/2019.2.2.rst
+++ b/doc/topics/releases/2019.2.2.rst
@@ -5,6 +5,14 @@ In Progress: Salt 2019.2.2 Release Notes
 Version 2019.2.2 is an **unreleased** bugfix release for :ref:`2019.2.0 <release-2019-2-0>`.
 This release is still in progress and has not been released yet.
 
+Python 2.7 Deprecation
+======================
+
+In light of Python 2.7 reaching its End of Life (EOL) on Jan 1st 2020,
+Python 2 will be deprecated from SaltStack no earlier than the Sodium
+release, that is either the Sodium release or a later release.
+This decision is pending further community discussion.
+
 Known Issues
 ============
 
@@ -15,11 +23,12 @@ URIs with IPv6 addresses are broken, preventing master-minion communication in I
 https://github.com/saltstack/salt/issues/54763
 https://github.com/saltstack/salt/issues/54762
 
-Minion fails to start when it contains below values in minion configuration file.Fix planned in 2019.2.2 release.
-auth_tries: 2
-master_tries: -1
-auth_safemode: false
-ping_interval: 5
+Minion fails to start when it contains below values in minion configuration file. Fix planned in 2019.2.2 release.
+.. code-block:: jinja
+  auth_tries: 2
+  master_tries: -1
+  auth_safemode: false
+  ping_interval: 5
 https://github.com/saltstack/salt/issues/54776
 
 Returners (except for default salt master returner) not loading properly in Py3. Fix planned in 2019.2.2 release.

--- a/doc/topics/releases/2019.2.2.rst
+++ b/doc/topics/releases/2019.2.2.rst
@@ -17,40 +17,49 @@ Known Issues
 ============
 
 Proxy minion fails to start. Fix planned in 2019.2.2 release.
+
 * `#54751`_
 .. _`#54751`: https://github.com/saltstack/salt/issues/54751
 
 URIs with IPv6 addresses are broken, preventing master-minion communication in IPv6-only environments. Fix planned in 2019.2.2 release.
+
 * `#54763`_
 .. _`#54763`: https://github.com/saltstack/salt/issues/54763
 * `#54762`_
 .. _`#54762`: https://github.com/saltstack/salt/issues/54762
 
 Minion fails to start when it contains below values in minion configuration file. Fix planned in 2019.2.2 release.
-.. code-block:: jinja
+
+.. code-block:: bash
     auth_tries: 2
     master_tries: -1
     auth_safemode: false
     ping_interval: 5
+
 * `#54776`_
 .. _`#54776`: https://github.com/saltstack/salt/issues/54776
 
 Returners (except for default salt master returner) not loading properly in Py3. Fix planned in 2019.2.2 release.
+
 * `#54731`_
 .. _`#54731`: https://github.com/saltstack/salt/pull/54731
 
 salt-call state.show_states gives  "Passed invalid arguments" error when a sls defined in top.sls file is missing. Fix planned in 2019.2.2 release.
+
 * `#54758`_
 .. _`#54758`: https://github.com/saltstack/salt/issues/54758
 
 Jinja from import is broken. Fix planned in 2019.2.2 release.
+
 * `#54765`_
 .. _`#54765`: https://github.com/saltstack/salt/issues/54765
 
 Affects only Debian 10. pkgrepo.managed does not work if used with proxy (configured at salt-minion). No fix date available yet.
+
 * `#54771`_
 .. _`#54771`: https://github.com/saltstack/salt/issues/54771
 
 Deprecation warnings for pyzmq. No fix date available yet.
+
 * `#54759`_
 .. _`#54759`: https://github.com/saltstack/salt/issues/54759

--- a/doc/topics/releases/2019.2.2.rst
+++ b/doc/topics/releases/2019.2.2.rst
@@ -17,13 +17,11 @@ Known Issues
 ============
 
 Proxy minion fails to start. Fix planned in 2019.2.2 release.
-
 * `#54751`_
 
 .. _`#54751`: https://github.com/saltstack/salt/issues/54751
 
 URIs with IPv6 addresses are broken, preventing master-minion communication in IPv6-only environments. Fix planned in 2019.2.2 release.
-
 * `#54763`_
 
 .. _`#54763`: https://github.com/saltstack/salt/issues/54763
@@ -32,44 +30,32 @@ URIs with IPv6 addresses are broken, preventing master-minion communication in I
 
 .. _`#54762`: https://github.com/saltstack/salt/issues/54762
 
-Minion fails to start when it contains below values in minion configuration file. Fix planned in 2019.2.2 release.
-
-.. code-block:: yaml
-    auth_tries: 2
-    master_tries: -1
-    auth_safemode: false
-    ping_interval: 5
-
+Minion fails to start when it contains `ping_interval` in minion configuration file. Fix planned in 2019.2.2 release.
 * `#54776`_
 
 .. _`#54776`: https://github.com/saltstack/salt/issues/54776
 
 Returners (except for default salt master returner) not loading properly in Py3. Fix planned in 2019.2.2 release.
-
 * `#54731`_
 
 .. _`#54731`: https://github.com/saltstack/salt/pull/54731
 
 salt-call state.show_states gives  "Passed invalid arguments" error when a sls defined in top.sls file is missing. Fix planned in 2019.2.2 release.
-
 * `#54758`_
 
 .. _`#54758`: https://github.com/saltstack/salt/issues/54758
 
 Jinja from import is broken. Fix planned in 2019.2.2 release.
-
 * `#54765`_
 
 .. _`#54765`: https://github.com/saltstack/salt/issues/54765
 
 Affects only Debian 10. pkgrepo.managed does not work if used with proxy (configured at salt-minion). No fix date available yet.
-
 * `#54771`_
 
 .. _`#54771`: https://github.com/saltstack/salt/issues/54771
 
 Deprecation warnings for pyzmq. No fix date available yet.
-
 * `#54759`_
 
 .. _`#54759`: https://github.com/saltstack/salt/issues/54759

--- a/doc/topics/releases/2019.2.2.rst
+++ b/doc/topics/releases/2019.2.2.rst
@@ -4,3 +4,37 @@ In Progress: Salt 2019.2.2 Release Notes
 
 Version 2019.2.2 is an **unreleased** bugfix release for :ref:`2019.2.0 <release-2019-2-0>`.
 This release is still in progress and has not been released yet.
+
+Known Issues
+============
+
+Proxy minion fails to start. Fix planned in 2019.2.2 release.
+https://github.com/saltstack/salt/issues/54751
+
+URIs with IPv6 addresses are broken, preventing master-minion communication in IPv6-only environments. Fix planned in 2019.2.2 release.
+https://github.com/saltstack/salt/issues/54763
+https://github.com/saltstack/salt/issues/54762
+
+Minion fails to start when it contains below values in minion configuration file.Fix planned in 2019.2.2 release.
+cat > /etc/salt/minion.d/test.conf << EOF
+auth_tries: 2
+master_tries: -1
+auth_safemode: false
+ping_interval: 5
+EOF
+https://github.com/saltstack/salt/issues/54776
+
+Returners (except for default salt master returner) not loading properly in Py3. Fix planned in 2019.2.2 release.
+https://github.com/saltstack/salt/pull/54731
+
+salt-call state.show_states gives  "Passed invalid arguments" error when a sls defined in top.sls file is missing. Fix planned in 2019.2.2 release.
+https://github.com/saltstack/salt/issues/54758
+
+Jinja from import is broken. Fix planned in 2019.2.2 release.
+https://github.com/saltstack/salt/issues/54765
+
+Affects only Debian 10. pkgrepo.managed does not work if used with proxy (configured at salt-minion). No fix date available yet.
+https://github.com/saltstack/salt/issues/54771
+
+Deprecation warnings for pyzmq. No fix date available yet.
+https://github.com/saltstack/salt/issues/54759

--- a/doc/topics/releases/2019.2.2.rst
+++ b/doc/topics/releases/2019.2.2.rst
@@ -34,7 +34,7 @@ URIs with IPv6 addresses are broken, preventing master-minion communication in I
 
 Minion fails to start when it contains below values in minion configuration file. Fix planned in 2019.2.2 release.
 
-.. code-block:: bash
+.. code-block:: yaml
     auth_tries: 2
     master_tries: -1
     auth_safemode: false


### PR DESCRIPTION
### What does this PR do?

Update release notes for the 2019.2.2 release. (Currently unreleased)