### PR TITLE
Replace inspect.getargspec -- it's deprecated in Python 3.0

### DIFF
--- a/salt/modules/napalm_mod.py
+++ b/salt/modules/napalm_mod.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-'''
+"""
 NAPALM helpers
 ==============
 
 Helpers for the NAPALM modules.
 
 .. versionadded:: 2017.7.0
-'''
+"""
 from __future__ import absolute_import, unicode_literals, print_function
 
 # Import python stdlib
@@ -24,30 +24,35 @@ from salt.exceptions import CommandExecutionError
 
 try:
     from netmiko import BaseConnection
+
     HAS_NETMIKO = True
 except ImportError:
     HAS_NETMIKO = False
 
 try:
     import napalm.base.netmiko_helpers
+
     HAS_NETMIKO_HELPERS = True
 except ImportError:
     HAS_NETMIKO_HELPERS = False
 
 try:
     import jxmlease  # pylint: disable=unused-import
+
     HAS_JXMLEASE = True
 except ImportError:
     HAS_JXMLEASE = False
 
 try:
     import ciscoconfparse  # pylint: disable=unused-import
+
     HAS_CISCOCONFPARSE = True
 except ImportError:
     HAS_CISCOCONFPARSE = False
 
 try:
     import scp  # pylint: disable=unused-import
+
     HAS_SCP = True
 except ImportError:
     HAS_SCP = False
@@ -56,8 +61,8 @@ except ImportError:
 # module properties
 # ----------------------------------------------------------------------------------------------------------------------
 
-__virtualname__ = 'napalm'
-__proxyenabled__ = ['*']
+__virtualname__ = "napalm"
+__proxyenabled__ = ["*"]
 # uses NAPALM-based proxy to interact with network devices
 
 log = logging.getLogger(__file__)
@@ -68,10 +73,11 @@ log = logging.getLogger(__file__)
 
 
 def __virtual__():
-    '''
+    """
     NAPALM library must be installed for this module to work and run in a (proxy) minion.
-    '''
+    """
     return salt.utils.napalm.virtual(__opts__, __virtualname__, __file__)
+
 
 # ----------------------------------------------------------------------------------------------------------------------
 # helper functions -- will not be exported
@@ -79,7 +85,7 @@ def __virtual__():
 
 
 def _get_netmiko_args(optional_args):
-    '''
+    """
     Check for Netmiko arguments that were passed in as NAPALM optional arguments.
 
     Return a dictionary of these optional args that will be passed into the
@@ -91,19 +97,21 @@ def _get_netmiko_args(optional_args):
         older versions of NAPALM, and stability across Salt features.
         If the netmiko helpers module is available however, it will prefer that
         implementation nevertheless.
-    '''
+    """
     if HAS_NETMIKO_HELPERS:
         return napalm.base.netmiko_helpers.netmiko_args(optional_args)
     # Older version don't have the netmiko_helpers module, the following code is
     # simply a port from the NAPALM code base, for backwards compatibility:
     # https://github.com/napalm-automation/napalm/blob/develop/napalm/base/netmiko_helpers.py
-    netmiko_args, _, _, netmiko_defaults = inspect.getargspec(BaseConnection.__init__)
+    netmiko_args, _, _, netmiko_defaults, _, _, _ = inspect.getfullargspec(
+        BaseConnection.__init__
+    )
     check_self = netmiko_args.pop(0)
-    if check_self != 'self':
-        raise ValueError('Error processing Netmiko arguments')
+    if check_self != "self":
+        raise ValueError("Error processing Netmiko arguments")
     netmiko_argument_map = dict(six.moves.zip(netmiko_args, netmiko_defaults))
     # Netmiko arguments that are integrated into NAPALM already
-    netmiko_filter = ['ip', 'host', 'username', 'password', 'device_type', 'timeout']
+    netmiko_filter = ["ip", "host", "username", "password", "device_type", "timeout"]
     # Filter out all of the arguments that are integrated into NAPALM
     for k in netmiko_filter:
         netmiko_argument_map.pop(k)
@@ -119,13 +127,15 @@ def _get_netmiko_args(optional_args):
 
 
 def _inject_junos_proxy(napalm_device):
-    '''
+    """
     Inject the junos.conn key into the __proxy__, reusing the existing NAPALM
     connection to the Junos device.
-    '''
+    """
+
     def _ret_device():
-        return napalm_device['DRIVER'].device
-    __proxy__['junos.conn'] = _ret_device
+        return napalm_device["DRIVER"].device
+
+    __proxy__["junos.conn"] = _ret_device
     # Injecting the junos.conn key into the __proxy__ object, we can then
     # access the features that already exist into the junos module, as long
     # as the rest of the dependencies are installed (jxmlease).
@@ -137,25 +147,24 @@ def _inject_junos_proxy(napalm_device):
 
 
 def _junos_prep_fun(napalm_device):
-    '''
+    """
     Prepare the Junos function.
-    '''
-    if __grains__['os'] != 'junos':
+    """
+    if __grains__["os"] != "junos":
         return {
-            'out': None,
-            'result': False,
-            'comment': 'This function is only available on Junos'
+            "out": None,
+            "result": False,
+            "comment": "This function is only available on Junos",
         }
     if not HAS_JXMLEASE:
         return {
-            'out': None,
-            'result': False,
-            'comment': 'Please install jxmlease (``pip install jxmlease``) to be able to use this function.'
+            "out": None,
+            "result": False,
+            "comment": "Please install jxmlease (``pip install jxmlease``) to be able to use this function.",
         }
     _inject_junos_proxy(napalm_device)
-    return {
-        'result': True
-    }
+    return {"result": True}
+
 
 # ----------------------------------------------------------------------------------------------------------------------
 # callable functions
@@ -164,7 +173,7 @@ def _junos_prep_fun(napalm_device):
 
 @proxy_napalm_wrap
 def alive(**kwargs):  # pylint: disable=unused-argument
-    '''
+    """
     Returns the alive status of the connection layer.
     The output is a dictionary under the usual dictionary
     output of the NAPALM modules.
@@ -183,17 +192,15 @@ def alive(**kwargs):  # pylint: disable=unused-argument
         out:
             is_alive: False
         comment: ''
-    '''
+    """
     return salt.utils.napalm.call(
-        napalm_device,  # pylint: disable=undefined-variable
-        'is_alive',
-        **{}
+        napalm_device, "is_alive", **{}  # pylint: disable=undefined-variable
     )
 
 
 @proxy_napalm_wrap
 def reconnect(force=False, **kwargs):  # pylint: disable=unused-argument
-    '''
+    """
     Reconnect the NAPALM proxy when the connection
     is dropped by the network device.
     The connection can be forced to be restarted
@@ -209,41 +216,33 @@ def reconnect(force=False, **kwargs):  # pylint: disable=unused-argument
 
         salt '*' napalm.reconnect
         salt '*' napalm.reconnect force=True
-    '''
-    default_ret = {
-        'out': None,
-        'result': True,
-        'comment': 'Already alive.'
-    }
+    """
+    default_ret = {"out": None, "result": True, "comment": "Already alive."}
     if not salt.utils.napalm.is_proxy(__opts__):
         # regular minion is always alive
         # otherwise, the user would not be able to execute this command
         return default_ret
     is_alive = alive()
-    log.debug('Is alive fetch:')
+    log.debug("Is alive fetch:")
     log.debug(is_alive)
-    if not is_alive.get('result', False) or\
-       not is_alive.get('out', False) or\
-       not is_alive.get('out', {}).get('is_alive', False) or\
-       force:  # even if alive, but the user wants to force a restart
-        proxyid = __opts__.get('proxyid') or __opts__.get('id')
+    if (
+        not is_alive.get("result", False)
+        or not is_alive.get("out", False)
+        or not is_alive.get("out", {}).get("is_alive", False)
+        or force
+    ):  # even if alive, but the user wants to force a restart
+        proxyid = __opts__.get("proxyid") or __opts__.get("id")
         # close the connection
-        log.info('Closing the NAPALM proxy connection with %s', proxyid)
+        log.info("Closing the NAPALM proxy connection with %s", proxyid)
         salt.utils.napalm.call(
-            napalm_device,  # pylint: disable=undefined-variable
-            'close',
-            **{}
+            napalm_device, "close", **{}  # pylint: disable=undefined-variable
         )
         # and re-open
-        log.info('Re-opening the NAPALM proxy connection with %s', proxyid)
+        log.info("Re-opening the NAPALM proxy connection with %s", proxyid)
         salt.utils.napalm.call(
-            napalm_device,  # pylint: disable=undefined-variable
-            'open',
-            **{}
+            napalm_device, "open", **{}  # pylint: disable=undefined-variable
         )
-        default_ret.update({
-            'comment': 'Connection restarted!'
-        })
+        default_ret.update({"comment": "Connection restarted!"})
         return default_ret
     # otherwise, I have nothing to do here:
     return default_ret
@@ -251,7 +250,7 @@ def reconnect(force=False, **kwargs):  # pylint: disable=unused-argument
 
 @proxy_napalm_wrap
 def call(method, *args, **kwargs):
-    '''
+    """
     Execute arbitrary methods from the NAPALM library.
     To see the expected output, please consult the NAPALM documentation.
 
@@ -267,11 +266,11 @@ def call(method, *args, **kwargs):
         salt '*' napalm.call get_lldp_neighbors
         salt '*' napalm.call get_firewall_policies
         salt '*' napalm.call get_bgp_config group='my-group'
