### PR TITLE
fix network ping test on windows with ipv6

### DIFF
--- a/tests/integration/modules/test_network.py
+++ b/tests/integration/modules/test_network.py
@@ -23,7 +23,7 @@ class NetworkTest(ModuleCase):
         network.ping
         '''
         ret = self.run_function('network.ping', [URL])
-        exp_out = ['ping', URL, 'ttl', 'time']
+        exp_out = ['ping', URL, 'ms', 'time']
         for out in exp_out:
             self.assertIn(out, ret.lower())
 


### PR DESCRIPTION
### What does this PR do?
fixes windows ping test when it has ipv6

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/55481

### Previous Behavior
https://jenkinsci.saltstack.com/job/pr-windows2019-py2/job/master/153/testReport/junit/integration.modules.test_network/NetworkTest/test_network_ping/
