### PR TITLE
Master Port #50344

### DIFF
--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -147,6 +147,12 @@ Module Deprecations
         - :py:func:`dockermod.load <salt.modules.dockermod.load>`
         - :py:func:`dockermod.tag <salt.modules.dockermod.tag_>`
 
+- The :py:mod:`test <salt.modules.test>` execution module has been changed as follows:
+
+    - Support for the :py:func:`test.rand_str <salt.modules.test.rand_str>` has been
+      removed. Please use the :py:func:`test.random_hash <salt.modules.test.random_hash>`
+      function instead.
+
 State Deprecations
 ------------------
 

--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -147,12 +147,6 @@ Module Deprecations
         - :py:func:`dockermod.load <salt.modules.dockermod.load>`
         - :py:func:`dockermod.tag <salt.modules.dockermod.tag_>`
 
-- The :py:mod:`test <salt.modules.test>` execution module has been changed as follows:
-
-    - Support for the :py:func:`test.rand_str <salt.modules.test.rand_str>` has been
-      removed. Please use the :py:func:`test.random_hash <salt.modules.test.random_hash>`
-      function instead.
-
 State Deprecations
 ------------------
 

--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -18,7 +18,6 @@ import salt.utils.args
 import salt.utils.functools
 import salt.utils.hashutils
 import salt.utils.platform
-import salt.utils.versions
 import salt.version
 import salt.loader
 from salt.ext import six
@@ -494,14 +493,6 @@ def opts_pkg():
     ret.update(__opts__)
     ret['grains'] = __grains__
     return ret
-
-
-def rand_str(size=9999999999, hash_type=None):
-    salt.utils.versions.warn_until(
-        'Neon',
-        'test.rand_str has been renamed to test.random_hash'
-    )
-    return random_hash(size=size, hash_type=hash_type)
 
 
 def random_hash(size=9999999999, hash_type=None):

--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -495,6 +495,16 @@ def opts_pkg():
     return ret
 
 
+def rand_str(size=9999999999, hash_type=None):
+    '''
+    This function has been renamed to
+    random_hash. This function will stay to
+    ensure backwards compatibility, but please
+    switch to using the prefered name random_hash.
+    '''
+    return random_hash(size=size, hash_type=hash_type)
+
+
 def random_hash(size=9999999999, hash_type=None):
     '''
     .. versionadded:: 2015.5.2


### PR DESCRIPTION
Master Port #50344

(Neon Deprecation)

Note: to ensure backwards compatibility we are going to keep `rand_str` in attempt to not require users to update their states with each feature release.