### PR TITLE
Add is_installed in various pkg manager

### DIFF
--- a/salt/modules/aixpkg.py
+++ b/salt/modules/aixpkg.py
@@ -411,3 +411,22 @@ def upgrade_available(name):
         salt '*' pkg.upgrade_available <package name>
     '''
     return latest_version(name) != ''
+
+
+def is_installed(pkgname, **kwargs):
+    '''
+    Returns True or False if pkgname is installed.
+
+    Returns a boolean.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.is_installed <package>
+    '''
+    if (isinstance(pkgname, str) and
+        __salt__['pkg_resource.version'](pkgname, **kwargs)):
+        return True
+    else:
+        return False

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2840,3 +2840,22 @@ def _get_http_proxy_url():
             )
 
     return http_proxy_url
+
+
+def is_installed(pkgname, **kwargs):
+    '''
+    Returns True or False if pkgname is installed.
+
+    Returns a boolean.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.is_installed <package>
+    '''
+    if (isinstance(pkgname, str) and
+        __salt__['pkg_resource.version'](pkgname, **kwargs)):
+        return True
+    else:
+        return False

--- a/salt/modules/ebuildpkg.py
+++ b/salt/modules/ebuildpkg.py
@@ -1253,3 +1253,22 @@ def check_extra_requirements(pkgname, pkgver):
             return False
 
     return True
+
+
+def is_installed(pkgname, **kwargs):
+    '''
+    Returns True or False if pkgname is installed.
+
+    Returns a boolean.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.is_installed <package>
+    '''
+    if (isinstance(pkgname, str) and
+        __salt__['pkg_resource.version'](pkgname, **kwargs)):
+        return True
+    else:
+        return False

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -567,3 +567,22 @@ def file_dict(*packages):
             continue  # unexpected string
 
     return {'errors': errors, 'files': files}
+
+
+def is_installed(pkgname, **kwargs):
+    '''
+    Returns True or False if pkgname is installed.
+
+    Returns a boolean.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.is_installed <package>
+    '''
+    if (isinstance(pkgname, str) and
+        __salt__['pkg_resource.version'](pkgname, **kwargs)):
+        return True
+    else:
+        return False

--- a/salt/modules/mac_brew_pkg.py
+++ b/salt/modules/mac_brew_pkg.py
@@ -534,3 +534,22 @@ def info_installed(*names):
         salt '*' pkg.info_installed <package1> <package2> <package3> ...
     '''
     return _info(*names)
+
+
+def is_installed(pkgname, **kwargs):
+    '''
+    Returns True or False if pkgname is installed.
+
+    Returns a boolean.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.is_installed <package>
+    '''
+    if (isinstance(pkgname, str) and
+        __salt__['pkg_resource.version'](pkgname, **kwargs)):
+        return True
+    else:
+        return False

--- a/salt/modules/openbsdpkg.py
+++ b/salt/modules/openbsdpkg.py
@@ -411,3 +411,22 @@ def upgrade(name=None,
         )
 
     return ret
+
+
+def is_installed(pkgname, **kwargs):
+    '''
+    Returns True or False if pkgname is installed.
+
+    Returns a boolean.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.is_installed <package>
+    '''
+    if (isinstance(pkgname, str) and
+        __salt__['pkg_resource.version'](pkgname, **kwargs)):
+        return True
+    else:
+        return False

--- a/salt/modules/pacmanpkg.py
+++ b/salt/modules/pacmanpkg.py
@@ -1064,3 +1064,22 @@ def list_repo_pkgs(*args, **kwargs):
             )
             byrepo_ret[pkgname] = [x.vstring for x in sorted_versions]
         return byrepo_ret
+
+
+def is_installed(pkgname, **kwargs):
+    '''
+    Returns True or False if pkgname is installed.
+
+    Returns a boolean.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.is_installed <package>
+    '''
+    if (isinstance(pkgname, str) and
+        __salt__['pkg_resource.version'](pkgname, **kwargs)):
+        return True
+    else:
+        return False

