### PR TITLE
flat roster: pass master options to apply_sdb

### DIFF
--- a/salt/roster/flat.py
+++ b/salt/roster/flat.py
@@ -32,5 +32,5 @@ def targets(tgt, tgt_type='glob', **kwargs):
                            **kwargs)
     conditioned_raw = {}
     for minion in raw:
-        conditioned_raw[six.text_type(minion)] = salt.config.apply_sdb(raw[minion])
+        conditioned_raw[six.text_type(minion)] = salt.config.apply_sdb(__opts__, raw[minion])
     return __utils__['roster_matcher.targets'](conditioned_raw, tgt, tgt_type, 'ipv4')


### PR DESCRIPTION
### What does this PR do?

Despite being more convenient and consistent, in avoiding to having to specify the sdb options
again for each host, `apply_sdb` (or actually `sdb_get` I think) also somehow manages to mess up
the previously passed options in the next iteration.

### Previous Behavior

Using sdb in the flat roster copied the entry of the current host into the key of the current one. It also required the sdb configuration to be present in each roster entry.

### New Behavior

Pass the master config available in `__opts__` to `apply_sdb`, centralizing the sdb configuration properly and keeping `sdb_get` from messing things up.

### Tests written?

No, I couldn't find any existing tests for this and writing an entire suite for this feature
is a bit beyond my experience with this project.
