### PR TITLE
doc: escape special characters on linux for cmd.run

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -982,8 +982,8 @@ def run(cmd,
         .. warning::
 
             For versions 2018.3.3 and above on macosx while using runas,
-            to pass special characters to the command you need to escape
-            the characters on the shell.
+            on linux while using run, to pass special characters to the
+            command you need to escape the characters on the shell.
 
             Example:
 


### PR DESCRIPTION
### What does this PR do?
This PR documents that the special characters in the commands (for cmd.run) need to be escaped on Linux shell.

### What issues does this PR fix or reference?
#53359

### Previous Behavior
It is only documented for macOS

### Tests written?
NA
