### PR TITLE
Include custom executors in salt-ssh thin package

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1557,6 +1557,7 @@ def mod_data(fsclient):
     '''
     # TODO, change out for a fileserver backend
     sync_refs = [
+            'executors',
             'modules',
             'states',
             'grains',


### PR DESCRIPTION
### What does this PR do?

So I started to partially codify my hobby infrastructure using Salt. 
In this context I don't want to run the full master/minion setup, so salt-ssh seems
like a neat solution. But I wasn't super happy with its requirements, that is I don't
want to allow root login via SSH from my laptop, nor passwordless sudo once logged in.
So I hacked a custom executor that reads the sudo password from the minion config,
puts it into an environment variable, writes a small script that just echos that
variable and then sets `SUDO_ASKPASS` to that script. Only issue is that salt-ssh wouldn't
ship my custom executor. So here's the fix to that.

Of course I would love to see more official support for a setup like that, but until then :)

### What issues does this PR fix or reference?

### Previous Behavior
Custom executors were not included in the salt-ssh thin package

### New Behavior
Custom executors are included in the salt-ssh thin package

### Tests written?

No, I couldn't find any existing tests for this and writing an entire suite for the thin package feature is a bit beyond me...