--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -690,4 +690,22 @@ def file_dict(*packages):
             del ret[field]
     return ret
 
+
+def is_installed(pkgname, **kwargs):
+    '''
+    Returns True or False if pkgname is installed.
+
+    Returns a boolean.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.is_installed <package>
+    '''
+    if (isinstance(pkgname, str) and
+        __salt__['pkg_resource.version'](pkgname, **kwargs)):
+        return True
+    else:
+        return False
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -2474,3 +2474,22 @@ def version_cmp(pkg1, pkg2, ignore_epoch=False):
         log.error(exc)
 
     return None
+
+
+def is_installed(pkgname, **kwargs):
+    '''
+    Returns True or False if pkgname is installed.
+
+    Returns a boolean.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.is_installed <package>
+    '''
+    if (isinstance(pkgname, str) and
+        __salt__['pkg_resource.version'](pkgname, **kwargs)):
+        return True
+    else:
+        return False

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -380,3 +380,22 @@ def purge(name=None, pkgs=None, **kwargs):
         salt '*' pkg.purge pkgs='["foo", "bar"]'
     '''
     return remove(name=name, pkgs=pkgs)
+
+
+def is_installed(pkgname, **kwargs):
+    '''
+    Returns True or False if pkgname is installed.
+
+    Returns a boolean.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.is_installed <package>
+    '''
+    if (isinstance(pkgname, str) and
+        __salt__['pkg_resource.version'](pkgname, **kwargs)):
+        return True
+    else:
+        return False

--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -517,3 +517,22 @@ def purge(name=None, pkgs=None, **kwargs):
         salt '*' pkg.purge pkgs='["foo", "bar"]'
     '''
     return remove(name=name, pkgs=pkgs, **kwargs)
+
+
+def is_installed(pkgname, **kwargs):
+    '''
+    Returns True or False if pkgname is installed.
+
+    Returns a boolean.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.is_installed <package>
+    '''
+    if (isinstance(pkgname, str) and
+        __salt__['pkg_resource.version'](pkgname, **kwargs)):
+        return True
+    else:
+        return False

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -3225,3 +3225,22 @@ def list_installed_patches():
         salt '*' pkg.list_installed_patches
     '''
     return _get_patches(installed_only=True)
+
+
+def is_installed(pkgname, **kwargs):
+    '''
+    Returns True or False if pkgname is installed.
+
+    Returns a boolean.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.is_installed <package>
+    '''
+    if (isinstance(pkgname, str) and
+        __salt__['pkg_resource.version'](pkgname, **kwargs)):
+        return True
+    else:
+        return False

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -2421,3 +2421,22 @@ def resolve_capabilities(pkgs, refresh, **kwargs):
         else:
             ret.append(name)
     return ret
+
+
+def is_installed(pkgname, **kwargs):
+    '''
+    Returns True or False if pkgname is installed.
+
+    Returns a boolean.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.is_installed <package>
+    '''
+    if (isinstance(pkgname, str) and
+        __salt__['pkg_resource.version'](pkgname, **kwargs)):
+        return True
+    else:
+        return False

--- a/tests/unit/modules/test_aptpkg.py
+++ b/tests/unit/modules/test_aptpkg.py
@@ -158,6 +158,20 @@ class AptPkgTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(aptpkg.__salt__, {'pkg_resource.version': mock}):
             self.assertEqual(aptpkg.version(*['wget']), version)
 
+    def test_is_installed(self):
+        '''
+        Test - Returns True is the package is installed or False if not
+        '''
+        version_installed = LOWPKG_INFO['wget']['version']
+        mock_installed = MagicMock(return_value=version_installed)
+        mock_not_installed = MagicMock(return_value='')
+        with patch.dict(aptpkg.__salt__, {'pkg_resource.version':
+                                          mock_installed}):
+            self.assertEqual(aptpkg.is_installed('wget'), True)
+        with patch.dict(aptpkg.__salt__, {'pkg_resource.version':
+                                          mock_not_installed}):
+            self.assertEqual(aptpkg.is_installed('tmux'), False)
+
     def test_upgrade_available(self):
         '''
         Test - Check whether or not an upgrade is available for a given package.

