### PR TITLE
Redo "Import abstract base classes from collection.abc in python 3.3+"

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -29,7 +29,11 @@ import time
 import glob
 import hashlib
 import mmap
-from collections import Iterable, Mapping, namedtuple
+try:
+    from collections.abc import Iterable, Mapping
+except ImportError:
+    from collections import Iterable, Mapping
+from collections import namedtuple
 from functools import reduce  # pylint: disable=redefined-builtin
 
 # pylint: disable=import-error,no-name-in-module,redefined-builtin

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -17,7 +17,10 @@ import os.path
 import logging
 # pylint: disable=W0611
 import operator  # do not remove
-from collections import Iterable, Mapping  # do not remove
+try:
+    from collections.abc import Iterable, Mapping  # do not remove
+except ImportError:
+    from collections import Iterable, Mapping  # do not remove
 from functools import reduce  # do not remove
 import datetime  # do not remove.
 import tempfile  # do not remove. Used in salt.modules.file.__clean_tmp

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -291,7 +291,11 @@ import shutil
 import sys
 import time
 import traceback
-from collections import Iterable, Mapping, defaultdict
+from collections import defaultdict
+try:
+    from collections.abc import Iterable, Mapping
+except ImportError:
+    from collections import Iterable, Mapping
 from datetime import datetime, date   # python3 problem in the making?
 
 # Import salt libs

--- a/salt/utils/dictdiffer.py
+++ b/salt/utils/dictdiffer.py
@@ -13,7 +13,10 @@
 '''
 from __future__ import absolute_import, print_function, unicode_literals
 import copy
-from collections import Mapping
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 from salt.ext import six
 
 


### PR DESCRIPTION
### What does this PR do?

This PR reintroduces #54309

Starting from Python 3.3 abstract base classes from `collections` was moved to `collections.abc`. For backward compatibility those classes can be imported from `collections` directly. Since Python 3.7, importing abstract base classes from `collections` directly leads to this warning:

```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
```

This PR moves imports of abstract base classes from `collections` to `collections.abc` in compatible versions of Python (with a falback to importing from `collections`).

### What issues does this PR fix or reference?

This PR fixes #52120 

This has been previously fixed in #49487 but it seems the fix was incomplete.


### Commits signed with GPG?

No

