### PR TITLE
Fix CherryPy CORS on Python3

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -820,9 +820,11 @@ def cors_tool():
             resp_head['Connection'] = 'keep-alive'
             resp_head['Access-Control-Max-Age'] = '1400'
 
-        # CORS requests should short-circuit the other tools.
-        cherrypy.response.body = ''
+        # Note: CherryPy on Py3 uses binary objects for the response
+        # Python 2.6 also supports the byte prefix, so no need for conditionals
+        cherrypy.response.body = b''
         cherrypy.response.status = 200
+        # CORS requests should short-circuit the other tools.
         cherrypy.serving.request.handler = None
 
         # Needed to avoid the auth_tool check.

--- a/tests/unit/netapi/test_rest_cherrypy.py
+++ b/tests/unit/netapi/test_rest_cherrypy.py
@@ -87,3 +87,19 @@ class TestInFormats(BaseToolsTest):
         ))
         self.assertEqual(response.status, '200 OK')
         self.assertDictEqual(request.unserialized_data, data)
+
+
+class TestCors(BaseToolsTest):
+    def __get_cp_config__(self):
+        return {
+            'tools.cors_tool.on': True,
+        }
+
+    def test_option_request(self):
+        request, response = self.request(
+            '/', method='OPTIONS', headers=(
+                ('Origin', 'https://domain.com'),
+            ))
+        self.assertEqual(response.status, '200 OK')
+        self.assertEqual(response.headers.get(
+            'Access-Control-Allow-Origin'), 'https://domain.com')


### PR DESCRIPTION
# What does this PR do?

Fixes a salt_cherrypy bug on Python3 (500 Internal Server Error).

### What issues does this PR fix or reference?

Fixes #55087

### Tests written?

I created a unit test for the cors_tool that verifies whether CORS OPTIONS request returns HTTP 200 OK. Test failed before the second commit which fixes the bug.

### Commits signed with GPG?

No (no backdoors included, trivial to verify :D)