-    '''
+    """
     clean_kwargs = {}
     for karg, warg in six.iteritems(kwargs):
         # remove the __pub args
-        if not karg.startswith('__pub_'):
+        if not karg.startswith("__pub_"):
             clean_kwargs[karg] = warg
     return salt.utils.napalm.call(
         napalm_device,  # pylint: disable=undefined-variable
@@ -282,11 +281,8 @@ def call(method, *args, **kwargs):
 
 
 @proxy_napalm_wrap
-def compliance_report(filepath=None,
-                      string=None,
-                      renderer='jinja|yaml',
-                      **kwargs):
-    '''
+def compliance_report(filepath=None, string=None, renderer="jinja|yaml", **kwargs):
+    """
     Return the compliance report.
 
     filepath
@@ -405,21 +401,20 @@ def compliance_report(filepath=None,
                 skipped:
             result:
                 True
-    '''
-    validation_string = __salt__['slsutil.renderer'](path=filepath,
-                                                     string=string,
-                                                     default_renderer=renderer,
-                                                     **kwargs)
+    """
+    validation_string = __salt__["slsutil.renderer"](
+        path=filepath, string=string, default_renderer=renderer, **kwargs
+    )
     return salt.utils.napalm.call(
         napalm_device,  # pylint: disable=undefined-variable
-        'compliance_report',
-        validation_source=validation_string
+        "compliance_report",
+        validation_source=validation_string,
     )
 
 
 @proxy_napalm_wrap
 def netmiko_args(**kwargs):
-    '''
+    """
     .. versionadded:: 2019.2.0
 
     Return the key-value arguments used for the authentication arguments for
@@ -447,32 +442,34 @@ def netmiko_args(**kwargs):
     .. code-block:: bash
 
         salt '*' napalm.netmiko_args
-    '''
+    """
     if not HAS_NETMIKO:
-        raise CommandExecutionError('Please install netmiko to be able to use this feature.')
+        raise CommandExecutionError(
+            "Please install netmiko to be able to use this feature."
+        )
     kwargs = {}
     napalm_opts = salt.utils.napalm.get_device_opts(__opts__, salt_obj=__salt__)
-    optional_args = napalm_opts['OPTIONAL_ARGS']
+    optional_args = napalm_opts["OPTIONAL_ARGS"]
     netmiko_args = _get_netmiko_args(optional_args)
-    kwargs['host'] = napalm_opts['HOSTNAME']
-    kwargs['username'] = napalm_opts['USERNAME']
-    kwargs['password'] = napalm_opts['PASSWORD']
-    kwargs['timeout'] = napalm_opts['TIMEOUT']
+    kwargs["host"] = napalm_opts["HOSTNAME"]
+    kwargs["username"] = napalm_opts["USERNAME"]
+    kwargs["password"] = napalm_opts["PASSWORD"]
+    kwargs["timeout"] = napalm_opts["TIMEOUT"]
     kwargs.update(netmiko_args)
     netmiko_device_type_map = {
-        'junos': 'juniper_junos',
-        'ios': 'cisco_ios',
-        'iosxr': 'cisco_xr',
-        'eos': 'arista_eos',
-        'nxos_ssh': 'cisco_nxos',
-        'asa': 'cisco_asa',
-        'fortios': 'fortinet',
-        'panos': 'paloalto_panos',
-        'aos': 'alcatel_aos',
-        'vyos': 'vyos',
-        'f5': 'f5_ltm',
-        'ce': 'huawei',
-        's350': 'cisco_s300'
+        "junos": "juniper_junos",
+        "ios": "cisco_ios",
+        "iosxr": "cisco_xr",
+        "eos": "arista_eos",
+        "nxos_ssh": "cisco_nxos",
+        "asa": "cisco_asa",
+        "fortios": "fortinet",
+        "panos": "paloalto_panos",
+        "aos": "alcatel_aos",
+        "vyos": "vyos",
+        "f5": "f5_ltm",
+        "ce": "huawei",
+        "s350": "cisco_s300",
     }
     # If you have a device type that is not listed here, please submit a PR
     # to add it, and/or add the map into your opts/Pillar: netmiko_device_type_map
@@ -482,15 +479,17 @@ def netmiko_args(**kwargs):
     #   junos: juniper_junos
     #   ios: cisco_ios
     #
-    #etc.
-    netmiko_device_type_map.update(__salt__['config.get']('netmiko_device_type_map', {}))
-    kwargs['device_type'] = netmiko_device_type_map[__grains__['os']]
+    # etc.
+    netmiko_device_type_map.update(
+        __salt__["config.get"]("netmiko_device_type_map", {})
+    )
+    kwargs["device_type"] = netmiko_device_type_map[__grains__["os"]]
     return kwargs
 
 
 @proxy_napalm_wrap
 def netmiko_fun(fun, *args, **kwargs):
-    '''
+    """
     .. versionadded:: 2019.2.0
 
     Call an arbitrary function from the :mod:`Netmiko<salt.modules.netmiko_mod>`
@@ -514,9 +513,9 @@ def netmiko_fun(fun, *args, **kwargs):
     .. code-block:: bash
 
         salt '*' napalm.netmiko_fun send_command 'show version'
-    '''
-    if 'netmiko.' not in fun:
-        fun = 'netmiko.{fun}'.format(fun=fun)
+    """
+    if "netmiko." not in fun:
+        fun = "netmiko.{fun}".format(fun=fun)
     netmiko_kwargs = netmiko_args()
     kwargs.update(netmiko_kwargs)
     return __salt__[fun](*args, **kwargs)
@@ -524,7 +523,7 @@ def netmiko_fun(fun, *args, **kwargs):
 
 @proxy_napalm_wrap
 def netmiko_call(method, *args, **kwargs):
-    '''
+    """
     .. versionadded:: 2019.2.0
 
     Execute an arbitrary Netmiko method, passing the authentication details from
@@ -545,15 +544,15 @@ def netmiko_call(method, *args, **kwargs):
     .. code-block:: bash
 
         salt '*' napalm.netmiko_call send_command 'show version'
-    '''
+    """
     netmiko_kwargs = netmiko_args()
     kwargs.update(netmiko_kwargs)
-    return __salt__['netmiko.call'](method, *args, **kwargs)
+    return __salt__["netmiko.call"](method, *args, **kwargs)
 
 
 @proxy_napalm_wrap
 def netmiko_multi_call(*methods, **kwargs):
-    '''
+    """
     .. versionadded:: 2019.2.0
 
     Execute a list of arbitrary Netmiko methods, passing the authentication
@@ -572,15 +571,15 @@ def netmiko_multi_call(*methods, **kwargs):
     .. code-block:: bash
 
         salt '*' napalm.netmiko_multi_call "{'name': 'send_command', 'args': ['show version']}" "{'name': 'send_command', 'args': ['show interfaces']}"
-    '''
+    """
     netmiko_kwargs = netmiko_args()
     kwargs.update(netmiko_kwargs)
-    return __salt__['netmiko.multi_call'](*methods, **kwargs)
+    return __salt__["netmiko.multi_call"](*methods, **kwargs)
 
 
 @proxy_napalm_wrap
 def netmiko_commands(*commands, **kwargs):
-    '''
+    """
     .. versionadded:: 2019.2.0
 
     Invoke one or more commands to be executed on the remote device, via Netmiko.
@@ -620,7 +619,7 @@ def netmiko_commands(*commands, **kwargs):
     .. code-block:: bash
 
         salt '*' napalm.netmiko_commands 'show version' 'show interfaces'
-    '''
+    """
     conn = netmiko_conn(**kwargs)
     ret = []
     for cmd in commands:
@@ -630,7 +629,7 @@ def netmiko_commands(*commands, **kwargs):
 
 @proxy_napalm_wrap
 def netmiko_config(*config_commands, **kwargs):
-    '''
+    """
     .. versionadded:: 2019.2.0
 
     Load a list of configuration commands on the remote device, via Netmiko.
@@ -692,16 +691,15 @@ def netmiko_config(*config_commands, **kwargs):
 
         salt '*' napalm.netmiko_config 'set system ntp peer 1.2.3.4' commit=True
         salt '*' napalm.netmiko_config https://bit.ly/2sgljCB
-    '''
+    """
     netmiko_kwargs = netmiko_args()
     kwargs.update(netmiko_kwargs)
-    return __salt__['netmiko.send_config'](config_commands=config_commands,
-                                           **kwargs)
+    return __salt__["netmiko.send_config"](config_commands=config_commands, **kwargs)
 
 
 @proxy_napalm_wrap
 def netmiko_conn(**kwargs):
-    '''
+    """
     .. versionadded:: 2019.2.0
 
     Return the connection object with the network device, over Netmiko, passing
@@ -719,15 +717,15 @@ def netmiko_conn(**kwargs):
         conn = __salt__['napalm.netmiko_conn']()
         res = conn.send_command('show interfaces')
         conn.disconnect()
-    '''
+    """
     netmiko_kwargs = netmiko_args()
     kwargs.update(netmiko_kwargs)
-    return __salt__['netmiko.get_connection'](**kwargs)
+    return __salt__["netmiko.get_connection"](**kwargs)
 
 
 @proxy_napalm_wrap
 def junos_rpc(cmd=None, dest=None, format=None, **kwargs):
-    '''
+    """
     .. versionadded:: 2019.2.0
 
     Execute an RPC request on the remote Junos device.
