### PR TITLE
Split monit status fields on monit version

### DIFF
--- a/salt/modules/monit.py
+++ b/salt/modules/monit.py
@@ -144,17 +144,27 @@ def status(svc_name=""):
         salt '*' monit.status
         salt '*' monit.status <service name>
     """
+
     cmd = "monit status"
     res = __salt__["cmd.run"](cmd)
-    prostr = "Process" + " " * 28
+
+    # Monit uses a different separator since 5.18.0
+    if version() < "5.18.0":
+        fieldlength = 33
+    else:
+        fieldlength = 28
+
+    separator = 3 + fieldlength
+    prostr = "Process" + " " * fieldlength
+
     s = res.replace("Process", prostr).replace("'", "").split("\n\n")
     entries = {}
     for process in s[1:-1]:
         pro = process.splitlines()
         tmp = {}
         for items in pro:
-            key = items[:36].strip()
-            tmp[key] = items[35:].strip()
+            key = items[:separator].strip()
+            tmp[key] = items[separator - 1 :].strip()
         entries[pro[0].split()[1]] = tmp
     if svc_name == "":
         ret = entries


### PR DESCRIPTION
### What does this PR do?

With the commit [471c4bb](https://bitbucket.org/tildeslash/monit/commits/471c4bbc388c1c536f07ce1dd26b811bd39a9467) on monit, the field size changed from 28 to 33. So splitting hard after 35 chars, new versions of monit break when using `monit.status`.

This commit is released since monit 5.17.0.

### What issues does this PR fix or reference?

No issue created yet.

### Previous Behavior
```
local:
    ----------
    Process:
        zabbix-agent
    children                     5:
    cpu                          0.0%:
    cpu total                    0.0%:
    data collected               Mon,:
        28 Oct 2019 04:54:46
    disk read                    0 B/s:
        s [44 kB total]
    disk write                   0 B/s:
        s [4 kB total]
    effective uid                998:
    gid                          996:
    memory                       0.0%:
        [2.3 MB]
    memory total                 0.3%:
        [26 MB]
    monitoring mode              activ:
        ve
    monitoring status            Monit:
        tored
    on reboot                    start:
        t
    parent pid                   1:
    pid                          1149:
    port response time           0.263:
        3 ms to localhost:10050 type TCP/IP protocol DEFAULT
    security attribute           (null:
        l)
    status                       OK:
    threads                      1:
    uid                          998:
    uptime                       25d 2:
        22h 22m
```

### New Behavior

```
local:
    ----------
    Process:
        zabbix-agent
    children:
        5
    cpu:
        0.0%
    cpu total:
        0.0%
    data collected:
        Mon, 28 Oct 2019 04:50:16
    disk read:
        0 B/s [44 kB total]
    disk write:
        0 B/s [4 kB total]
    effective uid:
        998
    gid:
        996
    memory:
        0.0% [2.3 MB]
    memory total:
        0.3% [26 MB]
    monitoring mode:
        active
    monitoring status:
        Monitored
    on reboot:
        start
    parent pid:
        1
    pid:
        1149
    port response time:
        0.218 ms to localhost:10050 type TCP/IP protocol DEFAULT
    security attribute:
        (null)
    status:
        OK
    threads:
        1
    uid:
        998
    uptime:
        25d 22h 17m
```

### Tests written?

No

### Commits signed with GPG?

No

--- 

Can you also please backport the fix onto current release?