### PR TITLE
[master] Deprecate the multiprocessing process long names

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -508,8 +508,7 @@ class AsyncClientMixin(object):
         to watch for the return
         '''
         async_pub = pub if pub is not None else self._gen_async_pub()
-
-        proc = salt.utils.process.SignalHandlingMultiprocessingProcess(
+        proc = salt.utils.process.SignalHandlingProcess(
                 target=self._proc_function,
                 args=(fun, low, user, async_pub['tag'], async_pub['jid']))
         with salt.utils.process.default_signals(signal.SIGINT, signal.SIGTERM):

--- a/salt/client/netapi.py
+++ b/salt/client/netapi.py
@@ -14,7 +14,7 @@ import salt.utils.process
 log = logging.getLogger(__name__)
 
 
-class RunNetapi(salt.utils.process.SignalHandlingMultiprocessingProcess):
+class RunNetapi(salt.utils.process.SignalHandlingProcess):
     '''
     Runner class that's pickable for netapi modules
     '''

--- a/salt/client/netapi.py
+++ b/salt/client/netapi.py
@@ -27,7 +27,6 @@ class RunNetapi(salt.utils.process.SignalHandlingProcess):
     # We do this so that __init__ will be invoked on Windows in the child
     # process so that a register_after_fork() equivalent will work on Windows.
     def __setstate__(self, state):
-        self._is_child = True
         self.__init__(
             state['opts'],
             state['fname'],

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -48,7 +48,7 @@ import salt.utils.thin
 import salt.utils.url
 import salt.utils.verify
 from salt.utils.platform import is_windows
-from salt.utils.process import MultiprocessingProcess
+from salt.utils.process import Process
 import salt.roster
 from salt.template import compile_template
 
@@ -586,7 +586,7 @@ class SSH(object):
                         self.targets[host],
                         mine,
                         )
-                routine = MultiprocessingProcess(
+                routine = Process(
                                 target=self.handle_routine,
                                 args=args)
                 routine.start()

--- a/salt/engines/__init__.py
+++ b/salt/engines/__init__.py
@@ -85,7 +85,6 @@ class Engine(SignalHandlingProcess):
     # We do this so that __init__ will be invoked on Windows in the child
     # process so that a register_after_fork() equivalent will work on Windows.
     def __setstate__(self, state):
-        self._is_child = True
         self.__init__(
             state['opts'],
             state['fun'],

--- a/salt/engines/__init__.py
+++ b/salt/engines/__init__.py
@@ -12,7 +12,7 @@ import logging
 import salt
 import salt.loader
 import salt.utils.platform
-from salt.utils.process import SignalHandlingMultiprocessingProcess
+from salt.utils.process import SignalHandlingProcess
 
 log = logging.getLogger(__name__)
 
@@ -65,7 +65,7 @@ def start_engines(opts, proc_mgr, proxy=None):
                     )
 
 
-class Engine(SignalHandlingMultiprocessingProcess):
+class Engine(SignalHandlingProcess):
     '''
     Execute the given engine in a new process
     '''

--- a/salt/master.py
+++ b/salt/master.py
@@ -138,7 +138,7 @@ class SMaster(object):
         return salt.daemons.masterapi.access_keys(self.opts)
 
 
-class Maintenance(salt.utils.process.SignalHandlingMultiprocessingProcess):
+class Maintenance(salt.utils.process.SignalHandlingProcess):
     '''
     A generalized maintenance process which performs maintenance routines.
     '''
@@ -353,7 +353,7 @@ class Maintenance(salt.utils.process.SignalHandlingMultiprocessingProcess):
             old_present.update(present)
 
 
-class FileserverUpdate(salt.utils.process.SignalHandlingMultiprocessingProcess):
+class FileserverUpdate(salt.utils.process.SignalHandlingProcess):
     '''
     A process from which to update any dynamic fileserver backends
     '''
@@ -782,7 +782,7 @@ class Master(SMaster):
         sys.exit(0)
 
 
-class Halite(salt.utils.process.SignalHandlingMultiprocessingProcess):
+class Halite(salt.utils.process.SignalHandlingProcess):
     '''
     Manage the Halite server
     '''
@@ -821,7 +821,7 @@ class Halite(salt.utils.process.SignalHandlingMultiprocessingProcess):
         halite.start(self.hopts)
 
 
-class ReqServer(salt.utils.process.SignalHandlingMultiprocessingProcess):
+class ReqServer(salt.utils.process.SignalHandlingProcess):
     '''
     Starts up the master request server, minions send results to this
     interface.
