### PR TITLE
[PyTest #27] When running under PyTest, use `pytest.mark.skipif` instead

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -241,9 +241,11 @@ def pytest_configure(config):
 # ----- Test Setup -------------------------------------------------------------------------------------------------->
 def _has_unittest_attr(item, attr):
     # XXX: This is a hack while we support both runtests.py and PyTest
-    if hasattr(item._obj, attr):
+    if hasattr(item.obj, attr):
         return True
-    if item.parent and hasattr(item.parent._obj, attr):
+    if item.cls and hasattr(item.cls, attr):
+        return True
+    if item.parent and hasattr(item.parent.obj, attr):
         return True
     return False
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -239,25 +239,34 @@ def pytest_configure(config):
 
 
 # ----- Test Setup -------------------------------------------------------------------------------------------------->
+def _has_unittest_attr(item, attr):
+    # XXX: This is a hack while we support both runtests.py and PyTest
+    if hasattr(item._obj, attr):
+        return True
+    if item.parent and hasattr(item.parent._obj, attr):
+        return True
+    return False
+
+
 @pytest.hookimpl(tryfirst=True)
 def pytest_runtest_setup(item):
     '''
     Fixtures injection based on markers or test skips based on CLI arguments
     '''
     destructive_tests_marker = item.get_closest_marker('destructive_test')
-    if destructive_tests_marker is not None:
+    if destructive_tests_marker is not None or _has_unittest_attr(item, '__destructive_test__'):
         if item.config.getoption('--run-destructive') is False:
             pytest.skip('Destructive tests are disabled')
     os.environ['DESTRUCTIVE_TESTS'] = six.text_type(item.config.getoption('--run-destructive'))
 
     expensive_tests_marker = item.get_closest_marker('expensive_test')
-    if expensive_tests_marker is not None:
+    if expensive_tests_marker is not None or _has_unittest_attr(item, '__expensive_test__'):
         if item.config.getoption('--run-expensive') is False:
             pytest.skip('Expensive tests are disabled')
     os.environ['EXPENSIVE_TESTS'] = six.text_type(item.config.getoption('--run-expensive'))
 
     skip_if_not_root_marker = item.get_closest_marker('skip_if_not_root')
-    if skip_if_not_root_marker is not None:
+    if skip_if_not_root_marker is not None or _has_unittest_attr(item, '__skip_if_not_root__'):
         if os.getuid() != 0:
             pytest.skip('You must be logged in as root to run this test')
 

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -97,6 +97,11 @@ def destructiveTest(caller):
             def test_create_user(self):
                 pass
     '''
+    # Late import
+    from tests.support.runtests import RUNTIME_VARS
+    if RUNTIME_VARS.PYTEST_SESSION:
+        setattr(caller, '__destructive_test__', True)
+
     if inspect.isclass(caller):
         # We're decorating a class
         old_setup = getattr(caller, 'setUp', None)
@@ -131,6 +136,11 @@ def expensiveTest(caller):
             def test_create_user(self):
                 pass
     '''
+    # Late import
+    from tests.support.runtests import RUNTIME_VARS
+    if RUNTIME_VARS.PYTEST_SESSION:
+        setattr(caller, '__expensive_test__', True)
+
     if inspect.isclass(caller):
         # We're decorating a class
         old_setup = getattr(caller, 'setUp', None)
@@ -1179,6 +1189,11 @@ def skip_if_binaries_missing(*binaries, **kwargs):
 
 
 def skip_if_not_root(func):
+    # Late import
+    from tests.support.runtests import RUNTIME_VARS
+    if RUNTIME_VARS.PYTEST_SESSION:
+        setattr(func, '__skip_if_not_root__', True)
+
     if not sys.platform.startswith('win'):
         if os.getuid() != 0:
             func.__unittest_skip__ = True

--- a/tests/support/unit.py
+++ b/tests/support/unit.py
@@ -62,7 +62,7 @@ if sys.version_info < (2, 7):
             expectedFailure,
             TestSuite as __TestSuite,
             skip,
-            skipIf,
+            skipIf as _skipIf,
             TestResult as _TestResult,
             TextTestResult as __TextTestResult
         )
@@ -106,7 +106,7 @@ else:
         expectedFailure,
         TestSuite as _TestSuite,
         skip,
-        skipIf,
+        skipIf as _skipIf,
         TestResult,
         TextTestResult as _TextTestResult,
         SkipTest,
@@ -428,6 +428,14 @@ class TextTestRunner(_TextTestRunner):
     Custom Text tests runner to log the start and the end of a test case
     '''
     resultclass = TextTestResult
+
+
+def skipIf(skip, reason):
+    from tests.support.runtests import RUNTIME_VARS
+    if RUNTIME_VARS.PYTEST_SESSION:
+        import pytest
+        return pytest.mark.skipif(skip, reason=reason)
+    return _skipIf(skip, reason)
 
 
 __all__ = [

--- a/tests/unit/modules/test_gpg.py
+++ b/tests/unit/modules/test_gpg.py
@@ -14,7 +14,6 @@ import time
 # Import Salt Testing libs
 from tests.support.helpers import destructiveTest
 from tests.support.unit import TestCase, skipIf
-from tests.support.paths import TMP
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import (
     NO_MOCK,
@@ -22,6 +21,7 @@ from tests.support.mock import (
     MagicMock,
     patch
 )
+from tests.support.runtests import RUNTIME_VARS
 
 # Import Salt libs
 import salt.utils.platform
@@ -179,14 +179,14 @@ class GpgTestCase(TestCase, LoaderModuleMockMixin):
     @skipIf(not HAS_GPG, 'GPG Module Unavailable')
     def setUp(self):
         super(GpgTestCase, self).setUp()
-        self.gpghome = os.path.join(TMP, 'gpghome')
+        self.gpghome = os.path.join(RUNTIME_VARS.TMP, 'gpghome')
         if not os.path.isdir(self.gpghome):
             # left behind... Don't fail because of this!
             os.makedirs(self.gpghome)
-        self.gpgfile_pub = os.path.join(TMP, 'gpgfile.pub')
+        self.gpgfile_pub = os.path.join(RUNTIME_VARS.TMP, 'gpgfile.pub')
         with salt.utils.files.fopen(self.gpgfile_pub, 'wb') as fp:
             fp.write(salt.utils.stringutils.to_bytes(GPG_TEST_PUB_KEY))
-        self.gpgfile_priv = os.path.join(TMP, 'gpgfile.priv')
+        self.gpgfile_priv = os.path.join(RUNTIME_VARS.TMP, 'gpgfile.priv')
         with salt.utils.files.fopen(self.gpgfile_priv, 'wb') as fp:
             fp.write(salt.utils.stringutils.to_bytes(GPG_TEST_PRIV_KEY))
         self.user = 'salt'

--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -27,7 +27,7 @@ from tests.support.mock import (
     call,
     mock_open,
     patch)
-from tests.support.paths import TMP
+from tests.support.runtests import RUNTIME_VARS
 
 # Import salt libs
 import salt.utils.files
@@ -2358,7 +2358,7 @@ class TestFilePrivateFunctions(TestCase, LoaderModuleMockMixin):
         # Run _check_directory function
         # Verify that it returns correctly
         # Delete tmp directory structure
-        root_tmp_dir = os.path.join(TMP, 'test__check_dir')
+        root_tmp_dir = os.path.join(RUNTIME_VARS.TMP, 'test__check_dir')
         expected_dir_mode = 0o777
         depth = 3
         try:


### PR DESCRIPTION
### What does this PR do?
See title