### PR TITLE
Fix issue when scheduling when-type jobs on the Master

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -330,7 +330,7 @@ class Maintenance(salt.utils.process.SignalHandlingMultiprocessingProcess):
             if self.schedule.loop_interval < self.loop_interval:
                 self.loop_interval = self.schedule.loop_interval
         except Exception as exc:
-            log.error('Exception %s occurred in scheduled job', exc)
+            log.error('Exception %s occurred in scheduled job', exc, exc_info=True)
         self.schedule.cleanup_subprocesses()
 
     def handle_presence(self, old_present):

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -959,7 +959,7 @@ class Schedule(object):
                             log.error(data['_error'])
                             return
                         when_ = self.opts['pillar']['whens'][i]
-                    elif ('whens' in self.opts['grains'] and
+                    elif ('grains' in self.opts and 'whens' in self.opts['grains'] and
                           i in self.opts['grains']['whens']):
                         if not isinstance(self.opts['grains']['whens'],
                                           dict):


### PR DESCRIPTION
When scheduling a job on the Master, using the ``when`` feature, it
b0rks as the Master doesn't have Grains.

Similarly, adding more details to the error message, otherwise it only
says ``Exception u'grains' occurred in scheduled job`` which is not
overly descriptive. A log like below could probably be more helpful:

```
2019-10-03 11:49:37,400 [salt.master      :322 ][ERROR   ][179643] Exception u'grains' occurred in scheduled job
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/master.py", line 316, in handle_schedule
    self.schedule.eval()
  File "/usr/lib/python2.7/dist-packages/salt/utils/schedule.py", line 1042, in eval
    elif ('whens' in self.opts['grains'] and
KeyError: u'grains'
```