### PR TITLE
[DOCS] Add runas info to cmd.script for windows server

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2382,14 +2382,16 @@ def script(source,
             For Window's users, specifically Server users, it may be necessary
             to specify your runas user using the User Logon Name instead of the
             legacy logon name. Traditionally, logons would be in the following
-            format:
-                Domain\User
+            format.
+
+                ``Domain/user``
 
             In the event this causes issues when executing scripts, use the UPN
-            format which looks like the following:
-                User@domain.local
+            format which looks like the following.
 
-            More information on this can be found in github issue #55080
+                ``user@domain.local``
+
+            More information <https://github.com/saltstack/salt/issues/55080>
 
     :param str password: Windows only. Required when specifying ``runas``. This
         parameter will be ignored on non-Windows platforms.

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2377,6 +2377,20 @@ def script(source,
         on a Windows minion you must also use the ``password`` argument, and
         the target user account must be in the Administrators group.
 
+        .. note::
+
+            For Window's users, specifically Server users, it may be necessary
+            to specify your runas user using the User Logon Name instead of the
+            legacy logon name. Traditionally, logons would be in the following
+            format:
+                Domain\User
+
+            In the event this causes issues when executing scripts, use the UPN
+            format which looks like the following:
+                User@domain.local
+
+            More information on this can be found in github issue #55080
+
     :param str password: Windows only. Required when specifying ``runas``. This
         parameter will be ignored on non-Windows platforms.
 


### PR DESCRIPTION
### What does this PR do?
Add documentation to cmd.script that indicates Window's Server users may need to use
a different format when specifying runas parameters.

Specifically, using the style `domain\user` has caused issues, whereas using the style `user@domain.local` is the correct way. 

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/55080

### Tests written?
No

### Commits signed with GPG?
Yes
