### PR TITLE
Stop sync_grains from updating grains twice.

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2186,6 +2186,8 @@ class Minion(MinionBase):
         '''
         Refresh the pillar
         '''
+        self.module_refresh(force_refresh)
+
         if self.connected:
             log.debug('Refreshing pillar')
             async_pillar = salt.pillar.get_async_pillar(
@@ -2203,7 +2205,6 @@ class Minion(MinionBase):
                           'One or more masters may be down!')
             finally:
                 async_pillar.destroy()
-        self.module_refresh(force_refresh)
         self.matchers_refresh()
         self.beacons_refresh()
         evt = salt.utils.event.get_event('minion', opts=self.opts)

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -425,7 +425,6 @@ def sync_grains(saltenv=None, refresh=True, extmod_whitelist=None, extmod_blackl
     '''
     ret = _sync('grains', saltenv, extmod_whitelist, extmod_blacklist)
     if refresh:
-        refresh_modules()
         refresh_pillar()
     return ret
 

--- a/tests/integration/modules/test_saltutil.py
+++ b/tests/integration/modules/test_saltutil.py
@@ -65,6 +65,12 @@ class SaltUtilModuleTest(ModuleCase):
         self.assertIn('priv', ret['return'])
 
 
+class SyncGrainsTest(ModuleCase):
+    def test_sync_grains(self):
+        ret = self.run_function('saltutil.sync_grains')
+        self.assertEqual(ret, [])
+
+
 class SaltUtilSyncModuleTest(ModuleCase):
     '''
     Testcase for the saltutil sync execution module


### PR DESCRIPTION
### What does this PR do?
Stop sync_grains from updating grains twice.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/55174

### New Behavior
Remove this section if not relevant

### Tests written?
No... not yet

### Commits signed with GPG?
Yes
