### PR TITLE
Skip `test_pkg_upgrade_has_pending_upgrades` on Arch Linux

### DIFF
--- a/tests/integration/modules/test_pkg.py
+++ b/tests/integration/modules/test_pkg.py
@@ -267,6 +267,9 @@ class PkgModuleTest(ModuleCase, SaltReturnAssertsMixin):
         '''
         Test running a system upgrade when there are packages that need upgrading
         '''
+        if grains['os'] == 'Arch':
+            self.skipTest('Arch moved to Python 3.8 and we\'re not ready for it yet')
+
         func = 'pkg.upgrade'
 
         # First make sure that an up-to-date copy of the package db is available


### PR DESCRIPTION
### What does this PR do?
See title.
Because Arch has moved to Python 3.8 and we're not there yet.

### Previous Behavior
We'd fail because at the end of the test run because python was upgraded from 3.7 to 3.8
https://jenkinsci.saltstack.com/job/pr-kitchen-archlts-py3/job/PR-55276/4/


### New Behavior
We skip the upgrade to Py3.8