### PR TITLE
Salt's config does not set `config_dir`

### DIFF
--- a/salt/modules/beacons.py
+++ b/salt/modules/beacons.py
@@ -370,7 +370,7 @@ def save(**kwargs):
     beacons = list_(return_yaml=False, include_pillar=False, **kwargs)
 
     # move this file into an configurable opt
-    sfn = os.path.join(__opts__['config_dir'],
+    sfn = os.path.join(os.path.dirname(__opts__['conf_file']),
                        os.path.dirname(__opts__['default_include']),
                        'beacons.conf')
     if beacons:

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -693,17 +693,15 @@ class TestDaemon(object):
 
     @classmethod
     def transplant_configs(cls, transport='zeromq'):
-        if os.path.isdir(RUNTIME_VARS.TMP_CONF_DIR):
-            shutil.rmtree(RUNTIME_VARS.TMP_CONF_DIR)
-        if os.path.isdir(RUNTIME_VARS.TMP_ROOT_DIR):
-            shutil.rmtree(RUNTIME_VARS.TMP_ROOT_DIR)
+        if os.path.isdir(RUNTIME_VARS.TMP):
+            shutil.rmtree(RUNTIME_VARS.TMP)
+        os.makedirs(RUNTIME_VARS.TMP)
         os.makedirs(RUNTIME_VARS.TMP_ROOT_DIR)
         os.makedirs(RUNTIME_VARS.TMP_CONF_DIR)
         os.makedirs(RUNTIME_VARS.TMP_SUB_MINION_CONF_DIR)
         os.makedirs(RUNTIME_VARS.TMP_SYNDIC_MASTER_CONF_DIR)
         os.makedirs(RUNTIME_VARS.TMP_SYNDIC_MINION_CONF_DIR)
-        if not os.path.exists(RUNTIME_VARS.TMP):
-            os.makedirs(RUNTIME_VARS.TMP)
+
         print(' * Transplanting configuration files to \'{0}\''.format(RUNTIME_VARS.TMP_CONF_DIR))
         tests_known_hosts_file = os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'salt_ssh_known_hosts')
         with salt.utils.files.fopen(tests_known_hosts_file, 'w') as known_hosts:

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -253,16 +253,6 @@ class TestDaemon(object):
         finally:
             self.post_setup_minions()
 
-    def start_daemon(self, cls, opts, start_fun):
-        def start(cls, opts, start_fun):
-            salt.utils.process.appendproctitle('{0}-{1}'.format(self.__class__.__name__, cls.__name__))
-            daemon = cls(opts)
-            getattr(daemon, start_fun)()
-        process = multiprocessing.Process(target=start,
-                                          args=(cls, opts, start_fun))
-        process.start()
-        return process
-
     def start_zeromq_daemons(self):
         '''
         Fire up the daemons used for zeromq tests

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -710,11 +710,11 @@ class TestDaemon(object):
         # This master connects to syndic_master via a syndic
         master_opts = salt.config._read_conf_file(os.path.join(RUNTIME_VARS.CONF_DIR, 'master'))
         master_opts['known_hosts_file'] = tests_known_hosts_file
-        master_opts['cachedir'] = os.path.join(TMP_ROOT_DIR, 'cache')
+        master_opts['cachedir'] = 'cache'
         master_opts['user'] = RUNTIME_VARS.RUNNING_TESTS_USER
         master_opts['config_dir'] = RUNTIME_VARS.TMP_CONF_DIR
         master_opts['root_dir'] = os.path.join(TMP_ROOT_DIR)
-        master_opts['pki_dir'] = os.path.join(TMP_ROOT_DIR, 'pki', 'master')
+        master_opts['pki_dir'] = 'pki'
         master_opts['syndic_master'] = 'localhost'
         file_tree = {
             'root_dir':  os.path.join(FILES, 'pillar', 'base', 'file_tree'),
@@ -762,11 +762,11 @@ class TestDaemon(object):
 
         # This minion connects to master
         minion_opts = salt.config._read_conf_file(os.path.join(RUNTIME_VARS.CONF_DIR, 'minion'))
-        minion_opts['cachedir'] = os.path.join(TMP_ROOT_DIR, 'cache')
+        minion_opts['cachedir'] = 'cache'
         minion_opts['user'] = RUNTIME_VARS.RUNNING_TESTS_USER
         minion_opts['config_dir'] = RUNTIME_VARS.TMP_CONF_DIR
         minion_opts['root_dir'] = os.path.join(TMP_ROOT_DIR)
-        minion_opts['pki_dir'] = os.path.join(TMP_ROOT_DIR, 'pki')
+        minion_opts['pki_dir'] = 'pki'
         minion_opts['hosts.file'] = os.path.join(TMP_ROOT_DIR, 'hosts')
         minion_opts['aliases.file'] = os.path.join(TMP_ROOT_DIR, 'aliases')
         if virtualenv_binary:
@@ -774,11 +774,11 @@ class TestDaemon(object):
 
         # This sub_minion also connects to master
         sub_minion_opts = salt.config._read_conf_file(os.path.join(RUNTIME_VARS.CONF_DIR, 'sub_minion'))
-        sub_minion_opts['cachedir'] = os.path.join(TMP, 'rootdir-sub-minion', 'cache')
+        sub_minion_opts['cachedir'] = 'cache'
         sub_minion_opts['user'] = RUNTIME_VARS.RUNNING_TESTS_USER
         sub_minion_opts['config_dir'] = RUNTIME_VARS.TMP_SUB_MINION_CONF_DIR
         sub_minion_opts['root_dir'] = os.path.join(TMP, 'rootdir-sub-minion')
-        sub_minion_opts['pki_dir'] = os.path.join(TMP, 'rootdir-sub-minion', 'pki', 'minion')
+        sub_minion_opts['pki_dir'] = 'pki'
         sub_minion_opts['hosts.file'] = os.path.join(TMP_ROOT_DIR, 'hosts')
         sub_minion_opts['aliases.file'] = os.path.join(TMP_ROOT_DIR, 'aliases')
         if virtualenv_binary:
@@ -786,11 +786,11 @@ class TestDaemon(object):
 
         # This is the master of masters
         syndic_master_opts = salt.config._read_conf_file(os.path.join(RUNTIME_VARS.CONF_DIR, 'syndic_master'))
-        syndic_master_opts['cachedir'] = os.path.join(TMP, 'rootdir-syndic-master', 'cache')
+        syndic_master_opts['cachedir'] = 'cache'
         syndic_master_opts['user'] = RUNTIME_VARS.RUNNING_TESTS_USER
         syndic_master_opts['config_dir'] = RUNTIME_VARS.TMP_SYNDIC_MASTER_CONF_DIR
         syndic_master_opts['root_dir'] = os.path.join(TMP, 'rootdir-syndic-master')
-        syndic_master_opts['pki_dir'] = os.path.join(TMP, 'rootdir-syndic-master', 'pki', 'master')
+        syndic_master_opts['pki_dir'] = 'pki'
 
         # This is the syndic for master
         # Let's start with a copy of the syndic master configuration
@@ -798,20 +798,16 @@ class TestDaemon(object):
         # Let's update with the syndic configuration
         syndic_opts.update(salt.config._read_conf_file(os.path.join(RUNTIME_VARS.CONF_DIR, 'syndic')))
         syndic_opts['config_dir'] = RUNTIME_VARS.TMP_SYNDIC_MINION_CONF_DIR
-        syndic_opts['cachedir'] = os.path.join(TMP_ROOT_DIR, 'cache')
+        syndic_opts['cachedir'] = 'cache'
         syndic_opts['root_dir'] = os.path.join(TMP_ROOT_DIR)
 
         # This proxy connects to master
         proxy_opts = salt.config._read_conf_file(os.path.join(CONF_DIR, 'proxy'))
-        proxy_opts['cachedir'] = os.path.join(TMP, 'rootdir-proxy', 'cache')
-        if not os.path.exists(proxy_opts['cachedir']):
-            os.makedirs(proxy_opts['cachedir'])
+        proxy_opts['cachedir'] = 'cache'
         # proxy_opts['user'] = running_tests_user
         proxy_opts['config_dir'] = RUNTIME_VARS.TMP_CONF_DIR
         proxy_opts['root_dir'] = os.path.join(TMP, 'rootdir-proxy')
-        proxy_opts['pki_dir'] = os.path.join(TMP, 'rootdir-proxy', 'pki')
-        if not os.path.exists(proxy_opts['pki_dir']):
-            os.makedirs(proxy_opts['pki_dir'])
+        proxy_opts['pki_dir'] = 'pki'
         proxy_opts['hosts.file'] = os.path.join(TMP, 'rootdir-proxy', 'hosts')
         proxy_opts['aliases.file'] = os.path.join(TMP, 'rootdir-proxy', 'aliases')
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -712,7 +712,6 @@ class TestDaemon(object):
         master_opts['known_hosts_file'] = tests_known_hosts_file
         master_opts['cachedir'] = 'cache'
         master_opts['user'] = RUNTIME_VARS.RUNNING_TESTS_USER
-        master_opts['config_dir'] = RUNTIME_VARS.TMP_CONF_DIR
         master_opts['root_dir'] = os.path.join(TMP_ROOT_DIR)
         master_opts['pki_dir'] = 'pki'
         master_opts['syndic_master'] = 'localhost'
@@ -764,7 +763,6 @@ class TestDaemon(object):
         minion_opts = salt.config._read_conf_file(os.path.join(RUNTIME_VARS.CONF_DIR, 'minion'))
         minion_opts['cachedir'] = 'cache'
         minion_opts['user'] = RUNTIME_VARS.RUNNING_TESTS_USER
-        minion_opts['config_dir'] = RUNTIME_VARS.TMP_CONF_DIR
         minion_opts['root_dir'] = os.path.join(TMP_ROOT_DIR)
         minion_opts['pki_dir'] = 'pki'
         minion_opts['hosts.file'] = os.path.join(TMP_ROOT_DIR, 'hosts')
@@ -776,7 +774,6 @@ class TestDaemon(object):
         sub_minion_opts = salt.config._read_conf_file(os.path.join(RUNTIME_VARS.CONF_DIR, 'sub_minion'))
         sub_minion_opts['cachedir'] = 'cache'
         sub_minion_opts['user'] = RUNTIME_VARS.RUNNING_TESTS_USER
-        sub_minion_opts['config_dir'] = RUNTIME_VARS.TMP_SUB_MINION_CONF_DIR
         sub_minion_opts['root_dir'] = os.path.join(TMP, 'rootdir-sub-minion')
         sub_minion_opts['pki_dir'] = 'pki'
         sub_minion_opts['hosts.file'] = os.path.join(TMP_ROOT_DIR, 'hosts')
@@ -788,7 +785,6 @@ class TestDaemon(object):
         syndic_master_opts = salt.config._read_conf_file(os.path.join(RUNTIME_VARS.CONF_DIR, 'syndic_master'))
         syndic_master_opts['cachedir'] = 'cache'
         syndic_master_opts['user'] = RUNTIME_VARS.RUNNING_TESTS_USER
-        syndic_master_opts['config_dir'] = RUNTIME_VARS.TMP_SYNDIC_MASTER_CONF_DIR
         syndic_master_opts['root_dir'] = os.path.join(TMP, 'rootdir-syndic-master')
         syndic_master_opts['pki_dir'] = 'pki'
 
@@ -797,7 +793,6 @@ class TestDaemon(object):
         syndic_opts = copy.deepcopy(syndic_master_opts)
         # Let's update with the syndic configuration
         syndic_opts.update(salt.config._read_conf_file(os.path.join(RUNTIME_VARS.CONF_DIR, 'syndic')))
-        syndic_opts['config_dir'] = RUNTIME_VARS.TMP_SYNDIC_MINION_CONF_DIR
         syndic_opts['cachedir'] = 'cache'
         syndic_opts['root_dir'] = os.path.join(TMP_ROOT_DIR)
 
@@ -805,7 +800,6 @@ class TestDaemon(object):
         proxy_opts = salt.config._read_conf_file(os.path.join(CONF_DIR, 'proxy'))
         proxy_opts['cachedir'] = 'cache'
         # proxy_opts['user'] = running_tests_user
-        proxy_opts['config_dir'] = RUNTIME_VARS.TMP_CONF_DIR
         proxy_opts['root_dir'] = os.path.join(TMP, 'rootdir-proxy')
         proxy_opts['pki_dir'] = 'pki'
         proxy_opts['hosts.file'] = os.path.join(TMP, 'rootdir-proxy', 'hosts')

--- a/tests/integration/files/conf/syndic
+++ b/tests/integration/files/conf/syndic
@@ -3,7 +3,8 @@ id: syndic
 interface: 127.0.0.1
 syndic_master: localhost
 syndic_master_port: 54506
-syndic_log_file: syndic.log
-syndic_pidfile: syndic.pid
+syndic_log_file: logs/syndic.log
+syndic_pidfile: run/syndic.pid
 tcp_pub_port: 64510
 tcp_pull_port: 64511
+sock_dir: syndic_sock

--- a/tests/integration/modules/test_beacons.py
+++ b/tests/integration/modules/test_beacons.py
@@ -11,6 +11,7 @@ import os
 from salt.exceptions import CommandExecutionError
 
 # Salttesting libs
+from tests.support.runtests import RUNTIME_VARS
 from tests.support.case import ModuleCase
 from tests.support.unit import skipIf
 
@@ -21,7 +22,7 @@ class BeaconsAddDeleteTest(ModuleCase):
     '''
     def setUp(self):
         self.minion_conf_d_dir = os.path.join(
-                self.minion_opts['config_dir'],
+                RUNTIME_VARS.TMP_CONF_DIR,
                 os.path.dirname(self.minion_opts['default_include']))
         if not os.path.isdir(self.minion_conf_d_dir):
             os.makedirs(self.minion_conf_d_dir)
