### PR TITLE
Fixes config_data parameter in compile_config

### DIFF
--- a/salt/modules/win_dsc.py
+++ b/salt/modules/win_dsc.py
@@ -318,7 +318,7 @@ def compile_config(
         cmd.append(script_parameters)
     cmd.extend([";", config_name])
     if config_data:
-        cmd.extend(['-ConfigurationData', config_data])
+        cmd.extend(["-ConfigurationData", config_data])
     cmd.append(
         "| Select-Object -Property FullName, Extension, Exists, "
         '@{Name="LastWriteTime";Expression={Get-Date ($_.LastWriteTime) '

--- a/salt/modules/win_dsc.py
+++ b/salt/modules/win_dsc.py
@@ -318,7 +318,7 @@ def compile_config(
         cmd.append(script_parameters)
     cmd.extend([";", config_name])
     if config_data:
-        cmd.append(config_data)
+        cmd.extend(['-ConfigurationData', config_data])
     cmd.append(
         "| Select-Object -Property FullName, Extension, Exists, "
         '@{Name="LastWriteTime";Expression={Get-Date ($_.LastWriteTime) '

--- a/tests/integration/files/file/base/HelloWorld.ps1
+++ b/tests/integration/files/file/base/HelloWorld.ps1
@@ -1,0 +1,16 @@
+Configuration HelloWorld {
+
+    # Import the module that contains the File resource.
+    Import-DscResource -ModuleName PsDesiredStateConfiguration
+
+    # The Node statement specifies which targets to compile MOF files for, when this configuration is executed.
+    Node $AllNodes.NodeName {
+
+        # The File resource can ensure the state of files, or copy them from a source to a destination with persistent updates.
+        File HelloWorld {
+            DestinationPath = "C:\Temp\HelloWorld.txt"
+            Ensure = "Present"
+            Contents   = "Hello World from DSC!"
+        }
+    }
+}

--- a/tests/integration/files/file/base/HelloWorld.psd1
+++ b/tests/integration/files/file/base/HelloWorld.psd1
@@ -1,0 +1,9 @@
+@{
+    AllNodes = @(
+        @{
+            NodeName = 'localhost'
+            PSDscAllowPlainTextPassword = $true
+            PSDscAllowDomainUser = $true
+        }
+    )
+}

--- a/tests/integration/modules/test_win_dsc.py
+++ b/tests/integration/modules/test_win_dsc.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+# Import Python libs
+from __future__ import absolute_import
+import os
+
+# Import Salt Testing libs
+from tests.support.runtests import RUNTIME_VARS
+from tests.support.case import ModuleCase
+from tests.support.unit import skipIf
+from tests.support.helpers import destructiveTest
+
+# Import Salt Libs
+import salt.utils.files
+import salt.utils.platform
+
+@skipIf(not salt.utils.platform.is_windows(), 'Tests for only Windows')
+class DscModuleTest(ModuleCase):
+    '''
+    Validate PowerShell DSC module
+    '''
+    def setUp(self):
+        self.ps1file = os.path.join(RUNTIME_VARS.TMP, 'HelloWorld.ps1')
+        with salt.utils.files.fopen(os.path.join(RUNTIME_VARS.FILES, 'file', 'base', 'HelloWorld.ps1'), 'rb') as sfp:
+            with salt.utils.files.fopen(self.ps1file, 'wb') as dfp:
+                dfp.write(sfp.read())
+        self.psd1file = os.path.join(RUNTIME_VARS.TMP, 'HelloWorld.psd1')
+        with salt.utils.files.fopen(os.path.join(RUNTIME_VARS.FILES, 'file', 'base', 'HelloWorld.psd1'), 'rb') as sfp:
+            with salt.utils.files.fopen(self.psd1file, 'wb') as dfp:
+                dfp.write(sfp.read())
+        super(DscModuleTest, self).setUp()
+
+    def tearDown(self):
+        if os.path.isfile(self.ps1file):
+            os.remove(self.ps1file)
+        if os.path.isfile(self.psd1file):
+            os.remove(self.psd1file)
+        super(DscModuleTest, self).tearDown()
+
+    @destructiveTest
+    def test_compile_config():
+        ret = self.run_function('dsc.compile_config', self.ps1file, config_name='HelloWorld', config_data=self.psd1file)
+        self.assertTrue(ret['Exists'])

--- a/tests/integration/modules/test_win_dsc.py
+++ b/tests/integration/modules/test_win_dsc.py
@@ -2,32 +2,38 @@
 
 # Import Python libs
 from __future__ import absolute_import
-import os
 
-# Import Salt Testing libs
-from tests.support.runtests import RUNTIME_VARS
-from tests.support.case import ModuleCase
-from tests.support.unit import skipIf
-from tests.support.helpers import destructiveTest
+import os
 
 # Import Salt Libs
 import salt.utils.files
 import salt.utils.platform
+from tests.support.case import ModuleCase
+from tests.support.helpers import destructiveTest
+
+# Import Salt Testing libs
+from tests.support.runtests import RUNTIME_VARS
+from tests.support.unit import skipIf
 
 
-@skipIf(not salt.utils.platform.is_windows(), 'Tests for only Windows')
+@skipIf(not salt.utils.platform.is_windows(), "Tests for only Windows")
 class DscModuleTest(ModuleCase):
-    '''
+    """
     Validate PowerShell DSC module
-    '''
+    """
+
     def setUp(self):
-        self.ps1file = os.path.join(RUNTIME_VARS.TMP, 'HelloWorld.ps1')
-        with salt.utils.files.fopen(os.path.join(RUNTIME_VARS.FILES, 'file', 'base', 'HelloWorld.ps1'), 'rb') as sfp:
-            with salt.utils.files.fopen(self.ps1file, 'wb') as dfp:
+        self.ps1file = os.path.join(RUNTIME_VARS.TMP, "HelloWorld.ps1")
+        with salt.utils.files.fopen(
+            os.path.join(RUNTIME_VARS.FILES, "file", "base", "HelloWorld.ps1"), "rb"
+        ) as sfp:
+            with salt.utils.files.fopen(self.ps1file, "wb") as dfp:
                 dfp.write(sfp.read())
-        self.psd1file = os.path.join(RUNTIME_VARS.TMP, 'HelloWorld.psd1')
-        with salt.utils.files.fopen(os.path.join(RUNTIME_VARS.FILES, 'file', 'base', 'HelloWorld.psd1'), 'rb') as sfp:
-            with salt.utils.files.fopen(self.psd1file, 'wb') as dfp:
+        self.psd1file = os.path.join(RUNTIME_VARS.TMP, "HelloWorld.psd1")
+        with salt.utils.files.fopen(
+            os.path.join(RUNTIME_VARS.FILES, "file", "base", "HelloWorld.psd1"), "rb"
+        ) as sfp:
+            with salt.utils.files.fopen(self.psd1file, "wb") as dfp:
                 dfp.write(sfp.read())
         super(DscModuleTest, self).setUp()
 
@@ -40,5 +46,10 @@ class DscModuleTest(ModuleCase):
 
     @destructiveTest
     def test_compile_config(self):
-        ret = self.run_function('dsc.compile_config', self.ps1file, config_name='HelloWorld', config_data=self.psd1file)
-        self.assertTrue(ret['Exists'])
+        ret = self.run_function(
+            "dsc.compile_config",
+            self.ps1file,
+            config_name="HelloWorld",
+            config_data=self.psd1file,
+        )
+        self.assertTrue(ret["Exists"])

--- a/tests/integration/modules/test_win_dsc.py
+++ b/tests/integration/modules/test_win_dsc.py
@@ -14,6 +14,7 @@ from tests.support.helpers import destructiveTest
 import salt.utils.files
 import salt.utils.platform
 
+
 @skipIf(not salt.utils.platform.is_windows(), 'Tests for only Windows')
 class DscModuleTest(ModuleCase):
     '''
@@ -38,6 +39,6 @@ class DscModuleTest(ModuleCase):
         super(DscModuleTest, self).tearDown()
 
     @destructiveTest
-    def test_compile_config():
+    def test_compile_config(self):
         ret = self.run_function('dsc.compile_config', self.ps1file, config_name='HelloWorld', config_data=self.psd1file)
         self.assertTrue(ret['Exists'])


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with compiling DSC when config_data is defined and dot sourcing is required
### What issues does this PR fix or reference?
Fixes #55425
### Previous Behavior
The config_data parameter is appended to the powershell command. Powershell interprets this as the value for a different positional parameter.
### New Behavior
`-ConfigurationData` is explicitly added to the powershell command before config_data
### Tests written?
Yes

### Commits signed with GPG?

Yes
