### PR TITLE
Ignore return code in "run_all" and do not raise an exception therefore

### DIFF
--- a/changelog/51620.fixed
+++ b/changelog/51620.fixed
@@ -1,0 +1,1 @@
+Do not raise an exception in pkg.info_installed on nonzero return code

--- a/salt/modules/rpm_lowpkg.py
+++ b/salt/modules/rpm_lowpkg.py
@@ -615,17 +615,9 @@ def info(*packages, **kwargs):
         output_loglevel="trace",
         env={"TZ": "UTC"},
         clean_env=True,
+        ignore_retcode=True,
     )
-    if call["retcode"] != 0:
-        comment = ""
-        if "stderr" in call:
-            comment += call["stderr"] or call["stdout"]
-        raise CommandExecutionError(comment)
-    elif "error" in call["stderr"]:
-        raise CommandExecutionError(call["stderr"])
-    else:
-        out = call["stdout"]
-
+    out = call["stdout"]
     _ret = list()
     for pkg_info in re.split(r"----*", out):
         pkg_info = pkg_info.strip()

--- a/tests/pytests/unit/modules/test_rpm_lowpkg.py
+++ b/tests/pytests/unit/modules/test_rpm_lowpkg.py
@@ -2,6 +2,7 @@
     :codeauthor: Jayesh Kariya <jayeshk@saltstack.com>
 """
 
+import textwrap
 
 import pytest
 
@@ -377,3 +378,75 @@ def test_version_cmp_python():
             mock_log.warning.mock_calls[1][1][0]
             == "Falling back on salt.utils.versions.version_cmp() for version comparisons"
         )
+
+
+def test_info():
+    """
+    Confirm that a nonzero retcode does not raise an exception.
+    """
+    rpm_out = textwrap.dedent(
+        """\
+        name: bash
+        relocations: (not relocatable)
+        version: 4.4.19
+        vendor: CentOS
+        release: 10.el8
+        build_date_time_t: 1573230816
+        build_date: 1573230816
+        install_date_time_t: 1578952147
+        install_date: 1578952147
+        build_host: x86-01.mbox.centos.org
+        group: Unspecified
+        source_rpm: bash-4.4.19-10.el8.src.rpm
+        size: 6930068
+        arch: x86_64
+        license: GPLv3+
+        signature: RSA/SHA256, Wed Dec  4 22:45:04 2019, Key ID 05b555b38483c65d
+        packager: CentOS Buildsys <bugs@centos.org>
+        url: https://www.gnu.org/software/bash
+        summary: The GNU Bourne Again shell
+        edition: 4.4.19-10.el8
+        description:
+        The GNU Bourne Again shell (Bash) is a shell or command language
+        interpreter that is compatible with the Bourne shell (sh). Bash
+        incorporates useful features from the Korn shell (ksh) and the C shell
+        (csh). Most sh scripts can be run by bash without modification.
+        -----"""
+    )
+    dunder_salt = {
+        "cmd.run_stdout": MagicMock(return_value="LONGSIZE"),
+        "cmd.run_all": MagicMock(
+            return_value={
+                "retcode": 123,
+                "stdout": rpm_out,
+                "stderr": "",
+                "pid": 12345,
+            }
+        ),
+    }
+    expected = {
+        "bash": {
+            "relocations": "(not relocatable)",
+            "version": "4.4.19",
+            "vendor": "CentOS",
+            "release": "10.el8",
+            "build_date_time_t": 1573230816,
+            "build_date": "2019-11-08T16:33:36Z",
+            "install_date_time_t": 1578952147,
+            "install_date": "2020-01-13T21:49:07Z",
+            "build_host": "x86-01.mbox.centos.org",
+            "group": "Unspecified",
+            "source_rpm": "bash-4.4.19-10.el8.src.rpm",
+            "size": "6930068",
+            "arch": "x86_64",
+            "license": "GPLv3+",
+            "signature": "RSA/SHA256, Wed Dec  4 22:45:04 2019, Key ID 05b555b38483c65d",
+            "packager": "CentOS Buildsys <bugs@centos.org>",
+            "url": "https://www.gnu.org/software/bash",
+            "summary": "The GNU Bourne Again shell",
+            "description": "The GNU Bourne Again shell (Bash) is a shell or command language\ninterpreter that is compatible with the Bourne shell (sh). Bash\nincorporates useful features from the Korn shell (ksh) and the C shell\n(csh). Most sh scripts can be run by bash without modification.",
+        }
+    }
+    with patch.dict(rpm.__salt__, dunder_salt):
+        result = rpm.info("bash")
+        assert result == expected, result

--- a/tests/pytests/unit/modules/test_rpm_lowpkg.py
+++ b/tests/pytests/unit/modules/test_rpm_lowpkg.py
@@ -380,6 +380,7 @@ def test_version_cmp_python():
         )
 
 
+@pytest.mark.skip_on_windows
 def test_info():
     """
     Confirm that a nonzero retcode does not raise an exception.


### PR DESCRIPTION
This is https://github.com/saltstack/salt/pull/51623, reopened against master. It is a bugfix for https://github.com/saltstack/salt/issues/51620, so it should be targeted for 2019.2.3.