### PR TITLE
.modules.pacmanpkg.purge: Do not cascade

### DIFF
--- a/salt/modules/pacmanpkg.py
+++ b/salt/modules/pacmanpkg.py
@@ -718,7 +718,7 @@ def _uninstall(action='remove', name=None, pkgs=None, **kwargs):
     if not targets:
         return {}
 
-    remove_arg = '-Rsc' if action == 'purge' else '-R'
+    remove_arg = '-Rs' if action == 'purge' else '-R'
 
     cmd = []
     if salt.utils.systemd.has_scope(__context__) \
@@ -815,7 +815,7 @@ def purge(name=None, pkgs=None, **kwargs):
     .. _`systemd.kill(5)`: https://www.freedesktop.org/software/systemd/man/systemd.kill.html
 
     Recursively remove a package and all dependencies which were installed
-    with it, this will call a ``pacman -Rsc``
+    with it, this will call a ``pacman -Rs``
 
     name
         The name of the package to be deleted.


### PR DESCRIPTION
### What does this PR do?

Remove cascade option from the pacmanpkg module.

### Previous Behavior
`pacmanpkg.purge` invokes pacman with `-Rsc`.

The `-c` option there is "cascade", meaning that if a package is required by any other packages, those will be removed, too. This is not the default behaviour, and can lead to the removal of likely still required packages ([pacman(8)][man:pacman] also warns about using this option).

Based on the module description for this action, the user does generally not expect this to remove packages like this.

[man:pacman]: http://jlk.fjfi.cvut.cz/arch/manpages/man/core/pacman/pacman.8.en#REMOVE_OPTIONS_(APPLY_TO__FI_-R_FR)

### New Behavior
`pacmanpkg.purge` invokes pacman with `-Rs`. This does what the description claims: Remove packages and its dependencies.

This will error out if the package is still required by another package (rather than "force-remove this package no matter what").

### Tests written?

No

### Commits signed with GPG?

No