### PR TITLE
Stop _virtual from hard coding the 'virtual' key.

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -680,7 +680,8 @@ def _virtual(osdata):
     # Provides:
     #   virtual
     #   virtual_subtype
-    grains = {'virtual': 'physical'}
+
+    grains = {'virtual': osdata.get('virtual', 'physical')}
 
     # Skip the below loop on platforms which have none of the desired cmds
     # This is a temporary measure until we can write proper virtual hardware

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -1306,9 +1306,9 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
                                         'smbios.get': salt.modules.smbios.get}):
             with patch.object(core,
                               '_windows_virtual',
-                              return_value=MagicMock(return_value={'virtual': 'something'})) as _windows_virtual:
-                _windows_virtual.assert_called_once()
+                              return_value={'virtual': 'something'}) as _windows_virtual:
                 osdata_grains = core.os_data()
+                _windows_virtual.assert_called_once()
 
             self.assertIn('virtual', osdata_grains)
             self.assertNotEqual(osdata_grains['virtual'], 'physical')

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -9,6 +9,7 @@ import logging
 import os
 import socket
 import textwrap
+import platform
 
 # Import Salt Testing Libs
 try:
@@ -33,6 +34,8 @@ import salt.utils.files
 import salt.utils.network
 import salt.utils.platform
 import salt.utils.path
+import salt.modules.cmdmod
+import salt.modules.smbios
 import salt.grains.core as core
 
 # Import 3rd-party libs
@@ -1263,3 +1266,49 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         finally:
             # change back to original directory
             os.chdir(cwd)
+
+    def test_virtual_set_virtual_grain(self):
+        osdata = {}
+
+        (osdata['kernel'], osdata['nodename'],
+         osdata['kernelrelease'], osdata['kernelversion'], osdata['cpuarch'], _) = platform.uname()
+
+        with patch.dict(core.__salt__, {'cmd.run': salt.modules.cmdmod.run,
+                                        'cmd.run_all': salt.modules.cmdmod.run_all,
+                                        'cmd.retcode': salt.modules.cmdmod.retcode,
+                                        'smbios.get': salt.modules.smbios.get}):
+
+            virtual_grains = core._virtual(osdata)
+
+        self.assertIn('virtual', virtual_grains)
+
+    def test_virtual_has_virtual_grain(self):
+        osdata = {'virtual': 'something'}
+
+        (osdata['kernel'], osdata['nodename'],
+         osdata['kernelrelease'], osdata['kernelversion'], osdata['cpuarch'], _) = platform.uname()
+
+        with patch.dict(core.__salt__, {'cmd.run': salt.modules.cmdmod.run,
+                                        'cmd.run_all': salt.modules.cmdmod.run_all,
+                                        'cmd.retcode': salt.modules.cmdmod.retcode,
+                                        'smbios.get': salt.modules.smbios.get}):
+
+            virtual_grains = core._virtual(osdata)
+
+        self.assertIn('virtual', virtual_grains)
+        self.assertNotEqual(virtual_grains['virtual'], 'physical')
+
+    @skipIf(not salt.utils.platform.is_windows(), 'System is not Windows')
+    def test_osdata_virtual_key_win(self):
+        with patch.dict(core.__salt__, {'cmd.run': salt.modules.cmdmod.run,
+                                        'cmd.run_all': salt.modules.cmdmod.run_all,
+                                        'cmd.retcode': salt.modules.cmdmod.retcode,
+                                        'smbios.get': salt.modules.smbios.get}):
+            with patch.object(core,
+                              '_windows_virtual',
+                              return_value=MagicMock(return_value={'virtual': 'something'})) as _windows_virtual:
+                _windows_virtual.assert_called_once()
+                osdata_grains = core.os_data()
+
+            self.assertIn('virtual', osdata_grains)
+            self.assertNotEqual(osdata_grains['virtual'], 'physical')


### PR DESCRIPTION
### What does this PR do?
Stop _virtual from hard coding the 'virtual' key.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/55406

### Previous Behavior
_virtual hard coded 'virtual' key to 'physical'.

### New Behavior
_virtual does not hard coded 'virtual' key to 'physical'.

### Tests written?
Yes

### Commits signed with GPG?
Yes
