### PR TITLE
[2019.2.1] Fix global disabling code in scheduler

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -1596,22 +1596,10 @@ class Schedule(object):
             if '_continue' in data and data['_continue']:
                 run = False
 
-            # If there is no job specific enabled available,
-            # grab the global which defaults to True.
-            if 'enabled' not in data:
-                data['enabled'] = self.enabled
-
-            # If globally disabled, disable the job
-            if not self.enabled:
-                data['enabled'] = self.enabled
-                data['_skip_reason'] = 'disabled'
-                data['_skipped_time'] = now
-                data['_skipped'] = True
-                run = False
-
-            # Job is disabled, set run to False
-            if 'enabled' in data and not data['enabled']:
-                data['_enabled'] = False
+            # If globally disabled or job
+            # is diabled skip the job
+            if not self.enabled or not data.get('enabled', True):
+                log.trace('Job: %s is disabled', job_name)
                 data['_skip_reason'] = 'disabled'
                 data['_skipped_time'] = now
                 data['_skipped'] = True
@@ -1624,14 +1612,6 @@ class Schedule(object):
 
             try:
                 if run:
-                    # Job is disabled, continue
-                    if 'enabled' in data and not data['enabled']:
-                        log.debug('Job: %s is disabled', job_name)
-                        data['_skip_reason'] = 'disabled'
-                        data['_skipped_time'] = now
-                        data['_skipped'] = True
-                        continue
-
                     if 'jid_include' not in data or data['jid_include']:
                         data['jid_include'] = True
                         log.debug('schedule: Job %s was scheduled with jid_include, '

--- a/tests/integration/scheduler/test_eval.py
+++ b/tests/integration/scheduler/test_eval.py
@@ -506,6 +506,9 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertNotIn('_last_run', ret)
         self.assertEqual(ret['_skip_reason'], 'disabled')
 
+        # Ensure job data still matches
+        self.assertEqual(ret, job['schedule'][job_name])
+
     def test_eval_global_disabled_job_enabled(self):
         '''
         verify that scheduled job does not run
@@ -531,6 +534,9 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.schedule.job_status(job_name)
         self.assertNotIn('_last_run', ret)
         self.assertEqual(ret['_skip_reason'], 'disabled')
+
+        # Ensure job is still enabled
+        self.assertEqual(ret['enabled'], True)
 
     def test_eval_run_on_start(self):
         '''


### PR DESCRIPTION
### What does this PR do?
Rework code that handles individual jobs being disabled and scheduler being globally being disabled.   

### What issues does this PR fix or reference?
#54820 

### Previous Behavior
Previously disabling the schedule would result in individual jobs being disabled when they were run through eval.

### New Behavior
This change does not change schedule items.

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.
Yes.  Existing tests updated.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
