### PR TITLE
Deprecate enviroment for environment in heat modules

### DIFF
--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -147,21 +147,12 @@ Module Deprecations
         - :py:func:`dockermod.load <salt.modules.dockermod.load>`
         - :py:func:`dockermod.tag <salt.modules.dockermod.tag_>`
 
-- The heat module has removed the ``enviroment`` kwarg from the
-  :py:func:`heat.create_stack <salt.modules.heat.create_stack>` and
-  :py:func:`heat.update_stack <salt.modules.heat.update_stack>` functions due
-  to a spelling error. Please use ``environment`` instead.
-
 State Deprecations
 ------------------
 
 - The hipchat state has been removed due to the service being retired.
   :py:func:`MS Teams <salt.states.msteams>` or
   :py:func:`Slack <salt.states.slack>` may be suitable replacements.
-
-- The heat state module has removed the ``enviroment`` kwarg from the
-  :py:func:`heat.deployed <salt.states.heat.deployed>` function due
-  to a spelling error. Please use ``environment`` instead.
 
 Fileserver Deprecations
 -----------------------

--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -147,12 +147,21 @@ Module Deprecations
         - :py:func:`dockermod.load <salt.modules.dockermod.load>`
         - :py:func:`dockermod.tag <salt.modules.dockermod.tag_>`
 
+- The heat module has removed the ``enviroment`` kwarg from the
+  :py:func:`heat.create_stack <salt.modules.heat.create_stack>` and
+  :py:func:`heat.update_stack <salt.modules.heat.update_stack>` functions due
+  to a spelling error. Please use ``environment`` instead.
+
 State Deprecations
 ------------------
 
 - The hipchat state has been removed due to the service being retired.
   :py:func:`MS Teams <salt.states.msteams>` or
   :py:func:`Slack <salt.states.slack>` may be suitable replacements.
+
+- The heat state module has removed the ``enviroment`` kwarg from the
+  :py:func:`heat.deployed <salt.states.heat.deployed>` function due
+  to a spelling error. Please use ``environment`` instead.
 
 Fileserver Deprecations
 -----------------------

--- a/salt/modules/heat.py
+++ b/salt/modules/heat.py
@@ -431,7 +431,7 @@ def delete_stack(name=None, poll=0, timeout=60, profile=None):
 
 def create_stack(name=None, template_file=None, environment=None,
                  parameters=None, poll=0, rollback=False, timeout=60,
-                 profile=None, enviroment=None):
+                 profile=None):
     '''
     Create a stack (heat stack-create)
 
@@ -472,16 +472,9 @@ def create_stack(name=None, template_file=None, environment=None,
     .. versionadded:: 2017.7.5,2018.3.1
 
         The spelling mistake in parameter `enviroment` was corrected to `environment`.
-        The misspelled version is still supported for backward compatibility, but will
-        be removed in Salt Neon.
+        The `enviroment` spelling mistake has been removed in Salt Neon.
 
     '''
