### PR TITLE
Implemented the update_endtime and get_endtime functions for the etcd_returner from PR #51363.

### DIFF
--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -226,7 +226,7 @@ def get_jid(jid):
     # Iterate through all of the children at our job path that are directories.
     # Anything that is a directory should be a minion that contains some results.
     ret = {}
-    for item in items.children:
+    for item in items.leaves:
         if not item.dir: continue
 
         # Extract the minion name from the key in the job, and use it to build
@@ -272,7 +272,7 @@ def get_fun(fun):
     # Walk through the list of all the minions that have a jid registered,
     # and cross reference this with the job returns.
     ret = {}
-    for item in items.children:
+    for item in items.leaves:
 
         # Now that we have a minion and it's last jid, we use it to fetch the
         # function field (fun) that was registered by returner().
@@ -317,7 +317,7 @@ def get_jids():
     # Anything that's a directory is a job id. Since that's all we're returning,
     # aggregate them into a list.
     ret = []
-    for item in items.children:
+    for item in items.leaves:
         comps = str(item.key).split('/')
         if item.dir:
             jid = comps[-1]
@@ -347,7 +347,7 @@ def get_minions():
     # We can just walk through everything that isn't a directory. This path
     # is simply a list of minions and the last job that each one returned.
     ret = []
-    for item in items.children:
+    for item in items.leaves:
         if not item.dir:
             comps = str(item.key).split('/')
             ret.append(comps[-1])

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -235,7 +235,7 @@ def _purge_jobs():
     except salt.utils.etcd_util.etcd.EtcdKeyNotFound as E:
         return 0
 
-    # Iterate through all of the children at our job path while looking for 
+    # Iterate through all of the children at our job path while looking for
     # the .lock.p key. If one isn't found, then we can remove this job because
     # it has expired.
     count = 0

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -119,7 +119,7 @@ The other key under an event, is the "tag" key. The "tag" key simply contains
 the path to the package that was registered as the tag attribute for the event.
 The value of the "index" key corresponds to the modifiedIndex of this particular
 path.
-'''
+"""
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -102,7 +102,12 @@ def _get_conn(opts, profile=None):
     """
     if profile is None:
         profile = opts.get('etcd.returner')
+
+    # Grab the returner_root from the options
     path = opts.get('etcd.returner_root', '/salt/return')
+
+    # Grab a connection using etcd_util, and then return the EtcdClient
+    # from one of its attributes
     wrapper = salt.utils.etcd_util.get_conn(opts, profile)
     return wrapper.client, path
 
@@ -118,31 +123,51 @@ def returner(ret):
         ttl = __opts__.get("etcd.ttl")
 
     client, path = _get_conn(__opts__, write_profile)
-    # Make a note of this minion for the external job cache
-    client.set(
-        "/".join((path, "minions", ret["id"])), ret["jid"], ttl=ttl,
-    )
 
+    # if a minion is returning a standalone job, get a jid
+    if ret['jid'] == 'req':
+        ret['jid'] = prep_jid(nocache=ret.get('nocache', False))
+
+    # Update the given minion in the external job cache with the current (latest job)
+    # This is used by get_fun() to return the last function that was called
+    minionp = '/'.join([path, 'minions', ret['id']])
+    jid.debug("sdstack_etcd returner <returner> updating (last) job id (ttl={ttl:d}) of {id:s} at {path:s} with job {jid:s}".format(jid=ret['jid'], id=ret['id'], path=minionp, ttl=ttl))
+    res = client.set(minionp, ret['jid'], ttl=ttl)
+    if hasattr(res, '_prev_node'):
+        log.trace("sdstack_etcd returner <returner> the previous job id {old:s} for {id:s} at {path:s} was set to {new:s}".format(old=res._prev_node.value, id=ret['id'], path=minionp, new=res.value))
+
+    # Iterate through all the fields in the ret dict and dump it under jobs/$jid/id/$field
+    jobp = '/'.join([path, 'jobs', ret['jid'], ret['id'])
+    log.debug("sdstack_etcd returner <returner> writing job data (ttl={ttl:d}) for {jid:s} to {path:s} with {data:s}".format(jid=ret['jid'], path=jobp, ttl=ttl, data=repr(ret)))
     for field in ret:
-        # Not using os.path.join because we're not dealing with file paths
-        dest = "/".join((path, "jobs", ret["jid"], ret["id"], field))
-        client.set(dest, salt.utils.json.dumps(ret[field]), ttl=ttl)
+        fieldp = '/'.join([jobp, field])
+        log.trace("sdstack_etcd returner <returner> setting field {0} at {1} to {2:s}".format(field, fieldp, repr(ret[field])))
+        data = salt.utils.json.dumps(ret[field])
+        res = client.set(fieldp, data, ttl=ttl)
+    return
 
 
 def save_load(jid, load, minions=None):
     """
     Save the load to the specified jid
-    """
-    log.debug("sdstack_etcd returner <save_load> called jid: {0}".format(jid))
-    write_profile = __opts__.get("etcd.returner_write_profile")
+    '''
+    write_profile = __opts__.get('etcd.returner_write_profile')
     client, path = _get_conn(__opts__, write_profile)
     if write_profile:
         ttl = __opts__.get(write_profile, {}).get("etcd.ttl")
     else:
-        ttl = __opts__.get("etcd.ttl")
-    client.set(
-        "/".join((path, "jobs", jid, ".load.p")), salt.utils.json.dumps(load), ttl=ttl,
-    )
+        ttl = __opts__.get('etcd.ttl')
+
+    # Figure out the path using jobs/$jid/.load.p
+    savep = '/'.join([path, 'jobs', jid, '.load.p']),
+    log.debug('sdstack_etcd returner <save_load> setting load data (ttl={ttl:d}) for jid {jid:s} at {path:s} with {data:s}'.format(jid=jid, ttl=ttl, path=savep, data=load))
+
+    # Now we can just store the current load
+    data = salt.utils.json.dumps(load)
+    res = client.set(savep, data, ttl=ttl)
+
+    log.trace('sdstack_etcd returner <save_load> saved load data for job {jid:s} at {path:s} with {data:s}'.format(jid=jid, path=loadp, data=repr(load)))
+    return
 
 
 def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument
@@ -160,94 +185,174 @@ def clean_old_jobs():
 def get_load(jid):
     """
     Return the load data that marks a specified jid
-    """
-    log.debug("sdstack_etcd returner <get_load> called jid: {0}".format(jid))
-    read_profile = __opts__.get("etcd.returner_read_profile")
+    '''
+    read_profile = __opts__.get('etcd.returner_read_profile')
     client, path = _get_conn(__opts__, read_profile)
 
-    loadp = '/'.join((path, 'jobs', jid, '.load.p'))
+    # Figure out the path that our job should be at
+    loadp = '/'.join([path, 'jobs', jid, '.load.p'])
+    log.debug('sdstack_etcd returner <get_load> reading load data for jid {jid:s} from {path:s}'.format(jid=jid, path=loadp))
+
+    # Read it. If EtcdKeyNotFound was raised then the key doesn't exist and so
+    # we need to return None, because that's what our caller expects on a
+    # non-existent job.
     try:
         res = client.get(loadp)
-    except:
-        log.error("etcd returner <get_load> could not find path: {:s}".format(loadp))
+    except salt.utils.etcd_util.etcd.EtcdKeyNotFound as E:
+        log.error("sdstack_etcd returner <get_load> could not find job {jid:s} at the path {path:s}".format(jid=jid, path=loadp))
         return None
+    log.trace('sdstack_etcd returner <get_load> found load data for jid {jid:s} at {path:s} with value {data:s}'.format(jid=jid, path=loadp, data=repr(res.value))))
     return salt.utils.json.loads(res.value)
 
 
 def get_jid(jid):
     """
     Return the information returned when the specified job id was executed
-    """
-    log.debug("sdstack_etcd returner <get_jid> called jid: {0}".format(jid))
-    ret = {}
+    '''
     client, path = _get_conn(__opts__)
-    items = client.get("/".join((path, "jobs", jid)))
-    for item in items.children:
-        if str(item.key).endswith(".load.p"):
-            continue
-        comps = str(item.key).split('/')
 
-        returnp = '/'.join((path, 'jobs', jid, comps[-1], 'return'))
+    # Figure out the path that our job should be at
+    jobp = '/'.join([path, 'jobs', jid])
+    log.debug('sdstack_etcd returner <get_jid> reading job fields for jid {jid:s} from {path:s}'.format(jid=jid, path=jobp))
+
+    # Try and read the job directory. If we have a missing key exception then no
+    # minions have returned anything yet and so we return an empty dict for the
+    # caller.
+    try:
+        items = client.get(jobp)
+    except salt.utils.etcd_util.etcd.EtcdKeyNotFound as E:
+        return {}
+
+    # Iterate through all of the children at our job path that are directories.
+    # Anything that is a directory should be a minion that contains some results.
+    ret = {}
+    for item in items.children:
+        if not item.dir: continue
+
+        # Extract the minion name from the key in the job, and use it to build
+        # the path to the return value
+        comps = str(item.key).split('/')
+        returnp = '/'.join([path, 'jobs', jid, comps[-1], 'return'])
+
+        # Now we know the minion and the path to the return for its job, we can
+        # just grab it. If the key exists, but the value is missing entirely,
+        # then something that shouldn't happen has happened.
         try:
             res = client.get(returnp)
-        except:
-            log.debug("etcd returner <get_jid> returned nothing for minion: {:s}".format(returnp))
+        except salt.utils.etcd_util.etcd.EtcdKeyNotFound as E:
+            log.debug("sdstack_etcd returner <get_jid> returned nothing from minion {id:s} for job {jid:s} at path {path:s}".format(id=comps[-1], jid=jid, path=returnp))
             continue
+
+        # We found something, so update our return dict with the minion id and
+        # the result that it returned.
         data = res.value
         ret[comps[-1]] = {'return': salt.utils.json.loads(data)}
+        log.trace("sdstack_etcd returner <get_jid> job {jid:s} from minion {id:s} at path {path:s} returned {ret:s}".format(id=comps[-1], jid=jid, path=returnp, ret=repr(data)))
     return ret
 
 
 def get_fun(fun):
     """
     Return a dict of the last function called for all minions
-    """
-    log.debug("sdstack_etcd returner <get_fun> called fun: {0}".format(fun))
-    ret = {}
+    '''
     client, path = _get_conn(__opts__)
-    items = client.get("/".join((path, "minions")))
-    for item in items.children:
-        comps = str(item.key).split('/')
 
-        funp = '/'.join((path, 'jobs', str(item.value), comps[-1], 'fun'))
+    # Find any minions that had their last function registered by returner()
+    minionsp = '/'.join([path, 'minions'])
+    log.debug('sdstack_etcd returner <get_fun> reading minions at {path:s} for function {fun:s}'.format(path=minionsp, fun=fun))
+
+    # If the minions key isn't found, then no minions registered a function
+    # and thus we need to return an empty dict so the caller knows that
+    # nothing is available.
+    try:
+        items = client.get(minionsp)
+    except salt.utils.etcd_util.etcd.EtcdKeyNotFound as E:
+        return {}
+
+    # Walk through the list of all the minions that have a jid registered,
+    # and cross reference this with the job returns.
+    ret = {}
+    for item in items.children:
+
+        # Now that we have a minion and it's last jid, we use it to fetch the
+        # function field (fun) that was registered by returner().
+        comps = str(item.key).split('/')
+        funp = '/'.join([path, 'jobs', str(item.value), comps[-1], 'fun'])
+
+        # Try and read the field, and skip it if it doesn't exist or wasn't
+        # registered for some reason.
         try:
             res = client.get(funp)
-        except:
-            log.debug("etcd returner <get_fun> returned nothing for minion: {:s}".format(returnp))
-            continue
-        data = res.value
-        efun = salt.utils.json.loads(data)
-        if efun == fun:
-            ret[comps[-1]] = str(efun)
+        except salt.utils.etcd_util.etcd.EtcdKeyNotFound as E:
+            log.debug("sdstack_etcd returner <get_fun> returned nothing from minion {id:s} for job {jid:s} at path {path:s}".format(id=comps[-1], jid=str(item.value), path=funp))
+            continue.
+
+        # Check if the function field (fun) matches what the user is looking for
+        # If it does, then we can just add the minion to our results
+        data = salt.utils.json.loads(res.value)
+        if data == fun:
+            ret[comps[-1]] = str(data)
+            log.trace("sdstack_etcd returner <get_fun> found job {jid:s} for minion {id:s} using {fun:s} at {path:s}".format(jid=comps[-1], fun=data, id=item.value, path=item.key))
+        continue
     return ret
 
 
 def get_jids():
     """
     Return a list of all job ids
-    """
-    log.debug("sdstack_etcd returner <get_jids> called")
-    ret = []
+    '''
     client, path = _get_conn(__opts__)
-    items = client.get("/".join((path, "jobs")))
+
+    # Enumerate all the jobs that are available.
+    jobsp = '/'.join([path, 'jobs'])
+    log.debug("sdstack_etcd returner <get_jids> listing jobs at {path:s}".format(path=jobsp))
+
+    # Fetch all the jobs. If the key doesn't exist, then it's likely that no
+    # jobs have been created yet so return an empty list to the caller.
+    try:
+        items = client.get(jobsp)
+    except salt.utils.etcd_util.etcd.EtcdKeyNotFound as E:
+        return []
+
+    # Anything that's a directory is a job id. Since that's all we're returning,
+    # aggregate them into a list.
+    ret = []
     for item in items.children:
-        if item.dir is True:
-            jid = str(item.key).split("/")[-1]
+        comps = str(item.key).split('/')
+        if item.dir:
+            jid = comps[-1]
             ret.append(jid)
+            log.trace("sdstack_etcd returner <get_jids> found job {jid:s} at {path:s}".format(jid=comps[-1], path=item.key))
+        continue
     return ret
 
 
 def get_minions():
     """
     Return a list of minions
-    """
-    log.debug("sdstack_etcd returner <get_minions> called")
-    ret = []
+    '''
     client, path = _get_conn(__opts__)
-    items = client.get("/".join((path, "minions")))
+
+    # Find any minions that have returned anything
+    minionsp = '/'.join([path, 'minions'])
+    log.debug('sdstack_etcd returner <get_minions> reading minions at {path:s}'.format(path=minionsp))
+
+    # If no minions were found, then nobody has returned anything recently
+    # (due to ttl). In this case, return an empty last for the caller.
+    try:
+        items = client.get(minionsp)
+    except salt.utils.etcd_util.etcd.EtcdKeyNotFound as E:
+        return []
+
+    # We can just walk through everything that isn't a directory. This path
+    # is simply a list of minions and the last job that each one returned.
+    ret = []
     for item in items.children:
-        comps = str(item.key).split("/")
-        ret.append(comps[-1])
+        if not item.dir:
+            comps = str(item.key).split('/')
+            ret.append(comps[-1])
+            log.trace("sdstack_etcd returner <get_minions> found minion {id:s} at {path:s}".format(id=comps[-1], path=item.key))
+        continue
     return ret
 
 

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -222,7 +222,7 @@ def returner(ret):
         data = salt.utils.json.dumps(ret[field])
         try:
             res = client.write(fieldp, data)
-        except Exception as E:
+        except Exception as E:  # pylint: disable=broad-except
             log.trace("sdstack_etcd returner <returner> unable to set field {field:s} for job {jid:s} at {path:s} to {result} due to exception ({exception})".format(field=field, jid=ret['jid'], path=fieldp, result=ret[field], exception=E))
             exceptions.append((E, field, ret[field]))
             continue
@@ -268,7 +268,7 @@ def save_load(jid, load, minions=None):
 
     # If we failed here, it's okay because the lock won't get written so this
     # essentially means the job will get scheduled for deletion.
-    except Exception as E:
+    except Exception as E:  # pylint: disable=broad-except
         log.trace("sdstack_etcd returner <save_load> unable to store load for job {jid:s} to the path {path:s} due to exception ({exception}) being raised".format(jid=jid, path=loadp, exception=E))
         return
 
@@ -281,7 +281,7 @@ def save_load(jid, load, minions=None):
             j1, j2 = salt.utils.json.dumps(res.value, sort_keys=True), salt.utils.json.dumps(res._prev_node.value, sort_keys=True)
             if j1 != j2:
                 log.warning("sdstack_etcd returner <save_load> overwrote the load data for job {jid:s} at {path:s} with {data}. Old data was {old}".format(jid=jid, path=res.key, data=d1, old=d2))
-    except Exception as E:
+    except Exception as E:  # pylint: disable=broad-except
         log.debug("sdstack_etcd returner <save_load> unable to compare load data for job {jid:s} at {path:s} due to exception ({exception}) being raised".format(jid=jid, path=loadp, exception=E))
         if not res.newKey:
             log.trace("sdstack_etcd returner <save_load> -- old load data for job {jid:s}: {data}".format(jid=jid, data=res._prev_node.value))
@@ -297,13 +297,13 @@ def save_load(jid, load, minions=None):
         if res.ttl is not None:
             log.trace('sdstack_etcd returner <save_load> job {jid:s} at {path:s} will expire in {ttl:d} seconds'.format(jid=jid, path=res.key, ttl=res.ttl))
 
-    except Exception as E:
+    except Exception as E:  # pylint: disable=broad-except
         log.trace("sdstack_etcd returner <save_load> unable to write lock for job {jid:s} to the path {path:s} due to exception ({exception}) being raised".format(jid=jid, path=lockp, exception=E))
 
     return
 
 
-def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument
+def save_minions(jid, minions, syndic_id=None): # pylint: disable=unused-argument
     '''
     Save/update the minion list for a given jid. The syndic_id argument is
     included for API compatibility only.
@@ -354,7 +354,7 @@ def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argume
             node.value = jid
             client.update(node)
 
-        except Exception as E:
+        except Exception as E:  # pylint: disable=broad-except
             log.trace("sdstack_etcd returner <save_minions> unable to write job id {jid:s} for minion {minion:s} to {path:s} due to exception ({exception})".format(jid=jid, minion=minion, path=minionp, exception=E))
             exceptions.append((E, 'job', minion))
 
@@ -366,7 +366,7 @@ def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argume
         try:
             res = client.write('/'.join([resultp, 'jid']), jid)
 
-        except Exception as E:
+        except Exception as E:  # pylint: disable=broad-except
             log.trace("sdstack_etcd returner <save_minions> unable to write job id {jid:s} to the result for the minion {minion:s} at {path:s} due to exception ({exception})".format(jid=jid, minion=minion, path='/'.join([resultp, 'jid']), exception=E))
             exceptions.append((E, 'result.jid', minion))
 
@@ -374,7 +374,7 @@ def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argume
         try:
             res = client.write('/'.join([resultp, 'id']), minion)
 
-        except Exception as E:
+        except Exception as E:  # pylint: disable=broad-except
             log.trace("sdstack_etcd returner <save_minions> unable to write minion id {minion:s} to the result for job {jid:s} at {path:s} due to exception ({exception})".format(jid=jid, minion=minion, path='/'.join([resultp, 'id']), exception=E))
             exceptions.append((E, 'result.id', minion))
 
@@ -383,7 +383,7 @@ def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argume
             if syndic_id is not None:
                 res = client.write('/'.join([resultp, 'master_id']), syndic_id)
 
-        except Exception as E:
+        except Exception as E:  # pylint: disable=broad-except
             log.trace("sdstack_etcd returner <save_minions> unable to write master_id {syndic:s} to the result for job {jid:s} at {path:s} due to exception ({exception})".format(jid=jid, path='/'.join([resultp, 'master_id']), syndic=syndic_id, exception=E))
             exceptions.append((E, 'result.master_id', minion))
 
@@ -671,7 +671,7 @@ def get_jid(jid):
 
             # We use a general exception here instead of ValueError jic someone
             # changes the semantics of salt.utils.json.loads out from underneath us
-            except Exception as E:
+            except Exception as E:  # pylint: disable=broad-except
                 log.warning("sdstack_etcd returner <get_jid> unable to decode field {name:s} from minion {minion:s} for job {jid:s} at {path:s}".format(minion=comps[-1], jid=jid, path=item.key, name=name))
                 res[name] = item.value
             continue
@@ -776,7 +776,7 @@ def get_jids():
             data = salt.utils.json.loads(res.value)
 
         # If we can't decode the json, then we're screwed so log it in case the user cares
-        except Exception as E:
+        except Exception as E:  # pylint: disable=broad-except
             log.error("sdstack_etcd returner <get_jids> could not decode data for job {jid:s} at the path {path:s} due to exception ({exception}) being raised. Data was {data}".format(jid=jid, path=loadp, exception=E, data=res.value))
             continue
 
@@ -819,7 +819,7 @@ def get_minions():
     return ret
 
 
-def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
+def prep_jid(nocache=False, passed_jid=None):   # pylint: disable=unused-argument
     '''
     Do any work necessary to prepare a JID, including sending a custom id.
     '''
@@ -874,7 +874,7 @@ def event_return(events):
             node.value = json
             res = client.update(node)
 
-        except Exception as E:
+        except Exception as E:  # pylint: disable=broad-except
             log.trace("sdstack_etcd returner <event_return> unable to write event with the tag {name:s} into {path:s} due to exception ({exception}) being raised".format(name=package['tag'], path=packagep, exception=E))
             exceptions.append((E, package))
             continue
@@ -919,7 +919,7 @@ def event_return(events):
             log.trace("sdstack_etcd returner <event_return> updating event {event:d} at {path:s} with tag {name:s}".format(path=tagp, event=event, name=package['tag']))
             client.write(tagp, package['tag'])
 
-        except Exception as E:
+        except Exception as E:  # pylint: disable=broad-except
             log.trace("sdstack_etcd returner <event_return> unable to update event {event:d} at {path:s} with tag {name:s} due to exception ({exception}) being raised".format(path=tagp, name=package['tag'], event=event, exception=E))
             exceptions.append((E, package))
             continue
@@ -932,7 +932,7 @@ def event_return(events):
 
         # If we can't write the lock, it's fine because the maintenance thread
         # will purge this event from the cache anyways if it's not written.
-        except Exception as E:
+        except Exception as E:  # pylint: disable=broad-except
             log.error("sdstack_etcd returner <event_return> unable to write lock for event {event:d} with the tag {name:s} to {path:s} due to exception ({exception}) being raised".format(path=lockp, name=package['tag'], event=event, exception=E))
             exceptions.append((E, package))
 
@@ -993,7 +993,7 @@ def get_jids_filter(count, filter_find_job=True):
             data = salt.utils.json.loads(res.value)
 
         # If we can't decode the json, then we're screwed so log it in case the user cares
-        except Exception as E:
+        except Exception as E:  # pylint: disable=broad-except
             log.error("sdstack_etcd returner <get_jids_filter> could not decode data for job {jid:s} at the path {path:s} due to exception ({exception}) being raised. Data was {data}".format(jid=jid, path=loadp, exception=E, data=res.value))
             continue
 
@@ -1002,6 +1002,7 @@ def get_jids_filter(count, filter_find_job=True):
 
         ret.append(salt.utils.jid.format_jid_instance_ext(jid, data))
     return ret
+
 
 def update_endtime(jid, time):
     '''
@@ -1036,10 +1037,11 @@ def update_endtime(jid, time):
 
     # If we failed here, it's okay because the lock won't get written so this
     # essentially means the job will get scheduled for deletion.
-    except Exception as E:
+    except Exception as E:  # pylint: disable=broad-except
         log.trace("sdstack_etcd returner <update_endtime> unable to store endtime for job {jid:s} to the path {path:s} due to exception ({exception}) being raised".format(jid=jid, path=timep, exception=E))
         return
     log.trace("sdstack_etcd returner <update_endtime> successfully wrote endtime for job {jid:s} to the path {path:s} with {data}".format(jid=jid, path=timep, data=time))
+
 
 def get_endtime(jid):
     '''

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -686,10 +686,10 @@ def event_return(events):
             log.error("sdstack_etcd returner <event_return> unable to cache event for {index:d} due to event already existing".format(index=res.createdIndex))
 
         # If we got here, then we should be able to write the tag under the current index
-        tagp = '/'.join([path, Schema['event-path'], package['tag'])
+        tagp = '/'.join([path, Schema['event-path'], package['tag']])
         try:
             log.trace("sdstack_etcd returner <event_return> updating cached tag at {path:s} for the event {index:d} with the tag {name:s}".format(path='/'.join([path, Schema['event-cache'], str(res.createdIndex), 'tag']), index=res.createdIndex, name=package['tag']))
-            client.write('/'.join([path, Schema['event-cache'], str(res.createdIndex), 'tag']), tagp])
+            client.write('/'.join([path, Schema['event-cache'], str(res.createdIndex), 'tag']), tagp)
 
         except Exception as E:
             log.trace("sdstack_etcd returner <event_return> unable to cache tag {name:s} under index {index:d} due to exception ({exception}) being raised".format(name=package['tag'], index=res.createdIndex, exception=E))

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -409,14 +409,14 @@ def _purge_events():
         count += 1
 
         # Descend trying to clean up every parent directory
-        log.debug('sdstack_etcd returner <_purge_events> recursively removing directories for event {index:d} at {path:s}'.format(index=index, path='/'.join(comp[:i])))
+        log.debug('sdstack_etcd returner <_purge_events> recursively removing directories for event {index:d} at {path:s}'.format(index=index, path='/'.join(comp)))
         for i in range(len(comp), 0, -1):
             log.trace('sdstack_etcd returner <_purge_events> removing directory for event {index:d} at {path:s}'.format(index=index, path='/'.join(comp[:i])))
             try:
                 client.delete('/'.join([path, Schema['event-path']] + comp[:i]), dir=True)
             except Exception as E:
-                log.debug('sdstack_etcd returner <_purge_events> exception ({exception:s}) was raised while trying to remove directory at {path:s}'.format(path='/'.join([path, Schema['event-path']], comp[:i]), exception=E))
-                break;
+                log.debug('sdstack_etcd returner <_purge_events> exception ({exception:s}) was raised while trying to remove directory at {path:s}'.format(path='/'.join([path, Schema['event-path'], comp[:i]]), exception=E))
+                break
             continue
         continue
     return count

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -68,6 +68,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
 import logging
+import uuid
 
 # Import salt libs
 import salt.utils.jid
