### PR TITLE
fix OSError: /usr/local/opt/openssl@1.1/lib/libcrypto.dylib: cannot o…

### DIFF
--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import glob
 import sys
 import os
+import platform
 
 # Import Salt libs
 import salt.utils.platform
@@ -35,7 +36,10 @@ def _load_libcrypto():
             os.path.dirname(sys.executable),
             'libcrypto.so*'))[0])
     else:
-        lib = find_library('crypto')
+        if platform.system() == 'Darwin' and int(platform.release().split('.')[0]) > 19:
+            lib = '/usr/local/opt/openssl@1.1/lib/libcrypto.dylib'
+        else:
+            lib = find_library('crypto')
         if not lib and sys.platform.startswith('sunos5'):
             # ctypes.util.find_library defaults to 32 bit library path on sunos5, test for 64 bit python execution
             lib = find_library('crypto', sys.maxsize > 2**32)


### PR DESCRIPTION


### What does this PR do?
salt-ssh on MacOS catalina to deploy configuration on remote host, got
OSError: /usr/local/opt/openssl@1.1/lib/libcrypto.dylib: cannot open shared object file: No such file or directory

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