@@ -768,26 +766,23 @@ def junos_rpc(cmd=None, dest=None, format=None, **kwargs):
 
         salt '*' napalm.junos_rpc get-lldp-neighbors-information
         salt '*' napalm.junos_rcp get-config <configuration><system><ntp/></system></configuration>
-    '''
+    """
     prep = _junos_prep_fun(napalm_device)  # pylint: disable=undefined-variable
-    if not prep['result']:
+    if not prep["result"]:
         return prep
     if not format:
-        format = 'xml'
-    rpc_ret = __salt__['junos.rpc'](cmd=cmd,
-                                    dest=dest,
-                                    format=format,
-                                    **kwargs)
-    rpc_ret['comment'] = rpc_ret.pop('message', '')
-    rpc_ret['result'] = rpc_ret.pop('out', False)
-    rpc_ret['out'] = rpc_ret.pop('rpc_reply', None)
+        format = "xml"
+    rpc_ret = __salt__["junos.rpc"](cmd=cmd, dest=dest, format=format, **kwargs)
+    rpc_ret["comment"] = rpc_ret.pop("message", "")
+    rpc_ret["result"] = rpc_ret.pop("out", False)
+    rpc_ret["out"] = rpc_ret.pop("rpc_reply", None)
     # The comment field is "message" in the Junos module
     return rpc_ret
 
 
 @proxy_napalm_wrap
 def junos_commit(**kwargs):
-    '''
+    """
     .. versionadded:: 2019.2.0
 
     Commit the changes loaded in the candidate configuration.
@@ -827,16 +822,16 @@ def junos_commit(**kwargs):
         salt '*' napalm.junos_commit comment='Commitiing via Salt' detail=True
         salt '*' napalm.junos_commit dev_timeout=60 confirm=10
         salt '*' napalm.junos_commit sync=True dev_timeout=90
-    '''
+    """
     prep = _junos_prep_fun(napalm_device)  # pylint: disable=undefined-variable
-    if not prep['result']:
+    if not prep["result"]:
         return prep
-    return __salt__['junos.commit'](**kwargs)
+    return __salt__["junos.commit"](**kwargs)
 
 
 @proxy_napalm_wrap
 def junos_install_os(path=None, **kwargs):
-    '''
+    """
     .. versionadded:: 2019.2.0
 
     Installs the given image on the device.
@@ -866,16 +861,16 @@ def junos_install_os(path=None, **kwargs):
     .. code-block:: bash
 
         salt '*' napalm.junos_install_os salt://images/junos_16_1.tgz reboot=True
-    '''
+    """
     prep = _junos_prep_fun(napalm_device)  # pylint: disable=undefined-variable
-    if not prep['result']:
+    if not prep["result"]:
         return prep
-    return __salt__['junos.install_os'](path=path, **kwargs)
+    return __salt__["junos.install_os"](path=path, **kwargs)
 
 
 @proxy_napalm_wrap
 def junos_facts(**kwargs):
-    '''
+    """
     .. versionadded:: 2019.2.0
 
     The complete list of Junos facts collected by ``junos-eznc``.
@@ -885,26 +880,26 @@ def junos_facts(**kwargs):
     .. code-block:: bash
 
         salt '*' napalm.junos_facts
-    '''
+    """
     prep = _junos_prep_fun(napalm_device)  # pylint: disable=undefined-variable
-    if not prep['result']:
+    if not prep["result"]:
         return prep
-    facts = dict(napalm_device['DRIVER'].device.facts)  # pylint: disable=undefined-variable
-    if 'version_info' in facts:
-        facts['version_info'] = \
-            dict(facts['version_info'])
+    facts = dict(
+        napalm_device["DRIVER"].device.facts
+    )  # pylint: disable=undefined-variable
+    if "version_info" in facts:
+        facts["version_info"] = dict(facts["version_info"])
     # For backward compatibility. 'junos_info' is present
     # only of in newer versions of facts.
-    if 'junos_info' in facts:
-        for re in facts['junos_info']:
-            facts['junos_info'][re]['object'] = \
-                dict(facts['junos_info'][re]['object'])
+    if "junos_info" in facts:
+        for re in facts["junos_info"]:
+            facts["junos_info"][re]["object"] = dict(facts["junos_info"][re]["object"])
     return facts
 
 
 @proxy_napalm_wrap
 def junos_cli(command, format=None, dev_timeout=None, dest=None, **kwargs):
-    '''
+    """
     .. versionadded:: 2019.2.0
 
     Execute a CLI command and return the output in the specified format.
@@ -928,20 +923,18 @@ def junos_cli(command, format=None, dev_timeout=None, dest=None, **kwargs):
     .. code-block:: bash
 
         salt '*' napalm.junos_cli 'show lldp neighbors'
-    '''
+    """
     prep = _junos_prep_fun(napalm_device)  # pylint: disable=undefined-variable
-    if not prep['result']:
+    if not prep["result"]:
         return prep
-    return __salt__['junos.cli'](command,
-                                 format=format,
-                                 dev_timeout=dev_timeout,
-                                 dest=dest,
-                                 **kwargs)
+    return __salt__["junos.cli"](
+        command, format=format, dev_timeout=dev_timeout, dest=dest, **kwargs
+    )
 
 
 @proxy_napalm_wrap
 def junos_copy_file(src, dst, **kwargs):
-    '''
+    """
     .. versionadded:: 2019.2.0
 
     Copies the file on the remote Junos device.
@@ -958,17 +951,17 @@ def junos_copy_file(src, dst, **kwargs):
     .. code-block:: bash
 
         salt '*' napalm.junos_copy_file https://example.com/junos.cfg /var/tmp/myjunos.cfg
-    '''
+    """
     prep = _junos_prep_fun(napalm_device)  # pylint: disable=undefined-variable
-    if not prep['result']:
+    if not prep["result"]:
         return prep
-    cached_src = __salt__['cp.cache_file'](src)
-    return __salt__['junos.file_copy'](cached_src, dst)
+    cached_src = __salt__["cp.cache_file"](src)
+    return __salt__["junos.file_copy"](cached_src, dst)
 
 
 @proxy_napalm_wrap
 def junos_call(fun, *args, **kwargs):
-    '''
+    """
     .. versionadded:: 2019.2.0
 
     Execute an arbitrary function from the
@@ -991,25 +984,25 @@ def junos_call(fun, *args, **kwargs):
     .. code-block:: bash
 
         salt '*' napalm.junos_fun cli 'show system commit'
-    '''
+    """
     prep = _junos_prep_fun(napalm_device)  # pylint: disable=undefined-variable
-    if not prep['result']:
+    if not prep["result"]:
         return prep
-    if 'junos.' not in fun:
-        mod_fun = 'junos.{}'.format(fun)
+    if "junos." not in fun:
+        mod_fun = "junos.{}".format(fun)
     else:
         mod_fun = fun
     if mod_fun not in __salt__:
         return {
-            'out': None,
-            'result': False,
-            'comment': '{} is not a valid function'.format(fun)
+            "out": None,
+            "result": False,
+            "comment": "{} is not a valid function".format(fun),
         }
     return __salt__[mod_fun](*args, **kwargs)
 
 
 def pyeapi_nxos_api_args(**prev_kwargs):
-    '''
+    """
     .. versionadded:: 2019.2.0
 
     Return the key-value arguments used for the authentication arguments for the
@@ -1020,24 +1013,24 @@ def pyeapi_nxos_api_args(**prev_kwargs):
     .. code-block:: bash
 
         salt '*' napalm.pyeapi_nxos_api_args
-    '''
+    """
     kwargs = {}
     napalm_opts = salt.utils.napalm.get_device_opts(__opts__, salt_obj=__salt__)
-    optional_args = napalm_opts['OPTIONAL_ARGS']
-    kwargs['host'] = napalm_opts['HOSTNAME']
-    kwargs['username'] = napalm_opts['USERNAME']
-    kwargs['password'] = napalm_opts['PASSWORD']
-    kwargs['timeout'] = napalm_opts['TIMEOUT']
-    kwargs['transport'] = optional_args.get('transport')
-    kwargs['port'] = optional_args.get('port')
-    kwargs['verify'] = optional_args.get('verify')
+    optional_args = napalm_opts["OPTIONAL_ARGS"]
+    kwargs["host"] = napalm_opts["HOSTNAME"]
+    kwargs["username"] = napalm_opts["USERNAME"]
+    kwargs["password"] = napalm_opts["PASSWORD"]
+    kwargs["timeout"] = napalm_opts["TIMEOUT"]
+    kwargs["transport"] = optional_args.get("transport")
+    kwargs["port"] = optional_args.get("port")
+    kwargs["verify"] = optional_args.get("verify")
     prev_kwargs.update(kwargs)
     return prev_kwargs
 
 
 @proxy_napalm_wrap
 def pyeapi_run_commands(*commands, **kwargs):
