### PR TITLE
Ensure os.environ does not contain unicode chars

### DIFF
--- a/tests/integration/modules/test_pip.py
+++ b/tests/integration/modules/test_pip.py
@@ -17,6 +17,7 @@ import tempfile
 from tests.support.runtests import RUNTIME_VARS
 from tests.support.case import ModuleCase
 from tests.support.unit import skipIf
+from tests.support.helpers import patched_environ
 
 # Import salt libs
 import salt.utils.files
@@ -30,29 +31,20 @@ class PipModuleTest(ModuleCase):
 
     def setUp(self):
         super(PipModuleTest, self).setUp()
-
-        # Restore the environ
-        def cleanup_environ(environ):
-            os.environ.clear()
-            os.environ.update(environ)
-
-        self.addCleanup(cleanup_environ, os.environ.copy())
-
         self.venv_test_dir = tempfile.mkdtemp(dir=RUNTIME_VARS.TMP)
         # Remove the venv test directory
         self.addCleanup(shutil.rmtree, self.venv_test_dir, ignore_errors=True)
         self.venv_dir = os.path.join(self.venv_test_dir, 'venv')
-        for key in os.environ.copy():
-            if key.startswith('PIP_'):
-                os.environ.pop(key)
         self.pip_temp = os.path.join(self.venv_test_dir, '.pip-temp')
-        # Remove the pip-temp directory
-        self.addCleanup(shutil.rmtree, self.pip_temp, ignore_errors=True)
         if not os.path.isdir(self.pip_temp):
             os.makedirs(self.pip_temp)
-        os.environ['PIP_SOURCE_DIR'] = os.environ['PIP_BUILD_DIR'] = ''
-        for item in ('venv_dir', 'venv_test_dir', 'pip_temp'):
-            self.addCleanup(delattr, self, item)
+        self.patched_environ = patched_environ(
+            PIP_SOURCE_DIR='',
+            PIP_BUILD_DIR='',
+            __cleanup__=[k for k in os.environ if k.startswith('PIP_')]
+        )
+        self.patched_environ.__enter__()
+        self.addCleanup(self.patched_environ.__exit__)
 
     def _create_virtualenv(self, path):
         '''

--- a/tests/support/gitfs.py
+++ b/tests/support/gitfs.py
@@ -33,7 +33,7 @@ from salt.pillar import git_pillar
 from tests.support.case import ModuleCase
 from tests.support.unit import SkipTest
 from tests.support.mixins import AdaptedConfigurationTestCaseMixin, LoaderModuleMockMixin, SaltReturnAssertsMixin
-from tests.support.helpers import get_unused_localhost_port, requires_system_grains
+from tests.support.helpers import get_unused_localhost_port, requires_system_grains, patched_environ
 from tests.support.runtests import RUNTIME_VARS
 from tests.support.mock import patch
 from pytestsalt.utils import SaltDaemonScriptBase as _SaltDaemonScriptBase, terminate_process
@@ -893,15 +893,8 @@ class GitPillarSSHTestBase(GitPillarTestBase, SSHDMixin):
         passphraselsess key is used to auth without needing to modify the root
         user's ssh config file.
         '''
-
-        def cleanup_environ(environ):
-            os.environ.clear()
-            os.environ.update(environ)
-
-        self.addCleanup(cleanup_environ, os.environ.copy())
-
-        os.environ['GIT_SSH'] = self.git_ssh
-        return super(GitPillarSSHTestBase, self).get_pillar(ext_pillar_conf)
+        with patched_environ(GIT_SSH=self.git_ssh):
+            return super(GitPillarSSHTestBase, self).get_pillar(ext_pillar_conf)
 
 
 class GitPillarHTTPTestBase(GitPillarTestBase, WebserverMixin):

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -1634,3 +1634,25 @@ def dedent(text, linesep=os.linesep):
     if not isinstance(text, six.text_type):
         return salt.utils.stringutils.to_bytes(clean_text)
     return clean_text
+
+
+class PatchedEnviron(object):
+
+    def __init__(self, **kwargs):
+        self.cleanup_keys = kwargs.pop('__cleanup__', ())
+        self.kwargs = kwargs
+        self.original_environ = None
+
+    def __enter__(self):
+        self.original_environ = os.environ.copy()
+        for key in self.cleanup_keys:
+            os.environ.pop(key, None)
+        os.environ.update(**self.kwargs)
+        return self
+
+    def __exit__(self, *args):
+        os.environ.clear()
+        os.environ.update(self.original_environ)
+
+
+patched_environ = PatchedEnviron

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -1647,6 +1647,22 @@ class PatchedEnviron(object):
         self.original_environ = os.environ.copy()
         for key in self.cleanup_keys:
             os.environ.pop(key, None)
+
+        # Make sure there are no unicode characters in the self.kwargs if we're
+        # on Python 2. These are being added to `os.environ` and causing
+        # problems
+        if sys.version_info < (3,):
+            kwargs = self.kwargs.copy()
+            clean_kwargs = {}
+            for k in self.kwargs:
+                key = k
+                if isinstance(key, six.text_type):
+                    key = key.encode('utf-8')
+                if isinstance(self.kwargs[k], six.text_type):
+                    kwargs[k] = kwargs[k].encode('utf-8')
+                clean_kwargs[key] = kwargs[k]
+            self.kwargs = clean_kwargs
+
         os.environ.update(**self.kwargs)
         return self
 

--- a/tests/unit/netapi/test_rest_tornado.py
+++ b/tests/unit/netapi/test_rest_tornado.py
@@ -9,6 +9,7 @@ import hashlib
 # Import Salt Testing Libs
 from tests.support.mixins import AdaptedConfigurationTestCaseMixin
 from tests.support.unit import TestCase, skipIf
+from tests.support.helpers import patched_environ
 
 # Import Salt libs
 import salt.auth
@@ -94,15 +95,12 @@ class SaltnadoTestCase(TestCase, AdaptedConfigurationTestCaseMixin, AsyncHTTPTes
 
     def setUp(self):
         super(SaltnadoTestCase, self).setUp()
-        self.async_timeout_prev = os.environ.pop('ASYNC_TEST_TIMEOUT', None)
-        os.environ['ASYNC_TEST_TIMEOUT'] = str(30)
+        self.patched_environ = patched_environ(ASYNC_TEST_TIMEOUT='30')
+        self.patched_environ.__enter__()
+        self.addCleanup(self.patched_environ.__exit__)
 
     def tearDown(self):
         super(SaltnadoTestCase, self).tearDown()
-        if self.async_timeout_prev is None:
-            os.environ.pop('ASYNC_TEST_TIMEOUT', None)
-        else:
-            os.environ['ASYNC_TEST_TIMEOUT'] = self.async_timeout_prev
         if hasattr(self, 'http_server'):
             del self.http_server
         if hasattr(self, 'io_loop'):


### PR DESCRIPTION

<pr-train-toc>

#### PR chain:
#55517 (This global scoped code prevents pytest tests collection.)
#55518 (Drop module level setup)
👉 #55519 (Ensure os.environ does not contain unicode chars) 👈 **YOU ARE HERE**
#55520 (Salt's config does not set `config_dir`)
#55521 (Remove unneeded file)
#55368 **[combined branch]** ([WIP] Bring PyTest to master - Split the test suite)

</pr-train-toc>