### PR TITLE
Deprecate jinja filters for neon

### DIFF
--- a/doc/topics/jinja/index.rst
+++ b/doc/topics/jinja/index.rst
@@ -914,7 +914,7 @@ Example:
     Renamed from ``json_decode_list`` to ``json_encode_list``. When you encode
     something you get bytes, and when you decode, you get your locale's
     encoding (usually a ``unicode`` type). This filter was incorrectly-named
-    when it was added. ``json_decode_list`` will be supported until the Neon
+    when it was added. ``json_decode_list`` will be supported until the Aluminium
     release.
 .. deprecated:: 2018.3.3,2019.2.0
     The :jinja_ref:`tojson` filter accomplishes what this filter was designed
@@ -947,7 +947,7 @@ Returns:
     Renamed from ``json_decode_dict`` to ``json_encode_dict``. When you encode
     something you get bytes, and when you decode, you get your locale's
     encoding (usually a ``unicode`` type). This filter was incorrectly-named
-    when it was added. ``json_decode_dict`` will be supported until the Neon
+    when it was added. ``json_decode_dict`` will be supported until the Aluminium
     release.
 .. deprecated:: 2018.3.3,2019.2.0
     The :jinja_ref:`tojson` filter accomplishes what this filter was designed
@@ -995,8 +995,8 @@ installed, then the upstream version of the filter will be used. See the
 .. versionadded:: 2017.7.0
 .. versionadded:: 2018.3.0
     Renamed from ``rand_str`` to ``random_hash`` to more accurately describe
-    what the filter does. ``rand_str`` will be supported until the Neon
-    release.
+    what the filter does. ``rand_str`` will be supported to ensure backwards
+    compatibility but please use the preferred ``random_hash``.
 
 Generates a random number between 1 and the number passed to the filter, and
 then hashes it. The default hash type is the one specified by the minion's

--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -193,3 +193,12 @@ salt.auth.Authorize Class Removal
 - The salt.auth.Authorize Class inside of the `salt/auth/__init__.py` file has been removed and
   the `any_auth` method inside of the file `salt/utils/minions.py`. These method and classes were
   not being used inside of the salt code base.
+
+Jinja Filter Deprecations
+-------------------------
+
+- The following jinja filters are set to be removed in the Aluminium release:
+
+  - :jinja_ref:`json_decode_dict` in favor of :jinja_ref:`tojson`
+  - :jinja_ref:`json_decode_list` in favor of :jinja_ref:`tojson`
+  - :jinja_ref:`str_to_num` in favor of :jinja_ref:`to_num`

--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -201,4 +201,3 @@ Jinja Filter Deprecations
 
   - :jinja_ref:`json_decode_dict` in favor of :jinja_ref:`tojson`
   - :jinja_ref:`json_decode_list` in favor of :jinja_ref:`tojson`
-  - :jinja_ref:`str_to_num` in favor of :jinja_ref:`to_num`

--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -193,11 +193,3 @@ salt.auth.Authorize Class Removal
 - The salt.auth.Authorize Class inside of the `salt/auth/__init__.py` file has been removed and
   the `any_auth` method inside of the file `salt/utils/minions.py`. These method and classes were
   not being used inside of the salt code base.
