### PR TITLE
fixing user-data parsing issue -- content type actually is text/plain

### DIFF
--- a/salt/grains/metadata.py
+++ b/salt/grains/metadata.py
@@ -55,7 +55,8 @@ def _search(prefix="latest/"):
     if 'body' not in linedata:
         return ret
     body = salt.utils.stringutils.to_unicode(linedata['body'])
-    if linedata['headers'].get('Content-Type', 'text/plain') == 'application/octet-stream':
+    if linedata['headers'].get('Content-Type', 'text/plain') == 'application/octet-stream' or 'latest/user-data' in prefix:
+        # https://github.com/saltstack/salt/issues/55298
         return body
     for line in body.split('\n'):
         if line.endswith('/'):


### PR DESCRIPTION
### What does this PR do?
Fixes the issue found in https://github.com/saltstack/salt/issues/55298

At some point in the recent past, the EC2 metadata endpoint has changed the content-type, and the metadata grains is expecting that user-data uses an explicit content-type, when in fact, it's just using plain old `text/plain`. I've extended the `if` statement here to add an `or` operator for backwards compatibility.

Let me know if there's anything I should change/add/remove -- this is a very simple change.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/55298

### Previous Behavior
```
root@ip-10-251-2-252:/usr/lib/python2.7/dist-packages/salt/grains# salt-call --local grains.get user-data
local:
    ----------
    # another comment here:
        #!/bin/bash
        touch /tmp/hello_test.txt
        # another comment here
        # just to test
    # just to test:
        #!/bin/bash
        touch /tmp/hello_test.txt
        # another comment here
        # just to test
    #!/bin/bash:
        #!/bin/bash
        touch /tmp/hello_test.txt
        # another comment here
        # just to test
    touch /tmp/hello_test.txt:
        None
```

### New Behavior
```
root@ip-10-251-2-252:~# salt-call --local grains.get user-data
local:
    #!/bin/bash
    touch /tmp/hello_test.txt
    # another comment here
    # just to test
```

### Tests written?
No -- I didn't locate any existing tests for the metadata grain module

### Commits signed with GPG?
No