### PR TITLE
virt: adding kernel boot parameters to libvirt xml

### DIFF
--- a/salt/states/virt.py
+++ b/salt/states/virt.py
@@ -350,11 +350,15 @@ def running(name,
 
         .. versionadded:: Neon
 
-    :param boot: Specifies kernel for the virtual machine, as well as boot
-                 parameters for the virtual machine. This is an optionl
-                 parameter, and all of the keys are optional within the
-                 dictionary.
+    :param boot:
+        Specifies kernel for the virtual machine, as well as boot parameters
+        for the virtual machine. This is an optionl parameter, and all of the
+        keys are optional within the dictionary. If a remote path is provided
+        to kernel or initrd, salt will handle the downloading of the specified
+        remote fild, and will modify the XML accordingly.
+
         .. code-block:: python
+
             {
                 'kernel': '/root/f8-i386-vmlinuz',
                 'initrd': '/root/f8-i386-initrd',

--- a/salt/states/virt.py
+++ b/salt/states/virt.py
@@ -264,7 +264,8 @@ def running(name,
             username=None,
             password=None,
             os_type=None,
-            arch=None):
+            arch=None,
+            boot=None):
     '''
     Starts an existing guest, or defines and starts a new VM with specified arguments.
 
@@ -349,6 +350,19 @@ def running(name,
 
         .. versionadded:: Neon
 
+    :param boot: Specifies kernel for the virtual machine, as well as boot
+                 parameters for the virtual machine. This is an optionl
+                 parameter, and all of the keys are optional within the
+                 dictionary.
+        .. code-block:: python
+            {
+                'kernel': '/root/f8-i386-vmlinuz',
+                'initrd': '/root/f8-i386-initrd',
+                'cmdline': 'console=ttyS0 ks=http://example.com/f8-i386/os/'
+            }
+
+        .. versionadded:: neon
+
     .. rubric:: Example States
 
     Make sure an already-defined virtual machine called ``domain_name`` is running:
@@ -413,7 +427,8 @@ def running(name,
                                                      live=False,
                                                      connection=connection,
                                                      username=username,
-                                                     password=password)
+                                                     password=password,
+                                                     boot=boot)
                     if status['definition']:
                         action_msg = 'updated and started'
                 __salt__['virt.start'](name)
@@ -431,7 +446,8 @@ def running(name,
                                                      graphics=graphics,
                                                      connection=connection,
                                                      username=username,
-                                                     password=password)
+                                                     password=password,
+                                                     boot=boot)
                     ret['changes'][name] = status
                     if status.get('errors', None):
                         ret['comment'] = 'Domain {0} updated, but some live update(s) failed'.format(name)
@@ -466,7 +482,8 @@ def running(name,
                                   priv_key=priv_key,
                                   connection=connection,
                                   username=username,
-                                  password=password)
+                                  password=password,
+                                  boot=boot)
             ret['changes'][name] = 'Domain defined and started'
             ret['comment'] = 'Domain {0} defined and started'.format(name)
     except libvirt.libvirtError as err:

--- a/salt/templates/virt/libvirt_domain.jinja
+++ b/salt/templates/virt/libvirt_domain.jinja
@@ -5,7 +5,17 @@
         <currentMemory unit='KiB'>{{ mem }}</currentMemory>
         <os>
                 <type arch='{{ arch }}'>{{ os_type }}</type>
-                {% if kernel %}<kernel>{{ kernel }}</kernel>{% endif %}
+                {% if boot %}
+                  {% if 'kernel' in boot %}
+                    <kernel>{{ boot.kernel }}</kernel>
+                  {% endif %}
+                  {% if 'initrd' in boot %}
+                    <initrd>{{ boot.initrd }}</initrd>
+                  {% endif %}
+                  {% if 'cmdline' in boot %}
+                    <cmdline>{{ boot.cmdline }}</cmdline>
+                  {% endif %}
+                {% endif %}
                 {% for dev in boot_dev %}
                 <boot dev='{{ dev }}' />
                 {% endfor %}

--- a/tests/unit/states/test_virt.py
+++ b/tests/unit/states/test_virt.py
@@ -344,14 +344,13 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
         }
 
         with patch.dict(virt.__salt__, {  # pylint: disable=no-member
-                    'virt.vm_state': MagicMock(return_value='running'),
+                    'virt.vm_state': MagicMock(return_value={'myvm': 'running'}),
                     'virt.update': MagicMock(return_value={'definition': True, 'cpu': True})
                 }):
             ret.update({'changes': {'myvm': {'definition': True, 'cpu': True}},
                         'result': True,
                         'comment': 'Domain myvm updated, restart to fully apply the changes'})
             self.assertDictEqual(virt.running('myvm', update=True, boot=boot), ret)
-
 
         # Working update case when stopped
         with patch.dict(virt.__salt__, {  # pylint: disable=no-member

--- a/tests/unit/states/test_virt.py
+++ b/tests/unit/states/test_virt.py
@@ -246,7 +246,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                                               mem=2048,
                                               image='/path/to/img.qcow2'), ret)
             init_mock.assert_called_with('myvm', cpu=2, mem=2048, image='/path/to/img.qcow2',
-                                         os_type=None, arch=None,
+                                         os_type=None, arch=None, boot=None,
                                          disk=None, disks=None, nic=None, interfaces=None,
                                          graphics=None, hypervisor=None,
                                          seed=True, install=True, pub_key=None, priv_key=None,
@@ -311,6 +311,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                                          graphics=graphics,
                                          hypervisor='qemu',
                                          seed=False,
+                                         boot=None,
                                          install=False,
                                          pub_key='/path/to/key.pub',
                                          priv_key='/path/to/key',
@@ -334,6 +335,23 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                         'result': True,
                         'comment': 'Domain myvm updated, restart to fully apply the changes'})
             self.assertDictEqual(virt.running('myvm', update=True, cpu=2), ret)
+
+        # Working update case when running with boot params
+        boot = {
+            'kernel': '/root/f8-i386-vmlinuz',
+            'initrd': '/root/f8-i386-initrd',
+            'cmdline': 'console=ttyS0 ks=http://example.com/f8-i386/os/'
+        }
+
+        with patch.dict(virt.__salt__, {  # pylint: disable=no-member
+                    'virt.vm_state': MagicMock(return_value='running'),
+                    'virt.update': MagicMock(return_value={'definition': True, 'cpu': True})
+                }):
+            ret.update({'changes': {'myvm': {'definition': True, 'cpu': True}},
+                        'result': True,
+                        'comment': 'Domain myvm updated, restart to fully apply the changes'})
+            self.assertDictEqual(virt.running('myvm', update=True, boot=boot), ret)
+
 
         # Working update case when stopped
         with patch.dict(virt.__salt__, {  # pylint: disable=no-member


### PR DESCRIPTION
### What does this PR do?
This PR adds the kernel path, initrd path, and kernel boot command line parameters to libvirt xml for use with SUSE's autoyast and Red Hat's kickstart. 

### What issues does this PR fix or reference?
N/A

### New Behavior
Adds an additional parameter 'boot=None' to a number of functions, allowing the kernel path, the initrd path, and the kernel boot command line string to be parse and added to the xml.

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

Yes

### Commits signed with GPG?

Yes
