### PR TITLE
Fix PY3 dict_keys TypeError in modules/capirca_acl

### DIFF
--- a/salt/modules/capirca_acl.py
+++ b/salt/modules/capirca_acl.py
@@ -401,8 +401,8 @@ def _lookup_element(lst, key):
     for ele in lst:
         if not ele or not isinstance(ele, dict):
             continue
-        if ele.keys()[0] == key:
-            return ele.values()[0]
+        if list(ele.keys())[0] == key:
+            return list(ele.values())[0]
     return {}
 
 
@@ -452,14 +452,14 @@ def _merge_list_of_dict(first, second, prepend=True):
     merged = []
     appended = []
     for ele in first:
-        if _lookup_element(second, ele.keys()[0]):
+        if _lookup_element(second, list(ele.keys())[0]):
             overlaps.append(ele)
         elif prepend:
             merged.append(ele)
         elif not prepend:
             appended.append(ele)
     for ele in second:
-        ele_key = ele.keys()[0]
+        ele_key = list(ele.keys())[0]
         if _lookup_element(overlaps, ele_key):
             # If theres an overlap, get the value from the first
             # But inserted into the right position
@@ -532,8 +532,8 @@ def _get_policy_object(platform,
     for filter_ in filters:
         if not filter_ or not isinstance(filter_, dict):
             continue  # go to the next filter
-        filter_name = filter_.keys()[0]
-        filter_config = filter_.values()[0]
+        filter_name = list(filter_.keys())[0]
+        filter_config = list(filter_.values())[0]
         header = capirca.lib.policy.Header()  # same header everywhere
         target_opts = [
             platform,
@@ -549,8 +549,8 @@ def _get_policy_object(platform,
         filter_terms = []
         for term_ in filter_config.get('terms', []):
             if term_ and isinstance(term_, dict):
-                term_name = term_.keys()[0]
-                term_fields = term_.values()[0]
+                term_name = list(term_.keys())[0]
+                term_fields = list(term_.values())[0]
                 term = _get_term_object(filter_name,
                                         term_name,
                                         pillar_key=pillar_key,


### PR DESCRIPTION
### What does this PR do?
It fixes a PY3 incompatibility in modules/capirca_acl.py.

### What issues does this PR fix or reference?
In modules/capirca_acl.py there are some places where the first key of a dict is referenced.
Like so: dict.keys()[0]
This works in PY2 because .keys() gives back a list.
In PY3 .keys() returns a dict_keys object, which can't be indexed

### Previous Behavior
modules/capirca_acl.py is throwing:
TypeError: 'dict_keys' object does not support indexing
for the lines changed in this commit.

### New Behavior
Sunshine, Unicorns and Rainbows. modules/capirca_acl.py is working on PY3 installation.

### Tests written?
No. Small bug/typo. 

### Commits signed with GPG?
No
