### PR TITLE
Fix typo in gitfs.rts

### DIFF
--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -381,7 +381,7 @@ In the example configuration above, the following is true:
 
 2. The first remote will serve all files in the repository. The second
    remote will only serve files from the ``salt`` directory (and its
-   subdirectories). The third remote will only server files from the
+   subdirectories). The third remote will only serve files from the
    ``other/salt`` directory (and its subdirectories), while the fourth remote
    will only serve files from the ``salt/states`` directory (and its
    subdirectories).


### PR DESCRIPTION
There's a typo in the Git Fileserver Backend Walkthrough:
>The first remote will serve all files in the repository. The second remote will only serve files from the salt directory (and its subdirectories). The third remote will only *server* files from the other/salt directory (and its subdirectories), while the fourth remote will only serve files from the salt/states directory (and its subdirectories).

### What does this PR do?
Fix a typo in the Git Fileserver Backend Walkthrough

### What issues does this PR fix or reference?
This PR fixes the typo in this segment:
>The first remote will serve all files in the repository. The second remote will only serve files from the salt directory (and its subdirectories). The third remote will only *server* files from the other/salt directory (and its subdirectories), while the fourth remote will only serve files from the salt/states directory (and its subdirectories).

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
