### PR TITLE
Bump deprecation warning to Aluminium for neutron module

### DIFF
--- a/salt/utils/openstack/neutron.py
+++ b/salt/utils/openstack/neutron.py
@@ -31,6 +31,7 @@ except ImportError:
 
 # Import salt libs
 from salt import exceptions
+import salt.utils.versions
 
 # Get logging started
 log = logging.getLogger(__name__)
@@ -81,8 +82,8 @@ class SaltNeutron(NeutronShell):
         '''
         Set up neutron credentials
         '''
-        __utils__['versions.warn_until'](
-            'Neon',
+        salt.utils.versions.warn_until(
+            'Aluminium',
             (
                 'The neutron module has been deprecated and will be removed in {version}.  '
                 'Please update to using the neutronng module'


### PR DESCRIPTION
### What does this PR do?
the neutron module was set to be deprecated in `neon` in favor of neutronng but if you look at all the uses of `salt.utils.openstack.neutron` which the neutron module uses when initializing its auth there is the neutron pillar that is still using the old nuetron module. So I added this issue: https://github.com/saltstack/salt/issues/55663 to track the work to migrate the neutron pillar to use the new neutronng module instead before we can entirely deprecate the `neutron` module. So for now we are going to bump the deprecation warning in the neutron module to gives us enough time for this migration.

This PR also fixes an issue where the `salt.utils.openstack.neutron` tries to call `__utils__` to add the deprecation warning, but `__utils__` is not packed into the utils loader so it fails. 

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/49430