### PR TITLE
Zenoss: allow specifing of API key for Zenoss cloud + minor improvements

### DIFF
--- a/salt/modules/zenoss.py
+++ b/salt/modules/zenoss.py
@@ -5,7 +5,7 @@ Module for working with the Zenoss API
 
 :configuration: This module requires a 'zenoss' entry in the master/minion config.
 
-    For example:
+    Example for authenticating with a user:
 
     .. code-block:: yaml
 
@@ -15,6 +15,17 @@ Module for working with the Zenoss API
           password: admin123
           verify_ssl: True
           ca_bundle: /etc/ssl/certs/ca-certificates.crt
+
+    Example for Zenoss Cloud:
+
+    .. code-block:: yaml
+
+         zenoss:
+          hostname: https://company.zenoss.io/ab1
+          api_key: FFFFFFFFFFFFFFFFFFFFFFFFFF
+          verify_ssl: True
+          ca_bundle: /etc/ssl/certs/ca-certificates.crt
+
 """
 
 import logging
@@ -56,14 +67,24 @@ def _session():
     """
 
     config = __salt__["config.option"]("zenoss")
-    return salt.utils.http.session(
-        user=config.get("username"),
-        password=config.get("password"),
-        verify_ssl=config.get("verify_ssl", True),
-        ca_bundle=config.get("ca_bundle"),
-        headers={"Content-type": "application/json; charset=utf-8"},
-    )
 
+    if config.get('api_key'):
+        return salt.utils.http.session(
+            verify_ssl=config.get("verify_ssl", True),
+            ca_bundle=config.get("ca_bundle"),
+            headers={
+                "Content-type": "application/json; charset=utf-8",
+                "z-api-key": config.get("api_key"),
+            },
+        )
+    else:
+        return salt.utils.http.session(
+            user=config.get("username"),
+            password=config.get("password"),
+            verify_ssl=config.get("verify_ssl", True),
+            ca_bundle=config.get("ca_bundle"),
+            headers={"Content-type": "application/json; charset=utf-8"},
+        )
 
 def _router_request(router, method, data=None):
     """

--- a/salt/modules/zenoss.py
+++ b/salt/modules/zenoss.py
@@ -71,10 +71,12 @@ def _session():
     if not config.get("hostname", None):
         raise Exception("zenoss.hostname config option is not set")
 
-    if not config.get('api_key') and not (config.get('username') and config.get('password')):
+    if not config.get("api_key") and not (
+        config.get("username") and config.get("password")
+    ):
         raise Exception("No api_key, nor username and passssword, configured")
 
-    if config.get('api_key'):
+    if config.get("api_key"):
         return salt.utils.http.session(
             verify_ssl=config.get("verify_ssl", True),
             ca_bundle=config.get("ca_bundle"),
@@ -91,6 +93,7 @@ def _session():
             ca_bundle=config.get("ca_bundle"),
             headers={"Content-type": "application/json; charset=utf-8"},
         )
+
 
 def _router_request(router, method, data=None):
     """
@@ -109,15 +112,16 @@ def _router_request(router, method, data=None):
     response = _session().post(url, data=req_data)
 
     # zenoss cloud always returns json, so we just display the error message
-    if config.get('api_key') and response.status_code != 200:
+    if config.get("api_key") and response.status_code != 200:
         try:
             data = salt.utils.json.loads(response.content)
         except ValueError:
             pass
         else:
-            if 'error' in data:
-                raise Exception("API (code {}): {}".format(response.status_code,
-                                                           data['error']))
+            if "error" in data:
+                raise Exception(
+                    "API (code {}): {}".format(response.status_code, data["error"])
+                )
 
         log.error("Request failed. Bad authentication")
         raise Exception("Request failed. Bad authentication")
@@ -156,15 +160,18 @@ def find_device(device=None):
     if not device:
         device = __salt__["grains.get"]("fqdn")
 
-    data = [{"uid": "/zport/dmd/Devices",
-             "params": {
+    data = [
+        {
+            "uid": "/zport/dmd/Devices",
+            "params": {
                 "name": device,
-             },
-             "dir": "DESC",
-             "sort": "name",
-             "start": 0,
-             "limit": 1,
-             }]
+            },
+            "dir": "DESC",
+            "sort": "name",
+            "start": 0,
+            "limit": 1,
+        }
+    ]
     all_devices = _router_request("DeviceRouter", "getDevices", data=data)
     for dev in all_devices["devices"]:
         if dev["name"] == device:

