### PR TITLE
docs(cron.py): fix `cron.identifier_exists` => `cron.get_entry`

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -396,7 +396,7 @@ class FileserverUpdate(salt.utils.process.SignalHandlingMultiprocessingProcess):
                 update_func = self.fileserver.servers[fstr]
             except KeyError:
                 log.debug(
-                    'No update function for the %s filserver backend',
+                    'No update function for the %s fileserver backend',
                     backend
                 )
                 continue

--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -468,7 +468,7 @@ def get_entry(user, identifier=None, cmd=None):
 
     .. code-block:: bash
 
-        salt '*' cron.identifier_exists root identifier=task1
+        salt '*' cron.get_entry root identifier=task1
     '''
     cron_entries = list_tab(user).get('crons', False)
     for cron_entry in cron_entries:


### PR DESCRIPTION
### What does this PR do?

Documentation change only.

```sls
'cron.identifier_exists' is not available.
```

Running the same with `cron.get_entry` works fine.

### Commits signed with GPG?

Yes.