### PR TITLE
PY3 incompatibility in modules/capirca_acl.py

### DIFF
--- a/salt/modules/capirca_acl.py
+++ b/salt/modules/capirca_acl.py
@@ -399,8 +399,8 @@ def _lookup_element(lst, key):
     for ele in lst:
         if not ele or not isinstance(ele, dict):
             continue
-        if ele.keys()[0] == key:
-            return ele.values()[0]
+        if list(ele.keys())[0] == key:
+            return list(ele.values())[0]
     return {}
 
 
@@ -527,8 +527,8 @@ def _get_policy_object(platform,
     for filter_ in filters:
         if not filter_ or not isinstance(filter_, dict):
             continue  # go to the next filter
-        filter_name = filter_.keys()[0]
-        filter_config = filter_.values()[0]
+        filter_name = list(filter_.keys())[0]
+        filter_config = list(filter_.values())[0]
         header = capirca.lib.policy.Header()  # same header everywhere
         target_opts = [
             platform,

--- a/salt/modules/capirca_acl.py
+++ b/salt/modules/capirca_acl.py
@@ -451,7 +451,6 @@ def _merge_list_of_dict(first, second, prepend=True):
     appended = []
     for ele in first:
         if _lookup_element(second, list(ele.keys())[0]):
-                list(ele.keys())[0]):
             overlaps.append(ele)
         elif prepend:
             merged.append(ele)

--- a/salt/modules/capirca_acl.py
+++ b/salt/modules/capirca_acl.py
@@ -450,14 +450,15 @@ def _merge_list_of_dict(first, second, prepend=True):
     merged = []
     appended = []
     for ele in first:
-        if _lookup_element(second, ele.keys()[0]):
+        if _lookup_element(second, list(ele.keys())[0]):
+                list(ele.keys())[0]):
             overlaps.append(ele)
         elif prepend:
             merged.append(ele)
         elif not prepend:
             appended.append(ele)
     for ele in second:
-        ele_key = ele.keys()[0]
+        ele_key = list(ele.keys())[0]
         if _lookup_element(overlaps, ele_key):
             # If theres an overlap, get the value from the first
             # But inserted into the right position
@@ -544,8 +545,8 @@ def _get_policy_object(platform,
         filter_terms = []
         for term_ in filter_config.get('terms', []):
             if term_ and isinstance(term_, dict):
-                term_name = term_.keys()[0]
-                term_fields = term_.values()[0]
+                term_name = list(term_.keys())[0]
+                term_fields = list(term_.values())[0]
                 term = _get_term_object(filter_name,
                                         term_name,
                                         pillar_key=pillar_key,


### PR DESCRIPTION
### What does this PR do?
It fixes a PY3 incompatibility in modules/capirca_acl.py.

### What issues does this PR fix or reference?
In modules/capirca_acl.py there are some places where the first key of a dict is referenced.
Like so: dict.keys()[0]
This works in PY2 because .keys() gives back a list.
In PY3 .keys() returns a dict_keys object, which can't be indexed

### Previous Behavior
modules/capirca_acl.py is throwing:
TypeError: 'dict_keys' object does not support indexing
for code on lines 404, 405, 535, 536

### New Behavior
Sunshine, Unicorns and Rainbows. modules/capirca_acl.py is working on PY3 installation.

### Tests written?
No. Small bug/typo. 

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