--- a/salt/modules/zenoss.py
+++ b/salt/modules/zenoss.py
@@ -66,7 +66,13 @@ def _session():
     Create a session to be used when connecting to Zenoss.
     """
 
-    config = __salt__["config.option"]("zenoss")
+    config = __salt__["config.option"]("zenoss") or {}
+
+    if not config.get("hostname", None):
+        raise Exception("zenoss.hostname config option is not set")
+
+    if not config.get('api_key') and not (config.get('username') and config.get('password')):
+        raise Exception("No api_key, nor username and passssword, configured")
 
     if config.get('api_key'):
         return salt.utils.http.session(
@@ -102,12 +108,26 @@ def _router_request(router, method, data=None):
     url = "{}/zport/dmd/{}_router".format(config.get("hostname"), ROUTERS[router])
     response = _session().post(url, data=req_data)
 
+    # zenoss cloud always returns json, so we just display the error message
+    if config.get('api_key') and response.status_code != 200:
+        try:
+            data = salt.utils.json.loads(response.content)
+        except ValueError:
+            pass
+        else:
+            if 'error' in data:
+                raise Exception("API (code {}): {}".format(response.status_code,
+                                                           data['error']))
+
+        log.error("Request failed. Bad authentication")
+        raise Exception("Request failed. Bad authentication")
+
     # The API returns a 200 response code even whe auth is bad.
     # With bad auth, the login page is displayed. Here I search for
     # an element on the login form to determine if auth failed.
-    if re.search('name="__ac_name"', response.content):
-        log.error("Request failed. Bad username/password.")
-        raise Exception("Request failed. Bad username/password.")
+    elif response.status_code == 403 or re.search('name="__ac_name"', response.content):
+        log.error("Request failed. Bad authentication")
+        raise Exception("Request failed. Bad authentication")
 
     return salt.utils.json.loads(response.content).get("result", None)
 
@@ -133,8 +153,18 @@ def find_device(device=None):
 
         salt '*' zenoss.find_device
     """
+    if not device:
+        device = __salt__["grains.get"]("fqdn")
 
-    data = [{"uid": "/zport/dmd/Devices", "params": {}, "limit": None}]
+    data = [{"uid": "/zport/dmd/Devices",
+             "params": {
+                "name": device,
+             },
+             "dir": "DESC",
+             "sort": "name",
+             "start": 0,
+             "limit": 1,
+             }]
     all_devices = _router_request("DeviceRouter", "getDevices", data=data)
     for dev in all_devices["devices"]:
         if dev["name"] == device:

--- a/salt/states/zenoss.py
+++ b/salt/states/zenoss.py
@@ -94,7 +94,9 @@ def monitored(name, device_class=None, collector="localhost", prod_state=None):
         ret["changes"] = {}
 
         if result:
-            ret["comment"] = "Failed to add {}: {}".format(name, result.get("msg", "unknown error"))
+            ret["comment"] = "Failed to add {}: {}".format(
+                name, result.get("msg", "unknown error")
+            )
         else:
             ret["comment"] = "Failed to add {} to Zenoss".format(name)
     return ret


### PR DESCRIPTION
# What does this PR do?
* Add the ability to specific API key, which is used for Zenoss Cloud

Details can be found at https://help.zenoss.com/dev/collection-zone-and-resource-manager-apis/using-curl

* Improve various bug fixed and improvements, see below

**Update: rebased this against master,  additional improvements, and fix for #53966**

### Previous Behavior
1. Cannot be used with Zenoss Cloud
2. Does not handle authentication failures against Zenoss Cloud
3. `find_device` will fetch all devices on Zenoss, and the loops over to find a match. Very wasteful
4. `zenoss.monitored` reports success even when there is an error

### New Behavior
1. Can be used with Zenoss Cloud
2. Authentication failure raises with the error message from the API
3. `find_devices` will only fetch one result that is either a match or not
4. `zenoss.monitored` correctly reports errors

### Tests written?
No

### Commits signed with GPG?
No