-
-Jinja Filter Deprecations
--------------------------
-
-- The following jinja filters are set to be removed in the Aluminium release:
-
-  - :jinja_ref:`json_decode_dict` in favor of :jinja_ref:`tojson`
-  - :jinja_ref:`json_decode_list` in favor of :jinja_ref:`tojson`

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -359,8 +359,8 @@ def encode(data, encoding=None, errors='strict', keep=False,
         return data
 
 
-@jinja_filter('json_decode_dict')  # Remove this for Neon
-@jinja_filter('json_encode_dict')  # Remove this for Neon
+@jinja_filter('json_decode_dict')  # Remove this for Aluminium
+@jinja_filter('json_encode_dict')  # Remove this for Aluminium
 def encode_dict(data, encoding=None, errors='strict', keep=False,
                 preserve_dict_class=False, preserve_tuples=False):
     '''
@@ -412,8 +412,8 @@ def encode_dict(data, encoding=None, errors='strict', keep=False,
     return rv
 
 
-@jinja_filter('json_decode_list')  # Remove this for Neon
-@jinja_filter('json_encode_list')  # Remove this for Neon
+@jinja_filter('json_decode_list')  # Remove this for Aluminium
+@jinja_filter('json_encode_list')  # Remove this for Aluminium
 def encode_list(data, encoding=None, errors='strict', keep=False,
                 preserve_dict_class=False, preserve_tuples=False):
     '''

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -360,7 +360,7 @@ def encode(data, encoding=None, errors='strict', keep=False,
 
 
 @jinja_filter('json_decode_dict')  # Remove this for Aluminium
-@jinja_filter('json_encode_dict')  # Remove this for Aluminium
+@jinja_filter('json_encode_dict')
 def encode_dict(data, encoding=None, errors='strict', keep=False,
                 preserve_dict_class=False, preserve_tuples=False):
     '''
@@ -413,7 +413,7 @@ def encode_dict(data, encoding=None, errors='strict', keep=False,
 
 
 @jinja_filter('json_decode_list')  # Remove this for Aluminium
-@jinja_filter('json_encode_list')  # Remove this for Aluminium
+@jinja_filter('json_encode_list')
 def encode_list(data, encoding=None, errors='strict', keep=False,
                 preserve_dict_class=False, preserve_tuples=False):
     '''

--- a/salt/utils/hashutils.py
+++ b/salt/utils/hashutils.py
@@ -159,6 +159,7 @@ def hmac_compute(string, shared_secret):
     return hmac_hash
 
 
+@jinja_filter('rand_str')
 @jinja_filter('random_hash')
 def random_hash(size=9999999999, hash_type=None):
     '''

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -564,14 +564,6 @@ def lst_avg(lst):
 
         2.5
     '''
-    salt.utils.versions.warn_until(
-        'Neon',
-        'This results of this function are currently being rounded.'
-        'Beginning in the Salt Neon release, results will no longer be '
-        'rounded and this warning will be removed.',
-        stacklevel=3
-    )
-
     if not isinstance(lst, collections.Hashable):
         return float(sum(lst)/len(lst))
     return float(lst)

--- a/salt/utils/stringutils.py
+++ b/salt/utils/stringutils.py
@@ -161,7 +161,7 @@ def to_unicode(s, encoding=None, errors='strict', normalize=False):
         raise TypeError('expected str, bytes, or bytearray not {}'.format(type(s)))
 
 
-@jinja_filter('str_to_num')  # Remove this for Aluminium
+@jinja_filter('str_to_num')
 @jinja_filter('to_num')
 def to_num(text):
     '''

--- a/salt/utils/stringutils.py
+++ b/salt/utils/stringutils.py
@@ -161,7 +161,7 @@ def to_unicode(s, encoding=None, errors='strict', normalize=False):
         raise TypeError('expected str, bytes, or bytearray not {}'.format(type(s)))
 
 
-@jinja_filter('str_to_num')  # Remove this for Neon
+@jinja_filter('str_to_num')  # Remove this for Aluminium
 @jinja_filter('to_num')
 def to_num(text):
     '''


### PR DESCRIPTION
### What does this PR do?
- in this pr https://github.com/saltstack/salt/pull/48339 a note was added in the jinja docs that the `tojson` jinja filter would replace `json_encode_dict` and `json_encode_list`, but it was never added to the release notes for a release to properly deprecate it. This PR will add this notification in the neon release notes for `json_decode_*` as this was improperly named. we will keep `json_encode_*` as it still makes sense and we want to decrease users having to update their states.

- we want to keep `str_to_num` and `rand_str` to ensure users do not have to update their states, but its already documented they these are no the preferred method.

Fixes issue https://github.com/saltstack/salt/issues/49428