### PR TITLE
salt.utils.args: make parse_input non-destructive on its input args

### DIFF
--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -112,15 +112,15 @@ def parse_input(args, condition=True, no_parse=None):
             else:
                 _args.append(yamlify_arg(arg))
         elif isinstance(arg, dict):
-            # Yes, we're popping this key off and adding it back if
-            # condition_input is called below, but this is the only way to
-            # gracefully handle both CLI and API input.
-            if arg.pop('__kwarg__', False) is True:
+            if arg.get('__kwarg__'):
                 _kwargs.update(arg)
             else:
                 _args.append(arg)
         else:
             _args.append(arg)
+    _kwargs.update(kwargs)
+    # remove __kwargs__ if it was added above
+    _kwargs.pop('__kwargs__', None)
     if condition:
         return condition_input(_args, _kwargs)
     return _args, _kwargs


### PR DESCRIPTION
popping __kwargs__ off the input data invalidates the inputs for future
calls, this breaks salt.cli.batch among other things; possibly other
usecases that save low data and re-use it.

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
