### PR TITLE
31022 fix rbenv build env parsing

### DIFF
--- a/salt/states/rbenv.py
+++ b/salt/states/rbenv.py
@@ -18,6 +18,18 @@ directories to the users PATH. If you are installing as root and want other
 users to be able to access rbenv then you will need to add RBENV_ROOT to
 their environment.
 
+To pass additional environment based compile time options to rbenv_build, you
+can setup a build_env dictionary in the pillar/grains/master configuration. The
+following example would pass `CONFIGURE_OPTS="--no-tcmalloc" CFLAGS="-fno-tree-dce"``
+to the rbenv_build process.
+
+.. code-block:: yaml
+
+        rbenv:
+          build_env:
+            CONFIGURE_OPTS: "--no-tcmalloc"
+            CFLAGS: "-fno-tree-dce"
+
 The following state configuration demonstrates how to install Ruby 1.9.x
 and 2.x using rbenv on Ubuntu/Debian:
 


### PR DESCRIPTION
### What does this PR do?
Fixes the rbenv module issue with not passing the build_config compile environment options to the command line for use. They were getting lost along the way. At some point in the past a change was made on how the options where being handled as strings and I believe that is when this stopped working. I don't know that many people use this option and my use case was trivial so I never bothered to debug. Please see the referenced issue for more details on the problem.

Originally, the build_env was passed as a string, converted to a list, back to a string and then expected to be a list or dictionary. If it was a list, it was converted to a dictionary. This PR changes the expectation of the pillar/grain input to be in a dictionary format, while retaining compatibility for previous setups. 

Also, not a python expert so guessing on some of the use of the built in tools and practices I worked with. 

### What issues does this PR fix or reference?
Fixes #31022 

### Previous Behavior
The rbenv state would work fine but any compile time options you might have tried to set via pillar or grains would be ignored. For instance, if you tried to compile a ruby with `RUBY_CONFIGURE_OPTS="--with-jemalloc`, that compile time option never made it to the ruby build process.

### New Behavior
The build_env pillar/grains options are now handled properly and not lost in the process. If you use the state to compile a ruby with extra options, you will now see the compiled in options present.

### Tests written?
No, tests updated. I know enough python to get this far.

I did test this works for my old configuration that was previously getting silently ignored and I tested under the new dictionary setup I propose for going forward since this appears to be what is asked for in the code anyway.

### Commits signed with GPG?

No

