### PR TITLE
[develop, neon] fix(cron.py): ensure `get_entry` includes the `special` entries as well

### DIFF
--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -470,7 +470,7 @@ def get_entry(user, identifier=None, cmd=None):
 
         salt '*' cron.identifier_exists root identifier=task1
     '''
-    cron_entries = list_tab(user).get('crons', False)
+    cron_entries = list_tab(user).get('crons', []) + list_tab(user).get('special', [])
     for cron_entry in cron_entries:
         if identifier and cron_entry.get('identifier') == identifier:
             return cron_entry


### PR DESCRIPTION
### What does this PR do?

CC: @mchugh19.

Follow-up to https://github.com/saltstack/salt/pull/52441, which was introduced due to a PR in SaltStack Formulas: https://github.com/saltstack-formulas/cron-formula/pull/4.

While working through that `cron-formula` PR, found that `special` entries are not included by `get_entry`.

So the formula creates the following crontab for `root`:

```bash
# Lines below here are managed by Salt, do not edit
# comment1 SALT_CRON_IDENTIFIER:task1
0 0 7 1 6 echo test > /tmp/test
# comment4 SALT_CRON_IDENTIFIER:task4
*/5 * * * * echo task4 > /tmp/test4
# comment3 SALT_CRON_IDENTIFIER:task3
@hourly echo task3 > /tmp/test3
```

`task3` isn't being found with the current version of `cron.get_entry`:

```sls
$ sudo salt-call --config-dir=/tmp/kitchen/etc/salt cron.get_entry root task3
local:
    False
```

Found only `task1` and `task4` accessible by `get_entry`:

```sls
[
    {
        "minute": "0",
        "hour": "0",
        "daymonth": "7",
        "month": "1",
        "dayweek": "6",
        "identifier": "task1",
        "cmd": "echo test > /tmp/test",
        "comment": "comment1",
        "commented": false
    },
    {
        "minute": "*/5",
        "hour": "*",
        "daymonth": "*",
        "month": "*",
        "dayweek": "*",
        "identifier": "task4",
        "cmd": "echo task4 > /tmp/test4",
        "comment": "comment4",
        "commented": false
    }
]
```

`list_tab(user)` contains it under the `special` key:

```sls
{
    "pre": [],
    "crons": [
        {
            "minute": "0",
            "hour": "0",
            "daymonth": "7",
            "month": "1",
            "dayweek": "6",
            "identifier": "task1",
            "cmd": "echo test > /tmp/test",
            "comment": "comment1",
            "commented": false
        },
        {
            "minute": "*/5",
            "hour": "*",
            "daymonth": "*",
            "month": "*",
            "dayweek": "*",
            "identifier": "task4",
            "cmd": "echo task4 > /tmp/test4",
            "comment": "comment4",
            "commented": false
        }
    ],
    "special": [
        {
            "spec": "@hourly",
            "cmd": "echo task3 > /tmp/test3",
            "identifier": "task3",
            "comment": "comment3",
            "commented": false
        }
    ],
    "env": []
}
```

So after applying the fix:

```sls
$ sudo salt-call --config-dir=/tmp/kitchen/etc/salt cron.get_entry root task3
[
    {
        "minute": "0",
        "hour": "0",
        "daymonth": "7",
        "month": "1",
        "dayweek": "6",
        "identifier": "task1",
        "cmd": "echo test > /tmp/test",
        "comment": "comment1",
        "commented": false
    },
    {
        "minute": "*/5",
        "hour": "*",
        "daymonth": "*",
        "month": "*",
        "dayweek": "*",
        "identifier": "task4",
        "cmd": "echo task4 > /tmp/test4",
        "comment": "comment4",
        "commented": false
    },
    {
        "spec": "@hourly",
        "cmd": "echo task3 > /tmp/test3",
        "identifier": "task3",
        "comment": "comment3",
        "commented": false
    }
]
local:
    ----------
    cmd:
        echo task3 > /tmp/test3
    comment:
        comment3
    commented:
        False
    identifier:
        task3
    spec:
        @hourly
```

The `saltcheck` tests using this fixed version of `cron.py` are all working as expected:

* https://travis-ci.org/myii/cron-formula/builds/598399086

### What issues does this PR fix or reference?

### Tests written?

No

### Commits signed with GPG?

Yes