### PR TITLE
docs: Add py36-salt to FreeBSD documentation

### DIFF
--- a/doc/topics/installation/freebsd.rst
+++ b/doc/topics/installation/freebsd.rst
@@ -12,16 +12,22 @@ Salt is available in the FreeBSD ports tree at `sysutils/py-salt
 FreeBSD binary repo
 ===================
 
+Install Salt via the official package repository. Salt is packaged both as a Python 2.7 or 3.6 version.
+
 .. code-block:: bash
 
     pkg install py27-salt
 
+.. code-block:: bash
+
+    pkg install py36-salt
+
 FreeBSD ports
 =============
 
-By default salt is packaged using python 2.7, but if you build your own packages from FreeBSD ports either by hand or with poudriere you can instead package it with your choice of python. Add a line to /etc/make.conf to choose your python flavour:
+You can also build your own packages from FreeBSD ports either by hand or with poudriere you can instead package it with your choice of python. Add a line to /etc/make.conf to choose your python flavour:
 
-.. code-block:: text
+.. code-block:: bash
 
     echo "DEFAULT_VERSIONS+= python=3.6" >> /etc/make.conf
 


### PR DESCRIPTION
### What issues does this PR fix or reference?

None.  Minor docs update.  Came across it, and wanted to contribute a small fix.

### Previous Behavior

Old docs mentioned only the Python 2.7 version.

### New Behavior

The exist a version for Python 3.6.

### Tests written?

No -> Docs changes only.

### Commits signed with GPG?

Yes