--- a/tests/unit/modules/test_mac_brew_pkg.py
+++ b/tests/unit/modules/test_mac_brew_pkg.py
@@ -127,6 +127,19 @@ class BrewTestCase(TestCase, LoaderModuleMockMixin):
     # Only tested a few basics
     # Full functionality should be tested in integration phase
 
+    def test_is_installed(self):
+        '''
+        Test - Returns True is the package is installed or False if not
+        '''
+        mock_installed = MagicMock(return_value='0.1.5')
+        mock_not_installed = MagicMock(return_value='')
+        with patch.dict(mac_brew.__salt__, {'pkg_resource.version':
+                                            mock_installed}):
+            self.assertEqual(mac_brew.is_installed('wget'), True)
+        with patch.dict(mac_brew.__salt__, {'pkg_resource.version':
+                                            mock_not_installed}):
+            self.assertEqual(mac_brew.is_installed('tmux'), False)
+
     def test_remove(self):
         '''
         Tests if package to be removed exists

--- a/tests/unit/modules/test_openbsdpkg.py
+++ b/tests/unit/modules/test_openbsdpkg.py
@@ -112,6 +112,19 @@ class OpenbsdpkgTestCase(TestCase, LoaderModuleMockMixin):
         run_all_mock.assert_has_calls(expected_calls, any_order=True)
         self.assertEqual(run_all_mock.call_count, 3)
 
+    def test_is_installed(self):
+        '''
+        Test - Returns True is the package is installed or False if not
+        '''
+        mock_installed = MagicMock(return_value='1.6.23')
+        mock_not_installed = MagicMock(return_value='')
+        with patch.dict(openbsdpkg.__salt__, {'pkg_resource.version':
+                                              mock_installed}):
+            self.assertEqual(openbsdpkg.is_installed('wget'), True)
+        with patch.dict(openbsdpkg.__salt__, {'pkg_resource.version':
+                                              mock_not_installed}):
+            self.assertEqual(openbsdpkg.is_installed('tmux'), False)
+
     def test_upgrade_available(self):
         '''
         Test upgrade_available when an update is available.

--- a/tests/unit/modules/test_pacmanpkg.py
+++ b/tests/unit/modules/test_pacmanpkg.py
@@ -131,3 +131,16 @@ class PacmanTestCase(TestCase, LoaderModuleMockMixin):
                 }):
             results = pacman.group_diff('testgroup')
             self.assertEqual(results['default'], {'installed': ['A'], 'not installed': ['C']})
+
+    def test_is_installed(self):
+        '''
+        Test - Returns True is the package is installed or False if not
+        '''
+        mock_installed = MagicMock(return_value='1.6.23')
+        mock_not_installed = MagicMock(return_value='')
+        with patch.dict(pacman.__salt__, {'pkg_resource.version':
+                                          mock_installed}):
+            self.assertEqual(pacman.is_installed('wget'), True)
+        with patch.dict(pacman.__salt__, {'pkg_resource.version':
+                                          mock_not_installed}):
+            self.assertEqual(pacman.is_installed('tmux'), False)

--- a/tests/unit/modules/test_pkgin.py
+++ b/tests/unit/modules/test_pkgin.py
@@ -176,3 +176,16 @@ class PkginTestCase(TestCase, LoaderModuleMockMixin):
                     ]
                 }
             })
+
+    def test_is_installed(self):
+        '''
+        Test - Returns True is the package is installed or False if not
+        '''
+        mock_installed = MagicMock(return_value='1.6.23')
+        mock_not_installed = MagicMock(return_value='')
+        with patch.dict(pkgin.__salt__, {'pkg_resource.version':
+                                         mock_installed}):
+            self.assertEqual(pkgin.is_installed('wget'), True)
+        with patch.dict(pkgin.__salt__, {'pkg_resource.version':
+                                         mock_not_installed}):
+            self.assertEqual(pkgin.is_installed('tmux'), False)

