### PR TITLE
Null yaml dumper for threadsafe loader

### DIFF
--- a/salt/utils/yamldumper.py
+++ b/salt/utils/yamldumper.py
@@ -59,8 +59,13 @@ def represent_ordereddict(dumper, data):
     return dumper.represent_dict(list(data.items()))
 
 
+def represent_undefined(dumper, data):
+    return dumper.represent_scalar(u'tag:yaml.org,2002:null', u'NULL')
+
+
 OrderedDumper.add_representer(OrderedDict, represent_ordereddict)
 SafeOrderedDumper.add_representer(OrderedDict, represent_ordereddict)
+SafeOrderedDumper.add_representer(None, represent_undefined)
 
 OrderedDumper.add_representer(
     collections.defaultdict,


### PR DESCRIPTION
### What does this PR do?
Add NULL yaml dumper in preparation for the Threadsafe Loader PR.
Pulled out from https://github.com/saltstack/salt/pull/54878

This fixes a test that fails with the thread safe loader changes