@@ -393,3 +394,35 @@ def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     Do any work necessary to prepare a JID, including sending a custom id.
     '''
     return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid(__opts__)
+
+
+def event_return(events):
+    '''
+    Return event to etcd server
+
+    Requires that configuration enabled via 'event_return'
+    option in master config.
+    '''
+    ttl = __opts__.get('etcd.ttl', 5)
+    client, path = _get_conn(__opts__)
+
+    exceptions = []
+    for event in events:
+        package = {
+            'tag': event.get('tag', ''),
+            'data': event.get('data', ''),
+            'master_id': __opts__['id'],
+        }
+        path = '/'.join([path, 'events', package['tag']])
+        json = salt.utils.json.dumps(package)
+        try:
+            res = client.set(path, json, ttl=ttl)
+        except Exception, err:
+            log.exception('etcd: Unable to write event into returner path %s due to exception %s: %r', path, package, err)
+            exceptions.append(err)
+            continue
+        if not res:
+            log.error('etcd: Unable to write event into returner path %s: %r', path, package)
+        continue
+    return
+

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -514,7 +514,7 @@ def _purge_events():
         # even matter because we can't do anything without a tag. So similar to
         # before, we just remove it and cycle to the next event.
         except etcd.EtcdKeyNotFound as E:
-            log.warning('sdstack_etcd returner <_purge_events> event {event:d} at {path:p} is corrupt (missing tag) and will be removed'.format(event=event, path=ev.key))
+            log.warning('sdstack_etcd returner <_purge_events> event {event:d} at {path:s} is corrupt (missing tag) and will be removed'.format(event=event, path=ev.key))
 
             log.debug('sdstack_etcd returner <_purge_events> removing corrupt event {event:d} at {path:s}'.format(event=event, path=ev.key))
             client.delete(ev.key, recursive=True)

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -850,7 +850,7 @@ def event_return(events):
             log.trace("sdstack_etcd returner <event_return> fetching already existing event with the tag {name:s} at {path:s}".format(name=package['tag'], path=packagep))
             node = client.read(packagep)
 
-            log.debug("sdstack_etcd returner <event_return> updating package for event ({event:d}) with the tag {name:s} at {path:s}".format(event=res.createdIndex, name=package['tag'], path=packagep))
+            log.debug("sdstack_etcd returner <event_return> updating package for event ({event:d}) with the tag {name:node} at {path:s}".format(event=node.modifiedIndex, name=package['tag'], path=packagep))
             node.value = json
             res = client.update(node)
 

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -686,10 +686,9 @@ def event_return(events):
             log.error("sdstack_etcd returner <event_return> unable to cache event for {index:d} due to event already existing".format(index=res.createdIndex))
 
         # If we got here, then we should be able to write the tag under the current index
-        tagp = '/'.join([path, Schema['event-path'], package['tag']])
         try:
             log.trace("sdstack_etcd returner <event_return> updating cached tag at {path:s} for the event {index:d} with the tag {name:s}".format(path='/'.join([path, Schema['event-cache'], str(res.createdIndex), 'tag']), index=res.createdIndex, name=package['tag']))
-            client.write('/'.join([path, Schema['event-cache'], str(res.createdIndex), 'tag']), tagp)
+            client.write('/'.join([path, Schema['event-cache'], str(res.createdIndex), 'tag']), package['tag'])
 
         except Exception as E:
             log.trace("sdstack_etcd returner <event_return> unable to cache tag {name:s} under index {index:d} due to exception ({exception}) being raised".format(name=package['tag'], index=res.createdIndex, exception=E))

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -239,7 +239,7 @@ def save_load(jid, load, minions=None):
 
     # Check if the specified jid is 'req', as only incorrect code will do this
     if jid == 'req':
-        log.debug('sdstack_etcd returner <save_load> was called using a request job id ({jid:s}) with {data:s}'.format(jid=jid, data=load))
+        log.debug('sdstack_etcd returner <save_load> was called using a request job id ({jid:s}) with {data}'.format(jid=jid, data=load))
 
     # Build the paths that we'll use for registration of our job
     loadp = '/'.join([path, Schema['job-cache'], jid, '.load.p'])
@@ -248,7 +248,7 @@ def save_load(jid, load, minions=None):
     ## Now we can just store the current load
     json = salt.utils.json.dumps(load)
 
-    log.debug('sdstack_etcd returner <save_load> storing load data for job {jid:s} to {path:s} with {data:s}'.format(jid=jid, path=loadp, data=load))
+    log.debug('sdstack_etcd returner <save_load> storing load data for job {jid:s} to {path:s} with {data}'.format(jid=jid, path=loadp, data=load))
     try:
         res = client.write(loadp, json, prevExist=False)
 
@@ -258,7 +258,7 @@ def save_load(jid, load, minions=None):
         node = client.read(loadp)
         node.value = json
 
-        log.debug('sdstack_etcd returner <save_load> updating load data for job {jid:s} at {path:s} with {data:s}'.format(jid=jid, path=loadp, data=load))
+        log.debug('sdstack_etcd returner <save_load> updating load data for job {jid:s} at {path:s} with {data}'.format(jid=jid, path=loadp, data=load))
         res = client.update(node)
 
     # If we failed here, it's okay because the lock won't get written so this
@@ -275,12 +275,12 @@ def save_load(jid, load, minions=None):
             d1, d2 = salt.utils.json.loads(res.value), salt.utils.json.loads(res._prev_node.value)
             j1, j2 = salt.utils.json.dumps(res.value, sort_keys=True), salt.utils.json.dumps(res._prev_node.value, sort_keys=True)
             if j1 != j2:
-                log.warning("sdstack_etcd returner <save_load> overwrote the load data for job {jid:s} at {path:s} with {data:s}. Old data was {old:s}".format(jid=jid, path=res.key, data=d1, old=d2))
+                log.warning("sdstack_etcd returner <save_load> overwrote the load data for job {jid:s} at {path:s} with {data}. Old data was {old}".format(jid=jid, path=res.key, data=d1, old=d2))
     except Exception as E:
         log.debug("sdstack_etcd returner <save_load> unable to compare load data for job {jid:s} at {path:s} due to exception ({exception}) being raised".format(jid=jid, path=loadp, exception=E))
         if not res.newKey:
-            log.trace("sdstack_etcd returner <save_load> -- old load data for job {jid:s}: {data:s}".format(jid=jid, data=res._prev_node.value))
-        log.trace("sdstack_etcd returner <save_load> -- new load data for job {jid:s}: {data:s}".format(jid=jid, data=res.value))
+            log.trace("sdstack_etcd returner <save_load> -- old load data for job {jid:s}: {data}".format(jid=jid, data=res._prev_node.value))
+        log.trace("sdstack_etcd returner <save_load> -- new load data for job {jid:s}: {data}".format(jid=jid, data=res.value))
 
     # Since this is when a job is being created, create a lock that we can
     # check to see if the job has expired. This allows a user to signal to
@@ -772,7 +772,7 @@ def get_jids():
 
         # If we can't decode the json, then we're screwed so log it in case the user cares
         except Exception as E:
-            log.error("sdstack_etcd returner <get_jids> could not decode data for job {jid:s} at the path {path:s} due to exception ({exception}) being raised. Data was {data:s}".format(jid=jid, path=loadp, exception=E, data=res.value))
+            log.error("sdstack_etcd returner <get_jids> could not decode data for job {jid:s} at the path {path:s} due to exception ({exception}) being raised. Data was {data}".format(jid=jid, path=loadp, exception=E, data=res.value))
             continue
 
         # Cool. Everything seems to be good...
@@ -989,7 +989,7 @@ def get_jids_filter(count, filter_find_job=True):
 
         # If we can't decode the json, then we're screwed so log it in case the user cares
         except Exception as E:
-            log.error("sdstack_etcd returner <get_jids_filter> could not decode data for job {jid:s} at the path {path:s} due to exception ({exception}) being raised. Data was {data:s}".format(jid=jid, path=loadp, exception=E, data=res.value))
+            log.error("sdstack_etcd returner <get_jids_filter> could not decode data for job {jid:s} at the path {path:s} due to exception ({exception}) being raised. Data was {data}".format(jid=jid, path=loadp, exception=E, data=res.value))
             continue
 
         if filter_find_job and data['fun'] == 'saltutil.find_job':

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -190,7 +190,8 @@ def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argume
     Save/update the minion list for a given jid. The syndic_id argument is
     included for API compatibility only.
     '''
-    client, path = _get_conn(__opts__, read_profile)
+    write_profile = __opts__.get('etcd.returner_write_profile')
+    client, path = _get_conn(__opts__, write_profile)
 
     # Figure out the path that our job should be at
     jobp = '/'.join([path, 'jobs', jid])
@@ -258,7 +259,8 @@ def get_jid(jid):
     # Anything that is a directory should be a minion that contains some results.
     ret = {}
     for item in items.leaves:
-        if not item.dir: continue
+        if not item.dir:
+            continue
 
         # Extract the minion name from the key in the job, and use it to build
         # the path to the return value

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -303,7 +303,7 @@ def save_load(jid, load, minions=None):
     return
 
 
-def save_minions(jid, minions, syndic_id=None): # pylint: disable=unused-argument
+def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument
     '''
     Save/update the minion list for a given jid. The syndic_id argument is
     included for API compatibility only.

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -189,8 +189,8 @@ def returner(ret):
     # it's likely there's no load saved since this job came directly from a
     # minion.
     if ret['jid'] == 'req':
-        log.debug('sdstack_etcd returner <returner> received a new job id request ({jid:s}) for {data}'.format(jid=jid, data=ret))
-        save_load(jid, ret)
+        log.debug('sdstack_etcd returner <returner> received a new job id request () for {data}'.format(jid=ret['jid'], data=ret))
+        save_load(ret['jid'], ret)
 
     # Update the given minion in the external job cache with the current (latest job)
     # This is used by get_fun() to return the last function that was called

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -189,7 +189,7 @@ def returner(ret):
     # it's likely there's no load saved since this job came directly from a
     # minion.
     if ret['jid'] == 'req':
-        log.debug('sdstack_etcd returner <returner> received a new job id request () for {data}'.format(jid=ret['jid'], data=ret))
+        log.debug('sdstack_etcd returner <returner> received a new job id request ({jid:s}) for {data}'.format(jid=ret['jid'], data=ret))
         save_load(ret['jid'], ret)
 
     # Update the given minion in the external job cache with the current (latest job)
@@ -238,7 +238,7 @@ def save_load(jid, load, minions=None):
 
     # Check if the specified jid is 'req', as only incorrect code will do this
     if jid == 'req':
-        log.warning('sdstack_etcd returner <save_load> was called using a request job id ({jid:s}) with {data:s}'.format(jid=jid, data=load))
+        log.debug('sdstack_etcd returner <save_load> was called using a request job id ({jid:s}) with {data:s}'.format(jid=jid, data=load))
 
     # Build the paths that we'll use for registration of our job
     loadp = '/'.join([path, Schema['job-cache'], jid, '.load.p'])
@@ -293,7 +293,7 @@ def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argume
 
     # Check if the specified jid is 'req', as only incorrect code will do that
     if jid == 'req':
-        log.warning('sdstack_etcd returner <save_minions> was called with a request job id ({jid:s}) for minions {minions:s}'.format(jid=jid, minions=repr(minions)))
+        log.debug('sdstack_etcd returner <save_minions> was called with a request job id ({jid:s}) for minions {minions:s}'.format(jid=jid, minions=repr(minions)))
 
     # Figure out the path that our job should be at
     jobp = '/'.join([path, Schema['job-cache'], jid])

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -332,7 +332,7 @@ def _purge_jobs():
 
         # It's not, so the job is dead and we can remove it
         except etcd.EtcdKeyNotFound as E:
-            log.debug('sdstack_etcd returner <_purge_jobs> job {jid:s} at {path:s} has expired'.format(jid=jid, path=res.key))
+            log.debug('sdstack_etcd returner <_purge_jobs> job {jid:s} at {path:s} has expired'.format(jid=jid, path=lockp))
 
             res = client.delete(job.key, recursive=True)
             count += 1

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -421,22 +421,22 @@ def event_return(events):
             'data': event.get('data', ''),
             'master_id': __opts__['id'],
         }
-        json = salt.utils.json.dumps(package)
 
         # Use the tag from the event package to build a watchable path
         eventp = '/'.join([path, 'events', package['tag']])
 
         # Now we can write the event package into the event path
         try:
+            json = salt.utils.json.dumps(package)
             res = client.set(eventp, json, ttl=ttl)
         except Exception as E:
-            log.trace("sdstack_etcd returner <event_return> unable to write event into returner path {path:s} due to exception {exception:s}: {data}".format(path=eventp, data=package, exception=E))
+            log.trace("sdstack_etcd returner <event_return> unable to write event with the tag {name:s} into the path {path:s} due to exception ({exception}) being raised".format(name=package['tag'], path=eventp, exception=E))
             exceptions.append((E, package))
             continue
 
-        log.trace("sdstack_etcd returner <event_return> wrote event (ttl={ttl:d}) with the name {name:s} to {path:s} with the data {data}".format(path=res.key, name=package['tag'], ttl=ttl, data=res.value))
+        log.trace("sdstack_etcd returner <event_return> wrote event (ttl={ttl:d}) with the tag {name:s} to {path:s} using {data}".format(path=res.key, name=package['tag'], ttl=ttl, data=res.value))
 
     # Go back through all of the exceptions that occurred and log them.
     for e, pack in exceptions:
-        log.exception("sdstack_etcd returner <event_return> exception ({exception:s}) was raised while trying to write event {name:s} with the data {data}".format(exception=e, name=pack['tag'], data=pack))
+        log.exception("sdstack_etcd returner <event_return> exception ({exception}) was raised while trying to write event {name:s} with the data {data}".format(exception=e, name=pack['tag'], data=pack))
     return

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -425,9 +425,7 @@ def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argume
         "sdstack_etcd returner <save_minions> adding minions {syndics:s} for job {jid:s} to {path:s}".format(
             jid=jid,
             path=jobp,
-            syndics=""
-            if syndic_id is None
-            else " from syndic {0}".format(syndic_id),
+            syndics="" if syndic_id is None else " from syndic {0}".format(syndic_id),
         )
     )
 
@@ -465,7 +463,8 @@ def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argume
                     minion=minion,
                     jid=jid,
                     path=node.key,
-                    syndics="" if syndic_id is None
+                    syndics=""
+                    if syndic_id is None
                     else " from syndic {0}".format(syndic_id),
                 )
             )
@@ -560,7 +559,11 @@ def _purge_jobs():
     try:
         jobs = client.read(jobp)
     except etcd.EtcdKeyNotFound as E:
-        log.debug("sdstack_etcd returner <_purge_jobs> no jobs were found at {path:s}".format(path=jobp))
+        log.debug(
+            "sdstack_etcd returner <_purge_jobs> no jobs were found at {path:s}".format(
+                path=jobp
+            )
+        )
         return 0
 
     # Iterate through all of the children at our job path while looking for
@@ -1203,7 +1206,7 @@ def get_minions():
     return ret
 
 
-def prep_jid(nocache=False, passed_jid=None):    # pylint: disable=unused-argument
+def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
     """
     Do any work necessary to prepare a JID, including sending a custom id.
     """

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -131,7 +131,7 @@ def returner(ret):
     # Update the given minion in the external job cache with the current (latest job)
     # This is used by get_fun() to return the last function that was called
     minionp = '/'.join([path, 'minions', ret['id']])
-    jid.debug("sdstack_etcd returner <returner> updating (last) job id (ttl={ttl:d}) of {id:s} at {path:s} with job {jid:s}".format(jid=ret['jid'], id=ret['id'], path=minionp, ttl=ttl))
+    log.debug("sdstack_etcd returner <returner> updating (last) job id (ttl={ttl:d}) of {id:s} at {path:s} with job {jid:s}".format(jid=ret['jid'], id=ret['id'], path=minionp, ttl=ttl))
     res = client.set(minionp, ret['jid'], ttl=ttl)
     if hasattr(res, '_prev_node'):
         log.trace("sdstack_etcd returner <returner> the previous job id {old:s} for {id:s} at {path:s} was set to {new:s}".format(old=res._prev_node.value, id=ret['id'], path=minionp, new=res.value))

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -74,6 +74,11 @@ key and when configured via the "etcd.ttl" or "keep_jobs" will have the ttl
 applied to it. When this file is expired via the ttl or explicitly removed by
 the administrator, the job will then be scheduled for removal.
 
+A third key was introduced called ".endtime". This is written alongside both the
+load and the lock when the "update_endtime" function is used to store the time
+when a job has completed. Similar to the local_cache returner, this job-completion
+time can be fetched using the "get_endtime" function.
+
 event
 +++++
 This key is essentially a namespace for all of the events (packages) that are

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -226,7 +226,6 @@ def _purge_jobs():
 
     # Figure out the path that our jobs should exist at
     jobp = '/'.join([path, 'jobs'])
-    log.debug('sdstack_etcd returner <get_jid> reading job fields for job {jid:s} from {path:s}'.format(jid=jid, path=jobp))
 
     # Try and read the job directory. If we have a missing key exception then no
     # minions have returned anything yet and so we can simply leave.
@@ -254,8 +253,96 @@ def _purge_jobs():
         # It's not, so the job is dead and we can remove it
         except etcd.EtcdKeyNotFound as E:
             res = client.delete(job.key, recursive=True)
-            log.trace('sdstack_etcd returner <_purge_jobs> job {jid:s} at {path:s} has expired'.format(jid=res.key.split('/')[-1], path=res.key))
+            log.debug('sdstack_etcd returner <_purge_jobs> job {jid:s} at {path:s} has expired'.format(jid=res.key.split('/')[-1], path=res.key))
             count += 1
+        continue
+    return count
+
+
+def _purge_events():
+    write_profile = __opts__.get('etcd.returner_write_profile')
+    client, path, _ = _get_conn(__opts__, write_profile)
+
+    # Figure out the path that our event cache should exist at
+    cachep = '/'.join([path, 'cache'])
+
+    # Try and read the event cache directory. If we have a missing key exception then no
+    # events have been cached and so we can simply leave.
+    try:
+        cache = client.read(cachep)
+    except etcd.EtcdKeyNotFound as E:
+        return 0
+
+    # Iterate through all of the children at our cache path while looking for
+    # the id key. If one isn't found, then we can remove this event because
+    # it has expired.
+    count = 0
+    for event in cache.leaves:
+        if not event.dir:
+            log.warning('sdstack_etcd returner <_purge_events> found a non-event at {path:s} {expire:s}'.format(path=event.key, expire='that will need to be manually removed' if event.ttl is None else 'that will expire in {ttl:d} seconds'.format(event.ttl)))
+            continue
+
+        # Build our index and tag paths
+        indexp = '/'.join([event.key, 'id'])
+        tagp = '/'.join([event.key, 'tag'])
+
+        # Grab the actual tag from our indexp in case we need to remove it. If this key
+        # doesn't exist, then the current entry in our cache doesn't even matter
+        # because we can't do anything without a tag
+        try:
+            tag = client.read(tagp)
+
+        except Exception as E:
+            log.warning('sdstack_etcd returner <_purge_events> unable to find path to event for index {expire:s} which should be at {path:p}'.format(path=tagp, expire='that will need to be manually removed' if event.ttl is None else 'that will expire in {ttl:d} seconds'.format(event.ttl)))
+
+            log.debug('sdstack_etcd returner <_purge_events> removing event cache at {path:s}'.format(path=event.key))
+            client.delete(event.key, recursive=True)
+            count += 1
+            continue
+
+        # Ping the index to see if it's alive
+        try:
+            index = client.read(indexp)
+            alive = True
+
+        # It's not, so the job is dead and we can remove it
+        except etcd.EtcdKeyNotFound as E:
+            alive = False
+
+        # Cycle to the next event iteration if it's still alive
+        if alive:
+            log.trace('sdstack_etcd returner <_purge_events> event {index:s} at {path:s} is still alive'.format(index=event.key.split('/')[-1], path=event.key))
+            continue
+
+        ## Remove the event cache and its tag
+
+        # Remove the whole event cache entry
+        res = client.delete(event.key, recursive=True)
+        log.debug('sdstack_etcd returner <_purge_events> event {index:s} at {path:s} has expired'.format(index=res.key.split('/')[-1], path=res.key))
+
+        # Remove the old event tag
+        comp = tag.value.split('/')
+        try:
+            res = client.delete('/'.join([path, 'events'] + comp), prevIndex=index.value)
+
+        except etcd.EtcdCompareFailed as E:
+            log.warning('sdstack_etcd returner <_purge_events> event tag at {path:s} does not match modification index {mod:d}'.format(path=tag.value, mod=index.value))
+            log.trace('sdstack_etcd returner <_purge_events> forcefully removing event tag at {path:s}'.format(path=tag.value))
+            res = client.delete('/'.join([path, 'events'] + comp))
+
+        # Remove the last component (the key), so we can walk through the directories trying to remove them one-by-one
+        comp.pop(-1)
+        count += 1
+
+        # Descend trying to clean up every parent directory
+        for i in range(len(comp), 0, -1):
+            log.trace('sdstack_etcd returner <_purge_events> removing directory at {path:s}'.format('/'.join(comp[:i])))
+            try:
+                client.delete('/'.join([path, 'events'] + comp[:i]), dir=True)
+            except Exception as E:
+                log.debug('sdstack_etcd returner <_purge_events> exception ({exception:s}) was raised while trying to remove directory at {path:s}'.format(path='/'.join([path, 'events'], comp[:i]), exception=E))
+                break;
+            continue
         continue
     return count
 
@@ -269,8 +356,11 @@ def clean_old_jobs():
     :return:
     '''
 
-    jobc = _purge_jobs(ttl)
+    jobc = _purge_jobs()
     log.trace('sdstack_etcd returner <clean_old_jobs> successfully removed {:d} jobs'.format(jobc))
+
+    eventsc = _purge_events()
+    log.trace('sdstack_etcd returner <clean_old_jobs> successfully removed {:d} events'.format(eventsc))
 
 
 def get_load(jid):

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -850,7 +850,7 @@ def event_return(events):
             log.trace("sdstack_etcd returner <event_return> fetching already existing event with the tag {name:s} at {path:s}".format(name=package['tag'], path=packagep))
             node = client.read(packagep)
 
-            log.debug("sdstack_etcd returner <event_return> updating package for event ({event:d}) with the tag {name:node} at {path:s}".format(event=node.modifiedIndex, name=package['tag'], path=packagep))
+            log.debug("sdstack_etcd returner <event_return> updating package for event ({event:d}) with the tag {name:s} at {path:s}".format(event=node.modifiedIndex, name=package['tag'], path=packagep))
             node.value = json
             res = client.update(node)
 

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -389,10 +389,6 @@ def _purge_events():
         ## Remove the event cache and its tag
         log.debug('sdstack_etcd returner <_purge_events> event {index:d} at {path:s} has expired'.format(index=index, path=event.key))
 
-        # Remove the whole event cache entry
-        log.trace('sdstack_etcd returner <_purge_events> (recursively) removing cache for event {index:d} at {path:s}'.format(index=index, path=event.key))
-        res = client.delete(event.key, recursive=True)
-
         # Remove the event tag associated with the current index associated with the current index
         log.trace('sdstack_etcd returner <_purge_events> removing tag for event {index:d} at {path:s}'.format(index=index, path=ev_tag.value))
         comp = ev_tag.value.split('/')
@@ -412,7 +408,11 @@ def _purge_events():
                 log.debug('sdstack_etcd returner <_purge_events> exception ({exception:s}) was raised while trying to remove directory at {path:s}'.format(path='/'.join([path, Schema['event-path']] + comp[:i]), exception=E))
                 break
             continue
-        continue
+
+        # Remove the whole event cache entry
+        log.trace('sdstack_etcd returner <_purge_events> (recursively) removing cache for event {index:d} at {path:s}'.format(index=index, path=event.key))
+        res = client.delete(event.key, recursive=True)
+
     return count
 
 

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -409,7 +409,7 @@ def _purge_events():
             try:
                 client.delete('/'.join([path, Schema['event-path']] + comp[:i]), dir=True)
             except Exception as E:
-                log.debug('sdstack_etcd returner <_purge_events> exception ({exception:s}) was raised while trying to remove directory at {path:s}'.format(path='/'.join([path, Schema['event-path'], comp[:i]]), exception=E))
+                log.debug('sdstack_etcd returner <_purge_events> exception ({exception:s}) was raised while trying to remove directory at {path:s}'.format(path='/'.join([path, Schema['event-path']] + comp[:i]), exception=E))
                 break
             continue
         continue

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -68,7 +68,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
 import logging
-import uuid
 
 # Import salt libs
 import salt.utils.jid
@@ -418,11 +417,10 @@ def event_return(events):
         try:
             res = client.set(path, json, ttl=ttl)
         except Exception, err:
-            log.exception('etcd: Unable to write event into returner path %s due to exception %s: %r', path, package, err)
+            log.exception('etcd: Unable to write event into returner path %s due to exception %s: %s', path, package, repr(err))
             exceptions.append(err)
             continue
         if not res:
             log.error('etcd: Unable to write event into returner path %s: %r', path, package)
         continue
     return
-

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -200,7 +200,7 @@ def returner(ret):
     # which will expire according to the ttl anyways..
     log.debug("sdstack_etcd returner <returner> updating (last) job id of {minion:s} at {path:s} with job {jid:s}".format(jid=ret['jid'], minion=ret['id'], path=minionp))
     res = client.write(minionp, ret['jid'], ttl=ttl if ttl > 0 else None)
-    if hasattr(res, '_prev_node'):
+    if not res.newKey:
         log.debug("sdstack_etcd returner <returner> the previous job id {old:s} for {minion:s} at {path:s} was set to {new:s}".format(old=res._prev_node.value, minion=ret['id'], path=minionp, new=res.value))
 
     # Figure out the path for the specified job and minion
@@ -259,14 +259,27 @@ def save_load(jid, load, minions=None):
 
         log.debug('sdstack_etcd returner <save_load> updating load data for job {jid:s} at {path:s} with {data:s}'.format(jid=jid, path=loadp, data=load))
         res = client.update(node)
-        if res._prev_node.value != res.value:
-            log.warning("sdstack_etcd returner <save_load> overwrote the load data for job {jid:s} at {path:s} with {data:s}. Old data was {old:s}".format(jid=jid, path=res.key, data=res.value, old=res._prev_node.value))
 
     # If we failed here, it's okay because the lock won't get written so this
     # essentially means the job will get scheduled for deletion.
     except Exception as E:
         log.trace("sdstack_etcd returner <save_load> unable to store load for job {jid:s} to the path {path:s} due to exception ({exception}) being raised".format(jid=jid, path=loadp, exception=E))
         return
+
+    # Check if the previous node value and the current node value are different
+    # so we can let the user know that something changed and that some data
+    # might've been lost.
+    try:
+        if not res.newKey:
+            d1, d2 = salt.utils.json.loads(res.value), salt.utils.json.loads(res._prev_node.value)
+            j1, j2 = salt.utils.json.dumps(res.value, sort_keys=True), salt.utils.json.dumps(res._prev_node.value, sort_keys=True)
+            if j1 != j2:
+                log.warning("sdstack_etcd returner <save_load> overwrote the load data for job {jid:s} at {path:s} with {data:s}. Old data was {old:s}".format(jid=jid, path=res.key, data=d1, old=d2))
+    except Exception as E:
+        log.debug("sdstack_etcd returner <save_load> unable to compare load data for job {jid:s} at {path:s} due to exception ({exception}) being raised".format(jid=jid, path=loadp, exception=E))
+        if not res.newKey:
+            log.trace("sdstack_etcd returner <save_load> -- old load data for job {jid:s}: {data:s}".format(jid=jid, data=res._prev_node.value))
+        log.trace("sdstack_etcd returner <save_load> -- new load data for job {jid:s}: {data:s}".format(jid=jid, data=res.value))
 
     # Since this is when a job is being created, create a lock that we can
     # check to see if the job has expired. This allows a user to signal to

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -180,12 +180,11 @@ def returner(ret):
     write_profile = __opts__.get('etcd.returner_write_profile')
     client, path, ttl = _get_conn(__opts__, write_profile)
 
-    # If a minion is returning a standalone job, update it with a new jid, and
-    # save it to ensure it can be queried similar to the mysql returner.
+    # If a minion is returning a standalone job, make sure to save the load as
+    # it's likely there's no load saved since this job came directly from a
+    # minion.
     if ret['jid'] == 'req':
-        jid = prep_jid(nocache=ret.get('nocache', False))
-        log.debug('sdstack_etcd returner <returner> satisfying request for new job id request with {jid:s}'.format(jid=jid))
-        ret['jid'] = jid
+        log.debug('sdstack_etcd returner <returner> received a new job id request ({jid:s}) for {data}'.format(jid=jid, data=ret))
         save_load(jid, ret)
 
     # Update the given minion in the external job cache with the current (latest job)

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -250,7 +250,7 @@ def save_load(jid, load, minions=None):
     # If we failed here, it's okay because the lock won't get written so this
     # will get scheduled for deletion.
     except Exception as E:
