### PR TITLE
.modules.pacmanpkg.purge: Behave like .modules.aptpkg.purge

### DIFF
--- a/salt/modules/pacmanpkg.py
+++ b/salt/modules/pacmanpkg.py
@@ -718,7 +718,7 @@ def _uninstall(action='remove', name=None, pkgs=None, **kwargs):
     if not targets:
         return {}
 
-    remove_arg = '-Rs' if action == 'purge' else '-R'
+    remove_arg = '-Rn' if action == 'purge' else '-R'
 
     cmd = []
     if salt.utils.systemd.has_scope(__context__) \
@@ -814,8 +814,7 @@ def purge(name=None, pkgs=None, **kwargs):
     .. _`systemd-run(1)`: https://www.freedesktop.org/software/systemd/man/systemd-run.html
     .. _`systemd.kill(5)`: https://www.freedesktop.org/software/systemd/man/systemd.kill.html
 
-    Recursively remove a package and all dependencies which were installed
-    with it, this will call a ``pacman -Rs``
+    Remove packages via ``pacman -Rn`` along with all configuration files.
 
     name
         The name of the package to be deleted.

--- a/salt/modules/pacmanpkg.py
+++ b/salt/modules/pacmanpkg.py
@@ -718,7 +718,7 @@ def _uninstall(action='remove', name=None, pkgs=None, **kwargs):
     if not targets:
         return {}
 
-    remove_arg = '-Rsc' if action == 'purge' else '-R'
+    remove_arg = '-Rs' if action == 'purge' else '-R'
 
     cmd = []
     if salt.utils.systemd.has_scope(__context__) \
@@ -815,7 +815,7 @@ def purge(name=None, pkgs=None, **kwargs):
     .. _`systemd.kill(5)`: https://www.freedesktop.org/software/systemd/man/systemd.kill.html
 
     Recursively remove a package and all dependencies which were installed
-    with it, this will call a ``pacman -Rsc``
+    with it, this will call a ``pacman -Rs``
 
     name
         The name of the package to be deleted.


### PR DESCRIPTION
### What does this PR do?

Make `pacmanpkg.purge` behave like `aptpkg.purge`, i.e. remove a package along with its configuration files.

### Previous Behavior
`pacmanpkg.purge` invokes pacman with `-Rs`, i.e. it removes packages along with its dependencies.

The word "purge" in the context of package manager operations (to my knowledge) describes something else: apt uses `purge` for removing packages and its configuration files, whereas pacman does not have any meaning attributed to that word.

More importantly, the same action (`pkg.purge`) does different things on different systems.

### New Behavior
`pacmanpkg.purge` invokes pacman with `-Rn`, i.e. it removes packages along with its configuration files.

This is more in line with what at least Debian users would expect, and does not conflict with any predisposed understanding that Arch users might have.

It *does*, however, introduce a significant, backward-incompatible change for pacman-based systems.
Also, this removes the possibility for recursively removing unrequired dependencies on pacman-based systems, so it might be wise to add a new action for pacman in the vein of `aptpkg.autoremove`.

### Tests written?
No

### Commits signed with GPG?

No