### PR TITLE
remove Google+ from README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,6 @@ services`_ offerings.
 * Facebook - `<https://www.facebook.com/SaltStack/>`_
 * LinkedIn - `<https://www.linkedin.com/company/salt-stack-inc>`_
 * LinkedIn Group - `<https://www.linkedin.com/groups/4877160>`_
-* Google+ - `<https://plus.google.com/b/112856352920437801867/+SaltStackInc/posts>`_
 
 .. _global community: http://www.meetup.com/pro/saltstack/
 .. _SaltConf: http://saltconf.com/


### PR DESCRIPTION
See https://plus.google.com/ , Google+ is shutdown.

### What does this PR do?
Remove Google+ from README.rst

### What issues does this PR fix or reference?
https://plus.google.com/
