### PR TITLE
Always try to reinitialize Crypto.Random when forking minion process

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -30,6 +30,7 @@ from salt.ext.six.moves import range
 from salt.utils.zeromq import zmq, ZMQDefaultLoop, install_zmq, ZMQ_VERSION_INFO
 import salt.transport.client
 import salt.defaults.exitcodes
+import salt.utils.crypt
 
 from salt.utils.ctx import RequestContext
 
@@ -1531,6 +1532,7 @@ class Minion(MinionBase):
                     name='ProcessPayload',
                     args=(instance, self.opts, data, self.connected)
                 )
+                process._after_fork_methods.append((salt.utils.crypt.reinit_crypto, [], {}))
         else:
             process = threading.Thread(
                 target=self._target,

--- a/tests/unit/test_minion.py
+++ b/tests/unit/test_minion.py
@@ -21,6 +21,8 @@ import salt.syspaths
 import tornado
 import tornado.testing
 from salt.ext.six.moves import range
+import salt.utils.crypt
+import salt.utils.process
 
 
 class MinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
@@ -338,6 +340,26 @@ class MinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             assert execmock.called_with(minion.opts, minion.functions)
         finally:
             minion.destroy()
+
+    @patch('salt.utils.process.default_signals')
+    def test_reinit_crypto_on_fork(self, def_mock):
+        '''
+        Ensure salt.utils.crypt.reinit_crypto() is executed when forking for new job
+        '''
+        mock_opts = self.get_config('minion', from_scratch=True)
+        mock_opts["multiprocessing"] = True
+
+        io_loop = tornado.ioloop.IOLoop()
+        io_loop.make_current()
+        minion = salt.minion.Minion(mock_opts, io_loop=io_loop)
+
+        job_data = {"jid": "test-jid", "fun": "test.ping"}
+
+        def mock_start(self):
+            assert len([x for x in self._after_fork_methods if x[0] == salt.utils.crypt.reinit_crypto]) == 1  # pylint: disable=comparison-with-callable
+
+        with patch.object(salt.utils.process.SignalHandlingProcess, 'start', mock_start):
+            io_loop.run_sync(lambda: minion._handle_decoded_payload(job_data))
 
 
 class MinionAsyncTestCase(TestCase, AdaptedConfigurationTestCaseMixin, tornado.testing.AsyncTestCase):


### PR DESCRIPTION
### What does this PR do?
Always try to reinitialize Crypto.Random when processing minion events to avoid issues when minion tries to sign something during/after job execution. 

### What issues does this PR fix or reference?
Fix #55116

### Previous Behavior
When having minion configured with option `minion_sign_messages: True`, any job result event would fail with `PID check failed. RNG must be re-initialized after fork()` when using RHEL 6 or TCP transport

### New Behavior
Minion successfully responds with job result

### Tests written?
~~No, AFAIK the only way how to really test this is to enable `minion_sign_messages` for integration tests. As this is currently global for all tests, it might affect other tests that inspect raw events (cc @waynew )~~

Yes

### Commits signed with GPG?

Yes