@@ -951,7 +951,7 @@ class ReqServer(salt.utils.process.SignalHandlingMultiprocessingProcess):
         self.destroy()
 
 
-class MWorker(salt.utils.process.SignalHandlingMultiprocessingProcess):
+class MWorker(salt.utils.process.SignalHandlingProcess):
     '''
     The worker multiprocess instance to manage the backend operations for the
     salt master.

--- a/salt/master.py
+++ b/salt/master.py
@@ -161,7 +161,6 @@ class Maintenance(salt.utils.process.SignalHandlingProcess):
     # We do this so that __init__ will be invoked on Windows in the child
     # process so that a register_after_fork() equivalent will work on Windows.
     def __setstate__(self, state):
-        self._is_child = True
         self.__init__(
             state['opts'],
             log_queue=state['log_queue'],
@@ -370,7 +369,6 @@ class FileserverUpdate(salt.utils.process.SignalHandlingProcess):
     # We do this so that __init__ will be invoked on Windows in the child
     # process so that a register_after_fork() equivalent will work on Windows.
     def __setstate__(self, state):
-        self._is_child = True
         self.__init__(
             state['opts'],
             log_queue=state['log_queue'],
@@ -799,7 +797,6 @@ class Halite(salt.utils.process.SignalHandlingProcess):
     # We do this so that __init__ will be invoked on Windows in the child
     # process so that a register_after_fork() equivalent will work on Windows.
     def __setstate__(self, state):
-        self._is_child = True
         self.__init__(
             state['hopts'],
             log_queue=state['log_queue'],
@@ -848,7 +845,6 @@ class ReqServer(salt.utils.process.SignalHandlingProcess):
     # We do this so that __init__ will be invoked on Windows in the child
     # process so that a register_after_fork() equivalent will work on Windows.
     def __setstate__(self, state):
-        self._is_child = True
         self.__init__(
             state['opts'],
             state['key'],
@@ -991,7 +987,6 @@ class MWorker(salt.utils.process.SignalHandlingProcess):
     # These methods are only used when pickling so will not be used on
     # non-Windows platforms.
     def __setstate__(self, state):
-        self._is_child = True
         super(MWorker, self).__init__(
             log_queue=state['log_queue'],
             log_queue_level=state['log_queue_level']

--- a/salt/metaproxy/proxy.py
+++ b/salt/metaproxy/proxy.py
@@ -59,7 +59,7 @@ from salt.minion import ProxyMinion
 
 from salt.defaults import DEFAULT_TARGET_DELIM
 from salt.utils.process import (default_signals,
-                                SignalHandlingMultiprocessingProcess)
+                                SignalHandlingProcess)
 
 
 import tornado.gen  # pylint: disable=F0401
@@ -725,7 +725,7 @@ def handle_decoded_payload(self, data):
             # running on windows
             instance = None
         with default_signals(signal.SIGINT, signal.SIGTERM):
-            process = SignalHandlingMultiprocessingProcess(
+            process = SignalHandlingProcess(
                 target=self._target, args=(instance, self.opts, data, self.connected)
             )
     else:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -100,7 +100,7 @@ from salt.utils.debug import enable_sigusr1_handler
 from salt.utils.event import tagify
 from salt.utils.odict import OrderedDict
 from salt.utils.process import (default_signals,
-                                SignalHandlingMultiprocessingProcess,
+                                SignalHandlingProcess,
                                 ProcessManager)
 from salt.exceptions import (
     CommandExecutionError,
@@ -1524,7 +1524,7 @@ class Minion(MinionBase):
                 # running on windows
                 instance = None
             with default_signals(signal.SIGINT, signal.SIGTERM):
-                process = SignalHandlingMultiprocessingProcess(
+                process = SignalHandlingProcess(
                     target=self._target, args=(instance, self.opts, data, self.connected)
                 )
         else:

--- a/salt/state.py
+++ b/salt/state.py
@@ -1794,7 +1794,7 @@ class State(object):
         if not name:
             name = low.get('name', low.get('__id__'))
 
-        proc = salt.utils.process.MultiprocessingProcess(
+        proc = salt.utils.process.Process(
                 target=self._call_parallel_target,
                 args=(name, cdata, low))
         proc.start()

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -158,7 +158,6 @@ if USE_LOAD_BALANCER:
         # process so that a register_after_fork() equivalent will work on
         # Windows.
         def __setstate__(self, state):
-            self._is_child = True
             self.__init__(
                 state['opts'],
                 state['socket_queue'],

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -74,7 +74,7 @@ if USE_LOAD_BALANCER:
     import threading
     import multiprocessing
     import tornado.util
-    from salt.utils.process import SignalHandlingMultiprocessingProcess
+    from salt.utils.process import SignalHandlingProcess
 
 log = logging.getLogger(__name__)
 
@@ -135,7 +135,7 @@ def _set_tcp_keepalive(sock, opts):
 
 
 if USE_LOAD_BALANCER:
-    class LoadBalancerServer(SignalHandlingMultiprocessingProcess):
+    class LoadBalancerServer(SignalHandlingProcess):
         '''
         Raw TCP server which runs in its own process and will listen
         for incoming connections. Each incoming connection will be

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -1035,7 +1035,7 @@ class AsyncEventPublisher(object):
         self.close()
 
 
