### PR TITLE
Adds an example of running states on the Salt Master during an orchestration

### DIFF
--- a/doc/topics/orchestrate/orchestrate_runner.rst
+++ b/doc/topics/orchestrate/orchestrate_runner.rst
@@ -140,7 +140,7 @@ can specify the "name" argument to avoid conflicting IDs:
 State
 ^^^^^
 
-To execute a state, use :mod:`salt.state <salt.states.saltmod.state>`.
+To execute a state on a Salt Minion, use :mod:`salt.state <salt.states.saltmod.state>`.
 
 .. code-block:: yaml
 
@@ -154,6 +154,20 @@ To execute a state, use :mod:`salt.state <salt.states.saltmod.state>`.
 .. code-block:: bash
 
     salt-run state.orchestrate orch.webserver
+    
+To execute a state on the Salt Master running your orchestration simply write your state as you normally would.  This is great for running scripts or sending API requests that you want your Salt Master to do directly.
+
+.. code-block:: yaml
+
+    # /srv/salt/orch/report/init.sls
+    run_report_script:
+      cmd.script:
+        - name: salt://orch/report/files/report.sh
+        - args: "'-a April' '-b June'"
+
+.. code-block:: bash
+
+    salt-run state.orchestrate orch.report
 
 Highstate
 ^^^^^^^^^


### PR DESCRIPTION
### What does this PR do?
Adds an example of running states on the Salt Master during an orchestration.

### What issues does this PR fix or reference?
There was no example of running states on the Salt Master directly during an orchestration in the docs.  This led me to believe that in order to have something run on the Salt Master I had to either use a runner or target the Salt Master specifically which I did not want to do.

### Previous Behavior
Only provided an example of running a state on a minion.

### New Behavior
Provides an example of running states on Minions and the Salt Master running the orchestration.

### Tests written?
No

### Commits signed with GPG?
Yes
