### PR TITLE
Split up the --async option's emitting of the jid into two flushing writes to stderr and stdout

### DIFF
--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -148,7 +148,8 @@ class SaltCMD(salt.utils.parsers.SaltCMDOptionParser):
 
         if self.config['async']:
             jid = self.local_client.cmd_async(**kwargs)
-            salt.utils.stringutils.print_cli('Executed command with job ID: {0}'.format(jid))
+            six.print_('Executed command with job ID:', end=' ', file=sys.stderr, flush=True)
+            six.print_('{0}'.format(jid), end='\n', file=sys.stdout, flush=True)
             return
 
         # local will be None when there was an error


### PR DESCRIPTION
### What does this PR do?
This splits up the emitting of the jid when passing the `--async` option to the `salt` command. This allows the user to use their shell to immediately capture the jid without needing to do any extra shell gymnastics (which is a pita on Windows).

This simplifies the method to capture the jid in a bourne-compliant shell:
```
$ jid=`salt \* test.ping`
...
$ salt-run jobs.print_job $jid
$ salt-run state.event "tagmatch=$jid"
```

..and in the windows command-prompt:
```
C> for /f %j in ('salt * test.ping') do set jid=%j
...
C> salt-run jobs.print_job %jid%
C> salt-run sate.event tagmatch=%jid%
```

### What issues does this PR fix or reference?
This closes issue #54906.

### Previous Behavior
Prior to this the `salt.stringutils.print_cli` command was used to emit the jid which is used to prevent scrollback with `less`. This is unnecessary because when using the `--async` option, only one line is emitted before terminating and so someone would literally need to explicitly close the fd, or use explicitly use a non-linebuffered fd to interrupt less.

### New Behavior
The emitting of the jid is split between two writes. The first is to stderr for the "Executed command with job ID:" message, and the second is the jid being written to stdout. Both writes are being flushed so that the behaviour appears the same, but when explicitly using i/o redirection to capture the jid only the identifier will be caught.

### Tests written?
No. The previous test should still work.

### Commits signed with GPG?
No.