-class EventPublisher(salt.utils.process.SignalHandlingMultiprocessingProcess):
+class EventPublisher(salt.utils.process.SignalHandlingProcess):
     '''
     The interface that takes master events and republishes them out to anyone
     who wants to listen
@@ -1144,7 +1144,7 @@ class EventPublisher(salt.utils.process.SignalHandlingMultiprocessingProcess):
         self.close()
 
 
-class EventReturn(salt.utils.process.SignalHandlingMultiprocessingProcess):
+class EventReturn(salt.utils.process.SignalHandlingProcess):
     '''
     A dedicated process which listens to the master event bus and queues
     and forwards events to the specified returner.

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -1050,7 +1050,6 @@ class EventPublisher(salt.utils.process.SignalHandlingProcess):
     # We do this so that __init__ will be invoked on Windows in the child
     # process so that a register_after_fork() equivalent will work on Windows.
     def __setstate__(self, state):
-        self._is_child = True
         self.__init__(
             state['opts'],
             log_queue=state['log_queue'],
@@ -1174,7 +1173,6 @@ class EventReturn(salt.utils.process.SignalHandlingProcess):
     # We do this so that __init__ will be invoked on Windows in the child
     # process so that a register_after_fork() equivalent will work on Windows.
     def __setstate__(self, state):
-        self._is_child = True
         self.__init__(
             state['opts'],
             log_queue=state['log_queue'],

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -29,7 +29,7 @@ import salt.payload
 from salt.exceptions import SaltException
 import salt.config
 from salt.utils.cache import CacheCli as cache_cli
-from salt.utils.process import MultiprocessingProcess
+from salt.utils.process import Process
 
 # Import third party libs
 from salt.ext import six
@@ -510,7 +510,7 @@ class CacheTimer(Thread):
                 count = 0
 
 
-class CacheWorker(MultiprocessingProcess):
+class CacheWorker(Process):
     '''
     Worker for ConnectedCache which runs in its
     own process to prevent blocking of ConnectedCache
@@ -553,7 +553,7 @@ class CacheWorker(MultiprocessingProcess):
         log.debug('ConCache CacheWorker update finished')
 
 
-class ConnectedCache(MultiprocessingProcess):
+class ConnectedCache(Process):
     '''
     Provides access to all minions ids that the master has
     successfully authenticated. The cache is cleaned up regularly by

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -528,7 +528,6 @@ class CacheWorker(Process):
     # We do this so that __init__ will be invoked on Windows in the child
     # process so that a register_after_fork() equivalent will work on Windows.
     def __setstate__(self, state):
-        self._is_child = True
         self.__init__(
             state['opts'],
             log_queue=state['log_queue'],
@@ -591,7 +590,6 @@ class ConnectedCache(Process):
     # We do this so that __init__ will be invoked on Windows in the child
     # process so that a register_after_fork() equivalent will work on Windows.
     def __setstate__(self, state):
-        self._is_child = True
         self.__init__(
             state['opts'],
             log_queue=state['log_queue'],

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -29,6 +29,7 @@ import salt.utils.path
 import salt.utils.platform
 import salt.log.setup
 import salt.defaults.exitcodes
+import salt.utils.versions
 from salt.log.mixins import NewStyleClassMixIn
 
 # Import 3rd-party libs
@@ -404,9 +405,9 @@ class ProcessManager(object):
         if salt.utils.platform.is_windows():
             # Need to ensure that 'log_queue' and 'log_queue_level' is
             # correctly transferred to processes that inherit from
-            # 'MultiprocessingProcess'.
-            if type(MultiprocessingProcess) is type(tgt) and (
-                    issubclass(tgt, MultiprocessingProcess)):
+            # 'Process'.
+            if type(Process) is type(tgt) and (
+                    issubclass(tgt, Process)):
                 need_log_queue = True
             else:
                 need_log_queue = False
@@ -446,7 +447,7 @@ class ProcessManager(object):
         else:
             process = multiprocessing.Process(target=tgt, args=args, kwargs=kwargs, name=name)
 
-        if isinstance(process, SignalHandlingMultiprocessingProcess):
+        if isinstance(process, SignalHandlingProcess):
             with default_signals(signal.SIGINT, signal.SIGTERM):
                 process.start()
         else:
@@ -683,12 +684,12 @@ class ProcessManager(object):
                 )
 
 
-class MultiprocessingProcess(multiprocessing.Process, NewStyleClassMixIn):
+class Process(multiprocessing.Process, NewStyleClassMixIn):
 
     def __init__(self, *args, **kwargs):
         log_queue = kwargs.pop('log_queue', None)
         log_queue_level = kwargs.pop('log_queue_level', None)
-        super(MultiprocessingProcess, self).__init__(*args, **kwargs)
+        super(Process, self).__init__(*args, **kwargs)
         if salt.utils.platform.is_windows():
             # On Windows, subclasses should call super if they define
             # __setstate__ and/or __getstate__
@@ -709,7 +710,7 @@ class MultiprocessingProcess(multiprocessing.Process, NewStyleClassMixIn):
             salt.log.setup.set_multiprocessing_logging_level(self.log_queue_level)
 
         self._after_fork_methods = [
-            (MultiprocessingProcess._setup_process_logging, [self], {}),
+            (Process._setup_process_logging, [self], {}),
         ]
         self._finalize_methods = [
             (salt.log.setup.shutdown_multiprocessing_logging, [], {})
@@ -744,7 +745,7 @@ class MultiprocessingProcess(multiprocessing.Process, NewStyleClassMixIn):
         for method, args, kwargs in self._after_fork_methods:
             method(*args, **kwargs)
         try:
-            return super(MultiprocessingProcess, self).run()
+            return super(Process, self).run()
         except SystemExit:
             # These are handled by multiprocessing.Process._bootstrap()
             raise
@@ -761,12 +762,30 @@ class MultiprocessingProcess(multiprocessing.Process, NewStyleClassMixIn):
                 method(*args, **kwargs)
 
 
-class SignalHandlingMultiprocessingProcess(MultiprocessingProcess):
+class MultiprocessingProcess(Process):
+    '''
+    This class exists for backwards compatibility and to properly deprecate it.
+    '''
+
     def __init__(self, *args, **kwargs):
-        super(SignalHandlingMultiprocessingProcess, self).__init__(*args, **kwargs)
+        salt.utils.versions.warn_until_date(
+            '20220101',
+            'Please stop using \'{name}.MultiprocessingProcess\' and instead use '
+            '\'{name}.Process\'. \'{name}.MultiprocessingProcess\' will go away '
+            'after {{date}}.'.format(
+                name=__name__
+            ),
+            stacklevel=3
+        )
+        super(MultiprocessingProcess, self).__init__(*args, **kwargs)
+
+
+class SignalHandlingProcess(Process):
+    def __init__(self, *args, **kwargs):
+        super(SignalHandlingProcess, self).__init__(*args, **kwargs)
         self._signal_handled = multiprocessing.Event()
         self._after_fork_methods.append(
-            (SignalHandlingMultiprocessingProcess._setup_signals, [self], {})
+            (SignalHandlingProcess._setup_signals, [self], {})
         )
 
     def signal_handled(self):
@@ -811,7 +830,25 @@ class SignalHandlingMultiprocessingProcess(MultiprocessingProcess):
 
     def start(self):
         with default_signals(signal.SIGINT, signal.SIGTERM):
-            super(SignalHandlingMultiprocessingProcess, self).start()
+            super(SignalHandlingProcess, self).start()
+
+
+class SignalHandlingMultiprocessingProcess(SignalHandlingProcess):
+    '''
+    This class exists for backwards compatibility and to properly deprecate it.
+    '''
+
+    def __init__(self, *args, **kwargs):
+        salt.utils.versions.warn_until_date(
+            '20220101',
+            'Please stop using \'{name}.SignalHandlingMultiprocessingProcess\' and instead use '
+            '\'{name}.SignalHandlingProcess\'. \'{name}.SignalHandlingMultiprocessingProcess\' '
+            'will go away after {{date}}.'.format(
+                name=__name__
+            ),
+            stacklevel=3
+        )
+        super(SignalHandlingMultiprocessingProcess, self).__init__(*args, **kwargs)
 
 
 @contextlib.contextmanager

--- a/salt/utils/reactor.py
+++ b/salt/utils/reactor.py
@@ -39,7 +39,7 @@ REACTOR_INTERNAL_KEYWORDS = frozenset([
 ])
 
 
-class Reactor(salt.utils.process.SignalHandlingMultiprocessingProcess, salt.state.Compiler):
+class Reactor(salt.utils.process.SignalHandlingProcess, salt.state.Compiler):
     '''
     Read in the reactor configuration variable and compare it to events
     processed on the master.

--- a/salt/utils/reactor.py
+++ b/salt/utils/reactor.py
@@ -63,7 +63,6 @@ class Reactor(salt.utils.process.SignalHandlingProcess, salt.state.Compiler):
     # These methods are only used when pickling so will not be used on
     # non-Windows platforms.
     def __setstate__(self, state):
-        self._is_child = True
         Reactor.__init__(
             self, state['opts'],
             log_queue=state['log_queue'],

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -1679,7 +1679,7 @@ class Schedule(object):
 
         try:
             if multiprocessing_enabled:
-                thread_cls = salt.utils.process.SignalHandlingMultiprocessingProcess
+                thread_cls = salt.utils.process.SignalHandlingProcess
             else:
                 thread_cls = threading.Thread
 

--- a/tests/support/mixins.py
+++ b/tests/support/mixins.py
@@ -753,7 +753,7 @@ class SaltMinionEventAssertsMixin(object):
     def __new__(cls, *args, **kwargs):
         # We have to cross-call to re-gen a config
         cls.q = multiprocessing.Queue()
-        cls.fetch_proc = salt.utils.process.SignalHandlingMultiprocessingProcess(
+        cls.fetch_proc = salt.utils.process.SignalHandlingProcess(
             target=_fetch_events, args=(cls.q,)
         )
         cls.fetch_proc.start()

--- a/tests/unit/test_minion.py
+++ b/tests/unit/test_minion.py
@@ -134,8 +134,8 @@ class MinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         jid isn't already present in the jid_queue.
         '''
         with patch('salt.minion.Minion.ctx', MagicMock(return_value={})), \
-                patch('salt.utils.process.SignalHandlingMultiprocessingProcess.start', MagicMock(return_value=True)), \
-                patch('salt.utils.process.SignalHandlingMultiprocessingProcess.join', MagicMock(return_value=True)):
+                patch('salt.utils.process.SignalHandlingProcess.start', MagicMock(return_value=True)), \
+                patch('salt.utils.process.SignalHandlingProcess.join', MagicMock(return_value=True)):
             mock_jid = 11111
             mock_opts = salt.config.DEFAULT_MINION_OPTS
             mock_data = {'fun': 'foo.bar',
@@ -163,8 +163,8 @@ class MinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         minion's jid_queue high water mark (minion_jid_queue_hwm) is hit.
         '''
         with patch('salt.minion.Minion.ctx', MagicMock(return_value={})), \
-                patch('salt.utils.process.SignalHandlingMultiprocessingProcess.start', MagicMock(return_value=True)), \
-                patch('salt.utils.process.SignalHandlingMultiprocessingProcess.join', MagicMock(return_value=True)):
+                patch('salt.utils.process.SignalHandlingProcess.start', MagicMock(return_value=True)), \
+                patch('salt.utils.process.SignalHandlingProcess.join', MagicMock(return_value=True)):
             mock_opts = salt.config.DEFAULT_MINION_OPTS
             mock_opts['minion_jid_queue_hwm'] = 2
             mock_data = {'fun': 'foo.bar',
@@ -191,8 +191,8 @@ class MinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         as per process_count_max.
         '''
         with patch('salt.minion.Minion.ctx', MagicMock(return_value={})), \
-                patch('salt.utils.process.SignalHandlingMultiprocessingProcess.start', MagicMock(return_value=True)), \
-                patch('salt.utils.process.SignalHandlingMultiprocessingProcess.join', MagicMock(return_value=True)), \
+                patch('salt.utils.process.SignalHandlingProcess.start', MagicMock(return_value=True)), \
+                patch('salt.utils.process.SignalHandlingProcess.join', MagicMock(return_value=True)), \
                 patch('salt.utils.minion.running', MagicMock(return_value=[])), \
                 patch('tornado.gen.sleep', MagicMock(return_value=tornado.concurrent.Future())):
             process_count_max = 10
@@ -215,7 +215,7 @@ class MinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                     mock_data = {'fun': 'foo.bar',
                                  'jid': i}
                     io_loop.run_sync(lambda data=mock_data: minion._handle_decoded_payload(data))
-                    self.assertEqual(salt.utils.process.SignalHandlingMultiprocessingProcess.start.call_count, i + 1)
+                    self.assertEqual(salt.utils.process.SignalHandlingProcess.start.call_count, i + 1)
                     self.assertEqual(len(minion.jid_queue), i + 1)
                     salt.utils.minion.running.return_value += [i]
 
@@ -225,7 +225,7 @@ class MinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
 
                 self.assertRaises(SleepCalledException,
                                   lambda: io_loop.run_sync(lambda: minion._handle_decoded_payload(mock_data)))
-                self.assertEqual(salt.utils.process.SignalHandlingMultiprocessingProcess.start.call_count,
+                self.assertEqual(salt.utils.process.SignalHandlingProcess.start.call_count,
                                  process_count_max)
                 self.assertEqual(len(minion.jid_queue), process_count_max + 1)
             finally:
@@ -237,8 +237,8 @@ class MinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         '''
         with patch('salt.minion.Minion.ctx', MagicMock(return_value={})), \
                 patch('salt.minion.Minion.sync_connect_master', MagicMock(side_effect=RuntimeError('stop execution'))), \
-                patch('salt.utils.process.SignalHandlingMultiprocessingProcess.start', MagicMock(return_value=True)), \
-                patch('salt.utils.process.SignalHandlingMultiprocessingProcess.join', MagicMock(return_value=True)):
+                patch('salt.utils.process.SignalHandlingProcess.start', MagicMock(return_value=True)), \
+                patch('salt.utils.process.SignalHandlingProcess.join', MagicMock(return_value=True)):
             mock_opts = self.get_config('minion', from_scratch=True)
             mock_opts['beacons_before_connect'] = True
             io_loop = tornado.ioloop.IOLoop()
@@ -263,8 +263,8 @@ class MinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         '''
         with patch('salt.minion.Minion.ctx', MagicMock(return_value={})), \
                 patch('salt.minion.Minion.sync_connect_master', MagicMock(side_effect=RuntimeError('stop execution'))), \
-                patch('salt.utils.process.SignalHandlingMultiprocessingProcess.start', MagicMock(return_value=True)), \
-                patch('salt.utils.process.SignalHandlingMultiprocessingProcess.join', MagicMock(return_value=True)):
+                patch('salt.utils.process.SignalHandlingProcess.start', MagicMock(return_value=True)), \
+                patch('salt.utils.process.SignalHandlingProcess.join', MagicMock(return_value=True)):
             mock_opts = self.get_config('minion', from_scratch=True)
             mock_opts['scheduler_before_connect'] = True
             io_loop = tornado.ioloop.IOLoop()
@@ -285,8 +285,8 @@ class MinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
     def test_when_ping_interval_is_set_the_callback_should_be_added_to_periodic_callbacks(self):
         with patch('salt.minion.Minion.ctx', MagicMock(return_value={})), \
                 patch('salt.minion.Minion.sync_connect_master', MagicMock(side_effect=RuntimeError('stop execution'))), \
-                patch('salt.utils.process.SignalHandlingMultiprocessingProcess.start', MagicMock(return_value=True)), \
-                patch('salt.utils.process.SignalHandlingMultiprocessingProcess.join', MagicMock(return_value=True)):
+                patch('salt.utils.process.SignalHandlingProcess.start', MagicMock(return_value=True)), \
+                patch('salt.utils.process.SignalHandlingProcess.join', MagicMock(return_value=True)):
             mock_opts = self.get_config('minion', from_scratch=True)
             mock_opts['ping_interval'] = 10
             io_loop = tornado.ioloop.IOLoop()

--- a/tests/unit/utils/test_process.py
+++ b/tests/unit/utils/test_process.py
@@ -238,7 +238,7 @@ class TestProcess(TestCase):
         # pylint: enable=assignment-from-none
 
 
-class TestSignalHandlingMultiprocessingProcess(TestCase):
+class TestSignalHandlingProcess(TestCase):
 
     @classmethod
     def Process(cls, pid):
@@ -256,7 +256,7 @@ class TestSignalHandlingMultiprocessingProcess(TestCase):
     def test_process_does_not_exist(self):
         try:
             with patch('psutil.Process', self.Process):
-                proc = salt.utils.process.SignalHandlingMultiprocessingProcess(target=self.target)
+                proc = salt.utils.process.SignalHandlingProcess(target=self.target)
                 proc.start()
         except psutil.NoSuchProcess:
             assert False, "psutil.NoSuchProcess raised"
@@ -265,7 +265,7 @@ class TestSignalHandlingMultiprocessingProcess(TestCase):
     def test_process_children_do_not_exist(self):
         try:
             with patch('psutil.Process.children', self.children):
-                proc = salt.utils.process.SignalHandlingMultiprocessingProcess(target=self.target)
+                proc = salt.utils.process.SignalHandlingProcess(target=self.target)
                 proc.start()
         except psutil.NoSuchProcess:
             assert False, "psutil.NoSuchProcess raised"
@@ -300,7 +300,7 @@ class TestSignalHandlingMultiprocessingProcess(TestCase):
     @skipIf(sys.platform.startswith('win'), 'No os.fork on Windows')
     def test_signal_processing_regression_test(self):
         evt = multiprocessing.Event()
-        sh_proc = salt.utils.process.SignalHandlingMultiprocessingProcess(
+        sh_proc = salt.utils.process.SignalHandlingProcess(
             target=self.run_forever_target,
             args=(self.run_forever_sub_target, evt)
         )
@@ -322,27 +322,27 @@ class TestSignalHandlingMultiprocessingProcess(TestCase):
 
     @skipIf(NO_MOCK, NO_MOCK_REASON)
     def test_signal_processing_test_after_fork_called(self):
-        'Validate MultiprocessingProcess and sub classes call after fork methods'
+        'Validate Process and sub classes call after fork methods'
         evt = multiprocessing.Event()
-        sig_to_mock = 'salt.utils.process.SignalHandlingMultiprocessingProcess._setup_signals'
-        log_to_mock = 'salt.utils.process.MultiprocessingProcess._setup_process_logging'
+        sig_to_mock = 'salt.utils.process.SignalHandlingProcess._setup_signals'
+        log_to_mock = 'salt.utils.process.Process._setup_process_logging'
         with patch(sig_to_mock) as ma, patch(log_to_mock) as mb:
-            self.sh_proc = salt.utils.process.SignalHandlingMultiprocessingProcess(target=self.no_op_target)
+            self.sh_proc = salt.utils.process.SignalHandlingProcess(target=self.no_op_target)
             self.sh_proc.run()
         ma.assert_called()
         mb.assert_called()
 
     @skipIf(NO_MOCK, NO_MOCK_REASON)
     def test_signal_processing_test_final_methods_called(self):
-        'Validate MultiprocessingProcess and sub classes call finalize methods'
+        'Validate Process and sub classes call finalize methods'
         evt = multiprocessing.Event()
         teardown_to_mock = 'salt.log.setup.shutdown_multiprocessing_logging'
-        log_to_mock = 'salt.utils.process.MultiprocessingProcess._setup_process_logging'
-        sig_to_mock = 'salt.utils.process.SignalHandlingMultiprocessingProcess._setup_signals'
+        log_to_mock = 'salt.utils.process.Process._setup_process_logging'
+        sig_to_mock = 'salt.utils.process.SignalHandlingProcess._setup_signals'
         # Mock _setup_signals so we do not register one for this process.
         with patch(sig_to_mock):
             with patch(teardown_to_mock) as ma, patch(log_to_mock) as mb:
-                self.sh_proc = salt.utils.process.SignalHandlingMultiprocessingProcess(target=self.no_op_target)
+                self.sh_proc = salt.utils.process.SignalHandlingProcess(target=self.no_op_target)
                 self.sh_proc.run()
         ma.assert_called()
         mb.assert_called()
@@ -356,13 +356,13 @@ class TestSignalHandlingMultiprocessingProcess(TestCase):
 
     @skipIf(sys.platform.startswith('win'), 'Required signals not supported on windows')
     def test_signal_processing_handle_signals_called(self):
-        'Validate SignalHandlingMultiprocessingProcess handles signals'
+        'Validate SignalHandlingProcess handles signals'
         # Gloobal event to stop all processes we're creating
         evt = multiprocessing.Event()
 
         # Create a process to test signal handler
         val = multiprocessing.Value('i', 0)
-        proc = salt.utils.process.SignalHandlingMultiprocessingProcess(
+        proc = salt.utils.process.SignalHandlingProcess(
             target=self.pid_setting_target,
             args=(self.run_forever_sub_target, val, evt),
         )


### PR DESCRIPTION
### What does this PR do?
Deprecate the multiprocessing process long names.

Who on earth named these classes?!

Oh. It was me.
I must have been insane at the time because these names are absurd.

This PR should only be merged after https://github.com/saltstack/salt/pull/55047 since it includes code from that PR to provide the deprecation by date feature.

### Previous Behavior
We had insane names two classes.

### New Behavior
We have proper names for those two classes.
The previous names still exist but are deprecated and set to be removed on the first release after Jan, 1st, 2022.

### Tests written?

No, this is just deprecating class names.

### Commits signed with GPG?

Yes