### PR TITLE
Bump deprecation of override_name to sodium

### DIFF
--- a/salt/utils/context.py
+++ b/salt/utils/context.py
@@ -210,7 +210,7 @@ class NamespacedDictWrapper(MutableMapping, dict):
         if override_name is not None:
             import salt.utils.versions
             salt.utils.versions.warn_until(
-                'Neon',
+                'Sodium',
                 'Overriding the class name is no longer supported. Please '
                 'remove the override_name argument before it is removed in '
                 'Salt Sodium.'


### PR DESCRIPTION
### What does this PR do?
This needs to be bumped to sodium, because the warn_untils message actually states sodium and not neon.