@@ -71,7 +72,7 @@ class BeaconsTest(ModuleCase):
     def setUp(self):
         if self.minion_conf_d_dir is None:
             self.minion_conf_d_dir = os.path.join(
-                    self.minion_opts['config_dir'],
+                    RUNTIME_VARS.TMP_CONF_DIR,
                     os.path.dirname(self.minion_opts['default_include']))
             if not os.path.isdir(self.minion_conf_d_dir):
                 os.makedirs(self.minion_conf_d_dir)

--- a/tests/integration/modules/test_hosts.py
+++ b/tests/integration/modules/test_hosts.py
@@ -6,17 +6,17 @@ Test the hosts module
 from __future__ import absolute_import, print_function, unicode_literals
 import os
 import shutil
+import logging
 
 # Import Salt Testing libs
 from tests.support.runtests import RUNTIME_VARS
 from tests.support.case import ModuleCase
-from tests.support.paths import FILES
 
 # Import Salt libs
 import salt.utils.files
 import salt.utils.stringutils
 
-HFN = os.path.join(RUNTIME_VARS.TMP, 'hosts')
+log = logging.getLogger(__name__)
 
 
 class HostsModuleTest(ModuleCase):
@@ -26,30 +26,25 @@ class HostsModuleTest(ModuleCase):
 
     maxDiff = None
 
-    def __clean_hosts(self):
-        '''
-        Clean out the hosts file
-        '''
-        shutil.copyfile(os.path.join(FILES, 'hosts'), HFN)
+    @classmethod
+    def setUpClass(cls):
+        cls.hosts_file = os.path.join(RUNTIME_VARS.TMP, 'hosts')
 
     def __clear_hosts(self):
         '''
         Delete the tmp hosts file
         '''
-        if os.path.isfile(HFN):
-            os.remove(HFN)
+        if os.path.isfile(self.hosts_file):
+            os.remove(self.hosts_file)
 
-    def tearDown(self):
-        '''
-        Make sure the tmp hosts file is gone
-        '''
-        self.__clear_hosts()
+    def setUp(self):
+        shutil.copyfile(os.path.join(RUNTIME_VARS.FILES, 'hosts'), self.hosts_file)
+        self.addCleanup(self.__clear_hosts)
 
     def test_list_hosts(self):
         '''
         hosts.list_hosts
         '''
-        self.__clean_hosts()
         hosts = self.run_function('hosts.list_hosts')
         self.assertEqual(len(hosts), 10)
         self.assertEqual(hosts['::1'], ['ip6-localhost', 'ip6-loopback'])
@@ -60,8 +55,8 @@ class HostsModuleTest(ModuleCase):
         hosts.list_hosts
         without a hosts file
         '''
-        if os.path.isfile(HFN):
-            os.remove(HFN)
+        if os.path.isfile(self.hosts_file):
+            os.remove(self.hosts_file)
         hosts = self.run_function('hosts.list_hosts')
         self.assertEqual(hosts, {})
 
@@ -69,7 +64,6 @@ class HostsModuleTest(ModuleCase):
         '''
         hosts.get_ip
         '''
-        self.__clean_hosts()
         self.assertEqual(
             self.run_function('hosts.get_ip', ['myname']), '127.0.0.1'
         )
@@ -81,7 +75,6 @@ class HostsModuleTest(ModuleCase):
         '''
         hosts.get_alias
         '''
-        self.__clean_hosts()
         self.assertEqual(
             self.run_function('hosts.get_alias', ['127.0.0.1']),
             ['localhost', 'myname']
@@ -100,7 +93,6 @@ class HostsModuleTest(ModuleCase):
         '''
         hosts.has_pair
         '''
-        self.__clean_hosts()
         self.assertTrue(
             self.run_function('hosts.has_pair', ['127.0.0.1', 'myname'])
         )
@@ -112,7 +104,6 @@ class HostsModuleTest(ModuleCase):
         '''
         hosts.set_hosts
         '''
-        self.__clean_hosts()
         self.assertTrue(
             self.run_function('hosts.set_host', ['192.168.1.123', 'newip'])
         )
@@ -132,7 +123,6 @@ class HostsModuleTest(ModuleCase):
         '''
         hosts.add_host
         '''
-        self.__clean_hosts()
         self.assertTrue(
             self.run_function('hosts.add_host', ['192.168.1.123', 'newip'])
         )
@@ -146,7 +136,6 @@ class HostsModuleTest(ModuleCase):
         self.assertEqual(len(self.run_function('hosts.list_hosts')), 11)
 
     def test_rm_host(self):
-        self.__clean_hosts()
         self.assertTrue(
             self.run_function('hosts.has_pair', ['127.0.0.1', 'myname'])
         )
@@ -169,7 +158,7 @@ class HostsModuleTest(ModuleCase):
         # use an empty one so we can prove the syntax of the entries
         # being added by the hosts module
         self.__clear_hosts()
-        with salt.utils.files.fopen(HFN, 'w'):
+        with salt.utils.files.fopen(self.hosts_file, 'w'):
             pass
 
         self.assertTrue(
@@ -208,7 +197,7 @@ class HostsModuleTest(ModuleCase):
         )
 
         # now read the lines and ensure they're formatted correctly
-        with salt.utils.files.fopen(HFN, 'r') as fp_:
+        with salt.utils.files.fopen(self.hosts_file, 'r') as fp_:
             lines = salt.utils.stringutils.to_unicode(fp_.read()).splitlines()
         self.assertEqual(lines, [
             '192.168.1.3\t\thost3.fqdn.com',

--- a/tests/integration/modules/test_mac_keychain.py
+++ b/tests/integration/modules/test_mac_keychain.py
@@ -18,16 +18,6 @@ from salt.exceptions import CommandExecutionError
 # Import 3rd-party libs
 from salt.ext import six
 
-CERT = os.path.join(
-    RUNTIME_VARS.FILES,
-    'file',
-    'base',
-    'certs',
-    'salttest.p12'
-)
-CERT_ALIAS = 'Salt Test'
-PASSWD = 'salttest'
-
 
 @destructiveTest
 @skip_if_not_root
@@ -35,6 +25,19 @@ class MacKeychainModuleTest(ModuleCase):
     '''
     Integration tests for the mac_keychain module
     '''
+
+    @classmethod
+    def setUpClass(cls):
+        cls.cert = os.path.join(
+            RUNTIME_VARS.FILES,
+            'file',
+            'base',
+            'certs',
+            'salttest.p12'
+        )
+        cls.cert_alias = 'Salt Test'
+        cls.passwd = 'salttest'
+
     def setUp(self):
         '''
         Sets up the test requirements
@@ -54,53 +57,53 @@ class MacKeychainModuleTest(ModuleCase):
         '''
         # Remove the salttest cert, if left over.
         certs_list = self.run_function('keychain.list_certs')
-        if CERT_ALIAS in certs_list:
-            self.run_function('keychain.uninstall', [CERT_ALIAS])
+        if self.cert_alias in certs_list:
+            self.run_function('keychain.uninstall', [self.cert_alias])
 
     def test_mac_keychain_install(self):
         '''
         Tests that attempts to install a certificate
         '''
-        install_cert = self.run_function('keychain.install', [CERT, PASSWD])
+        install_cert = self.run_function('keychain.install', [self.cert, self.passwd])
         self.assertTrue(install_cert)
 
         # check to ensure the cert was installed
         certs_list = self.run_function('keychain.list_certs')
-        self.assertIn(CERT_ALIAS, certs_list)
+        self.assertIn(self.cert_alias, certs_list)
 
     def test_mac_keychain_uninstall(self):
         '''
         Tests that attempts to uninstall a certificate
         '''
-        self.run_function('keychain.install', [CERT, PASSWD])
+        self.run_function('keychain.install', [self.cert, self.passwd])
         certs_list = self.run_function('keychain.list_certs')
 
-        if CERT_ALIAS not in certs_list:
-            self.run_function('keychain.uninstall', [CERT_ALIAS])
+        if self.cert_alias not in certs_list:
+            self.run_function('keychain.uninstall', [self.cert_alias])
             self.skipTest('Failed to install keychain')
 
         # uninstall cert
-        self.run_function('keychain.uninstall', [CERT_ALIAS])
+        self.run_function('keychain.uninstall', [self.cert_alias])
         certs_list = self.run_function('keychain.list_certs')
 
         # check to ensure the cert was uninstalled
         try:
-            self.assertNotIn(CERT_ALIAS, six.text_type(certs_list))
+            self.assertNotIn(self.cert_alias, six.text_type(certs_list))
         except CommandExecutionError:
-            self.run_function('keychain.uninstall', [CERT_ALIAS])
+            self.run_function('keychain.uninstall', [self.cert_alias])
 
     def test_mac_keychain_get_friendly_name(self):
         '''
         Test that attempts to get friendly name of a cert
         '''
-        self.run_function('keychain.install', [CERT, PASSWD])
+        self.run_function('keychain.install', [self.cert, self.passwd])
         certs_list = self.run_function('keychain.list_certs')
-        if CERT_ALIAS not in certs_list:
-            self.run_function('keychain.uninstall', [CERT_ALIAS])
+        if self.cert_alias not in certs_list:
+            self.run_function('keychain.uninstall', [self.cert_alias])
             self.skipTest('Failed to install keychain')
 
-        get_name = self.run_function('keychain.get_friendly_name', [CERT, PASSWD])
-        self.assertEqual(get_name, CERT_ALIAS)
+        get_name = self.run_function('keychain.get_friendly_name', [self.cert, self.passwd])
+        self.assertEqual(get_name, self.cert_alias)
 
     def test_mac_keychain_get_default_keychain(self):
         '''

--- a/tests/support/events.py
+++ b/tests/support/events.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+'''
+    tests.support.events
+    ~~~~~~~~~~~~~~~~~~~~
+'''
+
+# Import Python libs
+from __future__ import absolute_import, unicode_literals
+import os
+import time
+import multiprocessing
+from contextlib import contextmanager
+
+# Import Salt libs
+import salt.utils.event
+from salt.utils.process import clean_proc
+
+
+@contextmanager
+def eventpublisher_process(sock_dir):
+    proc = salt.utils.event.EventPublisher({'sock_dir': sock_dir})
+    proc.start()
+    try:
+        if os.environ.get('TRAVIS_PYTHON_VERSION', None) is not None:
+            # Travis is slow
+            time.sleep(10)
+        else:
+            time.sleep(2)
+        yield
+    finally:
+        clean_proc(proc)
+
+
+class EventSender(multiprocessing.Process):
+    def __init__(self, data, tag, wait, sock_dir):
+        super(EventSender, self).__init__()
+        self.data = data
+        self.tag = tag
+        self.wait = wait
+        self.sock_dir = sock_dir
+
+    def run(self):
+        me = salt.utils.event.MasterEvent(self.sock_dir, listen=False)
+        time.sleep(self.wait)
+        me.fire_event(self.data, self.tag)
+        # Wait a few seconds before tearing down the zmq context
+        if os.environ.get('TRAVIS_PYTHON_VERSION', None) is not None:
+            # Travis is slow
+            time.sleep(10)
+        else:
+            time.sleep(2)
+
+
+@contextmanager
+def eventsender_process(data, tag, sock_dir, wait=0):
+    proc = EventSender(data, tag, wait, sock_dir=sock_dir)
+    proc.start()
+    try:
+        yield
+    finally:
+        clean_proc(proc)

