### PR TITLE
Master Port #50343

### DIFF
--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -167,12 +167,6 @@ Fileserver Deprecations
     - The ``svnfs_env_whitelist`` config option has been removed in favor of ``svnfs_saltenv_whitelist``.
     - The ``svnfs_env_blacklist`` config option has been removed in favor of ``svnfs_saltenv_blacklist``.
 
-- The :py:mod`firewalld <salt.states.firewalld>` state has been changed as follows:
-
-    - The default setting for the ``prune_services`` option in the
-      :py:func:`firewalld.present <salt.states.firewalld.present>` function has changed
-      from ``True`` to ``False``.
-
 Engine Removal
 --------------
 
@@ -185,18 +179,6 @@ Returner Removal
 - The hipchat returner has been removed due to the service being retired. For users migrating
   to Slack, the :py:func:`slack <salt.returners.slack_returner>` returner may be a suitable
   replacement.
-
-- The :py:mod`firewalld <salt.modules.firewalld>` module has been changed as
-  follows:
-
-    - Support for the ``force_masquerade`` option has been removed from the
-      :py:func:`firewalld.add_port <salt.module.firewalld.add_port` function. Please
-      use the :py:func:`firewalld.add_masquerade <salt.modules.firewalld.add_masquerade`
-      function instead.
-    - Support for the ``force_masquerade`` option has been removed from the
-      :py:func:`firewalld.add_port_fwd <salt.module.firewalld.add_port_fwd` function. Please
-      use the :py:func:`firewalld.add_masquerade <salt.modules.firewalld.add_masquerade`
-      function instead.
 
 Grain Deprecations
 ------------------

--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -167,6 +167,12 @@ Fileserver Deprecations
     - The ``svnfs_env_whitelist`` config option has been removed in favor of ``svnfs_saltenv_whitelist``.
     - The ``svnfs_env_blacklist`` config option has been removed in favor of ``svnfs_saltenv_blacklist``.
 
+- The :py:mod`firewalld <salt.states.firewalld>` state has been changed as follows:
+
+    - The default setting for the ``prune_services`` option in the
+      :py:func:`firewalld.present <salt.states.firewalld.present>` function has changed
+      from ``True`` to ``False``.
+
 Engine Removal
 --------------
 
@@ -179,6 +185,18 @@ Returner Removal
 - The hipchat returner has been removed due to the service being retired. For users migrating
   to Slack, the :py:func:`slack <salt.returners.slack_returner>` returner may be a suitable
   replacement.
+
+- The :py:mod`firewalld <salt.modules.firewalld>` module has been changed as
+  follows:
+
+    - Support for the ``force_masquerade`` option has been removed from the
+      :py:func:`firewalld.add_port <salt.module.firewalld.add_port` function. Please
+      use the :py:func:`firewalld.add_masquerade <salt.modules.firewalld.add_masquerade`
+      function instead.
+    - Support for the ``force_masquerade`` option has been removed from the
+      :py:func:`firewalld.add_port_fwd <salt.module.firewalld.add_port_fwd` function. Please
+      use the :py:func:`firewalld.add_masquerade <salt.modules.firewalld.add_masquerade`
+      function instead.
 
 Grain Deprecations
 ------------------

--- a/salt/modules/firewalld.py
+++ b/salt/modules/firewalld.py
@@ -13,7 +13,6 @@ import re
 # Import Salt Libs
 from salt.exceptions import CommandExecutionError
 import salt.utils.path
-import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
@@ -618,8 +617,7 @@ def remove_masquerade(zone=None, permanent=True):
     return __firewall_cmd(cmd)
 
 
-# TODO: remove force_masquerade parameter in future release
-def add_port(zone, port, permanent=True, force_masquerade=None):
+def add_port(zone, port, permanent=True):
     '''
     Allow specific ports in a zone.
 
@@ -631,21 +629,6 @@ def add_port(zone, port, permanent=True, force_masquerade=None):
 
         salt '*' firewalld.add_port internal 443/tcp
     '''
-
-    # Previously, masquerading was always enabled here
-    # This will be deprecated in a future release
-    if force_masquerade is None:
-        force_masquerade = True
-        salt.utils.versions.warn_until(
-            'Neon',
-            'add_port function will no longer force enable masquerading '
-            'in future releases. Use add_masquerade to enable masquerading.')
-
-    # (DEPRECATED) Force enable masquerading
-    # TODO: remove in future release
-    if force_masquerade and not get_masquerade(zone):
-        add_masquerade(zone)
-
     cmd = '--zone={0} --add-port={1}'.format(zone, port)
 
     if permanent:
@@ -694,8 +677,7 @@ def list_ports(zone, permanent=True):
     return __firewall_cmd(cmd).split()
 
 
-# TODO: remove force_masquerade parameter in future release
-def add_port_fwd(zone, src, dest, proto='tcp', dstaddr='', permanent=True, force_masquerade=None):
+def add_port_fwd(zone, src, dest, proto='tcp', dstaddr='', permanent=True):
     '''
     Add port forwarding.
 
@@ -707,21 +689,6 @@ def add_port_fwd(zone, src, dest, proto='tcp', dstaddr='', permanent=True, force
 
         salt '*' firewalld.add_port_fwd public 80 443 tcp
     '''
