### PR TITLE
fix config_unset in states/git

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -3166,9 +3166,10 @@ def config_unset(name,
     for key_name in pre:
         if key_name not in post:
             ret['changes'][key_name] = pre[key_name]
-        unset = [x for x in pre[key_name] if x not in post[key_name]]
-        if unset:
-            ret['changes'][key_name] = unset
+        else:
+            unset = [x for x in pre[key_name] if x not in post[key_name]]
+            if unset:
+                ret['changes'][key_name] = unset
 
     if value_regex is None:
         post_matches = post

--- a/tests/integration/states/test_git.py
+++ b/tests/integration/states/test_git.py
@@ -826,6 +826,26 @@ class GitTest(ModuleCase, SaltReturnAssertsMixin):
             **{'global': False})
         self.assertSaltTrueReturn(ret)
 
+    @with_tempdir()
+    def test_config_unset_whole_section(self, name):
+        '''
+        git.config
+        '''
+        self.run_function('git.init', [name])
+
+        self.run_state(
+            'git.config_set',
+            name='http.proxy',
+            value='http://127.0.0.1:3128',
+            repo=name,
+            **{'global': False})
+        ret = self.run_state(
+            'git.config_unset',
+            name='http.proxy',
+            repo=name,
+            **{'global': False})
+        self.assertSaltTrueReturn(ret)
+
 
 @ensure_min_git
 @uses_git_opts


### PR DESCRIPTION
### What does this PR do?
Fix `KeyError` exception in `states/git` `config_unset()`.
After applying changes, when building changes dict
`config_unset` throws `KeyError` when the whole section is removed from git config

### What issues does this PR fix or reference?
Fixes #31311

### Tests written?

Yes

### Commits signed with GPG?

Yes