### PR TITLE
update docs to build off master instead of develop

### DIFF
--- a/doc/_themes/saltstack2/layout.html
+++ b/doc/_themes/saltstack2/layout.html
@@ -52,7 +52,8 @@
             SEARCH_CX:   '{{ search_cx }}',
             COLLAPSE_INDEX: false,
             FILE_SUFFIX: '{{ '' if no_search_suffix else file_suffix }}',
-            HAS_SOURCE:  '{{ has_source|lower }}'
+            HAS_SOURCE:  '{{ has_source|lower }}',
+            REPO_PRIMARY_BRANCH_TAB_NAME: '{{ repo_primary_branch | capitalize }}'
         };
     </script>
     {%- for scriptfile in script_files %}

--- a/doc/_themes/saltstack2/layout.html
+++ b/doc/_themes/saltstack2/layout.html
@@ -188,6 +188,9 @@
                                     {% if not (build_type == repo_primary_branch or build_type == "next") and on_saltstack %}
                                     <li><a class="icon-dl" href="/en/pdf/Salt-{{ release }}.pdf"><img height="25" width="25" class="nolightbox" src="{{ pathto('_static/images/pdf_icon.svg', 1) }}"></a></li>
                                     <li><a class="icon-dl" href="/en/epub/Salt-{{ release }}.epub"><img height="25" width="18" class="nolightbox" src="{{ pathto('_static/images/epub_icon.svg', 1) }}"></a></li>
+                                    {% elif build_type == repo_primary_branch and on_saltstack %}
+                                    <li><a class="icon-dl" href="/en/pdf/Salt-{{ repo_primary_branch }}.pdf"><img height="25" width="25" class="nolightbox" src="{{ pathto('_static/images/pdf_icon.svg', 1) }}"></a></li>
+                                    <li><a class="icon-dl" href="/en/epub/Salt-{{ repo_primary_branch }}.epub"><img height="25" width="18" class="nolightbox" src="{{ pathto('_static/images/epub_icon.svg', 1) }}"></a></li>
                                     {% endif %}
                                 </ul>
                             </nav>

--- a/doc/_themes/saltstack2/layout.html
+++ b/doc/_themes/saltstack2/layout.html
@@ -184,7 +184,7 @@
                                 <ul class="nav navbar-nav">
                                     {%- block relbar_small %}{{ relbar() }}{% endblock %}
 
-                                    {% if not (build_type == "{{ repo_primary_branch }}" or build_type == "next") and on_saltstack %}
+                                    {% if not (build_type == repo_primary_branch or build_type == "next") and on_saltstack %}
                                     <li><a class="icon-dl" href="/en/pdf/Salt-{{ release }}.pdf"><img height="25" width="25" class="nolightbox" src="{{ pathto('_static/images/pdf_icon.svg', 1) }}"></a></li>
                                     <li><a class="icon-dl" href="/en/epub/Salt-{{ release }}.epub"><img height="25" width="18" class="nolightbox" src="{{ pathto('_static/images/epub_icon.svg', 1) }}"></a></li>
                                     {% endif %}
@@ -285,12 +285,12 @@
 <!--                <a class="ss-logo" href="http://saltstack.com"><img width="250" height="63" class="nolightbox sidebar-logo" src="{{ pathto('_static/images/saltstack_logo.svg', 1) }}"></a>
 
                 {% if on_saltstack %}
