### PR TITLE
Update to net.py and bgp.py

### DIFF
--- a/salt/runners/bgp.py
+++ b/salt/runners/bgp.py
@@ -104,11 +104,11 @@ try:
     from netaddr import IPNetwork
     from netaddr import IPAddress
     # pylint: disable=unused-import
-    from napalm_base import helpers as napalm_helpers
+    from napalm.base import helpers as napalm_helpers
     # pylint: enable=unused-import
-    HAS_NAPALM_BASE = True
+    HAS_NAPALM = True
 except ImportError:
-    HAS_NAPALM_BASE = False
+    HAS_NAPALM = False
 
 # Import salt lib
 import salt.output
@@ -155,9 +155,9 @@ _DEFAULT_LABELS_MAPPING = {
 
 
 def __virtual__():
-    if HAS_NAPALM_BASE:
+    if HAS_NAPALM:
         return __virtualname__
-    return (False, 'The napalm-base module could not be imported')
+    return (False, 'The napalm module could not be imported')
 
 # -----------------------------------------------------------------------------
 # helper functions -- will not be exported

--- a/salt/runners/net.py
+++ b/salt/runners/net.py
@@ -78,12 +78,12 @@ from salt.ext.six.moves import map
 
 # Import third party libs
 try:
-    from netaddr import IPNetwork  # netaddr is already required by napalm-base
+    from netaddr import IPNetwork  # netaddr is already required by napalm
     from netaddr.core import AddrFormatError
-    from napalm_base import helpers as napalm_helpers
-    HAS_NAPALM_BASE = True
+    from napalm.base import helpers as napalm_helpers
+    HAS_NAPALM = True
 except ImportError:
-    HAS_NAPALM_BASE = False
+    HAS_NAPALM = False
 
 # -----------------------------------------------------------------------------
 # module properties
@@ -113,9 +113,9 @@ __virtualname__ = 'net'
 
 
 def __virtual__():
-    if HAS_NAPALM_BASE:
+    if HAS_NAPALM:
         return __virtualname__
-    return (False, 'The napalm-base module could not be imported')
+    return (False, 'The napalm module could not be imported')
 
 
 def _get_net_runner_opts():


### PR DESCRIPTION
### What does this PR do?
Redirect to start using new "napalm" module instead of "napalm-base"

### Previous Behavior
sudo salt-run net.find 1.1.1.1
'net' __virtual__ False: The napalm-base module could not be imported

### New Behavior
Return the findings