-    '''
+    """
     Execute a list of commands on the Arista switch, via the ``pyeapi`` library.
     This function forwards the existing connection details to the
     :mod:`pyeapi.run_commands <salt.module.arista_pyeapi.run_commands>`
@@ -1056,14 +1049,14 @@ def pyeapi_run_commands(*commands, **kwargs):
 
         salt '*' napalm.pyeapi_run_commands 'show version' encoding=text
         salt '*' napalm.pyeapi_run_commands 'show ip bgp neighbors'
-    '''
+    """
     pyeapi_kwargs = pyeapi_nxos_api_args(**kwargs)
-    return __salt__['pyeapi.run_commands'](*commands, **pyeapi_kwargs)
+    return __salt__["pyeapi.run_commands"](*commands, **pyeapi_kwargs)
 
 
 @proxy_napalm_wrap
 def pyeapi_call(method, *args, **kwargs):
-    '''
+    """
     .. versionadded:: 2019.2.0
 
     Invoke an arbitrary method from the ``pyeapi`` library.
@@ -1083,14 +1076,14 @@ def pyeapi_call(method, *args, **kwargs):
 
         salt '*' napalm.pyeapi_call run_commands 'show version' encoding=text
         salt '*' napalm.pyeapi_call get_config as_string=True
-   '''
+   """
     pyeapi_kwargs = pyeapi_nxos_api_args(**kwargs)
-    return __salt__['pyeapi.call'](method, *args, **pyeapi_kwargs)
+    return __salt__["pyeapi.call"](method, *args, **pyeapi_kwargs)
 
 
 @proxy_napalm_wrap
 def pyeapi_conn(**kwargs):
-    '''
+    """
     .. versionadded:: 2019.2.0
 
     Return the connection object with the Arista switch, over ``pyeapi``,
@@ -1108,20 +1101,22 @@ def pyeapi_conn(**kwargs):
         conn = __salt__['napalm.pyeapi_conn']()
         res1 = conn.run_commands('show version')
         res2 = conn.get_config(as_string=True)
-    '''
+    """
     pyeapi_kwargs = pyeapi_nxos_api_args(**kwargs)
-    return __salt__['pyeapi.get_connection'](**pyeapi_kwargs)
+    return __salt__["pyeapi.get_connection"](**pyeapi_kwargs)
 
 
 @proxy_napalm_wrap
-def pyeapi_config(commands=None,
-                  config_file=None,
-                  template_engine='jinja',
-                  context=None,
-                  defaults=None,
-                  saltenv='base',
-                  **kwargs):
-    '''
+def pyeapi_config(
+    commands=None,
+    config_file=None,
+    template_engine="jinja",
+    context=None,
+    defaults=None,
+    saltenv="base",
+    **kwargs
+):
+    """
     .. versionadded:: 2019.2.0
 
     Configures the Arista switch with the specified commands, via the ``pyeapi``
@@ -1168,22 +1163,22 @@ def pyeapi_config(commands=None,
     .. code-block:: bash
 
         salt '*' napalm.pyeapi_config 'ntp server 1.2.3.4'
-   '''
+   """
     pyeapi_kwargs = pyeapi_nxos_api_args(**kwargs)
-    return __salt__['pyeapi.config'](commands=commands,
-                                     config_file=config_file,
-                                     template_engine=template_engine,
-                                     context=context,
-                                     defaults=defaults,
-                                     saltenv=saltenv,
-                                     **pyeapi_kwargs)
+    return __salt__["pyeapi.config"](
+        commands=commands,
+        config_file=config_file,
+        template_engine=template_engine,
+        context=context,
+        defaults=defaults,
+        saltenv=saltenv,
+        **pyeapi_kwargs
+    )
 
 
 @proxy_napalm_wrap
-def nxos_api_rpc(commands,
-                 method='cli',
-                 **kwargs):
-    '''
+def nxos_api_rpc(commands, method="cli", **kwargs):
+    """
     .. versionadded:: 2019.2.0
 
     Execute an arbitrary RPC request via the Nexus API.
