### PR TITLE
Address flakiness of test_salt_documentation

### DIFF
--- a/tests/integration/shell/test_matcher.py
+++ b/tests/integration/shell/test_matcher.py
@@ -6,7 +6,7 @@ import time
 
 # Import Salt Testing libs
 from tests.support.case import ShellCase
-from tests.support.helpers import flaky
+from tests.support.helpers import flaky, dedent
 from tests.support.mixins import ShellCaseCommonTestsMixin
 from tests.support.unit import skipIf
 
@@ -347,13 +347,27 @@ class MatchTest(ShellCase, ShellCaseCommonTestsMixin):
         data = '\n'.join(data)
         self.assertIn('minion', data)
 
-    @flaky
     def test_salt_documentation(self):
         '''
         Test to see if we're supporting --doc
         '''
-        data = self.run_salt('-d "*" user')
-        self.assertIn('user.add:', data)
+        expect_to_find = 'test.ping:'
+        stdout, stderr = self.run_salt('-d "*" test', catch_stderr=True)
+        error_msg = dedent('''
+        Failed to find \'{expected}\' in output
+
+        {sep}
+        --- STDOUT -----
+        {stdout}
+        {sep}
+        --- STDERR -----
+        {stderr}
+        {sep}
+        '''.format(sep='-' * 80,
+                   expected=expect_to_find,
+                   stdout='\n'.join(stdout).strip(),
+                   stderr='\n'.join(stderr).strip()))
+        self.assertIn(expect_to_find, stdout, msg=error_msg)
 
     def test_salt_documentation_too_many_arguments(self):
         '''


### PR DESCRIPTION
### What does this PR do?
Address flakiness of `integration.shell.test_shell.MatchTest.test_salt_documentation`