### PR TITLE
Fix issue 54755 and add regression tests

### DIFF
--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -58,8 +58,10 @@ def purge_pip():
         sys.modules.pop(name)
         del entry
 
-    if 'pip' in globals() or 'pip' in locals():
-        del pip
+    if 'pip' in globals():
+        del globals()['pip']
+    if 'pip' in locals():
+        del locals()['pip']
     sys_modules_pip = sys.modules.pop('pip', None)
     if sys_modules_pip is not None:
         del sys_modules_pip

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -24,6 +24,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import re
 import types
 import logging
+import sys
 try:
     import pkg_resources
     HAS_PKG_RESOURCES = True
@@ -39,13 +40,15 @@ from salt.exceptions import CommandExecutionError, CommandNotFoundError
 # Import 3rd-party libs
 import salt.ext.six as six
 # pylint: disable=import-error
-try:
-    import pip
-    HAS_PIP = True
-except ImportError:
-    HAS_PIP = False
+
+
+def purge_pip():
+    '''
+    Purge pip and it's sub-modules
+    '''
     # Remove references to the loaded pip module above so reloading works
-    import sys
+    if 'pip' not in sys.modules:
+        return
     pip_related_entries = [
         (k, v) for (k, v) in sys.modules.items()
         or getattr(v, '__module__', '').startswith('pip.')
@@ -55,7 +58,8 @@ except ImportError:
         sys.modules.pop(name)
         del entry
 
-    del pip
+    if 'pip' in globals() or 'pip' in locals():
+        del pip
     sys_modules_pip = sys.modules.pop('pip', None)
     if sys_modules_pip is not None:
         del sys_modules_pip
@@ -83,6 +87,14 @@ def pip_has_exceptions_mod(ver):
         oper='>=',
         ver2='1.0'
     )
+
+
+purge_pip()
+try:
+    import pip
+    HAS_PIP = True
+except ImportError:
+    HAS_PIP = False
 
 
 if HAS_PIP is True:

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -89,7 +89,6 @@ def pip_has_exceptions_mod(ver):
     )
 
 
-purge_pip()
 try:
     import pip
     HAS_PIP = True
@@ -98,6 +97,12 @@ except ImportError:
 
 
 if HAS_PIP is True:
+    if not hasattr(purge_pip, '__pip_ver__'):
+        purge_pip.__pip_ver__ = pip.__version__
+    elif purge_pip.__pip_ver__ != pip.__version__:
+        purge_pip()
+        import pip
+        purge_pip.__pip_ver__ = pip.__version__
     if pip_has_internal_exceptions_mod(pip.__version__):
         from pip._internal.exceptions import InstallationError  # pylint: disable=E0611,E0401
     elif pip_has_exceptions_mod(pip.__version__):

--- a/tests/integration/files/file/base/issue-54755.sls
+++ b/tests/integration/files/file/base/issue-54755.sls
@@ -1,0 +1,5 @@
+issue-54755:
+  file.managed:
+    - name: {{ pillar['file_path'] }}
+    - contents: issue-54755
+    - unless: /bin/bash -c false

--- a/tests/integration/states/test_pip_state.py
+++ b/tests/integration/states/test_pip_state.py
@@ -598,3 +598,30 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
                 shutil.rmtree(ographite, ignore_errors=True)
             if os.path.isdir(venv_dir):
                 shutil.rmtree(venv_dir)
+
+
+class PipStateInRequisiteTest(ModuleCase, SaltReturnAssertsMixin):
+
+    @with_tempdir()
+    def test_issue_54755(self, tmpdir):
+        '''
+        Verify github issue 54755 is resolved. This only fails when there is no
+        pip module in the python environment. Since the test suite normally has
+        a pip module this test will pass and is here for posterity. See also
+
+        unit.states.test_pip_state.PipStateUtilsTest.test_pip_purge_method_with_pip
+
+         and
+
+        unit.states.test_pip_state.PipStateUtilsTest.test_pip_purge_method_without_pip
+
+        Which also validate this issue and will pass/fail regardless of whether
+        or not pip is installed.
+        '''
+        file_path = os.path.join(tmpdir, 'issue-54755')
+        ret = self.run_function('state.sls', mods='issue-54755', pillar={'file_path': file_path})
+        key = 'file_|-issue-54755_|-{}_|-managed'.format(file_path)
+        assert key in ret
+        assert ret[key]['result'] is True
+        with salt.utils.files.fopen(file_path, 'r') as fp:
+            assert fp.read().strip() == 'issue-54755'

--- a/tests/unit/states/test_pip_state.py
+++ b/tests/unit/states/test_pip_state.py
@@ -10,6 +10,7 @@
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
 import logging
+import sys
 
 # Import Salt Testing libs
 from tests.support.mixins import LoaderModuleMockMixin, SaltReturnAssertsMixin
@@ -283,6 +284,9 @@ class PipStateTest(TestCase, SaltReturnAssertsMixin, LoaderModuleMockMixin):
                 {'test': ret}
             )
 
+
+class PipStateUtilsTest(TestCase):
+
     def test_has_internal_exceptions_mod_function(self):
         assert pip_state.pip_has_internal_exceptions_mod('10.0')
         assert pip_state.pip_has_internal_exceptions_mod('18.1')
@@ -292,3 +296,17 @@ class PipStateTest(TestCase, SaltReturnAssertsMixin, LoaderModuleMockMixin):
         assert pip_state.pip_has_exceptions_mod('1.0')
         assert not pip_state.pip_has_exceptions_mod('0.1')
         assert not pip_state.pip_has_exceptions_mod('10.0')
+
+    def test_pip_purge_method_with_pip(self):
+        mock_modules = sys.modules.copy()
+        mock_modules.pop('pip', None)
+        mock_modules['pip'] = object()
+        with patch('sys.modules', mock_modules):
+            pip_state.purge_pip()
+        assert 'pip' not in mock_modules
+
+    def test_pip_purge_method_without_pip(self):
+        mock_modules = sys.modules.copy()
+        mock_modules.pop('pip', None)
+        with patch('sys.modules', mock_modules):
+            pip_state.purge_pip()


### PR DESCRIPTION
### What does this PR do?

Address #54755 and add regression tests.

In general we should try to address this kind of thing without mucking around with already imported modules. Ideally we'd recognize that pip was upgraded and re-start the minion automatically. This will however address the bugs reported against the pip_state and other states using the `unless` requisite. 

### What issues does this PR fix or reference?

#54755

### Previous Behavior

If no pip module is in the python environment imports of the pip state failed with multiple tracebacks. This is due to us trying to `del pip` when there is no `pip` variable defined.

### New Behavior

Use a `purge_pip` method before trying to import `pip` this method will only try to remove the `pip` module and/or `pip` variable if it exists. 

### Tests written?

Yes

### Commits signed with GPG?

Yes