### PR TITLE
Add the http.downloaded state and http.download module

### DIFF
--- a/salt/utils/path.py
+++ b/salt/utils/path.py
@@ -19,7 +19,8 @@ import struct
 import salt.utils.args
 import salt.utils.platform
 import salt.utils.stringutils
-from salt.exceptions import CommandNotFoundError
+import salt.utils.pycrypto
+from salt.exceptions import CommandNotFoundError, SaltInvocationError
 from salt.utils.decorators import memoize as real_memoize
 from salt.utils.decorators.jinja import jinja_filter
 
@@ -29,9 +30,17 @@ from salt.ext import six
 try:
     import win32file
     from pywintypes import error as pywinerror
+
     HAS_WIN32FILE = True
 except ImportError:
     HAS_WIN32FILE = False
+
+try:
+    import pathlib
+    HAS_PATHLIB = True
+except ImportError:
+    HAS_PATHLIB = False
+
 
 log = logging.getLogger(__name__)
 
@@ -69,6 +78,97 @@ def islink(path):
         return False
     else:
         return True
+
+
+def is_absolute(path):
+    '''
+    Test if the path absolute.
+    :param path: Absolute path.
+    :return: True if the path is absolute, else False.
+    '''
+    if HAS_PATHLIB:
+        return pathlib.PurePath(path).is_absolute()
+    else:
+        raise SaltInvocationError('Please install Python3 and pathlib')
+
+
+def exist(path):
+    '''
+    Test if the path exist.
+    :param path: Absolute path.
+    :return: True if the path exist, else False.
+    '''
+    if HAS_PATHLIB:
+        return pathlib.Path(path).exists()
+    else:
+        raise SaltInvocationError('Please install Python3 and pathlib')
+
+
+def is_dir(path):
+    '''
+    Test if the path is a directory.
+    :param path: Absolute path.
+    :return: True if the path is a directory, else False.
+    '''
+    if HAS_PATHLIB:
+        return True if exist(path) and pathlib.Path(path).is_dir() else False
+    else:
+        raise SaltInvocationError('Please install Python3 and pathlib')
+
+
+def is_file(path):
+    '''
+    Test if the path is a file.
+    :param path: Absolute path.
+    :return: True if the path is a file, else False.
+    '''
+    if HAS_PATHLIB:
+        return True if exist(path) and pathlib.Path(path).is_file() else False
+    else:
+        raise SaltInvocationError('Please install Python3 and pathlib')
+
+
+def dir_is_present(path, parents=True):
+    '''
+    Make the directory if it's not present.
+    :param path: Absolute path to the directory to create.
+    :param parents: Make the parents directories.
+    :return: True if the directory is present, else False.
+    '''
+    if HAS_PATHLIB:
+        if not exist(path):
+            pathlib.Path(path).mkdir(parents=parents, exist_ok=True)
+        return is_dir(path)
+    else:
+        raise SaltInvocationError('Please install Python3 and pathlib')
+
+
+def file_is_present(path):
+    '''
+    Touch the file if it's not present.
+    :param path: Absolute path to the file to create.
+    :return: True if the file is present, else False.
+    '''
+    if HAS_PATHLIB:
+        if not exist(path):
+            pathlib.Path(path).touch()
+        return is_file(path)
+    else:
+        raise SaltInvocationError('Please install Python3 and pathlib')
+
+
+def random_tmp_file(tmp_dir='/tmp'):
+    '''
+    Create a temporary file with a random name.
+    :param tmp_dir: Absolute path to the directory to create the random file.
+    :return: The path to the file created.
+    '''
+    ret = None
+    if is_absolute(tmp_dir):
+        tmp_file = join(tmp_dir, salt.utils.pycrypto.secure_password())
+        if file_is_present(tmp_file):
+            ret = tmp_file
+    return ret
 
 
 def readlink(path):
@@ -111,7 +211,7 @@ def readlink(path):
 
     path_buffer_offset = data_parser.size
     absolute_substitute_name_offset = path_buffer_offset + SubstituteNameOffset
-    target_bytes = reparse_data[absolute_substitute_name_offset:absolute_substitute_name_offset+SubstituteNameLength]
+    target_bytes = reparse_data[absolute_substitute_name_offset:absolute_substitute_name_offset + SubstituteNameLength]
     target = target_bytes.decode('UTF-16')
 
     if target.startswith('\\??\\'):
@@ -191,6 +291,7 @@ def which(exe=None):
     '''
     Python clone of /usr/bin/which
     '''
