### PR TITLE
Fix Error in Creation of Kubernetes Service

### DIFF
--- a/salt/modules/kubernetesmod.py
+++ b/salt/modules/kubernetesmod.py
@@ -1569,7 +1569,7 @@ def __dict_to_service_spec(spec):
         if key == 'ports':
             spec_obj.ports = []
             for port in value:
-                kube_port = kubernetes.client.V1ServicePort()
+                kube_port = kubernetes.client.V1ServicePort(port=port.get('port', ''))
                 if isinstance(port, dict):
                     for port_key, port_value in iteritems(port):
                         if hasattr(kube_port, port_key):


### PR DESCRIPTION
### What does this PR do?
Resolves an error in creating a kubernetes service by passing a port value into the Kubernetes V1ServicePort constructor.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/55287

### Previous Behavior
Initialize the port object with an empty argument lsit

### New Behavior
Pull the port value off and pass it to the argument list

### Tests written?
No

### Commits signed with GPG?
Yes