### PR TITLE
Fix rst markup in grains topic

### DIFF
--- a/doc/topics/grains/index.rst
+++ b/doc/topics/grains/index.rst
@@ -44,7 +44,7 @@ Grains data can be listed by using the 'grains.items' module:
 Using grains in a state
 =======================
 
-To use a grain in a state you can access it via `{{ grains['key'] }}`.
+To use a grain in a state you can access it via ``{{ grains['key'] }}``.
 
 Grains in the Minion Config
 ===========================


### PR DESCRIPTION
### What does this PR do?
Add missing '\`' (backtick) to `{{ grains['key'] }}` in the grains topic.

### What issues does this PR fix or reference?
Fixes missing markup.

### Tests written?
No

### Commits signed with GPG?
No