+
     def _is_executable_file_or_link(exe):
         # check for os.X_OK doesn't suffice because directory may executable
         return (os.access(exe, os.X_OK) and
@@ -339,7 +440,8 @@ def sanitize_win_path(winpath):
         winpath = winpath.translate(dict((ord(c), '_') for c in intab))
     elif isinstance(winpath, six.string_types):
         outtab = '_' * len(intab)
-        trantab = ''.maketrans(intab, outtab) if six.PY3 else string.maketrans(intab, outtab)  # pylint: disable=no-member
+        trantab = ''.maketrans(intab, outtab) if six.PY3 else string.maketrans(intab,
+                                                                               outtab)  # pylint: disable=no-member
         winpath = winpath.translate(trantab)
     return winpath
 

--- a/tests/unit/modules/test_http.py
+++ b/tests/unit/modules/test_http.py
@@ -5,15 +5,15 @@
 
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
+import os
+import tempfile
 
 # Import Salt Testing Libs
+from salt.ext import six
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import TestCase, skipIf
-from tests.support.mock import (
-    patch,
-    NO_MOCK,
-    NO_MOCK_REASON
-)
+from tests.support.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
+from tests.support.helpers import destructiveTest
 
 # Import Salt Libs
 import salt.modules.http as http
@@ -21,10 +21,30 @@ import salt.utils.http
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+@destructiveTest
 class HttpTestCase(TestCase, LoaderModuleMockMixin):
     '''
     Test cases for salt.modules.http
     '''
+
+    def setUp(self):
+        if six.PY3:
+            self.dir_exist = tempfile.TemporaryDirectory().name
+        else:
+            self.dir_exist = tempfile.tempdir
+        if not os.path.exists(self.dir_exist):
+            os.mkdir(self.dir_exist)
+        self.file_absent = os.path.join(self.dir_exist, 'file_absent.txt')
+
+    def tearDown(self):
+        if os.path.exists(self.file_absent):
+            os.remove(self.file_absent)
+        if os.path.exists(self.dir_exist):
+            os.rmdir(self.dir_exist)
+
+        del self.dir_exist
+        del self.file_absent
+
     def setup_loader_modules(self):
         return {http: {}}
 
@@ -34,3 +54,52 @@ class HttpTestCase(TestCase, LoaderModuleMockMixin):
         '''
         with patch.object(salt.utils.http, 'query', return_value='A'):
             self.assertEqual(http.query('url'), 'A')
+
+    def test_download_hash_is_valid(self):
+        mock_file_modules = {'file.write': MagicMock(return_value=True),
+                             'file.remove': MagicMock(return_value=True),
+                             'file.rename': MagicMock(return_value=True)}
+        with patch.dict(http.__salt__, mock_file_modules):
+            with patch('urllib.request') as mock_request:
+                mock_request.return_value.content = "Fake content"
+                with patch.object(salt.utils.hashutils, 'get_hash', return_value='123456'):
+                    ret_wanted = {'Changes': self.file_absent,
+                                  'Success': '{} is present.'.format(self.file_absent)}
+                    ret = http.download(self.file_absent,
+                                        'http://fake/url/file.tar.gz',
+                                        '123456')
+                    self.assertEqual(ret, ret_wanted)
+
+    def test_download_hash_is_not_valid(self):
+        mock_file_modules = {'file.write': MagicMock(return_value=True),
+                             'file.remove': MagicMock(return_value=True),
+                             'file.rename': MagicMock(return_value=True)}
+        with patch.dict(http.__salt__, mock_file_modules):
+            with patch('urllib.request') as mock_request:
+                mock_request.return_value.content = "Fake content"
+                with patch.object(salt.utils.hashutils, 'get_hash', return_value='123456'):
+                    ret_wanted = {'Error': {
+                        'Hash not equals': {
+                            'present': '123456',
+                            'wanted': '654321'
+                        }
+                    }
+                    }
+                    ret = http.download(self.file_absent,
+                                        'http://fake/url/file.tar.gz',
+                                        '654321')
+                    self.assertEqual(ret, ret_wanted)
+
+    def test_download_is_already_present(self):
+        mock_file_modules = {'file.write': MagicMock(return_value=True),
+                             'file.remove': MagicMock(return_value=True),
+                             'file.rename': MagicMock(return_value=True)}
+        with patch.dict(http.__salt__, mock_file_modules):
+            with patch('urllib.request') as mock_request:
+                mock_request.return_value.content = "Fake content"
+                with patch.object(salt.utils.hashutils, 'get_hash', return_value='123456'):
+                    with patch.object(salt.utils.path, 'is_file', return_value=True):
+                        ret_wanted = {'Success': '{} is already present.'.format(self.file_absent)}
+                        ret = http.download(self.file_absent,
+                                            'http://fake/url/file.tar.gz')
+                        self.assertEqual(ret, ret_wanted)

--- a/tests/unit/utils/test_path.py
+++ b/tests/unit/utils/test_path.py
@@ -15,6 +15,7 @@ import tempfile
 # Import Salt Testing libs
 from tests.support.unit import TestCase, skipIf
 from tests.support.mock import patch, NO_MOCK, NO_MOCK_REASON
+from tests.support.helpers import destructiveTest
 
 # Import Salt libs
 import salt.utils.compat
@@ -27,7 +28,6 @@ from salt.ext import six
 
 
 class PathJoinTestCase(TestCase):
-
     PLATFORM_FUNC = platform.system
     BUILTIN_MODULES = sys.builtin_module_names
 
@@ -267,7 +267,7 @@ class TestWhich(TestCase):
             # Let's patch os.environ to provide a custom PATH variable
             with patch.dict(os.environ, {'PATH': os.sep + 'bin',
                                          'PATHEXT': '.COM;.EXE;.BAT;.CMD;.VBS;'
-                                         '.VBE;.JS;.JSE;.WSF;.WSH;.MSC;.PY'}):
+                                                    '.VBE;.JS;.JSE;.WSF;.WSH;.MSC;.PY'}):
                 # Let's also patch is_windows to return True
                 with patch('salt.utils.platform.is_windows', lambda: True):
                     with patch('os.path.isfile', lambda x: True):
@@ -275,3 +275,82 @@ class TestWhich(TestCase):
                             salt.utils.path.which('this-binary-exists-under-windows'),
                             os.path.join(os.sep + 'bin', 'this-binary-exists-under-windows.CMD')
                         )
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@destructiveTest
+class TestPath(TestCase):
+    def setUp(self):
+        if six.PY3:
+            self.working_dir = tempfile.TemporaryDirectory().name
+        else:
+            self.working_dir = tempfile.tempdir
+        if not os.path.exists(self.working_dir):
+            os.mkdir(self.working_dir)
+        self.dir_exist = os.path.join(self.working_dir, 'dir_exist')
+        if not os.path.exists(self.dir_exist):
+            os.mkdir(self.dir_exist)
+        self.dir_absent = os.path.join(self.working_dir, 'dir_absent')
+        self.file_exist = os.path.join(self.dir_exist, 'file_exist.txt')
+        with salt.utils.fopen(self.file_exist, 'a'):
+            os.utime(self.file_exist, None)
+        self.file_absent = os.path.join(self.dir_exist, 'file_absent.txt')
+
+    def tearDown(self):
+        if os.path.exists(self.file_exist):
+            os.remove(self.file_exist)
+        if os.path.exists(self.file_absent):
+            os.remove(self.file_absent)
+        if os.path.exists(self.dir_exist):
+            os.rmdir(self.dir_exist)
+        if os.path.exists(self.dir_absent):
+            os.rmdir(self.dir_absent)
+        if os.path.exists(self.working_dir):
+            os.rmdir(self.working_dir)
+
+        del self.dir_exist
+        del self.dir_absent
+        del self.file_exist
+        del self.file_absent
+        del self.working_dir
+
+    def test_path_is_absolute(self):
+        self.assertTrue(salt.utils.path.is_absolute(self.dir_exist))
+
+    def test_path_is_not_absolute(self):
+        self.assertFalse(salt.utils.path.is_absolute('test'))
+
+    def test_path_exist(self):
+        self.assertTrue(salt.utils.path.exist(self.dir_exist))
+
+    def test_path_not_exist(self):
+        self.assertFalse(salt.utils.path.exist(self.dir_absent))
+
+    def test_path_is_dir(self):
+        self.assertTrue(salt.utils.path.is_dir(self.dir_exist))
+
+    def test_path_is_not_dir(self):
+        self.assertFalse(salt.utils.path.is_dir(self.dir_absent))
+        self.assertFalse(salt.utils.path.is_dir(self.file_exist))
+
+    def test_path_is_file(self):
+        self.assertTrue(salt.utils.path.is_file(self.file_exist))
+
+    def test_path_is_not_file(self):
+        self.assertFalse(salt.utils.path.is_file(self.dir_exist))
+        self.assertFalse(salt.utils.path.is_file(self.file_absent))
+
+    def test_path_dir_is_present(self):
+        self.assertTrue(salt.utils.path.dir_is_present(self.dir_exist))
+        self.assertTrue(salt.utils.path.dir_is_present(self.dir_absent))
+        self.assertTrue(os.path.exists(self.dir_absent))
+
+    def test_path_file_is_present(self):
+        self.assertTrue(salt.utils.path.file_is_present(self.file_exist))
+        self.assertTrue(salt.utils.path.file_is_present(self.file_absent))
+        self.assertTrue(os.path.exists(self.file_absent))
+
+    def test_path_random_tmp_file(self):
+        tmp_file = salt.utils.path.random_tmp_file(self.dir_exist)
+        self.assertTrue(os.path.exists(tmp_file))
+        os.remove(tmp_file)


### PR DESCRIPTION
Signed-off-by: Arthur REGNARD <arthur.regnard@gmail.com>

### What does this PR do?
ADD the http.dowloaded states and the http.download modules to download a web file on the host file system.  

### What issues does this PR fix or reference?
ADD some utils to the path library.

### New Behavior
New states:
```yaml
web_archive_is_dowloaded:
  http.downloaded:
    - name: /tmp/my_arch.tar.gz
    - source: http://host.com/arch_1.2.3.tar.gz
```

New modules:
```bash
salt '*' http.download /tmp/my_arch.tar.gz http://host.com/arch_1.2.3.tar.gz
```

### Tests written ?
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