-        log.trace("sdstack_etcd returner <save_load> unable to store load for job {jid:s} to the path {path:s} due to exception ({exception}) being raised".format(jid=jid, path=loadp, exception=E)
+        log.trace("sdstack_etcd returner <save_load> unable to store load for job {jid:s} to the path {path:s} due to exception ({exception}) being raised".format(jid=jid, path=loadp, exception=E))
         return
 
     # Since this is when a job is being created, create a lock that we can
@@ -264,7 +264,7 @@ def save_load(jid, load, minions=None):
             log.trace('sdstack_etcd returner <save_load> job {jid:s} at {path:s} will expire in {ttl:d} seconds'.format(jid=jid, path=res.key, ttl=res.ttl))
 
     except Exception as E:
-        log.trace("sdstack_etcd returner <save_load> unable to write lock for job {jid:s} to the path {path:s} due to exception ({exception}) being raised".format(jid=jid, path=lockp, exception=E)
+        log.trace("sdstack_etcd returner <save_load> unable to write lock for job {jid:s} to the path {path:s} due to exception ({exception}) being raised".format(jid=jid, path=lockp, exception=E))
 
     return
 

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -38,7 +38,7 @@ Once the etcd options are configured, the returner may be used:
 
 CLI Example:
 
-    salt '*' test.ping --return etcd
+    salt "*" test.ping --return etcd
 
 A username and password can be set:
 
@@ -102,7 +102,7 @@ of the key containing the event package. Underneath each event, there are
 three sub-keys. These are the "index" key, the "tag" key, and the "lock" key.
 
 The "index" key contains the modifiedIndex of the package that was stored under
-the event key. This is used to determine the original creator for the event's
+the event key. This is used to determine the original creator for the event"s
 package and is used to keep track of whether the package for the event has
 been modified by another event (since event tags can be overwritten preserving
 the semantics of the original etcd returner).
@@ -130,23 +130,25 @@ import time
 import salt.utils.jid
 import salt.utils.json
 from salt.ext.six.moves import range
+
 try:
     import salt.utils.etcd_util
     from salt.utils.etcd_util import etcd
     HAS_LIBS = True
+
 except ImportError:
     HAS_LIBS = False
 
 log = logging.getLogger(__name__)
 
 Schema = {
-    "minion-fun": 'minion.job',
-    "package-path": 'event',
-    "event-cache": 'event.cache',
-    "job-cache": 'job',
+    "minion-fun": "minion.job",
+    "package-path": "event",
+    "event-cache": "event.cache",
+    "job-cache": "job",
 }
 
-# Define the module's virtual name
+# Define the module"s virtual name
 __virtualname__ = "etcd"
 
 
@@ -161,21 +163,21 @@ def __virtual__():
 
 
 def _get_conn(opts, profile=None):
-    '''
+    """
     Establish a connection to an etcd profile.
-    '''
+    """
     if profile is None:
-        profile = opts.get('etcd.returner')
+        profile = opts.get("etcd.returner")
 
     # Grab the returner_root from the options
-    path = opts.get('etcd.returner_root', '/salt/return')
+    path = opts.get("etcd.returner_root", "/salt/return")
 
     # Calculate the time-to-live for a job while giving etcd.ttl priority.
     # The etcd.ttl option specifies the number of seconds, whereas the keep_jobs
     # option specifies the number of hours. If any of these values are zero,
     # then jobs are forever persistent.
 
-    ttl = opts.get('etcd.ttl', int(opts.get('keep_jobs', 0)) * 60 * 60)
+    ttl = opts.get("etcd.ttl", int(opts.get("keep_jobs", 0)) * 60 * 60)
 
     # Grab a connection using etcd_util, and then return the EtcdClient
     # from one of its attributes
@@ -184,344 +186,563 @@ def _get_conn(opts, profile=None):
 
 
 def returner(ret):
-    '''
+    """
     Return data to an etcd profile.
-    '''
-    write_profile = __opts__.get('etcd.returner_write_profile')
+    """
+    write_profile = __opts__.get("etcd.returner_write_profile")
     client, path, ttl = _get_conn(__opts__, write_profile)
 
     # If a minion is returning a standalone job, update the jid for the load
-    # when it's saved since this job came directly from a minion.
-    if ret['jid'] == 'req':
-        new_jid = prep_jid(nocache=ret.get('nocache', False))
-        log.debug('sdstack_etcd returner <returner> satisfying a new job id request ({jid:s}) with id {new:s} for {data}'.format(jid=ret['jid'], new=new_jid, data=ret))
-        ret['jid'] = new_jid
+    # when it"s saved since this job came directly from a minion.
+    if ret["jid"] == "req":
+        new_jid = prep_jid(nocache=ret.get("nocache", False))
+        log.debug(
+            "sdstack_etcd returner <returner> satisfying a new job id request ({jid:s}) with id {new:s} for {data}".format(
+                jid=ret["jid"], new=new_jid, data=ret
+            )
+        )
+        ret["jid"] = new_jid
         save_load(new_jid, ret)
 
     # Update the given minion in the external job cache with the current (latest job)
     # This is used by get_fun() to return the last function that was called
-    minionp = '/'.join([path, Schema['minion-fun'], ret['id']])
+    minionp = "/".join([path, Schema["minion-fun"], ret["id"]])
 
     # We can use the ttl here because our minionp is actually linked to the job
     # which will expire according to the ttl anyways..
-    log.debug("sdstack_etcd returner <returner> updating (last) job id of {minion:s} at {path:s} with job {jid:s}".format(jid=ret['jid'], minion=ret['id'], path=minionp))
-    res = client.write(minionp, ret['jid'], ttl=ttl if ttl > 0 else None)
+    log.debug(
+        "sdstack_etcd returner <returner> updating (last) job id of {minion:s} at {path:s} with job {jid:s}".format(
+            jid=ret["jid"], minion=ret["id"], path=minionp
+        )
+    )
+    res = client.write(minionp, ret["jid"], ttl=ttl if ttl > 0 else None)
     if not res.newKey:
-        log.debug("sdstack_etcd returner <returner> the previous job id {old:s} for {minion:s} at {path:s} was set to {new:s}".format(old=res._prev_node.value, minion=ret['id'], path=minionp, new=res.value))
+        log.debug(
+            "sdstack_etcd returner <returner> the previous job id {old:s} for {minion:s} at {path:s} was set to {new:s}".format(
+                old=res._prev_node.value, minion=ret["id"], path=minionp, new=res.value
+            )
+        )
 
     # Figure out the path for the specified job and minion
-    jobp = '/'.join([path, Schema['job-cache'], ret['jid'], ret['id']])
-    log.debug("sdstack_etcd returner <returner> writing job data for {jid:s} to {path:s} with {data}".format(jid=ret['jid'], path=jobp, data=ret))
+    jobp = "/".join([path, Schema["job-cache"], ret["jid"], ret["id"]])
+    log.debug(
+        "sdstack_etcd returner <returner> writing job data for {jid:s} to {path:s} with {data}".format(
+            jid=ret["jid"], path=jobp, data=ret
+        )
+    )
 
     # Iterate through all the fields in the return dict and dump them under the
     # jobs/$jid/id/$field key. We aggregate all the exceptions so that if an
     # error happens, the rest of the fields will still be written.
     exceptions = []
     for field in ret:
-        fieldp = '/'.join([jobp, field])
+        fieldp = "/".join([jobp, field])
         data = salt.utils.json.dumps(ret[field])
         try:
             res = client.write(fieldp, data)
         except Exception as E:  # pylint: disable=broad-except
-            log.trace("sdstack_etcd returner <returner> unable to set field {field:s} for job {jid:s} at {path:s} to {result} due to exception ({exception})".format(field=field, jid=ret['jid'], path=fieldp, result=ret[field], exception=E))
+            log.trace(
+                "sdstack_etcd returner <returner> unable to set field {field:s} for job {jid:s} at {path:s} to {result} due to exception ({exception})".format(
+                    field=field,
+                    jid=ret["jid"],
+                    path=fieldp,
+                    result=ret[field],
+                    exception=E,
+                )
+            )
             exceptions.append((E, field, ret[field]))
             continue
-        log.trace("sdstack_etcd returner <returner> set field {field:s} for job {jid:s} at {path:s} to {result}".format(field=field, jid=ret['jid'], path=res.key, result=ret[field]))
+        log.trace(
+            "sdstack_etcd returner <returner> set field {field:s} for job {jid:s} at {path:s} to {result}".format(
+                field=field, jid=ret["jid"], path=res.key, result=ret[field]
+            )
+        )
 
     # Go back through all the exceptions that occurred while trying to write the
     # fields and log them.
     for E, field, value in exceptions:
-        log.exception("sdstack_etcd returner <returner> exception ({exception}) was raised while trying to set the field {field:s} for job {jid:s} to {value}".format(exception=E, field=field, jid=ret['jid'], value=value))
+        log.exception(
+            "sdstack_etcd returner <returner> exception ({exception}) was raised while trying to set the field {field:s} for job {jid:s} to {value}".format(
+                exception=E, field=field, jid=ret["jid"], value=value
+            )
+        )
     return
 
 
 def save_load(jid, load, minions=None):
-    '''
+    """
     Save the load to the specified jid.
-    '''
-    write_profile = __opts__.get('etcd.returner_write_profile')
+    """
+    write_profile = __opts__.get("etcd.returner_write_profile")
     client, path, ttl = _get_conn(__opts__, write_profile)
 
-    # Check if the specified jid is 'req', as only incorrect code will do this
-    if jid == 'req':
-        log.debug('sdstack_etcd returner <save_load> was called using a request job id ({jid:s}) with {data}'.format(jid=jid, data=load))
+    # Check if the specified jid is "req", as only incorrect code will do this
+    if jid == "req":
+        log.debug(
+            "sdstack_etcd returner <save_load> was called using a request job id ({jid:s}) with {data}".format(
+                jid=jid, data=load
+            )
+        )
 
-    # Build the paths that we'll use for registration of our job
-    loadp = '/'.join([path, Schema['job-cache'], jid, '.load.p'])
-    lockp = '/'.join([path, Schema['job-cache'], jid, '.lock.p'])
+    # Build the paths that we"ll use for registration of our job
+    loadp = "/".join([path, Schema["job-cache"], jid, ".load.p"])
+    lockp = "/".join([path, Schema["job-cache"], jid, ".lock.p"])
 
     ## Now we can just store the current load
     json = salt.utils.json.dumps(load)
 
-    log.debug('sdstack_etcd returner <save_load> storing load data for job {jid:s} to {path:s} with {data}'.format(jid=jid, path=loadp, data=load))
+    log.debug(
+        "sdstack_etcd returner <save_load> storing load data for job {jid:s} to {path:s} with {data}".format(
+            jid=jid, path=loadp, data=load
+        )
+    )
     try:
         res = client.write(loadp, json, prevExist=False)
 
     # If the key already exists, then warn the user and update the key. There
-    # isn't anything we can really do about this because it's up to Salt really.
+    # isn"t anything we can really do about this because it"s up to Salt really.
     except etcd.EtcdAlreadyExist as E:
         node = client.read(loadp)
         node.value = json
 
-        log.debug('sdstack_etcd returner <save_load> updating load data for job {jid:s} at {path:s} with {data}'.format(jid=jid, path=loadp, data=load))
+        log.debug(
+            "sdstack_etcd returner <save_load> updating load data for job {jid:s} at {path:s} with {data}".format(
+                jid=jid, path=loadp, data=load
+            )
+        )
         res = client.update(node)
 
-    # If we failed here, it's okay because the lock won't get written so this
+    # If we failed here, it"s okay because the lock won"t get written so this
     # essentially means the job will get scheduled for deletion.
     except Exception as E:  # pylint: disable=broad-except
-        log.trace("sdstack_etcd returner <save_load> unable to store load for job {jid:s} to the path {path:s} due to exception ({exception}) being raised".format(jid=jid, path=loadp, exception=E))
+        log.trace(
+            "sdstack_etcd returner <save_load> unable to store load for job {jid:s} to the path {path:s} due to exception ({exception}) being raised".format(
+                jid=jid, path=loadp, exception=E
+            )
+        )
         return
 
     # Check if the previous node value and the current node value are different
     # so we can let the user know that something changed and that some data
-    # might've been lost.
+    # might"ve been lost.
     try:
         if not res.newKey:
-            d1, d2 = salt.utils.json.loads(res.value), salt.utils.json.loads(res._prev_node.value)
-            j1, j2 = salt.utils.json.dumps(res.value, sort_keys=True), salt.utils.json.dumps(res._prev_node.value, sort_keys=True)
+            d1, d2 = (
+                salt.utils.json.loads(res.value),
+                salt.utils.json.loads(res._prev_node.value),
+            )
+            j1, j2 = (
+                salt.utils.json.dumps(res.value, sort_keys=True),
+                salt.utils.json.dumps(res._prev_node.value, sort_keys=True),
+            )
             if j1 != j2:
-                log.warning("sdstack_etcd returner <save_load> overwrote the load data for job {jid:s} at {path:s} with {data}. Old data was {old}".format(jid=jid, path=res.key, data=d1, old=d2))
+                log.warning(
+                    "sdstack_etcd returner <save_load> overwrote the load data for job {jid:s} at {path:s} with {data}. Old data was {old}".format(
+                        jid=jid, path=res.key, data=d1, old=d2
+                    )
+                )
     except Exception as E:  # pylint: disable=broad-except
-        log.debug("sdstack_etcd returner <save_load> unable to compare load data for job {jid:s} at {path:s} due to exception ({exception}) being raised".format(jid=jid, path=loadp, exception=E))
+        log.debug(
+            "sdstack_etcd returner <save_load> unable to compare load data for job {jid:s} at {path:s} due to exception ({exception}) being raised".format(
+                jid=jid, path=loadp, exception=E
+            )
+        )
         if not res.newKey:
-            log.trace("sdstack_etcd returner <save_load> -- old load data for job {jid:s}: {data}".format(jid=jid, data=res._prev_node.value))
-        log.trace("sdstack_etcd returner <save_load> -- new load data for job {jid:s}: {data}".format(jid=jid, data=res.value))
+            log.trace(
+                "sdstack_etcd returner <save_load> -- old load data for job {jid:s}: {data}".format(
+                    jid=jid, data=res._prev_node.value
+                )
+            )
+        log.trace(
+            "sdstack_etcd returner <save_load> -- new load data for job {jid:s}: {data}".format(
+                jid=jid, data=res.value
+            )
+        )
 
     # Since this is when a job is being created, create a lock that we can
     # check to see if the job has expired. This allows a user to signal to
-    # salt that it's okay to remove the entire key by removing this lock.
-    log.trace('sdstack_etcd returner <save_load> writing lock file for job {jid:s} at {path:s} using index {index:d}'.format(jid=jid, path=lockp, index=res.modifiedIndex))
+    # salt that it"s okay to remove the entire key by removing this lock.
+    log.trace(
+        "sdstack_etcd returner <save_load> writing lock file for job {jid:s} at {path:s} using index {index:d}".format(
+            jid=jid, path=lockp, index=res.modifiedIndex
+        )
+    )
 
     try:
         res = client.write(lockp, res.modifiedIndex, ttl=ttl if ttl > 0 else None)
         if res.ttl is not None:
-            log.trace('sdstack_etcd returner <save_load> job {jid:s} at {path:s} will expire in {ttl:d} seconds'.format(jid=jid, path=res.key, ttl=res.ttl))
+            log.trace(
+                "sdstack_etcd returner <save_load> job {jid:s} at {path:s} will expire in {ttl:d} seconds".format(
+                    jid=jid, path=res.key, ttl=res.ttl
+                )
+            )
 
     except Exception as E:  # pylint: disable=broad-except
-        log.trace("sdstack_etcd returner <save_load> unable to write lock for job {jid:s} to the path {path:s} due to exception ({exception}) being raised".format(jid=jid, path=lockp, exception=E))
+        log.trace(
+            "sdstack_etcd returner <save_load> unable to write lock for job {jid:s} to the path {path:s} due to exception ({exception}) being raised".format(
+                jid=jid, path=lockp, exception=E
+            )
+        )
 
     return
 
 
 def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument
-    '''
+    """
     Save/update the minion list for a given jid. The syndic_id argument is
     included for API compatibility only.
-    '''
-    write_profile = __opts__.get('etcd.returner_write_profile')
+    """
+    write_profile = __opts__.get("etcd.returner_write_profile")
     client, path, _ = _get_conn(__opts__, write_profile)
 
-    # Check if the specified jid is 'req', as only incorrect code will do that
-    if jid == 'req':
-        log.debug('sdstack_etcd returner <save_minions> was called with a request job id ({jid:s}) for minions {minions:s}'.format(jid=jid, minions=repr(minions)))
+    # Check if the specified jid is "req", as only incorrect code will do that
+    if jid == "req":
+        log.debug(
+            "sdstack_etcd returner <save_minions> was called with a request job id ({jid:s}) for minions {minions:s}".format(
+                jid=jid, minions=repr(minions)
+            )
+        )
 
     # Figure out the path that our job should be at
-    jobp = '/'.join([path, Schema['job-cache'], jid])
-    loadp = '/'.join([jobp, '.load.p'])
+    jobp = "/".join([path, Schema["job-cache"], jid])
+    loadp = "/".join([jobp, ".load.p"])
 
     # Now we can try and read the load out of it.
     try:
         load = client.read(loadp)
 
-    # If it doesn't exist, then bitch and complain because somebody lied to us
+    # If it doesn"t exist, then bitch and complain because somebody lied to us
     except etcd.EtcdKeyNotFound as E:
-        log.error('sdstack_etcd returner <save_minions> was called with an invalid job id ({jid:s}) for minions {minions:s}'.format(jid=jid, minions=repr(minions)))
+        log.error(
+            "sdstack_etcd returner <save_minions> was called with an invalid job id ({jid:s}) for minions {minions:s}".format(
+                jid=jid, minions=repr(minions)
+            )
+        )
         return
 
-    log.debug('sdstack_etcd returner <save_minions> adding minions{syndics:s} for job {jid:s} to {path:s}'.format(jid=jid, path=jobp, syndics='' if syndic_id is None else ' from syndic {0}'.format(syndic_id)))
+    log.debug(
+        "sdstack_etcd returner <save_minions> adding minions {syndics:s} for job {jid:s} to {path:s}".format(
+            jid=jid,
+            path=jobp,
+            syndics="" if syndic_id is None else " from syndic {0}".format(syndic_id),
+        )
+    )
 
     # Iterate through all of the minions we received and update both the job
     # and minion-fun cache with what we know. Most of the other returners
-    # don't do this, but it is definitely being called and is necessary for
+    # don"t do this, but it is definitely being called and is necessary for
     # syndics to actually work.
     exceptions = []
     for minion in minions:
-        minionp = '/'.join([path, Schema['minion-fun'], minion])
+        minionp = "/".join([path, Schema["minion-fun"], minion])
 
-        # Go ahead and write the job to the minion-fun cache and log if we've
+        # Go ahead and write the job to the minion-fun cache and log if we"ve
         # overwritten an already existing job id.
-        log.debug('sdstack_etcd returner <save_minions> writing (last) job id of {minion:s}{syndics:s} at {path:s} with job {jid:s}'.format(jid=jid, path=minionp, minion=minion, syndics='' if syndic_id is None else ' from syndic {0}'.format(syndic_id)))
+        log.debug(
+            "sdstack_etcd returner <save_minions> writing (last) job id of {minion:s}{syndics:s} at {path:s} with job {jid:s}".format(
+                jid=jid,
+                path=minionp,
+                minion=minion,
+                syndics="" if syndic_id is None
+                else " from syndic {0}".format(syndic_id),
+            )
+        )
         try:
             client.write(minionp, jid, ttl=load.ttl, prevExist=False)
 
-        # If the minion already exists, then that's fine as we'll just update it
+        # If the minion already exists, then that"s fine as we"ll just update it
         # and move on.
         except etcd.EtcdAlreadyExist as E:
             node = client.read(minionp)
 
-            log.debug('sdstack_etcd returner <save_minions> updating previous job id ({old:s}) of {minion:s}{syndics:s} at {path:s} with job {jid:s}'.format(old=node.value, minion=minion, jid=jid, path=node.key, syndics='' if syndic_id is None else ' from syndic {0}'.format(syndic_id)))
+            log.debug(
+                "sdstack_etcd returner <save_minions> updating previous job id ({old:s}) of {minion:s}{syndics:s} at {path:s} with job {jid:s}".format(
+                    old=node.value,
+                    minion=minion,
+                    jid=jid,
+                    path=node.key,
+                    syndics="" if syndic_id is None
+                    else " from syndic {0}".format(syndic_id),
+                )
+            )
 
             node.value = jid
             client.update(node)
 
         except Exception as E:  # pylint: disable=broad-except
-            log.trace("sdstack_etcd returner <save_minions> unable to write job id {jid:s} for minion {minion:s} to {path:s} due to exception ({exception})".format(jid=jid, minion=minion, path=minionp, exception=E))
-            exceptions.append((E, 'job', minion))
+            log.trace(
+                "sdstack_etcd returner <save_minions> unable to write job id {jid:s} for minion {minion:s} to {path:s} due to exception ({exception})".format(
+                    jid=jid, minion=minion, path=minionp, exception=E
+                )
+            )
+            exceptions.append((E, "job", minion))
 
-        # Now we can try and update the job. We don't have much, just the jid,
+        # Now we can try and update the job. We don"t have much, just the jid,
         # the minion, and the master id (syndic_id)
-        resultp = '/'.join([jobp, minion])
+        resultp = "/".join([jobp, minion])
 
         # One... (jid)
         try:
-            res = client.write('/'.join([resultp, 'jid']), jid)
+            res = client.write("/".join([resultp, "jid"]), jid)
 
         except Exception as E:  # pylint: disable=broad-except
-            log.trace("sdstack_etcd returner <save_minions> unable to write job id {jid:s} to the result for the minion {minion:s} at {path:s} due to exception ({exception})".format(jid=jid, minion=minion, path='/'.join([resultp, 'jid']), exception=E))
-            exceptions.append((E, 'result.jid', minion))
+            log.trace(
+                "sdstack_etcd returner <save_minions> unable to write job id {jid:s} to the result for the minion {minion:s} at {path:s} due to exception ({exception})".format(
+                    jid=jid, minion=minion, path="/".join([resultp, "jid"]), exception=E
+                )
+            )
+            exceptions.append((E, "result.jid", minion))
 
         # Two... (id)
         try:
-            res = client.write('/'.join([resultp, 'id']), minion)
+            res = client.write("/".join([resultp, "id"]), minion)
 
         except Exception as E:  # pylint: disable=broad-except
-            log.trace("sdstack_etcd returner <save_minions> unable to write minion id {minion:s} to the result for job {jid:s} at {path:s} due to exception ({exception})".format(jid=jid, minion=minion, path='/'.join([resultp, 'id']), exception=E))
-            exceptions.append((E, 'result.id', minion))
+            log.trace(
+                "sdstack_etcd returner <save_minions> unable to write minion id {minion:s} to the result for job {jid:s} at {path:s} due to exception ({exception})".format(
+                    jid=jid, minion=minion, path="/".join([resultp, "id"]), exception=E
+                )
+            )
+            exceptions.append((E, "result.id", minion))
 
         # Three... (master_id)
         try:
             if syndic_id is not None:
-                res = client.write('/'.join([resultp, 'master_id']), syndic_id)
+                res = client.write("/".join([resultp, "master_id"]), syndic_id)
 
         except Exception as E:  # pylint: disable=broad-except
-            log.trace("sdstack_etcd returner <save_minions> unable to write master_id {syndic:s} to the result for job {jid:s} at {path:s} due to exception ({exception})".format(jid=jid, path='/'.join([resultp, 'master_id']), syndic=syndic_id, exception=E))
-            exceptions.append((E, 'result.master_id', minion))
+            log.trace(
+                "sdstack_etcd returner <save_minions> unable to write master_id {syndic:s} to the result for job {jid:s} at {path:s} due to exception ({exception})".format(
+                    jid=jid,
+                    path="/".join([resultp, "master_id"]),
+                    syndic=syndic_id,
+                    exception=E,
+                )
+            )
+            exceptions.append((E, "result.master_id", minion))
 
         # Crruuunch.
 
     # Go back through all the exceptions that occurred while trying to write the
     # fields and log them.
     for E, field, minion in exceptions:
-        if field == 'job':
-            log.exception("sdstack_etcd returner <save_minions> exception ({exception}) was raised while trying to update the function cache for minion {minion:s} to job {jid:s}".format(exception=E, minion=minion, jid=jid))
+        if field == "job":
+            log.exception(
+                "sdstack_etcd returner <save_minions> exception ({exception}) was raised while trying to update the function cache for minion {minion:s} to job {jid:s}".format(
+                    exception=E, minion=minion, jid=jid
+                )
+            )
             continue
-        log.exception("sdstack_etcd returner <save_minions> exception ({exception}) was raised while trying to update the {field:s} field in the result for job {jid:s} belonging to minion {minion:s}".format(exception=E, field=field, minion=minion, jid=jid))
+        log.exception(
+            "sdstack_etcd returner <save_minions> exception ({exception}) was raised while trying to update the {field:s} field in the result for job {jid:s} belonging to minion {minion:s}".format(
+                exception=E, field=field, minion=minion, jid=jid
+            )
+        )
     return
 
 
 def _purge_jobs():
-    write_profile = __opts__.get('etcd.returner_write_profile')
+    write_profile = __opts__.get("etcd.returner_write_profile")
     client, path, _ = _get_conn(__opts__, write_profile)
 
     # Figure out the path that our jobs should exist at
-    jobp = '/'.join([path, Schema['job-cache']])
+    jobp = "/".join([path, Schema["job-cache"]])
 
     # Try and read the job directory. If we have a missing key exception then no
     # minions have returned anything yet and so we can simply leave.
-    log.trace('sdstack_etcd returner <_purge_jobs> reading jobs at {path:s}'.format(path=jobp))
+    log.trace(
+        "sdstack_etcd returner <_purge_jobs> reading jobs at {path:s}".format(path=jobp)
+    )
     try:
         jobs = client.read(jobp)
     except etcd.EtcdKeyNotFound as E:
-        log.debug('sdstack_etcd returner <_purge_jobs> no jobs were found at {path:s}'.format(path=jobp))
+        log.debug("sdstack_etcd returner <_purge_jobs> no jobs were found at {path:s}".format(path=jobp))
         return 0
 
     # Iterate through all of the children at our job path while looking for
-    # the .lock.p key. If one isn't found, then we can remove this job because
+    # the .lock.p key. If one isn"t found, then we can remove this job because
     # it has expired.
     count = 0
     for job in jobs.leaves:
         if not job.dir:
-            log.warning('sdstack_etcd returner <_purge_jobs> found a non-job at {path:s} {expire:s}'.format(path=job.key, expire='that will need to be manually removed' if job.ttl is None else 'that will expire in {ttl:d} seconds'.format(ttl=job.ttl)))
+            log.warning(
+                "sdstack_etcd returner <_purge_jobs> found a non-job at {path:s} {expire:s}".format(
+                    path=job.key,
+                    expire="that will need to be manually removed"
+                    if job.ttl is None
+                    else "that will expire in {ttl:d} seconds".format(ttl=job.ttl),
+                )
+            )
             continue
-        jid = job.key.split('/')[-1]
+        jid = job.key.split("/")[-1]
 
-        # Build our lock path that we'll use to see if the job is alive
-        lockp = '/'.join([job.key, '.lock.p'])
+        # Build our lock path that we"ll use to see if the job is alive
+        lockp = "/".join([job.key, ".lock.p"])
 
-        # Ping it to see if it's alive
-        log.trace('sdstack_etcd returner <_purge_jobs> checking lock for job {jid:s} at {path:s}'.format(jid=jid, path=lockp))
+        # Ping it to see if it"s alive
+        log.trace(
+            "sdstack_etcd returner <_purge_jobs> checking lock for job {jid:s} at {path:s}".format(
+                jid=jid, path=lockp
+            )
+        )
         try:
             res = client.read(lockp)
 
-            log.debug('sdstack_etcd returner <_purge_jobs> job {jid:s} at {path:s} is still alive and {expire:s}'.format(jid=jid, path=res.key, expire='will need to be manually removed' if res.ttl is None else 'will expire in {ttl:d} seconds'.format(ttl=res.ttl)))
+            log.debug(
+                "sdstack_etcd returner <_purge_jobs> job {jid:s} at {path:s} is still alive and {expire:s}".format(
+                    jid=jid,
+                    path=res.key,
+                    expire="will need to be manually removed"
+                    if res.ttl is None
+                    else "will expire in {ttl:d} seconds".format(ttl=res.ttl),
+                )
+            )
 
-        # It's not, so the job is dead and we can remove it
+        # It"s not, so the job is dead and we can remove it
         except etcd.EtcdKeyNotFound as E:
-            log.debug('sdstack_etcd returner <_purge_jobs> job {jid:s} at {path:s} has expired'.format(jid=jid, path=lockp))
+            log.debug(
+                "sdstack_etcd returner <_purge_jobs> job {jid:s} at {path:s} has expired".format(
+                    jid=jid, path=lockp
+                )
+            )
 
             res = client.delete(job.key, recursive=True)
             count += 1
         continue
-    log.trace('sdstack_etcd returner <_purge_jobs> purged {count:d} jobs'.format(count=count))
+    log.trace(
+        "sdstack_etcd returner <_purge_jobs> purged {count:d} jobs".format(count=count)
+    )
     return count
 
 
 def _purge_events():
-    write_profile = __opts__.get('etcd.returner_write_profile')
+    write_profile = __opts__.get("etcd.returner_write_profile")
     client, path, _ = _get_conn(__opts__, write_profile)
 
     # Figure out the path that our event cache should exist at
-    cachep = '/'.join([path, Schema['event-cache']])
+    cachep = "/".join([path, Schema["event-cache"]])
 
     # Try and read the event cache directory. If we have a missing key exception then no
     # events have been cached and so we can simply leave.
-    log.trace('sdstack_etcd returner <_purge_events> reading event cache at {path:s}'.format(path=cachep))
+    log.trace(
+        "sdstack_etcd returner <_purge_events> reading event cache at {path:s}".format(path=cachep)
+    )
     try:
         cache = client.read(cachep)
     except etcd.EtcdKeyNotFound as E:
         return 0
 
     # Iterate through all of the children at our cache path while looking for
-    # the id key. If one isn't found, then we can remove this event because
+    # the id key. If one isn"t found, then we can remove this event because
     # it has expired.
     count = 0
     for ev in cache.leaves:
         if not ev.dir:
-            log.warning('sdstack_etcd returner <_purge_events> found a non-event at {path:s} {expire:s}'.format(path=ev.key, expire='that will need to be manually removed' if ev.ttl is None else 'that will expire in {ttl:d} seconds'.format(ttl=ev.ttl)))
+            log.warning(
+                "sdstack_etcd returner <_purge_events> found a non-event at {path:s} {expire:s}".format(
+                    path=ev.key,
+                    expire="that will need to be manually removed"
+                    if ev.ttl is None
+                    else "that will expire in {ttl:d} seconds".format(ttl=ev.ttl),
+                )
+            )
             continue
 
         # Figure out the event id from the key path
         try:
-            event = int(ev.key.split('/')[-1])
+            event = int(ev.key.split("/")[-1])
         except ValueError:
-            log.warning('sdstack_etcd returner <_purge_events> found an incorrectly structured event at {path:s} {expire:s}'.format(path=ev.key, expire='that will need to be manually removed' if ev.ttl is None else 'that will expire in {ttl:d} seconds'.format(ttl=ev.ttl)))
+            log.warning(
+                "sdstack_etcd returner <_purge_events> found an incorrectly structured event at {path:s} {expire:s}".format(
+                    path=ev.key,
+                    expire="that will need to be manually removed"
+                    if ev.ttl is None
+                    else "that will expire in {ttl:d} seconds".format(ttl=ev.ttl),
+                )
+            )
             continue
 
-        # Build all of the event paths that we're going to use
-        ev_lockp = '/'.join([ev.key, 'lock'])
-        ev_indexp = '/'.join([ev.key, 'index'])
-        ev_tagp = '/'.join([ev.key, 'tag'])
+        # Build all of the event paths that we"re going to use
+        ev_lockp = "/".join([ev.key, "lock"])
+        ev_indexp = "/".join([ev.key, "index"])
+        ev_tagp = "/".join([ev.key, "tag"])
 
-        # Ping the event lock to see if it's actually alive
+        # Ping the event lock to see if it"s actually alive
         try:
             ev_lock = client.read(ev_lockp)
 
-            log.debug('sdstack_etcd returner <_purge_events> event {event:d} at {path:s} is still alive and {expire:s}'.format(event=event, path=ev.key, expire='will need to be manually removed' if ev_lock.ttl is None else 'will expire in {ttl:d} seconds'.format(ttl=ev_lock.ttl)))
+            log.debug(
+                "sdstack_etcd returner <_purge_events> event {event:d} at {path:s} is still alive and {expire:s}".format(
+                    event=event,
+                    path=ev.key,
+                    expire="will need to be manually removed"
+                    if ev_lock.ttl is None
+                    else "will expire in {ttl:d} seconds".format(ttl=ev_lock.ttl),
+                )
+            )
             continue
 
         except etcd.EtcdKeyNotFound as E:
-            log.debug('sdstack_etcd returner <_purge_events> event {event:d} at {path:s} has expired and will be removed'.format(event=event, path=ev.key))
+            log.debug(
+                "sdstack_etcd returner <_purge_events> event {event:d} at {path:s} has expired and will be removed".format(
+                    event=event, path=ev.key
+                )
+            )
 
         # Now that we know the event is dead, we can read the index so that
         # we can check it against the actual event later.
-        log.trace('sdstack_etcd returner <_purge_events> reading modifiedIndex for event {event:d} at {path:s}'.format(event=event, path=ev_indexp))
+        log.trace(
+            "sdstack_etcd returner <_purge_events> reading modifiedIndex for event {event:d} at {path:s}".format(
+                event=event, path=ev_indexp
+            )
+        )
         try:
             ev_index = client.read(ev_indexp)
 
-        # If we can't find the index here, then we just remove the event because
+        # If we can"t find the index here, then we just remove the event because
         # we have no way to detect whether the event tag actually belongs to us.
-        # So in this case, we're done.
+        # So in this case, we"re done.
         except etcd.EtcdKeyNotFound as E:
-            log.warning('sdstack_etcd returner <_purge_events> event {event:d} at {path:s} is corrupt (missing id) and will be removed'.format(event=event, path=ev.key))
+            log.warning(
+                "sdstack_etcd returner <_purge_events> event {event:d} at {path:s} is corrupt (missing id) and will be removed".format(
+                    event=event, path=ev.key
+                )
+            )
 
-            log.debug('sdstack_etcd returner <_purge_events> removing corrupt event {event:d} at {path:s}'.format(event=event, path=ev.key))
+            log.debug(
+                "sdstack_etcd returner <_purge_events> removing corrupt event {event:d} at {path:s}".format(
+                    event=event, path=ev.key
+                )
+            )
             res = client.delete(ev.key, recursive=True)
 
             count += 1
             continue
 
-        # Now we grab the tag because this is what we'll check the ev_index against
-        log.trace('sdstack_etcd returner <_purge_events> reading tag for event {event:d} at {path:s}'.format(event=event, path=ev_tagp))
+        # Now we grab the tag because this is what we"ll check the ev_index against
+        log.trace(
+            "sdstack_etcd returner <_purge_events> reading tag for event {event:d} at {path:s}".format(
+                event=event, path=ev_tagp
+            )
+        )
         try:
             ev_tag = client.read(ev_tagp)
 
-        # If the tag key doesn't exist, then the current entry in our cache doesn't
-        # even matter because we can't do anything without a tag. So similar to
+        # If the tag key doesn"t exist, then the current entry in our cache doesn"t
+        # even matter because we can"t do anything without a tag. So similar to
         # before, we just remove it and cycle to the next event.
         except etcd.EtcdKeyNotFound as E:
-            log.warning('sdstack_etcd returner <_purge_events> event {event:d} at {path:s} is corrupt (missing tag) and will be removed'.format(event=event, path=ev.key))
+            log.warning(
+                "sdstack_etcd returner <_purge_events> event {event:d} at {path:s} is corrupt (missing tag) and will be removed".format(
+                    event=event, path=ev.key
+                )
+            )
 
-            log.debug('sdstack_etcd returner <_purge_events> removing corrupt event {event:d} at {path:s}'.format(event=event, path=ev.key))
+            log.debug(
+                "sdstack_etcd returner <_purge_events> removing corrupt event {event:d} at {path:s}".format(
+                    event=event, path=ev.key
+                )
+            )
             client.delete(ev.key, recursive=True)
 
             count += 1
@@ -531,42 +752,70 @@ def _purge_events():
         ## current event is the owner), and then we can remove the cache entry.
 
         # Remove the package associated with the current event index
-        log.trace('sdstack_etcd returner <_purge_events> removing package for event {event:d} at {path:s}'.format(event=event, path=ev_tag.value))
-        packagep = ev_tag.value.split('/')
+        log.trace(
+            "sdstack_etcd returner <_purge_events> removing package for event {event:d} at {path:s}".format(
+                event=event, path=ev_tag.value
+            )
+        )
+        packagep = ev_tag.value.split("/")
 
         # Try and remove the package path that was cached while checking that
-        # its modifiedIndex is what we expect. If it's not, then we know that
-        # we're not the only person that's using this event and so we don't
+        # its modifiedIndex is what we expect. If it"s not, then we know that
+        # we"re not the only person that"s using this event and so we don"t
         # need to delete it yet, because another event will do it eventually.
-        basep = [path, Schema['package-path']]
+        basep = [path, Schema["package-path"]]
         try:
-            res = client.delete('/'.join(basep + packagep), prevIndex=ev_index.value)
+            res = client.delete("/".join(basep + packagep), prevIndex=ev_index.value)
 
         # Our package is in use by someone else, so we can simply remove the cache
         # entry and then cycle to the next event.
         except etcd.EtcdCompareFailed as E:
-            log.debug('sdstack_etcd returner <_purge_events> refusing to remove package for event {event:d} at {path:s} as it is still in use'.format(event=event, path='/'.join(basep + packagep[:])))
+            log.debug(
+                "sdstack_etcd returner <_purge_events> refusing to remove package for event {event:d} at {path:s} as it is still in use".format(
+                    event=event, path="/".join(basep + packagep[:])
+                )
+            )
             count += 1
 
             # Remove the whole event cache entry
-            log.debug('sdstack_etcd returner <_purge_events> removing (duplicate) event {event:d} at {path:s}'.format(event=event, path=ev.key))
+            log.debug(
+                "sdstack_etcd returner <_purge_events> removing (duplicate) event {event:d} at {path:s}".format(
+                    event=event, path=ev.key
+                )
+            )
             res = client.delete(ev.key, recursive=True)
             continue
 
         # Walk through each component of the package path trying to remove them unless the directory is not empty
         packagep.pop(-1)
-        log.debug('sdstack_etcd returner <_purge_events> (recursively) removing parent keys for event {event:d} package at {path:s}'.format(event=event, path='/'.join(basep + packagep[:])))
+        log.debug(
+            "sdstack_etcd returner <_purge_events> (recursively) removing parent keys for event {event:d} package at {path:s}".format(
+                event=event, path="/".join(basep + packagep[:])
+            )
+        )
         for i in range(len(packagep), 0, -1):
-            log.trace('sdstack_etcd returner <_purge_events> removing directory for event {event:d} package at {path:s}'.format(event=event, path='/'.join(basep + packagep[:i])))
+            log.trace(
+                "sdstack_etcd returner <_purge_events> removing directory for event {event:d} package at {path:s}".format(
+                    event=event, path="/".join(basep + packagep[:i])
+                )
+            )
             try:
-                client.delete('/'.join(basep + packagep[:i]), dir=True)
+                client.delete("/".join(basep + packagep[:i]), dir=True)
             except etcd.EtcdDirNotEmpty as E:
-                log.debug('sdstack_etcd returner <_purge_events> Unable to remove directory for event {event:d} package at {path:s} due to other tags under it still being in use ({exception})'.format(path='/'.join(basep + packagep[:i]), event=event, exception=E))
+                log.debug(
+                    "sdstack_etcd returner <_purge_events> Unable to remove directory for event {event:d} package at {path:s} due to other tags under it still being in use ({exception})".format(
+                        path="/".join(basep + packagep[:i]), event=event, exception=E
+                    )
+                )
                 break
             continue
 
-        # Remove the whole event cache entry now that we've properly removed the package
-        log.debug('sdstack_etcd returner <_purge_events> removing event {event:d} at {path:s}'.format(event=event, path=ev.key))
+        # Remove the whole event cache entry now that we"ve properly removed the package
+        log.debug(
+            "sdstack_etcd returner <_purge_events> removing event {event:d} at {path:s}".format(
+                event=event, path=ev.key
+            )
+        )
         res = client.delete(ev.key, recursive=True)
 
         count += 1
@@ -575,73 +824,103 @@ def _purge_events():
 
 
 def clean_old_jobs():
-    '''
-    Called in the master's event loop every loop_interval. Removes any jobs,
+    """
+    Called in the master"s event loop every loop_interval. Removes any jobs,
     and returns that are older than the etcd.ttl option (seconds), or the
     keep_jobs option (hours).
 
     :return:
-    '''
+    """
 
-    # First we'll purge the jobs...
+    # First we"ll purge the jobs...
     jobc = _purge_jobs()
     if jobc > 0:
-        log.trace('sdstack_etcd returner <clean_old_jobs> successfully removed {count:d} jobs'.format(count=jobc))
+        log.trace(
+            "sdstack_etcd returner <clean_old_jobs> successfully removed {count:d} jobs".format(
+                count=jobc
+            )
+        )
 
-    # ...and then we'll purge the events
+    # ...and then we"ll purge the events
     eventsc = _purge_events()
     if eventsc > 0:
-        log.trace('sdstack_etcd returner <clean_old_jobs> successfully removed {count:d} events'.format(count=eventsc))
+        log.trace(
+            "sdstack_etcd returner <clean_old_jobs> successfully removed {count:d} events".format(
+                count=eventsc
+            )
+        )
 
     # Log that we hit a cleanup iteration
-    log.debug('sdstack_etcd returner <clean_old_jobs> completed purging jobs and events')
+    log.debug(
+        "sdstack_etcd returner <clean_old_jobs> completed purging jobs and events"
+    )
 
 
 def get_load(jid):
-    '''
+    """
     Return the load data that marks a specified jid.
-    '''
-    read_profile = __opts__.get('etcd.returner_read_profile')
+    """
+    read_profile = __opts__.get("etcd.returner_read_profile")
     client, path, _ = _get_conn(__opts__, read_profile)
 
     # Figure out the path that our job should be at
-    loadp = '/'.join([path, Schema['job-cache'], jid, '.load.p'])
+    loadp = "/".join([path, Schema["job-cache"], jid, ".load.p"])
 
-    # Read it. If EtcdKeyNotFound was raised then the key doesn't exist and so
-    # we need to return None, because that's what our caller expects on a
+    # Read it. If EtcdKeyNotFound was raised then the key doesn"t exist and so
+    # we need to return None, because that"s what our caller expects on a
     # non-existent job.
-    log.debug('sdstack_etcd returner <get_load> reading load data for job {jid:s} from {path:s}'.format(jid=jid, path=loadp))
+    log.debug(
+        "sdstack_etcd returner <get_load> reading load data for job {jid:s} from {path:s}".format(
+            jid=jid, path=loadp
+        )
+    )
     try:
         res = client.read(loadp)
     except etcd.EtcdKeyNotFound as E:
-        log.error("sdstack_etcd returner <get_load> could not find job {jid:s} at the path {path:s}".format(jid=jid, path=loadp))
+        log.error(
+            "sdstack_etcd returner <get_load> could not find job {jid:s} at the path {path:s}".format(
+                jid=jid, path=loadp
+            )
+        )
         return None
-    log.debug('sdstack_etcd returner <get_load> found load data for job {jid:s} at {path:s} with value {data}'.format(jid=jid, path=res.key, data=res.value))
+    log.debug("sdstack_etcd returner <get_load> found load data for job {jid:s} at {path:s} with value {data}".format(jid=jid, path=res.key, data=res.value))
     return salt.utils.json.loads(res.value)
 
 
 def get_jid(jid):
-    '''
+    """
     Return the information returned when the specified job id was executed.
-    '''
+    """
     client, path, _ = _get_conn(__opts__)
 
     # Figure out the path that our job should be at
-    resultsp = '/'.join([path, Schema['job-cache'], jid])
+    resultsp = "/".join([path, Schema["job-cache"], jid])
 
     # Try and read the job directory. If we have a missing key exception then no
     # minions have returned anything yet and so we return an empty dict for the
     # caller.
-    log.debug('sdstack_etcd returner <get_jid> reading minions that have returned results for job {jid:s} at {path:s}'.format(jid=jid, path=resultsp))
+    log.debug(
+        "sdstack_etcd returner <get_jid> reading minions that have returned results for job {jid:s} at {path:s}".format(
+            jid=jid, path=resultsp
+        )
+    )
     try:
         results = client.read(resultsp)
     except etcd.EtcdKeyNotFound as E:
-        log.trace('sdstack_etcd returner <get_jid> unable to read job {jid:s} from {path:s}'.format(jid=jid, path=resultsp))
+        log.trace(
+            "sdstack_etcd returner <get_jid> unable to read job {jid:s} from {path:s}".format(
+                jid=jid, path=resultsp
+            )
+        )
         return {}
 
     # Iterate through all of the children at our job path that are directories.
     # Anything that is a directory should be a minion that contains some results.
-    log.debug('sdstack_etcd returner <get_jid> iterating through minions with results for job {jid:s} from {path:s}'.format(jid=results.key.split('/')[-1], path=results.key))
+    log.debug(
+        "sdstack_etcd returner <get_jid> iterating through minions with results for job {jid:s} from {path:s}".format(
+            jid=results.key.split("/")[-1], path=results.key
+        )
+    )
     ret = {}
     for item in results.leaves:
         if not item.dir:
@@ -649,53 +928,73 @@ def get_jid(jid):
 
         # Extract the minion name from the key in the job, and use it to build
         # the path to the return value
-        comps = item.key.split('/')
-        returnp = '/'.join([resultsp, comps[-1], 'return'])
+        comps = item.key.split("/")
+        returnp = "/".join([resultsp, comps[-1], "return"])
 
         # Now we know the minion and the path to the return for its job, we can
         # just grab it. If the key exists, but the value is missing entirely,
-        # then something that shouldn't happen has happened.
-        log.trace('sdstack_etcd returner <get_jid> grabbing result from minion {minion:s} for job {jid:s} at {path:s}'.format(minion=comps[-1], jid=jid, path=returnp))
+        # then something that shouldn"t happen has happened.
+        log.trace(
+            "sdstack_etcd returner <get_jid> grabbing result from minion {minion:s} for job {jid:s} at {path:s}".format(
+                minion=comps[-1], jid=jid, path=returnp
+            )
+        )
         try:
             result = client.read(returnp, recursive=True)
         except etcd.EtcdKeyNotFound as E:
-            log.debug("sdstack_etcd returner <get_jid> returned nothing from minion {minion:s} for job {jid:s} at {path:s}".format(minion=comps[-1], jid=jid, path=returnp))
+            log.debug(
+                "sdstack_etcd returner <get_jid> returned nothing from minion {minion:s} for job {jid:s} at {path:s}".format(
+                    minion=comps[-1], jid=jid, path=returnp
+                )
+            )
             continue
 
         # Aggregate any keys that we found into a dictionary
         res = {}
         for item in result.leaves:
-            name = item.key.split('/')[-1]
+            name = item.key.split("/")[-1]
             try:
                 res[name] = salt.utils.json.loads(item.value)
 
             # We use a general exception here instead of ValueError jic someone
             # changes the semantics of salt.utils.json.loads out from underneath us
             except Exception as E:  # pylint: disable=broad-except
-                log.warning("sdstack_etcd returner <get_jid> unable to decode field {name:s} from minion {minion:s} for job {jid:s} at {path:s}".format(minion=comps[-1], jid=jid, path=item.key, name=name))
+                log.warning(
+                    "sdstack_etcd returner <get_jid> unable to decode field {name:s} from minion {minion:s} for job {jid:s} at {path:s}".format(
+                        minion=comps[-1], jid=jid, path=item.key, name=name
+                    )
+                )
                 res[name] = item.value
             continue
 
         # We found something, so update our return dict for the minion id with
         # the results that it returned.
         ret[comps[-1]] = res
-        log.debug("sdstack_etcd returner <get_jid> job {jid:s} from minion {minion:s} at path {path:s} returned {result}".format(minion=comps[-1], jid=jid, path=result.key, result=res))
+        log.debug(
+            "sdstack_etcd returner <get_jid> job {jid:s} from minion {minion:s} at path {path:s} returned {result}".format(
+                minion=comps[-1], jid=jid, path=result.key, result=res
+            )
+        )
     return ret
 
 
 def get_fun(fun):
-    '''
+    """
     Return a dict containing the last function called for all the minions that have called a function.
-    '''
+    """
     client, path, _ = _get_conn(__opts__)
 
     # Find any minions that had their last function registered by returner()
-    minionsp = '/'.join([path, Schema['minion-fun']])
+    minionsp = "/".join([path, Schema["minion-fun"]])
 
-    # If the minions key isn't found, then no minions registered a function
+    # If the minions key isn"t found, then no minions registered a function
     # and thus we need to return an empty dict so the caller knows that
     # nothing is available.
-    log.debug('sdstack_etcd returner <get_fun> reading minions at {path:s} for function {fun:s}'.format(path=minionsp, fun=fun))
+    log.debug(
+        "sdstack_etcd returner <get_fun> reading minions at {path:s} for function {fun:s}".format(
+            path=minionsp, fun=fun
+        )
+    )
     try:
         minions = client.read(minionsp)
     except etcd.EtcdKeyNotFound as E:
@@ -703,143 +1002,222 @@ def get_fun(fun):
 
     # Walk through the list of all the minions that have a jid registered,
     # and cross reference this with the job returns.
-    log.debug('sdstack_etcd returner <get_fun> iterating through minions for function {fun:s} at {path:s}'.format(fun=fun, path=minions.key))
+    log.debug(
+        "sdstack_etcd returner <get_fun> iterating through minions for function {fun:s} at {path:s}".format(
+            fun=fun, path=minions.key
+        )
+    )
     ret = {}
     for minion in minions.leaves:
         if minion.dir:
-            log.warning('sdstack_etcd returner <get_fun> found a non-minion at {path:s} {expire:s}'.format(path=minion.key, expire='that will need to be manually removed' if minion.ttl is None else 'that will expire in {ttl:d} seconds'.format(ttl=minion.ttl)))
+            log.warning(
+                "sdstack_etcd returner <get_fun> found a non-minion at {path:s} {expire:s}".format(
+                    path=minion.key,
+                    expire="that will need to be manually removed"
+                    if minion.ttl is None
+                    else "that will expire in {ttl:d} seconds".format(ttl=minion.ttl),
+                )
+            )
             continue
 
-        # Now that we have a minion and it's last jid, we use it to fetch the
+        # Now that we have a minion and it"s last jid, we use it to fetch the
         # function field (fun) that was registered by returner().
-        jid, comps = minion.value, minion.key.split('/')
-        funp = '/'.join([path, Schema['job-cache'], jid, comps[-1], 'fun'])
+        jid, comps = minion.value, minion.key.split("/")
+        funp = "/".join([path, Schema["job-cache"], jid, comps[-1], "fun"])
 
-        # Try and read the field, and skip it if it doesn't exist or wasn't
+        # Try and read the field, and skip it if it doesn"t exist or wasn"t
         # registered for some reason.
-        log.trace('sdstack_etcd returner <get_fun> reading function from minion {minion:s} for job {jid:s} at {path:s}'.format(minion=comps[-1], jid=jid, path=funp))
+        log.trace(
+            "sdstack_etcd returner <get_fun> reading function from minion {minion:s} for job {jid:s} at {path:s}".format(
+                minion=comps[-1], jid=jid, path=funp
+            )
+        )
         try:
             res = client.read(funp)
         except etcd.EtcdKeyNotFound as E:
-            log.debug("sdstack_etcd returner <get_fun> returned nothing from minion {minion:s} for job {jid:s} at path {path:s}".format(minion=comps[-1], jid=jid, path=funp))
+            log.debug(
+                "sdstack_etcd returner <get_fun> returned nothing from minion {minion:s} for job {jid:s} at path {path:s}".format(
+                    minion=comps[-1], jid=jid, path=funp
+                )
+            )
             continue
 
         # Check if the function field (fun) matches what the user is looking for
         # If it does, then we can just add the minion to our results
-        log.trace('sdstack_etcd returner <get_fun> decoding json data from minion {minion:s} for job {jid:s} at {path:s}'.format(minion=comps[-1], jid=jid, path=funp))
+        log.trace(
+            "sdstack_etcd returner <get_fun> decoding json data from minion {minion:s} for job {jid:s} at {path:s}".format(
+                minion=comps[-1], jid=jid, path=funp
+            )
+        )
         data = salt.utils.json.loads(res.value)
         if data == fun:
             ret[comps[-1]] = str(data)
-            log.debug("sdstack_etcd returner <get_fun> found job {jid:s} for minion {minion:s} using {fun:s} at {path:s}".format(minion=comps[-1], fun=data, jid=jid, path=minion.key))
+            log.debug(
+                "sdstack_etcd returner <get_fun> found job {jid:s} for minion {minion:s} using {fun:s} at {path:s}".format(
+                    minion=comps[-1], fun=data, jid=jid, path=minion.key
+                )
+            )
         continue
     return ret
 
 
 def get_jids():
-    '''
+    """
     Return a list of all job ids that have returned something.
-    '''
+    """
     client, path, _ = _get_conn(__opts__)
 
     # Enumerate all the jobs that are available.
-    jobsp = '/'.join([path, Schema['job-cache']])
+    jobsp = "/".join([path, Schema["job-cache"]])
 
-    # Fetch all the jobs. If the key doesn't exist, then it's likely that no
+    # Fetch all the jobs. If the key doesn"t exist, then it"s likely that no
     # jobs have been created yet so return an empty list to the caller.
-    log.debug("sdstack_etcd returner <get_jids> listing jobs at {path:s}".format(path=jobsp))
+    log.debug(
+        "sdstack_etcd returner <get_jids> listing jobs at {path:s}".format(path=jobsp)
+    )
     try:
         jobs = client.read(jobsp)
     except etcd.EtcdKeyNotFound as E:
         return []
 
-    # Anything that's a directory is a job id. Since that's all we're returning,
+    # Anything that"s a directory is a job id. Since that"s all we"re returning,
     # aggregate them into a list.
-    log.debug("sdstack_etcd returner <get_jids> iterating through jobs at {path:s}".format(path=jobs.key))
+    log.debug(
+        "sdstack_etcd returner <get_jids> iterating through jobs at {path:s}".format(
+            path=jobs.key
+        )
+    )
     ret = {}
     for job in jobs.leaves:
         if not job.dir:
-            log.warning('sdstack_etcd returner <get_jids> found a non-job at {path:s} {expire:s}'.format(path=job.key, expire='that will need to be manually removed' if job.ttl is None else 'that will expire in {ttl:d} seconds'.format(ttl=job.ttl)))
+            log.warning(
+                "sdstack_etcd returner <get_jids> found a non-job at {path:s} {expire:s}".format(
+                    path=job.key,
+                    expire="that will need to be manually removed"
+                    if job.ttl is None
+                    else "that will expire in {ttl:d} seconds".format(ttl=job.ttl),
+                )
+            )
             continue
 
-        jid = job.key.split('/')[-1]
-        loadp = '/'.join([job.key, '.load.p'])
+        jid = job.key.split("/")[-1]
+        loadp = "/".join([job.key, ".load.p"])
 
         # Now we can load the data from the job
         try:
             res = client.read(loadp)
         except etcd.EtcdKeyNotFound as E:
-            log.error("sdstack_etcd returner <get_jids> could not find job data {jid:s} at the path {path:s}".format(jid=jid, path=loadp))
+            log.error(
+                "sdstack_etcd returner <get_jids> could not find job data {jid:s} at the path {path:s}".format(
+                    jid=jid, path=loadp
+                )
+            )
             continue
 
         # Decode the load data so we can stash the job data for our caller
         try:
             data = salt.utils.json.loads(res.value)
 
-        # If we can't decode the json, then we're screwed so log it in case the user cares
+        # If we can"t decode the json, then we"re screwed so log it in case the user cares
         except Exception as E:  # pylint: disable=broad-except
-            log.error("sdstack_etcd returner <get_jids> could not decode data for job {jid:s} at the path {path:s} due to exception ({exception}) being raised. Data was {data}".format(jid=jid, path=loadp, exception=E, data=res.value))
+            log.error(
+                "sdstack_etcd returner <get_jids> could not decode data for job {jid:s} at the path {path:s} due to exception ({exception}) being raised. Data was {data}".format(
+                    jid=jid, path=loadp, exception=E, data=res.value
+                )
+            )
             continue
 
         # Cool. Everything seems to be good...
         ret[jid] = salt.utils.jid.format_jid_instance(jid, data)
-        log.trace("sdstack_etcd returner <get_jids> found job {jid:s} at {path:s}".format(jid=jid, path=job.key))
+        log.trace(
+            "sdstack_etcd returner <get_jids> found job {jid:s} at {path:s}".format(
+                jid=jid, path=job.key
+            )
+        )
 
-    log.debug("sdstack_etcd returner <get_jids> found {count:d} jobs at {path:s}".format(count=len(ret), path=jobs.key))
+    log.debug(
+        "sdstack_etcd returner <get_jids> found {count:d} jobs at {path:s}".format(
+            count=len(ret), path=jobs.key
+        )
+    )
     return ret
 
 
 def get_minions():
-    '''
+    """
     Return a list of all minions that have returned something.
-    '''
+    """
     client, path, _ = _get_conn(__opts__)
 
     # Find any minions that have returned anything
-    minionsp = '/'.join([path, Schema['minion-fun']])
+    minionsp = "/".join([path, Schema["minion-fun"]])
 
     # If no minions were found, then nobody has returned anything recently. In
     # this case, return an empty last for the caller.
-    log.debug('sdstack_etcd returner <get_minions> reading minions at {path:s}'.format(path=minionsp))
+    log.debug(
+        "sdstack_etcd returner <get_minions> reading minions at {path:s}".format(
+            path=minionsp
+        )
+    )
     try:
         minions = client.read(minionsp)
     except etcd.EtcdKeyNotFound as E:
         return []
 
-    # We can just walk through everything that isn't a directory. This path
+    # We can just walk through everything that isn"t a directory. This path
     # is simply a list of minions and the last job that each one returned.
-    log.debug('sdstack_etcd returner <get_minions> iterating through minions at {path:s}'.format(path=minions.key))
+    log.debug(
+        "sdstack_etcd returner <get_minions> iterating through minions at {path:s}".format(
+            path=minions.key
+        )
+    )
     ret = []
     for minion in minions.leaves:
         if minion.dir:
-            log.warning('sdstack_etcd returner <get_minions> found a non-minion at {path:s} {expire:s}'.format(path=minion.key, expire='that will need to be manually removed' if minion.ttl is None else 'that will expire in {ttl:d} seconds'.format(ttl=minion.ttl)))
+            log.warning(
+                "sdstack_etcd returner <get_minions> found a non-minion at {path:s} {expire:s}".format(
+                    path=minion.key,
+                    expire="that will need to be manually removed"
+                    if minion.ttl is None
+                    else "that will expire in {ttl:d} seconds".format(ttl=minion.ttl),
+                )
+            )
             continue
-        comps = str(minion.key).split('/')
-        log.trace("sdstack_etcd returner <get_minions> found minion {minion:s} at {path:s}".format(minion=comps[-1], path=minion.key))
+        comps = str(minion.key).split("/")
+        log.trace(
+            "sdstack_etcd returner <get_minions> found minion {minion:s} at {path:s}".format(
+                minion=comps[-1], path=minion.key
+            )
+        )
         ret.append(comps[-1])
     return ret
 
 
 def prep_jid(nocache=False, passed_jid=None):   # pylint: disable=unused-argument
-    '''
+    """
     Do any work necessary to prepare a JID, including sending a custom id.
-    '''
+    """
     return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid(__opts__)
 
 
 def event_return(events):
-    '''
+    """
     Return event to etcd server
 
-    Requires that configuration enabled via 'event_return'
+    Requires that configuration enabled via "event_return"
     option in master config.
-    '''
-    write_profile = __opts__.get('etcd.returner_write_profile')
+    """
+    write_profile = __opts__.get("etcd.returner_write_profile")
     client, path, ttl = _get_conn(__opts__, write_profile)
 
     # Iterate through all the events, and add them to the events path based
     # on the tag that is labeled in each event. We aggregate all errors into
     # a list so the writing of the events are as atomic as possible.
-    log.debug("sdstack_etcd returner <event_return> iterating through {count:d} events to write into our profile".format(count=len(events)))
+    log.debug(
+        "sdstack_etcd returner <event_return> iterating through {count:d} events to write into our profile".format(
+            count=len(events)
+        )
+    )
     exceptions = []
     for event in events:
 
@@ -847,35 +1225,51 @@ def event_return(events):
         # but we add these just in case the schema changes as a result of a
         # refactor or something. Some of the other returns also include a
         # timestamp despite the time only having meaning to the minion that
-        # it's coming from. We'll include it in case the user wants it too
+        # it"s coming from. We"ll include it in case the user wants it too
         # for some reason.
 
         package = dict(event)
-        package.setdefault('master_id', __opts__['id'])
-        package.setdefault('timestamp', time.time())
+        package.setdefault("master_id", __opts__["id"])
+        package.setdefault("timestamp", time.time())
 
         # Use the tag from the event package to build a watchable path
-        packagep = '/'.join([path, Schema['package-path'], package['tag']])
+        packagep = "/".join([path, Schema["package-path"], package["tag"]])
 
         # Now we can write the event package into the event path
-        log.debug("sdstack_etcd returner <event_return> writing package into event path at {path:s}".format(path=packagep))
+        log.debug(
+            "sdstack_etcd returner <event_return> writing package into event path at {path:s}".format(
+                path=packagep
+            )
+        )
         json = salt.utils.json.dumps(package)
         try:
-            # Try and write the event if it doesn't exist
+            # Try and write the event if it doesn"t exist
             res = client.write(packagep, json, prevExist=False)
 
-        # If the event doesn't actually exist, then just modify it instead of re-creating it
+        # If the event doesn"t actually exist, then just modify it instead of re-creating it
         # and tampering with the createdIndex
         except etcd.EtcdAlreadyExist as E:
-            log.trace("sdstack_etcd returner <event_return> fetching already existing event with the tag {name:s} at {path:s}".format(name=package['tag'], path=packagep))
+            log.trace(
+                "sdstack_etcd returner <event_return> fetching already existing event with the tag {name:s} at {path:s}".format(
+                    name=package["tag"], path=packagep
+                )
+            )
             node = client.read(packagep)
 
-            log.debug("sdstack_etcd returner <event_return> updating package for event ({event:d}) with the tag {name:s} at {path:s}".format(event=node.modifiedIndex, name=package['tag'], path=packagep))
+            log.debug(
+                "sdstack_etcd returner <event_return> updating package for event ({event:d}) with the tag {name:s} at {path:s}".format(
+                    event=node.modifiedIndex, name=package["tag"], path=packagep
+                )
+            )
             node.value = json
             res = client.update(node)
 
         except Exception as E:  # pylint: disable=broad-except
-            log.trace("sdstack_etcd returner <event_return> unable to write event with the tag {name:s} into {path:s} due to exception ({exception}) being raised".format(name=package['tag'], path=packagep, exception=E))
+            log.trace(
+                "sdstack_etcd returner <event_return> unable to write event with the tag {name:s} into {path:s} due to exception ({exception}) being raised".format(
+                    name=package["tag"], path=packagep, exception=E
+                )
+            )
             exceptions.append((E, package))
             continue
 
@@ -884,120 +1278,187 @@ def event_return(events):
         # this identifer can be arbitrary as the index sub-key is responsible
         # for determining ownership of the event package that was registered.
         event = res.modifiedIndex
-        log.trace("sdstack_etcd returner <event_return> wrote event {event:d} with the tag {name:s} to {path:s} using {data}".format(path=res.key, event=event, name=package['tag'], data=res.value))
+        log.trace(
+            "sdstack_etcd returner <event_return> wrote event {event:d} with the tag {name:s} to {path:s} using {data}".format(
+                path=res.key, event=event, name=package["tag"], data=res.value
+            )
+        )
 
-        # Now we'll need to store the modifiedIndex for said event so that we can
+        # Now we"ll need to store the modifiedIndex for said event so that we can
         # use it to determine ownership. This modifiedIndex is what links the
         # actual event with the tag. If we were using the etcd3 api, then we
-        # could make these 3 writes (index, tag, and lock) atomic. But we're
+        # could make these 3 writes (index, tag, and lock) atomic. But we"re
         # not, and so this is a manual effort and potentially racy depending on
         # the uniqueness of the modifiedIndex (which etcd guarantees unique)
 
-        basep = '/'.join([path, Schema['event-cache'], str(event)])
+        basep = "/".join([path, Schema["event-cache"], str(event)])
 
-        # Here we'll write our modifiedIndex to our event cache.
-        indexp = '/'.join([basep, 'index'])
+        # Here we"ll write our modifiedIndex to our event cache.
+        indexp = "/".join([basep, "index"])
         try:
             # If the event is a new key, then we can simply cache it without concern
             if res.newKey:
-                log.trace("sdstack_etcd returner <event_return> writing new event {event:d} with the modifiedIndex {index:d} for the tag {name:s} at {path:s}".format(path=indexp, event=event, index=res.modifiedIndex, name=package['tag']))
+                log.trace(
+                    "sdstack_etcd returner <event_return> writing new event {event:d} with the modifiedIndex {index:d} for the tag {name:s} at {path:s}".format(
+                        path=indexp,
+                        event=event,
+                        index=res.modifiedIndex,
+                        name=package["tag"],
+                    )
+                )
                 client.write(indexp, res.modifiedIndex, prevExist=False)
 
             # Otherwise, the event was updated and thus we need to update our cache too
             else:
-                log.trace("sdstack_etcd returner <event_return> updating event {event:d} with the tag {name:s} at {path:s} with the modifiedIndex {index:d}".format(path=indexp, event=event, index=res.modifiedIndex, name=package['tag']))
+                log.trace(
+                    "sdstack_etcd returner <event_return> updating event {event:d} with the tag {name:s} at {path:s} with the modifiedIndex {index:d}".format(
+                        path=indexp,
+                        event=event,
+                        index=res.modifiedIndex,
+                        name=package["tag"],
+                    )
+                )
                 client.write(indexp, res.modifiedIndex)
 
         except etcd.EtcdAlreadyExist as E:
-            log.error("sdstack_etcd returner <event_return> unable to write modifiedIndex {index:d} for tag {name:s} to event {event:d} due to the event already existing".format(event=event, index=res.modifiedIndex, name=package['tag']))
+            log.error(
+                "sdstack_etcd returner <event_return> unable to write modifiedIndex {index:d} for tag {name:s} to event {event:d} due to the event already existing".format(
+                    event=event, index=res.modifiedIndex, name=package["tag"]
+                )
+            )
             exceptions.append((E, package))
             continue
 
         # If we got here, then we should be able to write the tag using the event index
-        tagp = '/'.join([basep, 'tag'])
+        tagp = "/".join([basep, "tag"])
         try:
-            log.trace("sdstack_etcd returner <event_return> updating event {event:d} at {path:s} with tag {name:s}".format(path=tagp, event=event, name=package['tag']))
-            client.write(tagp, package['tag'])
+            log.trace(
+                "sdstack_etcd returner <event_return> updating event {event:d} at {path:s} with tag {name:s}".format(
+                    path=tagp, event=event, name=package["tag"]
+                )
+            )
+            client.write(tagp, package["tag"])
 
         except Exception as E:  # pylint: disable=broad-except
-            log.trace("sdstack_etcd returner <event_return> unable to update event {event:d} at {path:s} with tag {name:s} due to exception ({exception}) being raised".format(path=tagp, name=package['tag'], event=event, exception=E))
+            log.trace(
+                "sdstack_etcd returner <event_return> unable to update event {event:d} at {path:s} with tag {name:s} due to exception ({exception}) being raised".format(
+                    path=tagp, name=package["tag"], event=event, exception=E
+                )
+            )
             exceptions.append((E, package))
             continue
 
-        # Now that both have been written, let's write our lock to actually enable the event
-        lockp = '/'.join([basep, 'lock'])
+        # Now that both have been written, let"s write our lock to actually enable the event
+        lockp = "/".join([basep, "lock"])
         try:
-            log.trace("sdstack_etcd returner <event_return> writing lock for event {event:d} with the tag {name:s} to {path:s} {expire:s}".format(path=lockp, event=event, name=package['tag'], expire='that will need to be manually removed' if ttl is None else 'that will expire in {ttl:d} seconds'.format(ttl=ttl)))
+            log.trace(
+                "sdstack_etcd returner <event_return> writing lock for event {event:d} with the tag {name:s} to {path:s} {expire:s}".format(
+                    path=lockp,
+                    event=event,
+                    name=package["tag"],
+                    expire="that will need to be manually removed"
+                    if ttl is None
+                    else "that will expire in {ttl:d} seconds".format(ttl=ttl),
+                )
+            )
             client.write(lockp, res.createdIndex, ttl=ttl if ttl > 0 else None)
 
-        # If we can't write the lock, it's fine because the maintenance thread
-        # will purge this event from the cache anyways if it's not written.
+        # If we can"t write the lock, it"s fine because the maintenance thread
+        # will purge this event from the cache anyways if it"s not written.
         except Exception as E:  # pylint: disable=broad-except
-            log.error("sdstack_etcd returner <event_return> unable to write lock for event {event:d} with the tag {name:s} to {path:s} due to exception ({exception}) being raised".format(path=lockp, name=package['tag'], event=event, exception=E))
+            log.error(
+                "sdstack_etcd returner <event_return> unable to write lock for event {event:d} with the tag {name:s} to {path:s} due to exception ({exception}) being raised".format(
+                    path=lockp, name=package["tag"], event=event, exception=E
+                )
+            )
             exceptions.append((E, package))
 
         continue
 
     # Go back through all of the exceptions that occurred and log them.
     for E, pack in exceptions:
-        log.exception("sdstack_etcd returner <event_return> exception ({exception}) was raised while trying to write event {name:s} with the data {data}".format(exception=E, name=pack['tag'], data=pack))
+        log.exception(
+            "sdstack_etcd returner <event_return> exception ({exception}) was raised while trying to write event {name:s} with the data {data}".format(
+                exception=E, name=pack["tag"], data=pack
+            )
+        )
     return
 
 
 def get_jids_filter(count, filter_find_job=True):
-    '''
+    """
     Return a list of all job ids
     :param int count: show not more than the count of most recent jobs
-    :param bool filter_find_jobs: filter out 'saltutil.find_job' jobs
-    '''
-    read_profile = __opts__.get('etcd.returner_read_profile')
+    :param bool filter_find_jobs: filter out "saltutil.find_job" jobs
+    """
+    read_profile = __opts__.get("etcd.returner_read_profile")
     client, path, ttl = _get_conn(__opts__, read_profile)
 
     # Enumerate all the jobs that are available.
-    jobsp = '/'.join([path, Schema['job-cache']])
+    jobsp = "/".join([path, Schema["job-cache"]])
 
-    # Fetch all the jobs. If the key doesn't exist, then it's likely that no
+    # Fetch all the jobs. If the key doesn"t exist, then it"s likely that no
     # jobs have been created yet so return an empty list to the caller.
-    log.debug("sdstack_etcd returner <get_jids_filter> listing jobs at {path:s}".format(path=jobsp))
+    log.debug(
+        "sdstack_etcd returner <get_jids_filter> listing jobs at {path:s}".format(
+            path=jobsp
+        )
+    )
     try:
         jobs = client.read(jobsp, sorted=True)
     except etcd.EtcdKeyNotFound as E:
         return []
 
-    # Anything that's a directory is a job id. Since that's all we're returning,
+    # Anything that"s a directory is a job id. Since that"s all we"re returning,
     # aggregate them into a list. We do this ahead of time in order to conserve
     # memory by avoiding just decoding everything here
-    log.debug("sdstack_etcd returner <get_jids_filter> collecting jobs at {path:s}".format(path=jobs.key))
+    log.debug(
+        "sdstack_etcd returner <get_jids_filter> collecting jobs at {path:s}".format(
+            path=jobs.key
+        )
+    )
     jids = []
     for job in jobs.leaves:
         if not job.dir:
             continue
-        jids.append(job.key.split('/')[-1])
+        jids.append(job.key.split("/")[-1])
 
-    log.debug("sdstack_etcd returner <get_jids_filter> collecting {count:d} job loads at {path:s}".format(path=jobs.key, count=count))
+    log.debug(
+        "sdstack_etcd returner <get_jids_filter> collecting {count:d} job loads at {path:s}".format(
+            path=jobs.key, count=count
+        )
+    )
     ret = []
     for jid in jids[-count:]:
 
         # Figure out the path to .load.p from the current jid
-        loadp = '/'.join([jobsp, jid, '.load.p'])
+        loadp = "/".join([jobsp, jid, ".load.p"])
 
         # Now we can load the data from the job
         try:
             res = client.read(loadp)
         except etcd.EtcdKeyNotFound as E:
-            log.error("sdstack_etcd returner <get_jids_filter> could not find job data {jid:s} at the path {path:s}".format(jid=jid, path=loadp))
+            log.error(
+                "sdstack_etcd returner <get_jids_filter> could not find job data {jid:s} at the path {path:s}".format(
+                    jid=jid, path=loadp
+                )
+            )
             continue
 
         # Decode the load data so we can stash it for the caller
         try:
             data = salt.utils.json.loads(res.value)
 
-        # If we can't decode the json, then we're screwed so log it in case the user cares
+        # If we can"t decode the json, then we"re screwed so log it in case the user cares
         except Exception as E:  # pylint: disable=broad-except
-            log.error("sdstack_etcd returner <get_jids_filter> could not decode data for job {jid:s} at the path {path:s} due to exception ({exception}) being raised. Data was {data}".format(jid=jid, path=loadp, exception=E, data=res.value))
+            log.error(
+                "sdstack_etcd returner <get_jids_filter> could not decode data for job {jid:s} at the path {path:s} due to exception ({exception}) being raised. Data was {data}".format(
+                    jid=jid, path=loadp, exception=E, data=res.value
+                )
+            )
             continue
 
-        if filter_find_job and data['fun'] == 'saltutil.find_job':
+        if filter_find_job and data["fun"] == "saltutil.find_job":
             continue
 
         ret.append(salt.utils.jid.format_jid_instance_ext(jid, data))
@@ -1005,25 +1466,33 @@ def get_jids_filter(count, filter_find_job=True):
 
 
 def update_endtime(jid, time):
-    '''
+    """
     Update (or store) the end time for a given job
 
     Endtime is stored as a plain text string
-    '''
-    write_profile = __opts__.get('etcd.returner_write_profile')
+    """
+    write_profile = __opts__.get("etcd.returner_write_profile")
     client, path, ttl = _get_conn(__opts__, write_profile)
 
-    # Check if the specified jid is 'req', as only incorrect code will do this
-    if jid == 'req':
-        log.debug('sdstack_etcd returner <update_endtime> was called using a request job id ({jid:s}) with {data}'.format(jid=jid, data=time))
+    # Check if the specified jid is "req", as only incorrect code will do this
+    if jid == "req":
+        log.debug(
+            "sdstack_etcd returner <update_endtime> was called using a request job id ({jid:s}) with {data}".format(
+                jid=jid, data=time
+            )
+        )
 
-    # Build the path that we'll use to update the endtime
-    timep = '/'.join([path, Schema['job-cache'], jid, '.endtime'])
+    # Build the path that we"ll use to update the endtime
+    timep = "/".join([path, Schema["job-cache"], jid, ".endtime"])
 
     ## Now we can simply update it
     json = salt.utils.json.dumps(time)
 
-    log.debug('sdstack_etcd returner <update_endtime> storing endtime for job {jid:s} to {path:s} with {data}'.format(jid=jid, path=timep, data=time))
+    log.debug(
+        "sdstack_etcd returner <update_endtime> storing endtime for job {jid:s} to {path:s} with {data}".format(
+            jid=jid, path=timep, data=time
+        )
+    )
     try:
         res = client.write(timep, json, prevExist=False)
 
@@ -1032,37 +1501,61 @@ def update_endtime(jid, time):
         node = client.read(timep)
         node.value = json
 
-        log.debug('sdstack_etcd returner <update_endtime> updating endtime for job {jid:s} at {path:s} with {data}'.format(jid=jid, path=timep, data=time))
+        log.debug(
+            "sdstack_etcd returner <update_endtime> updating endtime for job {jid:s} at {path:s} with {data}".format(
+                jid=jid, path=timep, data=time
+            )
+        )
         res = client.update(node)
 
-    # If we failed here, it's okay because the lock won't get written so this
+    # If we failed here, it"s okay because the lock won"t get written so this
     # essentially means the job will get scheduled for deletion.
     except Exception as E:  # pylint: disable=broad-except
-        log.trace("sdstack_etcd returner <update_endtime> unable to store endtime for job {jid:s} to the path {path:s} due to exception ({exception}) being raised".format(jid=jid, path=timep, exception=E))
+        log.trace(
+            "sdstack_etcd returner <update_endtime> unable to store endtime for job {jid:s} to the path {path:s} due to exception ({exception}) being raised".format(
+                jid=jid, path=timep, exception=E
+            )
+        )
         return
-    log.trace("sdstack_etcd returner <update_endtime> successfully wrote endtime for job {jid:s} to the path {path:s} with {data}".format(jid=jid, path=timep, data=time))
+    log.trace(
+        "sdstack_etcd returner <update_endtime> successfully wrote endtime for job {jid:s} to the path {path:s} with {data}".format(
+            jid=jid, path=timep, data=time
+        )
+    )
 
 
 def get_endtime(jid):
-    '''
+    """
     Retrieve the stored endtime for a given job
 
     Returns False if no endtime is present
-    '''
-    read_profile = __opts__.get('etcd.returner_read_profile')
+    """
+    read_profile = __opts__.get("etcd.returner_read_profile")
     client, path, _ = _get_conn(__opts__, read_profile)
 
     # Figure out the path that our endtime should be at
-    timep = '/'.join([path, Schema['job-cache'], jid, '.endtime'])
+    timep = "/".join([path, Schema["job-cache"], jid, ".endtime"])
 
-    # Read it. If EtcdKeyNotFound was raised then the key doesn't exist and so
-    # we need to return False, because that's what salt.returners.local_cache
-    # returns when the endtime hasn't been written..
-    log.debug('sdstack_etcd returner <get_endtime> reading endtime for job {jid:s} from {path:s}'.format(jid=jid, path=timep))
+    # Read it. If EtcdKeyNotFound was raised then the key doesn"t exist and so
+    # we need to return False, because that"s what salt.returners.local_cache
+    # returns when the endtime hasn"t been written..
+    log.debug(
+        "sdstack_etcd returner <get_endtime> reading endtime for job {jid:s} from {path:s}".format(
+            jid=jid, path=timep
+        )
+    )
     try:
         res = client.read(timep)
     except etcd.EtcdKeyNotFound as E:
-        log.debug("sdstack_etcd returner <get_endtime> could not find endtime for job {jid:s} at the path {path:s}".format(jid=jid, path=timep))
+        log.debug(
+            "sdstack_etcd returner <get_endtime> could not find endtime for job {jid:s} at the path {path:s}".format(
+                jid=jid, path=timep
+            )
+        )
         return False
-    log.debug('sdstack_etcd returner <get_endtime> found endtime for job {jid:s} at {path:s} with value {data}'.format(jid=jid, path=res.key, data=res.value))
+    log.debug(
+        "sdstack_etcd returner <get_endtime> found endtime for job {jid:s} at {path:s} with value {data}".format(
+            jid=jid, path=res.key, data=res.value
+        )
+    )
     return salt.utils.json.loads(res.value)

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -316,7 +316,7 @@ def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argume
 
     # Now we can try and read the load out of it.
     try:
-        load = cient.read(loadp)
+        load = client.read(loadp)
 
     # If it doesn't exist, then bitch and complain because somebody lied to us
     except etcd.EtcdKeyNotFound as E:
@@ -379,7 +379,7 @@ def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argume
                 res = client.write('/'.join([resultp, 'master_id']), syndic_id)
 
         except Exception as E:
-            log.trace("sdstack_etcd returner <save_minions> unable to write master_id {syndic:s} to the result for job {jid:s} at {path:s} due to exception ({exception})".format(jid=jid, minion=minion, path='/'.join([resultp, 'master_id']), syndic=syndic_id, exception=E))
+            log.trace("sdstack_etcd returner <save_minions> unable to write master_id {syndic:s} to the result for job {jid:s} at {path:s} due to exception ({exception})".format(jid=jid, path='/'.join([resultp, 'master_id']), syndic=syndic_id, exception=E))
             exceptions.append((E, 'result.master_id', minion))
 
         # Crruuunch.
@@ -388,7 +388,7 @@ def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argume
     # fields and log them.
     for E, field, minion in exceptions:
         if field == 'job':
-            log.exception("sdstack_etcd returner <save_minions> exception ({exception}) was raised while trying to update the function cache for minion {minion:s} to job {jid:s}".format(exception=E, field=field, minion=minion, jid=jid))
+            log.exception("sdstack_etcd returner <save_minions> exception ({exception}) was raised while trying to update the function cache for minion {minion:s} to job {jid:s}".format(exception=E, minion=minion, jid=jid))
             continue
         log.exception("sdstack_etcd returner <save_minions> exception ({exception}) was raised while trying to update the {field:s} field in the result for job {jid:s} belonging to minion {minion:s}".format(exception=E, field=field, minion=minion, jid=jid))
     return

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -414,13 +414,16 @@ def event_return(events):
         }
         path = '/'.join([path, 'events', package['tag']])
         json = salt.utils.json.dumps(package)
+
         try:
             res = client.set(path, json, ttl=ttl)
-        except Exception, err:
-            log.exception('etcd: Unable to write event into returner path %s due to exception %s: %s', path, package, repr(err))
+        except Exception as err:
+            log.exception('etcd: Unable to write event into returner path {:s} due to exception {:s}: {!r}', path, package, err)
             exceptions.append(err)
             continue
+
         if not res:
-            log.error('etcd: Unable to write event into returner path %s: %r', path, package)
+            log.error('etcd: Unable to write event into returner path {:s}: {!r}', path, package)
         continue
+
     return

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -402,28 +402,41 @@ def event_return(events):
     Requires that configuration enabled via 'event_return'
     option in master config.
     '''
-    ttl = __opts__.get('etcd.ttl', 5)
-    client, path = _get_conn(__opts__)
+    write_profile = __opts__.get('etcd.returner_write_profile')
+    client, path = _get_conn(__opts__, write_profile)
+    if write_profile:
+        ttl = __opts__.get(write_profile, {}).get('etcd.ttl')
+    else:
+        ttl = __opts__.get('etcd.ttl')
 
+    # Iterate through all the events, and add them to the events path based
+    # on the tag that is labeled in each event. We aggregate all errors into
+    # a list so the writing of the events are as atomic as possible.
     exceptions = []
     for event in events:
+
+        # Package the event data into a value to write into our etcd profile
         package = {
             'tag': event.get('tag', ''),
             'data': event.get('data', ''),
             'master_id': __opts__['id'],
         }
-        path = '/'.join([path, 'events', package['tag']])
         json = salt.utils.json.dumps(package)
 
+        # Use the tag from the event package to build a watchable path
+        eventp = '/'.join([path, 'events', package['tag']])
+
+        # Now we can write the event package into the event path
         try:
-            res = client.set(path, json, ttl=ttl)
-        except Exception as err:
-            log.exception('etcd: Unable to write event into returner path {:s} due to exception {:s}: {}'.format(path, package, err))
-            exceptions.append(err)
+            res = client.set(eventp, json, ttl=ttl)
+        except Exception as E:
+            log.trace("sdstack_etcd returner <event_return> unable to write event into returner path {path:s} due to exception {exception:s}: {data}".format(path=eventp, data=package, exception=E))
+            exceptions.append((E, package))
             continue
 
-        if not res:
-            log.error('etcd: Unable to write event into returner path {:s}: {}'.format(path, package))
-        continue
+        log.trace("sdstack_etcd returner <event_return> wrote event (ttl={ttl:d}) with the name {name:s} to {path:s} with the data {data}".format(path=res.key, name=package['tag'], ttl=ttl, data=res.value))
 
+    # Go back through all of the exceptions that occurred and log them.
+    for e, pack in exceptions:
+        log.exception("sdstack_etcd returner <event_return> exception ({exception:s}) was raised while trying to write event {name:s} with the data {data}".format(exception=e, name=pack['tag'], data=pack))
     return

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -462,7 +462,7 @@ def event_return(events):
     option in master config.
     '''
     write_profile = __opts__.get('etcd.returner_write_profile')
-    client, path, _ = _get_conn(__opts__, write_profile)
+    client, path, ttl = _get_conn(__opts__, write_profile)
 
     # Iterate through all the events, and add them to the events path based
     # on the tag that is labeled in each event. We aggregate all errors into
@@ -477,19 +477,52 @@ def event_return(events):
             'master_id': __opts__['id'],
         }
 