@@ -1200,20 +1195,22 @@ def nxos_api_rpc(commands,
     .. code-block:: bash
 
         salt '*' napalm.nxos_api_rpc 'show version'
-    '''
+    """
     nxos_api_kwargs = pyeapi_nxos_api_args(**kwargs)
-    return __salt__['nxos_api.rpc'](commands, method=method, **nxos_api_kwargs)
+    return __salt__["nxos_api.rpc"](commands, method=method, **nxos_api_kwargs)
 
 
 @proxy_napalm_wrap
-def nxos_api_config(commands=None,
-                    config_file=None,
-                    template_engine='jinja',
-                    context=None,
-                    defaults=None,
-                    saltenv='base',
-                    **kwargs):
-    '''
+def nxos_api_config(
+    commands=None,
+    config_file=None,
+    template_engine="jinja",
+    context=None,
+    defaults=None,
+    saltenv="base",
+    **kwargs
+):
+    """
      .. versionadded:: 2019.2.0
 
     Configures the Nexus switch with the specified commands, via the NX-API.
@@ -1258,20 +1255,22 @@ def nxos_api_config(commands=None,
 
         salt '*' napalm.nxos_api_config 'spanning-tree mode mstp'
         salt '*' napalm.nxos_api_config config_file=https://bit.ly/2LGLcDy context="{'servers': ['1.2.3.4']}"
-    '''
+    """
     nxos_api_kwargs = pyeapi_nxos_api_args(**kwargs)
-    return __salt__['nxos_api.config'](commands=commands,
-                                       config_file=config_file,
-                                       template_engine=template_engine,
-                                       context=context,
-                                       defaults=defaults,
-                                       saltenv=saltenv,
-                                       **nxos_api_kwargs)
+    return __salt__["nxos_api.config"](
+        commands=commands,
+        config_file=config_file,
+        template_engine=template_engine,
+        context=context,
+        defaults=defaults,
+        saltenv=saltenv,
+        **nxos_api_kwargs
+    )
 
 
 @proxy_napalm_wrap
 def nxos_api_show(commands, raw_text=True, **kwargs):
-    '''
+    """
     .. versionadded:: 2019.2.0
 
     Execute one or more show (non-configuration) commands.
@@ -1288,16 +1287,14 @@ def nxos_api_show(commands, raw_text=True, **kwargs):
 
         salt '*' napalm.nxos_api_show 'show version'
         salt '*' napalm.nxos_api_show 'show bgp sessions' 'show processes' raw_text=False
-    '''
+    """
     nxos_api_kwargs = pyeapi_nxos_api_args(**kwargs)
-    return __salt__['nxos_api.show'](commands,
-                                     raw_text=raw_text,
-                                     **nxos_api_kwargs)
+    return __salt__["nxos_api.show"](commands, raw_text=raw_text, **nxos_api_kwargs)
 
 
 @proxy_napalm_wrap
 def rpc(command, **kwargs):
-    '''
+    """
     .. versionadded:: 2019.2.0
 
     This is a wrapper to execute RPC requests on various network operating
@@ -1340,21 +1337,21 @@ def rpc(command, **kwargs):
 
         salt '*' napalm.rpc 'show version'
         salt '*' napalm.rpc get-interfaces
-    '''
+    """
     default_map = {
-        'junos': 'napalm.junos_rpc',
-        'eos': 'napalm.pyeapi_run_commands',
-        'nxos': 'napalm.nxos_api_rpc'
+        "junos": "napalm.junos_rpc",
+        "eos": "napalm.pyeapi_run_commands",
+        "nxos": "napalm.nxos_api_rpc",
     }
-    napalm_map = __salt__['config.get']('napalm_rpc_map', {})
+    napalm_map = __salt__["config.get"]("napalm_rpc_map", {})
     napalm_map.update(default_map)
-    fun = napalm_map.get(__grains__['os'], 'napalm.netmiko_commands')
+    fun = napalm_map.get(__grains__["os"], "napalm.netmiko_commands")
     return __salt__[fun](command, **kwargs)
 
 
 @depends(HAS_CISCOCONFPARSE)
-def config_find_lines(regex, source='running'):
-    r'''
+def config_find_lines(regex, source="running"):
+    r"""
     .. versionadded:: 2019.2.0
 
     Return the configuration lines that match the regular expressions from the
@@ -1373,15 +1370,14 @@ def config_find_lines(regex, source='running'):
     .. code-block:: bash
 
         salt '*' napalm.config_find_lines '^interface Ethernet1\d'
-    '''
-    config_txt = __salt__['net.config'](source=source)['out'][source]
-    return __salt__['ciscoconfparse.find_lines'](config=config_txt,
-                                                 regex=regex)
+    """
+    config_txt = __salt__["net.config"](source=source)["out"][source]
+    return __salt__["ciscoconfparse.find_lines"](config=config_txt, regex=regex)
 
 
 @depends(HAS_CISCOCONFPARSE)
-def config_lines_w_child(parent_regex, child_regex, source='running'):
-    r'''
+def config_lines_w_child(parent_regex, child_regex, source="running"):
+    r"""
      .. versionadded:: 2019.2.0
 
     Return the configuration lines that match the regular expressions from the
@@ -1411,16 +1407,16 @@ def config_lines_w_child(parent_regex, child_regex, source='running'):
 
         salt '*' napalm.config_lines_w_child '^interface' 'ip address'
         salt '*' napalm.config_lines_w_child '^interface' 'shutdown' source=candidate
-    '''
-    config_txt = __salt__['net.config'](source=source)['out'][source]
-    return __salt__['ciscoconfparse.find_lines_w_child'](config=config_txt,
-                                                         parent_regex=parent_regex,
-                                                         child_regex=child_regex)
+    """
+    config_txt = __salt__["net.config"](source=source)["out"][source]
+    return __salt__["ciscoconfparse.find_lines_w_child"](
+        config=config_txt, parent_regex=parent_regex, child_regex=child_regex
+    )
 
 
 @depends(HAS_CISCOCONFPARSE)
-def config_lines_wo_child(parent_regex, child_regex, source='running'):
-    '''
+def config_lines_wo_child(parent_regex, child_regex, source="running"):
+    """
       .. versionadded:: 2019.2.0
 
     Return the configuration lines that match the regular expressions from the
@@ -1451,16 +1447,16 @@ def config_lines_wo_child(parent_regex, child_regex, source='running'):
 
         salt '*' napalm.config_lines_wo_child '^interface' 'ip address'
         salt '*' napalm.config_lines_wo_child '^interface' 'shutdown' source=candidate
-    '''
-    config_txt = __salt__['net.config'](source=source)['out'][source]
-    return __salt__['ciscoconfparse.find_lines_wo_child'](config=config_txt,
-                                                          parent_regex=parent_regex,
-                                                          child_regex=child_regex)
+    """
+    config_txt = __salt__["net.config"](source=source)["out"][source]
+    return __salt__["ciscoconfparse.find_lines_wo_child"](
+        config=config_txt, parent_regex=parent_regex, child_regex=child_regex
+    )
 
 
 @depends(HAS_CISCOCONFPARSE)
-def config_filter_lines(parent_regex, child_regex, source='running'):
-    r'''
+def config_filter_lines(parent_regex, child_regex, source="running"):
+    r"""
     .. versionadded:: 2019.2.0
 
     Return a list of detailed matches, for the configuration blocks (parent-child
@@ -1498,15 +1494,15 @@ def config_filter_lines(parent_regex, child_regex, source='running'):
 
         salt '*' napalm.config_filter_lines '^interface' 'ip address'
         salt '*' napalm.config_filter_lines '^interface' 'shutdown' source=candidate
-    '''
-    config_txt = __salt__['net.config'](source=source)['out'][source]
-    return __salt__['ciscoconfparse.filter_lines'](config=config_txt,
-                                                   parent_regex=parent_regex,
-                                                   child_regex=child_regex)
+    """
+    config_txt = __salt__["net.config"](source=source)["out"][source]
+    return __salt__["ciscoconfparse.filter_lines"](
+        config=config_txt, parent_regex=parent_regex, child_regex=child_regex
+    )
 
 
-def config_tree(source='running', with_tags=False):
-    '''
+def config_tree(source="running", with_tags=False):
+    """
     .. versionadded:: 2019.2.0
 
     Transform Cisco IOS style configuration to structured Python dictionary.
@@ -1525,16 +1521,15 @@ def config_tree(source='running', with_tags=False):
     .. code-block:: bash
 
         salt '*' napalm.config_tree
-    '''
-    config_txt = __salt__['net.config'](source=source)['out'][source]
-    return __salt__['iosconfig.tree'](config=config_txt)
+    """
+    config_txt = __salt__["net.config"](source=source)["out"][source]
+    return __salt__["iosconfig.tree"](config=config_txt)
 
 
-def config_merge_tree(source='running',
-                      merge_config=None,
-                      merge_path=None,
-                      saltenv='base'):
-    '''
+def config_merge_tree(
+    source="running", merge_config=None, merge_path=None, saltenv="base"
+):
+    """
     .. versionadded:: 2019.2.0
 
     Return the merge tree of the ``initial_config`` with the ``merge_config``,
@@ -1563,19 +1558,20 @@ def config_merge_tree(source='running',
     .. code-block:: bash
 
         salt '*' napalm.config_merge_tree merge_path=salt://path/to/merge.cfg
-    '''
-    config_txt = __salt__['net.config'](source=source)['out'][source]
-    return __salt__['iosconfig.merge_tree'](initial_config=config_txt,
-                                            merge_config=merge_config,
-                                            merge_path=merge_path,
-                                            saltenv=saltenv)
+    """
+    config_txt = __salt__["net.config"](source=source)["out"][source]
+    return __salt__["iosconfig.merge_tree"](
+        initial_config=config_txt,
+        merge_config=merge_config,
+        merge_path=merge_path,
+        saltenv=saltenv,
+    )
 
 
-def config_merge_text(source='running',
-                      merge_config=None,
-                      merge_path=None,
-                      saltenv='base'):
-    '''
+def config_merge_text(
+    source="running", merge_config=None, merge_path=None, saltenv="base"
+):
+    """
     .. versionadded:: 2019.2.0
 
     Return the merge result of the configuration from ``source`` with the
@@ -1605,19 +1601,20 @@ def config_merge_text(source='running',
     .. code-block:: bash
 
         salt '*' napalm.config_merge_text merge_path=salt://path/to/merge.cfg
-    '''
-    config_txt = __salt__['net.config'](source=source)['out'][source]
-    return __salt__['iosconfig.merge_text'](initial_config=config_txt,
-                                            merge_config=merge_config,
-                                            merge_path=merge_path,
-                                            saltenv=saltenv)
+    """
+    config_txt = __salt__["net.config"](source=source)["out"][source]
+    return __salt__["iosconfig.merge_text"](
+        initial_config=config_txt,
+        merge_config=merge_config,
+        merge_path=merge_path,
+        saltenv=saltenv,
+    )
 
 
-def config_merge_diff(source='running',
-                      merge_config=None,
-                      merge_path=None,
-                      saltenv='base'):
-    '''
+def config_merge_diff(
+    source="running", merge_config=None, merge_path=None, saltenv="base"
+):
+    """
     .. versionadded:: 2019.2.0
 
     Return the merge diff, as text, after merging the merge config into the
@@ -1646,19 +1643,20 @@ def config_merge_diff(source='running',
     .. code-block:: bash
 
         salt '*' napalm.config_merge_diff merge_path=salt://path/to/merge.cfg
-    '''
-    config_txt = __salt__['net.config'](source=source)['out'][source]
-    return __salt__['iosconfig.merge_diff'](initial_config=config_txt,
-                                            merge_config=merge_config,
-                                            merge_path=merge_path,
-                                            saltenv=saltenv)
+    """
+    config_txt = __salt__["net.config"](source=source)["out"][source]
+    return __salt__["iosconfig.merge_diff"](
+        initial_config=config_txt,
+        merge_config=merge_config,
+        merge_path=merge_path,
+        saltenv=saltenv,
+    )
 
 
-def config_diff_tree(source1='candidate',
-                     candidate_path=None,
-                     source2='running',
-                     running_path=None):
-    '''
+def config_diff_tree(
+    source1="candidate", candidate_path=None, source2="running", running_path=None
+):
+    """
     .. versionadded:: 2019.2.0
 
     Return the diff, as Python dictionary, between two different sources.
@@ -1707,21 +1705,22 @@ def config_diff_tree(source1='candidate',
 
         salt '*' napalm.config_diff_tree
         salt '*' napalm.config_diff_tree running startup
-    '''
-    get_config = __salt__['net.config']()['out']
+    """
+    get_config = __salt__["net.config"]()["out"]
     candidate_cfg = get_config[source1]
     running_cfg = get_config[source2]
-    return __salt__['iosconfig.diff_tree'](candidate_config=candidate_cfg,
-                                           candidate_path=candidate_path,
-                                           running_config=running_cfg,
-                                           running_path=running_path)
+    return __salt__["iosconfig.diff_tree"](
+        candidate_config=candidate_cfg,
+        candidate_path=candidate_path,
+        running_config=running_cfg,
+        running_path=running_path,
+    )
 
 
-def config_diff_text(source1='candidate',
-                     candidate_path=None,
-                     source2='running',
-                     running_path=None):
-    '''
+def config_diff_text(
+    source1="candidate", candidate_path=None, source2="running", running_path=None
+):
+    """
     .. versionadded:: 2019.2.0
 
     Return the diff, as text, between the two different configuration sources.
@@ -1763,23 +1762,23 @@ def config_diff_text(source1='candidate',
         salt '*' napalm.config_diff_text candidate_path=https://bit.ly/2mAdq7z
         # Would compare the running config with the configuration available at
         # https://bit.ly/2mAdq7z
-    '''
-    get_config = __salt__['net.config']()['out']
+    """
+    get_config = __salt__["net.config"]()["out"]
     candidate_cfg = get_config[source1]
     running_cfg = get_config[source2]
-    return __salt__['iosconfig.diff_text'](candidate_config=candidate_cfg,
-                                           candidate_path=candidate_path,
-                                           running_config=running_cfg,
-                                           running_path=running_path)
+    return __salt__["iosconfig.diff_text"](
+        candidate_config=candidate_cfg,
+        candidate_path=candidate_path,
+        running_config=running_cfg,
+        running_path=running_path,
+    )
 
 
 @depends(HAS_SCP)
-def scp_get(remote_path,
-            local_path='',
-            recursive=False,
-            preserve_times=False,
-            **kwargs):
-    '''
+def scp_get(
+    remote_path, local_path="", recursive=False, preserve_times=False, **kwargs
+):
+    """
     .. versionadded:: 2019.2.0
 
     Transfer files and directories from remote network device to the localhost
@@ -1844,25 +1843,29 @@ def scp_get(remote_path,
     .. code-block:: bash
 
         salt '*' napalm.scp_get /var/tmp/file /tmp/file auto_add_policy=True
-    '''
+    """
     conn_args = netmiko_args(**kwargs)
-    conn_args['hostname'] = conn_args['host']
+    conn_args["hostname"] = conn_args["host"]
     kwargs.update(conn_args)
-    return __salt__['scp.get'](remote_path,
-                               local_path=local_path,
-                               recursive=recursive,
-                               preserve_times=preserve_times,
-                               **kwargs)
+    return __salt__["scp.get"](
+        remote_path,
+        local_path=local_path,
+        recursive=recursive,
+        preserve_times=preserve_times,
+        **kwargs
+    )
 
 
 @depends(HAS_SCP)
-def scp_put(files,
-            remote_path=None,
-            recursive=False,
-            preserve_times=False,
-            saltenv='base',
-            **kwargs):
-    '''
+def scp_put(
+    files,
+    remote_path=None,
+    recursive=False,
+    preserve_times=False,
+    saltenv="base",
+    **kwargs
+):
+    """
     .. versionadded:: 2019.2.0
 
     Transfer files and directories to remote network device.
@@ -1945,13 +1948,15 @@ def scp_put(files,
     .. code-block:: bash
 
         salt '*' napalm.scp_put /path/to/file /var/tmp/file auto_add_policy=True
-    '''
+    """
     conn_args = netmiko_args(**kwargs)
-    conn_args['hostname'] = conn_args['host']
+    conn_args["hostname"] = conn_args["host"]
     kwargs.update(conn_args)
-    return __salt__['scp.put'](files,
-                               remote_path=remote_path,
-                               recursive=recursive,
-                               preserve_times=preserve_times,
-                               saltenv=saltenv,
-                               **kwargs)
+    return __salt__["scp.put"](
+        files,
+        remote_path=remote_path,
+        recursive=recursive,
+        preserve_times=preserve_times,
+        saltenv=saltenv,
+        **kwargs
+    )

--- a/salt/modules/netmiko_mod.py
+++ b/salt/modules/netmiko_mod.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-'''
+"""
 Netmiko Execution Module
 ========================
 
@@ -181,7 +181,7 @@ outside a ``netmiko`` Proxy, e.g.:
     Remember that the above applies only when not running in a ``netmiko`` Proxy
     Minion. If you want to use the :mod:`<salt.proxy.netmiko_px>`, please follow
     the documentation notes for a proper setup.
-'''
+"""
 from __future__ import absolute_import
 
 # Import python stdlib
@@ -191,6 +191,7 @@ import inspect
 # Import Salt libs
 from salt.ext import six
 from salt.exceptions import CommandExecutionError
+
 try:
     from salt.utils.args import clean_kwargs
 except ImportError:
@@ -200,6 +201,7 @@ except ImportError:
 try:
     from netmiko import ConnectHandler
     from netmiko import BaseConnection
+
     HAS_NETMIKO = True
 except ImportError:
     HAS_NETMIKO = False
@@ -208,10 +210,10 @@ except ImportError:
 # execution module properties
 # -----------------------------------------------------------------------------
 
-__proxyenabled__ = ['*']
+__proxyenabled__ = ["*"]
 # Any Proxy Minion should be able to execute these (not only netmiko)
 
-__virtualname__ = 'netmiko'
+__virtualname__ = "netmiko"
 # The Execution Module will be identified as ``netmiko``
 
 # -----------------------------------------------------------------------------
@@ -226,12 +228,16 @@ log = logging.getLogger(__name__)
 
 
 def __virtual__():
-    '''
+    """
     Execution module available only if Netmiko is installed.
-    '''
+    """
     if not HAS_NETMIKO:
-        return False, 'The netmiko execution module requires netmiko library to be installed.'
+        return (
+            False,
+            "The netmiko execution module requires netmiko library to be installed.",
+        )
     return __virtualname__
+
 
 # -----------------------------------------------------------------------------
 # helper functions
@@ -239,15 +245,17 @@ def __virtual__():
 
 
 def _prepare_connection(**kwargs):
-    '''
+    """
     Prepare the connection with the remote network device, and clean up the key
     value pairs, removing the args used for the connection init.
-    '''
+    """
     init_args = {}
     fun_kwargs = {}
-    netmiko_kwargs = __salt__['config.get']('netmiko', {})
+    netmiko_kwargs = __salt__["config.get"]("netmiko", {})
     netmiko_kwargs.update(kwargs)  # merge the CLI args with the opts/pillar
-    netmiko_init_args, _, _, netmiko_defaults = inspect.getargspec(BaseConnection.__init__)
+    netmiko_init_args, _, _, _, _, _, _ = inspect.getfullargspec(
+        BaseConnection.__init__
+    )
     check_self = netmiko_init_args.pop(0)
     for karg, warg in six.iteritems(netmiko_kwargs):
         if karg not in netmiko_init_args:
@@ -259,13 +267,14 @@ def _prepare_connection(**kwargs):
     conn = ConnectHandler(**init_args)
     return conn, fun_kwargs
 
+
 # -----------------------------------------------------------------------------
 # callable functions
 # -----------------------------------------------------------------------------
 
 
 def get_connection(**kwargs):
-    '''
+    """
     Return the Netmiko connection object.
 
     .. warning::
@@ -286,16 +295,16 @@ def get_connection(**kwargs):
                                                   password='example')
         show_if = conn.send_command('show interfaces')
         conn.disconnect()
-    '''
+    """
     kwargs = clean_kwargs(**kwargs)
-    if 'netmiko.conn' in __proxy__:
-        return __proxy__['netmiko.conn']()
+    if "netmiko.conn" in __proxy__:
+        return __proxy__["netmiko.conn"]()
     conn, kwargs = _prepare_connection(**kwargs)
     return conn
 
 
 def call(method, *args, **kwargs):
-    '''
+    """
     Invoke an arbitrary Netmiko method.
 
     method
@@ -306,10 +315,10 @@ def call(method, *args, **kwargs):
 
     kwargs
         Key-value dictionary to send to the method invoked.
-    '''
+    """
     kwargs = clean_kwargs(**kwargs)
-    if 'netmiko.call' in __proxy__:
-        return __proxy__['netmiko.call'](method, *args, **kwargs)
+    if "netmiko.call" in __proxy__:
+        return __proxy__["netmiko.call"](method, *args, **kwargs)
     conn, kwargs = _prepare_connection(**kwargs)
     ret = getattr(conn, method)(*args, **kwargs)
     conn.disconnect()
@@ -317,7 +326,7 @@ def call(method, *args, **kwargs):
 
 
 def multi_call(*methods, **kwargs):
-    '''
+    """
     Invoke multiple Netmiko methods at once, and return their output, as list.
 
     methods
@@ -330,26 +339,26 @@ def multi_call(*methods, **kwargs):
     kwargs
         Key-value dictionary with the connection details (when not running
         under a Proxy Minion).
-    '''
+    """
     kwargs = clean_kwargs(**kwargs)
-    if 'netmiko.conn' in __proxy__:
-        conn = __proxy__['netmiko.conn']()
+    if "netmiko.conn" in __proxy__:
+        conn = __proxy__["netmiko.conn"]()
     else:
         conn, kwargs = _prepare_connection(**kwargs)
     ret = []
     for method in methods:
         # Explicit unpacking
-        method_name = method['name']
-        method_args = method.get('args', [])
-        method_kwargs = method.get('kwargs', [])
+        method_name = method["name"]
+        method_args = method.get("args", [])
+        method_kwargs = method.get("kwargs", [])
         ret.append(getattr(conn, method_name)(*method_args, **method_kwargs))
-    if 'netmiko.conn' not in __proxy__:
+    if "netmiko.conn" not in __proxy__:
         conn.disconnect()
     return ret
 
 
 def send_command(command_string, **kwargs):
-    '''
+    """
     Execute command_string on the SSH channel using a pattern-based mechanism.
     Generally used for show commands. By default this method will keep waiting
     to receive data until the network device prompt is detected. The current
@@ -390,12 +399,12 @@ def send_command(command_string, **kwargs):
 
         salt '*' netmiko.send_command 'show version'
         salt '*' netmiko.send_command 'show_version' host='router1.example.com' username='example' device_type='cisco_ios'
-    '''
-    return call('send_command', command_string, **kwargs)
+    """
+    return call("send_command", command_string, **kwargs)
 
 
 def send_command_timing(command_string, **kwargs):
-    '''
+    """
     Execute command_string on the SSH channel using a delay-based mechanism.
     Generally used for show commands.
 
@@ -427,12 +436,12 @@ def send_command_timing(command_string, **kwargs):
 
         salt '*' netmiko.send_command_timing 'show version'
         salt '*' netmiko.send_command_timing 'show version' host='router1.example.com' username='example' device_type='arista_eos'
-    '''
-    return call('send_command_timing', command_string, **kwargs)
+    """
+    return call("send_command_timing", command_string, **kwargs)
 
 
 def enter_config_mode(**kwargs):
-    '''
+    """
     Enter into config mode.
 
     config_command
@@ -447,12 +456,12 @@ def enter_config_mode(**kwargs):
 
         salt '*' netmiko.enter_config_mode
         salt '*' netmiko.enter_config_mode device_type='juniper_junos' ip='192.168.0.1' username='example'
-    '''
-    return call('config_mode', **kwargs)
+    """
+    return call("config_mode", **kwargs)
 
 
 def exit_config_mode(**kwargs):
-    '''
+    """
     Exit from configuration mode.
 
     exit_config
@@ -467,19 +476,21 @@ def exit_config_mode(**kwargs):
 
         salt '*' netmiko.exit_config_mode
         salt '*' netmiko.exit_config_mode device_type='juniper' ip='192.168.0.1' username='example'
-    '''
-    return call('exit_config_mode', **kwargs)
+    """
+    return call("exit_config_mode", **kwargs)
 
 
-def send_config(config_file=None,
-                config_commands=None,
-                template_engine='jinja',
-                commit=False,
-                context=None,
-                defaults=None,
-                saltenv='base',
-                **kwargs):
-    '''
+def send_config(
+    config_file=None,
+    config_commands=None,
+    template_engine="jinja",
+    commit=False,
+    context=None,
+    defaults=None,
+    saltenv="base",
+    **kwargs
+):
+    """
     Send configuration commands down the SSH channel.
     Return the configuration lines sent to the device.
 
@@ -551,31 +562,29 @@ def send_config(config_file=None,
         salt '*' netmiko.send_config config_commands="['snmp-server location {{ grains.location }}']"
         salt '*' netmiko.send_config config_file=salt://config.txt
         salt '*' netmiko.send_config config_file=https://bit.ly/2sgljCB device_type='cisco_ios' ip='1.2.3.4' username='example'
-    '''
+    """
     if config_file:
-        file_str = __salt__['cp.get_file_str'](config_file, saltenv=saltenv)
+        file_str = __salt__["cp.get_file_str"](config_file, saltenv=saltenv)
         if file_str is False:
-            raise CommandExecutionError('Source file {} not found'.format(config_file))
+            raise CommandExecutionError("Source file {} not found".format(config_file))
     elif config_commands:
         if isinstance(config_commands, (six.string_types, six.text_type)):
             config_commands = [config_commands]
-        file_str = '\n'.join(config_commands)
+        file_str = "\n".join(config_commands)
         # unify all the commands in a single file, to render them in a go
     if template_engine:
-        file_str = __salt__['file.apply_template_on_contents'](file_str,
-                                                               template_engine,
-                                                               context,
-                                                               defaults,
-                                                               saltenv)
+        file_str = __salt__["file.apply_template_on_contents"](
+            file_str, template_engine, context, defaults, saltenv
+        )
     # whatever the source of the commands would be, split them line by line
     config_commands = [line for line in file_str.splitlines() if line.strip()]
     kwargs = clean_kwargs(**kwargs)
-    if 'netmiko.conn' in __proxy__:
-        conn = __proxy__['netmiko.conn']()
+    if "netmiko.conn" in __proxy__:
+        conn = __proxy__["netmiko.conn"]()
     else:
         conn, kwargs = _prepare_connection(**kwargs)
     if commit:
-        kwargs['exit_config_mode'] = False  # don't exit config mode after
+        kwargs["exit_config_mode"] = False  # don't exit config mode after
         # loading the commands, wait for explicit commit
     ret = conn.send_config_set(config_commands=config_commands, **kwargs)
     if commit:
@@ -584,7 +593,7 @@ def send_config(config_file=None,
 
 
 def commit(**kwargs):
-    '''
+    """
     Commit the configuration changes.
 
     .. warning::
@@ -597,5 +606,5 @@ def commit(**kwargs):
     .. code-block:: bash
 
         salt '*' netmiko.commit
-    '''
-    return call('commit', **kwargs)
+    """
+    return call("commit", **kwargs)

--- a/salt/modules/scp_mod.py
+++ b/salt/modules/scp_mod.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-'''
+"""
 SCP Module
 ==========
 
 .. versionadded:: 2019.2.0
 
 Module to copy files via `SCP <https://man.openbsd.org/scp>`_
-'''
+"""
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
@@ -19,29 +19,32 @@ from salt.ext import six
 try:
     import scp
     import paramiko
+
     HAS_SCP = True
 except ImportError:
     HAS_SCP = False
 
-__proxyenabled__ = ['*']
-__virtualname__ = 'scp'
+__proxyenabled__ = ["*"]
+__virtualname__ = "scp"
 
 log = logging.getLogger(__name__)
 
 
 def __virtual__():
     if not HAS_SCP:
-        return False, 'Please install SCP for this modules: pip install scp'
+        return False, "Please install SCP for this modules: pip install scp"
     return __virtualname__
 
 
 def _select_kwargs(**kwargs):
     paramiko_kwargs = {}
     scp_kwargs = {}
-    PARAMIKO_KWARGS, _, _, _ = inspect.getargspec(paramiko.SSHClient.connect)
+    PARAMIKO_KWARGS, _, _, _, _, _, _ = inspect.getfullargspec(
+        paramiko.SSHClient.connect
+    )
     PARAMIKO_KWARGS.pop(0)  # strip self
-    PARAMIKO_KWARGS.append('auto_add_policy')
-    SCP_KWARGS, _, _, _ = inspect.getargspec(scp.SCPClient.__init__)
+    PARAMIKO_KWARGS.append("auto_add_policy")
+    SCP_KWARGS, _, _, _, _, _, _ = inspect.getfullargspec(scp.SCPClient.__init__)
     SCP_KWARGS.pop(0)  # strip self
     SCP_KWARGS.pop(0)  # strip transport arg (it is passed in _prepare_connection)
     for karg, warg in six.iteritems(kwargs):
@@ -53,25 +56,20 @@ def _select_kwargs(**kwargs):
 
 
 def _prepare_connection(**kwargs):
-    '''
+    """
     Prepare the underlying SSH connection with the remote target.
-    '''
+    """
     paramiko_kwargs, scp_kwargs = _select_kwargs(**kwargs)
     ssh = paramiko.SSHClient()
-    if paramiko_kwargs.pop('auto_add_policy', False):
+    if paramiko_kwargs.pop("auto_add_policy", False):
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     ssh.connect(**paramiko_kwargs)
-    scp_client = scp.SCPClient(ssh.get_transport(),
-                               **scp_kwargs)
+    scp_client = scp.SCPClient(ssh.get_transport(), **scp_kwargs)
     return scp_client
 
 
-def get(remote_path,
-        local_path='',
-        recursive=False,
-        preserve_times=False,
-        **kwargs):
-    '''
+def get(remote_path, local_path="", recursive=False, preserve_times=False, **kwargs):
+    """
     Transfer files and directories from remote host to the localhost of the
     Minion.
 
@@ -140,24 +138,23 @@ def get(remote_path,
     .. code-block:: bash
 
         salt '*' scp.get /var/tmp/file /tmp/file hostname=10.10.10.1 auto_add_policy=True
-    '''
+    """
     scp_client = _prepare_connection(**kwargs)
-    get_kwargs = {
-        'recursive': recursive,
-        'preserve_times': preserve_times
-    }
+    get_kwargs = {"recursive": recursive, "preserve_times": preserve_times}
     if local_path:
-        get_kwargs['local_path'] = local_path
+        get_kwargs["local_path"] = local_path
     return scp_client.get(remote_path, **get_kwargs)
 
 
-def put(files,
-        remote_path=None,
-        recursive=False,
-        preserve_times=False,
-        saltenv='base',
-        **kwargs):
-    '''
+def put(
+    files,
+    remote_path=None,
+    recursive=False,
+    preserve_times=False,
+    saltenv="base",
+    **kwargs
+):
+    """
     Transfer files and directories to remote host.
 
     files
@@ -227,18 +224,15 @@ def put(files,
     .. code-block:: bash
 
         salt '*' scp.put /path/to/file /var/tmp/file hostname=server1 auto_add_policy=True
-    '''
+    """
     scp_client = _prepare_connection(**kwargs)
-    put_kwargs = {
-        'recursive': recursive,
-        'preserve_times': preserve_times
-    }
+    put_kwargs = {"recursive": recursive, "preserve_times": preserve_times}
     if remote_path:
-        put_kwargs['remote_path'] = remote_path
+        put_kwargs["remote_path"] = remote_path
     cached_files = []
     if not isinstance(files, (list, tuple)):
         files = [files]
     for file_ in files:
-        cached_file = __salt__['cp.cache_file'](file_, saltenv=saltenv)
+        cached_file = __salt__["cp.cache_file"](file_, saltenv=saltenv)
         cached_files.append(cached_file)
     return scp_client.put(cached_files, **put_kwargs)

--- a/salt/modules/testinframod.py
+++ b/salt/modules/testinframod.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-'''
+"""
 This module exposes the functionality of the TestInfra library
 for use with SaltStack in order to verify the state of your minions.
 In order to allow for the addition of new resource types in TestInfra this
 module dynamically generates wrappers for the various resources by iterating
 over the values in the ``__all__`` variable exposed by the testinfra.modules
 namespace.
-'''
+"""
 from __future__ import absolute_import, unicode_literals, print_function
 import inspect
 import logging
@@ -19,6 +19,7 @@ log = logging.getLogger(__name__)
 try:
     import testinfra
     from testinfra import modules
+
     TESTINFRA_PRESENT = True
 except ImportError:
     TESTINFRA_PRESENT = False
@@ -26,8 +27,8 @@ except ImportError:
 __all__ = []
 
 
-__virtualname__ = 'testinfra'
-default_backend = 'local://'
+__virtualname__ = "testinfra"
+default_backend = "local://"
 
 
 class InvalidArgumentError(Exception):
@@ -37,7 +38,7 @@ class InvalidArgumentError(Exception):
 def __virtual__():
     if TESTINFRA_PRESENT:
         return __virtualname__
-    return False, 'The Testinfra package is not available'
+    return False, "The Testinfra package is not available"
 
 
 def _get_module(module_name, backend=default_backend):
@@ -62,12 +63,12 @@ def _to_pascal_case(snake_case):
     :rtype: str
 
     """
-    space_case = re.sub('_', ' ', snake_case)
+    space_case = re.sub("_", " ", snake_case)
     wordlist = []
     for word in space_case.split():
         wordlist.append(word[0].upper())
         wordlist.append(word[1:])
-    return ''.join(wordlist)
+    return "".join(wordlist)
 
 
 def _to_snake_case(pascal_case):
@@ -78,11 +79,12 @@ def _to_snake_case(pascal_case):
     :rtype: str
 
     """
-    snake_case = re.sub('(^|[a-z])([A-Z])',
-                        lambda match: '{0}_{1}'.format(match.group(1).lower(),
-                                                       match.group(2).lower()),
-                        pascal_case)
-    return snake_case.lower().strip('_')
+    snake_case = re.sub(
+        "(^|[a-z])([A-Z])",
+        lambda match: "{0}_{1}".format(match.group(1).lower(), match.group(2).lower()),
+        pascal_case,
+    )
+    return snake_case.lower().strip("_")
 
 
 def _get_method_result(module_, module_instance, method_name, method_arg=None):
@@ -98,35 +100,37 @@ def _get_method_result(module_, module_instance, method_name, method_arg=None):
     :rtype: variable
 
     """
-    log.debug('Trying to call %s on %s', method_name, module_)
+    log.debug("Trying to call %s on %s", method_name, module_)
     try:
         method_obj = getattr(module_, method_name)
     except AttributeError:
         try:
             method_obj = getattr(module_instance, method_name)
         except AttributeError:
-            raise InvalidArgumentError('The {0} module does not have any '
-                                       'property or method named {1}'.format(
-                                           module_, method_name))
+            raise InvalidArgumentError(
+                "The {0} module does not have any "
+                "property or method named {1}".format(module_, method_name)
+            )
     if isinstance(method_obj, property):
         return method_obj.fget(module_instance)
     elif isinstance(method_obj, (types.MethodType, types.FunctionType)):
         if not method_arg:
-            raise InvalidArgumentError('{0} is a method of the {1} module. An '
-                                       'argument dict is required.'
-                                       .format(method_name,
-                                               module_))
+            raise InvalidArgumentError(
+                "{0} is a method of the {1} module. An "
+                "argument dict is required.".format(method_name, module_)
+            )
         try:
-            return getattr(module_instance,
-                             method_name)(method_arg['parameter'])
+            return getattr(module_instance, method_name)(method_arg["parameter"])
         except KeyError:
-            raise InvalidArgumentError('The argument dict supplied has no '
-                                       'key named "parameter": {0}'
-                                       .format(method_arg))
+            raise InvalidArgumentError(
+                "The argument dict supplied has no "
+                'key named "parameter": {0}'.format(method_arg)
+            )
         except AttributeError:
-            raise InvalidArgumentError('The {0} module does not have any '
-                                       'property or method named {1}'.format(
-                                           module_, method_name))
+            raise InvalidArgumentError(
+                "The {0} module does not have any "
+                "property or method named {1}".format(module_, method_name)
+            )
     else:
         return method_obj
     return None
@@ -147,28 +151,30 @@ def _apply_assertion(expected, result):
     :rtype: bool
 
     """
-    log.debug('Expected result: %s. Actual result: %s', expected, result)
+    log.debug("Expected result: %s. Actual result: %s", expected, result)
     if isinstance(expected, bool):
         return result is expected
     elif isinstance(expected, dict):
         try:
-            comparison = getattr(operator, expected['comparison'])
+            comparison = getattr(operator, expected["comparison"])
         except AttributeError:
-            if expected.get('comparison') == 'search':
+            if expected.get("comparison") == "search":
                 comparison = re.search
             else:
-                raise InvalidArgumentError('Comparison {0} is not a valid '
-                                           'selection.'.format(
-                                               expected.get('comparison')))
+                raise InvalidArgumentError(
+                    "Comparison {0} is not a valid "
+                    "selection.".format(expected.get("comparison"))
+                )
         except KeyError:
-            log.exception('The comparison dictionary provided is missing '
-                          'expected keys. Either "expected" or "comparison" '
-                          'are not present.')
+            log.exception(
+                "The comparison dictionary provided is missing "
+                'expected keys. Either "expected" or "comparison" '
+                "are not present."
+            )
             raise
-        return comparison(expected['expected'], result)
+        return comparison(expected["expected"], result)
     else:
-        raise TypeError('Expected bool or dict but received {0}'
-                        .format(type(expected)))
+        raise TypeError("Expected bool or dict but received {0}".format(type(expected)))
 
 
 # This does not currently generate documentation from the underlying modules
@@ -217,33 +223,33 @@ def _copy_function(module_name, name=None):
             comparison: eq
     ```
     """
-    log.debug('Generating function for testinfra.%s', module_name)
+    log.debug("Generating function for testinfra.%s", module_name)
 
     def _run_tests(name, **methods):
         success = True
         pass_msgs = []
         fail_msgs = []
         try:
-            log.debug('Retrieving %s module.', module_name)
+            log.debug("Retrieving %s module.", module_name)
             mod = _get_module(module_name)
-            log.debug('Retrieved module is %s', mod.__dict__)
+            log.debug("Retrieved module is %s", mod.__dict__)
         except NotImplementedError:
             log.exception(
-                'The %s module is not supported for this backend and/or '
-                'platform.', module_name)
+                "The %s module is not supported for this backend and/or " "platform.",
+                module_name,
+            )
             success = False
             return success, pass_msgs, fail_msgs
-        if hasattr(inspect, 'signature'):
+        if hasattr(inspect, "signature"):
             mod_sig = inspect.signature(mod)
             parameters = mod_sig.parameters
         else:
             if isinstance(mod.__init__, types.MethodType):
-                mod_sig = inspect.getargspec(mod.__init__)
-            elif hasattr(mod, '__call__'):
-                mod_sig = inspect.getargspec(mod.__call__)
+                mod_sig = inspect.getfullargspec(mod.__init__)
+            elif hasattr(mod, "__call__"):
+                mod_sig = inspect.getfullargspec(mod.__call__)
             parameters = mod_sig.args
-        log.debug('Parameters accepted by module %s: %s',
-                  module_name, parameters)
+        log.debug("Parameters accepted by module %s: %s", module_name, parameters)
         additional_args = {}
         for arg in set(parameters).intersection(set(methods)):
             additional_args[arg] = methods.pop(arg)
@@ -253,29 +259,34 @@ def _copy_function(module_name, name=None):
             else:
                 modinstance = mod()
         except TypeError:
-            log.exception('Module failed to instantiate')
+            log.exception("Module failed to instantiate")
             raise
         valid_methods = {}
-        log.debug('Called methods are: %s', methods)
+        log.debug("Called methods are: %s", methods)
         for meth_name in methods:
-            if not meth_name.startswith('_'):
+            if not meth_name.startswith("_"):
                 valid_methods[meth_name] = methods[meth_name]
-        log.debug('Valid methods are: %s', valid_methods)
+        log.debug("Valid methods are: %s", valid_methods)
         for meth, arg in valid_methods.items():
             result = _get_method_result(mod, modinstance, meth, arg)
             assertion_result = _apply_assertion(arg, result)
             if not assertion_result:
                 success = False
-                fail_msgs.append('Assertion failed: {modname} {n} {m} {a}. '
-                            'Actual result: {r}'.format(
-                                modname=module_name, n=name, m=meth, a=arg, r=result
-                            ))
+                fail_msgs.append(
+                    "Assertion failed: {modname} {n} {m} {a}. "
+                    "Actual result: {r}".format(
+                        modname=module_name, n=name, m=meth, a=arg, r=result
+                    )
+                )
             else:
-                pass_msgs.append('Assertion passed:  {modname} {n} {m} {a}. '
-                            'Actual result: {r}'.format(
-                                modname=module_name, n=name, m=meth, a=arg, r=result
-                            ))
+                pass_msgs.append(
+                    "Assertion passed:  {modname} {n} {m} {a}. "
+                    "Actual result: {r}".format(
+                        modname=module_name, n=name, m=meth, a=arg, r=result
+                    )
+                )
         return success, pass_msgs, fail_msgs
+
     func = _run_tests
     if name is not None:
         # types.FunctionType requires a str for __name__ attribute, using a
@@ -283,11 +294,9 @@ def _copy_function(module_name, name=None):
         name = str(name)  # future lint: disable=blacklisted-function
     else:
         name = func.__name__
-    return types.FunctionType(func.__code__,
-                              func.__globals__,
-                              name,
-                              func.__defaults__,
-                              func.__closure__)
+    return types.FunctionType(
+        func.__code__, func.__globals__, name, func.__defaults__, func.__closure__
+    )
 
 
 def _register_functions():


### PR DESCRIPTION
### What does this PR do?
Replaces `inspect.getargspec` with `inspect.getfullargspec` (it's deprecated in Python3.0)
Removes netmiko_defaults as it was not being used in netmiko_mod

My IDE also automatically runs Black on write, so the code was also formatted.

### What issues does this PR fix or reference?
N/A

### Tests written?
No (this is an improvement that shouldn't modify the values returned by the previously used function)

### Commits signed with GPG?
Yes