### PR TITLE
Fix Kubernetes Secret Encoding Under Python 3

### DIFF
--- a/salt/modules/kubernetesmod.py
+++ b/salt/modules/kubernetesmod.py
@@ -1118,7 +1118,7 @@ def create_secret(
 
     # encode the secrets using base64 as required by kubernetes
     for key in data:
-        data[key] = base64.b64encode(data[key])
+        data[key] = __base64_str(data[key])
 
     body = kubernetes.client.V1Secret(
         metadata=__dict_to_object_meta(name, namespace, {}),
@@ -1355,7 +1355,7 @@ def replace_secret(name,
 
     # encode the secrets using base64 as required by kubernetes
     for key in data:
-        data[key] = base64.b64encode(data[key])
+        data[key] = __base64_str(data[key])
 
     body = kubernetes.client.V1Secret(
         metadata=__dict_to_object_meta(name, namespace, {}),
@@ -1593,3 +1593,13 @@ def __enforce_only_strings_dict(dictionary):
         ret[six.text_type(key)] = six.text_type(value)
 
     return ret
+
+
+def __base64_str(string):
+    '''
+    Converts a string of data into a base64 encoded string based on python version
+    '''
+    if sys.version_info >= (3, 0):
+        return str(base64.b64encode(string.encode('utf-8')), 'utf-8')
+    else:
+        return base64.b64encode(string)

--- a/tests/unit/modules/test_kubernetesmod.py
+++ b/tests/unit/modules/test_kubernetesmod.py
@@ -149,6 +149,42 @@ class KubernetesTestCase(TestCase, LoaderModuleMockMixin):
                     create_namespaced_deployment().to_dict.called)
                 # pylint: enable=E1120
 
+    def test_create_secret(self):
+        '''
+        Tests secret creation.
+        :return:
+        '''
+        with mock_kubernetes_library() as mock_kubernetes_lib:
+            with patch.dict(kubernetes.__salt__, {'config.option': Mock(side_effect=self.settings)}):
+                mock_kubernetes_lib.client.CoreV1Api.return_value = Mock(
+                    **{"create_namespaced_secret.return_value.to_dict.return_value": {}}
+                )
+                self.assertEqual(kubernetes.create_secret("test", "default", {}, None,
+                                                          None, None), {})
+                # pylint: disable=E1120
+                self.assertTrue(
+                    kubernetes.kubernetes.client.CoreV1Api().
+                    create_namespaced_secret().to_dict.called)
+                # pylint: enable=E1120
+
+    def test_replace_secret(self):
+        '''
+        Tests secret replacement.
+        :return:
+        '''
+        with mock_kubernetes_library() as mock_kubernetes_lib:
+            with patch.dict(kubernetes.__salt__, {'config.option': Mock(side_effect=self.settings)}):
+                mock_kubernetes_lib.client.CoreV1Api.return_value = Mock(
+                    **{"replace_namespaced_secret.return_value.to_dict.return_value": {}}
+                )
+                self.assertEqual(kubernetes.replace_secret("test", {}, None,
+                                                          None, None, "default"), {})
+                # pylint: disable=E1120
+                self.assertTrue(
+                    kubernetes.kubernetes.client.CoreV1Api().
+                    replace_namespaced_secret().to_dict.called)
+                # pylint: enable=E1120
+
     @staticmethod
     def settings(name, value=None):
         '''


### PR DESCRIPTION
### What does this PR do?
Base64 encode secret data properly under Python3. Secret data sent to the Kubernetes API must be a base64 encoded String object.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/55292

### Previous Behavior
A fatal error occurred

### New Behavior
Resolve fatal error

### Tests written?
No

### Commits signed with GPG?
Yes