### PR TITLE
Fix the linux_acl module on FreeBSD (and probably Illumos)

### DIFF
--- a/salt/modules/linux_acl.py
+++ b/salt/modules/linux_acl.py
@@ -62,7 +62,14 @@ def getfacl(*args, **kwargs):
     _raise_on_no_files(*args)
 
     ret = {}
-    cmd = 'getfacl --absolute-names'
+
+    if salt.utils.platform.is_linux():
+        # On Linux, --absolute-names makes returned paths absolute, not relative
+        cmd = 'getfacl --absolute-names'
+    else:
+        # FreeBSD and Illumos return absolute paths by default
+        cmd = 'getfacl'
+
     if recursive:
         cmd += ' -R'
     for dentry in args:

--- a/tests/integration/modules/test_linux_acl.py
+++ b/tests/integration/modules/test_linux_acl.py
@@ -10,6 +10,7 @@ from tests.support.runtests import RUNTIME_VARS
 from tests.support.case import ModuleCase
 from tests.support.mixins import AdaptedConfigurationTestCaseMixin
 from tests.support.helpers import skip_if_binaries_missing
+from tests.support.unit import skipIf
 
 # Import salt libs
 import salt.utils.files
@@ -54,6 +55,8 @@ class LinuxAclModuleTest(ModuleCase, AdaptedConfigurationTestCaseMixin):
         shutil.rmtree(self.mydir, ignore_errors=True)
         super(LinuxAclModuleTest, self).tearDown()
 
+    @skipIf(not salt.utils.platform.is_linux(),
+            "Only Linux's getfacl has --version")
     def test_version(self):
         self.assertRegex(self.run_function('acl.version'), r'\d+\.\d+\.\d+')
 


### PR DESCRIPTION
### What does this PR do?
Fixes all of the commands in the linux_acl module on FreeBSD.  It probably fixes them for Illumos too, but I haven't tested on that platform.

### What issues does this PR fix or reference?
No open issues

### Previous Behavior
`linux_acl.getfacl` would return an error on FreeBSD because `--absolute-names` was unrecognized.  `linux_acl.{wipefacls,modfacl,delfacl}` with the `recursive` flag would probably return an error on Illumos (but I didn't check) because `-R` was unrecognized.

### New Behavior
`linux_acl.getfacl` now works on FreeBSD, as long as `recursive` isn't specified.  If it is, a `CommandExecutionError` will be raised.  The other commands, when used with the `recursive` flag on Illumos, will now also raise a `CommandExecutionError`

### Tests written?
No.  The existing tests in tests/unit/modules/test_linux_acl.py and tests/integration/modules/test_linu_acl.py provide adequate coverage.  I modified them so that all will pass on FreeBSD.

### Commits signed with GPG?

Yes