-
+                {#
                 {% if [True, False]|random %}
                 <a href="http://saltconf.com/register" target="_blank"><img class="nolightbox sidebar-banner center" src="{{ pathto('_static/images/banner-saltconf.png', 1) }}"/></a>
                 {% else %}
                 <a href="http://saltstack.com/support" target="_blank"><img class="nolightbox sidebar-banner center" src="{{ pathto('_static/images/banner-support.png', 1) }}"/></a>
-                {% endif %}-->
+                {% endif %} #}-->
                 <a href="https://saltconf.com/menu-ad" target="_blank"><img class="nolightbox sidebar-banner center" src="https://get.saltstack.com/rs/304-PHQ-615/images/Salt-docs-menu-ad-250x63.jpg"/></a>
 
 
@@ -304,11 +304,11 @@
 
                 <div class="releaselinks versions {{ build_type }}">
 
-                <a class="btn btn-secondary{% if build_type == "previous" or build_type == "inactive" %} active{% endif %}" id="previous"{% if build_type == "previous" or build_type == "inactive" %} title="View release notes"{% else %} title="Switch to docs for the previous stable release"{% endif %} data-container="body" data-toggle="tooltip" data-placement="bottom" href="/en/{{ previous_release_dir }}/">{{ previous_release }}{% if build_type == "previous" or build_type == "inactive" %} <i class="glyphicon glyphicon-ok"></i>{%- endif %}</a>
+                <a class="btn btn-secondary{% if build_type == "previous" or build_type == "inactive" %} active{% endif %}" id="previous"{% if build_type == "previous" or build_type == "inactive" %} title="View release notes"{% else %} title="Switch to docs for the previous stable release"{% endif %} data-container="body" data-toggle="tooltip" data-placement="bottom" href="/en/{{ previous_release_dir }}/">{{ previous_release }}{% if build_type == "previous" or build_type == "inactive" %} <i class="glyphicon glyphicon-ok"></i>{% endif %}</a>
 
                 <a  class="btn btn-secondary{% if build_type == "latest" %} active{% endif %}" id="latest"{% if build_type == "latest" %} title="View release notes"{% else %} title="Switch to docs for the latest stable release"{% endif %} data-container="body" data-toggle="tooltip" data-placement="bottom" href="/en/latest/">{{ latest_release }}{% if build_type == "latest" %} <i class="glyphicon glyphicon-ok"></i>{% endif %}</a>
 
-                <a  class="btn btn-secondary{% if build_type == "{{ repo_primary_branch }}" %} active{% endif %}" id="{{ repo_primary_branch }}"{% if build_type == "{{ repo_primary_branch }}" %} title="View all release notes"{% endif %} title="Switch to docs built recently from the {{ repo_primary_branch }} branch" data-container="body" data-toggle="tooltip" data-placement="bottom" href="/en/{{ repo_primary_branch }}/">{{ repo_primary_branch | capitalize }}{% if build_type == "{{ repo_primary_branch }}" %} <i class="glyphicon glyphicon-ok"></i>{% endif %}</a>
+                <a  class="btn btn-secondary{% if build_type == repo_primary_branch %} active{% endif %}" id="{{ repo_primary_branch }}"{% if build_type == repo_primary_branch %} title="View all release notes"{% endif %} title="Switch to docs built recently from the {{ repo_primary_branch }} branch" data-container="body" data-toggle="tooltip" data-placement="bottom" href="/en/{{ repo_primary_branch }}/">{{ repo_primary_branch | capitalize }}{% if build_type == repo_primary_branch %} <i class="glyphicon glyphicon-ok"></i>{% endif %}</a>
 
                 </div>
 

--- a/doc/_themes/saltstack2/static/js/webhelp.min_v1.4.4.js
+++ b/doc/_themes/saltstack2/static/js/webhelp.min_v1.4.4.js
@@ -125,7 +125,7 @@ $( document ).ready(function() {
             window.location.href = window.location.href.replace($currentVer.attr("href"), clickedVer);
         }
         else {
-            if ($currentVer.text().indexOf("{{ repo_primary_branch | capitalize }}") == -1) {
+            if ($currentVer.text().indexOf(DOCUMENTATION_OPTIONS.REPO_PRIMARY_BRANCH_TAB_NAME) == -1) {
                 window.location.href = clickedVer + "topics/releases/" + $currentVer.text().trim() + ".html";
             }
             else window.location.href = clickedVer + "topics/releases/";

--- a/doc/_themes/saltstack2/static/js/webhelp.min_v1.4.4.js
+++ b/doc/_themes/saltstack2/static/js/webhelp.min_v1.4.4.js
@@ -125,7 +125,7 @@ $( document ).ready(function() {
             window.location.href = window.location.href.replace($currentVer.attr("href"), clickedVer);
         }
         else {
-            if ($currentVer.text().indexOf("Develop") == -1) {
+            if ($currentVer.text().indexOf("{{ repo_primary_branch | capitalize }}") == -1) {
                 window.location.href = clickedVer + "topics/releases/" + $currentVer.text().trim() + ".html";
             }
             else window.location.href = clickedVer + "topics/releases/";

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -268,22 +268,31 @@ if on_saltstack:
     copyright = time.strftime("%Y")
 
 # < --- START do not merge these settings to other branches START ---> #
-build_type = 'latest'  # latest, previous, develop, next
-release = latest_release
+build_type = repo_primary_branch # latest, previous, master, next
 # < --- END do not merge these settings to other branches END ---> #
 
 # Set google custom search engine
 
-if release == latest_release:
+if build_type == repo_primary_branch:
+    release = latest_release
+    search_cx = '011515552685726825874:v1had6i279q' # master
+    #search_cx = '011515552685726825874:x17j5zl74g8' # develop
+elif build_type == 'next':
+    release = next_release
     search_cx = '011515552685726825874:ht0p8miksrm' # latest
-elif release.startswith('2018.3'):
-    search_cx = '011515552685726825874:vadptdpvyyu' # 2018.3
-elif release.startswith('2017.7'):
-    search_cx = '011515552685726825874:w-hxmnbcpou' # 2017.7
-elif release.startswith('2016.11'):
-    search_cx = '011515552685726825874:dlsj745pvhq' # 2016.11
-else:
-    search_cx = '011515552685726825874:x17j5zl74g8'  # develop
+elif build_type == 'previous':
+    release = previous_release
+    if release.startswith('2018.3'):
+        search_cx = '011515552685726825874:vadptdpvyyu' # 2018.3
+    elif release.startswith('2017.7'):
+        search_cx = '011515552685726825874:w-hxmnbcpou' # 2017.7
+    elif release.startswith('2016.11'):
+        search_cx = '011515552685726825874:dlsj745pvhq' # 2016.11
+    else:
+        search_cx = '011515552685726825874:ht0p8miksrm' # latest
+else: # latest or something else
+    release = latest_release
+    search_cx = '011515552685726825874:ht0p8miksrm' # latest
 
 needs_sphinx = '1.3'
 
@@ -365,7 +374,7 @@ rst_prolog = """\
 
 # A shortcut for linking to tickets on the GitHub issue tracker
 extlinks = {
-    'blob': ('https://github.com/saltstack/salt/blob/%s/%%s' % 'develop', None),
+    'blob': ('https://github.com/saltstack/salt/blob/%s/%%s' % repo_primary_branch, None),
     'issue': ('https://github.com/saltstack/salt/issues/%s', 'issue #'),
     'pull': ('https://github.com/saltstack/salt/pull/%s', 'PR #'),
     'formula_url': ('https://github.com/saltstack-formulas/%s', ''),


### PR DESCRIPTION
### What does this PR do?
updates docs so that it can build master instead of develop as the next release

This PR will need merged first, then https://github.com/saltstack/builddocs/pull/31 , then https://github.com/saltstack/salt/pull/55133 and https://github.com/saltstack/salt/pull/55134

A copy of the compiled docs as they would appear on the website is available here: https://github.com/bryceml/salt/tree/new_docs