### PR TITLE
Implemented salt.cache.init_kwargs for the etcd, mysql, and consul cache modules as required by salt.cache.__init__.

### DIFF
--- a/salt/cache/consul.py
+++ b/salt/cache/consul.py
@@ -101,6 +101,8 @@ def __virtual__():
 
     return __virtualname__
 
+def init_kwargs(kwargs):
+    return {}
 
 def store(bank, key, data):
     """

--- a/salt/cache/consul.py
+++ b/salt/cache/consul.py
@@ -101,8 +101,10 @@ def __virtual__():
 
     return __virtualname__
 
+
 def init_kwargs(kwargs):
     return {}
+
 
 def store(bank, key, data):
     """

--- a/salt/cache/etcd_cache.py
+++ b/salt/cache/etcd_cache.py
@@ -92,8 +92,10 @@ def __virtual__():
 
     return __virtualname__
 
+
 def init_kwargs(kwargs):
     return {}
+
 
 def _init_client():
     """Setup client and init datastore.

--- a/salt/cache/etcd_cache.py
+++ b/salt/cache/etcd_cache.py
@@ -92,6 +92,8 @@ def __virtual__():
 
     return __virtualname__
 
+def init_kwargs(kwargs):
+    return {}
 
 def _init_client():
     """Setup client and init datastore.

--- a/salt/cache/mysql_cache.py
+++ b/salt/cache/mysql_cache.py
@@ -91,8 +91,10 @@ def __virtual__():
     """
     return bool(MySQLdb), "No python mysql client installed." if MySQLdb is None else ""
 
+
 def init_kwargs(kwargs):
     return {}
+
 
 def run_query(conn, query, retries=3):
     """

--- a/salt/cache/mysql_cache.py
+++ b/salt/cache/mysql_cache.py
@@ -91,6 +91,8 @@ def __virtual__():
     """
     return bool(MySQLdb), "No python mysql client installed." if MySQLdb is None else ""
 
+def init_kwargs(kwargs):
+    return {}
 
 def run_query(conn, query, retries=3):
     """


### PR DESCRIPTION
### What does this PR do?
This implements a function that is called by salt.cache.__init__ on all lazyloaded cache modules. The original author only implemented it for localfs and redis.

Closes issue #54880.

### What issues does this PR fix or reference?
4475d17

### Previous Behavior
Results in a potentially misleading debugging error being logged. Cache module inconsistencies. Similar problems to the returners.

### New Behavior
All cache modules now follow the same schema.

### Tests written?
Nope. Original author added semantics and didn't bother to update the other related modules.
Maybe It'd be better to standardize the schema for the different module types and validate them to catch module inconsistencies since this is a very common problem.