### PR TITLE
Updating download link for openSUSE

### DIFF
--- a/doc/topics/tutorials/cloud_controller.rst
+++ b/doc/topics/tutorials/cloud_controller.rst
@@ -197,9 +197,7 @@ https://alt.fedoraproject.org/cloud
 openSUSE
 ~~~~~~~~
 
-http://download.opensuse.org/repositories/openSUSE:/Leap:/42.1:/Images/images
-
-(look for JeOS-for-kvm-and-xen variant)
+https://download.opensuse.org/distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-kvm-and-xen-Current.qcow2.meta4
 
 SUSE
 ~~~~


### PR DESCRIPTION
### What does this PR do?
Add direct "meta link" to the latest openSUSE Leap 15.1.

### What issues does this PR fix or reference?
outdated and out of support openSUSE42.1


