### PR TITLE
Fix for issue #55562

### DIFF
--- a/salt/states/opsgenie.py
+++ b/salt/states/opsgenie.py
@@ -75,7 +75,7 @@ def create_alert(name=None, api_key=None, reason=None, action_type="Create"):
     ret = {
         'result': '',
         'name': '',
-        'changes': '',
+        'changes': {},
         'comment': ''
     }
 


### PR DESCRIPTION
Ensures changes is returned as a dictionary rather than an empty string.

### What does this PR do?

Fixes return handling from opsgenie states by ensuring changes is a dictionary. Failing to do this means the create_alert and close_alert states always appear to have failed (return becomes False) even if OpsGenie API call was successful.

### What issues does this PR fix or reference?

fixes #55562

### Previous Behavior

create_alert and close_alert states always return false as state return receiving code triggers exception when trying to use changes as dictionary. True return value is ignored.

### New Behavior

create_alert and close_alert states always return true or false as appropriate along with changes as an empty dictionary. No exception triggered in receiving code.

### Tests written?

No

### Commits signed with GPG?

Yes