+
         # Use the tag from the event package to build a watchable path
         eventp = '/'.join([path, 'events', package['tag']])
 
         # Now we can write the event package into the event path
         try:
             json = salt.utils.json.dumps(package)
-            res = client.set(eventp, json)
+            res = client.write(eventp, json)
+
         except Exception as E:
             log.trace("sdstack_etcd returner <event_return> unable to write event with the tag {name:s} into the path {path:s} due to exception ({exception}) being raised".format(name=package['tag'], path=eventp, exception=E))
             exceptions.append((E, package))
             continue
 
-        log.trace("sdstack_etcd returner <event_return> wrote event with the tag {name:s} to {path:s} using {data}".format(path=res.key, name=package['tag'], data=res.value))
+        log.trace("sdstack_etcd returner <event_return> wrote event ({index:d}) with the tag {name:s} to {path:s} using {data}".format(path=res.key, name=package['tag'], data=res.value, index=res.modifiedIndex))
+
+        # Next we need to cache the index for said event so that we can use it to
+        # determine whether it is ready to be purged or not. We do this by using
+        # the modifiedIndex to write the tag into a cache.
+
+        index = res.createdIndex
+
+        try:
+            # If the event is a new key, then we can simply cache it with the specified ttl
+            if res.newKey:
+                etcd.write('/'.join([path, 'cache', str(index), 'id']), res.modifiedIndex, prevExist=False, ttl=ttl if ttl > 0 else None)
+
+            # Otherwise, the event was updated and thus we need to update our cache too
+            else:
+                etcd.write('/'.join([path, 'cache', str(index), 'id']), res.modifiedIndex, prevValue=res._prev_node.modifiedIndex, ttl=ttl if ttl > 0 else None)
+
+        except etcd.EtcdCompareFailed as E:
+            log.error("sdstack_etcd returner <event_return> unable to update cache for {index:d} due to non-matching modification index ({mod:d})".format(index=index, mod=res._prev_node.modifiedIndex))
+
+        except etcd.EtcdAlreadyExist as E:
+            log.error("sdstack_etcd returner <event_return> unable to cache event for {index:d} due to event already existing".format(index=index))
+
+        # If we got here, then we should be able to write the tag under the current index
+        try:
+            etcd.write('/'.join([path, 'cache', str(index), 'tag']), package['tag'])
+
+        except Exception as E:
+            log.trace("sdstack_etcd returner <event_return> unable to cache tag {name:s} under index {index:d} due to exception ({exception}) being raised".format(name=package['tag'], index=index, exception=E))
+            exceptions.append((E, package))
+
+        continue
 
     # Go back through all of the exceptions that occurred and log them.
     for e, pack in exceptions:

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -115,6 +115,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
 import logging
