### PR TITLE
num_cpus and cpu_model support for IBM/S390

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -148,7 +148,7 @@ def _linux_cpudata():
                 val = comps[1].strip()
                 if key == 'processor':
                     grains['num_cpus'] = int(val) + 1
-                # head -2 /proc/cpuinfo 
+                # head -2 /proc/cpuinfo
                 # vendor_id       : IBM/S390
                 # # processors    : 2
                 elif key == '# processors':

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -148,6 +148,13 @@ def _linux_cpudata():
                 val = comps[1].strip()
                 if key == 'processor':
                     grains['num_cpus'] = int(val) + 1
+                # head -2 /proc/cpuinfo 
+                # vendor_id       : IBM/S390
+                # # processors    : 2
+                elif key == '# processors':
+                    grains['num_cpus'] = int(val)
+                elif key == 'vendor_id':
+                    grains['cpu_model'] = val
                 elif key == 'model name':
                     grains['cpu_model'] = val
                 elif key == 'flags':


### PR DESCRIPTION
Added support for IBM/S390 in core.py

### What does this PR do?
Correct # CPU grains output on S390x systems

### What issues does this PR fix or reference?

### Previous Behavior
salt-call grains.item num_cpus --out=pprint
{u'local': {u'num_cpus': 0}}


### New Behavior
salt-call grains.item num_cpus --out=pprint
{u'local': {u'num_cpus': 2}}



### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
