### PR TITLE
Try to use the same version matching python binary

### DIFF
--- a/tests/integration/modules/test_pip.py
+++ b/tests/integration/modules/test_pip.py
@@ -68,7 +68,22 @@ class PipModuleTest(ModuleCase):
             if salt.utils.is_windows():
                 python = os.path.join(sys.real_prefix, os.path.basename(sys.executable))
             else:
-                python = os.path.join(sys.real_prefix, 'bin', os.path.basename(sys.executable))
+                python_binary_names = [
+                    'python{}.{}'.format(*sys.version_info),
+                    'python{}'.format(*sys.version_info),
+                    'python'
+                ]
+                for binary_name in python_binary_names:
+                    python = os.path.join(sys.real_prefix, 'bin', binary_name)
+                    if os.path.exists(python):
+                        break
+                else:
+                    self.fail(
+                        'Couldn\'t find a python binary name under \'{}\' matching: {}'.format(
+                            os.path.join(sys.real_prefix, 'bin'),
+                            python_binary_names
+                        )
+                    )
             # We're running off a virtualenv, and we don't want to create a virtualenv off of
             # a virtualenv
             kwargs = {'python': python}

--- a/tests/integration/states/test_pip_state.py
+++ b/tests/integration/states/test_pip_state.py
@@ -87,7 +87,22 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
             if salt.utils.is_windows():
                 python = os.path.join(sys.real_prefix, os.path.basename(sys.executable))
             else:
-                python = os.path.join(sys.real_prefix, 'bin', os.path.basename(sys.executable))
+                python_binary_names = [
+                    'python{}.{}'.format(*sys.version_info),
+                    'python{}'.format(*sys.version_info),
+                    'python'
+                ]
+                for binary_name in python_binary_names:
+                    python = os.path.join(sys.real_prefix, 'bin', binary_name)
+                    if os.path.exists(python):
+                        break
+                else:
+                    self.fail(
+                        'Couldn\'t find a python binary name under \'{}\' matching: {}'.format(
+                            os.path.join(sys.real_prefix, 'bin'),
+                            python_binary_names
+                        )
+                    )
             # We're running off a virtualenv, and we don't want to create a virtualenv off of
             # a virtualenv, let's point to the actual python that created the virtualenv
             kwargs = {'python': python}


### PR DESCRIPTION
### What does this PR do?
See title.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-jenkins/pull/1615

### Previous Behavior
Fails for CentOS 6 for which python 2.6 is the default.

### New Behavior
Works as supposed for CentOS 6

### Tests written?

No

### Commits signed with GPG?

Yes