### PR TITLE
[master] Update `salt.utils.version.warn_until_date()` to support depenceny injection

### DIFF
--- a/salt/utils/versions.py
+++ b/salt/utils/versions.py
@@ -172,17 +172,11 @@ def warn_until(version,
             )
 
 
-def _get_utcnow_date():
-    '''
-    This function exists because we can't easily patch builtin objects when mocking
-    '''
-    return datetime.datetime.utcnow().date()
-
-
 def warn_until_date(date,
                     message,
                     category=DeprecationWarning,
                     stacklevel=None,
+                    _current_date=None,
                     _dont_call_warnings=False):
     '''
     Helper function to raise a warning, by default, a ``DeprecationWarning``,
@@ -221,7 +215,7 @@ def warn_until_date(date,
         # Attribute the warning to the calling function, not to warn_until_date()
         stacklevel = 2
 
-    today = _get_utcnow_date()
+    today = _current_date or datetime.datetime.utcnow().date()
     if today >= date:
         caller = inspect.getframeinfo(sys._getframe(stacklevel - 1))
         raise RuntimeError(

--- a/tests/unit/utils/test_versions.py
+++ b/tests/unit/utils/test_versions.py
@@ -297,55 +297,75 @@ class VersionFuncsTestCase(TestCase):
         # We *always* want *all* warnings thrown on this module
         warnings.filterwarnings('always', '', DeprecationWarning, __name__)
 
-        fake_utcnow = datetime.date(2000, 1, 1)
+        _current_date = datetime.date(2000, 1, 1)
 
-        with patch('salt.utils.versions._get_utcnow_date', return_value=fake_utcnow):
+        # Test warning with datetime.date instance
+        with warnings.catch_warnings(record=True) as recorded_warnings:
+            salt.utils.versions.warn_until_date(
+                datetime.date(2000, 1, 2),
+                'Deprecation Message!',
+                _current_date=_current_date
+            )
+            self.assertEqual(
+                'Deprecation Message!', six.text_type(recorded_warnings[0].message)
+            )
 
-            # Test warning with datetime.date instance
-            with warnings.catch_warnings(record=True) as recorded_warnings:
-                salt.utils.versions.warn_until_date(datetime.date(2000, 1, 2), 'Deprecation Message!')
-                self.assertEqual(
-                    'Deprecation Message!', six.text_type(recorded_warnings[0].message)
-                )
+        # Test warning with datetime.datetime instance
+        with warnings.catch_warnings(record=True) as recorded_warnings:
+            salt.utils.versions.warn_until_date(
+                datetime.datetime(2000, 1, 2),
+                'Deprecation Message!',
+                _current_date=_current_date
+            )
+            self.assertEqual(
+                'Deprecation Message!', six.text_type(recorded_warnings[0].message)
+            )
 
-            # Test warning with datetime.datetime instance
-            with warnings.catch_warnings(record=True) as recorded_warnings:
-                salt.utils.versions.warn_until_date(datetime.datetime(2000, 1, 2), 'Deprecation Message!')
-                self.assertEqual(
-                    'Deprecation Message!', six.text_type(recorded_warnings[0].message)
-                )
+        # Test warning with date as a string
+        with warnings.catch_warnings(record=True) as recorded_warnings:
+            salt.utils.versions.warn_until_date(
+                '20000102',
+                'Deprecation Message!',
+                _current_date=_current_date
+            )
+            self.assertEqual(
+                'Deprecation Message!', six.text_type(recorded_warnings[0].message)
+            )
 
-            # Test warning with date as a string
-            with warnings.catch_warnings(record=True) as recorded_warnings:
-                salt.utils.versions.warn_until_date('20000102', 'Deprecation Message!')
-                self.assertEqual(
-                    'Deprecation Message!', six.text_type(recorded_warnings[0].message)
-                )
+        # the deprecation warning is not issued because we passed
+        # _dont_call_warning
+        with warnings.catch_warnings(record=True) as recorded_warnings:
+            salt.utils.versions.warn_until_date(
+                '20000102',
+                'Deprecation Message!',
+                _dont_call_warnings=True,
+                _current_date=_current_date
+            )
+            self.assertEqual(0, len(recorded_warnings))
 
-            # the deprecation warning is not issued because we passed
-            # _dont_call_warning
-            with warnings.catch_warnings(record=True) as recorded_warnings:
-                salt.utils.versions.warn_until_date('20000102', 'Deprecation Message!', _dont_call_warnings=True)
-                self.assertEqual(0, len(recorded_warnings))
+        # Let's test for RuntimeError raise
+        with self.assertRaisesRegex(
+                RuntimeError,
+                r'Deprecation Message! This warning\(now exception\) triggered on '
+                r'filename \'(.*)test_versions.py\', line number ([\d]+), is '
+                r'supposed to be shown until ([\d-]+). Today is ([\d-]+). '
+                r'Please remove the warning.'):
+            salt.utils.versions.warn_until_date('20000101', 'Deprecation Message!')
 
-            # Let's test for RuntimeError raise
-            with self.assertRaisesRegex(
-                    RuntimeError,
-                    r'Deprecation Message! This warning\(now exception\) triggered on '
-                    r'filename \'(.*)test_versions.py\', line number ([\d]+), is '
-                    r'supposed to be shown until ([\d-]+). Today is ([\d-]+). '
-                    r'Please remove the warning.'):
-                salt.utils.versions.warn_until_date('20000101', 'Deprecation Message!')
-
-            # Even though we're calling warn_until_date, we pass _dont_call_warnings
-            # because we're only after the RuntimeError
-            with self.assertRaisesRegex(
-                    RuntimeError,
-                    r'Deprecation Message! This warning\(now exception\) triggered on '
-                    r'filename \'(.*)test_versions.py\', line number ([\d]+), is '
-                    r'supposed to be shown until ([\d-]+). Today is ([\d-]+). '
-                    r'Please remove the warning.'):
-                salt.utils.versions.warn_until_date('20000101', 'Deprecation Message!', _dont_call_warnings=True)
+        # Even though we're calling warn_until_date, we pass _dont_call_warnings
+        # because we're only after the RuntimeError
+        with self.assertRaisesRegex(
+                RuntimeError,
+                r'Deprecation Message! This warning\(now exception\) triggered on '
+                r'filename \'(.*)test_versions.py\', line number ([\d]+), is '
+                r'supposed to be shown until ([\d-]+). Today is ([\d-]+). '
+                r'Please remove the warning.'):
+            salt.utils.versions.warn_until_date(
+                '20000101',
+                'Deprecation Message!',
+                _dont_call_warnings=True,
+                _current_date=_current_date
+            )
 
     def test_warn_until_date_bad_strptime_format(self):
         # We *always* want *all* warnings thrown on this module


### PR DESCRIPTION
### What does this PR do?
See title.

### Previous Behavior
We have to mock the current date when testing

### New Behavior
We now provide the current date when testing

### Tests written?

No, update tests.

### Commits signed with GPG?

Yes