### PR TITLE
[master] Move "FQDNs" grains calculation to "network" module and allow disabled them

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2338,10 +2338,14 @@ def fqdns():
     """
     Return all known FQDNs for the system by enumerating all interfaces and
     then trying to reverse resolve them (excluding 'lo' interface).
+    To disable the fqdns grain, set enable_fqdns_grains: False in the minion configuration file.
     """
     # Provides:
     # fqdns
-    return __salt__["network.fqdns"]()
+    opt = {"fqdns": []}
+    if __opts__.get("enable_fqdns_grains", True) == True:
+        opt = __salt__["network.fqdns"]()
+    return opt
 
 
 def ip_fqdn():

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -25,6 +25,7 @@ from errno import EACCES, EPERM
 
 import salt.exceptions
 import salt.log
+
 # Solve the Chicken and egg problem where grains need to run before any
 # of the modules are loaded and are generally available for any usage.
 import salt.modules.cmdmod

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2384,7 +2384,10 @@ def fqdns():
     pool.close()
     pool.join()
 
-    [fqdns.update(item) for item in results if item]
+    for item in results:
+        if item:
+            fqdns.update(item)
+
     elapsed = time.time() - start
     log.debug("Elapsed time getting FQDNs: {} seconds".format(elapsed))
 

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -42,6 +42,8 @@ from distro import linux_distribution
 from salt.ext import six
 from salt.ext.six.moves import range
 
+from multiprocessing.dummy import Pool as ThreadPool
+
 try:
     import dateutil.tz  # pylint: disable=import-error
 
@@ -2354,16 +2356,9 @@ def fqdns():
     grains = {}
     fqdns = set()
 
-    addresses = salt.utils.network.ip_addrs(
-        include_loopback=False, interface_data=_INTERFACES
-    )
-    addresses.extend(
-        salt.utils.network.ip_addrs6(include_loopback=False, interface_data=_INTERFACES)
-    )
-    err_message = "An exception occurred resolving address '%s': %s"
-    for ip in addresses:
+    def _lookup_fqdn(ip):
         try:
-            fqdns.add(socket.getfqdn(socket.gethostbyaddr(ip)[0]))
+            return [socket.getfqdn(socket.gethostbyaddr(ip)[0])]
         except socket.herror as err:
             if err.errno in (0, HOST_NOT_FOUND, NO_DATA):
                 # No FQDN for this IP address, so we don't need to know this all the time.
@@ -2372,6 +2367,26 @@ def fqdns():
                 log.error(err_message, ip, err)
         except (socket.error, socket.gaierror, socket.timeout) as err:
             log.error(err_message, ip, err)
+
+    start = time.time()
+
+    addresses = salt.utils.network.ip_addrs(include_loopback=False,
+                                            interface_data=_INTERFACES)
+    addresses.extend(salt.utils.network.ip_addrs6(include_loopback=False,
+                                                  interface_data=_INTERFACES))
+    err_message = "Exception during resolving address: %s"
+
+    # Create a ThreadPool to process the underlying calls to 'socket.gethostbyaddr' in parallel.
+    # This avoid blocking the execution when the "fqdn" is not defined for certains IP addresses, which was causing
+    # that "socket.timeout" was reached multiple times secuencially, blocking execution for several seconds.
+    pool = ThreadPool(8)
+    results = pool.map(_lookup_fqdn, addresses)
+    pool.close()
+    pool.join()
+
+    [fqdns.update(item) for item in results if item]
+    elapsed = time.time() - start
+    log.debug("Elapsed time getting FQDNs: {} seconds".format(elapsed))
 
     grains["fqdns"] = sorted(list(fqdns))
     return grains

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2343,7 +2343,7 @@ def fqdns():
     # Provides:
     # fqdns
     opt = {"fqdns": []}
-    if __opts__.get("enable_fqdns_grains", True) == True:
+    if __opts__.get("enable_fqdns_grains", True):
         opt = __salt__["network.fqdns"]()
     return opt
 

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2344,7 +2344,7 @@ def fqdns():
     # Provides:
     # fqdns
     opt = {"fqdns": []}
-    if __opts__.get("enable_fqdns_grains", True) == True:
+    if __opts__.get("enable_fqdns_grains", True) is True:
         opt = __salt__["network.fqdns"]()
     return opt
 

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2339,14 +2339,10 @@ def fqdns():
     """
     Return all known FQDNs for the system by enumerating all interfaces and
     then trying to reverse resolve them (excluding 'lo' interface).
-    To disable the fqdns grain, set enable_fqdns_grains: False in the minion configuration file.
     """
     # Provides:
     # fqdns