-    if environment is None and enviroment is not None:
-        salt.utils.versions.warn_until('Neon', (
-            "Please use the 'environment' parameter instead of the misspelled 'enviroment' "
-            "parameter which will be removed in Salt Neon."
-        ))
-        environment = enviroment
     h_client = _auth(profile)
     ret = {
         'result': True,
@@ -496,9 +489,11 @@ def create_stack(name=None, template_file=None, environment=None,
             template=None,
             source=template_file,
             source_hash=None,
+            source_hash_name=None,
             user=None,
             group=None,
             mode=None,
+            attrs=None,
             saltenv='base',
             context=None,
             defaults=None,
@@ -514,6 +509,7 @@ def create_stack(name=None, template_file=None, environment=None,
             user=None,
             group=None,
             mode=None,
+            attrs=None,
             saltenv='base',
             backup=None,
             makedirs=True,
@@ -556,9 +552,11 @@ def create_stack(name=None, template_file=None, environment=None,
             template=None,
             source=environment,
             source_hash=None,
+            source_hash_name=None,
             user=None,
             group=None,
             mode=None,
+            attrs=None,
             saltenv='base',
             context=None,
             defaults=None,
@@ -574,6 +572,7 @@ def create_stack(name=None, template_file=None, environment=None,
             user=None,
             group=None,
             mode=None,
+            attrs=None,
             saltenv='base',
             backup=None,
             makedirs=True,
@@ -626,7 +625,7 @@ def create_stack(name=None, template_file=None, environment=None,
 
 def update_stack(name=None, template_file=None, environment=None,
                  parameters=None, poll=0, rollback=False, timeout=60,
-                 profile=None, enviroment=None):
+                 profile=None):
     '''
     Update a stack (heat stack-template)
 
@@ -667,16 +666,9 @@ def update_stack(name=None, template_file=None, environment=None,
     .. versionadded:: 2017.7.5,2018.3.1
 
         The spelling mistake in parameter `enviroment` was corrected to `environment`.
-        The misspelled version is still supported for backward compatibility, but will
-        be removed in Salt Neon.
+        The `enviroment` spelling mistake has been removed in Salt Neon.
 
     '''
-    if environment is None and enviroment is not None:
-        salt.utils.versions.warn_until('Neon', (
-            "Please use the 'environment' parameter instead of the misspelled 'enviroment' "
-            "parameter which will be removed in Salt Neon."
-        ))
-        environment = enviroment
     h_client = _auth(profile)
     ret = {
         'result': True,
@@ -695,9 +687,11 @@ def update_stack(name=None, template_file=None, environment=None,
             template=None,
             source=template_file,
             source_hash=None,
+            source_hash_name=None,
             user=None,
             group=None,
             mode=None,
+            attrs=None,
             saltenv='base',
             context=None,
             defaults=None,
@@ -713,6 +707,7 @@ def update_stack(name=None, template_file=None, environment=None,
             user=None,
             group=None,
             mode=None,
+            attrs=None,
             saltenv='base',
             backup=None,
             makedirs=True,
@@ -755,9 +750,11 @@ def update_stack(name=None, template_file=None, environment=None,
             template=None,
             source=environment,
             source_hash=None,
+            source_hash_name=None,
             user=None,
             group=None,
             mode=None,
+            attrs=None,
             saltenv='base',
             context=None,
             defaults=None,
@@ -773,6 +770,7 @@ def update_stack(name=None, template_file=None, environment=None,
             user=None,
             group=None,
             mode=None,
+            attrs=None,
             saltenv='base',
             backup=None,
             makedirs=True,

--- a/salt/states/heat.py
+++ b/salt/states/heat.py
@@ -36,8 +36,7 @@ mysql:
 .. versionadded:: 2017.7.5,2018.3.1
 
     The spelling mistake in parameter `enviroment` was corrected to `environment`.
-    The misspelled version is still supported for backward compatibility, but will
-    be removed in Salt Neon.
+    The `enviroment` spelling mistake has been removed in Salt Neon.
 
 '''
 # Import Python libs
@@ -132,16 +131,9 @@ def deployed(name, template=None, environment=None, params=None, poll=5,
     .. versionadded:: 2017.7.5,2018.3.1
 
         The spelling mistake in parameter `enviroment` was corrected to `environment`.
-        The misspelled version is still supported for backward compatibility, but will
-        be removed in Salt Neon.
+        The `enviroment` spelling mistake has been removed in Salt Neon.
 
     '''
-    if environment is None and 'enviroment' in connection_args:
-        salt.utils.versions.warn_until('Neon', (
-            "Please use the 'environment' parameter instead of the misspelled 'enviroment' "
-            "parameter which will be removed in Salt Neon."
-        ))
-        environment = connection_args.pop('enviroment')
     log.debug('Deployed with(' +
               '{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9})'
               .format(name, template, environment, params, poll, rollback,

--- a/tests/integration/files/file/base/templates/heat-env.yml
+++ b/tests/integration/files/file/base/templates/heat-env.yml
@@ -1,0 +1,4 @@
+parameter_defaults: ''
+parameters: ''
+resource_registry: ''
+event_sinks: ''

--- a/tests/integration/files/file/base/templates/heat-template.yml
+++ b/tests/integration/files/file/base/templates/heat-template.yml
@@ -1,0 +1,1 @@
+HeatTemplateFormatVersion: 4.0

--- a/tests/unit/modules/test_heat.py
+++ b/tests/unit/modules/test_heat.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+
+# Import Python Libs
+from __future__ import absolute_import, unicode_literals, print_function
+import os
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase
+from tests.support.runtests import RUNTIME_VARS
+from tests.support.mock import (
+    MagicMock,
+    patch,
+)
+
+# Import Salt Libs
+import salt.modules.heat as heat
+import salt.modules.file as file_
+
+
+class MockStacks(object):
+    '''
+    Mock stacks.StackManager
+    '''
+    def validate(self, **kwargs):
+        '''
+        Mock of stacks.StackManager.validate method
+        '''
+        self.mock_val_ret = MagicMock()
+        self.mock_val_ret.json.return_value = {'result': 'mocked response'}
+        self.mock_validate = MagicMock()
+        self.mock_validate.post.return_value = self.mock_val_ret
+        return self.mock_validate
+
+    def create(self, **kwargs):
+        self.mock_create_ret = MagicMock()
+        self.mock_create_ret.json.return_value = {'result': 'mocked create',
+                                                  'fields': kwargs}
+        self.mock_create = MagicMock()
+        self.mock_create.post.return_value = self.mock_create_ret
+        return self.mock_create
+
+    def update(self, name, **kwargs):
+        self.mock_update_ret = MagicMock()
+        self.mock_update_ret.json.return_value = {'result': 'mocked update',
+                                                  'fields': kwargs, 'name': name}
+        self.mock_update = MagicMock()
+        self.mock_update.post.return_value = self.mock_update_ret
+        return self.mock_update
+
+
+class MockClient(object):
+    """
+    Mock of Client class
+    """
+    def __init__(self, profile=None, **conn_args):
+        self.stacks = MockStacks()
+
+
+class HeatTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    Test cases for salt.modules.heat
+    '''
+
+    def setup_loader_modules(self):
+        return {
+            heat: {
+                '_auth': MockClient,
+            },
+            file_: {
+                '__opts__': {'hash_type': 'sha256',
+                             'cachedir': os.path.join(RUNTIME_VARS.TMP,
+                                                      'rootdir', 'cache'),
+                             'test': False},
+                '__salt__': {'config.option':
+                             MagicMock(return_value={'obfuscate_templates':
+                                                     False}),
+                             'config.backup_mode':
+                             MagicMock(return_value=False)}
+            }
+        }
+
+    def test_heat_create_stack(self):
+        '''
+        Test salt.modules.heat.create_stack method
+        '''
+        patch_file = patch.dict(heat.__salt__,
+                                {'file.get_managed': file_.get_managed,
+                                 'file.manage_file': file_.manage_file, },
+                               )
+        with patch_file:
+            ret = heat.create_stack(name='mystack',
+                                    profile='openstack1',
+                                    template_file=os.path.join(RUNTIME_VARS.BASE_FILES,
+                                                               'templates', 'heat-template.yml'))
+        assert ret == {'result': True, 'comment': "Created stack 'mystack'."}
+
+    def test_heat_create_stack_environment(self):
+        '''
+        Test salt.modules.heat.create_stack method with environment set
+        '''
+        patch_file = patch.dict('salt.modules.heat.__salt__',
+                                {'file.get_managed': file_.get_managed,
+                                 'file.manage_file': file_.manage_file, },
+                               )
+        with patch_file:
+            ret = heat.create_stack(name='mystack',
+                                    profile='openstack1',
+                                    environment=os.path.join(RUNTIME_VARS.BASE_FILES,
+                                                             'templates', 'heat-env.yml'),
+                                    template_file=os.path.join(RUNTIME_VARS.BASE_FILES,
+                                                               'templates', 'heat-template.yml'))
+        assert ret == {'result': True, 'comment': "Created stack 'mystack'."}
+
+    def test_heat_create_stack_environment_err(self):
+        '''
+        Test salt.modules.heat.create_stack method with environment set
+        and there is an error reading the environment file
+        '''
+        patch_file = patch.dict('salt.modules.heat.__salt__',
+                                {'file.get_managed': file_.get_managed,
+                                 'file.manage_file': MagicMock(side_effect=[{'result': True}, {'result': False}]), },
+                               )
+        patch_template = patch('salt.modules.heat._parse_template', MagicMock(return_value=True))
+        env_file = os.path.join(RUNTIME_VARS.BASE_FILES, 'templates', 'heat-env.yml')
+        with patch_file, patch_template:
+            ret = heat.create_stack(name='mystack',
+                                    profile='openstack1',
+                                    environment=env_file,
+                                    template_file=os.path.join(RUNTIME_VARS.BASE_FILES,
+                                                               'templates', 'heat-template.yml'))
+        assert ret == {'result': False, 'comment': 'Can not open environment: {0}, '.format(env_file)}
+
+    def test_heat_update_stack(self):
+        '''
+        Test salt.modules.heat.update_method method
+        '''
+        patch_file = patch.dict(heat.__salt__,
+                                {'file.get_managed': file_.get_managed,
+                                 'file.manage_file': file_.manage_file, },
+                               )
+        with patch_file:
+            ret = heat.update_stack(name='mystack',
+                                    profile='openstack1',
+                                    template_file=os.path.join(RUNTIME_VARS.BASE_FILES,
+                                                               'templates', 'heat-template.yml'))
+        assert ret == {'result': True, 'comment': ("Updated stack 'mystack'.",)}
+
+    def test_heat_update_stack_env(self):
+        '''
+        Test salt.modules.heat.update_method method
+        with environment set
+        '''
+        patch_file = patch.dict(heat.__salt__,
+                                {'file.get_managed': file_.get_managed,
+                                 'file.manage_file': file_.manage_file, },
+                               )
+        with patch_file:
+            ret = heat.update_stack(name='mystack',
+                                    profile='openstack1',
+                                    template_file=os.path.join(RUNTIME_VARS.BASE_FILES,
+                                                               'templates', 'heat-template.yml'),
+                                    environment=os.path.join(RUNTIME_VARS.BASE_FILES,
+                                                             'templates', 'heat-env.yml'))
+        assert ret == {'result': True, 'comment': ("Updated stack 'mystack'.",)}
+
+    def test_heat_update_stack_env_err(self):
+        '''
+        Test salt.modules.heat.update_method method
+        with environment set and there is an error
+        reading the environment file
+        '''
+        patch_file = patch.dict(heat.__salt__,
+                                {'file.get_managed': file_.get_managed,
+                                 'file.manage_file':
+                                 MagicMock(side_effect=[{'result': True},
+                                                        {'result': False}]), }
+                               )
+        with patch_file:
+            ret = heat.update_stack(name='mystack',
+                                    profile='openstack1',
+                                    template_file=os.path.join(RUNTIME_VARS.BASE_FILES,
+                                                               'templates', 'heat-template.yml'),
+                                    environment=os.path.join(RUNTIME_VARS.BASE_FILES,
+                                                             'templates', 'heat-env.yml'))
+        assert ret == {'result': False,
+                       'comment': 'Error parsing template Template format version not found.'}

--- a/tests/unit/states/test_heat.py
+++ b/tests/unit/states/test_heat.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+
+# Import Python Libs
+from __future__ import absolute_import, unicode_literals, print_function
+import os
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase
+from tests.support.runtests import RUNTIME_VARS
+from tests.support.mock import (
+    MagicMock,
+    patch,
+)
+
+# Import Salt Libs
+import tests.unit.modules.test_heat
+import salt.states.heat as heat
+import salt.modules.file as file_
+import salt.modules.heat
+
+
+class HeatTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    Test cases for salt.states.heat
+    '''
+    def setup_loader_modules(self):
+        return {
+            heat: {
+                '_auth': tests.unit.modules.test_heat.MockClient,
+                '__opts__': {'test': False},
+            },
+            salt.modules.heat: {'_auth':
+                                tests.unit.modules.test_heat.MockClient, },
+            file_: {
+                '__opts__': {'hash_type': 'sha256',
+                             'cachedir': os.path.join(RUNTIME_VARS.TMP,
+                                                      'rootdir', 'cache'),
+                             'test': False},
+                '__salt__': {'config.option':
+                             MagicMock(return_value={'obfuscate_templates':
+                                                     False}),
+                             'config.backup_mode':
+                             MagicMock(return_value=False)}
+            }
+        }
+
+    def test_heat_deployed(self):
+        '''
+        Test salt.states.heat.deployed method
+        '''
+        exp_ret = {'name': ('mystack',),
+                   'comment': "Created stack 'mystack'.",
+                   'changes': {'stack_name': 'mystack',
+                               'comment': 'Create stack'},
+                   'result': True}
+
+        patch_heat = patch.dict(heat.__salt__,
+                         {'heat.show_stack': MagicMock(return_value={'result': False}),
+                         'heat.create_stack': salt.modules.heat.create_stack})
+
+        patch_file = patch.dict('salt.modules.heat.__salt__',
+                         {'file.get_managed': file_.get_managed,
+                         'file.manage_file': file_.manage_file, },)
+
+        patch_create = patch('salt.modules.heat.create_stack',
+                         MagicMock(return_value={'result': True, 'comment':
+                                                "Created stack 'mystack'."}))
+
+        with patch_heat, patch_file, patch_create:
+            ret = heat.deployed(name='mystack',
+                                profile='openstack1',
+                                template=os.path.join(RUNTIME_VARS.BASE_FILES,
+                                             'templates', 'heat-template.yml'),
+                                poll=0)
+        assert ret == exp_ret
+
+    def test_heat_deployed_environment(self):
+        '''
+        Test salt.states.heat.deployed method
+        with environment set
+        '''
+        exp_ret = {'name': ('mystack',),
+                   'comment': "Created stack 'mystack'.",
+                   'changes': {'stack_name': 'mystack',
+                               'comment': 'Create stack'},
+                   'result': True}
+
+        patch_heat = patch.dict(heat.__salt__,
+                         {'heat.show_stack': MagicMock(return_value={'result': False}),
+                         'heat.create_stack': salt.modules.heat.create_stack})
+
+        patch_file = patch.dict('salt.modules.heat.__salt__',
+                         {'file.get_managed': file_.get_managed,
+                         'file.manage_file': file_.manage_file, },)
+
+        patch_create = patch('salt.modules.heat.create_stack',
+                         MagicMock(return_value={'result': True, 'comment':
+                                                "Created stack 'mystack'."}))
+
+        with patch_heat, patch_file, patch_create:
+            ret = heat.deployed(name='mystack',
+                                profile='openstack1',
+                                template=os.path.join(RUNTIME_VARS.BASE_FILES,
+                                             'templates', 'heat-template.yml'),
+                                poll=0,
+                                environment=os.path.join(RUNTIME_VARS.BASE_FILES,
+                                                'templates', 'heat-env.yml'))
+        assert ret == exp_ret
+
+    def test_heat_deployed_environment_error(self):
+        '''
+        Test salt.states.heat.deployed method
+        with environment set and there is an error
+        reading the environment file.
+        '''
+        exp_ret = {'name': ('mystack',),
+                   'comment': 'Error parsing template Template format version not found.',
+                   'changes': {'stack_name': 'mystack',
+                               'comment': 'Create stack'},
+                   'result': False}
+
+        patch_heat = patch.dict(heat.__salt__,
+                         {'heat.show_stack': MagicMock(return_value={'result': False}),
+                         'heat.create_stack': salt.modules.heat.create_stack})
+
+        patch_file = patch.dict('salt.modules.heat.__salt__',
+                         {'file.get_managed': file_.get_managed,
+                          'file.manage_file': MagicMock(side_effect=[{'result': True},
+                                                                     {'result': False}])})
+
+        patch_create = patch('salt.modules.heat.create_stack',
+                         MagicMock(return_value={'result': True, 'comment':
+                                                "Created stack 'mystack'."}))
+
+        with patch_heat, patch_file, patch_create:
+            ret = heat.deployed(name='mystack',
+                                profile='openstack1',
+                                template=os.path.join(RUNTIME_VARS.BASE_FILES,
+                                             'templates', 'heat-template.yml'),
+                                poll=0,
+                                environment=os.path.join(RUNTIME_VARS.BASE_FILES,
+                                                'templates', 'heat-env.yml'))
+        assert ret == exp_ret


### PR DESCRIPTION
### What does this PR do?
Deprecate spelling mistake `enviroment` for `environment` in heat execution and state modules

Also fixes an issue in the heat modules where the `file` module calls where not passing all the correct args.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/49417

### Previous Behavior
User could use either `enviroment` or `environment` spellings

### New Behavior
User can only use `environment` (the correct spelling)

### Tests written?
Yes

### Commits signed with GPG?

Yes