### PR TITLE
Fix Error in Creation of Kubernetes Service

### DIFF
--- a/salt/modules/kubernetesmod.py
+++ b/salt/modules/kubernetesmod.py
@@ -1569,7 +1569,7 @@ def __dict_to_service_spec(spec):
         if key == 'ports':
             spec_obj.ports = []
             for port in value:
-                kube_port = kubernetes.client.V1ServicePort()
+                kube_port = kubernetes.client.V1ServicePort(port=port.get('port', ''))
                 if isinstance(port, dict):
                     for port_key, port_value in iteritems(port):
                         if hasattr(kube_port, port_key):

--- a/tests/unit/modules/test_kubernetesmod.py
+++ b/tests/unit/modules/test_kubernetesmod.py
@@ -149,6 +149,24 @@ class KubernetesTestCase(TestCase, LoaderModuleMockMixin):
                     create_namespaced_deployment().to_dict.called)
                 # pylint: enable=E1120
 
+    def test_create_service_empty_success(self):
+        '''
+        Tests empty service creation.
+        :return:
+        '''
+        with mock_kubernetes_library() as mock_kubernetes_lib:
+            with patch.dict(kubernetes.__salt__, {'config.option': Mock(side_effect=self.settings)}):
+                mock_kubernetes_lib.client.CoreV1Api.return_value = Mock(
+                    **{"create_namespaced_service.return_value.to_dict.return_value": {}}
+                )
+                self.assertEqual(kubernetes.create_service("test", "default", {}, {},
+                                                           None, None, None), {})
+                # pylint: disable=E1120
+                self.assertTrue(
+                    kubernetes.kubernetes.client.CoreV1Api().
+                    create_namespaced_service().to_dict.called)
+                # pylint: enable=E1120
+
     @staticmethod
     def settings(name, value=None):
         '''


### PR DESCRIPTION
### What does this PR do?
Resolves an error in creating a kubernetes service by passing a port value into the Kubernetes V1ServicePort constructor.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/55287

### Previous Behavior
Initialize the port object with an empty argument lsit

### New Behavior
Pull the port value off and pass it to the argument list

### Tests written?
No

### Commits signed with GPG?
Yes