### PR TITLE
master-port #50145

### DIFF
--- a/doc/ref/serializers/all/index.rst
+++ b/doc/ref/serializers/all/index.rst
@@ -14,5 +14,6 @@ serializer modules
     json
     msgpack
     python
+    toml
     yaml
     yamlex

--- a/doc/ref/serializers/all/salt.serializers.toml.rst
+++ b/doc/ref/serializers/all/salt.serializers.toml.rst
@@ -1,0 +1,6 @@
+=====================
+salt.serializers.toml
+=====================
+
+.. automodule:: salt.serializers.toml
+    :members:


### PR DESCRIPTION
make toml serializer discoverable in docs

### What does this PR do?
Port #50145 to master