-    opt = {"fqdns": []}
-    if __opts__.get("enable_fqdns_grains", True) is True:
-        opt = __salt__["network.fqdns"]()
-    return opt
+    return __salt__['network.fqdns']()
 
 
 def ip_fqdn():

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -25,7 +25,6 @@ from errno import EACCES, EPERM
 
 import salt.exceptions
 import salt.log
-
 # Solve the Chicken and egg problem where grains need to run before any
 # of the modules are loaded and are generally available for any usage.
 import salt.modules.cmdmod
@@ -42,7 +41,6 @@ import salt.utils.stringutils
 from distro import linux_distribution
 from salt.ext import six
 from salt.ext.six.moves import range
-
 from salt.utils.network import _get_interfaces
 
 try:

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2381,12 +2381,12 @@ def fqdns():
     # that "socket.timeout" was reached multiple times secuencially, blocking execution for several seconds.
 
     try:
-       pool = ThreadPool(8)
-       results = pool.map(_lookup_fqdn, addresses)
-       pool.close()
-       pool.join()
+        pool = ThreadPool(8)
+        results = pool.map(_lookup_fqdn, addresses)
+        pool.close()
+        pool.join()
     except Exception as exc:
-       log.error("Exception while creating a ThreadPool for resolving FQDNs: %s", exc)
+        log.error("Exception while creating a ThreadPool for resolving FQDNs: %s", exc)
 
     for item in results:
         if item:

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2342,7 +2342,7 @@ def fqdns():
     """
     # Provides:
     # fqdns
-    return __salt__['network.fqdns']()
+    return __salt__["network.fqdns"]()
 
 
 def ip_fqdn():

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -2102,12 +2102,12 @@ def fqdns():
     # that "socket.timeout" was reached multiple times secuencially, blocking execution for several seconds.
 
     try:
-       pool = ThreadPool(8)
-       results = pool.map(_lookup_fqdn, addresses)
-       pool.close()
-       pool.join()
+        pool = ThreadPool(8)
+        results = pool.map(_lookup_fqdn, addresses)
+        pool.close()
+        pool.join()
     except Exception as exc:
-       log.error("Exception while creating a ThreadPool for resolving FQDNs: %s", exc)
+        log.error("Exception while creating a ThreadPool for resolving FQDNs: %s", exc)
 
     for item in results:
         if item:

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -2080,8 +2080,7 @@ def fqdns():
 
     def _lookup_fqdn(ip):
         try:
-            name, aliaslist, addresslist = socket.gethostbyaddr(ip)
-            return [socket.getfqdn(name)] + [als for als in aliaslist if salt.utils.network.is_fqdn(als)]
+            return [socket.getfqdn(socket.gethostbyaddr(ip)[0])]
         except socket.herror as err:
             if err.errno in (0, HOST_NOT_FOUND, NO_DATA):
                 # No FQDN for this IP address, so we don't need to know this all the time.

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -18,6 +18,7 @@ from multiprocessing.pool import ThreadPool
 # Import salt libs
 import salt.utils.decorators.path
 import salt.utils.functools
+import salt.utils.network
 import salt.utils.validate.net
 from salt._compat import ipaddress
 from salt.exceptions import CommandExecutionError

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -21,6 +21,7 @@ import salt.utils.functools
 import salt.utils.validate.net
 from salt._compat import ipaddress
 from salt.exceptions import CommandExecutionError
+
 # Import 3rd-party libs
 from salt.ext import six
 from salt.ext.six.moves import range

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -2092,8 +2092,14 @@ def fqdns():
 
     start = time.time()
 
-    addresses = salt.utils.network.ip_addrs(include_loopback=False, interface_data=salt.utils.network._get_interfaces())
-    addresses.extend(salt.utils.network.ip_addrs6(include_loopback=False, interface_data=salt.utils.network._get_interfaces()))
+    addresses = salt.utils.network.ip_addrs(
+        include_loopback=False, interface_data=salt.utils.network._get_interfaces()
+    )
+    addresses.extend(
+        salt.utils.network.ip_addrs6(
+            include_loopback=False, interface_data=salt.utils.network._get_interfaces()
+        )
+    )
     err_message = "Exception during resolving address: %s"
 
     # Create a ThreadPool to process the underlying calls to 'socket.gethostbyaddr' in parallel.

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -2106,7 +2106,7 @@ def fqdns():
         results = pool.map(_lookup_fqdn, addresses)
         pool.close()
         pool.join()
-    except Exception as exc:
+    except Exception as exc:  # pylint: disable=broad-except
         log.error("Exception while creating a ThreadPool for resolving FQDNs: %s", exc)
 
     for item in results:

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -2101,6 +2101,7 @@ def fqdns():
     # This avoid blocking the execution when the "fqdn" is not defined for certains IP addresses, which was causing
     # that "socket.timeout" was reached multiple times secuencially, blocking execution for several seconds.
 
+    results = []
     try:
         pool = ThreadPool(8)
         results = pool.map(_lookup_fqdn, addresses)

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -12,6 +12,10 @@ import logging
 import os
 import re
 import socket
+import time
+
+from multiprocessing.pool import ThreadPool
+
 
 # Import salt libs
 import salt.utils.decorators.path
@@ -2057,3 +2061,59 @@ def ip_networks6(interface=None, include_loopback=False, verbose=False):
     return __utils__["network.ip_networks6"](
         interface=interface, include_loopback=include_loopback, verbose=verbose
     )
+
+
+def fqdns():
+    """
+    Return all known FQDNs for the system by enumerating all interfaces and
+    then trying to reverse resolve them (excluding 'lo' interface).
+    """
+    # Provides:
+    # fqdns
+
+    # Possible value for h_errno defined in netdb.h
+    HOST_NOT_FOUND = 1
+    NO_DATA = 4
+
+    grains = {}
+    fqdns = set()
+
+    def _lookup_fqdn(ip):
+        try:
+            name, aliaslist, addresslist = socket.gethostbyaddr(ip)
+            return [socket.getfqdn(name)] + [als for als in aliaslist if salt.utils.network.is_fqdn(als)]
+        except socket.herror as err:
+            if err.errno in (0, HOST_NOT_FOUND, NO_DATA):
+                # No FQDN for this IP address, so we don't need to know this all the time.
+                log.debug("Unable to resolve address %s: %s", ip, err)
+            else:
+                log.error(err_message, err)
+        except (socket.error, socket.gaierror, socket.timeout) as err:
+            log.error(err_message, err)
+
+    start = time.time()
+
+    addresses = salt.utils.network.ip_addrs(include_loopback=False, interface_data=salt.utils.network._get_interfaces())
+    addresses.extend(salt.utils.network.ip_addrs6(include_loopback=False, interface_data=salt.utils.network._get_interfaces()))
+    err_message = "Exception during resolving address: %s"
+
+    # Create a ThreadPool to process the underlying calls to 'socket.gethostbyaddr' in parallel.
+    # This avoid blocking the execution when the "fqdn" is not defined for certains IP addresses, which was causing
+    # that "socket.timeout" was reached multiple times secuencially, blocking execution for several seconds.
+
+    try:
+       pool = ThreadPool(8)
+       results = pool.map(_lookup_fqdn, addresses)
+       pool.close()
+       pool.join()
+    except Exception as exc:
+       log.error("Exception while creating a ThreadPool for resolving FQDNs: %s", exc)
+
+    for item in results:
+        if item:
+            fqdns.update(item)
+
+    elapsed = time.time() - start
+    log.debug("Elapsed time getting FQDNs: {} seconds".format(elapsed))
+
+    return {"fqdns": sorted(list(fqdns))}

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -13,9 +13,7 @@ import os
 import re
 import socket
 import time
-
 from multiprocessing.pool import ThreadPool
-
 
 # Import salt libs
 import salt.utils.decorators.path
@@ -23,7 +21,6 @@ import salt.utils.functools
 import salt.utils.validate.net
 from salt._compat import ipaddress
 from salt.exceptions import CommandExecutionError
-
 # Import 3rd-party libs
 from salt.ext import six
 from salt.ext.six.moves import range

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -56,7 +56,7 @@ except (ImportError, OSError, AttributeError, TypeError):
 
 
 _INTERFACES = {}
-def _get_interfaces(): #! function
+def _get_interfaces():
     '''
     Provide a dict of the connected interfaces and their ip addresses
     '''

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -56,6 +56,8 @@ except (ImportError, OSError, AttributeError, TypeError):
 
 
 _INTERFACES = {}
+
+
 def _get_interfaces():
     '''
     Provide a dict of the connected interfaces and their ip addresses

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -29,7 +29,6 @@ import salt.utils.stringutils
 import salt.utils.zeromq
 from salt._compat import ipaddress
 from salt.exceptions import SaltClientError, SaltSystemExit
-
 # Import 3rd-party libs
 from salt.ext import six
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -59,9 +59,9 @@ _INTERFACES = {}
 
 
 def _get_interfaces():
-    '''
+    """
     Provide a dict of the connected interfaces and their ip addresses