--- a/tests/unit/modules/test_pkgng.py
+++ b/tests/unit/modules/test_pkgng.py
@@ -174,3 +174,16 @@ class PkgNgTestCase(TestCase, LoaderModuleMockMixin):
                 ['pkg', 'upgrade', '--dry-run', '--quiet', '--no-repo-update'],
                 output_loglevel='trace', python_shell=False, ignore_retcode=True
             )
+
+    def test_is_installed(self):
+        '''
+        Test - Returns True is the package is installed or False if not
+        '''
+        mock_installed = MagicMock(return_value='1.6.23')
+        mock_not_installed = MagicMock(return_value='')
+        with patch.dict(pkgng.__salt__, {'pkg_resource.version':
+                                         mock_installed}):
+            self.assertEqual(pkgng.is_installed('wget'), True)
+        with patch.dict(pkgng.__salt__, {'pkg_resource.version':
+                                         mock_not_installed}):
+            self.assertEqual(pkgng.is_installed('tmux'), False)

--- a/tests/unit/modules/test_pkgutil.py
+++ b/tests/unit/modules/test_pkgutil.py
@@ -230,3 +230,16 @@ class PkgutilTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(pkgutil.__salt__,
                         {'pkg_resource.parse_targets': mock_pkg}):
             self.assertRaises(CommandExecutionError, pkgutil.purge)
+
+    def test_is_installed(self):
+        '''
+        Test - Returns True is the package is installed or False if not
+        '''
+        mock_installed = MagicMock(return_value='1.6.23')
+        mock_not_installed = MagicMock(return_value='')
+        with patch.dict(pkgutil.__salt__, {'pkg_resource.version':
+                                           mock_installed}):
+            self.assertEqual(pkgutil.is_installed('wget'), True)
+        with patch.dict(pkgutil.__salt__, {'pkg_resource.version':
+                                           mock_not_installed}):
+            self.assertEqual(pkgutil.is_installed('tmux'), False)

--- a/tests/unit/modules/test_yumpkg.py
+++ b/tests/unit/modules/test_yumpkg.py
@@ -666,6 +666,19 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
                     output_loglevel='trace',
                     python_shell=False)
 
+    def test_is_installed(self):
+        '''
+        Test - Returns True is the package is installed or False if not
+        '''
+        mock_installed = MagicMock(return_value='1.6.23')
+        mock_not_installed = MagicMock(return_value='')
+        with patch.dict(yumpkg.__salt__, {'pkg_resource.version':
+                                          mock_installed}):
+            self.assertEqual(yumpkg.is_installed('wget'), True)
+        with patch.dict(yumpkg.__salt__, {'pkg_resource.version':
+                                          mock_not_installed}):
+            self.assertEqual(yumpkg.is_installed('tmux'), False)
+
     def test_info_installed_with_all_versions(self):
         '''
         Test the return information of all versions for the named package(s), installed on the system.

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -1295,3 +1295,16 @@ Repository 'DUMMY' not found by its alias, number, or URI.
         with self.assertRaises(CommandExecutionError):
             for op in ['>>', '==', '<<', '+']:
                 zypper.Wildcard(_zpr)('libzypp', '{0}*.1'.format(op))
+
+    def test_is_installed(self):
+        '''
+        Test - Returns True is the package is installed or False if not
+        '''
+        mock_installed = MagicMock(return_value='1.6.23')
+        mock_not_installed = MagicMock(return_value='')
+        with patch.dict(zypper.__salt__, {'pkg_resource.version':
+                                          mock_installed}):
+            self.assertEqual(zypper.is_installed('wget'), True)
+        with patch.dict(zypper.__salt__, {'pkg_resource.version':
+                                          mock_not_installed}):
+            self.assertEqual(zypper.is_installed('tmux'), False)


### PR DESCRIPTION
### What does this PR do?
This PR aims to add a "is_installed"  in various pkg modules.

### New Behavior
salt '*' pkg.is_installed httpd
True/False

### Tests written?

Yes for modules with tests

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
