### PR TITLE
fallback to ext_pillar in pillar match if there is no pillar in __opts__

### DIFF
--- a/salt/matchers/pillar_exact_match.py
+++ b/salt/matchers/pillar_exact_match.py
@@ -22,7 +22,12 @@ def match(tgt, delimiter=':', opts=None):
                   'statement from master')
         return False
 
-    return salt.utils.data.subdict_match(opts['pillar'],
-                                         tgt,
-                                         delimiter=delimiter,
-                                         exact_match=True)
+    if 'pillar' in opts:
+        pillar = opts['pillar']
+    elif 'ext_pillar' in opts:
+        log.info('No pillar found, fallback to ext_pillar')
+        pillar = opts['ext_pillar']
+
+    return salt.utils.data.subdict_match(
+        pillar, tgt, delimiter=delimiter, exact_match=True
+    )

--- a/salt/matchers/pillar_match.py
+++ b/salt/matchers/pillar_match.py
@@ -22,6 +22,13 @@ def match(tgt, delimiter=DEFAULT_TARGET_DELIM, opts=None):
         log.error('Got insufficient arguments for pillar match '
                   'statement from master')
         return False
+
+    if 'pillar' in opts:
+        pillar = opts['pillar']
+    elif 'ext_pillar' in opts:
+        log.info('No pillar found, fallback to ext_pillar')
+        pillar = opts['ext_pillar']
+
     return salt.utils.data.subdict_match(
-        opts['pillar'], tgt, delimiter=delimiter
+        pillar, tgt, delimiter=delimiter
     )

--- a/salt/matchers/pillar_pcre_match.py
+++ b/salt/matchers/pillar_pcre_match.py
@@ -23,6 +23,12 @@ def match(tgt, delimiter=DEFAULT_TARGET_DELIM, opts=None):
                   'statement from master')
         return False
 
+    if 'pillar' in opts:
+        pillar = opts['pillar']
+    elif 'ext_pillar' in opts:
+        log.info('No pillar found, fallback to ext_pillar')
+        pillar = opts['ext_pillar']
+
     return salt.utils.data.subdict_match(
-        opts['pillar'], tgt, delimiter=delimiter, regex_match=True
+        pillar, tgt, delimiter=delimiter, regex_match=True
     )


### PR DESCRIPTION
### What does this PR do?
If there is 'pillar' in `__opts__` the matchers would break. This PR determines if there is a 'pillar' object and uses 'ext_pillar' if there is none.

### What issues does this PR fix or reference?
#52567

### Previous Behavior
Previously the matcher would just call `__opts__['pillar']`.

### New Behavior
The matcher checks for `__opts__['pillar']`. If there is none, it calls `__opts__['ext_pillar']` instead.

### Tests written?
No

### Commits signed with GPG?
No