### PR TITLE
Fix service.reload in gentoo_service module

### DIFF
--- a/salt/modules/gentoo_service.py
+++ b/salt/modules/gentoo_service.py
@@ -23,6 +23,11 @@ import salt.utils.odict as odict
 # Set up logging
 log = logging.getLogger(__name__)
 
+# Define the module's function aliases
+__func_alias__ = {
+    'reload_': 'reload'
+}
+
 # Define the module's virtual name
 __virtualname__ = 'service'
 


### PR DESCRIPTION
### What does this PR do?
It fixes gentoo_service.py module.

### What issues does this PR fix or reference?
gentoo_service module has reload_ function but service.reload doesn't work because there is no 'reload' alias defined.

### Tests written?
I believe the existing tests are enough for such changes.

### Commits signed with GPG?

Yes
