### PR TITLE
Added provider configuration for Proxmox API port. Fixes #55240

### DIFF
--- a/doc/topics/cloud/proxmox.rst
+++ b/doc/topics/cloud/proxmox.rst
@@ -110,6 +110,15 @@ The following settings are always required for PROXMOX:
 
 Optional Settings
 =================
+Optional Provider Settings
+
+ .. code-block:: yaml
+
+     # Proxmox Server Port (Default: 8006)
+     port: 8006
+
+ Optional Profile Settings
+
 Unlike other cloud providers in Salt Cloud, Proxmox does not utilize a
 ``size`` setting. This is because Proxmox allows the end-user to specify a
 more detailed configuration for their instances, than is allowed by many other

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -123,7 +123,7 @@ def _authenticate():
     )
     port = config.get_cloud_config_value(
         'port', get_configured_provider(), __opts__, 
-         default=8006, search_global=False
+        default=8006, search_global=False
      )
     username = config.get_cloud_config_value(
         'user', get_configured_provider(), __opts__, search_global=False

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -18,6 +18,7 @@ Set up the cloud configuration at ``/etc/salt/cloud.providers`` or
       user: myuser@pam or myuser@pve
       password: mypassword
       url: hypervisor.domain.tld
+      port: 8006
       driver: proxmox
       verify_ssl: True
 
@@ -105,6 +106,7 @@ def get_dependencies():
 
 
 url = None
+port = None
 ticket = None
 csrf = None
 verify_ssl = None
@@ -115,10 +117,14 @@ def _authenticate():
     '''
     Retrieve CSRF and API tickets for the Proxmox API
     '''
-    global url, ticket, csrf, verify_ssl
+    global url, port, ticket, csrf, verify_ssl
     url = config.get_cloud_config_value(
         'url', get_configured_provider(), __opts__, search_global=False
     )
+    port = config.get_cloud_config_value(
+        'port', get_configured_provider(), __opts__, 
+         default=8006, search_global=False
+     )
     username = config.get_cloud_config_value(
         'user', get_configured_provider(), __opts__, search_global=False
     ),
@@ -131,7 +137,7 @@ def _authenticate():
     )
 
     connect_data = {'username': username, 'password': passwd}
-    full_url = 'https://{0}:8006/api2/json/access/ticket'.format(url)
+    full_url = 'https://{0}:{1}/api2/json/access/ticket'.format(url, port)
 
     returned_data = requests.post(
         full_url, verify=verify_ssl, data=connect_data).json()
@@ -148,7 +154,7 @@ def query(conn_type, option, post_data=None):
         log.debug('Not authenticated yet, doing that now..')
         _authenticate()
 
-    full_url = 'https://{0}:8006/api2/json/{1}'.format(url, option)
+    full_url = 'https://{0}:{1}/api2/json/{2}'.format(url, port, option)
 
     log.debug('%s: %s (%s)', conn_type, full_url, post_data)
 
@@ -625,7 +631,7 @@ def _import_api():
     Load this json content into global variable "api"
     '''
     global api
-    full_url = 'https://{0}:8006/pve-docs/api-viewer/apidoc.js'.format(url)
+    full_url = 'https://{0}:{1}/pve-docs/api-viewer/apidoc.js'.format(url, port)
     returned_data = requests.get(full_url, verify=verify_ssl)
 
     re_filter = re.compile('(?<=pveapi =)(.*)(?=^;)', re.DOTALL | re.MULTILINE)


### PR DESCRIPTION
### What does this PR do?
This PR removes hardcoded values in the Salt-Cloud-Proxmox driver for the Proxmox PVE web service port. Added an optional provider configuration parameter to configure the service port defaulting to the original hardcoded values. Relevant documentation updates.   

### What issues does this PR fix or reference?
#55240

### Previous Behavior
The Salt-Cloud-Proxmox driver would only work with a Proxmox PVE deployment listening for service calls on TCP 8006.

### New Behavior
The Salt-Cloud-Proxmox driver defaults to communicating with a Proxmox PVE deployment on TCP 8006, however the port number can now be overridden with the "port" parameter in the provider configuration. 

### Tests written?
No

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