-    '''
+    """
 
     global _INTERFACES
     if not _INTERFACES:

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -55,6 +55,18 @@ except (ImportError, OSError, AttributeError, TypeError):
     pass
 
 
+_INTERFACES = {}
+def _get_interfaces(): #! function
+    '''
+    Provide a dict of the connected interfaces and their ip addresses
+    '''
+
+    global _INTERFACES
+    if not _INTERFACES:
+        _INTERFACES = interfaces()
+    return _INTERFACES
+
+
 def sanitize_host(host):
     """
     Sanitize host string.

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -29,6 +29,7 @@ import salt.utils.stringutils
 import salt.utils.zeromq
 from salt._compat import ipaddress
 from salt.exceptions import SaltClientError, SaltSystemExit
+
 # Import 3rd-party libs
 from salt.ext import six
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -1193,35 +1193,6 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         ):
             assert core.dns() == ret
 
-    def test_enablefqdnsFalse(self):
-        """
-        tests enable_fqdns_grains is set to False
-        """
-        with patch.dict("salt.grains.core.__opts__", {"enable_fqdns_grains": False}):
-            assert core.fqdns() == {"fqdns": []}
-
-    def test_enablefqdnsTrue(self):
-        """
-        testing that grains uses network.fqdns module
-        """
-        with patch.dict("salt.grains.core.__salt__", {"network.fqdns": MagicMock(return_value="my.fake.domain")}):
-            with patch.dict("salt.grains.core.__opts__", {"enable_fqdns_grains": True}):
-                assert core.fqdns() == "my.fake.domain"
-
-    def test_enablefqdnsNone(self):
-        """
-        testing default fqdns grains is returned when enable_fqdns_grains is None
-        """
-        with patch.dict("salt.grains.core.__opts__", {"enable_fqdns_grains": None}):
-            assert core.fqdns() == {"fqdns": []}
-
-    def test_enablefqdnswithoutpaching(self):
-        """
-        testing fqdns grains is enabled by default
-        """
-        with patch.dict('salt.grains.core.__salt__', {'network.fqdns': MagicMock(return_value="my.fake.domain")}):
-            assert core.fqdns() == 'my.fake.domain'
-
     @skipIf(not salt.utils.platform.is_linux(), "System is not Linux")
     @patch(
         "salt.utils.network.ip_addrs", MagicMock(return_value=["1.2.3.4", "5.6.7.8"])
@@ -1238,17 +1209,19 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         test the return for a dns grain. test for issue:
         https://github.com/saltstack/salt/issues/41230
         """
-        reverse_resolv_mock = [("foo.bar.baz", [], ["1.2.3.4"]),
-                               ("rinzler.evil-corp.com", [], ["5.6.7.8"]),
-                               ("foo.bar.baz", [], ["fe80::a8b2:93ff:fe00:0"]),
-                               ("bluesniff.foo.bar", [], ["fe80::a8b2:93ff:dead:beef"])]
+        reverse_resolv_mock = [
+            ("foo.bar.baz", [], ["1.2.3.4"]),
+            ("rinzler.evil-corp.com", [], ["5.6.7.8"]),
+            ("foo.bar.baz", [], ["fe80::a8b2:93ff:fe00:0"]),
+            ("bluesniff.foo.bar", [], ["fe80::a8b2:93ff:dead:beef"]),
+        ]
         ret = {"fqdns": ["bluesniff.foo.bar", "foo.bar.baz", "rinzler.evil-corp.com"]}
-        with patch.dict(core.__salt__, {"network.fqdns": salt.modules.network.fqdns}):
-            with patch.object(socket, "gethostbyaddr", side_effect=reverse_resolv_mock):
+        with patch.dict(core.__salt__, {'network.fqdns': salt.modules.network.fqdns}):
+            with patch.object(socket, 'gethostbyaddr', side_effect=reverse_resolv_mock):
                 fqdns = core.fqdns()
                 assert "fqdns" in fqdns
-                assert len(fqdns["fqdns"]) == len(ret["fqdns"])
-                assert set(fqdns["fqdns"]) == set(ret["fqdns"])
+                assert len(fqdns['fqdns']) == len(ret['fqdns'])
+                assert set(fqdns['fqdns']) == set(ret['fqdns'])
 
     @skipIf(not salt.utils.platform.is_linux(), "System is not Linux")
     @patch.object(salt.utils.platform, "is_windows", MagicMock(return_value=False))
@@ -1275,7 +1248,6 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
                     assert alias not in fqdns["fqdns"]
 
     @skipIf(not salt.utils.platform.is_linux(), "System is not Linux")
-    @patch.object(salt.utils, "is_windows", MagicMock(return_value=False))
     @patch("salt.utils.network.ip_addrs", MagicMock(return_value=["1.2.3.4"]))
     @patch("salt.utils.network.ip_addrs6", MagicMock(return_value=[]))
     def test_fqdns_socket_error(self):

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -1216,27 +1216,39 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
             ("bluesniff.foo.bar", [], ["fe80::a8b2:93ff:dead:beef"]),
         ]
         ret = {"fqdns": ["bluesniff.foo.bar", "foo.bar.baz", "rinzler.evil-corp.com"]}
-        with patch.dict(core.__salt__, {'network.fqdns': salt.modules.network.fqdns}):
-            with patch.object(socket, 'gethostbyaddr', side_effect=reverse_resolv_mock):
+        with patch.dict(core.__salt__, {"network.fqdns": salt.modules.network.fqdns}):
+            with patch.object(socket, "gethostbyaddr", side_effect=reverse_resolv_mock):
                 fqdns = core.fqdns()
                 assert "fqdns" in fqdns
-                assert len(fqdns['fqdns']) == len(ret['fqdns'])
-                assert set(fqdns['fqdns']) == set(ret['fqdns'])
+                assert len(fqdns["fqdns"]) == len(ret["fqdns"])
+                assert set(fqdns["fqdns"]) == set(ret["fqdns"])
 
     @skipIf(not salt.utils.platform.is_linux(), "System is not Linux")
     @patch.object(salt.utils.platform, "is_windows", MagicMock(return_value=False))
-    @patch("salt.utils.network.ip_addrs", MagicMock(return_value=["1.2.3.4", "5.6.7.8"]))
-    @patch("salt.utils.network.ip_addrs6",
-           MagicMock(return_value=["fe80::a8b2:93ff:fe00:0", "fe80::a8b2:93ff:dead:beef"]))
-    @patch("salt.utils.network.socket.getfqdn", MagicMock(side_effect=lambda v: v))  # Just pass-through
+    @patch(
+        "salt.utils.network.ip_addrs", MagicMock(return_value=["1.2.3.4", "5.6.7.8"])
+    )
+    @patch(
+        "salt.utils.network.ip_addrs6",
+        MagicMock(return_value=["fe80::a8b2:93ff:fe00:0", "fe80::a8b2:93ff:dead:beef"]),
+    )
+    @patch(
+        "salt.utils.network.socket.getfqdn", MagicMock(side_effect=lambda v: v)
+    )  # Just pass-through
     def test_fqdns_aliases(self):
         """
         FQDNs aliases
         """
-        reverse_resolv_mock = [("foo.bar.baz", ["throwmeaway", "this.is.valid.alias"], ["1.2.3.4"]),
-                               ("rinzler.evil-corp.com", ["false-hostname", "badaliass"], ["5.6.7.8"]),
-                               ("foo.bar.baz", [], ["fe80::a8b2:93ff:fe00:0"]),
-                               ("bluesniff.foo.bar", ["alias.bluesniff.foo.bar"], ["fe80::a8b2:93ff:dead:beef"])]
+        reverse_resolv_mock = [
+            ("foo.bar.baz", ["throwmeaway", "this.is.valid.alias"], ["1.2.3.4"]),
+            ("rinzler.evil-corp.com", ["false-hostname", "badaliass"], ["5.6.7.8"]),
+            ("foo.bar.baz", [], ["fe80::a8b2:93ff:fe00:0"]),
+            (
+                "bluesniff.foo.bar",
+                ["alias.bluesniff.foo.bar"],
+                ["fe80::a8b2:93ff:dead:beef"],
+            ),
+        ]
         with patch.dict(core.__salt__, {"network.fqdns": salt.modules.network.fqdns}):
             with patch.object(socket, "gethostbyaddr", side_effect=reverse_resolv_mock):
                 fqdns = core.fqdns()

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -1224,42 +1224,6 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
                 assert set(fqdns["fqdns"]) == set(ret["fqdns"])
 
     @skipIf(not salt.utils.platform.is_linux(), "System is not Linux")
-    @patch.object(salt.utils.platform, "is_windows", MagicMock(return_value=False))
-    @patch(
-        "salt.utils.network.ip_addrs", MagicMock(return_value=["1.2.3.4", "5.6.7.8"])
-    )
-    @patch(
-        "salt.utils.network.ip_addrs6",
-        MagicMock(return_value=["fe80::a8b2:93ff:fe00:0", "fe80::a8b2:93ff:dead:beef"]),
-    )
-    @patch(
-        "salt.utils.network.socket.getfqdn", MagicMock(side_effect=lambda v: v)
-    )  # Just pass-through
-    def test_fqdns_aliases(self):
-        """
-        FQDNs aliases
-        """
-        reverse_resolv_mock = [
-            ("foo.bar.baz", ["throwmeaway", "this.is.valid.alias"], ["1.2.3.4"]),
-            ("rinzler.evil-corp.com", ["false-hostname", "badaliass"], ["5.6.7.8"]),
-            ("foo.bar.baz", [], ["fe80::a8b2:93ff:fe00:0"]),
-            (
-                "bluesniff.foo.bar",
-                ["alias.bluesniff.foo.bar"],
-                ["fe80::a8b2:93ff:dead:beef"],
-            ),
-        ]
-        with patch.dict(core.__salt__, {"network.fqdns": salt.modules.network.fqdns}):
-            with patch.object(socket, "gethostbyaddr", side_effect=reverse_resolv_mock):
-                fqdns = core.fqdns()
-                assert "fqdns" in fqdns
-                for alias in ["this.is.valid.alias", "alias.bluesniff.foo.bar"]:
-                    assert alias in fqdns["fqdns"]
-
-                for alias in ["throwmeaway", "false-hostname", "badaliass"]:
-                    assert alias not in fqdns["fqdns"]
-
-    @skipIf(not salt.utils.platform.is_linux(), "System is not Linux")
     @patch("salt.utils.network.ip_addrs", MagicMock(return_value=["1.2.3.4"]))
     @patch("salt.utils.network.ip_addrs6", MagicMock(return_value=[]))
     def test_fqdns_socket_error(self):

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -1193,39 +1193,34 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         ):
             assert core.dns() == ret
 
-
     def test_enablefqdnsFalse(self):
         """
         tests enable_fqdns_grains is set to False
         """
-        with patch.dict("salt.grains.core.__opts__", {"enable_fqdns_grains":False}):
+        with patch.dict("salt.grains.core.__opts__", {"enable_fqdns_grains": False}):
             assert core.fqdns() == {"fqdns": []}
-
 
     def test_enablefqdnsTrue(self):
         """
         testing that grains uses network.fqdns module
         """
         with patch.dict("salt.grains.core.__salt__", {"network.fqdns": MagicMock(return_value="my.fake.domain")}):
-            with patch.dict("salt.grains.core.__opts__", {"enable_fqdns_grains":True}):
+            with patch.dict("salt.grains.core.__opts__", {"enable_fqdns_grains": True}):
                 assert core.fqdns() == "my.fake.domain"
-
 
     def test_enablefqdnsNone(self):
         """
         testing default fqdns grains is returned when enable_fqdns_grains is None
         """
-        with patch.dict("salt.grains.core.__opts__", {"enable_fqdns_grains":None}):
-             assert core.fqdns() == {"fqdns": []}
-
+        with patch.dict("salt.grains.core.__opts__", {"enable_fqdns_grains": None}):
+            assert core.fqdns() == {"fqdns": []}
 
     def test_enablefqdnswithoutpaching(self):
         """
         testing fqdns grains is enabled by default
         """
-        with patch.dict("salt.grains.core.__salt__", {"network.fqdns": MagicMock(return_value="my.fake.domain")}):
-            assert core.fqdns() == "my.fake.domain"
-
+        with patch.dict('salt.grains.core.__salt__', {'network.fqdns': MagicMock(return_value="my.fake.domain")}):
+            assert core.fqdns() == 'my.fake.domain'
 
     @skipIf(not salt.utils.platform.is_linux(), "System is not Linux")
     @patch(

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -14,6 +14,7 @@ import textwrap
 
 import salt.grains.core as core
 import salt.modules.cmdmod
+import salt.modules.network
 import salt.modules.smbios
 
 # Import Salt Libs
@@ -1192,6 +1193,40 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         ):
             assert core.dns() == ret
 
+
+    def test_enablefqdnsFalse(self):
+        """
+        tests enable_fqdns_grains is set to False
+        """
+        with patch.dict("salt.grains.core.__opts__", {"enable_fqdns_grains":False}):
+            assert core.fqdns() == {"fqdns": []}
+
+
+    def test_enablefqdnsTrue(self):
+        """
+        testing that grains uses network.fqdns module
+        """
+        with patch.dict("salt.grains.core.__salt__", {"network.fqdns": MagicMock(return_value="my.fake.domain")}):
+            with patch.dict("salt.grains.core.__opts__", {"enable_fqdns_grains":True}):
+                assert core.fqdns() == "my.fake.domain"
+
+
+    def test_enablefqdnsNone(self):
+        """
+        testing default fqdns grains is returned when enable_fqdns_grains is None
+        """
+        with patch.dict("salt.grains.core.__opts__", {"enable_fqdns_grains":None}):
+             assert core.fqdns() == {"fqdns": []}
+
+
+    def test_enablefqdnswithoutpaching(self):
+        """
+        testing fqdns grains is enabled by default
+        """
+        with patch.dict("salt.grains.core.__salt__", {"network.fqdns": MagicMock(return_value="my.fake.domain")}):
+            assert core.fqdns() == "my.fake.domain"
+
+
     @skipIf(not salt.utils.platform.is_linux(), "System is not Linux")
     @patch(
         "salt.utils.network.ip_addrs", MagicMock(return_value=["1.2.3.4", "5.6.7.8"])
@@ -1208,20 +1243,44 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         test the return for a dns grain. test for issue:
         https://github.com/saltstack/salt/issues/41230
         """
-        reverse_resolv_mock = [
-            ("foo.bar.baz", [], ["1.2.3.4"]),
-            ("rinzler.evil-corp.com", [], ["5.6.7.8"]),
-            ("foo.bar.baz", [], ["fe80::a8b2:93ff:fe00:0"]),
-            ("bluesniff.foo.bar", [], ["fe80::a8b2:93ff:dead:beef"]),
-        ]
+        reverse_resolv_mock = [("foo.bar.baz", [], ["1.2.3.4"]),
+                               ("rinzler.evil-corp.com", [], ["5.6.7.8"]),
+                               ("foo.bar.baz", [], ["fe80::a8b2:93ff:fe00:0"]),
+                               ("bluesniff.foo.bar", [], ["fe80::a8b2:93ff:dead:beef"])]
         ret = {"fqdns": ["bluesniff.foo.bar", "foo.bar.baz", "rinzler.evil-corp.com"]}
-        with patch.object(socket, "gethostbyaddr", side_effect=reverse_resolv_mock):
-            fqdns = core.fqdns()
-            self.assertIn("fqdns", fqdns)
-            self.assertEqual(len(fqdns["fqdns"]), len(ret["fqdns"]))
-            self.assertEqual(set(fqdns["fqdns"]), set(ret["fqdns"]))
+        with patch.dict(core.__salt__, {"network.fqdns": salt.modules.network.fqdns}):
+            with patch.object(socket, "gethostbyaddr", side_effect=reverse_resolv_mock):
+                fqdns = core.fqdns()
+                assert "fqdns" in fqdns
+                assert len(fqdns["fqdns"]) == len(ret["fqdns"])
+                assert set(fqdns["fqdns"]) == set(ret["fqdns"])
 
     @skipIf(not salt.utils.platform.is_linux(), "System is not Linux")
+    @patch.object(salt.utils.platform, "is_windows", MagicMock(return_value=False))
+    @patch("salt.utils.network.ip_addrs", MagicMock(return_value=["1.2.3.4", "5.6.7.8"]))
+    @patch("salt.utils.network.ip_addrs6",
+           MagicMock(return_value=["fe80::a8b2:93ff:fe00:0", "fe80::a8b2:93ff:dead:beef"]))
+    @patch("salt.utils.network.socket.getfqdn", MagicMock(side_effect=lambda v: v))  # Just pass-through
+    def test_fqdns_aliases(self):
+        """
+        FQDNs aliases
+        """
+        reverse_resolv_mock = [("foo.bar.baz", ["throwmeaway", "this.is.valid.alias"], ["1.2.3.4"]),
+                               ("rinzler.evil-corp.com", ["false-hostname", "badaliass"], ["5.6.7.8"]),
+                               ("foo.bar.baz", [], ["fe80::a8b2:93ff:fe00:0"]),
+                               ("bluesniff.foo.bar", ["alias.bluesniff.foo.bar"], ["fe80::a8b2:93ff:dead:beef"])]
+        with patch.dict(core.__salt__, {"network.fqdns": salt.modules.network.fqdns}):
+            with patch.object(socket, "gethostbyaddr", side_effect=reverse_resolv_mock):
+                fqdns = core.fqdns()
+                assert "fqdns" in fqdns
+                for alias in ["this.is.valid.alias", "alias.bluesniff.foo.bar"]:
+                    assert alias in fqdns["fqdns"]
+
+                for alias in ["throwmeaway", "false-hostname", "badaliass"]:
+                    assert alias not in fqdns["fqdns"]
+
+    @skipIf(not salt.utils.platform.is_linux(), "System is not Linux")
+    @patch.object(salt.utils, "is_windows", MagicMock(return_value=False))
     @patch("salt.utils.network.ip_addrs", MagicMock(return_value=["1.2.3.4"]))
     @patch("salt.utils.network.ip_addrs6", MagicMock(return_value=[]))
     def test_fqdns_socket_error(self):

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -16,7 +16,6 @@ import salt.grains.core as core
 import salt.modules.cmdmod
 import salt.modules.network
 import salt.modules.smbios
-
 # Import Salt Libs
 import salt.utils.dns
 import salt.utils.files
@@ -24,7 +23,6 @@ import salt.utils.network
 import salt.utils.path
 import salt.utils.platform
 from salt._compat import ipaddress
-
 # Import 3rd-party libs
 from salt.ext import six
 from tests.support.mixins import LoaderModuleMockMixin

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -1193,6 +1193,41 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         ):
             assert core.dns() == ret
 
+    def test_enablefqdnsFalse(self):
+        """
+        tests enable_fqdns_grains is set to False
+        """
+        with patch.dict("salt.grains.core.__opts__", {"enable_fqdns_grains": False}):
+            assert core.fqdns() == {"fqdns": []}
+
+    def test_enablefqdnsTrue(self):
+        """
+        testing that grains uses network.fqdns module
+        """
+        with patch.dict(
+            "salt.grains.core.__salt__",
+            {"network.fqdns": MagicMock(return_value="my.fake.domain")},
+        ):
+            with patch.dict("salt.grains.core.__opts__", {"enable_fqdns_grains": True}):
+                assert core.fqdns() == "my.fake.domain"
+
+    def test_enablefqdnsNone(self):
+        """
+        testing default fqdns grains is returned when enable_fqdns_grains is None
+        """
+        with patch.dict("salt.grains.core.__opts__", {"enable_fqdns_grains": None}):
+            assert core.fqdns() == {"fqdns": []}
+
+    def test_enablefqdnswithoutpaching(self):
+        """
+        testing fqdns grains is enabled by default
+        """
+        with patch.dict(
+            "salt.grains.core.__salt__",
+            {"network.fqdns": MagicMock(return_value="my.fake.domain")},
+        ):
+            assert core.fqdns() == "my.fake.domain"
+
     @skipIf(not salt.utils.platform.is_linux(), "System is not Linux")
     @patch(
         "salt.utils.network.ip_addrs", MagicMock(return_value=["1.2.3.4", "5.6.7.8"])
@@ -1241,20 +1276,26 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
 
         for errno in (0, core.HOST_NOT_FOUND, core.NO_DATA):
             mock_log = MagicMock()
-            with patch.object(
-                socket, "gethostbyaddr", side_effect=_gen_gethostbyaddr(errno)
+            with patch.dict(
+                core.__salt__, {"network.fqdns": salt.modules.network.fqdns}
             ):
-                with patch("salt.grains.core.log", mock_log):
-                    self.assertEqual(core.fqdns(), {"fqdns": []})
-                    mock_log.debug.assert_called_once()
-                    mock_log.error.assert_not_called()
+                with patch.object(
+                    socket, "gethostbyaddr", side_effect=_gen_gethostbyaddr(errno)
+                ):
+                    with patch("salt.modules.network.log", mock_log):
+                        self.assertEqual(core.fqdns(), {"fqdns": []})
+                        mock_log.debug.assert_called()
+                        mock_log.error.assert_not_called()
 
         mock_log = MagicMock()
-        with patch.object(socket, "gethostbyaddr", side_effect=_gen_gethostbyaddr(-1)):
-            with patch("salt.grains.core.log", mock_log):
-                self.assertEqual(core.fqdns(), {"fqdns": []})
-                mock_log.debug.assert_not_called()
-                mock_log.error.assert_called_once()
+        with patch.dict(core.__salt__, {"network.fqdns": salt.modules.network.fqdns}):
+            with patch.object(
+                socket, "gethostbyaddr", side_effect=_gen_gethostbyaddr(-1)
+            ):
+                with patch("salt.modules.network.log", mock_log):
+                    self.assertEqual(core.fqdns(), {"fqdns": []})
+                    mock_log.debug.assert_called_once()
+                    mock_log.error.assert_called()
 
     def test_core_virtual(self):
         """

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -16,6 +16,7 @@ import salt.grains.core as core
 import salt.modules.cmdmod
 import salt.modules.network
 import salt.modules.smbios
+
 # Import Salt Libs
 import salt.utils.dns
 import salt.utils.files
@@ -23,6 +24,7 @@ import salt.utils.network
 import salt.utils.path
 import salt.utils.platform
 from salt._compat import ipaddress
+
 # Import 3rd-party libs
 from salt.ext import six
 from tests.support.mixins import LoaderModuleMockMixin


### PR DESCRIPTION
This PR ports #52527 to `master` branch.

---

### What does this PR do?

This PR fixes an issue that is currently blocking the "core" grains execution for several seconds when the some "FQDNs" cannot be calculated.

Currently, in order to calculate the `fqdns` grain, all the IP addresses from the minion are processed sequentially. The problem here comes from the underlying calls to `socket.gethostbyaddr` which can takes 5 seconds until it's released (after reaching the `socket.timeout`) when there is no defined "fqdn" for that IP.

In some scenarios, depending on the minion network configuration, this situation makes the `fqdn` grain calculation to take even more than 15 seconds. This completely breaks minion execution not only at startup time but any time the minion refreshes its grains.

This PR makes the `fqdn_lookup` to be executed in parallel (using threads) so, in those cases we would only wait until "socket.timeout" is reached once and prevent from blocking the minion execution for such a long time.

Besides of that, the whole "fqdn" calculation logic has been moved to the `network` execution module. Since the process of calculating the "fqdns" can take too much in case of networking issues, it makes more sense to move if away from the "core" grains and also introduce a new configuration parameters called `enable_fqdns_grains`(default True) to allow not to calculate "fqdns" as part of the "core" grains rendering.

### Tests written?

Yes

### Commits signed with GPG?

Yes
