### PR TITLE
Check the type of the data passed to salt.matcher.confirm_top is a list instead of assuming an implicit false is a "bad data" error.

### DIFF
--- a/changelog/54882.fixed
+++ b/changelog/54882.fixed
@@ -1,0 +1,3 @@
+Fixes bogus warning message when an empty list is used for an environment in a
+topfile. This allows `[]` to be used as a placeholder in a topfile without
+needing to comment everything out as a workaround.

--- a/salt/matchers/confirm_top.py
+++ b/salt/matchers/confirm_top.py
@@ -19,7 +19,7 @@ def confirm_top(match, data, nodegroups=None):
     data matches this minion
     """
     matcher = 'compound'
-    if not isinstance(data, list):
+    if not data:
         log.error('Received bad data when setting the match from the top '
                   'file')
         return False

--- a/salt/matchers/confirm_top.py
+++ b/salt/matchers/confirm_top.py
@@ -18,9 +18,10 @@ def confirm_top(match, data, nodegroups=None):
     Takes the data passed to a top file environment and determines if the
     data matches this minion
     """
-    matcher = "compound"
-    if not data:
-        log.error("Received bad data when setting the match from the top " "file")
+    matcher = 'compound'
+    if not isinstance(data, list):
+        log.error('Received bad data when setting the match from the top '
+                  'file')
         return False
     for item in data:
         if isinstance(item, dict):

--- a/salt/matchers/confirm_top.py
+++ b/salt/matchers/confirm_top.py
@@ -1,11 +1,8 @@
-# -*- coding: utf-8 -*-
 """
 The matcher subsystem needs a function called "confirm_top", which
 takes the data passed to a top file environment and determines if that
 data matches this minion.
 """
-from __future__ import absolute_import
-
 import logging
 
 import salt.loader

--- a/salt/matchers/confirm_top.py
+++ b/salt/matchers/confirm_top.py
@@ -19,10 +19,6 @@ def confirm_top(match, data, nodegroups=None):
     data matches this minion
     """
     matcher = 'compound'
-    if not data:
-        log.error('Received bad data when setting the match from the top '
-                  'file')
-        return False
     for item in data:
         if isinstance(item, dict):
             if "match" in item:

--- a/salt/matchers/confirm_top.py
+++ b/salt/matchers/confirm_top.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-The matcher subsystem needs a function called 'confirm_top', which
+The matcher subsystem needs a function called "confirm_top", which
 takes the data passed to a top file environment and determines if that
 data matches this minion.
 """
@@ -18,7 +18,7 @@ def confirm_top(match, data, nodegroups=None):
     Takes the data passed to a top file environment and determines if the
     data matches this minion
     """
-    matcher = 'compound'
+    matcher = "compound"
     for item in data:
         if isinstance(item, dict):
             if "match" in item:
@@ -32,4 +32,4 @@ def confirm_top(match, data, nodegroups=None):
         m = matchers[funcname]
         return m(match)
     # except TypeError, KeyError:
-    #     log.error('Attempting to match with unknown matcher: %s', matcher)
+    #     log.error("Attempting to match with unknown matcher: %s", matcher)

--- a/tests/unit/matchers/test_confirm_top.py
+++ b/tests/unit/matchers/test_confirm_top.py
@@ -3,11 +3,11 @@
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
 
-# Import Salt Testing libs
-from tests.support.unit import TestCase
-
 import salt.config
 import salt.loader
+
+# Import Salt Testing libs
+from tests.support.unit import TestCase
 
 
 class ConfirmTop(TestCase):
@@ -16,5 +16,5 @@ class ConfirmTop(TestCase):
         self.matchers = salt.loader.matchers(opts)
 
     def test_sanity(self):
-        match = self.matchers['confirm_top.confirm_top']
-        self.assertTrue(match('*', []))
+        match = self.matchers["confirm_top.confirm_top"]
+        self.assertTrue(match("*", []))

--- a/tests/unit/matchers/test_confirm_top.py
+++ b/tests/unit/matchers/test_confirm_top.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
 
@@ -12,7 +14,7 @@ class ConfirmTop(TestCase):
     def setUp(self):
         opts = salt.config.DEFAULT_MINION_OPTS.copy()
         self.matchers = salt.loader.matchers(opts)
-        
+
     def test_sanity(self):
         match = self.matchers['confirm_top.confirm_top']
         self.assertTrue(match('*', []))

--- a/tests/unit/matchers/test_confirm_top.py
+++ b/tests/unit/matchers/test_confirm_top.py
@@ -1,12 +1,5 @@
-# -*- coding: utf-8 -*-
-
-# Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
-
 import salt.config
 import salt.loader
-
-# Import Salt Testing libs
 from tests.support.unit import TestCase
 
 

--- a/tests/unit/matchers/test_confirm_top.py
+++ b/tests/unit/matchers/test_confirm_top.py
@@ -1,0 +1,20 @@
+# Import python libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+import time
+
+# Import Salt Testing libs
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import patch, call, MagicMock
+
+import salt.config
+import salt.loader
+
+class ConfirmTop(TestCase):
+    def setUp(self):
+        opts = salt.config.DEFAULT_MINION_OPTS.copy()
+        self.matchers = salt.loader.matchers(opts)
+        
+    def test_sanity(self):
+        match = self.matchers['confirm_top.confirm_top']
+        self.assertTrue(match('*', []))

--- a/tests/unit/matchers/test_confirm_top.py
+++ b/tests/unit/matchers/test_confirm_top.py
@@ -1,14 +1,12 @@
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
 
-import time
-
 # Import Salt Testing libs
-from tests.support.unit import TestCase, skipIf
-from tests.support.mock import patch, call, MagicMock
+from tests.support.unit import TestCase
 
 import salt.config
 import salt.loader
+
 
 class ConfirmTop(TestCase):
     def setUp(self):


### PR DESCRIPTION
### What does this PR do?
This checks that the type of the data being passed to salt.matcher.confirm_top is not iterable before complaining that it was passed bad data. This pretty much cleans up a general error message that is emitted when given an empty list instead of actually bad data.

### What issues does this PR fix or reference?
Closes #54882 

### Previous Behavior
If an empty list is declared in the topfile such as for a placeholder, a log of level "ERROR" is made which informs the user that bad data was passed via the topfile. 

### New Behavior
This actually checks if the data is badly formatted (according to the error message that gets emitted) by verifying that the data is a list before complaining.

### Tests written?
Nope. This is just a one-liner that cleans up a misleading log.