### PR TITLE
Fix the mem_total and swap_total tests on FreeBSD and OpenBSD

### DIFF
--- a/tests/integration/grains/test_core.py
+++ b/tests/integration/grains/test_core.py
@@ -38,7 +38,7 @@ class TestGrainsCore(ModuleCase):
         physmem = self.run_function('sysctl.get', ['hw.physmem'])
         self.assertEqual(
             self.run_function('grains.items')['mem_total'],
-            int(physmem) / 1048576
+            int(physmem) // 1048576
         )
 
     @skipIf(not salt.utils.platform.is_openbsd(), 'Only run on OpenBSD')
@@ -49,7 +49,7 @@ class TestGrainsCore(ModuleCase):
         swapmem = self.run_function('cmd.run', ['swapctl -sk']).split(' ')[1]
         self.assertEqual(
             self.run_function('grains.items')['swap_total'],
-            int(swapmem) / 1048576
+            int(swapmem) // 1048576
         )
 
 


### PR DESCRIPTION
They were comparing a float to an int.  AFAICT these tests have never
passed.  Tested on FreeBSD 13.

### What does this PR do?
Fixes two unit tests

### What issues does this PR fix or reference?
No open issues

### Previous Behavior
the mem_total test would fail with an error like "8158 != 8158.6278486"

### New Behavior
The mem_total test passes

### Tests written?
No - existing test fixed instead

### Commits signed with GPG?
Yes