### PR TITLE
Port #51499 to master

### DIFF
--- a/tests/integration/files/file/base/issue-51499.sls
+++ b/tests/integration/files/file/base/issue-51499.sls
@@ -1,0 +1,6 @@
+{% if 'nonexistent_module.function' in salt %}
+{% do salt.log.warning("Module is available") %}
+{% endif %}
+always-passes:
+  test.succeed_without_changes:
+    - name: foo

--- a/tests/integration/modules/test_state.py
+++ b/tests/integration/modules/test_state.py
@@ -2118,3 +2118,16 @@ class StateModuleTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(state_run[state_id]['comment'],
                          'Success!')
         self.assertTrue(state_run[state_id]['result'])
+
+    def test_state_sls_lazyloader_allows_recursion(self):
+        '''
+        This tests that referencing dunders like __salt__ work
+        context: https://github.com/saltstack/salt/pull/51499
+        '''
+        state_run = self.run_function('state.sls', mods='issue-51499')
+
+        state_id = 'test_|-always-passes_|-foo_|-succeed_without_changes'
+        self.assertIn(state_id, state_run)
+        self.assertEqual(state_run[state_id]['comment'],
+                         'Success!')
+        self.assertTrue(state_run[state_id]['result'])


### PR DESCRIPTION
TODOs:
* [x] figure out how to port this or if it's required.  Things have changed somewhat,

### What does this PR do?

Ports #51499 to master.  See that PR for additional information.

It looks like the original loader changes are no longer necessary with refactoring that has occurred since the original issue was addressed.  The original author's tests look like they will show whether that is the case.

### Commits signed with GPG?

No.