### PR TITLE
Fix case where args or kwargs are not specified

### DIFF
--- a/salt/states/loop.py
+++ b/salt/states/loop.py
@@ -94,7 +94,11 @@ def until(name,
         ret['comment'] = 'The execution module {0} will be run'.format(name)
         ret['result'] = None
         return ret
-
+    if not m_args:
+        m_args = []
+    if not m_kwargs:
+        m_kwargs = {}
+    
     def timed_out():
         if time.time() >= timeout:
             return True


### PR DESCRIPTION
Currently, the m_ret line will error if the loop state definition does not specify values for args or kwargs, because None is neither iterable nor a map. If not specified, those values should be set to an empty list and empty dict.

### What does this PR do?

Integrate this fix commit in the main 2019.2 branch. Not sure this is the right process, see #52503 for more information.

### What issues does this PR fix or reference?

#52503 

Not 100% sure about the process there, I am completely open to criticism and suggestions. Similar merge request created for 2018.3 -> https://github.com/saltstack/salt/pull/55227