### PR TITLE
Expire0 patch 1

### DIFF
--- a/doc/ref/states/ordering.rst
+++ b/doc/ref/states/ordering.rst
@@ -5,10 +5,10 @@ Ordering States
 ===============
 
 The way in which configuration management systems are executed is a hotly
-debated topic in the configuration management world. Two
-major philosophies exist on the subject, to either execute in an imperative
-fashion where things are executed in the order in which they are defined, or
-in a declarative fashion where dependencies need to be mapped between objects.
+debated topic in the configuration management world. Two major philosophies
+exist on the subject, to either execute in an imperative fashion where things
+are executed in the order in which they are defined, or in a declarative
+fashion where dependencies need to be mapped between objects.
 
 Imperative ordering is finite and generally considered easier to write, but
 declarative ordering is much more powerful and flexible but generally considered
@@ -27,20 +27,17 @@ State Auto Ordering
 .. versionadded: 0.17.0
 
 Salt always executes states in a finite manner, meaning that they will always
-execute in the same order regardless of the system that is executing them.
-But in Salt 0.17.0, the ``state_auto_order`` option was added. This option
-makes states get evaluated in the order in which they are defined in sls
-files, including the top.sls file.
+execute in the same order regardless of the system that is executing them. This
+evaluation order makes it easy to know what order the states will be executed in,
+but it is important to note that the requisite system will override the ordering
+defined in the files, and the ``order`` option, described below, will also
+override the order in which states are executed.
 
-The evaluation order makes it easy to know what order the states will be
-executed in, but it is important to note that the requisite system will
-override the ordering defined in the files, and the ``order`` option described
-below will also override the order in which states are defined in sls files.
+This ordering system can be disabled in preference of lexicographic (classic)
+ordering by setting the ``state_auto_order`` option to ``False`` in the master
+configuration file. Otherwise, ``state_auto_order`` defaults to ``True``.
 
-If the classic ordering is preferred (lexicographic), then set
-``state_auto_order`` to ``False`` in the master configuration file. Otherwise,
-``state_auto_order`` defaults to ``True``.
-
+How compiler ordering is managed is described further in :ref:`compiler-ordering`.
 
 .. _ordering_requisites:
 

--- a/salt/modules/hosts.py
+++ b/salt/modules/hosts.py
@@ -297,7 +297,7 @@ def _write_hosts(hosts):
             if ip.startswith('comment'):
                 line = ''.join(aliases)
             else:
-                line = '{0}\t\t{1}'.format(
+                line = '{0}  {1}'.format(
                     ip,
                     ' '.join(aliases)
                     )


### PR DESCRIPTION
removing the \t tabs from the host file . This is causing a issue under saltstack#54413

Reference to issue [Issue](https://github.com/saltstack/salt/issues/54413)

What does this PR do?
Using hosts.add_host all the entry in /etc/hosts are separated by using 2 tab characters. Checking hosts' man entry:
Fields of the entry are separated by any number of blanks and/or tab characters.

This creates issues if a directive like $include is used inside the /etc/hosts file. By using tabs that directive does not work.

What issues does this PR fix or reference?
saltstack#54413 Previous Behavior

Tests written?
yes , I confirm the issue has been resolve and double spacing is being used. # # # # #