### PR TITLE
Fix win pkg 2019.2.3

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1447,6 +1447,9 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
                 'extra_install_flags': kwargs.get('extra_install_flags')
             }
         }
+    elif len(pkg_params) == 1:
+        for pkg in pkg_params:
+            pkg_params[pkg]['extra_install_flags'] = kwargs.get('extra_install_flags')
 
     # Get a list of currently installed software for comparison at the end
     old = list_pkgs(saltenv=saltenv, refresh=refresh, versions_as_list=True)


### PR DESCRIPTION
### What does this PR do?
Brings in `extra_install_flags` fix from 2018.3 branch. https://github.com/saltstack/salt/pull/53080/files

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/50041

### Tests written?
Yes

### Commits signed with GPG?
Yes