### PR TITLE
Master Port #49826

### DIFF
--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -154,6 +154,13 @@ State Deprecations
   :py:func:`MS Teams <salt.states.msteams>` or
   :py:func:`Slack <salt.states.slack>` may be suitable replacements.
 
+- The :py:mod:`win_servermanager <salt.states.win_servermanager>` state has been
+  changed as follows:
+
+    - Support for the ``force`` kwarg has been removed from the
+      :py:func:`win_servermanager.installed <salt.status.win_servermanager.installed>`
+      function. Please use ``recurse`` instead.
+
 Fileserver Deprecations
 -----------------------
 

--- a/doc/topics/releases/neon.rst
+++ b/doc/topics/releases/neon.rst
@@ -154,13 +154,6 @@ State Deprecations
   :py:func:`MS Teams <salt.states.msteams>` or
   :py:func:`Slack <salt.states.slack>` may be suitable replacements.
 
-- The :py:mod:`win_servermanager <salt.states.win_servermanager>` state has been
-  changed as follows:
-
-    - Support for the ``force`` kwarg has been removed from the
-      :py:func:`win_servermanager.installed <salt.status.win_servermanager.installed>`
-      function. Please use ``recurse`` instead.
-
 Fileserver Deprecations
 -----------------------
 

--- a/salt/states/win_servermanager.py
+++ b/salt/states/win_servermanager.py
@@ -27,8 +27,7 @@ def installed(name,
               recurse=False,
               restart=False,
               source=None,
-              exclude=None,
-              **kwargs):
+              exclude=None):
     '''
     Install the windows feature. To install a single feature, use the ``name``
     parameter. To install multiple features, use the ``features`` parameter.
@@ -113,15 +112,6 @@ def installed(name,
             - exclude:
               - Web-Server
     '''
-    if 'force' in kwargs:
-        salt.utils.versions.warn_until(
-            'Neon',
-            'Parameter \'force\' has been detected in the argument list. This'
-            'parameter is no longer used and has been replaced by \'recurse\''
-            'as of Salt 2018.3.0. This warning will be removed in Salt Neon.'
-        )
-        kwargs.pop('force')
-
     ret = {'name': name,
            'result': True,
            'changes': {},

--- a/salt/states/win_servermanager.py
+++ b/salt/states/win_servermanager.py
@@ -12,7 +12,6 @@ from __future__ import absolute_import, unicode_literals, print_function
 
 # Import salt modules
 import salt.utils.data
-import salt.utils.versions
 
 
 def __virtual__():
@@ -58,8 +57,9 @@ def installed(name,
             Install all sub-features as well. If the feature is installed but
             one of its sub-features are not installed set this will install
             additional sub-features. This argument was previously renamed from
-            ``force``. To ensure backwards compatibility ``force`` will to work
-            but please update your states to use the preferred ``recurse`` arg.
+            ``force``. To ensure backwards compatibility ``force`` will
+            continue to work but please update your states to use the preferred
+            ``recurse`` arg.
 
         source (Optional[str]):
             Path to the source files if missing from the target system. None

--- a/salt/states/win_servermanager.py
+++ b/salt/states/win_servermanager.py
@@ -26,7 +26,8 @@ def installed(name,
               recurse=False,
               restart=False,
               source=None,
-              exclude=None):
+              exclude=None,
+              **kwargs):
     '''
     Install the windows feature. To install a single feature, use the ``name``
     parameter. To install multiple features, use the ``features`` parameter.

--- a/salt/states/win_servermanager.py
+++ b/salt/states/win_servermanager.py
@@ -57,7 +57,9 @@ def installed(name,
         recurse (Optional[bool]):
             Install all sub-features as well. If the feature is installed but
             one of its sub-features are not installed set this will install
-            additional sub-features
+            additional sub-features. This argument was previously renamed from
+            ``force``. To ensure backwards compatibility ``force`` will to work
+            but please update your states to use the preferred ``recurse`` arg.
 
         source (Optional[str]):
             Path to the source files if missing from the target system. None
@@ -112,6 +114,9 @@ def installed(name,
             - exclude:
               - Web-Server
     '''
+    if 'force' in kwargs:
+        kwargs.pop('force')
+
     ret = {'name': name,
            'result': True,
            'changes': {},


### PR DESCRIPTION
Master Port #49826

(Neon Deprecation)

Note: updated the backport to keep the `force` argument to ensure users don't have to update their states with each feature release.