### PR TITLE
Aegiacometti patch 1

### DIFF
--- a/salt/runners/bgp.py
+++ b/salt/runners/bgp.py
@@ -104,11 +104,11 @@ try:
     from netaddr import IPNetwork
     from netaddr import IPAddress
     # pylint: disable=unused-import
-    from napalm_base import helpers as napalm_helpers
+    from napalm.base import helpers as napalm_helpers
     # pylint: enable=unused-import
-    HAS_NAPALM_BASE = True
+    HAS_NAPALM = True
 except ImportError:
-    HAS_NAPALM_BASE = False
+    HAS_NAPALM = False
 
 # Import salt lib
 import salt.output
@@ -155,9 +155,9 @@ _DEFAULT_LABELS_MAPPING = {
 
 
 def __virtual__():
-    if HAS_NAPALM_BASE:
+    if HAS_NAPALM:
         return __virtualname__
-    return (False, 'The napalm-base module could not be imported')
+    return (False, 'The napalm module could not be imported')
 
 # -----------------------------------------------------------------------------
 # helper functions -- will not be exported

--- a/salt/runners/net.py
+++ b/salt/runners/net.py
@@ -78,12 +78,12 @@ from salt.ext.six.moves import map
 
 # Import third party libs
 try:
-    from netaddr import IPNetwork  # netaddr is already required by napalm-base
+    from netaddr import IPNetwork  # netaddr is already required by napalm
     from netaddr.core import AddrFormatError
-    from napalm_base import helpers as napalm_helpers
-    HAS_NAPALM_BASE = True
+    from napalm.base import helpers as napalm_helpers
+    HAS_NAPALM = True
 except ImportError:
-    HAS_NAPALM_BASE = False
+    HAS_NAPALM = False
 
 # -----------------------------------------------------------------------------
 # module properties
@@ -113,9 +113,9 @@ __virtualname__ = 'net'
 
 
 def __virtual__():
-    if HAS_NAPALM_BASE:
+    if HAS_NAPALM:
         return __virtualname__
-    return (False, 'The napalm-base module could not be imported')
+    return (False, 'The napalm module could not be imported')
 
 
 def _get_net_runner_opts():

--- a/salt/runners/net.py
+++ b/salt/runners/net.py
@@ -224,8 +224,16 @@ def _find_interfaces_mac(ip):  # pylint: disable=invalid-name
         if not device_ipaddrs.get('result', False):
             continue
         for interface, interface_ipaddrs in six.iteritems(device_ipaddrs.get('out', {})):
-            ip_addresses = interface_ipaddrs.get('ipv4', {}).keys()
-            ip_addresses.extend(interface_ipaddrs.get('ipv6', {}).keys())
+            ip_addresses = set()
+            ip_addresses.add(list(interface_ipaddrs.get('ipv4', {}).keys())[0])
+            try:
+                ip_addresses.add(list(interface_ipaddrs.get('ipv4', {}).keys())[1])
+            except IndexError:
+                pass
+            try:
+                ip_addresses.add(list(interface_ipaddrs.get('ipv6', {}).keys())[0])
+            except (AttributeError, IndexError):
+                pass
             for ipaddr in ip_addresses:
                 if ip != ipaddr:
                     continue
@@ -352,6 +360,7 @@ def interfaces(device=None,
 
     best_row = {}
     best_net_match = None
+    compare = []
     for device, net_interfaces_out in six.iteritems(all_interfaces):  # pylint: disable=too-many-nested-blocks
         if not net_interfaces_out:
             continue
@@ -405,7 +414,6 @@ def interfaces(device=None,
                         if inet_ips:  # if any
                             if best:
                                 # determine the global best match
-                                compare = [best_net_match]
                                 compare.extend(list(map(_get_network_obj, inet_ips)))
                                 new_best_net_match = max(compare)
                                 if new_best_net_match != best_net_match:


### PR DESCRIPTION
### What does this PR do?
1.- Reflect new module name napalm instead of napalm-base. (runners/net.py and runners/bgp.py)
2.- Catch exception for IPv6 (runners/bgp.py)
3.- Support for IP secondary address (runners/bgp.py)
4.- the module (runners/bgp.py) was trowing an exemption because a variable list named "compare" was initiated with [None] instead of []. After adding items to the list there was a max(compare), and None is not supported for comparing of the list with types None and IPNetwork.

### Previous Behavior
1.-
sudo salt-run net.find 1.1.1.1
'net' virtual False: The napalm-base module could not be imported
4.-
sudo salt-run net.find 10.100.12.2
Passed invalid arguments: '>' not supported between instances of 'IPNetwork' and 'NoneType'

### New Behavior
Finding/using the module napalm and not asking for napalm-base.
Returns the findings of net.find module/function.