+import time
 
 # Import salt libs
 import salt.utils.jid
@@ -737,12 +738,16 @@ def event_return(events):
     exceptions = []
     for event in events:
 
-        # Package the event data into a value to write into our etcd profile
-        package = {
-            'tag': event.get('tag', ''),
-            'data': event.get('data', ''),
-            'master_id': __opts__['id'],
-        }
+        # Each event that we receive should already come with these properties,
+        # but we add these just in case the schema changes as a result of a
+        # refactor or something. Some of the other returns also include a
+        # timestamp despite the time only having meaning to the minion that
+        # it's coming from. We'll include it in case the user wants it too
+        # for some reason.
+
+        package = dict(event)
+        package.setdefault('master_id', __opts__['id'])
+        package.setdefault('timestamp', time.time())
 
         # Use the tag from the event package to build a watchable path
         eventp = '/'.join([path, Schema['event-path'], package['tag']])

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -1062,7 +1062,7 @@ def get_endtime(jid):
     try:
         res = client.read(timep)
     except etcd.EtcdKeyNotFound as E:
-        log.error("sdstack_etcd returner <get_endtime> could not find endtime for job {jid:s} at the path {path:s}".format(jid=jid, path=timep))
-        return None
+        log.debug("sdstack_etcd returner <get_endtime> could not find endtime for job {jid:s} at the path {path:s}".format(jid=jid, path=timep))
+        return False
     log.debug('sdstack_etcd returner <get_endtime> found endtime for job {jid:s} at {path:s} with value {data}'.format(jid=jid, path=res.key, data=res.value))
     return salt.utils.json.loads(res.value)

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -616,12 +616,12 @@ def event_return(events):
         try:
             # If the event is a new key, then we can simply cache it with the specified ttl
             if res.newKey:
-                log.trace("sdstack_etcd returner <event_return> writing new id ({id:s}) to {path:s} for the event {index:s} with the tag {name:s} {expire:s}".format(path='/'.join([path, 'cache', str(index), 'id']), id=str(index), index=res.modifiedIndex, name=package['tag'], expire='that will need to be manually removed' if ttl is None else 'that will expire in {ttl:d} seconds'.format(ttl)))
+                log.trace("sdstack_etcd returner <event_return> writing new id ({id:s}) to {path:s} for the event {index:s} with the tag {name:s} {expire:s}".format(path='/'.join([path, 'cache', str(index), 'id']), id=str(index), index=res.modifiedIndex, name=package['tag'], expire='that will need to be manually removed' if ttl is None else 'that will expire in {ttl:d} seconds'.format(ttl=ttl)))
                 etcd.write('/'.join([path, 'cache', str(index), 'id']), res.modifiedIndex, prevExist=False, ttl=ttl if ttl > 0 else None)
 
             # Otherwise, the event was updated and thus we need to update our cache too
             else:
-                log.trace("sdstack_etcd returner <event_return> updating id ({id:s}) at {path:s} for the event {index:s} with the tag {name:s} {expire:s}".format(path='/'.join([path, 'cache', str(index), 'id']), id=str(index), index=res.modifiedIndex, name=package['tag'], expire='that will need to be manually removed' if ttl is None else 'that will expire in {ttl:d} seconds'.format(ttl)))
+                log.trace("sdstack_etcd returner <event_return> updating id ({id:s}) at {path:s} for the event {index:s} with the tag {name:s} {expire:s}".format(path='/'.join([path, 'cache', str(index), 'id']), id=str(index), index=res.modifiedIndex, name=package['tag'], expire='that will need to be manually removed' if ttl is None else 'that will expire in {ttl:d} seconds'.format(ttl=ttl)))
                 etcd.write('/'.join([path, 'cache', str(index), 'id']), res.modifiedIndex, prevValue=res._prev_node.modifiedIndex, ttl=ttl if ttl > 0 else None)
 
         except etcd.EtcdCompareFailed as E:

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -677,7 +677,7 @@ def event_return(events):
             # Otherwise, the event was updated and thus we need to update our cache too
             else:
                 log.trace("sdstack_etcd returner <event_return> updating id ({id:d}) at {path:s} for the new event {index:d} with the tag {name:s} {expire:s}".format(path='/'.join([path, Schema['event-cache'], str(res.createdIndex), 'id']), id=res.createdIndex, index=res.modifiedIndex, name=package['tag'], expire='that will need to be manually removed' if ttl is None else 'that will expire in {ttl:d} seconds'.format(ttl=ttl)))
-                client.write('/'.join([path, Schema['event-cache'], str(res.createdIndex), 'id']), res.modifiedIndex, prevValue=res._prev_node.modifiedIndex, ttl=ttl if ttl > 0 else None)
+                client.write('/'.join([path, Schema['event-cache'], str(res.createdIndex), 'id']), res.modifiedIndex, ttl=ttl if ttl > 0 else None)
 
         except etcd.EtcdCompareFailed as E:
             log.error("sdstack_etcd returner <event_return> unable to update cache for {index:d} due to non-matching modification index ({mod:d})".format(index=res.createdIndex, mod=res._prev_node.modifiedIndex))

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -119,7 +119,7 @@ import logging
 # Import salt libs
 import salt.utils.jid
 import salt.utils.json
-
+from salt.ext.six.moves import range
 try:
     import salt.utils.etcd_util
     from salt.utils.etcd_util import etcd

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -750,7 +750,7 @@ def event_return(events):
         # for some reason.
 
         package = dict(event)
