### PR TITLE
Update smtp_return.py so it would accept '--trust-model always'

### DIFF
--- a/salt/returners/smtp_return.py
+++ b/salt/returners/smtp_return.py
@@ -216,7 +216,7 @@ def returner(ret):
                                    whitelist,
                                    input_data=template,
                                    **ret)
-    
+
     if isinstance(content, six.moves.StringIO):
         content = content.read()
 

--- a/salt/returners/smtp_return.py
+++ b/salt/returners/smtp_return.py
@@ -216,11 +216,14 @@ def returner(ret):
                                    whitelist,
                                    input_data=template,
                                    **ret)
+    
+    if isinstance(content, six.moves.StringIO):
+        content = content.read()
 
     if gpgowner:
         if HAS_GNUPG:
             gpg = gnupg.GPG(gnupghome=os.path.expanduser('~{0}/.gnupg'.format(gpgowner)),
-                            options=['--trust-model always'])
+                            options=['--trust-model=always'])
             encrypted_data = gpg.encrypt(content, to_addrs)
             if encrypted_data.ok:
                 log.debug('smtp_return: Encryption successful')


### PR DESCRIPTION
### What does this PR do?
This PR updates the smtp_return.py file to fix a problem where gpg didn't accept the option "--trust-model always".

### What issues does this PR fix or reference?
This PR references #54731 

### Previous Behavior
Refer to #54731 

### Tests written?
No