### PR TITLE
yumpkg.latest_version does not return installed versions.

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -555,7 +555,7 @@ def latest_version(*names, **kwargs):
                     # no need to check another match, if there was one
                     break
         else:
-            ret[name] = ''
+            ret[name] = cur_pkgs.get(name, '')
 
     # Return a string if only one package name passed
     if len(names) == 1:


### PR DESCRIPTION
When running yumpkg.latest_version it is possible for a package to be
installed and yet not have a latest version reported.

### What does this PR do?

When running yumpkg.latest_version it will not return versions for packages that are installed and the latest version. This makes that actually work as expected.

### What issues does this PR fix or reference?

No issues. I just made a PR instead so its easier to understand.

### Previous Behavior

I have java 1.7 and 1.8 installed on a amazon linux machine:

```
rpm -qa | egrep 'java-.*-openjdk-1'
java-1.7.0-openjdk-1.7.0.231-2.6.19.1.80.amzn1.x86_64
java-1.8.0-openjdk-1.8.0.222.b10-0.47.amzn1.x86_64
```

However running pkg.latest_version does not return a version for these packages (it does however return a package for the uninstalled 1.6 version):

```
# salt-call pkg.latest_version java-1.7.0-openjdk java-1.6.0-openjdk java-1.8.0-openjdk
local:
    ----------
    java-1.6.0-openjdk:
        1:1.6.0.41-1.13.13.1.77.amzn1
    java-1.7.0-openjdk:
    java-1.8.0-openjdk:
```

### New Behavior

```
local:
    ----------
    java-1.6.0-openjdk:
        1:1.6.0.41-1.13.13.1.77.amzn1
    java-1.7.0-openjdk:
        - 1:1.7.0.231-2.6.19.1.80.amzn1
    java-1.8.0-openjdk:
        - 1:1.8.0.222.b10-0.47.amzn1
```


### Tests written?

Sorry no, I didn't have enough time to sit down and make the tests work for this. =/

### Commits signed with GPG?

Yes