### PR TITLE
Fixes config_data parameter in compile_config

### DIFF
--- a/salt/modules/win_dsc.py
+++ b/salt/modules/win_dsc.py
@@ -308,7 +308,7 @@ def compile_config(path,
         cmd.append(script_parameters)
     cmd.extend([';', config_name])
     if config_data:
-        cmd.append(config_data)
+        cmd.extend(['-ConfigurationData', config_data])
     cmd.append('| Select-Object -Property FullName, Extension, Exists, '
                '@{Name="LastWriteTime";Expression={Get-Date ($_.LastWriteTime) '
                '-Format g}}')


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with compiling DSC when config_data is defined and dot sourcing is required
### What issues does this PR fix or reference?
Fixes #55425
### Previous Behavior
The config_data parameter is appended to the powershell command. Powershell interprets this as the value for a different positional parameter.

### New Behavior
`-ConfigurationData` is explicitly added to the powershell command before config_data

### Tests written?

No

### Commits signed with GPG?

Yes