### PR TITLE
compress docs with xz to save more space

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1001,7 +1001,7 @@ def docs_html(session, compress):
     session.run('make', 'clean', external=True)
     session.run('make', 'html', 'SPHINXOPTS=-W', external=True)
     if compress:
-        session.run('tar', '-czvf', 'html-archive.tar.gz', '_build/html', external=True)
+        session.run('tar', '-cJvf', 'html-archive.tar.xz', '_build/html', external=True)
     os.chdir('..')
 
 
@@ -1034,5 +1034,5 @@ def docs_man(session, compress, update):
         session.run('rm', '-rf', 'man/', external=True)
         session.run('cp', '-Rp', '_build/man', 'man/', external=True)
     if compress:
-        session.run('tar', '-czvf', 'man-archive.tar.gz', '_build/man', external=True)
+        session.run('tar', '-cJvf', 'man-archive.tar.xz', '_build/man', external=True)
     os.chdir('..')


### PR DESCRIPTION
### What does this PR do?
it saves space on jenkins by compressing the docs with xz instead of gz
