### PR TITLE
Support fractional keep_jobs times

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -72,7 +72,7 @@
 #verify_env: True
 
 # Set the number of hours to keep old job information in the job cache:
-#keep_jobs: 24
+#keep_jobs: 24.0
 
 # The number of seconds to wait when the client is requesting information
 # about running jobs.

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -303,14 +303,14 @@ Verify and set permissions on configuration directories at startup.
 ``keep_jobs``
 -------------
 
-Default: ``24``
+Default: ``24.0``
 
 Set the number of hours to keep old job information. Note that setting this option
 to ``0`` disables the cache cleaner.
 
 .. code-block:: yaml
 
-    keep_jobs: 24
+    keep_jobs: 24.0
 
 .. conf_master:: gather_job_timeout
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -626,7 +626,7 @@ VALID_OPTS = immutabletypes.freeze({
     'ret_port': int,
 
     # The number of hours to keep jobs around in the job cache on the master
-    'keep_jobs': int,
+    'keep_jobs': float,
 
     # If the returner supports `clean_old_jobs`, then at cleanup time,
     # archive the job data before deleting it.
@@ -1537,7 +1537,7 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze({
     'sock_pool_size': 1,
     'ret_port': 4506,
     'timeout': 5,
-    'keep_jobs': 24,
+    'keep_jobs': 24.0,
     'archive_jobs': False,
     'root_dir': salt.syspaths.ROOT_DIR,
     'pki_dir': os.path.join(salt.syspaths.CONFIG_DIR, 'pki', 'master'),

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -153,7 +153,7 @@ def clean_pub_auth(opts):
                     if not os.path.isfile(auth_file_path):
                         continue
                     if (time.time() - os.path.getmtime(auth_file_path) >
-                            (opts['keep_jobs'] * 3600)):
+                            (opts['keep_jobs'] * 3600.0)):
                         os.remove(auth_file_path)
     except (IOError, OSError):
         log.error('Unable to delete pub auth file')

--- a/salt/returners/couchbase_return.py
+++ b/salt/returners/couchbase_return.py
@@ -154,7 +154,7 @@ def _get_ttl():
     '''
     Return the TTL that we should store our objects with
     '''
-    return __opts__.get('couchbase.ttl', 24) * 60 * 60  # keep_jobs is in hours
+    return int(__opts__.get('couchbase.ttl', 24.0) * 60 * 60)  # keep_jobs is in hours
 
 
 #TODO: add to returner docs-- this is a new one

--- a/salt/returners/mysql.py
+++ b/salt/returners/mysql.py
@@ -579,7 +579,7 @@ def clean_old_jobs():
     if __opts__.get('keep_jobs', False) and int(__opts__.get('keep_jobs', 0)) > 0:
         try:
             with _get_serv() as cur:
-                sql = 'select date_sub(now(), interval {0} hour) as stamp;'.format(__opts__['keep_jobs'])
+                sql = 'select date_sub(now(), interval {0} second) as stamp;'.format(int(__opts__['keep_jobs'] * 3600))
                 cur.execute(sql)
                 rows = cur.fetchall()
                 stamp = rows[0][0]

--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -551,7 +551,7 @@ def clean_old_jobs():
     if __opts__.get('keep_jobs', False) and int(__opts__.get('keep_jobs', 0)) > 0:
         try:
             with _get_serv() as cur:
-                sql = "select (NOW() -  interval '{0}' hour) as stamp;".format(__opts__['keep_jobs'])
+                sql = "select (NOW() -  interval '{0} hour') as stamp;".format(__opts__['keep_jobs'])
                 cur.execute(sql)
                 rows = cur.fetchall()
                 stamp = rows[0][0]

--- a/salt/returners/postgres_local_cache.py
+++ b/salt/returners/postgres_local_cache.py
@@ -397,7 +397,7 @@ def get_jids():
           '''FROM jids'''
     if __opts__['keep_jobs'] != 0:
         sql = sql + " WHERE started > NOW() - INTERVAL '" \
-                + six.text_type(__opts__['keep_jobs']) + "' HOUR"
+                + six.text_type(__opts__['keep_jobs']) + " HOUR'"
 
     cur.execute(sql)
     ret = {}

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -199,7 +199,7 @@ def _get_serv(ret=None):
 
 
 def _get_ttl():
-    return __opts__.get('keep_jobs', 24) * 3600
+    return int(__opts__.get('keep_jobs', 24.0) * 3600)
 
 
 def returner(ret):


### PR DESCRIPTION
### What does this PR do?
Adds support for fractional `keep_jobs` interval times, so that times less than an hour can be specified.

### What issues does this PR fix or reference?
See #55295 

### Previous Behavior
Times specified are converted to `int`s.

### New Behavior
The time is now a float, so smaller / more precise intervals can be specified. Still using hours, rather than integer minutes or seconds, to preserve backwards compatibility.

### Tests written?
Existing tests apply appear to pass

### Commits signed with GPG?
Yes