### PR TITLE
[WIP] Warn that the "py" renderer can't be preceded by any other renderer

### DIFF
--- a/salt/renderers/py.py
+++ b/salt/renderers/py.py
@@ -109,6 +109,10 @@ Full Example
 
         return config
 
+.. note::
+    Currently, this renderer can't be preceded by any other renderer (previous results
+    are ignored). For example, the ``#!jinja|py`` pipeline is equivalent to just ``#!py``.
+
 """
 from __future__ import absolute_import, print_function, unicode_literals
 

--- a/salt/template.py
+++ b/salt/template.py
@@ -232,6 +232,13 @@ def check_render_pipe_str(pipestr, renderers, blacklist, whitelist):
     try:
         if parts[0] == pipestr and pipestr in OLD_STYLE_RENDERERS:
             parts = OLD_STYLE_RENDERERS[pipestr].split("|")
+        if "py" in parts[1:]:
+            log.warning(
+                'The "py" renderer ignores previously processed results. '
+                'The "#!%s" pipeline would be equivalent to just "#!%s"',
+                pipestr,
+                "|".join(parts[parts.index("py") :]),
+            )
         for part in parts:
             name, argline = (part + " ").split(" ", 1)
             if whitelist and name not in whitelist or blacklist and name in blacklist:


### PR DESCRIPTION
### What does this PR do?

Add a warning that any renderer that comes before the "py" one is ignored.

### Previous Behavior

The `jinja` part in `jinja|py` renderer pipeline is silently ignored. This happens because the `py` renderer can only handle files:

https://github.com/saltstack/salt/blob/0ac7520c670a8d77b479355c38c19678a85a59ce/salt/renderers/py.py#L129
https://github.com/saltstack/salt/blob/0ac7520c670a8d77b479355c38c19678a85a59ce/salt/utils/templates.py#L535

### New Behavior

A warning has been added:

`The "py" renderer ignores previously processed results. The "#!jinja|py" pipeline would be equivalent to just "#!py"`

### Tests written?

Yes

### Commits signed with GPG?

No