### PR TITLE
[master] Fix to git state module when calling git.config_get_regexp

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -710,7 +710,7 @@ def latest(name,
     use_lfs = bool(
         __salt__['git.config_get_regexp'](
             r'filter\.lfs\.',
-            **{'global': True}))
+            **{'global': True, 'ignore_retcode': True}))
     lfs_opts = {'identity': identity} if use_lfs else {}
 
     if os.path.isfile(target):

--- a/tests/integration/states/test_git.py
+++ b/tests/integration/states/test_git.py
@@ -7,6 +7,7 @@ Tests for the Git state
 from __future__ import absolute_import, print_function, unicode_literals
 import functools
 import inspect
+import logging
 import os
 import shutil
 import socket
@@ -15,7 +16,7 @@ import tempfile
 
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
-from tests.support.helpers import with_tempdir
+from tests.support.helpers import with_tempdir, TestsLoggingHandler
 from tests.support.mixins import SaltReturnAssertsMixin
 from tests.support.paths import TMP
 
@@ -171,6 +172,26 @@ class GitTest(ModuleCase, SaltReturnAssertsMixin):
         )
         self.assertSaltTrueReturn(ret)
         self.assertTrue(os.path.isdir(os.path.join(target, '.git')))
+
+    @with_tempdir(create=False)
+    def test_latest_config_get_regexp_retcode(self, target):
+        '''
+        git.latest
+        '''
+
+        log_format = '[%(levelname)-8s] %(jid)s %(message)s'
+        self.handler = TestsLoggingHandler(format=log_format,
+                                           level=logging.DEBUG)
+        ret_code_err = 'failed with return code: 1'
+        with self.handler:
+            ret = self.run_state(
+                'git.latest',
+                name=TEST_REPO,
+                target=target
+            )
+            self.assertSaltTrueReturn(ret)
+            self.assertTrue(os.path.isdir(os.path.join(target, '.git')))
+            assert any(ret_code_err in s for s in self.handler.messages) is False, False
 
     @with_tempdir(create=False)
     def test_latest_with_rev_and_submodules(self, target):


### PR DESCRIPTION
### What does this PR do?
When calling git.config_get_regexp to check for filter\.lfs\. in git config, if the option is not available this would result with a return code of 1 which would result in an error being logged.  Since one possible result is that the configuration would not be there, we ignore the return code.

### What issues does this PR fix or reference?
#54817 

### Previous Behavior
Error in logs when calling git.config_get_regexp

### New Behavior
No error in log

### Tests written?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