--- a/tests/support/mixins.py
+++ b/tests/support/mixins.py
@@ -116,7 +116,6 @@ class AdaptedConfigurationTestCaseMixin(object):
                    root_dir=rdict['root_dir'],
                    )
 
-        rdict['config_dir'] = conf_dir
         rdict['conf_file'] = os.path.join(conf_dir, config_for)
         with salt.utils.files.fopen(rdict['conf_file'], 'w') as wfh:
             salt.utils.yaml.safe_dump(rdict, wfh, default_flow_style=False)

--- a/tests/unit/modules/test_beacons.py
+++ b/tests/unit/modules/test_beacons.py
@@ -85,7 +85,8 @@ class BeaconsTestCase(TestCase, LoaderModuleMockMixin):
         Test saving beacons.
         '''
         comm1 = 'Beacons saved to {0}beacons.conf.'.format(RUNTIME_VARS.TMP + os.sep)
-        with patch.dict(beacons.__opts__, {'config_dir': '', 'beacons': {},
+        with patch.dict(beacons.__opts__, {'conf_file': os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'foo'),
+                                           'beacons': {},
                                            'default_include': RUNTIME_VARS.TMP + os.sep,
                                            'sock_dir': self.sock_dir}):
 

--- a/tests/unit/modules/test_schedule.py
+++ b/tests/unit/modules/test_schedule.py
@@ -199,7 +199,7 @@ class ScheduleTestCase(TestCase, LoaderModuleMockMixin):
         Test if it save all scheduled jobs on the minion.
         '''
         comm1 = 'Schedule (non-pillar items) saved.'
