### PR TITLE
Allow to pass arguments to fileserver.update runner

### DIFF
--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -2,7 +2,6 @@
 File server pluggable modules and generic backend functions
 """
 
-# Import python libs
 
 import errno
 import fnmatch
@@ -12,15 +11,12 @@ import re
 import time
 from collections.abc import Sequence
 
-# Import salt libs
 import salt.loader
 import salt.utils.data
 import salt.utils.files
 import salt.utils.path
 import salt.utils.url
 import salt.utils.versions
-
-# Import 3rd-party libs
 from salt.ext import six
 from salt.utils.args import get_function_argspec as _argspec
 from salt.utils.decorators import ensure_unicode_args

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -479,17 +479,17 @@ class Fileserver(object):
                 errors.extend(bad)
         return cleared, errors
 
-    def update(self, back=None):
+    def update(self, back=None, **kwargs):
         """
         Update all of the enabled fileserver backends which support the update
-        function, or
+        function
         """
         back = self.backends(back)
         for fsb in back:
             fstr = "{0}.update".format(fsb)
             if fstr in self.servers:
                 log.debug("Updating %s fileserver cache", fsb)
-                self.servers[fstr]()
+                self.servers[fstr](**kwargs)
 
     def update_intervals(self, back=None):
         """

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 """
 File server pluggable modules and generic backend functions
 """
 
 # Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import errno
 import fnmatch
@@ -41,7 +39,7 @@ def _unlock_cache(w_lock):
             os.rmdir(w_lock)
         elif os.path.isfile(w_lock):
             os.unlink(w_lock)
-    except (OSError, IOError) as exc:
+    except OSError as exc:
         log.trace("Error removing lockfile %s: %s", w_lock, exc)
 
 
