### PR TITLE
Fix the test_patch*failure tests on FreeBSD

### DIFF
--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -4432,9 +4432,9 @@ class PatchTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertSaltFalseReturn(ret)
         ret = ret[next(iter(ret))]
         self.assertIn('Patch would not apply cleanly', ret['comment'])
-        self.assertIn(
-            'saving rejects to file {0}'.format(reject_file),
-            ret['comment']
+        self.assertRegex(
+            ret['comment'],
+            'saving rejects to (file )?{0}'.format(reject_file)
         )
 
     def test_patch_directory_failure(self):
@@ -4469,9 +4469,9 @@ class PatchTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertSaltFalseReturn(ret)
         ret = ret[next(iter(ret))]
         self.assertIn('Patch would not apply cleanly', ret['comment'])
-        self.assertIn(
-            'saving rejects to file {0}'.format(reject_file),
-            ret['comment']
+        self.assertRegex(
+            ret['comment'],
+            'saving rejects to (file )?{0}'.format(reject_file)
         )
 
     def test_patch_single_file_remote_source(self):


### PR DESCRIPTION
FreeBSD's patch command has a slightly different error message than GNU
patch.  Adjust the tests' expectations to accept either error message.

Tested on FreeBSD 13 with the master branch.

### What does this PR do?
Fixes two integration tests

### What issues does this PR fix or reference?
None

### Previous Behavior
These two tests would fail because of a string mismatch

### New Behavior
These two tests will pass

### Tests written?
No - existing tests modified

### Commits signed with GPG?
Yes