### PR TITLE
Adds the possibility to also use downloadonly in kwargs

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -1016,8 +1016,9 @@ def upgrade(refresh=True, dist_upgrade=False, **kwargs):
         Skip refreshing the package database if refresh has already occurred within
         <value> seconds
 
-    download_only
-        Only download the packages, don't unpack or install them
+    download_only (or downloadonly)
+        Only download the packages, don't unpack or install them. Use
+        downloadonly to be in line with yum and zypper module.
 
         .. versionadded:: 2018.3.0
 
@@ -1048,7 +1049,7 @@ def upgrade(refresh=True, dist_upgrade=False, **kwargs):
         cmd.append('--force-yes')
     if kwargs.get('skip_verify', False):
         cmd.append('--allow-unauthenticated')
-    if kwargs.get('download_only', False):
+    if kwargs.get('download_only', False) or kwargs.get('downloadonly', False):
         cmd.append('--download-only')
 
     cmd.append('dist-upgrade' if dist_upgrade else 'upgrade')

--- a/tests/unit/modules/test_aptpkg.py
+++ b/tests/unit/modules/test_aptpkg.py
@@ -367,23 +367,17 @@ class AptPkgTestCase(TestCase, LoaderModuleMockMixin):
                 }
                 with patch.multiple(aptpkg, **patch_kwargs):
                     aptpkg.upgrade()
-                    args_matching = [True for args in patch_kwargs['__salt__']['cmd.run_all'].call_args.args if "--download-only" in args]
-                    print("=============================================================")
-                    [print(args) for args in patch_kwargs['__salt__']['cmd.run_all'].call_args.args]
+                    args_matching = [True for args in patch_kwargs['__salt__']['cmd.run_all'].call_args[0] if "--download-only" in args]
                     # Here we shouldn't see the parameter and args_matching should be empty.
                     self.assertFalse(any(args_matching))
 
                     aptpkg.upgrade(downloadonly=True)
-                    args_matching = [True for args in patch_kwargs['__salt__']['cmd.run_all'].call_args.args if "--download-only" in args]
-                    print("=============================================================")
-                    [print(args) for args in patch_kwargs['__salt__']['cmd.run_all'].call_args.args]
+                    args_matching = [True for args in patch_kwargs['__salt__']['cmd.run_all'].call_args[0] if "--download-only" in args]
                     # --download-only should be in the args list and we should have at least on True in the list.
                     self.assertTrue(any(args_matching))
 
                     aptpkg.upgrade(download_only=True)
-                    args_matching = [True for args in patch_kwargs['__salt__']['cmd.run_all'].call_args.args if "--download-only" in args]
-                    print("=============================================================")
-                    [print(args) for args in patch_kwargs['__salt__']['cmd.run_all'].call_args.args]
+                    args_matching = [True for args in patch_kwargs['__salt__']['cmd.run_all'].call_args[0] if "--download-only" in args]
                     # --download-only should be in the args list and we should have at least on True in the list.
                     self.assertTrue(any(args_matching))
 

--- a/tests/unit/modules/test_aptpkg.py
+++ b/tests/unit/modules/test_aptpkg.py
@@ -368,14 +368,23 @@ class AptPkgTestCase(TestCase, LoaderModuleMockMixin):
                 with patch.multiple(aptpkg, **patch_kwargs):
                     aptpkg.upgrade()
                     args_matching = [True for args in patch_kwargs['__salt__']['cmd.run_all'].call_args.args if "--download-only" in args]
+                    print("=============================================================")
+                    [print(args) for args in patch_kwargs['__salt__']['cmd.run_all'].call_args.args]
+                    # Here we shouldn't see the parameter and args_matching should be empty.
                     self.assertFalse(any(args_matching))
 
                     aptpkg.upgrade(downloadonly=True)
                     args_matching = [True for args in patch_kwargs['__salt__']['cmd.run_all'].call_args.args if "--download-only" in args]
+                    print("=============================================================")
+                    [print(args) for args in patch_kwargs['__salt__']['cmd.run_all'].call_args.args]
+                    # --download-only should be in the args list and we should have at least on True in the list.
                     self.assertTrue(any(args_matching))
 
                     aptpkg.upgrade(download_only=True)
                     args_matching = [True for args in patch_kwargs['__salt__']['cmd.run_all'].call_args.args if "--download-only" in args]
