### PR TITLE
runners/net.py Python 3 fixes

### DIFF
--- a/salt/runners/net.py
+++ b/salt/runners/net.py
@@ -224,7 +224,7 @@ def _find_interfaces_mac(ip):  # pylint: disable=invalid-name
         if not device_ipaddrs.get('result', False):
             continue
         for interface, interface_ipaddrs in six.iteritems(device_ipaddrs.get('out', {})):
-            ip_addresses = interface_ipaddrs.get('ipv4', {}).keys()
+            ip_addresses = list(interface_ipaddrs.get('ipv4', {}))
             ip_addresses.extend(interface_ipaddrs.get('ipv6', {}).keys())
             for ipaddr in ip_addresses:
                 if ip != ipaddr:
@@ -406,6 +406,7 @@ def interfaces(device=None,
                             if best:
                                 # determine the global best match
                                 compare = [best_net_match]
+                                if not best_net_match: compare = []
                                 compare.extend(list(map(_get_network_obj, inet_ips)))
                                 new_best_net_match = max(compare)
                                 if new_best_net_match != best_net_match:

--- a/salt/runners/net.py
+++ b/salt/runners/net.py
@@ -406,7 +406,8 @@ def interfaces(device=None,
                             if best:
                                 # determine the global best match
                                 compare = [best_net_match]
-                                if not best_net_match: compare = []
+                                if not best_net_match:
+                                    compare = []
                                 compare.extend(list(map(_get_network_obj, inet_ips)))
                                 new_best_net_match = max(compare)
                                 if new_best_net_match != best_net_match:


### PR DESCRIPTION
### What does this PR do?
Fixes errors when using Python 3.  Very small changes which also work in Python 2.

```
[root@salt salt]# salt --versions-report
Salt Version:
           Salt: 2019.2.2
 
Dependency Versions:
           cffi: Not Installed
       cherrypy: unknown
       dateutil: Not Installed
      docker-py: Not Installed
          gitdb: Not Installed
      gitpython: Not Installed
          ioflo: Not Installed
         Jinja2: 2.8.1
        libgit2: Not Installed
        libnacl: Not Installed
       M2Crypto: 0.35.2
           Mako: Not Installed
   msgpack-pure: Not Installed
 msgpack-python: 0.5.6
   mysql-python: Not Installed
      pycparser: Not Installed
       pycrypto: Not Installed
   pycryptodome: Not Installed
         pygit2: Not Installed
         Python: 3.6.8 (default, Aug  7 2019, 17:28:10)
   python-gnupg: Not Installed
         PyYAML: 3.12
          PyZMQ: 15.3.0
           RAET: Not Installed
          smmap: Not Installed
        timelib: Not Installed
        Tornado: 4.4.2
            ZMQ: 4.1.4
 
System Versions:
           dist: centos 7.7.1908 Core
         locale: UTF-8
        machine: x86_64
        release: 3.10.0-957.10.1.el7.x86_64
         system: Linux
        version: CentOS Linux 7.7.1908 Core
```

### What issues does this PR fix or reference?
fixes https://github.com/saltstack/salt/issues/55691

```
[root@salt runners]# salt-run net.find 1.2.3.4
Details for all interfaces that include network 1.2.3.4/32 - only best match returned
ARP Entries for IP 1.2.3.4
Exception occurred in runner net.find: Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/salt/client/mixins.py", line 377, in low
    data['return'] = func(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/runners/net.py", line 894, in find
    device, interface, mac = _find_interfaces_mac(ip)
  File "/usr/lib/python3.6/site-packages/salt/runners/net.py", line 228, in _find_interfaces_mac
    ip_addresses.extend(interface_ipaddrs.get('ipv6', {}).keys())
AttributeError: 'dict_keys' object has no attribute 'extend
```

and

```
[root@salt runners]# salt-run net.find 1.2.3.4

Passed invalid arguments: '>' not supported between instances of 'IPNetwork' and 'NoneType'
```
### Previous Behavior
When using Python 3, net.find <ip address> would return errors.

### New Behavior
net.find returns desired, error-free output.

### Tests written?
No

### Commits signed with GPG?
No
