### PR TITLE
Fix winexe and psexec bugs #54910 #54904

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1356,12 +1356,10 @@ def deploy_windows(host,
                 salt.utils.smb.delete_directory('salttemp', 'C$', conn=smb_conn)
         # Shell out to psexec to ensure salt-minion service started
         if use_winrm:
-            
             winrm_cmd(winrm_session, 'sc', ['stop', 'salt-minion'])
             time.sleep(10)
             winrm_cmd(winrm_session, 'sc', ['start', 'salt-minion'])
-        else:
-            
+        else:            
             stdout, stderr, ret_code = run_psexec_command(
                 'cmd.exe', '/c sc stop salt-minion', host, username, password
             )
@@ -1371,15 +1369,13 @@ def deploy_windows(host,
             stdout, stderr, ret_code = run_psexec_command(
                 'cmd.exe', '/c sc query salt-minion', host, username, password
             )
-            log.debug('%s', stdout) 
-            
+            log.debug('%s', stdout)
             retry = 0
             while 'STOP_PENDING' in stdout and retry < 100:
                 stdout, stderr, ret_code = run_psexec_command(
                     'cmd.exe', '/c sc query salt-minion', host, username, password
                 )
                 retry += 1
-            
             log.debug('Run psexec: sc start salt-minion')
             stdout, stderr, ret_code = run_psexec_command(
                 'cmd.exe', '/c sc start salt-minion', host, username, password

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1371,7 +1371,7 @@ def deploy_windows(host,
             stdout, stderr, ret_code = run_psexec_command(
                 'cmd.exe', '/c sc query salt-minion', host, username, password
             )
-            log.debug('%s',stdout) 
+            log.debug('%s', stdout) 
             
             retry = 0
             while 'STOP_PENDING' in stdout and retry < 100:

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -935,7 +935,7 @@ class Client(object):
 def run_winexe_command(cmd, args, host, username, password, port=445):
     '''
     Run a command remotly via the winexe executable
-    '''    
+    '''
     creds = "-U '{0}%{1}' //{2}".format(
         username,
         password,
@@ -1371,12 +1371,14 @@ def deploy_windows(host,
             stdout, stderr, ret_code = run_psexec_command(
                 'cmd.exe', '/c sc query salt-minion', host, username, password
             )
-            log.info('%s',stdout) 
+            log.debug('%s',stdout) 
             
-            while "STOP_PENDING" in stdout:
+            retry=0
+            while 'STOP_PENDING' in stdout and retry<100:
                 stdout, stderr, ret_code = run_psexec_command(
                     'cmd.exe', '/c sc query salt-minion', host, username, password
                 )
+                retry+=1
             
             log.debug('Run psexec: sc start salt-minion')
             stdout, stderr, ret_code = run_psexec_command(

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1359,7 +1359,7 @@ def deploy_windows(host,
             winrm_cmd(winrm_session, 'sc', ['stop', 'salt-minion'])
             time.sleep(10)
             winrm_cmd(winrm_session, 'sc', ['start', 'salt-minion'])
-        else:            
+        else:
             stdout, stderr, ret_code = run_psexec_command(
                 'cmd.exe', '/c sc stop salt-minion', host, username, password
             )

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1373,12 +1373,12 @@ def deploy_windows(host,
             )
             log.debug('%s',stdout) 
             
-            retry=0
-            while 'STOP_PENDING' in stdout and retry<100:
+            retry = 0
+            while 'STOP_PENDING' in stdout and retry < 100:
                 stdout, stderr, ret_code = run_psexec_command(
                     'cmd.exe', '/c sc query salt-minion', host, username, password
                 )
-                retry+=1
+                retry += 1
             
             log.debug('Run psexec: sc start salt-minion')
             stdout, stderr, ret_code = run_psexec_command(


### PR DESCRIPTION
minion fails to start after upgrade. start action is performed while minion is still shutting down.
- increased sleep time from 5 to 10 for winrm usage
- added while loop to verify minion stopped before starting it for psexec
- fixed run_winexe_command function

### What does this PR do?
Fix minion start issues

### What issues does this PR fix or reference?
fix bugs #54910 #54904

### Previous Behavior
minion fails to start after upgrade. start action is performed while minion is still shutting down.

### New Behavior
wait for minion to stop / increase sleep - depends on the used module

### Tests written?
No

### Commits signed with GPG?
No