-        package.setdefault('master_id', __opts__['id']
+        package.setdefault('master_id', __opts__['id'])
         package.setdefault('timestamp', time.time())
 
         # Use the tag from the event package to build a watchable path

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -137,7 +137,7 @@ def returner(ret):
         log.trace("sdstack_etcd returner <returner> the previous job id {old:s} for {id:s} at {path:s} was set to {new:s}".format(old=res._prev_node.value, id=ret['id'], path=minionp, new=res.value))
 
     # Iterate through all the fields in the ret dict and dump it under jobs/$jid/id/$field
-    jobp = '/'.join([path, 'jobs', ret['jid'], ret['id'])
+    jobp = '/'.join([path, 'jobs', ret['jid'], ret['id']])
     log.debug("sdstack_etcd returner <returner> writing job data (ttl={ttl:d}) for {jid:s} to {path:s} with {data:s}".format(jid=ret['jid'], path=jobp, ttl=ttl, data=repr(ret)))
     for field in ret:
         fieldp = '/'.join([jobp, field])
@@ -218,7 +218,7 @@ def get_load(jid):
     except salt.utils.etcd_util.etcd.EtcdKeyNotFound as E:
         log.error("sdstack_etcd returner <get_load> could not find job {jid:s} at the path {path:s}".format(jid=jid, path=loadp))
         return None
-    log.trace('sdstack_etcd returner <get_load> found load data for job {jid:s} at {path:s} with value {data:s}'.format(jid=jid, path=res.key, data=repr(res.value))))
+    log.trace('sdstack_etcd returner <get_load> found load data for job {jid:s} at {path:s} with value {data:s}'.format(jid=jid, path=res.key, data=repr(res.value)))
     return salt.utils.json.loads(res.value)
 
 
@@ -301,7 +301,7 @@ def get_fun(fun):
             res = client.get(funp)
         except salt.utils.etcd_util.etcd.EtcdKeyNotFound as E:
             log.debug("sdstack_etcd returner <get_fun> returned nothing from minion {id:s} for job {jid:s} at path {path:s}".format(id=comps[-1], jid=str(item.value), path=funp))
-            continue.
+            continue
 
         # Check if the function field (fun) matches what the user is looking for
         # If it does, then we can just add the minion to our results

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -393,16 +393,10 @@ def _purge_events():
         log.trace('sdstack_etcd returner <_purge_events> (recursively) removing cache for event {index:d} at {path:s}'.format(index=index, path=event.key))
         res = client.delete(event.key, recursive=True)
 
-        # Remove the old event tag
+        # Remove the event tag associated with the current index associated with the current index
         log.trace('sdstack_etcd returner <_purge_events> removing tag for event {index:d} at {path:s}'.format(index=index, path=ev_tag.value))
         comp = ev_tag.value.split('/')
-        try:
-            res = client.delete('/'.join([path, Schema['event-path']] + comp), prevIndex=ev_index.value)
-
-        except etcd.EtcdCompareFailed as E:
-            log.warning('sdstack_etcd returner <_purge_events> event tag at {path:s} does not match modification index {mod:d}'.format(path=ev_tag.value, mod=ev_index.value))
-            log.trace('sdstack_etcd returner <_purge_events> forcefully removing event tag at {path:s}'.format(path=ev_tag.value))
-            res = client.delete('/'.join([path, Schema['event-path']] + comp))
+        res = client.delete('/'.join([path, Schema['event-path']] + comp))
 
         # Remove the last component (the key), so we can walk through the directories trying to remove them one-by-one
         comp.pop(-1)

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -579,11 +579,13 @@ def get_jids():
     ret = []
     for item in items.leaves:
         comps = str(item.key).split('/')
-        if item.dir:
-            jid = comps[-1]
-            ret.append(jid)
-            log.trace("sdstack_etcd returner <get_jids> found job {jid:s} at {path:s}".format(jid=comps[-1], path=item.key))
-        continue
+        if not item.dir:
+            continue
+
+        jid = comps[-1]
+        ret.append(jid)
+
+        log.trace("sdstack_etcd returner <get_jids> found job {jid:s} at {path:s}".format(jid=comps[-1], path=item.key))
     return ret
 
 
@@ -609,11 +611,13 @@ def get_minions():
     log.debug('sdstack_etcd returner <get_minions> iterating through minions at {path:s}'.format(path=items.key))
     ret = []
     for item in items.leaves:
-        if not item.dir:
-            comps = str(item.key).split('/')
-            ret.append(comps[-1])
-            log.trace("sdstack_etcd returner <get_minions> found minion {minion:s} at {path:s}".format(minion=comps[-1], path=item.key))
-        continue
+        if item.dir:
+            continue
+
+        comps = str(item.key).split('/')
+        ret.append(comps[-1])
+
+        log.trace("sdstack_etcd returner <get_minions> found minion {minion:s} at {path:s}".format(minion=comps[-1], path=item.key))
     return ret
 
 

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -217,7 +217,7 @@ def returner(ret):
         try:
             res = client.write(fieldp, data)
         except Exception as E:
-            log.trace("sdstack_etcd returner <returner> unable to set field {field:s} for job {jid:s} at {path:s} to {result}".format(field=field, jid=ret['jid'], path=fieldp, result=ret[field]))
+            log.trace("sdstack_etcd returner <returner> unable to set field {field:s} for job {jid:s} at {path:s} to {result} due to exception ({exception})".format(field=field, jid=ret['jid'], path=fieldp, result=ret[field], exception=E))
             exceptions.append((E, field, ret[field]))
             continue
         log.trace("sdstack_etcd returner <returner> set field {field:s} for job {jid:s} at {path:s} to {result}".format(field=field, jid=ret['jid'], path=res.key, result=ret[field]))
@@ -236,23 +236,33 @@ def save_load(jid, load, minions=None):
     write_profile = __opts__.get('etcd.returner_write_profile')
     client, path, ttl = _get_conn(__opts__, write_profile)
 
-    # Check if the specified jid is 'req', as only incorrect code will do that
+    # Check if the specified jid is 'req', as only incorrect code will do this
     if jid == 'req':
         log.warning('sdstack_etcd returner <save_load> was called using a request job id ({jid:s}) with {data:s}'.format(jid=jid, data=load))
 
-    # Build the paths that we'll use for our job
+    # Build the paths that we'll use for registration of our job
     loadp = '/'.join([path, Schema['job-cache'], jid, '.load.p'])
     lockp = '/'.join([path, Schema['job-cache'], jid, '.lock.p'])
 
     ## Now we can just store the current load
-    data = salt.utils.json.dumps(load)
+    json = salt.utils.json.dumps(load)
 
     log.debug('sdstack_etcd returner <save_load> storing load data for job {jid:s} to {path:s} with {data:s}'.format(jid=jid, path=loadp, data=load))
     try:
-        res = client.write(loadp, data)
+        res = client.write(loadp, json, prevExist=False)
+
+    # If the key already exists, then warn the user and update the key. There
+    # isn't anything we can really do about this because it's up to Salt really.
+    except etcd.EtcdAlreadyExist as E:
+        node = client.read(loadp)
+        node.value = json
+
+        log.debug('sdstack_etcd returner <save_load> updating load data for job {jid:s} at {path:s} with {data:s}'.format(jid=jid, path=loadp, data=load))
+        res = client.update(node)
+        log.warning("sdstack_etcd returner <save_load> updated the load data for job {jid:s} at {path:s} with {data:s}. Old data was {old:s}".format(jid=jid, path=res.key, data=res.value, old=res._prev_node.value))
 
     # If we failed here, it's okay because the lock won't get written so this
-    # will get scheduled for deletion.
+    # essentially means the job will get scheduled for deletion.
     except Exception as E:
         log.trace("sdstack_etcd returner <save_load> unable to store load for job {jid:s} to the path {path:s} due to exception ({exception}) being raised".format(jid=jid, path=loadp, exception=E))
         return
@@ -767,11 +777,11 @@ def event_return(events):
         # and tampering with the createdIndex
         except etcd.EtcdAlreadyExist as E:
             log.trace("sdstack_etcd returner <event_return> fetching already existing event with the tag {name:s} at {path:s}".format(name=package['tag'], path=packagep))
-            res = client.read(packagep)
+            node = client.read(packagep)
 
             log.update("sdstack_etcd returner <event_return> updating package for event ({event:d}) with the tag {name:s} at {path:s}".format(event=res.createdIndex, name=package['tag'], path=packagep))
-            res.value = json
-            client.update(res)
+            node.value = json
+            res = client.update(node)
 
         except Exception as E:
             log.trace("sdstack_etcd returner <event_return> unable to write event with the tag {name:s} into {path:s} due to exception ({exception}) being raised".format(name=package['tag'], path=packagep, exception=E))

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -141,9 +141,10 @@ def returner(ret):
     log.debug("sdstack_etcd returner <returner> writing job data (ttl={ttl:d}) for {jid:s} to {path:s} with {data:s}".format(jid=ret['jid'], path=jobp, ttl=ttl, data=repr(ret)))
     for field in ret:
         fieldp = '/'.join([jobp, field])
-        log.trace("sdstack_etcd returner <returner> setting field {0} at {1} to {2:s}".format(field, fieldp, repr(ret[field])))
+
         data = salt.utils.json.dumps(ret[field])
         res = client.set(fieldp, data, ttl=ttl)
+        log.trace("sdstack_etcd returner <returner> set field {field:s} for job {jid:s} at {path:s} to {result:s}".format(field=field, jid=ret['jid'], path=res.key, result=repr(ret[field])))
     return
 
 
@@ -159,27 +160,43 @@ def save_load(jid, load, minions=None):
         ttl = __opts__.get('etcd.ttl')
 
     # Figure out the path using jobs/$jid/.load.p
-    savep = '/'.join([path, 'jobs', jid, '.load.p']),
-    log.debug('sdstack_etcd returner <save_load> setting load data (ttl={ttl:d}) for jid {jid:s} at {path:s} with {data:s}'.format(jid=jid, ttl=ttl, path=savep, data=load))
+    loadp = '/'.join([path, 'jobs', jid, '.load.p']),
+    log.debug('sdstack_etcd returner <save_load> setting load data (ttl={ttl:d}) for job {jid:s} at {path:s} with {data:s}'.format(jid=jid, ttl=ttl, path=loadp, data=load))
 
     # Now we can just store the current load
     data = salt.utils.json.dumps(load)
-    res = client.set(savep, data, ttl=ttl)
+    res = client.set(loadp, data, ttl=ttl)
 
-    log.trace('sdstack_etcd returner <save_load> saved load data for job {jid:s} at {path:s} with {data:s}'.format(jid=jid, path=loadp, data=repr(load)))
+    log.trace('sdstack_etcd returner <save_load> saved load data for job {jid:s} at {path:s} with {data:s}'.format(jid=jid, path=res.key, data=repr(load)))
     return
 
 
 def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument
     '''
-    Included for API consistency.
+    Save/update the minion list for a given jid. The syndic_id argument is
+    included for API compatibility only.
     '''
+    client, path = _get_conn(__opts__, read_profile)
+
+    # Figure out the path that our job should be at
+    jobp = '/'.join([path, 'jobs', jid])
+    log.debug('sdstack_etcd returner <save_minions> adding minions for job {jid:s} to {path:s}'.format(jid=jid, path=jobp))
+
+    # Iterate through all of the minions and add a directory for them to the job path
+    for minion in set(minions):
+        minionp = '/'.join([path, minion])
+        res = client.set(minionp, None, dir=True)
+        log.trace('sdstack_etcd returner <save_minions> added minion {id:s} for job {jid:s} to {path:s}'.format(id=minion, jid=jid, path=res.key))
+    return
 
 
 def clean_old_jobs():
     '''
     Included for API consistency.
     '''
+    # Old jobs should be cleaned by the ttl that's written for each key, so therefore
+    # the implementation of this api is not necessary.
+    pass
 
 
 def get_load(jid):
@@ -191,7 +208,7 @@ def get_load(jid):
 
     # Figure out the path that our job should be at
     loadp = '/'.join([path, 'jobs', jid, '.load.p'])
-    log.debug('sdstack_etcd returner <get_load> reading load data for jid {jid:s} from {path:s}'.format(jid=jid, path=loadp))
+    log.debug('sdstack_etcd returner <get_load> reading load data for job {jid:s} from {path:s}'.format(jid=jid, path=loadp))
 
     # Read it. If EtcdKeyNotFound was raised then the key doesn't exist and so
     # we need to return None, because that's what our caller expects on a
@@ -201,7 +218,7 @@ def get_load(jid):
     except salt.utils.etcd_util.etcd.EtcdKeyNotFound as E:
         log.error("sdstack_etcd returner <get_load> could not find job {jid:s} at the path {path:s}".format(jid=jid, path=loadp))
         return None
-    log.trace('sdstack_etcd returner <get_load> found load data for jid {jid:s} at {path:s} with value {data:s}'.format(jid=jid, path=loadp, data=repr(res.value))))
+    log.trace('sdstack_etcd returner <get_load> found load data for job {jid:s} at {path:s} with value {data:s}'.format(jid=jid, path=res.key, data=repr(res.value))))
     return salt.utils.json.loads(res.value)
 
 
@@ -213,7 +230,7 @@ def get_jid(jid):
 
     # Figure out the path that our job should be at
     jobp = '/'.join([path, 'jobs', jid])
-    log.debug('sdstack_etcd returner <get_jid> reading job fields for jid {jid:s} from {path:s}'.format(jid=jid, path=jobp))
+    log.debug('sdstack_etcd returner <get_jid> reading job fields for job {jid:s} from {path:s}'.format(jid=jid, path=jobp))
 
     # Try and read the job directory. If we have a missing key exception then no
     # minions have returned anything yet and so we return an empty dict for the
@@ -245,9 +262,8 @@ def get_jid(jid):
 
         # We found something, so update our return dict with the minion id and
         # the result that it returned.
-        data = res.value
-        ret[comps[-1]] = {'return': salt.utils.json.loads(data)}
-        log.trace("sdstack_etcd returner <get_jid> job {jid:s} from minion {id:s} at path {path:s} returned {ret:s}".format(id=comps[-1], jid=jid, path=returnp, ret=repr(data)))
+        ret[comps[-1]] = {'return': salt.utils.json.loads(res.value)}
+        log.trace("sdstack_etcd returner <get_jid> job {jid:s} from minion {id:s} at path {path:s} returned {result:s}".format(id=comps[-1], jid=jid, path=res.key, result=repr(res.value)))
     return ret
 
 

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -136,15 +136,29 @@ def returner(ret):
     if hasattr(res, '_prev_node'):
         log.trace("sdstack_etcd returner <returner> the previous job id {old:s} for {id:s} at {path:s} was set to {new:s}".format(old=res._prev_node.value, id=ret['id'], path=minionp, new=res.value))
 
-    # Iterate through all the fields in the ret dict and dump it under jobs/$jid/id/$field
+    # Figure out the path for the specified job and minion
     jobp = '/'.join([path, 'jobs', ret['jid'], ret['id']])
     log.debug("sdstack_etcd returner <returner> writing job data (ttl={ttl:d}) for {jid:s} to {path:s} with {data}".format(jid=ret['jid'], path=jobp, ttl=ttl, data=ret))
+
+    # Iterate through all the fields in the return dict and dump them under the
+    # jobs/$jid/id/$field key. We aggregate all the exceptions so that if an
+    # error happens, the rest of the fields will still be written.
+    exceptions = []
     for field in ret:
         fieldp = '/'.join([jobp, field])
-
         data = salt.utils.json.dumps(ret[field])
-        res = client.set(fieldp, data, ttl=ttl)
+        try:
+            res = client.set(fieldp, data, ttl=ttl)
+        except Exception as E:
+            log.trace("sdstack_etcd returner <returner> unable to set field {field:s} for job {jid:s} at {path:s} to {result}".format(field=field, jid=ret['jid'], path=fieldp, result=ret[field]))
+            exceptions.append((E, field, ret[field]))
+            continue
         log.trace("sdstack_etcd returner <returner> set field {field:s} for job {jid:s} at {path:s} to {result}".format(field=field, jid=ret['jid'], path=res.key, result=ret[field]))
+
+    # Go back through all the exceptions that occurred while trying to write the
+    # fields and log them.
+    for e, field, value in exceptions:
+        log.exception("sdstack_etcd returner <returner> exception ({exception:s}) was raised while trying to set the field {field:s} for job {jid:s} to {value}".format(exception=e, field=field, jid=ret['jid'], value=value))
     return
 
 

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -234,27 +234,37 @@ def save_load(jid, load, minions=None):
 
     # Check if the specified jid is 'req', as only incorrect code will do that
     if jid == 'req':
-        log.warning('sdstack_etcd returner <save_load> was called with a request job id ({jid:s}) with {data:s}'.format(jid=jid, data=load))
+        log.warning('sdstack_etcd returner <save_load> was called using a request job id ({jid:s}) with {data:s}'.format(jid=jid, data=load))
 
-    # Figure out the path using jobs/$jid/.load.p
+    # Build the paths that we'll use for our job
     loadp = '/'.join([path, Schema['job-cache'], jid, '.load.p'])
-    log.debug('sdstack_etcd returner <save_load> setting load data for job {jid:s} at {path:s} with {data:s}'.format(jid=jid, path=loadp, data=load))
+    lockp = '/'.join([path, Schema['job-cache'], jid, '.lock.p'])
 
-    # Now we can just store the current load
+    ## Now we can just store the current load
     data = salt.utils.json.dumps(load)
-    res = client.write(loadp, data)
 
