### PR TITLE
[master] Allow the __utils__ dunder in Grains modules (port #49128)

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -674,7 +674,7 @@ def grain_funcs(opts, proxy=None):
           __opts__ = salt.config.minion_config('/etc/salt/minion')
           grainfuncs = salt.loader.grain_funcs(__opts__)
     '''
-    return LazyLoader(
+    ret = LazyLoader(
         _module_dirs(
             opts,
             'grains',
@@ -684,6 +684,8 @@ def grain_funcs(opts, proxy=None):
         opts,
         tag='grains',
     )
+    ret.pack['__utils__'] = utils(opts, proxy=proxy)
+    return ret
 
 
 def _load_cached_grains(opts, cfn):


### PR DESCRIPTION
### What does this PR do?

Master port of #49128 (Allow the `__utils__` dunder in Grains modules)
