### PR TITLE
Added a support for a global proxy to pip module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Versions are `MAJOR.PATCH`.
 
 - [#54917](https://github.com/saltstack/salt/pull/54917) - Added get_settings, put_settings and flush_synced methods for Elasticsearch module. - [@Oloremo](https://github.com/Oloremo)
 - [#55418](https://github.com/saltstack/salt/pull/55418) - Added clean_parent argument for the archive state. - [@Oloremo](https://github.com/Oloremo)
+- [#55593](https://github.com/saltstack/salt/issues/55593) - Added a support for a global proxy to pip module. - [@Oloremo](https://github.com/Oloremo)
 
 ---
 

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -481,6 +481,11 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
         behind an authenticated proxy. If you provide
         ``user@proxy.server:port`` then you will be prompted for a password.
 
+        .. note::
+            If the the Minion has a globaly configured proxy - it will be used
+            even if no proxy was set here. To explicitly disable proxy for pip
+            you should pass ``False`` as a value.
+
     timeout
         Set the socket timeout (default 15 seconds)
 
@@ -711,8 +716,16 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
 
         cmd.extend(['--log', log])
 
+    config = __opts__
     if proxy:
         cmd.extend(['--proxy', proxy])
+    # If proxy arg is set to False we won't use the global proxy even if it's set.
+    elif proxy is not False and config.get('proxy_host') and config.get('proxy_port'):
+        if config.get('proxy_username') and config.get('proxy_password'):
+            http_proxy_url = 'http://{proxy_username}:{proxy_password}@{proxy_host}:{proxy_port}'.format(**config)
+        else:
+            http_proxy_url = 'http://{proxy_host}:{proxy_port}'.format(**config)
+        cmd.extend(['--proxy', http_proxy_url])
 
     if timeout:
         try:
@@ -995,6 +1008,11 @@ def uninstall(pkgs=None,
         behind an authenticated proxy.  If you provide
         ``user@proxy.server:port`` then you will be prompted for a password.
 
+        .. note::
+            If the the Minion has a globaly configured proxy - it will be used
+            even if no proxy was set here. To explicitly disable proxy for pip
+            you should pass ``False`` as a value.
+
     timeout
         Set the socket timeout (default 15 seconds)
 
@@ -1036,8 +1054,16 @@ def uninstall(pkgs=None,
 
         cmd.extend(['--log', log])
 
+    config = __opts__
     if proxy:
         cmd.extend(['--proxy', proxy])
+    # If proxy arg is set to False we won't use the global proxy even if it's set.
+    elif proxy is not False and config.get('proxy_host') and config.get('proxy_port'):
+        if config.get('proxy_username') and config.get('proxy_password'):
+            http_proxy_url = 'http://{proxy_username}:{proxy_password}@{proxy_host}:{proxy_port}'.format(**config)
+        else:
+            http_proxy_url = 'http://{proxy_host}:{proxy_port}'.format(**config)
+        cmd.extend(['--proxy', http_proxy_url])
 
     if timeout:
         try:

--- a/tests/unit/modules/test_pip.py
+++ b/tests/unit/modules/test_pip.py
@@ -750,6 +750,53 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
                 python_shell=False,
             )
 
+    def test_install_proxy_false_argument_in_resulting_command(self):
+        '''
+        Checking that there is no proxy set if proxy arg is set to False
+        even if the global proxy is set.
+        '''
+        pkg = 'pep8'
+        proxy = False
+        mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
+        config_mock = {'proxy_host': 'salt-proxy',
+                       'proxy_port': '3128',
+                       'proxy_username': 'salt-user',
+                       'proxy_password': 'salt-passwd'}
+        with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
+            with patch.dict(pip.__opts__, config_mock):
+                pip.install(pkg, proxy=proxy)
+                expected = [sys.executable, '-m', 'pip', 'install', pkg]
+                mock.assert_called_with(
+                    expected,
+                    saltenv='base',
+                    runas=None,
+                    use_vt=False,
+                    python_shell=False,
+                )
+
+    def test_install_global_proxy_in_resulting_command(self):
+        '''
+        Checking that there is proxy set if global proxy is set.
+        '''
+        pkg = 'pep8'
+        proxy = 'http://salt-user:salt-passwd@salt-proxy:3128'
+        mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
+        config_mock = {'proxy_host': 'salt-proxy',
+                       'proxy_port': '3128',
+                       'proxy_username': 'salt-user',
+                       'proxy_password': 'salt-passwd'}
+        with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
+            with patch.dict(pip.__opts__, config_mock):
+                pip.install(pkg)
+                expected = [sys.executable, '-m', 'pip', 'install', '--proxy', proxy, pkg]
+                mock.assert_called_with(
+                    expected,
+                    saltenv='base',
+                    runas=None,
+                    use_vt=False,
+                    python_shell=False,
+                )
+
     def test_install_multiple_requirements_arguments_in_resulting_command(self):
         with patch('salt.modules.pip._get_cached_requirements') as get_cached_requirements:
             cached_reqs = [
@@ -894,21 +941,54 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
                     python_shell=False,
                 )
 
-    def test_uninstall_proxy_argument_in_resulting_command(self):
+    def test_uninstall_global_proxy_in_resulting_command(self):
+        '''
+        Checking that there is proxy set if global proxy is set.
+        '''
         pkg = 'pep8'
-        proxy = 'salt-user:salt-passwd@salt-proxy:3128'
+        proxy = 'http://salt-user:salt-passwd@salt-proxy:3128'
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
+        config_mock = {'proxy_host': 'salt-proxy',
+                       'proxy_port': '3128',
+                       'proxy_username': 'salt-user',
+                       'proxy_password': 'salt-passwd'}
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
-            pip.uninstall(pkg, proxy=proxy)
-            expected = [sys.executable, '-m', 'pip', 'uninstall', '-y', '--proxy', proxy, pkg]
-            mock.assert_called_with(
-                expected,
-                saltenv='base',
-                cwd=None,
-                runas=None,
-                use_vt=False,
-                python_shell=False,
-            )
+            with patch.dict(pip.__opts__, config_mock):
+                pip.uninstall(pkg)
+                expected = [sys.executable, '-m', 'pip', 'uninstall', '-y', '--proxy', proxy, pkg]
+                mock.assert_called_with(
+                    expected,
+                    saltenv='base',
+                    cwd=None,
+                    runas=None,
+                    use_vt=False,
+                    python_shell=False,
+                )
+
+    def test_uninstall_proxy_false_argument_in_resulting_command(self):
+        '''
+        Checking that there is no proxy set if proxy arg is set to False
+        even if the global proxy is set.
+        '''
+        pkg = 'pep8'
+        proxy = False
+        mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
+        config_mock = {'proxy_host': 'salt-proxy',
+                       'proxy_port': '3128',
+                       'proxy_username': 'salt-user',
+                       'proxy_password': 'salt-passwd'}
+        with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
+            with patch.dict(pip.__opts__, config_mock):
+                pip.uninstall(pkg, proxy=proxy)
+                expected = [sys.executable, '-m', 'pip', 'uninstall', '-y', pkg]
+                mock.assert_called_with(
+                    expected,
+                    saltenv='base',
+                    cwd=None,
+                    runas=None,
+                    use_vt=False,
+                    python_shell=False,
+                )
 
     def test_uninstall_log_argument_in_resulting_command(self):
         pkg = 'pep8'


### PR DESCRIPTION
### What does this PR do?
Added support for a global Salt proxy to pip module

### What issues does this PR fix or reference?
#55593

### Previous Behavior
pip module and state doesn't support salt global proxy

### New Behavior
pip module and state does support salt global proxy

### Tests written?

Yes

### Commits signed with GPG?

Yes