### PR TITLE
Revert "Import abstract base classes from collection.abc in python 3.3+"

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -29,11 +29,7 @@ import time
 import glob
 import hashlib
 import mmap
-try:
-    from collections.abc import Iterable, Mapping
-except ImportError:
-    from collections import Iterable, Mapping
-from collections import namedtuple
+from collections import Iterable, Mapping, namedtuple
 from functools import reduce  # pylint: disable=redefined-builtin
 
 # pylint: disable=import-error,no-name-in-module,redefined-builtin

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -17,10 +17,7 @@ import os.path
 import logging
 # pylint: disable=W0611
 import operator  # do not remove
-try:
-    from collections.abc import Iterable, Mapping  # do not remove
-except ImportError:
-    from collections import Iterable, Mapping  # do not remove
+from collections import Iterable, Mapping  # do not remove
 from functools import reduce  # do not remove
 import datetime  # do not remove.
 import tempfile  # do not remove. Used in salt.modules.file.__clean_tmp

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -291,11 +291,7 @@ import shutil
 import sys
 import time
 import traceback
-from collections import defaultdict
-try:
-    from collections.abc import Iterable, Mapping
-except ImportError:
-    from collections import Iterable, Mapping
+from collections import Iterable, Mapping, defaultdict
 from datetime import datetime, date   # python3 problem in the making?
 
 # Import salt libs

--- a/salt/utils/dictdiffer.py
+++ b/salt/utils/dictdiffer.py
@@ -13,10 +13,7 @@
 '''
 from __future__ import absolute_import, print_function, unicode_literals
 import copy
-try:
-    from collections.abc import Mapping
-except ImportError:
-    from collections import Mapping
+from collections import Mapping
 from salt.ext import six
 
 


### PR DESCRIPTION
Reverts saltstack/salt#54309

I didn't know that all branches are temporarily frozen. This PR is okay and will be merged later.