### PR TITLE
Update zabbix module to avoid exception

### DIFF
--- a/salt/modules/zabbix.py
+++ b/salt/modules/zabbix.py
@@ -2426,7 +2426,10 @@ def run_query(method, params, **connection_args):
             ret = _query(method, params, conn_args['url'], conn_args['auth'])
             if isinstance(ret['result'], bool):
                 return ret['result']
-            return ret['result'] if (ret['result'] == True or len(ret['result']) > 0) else False
+            if ret['result'] is True or len(ret['result']) > 0:
+                return ret['result']
+            else:
+                return False
         else:
             raise KeyError
     except KeyError:

--- a/salt/modules/zabbix.py
+++ b/salt/modules/zabbix.py
@@ -2426,7 +2426,7 @@ def run_query(method, params, **connection_args):
             ret = _query(method, params, conn_args['url'], conn_args['auth'])
             if isinstance(ret['result'], bool):
                 return ret['result']
-            return ret['result'] if len(ret['result']) > 0 else False
+            return ret['result'] if (ret['result'] == True or len(ret['result']) > 0) else False
         else:
             raise KeyError
     except KeyError:


### PR DESCRIPTION
PORT #51038 to master

As seen here https://www.zabbix.com/documentation/current/manual/api/reference/configuration/import 

  >Return values
  (boolean) Returns **true** if importing has been successful.

This PR updates the module to avoid `Exception: object of type 'bool' has no len()` error when using these type of Zabbix server API calls. 

### Tests written?
No

### Commits signed with GPG?
No