-        with patch.dict(schedule.__opts__, {'config_dir': '', 'schedule': {},
+        with patch.dict(schedule.__opts__, {'schedule': {},
                                             'default_include': '/tmp',
                                             'sock_dir': self.sock_dir}):
 

--- a/tests/unit/netapi/test_rest_tornado.py
+++ b/tests/unit/netapi/test_rest_tornado.py
@@ -4,12 +4,15 @@
 from __future__ import absolute_import
 import os
 import copy
+import shutil
 import hashlib
 
 # Import Salt Testing Libs
 from tests.support.mixins import AdaptedConfigurationTestCaseMixin
 from tests.support.unit import TestCase, skipIf
 from tests.support.helpers import patched_environ
+from tests.support.runtests import RUNTIME_VARS
+from tests.support.events import eventpublisher_process
 
 # Import Salt libs
 import salt.auth
@@ -17,7 +20,6 @@ import salt.utils.event
 import salt.utils.json
 import salt.utils.yaml
 from salt.ext.six.moves import map, range  # pylint: disable=import-error
-from tests.unit.utils.test_event import eventpublisher_process, SOCK_DIR  # pylint: disable=import-error
 try:
     HAS_TORNADO = True
 except ImportError:
@@ -803,18 +805,20 @@ class TestSaltnadoUtils(AsyncTestCase):
 @skipIf(not HAS_TORNADO, 'The tornado package needs to be installed')
 class TestEventListener(AsyncTestCase):
     def setUp(self):
-        if not os.path.exists(SOCK_DIR):
-            os.makedirs(SOCK_DIR)
+        self.sock_dir = os.path.join(RUNTIME_VARS.TMP, 'test-socks')
+        if not os.path.exists(self.sock_dir):
+            os.makedirs(self.sock_dir)
+        self.addCleanup(shutil.rmtree, self.sock_dir, ignore_errors=True)
         super(TestEventListener, self).setUp()
 
     def test_simple(self):
         '''
         Test getting a few events
         '''
-        with eventpublisher_process():
-            me = salt.utils.event.MasterEvent(SOCK_DIR)
+        with eventpublisher_process(self.sock_dir):
+            me = salt.utils.event.MasterEvent(self.sock_dir)
             event_listener = saltnado.EventListener({},  # we don't use mod_opts, don't save?
-                                                    {'sock_dir': SOCK_DIR,
+                                                    {'sock_dir': self.sock_dir,
                                                      'transport': 'zeromq'})
             self._finished = False  # fit to event_listener's behavior
             event_future = event_listener.get_event(self, 'evt1', callback=self.stop)  # get an event future
@@ -831,10 +835,10 @@ class TestEventListener(AsyncTestCase):
         '''
         Test subscribing events using set_event_handler
         '''
-        with eventpublisher_process():
-            me = salt.utils.event.MasterEvent(SOCK_DIR)
+        with eventpublisher_process(self.sock_dir):
+            me = salt.utils.event.MasterEvent(self.sock_dir)
             event_listener = saltnado.EventListener({},  # we don't use mod_opts, don't save?
-                                                    {'sock_dir': SOCK_DIR,
+                                                    {'sock_dir': self.sock_dir,
                                                      'transport': 'zeromq'})
             self._finished = False  # fit to event_listener's behavior
             event_future = event_listener.get_event(self,
@@ -852,9 +856,9 @@ class TestEventListener(AsyncTestCase):
         '''
         Make sure timeouts work correctly
         '''
-        with eventpublisher_process():
+        with eventpublisher_process(self.sock_dir):
             event_listener = saltnado.EventListener({},  # we don't use mod_opts, don't save?
-                                                    {'sock_dir': SOCK_DIR,
+                                                    {'sock_dir': self.sock_dir,
                                                      'transport': 'zeromq'})
             self._finished = False  # fit to event_listener's behavior
             event_future = event_listener.get_event(self,
@@ -898,10 +902,10 @@ class TestEventListener(AsyncTestCase):
             if cnt[0] == 2:
                 self.stop()
 
-        with eventpublisher_process():
-            me = salt.utils.event.MasterEvent(SOCK_DIR)
+        with eventpublisher_process(self.sock_dir):
+            me = salt.utils.event.MasterEvent(self.sock_dir)
             event_listener = saltnado.EventListener({},  # we don't use mod_opts, don't save?
-                                                    {'sock_dir': SOCK_DIR,
+                                                    {'sock_dir': self.sock_dir,
                                                      'transport': 'zeromq'})
 
             self.assertEqual(0, len(event_listener.tag_map))

--- a/tests/unit/states/test_beacon.py
+++ b/tests/unit/states/test_beacon.py
@@ -4,10 +4,8 @@
 '''
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
-import os
 
 # Import Salt Testing Libs
-from tests.support.runtests import RUNTIME_VARS
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import skipIf, TestCase
 from tests.support.mock import (
@@ -19,8 +17,6 @@ from tests.support.mock import (
 
 # Import Salt Libs
 import salt.states.beacon as beacon
-
-SOCK_DIR = os.path.join(RUNTIME_VARS.TMP, 'test-socks')
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -44,7 +40,6 @@ class BeaconTestCase(TestCase, LoaderModuleMockMixin):
                'result': False,
                'comment': ''}
 
-        mock_dict = MagicMock(side_effect=[ret, []])
         mock_mod = MagicMock(return_value=ret)
         mock_lst = MagicMock(side_effect=[{beacon_name: {}},
                                           {beacon_name: {}},

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -40,8 +40,7 @@ from salt.exceptions import (
 
 log = logging.getLogger(__name__)
 
-SAMPLE_CONF_DIR = os.path.dirname(os.path.realpath(__file__)).split('tests')[0] + 'conf/'
-
+SAMPLE_CONF_DIR = os.path.join(RUNTIME_VARS.CODE_DIR, 'conf') + os.sep
 
 # mock hostname should be more complex than the systems FQDN
 MOCK_HOSTNAME = 'very.long.complex.fqdn.that.is.crazy.extra.long.example.com'
@@ -65,19 +64,19 @@ MOCK_ETC_HOSTNAME = '{}\n'.format(MOCK_HOSTNAME)
 PATH = 'path/to/some/cloud/conf/file'
 DEFAULT = {'default_include': PATH}
 
-MOCK_MASTER_DEFAULT_OPTS = {
-    'log_file': '{}/var/log/salt/master'.format(RUNTIME_VARS.TMP_ROOT_DIR),
-    'pidfile': '{}/var/run/salt-master.pid'.format(RUNTIME_VARS.TMP_ROOT_DIR),
-    'root_dir': RUNTIME_VARS.TMP_ROOT_DIR
-}
-if salt.utils.platform.is_windows():
-    MOCK_MASTER_DEFAULT_OPTS = {
-        'log_file': '{}\\var\\log\\salt\\master'.format(RUNTIME_VARS.TMP_ROOT_DIR),
-        'pidfile': '{}\\var\\run\\salt-master.pid'.format(RUNTIME_VARS.TMP_ROOT_DIR),
-    }
+
+class DefaultConfigsBase(object):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mock_master_default_opts = dict(
+            root_dir=RUNTIME_VARS.TMP_ROOT_DIR,
+            log_file=os.path.join(RUNTIME_VARS.TMP_ROOT_DIR, 'var', 'log', 'salt', 'master'),
+            pid_file=os.path.join(RUNTIME_VARS.TMP_ROOT_DIR, 'var', 'run', 'salt-master.pid')
+        )
 
 
-class SampleConfTest(TestCase):
+class SampleConfTest(DefaultConfigsBase, TestCase):
     '''
     Validate files in the salt/conf directory.
     '''
@@ -1519,7 +1518,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
-class APIConfigTestCase(TestCase):
+class APIConfigTestCase(DefaultConfigsBase, TestCase):
     '''
     TestCase for the api_config function in salt.config.__init__.py
     '''
@@ -1537,7 +1536,7 @@ class APIConfigTestCase(TestCase):
         various default dict updates. 'log_file' should be updated to match
         the DEFAULT_API_OPTS 'api_logfile' value.
         '''
-        with patch('salt.config.client_config', MagicMock(return_value=MOCK_MASTER_DEFAULT_OPTS)):
+        with patch('salt.config.client_config', MagicMock(return_value=self.mock_master_default_opts)):
 
             expected = '{}/var/log/salt/api'.format(
                 RUNTIME_VARS.TMP_ROOT_DIR if RUNTIME_VARS.TMP_ROOT_DIR != '/' else '')
@@ -1554,7 +1553,7 @@ class APIConfigTestCase(TestCase):
         various default dict updates. 'pidfile' should be updated to match
         the DEFAULT_API_OPTS 'api_pidfile' value.
         '''
-        with patch('salt.config.client_config', MagicMock(return_value=MOCK_MASTER_DEFAULT_OPTS)):
+        with patch('salt.config.client_config', MagicMock(return_value=self.mock_master_default_opts)):
 
             expected = '{}/var/run/salt-api.pid'.format(
                 RUNTIME_VARS.TMP_ROOT_DIR if RUNTIME_VARS.TMP_ROOT_DIR != '/' else '')
@@ -1582,7 +1581,7 @@ class APIConfigTestCase(TestCase):
             'api_logfile': hello_dir,
             'rest_timeout': 5
         }
-        mock_master_config.update(MOCK_MASTER_DEFAULT_OPTS.copy())
+        mock_master_config.update(self.mock_master_default_opts.copy())
 
         with patch('salt.config.client_config',
                    MagicMock(return_value=mock_master_config)):
@@ -1603,7 +1602,7 @@ class APIConfigTestCase(TestCase):
         mock_log = '/mock/root/var/log/salt/api'
         mock_pid = '/mock/root/var/run/salt-api.pid'
 
-        mock_master_config = MOCK_MASTER_DEFAULT_OPTS.copy()
+        mock_master_config = self.mock_master_default_opts.copy()
         mock_master_config['root_dir'] = '/mock/root/'
 
         if salt.utils.platform.is_windows():

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -10,7 +10,7 @@ import os
 import textwrap
 
 # Import Salt Testing libs
-from tests.support.helpers import with_tempdir, with_tempfile, patched_environ, destructiveTest
+from tests.support.helpers import with_tempdir, with_tempfile, patched_environ
 from tests.support.mixins import AdaptedConfigurationTestCaseMixin
 from tests.support.unit import skipIf, TestCase
 from tests.support.runtests import RUNTIME_VARS
@@ -32,7 +32,6 @@ import salt.utils.platform
 import salt.utils.yaml
 from salt.ext import six
 from salt.syspaths import CONFIG_DIR
-from salt import config as sconfig
 from salt.exceptions import (
     CommandExecutionError,
     SaltConfigurationError,
@@ -62,22 +61,19 @@ MOCK_ETC_HOSTS = textwrap.dedent('''\
     fe00::0        ip6-localnet
     ff00::0        ip6-mcastprefix
     '''.format(hostname=MOCK_HOSTNAME))
-MOCK_ETC_HOSTNAME = '{0}\n'.format(MOCK_HOSTNAME)
+MOCK_ETC_HOSTNAME = '{}\n'.format(MOCK_HOSTNAME)
 PATH = 'path/to/some/cloud/conf/file'
 DEFAULT = {'default_include': PATH}
 
 MOCK_MASTER_DEFAULT_OPTS = {
-    'log_file': '{0}/var/log/salt/master'.format(salt.syspaths.ROOT_DIR),
-    'pidfile': '{0}/var/run/salt-master.pid'.format(salt.syspaths.ROOT_DIR),
-    'root_dir': format(salt.syspaths.ROOT_DIR)
+    'log_file': '{}/var/log/salt/master'.format(RUNTIME_VARS.TMP_ROOT_DIR),
+    'pidfile': '{}/var/run/salt-master.pid'.format(RUNTIME_VARS.TMP_ROOT_DIR),
+    'root_dir': RUNTIME_VARS.TMP_ROOT_DIR
 }
 if salt.utils.platform.is_windows():
     MOCK_MASTER_DEFAULT_OPTS = {
-        'log_file': '{0}\\var\\log\\salt\\master'.format(
-            salt.syspaths.ROOT_DIR),
-        'pidfile': '{0}\\var\\run\\salt-master.pid'.format(
-            salt.syspaths.ROOT_DIR),
-        'root_dir': format(salt.syspaths.ROOT_DIR)
+        'log_file': '{}\\var\\log\\salt\\master'.format(RUNTIME_VARS.TMP_ROOT_DIR),
+        'pidfile': '{}\\var\\run\\salt-master.pid'.format(RUNTIME_VARS.TMP_ROOT_DIR),
     }
 
 
@@ -96,7 +92,7 @@ class SampleConfTest(TestCase):
         self.assertEqual(
             ret,
             {},
-            'Sample config file \'{0}\' must be commented out.'.format(
+            'Sample config file \'{}\' must be commented out.'.format(
                 master_config
             )
         )
@@ -111,7 +107,7 @@ class SampleConfTest(TestCase):
         self.assertEqual(
             ret,
             {},
-            'Sample config file \'{0}\' must be commented out.'.format(
+            'Sample config file \'{}\' must be commented out.'.format(
                 minion_config
             )
         )
@@ -126,7 +122,7 @@ class SampleConfTest(TestCase):
         self.assertEqual(
             ret,
             {},
-            'Sample config file \'{0}\' must be commented out.'.format(
+            'Sample config file \'{}\' must be commented out.'.format(
                 cloud_config
             )
         )
@@ -141,7 +137,7 @@ class SampleConfTest(TestCase):
         self.assertEqual(
             ret,
             {},
-            'Sample config file \'{0}\' must be commented out.'.format(
+            'Sample config file \'{}\' must be commented out.'.format(
                 cloud_profiles_config
             )
         )
@@ -156,7 +152,7 @@ class SampleConfTest(TestCase):
         self.assertEqual(
             ret,
             {},
-            'Sample config file \'{0}\' must be commented out.'.format(
+            'Sample config file \'{}\' must be commented out.'.format(
                 cloud_providers_config
             )
         )
@@ -171,7 +167,7 @@ class SampleConfTest(TestCase):
         self.assertEqual(
             ret,
             {},
-            'Sample config file \'{0}\' must be commented out.'.format(
+            'Sample config file \'{}\' must be commented out.'.format(
                 proxy_config
             )
         )
@@ -186,7 +182,7 @@ class SampleConfTest(TestCase):
         self.assertEqual(
             ret,
             {},
-            'Sample config file \'{0}\' must be commented out.'.format(
+            'Sample config file \'{}\' must be commented out.'.format(
                 roster_config
             )
         )
@@ -207,7 +203,7 @@ class SampleConfTest(TestCase):
             self.assertEqual(
                 ret,
                 {},
-                'Sample config file \'{0}\' must be commented out.'.format(
+                'Sample config file \'{}\' must be commented out.'.format(
                     conf_file
                 )
             )
@@ -228,7 +224,7 @@ class SampleConfTest(TestCase):
             self.assertEqual(
                 ret,
                 {},
-                'Sample config file \'{0}\' must be commented out.'.format(
+                'Sample config file \'{}\' must be commented out.'.format(
                     conf_file
                 )
             )
@@ -249,7 +245,7 @@ class SampleConfTest(TestCase):
             self.assertEqual(
                 ret,
                 {},
-                'Sample config file \'{0}\' must be commented out.'.format(
+                'Sample config file \'{}\' must be commented out.'.format(
                     conf_file
                 )
             )
@@ -259,14 +255,14 @@ def _unhandled_mock_read(filename):
     '''
     Raise an error because we should not be calling salt.utils.files.fopen()
     '''
-    raise CommandExecutionError('Unhandled mock read for {0}'.format(filename))
+    raise CommandExecutionError('Unhandled mock read for {}'.format(filename))
 
 
 def _salt_configuration_error(filename):
     '''
     Raise an error to indicate error in the Salt configuration file
     '''
-    raise SaltConfigurationError('Configuration error in {0}'.format(filename))
+    raise SaltConfigurationError('Configuration error in {}'.format(filename))
 
 
 class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
@@ -278,7 +274,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                 "root_dir: /\n"
                 "key_logfile: key\n"
             )
-        config = sconfig.master_config(fpath)
+        config = salt.config.master_config(fpath)
         self.assertEqual(config['hash_type'], 'sha256')
 
     @with_tempfile()
@@ -288,7 +284,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                 "root_dir: /\n"
                 "key_logfile: key\n"
             )
-        config = sconfig.minion_config(fpath)
+        config = salt.config.minion_config(fpath)
         self.assertEqual(config['hash_type'], 'sha256')
 
     @with_tempfile()
@@ -301,7 +297,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         with salt.utils.files.fopen(fpath, 'w') as fp_:
             fp_.write(temp_config)
 
-        config = sconfig.master_config(fpath)
+        config = salt.config.master_config(fpath)
         expect_path_join = os.path.join('/', 'key')
         expect_sep_join = '//key'
         if salt.utils.platform.is_windows():
@@ -320,10 +316,10 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         fpath = os.path.join(root_dir, 'config')
         with salt.utils.files.fopen(fpath, 'w') as fp_:
             fp_.write(
-                'root_dir: {0}\n'
-                'log_file: {1}\n'.format(root_dir, fpath)
+                'root_dir: {}\n'
+                'log_file: {}\n'.format(root_dir, fpath)
             )
-        config = sconfig.master_config(fpath)
+        config = salt.config.master_config(fpath)
         self.assertEqual(config['log_file'], fpath)
 
     @with_tempdir()
@@ -333,11 +329,10 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         fpath = os.path.join(root_dir, 'config')
         with salt.utils.files.fopen(fpath, 'w') as fp_:
             fp_.write(
-                'root_dir: {0}\n'
-                'log_file: {1}\n'.format(root_dir, fpath)
+                'root_dir: {}\n'
+                'log_file: {}\n'.format(root_dir, fpath)
             )
-        with patch('salt.syspaths.ROOT_DIR', RUNTIME_VARS.TMP):
-            config = salt.config.master_config(fpath)
+        config = salt.config.master_config(fpath)
         self.assertEqual(config['log_file'], fpath)
 
     @skipIf(
@@ -351,8 +346,8 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
 
         with salt.utils.files.fopen(env_fpath, 'w') as fp_:
             fp_.write(
-                'root_dir: {0}\n'
-                'log_file: {1}\n'.format(env_root_dir, env_fpath)
+                'root_dir: {}\n'
+                'log_file: {}\n'.format(env_root_dir, env_fpath)
             )
         with patched_environ(SALT_MASTER_CONFIG=env_fpath):
             # Should load from env variable, not the default configuration file.
@@ -364,8 +359,8 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         fpath = os.path.join(root_dir, 'config')
         with salt.utils.files.fopen(fpath, 'w') as fp_:
             fp_.write(
-                'root_dir: {0}\n'
-                'log_file: {1}\n'.format(root_dir, fpath)
+                'root_dir: {}\n'
+                'log_file: {}\n'.format(root_dir, fpath)
             )
         # Let's set the environment variable, yet, since the configuration
         # file path is not the default one, i.e., the user has passed an
@@ -386,8 +381,8 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
 
         with salt.utils.files.fopen(env_fpath, 'w') as fp_:
             fp_.write(
-                'root_dir: {0}\n'
-                'log_file: {1}\n'.format(env_root_dir, env_fpath)
+                'root_dir: {}\n'
+                'log_file: {}\n'.format(env_root_dir, env_fpath)
             )
 
         with patched_environ(SALT_MINION_CONFIG=env_fpath):
@@ -400,8 +395,8 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         fpath = os.path.join(root_dir, 'config')
         with salt.utils.files.fopen(fpath, 'w') as fp_:
             fp_.write(
-                'root_dir: {0}\n'
-                'log_file: {1}\n'.format(root_dir, fpath)
+                'root_dir: {}\n'
+                'log_file: {}\n'.format(root_dir, fpath)
             )
         # Let's set the environment variable, yet, since the configuration
         # file path is not the default one, i.e., the user has passed an
@@ -424,16 +419,16 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         with salt.utils.files.fopen(master_config, 'w') as fp_:
             fp_.write(
                 'blah: true\n'
-                'root_dir: {0}\n'
-                'log_file: {1}\n'.format(env_root_dir, master_config)
+                'root_dir: {}\n'
+                'log_file: {}\n'.format(env_root_dir, master_config)
             )
 
         # Now the client configuration file
         env_fpath = os.path.join(env_root_dir, 'config-env')
         with salt.utils.files.fopen(env_fpath, 'w') as fp_:
             fp_.write(
-                'root_dir: {0}\n'
-                'log_file: {1}\n'.format(env_root_dir, env_fpath)
+                'root_dir: {}\n'
+                'log_file: {}\n'.format(env_root_dir, env_fpath)
             )
 
         with patched_environ(SALT_MASTER_CONFIG=master_config,
@@ -448,8 +443,8 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         fpath = os.path.join(root_dir, 'config')
         with salt.utils.files.fopen(fpath, 'w') as fp_:
             fp_.write(
-                'root_dir: {0}\n'
-                'log_file: {1}\n'.format(root_dir, fpath)
+                'root_dir: {}\n'
+                'log_file: {}\n'.format(root_dir, fpath)
             )
         # Let's set the environment variable, yet, since the configuration
         # file path is not the default one, i.e., the user has passed an
@@ -471,8 +466,8 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         with salt.utils.files.fopen(minion_config, 'w') as fp_:
             fp_.write(
                 'blah: false\n'
-                'root_dir: {0}\n'
-                'log_file: {1}\n'.format(tempdir, minion_config)
+                'root_dir: {}\n'
+                'log_file: {}\n'.format(tempdir, minion_config)
             )
 
         # Now, let's populate an extra configuration file under minion.d
@@ -485,7 +480,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             fp_.write('blah: true\n')
 
         # Let's load the configuration
-        config = sconfig.minion_config(minion_config)
+        config = salt.config.minion_config(minion_config)
 
         self.assertEqual(config['log_file'], minion_config)
         # As proven by the assertion below, blah is True
@@ -502,8 +497,8 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         with salt.utils.files.fopen(master_config, 'w') as fp_:
             fp_.write(
                 'blah: false\n'
-                'root_dir: {0}\n'
-                'log_file: {1}\n'.format(tempdir, master_config)
+                'root_dir: {}\n'
+                'log_file: {}\n'.format(tempdir, master_config)
             )
 
         # Now, let's populate an extra configuration file under master.d
@@ -516,7 +511,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             fp_.write('blah: true\n')
 
         # Let's load the configuration
-        config = sconfig.master_config(master_config)
+        config = salt.config.master_config(master_config)
 
         self.assertEqual(config['log_file'], master_config)
         # As proven by the assertion below, blah is True
@@ -535,9 +530,9 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             wfh.write(
                 'file_roots:\n'
                 '  base:\n'
-                '    - {0}'.format(os.path.join(tempdir, '*'))
+                '    - {}'.format(os.path.join(tempdir, '*'))
             )
-        config = sconfig.master_config(fpath)
+        config = salt.config.master_config(fpath)
         base = config['file_roots']['base']
         self.assertEqual(set(base), set([
             os.path.join(tempdir, 'a'),
@@ -567,9 +562,9 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             wfh.write(
                 'pillar_roots:\n'
                 '  base:\n'
-                '    - {0}'.format(os.path.join(tempdir, '*'))
+                '    - {}'.format(os.path.join(tempdir, '*'))
             )
-        config = sconfig.master_config(fpath)
+        config = salt.config.master_config(fpath)
         base = config['pillar_roots']['base']
         self.assertEqual(set(base), set([
             os.path.join(tempdir, 'a'),
@@ -595,12 +590,12 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                 'id_function:\n'
                 '  test.echo:\n'
                 '    text: hello_world\n'
-                'root_dir: {0}\n'
-                'log_file: {1}\n'.format(tempdir, master_config)
+                'root_dir: {}\n'
+                'log_file: {}\n'.format(tempdir, master_config)
             )
 
         # Let's load the configuration
-        config = sconfig.master_config(master_config)
+        config = salt.config.master_config(master_config)
 
         self.assertEqual(config['log_file'], master_config)
         # 'master_config' appends '_master' to the ID
@@ -619,9 +614,9 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             wfh.write(
                 'file_roots:\n'
                 '  base:\n'
-                '    - {0}'.format(os.path.join(tempdir, '*'))
+                '    - {}'.format(os.path.join(tempdir, '*'))
             )
-        config = sconfig.minion_config(fpath)
+        config = salt.config.minion_config(fpath)
         base = config['file_roots']['base']
         self.assertEqual(set(base), set([
             os.path.join(tempdir, 'a'),
@@ -642,9 +637,9 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             wfh.write(
                 'pillar_roots:\n'
                 '  base:\n'
-                '    - {0}'.format(os.path.join(tempdir, '*'))
+                '    - {}'.format(os.path.join(tempdir, '*'))
             )
-        config = sconfig.minion_config(fpath)
+        config = salt.config.minion_config(fpath)
         base = config['pillar_roots']['base']
         self.assertEqual(set(base), set([
             os.path.join(tempdir, 'a'),
@@ -661,12 +656,12 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                 'id_function:\n'
                 '  test.echo:\n'
                 '    text: hello_world\n'
-                'root_dir: {0}\n'
-                'log_file: {1}\n'.format(tempdir, minion_config)
+                'root_dir: {}\n'
+                'log_file: {}\n'.format(tempdir, minion_config)
             )
 
         # Let's load the configuration
-        config = sconfig.minion_config(minion_config)
+        config = salt.config.minion_config(minion_config)
 
         self.assertEqual(config['log_file'], minion_config)
         self.assertEqual(config['id'], 'hello_world')
@@ -687,7 +682,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                 minion_id_caching: False
                 minion_id_lowercase: True
             '''))
-        config = sconfig.minion_config(minion_config)               # Load the configuration
+        config = salt.config.minion_config(minion_config)               # Load the configuration
         self.assertEqual(config['minion_id_caching'], False)        # Check the configuration
         self.assertEqual(config['minion_id_lowercase'], True)       # Check the configuration
         self.assertEqual(config['id'], 'king_bob')
@@ -709,37 +704,34 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                   - minion
                 '''))
 
-        master_config = sconfig.master_config(fpath)
-        minion_config = sconfig.minion_config(fpath)
+        master_config = salt.config.master_config(fpath)
+        minion_config = salt.config.minion_config(fpath)
         expected = ['roots', 'gitfs', 'hgfs', 'svnfs', 'minionfs']
 
         self.assertEqual(master_config['fileserver_backend'], expected)
         self.assertEqual(minion_config['fileserver_backend'], expected)
 
     def test_syndic_config(self):
-        syndic_conf_path = self.get_config_file_path('syndic')
-        minion_conf_path = self.get_config_file_path('minion')
-        syndic_opts = sconfig.syndic_config(
-            syndic_conf_path, minion_conf_path
-        )
-        syndic_opts.update(salt.minion.resolve_dns(syndic_opts))
+        minion_conf_path = self.get_config_file_path('syndic')
+        master_conf_path = os.path.join(os.path.dirname(minion_conf_path), 'master')
+        syndic_opts = salt.config.syndic_config(master_conf_path, minion_conf_path)
         root_dir = syndic_opts['root_dir']
         # id & pki dir are shared & so configured on the minion side
-        self.assertEqual(syndic_opts['id'], 'minion')
+        self.assertEqual(syndic_opts['id'], 'syndic')
         self.assertEqual(syndic_opts['pki_dir'], os.path.join(root_dir, 'pki'))
         # the rest is configured master side
-        self.assertIn(syndic_opts['master_uri'], ['tcp://127.0.0.1:54506', 'tcp://[::1]:54506'])
-        self.assertEqual(syndic_opts['master_port'], 54506)
-        self.assertIn(syndic_opts['master_ip'], ['127.0.0.1', '[::1]'])
+        if RUNTIME_VARS.PYTEST_SESSION is False:
+            # Pytest assigns ports dynamically
+            self.assertEqual(syndic_opts['master_port'], 54506)
         self.assertEqual(syndic_opts['master'], 'localhost')
-        self.assertEqual(syndic_opts['sock_dir'], os.path.join(root_dir, 'minion_sock'))
+        self.assertEqual(syndic_opts['sock_dir'], os.path.join(root_dir, 'syndic_sock'))
         self.assertEqual(syndic_opts['cachedir'], os.path.join(root_dir, 'cache'))
-        self.assertEqual(syndic_opts['log_file'], os.path.join(root_dir, 'syndic.log'))
-        self.assertEqual(syndic_opts['pidfile'], os.path.join(root_dir, 'syndic.pid'))
+        self.assertEqual(syndic_opts['log_file'], os.path.join(root_dir, 'logs', 'syndic.log'))
+        self.assertEqual(syndic_opts['pidfile'], os.path.join(root_dir, 'run', 'syndic.pid'))
         # Show that the options of localclient that repub to local master
         # are not merged with syndic ones
         self.assertEqual(syndic_opts['_master_conf_file'], minion_conf_path)
-        self.assertEqual(syndic_opts['_minion_conf_file'], syndic_conf_path)
+        self.assertEqual(syndic_opts['_minion_conf_file'], master_conf_path)
 
     @with_tempfile()
     def _get_tally(self, fpath, conf_func):
@@ -791,7 +783,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                       - foo
                       - bar
                       - baz'''))
-            if conf_func is sconfig.master_config:
+            if conf_func is salt.config.master_config:
                 wfh.write('\n\n')
                 wfh.write(textwrap.dedent('''
                     rest_cherrypy:
@@ -808,7 +800,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         '''
         This ensures that any strings which are loaded are unicode strings
         '''
-        tally = self._get_tally(sconfig.master_config)  # pylint: disable=no-value-for-parameter
+        tally = self._get_tally(salt.config.master_config)  # pylint: disable=no-value-for-parameter
         non_unicode = tally.get('non_unicode', [])
         self.assertEqual(len(non_unicode), 8 if six.PY2 else 0, non_unicode)
         self.assertTrue(tally['unicode'] > 0)
@@ -817,7 +809,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         '''
         This ensures that any strings which are loaded are unicode strings
         '''
-        tally = self._get_tally(sconfig.minion_config)  # pylint: disable=no-value-for-parameter
+        tally = self._get_tally(salt.config.minion_config)  # pylint: disable=no-value-for-parameter
         non_unicode = tally.get('non_unicode', [])
         self.assertEqual(len(non_unicode), 0, non_unicode)
         self.assertTrue(tally['unicode'] > 0)
@@ -832,7 +824,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         Tests passing in master_config_path and master_config kwargs.
         '''
         with patch('salt.config.load_config', MagicMock(return_value={})):
-            self.assertRaises(SaltCloudConfigError, sconfig.cloud_config, PATH,
+            self.assertRaises(SaltCloudConfigError, salt.config.cloud_config, PATH,
                               master_config_path='foo', master_config='bar')
 
     @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -841,7 +833,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         Tests passing in providers_config_path and providers_config kwargs.
         '''
         with patch('salt.config.load_config', MagicMock(return_value={})):
-            self.assertRaises(SaltCloudConfigError, sconfig.cloud_config, PATH,
+            self.assertRaises(SaltCloudConfigError, salt.config.cloud_config, PATH,
                               providers_config_path='foo', providers_config='bar')
 
     @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -850,7 +842,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         Tests passing in profiles_config_path and profiles_config kwargs.
         '''
         with patch('salt.config.load_config', MagicMock(return_value={})):
-            self.assertRaises(SaltCloudConfigError, sconfig.cloud_config, PATH,
+            self.assertRaises(SaltCloudConfigError, salt.config.cloud_config, PATH,
                               profiles_config_path='foo', profiles_config='bar')
 
     @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -862,7 +854,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         with patch('salt.config.load_config', MagicMock(return_value={})):
             with patch('salt.config.apply_cloud_config',
                        MagicMock(return_value={'providers': 'foo'})):
-                self.assertRaises(SaltCloudConfigError, sconfig.cloud_config, PATH,
+                self.assertRaises(SaltCloudConfigError, salt.config.cloud_config, PATH,
                                   providers_config='bar')
 
     @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -875,7 +867,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             with patch('salt.config.apply_cloud_config',
                        MagicMock(return_value={'providers': 'foo'})):
                 with patch('os.path.isfile', MagicMock(return_value=True)):
-                    self.assertRaises(SaltCloudConfigError, sconfig.cloud_config, PATH,
+                    self.assertRaises(SaltCloudConfigError, salt.config.cloud_config, PATH,
                                       providers_config_path='bar')
 
     @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -891,7 +883,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         the path.
         '''
         with patch('os.path.isdir', MagicMock(return_value=True)):
-            search_paths = sconfig.cloud_config('/etc/salt/cloud').get('deploy_scripts_search_path')
+            search_paths = salt.config.cloud_config('/etc/salt/cloud').get('deploy_scripts_search_path')
             etc_deploy_path = '/salt/cloud.deploy.d'
             deploy_path = '/salt/cloud/deploy'
             if salt.utils.platform.is_windows():
@@ -911,7 +903,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         Tests when the provider is not contained in a list of details
         '''
         overrides = {'providers': {'foo': [{'bar': 'baz'}]}}
-        self.assertRaises(SaltCloudConfigError, sconfig.apply_cloud_config,
+        self.assertRaises(SaltCloudConfigError, salt.config.apply_cloud_config,
                           overrides, defaults=DEFAULT)
 
     def test_apply_cloud_config_no_provider_detail_dict(self):
@@ -919,7 +911,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         Tests when the provider is not contained in the details dictionary
         '''
         overrides = {'providers': {'foo': {'bar': 'baz'}}}
-        self.assertRaises(SaltCloudConfigError, sconfig.apply_cloud_config,
+        self.assertRaises(SaltCloudConfigError, salt.config.apply_cloud_config,
                           overrides, defaults=DEFAULT)
 
     @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -936,7 +928,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             overrides = {'providers': {'foo': [{'driver': 'bar'}]}}
             ret = {'default_include': 'path/to/some/cloud/conf/file',
                    'providers': {'foo': {'bar': {'driver': 'foo:bar'}}}}
-            self.assertEqual(sconfig.apply_cloud_config(overrides, defaults=DEFAULT), ret)
+            self.assertEqual(salt.config.apply_cloud_config(overrides, defaults=DEFAULT), ret)
 
     @skipIf(NO_MOCK, NO_MOCK_REASON)
     def test_apply_cloud_config_success_dict(self):
@@ -952,7 +944,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             overrides = {'providers': {'foo': {'driver': 'bar'}}}
             ret = {'default_include': 'path/to/some/cloud/conf/file',
                    'providers': {'foo': {'bar': {'driver': 'foo:bar'}}}}
-            self.assertEqual(sconfig.apply_cloud_config(overrides, defaults=DEFAULT), ret)
+            self.assertEqual(salt.config.apply_cloud_config(overrides, defaults=DEFAULT), ret)
 
     # apply_vm_profiles_config tests
 
@@ -961,7 +953,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         Tests passing in a bad profile format in overrides
         '''
         overrides = {'foo': 'bar', 'conf_file': PATH}
-        self.assertRaises(SaltCloudConfigError, sconfig.apply_vm_profiles_config,
+        self.assertRaises(SaltCloudConfigError, salt.config.apply_vm_profiles_config,
                           PATH, overrides, defaults=DEFAULT)
 
     def test_apply_vm_profiles_config_success(self):
@@ -981,7 +973,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                     'provider': 'test-provider:digitalocean',
                     'image': 'Ubuntu 12.10 x64',
                     'size': '512MB'}}
-        self.assertEqual(sconfig.apply_vm_profiles_config(providers,
+        self.assertEqual(salt.config.apply_vm_profiles_config(providers,
                                                           overrides,
                                                           defaults=DEFAULT), ret)
 
@@ -1008,7 +1000,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                'dev-instances': {'profile': 'dev-instances',
                                  'ssh_username': 'test_user',
                                  'provider': 'test-config:ec2'}}
-        self.assertEqual(sconfig.apply_vm_profiles_config(providers,
+        self.assertEqual(salt.config.apply_vm_profiles_config(providers,
                                                           overrides,
                                                           defaults=DEFAULT), ret)
 
@@ -1035,7 +1027,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                                  'ssh_username': 'test_user',
                                  'minion': {'grains': {'role': 'webserver'}},
                                  'provider': 'test-config:ec2'}}
-        self.assertEqual(sconfig.apply_vm_profiles_config(providers,
+        self.assertEqual(salt.config.apply_vm_profiles_config(providers,
                                                           overrides,
                                                           defaults=DEFAULT), ret)
 
@@ -1054,7 +1046,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                            'driver': 'ec2'}],
                      'conf_file': PATH}
         self.assertRaises(SaltCloudConfigError,
-                          sconfig.apply_cloud_providers_config,
+                          salt.config.apply_cloud_providers_config,
                           overrides,
                           DEFAULT)
 
@@ -1101,7 +1093,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                          'id': 'ABCDEFGHIJKLMNOP',
                          'user': 'user@mycorp.com'}}}
         self.assertEqual(ret,
-                         sconfig.apply_cloud_providers_config(
+                         salt.config.apply_cloud_providers_config(
                              overrides,
                              defaults=DEFAULT))
 
@@ -1154,7 +1146,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                          'driver': 'ec2',
                          'id': 'ABCDEFGHIJKLMNOP',
                          'location': 'ap-southeast-1'}}}
-        self.assertEqual(ret, sconfig.apply_cloud_providers_config(
+        self.assertEqual(ret, salt.config.apply_cloud_providers_config(
             overrides,
             defaults=DEFAULT))
 
@@ -1174,7 +1166,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                            'driver': 'ec2'}],
                      'conf_file': PATH}
         self.assertRaises(SaltCloudConfigError,
-                          sconfig.apply_cloud_providers_config,
+                          salt.config.apply_cloud_providers_config,
                           overrides,
                           DEFAULT)
 
@@ -1194,7 +1186,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                            'driver': 'ec2'}],
                      'conf_file': PATH}
         self.assertRaises(SaltCloudConfigError,
-                          sconfig.apply_cloud_providers_config,
+                          salt.config.apply_cloud_providers_config,
                           overrides,
                           DEFAULT)
 
@@ -1214,7 +1206,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                            'driver': 'linode'}],
                      'conf_file': PATH}
         self.assertRaises(SaltCloudConfigError,
-                          sconfig.apply_cloud_providers_config,
+                          salt.config.apply_cloud_providers_config,
                           overrides,
                           DEFAULT)
 
