### PR TITLE
Make aptpkg.info return only installed packages

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2791,6 +2791,8 @@ def info_installed(*names, **kwargs):
     ret = dict()
     for pkg_name, pkg_nfo in __salt__['lowpkg.info'](*names, failhard=failhard).items():
         t_nfo = dict()
+        if pkg_nfo.get('status', 'ii')[1] != 'i':
+            continue    # return only packages that are really installed
         # Translate dpkg-specific keys to a common structure
         for key, value in pkg_nfo.items():
             if key == 'package':
@@ -2803,6 +2805,8 @@ def info_installed(*names, **kwargs):
                 t_nfo['packager'] = value
             elif key == 'homepage':
                 t_nfo['url'] = value
+            elif key == 'status':
+                continue    # only installed pkgs are returned, no need for status
             else:
                 t_nfo[key] = value
 

--- a/tests/unit/modules/test_aptpkg.py
+++ b/tests/unit/modules/test_aptpkg.py
@@ -90,7 +90,26 @@ LOWPKG_INFO = {
         'name': 'wget',
         'section': 'web',
         'source': 'wget',
-        'version': '1.15-1ubuntu1.14.04.2'
+        'version': '1.15-1ubuntu1.14.04.2',
+        'status': 'ii',
+    },
+    'apache2': {
+        'architecture': 'amd64',
+        'description': """Apache HTTP Server
+ The Apache HTTP Server Project's goal is to build a secure, efficient and
+ extensible HTTP server as standards-compliant open source software. The
+ result has long been the number one web server on the Internet.
+ .
+ Installing this package results in a full installation, including the
+ configuration files, init scripts and support scripts.""",
+        'homepage': 'http://httpd.apache.org/',
+        'install_date': '2016-08-30T22:20:15Z',
+        'maintainer': 'Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>',
+        'name': 'apache2',
+        'section': 'httpd',
+        'source': 'apache2',
+        'version': '2.4.18-2ubuntu3.9',
+        'status': 'rc',
     }
 }
 
@@ -244,14 +263,16 @@ class AptPkgTestCase(TestCase, LoaderModuleMockMixin):
             'url': 'homepage'
         }
 
-        installed = copy.deepcopy(LOWPKG_INFO)
+        installed = copy.deepcopy({'wget': LOWPKG_INFO['wget']})
         for name in names:
             if installed['wget'].get(names[name], False):
                 installed['wget'][name] = installed['wget'].pop(names[name])
 
         mock = MagicMock(return_value=LOWPKG_INFO)
         with patch.dict(aptpkg.__salt__, {'lowpkg.info': mock}):
+            del installed['wget']['status']
             self.assertEqual(aptpkg.info_installed('wget'), installed)
+            self.assertEqual(len(aptpkg.info_installed()), 1)
 
     def test_owner(self):
         '''


### PR DESCRIPTION
### What does this PR do?

Port of #51576 to master.

### What issues does this PR fix or reference?

None.

### Previous Behavior
`pkg.info_instaled` returned also packages in status `rc` or `pn`.

### New Behavior
`pkg.info_instaled` returnes only packages in `ii` or `hi`.

### Tests written?

Yes

### Commits signed with GPG?

No

