### PR TITLE
pool deleted state

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -4838,13 +4838,11 @@ def pool_undefine(name, **kwargs):
         conn.close()
 
 
-def pool_delete(name, fast=True, **kwargs):
+def pool_delete(name, **kwargs):
     '''
     Delete the resources of a defined libvirt storage pool.
 
     :param name: libvirt storage pool name
-    :param fast: if set to False, zeroes out all the data.
-                 Default value is True.
     :param connection: libvirt connection URI, overriding defaults
     :param username: username to connect with, overriding defaults
     :param password: password to connect with, overriding defaults
@@ -4860,10 +4858,7 @@ def pool_delete(name, fast=True, **kwargs):
     conn = __get_conn(**kwargs)
     try:
         pool = conn.storagePoolLookupByName(name)
-        flags = libvirt.VIR_STORAGE_POOL_DELETE_NORMAL
-        if fast:
-            flags = libvirt.VIR_STORAGE_POOL_DELETE_ZEROED
-        return not bool(pool.delete(flags))
+        return not bool(pool.delete(libvirt.VIR_STORAGE_POOL_DELETE_NORMAL))
     finally:
         conn.close()
 

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -2677,3 +2677,20 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
 
         isxen_mock.return_value = True
         self.assertEqual('xen', virt.get_hypervisor())
+
+    def test_pool_delete(self):
+        '''
+        Test virt.pool_delete function
+        '''
+        mock_pool = MagicMock()
+        mock_pool.delete = MagicMock(return_value=0)
+        self.mock_conn.storagePoolLookupByName = MagicMock(return_value=mock_pool)
+
+        res = virt.pool_delete('test-pool')
+        self.assertTrue(res)
+
+        self.mock_conn.storagePoolLookupByName.assert_called_once_with('test-pool')
+
+        # Shouldn't be called with another parameter so far since those are not implemented
+        # and thus throwing exceptions.
+        mock_pool.delete.assert_called_once_with(self.mock_libvirt.VIR_STORAGE_POOL_DELETE_NORMAL)


### PR DESCRIPTION
### What does this PR do?

Add a `virt.pool_deleted` state to use to ensure a virtual storage pool and optionally its volumes are deleted. This state handles the various libvirt storage backends specific implementations to avoid triggering exceptions if an function is not implemented on the libvirt side.

### Tests written?

Yes

### Commits signed with GPG?

Yes