### PR TITLE
Bump PyTest Salt package

### DIFF
--- a/requirements/pytest.txt
+++ b/requirements/pytest.txt
@@ -1,6 +1,6 @@
 # PyTest
 pytest >=4.6.6,<4.7   # PyTest 4.6.x are the last Py2 and Py3 releases
-pytest-salt >= 2019.12.18
+pytest-salt >= 2019.12.27
 pytest-tempdir >= 2019.10.12
 pytest-helpers-namespace >= 2019.1.8
 pytest-salt-runtests-bridge >= 2019.7.10

--- a/requirements/static/py2.7/darwin.txt
+++ b/requirements/static/py2.7/darwin.txt
@@ -92,7 +92,7 @@ pyparsing==2.4.5          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.12.18
+pytest-salt==2019.12.27
 pytest-tempdir==2019.10.12
 pytest==4.6.6
 python-dateutil==2.8.0

--- a/requirements/static/py2.7/linux.txt
+++ b/requirements/static/py2.7/linux.txt
@@ -91,7 +91,7 @@ pyparsing==2.4.5          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.12.18
+pytest-salt==2019.12.27
 pytest-tempdir==2019.10.12
 pytest==4.6.6
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto

--- a/requirements/static/py2.7/windows.txt
+++ b/requirements/static/py2.7/windows.txt
@@ -88,7 +88,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via packaging
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.12.18
+pytest-salt==2019.12.27
 pytest-tempdir==2019.10.12
 pytest==4.6.6
 python-dateutil==2.8.0

--- a/requirements/static/py3.4/linux.txt
+++ b/requirements/static/py3.4/linux.txt
@@ -82,7 +82,7 @@ pyparsing==2.4.5          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.12.18
+pytest-salt==2019.12.27
 pytest-tempdir==2019.10.12
 pytest==4.6.6
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto

--- a/requirements/static/py3.5/darwin.txt
+++ b/requirements/static/py3.5/darwin.txt
@@ -84,7 +84,7 @@ pyparsing==2.4.5          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.12.18
+pytest-salt==2019.12.27
 pytest-tempdir==2019.10.12
 pytest==4.6.6
 python-dateutil==2.8.0

--- a/requirements/static/py3.5/linux.txt
+++ b/requirements/static/py3.5/linux.txt
@@ -82,7 +82,7 @@ pyparsing==2.4.5          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.12.18
+pytest-salt==2019.12.27
 pytest-tempdir==2019.10.12
 pytest==4.6.6
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto

--- a/requirements/static/py3.5/windows.txt
+++ b/requirements/static/py3.5/windows.txt
@@ -80,7 +80,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via packaging
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.12.18
+pytest-salt==2019.12.27
 pytest-tempdir==2019.10.12
 pytest==4.6.6
 python-dateutil==2.8.0

--- a/requirements/static/py3.6/darwin.txt
+++ b/requirements/static/py3.6/darwin.txt
@@ -84,7 +84,7 @@ pyparsing==2.4.5          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.12.18
+pytest-salt==2019.12.27
 pytest-tempdir==2019.10.12
 pytest==4.6.6
 python-dateutil==2.8.0

--- a/requirements/static/py3.6/linux.txt
+++ b/requirements/static/py3.6/linux.txt
@@ -82,7 +82,7 @@ pyparsing==2.4.5          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.12.18
+pytest-salt==2019.12.27
 pytest-tempdir==2019.10.12
 pytest==4.6.6
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto

--- a/requirements/static/py3.6/windows.txt
+++ b/requirements/static/py3.6/windows.txt
@@ -80,7 +80,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via packaging
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.12.18
+pytest-salt==2019.12.27
 pytest-tempdir==2019.10.12
 pytest==4.6.6
 python-dateutil==2.8.0

--- a/requirements/static/py3.7/darwin.txt
+++ b/requirements/static/py3.7/darwin.txt
@@ -84,7 +84,7 @@ pyparsing==2.4.5          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.12.18
+pytest-salt==2019.12.27
 pytest-tempdir==2019.10.12
 pytest==4.6.6
 python-dateutil==2.8.0

--- a/requirements/static/py3.7/linux.txt
+++ b/requirements/static/py3.7/linux.txt
@@ -82,7 +82,7 @@ pyparsing==2.4.5          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.12.18
+pytest-salt==2019.12.27
 pytest-tempdir==2019.10.12
 pytest==4.6.6
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto

--- a/requirements/static/py3.7/windows.txt
+++ b/requirements/static/py3.7/windows.txt
@@ -80,7 +80,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via packaging
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.12.18
+pytest-salt==2019.12.27
 pytest-tempdir==2019.10.12
 pytest==4.6.6
 python-dateutil==2.8.0


### PR DESCRIPTION
### What does this PR do?
Previous pytest-salt packages didn't include the `sitecustomize.py` file required for coverage tracking of multiprocessing processes.

This new version fixes that.