### PR TITLE
Added clean_parent argument for the archive state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Versions are `MAJOR.PATCH`.
 ### Added
 
 - [#54917](https://github.com/saltstack/salt/pull/54917) - Added get_settings, put_settings and flush_synced methods for Elasticsearch module. - [@Oloremo](https://github.com/Oloremo)
+- [#55418](https://github.com/saltstack/salt/pull/55418) - Added clean_parent argument for the archive state. - [@Oloremo](https://github.com/Oloremo)
 
 ---
 

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -183,6 +183,7 @@ def extracted(name,
               force=False,
               overwrite=False,
               clean=False,
+              clean_parent=False,
               user=None,
               group=None,
               if_missing=None,
@@ -521,6 +522,12 @@ def extracted(name,
             ``overwrite`` is set to ``True``.
 
         .. versionadded:: 2016.11.1
+
+    clean_parent : False
+        Set this to ``True`` to remove a parent archive directory before the extration.
+        ``clean`` and ``clean_parent`` args are mutually exclusive.
+
+        .. versionadded:: Sodium
 
     user
         The user to own each extracted file. Not available on Windows.
@@ -1076,6 +1083,11 @@ def extracted(name,
                           ))
         return ret
 
+    if clean and clean_parent:
+        ret['comment'] = "You can't set both 'clean' and 'clean_parent' to True."
+        ret['result'] = False
+        return ret
+
     extraction_needed = overwrite
     contents_missing = False
 
@@ -1148,6 +1160,15 @@ def extracted(name,
                         )
                     )
                     return ret
+                if __opts__['test'] and clean_parent and contents is not None:
+                    ret['result'] = None
+                    ret['comment'] += (
+                        ' Since the \'clean_parent\' option is enabled, the '
+                        'destination parent directory would be removed first '
+                        'and than re-created and the archive would be '
+                        'extracted'
+                    )
+                    return ret
 
                 # Skip notices of incorrect types if we're cleaning
                 if not (clean and contents is not None):
@@ -1215,6 +1236,26 @@ def extracted(name,
                 ret['comment'] += ', after cleaning destination path(s)'
             _add_explanation(ret, source_hash_trigger, contents_missing)
             return ret
+
+        if clean_parent and contents is not None:
+            errors = []
+            log.debug('Removing directory %s due to clean_parent set to True', name)
+            try:
+                salt.utils.files.rm_rf(name.rstrip(os.sep))
+                ret['changes'].setdefault(
+                    'removed', "Directory {} was removed prior to the extraction".format(name))
+            except OSError as exc:
+                if exc.errno != errno.ENOENT:
+                    errors.append(six.text_type(exc))
+            if errors:
+                msg = (
+                    'Unable to remove the directory {}. The following '
+                    'errors were observed:\n'.format(name)
+                )
+                for error in errors:
+                    msg += '\n- {0}'.format(error)
+                ret['comment'] = msg
+                return ret
 
         if clean and contents is not None:
             errors = []

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -524,8 +524,10 @@ def extracted(name,
         .. versionadded:: 2016.11.1
 
     clean_parent : False
-        Set this to ``True`` to remove a parent archive directory before the extration.
-        ``clean`` and ``clean_parent`` args are mutually exclusive.
+        If ``True``, and the archive is extracted, delete the parent
+        directory (i.e. the directory into which the archive is extracted), and
+        then re-create that directory before extracting. Note that ``clean``
+        and ``clean_parent`` are mutually exclusive.
 
         .. versionadded:: Sodium
 
@@ -1084,7 +1086,7 @@ def extracted(name,
         return ret
 
     if clean and clean_parent:
-        ret['comment'] = "You can't set both 'clean' and 'clean_parent' to True."
+        ret['comment'] = "Only one of 'clean' and 'clean_parent' can be set to True"
         ret['result'] = False
         return ret
 

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -1167,7 +1167,7 @@ def extracted(name,
                     ret['comment'] += (
                         ' Since the \'clean_parent\' option is enabled, the '
                         'destination parent directory would be removed first '
-                        'and than re-created and the archive would be '
+                        'and then re-created and the archive would be '
                         'extracted'
                     )
                     return ret

--- a/tests/unit/states/test_archive.py
+++ b/tests/unit/states/test_archive.py
@@ -232,7 +232,7 @@ class ArchiveTestCase(TestCase, LoaderModuleMockMixin):
         '''
         gnutar = MagicMock(return_value='tar (GNU tar)')
         source = '/tmp/foo.tar.gz'
-        ret_comment = "You can't set both 'clean' and 'clean_parent' to True."
+        ret_comment = "Only one of 'clean' and 'clean_parent' can be set to True"
         mock_false = MagicMock(return_value=False)
         mock_true = MagicMock(return_value=True)
         state_single_mock = MagicMock(return_value={'local': {'result': True}})

--- a/tests/unit/states/test_archive.py
+++ b/tests/unit/states/test_archive.py
@@ -225,3 +225,47 @@ class ArchiveTestCase(TestCase, LoaderModuleMockMixin):
                 ret['comment'],
                 'Path {0} exists'.format(if_missing)
             )
+
+    def test_clean_parent_conflict(self):
+        '''
+        Tests the call of extraction with gnutar with both clean_parent plus clean set to True
+        '''
+        gnutar = MagicMock(return_value='tar (GNU tar)')
+        source = '/tmp/foo.tar.gz'
+        ret_comment = "You can't set both 'clean' and 'clean_parent' to True."
+        mock_false = MagicMock(return_value=False)
+        mock_true = MagicMock(return_value=True)
+        state_single_mock = MagicMock(return_value={'local': {'result': True}})
+        run_all = MagicMock(return_value={'retcode': 0, 'stdout': 'stdout', 'stderr': 'stderr'})
+        mock_source_list = MagicMock(return_value=(source, None))
+        list_mock = MagicMock(return_value={
+            'dirs': [],
+            'files': ['stdout'],
+            'links': [],
+            'top_level_dirs': [],
+            'top_level_files': ['stdout'],
+            'top_level_links': [],
+        })
+        isfile_mock = MagicMock(side_effect=_isfile_side_effect)
+
+        with patch.dict(archive.__salt__, {'cmd.run': gnutar,
+                                           'file.directory_exists': mock_false,
+                                           'file.file_exists': mock_false,
+                                           'state.single': state_single_mock,
+                                           'file.makedirs': mock_true,
+                                           'cmd.run_all': run_all,
+                                           'archive.list': list_mock,
+                                           'file.source_list': mock_source_list}),\
+                patch.dict(archive.__states__, {'file.directory': mock_true}),\
+                patch.object(os.path, 'isfile', isfile_mock),\
+                patch('salt.utils.path.which', MagicMock(return_value=True)):
+            ret = archive.extracted(os.path.join(os.sep + 'tmp', 'out'),
+                                    source,
+                                    options='xvzf',
+                                    enforce_toplevel=False,
+                                    clean=True,
+                                    clean_parent=True,
+                                    keep=True)
+            self.assertEqual(ret['result'], False)
+            self.assertEqual(ret['changes'], {})
+            self.assertEqual(ret['comment'], ret_comment)


### PR DESCRIPTION
### What does this PR do?

Adding new argument `clean_parent` to the archive state. This allows the state to remove parent directory before the extraction.

### What issues does this PR fix or reference?

#54012 

### Previous Behavior
archive state was unable to do so by itself.

### New Behavior
archive state now able to remove parent directory if requested

### Tests written?

Yes... kinda.

### Commits signed with GPG?

Yes