### PR TITLE
Handle exception in `salt.utils.args.format_call()`

### DIFF
--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -30,6 +30,7 @@ import salt.utils.minions
 import salt.utils.user
 import salt.utils.versions
 import salt.utils.zeromq
+from salt.exceptions import SaltInvocationError
 
 log = logging.getLogger(__name__)
 
@@ -95,9 +96,14 @@ class LoadAuth:
         _valid = ["username", "password", "eauth", "token"]
         _load = {key: value for (key, value) in load.items() if key in _valid}
 
-        fcall = salt.utils.args.format_call(
-            self.auth[fstr], _load, expected_extra_kws=AUTH_INTERNAL_KEYWORDS
-        )
+        try:
+            fcall = salt.utils.args.format_call(
+                self.auth[fstr],
+                load,
+                expected_extra_kws=AUTH_INTERNAL_KEYWORDS)
+        except SaltInvocationError as sie:
+            log.error("'format_call' failed: %r", sie)
+            return False
         try:
             if "kwargs" in fcall:
                 return self.auth[fstr](*fcall["args"], **fcall["kwargs"])
@@ -140,9 +146,14 @@ class LoadAuth:
         fstr = "{}.acl".format(mod)
         if fstr not in self.auth:
             return None
-        fcall = salt.utils.args.format_call(
-            self.auth[fstr], load, expected_extra_kws=AUTH_INTERNAL_KEYWORDS
-        )
+        try:
+            fcall = salt.utils.args.format_call(
+                self.auth[fstr],
+                load,
+                expected_extra_kws=AUTH_INTERNAL_KEYWORDS)
+        except SaltInvocationError as sie:
+            log.error("'format_call' failed: %r", sie)
+            return None
         try:
             return self.auth[fstr](*fcall["args"], **fcall["kwargs"])
         except Exception as e:  # pylint: disable=broad-except
@@ -175,9 +186,14 @@ class LoadAuth:
         fstr = "{}.groups".format(load["eauth"])
         if fstr not in self.auth:
             return False
-        fcall = salt.utils.args.format_call(
-            self.auth[fstr], load, expected_extra_kws=AUTH_INTERNAL_KEYWORDS
-        )
+        try:
+            fcall = salt.utils.args.format_call(
+                self.auth[fstr],
+                load,
+                expected_extra_kws=AUTH_INTERNAL_KEYWORDS)
+        except SaltInvocationError as sie:
+            log.error("'format_call' failed: %r", sie)
+            return False
         try:
             return self.auth[fstr](*fcall["args"], **fcall["kwargs"])
         except IndexError:


### PR DESCRIPTION
Re-based #54345 onto `master`…

### What does this PR do?

Without handling this exception, a SaltClient might hang in a loop waiting for a timeout and providing no clue as to why the call hangs/fails.
Handling this exception and logging a corresponding error msg improves this situation.

### What issues does this PR fix or reference?

### Previous Behavior
A SaltClient would hang/loop like this:
```
[DEBUG   ] Connecting the Minion to the Master URI (for the return server): tcp://127.0.0.1:54519
[DEBUG   ] Trying to connect to: tcp://127.0.0.1:54519
[DEBUG   ] SaltReqTimeoutError, retrying. (1/3)
[DEBUG   ] SaltReqTimeoutError, retrying. (2/3)
[DEBUG   ] SaltReqTimeoutError, retrying. (3/3)
```
### New Behavior
**CLI:**
```
Authentication failure of type "eauth" occurred for user $USER
```
**Master Log:**
```
[ERROR   ][354] 'format_call' failed: SaltInvocationError('auth takes at least 2 arguments (1 given)',)
```

### Tests written?
No

As it's still quite unclear why we're seeing a certain external auth issue here, there's no way yet to define a reproducable positive/negative scenario which could be used for testing this.
This fix just helps us to further narrow down our problem and ensures no-one else will waste time on the red herring `SaltReqTimeoutError` in this scenario anymore.

### Commits signed with GPG?
Yes