@@ -96,7 +94,7 @@ def wait_lock(lk_fn, dest, wait_timeout=0):
         if timeout:
             if time.time() > timeout:
                 raise ValueError(
-                    "Timeout({0}s) for {1} (lock: {2}) elapsed".format(
+                    "Timeout({}s) for {} (lock: {}) elapsed".format(
                         wait_timeout, dest, lk_fn
                     )
                 )
@@ -199,7 +197,7 @@ def check_env_cache(opts, env_cache):
             log.trace("Returning env cache data from %s", env_cache)
             serial = salt.payload.Serial(opts)
             return salt.utils.data.decode(serial.load(fp_))
-    except (IOError, OSError):
+    except OSError:
         pass
     return None
 
@@ -209,7 +207,7 @@ def generate_mtime_map(opts, path_map):
     Generate a dict of filename -> mtime
     """
     file_map = {}
-    for saltenv, path_list in six.iteritems(path_map):
+    for saltenv, path_list in path_map.items():
         for path in path_list:
             for directory, _, filenames in salt.utils.path.os_walk(path):
                 for item in filenames:
@@ -220,7 +218,7 @@ def generate_mtime_map(opts, path_map):
                         if is_file_ignored(opts, file_path):
                             continue
                         file_map[file_path] = os.path.getmtime(file_path)
-                    except (OSError, IOError):
+                    except OSError:
                         # skip dangling symlinks
                         log.info(
                             "Failed to get mtime on %s, dangling symlink?", file_path
@@ -239,7 +237,7 @@ def diff_mtime_map(map1, map2):
 
     # map1 and map2 are guaranteed to have same keys,
     # so compare mtimes
-    for filename, mtime in six.iteritems(map1):
+    for filename, mtime in map1.items():
         if map2[filename] != mtime:
             return True
 
@@ -329,14 +327,14 @@ def clear_lock(clear_func, role, remote=None, lock_type="update"):
 
     Returns the return data from ``clear_func``.
     """
-    msg = "Clearing {0} lock for {1} remotes".format(lock_type, role)
+    msg = "Clearing {} lock for {} remotes".format(lock_type, role)
     if remote:
-        msg += " matching {0}".format(remote)
+        msg += " matching {}".format(remote)
     log.debug(msg)
     return clear_func(remote=remote, lock_type=lock_type)
 
 
-class Fileserver(object):
+class Fileserver:
     """
     Create a fileserver wrapper object that wraps the fileserver functions and
     iterates over them to execute the desired function within the scope of the
@@ -358,7 +356,7 @@ class Fileserver(object):
                 try:
                     back = back.split(",")
                 except AttributeError:
-                    back = six.text_type(back).split(",")
+                    back = str(back).split(",")
 
         if isinstance(back, Sequence):
             # The test suite uses an ImmutableList type (based on
@@ -376,7 +374,7 @@ class Fileserver(object):
         # .keys() attribute rather than on the LazyDict itself.
         server_funcs = self.servers.keys()
         try:
-            subtract_only = all((x.startswith("-") for x in back))
+            subtract_only = all(x.startswith("-") for x in back)
         except AttributeError:
             pass
         else:
@@ -384,12 +382,12 @@ class Fileserver(object):
                 # Only subtracting backends from enabled ones
                 ret = self.opts["fileserver_backend"]
                 for sub in back:
-                    if "{0}.envs".format(sub[1:]) in server_funcs:
+                    if "{}.envs".format(sub[1:]) in server_funcs:
                         ret.remove(sub[1:])
                 return ret
 
         for sub in back:
-            if "{0}.envs".format(sub) in server_funcs:
+            if "{}.envs".format(sub) in server_funcs:
                 ret.append(sub)
         return ret
 
@@ -417,7 +415,7 @@ class Fileserver(object):
         cleared = []
         errors = []
         for fsb in back:
-            fstr = "{0}.clear_cache".format(fsb)
+            fstr = "{}.clear_cache".format(fsb)
             if fstr in self.servers:
                 log.debug("Clearing %s fileserver cache", fsb)
                 failed = self.servers[fstr]()
@@ -425,7 +423,7 @@ class Fileserver(object):
                     errors.extend(failed)
                 else:
                     cleared.append(
-                        "The {0} fileserver cache was successfully cleared".format(fsb)
+                        "The {} fileserver cache was successfully cleared".format(fsb)
                     )
         return cleared, errors
 
@@ -439,17 +437,17 @@ class Fileserver(object):
         locked = []
         errors = []
         for fsb in back:
-            fstr = "{0}.lock".format(fsb)
+            fstr = "{}.lock".format(fsb)
             if fstr in self.servers:
-                msg = "Setting update lock for {0} remotes".format(fsb)
+                msg = "Setting update lock for {} remotes".format(fsb)
                 if remote:
-                    if not isinstance(remote, six.string_types):
+                    if not isinstance(remote, str):
                         errors.append(
-                            "Badly formatted remote pattern '{0}'".format(remote)
+                            "Badly formatted remote pattern '{}'".format(remote)
                         )
                         continue
                     else:
-                        msg += " matching {0}".format(remote)
+                        msg += " matching {}".format(remote)
                 log.debug(msg)
                 good, bad = self.servers[fstr](remote=remote)
                 locked.extend(good)
@@ -472,7 +470,7 @@ class Fileserver(object):
         cleared = []
         errors = []
         for fsb in back:
-            fstr = "{0}.clear_lock".format(fsb)
+            fstr = "{}.clear_lock".format(fsb)
             if fstr in self.servers:
                 good, bad = clear_lock(self.servers[fstr], fsb, remote=remote)
                 cleared.extend(good)
@@ -486,7 +484,7 @@ class Fileserver(object):
         """
         back = self.backends(back)
         for fsb in back:
-            fstr = "{0}.update".format(fsb)
+            fstr = "{}.update".format(fsb)
             if fstr in self.servers:
                 log.debug("Updating %s fileserver cache", fsb)
                 self.servers[fstr](**kwargs)
@@ -499,7 +497,7 @@ class Fileserver(object):
         back = self.backends(back)
         ret = {}
         for fsb in back:
-            fstr = "{0}.update_intervals".format(fsb)
+            fstr = "{}.update_intervals".format(fsb)
             if fstr in self.servers:
                 ret[fsb] = self.servers[fstr]()
         return ret
@@ -513,7 +511,7 @@ class Fileserver(object):
         if sources:
             ret = {}
         for fsb in back:
-            fstr = "{0}.envs".format(fsb)
+            fstr = "{}.envs".format(fsb)
             kwargs = (
                 {"ignore_cache": True}
                 if "ignore_cache" in _argspec(self.servers[fstr]).args
@@ -543,7 +541,7 @@ class Fileserver(object):
         """
         back = self.backends(back)
         for fsb in back:
-            fstr = "{0}.init".format(fsb)
+            fstr = "{}.init".format(fsb)
             if fstr in self.servers:
                 self.servers[fstr]()
 
@@ -602,11 +600,11 @@ class Fileserver(object):
         if "saltenv" in kwargs:
             saltenv = kwargs.pop("saltenv")
 
-        if not isinstance(saltenv, six.string_types):
-            saltenv = six.text_type(saltenv)
+        if not isinstance(saltenv, str):
+            saltenv = str(saltenv)
 
         for fsb in back:
-            fstr = "{0}.find_file".format(fsb)
+            fstr = "{}.find_file".format(fsb)
             if fstr in self.servers:
                 fnd = self.servers[fstr](path, saltenv, **kwargs)
                 if fnd.get("path"):
@@ -626,13 +624,13 @@ class Fileserver(object):
 
         if "path" not in load or "loc" not in load or "saltenv" not in load:
             return ret
-        if not isinstance(load["saltenv"], six.string_types):
-            load["saltenv"] = six.text_type(load["saltenv"])
+        if not isinstance(load["saltenv"], str):
+            load["saltenv"] = str(load["saltenv"])
 
         fnd = self.find_file(load["path"], load["saltenv"])
         if not fnd.get("back"):
             return ret
-        fstr = "{0}.serve_file".format(fnd["back"])
+        fstr = "{}.serve_file".format(fnd["back"])
         if fstr in self.servers:
             return self.servers[fstr](load, fnd)
         return ret
@@ -647,8 +645,8 @@ class Fileserver(object):
 
         if "path" not in load or "saltenv" not in load:
             return "", None
-        if not isinstance(load["saltenv"], six.string_types):
-            load["saltenv"] = six.text_type(load["saltenv"])
+        if not isinstance(load["saltenv"], str):
+            load["saltenv"] = str(load["saltenv"])
 
         fnd = self.find_file(
             salt.utils.stringutils.to_unicode(load["path"]), load["saltenv"]
@@ -656,7 +654,7 @@ class Fileserver(object):
         if not fnd.get("back"):
             return "", None
         stat_result = fnd.get("stat", None)
-        fstr = "{0}.file_hash".format(fnd["back"])
+        fstr = "{}.file_hash".format(fnd["back"])
         if fstr in self.servers:
             return self.servers[fstr](load, fnd), stat_result
         return "", None
@@ -693,11 +691,11 @@ class Fileserver(object):
                 try:
                     saltenv = [x.strip() for x in saltenv.split(",")]
                 except AttributeError:
-                    saltenv = [x.strip() for x in six.text_type(saltenv).split(",")]
+                    saltenv = [x.strip() for x in str(saltenv).split(",")]
 
             for idx, val in enumerate(saltenv):
-                if not isinstance(val, six.string_types):
-                    saltenv[idx] = six.text_type(val)
+                if not isinstance(val, str):
+                    saltenv[idx] = str(val)
 
         ret = {}
         fsb = self.backends(load.pop("fsbackend", None))
@@ -772,11 +770,11 @@ class Fileserver(object):
         ret = set()
         if "saltenv" not in load:
             return []
-        if not isinstance(load["saltenv"], six.string_types):
-            load["saltenv"] = six.text_type(load["saltenv"])
+        if not isinstance(load["saltenv"], str):
+            load["saltenv"] = str(load["saltenv"])
 
         for fsb in self.backends(load.pop("fsbackend", None)):
-            fstr = "{0}.file_list".format(fsb)
+            fstr = "{}.file_list".format(fsb)
             if fstr in self.servers:
                 ret.update(self.servers[fstr](load))
         # some *fs do not handle prefix. Ensure it is filtered
@@ -797,11 +795,11 @@ class Fileserver(object):
         ret = set()
         if "saltenv" not in load:
             return []
-        if not isinstance(load["saltenv"], six.string_types):
-            load["saltenv"] = six.text_type(load["saltenv"])
+        if not isinstance(load["saltenv"], str):
+            load["saltenv"] = str(load["saltenv"])
 
         for fsb in self.backends(None):
-            fstr = "{0}.file_list_emptydirs".format(fsb)
+            fstr = "{}.file_list_emptydirs".format(fsb)
             if fstr in self.servers:
                 ret.update(self.servers[fstr](load))
         # some *fs do not handle prefix. Ensure it is filtered
@@ -822,11 +820,11 @@ class Fileserver(object):
         ret = set()
         if "saltenv" not in load:
             return []
-        if not isinstance(load["saltenv"], six.string_types):
-            load["saltenv"] = six.text_type(load["saltenv"])
+        if not isinstance(load["saltenv"], str):
+            load["saltenv"] = str(load["saltenv"])
 
         for fsb in self.backends(load.pop("fsbackend", None)):
-            fstr = "{0}.dir_list".format(fsb)
+            fstr = "{}.dir_list".format(fsb)
             if fstr in self.servers:
                 ret.update(self.servers[fstr](load))
         # some *fs do not handle prefix. Ensure it is filtered
@@ -847,21 +845,21 @@ class Fileserver(object):
         ret = {}
         if "saltenv" not in load:
             return {}
-        if not isinstance(load["saltenv"], six.string_types):
-            load["saltenv"] = six.text_type(load["saltenv"])
+        if not isinstance(load["saltenv"], str):
+            load["saltenv"] = str(load["saltenv"])
 
         for fsb in self.backends(load.pop("fsbackend", None)):
-            symlstr = "{0}.symlink_list".format(fsb)
+            symlstr = "{}.symlink_list".format(fsb)
             if symlstr in self.servers:
                 ret = self.servers[symlstr](load)
         # some *fs do not handle prefix. Ensure it is filtered
         prefix = load.get("prefix", "").strip("/")
         if prefix != "":
-            ret = dict([(x, y) for x, y in six.iteritems(ret) if x.startswith(prefix)])
+            ret = {x: y for x, y in ret.items() if x.startswith(prefix)}
         return ret
 
 
-class FSChan(object):
+class FSChan:
     """
     A class that mimics the transport channels allowing for local access to
     to the fileserver class class structure

--- a/salt/runners/fileserver.py
+++ b/salt/runners/fileserver.py
@@ -322,7 +322,7 @@ def empty_dir_list(saltenv="base", backend=None):
     return fileserver.file_list_emptydirs(load=load)
 
 
-def update(backend=None):
+def update(backend=None, **kwargs):
     """
     Update the fileserver cache. If no backend is provided, then the cache for
     all configured backends will be updated.
@@ -341,15 +341,19 @@ def update(backend=None):
             comma-separated list. In earlier versions, they needed to be passed
             as a python list (ex: ``backend="['roots', 'git']"``)
 
+    kwargs
+        Pass additional arguments to backend. See example below
+
     CLI Example:
 
     .. code-block:: bash
 
         salt-run fileserver.update
         salt-run fileserver.update backend=roots,git
+        salt-run fileserver.update backend=git remotes=myrepo,yourrepo
     """
     fileserver = salt.fileserver.Fileserver(__opts__)
-    fileserver.update(back=backend)
+    fileserver.update(back=backend, **kwargs)
     return True
 
 

--- a/salt/runners/fileserver.py
+++ b/salt/runners/fileserver.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
 """
 Directly manage the Salt fileserver plugins
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt libs
 import salt.fileserver

--- a/salt/runners/fileserver.py
+++ b/salt/runners/fileserver.py
@@ -2,7 +2,6 @@
 Directly manage the Salt fileserver plugins
 """
 
-# Import Salt libs
 import salt.fileserver
 
 

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -2,7 +2,6 @@
 Classes which provide the shared base for GitFS, git_pillar, and winrepo
 """
 
-# Import python libs
 
 import contextlib
 import copy
@@ -22,8 +21,6 @@ from datetime import datetime
 
 import salt.ext.tornado.ioloop
 import salt.fileserver
-
-# Import salt libs
 import salt.utils.configparser
 import salt.utils.data
 import salt.utils.files
@@ -38,8 +35,6 @@ import salt.utils.user
 import salt.utils.versions
 from salt.config import DEFAULT_MASTER_OPTS as _DEFAULT_MASTER_OPTS
 from salt.exceptions import FileserverConfigError, GitLockError, get_error_message
-
-# Import third party libs
 from salt.ext import six
 from salt.utils.event import tagify
 from salt.utils.odict import OrderedDict

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -2507,6 +2507,8 @@ class GitBase(object):
         """
         if remotes is None:
             remotes = []
+        elif isinstance(remotes, six.string_types):
+            remotes = remotes.split(",")
         elif not isinstance(remotes, list):
             log.error(
                 "Invalid 'remotes' argument (%s) for fetch_remotes. "
@@ -2518,7 +2520,7 @@ class GitBase(object):
         changed = False
         for repo in self.remotes:
             name = getattr(repo, "name", None)
-            if not remotes or (repo.id, name) in remotes:
+            if not remotes or (repo.id, name) in remotes or name in remotes:
                 try:
                     if repo.fetch():
                         # We can't just use the return value from repo.fetch()

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -16,7 +16,6 @@ import shlex
 import shutil
 import stat
 import subprocess
-import sys
 import time
 import weakref
 from datetime import datetime

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 """
 Classes which provide the shared base for GitFS, git_pillar, and winrepo
 """
 
 # Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import contextlib
 import copy
@@ -173,7 +171,7 @@ def enforce_types(key, val):
                     ret = item
                     break
             except TypeError:
-                if key.endswith("_" + six.text_type(item)):
+                if key.endswith("_" + str(item)):
                     ret = item
                     break
         else:
@@ -183,15 +181,15 @@ def enforce_types(key, val):
     if key not in non_string_params:
         key = _find_global(key)
         if key is None:
-            return six.text_type(val)
+            return str(val)
 
     expected = non_string_params[key]
     if expected == "stringlist":
-        if not isinstance(val, (six.string_types, list)):
-            val = six.text_type(val)
-        if isinstance(val, six.string_types):
+        if not isinstance(val, ((str,), list)):
+            val = str(val)
+        if isinstance(val, str):
             return [x.strip() for x in val.split(",")]
-        return [six.text_type(x) for x in val]
+        return [str(x) for x in val]
     else:
         try:
             return expected(val)
@@ -202,17 +200,17 @@ def enforce_types(key, val):
                 key,
                 val,
             )
-            return six.text_type(val)
+            return str(val)
 
 
 def failhard(role):
     """
     Fatal configuration issue, raise an exception
     """
-    raise FileserverConfigError("Failed to load {0}".format(role))
+    raise FileserverConfigError("Failed to load {}".format(role))
 
 
-class GitProvider(object):
+class GitProvider:
     """
     Base class for gitfs/git_pillar provider classes. Should never be used
     directly.
@@ -234,17 +232,17 @@ class GitProvider(object):
         self.opts = opts
         self.role = role
         self.global_saltenv = salt.utils.data.repack_dictlist(
-            self.opts.get("{0}_saltenv".format(self.role), []),
+            self.opts.get("{}_saltenv".format(self.role), []),
             strict=True,
             recurse=True,
-            key_cb=six.text_type,
-            val_cb=lambda x, y: six.text_type(y),
+            key_cb=str,
+            val_cb=lambda x, y: str(y),
         )
         self.conf = copy.deepcopy(per_remote_defaults)
 
         # Remove the 'salt://' from the beginning of any globally-defined
         # per-saltenv mountpoints
-        for saltenv, saltenv_conf in six.iteritems(self.global_saltenv):
+        for saltenv, saltenv_conf in self.global_saltenv.items():
             if "mountpoint" in saltenv_conf:
                 self.global_saltenv[saltenv]["mountpoint"] = salt.utils.url.strip_proto(
                     self.global_saltenv[saltenv]["mountpoint"]
@@ -271,7 +269,7 @@ class GitProvider(object):
                 remote[self.id],
                 strict=True,
                 recurse=True,
-                key_cb=six.text_type,
+                key_cb=str,
                 val_cb=enforce_types,
             )
 
@@ -311,8 +309,8 @@ class GitProvider(object):
                     log.critical(msg)
                 else:
                     msg = (
-                        "Invalid {0} configuration parameter '{1}' in "
-                        "remote '{2}'. Valid parameters are: {3}.".format(
+                        "Invalid {} configuration parameter '{}' in "
+                        "remote '{}'. Valid parameters are: {}.".format(
                             self.role,
                             param,
                             self.id,
@@ -363,14 +361,14 @@ class GitProvider(object):
         if "saltenv" not in self.conf:
             self.conf["saltenv"] = {}
         else:
-            for saltenv, saltenv_conf in six.iteritems(self.conf["saltenv"]):
+            for saltenv, saltenv_conf in self.conf["saltenv"].items():
                 if "mountpoint" in saltenv_conf:
                     saltenv_ptr = self.conf["saltenv"][saltenv]
                     saltenv_ptr["mountpoint"] = salt.utils.url.strip_proto(
                         saltenv_ptr["mountpoint"]
                     )
 
-        for key, val in six.iteritems(self.conf):
+        for key, val in self.conf.items():
             if key not in PER_SALTENV_PARAMS and not hasattr(self, key):
                 setattr(self, key, val)
 
@@ -384,7 +382,7 @@ class GitProvider(object):
             # when instantiating an instance of a GitBase subclass. Make sure
             # that we set this attribute so we at least have a sane default and
             # are able to fetch.
-            key = "{0}_refspecs".format(self.role)
+            key = "{}_refspecs".format(self.role)
             try:
                 default_refspecs = _DEFAULT_MASTER_OPTS[key]
             except KeyError:
@@ -425,7 +423,7 @@ class GitProvider(object):
                 )
                 failhard(self.role)
 
-        if not isinstance(self.url, six.string_types):
+        if not isinstance(self.url, str):
             log.critical(
                 "Invalid %s remote '%s'. Remotes must be strings, you "
                 "may need to enclose the URL in quotes",
@@ -435,12 +433,9 @@ class GitProvider(object):
             failhard(self.role)
 
         hash_type = getattr(hashlib, self.opts.get("hash_type", "md5"))
-        if six.PY3:
-            # We loaded this data from yaml configuration files, so, its safe
-            # to use UTF-8
-            self.hash = hash_type(self.id.encode("utf-8")).hexdigest()
-        else:
-            self.hash = hash_type(self.id).hexdigest()
+        # We loaded this data from yaml configuration files, so, its safe
+        # to use UTF-8
+        self.hash = hash_type(self.id.encode("utf-8")).hexdigest()
         self.cachedir_basename = getattr(self, "name", self.hash)
         self.cachedir = salt.utils.path.join(cache_root, self.cachedir_basename)
         self.linkdir = salt.utils.path.join(cache_root, "links", self.cachedir_basename)
@@ -451,7 +446,7 @@ class GitProvider(object):
         try:
             self.new = self.init_remote()
         except Exception as exc:  # pylint: disable=broad-except
-            msg = "Exception caught while initializing {0} remote '{1}': " "{2}".format(
+            msg = "Exception caught while initializing {} remote '{}': " "{}".format(
                 self.role, self.id, exc
             )
             if isinstance(self, GitPython):
@@ -622,8 +617,7 @@ class GitProvider(object):
             stderr=subprocess.STDOUT,
         )
         output = cmd.communicate()[0]
-        if six.PY3:
-            output = output.decode(__salt_system_encoding__)
+        output = output.decode(__salt_system_encoding__)
         if cmd.returncode != 0:
             log.warning(
                 "Failed to prune stale branches for %s remote '%s'. "
@@ -653,7 +647,7 @@ class GitProvider(object):
         lock_file = self._get_lock_file(lock_type=lock_type)
 
         def _add_error(errlist, exc):
-            msg = "Unable to remove update lock for {0} ({1}): {2} ".format(
+            msg = "Unable to remove update lock for {} ({}): {} ".format(
                 self.url, lock_file, exc
             )
             log.debug(msg)
@@ -679,7 +673,7 @@ class GitProvider(object):
             else:
                 _add_error(failed, exc)
         else:
-            msg = "Removed {0} lock for {1} remote '{2}'".format(
+            msg = "Removed {} lock for {} remote '{}'".format(
                 lock_type, self.role, self.id
             )
             log.debug(msg)
@@ -763,7 +757,7 @@ class GitProvider(object):
                 ssl_verify = None
             except salt.utils.configparser.NoOptionError:
                 ssl_verify = None
-            desired_ssl_verify = six.text_type(self.ssl_verify).lower()
+            desired_ssl_verify = str(self.ssl_verify).lower()
             log.debug(
                 "Current http.sslVerify for %s remote '%s': %s (desired: %s)",
                 self.role,
@@ -831,10 +825,8 @@ class GitProvider(object):
             )
             with os.fdopen(fh_, "wb"):
                 # Write the lock file and close the filehandle
-                os.write(
-                    fh_, salt.utils.stringutils.to_bytes(six.text_type(os.getpid()))
-                )
-        except (OSError, IOError) as exc:
+                os.write(fh_, salt.utils.stringutils.to_bytes(str(os.getpid())))
+        except OSError as exc:
             if exc.errno == errno.EEXIST:
                 with salt.utils.files.fopen(self._get_lock_file(lock_type), "r") as fd_:
                     try:
@@ -849,13 +841,13 @@ class GitProvider(object):
                 lock_file = self._get_lock_file(lock_type=lock_type)
                 if self.opts[global_lock_key]:
                     msg = (
-                        "{0} is enabled and {1} lockfile {2} is present for "
-                        "{3} remote '{4}'.".format(
+                        "{} is enabled and {} lockfile {} is present for "
+                        "{} remote '{}'.".format(
                             global_lock_key, lock_type, lock_file, self.role, self.id,
                         )
                     )
                     if pid:
-                        msg += " Process {0} obtained the lock".format(pid)
+                        msg += " Process {} obtained the lock".format(pid)
                         if not pid_exists(pid):
                             msg += (
                                 " but this process is not running. The "
@@ -866,7 +858,7 @@ class GitProvider(object):
                             )
                     log.warning(msg)
                     if failhard:
-                        six.reraise(*sys.exc_info())
+                        raise
                     return
                 elif pid and pid_exists(pid):
                     log.warning(
@@ -896,12 +888,12 @@ class GitProvider(object):
                         raise
                     return
             else:
-                msg = "Unable to set {0} lock for {1} ({2}): {3} ".format(
+                msg = "Unable to set {} lock for {} ({}): {} ".format(
                     lock_type, self.id, self._get_lock_file(lock_type), exc
                 )
                 log.error(msg, exc_info=True)
                 raise GitLockError(exc.errno, msg)
-        msg = "Set {0} lock for {1} remote '{2}'".format(lock_type, self.role, self.id)
+        msg = "Set {} lock for {} remote '{}'".format(lock_type, self.role, self.id)
         log.debug(msg)
         return msg
 
@@ -929,10 +921,8 @@ class GitProvider(object):
         """
         Set and automatically clear a lock
         """
-        if not isinstance(lock_type, six.string_types):
-            raise GitLockError(
-                errno.EINVAL, "Invalid lock_type '{0}'".format(lock_type)
-            )
+        if not isinstance(lock_type, str):
+            raise GitLockError(errno.EINVAL, "Invalid lock_type '{}'".format(lock_type))
 
         # Make sure that we have a positive integer timeout, otherwise just set
         # it to zero.
@@ -944,10 +934,7 @@ class GitProvider(object):
             if timeout < 0:
                 timeout = 0
 
-        if (
-            not isinstance(poll_interval, (six.integer_types, float))
-            or poll_interval < 0
-        ):
+        if not isinstance(poll_interval, ((int,), float)) or poll_interval < 0:
             poll_interval = 0.5
 
         if poll_interval > timeout:
@@ -964,7 +951,7 @@ class GitProvider(object):
                     # Break out of his loop once we've yielded the lock, to
                     # avoid continued attempts to iterate and establish lock
                     break
-                except (OSError, IOError, GitLockError) as exc:
+                except (OSError, GitLockError) as exc:
                     if not timeout or time.time() - time_start > timeout:
                         raise GitLockError(exc.errno, exc.strerror)
                     else:
@@ -1045,7 +1032,7 @@ class GitProvider(object):
                 # all_saltenvs not configured for this remote
                 pass
             target = self.opts.get("pillarenv") or self.opts.get("saltenv") or "base"
-            return self.base if target == "base" else six.text_type(target)
+            return self.base if target == "base" else str(target)
         return self.branch
 
     def get_tree(self, tgt_env):
@@ -1061,7 +1048,7 @@ class GitProvider(object):
 
         for ref_type in self.ref_types:
             try:
-                func_name = "get_tree_from_{0}".format(ref_type)
+                func_name = "get_tree_from_{}".format(ref_type)
                 func = getattr(self, func_name)
             except AttributeError:
                 log.error(
@@ -1077,7 +1064,7 @@ class GitProvider(object):
         if self.fallback:
             for ref_type in self.ref_types:
                 try:
-                    func_name = "get_tree_from_{0}".format(ref_type)
+                    func_name = "get_tree_from_{}".format(ref_type)
                     func = getattr(self, func_name)
                 except AttributeError:
                     log.error(
@@ -1182,7 +1169,7 @@ class GitPython(GitProvider):
         role="gitfs",
     ):
         self.provider = "gitpython"
-        super(GitPython, self).__init__(
+        super().__init__(
             opts,
             remote,
             per_remote_defaults,
@@ -1246,7 +1233,7 @@ class GitPython(GitProvider):
                     # function.
                     raise GitLockError(
                         exc.errno,
-                        "Checkout lock exists for {0} remote '{1}'".format(
+                        "Checkout lock exists for {} remote '{}'".format(
                             self.role, self.id
                         ),
                     )
@@ -1450,7 +1437,7 @@ class GitPython(GitProvider):
         """
         try:
             return git.RemoteReference(
-                self.repo, "refs/remotes/origin/{0}".format(ref)
+                self.repo, "refs/remotes/origin/{}".format(ref)
             ).commit.tree
         except ValueError:
             return None
@@ -1460,7 +1447,7 @@ class GitPython(GitProvider):
         Return a git.Tree object matching a tag ref fetched into refs/tags/
         """
         try:
-            return git.TagReference(self.repo, "refs/tags/{0}".format(ref)).commit.tree
+            return git.TagReference(self.repo, "refs/tags/{}".format(ref)).commit.tree
         except ValueError:
             return None
 
@@ -1497,7 +1484,7 @@ class Pygit2(GitProvider):
         role="gitfs",
     ):
         self.provider = "pygit2"
-        super(Pygit2, self).__init__(
+        super().__init__(
             opts,
             remote,
             per_remote_defaults,
@@ -1568,7 +1555,7 @@ class Pygit2(GitProvider):
                     # function.
                     raise GitLockError(
                         exc.errno,
-                        "Checkout lock exists for {0} remote '{1}'".format(
+                        "Checkout lock exists for {} remote '{}'".format(
                             self.role, self.id
                         ),
                     )
@@ -1630,7 +1617,7 @@ class Pygit2(GitProvider):
                     # head_ref == local_ref, then the local reference for HEAD
                     # in refs/heads/ already exists and again, no need to add.
                     if (
-                        isinstance(head_ref, six.string_types)
+                        isinstance(head_ref, str)
                         and head_ref not in refs
                         and head_ref != local_ref
                     ):
@@ -1740,7 +1727,7 @@ class Pygit2(GitProvider):
                 self.id,
             )
             return []
-        return super(Pygit2, self).clean_stale_refs()
+        return super().clean_stale_refs()
 
     def init_remote(self):
         """
@@ -1964,7 +1951,7 @@ class Pygit2(GitProvider):
         )
         for repo_path in blobs.get("files", []):
             files.add(add_mountpoint(relpath(repo_path)))
-        for repo_path, link_tgt in six.iteritems(blobs.get("symlinks", {})):
+        for repo_path, link_tgt in blobs.get("symlinks", {}).items():
             symlinks[add_mountpoint(relpath(repo_path))] = link_tgt
         return files, symlinks
 
@@ -2016,7 +2003,7 @@ class Pygit2(GitProvider):
         """
         try:
             return self.peel(
-                self.repo.lookup_reference("refs/remotes/origin/{0}".format(ref))
+                self.repo.lookup_reference("refs/remotes/origin/{}".format(ref))
             ).tree
         except KeyError:
             return None
@@ -2027,7 +2014,7 @@ class Pygit2(GitProvider):
         """
         try:
             return self.peel(
-                self.repo.lookup_reference("refs/tags/{0}".format(ref))
+                self.repo.lookup_reference("refs/tags/{}".format(ref))
             ).tree
         except KeyError:
             return None
@@ -2056,7 +2043,7 @@ class Pygit2(GitProvider):
             if not self.ssl_verify:
                 warnings.warn(
                     "pygit2 does not support disabling the SSL certificate "
-                    "check in versions prior to 0.23.2 (installed: {0}). "
+                    "check in versions prior to 0.23.2 (installed: {}). "
                     "Fetches for self-signed certificates will fail.".format(
                         PYGIT2_VERSION
                     )
@@ -2213,7 +2200,7 @@ GIT_PROVIDERS = {
 }
 
 
-class GitBase(object):
+class GitBase:
     """
     Base class for gitfs/git_pillar
     """
@@ -2307,9 +2294,9 @@ class GitBase(object):
         # error out and do not proceed.
         override_params = copy.deepcopy(per_remote_overrides)
         global_auth_params = [
-            "{0}_{1}".format(self.role, x)
+            "{}_{}".format(self.role, x)
             for x in AUTH_PARAMS
-            if self.opts["{0}_{1}".format(self.role, x)]
+            if self.opts["{}_{}".format(self.role, x)]
         ]
         if self.provider in AUTH_PROVIDERS:
             override_params += AUTH_PARAMS
@@ -2332,7 +2319,7 @@ class GitBase(object):
         global_values = set(override_params)
         global_values.update(set(global_only))
         for param in global_values:
-            key = "{0}_{1}".format(self.role, param)
+            key = "{}_{}".format(self.role, param)
             if key not in self.opts:
                 log.critical(
                     "Key '%s' not present in global configuration. This is "
@@ -2365,7 +2352,7 @@ class GitBase(object):
                 # available envs.
                 repo_obj.saltenv_revmap = {}
 
-                for saltenv, saltenv_conf in six.iteritems(repo_obj.saltenv):
+                for saltenv, saltenv_conf in repo_obj.saltenv.items():
                     if "ref" in saltenv_conf:
                         ref = saltenv_conf["ref"]
                         repo_obj.saltenv_revmap.setdefault(ref, []).append(saltenv)
@@ -2391,12 +2378,12 @@ class GitBase(object):
                 # per-remote 'saltenv' param. We won't add any matching envs
                 # from the global saltenv map to the revmap.
                 all_envs = []
-                for env_names in six.itervalues(repo_obj.saltenv_revmap):
+                for env_names in repo_obj.saltenv_revmap.values():
                     all_envs.extend(env_names)
 
                 # Add the global saltenv map to the reverse map, skipping envs
                 # explicitly mapped in the per-remote 'saltenv' param.
-                for key, conf in six.iteritems(repo_obj.global_saltenv):
+                for key, conf in repo_obj.global_saltenv.items():
                     if key not in all_envs and "ref" in conf:
                         repo_obj.saltenv_revmap.setdefault(conf["ref"], []).append(key)
 
@@ -2475,7 +2462,7 @@ class GitBase(object):
                 try:
                     shutil.rmtree(rdir)
                 except OSError as exc:
-                    errors.append("Unable to delete {0}: {1}".format(rdir, exc))
+                    errors.append("Unable to delete {}: {}".format(rdir, exc))
         return errors
 
     def clear_lock(self, remote=None, lock_type="update"):
@@ -2493,7 +2480,7 @@ class GitBase(object):
                         continue
                 except TypeError:
                     # remote was non-string, try again
-                    if not fnmatch.fnmatch(repo.url, six.text_type(remote)):
+                    if not fnmatch.fnmatch(repo.url, str(remote)):
                         continue
             success, failed = repo.clear_lock(lock_type=lock_type)
             cleared.extend(success)
@@ -2507,7 +2494,7 @@ class GitBase(object):
         """
         if remotes is None:
             remotes = []
-        elif isinstance(remotes, six.string_types):
+        elif isinstance(remotes, str):
             remotes = remotes.split(",")
         elif not isinstance(remotes, list):
             log.error(
@@ -2555,7 +2542,7 @@ class GitBase(object):
                         continue
                 except TypeError:
                     # remote was non-string, try again
-                    if not fnmatch.fnmatch(repo.url, six.text_type(remote)):
+                    if not fnmatch.fnmatch(repo.url, str(remote)):
                         continue
             success, failed = repo.lock()
             locked.extend(success)
@@ -2610,7 +2597,7 @@ class GitBase(object):
             salt.fileserver.reap_fileserver_cache_dir(
                 self.hash_cachedir, self.find_file
             )
-        except (OSError, IOError):
+        except OSError:
             # Hash file won't exist if no files have yet been served up
             pass
 
@@ -2632,10 +2619,10 @@ class GitBase(object):
         """
         Determine which provider to use
         """
-        if "verified_{0}_provider".format(self.role) in self.opts:
-            self.provider = self.opts["verified_{0}_provider".format(self.role)]
+        if "verified_{}_provider".format(self.role) in self.opts:
+            self.provider = self.opts["verified_{}_provider".format(self.role)]
         else:
-            desired_provider = self.opts.get("{0}_provider".format(self.role))
+            desired_provider = self.opts.get("{}_provider".format(self.role))
             if not desired_provider:
                 if self.verify_pygit2(quiet=True):
                     self.provider = "pygit2"
@@ -2648,7 +2635,7 @@ class GitBase(object):
                 except AttributeError:
                     # Should only happen if someone does something silly like
                     # set the provider to a numeric value.
-                    desired_provider = six.text_type(desired_provider).lower()
+                    desired_provider = str(desired_provider).lower()
                 if desired_provider not in self.git_providers:
                     log.critical(
                         "Invalid %s_provider '%s'. Valid choices are: %s",
@@ -2689,15 +2676,15 @@ class GitBase(object):
         errors = []
         if GITPYTHON_VERSION < GITPYTHON_MINVER:
             errors.append(
-                "{0} is configured, but the GitPython version is earlier than "
-                "{1}. Version {2} detected.".format(
+                "{} is configured, but the GitPython version is earlier than "
+                "{}. Version {} detected.".format(
                     self.role, GITPYTHON_MINVER, GITPYTHON_VERSION
                 )
             )
         if not salt.utils.path.which("git"):
             errors.append(
                 "The git command line utility is required when using the "
-                "'gitpython' {0}_provider.".format(self.role)
+                "'gitpython' {}_provider.".format(self.role)
             )
 
         if errors:
@@ -2707,7 +2694,7 @@ class GitBase(object):
                 _recommend()
             return False
 
-        self.opts["verified_{0}_provider".format(self.role)] = "gitpython"
+        self.opts["verified_{}_provider".format(self.role)] = "gitpython"
         log.debug("gitpython %s_provider enabled", self.role)
         return True
 
@@ -2736,15 +2723,15 @@ class GitBase(object):
         errors = []
         if PYGIT2_VERSION < PYGIT2_MINVER:
             errors.append(
-                "{0} is configured, but the pygit2 version is earlier than "
-                "{1}. Version {2} detected.".format(
+                "{} is configured, but the pygit2 version is earlier than "
+                "{}. Version {} detected.".format(
                     self.role, PYGIT2_MINVER, PYGIT2_VERSION
                 )
             )
         if LIBGIT2_VERSION < LIBGIT2_MINVER:
             errors.append(
-                "{0} is configured, but the libgit2 version is earlier than "
-                "{1}. Version {2} detected.".format(
+                "{} is configured, but the libgit2 version is earlier than "
+                "{}. Version {} detected.".format(
                     self.role, LIBGIT2_MINVER, LIBGIT2_VERSION
                 )
             )
@@ -2753,7 +2740,7 @@ class GitBase(object):
         ):
             errors.append(
                 "The git command line utility is required when using the "
-                "'pygit2' {0}_provider.".format(self.role)
+                "'pygit2' {}_provider.".format(self.role)
             )
 
         if errors:
@@ -2763,7 +2750,7 @@ class GitBase(object):
                 _recommend()
             return False
 
-        self.opts["verified_{0}_provider".format(self.role)] = "pygit2"
+        self.opts["verified_{}_provider".format(self.role)] = "pygit2"
         log.debug("pygit2 %s_provider enabled", self.role)
         return True
 
@@ -2775,11 +2762,11 @@ class GitBase(object):
         try:
             with salt.utils.files.fopen(remote_map, "w+") as fp_:
                 timestamp = datetime.now().strftime("%d %b %Y %H:%M:%S.%f")
-                fp_.write("# {0}_remote map as of {1}\n".format(self.role, timestamp))
+                fp_.write("# {}_remote map as of {}\n".format(self.role, timestamp))
                 for repo in self.remotes:
                     fp_.write(
                         salt.utils.stringutils.to_str(
-                            "{0} = {1}\n".format(repo.cachedir_basename, repo.id)
+                            "{} = {}\n".format(repo.cachedir_basename, repo.id)
                         )
                     )
         except OSError:
@@ -2910,7 +2897,7 @@ class GitFS(GitBase):
         ret = set()
         for repo in self.remotes:
             repo_envs = repo.envs()
-            for env_list in six.itervalues(repo.saltenv_revmap):
+            for env_list in repo.saltenv_revmap.values():
                 repo_envs.update(env_list)
             ret.update([x for x in repo_envs if repo.env_is_exposed(x)])
         return sorted(ret)
@@ -2926,12 +2913,12 @@ class GitFS(GitBase):
 
         dest = salt.utils.path.join(self.cache_root, "refs", tgt_env, path)
         hashes_glob = salt.utils.path.join(
-            self.hash_cachedir, tgt_env, "{0}.hash.*".format(path)
+            self.hash_cachedir, tgt_env, "{}.hash.*".format(path)
         )
         blobshadest = salt.utils.path.join(
-            self.hash_cachedir, tgt_env, "{0}.hash.blob_sha1".format(path)
+            self.hash_cachedir, tgt_env, "{}.hash.blob_sha1".format(path)
         )
-        lk_fn = salt.utils.path.join(self.hash_cachedir, tgt_env, "{0}.lk".format(path))
+        lk_fn = salt.utils.path.join(self.hash_cachedir, tgt_env, "{}.lk".format(path))
         destdir = os.path.dirname(dest)
         hashdir = os.path.dirname(blobshadest)
         if not os.path.isdir(destdir):
@@ -2990,9 +2977,9 @@ class GitFS(GitBase):
                         fnd["rel"] = path
                         fnd["path"] = dest
                         return _add_file_stat(fnd, blob_mode)
-            except IOError as exc:
+            except OSError as exc:
                 if exc.errno != errno.ENOENT:
-                    six.reraise(*sys.exc_info())
+                    raise
 
             with salt.utils.files.fopen(lk_fn, "w"):
                 pass
@@ -3027,7 +3014,7 @@ class GitFS(GitBase):
             load.pop("env")
 
         ret = {"data": "", "dest": ""}
-        required_load_keys = set(["path", "loc", "saltenv"])
+        required_load_keys = {"path", "loc", "saltenv"}
         if not all(x in load for x in required_load_keys):
             log.debug(
                 "Not all of the required keys present in payload. Missing: %s",
@@ -3066,21 +3053,21 @@ class GitFS(GitBase):
         hashdest = salt.utils.path.join(
             self.hash_cachedir,
             load["saltenv"],
-            "{0}.hash.{1}".format(relpath, self.opts["hash_type"]),
+            "{}.hash.{}".format(relpath, self.opts["hash_type"]),
         )
         try:
             with salt.utils.files.fopen(hashdest, "rb") as fp_:
                 ret["hsum"] = fp_.read()
             return ret
-        except IOError as exc:
+        except OSError as exc:
             if exc.errno != errno.ENOENT:
-                six.reraise(*sys.exc_info())
+                raise
 
         try:
             os.makedirs(os.path.dirname(hashdest))
         except OSError as exc:
             if exc.errno != errno.EEXIST:
-                six.reraise(*sys.exc_info())
+                raise
 
         ret["hsum"] = salt.utils.hashutils.get_hash(path, self.opts["hash_type"])
         with salt.utils.files.fopen(hashdest, "w+") as fp_:
@@ -3103,11 +3090,11 @@ class GitFS(GitBase):
                 return []
         list_cache = salt.utils.path.join(
             self.file_list_cachedir,
-            "{0}.p".format(load["saltenv"].replace(os.path.sep, "_|-")),
+            "{}.p".format(load["saltenv"].replace(os.path.sep, "_|-")),
         )
         w_lock = salt.utils.path.join(
             self.file_list_cachedir,
-            ".{0}.w".format(load["saltenv"].replace(os.path.sep, "_|-")),
+            ".{}.w".format(load["saltenv"].replace(os.path.sep, "_|-")),
         )
         cache_match, refresh_cache, save_cache = salt.fileserver.check_file_list_cache(
             self.opts, form, list_cache, w_lock
@@ -3180,13 +3167,7 @@ class GitFS(GitBase):
         else:
             prefix = ""
         symlinks = self._file_lists(load, "symlinks")
-        return dict(
-            [
-                (key, val)
-                for key, val in six.iteritems(symlinks)
-                if key.startswith(prefix)
-            ]
-        )
+        return {key: val for key, val in symlinks.items() if key.startswith(prefix)}
 
 
 class GitPillar(GitBase):

--- a/tests/unit/utils/test_gitfs.py
+++ b/tests/unit/utils/test_gitfs.py
@@ -16,6 +16,7 @@ import salt.utils.gitfs
 import salt.utils.platform
 import tests.support.paths
 from salt.exceptions import FileserverConfigError
+from tests.support.mixins import AdaptedConfigurationTestCaseMixin
 from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase, skipIf
 
@@ -30,6 +31,84 @@ except AttributeError:
 
 if HAS_PYGIT2:
     import pygit2
+
+
+class TestGitBase(TestCase, AdaptedConfigurationTestCaseMixin):
+    def setUp(self):
+        class MockedProvider(
+            salt.utils.gitfs.GitProvider
+        ):  # pylint: disable=abstract-method
+            def __init__(
+                self,
+                opts,
+                remote,
+                per_remote_defaults,
+                per_remote_only,
+                override_params,
+                cache_root,
+                role="gitfs",
+            ):
+                self.provider = "mocked"
+                self.fetched = False
+                super(MockedProvider, self).__init__(
+                    opts,
+                    remote,
+                    per_remote_defaults,
+                    per_remote_only,
+                    override_params,
+                    cache_root,
+                    role,
+                )
+
+            def init_remote(self):
+                self.repo = True
+                new = False
+                return new
+
+            def envs(self):
+                return ["base"]
+
+            def fetch(self):
+                self.fetched = True
+
+        git_providers = {
+            "mocked": MockedProvider,
+        }
+        gitfs_remotes = ["file://repo1.git", {"file://repo2.git": [{"name": "repo2"}]}]
+        self.opts = self.get_temp_config(
+            "master", gitfs_remotes=gitfs_remotes, verified_gitfs_provider="mocked"
+        )
+        self.main_class = salt.utils.gitfs.GitFS(
+            self.opts,
+            self.opts["gitfs_remotes"],
+            per_remote_overrides=salt.fileserver.gitfs.PER_REMOTE_OVERRIDES,
+            per_remote_only=salt.fileserver.gitfs.PER_REMOTE_ONLY,
+            git_providers=git_providers,
+        )
+
+    def tearDown(self):
+        # Providers are preserved with GitFS's instance_map
+        for remote in self.main_class.remotes:
+            remote.fetched = False
+        del self.main_class
+
+    def test_update_all(self):
+        self.main_class.update()
+        self.assertEqual(len(self.main_class.remotes), 2, "Wrong number of remotes")
+        self.assertTrue(self.main_class.remotes[0].fetched)
+        self.assertTrue(self.main_class.remotes[1].fetched)
+
+    def test_update_by_name(self):
+        self.main_class.update("repo2")
+        self.assertEqual(len(self.main_class.remotes), 2, "Wrong number of remotes")
+        self.assertFalse(self.main_class.remotes[0].fetched)
+        self.assertTrue(self.main_class.remotes[1].fetched)
+
+    def test_update_by_id_and_name(self):
+        self.main_class.update([("file://repo1.git", None)])
+        self.assertEqual(len(self.main_class.remotes), 2, "Wrong number of remotes")
+        self.assertTrue(self.main_class.remotes[0].fetched)
+        self.assertFalse(self.main_class.remotes[1].fetched)
 
 
 class TestGitFSProvider(TestCase):

--- a/tests/unit/utils/test_gitfs.py
+++ b/tests/unit/utils/test_gitfs.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 """
 These only test the provider selection and verification logic, they do not init
 any remotes.
 """
 
-from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 import shutil
@@ -50,7 +48,7 @@ class TestGitBase(TestCase, AdaptedConfigurationTestCaseMixin):
             ):
                 self.provider = "mocked"
                 self.fetched = False
-                super(MockedProvider, self).__init__(
+                super().__init__(
                     opts,
                     remote,
                     per_remote_defaults,
@@ -129,7 +127,7 @@ class TestGitFSProvider(TestCase):
             ("winrepo", salt.utils.gitfs.WinRepo),
         ):
 
-            key = "{0}_provider".format(role_name)
+            key = "{}_provider".format(role_name)
             with patch.object(
                 role_class, "verify_gitpython", MagicMock(return_value=True)
             ):
@@ -167,7 +165,7 @@ class TestGitFSProvider(TestCase):
             ("git_pillar", salt.utils.gitfs.GitPillar),
             ("winrepo", salt.utils.gitfs.WinRepo),
         ):
-            key = "{0}_provider".format(role_name)
+            key = "{}_provider".format(role_name)
             for provider in salt.utils.gitfs.GIT_PROVIDERS:
                 verify = "verify_gitpython"
                 mock1 = _get_mock(verify, provider)


### PR DESCRIPTION
### What does this PR do?

Allow to pass arguments to fileserver.update runner

This is useful to only update one GitFS remote.

### What issues does this PR fix or reference?

None. But #53622 is related.

### Previous Behavior

No way to only update one GitFS repo.

### Tests written?

No

### Commits signed with GPG?

No