### PR TITLE
Only look at local packages when removing from a venv

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -1045,6 +1045,7 @@ def freeze(bin_env=None,
            cwd=None,
            use_vt=False,
            env_vars=None,
+           local=False,
            **kwargs):
     '''
     Return a list of installed packages either globally or in the specified
@@ -1092,6 +1093,8 @@ def freeze(bin_env=None,
     if kwargs:
         cmd_kwargs.update(**kwargs)
     if bin_env and os.path.isdir(bin_env):
+        if local:
+            cmd.append('-l')
         cmd_kwargs['env'] = {'VIRTUAL_ENV': bin_env}
     if env_vars:
         cmd_kwargs.setdefault('env', {}).update(_format_env_vars(env_vars))
@@ -1108,6 +1111,7 @@ def list_(prefix=None,
           user=None,
           cwd=None,
           env_vars=None,
+          local=False,
           **kwargs):
     '''
     Filter list of installed apps from ``freeze`` and check to see if
@@ -1136,6 +1140,7 @@ def list_(prefix=None,
                        user=user,
                        cwd=cwd,
                        env_vars=env_vars,
+                       local=local,
                        **kwargs):
         if line.startswith('-f') or line.startswith('#'):
             # ignore -f line as it contains --find-links directory

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -979,7 +979,12 @@ def removed(name,
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
 
     try:
-        pip_list = __salt__['pip.list'](bin_env=bin_env, user=user, cwd=cwd)
+        pip_list = __salt__['pip.list'](
+            bin_env=bin_env,
+            user=user,
+            cwd=cwd,
+            local=True
+        )
     except (CommandExecutionError, CommandNotFoundError) as err:
         ret['result'] = False
         ret['comment'] = 'Error uninstalling \'{0}\': {1}'.format(name, err)

--- a/tests/unit/modules/test_pip.py
+++ b/tests/unit/modules/test_pip.py
@@ -981,8 +981,7 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
                 patch(
                      'salt.modules.pip.version',
                      MagicMock(return_value='6.1.1')
-                ) \
-            :
+                ):
                 ret = pip.freeze(bin_env=venv_path, local=True)
                 mock.assert_called_with(
                     expected,


### PR DESCRIPTION
### What does this PR do?

Corrects the behaviour of the `pip.absent` state when using a virtualenv with global access.

If a virtualenv was created with:
```
virtualenv --system-site-packages /venv/
```
Then you a python package in the system location and the virtualenv. For example, consider `paramiko`
```
yum install python-paramiko # Install to the global site-packages
/venv/bin/pip install paramiko # Install to the venv
```

When using the `pip.absent` state with this virtualenv, it will always mark the state as changed, even after it uninstalls the package after the first run:

```
remove package in venv:
  pip.removed:
    - name: paramiko
    - bin_env: /venv
```

This is because the call to `pip.list` returns pip packages from both the global and local spaces.

This PR adds the `local` attribute to the `pip.list` and `pip.freeze` execution modules, which matches the `pip -l` option:
```
-l, --local                 If in a virtualenv that has global access, do not output globally-installed packages.
```

The `pip.absent` state then sets `local=True` as it should always be operating on the local package list only.

### What issues does this PR fix or reference?
N/A



### Tests written?

Unit tests written for the  `pip.list` and `pip.freeze` execution modules.
No tests written for the `pip.absent` state. It feels like only integration tests would be useful here and I'm not sure how to go about this. Could anyone help?



### Commits signed with GPG?

Yes
