### PR TITLE
don't set milestones on non-pr jobs

### DIFF
--- a/.ci/docs
+++ b/.ci/docs
@@ -7,14 +7,17 @@ properties([
     buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')),
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > 1) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - 1)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > 1) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - 1)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 def shell_header
 

--- a/.ci/kitchen-amazon1-py2
+++ b/.ci/kitchen-amazon1-py2
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-amazon2-py2
+++ b/.ci/kitchen-amazon2-py2
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-amazon2-py3
+++ b/.ci/kitchen-amazon2-py3
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-archlts-py2
+++ b/.ci/kitchen-archlts-py2
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-archlts-py3
+++ b/.ci/kitchen-archlts-py3
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-centos6-py2
+++ b/.ci/kitchen-centos6-py2
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-centos7-py2
+++ b/.ci/kitchen-centos7-py2
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-centos7-py2-m2crypto
+++ b/.ci/kitchen-centos7-py2-m2crypto
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-centos7-py2-proxy
+++ b/.ci/kitchen-centos7-py2-proxy
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-centos7-py2-pycryptodomex
+++ b/.ci/kitchen-centos7-py2-pycryptodomex
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-centos7-py2-tcp
+++ b/.ci/kitchen-centos7-py2-tcp
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-centos7-py2-tornado
+++ b/.ci/kitchen-centos7-py2-tornado
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-centos7-py3
+++ b/.ci/kitchen-centos7-py3
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-centos7-py3-m2crypto
+++ b/.ci/kitchen-centos7-py3-m2crypto
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-centos7-py3-proxy
+++ b/.ci/kitchen-centos7-py3-proxy
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-centos7-py3-pycryptodomex
+++ b/.ci/kitchen-centos7-py3-pycryptodomex
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-centos7-py3-tcp
+++ b/.ci/kitchen-centos7-py3-tcp
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-debian10-py3
+++ b/.ci/kitchen-debian10-py3
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-debian8-py2
+++ b/.ci/kitchen-debian8-py2
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-debian9-py2
+++ b/.ci/kitchen-debian9-py2
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-debian9-py3
+++ b/.ci/kitchen-debian9-py3
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-fedora30-py2
+++ b/.ci/kitchen-fedora30-py2
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-fedora30-py3
+++ b/.ci/kitchen-fedora30-py3
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-macosxhighsierra-py2
+++ b/.ci/kitchen-macosxhighsierra-py2
@@ -22,14 +22,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 wrappedNode(jenkins_slave_label, global_timeout, '#jenkins-prod-pr') {
     withEnv([

--- a/.ci/kitchen-macosxhighsierra-py3
+++ b/.ci/kitchen-macosxhighsierra-py3
@@ -22,14 +22,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 wrappedNode(jenkins_slave_label, global_timeout, '#jenkins-prod-pr') {
     withEnv([

--- a/.ci/kitchen-macosxmojave-py2
+++ b/.ci/kitchen-macosxmojave-py2
@@ -22,14 +22,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 wrappedNode(jenkins_slave_label, global_timeout, '#jenkins-prod-pr') {
     withEnv([

--- a/.ci/kitchen-macosxmojave-py3
+++ b/.ci/kitchen-macosxmojave-py3
@@ -22,14 +22,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 wrappedNode(jenkins_slave_label, global_timeout, '#jenkins-prod-pr') {
     withEnv([

--- a/.ci/kitchen-macosxsierra-py2
+++ b/.ci/kitchen-macosxsierra-py2
@@ -22,14 +22,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 wrappedNode(jenkins_slave_label, global_timeout, '#jenkins-prod-pr') {
     withEnv([

--- a/.ci/kitchen-macosxsierra-py3
+++ b/.ci/kitchen-macosxsierra-py3
@@ -22,14 +22,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 wrappedNode(jenkins_slave_label, global_timeout, '#jenkins-prod-pr') {
     withEnv([

--- a/.ci/kitchen-opensuse15-py2
+++ b/.ci/kitchen-opensuse15-py2
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-opensuse15-py3
+++ b/.ci/kitchen-opensuse15-py3
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-ubuntu1604-py2
+++ b/.ci/kitchen-ubuntu1604-py2
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-ubuntu1604-py2-m2crypto
+++ b/.ci/kitchen-ubuntu1604-py2-m2crypto
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-ubuntu1604-py2-proxy
+++ b/.ci/kitchen-ubuntu1604-py2-proxy
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-ubuntu1604-py2-pycryptodomex
+++ b/.ci/kitchen-ubuntu1604-py2-pycryptodomex
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-ubuntu1604-py2-tcp
+++ b/.ci/kitchen-ubuntu1604-py2-tcp
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-ubuntu1604-py2-tornado
+++ b/.ci/kitchen-ubuntu1604-py2-tornado
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-ubuntu1604-py3
+++ b/.ci/kitchen-ubuntu1604-py3
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-ubuntu1604-py3-m2crypto
+++ b/.ci/kitchen-ubuntu1604-py3-m2crypto
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-ubuntu1604-py3-proxy
+++ b/.ci/kitchen-ubuntu1604-py3-proxy
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-ubuntu1604-py3-pycryptodomex
+++ b/.ci/kitchen-ubuntu1604-py3-pycryptodomex
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-ubuntu1604-py3-tcp
+++ b/.ci/kitchen-ubuntu1604-py3-tcp
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-ubuntu1804-py2
+++ b/.ci/kitchen-ubuntu1804-py2
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-ubuntu1804-py3
+++ b/.ci/kitchen-ubuntu1804-py3
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-windows2016-py2
+++ b/.ci/kitchen-windows2016-py2
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-windows2016-py3
+++ b/.ci/kitchen-windows2016-py3
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-windows2019-py2
+++ b/.ci/kitchen-windows2019-py2
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/kitchen-windows2019-py3
+++ b/.ci/kitchen-windows2019-py3
@@ -20,14 +20,17 @@ properties([
     ])
 ])
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > concurrent_builds) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - concurrent_builds)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > concurrent_builds) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - concurrent_builds)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 runTests(
     env: env,

--- a/.ci/lint
+++ b/.ci/lint
@@ -10,14 +10,17 @@ properties([
 
 def shell_header
 
-// Be sure to cancel any previously running builds
-def buildNumber = env.BUILD_NUMBER as int
-if (buildNumber > 1) {
-    // This will cancel the previous build which also defined a matching milestone
-    milestone(buildNumber - 1)
+// Only set milestones on PR builds
+if (env.CHANGE_ID) {
+    // Be sure to cancel any previously running builds
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > 1) {
+        // This will cancel the previous build which also defined a matching milestone
+        milestone(buildNumber - 1)
+    }
+    // Define a milestone for this build so that, if another build starts, this one will be aborted
+    milestone(buildNumber)
 }
-// Define a milestone for this build so that, if another build starts, this one will be aborted
-milestone(buildNumber)
 
 def lint_report_issues = []
 


### PR DESCRIPTION
### What does this PR do?
This turns off setting milestones on non-pr jobs so we don't abort previous jobs when additional jobs started.
