### PR TITLE
guestfs: create mount folder if initially computed one is busy

### DIFF
--- a/salt/modules/guestfs.py
+++ b/salt/modules/guestfs.py
@@ -61,6 +61,11 @@ def mount(location, access='rw', root=None):
                 location.lstrip(os.sep).replace('/', '.') + rand
             )
             log.debug('Establishing new root as %s', root)
+            if not os.path.isdir(root):
+                try:
+                    os.makedirs(root)
+                except OSError:
+                    log.info('Path already existing: %s', root)
         else:
             break
     cmd = 'guestmount -i -a {0} --{1} {2}'.format(location, access, root)

--- a/tests/unit/modules/test_guestfs.py
+++ b/tests/unit/modules/test_guestfs.py
@@ -28,10 +28,40 @@ class GuestfsTestCase(TestCase, LoaderModuleMockMixin):
     # 'mount' function tests: 1
     def test_mount(self):
         '''
-        Test if it mount an image
+        Test if it mounts an image
         '''
-        with patch('os.path.join', MagicMock(return_value=True)), \
-                patch('os.path.isdir', MagicMock(return_value=True)), \
+        # Test case with non-existing mount folder
+        run_mock = MagicMock(return_value='')
+        with patch('os.path.join', MagicMock(return_value='/tmp/guest/fedora.qcow')), \
+                patch('os.path.isdir', MagicMock(return_value=False)), \
+                patch('os.makedirs', MagicMock()) as makedirs_mock, \
                 patch('os.listdir', MagicMock(return_value=False)), \
-                patch.dict(guestfs.__salt__, {'cmd.run': MagicMock(return_value='')}):
+                patch.dict(guestfs.__salt__, {'cmd.run': run_mock}):
             self.assertTrue(guestfs.mount('/srv/images/fedora.qcow'))
+            run_mock.assert_called_once_with('guestmount -i -a /srv/images/fedora.qcow --rw /tmp/guest/fedora.qcow',
+                                             python_shell=False)
+            makedirs_mock.assert_called_once()
+
+        # Test case with existing but empty mount folder
+        run_mock.reset_mock()
+        with patch('os.path.join', MagicMock(return_value='/tmp/guest/fedora.qcow')), \
+                patch('os.path.isdir', MagicMock(return_value=True)), \
+                patch('os.makedirs', MagicMock()) as makedirs_mock, \
+                patch('os.listdir', MagicMock(return_value=False)), \
+                patch.dict(guestfs.__salt__, {'cmd.run': run_mock}):
+            self.assertTrue(guestfs.mount('/srv/images/fedora.qcow'))
+            run_mock.assert_called_once_with('guestmount -i -a /srv/images/fedora.qcow --rw /tmp/guest/fedora.qcow',
+                                             python_shell=False)
+            makedirs_mock.assert_not_called()
+
+        # Test case with existing but not empty mount folder
+        run_mock.reset_mock()
+        with patch('os.path.join', MagicMock(side_effect=['/tmp/guest/fedora.qcow', '/tmp/guest/fedora.qcowabc'])), \
+                patch('os.path.isdir', MagicMock(side_effect=[True, False])), \
+                patch('os.makedirs', MagicMock()) as makedirs_mock, \
+                patch('os.listdir', MagicMock(side_effect=[True, False])), \
+                patch.dict(guestfs.__salt__, {'cmd.run': run_mock}):
+            self.assertTrue(guestfs.mount('/srv/images/fedora.qcow'))
+            run_mock.assert_called_once_with('guestmount -i -a /srv/images/fedora.qcow --rw /tmp/guest/fedora.qcowabc',
+                                             python_shell=False)
+            makedirs_mock.assert_called_once()


### PR DESCRIPTION
# What does this PR do?

When mounting an image, if the computed folder is already existing and
not empty, then we try to find another one that could be used. But then
we need to create the folder if needed.

### What issues does this PR fix or reference?

Issue #55349.

### Previous Behavior

Running this fails:

```
mkdir -p /tmp/guest/var.testsuite-data.disk-image-template.qcow2/foobar
salt-call --local guestfs.mount /var/testsuite-data/disk-image-template.qcow2
```

### New Behavior

Running the same mounts the image without error

### Tests written?

Yes

### Commits signed with GPG?

Yes