### PR TITLE
Fix using password hashes with MariaDB

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -1435,7 +1435,10 @@ def user_create(user,
         args['password'] = six.text_type(password)
     elif password_hash is not None:
         if salt.utils.versions.version_cmp(server_version, compare_version) >= 0:
-            qry += ' IDENTIFIED BY %(password)s'
+            if 'MariaDB' in server_version:
+                qry += ' IDENTIFIED BY PASSWORD %(password)s'
+            else:
+                qry += ' IDENTIFIED BY %(password)s'
         else:
             qry += ' IDENTIFIED BY PASSWORD %(password)s'
         args['password'] = password_hash
@@ -1552,7 +1555,10 @@ def user_chpass(user,
     args['user'] = user
     args['host'] = host
     if salt.utils.versions.version_cmp(server_version, compare_version) >= 0:
-        qry = "ALTER USER %(user)s@%(host)s IDENTIFIED BY %(password)s;"
+        if 'MariaDB' in server_version and password_hash is not None:
+            qry = "ALTER USER %(user)s@%(host)s IDENTIFIED BY PASSWORD %(password)s;"
+        else:
+            qry = "ALTER USER %(user)s@%(host)s IDENTIFIED BY %(password)s;"
     else:
         qry = ('UPDATE mysql.user SET ' + password_column + '=' + password_sql +
                ' WHERE User=%(user)s AND Host = %(host)s;')


### PR DESCRIPTION
I rebased PR https://github.com/saltstack/salt/pull/54343 since that was all that was needed @dwoz 

> MariaDB 10.2.0 introduced the 'ALTER USER' statement, but it did NOT remove the need to denote password hashes with the PASSWORD keyword.
Both CREATE USER as well as ALTER USER still need IDENTIFIED BY PASSWORD

> This should be a more complete fix compared to previous attempts in #53861 and #54299

### What does this PR do?
Fix MariaDB user interactions.

### What issues does this PR fix or reference?
#53861 and #54299 and #54343

### Previous Behavior
Using password hashes as passwords

### New Behavior
Doing what it's told

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
