### PR TITLE
update openstack.py for more verbose auth example

### DIFF
--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -58,6 +58,8 @@ clouds.yml file on each minion.abs
         username: 'demo'
         password: secret
         project_name: 'demo'
+        user_domain_name: default,
+        project_domain_name: default,
         auth_url: 'http://openstack/identity'
 
 Or if you need to use a profile to setup some extra stuff, it can be passed as a


### PR DESCRIPTION
add user_domain_name and project_domain_name attributes as this is required for keystone v3

### What does this PR do?

Adds more verbose auth example to the openstack provider in salt-cloud docs. This doc fix will at least give the user a clue about what is possibly wrong when issuing any cloud related commands. 

### What issues does this PR fix or reference?

As currently written, the example configs will results in the following error message in keystone logs:

WARNING keystone.server.flask.application [req-61ad5636-8a54-4023-a626-c8b4c78692d0 - - - - -] Expecting to find domain in project. The server could not comply with the request since it is either malformed or otherwise incorrect. The client is assumed to be in error.: keystone.exception.ValidationError: Expecting to find domain in project. The server could not comply with the request since it is either malformed or otherwise incorrect. The client is assumed to be in error.

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

When configured with the new attributes, the basic auth example works as expected. 

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
