### PR TITLE
(Backport 51871) cmdmod: add 'binds' parameter in run_chroot

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2929,19 +2929,17 @@ def run_chroot(root,
 
     :param str root: Path to the root of the jail to use.
 
-    stdin
-        A string of standard input can be specified for the command to be run using
-        the ``stdin`` parameter. This can be useful in cases where sensitive
-        information must be read from standard input.:
+    :param str stdin: A string of standard input can be specified for
+        the command to be run using the ``stdin`` parameter. This can
+        be useful in cases where sensitive information must be read
+        from standard input.:
 
-    runas
-        User to run script as.
+    :param str runas: User to run script as.
 
-    group
-        Group to run script as.
+    :param str group: Group to run script as.
 
-    shell
-        Shell to execute under. Defaults to the system default shell.
+    :param str shell: Shell to execute under. Defaults to the system
+        default shell.
 
     :param str cmd: The command to run. ex: ``ls -lart /home``
 
@@ -2983,11 +2981,11 @@ def run_chroot(root,
         engine will be used to render the downloaded file. Currently jinja,
         mako, and wempy are supported.
 
-    :param bool rstrip:
-        Strip all whitespace off the end of output before it is returned.
+    :param bool rstrip: Strip all whitespace off the end of output
+        before it is returned.
 
-    :param str umask:
-         The umask (in octal) to use when running the command.
+    :param str umask: The umask (in octal) to use when running the
+         command.
 
     :param str output_encoding: Control the encoding used to decode the
         command's output.

--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -433,3 +433,33 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
             ret = cmdmod.run_all('some command', output_encoding='latin1')
 
         self.assertEqual(ret['stdout'], stdout)
+
+    def test_run_chroot_mount(self):
+        '''
+        Test cmdmod.run_chroot mount / umount balance
+        '''
+        mock_mount = MagicMock()
+        mock_umount = MagicMock()
+        mock_run_all = MagicMock()
+        with patch.dict(cmdmod.__salt__, {
+                'mount.mount': mock_mount,
+                'mount.umount': mock_umount}):
+            with patch('salt.modules.cmdmod.run_all', mock_run_all):
+                cmdmod.run_chroot('/mnt', 'cmd')
+                self.assertEqual(mock_mount.call_count, 3)
+                self.assertEqual(mock_umount.call_count, 3)
+
+    def test_run_chroot_mount_bind(self):
+        '''
+        Test cmdmod.run_chroot mount / umount balance with bind mount
+        '''
+        mock_mount = MagicMock()
+        mock_umount = MagicMock()
+        mock_run_all = MagicMock()
+        with patch.dict(cmdmod.__salt__, {
+                'mount.mount': mock_mount,
+                'mount.umount': mock_umount}):
+            with patch('salt.modules.cmdmod.run_all', mock_run_all):
+                cmdmod.run_chroot('/mnt', 'cmd', binds=['/var'])
+                self.assertEqual(mock_mount.call_count, 4)
+                self.assertEqual(mock_umount.call_count, 4)


### PR DESCRIPTION
### What does this PR do?

Sometimes we want to export directories from the system to the
chroot environment. For example, some services will require the
presence of /run inside the chroot, to request some PID information.

This patch add a new 'binds' parameter in the run_chroot function,
that will export those system directories into the chroot.

### Tests written?

Yes, added in this PR

(backport #51871, already merged in develop)