### PR TITLE
Improve robustness for invalid dmidecode characters and add test.

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -960,7 +960,7 @@ def _virtual(osdata):
                     grains['virtual'] = 'kvm'
         if os.path.isfile('/sys/devices/virtual/dmi/id/product_name'):
             try:
-                with salt.utils.files.fopen('/sys/devices/virtual/dmi/id/product_name', 'r') as fhr:
+                with salt.utils.files.fopen('/sys/devices/virtual/dmi/id/product_name', 'rb') as fhr:
                     output = salt.utils.stringutils.to_unicode(fhr.read(), errors='replace')
                     if 'VirtualBox' in output:
                         grains['virtual'] = 'VirtualBox'
@@ -2408,7 +2408,7 @@ def _hw_data(osdata):
             contents_file = os.path.join('/sys/class/dmi/id', fw_file)
             if os.path.exists(contents_file):
                 try:
-                    with salt.utils.files.fopen(contents_file, 'r') as ifile:
+                    with salt.utils.files.fopen(contents_file, 'rb') as ifile:
                         grains[key] = salt.utils.stringutils.to_unicode(ifile.read().strip(), errors='replace')
                         if key == 'uuid':
                             grains['uuid'] = grains['uuid'].lower()

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -1144,7 +1144,36 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
                                                                         'stderr': '',
                                                                         'stdout': virt})}):
                     with patch('salt.utils.files.fopen',
-                               mock_open(read_data='嗨')):
+                               mock_open(read_data='嗨'.encode("utf8"))):
+                        osdata = {'kernel': 'Linux', }
+                        ret = core._virtual(osdata)
+                        self.assertEqual(ret['virtual'], virt)
+
+    @patch('os.path.isfile')
+    @patch('os.path.isdir')
+    def test_core_virtual_invalid(self, mock_file, mock_dir):
+        '''
+        test virtual grain with an invalid unicode character in product_name file
+        '''
+        def path_side_effect(path):
+            if path == '/sys/devices/virtual/dmi/id/product_name':
+                return True
+            return False
+
+        virt = 'kvm'
+        mock_file.side_effect = path_side_effect
+        mock_dir.side_effect = path_side_effect
+        with patch.object(salt.utils.platform, 'is_windows',
+                          MagicMock(return_value=False)):
+            with patch.object(salt.utils.path, 'which',
+                              MagicMock(return_value=True)):
+                with patch.dict(core.__salt__, {'cmd.run_all':
+                                                MagicMock(return_value={'pid': 78,
+                                                                        'retcode': 0,
+                                                                        'stderr': '',
+                                                                        'stdout': virt})}):
+                    with patch('salt.utils.files.fopen',
+                               mock_open(read_data=b'\xff')):
                         osdata = {'kernel': 'Linux', }
                         ret = core._virtual(osdata)
                         self.assertEqual(ret['virtual'], virt)


### PR DESCRIPTION
### What does this PR do?

Ensures that salt does not crash when trying to load DMI data to build the core grains. DMI data is expected to be valid text, however on at least some hardware (Intel NUC marketed around 2014), it contains characters that aren't valid (\xff). This causes salt to crash during start up.

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/48184

### Previous Behavior
With Python 2.7, there is no bug because it was resolved in https://github.com/saltstack/salt/pull/48440

In Python 3, the difference in default behaviour of file opening causes the bug to resurface.

### New Behavior

Files are explicitly opened as bytes in both Python 2.7 and Python 3 versions, this prevents the bug from occurring and makes the previous bug fix work as intended.

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

Yes. 

Test previously written by @Ch3LL has been adapted and new test written for invalid character. test_core_virtual_unicode and test_core_virtual_invalid

### Commits signed with GPG?

Yes
