### PR TITLE
[wip] event throttling mechanism

### DIFF
--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -722,7 +722,6 @@ class SaltEvent(object):
 
         yield self.pusher.send(msg)
 
-
     def fire_event(self, data, tag, timeout=1000):
         '''
         Send a single event into the publisher with payload dict "data" and


### PR DESCRIPTION
### What does this PR do?

Mechanism to throttle events. When in a complex environment, this can help you put in a failsafe to prevent duplicate work.

Example Config:

```
event_throttles:
  cache_path: /dev/shm/event_throttles.dict
  cache_ttl: 300
  rules:
    - method: startswith
      match: minion/refresh/
```

Note: for the cache path, you probably want to use something like `/dev/shm` so that disk operations are fast an in memory only. 

Example Test:
(with the config above)

1. Run several times: `salt 'zort' saltutil.refresh_grains` 
2. The master should skip minion refresh events for 300 seconds after the first event. Can be verified in the log.

