### PR TITLE
Catch `CommandExecutionError` when stopping a service

### DIFF
--- a/tests/unit/modules/test_win_service.py
+++ b/tests/unit/modules/test_win_service.py
@@ -187,6 +187,20 @@ class WinServiceTestCase(TestCase, LoaderModuleMockMixin):
                 patch.object(win_service, '_status_wait', mock_info):
             self.assertTrue(win_service.stop('spongebob'))
 
+    @skipIf(not WINAPI, 'pywintypes not available')
+    def test_stop_refused(self):
+        '''
+        Test stopping a service, but Windows refuses to stop it
+        '''
+        mock_error = MagicMock(
+            side_effect=pywintypes.error(1061,
+                                         'StopService',
+                                         'The service cannot accept control messages at this time'))
+        mock_info = MagicMock(side_effect=[{'Status': 'Running'}])
+        with patch.object(win32serviceutil, 'StopService', mock_error), \
+                patch.object(win_service, '_status_wait', mock_info):
+            self.assertFalse(win_service.stop('spongebob'))
+
     def test_restart(self):
         '''
             Test to restart the named service


### PR DESCRIPTION
### What does this PR do?
It adds handling of a previously unhandled exception in `states.service.dead`.

### What issues does this PR fix or reference?
It's a follow-up to a previous PR (#54797) which targeted `2019.2`, now against `master`.

### Previous Behavior
The state `service.dead` could fail like this:
```
An exception occurred in this state: Traceback (most recent call last):
  File "c:\salt\bin\lib\site-packages\salt\state.py", line 1913, in call
    **cdata['kwargs'])
  File "c:\salt\bin\lib\site-packages\salt\loader.py", line 1898, in wrapper
    return f(*args, **kwargs)
  File "c:\salt\bin\lib\site-packages\salt\states\service.py", line 593, in dead
    func_ret = __salt__['service.stop'](name, **stop_kwargs)
  File "c:\salt\bin\lib\site-packages\salt\modules\win_service.py", line 453, in stop
    'Failed To Stop {0}: {1}'.format(name, exc[2]))
CommandExecutionError: Failed To Stop w3svc: The service cannot accept control messages at this time.
```

### New Behavior
The state will now handle this case properly with `Result: False` and show the corresponding exception error string as comment instead.

### Tests written?
Yes, but I don't have an environment to run SaltStack's Windows tests (depending on `pywintypes` being available) right now, so I'll have to wait for the CI pipeline to verify it...

### Commits signed with GPG?

Yes