### PR TITLE
update version numbers to be correct

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -255,7 +255,7 @@ on_saltstack = 'SALT_ON_SALTSTACK' in os.environ
 project = 'Salt'
 
 version = salt.version.__version__
-latest_release = '2019.2.0'  # latest release
+latest_release = '2019.2.1'  # latest release
 previous_release = '2018.3.4'  # latest release from previous branch
 previous_release_dir = '2018.3'  # path on web server for previous branch
 next_release = ''  # next release


### PR DESCRIPTION
### What does this PR do?
fixes docs links to show that 2019.2.1 is current latest