-    log.trace('sdstack_etcd returner <save_load> saved load data for job {jid:s} at {path:s} with {data}'.format(jid=jid, path=res.key, data=load))
+    log.debug('sdstack_etcd returner <save_load> storing load data for job {jid:s} to {path:s} with {data:s}'.format(jid=jid, path=loadp, data=load))
+    try:
+        res = client.write(loadp, data)
+
+    # If we failed here, it's okay because the lock won't get written so this
+    # will get scheduled for deletion.
+    except Exception as E:
+        log.trace("sdstack_etcd returner <save_load> unable to store load for job {jid:s} to the path {path:s} due to exception ({exception}) being raised".format(jid=jid, path=loadp, exception=E)
+        return
 
     # Since this is when a job is being created, create a lock that we can
     # check to see if the job has expired. This allows a user to signal to
-    # salt that its okey to remove the entire key by removing this lock.
-    lockp = '/'.join([path, Schema['job-cache'], jid, '.lock.p'])
+    # salt that it's okay to remove the entire key by removing this lock.
     log.trace('sdstack_etcd returner <save_load> writing lock file for job {jid:s} at {path:s} using index {index:d}'.format(jid=jid, path=lockp, index=res.modifiedIndex))
-    res = client.write(lockp, res.modifiedIndex, ttl=ttl if ttl > 0 else None)
 
-    if res.ttl is not None:
-        log.trace('sdstack_etcd returner <save_load> job {jid:s} at {path:s} will expire in {ttl:d} seconds'.format(jid=jid, path=res.key, ttl=res.ttl))
+    try:
+        res = client.write(lockp, res.modifiedIndex, ttl=ttl if ttl > 0 else None)
+        if res.ttl is not None:
+            log.trace('sdstack_etcd returner <save_load> job {jid:s} at {path:s} will expire in {ttl:d} seconds'.format(jid=jid, path=res.key, ttl=res.ttl))
+
+    except Exception as E:
+        log.trace("sdstack_etcd returner <save_load> unable to write lock for job {jid:s} to the path {path:s} due to exception ({exception}) being raised".format(jid=jid, path=lockp, exception=E)
 
     return
 
@@ -275,11 +285,12 @@ def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argume
     jobp = '/'.join([path, Schema['job-cache'], jid])
     log.debug('sdstack_etcd returner <save_minions> adding minions for job {jid:s} to {path:s}'.format(jid=jid, path=jobp))
 
-    # Iterate through all of the minions and add a directory for them to the job path
-    for minion in set(minions):
-        minionp = '/'.join([path, minion])
+    # Iterate through all of the minions we received and add the directory for them
+    # to the job path despite there being no content here.
+    for minion in minions:
+        minionp = '/'.join([jobp, minion])
         res = client.write(minionp, None, dir=True)
-        log.trace('sdstack_etcd returner <save_minions> added minion {minion:s} for job {jid:s} to {path:s}'.format(minion=minion, jid=jid, path=res.key))
+        log.trace('sdstack_etcd returner <save_minions> added minion {minion:s} path to job {jid:s} at {path:s}'.format(minion=minion, jid=jid, path=res.key))
     return
 
 
@@ -515,6 +526,7 @@ def get_jid(jid):
     try:
         items = client.read(jobp)
     except etcd.EtcdKeyNotFound as E:
+        log.trace('sdstack_etcd returner <get_jid> unable to read job {jid:s} from {path:s}'.format(jid=jid, path=jobp))
         return {}
 
     # Iterate through all of the children at our job path that are directories.

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -418,12 +418,12 @@ def event_return(events):
         try:
             res = client.set(path, json, ttl=ttl)
         except Exception as err:
-            log.exception('etcd: Unable to write event into returner path {:s} due to exception {:s}: {!r}'.format(path, package, err))
+            log.exception('etcd: Unable to write event into returner path {:s} due to exception {:s}: {}'.format(path, package, err))
             exceptions.append(err)
             continue
 
         if not res:
-            log.error('etcd: Unable to write event into returner path {:s}: {!r}'.format(path, package))
+            log.error('etcd: Unable to write event into returner path {:s}: {}'.format(path, package))
         continue
 
     return

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -997,3 +997,65 @@ def get_jids_filter(count, filter_find_job=True):
 
         ret.append(salt.utils.jid.format_jid_instance_ext(jid, data))
     return ret
+
+def update_endtime(jid, time):
+    '''
+    Update (or store) the end time for a given job
+
+    Endtime is stored as a plain text string
+    '''
+    write_profile = __opts__.get('etcd.returner_write_profile')
+    client, path, ttl = _get_conn(__opts__, write_profile)
+
+    # Check if the specified jid is 'req', as only incorrect code will do this
+    if jid == 'req':
+        log.debug('sdstack_etcd returner <update_endtime> was called using a request job id ({jid:s}) with {data}'.format(jid=jid, data=time))
+
+    # Build the path that we'll use to update the endtime
+    timep = '/'.join([path, Schema['job-cache'], jid, '.endtime'])
+
+    ## Now we can simply update it
+    json = salt.utils.json.dumps(time)
+
+    log.debug('sdstack_etcd returner <update_endtime> storing endtime for job {jid:s} to {path:s} with {data}'.format(jid=jid, path=timep, data=time))
+    try:
+        res = client.write(timep, json, prevExist=False)
+
+    # If the key already exists, then warn the user but still update the key.
+    except etcd.EtcdAlreadyExist as E:
+        node = client.read(timep)
+        node.value = json
+
+        log.debug('sdstack_etcd returner <update_endtime> updating endtime for job {jid:s} at {path:s} with {data}'.format(jid=jid, path=timep, data=time))
+        res = client.update(node)
+
+    # If we failed here, it's okay because the lock won't get written so this
+    # essentially means the job will get scheduled for deletion.
+    except Exception as E:
+        log.trace("sdstack_etcd returner <update_endtime> unable to store endtime for job {jid:s} to the path {path:s} due to exception ({exception}) being raised".format(jid=jid, path=timep, exception=E))
+        return
+    log.trace("sdstack_etcd returner <update_endtime> successfully wrote endtime for job {jid:s} to the path {path:s} with {data}".format(jid=jid, path=timep, data=time))
+
+def get_endtime(jid):
+    '''
+    Retrieve the stored endtime for a given job
+
+    Returns False if no endtime is present
+    '''
+    read_profile = __opts__.get('etcd.returner_read_profile')
+    client, path, _ = _get_conn(__opts__, read_profile)
+
+    # Figure out the path that our endtime should be at
+    timep = '/'.join([path, Schema['job-cache'], jid, '.endtime'])
+
+    # Read it. If EtcdKeyNotFound was raised then the key doesn't exist and so
+    # we need to return False, because that's what salt.returners.local_cache
+    # returns when the endtime hasn't been written..
+    log.debug('sdstack_etcd returner <get_endtime> reading endtime for job {jid:s} from {path:s}'.format(jid=jid, path=timep))
+    try:
+        res = client.read(timep)
+    except etcd.EtcdKeyNotFound as E:
+        log.error("sdstack_etcd returner <get_endtime> could not find endtime for job {jid:s} at the path {path:s}".format(jid=jid, path=timep))
+        return None
+    log.debug('sdstack_etcd returner <get_endtime> found endtime for job {jid:s} at {path:s} with value {data}'.format(jid=jid, path=res.key, data=res.value))
+    return salt.utils.json.loads(res.value)

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -850,7 +850,7 @@ def event_return(events):
             log.trace("sdstack_etcd returner <event_return> fetching already existing event with the tag {name:s} at {path:s}".format(name=package['tag'], path=packagep))
             node = client.read(packagep)
 
-            log.update("sdstack_etcd returner <event_return> updating package for event ({event:d}) with the tag {name:s} at {path:s}".format(event=res.createdIndex, name=package['tag'], path=packagep))
+            log.debug("sdstack_etcd returner <event_return> updating package for event ({event:d}) with the tag {name:s} at {path:s}".format(event=res.createdIndex, name=package['tag'], path=packagep))
             node.value = json
             res = client.update(node)
 

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -418,12 +418,12 @@ def event_return(events):
         try:
             res = client.set(path, json, ttl=ttl)
         except Exception as err:
-            log.exception('etcd: Unable to write event into returner path {:s} due to exception {:s}: {!r}', path, package, err)
+            log.exception('etcd: Unable to write event into returner path {:s} due to exception {:s}: {!r}'.format(path, package, err))
             exceptions.append(err)
             continue
 
         if not res:
-            log.error('etcd: Unable to write event into returner path {:s}: {!r}', path, package)
+            log.error('etcd: Unable to write event into returner path {:s}: {!r}'.format(path, package))
         continue
 
     return

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -101,9 +101,10 @@ def _get_conn(opts, profile=None):
     Establish a connection to etcd
     """
     if profile is None:
-        profile = opts.get("etcd.returner")
-    path = opts.get("etcd.returner_root", "/salt/return")
-    return salt.utils.etcd_util.get_conn(opts, profile), path
+        profile = opts.get('etcd.returner')
+    path = opts.get('etcd.returner_root', '/salt/return')
+    wrapper = salt.utils.etcd_util.get_conn(opts, profile)
+    return wrapper.client, path
 
 
 def returner(ret):

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -100,10 +100,17 @@ def _get_conn(opts, profile=None):
     # Grab the returner_root from the options
     path = opts.get('etcd.returner_root', '/salt/return')
 
+    # Calculate the time-to-live for a job while giving etcd.ttl priority.
+    # The etcd.ttl option specifies the number of seconds, whereas the keep_jobs
+    # option specifies the number of hours. If any of these values are zero,
+    # then jobs are forever persistent.
+
+    ttl = opts.get('etcd.ttl', int(opts.get('keep_jobs', 0)) * 60 * 60)
+
     # Grab a connection using etcd_util, and then return the EtcdClient
     # from one of its attributes
     wrapper = salt.utils.etcd_util.get_conn(opts, profile)
-    return wrapper.client, path
+    return wrapper.client, path, ttl
 
 
 def returner(ret):
@@ -112,7 +119,7 @@ def returner(ret):
     '''
     write_profile = __opts__.get('etcd.returner_write_profile')
 
-    client, path = _get_conn(__opts__, write_profile)
+    client, path, _ = _get_conn(__opts__, write_profile)
 
     # If a minion is returning a standalone job, update it with a new jid, and
     # save it to ensure it can be queried similar to the mysql returner.
@@ -159,14 +166,7 @@ def save_load(jid, load, minions=None):
     Save the load to the specified jid.
     '''
     write_profile = __opts__.get('etcd.returner_write_profile')
-    client, path = _get_conn(__opts__, write_profile)
-
-    # Calculate the time-to-live for a job while giving etcd.ttl priority.
-    # The etcd.ttl option specifies the number of seconds, whereas the keep_jobs
-    # option specifies the number of hours. If any of these values are zero,
-    # then jobs are forever persistent.
-
-    ttl = opts.get('etcd.ttl', int(opts.get('keep_jobs', 0)) * 60 * 60)
+    client, path, ttl = _get_conn(__opts__, write_profile)
 
     # Check if the specified jid is 'req', as only incorrect code will do that
     if jid == 'req':
@@ -200,7 +200,7 @@ def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argume
     included for API compatibility only.
     '''
     write_profile = __opts__.get('etcd.returner_write_profile')
-    client, path = _get_conn(__opts__, write_profile)
+    client, path, _ = _get_conn(__opts__, write_profile)
 
     # Check if the specified jid is 'req', as only incorrect code will do that
     if jid == 'req':
@@ -218,9 +218,9 @@ def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argume
     return
 
 
-def _purge_jobs(ttl):
+def _purge_jobs():
     write_profile = __opts__.get('etcd.returner_write_profile')
-    client, path = _get_conn(__opts__, write_profile)
+    client, path, _ = _get_conn(__opts__, write_profile)
 
     # Figure out the path that our jobs should exist at
     jobp = '/'.join([path, 'jobs'])
@@ -276,7 +276,7 @@ def get_load(jid):
     Return the load data that marks a specified jid.
     '''
     read_profile = __opts__.get('etcd.returner_read_profile')
-    client, path = _get_conn(__opts__, read_profile)
+    client, path, _ = _get_conn(__opts__, read_profile)
 
     # Figure out the path that our job should be at
     loadp = '/'.join([path, 'jobs', jid, '.load.p'])
@@ -298,7 +298,7 @@ def get_jid(jid):
     '''
     Return the information returned when the specified job id was executed.
     '''
-    client, path = _get_conn(__opts__)
+    client, path, _ = _get_conn(__opts__)
 
     # Figure out the path that our job should be at
     jobp = '/'.join([path, 'jobs', jid])
@@ -344,7 +344,7 @@ def get_fun(fun):
     '''
     Return a dict containing the last function called for all the minions that have called a function.
     '''
-    client, path = _get_conn(__opts__)
+    client, path, _ = _get_conn(__opts__)
 
     # Find any minions that had their last function registered by returner()
     minionsp = '/'.join([path, 'minions'])
@@ -390,7 +390,7 @@ def get_jids():
     '''
     Return a list of all job ids that have returned something.
     '''
-    client, path = _get_conn(__opts__)
+    client, path, _ = _get_conn(__opts__)
 
     # Enumerate all the jobs that are available.
     jobsp = '/'.join([path, 'jobs'])
@@ -420,7 +420,7 @@ def get_minions():
     '''
     Return a list of all minions that have returned something.
     '''
-    client, path = _get_conn(__opts__)
+    client, path, _ = _get_conn(__opts__)
 
     # Find any minions that have returned anything
     minionsp = '/'.join([path, 'minions'])
@@ -460,7 +460,7 @@ def event_return(events):
     option in master config.
     '''
     write_profile = __opts__.get('etcd.returner_write_profile')
-    client, path = _get_conn(__opts__, write_profile)
+    client, path, _ = _get_conn(__opts__, write_profile)
 
     # Iterate through all the events, and add them to the events path based
     # on the tag that is labeled in each event. We aggregate all errors into

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -161,6 +161,13 @@ def save_load(jid, load, minions=None):
     write_profile = __opts__.get('etcd.returner_write_profile')
     client, path = _get_conn(__opts__, write_profile)
 
+    # Calculate the time-to-live for a job while giving etcd.ttl priority.
+    # The etcd.ttl option specifies the number of seconds, whereas the keep_jobs
+    # option specifies the number of hours. If any of these values are zero,
+    # then jobs are forever persistent.
+
+    ttl = opts.get('etcd.ttl', int(opts.get('keep_jobs', 0)) * 60 * 60)
+
     # Check if the specified jid is 'req', as only incorrect code will do that
     if jid == 'req':
         log.warning('sdstack_etcd returner <save_load> was called for job {jid:s} with {data:s}'.format(jid=jid, data=load))
@@ -174,6 +181,16 @@ def save_load(jid, load, minions=None):
     res = client.set(loadp, data)
 
     log.trace('sdstack_etcd returner <save_load> saved load data for job {jid:s} at {path:s} with {data}'.format(jid=jid, path=res.key, data=load))
+
+    # Since this is when a job is being created, create a lock that we can
+    # check to see if the job has expired. This allows a user to signal to
+    # salt that its okey to remove the entire key by removing this lock.
+    lockp = '/'.join([path, 'jobs', jid, '.lock.p'])
+    res = client.set(lockp, res.modifiedIndex, ttl=ttl if ttl > 0 else None)
+
+    if res.ttl is not None:
+        log.trace('sdstack_etcd returner <save_load> job {jid:s} at {path:s} will expire in {ttl:d} seconds'.format(jid=jid, path=res.key, ttl=res.ttl))
+
     return
 
 
@@ -201,29 +218,57 @@ def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argume
     return
 
 
+def _purge_jobs(ttl):
+    write_profile = __opts__.get('etcd.returner_write_profile')
+    client, path = _get_conn(__opts__, write_profile)
+
+    # Figure out the path that our jobs should exist at
+    jobp = '/'.join([path, 'jobs'])
+    log.debug('sdstack_etcd returner <get_jid> reading job fields for job {jid:s} from {path:s}'.format(jid=jid, path=jobp))
+
+    # Try and read the job directory. If we have a missing key exception then no
+    # minions have returned anything yet and so we can simply leave.
+    try:
+        jobs = client.read(jobp)
+    except salt.utils.etcd_util.etcd.EtcdKeyNotFound as E:
+        return 0
+
+    # Iterate through all of the children at our job path while looking for 
+    # the .lock.p key. If one isn't found, then we can remove this job because
+    # it has expired.
+    count = 0
+    for job in jobs.leaves:
+        if not job.dir:
+            log.warning('sdstack_etcd returner <_purge_jobs> found a non-job at {path:s} {expire:s}'.format(path=job.key, expire='that will need to be manually removed' if job.ttl is None else 'that will expire in {ttl:d} seconds'.format(job.ttl)))
+            continue
+
+        # Build our lock path
+        lockp = '/'.join([job.key, '.lock.p'])
+
+        # Ping it to see if it's alive
+        try:
+            client.read(lockp)
+
+        # It's not, so the job is dead and we can remove it
+        except etcd.EtcdKeyNotFound:
+            res = client.delete(job.key, recursive=True)
+            log.trace('sdstack_etcd returner <_purge_jobs> job {jid:s} at {path:s} has expired'.format(jid=res.key.split('/')[-1], path=res.key))
+            count += 1
+        continue
+    return count
+
+
 def clean_old_jobs():
     '''
-    FIXME: This needs to be implemented
+    Called in the master's event loop every loop_interval. Removes any jobs,
+    and returns that are older than the etcd.ttl option (seconds), or the
+    keep_jobs option (hours).
+
+    :return:
     '''
-    # XXX:
-    # This needs to be implemented. The reason why we don't use ttl to
-    # automatically clean this up is because Salt doesn't know about ttl
-    # and so it assumes that records are always available until it
-    # removes them (which makes them unavailable). That's what this api
-    # call is for at least.
-    #
-    # If we use ttl to automatically remove records we encounter issues
-    # such as that Salt's main code isn't monitorying returner records
-    # in any way, instead treating returners as just a data store with
-    # nearly an arbitrary schema. Related is that it has not exposed an
-    # interface to returners for persisting a connection, modifying
-    # records at arbitrary times, and notifying (like an event-callback)
-    # Salt that a record change has happened.
-    #
-    # Because these features aren't available, this api needs to be
-    # implemented if we want salt to be able to clean old jobs that have
-    # expired.
-    pass
+
+    jobc = _purge_jobs(ttl)
+    log.trace('sdstack_etcd returner <clean_old_jobs> successfully removed {:d} jobs'.format(jobc))
 
 
 def get_load(jid):

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -686,9 +686,10 @@ def event_return(events):
             log.error("sdstack_etcd returner <event_return> unable to cache event for {index:d} due to event already existing".format(index=res.createdIndex))
 
         # If we got here, then we should be able to write the tag under the current index
+        tagp = '/'.join([path, Schema['event-path'], package['tag'])
         try:
             log.trace("sdstack_etcd returner <event_return> updating cached tag at {path:s} for the event {index:d} with the tag {name:s}".format(path='/'.join([path, Schema['event-cache'], str(res.createdIndex), 'tag']), index=res.createdIndex, name=package['tag']))
-            client.write('/'.join([path, Schema['event-cache'], str(res.createdIndex), 'tag']), package['tag'])
+            client.write('/'.join([path, Schema['event-cache'], str(res.createdIndex), 'tag']), tagp])
 
         except Exception as E:
             log.trace("sdstack_etcd returner <event_return> unable to cache tag {name:s} under index {index:d} due to exception ({exception}) being raised".format(name=package['tag'], index=res.createdIndex, exception=E))

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -97,9 +97,9 @@ def __virtual__():
 
 
 def _get_conn(opts, profile=None):
-    """
-    Establish a connection to etcd
-    """
+    '''
+    Establish a connection to an etcd profile.
+    '''
     if profile is None:
         profile = opts.get('etcd.returner')
 
@@ -113,10 +113,10 @@ def _get_conn(opts, profile=None):
 
 
 def returner(ret):
-    """
-    Return data to an etcd server or cluster
-    """
-    write_profile = __opts__.get("etcd.returner_write_profile")
+    '''
+    Return data to an etcd profile.
+    '''
+    write_profile = __opts__.get('etcd.returner_write_profile')
     if write_profile:
         ttl = __opts__.get(write_profile, {}).get("etcd.ttl")
     else:
@@ -148,8 +148,8 @@ def returner(ret):
 
 
 def save_load(jid, load, minions=None):
-    """
-    Save the load to the specified jid
+    '''
+    Save the load to the specified jid.
     '''
     write_profile = __opts__.get('etcd.returner_write_profile')
     client, path = _get_conn(__opts__, write_profile)
@@ -171,20 +171,20 @@ def save_load(jid, load, minions=None):
 
 
 def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argument
-    """
-    Included for API consistency
-    """
+    '''
+    Included for API consistency.
+    '''
 
 
 def clean_old_jobs():
-    """
-    Included for API consistency
-    """
+    '''
+    Included for API consistency.
+    '''
 
 
 def get_load(jid):
-    """
-    Return the load data that marks a specified jid
+    '''
+    Return the load data that marks a specified jid.
     '''
     read_profile = __opts__.get('etcd.returner_read_profile')
     client, path = _get_conn(__opts__, read_profile)
@@ -206,8 +206,8 @@ def get_load(jid):
 
 
 def get_jid(jid):
-    """
-    Return the information returned when the specified job id was executed
+    '''
+    Return the information returned when the specified job id was executed.
     '''
     client, path = _get_conn(__opts__)
 
@@ -252,8 +252,8 @@ def get_jid(jid):
 
 
 def get_fun(fun):
-    """
-    Return a dict of the last function called for all minions
+    '''
+    Return a dict containing the last function called for all the minions that have called a function.
     '''
     client, path = _get_conn(__opts__)
 
@@ -298,8 +298,8 @@ def get_fun(fun):
 
 
 def get_jids():
-    """
-    Return a list of all job ids
+    '''
+    Return a list of all job ids that have returned something.
     '''
     client, path = _get_conn(__opts__)
 
@@ -328,8 +328,8 @@ def get_jids():
 
 
 def get_minions():
-    """
-    Return a list of minions
+    '''
+    Return a list of all minions that have returned something.
     '''
     client, path = _get_conn(__opts__)
 
@@ -357,7 +357,7 @@ def get_minions():
 
 
 def prep_jid(nocache=False, passed_jid=None):  # pylint: disable=unused-argument
-    """
-    Do any work necessary to prepare a JID, including sending a custom id
-    """
+    '''
+    Do any work necessary to prepare a JID, including sending a custom id.
+    '''
     return passed_jid if passed_jid is not None else salt.utils.jid.gen_jid(__opts__)

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -185,12 +185,13 @@ def returner(ret):
     write_profile = __opts__.get('etcd.returner_write_profile')
     client, path, ttl = _get_conn(__opts__, write_profile)
 
-    # If a minion is returning a standalone job, make sure to save the load as
-    # it's likely there's no load saved since this job came directly from a
-    # minion.
+    # If a minion is returning a standalone job, update the jid for the load
+    # when it's saved since this job came directly from a minion.
     if ret['jid'] == 'req':
-        log.debug('sdstack_etcd returner <returner> received a new job id request ({jid:s}) for {data}'.format(jid=ret['jid'], data=ret))
-        save_load(ret['jid'], ret)
+        new_jid = prep_jid(nocache=ret.get('nocache', False))
+        log.debug('sdstack_etcd returner <returner> satisfying a new job id request ({jid:s}) with id {new:s} for {data}'.format(jid=ret['jid'], new=new_jid, data=ret))
+        ret['jid'] = new_jid
+        save_load(new_jid, ret)
 
     # Update the given minion in the external job cache with the current (latest job)
     # This is used by get_fun() to return the last function that was called

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -138,13 +138,13 @@ def returner(ret):
 
     # Iterate through all the fields in the ret dict and dump it under jobs/$jid/id/$field
     jobp = '/'.join([path, 'jobs', ret['jid'], ret['id']])
-    log.debug("sdstack_etcd returner <returner> writing job data (ttl={ttl:d}) for {jid:s} to {path:s} with {data:s}".format(jid=ret['jid'], path=jobp, ttl=ttl, data=repr(ret)))
+    log.debug("sdstack_etcd returner <returner> writing job data (ttl={ttl:d}) for {jid:s} to {path:s} with {data}".format(jid=ret['jid'], path=jobp, ttl=ttl, data=ret))
     for field in ret:
         fieldp = '/'.join([jobp, field])
 
         data = salt.utils.json.dumps(ret[field])
         res = client.set(fieldp, data, ttl=ttl)
-        log.trace("sdstack_etcd returner <returner> set field {field:s} for job {jid:s} at {path:s} to {result:s}".format(field=field, jid=ret['jid'], path=res.key, result=repr(ret[field])))
+        log.trace("sdstack_etcd returner <returner> set field {field:s} for job {jid:s} at {path:s} to {result}".format(field=field, jid=ret['jid'], path=res.key, result=ret[field]))
     return
 
 
@@ -167,7 +167,7 @@ def save_load(jid, load, minions=None):
     data = salt.utils.json.dumps(load)
     res = client.set(loadp, data, ttl=ttl)
 
-    log.trace('sdstack_etcd returner <save_load> saved load data for job {jid:s} at {path:s} with {data:s}'.format(jid=jid, path=res.key, data=repr(load)))
+    log.trace('sdstack_etcd returner <save_load> saved load data for job {jid:s} at {path:s} with {data}'.format(jid=jid, path=res.key, data=load))
     return
 
 
@@ -218,7 +218,7 @@ def get_load(jid):
     except salt.utils.etcd_util.etcd.EtcdKeyNotFound as E:
         log.error("sdstack_etcd returner <get_load> could not find job {jid:s} at the path {path:s}".format(jid=jid, path=loadp))
         return None
-    log.trace('sdstack_etcd returner <get_load> found load data for job {jid:s} at {path:s} with value {data:s}'.format(jid=jid, path=res.key, data=repr(res.value)))
+    log.trace('sdstack_etcd returner <get_load> found load data for job {jid:s} at {path:s} with value {data}'.format(jid=jid, path=res.key, data=res.value))
     return salt.utils.json.loads(res.value)
 
 
@@ -263,7 +263,7 @@ def get_jid(jid):
         # We found something, so update our return dict with the minion id and
         # the result that it returned.
         ret[comps[-1]] = {'return': salt.utils.json.loads(res.value)}
-        log.trace("sdstack_etcd returner <get_jid> job {jid:s} from minion {id:s} at path {path:s} returned {result:s}".format(id=comps[-1], jid=jid, path=res.key, result=repr(res.value)))
+        log.trace("sdstack_etcd returner <get_jid> job {jid:s} from minion {id:s} at path {path:s} returned {result}".format(id=comps[-1], jid=jid, path=res.key, result=res.value))
     return ret
 
 

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -47,13 +47,7 @@ A username and password can be set:
     etcd.username: larry  # Optional; requires etcd.password to be set
     etcd.password: 123pass  # Optional; requires etcd.username to be set
 
-You can also set a TTL (time to live) value for the returner:
-
-.. code-block:: yaml
-
-    etcd.ttl: 5
-
-Authentication with username and password, and ttl, currently requires the
+Authentication with username and password, currently requires the
 ``master`` branch of ``python-etcd``.
 
 You may also specify different roles for read and write operations. First,
@@ -117,10 +111,6 @@ def returner(ret):
     Return data to an etcd profile.
     '''
     write_profile = __opts__.get('etcd.returner_write_profile')
-    if write_profile:
-        ttl = __opts__.get(write_profile, {}).get("etcd.ttl")
-    else:
-        ttl = __opts__.get("etcd.ttl")
 
     client, path = _get_conn(__opts__, write_profile)
 
@@ -131,14 +121,14 @@ def returner(ret):
     # Update the given minion in the external job cache with the current (latest job)
     # This is used by get_fun() to return the last function that was called
     minionp = '/'.join([path, 'minions', ret['id']])
-    log.debug("sdstack_etcd returner <returner> updating (last) job id (ttl={ttl:d}) of {id:s} at {path:s} with job {jid:s}".format(jid=ret['jid'], id=ret['id'], path=minionp, ttl=ttl))
-    res = client.set(minionp, ret['jid'], ttl=ttl)
+    log.debug("sdstack_etcd returner <returner> updating (last) job id of {id:s} at {path:s} with job {jid:s}".format(jid=ret['jid'], id=ret['id'], path=minionp))
+    res = client.set(minionp, ret['jid'])
     if hasattr(res, '_prev_node'):
         log.trace("sdstack_etcd returner <returner> the previous job id {old:s} for {id:s} at {path:s} was set to {new:s}".format(old=res._prev_node.value, id=ret['id'], path=minionp, new=res.value))
 
     # Figure out the path for the specified job and minion
     jobp = '/'.join([path, 'jobs', ret['jid'], ret['id']])
-    log.debug("sdstack_etcd returner <returner> writing job data (ttl={ttl:d}) for {jid:s} to {path:s} with {data}".format(jid=ret['jid'], path=jobp, ttl=ttl, data=ret))
+    log.debug("sdstack_etcd returner <returner> writing job data for {jid:s} to {path:s} with {data}".format(jid=ret['jid'], path=jobp, data=ret))
 
     # Iterate through all the fields in the return dict and dump them under the
     # jobs/$jid/id/$field key. We aggregate all the exceptions so that if an
@@ -148,7 +138,7 @@ def returner(ret):
         fieldp = '/'.join([jobp, field])
         data = salt.utils.json.dumps(ret[field])
         try:
-            res = client.set(fieldp, data, ttl=ttl)
+            res = client.set(fieldp, data)
         except Exception as E:
             log.trace("sdstack_etcd returner <returner> unable to set field {field:s} for job {jid:s} at {path:s} to {result}".format(field=field, jid=ret['jid'], path=fieldp, result=ret[field]))
             exceptions.append((E, field, ret[field]))
@@ -168,18 +158,14 @@ def save_load(jid, load, minions=None):
     '''
     write_profile = __opts__.get('etcd.returner_write_profile')
     client, path = _get_conn(__opts__, write_profile)
-    if write_profile:
-        ttl = __opts__.get(write_profile, {}).get("etcd.ttl")
-    else:
-        ttl = __opts__.get('etcd.ttl')
 
     # Figure out the path using jobs/$jid/.load.p
     loadp = '/'.join([path, 'jobs', jid, '.load.p'])
-    log.debug('sdstack_etcd returner <save_load> setting load data (ttl={ttl:d}) for job {jid:s} at {path:s} with {data:s}'.format(jid=jid, ttl=ttl, path=loadp, data=load))
+    log.debug('sdstack_etcd returner <save_load> setting load data for job {jid:s} at {path:s} with {data:s}'.format(jid=jid, path=loadp, data=load))
 
     # Now we can just store the current load
     data = salt.utils.json.dumps(load)
-    res = client.set(loadp, data, ttl=ttl)
+    res = client.set(loadp, data)
 
     log.trace('sdstack_etcd returner <save_load> saved load data for job {jid:s} at {path:s} with {data}'.format(jid=jid, path=res.key, data=load))
     return
@@ -207,10 +193,26 @@ def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argume
 
 def clean_old_jobs():
     '''
-    Included for API consistency.
+    FIXME: This needs to be implemented
     '''
-    # Old jobs should be cleaned by the ttl that's written for each key, so therefore
-    # the implementation of this api is not necessary.
+    # XXX:
+    # This needs to be implemented. The reason why we don't use ttl to
+    # automatically clean this up is because Salt doesn't know about ttl
+    # and so it assumes that records are always available until it
+    # removes them (which makes them unavailable). That's what this api
+    # call is for at least.
+    #
+    # If we use ttl to automatically remove records we encounter issues
+    # such as that Salt's main code isn't monitorying returner records
+    # in any way, instead treating returners as just a data store with
+    # nearly an arbitrary schema. Related is that it has not exposed an
+    # interface to returners for persisting a connection, modifying
+    # records at arbitrary times, and notifying (like an event-callback)
+    # Salt that a record change has happened.
+    #
+    # Because these features aren't available, this api needs to be
+    # implemented if we want salt to be able to clean old jobs that have
+    # expired.
     pass
 
 
@@ -369,8 +371,8 @@ def get_minions():
     minionsp = '/'.join([path, 'minions'])
     log.debug('sdstack_etcd returner <get_minions> reading minions at {path:s}'.format(path=minionsp))
 
-    # If no minions were found, then nobody has returned anything recently
-    # (due to ttl). In this case, return an empty last for the caller.
+    # If no minions were found, then nobody has returned anything recently. In
+    # this case, return an empty last for the caller.
     try:
         items = client.get(minionsp)
     except salt.utils.etcd_util.etcd.EtcdKeyNotFound as E:
@@ -404,10 +406,6 @@ def event_return(events):
     '''
     write_profile = __opts__.get('etcd.returner_write_profile')
     client, path = _get_conn(__opts__, write_profile)
-    if write_profile:
-        ttl = __opts__.get(write_profile, {}).get('etcd.ttl')
-    else:
-        ttl = __opts__.get('etcd.ttl')
 
     # Iterate through all the events, and add them to the events path based
     # on the tag that is labeled in each event. We aggregate all errors into
@@ -428,13 +426,13 @@ def event_return(events):
         # Now we can write the event package into the event path
         try:
             json = salt.utils.json.dumps(package)
-            res = client.set(eventp, json, ttl=ttl)
+            res = client.set(eventp, json)
         except Exception as E:
             log.trace("sdstack_etcd returner <event_return> unable to write event with the tag {name:s} into the path {path:s} due to exception ({exception}) being raised".format(name=package['tag'], path=eventp, exception=E))
             exceptions.append((E, package))
             continue
 
-        log.trace("sdstack_etcd returner <event_return> wrote event (ttl={ttl:d}) with the tag {name:s} to {path:s} using {data}".format(path=res.key, name=package['tag'], ttl=ttl, data=res.value))
+        log.trace("sdstack_etcd returner <event_return> wrote event with the tag {name:s} to {path:s} using {data}".format(path=res.key, name=package['tag'], data=res.value))
 
     # Go back through all of the exceptions that occurred and log them.
     for e, pack in exceptions:

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -174,7 +174,7 @@ def save_load(jid, load, minions=None):
         ttl = __opts__.get('etcd.ttl')
 
     # Figure out the path using jobs/$jid/.load.p
-    loadp = '/'.join([path, 'jobs', jid, '.load.p']),
+    loadp = '/'.join([path, 'jobs', jid, '.load.p'])
     log.debug('sdstack_etcd returner <save_load> setting load data (ttl={ttl:d}) for job {jid:s} at {path:s} with {data:s}'.format(jid=jid, ttl=ttl, path=loadp, data=load))
 
     # Now we can just store the current load

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -134,6 +134,7 @@ from salt.ext.six.moves import range
 try:
     import salt.utils.etcd_util
     from salt.utils.etcd_util import etcd
+
     HAS_LIBS = True
 
 except ImportError:
@@ -424,7 +425,9 @@ def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argume
         "sdstack_etcd returner <save_minions> adding minions {syndics:s} for job {jid:s} to {path:s}".format(
             jid=jid,
             path=jobp,
-            syndics="" if syndic_id is None else " from syndic {0}".format(syndic_id),
+            syndics=""
+            if syndic_id is None
+            else " from syndic {0}".format(syndic_id),
         )
     )
 
@@ -443,7 +446,8 @@ def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argume
                 jid=jid,
                 path=minionp,
                 minion=minion,
-                syndics="" if syndic_id is None
+                syndics=""
+                if syndic_id is None
                 else " from syndic {0}".format(syndic_id),
             )
         )
@@ -625,7 +629,9 @@ def _purge_events():
     # Try and read the event cache directory. If we have a missing key exception then no
     # events have been cached and so we can simply leave.
     log.trace(
-        "sdstack_etcd returner <_purge_events> reading event cache at {path:s}".format(path=cachep)
+        "sdstack_etcd returner <_purge_events> reading event cache at {path:s}".format(
+            path=cachep
+        )
     )
     try:
         cache = client.read(cachep)
@@ -883,7 +889,11 @@ def get_load(jid):
             )
         )
         return None
-    log.debug("sdstack_etcd returner <get_load> found load data for job {jid:s} at {path:s} with value {data}".format(jid=jid, path=res.key, data=res.value))
+    log.debug(
+        "sdstack_etcd returner <get_load> found load data for job {jid:s} at {path:s} with value {data}".format(
+            jid=jid, path=res.key, data=res.value
+        )
+    )
     return salt.utils.json.loads(res.value)
 
 
@@ -1193,7 +1203,7 @@ def get_minions():
     return ret
 
 
-def prep_jid(nocache=False, passed_jid=None):   # pylint: disable=unused-argument
+def prep_jid(nocache=False, passed_jid=None):    # pylint: disable=unused-argument
     """
     Do any work necessary to prepare a JID, including sending a custom id.
     """

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -259,7 +259,8 @@ def save_load(jid, load, minions=None):
 
         log.debug('sdstack_etcd returner <save_load> updating load data for job {jid:s} at {path:s} with {data:s}'.format(jid=jid, path=loadp, data=load))
         res = client.update(node)
-        log.warning("sdstack_etcd returner <save_load> updated the load data for job {jid:s} at {path:s} with {data:s}. Old data was {old:s}".format(jid=jid, path=res.key, data=res.value, old=res._prev_node.value))
+        if res._prev_node.value != res.value:
+            log.warning("sdstack_etcd returner <save_load> overwrote the load data for job {jid:s} at {path:s} with {data:s}. Old data was {old:s}".format(jid=jid, path=res.key, data=res.value, old=res._prev_node.value))
 
     # If we failed here, it's okay because the lock won't get written so this
     # essentially means the job will get scheduled for deletion.

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -69,7 +69,7 @@ import salt.utils.json
 
 try:
     import salt.utils.etcd_util
-
+    from salt.utils.etcd_util import etcd
     HAS_LIBS = True
 except ImportError:
     HAS_LIBS = False
@@ -252,7 +252,7 @@ def _purge_jobs():
             client.read(lockp)
 
         # It's not, so the job is dead and we can remove it
-        except etcd.EtcdKeyNotFound:
+        except etcd.EtcdKeyNotFound as E:
             res = client.delete(job.key, recursive=True)
             log.trace('sdstack_etcd returner <_purge_jobs> job {jid:s} at {path:s} has expired'.format(jid=res.key.split('/')[-1], path=res.key))
             count += 1
@@ -289,7 +289,7 @@ def get_load(jid):
     # non-existent job.
     try:
         res = client.get(loadp)
-    except salt.utils.etcd_util.etcd.EtcdKeyNotFound as E:
+    except etcd.EtcdKeyNotFound as E:
         log.error("sdstack_etcd returner <get_load> could not find job {jid:s} at the path {path:s}".format(jid=jid, path=loadp))
         return None
     log.trace('sdstack_etcd returner <get_load> found load data for job {jid:s} at {path:s} with value {data}'.format(jid=jid, path=res.key, data=res.value))
@@ -311,7 +311,7 @@ def get_jid(jid):
     # caller.
     try:
         items = client.get(jobp)
-    except salt.utils.etcd_util.etcd.EtcdKeyNotFound as E:
+    except etcd.EtcdKeyNotFound as E:
         return {}
 
     # Iterate through all of the children at our job path that are directories.
@@ -331,7 +331,7 @@ def get_jid(jid):
         # then something that shouldn't happen has happened.
         try:
             res = client.get(returnp)
-        except salt.utils.etcd_util.etcd.EtcdKeyNotFound as E:
+        except etcd.EtcdKeyNotFound as E:
             log.debug("sdstack_etcd returner <get_jid> returned nothing from minion {id:s} for job {jid:s} at path {path:s}".format(id=comps[-1], jid=jid, path=returnp))
             continue
 
@@ -357,7 +357,7 @@ def get_fun(fun):
     # nothing is available.
     try:
         items = client.get(minionsp)
-    except salt.utils.etcd_util.etcd.EtcdKeyNotFound as E:
+    except etcd.EtcdKeyNotFound as E:
         return {}
 
     # Walk through the list of all the minions that have a jid registered,
@@ -374,7 +374,7 @@ def get_fun(fun):
         # registered for some reason.
         try:
             res = client.get(funp)
-        except salt.utils.etcd_util.etcd.EtcdKeyNotFound as E:
+        except etcd.EtcdKeyNotFound as E:
             log.debug("sdstack_etcd returner <get_fun> returned nothing from minion {id:s} for job {jid:s} at path {path:s}".format(id=comps[-1], jid=str(item.value), path=funp))
             continue
 
@@ -402,7 +402,7 @@ def get_jids():
     # jobs have been created yet so return an empty list to the caller.
     try:
         items = client.get(jobsp)
-    except salt.utils.etcd_util.etcd.EtcdKeyNotFound as E:
+    except etcd.EtcdKeyNotFound as E:
         return []
 
     # Anything that's a directory is a job id. Since that's all we're returning,
@@ -432,7 +432,7 @@ def get_minions():
     # this case, return an empty last for the caller.
     try:
         items = client.get(minionsp)
-    except salt.utils.etcd_util.etcd.EtcdKeyNotFound as E:
+    except etcd.EtcdKeyNotFound as E:
         return []
 
     # We can just walk through everything that isn't a directory. This path

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -873,7 +873,7 @@ def event_return(events):
         # not, and so this is a manual effort and potentially racy depending on
         # the uniqueness of the modifiedIndex (which etcd guarantees unique)
 
-        basep = '/'.join([path, Schema['event-cache'], event])
+        basep = '/'.join([path, Schema['event-cache'], str(event)])
 
         # Here we'll write our modifiedIndex to our event cache.
         indexp = '/'.join([basep, 'index'])

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -369,10 +369,14 @@ def clean_old_jobs():
     '''
 
     jobc = _purge_jobs()
-    log.trace('sdstack_etcd returner <clean_old_jobs> successfully removed {:d} jobs'.format(jobc))
+    if jobc > 0:
+        log.trace('sdstack_etcd returner <clean_old_jobs> successfully removed {:d} jobs'.format(jobc))
 
     eventsc = _purge_events()
-    log.trace('sdstack_etcd returner <clean_old_jobs> successfully removed {:d} events'.format(eventsc))
+    if eventsc > 0:
+        log.trace('sdstack_etcd returner <clean_old_jobs> successfully removed {:d} events'.format(eventsc))
+
+    log.debug('sdstack_etcd returner <clean_old_jobs> completed purging jobs and events')
 
 
 def get_load(jid):

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -57,7 +57,56 @@ create the profiles as specified above. Then add:
 
     etcd.returner_read_profile: my_etcd_read
     etcd.returner_write_profile: my_etcd_write
-"""
+
+Etcd Returner Schema
+--------------------
+The etcd returner has the following schema underneath the path set in the profile:
+
+job
++++
+The job key contains the jid of each job that has been returned. Underneath this
+job are two special keys. One of them is ".load.p" which contains information
+about the job when it was created. The other key is ".lock.p" which is responsible
+for whether the job is still valid or it is scheduled to be cleaned up.
+
+The contents if ".lock.p" contains the modificationIndex of the of the ".load.p"
+key and when configured via the "etcd.ttl" or "keep_jobs" will have the ttl
+applied to it. When this file is expired via the ttl or explicitly removed by
+the administrator, the job will then be scheduled for removal.
+
+event
++++++
+This key is essentially a namespace for all of the events that are submitted
+to Salt. When an event is received, the data for the event is written under
+this key using the "tag" parameter at its path. The creationIndex for this key
+is then cached in order to determine whether it should be scheduled for
+removal or not.
+
+minion.job
+++++++++++
+Underneath the minion.job key is a list of minions ids. Each minion id contains
+the jid of the last job that was returned by the minion. This key is used to
+support the external job cache feature of Salt.
+
+event.cache
++++++++++++
+Underneath this key is a list of all of the events that were received by the
+returner. Each event is identified by its creationIndex when the event was
+registered under the "event" key that was described previously. Each event
+under this key contains two keys. One of which is "id", and the other which
+is "tag".
+
+The "id" key contains the latest modificationIndex of the most recent event
+that was reigstered under the event key. This is used to determine whether
+the data for the event has been modified. When configured via the "etcd.ttl"
+or the "keep_jobs" option, this key will have the ttl applied to it. When
+the "id" key has expired or explicitly removed by the administrator, the
+event and its tag will be scheduled for removal.
+
+The other key under each event, is the "tag" key. The "tag" key simply
+contains the path to the tag that was registered with the event. The value
+of the "id" key points to the modificationIndex of this particular path.
+'''
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
@@ -75,6 +124,13 @@ except ImportError:
     HAS_LIBS = False
 
 log = logging.getLogger(__name__)
+
+Schema = {
+    "minion-fun": 'minion.job',
+    "event-path": 'event',
+    "event-cache": 'event.cache',
+    "job-cache": 'job',
+}
 
 # Define the module's virtual name
 __virtualname__ = "etcd"
@@ -130,7 +186,7 @@ def returner(ret):
 
     # Update the given minion in the external job cache with the current (latest job)
     # This is used by get_fun() to return the last function that was called
-    minionp = '/'.join([path, 'minions', ret['id']])
+    minionp = '/'.join([path, Schema['minion-fun'], ret['id']])
 
     # We can use the ttl here because our minionp is actually linked to the job
     # which will expire according to the ttl anyways..
@@ -140,7 +196,7 @@ def returner(ret):
         log.trace("sdstack_etcd returner <returner> the previous job id {old:s} for {id:s} at {path:s} was set to {new:s}".format(old=res._prev_node.value, id=ret['id'], path=minionp, new=res.value))
 
     # Figure out the path for the specified job and minion
-    jobp = '/'.join([path, 'jobs', ret['jid'], ret['id']])
+    jobp = '/'.join([path, Schema['job-cache'], ret['jid'], ret['id']])
     log.debug("sdstack_etcd returner <returner> writing job data for {jid:s} to {path:s} with {data}".format(jid=ret['jid'], path=jobp, data=ret))
 
     # Iterate through all the fields in the return dict and dump them under the
@@ -177,7 +233,7 @@ def save_load(jid, load, minions=None):
         log.warning('sdstack_etcd returner <save_load> was called with a request job id ({jid:s}) with {data:s}'.format(jid=jid, data=load))
 
     # Figure out the path using jobs/$jid/.load.p
-    loadp = '/'.join([path, 'jobs', jid, '.load.p'])
+    loadp = '/'.join([path, Schema['job-cache'], jid, '.load.p'])
     log.debug('sdstack_etcd returner <save_load> setting load data for job {jid:s} at {path:s} with {data:s}'.format(jid=jid, path=loadp, data=load))
 
     # Now we can just store the current load
@@ -189,7 +245,7 @@ def save_load(jid, load, minions=None):
     # Since this is when a job is being created, create a lock that we can
     # check to see if the job has expired. This allows a user to signal to
     # salt that its okey to remove the entire key by removing this lock.
-    lockp = '/'.join([path, 'jobs', jid, '.lock.p'])
+    lockp = '/'.join([path, Schema['job-cache'], jid, '.lock.p'])
     log.trace('sdstack_etcd returner <save_load> writing lock file for job {jid:s} at {path:s} using index {index:d}'.format(jid=jid, path=lockp, index=res.modifiedIndex))
     res = client.write(lockp, res.modifiedIndex, ttl=ttl if ttl > 0 else None)
 
@@ -212,7 +268,7 @@ def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argume
         log.warning('sdstack_etcd returner <save_minions> was called with a request job id ({jid:s}) for minions {minions:s}'.format(jid=jid, minions=repr(minions)))
 
     # Figure out the path that our job should be at
-    jobp = '/'.join([path, 'jobs', jid])
+    jobp = '/'.join([path, Schema['job-cache'], jid])
     log.debug('sdstack_etcd returner <save_minions> adding minions for job {jid:s} to {path:s}'.format(jid=jid, path=jobp))
 
     # Iterate through all of the minions and add a directory for them to the job path
@@ -228,7 +284,7 @@ def _purge_jobs():
     client, path, _ = _get_conn(__opts__, write_profile)
 
     # Figure out the path that our jobs should exist at
-    jobp = '/'.join([path, 'jobs'])
+    jobp = '/'.join([path, Schema['job-cache']])
 
     # Try and read the job directory. If we have a missing key exception then no
     # minions have returned anything yet and so we can simply leave.
@@ -270,7 +326,7 @@ def _purge_events():
     client, path, _ = _get_conn(__opts__, write_profile)
 
     # Figure out the path that our event cache should exist at
-    cachep = '/'.join([path, 'cache'])
+    cachep = '/'.join([path, Schema['event-cache']])
 
     # Try and read the event cache directory. If we have a missing key exception then no
     # events have been cached and so we can simply leave.
@@ -341,12 +397,12 @@ def _purge_events():
         log.trace('sdstack_etcd returner <_purge_events> removing tag for event {index:d} at {path:s}'.format(index=index, path=ev_tag.value))
         comp = ev_tag.value.split('/')
         try:
-            res = client.delete('/'.join([path, 'events'] + comp), prevIndex=ev_index.value)
+            res = client.delete('/'.join([path, Schema['event-path']] + comp), prevIndex=ev_index.value)
 
         except etcd.EtcdCompareFailed as E:
             log.warning('sdstack_etcd returner <_purge_events> event tag at {path:s} does not match modification index {mod:d}'.format(path=ev_tag.value, mod=ev_index.value))
             log.trace('sdstack_etcd returner <_purge_events> forcefully removing event tag at {path:s}'.format(path=ev_tag.value))
-            res = client.delete('/'.join([path, 'events'] + comp))
+            res = client.delete('/'.join([path, Schema['event-path']] + comp))
 
         # Remove the last component (the key), so we can walk through the directories trying to remove them one-by-one
         comp.pop(-1)
@@ -357,9 +413,9 @@ def _purge_events():
         for i in range(len(comp), 0, -1):
             log.trace('sdstack_etcd returner <_purge_events> removing directory for event {index:d} at {path:s}'.format(index=index, path='/'.join(comp[:i])))
             try:
-                client.delete('/'.join([path, 'events'] + comp[:i]), dir=True)
+                client.delete('/'.join([path, Schema['event-path']] + comp[:i]), dir=True)
             except Exception as E:
-                log.debug('sdstack_etcd returner <_purge_events> exception ({exception:s}) was raised while trying to remove directory at {path:s}'.format(path='/'.join([path, 'events'], comp[:i]), exception=E))
+                log.debug('sdstack_etcd returner <_purge_events> exception ({exception:s}) was raised while trying to remove directory at {path:s}'.format(path='/'.join([path, Schema['event-path']], comp[:i]), exception=E))
                 break;
             continue
         continue
@@ -394,7 +450,7 @@ def get_load(jid):
     client, path, _ = _get_conn(__opts__, read_profile)
 
     # Figure out the path that our job should be at
-    loadp = '/'.join([path, 'jobs', jid, '.load.p'])
+    loadp = '/'.join([path, Schema['job-cache'], jid, '.load.p'])
     log.debug('sdstack_etcd returner <get_load> reading load data for job {jid:s} from {path:s}'.format(jid=jid, path=loadp))
 
     # Read it. If EtcdKeyNotFound was raised then the key doesn't exist and so
@@ -416,7 +472,7 @@ def get_jid(jid):
     client, path, _ = _get_conn(__opts__)
 
     # Figure out the path that our job should be at
-    jobp = '/'.join([path, 'jobs', jid])
+    jobp = '/'.join([path, Schema['job-cache'], jid])
 
     # Try and read the job directory. If we have a missing key exception then no
     # minions have returned anything yet and so we return an empty dict for the
@@ -438,7 +494,7 @@ def get_jid(jid):
         # Extract the minion name from the key in the job, and use it to build
         # the path to the return value
         comps = str(item.key).split('/')
-        returnp = '/'.join([path, 'jobs', jid, comps[-1], 'return'])
+        returnp = '/'.join([path, Schema['job-cache'], jid, comps[-1], 'return'])
 
         # Now we know the minion and the path to the return for its job, we can
         # just grab it. If the key exists, but the value is missing entirely,
@@ -464,7 +520,7 @@ def get_fun(fun):
     client, path, _ = _get_conn(__opts__)
 
     # Find any minions that had their last function registered by returner()
-    minionsp = '/'.join([path, 'minions'])
+    minionsp = '/'.join([path, Schema['minion-fun']])
 
     # If the minions key isn't found, then no minions registered a function
     # and thus we need to return an empty dict so the caller knows that
@@ -484,7 +540,7 @@ def get_fun(fun):
         # Now that we have a minion and it's last jid, we use it to fetch the
         # function field (fun) that was registered by returner().
         comps = str(item.key).split('/')
-        funp = '/'.join([path, 'jobs', str(item.value), comps[-1], 'fun'])
+        funp = '/'.join([path, Schema['job-cache'], str(item.value), comps[-1], 'fun'])
 
         # Try and read the field, and skip it if it doesn't exist or wasn't
         # registered for some reason.
@@ -513,7 +569,7 @@ def get_jids():
     client, path, _ = _get_conn(__opts__)
 
     # Enumerate all the jobs that are available.
-    jobsp = '/'.join([path, 'jobs'])
+    jobsp = '/'.join([path, Schema['job-cache']])
 
     # Fetch all the jobs. If the key doesn't exist, then it's likely that no
     # jobs have been created yet so return an empty list to the caller.
@@ -544,7 +600,7 @@ def get_minions():
     client, path, _ = _get_conn(__opts__)
 
     # Find any minions that have returned anything
-    minionsp = '/'.join([path, 'minions'])
+    minionsp = '/'.join([path, Schema['minion-fun']])
 
     # If no minions were found, then nobody has returned anything recently. In
     # this case, return an empty last for the caller.
@@ -599,7 +655,7 @@ def event_return(events):
         }
 
         # Use the tag from the event package to build a watchable path
-        eventp = '/'.join([path, 'events', package['tag']])
+        eventp = '/'.join([path, Schema['event-path'], package['tag']])
 
         # Now we can write the event package into the event path
         log.debug("sdstack_etcd returner <event_return> writing package into event path at {path:s}".format(path=eventp))
@@ -621,13 +677,13 @@ def event_return(events):
         try:
             # If the event is a new key, then we can simply cache it with the specified ttl
             if res.newKey:
-                log.trace("sdstack_etcd returner <event_return> writing new id ({id:d}) to {path:s} for the new event {index:d} with the tag {name:s} {expire:s}".format(path='/'.join([path, 'cache', str(res.createdIndex), 'id']), id=res.createdIndex, index=res.modifiedIndex, name=package['tag'], expire='that will need to be manually removed' if ttl is None else 'that will expire in {ttl:d} seconds'.format(ttl=ttl)))
-                client.write('/'.join([path, 'cache', str(res.createdIndex), 'id']), res.modifiedIndex, prevExist=False, ttl=ttl if ttl > 0 else None)
+                log.trace("sdstack_etcd returner <event_return> writing new id ({id:d}) to {path:s} for the new event {index:d} with the tag {name:s} {expire:s}".format(path='/'.join([path, Schema['event-cache'], str(res.createdIndex), 'id']), id=res.createdIndex, index=res.modifiedIndex, name=package['tag'], expire='that will need to be manually removed' if ttl is None else 'that will expire in {ttl:d} seconds'.format(ttl=ttl)))
+                client.write('/'.join([path, Schema['event-cache'], str(res.createdIndex), 'id']), res.modifiedIndex, prevExist=False, ttl=ttl if ttl > 0 else None)
 
             # Otherwise, the event was updated and thus we need to update our cache too
             else:
-                log.trace("sdstack_etcd returner <event_return> updating id ({id:s}) at {path:s} for the new event {index:d} with the tag {name:s} {expire:s}".format(path='/'.join([path, 'cache', str(res.createdIndex), 'id']), id=res.createdIndex, index=res.modifiedIndex, name=package['tag'], expire='that will need to be manually removed' if ttl is None else 'that will expire in {ttl:d} seconds'.format(ttl=ttl)))
-                client.write('/'.join([path, 'cache', str(res.createdIndex), 'id']), res.modifiedIndex, prevValue=res._prev_node.modifiedIndex, ttl=ttl if ttl > 0 else None)
+                log.trace("sdstack_etcd returner <event_return> updating id ({id:s}) at {path:s} for the new event {index:d} with the tag {name:s} {expire:s}".format(path='/'.join([path, Schema['event-cache'], str(res.createdIndex), 'id']), id=res.createdIndex, index=res.modifiedIndex, name=package['tag'], expire='that will need to be manually removed' if ttl is None else 'that will expire in {ttl:d} seconds'.format(ttl=ttl)))
+                client.write('/'.join([path, Schema['event-cache'], str(res.createdIndex), 'id']), res.modifiedIndex, prevValue=res._prev_node.modifiedIndex, ttl=ttl if ttl > 0 else None)
 
         except etcd.EtcdCompareFailed as E:
             log.error("sdstack_etcd returner <event_return> unable to update cache for {index:d} due to non-matching modification index ({mod:d})".format(index=res.createdIndex, mod=res._prev_node.modifiedIndex))
@@ -637,8 +693,8 @@ def event_return(events):
 
         # If we got here, then we should be able to write the tag under the current index
         try:
-            log.trace("sdstack_etcd returner <event_return> updating cached tag at {path:s} for the event {index:d} with the tag {name:s}".format(path='/'.join([path, 'cache', str(res.createdIndex), 'tag']), index=res.createdIndex, name=package['tag']))
-            client.write('/'.join([path, 'cache', str(res.createdIndex), 'tag']), package['tag'])
+            log.trace("sdstack_etcd returner <event_return> updating cached tag at {path:s} for the event {index:d} with the tag {name:s}".format(path='/'.join([path, Schema['event-cache'], str(res.createdIndex), 'tag']), index=res.createdIndex, name=package['tag']))
+            client.write('/'.join([path, Schema['event-cache'], str(res.createdIndex), 'tag']), package['tag'])
 
         except Exception as E:
             log.trace("sdstack_etcd returner <event_return> unable to cache tag {name:s} under index {index:d} due to exception ({exception}) being raised".format(name=package['tag'], index=res.createdIndex, exception=E))

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -650,16 +650,33 @@ def get_jids():
     # Anything that's a directory is a job id. Since that's all we're returning,
     # aggregate them into a list.
     log.debug("sdstack_etcd returner <get_jids> iterating through jobs at {path:s}".format(path=jobs.key))
-    ret = []
+    ret = {}
     for job in jobs.leaves:
-        comps = job.key.split('/')
         if not job.dir:
-            log.warning('sdstack_etcd returner <get_minions> found a non-job at {path:s} {expire:s}'.format(path=job.key, expire='that will need to be manually removed' if job.ttl is None else 'that will expire in {ttl:d} seconds'.format(ttl=job.ttl)))
+            log.warning('sdstack_etcd returner <get_jids> found a non-job at {path:s} {expire:s}'.format(path=job.key, expire='that will need to be manually removed' if job.ttl is None else 'that will expire in {ttl:d} seconds'.format(ttl=job.ttl)))
             continue
 
-        jid = comps[-1]
-        ret.append(jid)
+        jid = job.key.split('/')[-1]
+        loadp = '/'.join([job.key, '.load.p'])
 
+        # Now we can load the data from the job
+        try:
+            res = client.read(loadp)
+        except etcd.EtcdKeyNotFound as E:
+            log.error("sdstack_etcd returner <get_jids> could not find job data {jid:s} at the path {path:s}".format(jid=jid, path=loadp))
+            continue
+
+        # Decode the load data so we can stash the job data for our caller
+        try:
+            data = salt.utils.json.loads(res.value)
+
+        # If we can't decode the json, then we're screwed so log it in case the user cares
+        except Exception as E:
+            log.error("sdstack_etcd returner <get_jids> could not decode data for job {jid:s} at the path {path:s} due to exception ({exception}). Data was {data:s}".format(jid=jid, path=loadp, exception=E, data=res.value))
+            continue
+
+        # Cool. Everything seems to be good...
+        ret[jid] = salt.utils.jid.format_jid_instance(jid, data)
         log.trace("sdstack_etcd returner <get_jids> found job {jid:s} at {path:s}".format(jid=jid, path=job.key))
 
     log.debug("sdstack_etcd returner <get_jids> found {count:d} jobs at {path:s}".format(count=len(ret), path=jobs.key))
@@ -839,10 +856,13 @@ def get_jids_filter(count, filter_find_job=True):
             log.error("sdstack_etcd returner <get_jids_filter> could not find job data {jid:s} at the path {path:s}".format(jid=jid, path=loadp))
             continue
 
+        # Decode the load data so we can stash it for the caller
         try:
             data = salt.utils.json.loads(res.value)
-        except:
-            log.error("sdstack_etcd returner <get_jids_filter> could not decode job data {jid:s} at the path {path:s}".format(jid=jid, path=loadp))
+
+        # If we can't decode the json, then we're screwed so log it in case the user cares
+        except Exception as E:
+            log.error("sdstack_etcd returner <get_jids_filter> could not decode data for job {jid:s} at the path {path:s} due to exception ({exception}). Data was {data:s}".format(jid=jid, path=loadp, exception=E, data=res.value))
             continue
 
         if filter_find_job and data['fun'] == 'saltutil.find_job':

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -622,12 +622,12 @@ def event_return(events):
             # If the event is a new key, then we can simply cache it with the specified ttl
             if res.newKey:
                 log.trace("sdstack_etcd returner <event_return> writing new id ({id:d}) to {path:s} for the new event {index:d} with the tag {name:s} {expire:s}".format(path='/'.join([path, 'cache', str(res.createdIndex), 'id']), id=res.createdIndex, index=res.modifiedIndex, name=package['tag'], expire='that will need to be manually removed' if ttl is None else 'that will expire in {ttl:d} seconds'.format(ttl=ttl)))
-                etcd.write('/'.join([path, 'cache', str(res.createdIndex), 'id']), res.modifiedIndex, prevExist=False, ttl=ttl if ttl > 0 else None)
+                client.write('/'.join([path, 'cache', str(res.createdIndex), 'id']), res.modifiedIndex, prevExist=False, ttl=ttl if ttl > 0 else None)
 
             # Otherwise, the event was updated and thus we need to update our cache too
             else:
                 log.trace("sdstack_etcd returner <event_return> updating id ({id:s}) at {path:s} for the new event {index:d} with the tag {name:s} {expire:s}".format(path='/'.join([path, 'cache', str(res.createdIndex), 'id']), id=res.createdIndex, index=res.modifiedIndex, name=package['tag'], expire='that will need to be manually removed' if ttl is None else 'that will expire in {ttl:d} seconds'.format(ttl=ttl)))
-                etcd.write('/'.join([path, 'cache', str(res.createdIndex), 'id']), res.modifiedIndex, prevValue=res._prev_node.modifiedIndex, ttl=ttl if ttl > 0 else None)
+                client.write('/'.join([path, 'cache', str(res.createdIndex), 'id']), res.modifiedIndex, prevValue=res._prev_node.modifiedIndex, ttl=ttl if ttl > 0 else None)
 
         except etcd.EtcdCompareFailed as E:
             log.error("sdstack_etcd returner <event_return> unable to update cache for {index:d} due to non-matching modification index ({mod:d})".format(index=res.createdIndex, mod=res._prev_node.modifiedIndex))
@@ -638,7 +638,7 @@ def event_return(events):
         # If we got here, then we should be able to write the tag under the current index
         try:
             log.trace("sdstack_etcd returner <event_return> updating cached tag at {path:s} for the event {index:d} with the tag {name:s}".format(path='/'.join([path, 'cache', str(res.createdIndex), 'tag']), index=res.createdIndex, name=package['tag']))
-            etcd.write('/'.join([path, 'cache', str(res.createdIndex), 'tag']), package['tag'])
+            client.write('/'.join([path, 'cache', str(res.createdIndex), 'tag']), package['tag'])
 
         except Exception as E:
             log.trace("sdstack_etcd returner <event_return> unable to cache tag {name:s} under index {index:d} due to exception ({exception}) being raised".format(name=package['tag'], index=res.createdIndex, exception=E))

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -114,9 +114,11 @@ def returner(ret):
 
     client, path = _get_conn(__opts__, write_profile)
 
-    # if a minion is returning a standalone job, get a jid
+    # If a minion is returning a standalone job, update it with a new jid, and
+    # save it to ensure it can be queried similar to the mysql returner.
     if ret['jid'] == 'req':
         ret['jid'] = prep_jid(nocache=ret.get('nocache', False))
+        save_load(ret['jid'], ret)
 
     # Update the given minion in the external job cache with the current (latest job)
     # This is used by get_fun() to return the last function that was called
@@ -159,6 +161,10 @@ def save_load(jid, load, minions=None):
     write_profile = __opts__.get('etcd.returner_write_profile')
     client, path = _get_conn(__opts__, write_profile)
 
+    # Check if the specified jid is 'req', as only incorrect code will do that
+    if jid == 'req':
+        log.warning('sdstack_etcd returner <save_load> was called for job {jid:s} with {data:s}'.format(jid=jid, data=load))
+
     # Figure out the path using jobs/$jid/.load.p
     loadp = '/'.join([path, 'jobs', jid, '.load.p'])
     log.debug('sdstack_etcd returner <save_load> setting load data for job {jid:s} at {path:s} with {data:s}'.format(jid=jid, path=loadp, data=load))
@@ -178,6 +184,10 @@ def save_minions(jid, minions, syndic_id=None):  # pylint: disable=unused-argume
     '''
     write_profile = __opts__.get('etcd.returner_write_profile')
     client, path = _get_conn(__opts__, write_profile)
+
+    # Check if the specified jid is 'req', as only incorrect code will do that
+    if jid == 'req':
+        log.warning('sdstack_etcd returner <save_minions> was called for job {jid:s} and minions {minions:s}'.format(jid=jid, minions=repr(minions)))
 
     # Figure out the path that our job should be at
     jobp = '/'.join([path, 'jobs', jid])

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -93,14 +93,18 @@ event.cache
 Underneath this key is a list of all of the events that were received by the
 returner. Each event is identified by its creationIndex when the event was
 registered under the "event" key that was described previously. Each event
-under this key contains two keys. One of which is "id", and the other which
-is "tag".
+under this key contains three keys. These are the "id" key, the "tag" key,
+and the "lock" key.
 
 The "id" key contains the latest modificationIndex of the most recent event
 that was reigstered under the event key. This is used to determine whether
-the data for the event has been modified. When configured via the "etcd.ttl"
-or the "keep_jobs" option, this key will have the ttl applied to it. When
-the "id" key has expired or explicitly removed by the administrator, the
+the data for the event has been modified or if the event's tag name collides
+with another event.
+
+The "lock" key is responsible for informing the maintenance service that the
+event is still in use. If the retuerner is configured via the "etcd.ttl" or
+the "keep_jobs" option, this key will have the ttl applied to it. When
+the "lock" key has expired or explicitly removed by the administrator, the
 event and its tag will be scheduled for removal.
 
 The other key under each event, is the "tag" key. The "tag" key simply
@@ -684,24 +688,25 @@ def event_return(events):
 
         # Next we need to cache the index for said event so that we can use it to
         # determine whether it is ready to be purged or not. We do this by using
-        # the modifiedIndex to write the tag into a cache.
+        # the modifiedIndex to link the cache event with the tag. If we were
+        # using the etcd3 api we could make all 3 of these writes atomic, but
+        # we're not and so this is a manual effort.
 
         try:
             # If the event is a new key, then we can simply cache it with the specified ttl
             if res.newKey:
-                log.trace("sdstack_etcd returner <event_return> writing new id ({id:d}) to {path:s} for the new event {index:d} with the tag {name:s} {expire:s}".format(path='/'.join([path, Schema['event-cache'], str(res.createdIndex), 'id']), id=res.createdIndex, index=res.modifiedIndex, name=package['tag'], expire='that will need to be manually removed' if ttl is None else 'that will expire in {ttl:d} seconds'.format(ttl=ttl)))
-                client.write('/'.join([path, Schema['event-cache'], str(res.createdIndex), 'id']), res.modifiedIndex, prevExist=False, ttl=ttl if ttl > 0 else None)
+                log.trace("sdstack_etcd returner <event_return> writing new id ({id:d}) to {path:s} for the new event {index:d} with the tag {name:s}".format(path='/'.join([path, Schema['event-cache'], str(res.createdIndex), 'id']), id=res.createdIndex, index=res.modifiedIndex, name=package['tag']))
+                client.write('/'.join([path, Schema['event-cache'], str(res.createdIndex), 'id']), res.modifiedIndex, prevExist=False)
 
             # Otherwise, the event was updated and thus we need to update our cache too
             else:
-                log.trace("sdstack_etcd returner <event_return> updating id ({id:d}) at {path:s} for the new event {index:d} with the tag {name:s} {expire:s}".format(path='/'.join([path, Schema['event-cache'], str(res.createdIndex), 'id']), id=res.createdIndex, index=res.modifiedIndex, name=package['tag'], expire='that will need to be manually removed' if ttl is None else 'that will expire in {ttl:d} seconds'.format(ttl=ttl)))
-                client.write('/'.join([path, Schema['event-cache'], str(res.createdIndex), 'id']), res.modifiedIndex, ttl=ttl if ttl > 0 else None)
-
-        except etcd.EtcdCompareFailed as E:
-            log.error("sdstack_etcd returner <event_return> unable to update cache for {index:d} due to non-matching modification index ({mod:d})".format(index=res.createdIndex, mod=res._prev_node.modifiedIndex))
+                log.trace("sdstack_etcd returner <event_return> updating id ({id:d}) at {path:s} for the existing event {index:d} with the tag {name:s}".format(path='/'.join([path, Schema['event-cache'], str(res.createdIndex), 'id']), id=res.createdIndex, index=res.modifiedIndex, name=package['tag']))
+                client.write('/'.join([path, Schema['event-cache'], str(res.createdIndex), 'id']), res.modifiedIndex)
 
         except etcd.EtcdAlreadyExist as E:
             log.error("sdstack_etcd returner <event_return> unable to cache event for {index:d} due to event already existing".format(index=res.createdIndex))
+            exceptions.append((E, package))
+            continue
 
         # If we got here, then we should be able to write the tag under the current index
         try:
@@ -710,6 +715,16 @@ def event_return(events):
 
         except Exception as E:
             log.trace("sdstack_etcd returner <event_return> unable to cache tag {name:s} under index {index:d} due to exception ({exception}) being raised".format(name=package['tag'], index=res.createdIndex, exception=E))
+            exceptions.append((E, package))
+            continue
+
+        # Now that both have been written, let's write our lock to actually enable the event
+        try:
+            log.trace("sdstack_etcd returner <event_return> writing new lock ({id:d}) to {path:s} for the event {index:d} with the tag {name:s} {expire:s}".format(path='/'.join([path, Schema['event-cache'], str(res.createdIndex), 'id']), id=res.createdIndex, index=res.modifiedIndex, name=package['tag'], expire='that will need to be manually removed' if ttl is None else 'that will expire in {ttl:d} seconds'.format(ttl=ttl)))
+            client.write('/'.join([path, Schema['event-cache'], str(res.createdIndex), 'lock']), res.modifiedIndex, ttl=ttl if ttl > 0 else None)
+
+        except Exception as E:
+            log.error("sdstack_etcd returner <event_return> unable to add lock for {index:d} due to exception ({exception}) being raised".format(index=res.createdIndex, exception=E))
             exceptions.append((E, package))
 
         continue


### PR DESCRIPTION
### What does this PR do?
This PR implements the `update_endtime` and `get_endtime` functions that are also implemented in the `salt.returners.local_cache` returner. It seems that these functions are updated when using the display_progress functionality in some of the runners. These aren't documented anywhere but within that returner, but this should implement everything that is supported collectively by all of the returners. The only thing it fails to implement is the `get_register` and `load_register` functions(?) which was only used by thorium which has since been deprecated.

The documentation for this PR has also been updated to describe the new ".endtime" addition to the schema.

Project 5 has a card mentioning that PR #51363 needs to be ported to master. Since I was the original author of that PR and needed these capabilities, I re-based it on top of master and added the new functionality. This PR is the result of that port with the new additions.

### What issues does this PR fix or reference?
This is PR #51363, ported to master as mentioned in project https://github.com/saltstack/salt/projects/5#card-28249107, along with two new functions that make it consistent with the `salt.returners.local_cache` returner.

### Previous Behavior
Previously these functions weren't implemented as none of the other returners seemed to define them. This might be for a particular case, but I figured that we might as well have a complete returner implementation that can be used as a reference.

### New Behavior
Now jobs can be updated with the `endtime` that is passed as a string to the `update_endtime` function. 

### Tests written?
This uses the exact same interface as the previous etcd returner that was already merged, so the already existing tests should exhaustively test this.

### Commits signed with GPG?
No

(edited to describe the new editions of this PR. Please review history of this comment to see prior reason for the PR)