+                    print("=============================================================")
+                    [print(args) for args in patch_kwargs['__salt__']['cmd.run_all'].call_args.args]
+                    # --download-only should be in the args list and we should have at least on True in the list.
                     self.assertTrue(any(args_matching))
 
     def test_show(self):

--- a/tests/unit/modules/test_aptpkg.py
+++ b/tests/unit/modules/test_aptpkg.py
@@ -367,17 +367,13 @@ class AptPkgTestCase(TestCase, LoaderModuleMockMixin):
                 }
                 with patch.multiple(aptpkg, **patch_kwargs):
                     aptpkg.upgrade()
-                    self.assertTrue("--download-only" not in \
-                                    patch_kwargs['__salt__']['cmd.run_all'].call_args.args[0])
+                    self.assertTrue("--download-only" not in patch_kwargs['__salt__']['cmd.run_all'].call_args.args[0])
                     aptpkg.upgrade(downloadonly=False)
-                    self.assertTrue("--download-only" not in \
-                                    patch_kwargs['__salt__']['cmd.run_all'].call_args.args[0])
+                    self.assertTrue("--download-only" not in patch_kwargs['__salt__']['cmd.run_all'].call_args.args[0])
                     aptpkg.upgrade(downloadonly=True)
-                    self.assertTrue("--download-only" in \
-                                    patch_kwargs['__salt__']['cmd.run_all'].call_args.args[0])
+                    self.assertTrue("--download-only" in patch_kwargs['__salt__']['cmd.run_all'].call_args.args[0])
                     aptpkg.upgrade(download_only=True)
-                    self.assertTrue("--download-only" in \
-                                    patch_kwargs['__salt__']['cmd.run_all'].call_args.args[0])
+                    self.assertTrue("--download-only" in patch_kwargs['__salt__']['cmd.run_all'].call_args.args[0])
 
     def test_show(self):
         '''

--- a/tests/unit/modules/test_aptpkg.py
+++ b/tests/unit/modules/test_aptpkg.py
@@ -367,13 +367,16 @@ class AptPkgTestCase(TestCase, LoaderModuleMockMixin):
                 }
                 with patch.multiple(aptpkg, **patch_kwargs):
                     aptpkg.upgrade()
-                    self.assertTrue("--download-only" not in patch_kwargs['__salt__']['cmd.run_all'].call_args.args[0])
-                    aptpkg.upgrade(downloadonly=False)
-                    self.assertTrue("--download-only" not in patch_kwargs['__salt__']['cmd.run_all'].call_args.args[0])
+                    args_matching = [True for args in patch_kwargs['__salt__']['cmd.run_all'].call_args.args if "--download-only" in args]
+                    self.assertFalse(any(args_matching))
+
                     aptpkg.upgrade(downloadonly=True)
-                    self.assertTrue("--download-only" in patch_kwargs['__salt__']['cmd.run_all'].call_args.args[0])
+                    args_matching = [True for args in patch_kwargs['__salt__']['cmd.run_all'].call_args.args if "--download-only" in args]
+                    self.assertTrue(any(args_matching))
+
                     aptpkg.upgrade(download_only=True)
-                    self.assertTrue("--download-only" in patch_kwargs['__salt__']['cmd.run_all'].call_args.args[0])
+                    args_matching = [True for args in patch_kwargs['__salt__']['cmd.run_all'].call_args.args if "--download-only" in args]
+                    self.assertTrue(any(args_matching))
 
     def test_show(self):
         '''


### PR DESCRIPTION
### What does this PR do?

This is the same as #54793, but for master.

The download_only parameter in the apt module is not in line with the yum and zypper modules. Both of them use downloadonly without the underline.

With this change apt now additionally supports the downloadonly parameter.

### What issues does this PR fix or reference?

Fixes #54790

### Previous Behavior
The apt module had to be used with `download_only`.

### New Behavior
The apt module can now also be used with `downloadonly`.

### Tests written?

Yes

### Commits signed with GPG?

Yes