@@ -1234,7 +1226,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                            'driver': 'linode'}],
                      'conf_file': PATH}
         self.assertRaises(SaltCloudConfigError,
-                          sconfig.apply_cloud_providers_config,
+                          salt.config.apply_cloud_providers_config,
                           overrides,
                           DEFAULT)
 
@@ -1246,7 +1238,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         '''
         opts = {'providers': 'test'}
         provider = 'foo:bar'
-        self.assertFalse(sconfig.is_provider_configured(opts, provider))
+        self.assertFalse(salt.config.is_provider_configured(opts, provider))
 
     def test_is_provider_configured_no_driver(self):
         '''
@@ -1254,7 +1246,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         '''
         opts = {'providers': {'foo': 'baz'}}
         provider = 'foo:bar'
-        self.assertFalse(sconfig.is_provider_configured(opts, provider))
+        self.assertFalse(salt.config.is_provider_configured(opts, provider))
 
     def test_is_provider_configured_key_is_none(self):
         '''
@@ -1263,7 +1255,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         opts = {'providers': {'foo': {'bar': {'api_key': None}}}}
         provider = 'foo:bar'
         self.assertFalse(
-            sconfig.is_provider_configured(opts,
+            salt.config.is_provider_configured(opts,
                                            provider,
                                            required_keys=('api_key',)))
 
@@ -1275,7 +1267,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         provider = 'foo:bar'
         ret = {'api_key': 'baz'}
         self.assertEqual(
-            sconfig.is_provider_configured(opts,
+            salt.config.is_provider_configured(opts,
                                            provider,
                                            required_keys=('api_key',)), ret)
 
@@ -1286,7 +1278,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         '''
         opts = {'providers': {'foo': {'bar': {'api_key': 'baz'}}}}
         provider = 'foo'
-        self.assertFalse(sconfig.is_provider_configured(opts, provider))
+        self.assertFalse(salt.config.is_provider_configured(opts, provider))
 
     def test_is_provider_configured_multiple_key_is_none(self):
         '''
@@ -1296,7 +1288,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         opts = {'providers': {'foo': {'bar': {'api_key': None}}}}
         provider = 'bar'
         self.assertFalse(
-            sconfig.is_provider_configured(opts,
+            salt.config.is_provider_configured(opts,
                                            provider,
                                            required_keys=('api_key',)))
 
@@ -1309,7 +1301,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         provider = 'bar'
         ret = {'api_key': 'baz'}
         self.assertEqual(
-            sconfig.is_provider_configured(opts,
+            salt.config.is_provider_configured(opts,
                                            provider,
                                            required_keys=('api_key',)), ret)
 
@@ -1332,7 +1324,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
 
         with patched_environ(SALT_CLOUD_CONFIG=env_fpath):
             # Should load from env variable, not the default configuration file
-            config = sconfig.cloud_config('/etc/salt/cloud')
+            config = salt.config.cloud_config('/etc/salt/cloud')
             self.assertEqual(config['log_file'], env_fpath)
 
         root_dir = os.path.join(tempdir, 'foo', 'bar')
@@ -1359,12 +1351,12 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             if not os.path.isdir(directory):
                 os.makedirs(directory)
 
-        default_config = sconfig.cloud_config(config_file_path)
+        default_config = salt.config.cloud_config(config_file_path)
         default_config['deploy_scripts_search_path'] = deploy_dir_path
         with salt.utils.files.fopen(config_file_path, 'w') as cfd:
             salt.utils.yaml.safe_dump(default_config, cfd, default_flow_style=False)
 
-        default_config = sconfig.cloud_config(config_file_path)
+        default_config = salt.config.cloud_config(config_file_path)
 
         # Our custom deploy scripts path was correctly added to the list
         self.assertIn(
@@ -1383,7 +1375,8 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         Tests that cloud.{providers,profiles}.d directories are loaded, even if not
         directly passed in through path
         '''
-        config = sconfig.cloud_config(self.get_config_file_path('cloud'))
+        log.warning('Clound config file path: %s', self.get_config_file_path('cloud'))
+        config = salt.config.cloud_config(self.get_config_file_path('cloud'))
         self.assertIn('ec2-config', config['providers'])
         self.assertIn('ec2-test', config['profiles'])
 
@@ -1400,7 +1393,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
 
         with patch('glob.glob', MagicMock(return_value=include_file)):
             with patch('salt.config._read_conf_file', MagicMock(return_value=config_opts)):
-                configuration = sconfig.include_config(include_file, config_path, verbose=False)
+                configuration = salt.config.include_config(include_file, config_path, verbose=False)
 
         self.assertEqual(config_opts, configuration)
 
@@ -1415,7 +1408,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
 
         with patch('glob.glob', MagicMock(return_value=include_file)):
             with patch('salt.config._read_conf_file', _salt_configuration_error):
-                configuration = sconfig.include_config(include_file, config_path, verbose=False)
+                configuration = salt.config.include_config(include_file, config_path, verbose=False)
 
         self.assertEqual(config_opts, configuration)
 
@@ -1430,7 +1423,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         with patch('glob.glob', MagicMock(return_value=include_file)):
             with patch('salt.config._read_conf_file', _salt_configuration_error):
                 with self.assertRaises(SystemExit):
-                    sconfig.include_config(include_file,
+                    salt.config.include_config(include_file,
                                            config_path,
                                            verbose=False,
                                            exit_on_config_errors=True)
@@ -1462,36 +1455,36 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         '''
         Ensure that the environment and saltenv options work properly
         '''
-        with patch.object(sconfig, '_adjust_log_file_override', Mock()), \
-                patch.object(sconfig, '_update_ssl_config', Mock()), \
-                patch.object(sconfig, '_update_discovery_config', Mock()):
+        with patch.object(salt.config, '_adjust_log_file_override', Mock()), \
+                patch.object(salt.config, '_update_ssl_config', Mock()), \
+                patch.object(salt.config, '_update_discovery_config', Mock()):
 
             # MASTER CONFIG
 
             # Ensure that environment overrides saltenv when saltenv not
             # explicitly passed.
             defaults = self._get_defaults(environment='foo')
-            ret = sconfig.apply_master_config(defaults=defaults)
+            ret = salt.config.apply_master_config(defaults=defaults)
             self.assertEqual(ret['environment'], 'foo')
             self.assertEqual(ret['saltenv'], 'foo')
 
             # Ensure that environment overrides saltenv when saltenv not
             # explicitly passed.
             defaults = self._get_defaults(environment='foo', saltenv='bar')
-            ret = sconfig.apply_master_config(defaults=defaults)
+            ret = salt.config.apply_master_config(defaults=defaults)
             self.assertEqual(ret['environment'], 'bar')
             self.assertEqual(ret['saltenv'], 'bar')
 
             # If environment was not explicitly set, it should not be in the
             # opts at all.
             defaults = self._get_defaults()
-            ret = sconfig.apply_master_config(defaults=defaults)
+            ret = salt.config.apply_master_config(defaults=defaults)
             self.assertNotIn('environment', ret)
             self.assertEqual(ret['saltenv'], None)
 
             # Same test as above but with saltenv explicitly set
             defaults = self._get_defaults(saltenv='foo')
-            ret = sconfig.apply_master_config(defaults=defaults)
+            ret = salt.config.apply_master_config(defaults=defaults)
             self.assertNotIn('environment', ret)
             self.assertEqual(ret['saltenv'], 'foo')
 
@@ -1500,27 +1493,27 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             # Ensure that environment overrides saltenv when saltenv not
             # explicitly passed.
             defaults = self._get_defaults(environment='foo')
-            ret = sconfig.apply_minion_config(defaults=defaults)
+            ret = salt.config.apply_minion_config(defaults=defaults)
             self.assertEqual(ret['environment'], 'foo')
             self.assertEqual(ret['saltenv'], 'foo')
 
             # Ensure that environment overrides saltenv when saltenv not
             # explicitly passed.
             defaults = self._get_defaults(environment='foo', saltenv='bar')
-            ret = sconfig.apply_minion_config(defaults=defaults)
+            ret = salt.config.apply_minion_config(defaults=defaults)
             self.assertEqual(ret['environment'], 'bar')
             self.assertEqual(ret['saltenv'], 'bar')
 
             # If environment was not explicitly set, it should not be in the
             # opts at all.
             defaults = self._get_defaults()
-            ret = sconfig.apply_minion_config(defaults=defaults)
+            ret = salt.config.apply_minion_config(defaults=defaults)
             self.assertNotIn('environment', ret)
             self.assertEqual(ret['saltenv'], None)
 
             # Same test as above but with saltenv explicitly set
             defaults = self._get_defaults(saltenv='foo')
-            ret = sconfig.apply_minion_config(defaults=defaults)
+            ret = salt.config.apply_minion_config(defaults=defaults)
             self.assertNotIn('environment', ret)
             self.assertEqual(ret['saltenv'], 'foo')
 
@@ -1546,11 +1539,11 @@ class APIConfigTestCase(TestCase):
         '''
         with patch('salt.config.client_config', MagicMock(return_value=MOCK_MASTER_DEFAULT_OPTS)):
 
-            expected = '{0}/var/log/salt/api'.format(
-                salt.syspaths.ROOT_DIR if salt.syspaths.ROOT_DIR != '/' else '')
+            expected = '{}/var/log/salt/api'.format(
+                RUNTIME_VARS.TMP_ROOT_DIR if RUNTIME_VARS.TMP_ROOT_DIR != '/' else '')
             if salt.utils.platform.is_windows():
-                expected = '{0}\\var\\log\\salt\\api'.format(
-                    salt.syspaths.ROOT_DIR)
+                expected = '{}\\var\\log\\salt\\api'.format(
+                    RUNTIME_VARS.TMP_ROOT_DIR)
 
             ret = salt.config.api_config('/some/fake/path')
             self.assertEqual(ret['log_file'], expected)
@@ -1563,27 +1556,26 @@ class APIConfigTestCase(TestCase):
         '''
         with patch('salt.config.client_config', MagicMock(return_value=MOCK_MASTER_DEFAULT_OPTS)):
 
-            expected = '{0}/var/run/salt-api.pid'.format(
-                salt.syspaths.ROOT_DIR if salt.syspaths.ROOT_DIR != '/' else '')
+            expected = '{}/var/run/salt-api.pid'.format(
+                RUNTIME_VARS.TMP_ROOT_DIR if RUNTIME_VARS.TMP_ROOT_DIR != '/' else '')
             if salt.utils.platform.is_windows():
-                expected = '{0}\\var\\run\\salt-api.pid'.format(
-                    salt.syspaths.ROOT_DIR)
+                expected = '{}\\var\\run\\salt-api.pid'.format(
+                    RUNTIME_VARS.TMP_ROOT_DIR)
 
             ret = salt.config.api_config('/some/fake/path')
             self.assertEqual(ret['pidfile'], expected)
 
-    @destructiveTest
     def test_master_config_file_overrides_defaults(self):
         '''
         Tests the opts value of the api config values after running through the
         various default dict updates that should be overridden by settings in
         the user's master config file.
         '''
-        foo_dir = '/foo/bar/baz'
-        hello_dir = '/hello/world'
+        foo_dir = os.path.join(RUNTIME_VARS.TMP_ROOT_DIR, 'foo/bar/baz')
+        hello_dir = os.path.join(RUNTIME_VARS.TMP_ROOT_DIR, 'hello/world')
         if salt.utils.platform.is_windows():
-            foo_dir = 'c:\\foo\\bar\\baz'
-            hello_dir = 'c:\\hello\\world'
+            foo_dir = 'c:\\{}'.format(foo_dir.replace('/', '\\'))
+            hello_dir = 'c:\\{}'.format(hello_dir.replace('/', '\\'))
 
         mock_master_config = {
             'api_pidfile': foo_dir,
@@ -1601,7 +1593,6 @@ class APIConfigTestCase(TestCase):
             self.assertEqual(ret['api_logfile'], hello_dir)
             self.assertEqual(ret['log_file'], hello_dir)
 
-    @destructiveTest
     def test_api_config_prepend_root_dirs_return(self):
         '''
         Tests the opts value of the api_logfile, log_file, api_pidfile, and pidfile

--- a/tests/unit/utils/test_cloud.py
+++ b/tests/unit/utils/test_cloud.py
@@ -12,62 +12,69 @@
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
 import os
+import shutil
 import tempfile
 
 # Import Salt Testing libs
 from tests.support.runtests import RUNTIME_VARS
-from tests.support.unit import TestCase, skipIf
+from tests.support.unit import TestCase, skipIf, SkipTest
 
 # Import salt libs
 import salt.utils.cloud as cloud
 import salt.utils.platform
 from salt.ext import six
 
-GPG_KEYDIR = os.path.join(RUNTIME_VARS.TMP, 'gpg-keydir')
-
-# The keyring library uses `getcwd()`, let's make sure we in a good directory
-# before importing keyring
-if not os.path.isdir(GPG_KEYDIR):
-    os.makedirs(GPG_KEYDIR)
-
-os.chdir(GPG_KEYDIR)
-
-# Import external deps
-try:
-    import keyring
-    import keyring.backend
-
-    class TestKeyring(keyring.backend.KeyringBackend):
-        '''
-        A test keyring which always outputs same password
-        '''
-        def __init__(self):
-            self.__storage = {}
-
-        def supported(self):
-            return 0
-
-        def set_password(self, servicename, username, password):
-            self.__storage.setdefault(servicename, {}).update({username: password})
-            return 0
-
-        def get_password(self, servicename, username):
-            return self.__storage.setdefault(servicename, {}).get(username, None)
-
-        def delete_password(self, servicename, username):
-            self.__storage.setdefault(servicename, {}).pop(username, None)
-            return 0
-
-    # set the keyring for keyring lib
-    keyring.set_keyring(TestKeyring())
-    HAS_KEYRING = True
-except ImportError:
-    HAS_KEYRING = False
-finally:
-    os.chdir(RUNTIME_VARS.CODE_DIR)
-
 
 class CloudUtilsTestCase(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        old_cwd = os.getcwd()
+        cls.gpg_keydir = gpg_keydir = os.path.join(RUNTIME_VARS.TMP, 'gpg-keydir')
+        try:
+            # The keyring library uses `getcwd()`, let's make sure we in a good directory
+            # before importing keyring
+            if not os.path.isdir(gpg_keydir):
+                os.makedirs(gpg_keydir)
+            os.chdir(gpg_keydir)
+
+            # Late import because of the above reason
+            import keyring
+            import keyring.backend
+
+            class CustomKeyring(keyring.backend.KeyringBackend):
+                '''
+                A test keyring which always outputs same password
+                '''
+                def __init__(self):
+                    self.__storage = {}
+
+                def supported(self):
+                    return 0
+
+                def set_password(self, servicename, username, password):
+                    self.__storage.setdefault(servicename, {}).update({username: password})
+                    return 0
+
+                def get_password(self, servicename, username):
+                    return self.__storage.setdefault(servicename, {}).get(username, None)
+
+                def delete_password(self, servicename, username):
+                    self.__storage.setdefault(servicename, {}).pop(username, None)
+                    return 0
+
+            # set the keyring for keyring lib
+            keyring.set_keyring(CustomKeyring())
+        except ImportError:
+            raise SkipTest('The "keyring" python module is not installed')
+        finally:
+            os.chdir(old_cwd)
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.exists(cls.gpg_keydir):
+            shutil.rmtree(cls.gpg_keydir)
+        del cls.gpg_keydir
 
     def test_ssh_password_regex(self):
         '''Test matching ssh password patterns'''
@@ -87,11 +94,12 @@ class CloudUtilsTestCase(TestCase):
                 cloud.SSH_PASSWORD_PROMP_RE.match(pattern.lower().strip()), None
             )
 
-    @skipIf(HAS_KEYRING is False, 'The "keyring" python module is not installed')
     def test__save_password_in_keyring(self):
         '''
         Test storing password in the keyring
         '''
+        # Late import
+        import keyring
         cloud._save_password_in_keyring(
             'salt.cloud.provider.test_case_provider',
             'fake_username',
@@ -107,8 +115,9 @@ class CloudUtilsTestCase(TestCase):
         )
         self.assertEqual(stored_pw, 'fake_password_c8231')
 
-    @skipIf(HAS_KEYRING is False, 'The "keyring" python module is not installed')
     def test_retrieve_password_from_keyring(self):
+        # Late import
+        import keyring
         keyring.set_password(
             'salt.cloud.provider.test_case_provider',
             'fake_username',

--- a/tests/unit/utils/test_event.py
+++ b/tests/unit/utils/test_event.py
@@ -12,86 +12,41 @@ from __future__ import absolute_import, unicode_literals, print_function
 import os
 import hashlib
 import time
+import shutil
 import warnings
+
+# Import Salt Testing libs
+from tests.support.unit import expectedFailure, skipIf, TestCase
+from tests.support.runtests import RUNTIME_VARS
+from tests.support.events import eventpublisher_process, eventsender_process
+
+# Import salt libs
+import salt.config
+import salt.utils.event
+import salt.utils.stringutils
+
+# Import 3rd-+arty libs
 from tornado.testing import AsyncTestCase
 import zmq
 import zmq.eventloop.ioloop
 # support pyzmq 13.0.x, TODO: remove once we force people to 14.0.x
 if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
     zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
-from contextlib import contextmanager
-from multiprocessing import Process
-
-# Import Salt Testing libs
-from tests.support.unit import expectedFailure, skipIf, TestCase
-from tests.support.runtests import RUNTIME_VARS
-
-# Import salt libs
-import salt.config
-import salt.utils.event
-import salt.utils.stringutils
-from salt.utils.process import clean_proc
-
-# Import 3rd-+arty libs
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 from tests.support.processes import terminate_process
-
-SOCK_DIR = os.path.join(RUNTIME_VARS.TMP, 'test-socks')
 
 NO_LONG_IPC = False
 if getattr(zmq, 'IPC_PATH_MAX_LEN', 103) <= 103:
     NO_LONG_IPC = True
 
 
-@contextmanager
-def eventpublisher_process():
-    proc = salt.utils.event.EventPublisher({'sock_dir': SOCK_DIR})
-    proc.start()
-    try:
-        if os.environ.get('TRAVIS_PYTHON_VERSION', None) is not None:
-            # Travis is slow
-            time.sleep(10)
-        else:
-            time.sleep(2)
-        yield
-    finally:
-        clean_proc(proc)
-
-
-class EventSender(Process):
-    def __init__(self, data, tag, wait):
-        super(EventSender, self).__init__()
-        self.data = data
-        self.tag = tag
-        self.wait = wait
-
-    def run(self):
-        me = salt.utils.event.MasterEvent(SOCK_DIR, listen=False)
-        time.sleep(self.wait)
-        me.fire_event(self.data, self.tag)
-        # Wait a few seconds before tearing down the zmq context
-        if os.environ.get('TRAVIS_PYTHON_VERSION', None) is not None:
-            # Travis is slow
-            time.sleep(10)
-        else:
-            time.sleep(2)
-
-
-@contextmanager
-def eventsender_process(data, tag, wait=0):
-    proc = EventSender(data, tag, wait)
-    proc.start()
-    try:
-        yield
-    finally:
-        clean_proc(proc)
-
-
 @skipIf(NO_LONG_IPC, "This system does not support long IPC paths. Skipping event tests!")
 class TestSaltEvent(TestCase):
     def setUp(self):
-        if not os.path.exists(SOCK_DIR):
-            os.makedirs(SOCK_DIR)
+        self.sock_dir = os.path.join(RUNTIME_VARS.TMP, 'test-socks')
+        if not os.path.exists(self.sock_dir):
+            os.makedirs(self.sock_dir)
+        self.addCleanup(shutil.rmtree, self.sock_dir, ignore_errors=True)
 
     def assertGotEvent(self, evt, data, msg=None):
         self.assertIsNotNone(evt, msg)
@@ -102,28 +57,28 @@ class TestSaltEvent(TestCase):
             self.assertEqual(data[key], evt[key], assertMsg)
 
     def test_master_event(self):
-        me = salt.utils.event.MasterEvent(SOCK_DIR, listen=False)
+        me = salt.utils.event.MasterEvent(self.sock_dir, listen=False)
         self.assertEqual(
             me.puburi, '{0}'.format(
-                os.path.join(SOCK_DIR, 'master_event_pub.ipc')
+                os.path.join(self.sock_dir, 'master_event_pub.ipc')
             )
         )
         self.assertEqual(
             me.pulluri,
             '{0}'.format(
-                os.path.join(SOCK_DIR, 'master_event_pull.ipc')
+                os.path.join(self.sock_dir, 'master_event_pull.ipc')
             )
         )
 
     def test_minion_event(self):
-        opts = dict(id='foo', sock_dir=SOCK_DIR)
+        opts = dict(id='foo', sock_dir=self.sock_dir)
         id_hash = hashlib.sha256(salt.utils.stringutils.to_bytes(opts['id'])).hexdigest()[:10]
         me = salt.utils.event.MinionEvent(opts, listen=False)
         self.assertEqual(
             me.puburi,
             '{0}'.format(
                 os.path.join(
-                    SOCK_DIR, 'minion_event_{0}_pub.ipc'.format(id_hash)
+                    self.sock_dir, 'minion_event_{0}_pub.ipc'.format(id_hash)
                 )
             )
         )
@@ -131,7 +86,7 @@ class TestSaltEvent(TestCase):
             me.pulluri,
             '{0}'.format(
                 os.path.join(
-                    SOCK_DIR, 'minion_event_{0}_pull.ipc'.format(id_hash)
+                    self.sock_dir, 'minion_event_{0}_pull.ipc'.format(id_hash)
                 )
             )
         )
@@ -143,13 +98,13 @@ class TestSaltEvent(TestCase):
         self.assertEqual(me.pulluri, 4511)
 
     def test_minion_event_no_id(self):
-        me = salt.utils.event.MinionEvent(dict(sock_dir=SOCK_DIR), listen=False)
+        me = salt.utils.event.MinionEvent(dict(sock_dir=self.sock_dir), listen=False)
         id_hash = hashlib.sha256(salt.utils.stringutils.to_bytes('')).hexdigest()[:10]
         self.assertEqual(
             me.puburi,
             '{0}'.format(
                 os.path.join(
-                    SOCK_DIR, 'minion_event_{0}_pub.ipc'.format(id_hash)
+                    self.sock_dir, 'minion_event_{0}_pub.ipc'.format(id_hash)
                 )
             )
         )
@@ -157,23 +112,23 @@ class TestSaltEvent(TestCase):
             me.pulluri,
             '{0}'.format(
                 os.path.join(
-                    SOCK_DIR, 'minion_event_{0}_pull.ipc'.format(id_hash)
+                    self.sock_dir, 'minion_event_{0}_pull.ipc'.format(id_hash)
                 )
             )
         )
 
     def test_event_single(self):
         '''Test a single event is received'''
-        with eventpublisher_process():
-            me = salt.utils.event.MasterEvent(SOCK_DIR, listen=True)
+        with eventpublisher_process(self.sock_dir):
+            me = salt.utils.event.MasterEvent(self.sock_dir, listen=True)
             me.fire_event({'data': 'foo1'}, 'evt1')
             evt1 = me.get_event(tag='evt1')
             self.assertGotEvent(evt1, {'data': 'foo1'})
 
     def test_event_single_no_block(self):
         '''Test a single event is received, no block'''
-        with eventpublisher_process():
-            me = salt.utils.event.MasterEvent(SOCK_DIR, listen=True)
+        with eventpublisher_process(self.sock_dir):
+            me = salt.utils.event.MasterEvent(self.sock_dir, listen=True)
             start = time.time()
             finish = start + 5
             evt1 = me.get_event(wait=0, tag='evt1', no_block=True)
@@ -188,8 +143,8 @@ class TestSaltEvent(TestCase):
 
     def test_event_single_wait_0_no_block_False(self):
         '''Test a single event is received with wait=0 and no_block=False and doesn't spin the while loop'''
-        with eventpublisher_process():
-            me = salt.utils.event.MasterEvent(SOCK_DIR, listen=True)
+        with eventpublisher_process(self.sock_dir):
+            me = salt.utils.event.MasterEvent(self.sock_dir, listen=True)
             me.fire_event({'data': 'foo1'}, 'evt1')
             # This is too fast and will be None but assures we're not blocking
             evt1 = me.get_event(wait=0, tag='evt1', no_block=False)
@@ -197,8 +152,8 @@ class TestSaltEvent(TestCase):
 
     def test_event_timeout(self):
         '''Test no event is received if the timeout is reached'''
-        with eventpublisher_process():
-            me = salt.utils.event.MasterEvent(SOCK_DIR, listen=True)
+        with eventpublisher_process(self.sock_dir):
+            me = salt.utils.event.MasterEvent(self.sock_dir, listen=True)
             me.fire_event({'data': 'foo1'}, 'evt1')
             evt1 = me.get_event(tag='evt1')
             self.assertGotEvent(evt1, {'data': 'foo1'})
@@ -207,48 +162,48 @@ class TestSaltEvent(TestCase):
 
     def test_event_no_timeout(self):
         '''Test no wait timeout, we should block forever, until we get one '''
-        with eventpublisher_process():
-            me = salt.utils.event.MasterEvent(SOCK_DIR, listen=True)
-            with eventsender_process({'data': 'foo2'}, 'evt2', 5):
+        with eventpublisher_process(self.sock_dir):
+            me = salt.utils.event.MasterEvent(self.sock_dir, listen=True)
+            with eventsender_process({'data': 'foo2'}, 'evt2', self.sock_dir, 5):
                 evt = me.get_event(tag='evt2', wait=0, no_block=False)
             self.assertGotEvent(evt, {'data': 'foo2'})
 
     def test_event_matching(self):
         '''Test a startswith match'''
-        with eventpublisher_process():
-            me = salt.utils.event.MasterEvent(SOCK_DIR, listen=True)
+        with eventpublisher_process(self.sock_dir):
+            me = salt.utils.event.MasterEvent(self.sock_dir, listen=True)
             me.fire_event({'data': 'foo1'}, 'evt1')
             evt1 = me.get_event(tag='ev')
             self.assertGotEvent(evt1, {'data': 'foo1'})
 
     def test_event_matching_regex(self):
         '''Test a regex match'''
-        with eventpublisher_process():
-            me = salt.utils.event.MasterEvent(SOCK_DIR, listen=True)
+        with eventpublisher_process(self.sock_dir):
+            me = salt.utils.event.MasterEvent(self.sock_dir, listen=True)
             me.fire_event({'data': 'foo1'}, 'evt1')
             evt1 = me.get_event(tag='^ev', match_type='regex')
             self.assertGotEvent(evt1, {'data': 'foo1'})
 
     def test_event_matching_all(self):
         '''Test an all match'''
-        with eventpublisher_process():
-            me = salt.utils.event.MasterEvent(SOCK_DIR, listen=True)
+        with eventpublisher_process(self.sock_dir):
+            me = salt.utils.event.MasterEvent(self.sock_dir, listen=True)
             me.fire_event({'data': 'foo1'}, 'evt1')
             evt1 = me.get_event(tag='')
             self.assertGotEvent(evt1, {'data': 'foo1'})
 
     def test_event_matching_all_when_tag_is_None(self):
         '''Test event matching all when not passing a tag'''
-        with eventpublisher_process():
-            me = salt.utils.event.MasterEvent(SOCK_DIR, listen=True)
+        with eventpublisher_process(self.sock_dir):
+            me = salt.utils.event.MasterEvent(self.sock_dir, listen=True)
             me.fire_event({'data': 'foo1'}, 'evt1')
             evt1 = me.get_event()
             self.assertGotEvent(evt1, {'data': 'foo1'})
 
     def test_event_not_subscribed(self):
         '''Test get_event drops non-subscribed events'''
-        with eventpublisher_process():
-            me = salt.utils.event.MasterEvent(SOCK_DIR, listen=True)
+        with eventpublisher_process(self.sock_dir):
+            me = salt.utils.event.MasterEvent(self.sock_dir, listen=True)
             me.fire_event({'data': 'foo1'}, 'evt1')
             me.fire_event({'data': 'foo2'}, 'evt2')
             evt2 = me.get_event(tag='evt2')
@@ -258,8 +213,8 @@ class TestSaltEvent(TestCase):
 
     def test_event_subscription_cache(self):
         '''Test subscriptions cache a message until requested'''
-        with eventpublisher_process():
-            me = salt.utils.event.MasterEvent(SOCK_DIR, listen=True)
+        with eventpublisher_process(self.sock_dir):
+            me = salt.utils.event.MasterEvent(self.sock_dir, listen=True)
             me.subscribe('evt1')
             me.fire_event({'data': 'foo1'}, 'evt1')
             me.fire_event({'data': 'foo2'}, 'evt2')
@@ -270,8 +225,8 @@ class TestSaltEvent(TestCase):
 
     def test_event_subscriptions_cache_regex(self):
         '''Test regex subscriptions cache a message until requested'''
-        with eventpublisher_process():
-            me = salt.utils.event.MasterEvent(SOCK_DIR, listen=True)
+        with eventpublisher_process(self.sock_dir):
+            me = salt.utils.event.MasterEvent(self.sock_dir, listen=True)
             me.subscribe('e..1$', 'regex')
             me.fire_event({'data': 'foo1'}, 'evt1')
             me.fire_event({'data': 'foo2'}, 'evt2')
@@ -282,9 +237,9 @@ class TestSaltEvent(TestCase):
 
     def test_event_multiple_clients(self):
         '''Test event is received by multiple clients'''
-        with eventpublisher_process():
-            me1 = salt.utils.event.MasterEvent(SOCK_DIR, listen=True)
-            me2 = salt.utils.event.MasterEvent(SOCK_DIR, listen=True)
+        with eventpublisher_process(self.sock_dir):
+            me1 = salt.utils.event.MasterEvent(self.sock_dir, listen=True)
+            me2 = salt.utils.event.MasterEvent(self.sock_dir, listen=True)
             # We need to sleep here to avoid a race condition wherein
             # the second socket may not be connected by the time the first socket
             # sends the event.
@@ -299,8 +254,8 @@ class TestSaltEvent(TestCase):
     def test_event_nested_sub_all(self):
         '''Test nested event subscriptions do not drop events, get event for all tags'''
         # Show why not to call get_event(tag='')
-        with eventpublisher_process():
-            me = salt.utils.event.MasterEvent(SOCK_DIR, listen=True)
+        with eventpublisher_process(self.sock_dir):
+            me = salt.utils.event.MasterEvent(self.sock_dir, listen=True)
             me.fire_event({'data': 'foo1'}, 'evt1')
             me.fire_event({'data': 'foo2'}, 'evt2')
             evt2 = me.get_event(tag='')
@@ -310,8 +265,8 @@ class TestSaltEvent(TestCase):
 
     def test_event_many(self):
         '''Test a large number of events, one at a time'''
-        with eventpublisher_process():
-            me = salt.utils.event.MasterEvent(SOCK_DIR, listen=True)
+        with eventpublisher_process(self.sock_dir):
+            me = salt.utils.event.MasterEvent(self.sock_dir, listen=True)
             for i in range(500):
                 me.fire_event({'data': '{0}'.format(i)}, 'testevents')
                 evt = me.get_event(tag='testevents')
@@ -319,8 +274,8 @@ class TestSaltEvent(TestCase):
 
     def test_event_many_backlog(self):
         '''Test a large number of events, send all then recv all'''
-        with eventpublisher_process():
-            me = salt.utils.event.MasterEvent(SOCK_DIR, listen=True)
+        with eventpublisher_process(self.sock_dir):
+            me = salt.utils.event.MasterEvent(self.sock_dir, listen=True)
             # Must not exceed zmq HWM
             for i in range(500):
                 me.fire_event({'data': '{0}'.format(i)}, 'testevents')
@@ -332,8 +287,8 @@ class TestSaltEvent(TestCase):
     # we don't need to perform extensive testing.
     def test_send_master_event(self):
         '''Tests that sending an event through fire_master generates expected event'''
-        with eventpublisher_process():
-            me = salt.utils.event.MasterEvent(SOCK_DIR, listen=True)
+        with eventpublisher_process(self.sock_dir):
+            me = salt.utils.event.MasterEvent(self.sock_dir, listen=True)
             data = {'data': 'foo1'}
             me.fire_master(data, 'test_master')
 
@@ -347,7 +302,11 @@ class TestAsyncEventPublisher(AsyncTestCase):
 
     def setUp(self):
         super(TestAsyncEventPublisher, self).setUp()
-        self.opts = {'sock_dir': SOCK_DIR}
+        self.sock_dir = os.path.join(RUNTIME_VARS.TMP, 'test-socks')
+        if not os.path.exists(self.sock_dir):
+            os.makedirs(self.sock_dir)
+        self.addCleanup(shutil.rmtree, self.sock_dir, ignore_errors=True)
+        self.opts = {'sock_dir': self.sock_dir}
         self.publisher = salt.utils.event.AsyncEventPublisher(
             self.opts,
             self.io_loop,


### PR DESCRIPTION

<pr-train-toc>

#### PR chain:
#55517 (This global scoped code prevents pytest tests collection.)
#55518 (Drop module level setup)
#55519 (Ensure os.environ does not contain unicode chars)
👉 #55520 (Salt's config does not set `config_dir`) 👈 **YOU ARE HERE**
#55521 (Remove unneeded file)
#55368 **[combined branch]** ([WIP] Bring PyTest to master - Split the test suite)

</pr-train-toc>