### PR TITLE
Fixes issue with master_sign_pubkey

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -367,7 +367,8 @@ class MasterKeys(dict):
                                                   opts['master_sign_key_name'] + '.pub')
                 self.rsa_sign_path = os.path.join(self.opts['pki_dir'],
                                                   opts['master_sign_key_name'] + '.pem')
-                self.sign_key = self.__get_keys(name=opts['master_sign_key_name'])
+                self.sign_key = self.__get_keys(name=opts['master_sign_key_name'],
+                                                passphrase=key_pass)
 
     # We need __setstate__ and __getstate__ to avoid pickling errors since
     # some of the member variables correspond to Cython objects which are


### PR DESCRIPTION
### What does this PR do?
Fixes issue generating encrypted keys with master_sign_pubkey enabled with key_pass also configured.

### What issues does this PR fix or reference?
No open issue

### Previous Behavior
When the above options are enabled keys are generated, but not encrypted.

### New Behavior
Keys are encrypted with passphrase

### Tests written?
No. Tests already exists for this.

### Commits signed with GPG?

Yes/No