-
-    # Previously, masquerading was always enabled here
-    # This will be deprecated in a future release
-    if force_masquerade is None:
-        force_masquerade = True
-        salt.utils.versions.warn_until(
-            'Neon',
-            'add_port_fwd function will no longer force enable masquerading '
-            'in future releases. Use add_masquerade to enable masquerading.')
-
-    # (DEPRECATED) Force enable masquerading
-    # TODO: remove in future release
-    if force_masquerade and not get_masquerade(zone):
-        add_masquerade(zone)
-
     cmd = '--zone={0} --add-forward-port=port={1}:proto={2}:toport={3}:toaddr={4}'.format(
         zone,
         src,

--- a/salt/modules/firewalld.py
+++ b/salt/modules/firewalld.py
@@ -617,7 +617,7 @@ def remove_masquerade(zone=None, permanent=True):
     return __firewall_cmd(cmd)
 
 
-def add_port(zone, port, permanent=True):
+def add_port(zone, port, permanent=True, force_masquerade=False):
     '''
     Allow specific ports in a zone.
 
@@ -628,7 +628,14 @@ def add_port(zone, port, permanent=True):
     .. code-block:: bash
 
         salt '*' firewalld.add_port internal 443/tcp
+
+    force_masquerade
+        when a zone is created ensure masquerade is also enabled
+        on that zone.
     '''
+    if force_masquerade and not get_masquerade(zone):
+        add_masquerade(zone)
+
     cmd = '--zone={0} --add-port={1}'.format(zone, port)
 
     if permanent:
@@ -677,7 +684,7 @@ def list_ports(zone, permanent=True):
     return __firewall_cmd(cmd).split()
 
 
-def add_port_fwd(zone, src, dest, proto='tcp', dstaddr='', permanent=True):
+def add_port_fwd(zone, src, dest, proto='tcp', dstaddr='', permanent=True, force_masquerade=False):
     '''
     Add port forwarding.
 
@@ -688,7 +695,14 @@ def add_port_fwd(zone, src, dest, proto='tcp', dstaddr='', permanent=True):
     .. code-block:: bash
 
         salt '*' firewalld.add_port_fwd public 80 443 tcp
+
+    force_masquerade
+        when a zone is created ensure masquerade is also enabled
+        on that zone.
     '''
+    if force_masquerade and not get_masquerade(zone):
+        add_masquerade(zone)
+
     cmd = '--zone={0} --add-forward-port=port={1}:proto={2}:toport={3}:toaddr={4}'.format(
         zone,
         src,

--- a/salt/states/firewalld.py
+++ b/salt/states/firewalld.py
@@ -84,7 +84,6 @@ import logging
 from salt.exceptions import CommandExecutionError
 from salt.output import nested
 import salt.utils.path
-import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
@@ -163,9 +162,7 @@ def present(name,
             port_fwd=None,
             prune_port_fwd=False,
             services=None,
-            # TODO: prune_services=False in future release
-            # prune_services=False,
-            prune_services=None,
+            prune_services=False,
             interfaces=None,
             prune_interfaces=False,
             sources=None,
@@ -206,7 +203,7 @@ def present(name,
     services : None
         List of services to add to the zone.
 
-    prune_services : True
+    prune_services : False
         If ``True``, remove all but the specified services from the zone.
         .. note:: Currently defaults to True for compatibility, but will be changed to False in a future release.
 
@@ -228,15 +225,6 @@ def present(name,
     prune_rich_rules : False
         If ``True``, remove all but the specified rich rules from the zone.
     '''
-
-    # if prune_services == None, set to True and log a deprecation warning
-    if prune_services is None:
-        prune_services = True
-        salt.utils.versions.warn_until(
-            'Neon',
-            'The \'prune_services\' argument default is currently True, '
-            'but will be changed to False in the Neon release.')
-
     ret = _present(name, block_icmp, prune_block_icmp, default, masquerade, ports, prune_ports,
             port_fwd, prune_port_fwd, services, prune_services, interfaces, prune_interfaces,
             sources, prune_sources, rich_rules, prune_rich_rules)

--- a/salt/states/firewalld.py
+++ b/salt/states/firewalld.py
@@ -501,7 +501,6 @@ def _present(name,
         for port in new_ports:
             if not __opts__['test']:
                 try:
-                    # TODO: force_masquerade to be removed in future release
                     __salt__['firewalld.add_port'](name, port, permanent=True, force_masquerade=False)
                 except CommandExecutionError as err:
                     ret['comment'] = 'Error: {0}'.format(err)
@@ -550,7 +549,6 @@ def _present(name,
         for fwd in new_port_fwd:
             if not __opts__['test']:
                 try:
-                    # TODO: force_masquerade to be removed in future release
                     __salt__['firewalld.add_port_fwd'](name, fwd.srcport,
                         fwd.destport, fwd.protocol, fwd.destaddr, permanent=True,
                         force_masquerade=False)


### PR DESCRIPTION
Master Port #50343

(Neon deprecation)

note: updated the backport to not remove `force_masquerade` as i think it makes more sense to keep this argument in case a user does indeed want to masquerade a zone. The default is now False instead of True, but this argument still leaves the user the ability to use this feature.