### PR TITLE
flat roster: pass master options to apply_sdb

### DIFF
--- a/salt/roster/flat.py
+++ b/salt/roster/flat.py
@@ -36,5 +36,7 @@ def targets(tgt, tgt_type="glob", **kwargs):
     )
     conditioned_raw = {}
     for minion in raw:
-        conditioned_raw[six.text_type(minion)] = salt.config.apply_sdb(raw[minion])
+        conditioned_raw[six.text_type(minion)] = salt.config.apply_sdb(
+            __opts__, raw[minion]
+        )
     return __utils__["roster_matcher.targets"](conditioned_raw, tgt, tgt_type, "ipv4")

--- a/tests/unit/roster/test_flat.py
+++ b/tests/unit/roster/test_flat.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""
+unit tests for flat roster
+"""
+from __future__ import absolute_import
+
+import os
+
+import salt.loader
+import salt.roster.flat as flat
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.mock import MagicMock, patch
+from tests.support.runtests import RUNTIME_VARS
+from tests.support.unit import TestCase
+
+
+class FlatTestCase(TestCase, LoaderModuleMockMixin):
+    """
+    Test cases for flat roster
+    """
+
+    def setup_loader_modules(self):
+        self.opts = salt.config.master_config(
+            os.path.join(RUNTIME_VARS.TMP_CONF_DIR, "master")
+        )
+        utils = salt.loader.utils(self.opts, whitelist=["roster_matcher"])
+        return {flat: {"__utils__": utils, "__opts__": self.opts}}
+
+    def test_targets(self):
+        roster = {"foo": {"host": "example.org"}}
+
+        mock_salt_config = MagicMock()
+        with patch(
+            "salt.roster.flat.get_roster_file", MagicMock(return_value="")
+        ), patch("salt.loader.render", MagicMock(),), patch(
+            "salt.config", mock_salt_config
+        ), patch(
+            "salt.config.apply_sdb", MagicMock(return_value=roster["foo"])
+        ), patch(
+            "salt.roster.flat.compile_template", MagicMock(return_value=roster)
+        ):
+
+            ret = flat.targets("foo")
+
+            mock_salt_config.apply_sdb.assert_any_call(self.opts, roster["foo"])
+
+            self.assertTrue("foo" in ret)
+            self.assertTrue("host" in ret["foo"])
+            self.assertTrue(ret["foo"]["host"] == "example.org")


### PR DESCRIPTION
### What does this PR do?

Despite being more convenient and consistent, in avoiding to having to specify the sdb options
again for each host, `apply_sdb` (or actually `sdb_get` I think) also somehow manages to mess up
the previously passed options in the next iteration.

### Previous Behavior

Using sdb in the flat roster copied the entry of the current host into the key of the current one. It also required the sdb configuration to be present in each roster entry.

### New Behavior

Pass the master config available in `__opts__` to `apply_sdb`, centralizing the sdb configuration properly and keeping `sdb_get` from messing things up.

### Tests written?

No, I couldn't find any existing tests for this and writing an entire suite for this feature
is a bit beyond my experience with this project.
