### PR TITLE
Misc fixes to the localemod module

### DIFF
--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -303,8 +303,7 @@ def gen_locale(locale, **kwargs):
                 "Locale \"{0}\" is not available.".format(locale))
 
     if not valid:
-        log.error(
-            'The provided locale "%s" is not found in %s', locale, search)
+        log.error('The provided locale "%s" is not found', locale)
         return False
 
     if os.path.exists('/etc/locale.gen'):

--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -152,7 +152,7 @@ def get_locale():
         elif 'Solaris' in __grains__['os_family']:
             cmd = 'grep "^LANG=" /etc/default/init'
         else:  # don't waste time on a failing cmd.run
-            raise CommandExecutionError('Error: "{0}" is unsupported!'.format(__grains__['oscodename']))
+            raise CommandExecutionError('Error: "{0}" is unsupported!'.format(__grains__['os_family']))
 
         if cmd:
             try:

--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -275,7 +275,6 @@ def gen_locale(locale, **kwargs):
     on_debian = __grains__.get('os') == 'Debian'
     on_ubuntu = __grains__.get('os') == 'Ubuntu'
     on_gentoo = __grains__.get('os_family') == 'Gentoo'
-    on_suse = __grains__.get('os_family') == 'Suse'
     on_solaris = __grains__.get('os_family') == 'Solaris'
 
     if on_solaris:  # all locales are pre-generated
@@ -295,13 +294,9 @@ def gen_locale(locale, **kwargs):
                                         '^{0}$'.format(locale),
                                         flags=re.MULTILINE)
     else:  # directory-based search
-        if on_suse:
-            search = '/usr/share/locale'
-        else:
-            search = '/usr/share/i18n/locales'
-
         try:
-            valid = locale_search_str in os.listdir(search)
+            valid = locale_search_str in os.listdir('/usr/share/i18n/locales') \
+                    or locale_search_str in os.listdir('/usr/share/locale')
         except OSError as ex:
             log.error(ex)
             raise CommandExecutionError(

--- a/tests/integration/modules/test_localemod.py
+++ b/tests/integration/modules/test_localemod.py
@@ -45,9 +45,9 @@ class LocaleModuleTest(ModuleCase):
             )
 
         locale = self.run_function('locale.get_locale')
-        self.assertEqual(ret['retcode'], 0)
         new_locale = _find_new_locale(locale)
         ret = self.run_function('locale.gen_locale', [new_locale])
+        self.assertEqual(ret['retcode'], 0)
         self.assertNotIn('ERROR:', locale)
 
     @destructiveTest

--- a/tests/integration/modules/test_localemod.py
+++ b/tests/integration/modules/test_localemod.py
@@ -26,12 +26,7 @@ def _find_new_locale(current_locale):
 @skipIf(salt.utils.platform.is_freebsd(), 'locale module is not supported on FreeBSD')
 @requires_salt_modules('locale')
 class LocaleModuleTest(ModuleCase):
-    def test_get_locale(self):
-        locale = self.run_function('locale.get_locale')
-        self.assertNotIn('ERROR:', locale)
-
-    @destructiveTest
-    def test_gen_locale(self):
+    def _requires_charmaps(self):
         # Make sure charmaps are available on test system before attempting
         # call gen_locale. We log this error to the user in the function, but
         # we don't want to fail this test if this is missing on the test system.
@@ -44,6 +39,15 @@ class LocaleModuleTest(ModuleCase):
                 char_maps['stderr'])
             )
 
+
+    def test_get_locale(self):
+        locale = self.run_function('locale.get_locale')
+        self.assertNotIn('ERROR:', locale)
+
+    @destructiveTest
+    def test_gen_locale(self):
+        self._requires_charmaps()
+
         locale = self.run_function('locale.get_locale')
         self.assertNotIn('ERROR:', locale)
         new_locale = _find_new_locale(locale)
@@ -53,6 +57,8 @@ class LocaleModuleTest(ModuleCase):
 
     @destructiveTest
     def test_set_locale(self):
+        self._requires_charmaps()
+
         original_locale = self.run_function('locale.get_locale')
         locale_to_set = _find_new_locale(original_locale)
         ret = self.run_function('locale.gen_locale', [locale_to_set])

--- a/tests/integration/modules/test_localemod.py
+++ b/tests/integration/modules/test_localemod.py
@@ -45,6 +45,7 @@ class LocaleModuleTest(ModuleCase):
             )
 
         locale = self.run_function('locale.get_locale')
+        self.assertEqual(ret['retcode'], 0)
         new_locale = _find_new_locale(locale)
         ret = self.run_function('locale.gen_locale', [new_locale])
         self.assertNotIn('ERROR:', locale)
@@ -56,6 +57,6 @@ class LocaleModuleTest(ModuleCase):
         self.run_function('locale.gen_locale', [locale_to_set])
         ret = self.run_function('locale.set_locale', [locale_to_set])
         new_locale = self.run_function('locale.get_locale')
-        self.assertTrue(ret)
+        self.assertEqual(ret['retcode'], 0)
         self.assertEqual(locale_to_set, new_locale)
         self.run_function('locale.set_locale', [original_locale])

--- a/tests/integration/modules/test_localemod.py
+++ b/tests/integration/modules/test_localemod.py
@@ -45,18 +45,22 @@ class LocaleModuleTest(ModuleCase):
             )
 
         locale = self.run_function('locale.get_locale')
+        self.assertNotIn('ERROR:', locale)
         new_locale = _find_new_locale(locale)
         ret = self.run_function('locale.gen_locale', [new_locale])
-        self.assertEqual(ret['retcode'], 0)
-        self.assertNotIn('ERROR:', locale)
+        # Assert that ret is literally True, not a truthy value like "ERROR:..."
+        self.assertTrue(ret is True)
 
     @destructiveTest
     def test_set_locale(self):
         original_locale = self.run_function('locale.get_locale')
         locale_to_set = _find_new_locale(original_locale)
-        self.run_function('locale.gen_locale', [locale_to_set])
+        ret = self.run_function('locale.gen_locale', [locale_to_set])
+        # Assert that ret is literally True, not a truthy value like "ERROR:..."
+        self.assertTrue(ret is True)
         ret = self.run_function('locale.set_locale', [locale_to_set])
+        # Assert that ret is literally True, not a truthy value like "ERROR:..."
+        self.assertTrue(ret is True)
         new_locale = self.run_function('locale.get_locale')
-        self.assertEqual(ret['retcode'], 0)
         self.assertEqual(locale_to_set, new_locale)
         self.run_function('locale.set_locale', [original_locale])

--- a/tests/integration/modules/test_localemod.py
+++ b/tests/integration/modules/test_localemod.py
@@ -27,7 +27,7 @@ def _find_new_locale(current_locale):
 class LocaleModuleTest(ModuleCase):
     def test_get_locale(self):
         locale = self.run_function('locale.get_locale')
-        self.assertNotIn('Unsupported platform!', locale)
+        self.assertNotIn('ERROR:', locale)
 
     @destructiveTest
     def test_gen_locale(self):
@@ -46,7 +46,7 @@ class LocaleModuleTest(ModuleCase):
         locale = self.run_function('locale.get_locale')
         new_locale = _find_new_locale(locale)
         ret = self.run_function('locale.gen_locale', [new_locale])
-        self.assertTrue(ret)
+        self.assertNotIn('ERROR:', locale)
 
     @destructiveTest
     def test_set_locale(self):

--- a/tests/integration/modules/test_localemod.py
+++ b/tests/integration/modules/test_localemod.py
@@ -23,6 +23,7 @@ def _find_new_locale(current_locale):
 
 @skipIf(salt.utils.platform.is_windows(), 'minion is windows')
 @skipIf(salt.utils.platform.is_darwin(), 'locale method is not supported on mac')
+@skipIf(salt.utils.platform.is_freebsd(), 'locale module is not supported on FreeBSD')
 @requires_salt_modules('locale')
 class LocaleModuleTest(ModuleCase):
     def test_get_locale(self):

--- a/tests/unit/modules/test_localemod.py
+++ b/tests/unit/modules/test_localemod.py
@@ -486,9 +486,8 @@ class LocalemodTestCase(TestCase, LoaderModuleMockMixin):
         '''
         assert not localemod.gen_locale('foo')
         assert localemod.log.error.called
-        msg = localemod.log.error.call_args[0][0] % (localemod.log.error.call_args[0][1],
-                                                     localemod.log.error.call_args[0][2])
-        assert msg == 'The provided locale "foo" is not found in /usr/share/i18n/SUPPORTED'
+        msg = localemod.log.error.call_args[0][0] % localemod.log.error.call_args[0][1]
+        assert msg == 'The provided locale "foo" is not found'
 
     @patch('salt.modules.localemod.log', MagicMock())
     @patch('salt.modules.localemod.__grains__', {'os_family': 'Suse'})
@@ -501,10 +500,9 @@ class LocalemodTestCase(TestCase, LoaderModuleMockMixin):
         '''
         assert not localemod.gen_locale('de_DE.utf8')
         assert localemod.log.error.called
-        msg = localemod.log.error.call_args[0][0] % (localemod.log.error.call_args[0][1],
-                                                     localemod.log.error.call_args[0][2])
+        msg = localemod.log.error.call_args[0][0] % localemod.log.error.call_args[0][1]
         assert localemod.os.listdir.call_args[0][0] == '/usr/share/locale'
-        assert msg == 'The provided locale "en_GB.utf8" is not found in /usr/share/locale'
+        assert msg == 'The provided locale "en_GB.utf8" is not found'
 
     @patch('salt.modules.localemod.log', MagicMock())
     @patch('salt.modules.localemod.__grains__', {'os_family': 'Suse'})

--- a/tests/unit/modules/test_localemod.py
+++ b/tests/unit/modules/test_localemod.py
@@ -292,7 +292,7 @@ class LocalemodTestCase(TestCase, LoaderModuleMockMixin):
         '''
         with pytest.raises(CommandExecutionError) as exc_info:
             localemod.get_locale()
-        assert '"DrunkDragon" is unsupported' in six.text_type(exc_info.value)
+        assert '"BSD" is unsupported' in six.text_type(exc_info.value)
 
     @patch('salt.utils.path.which', MagicMock(return_value="/usr/bin/localctl"))
     @patch('salt.modules.localemod.__grains__', {'os_family': 'Ubuntu', 'osmajorrelease': 42})


### PR DESCRIPTION
### What does this PR do?
1) Fixes the error message for locale.get_locale on unsupported platforms.  Previously it would raise a KeyError
2) Skips the localemod tests on FreeBSD, where that module is unsupported
3) Fixes some localemod tests whose pass conditions were too generous.

### What issues does this PR fix or reference?
none

### Previous Behavior
Calling localemod.get_locale on an unsupported platform would raise an unhelpful KeyError

### New Behavior
Calling localemod.get_locale on an unsupported platform would raise a CommandExecutionError, as it should

### Tests written?
No.  The existing localemod tests are now skipped on FreeBSD.  If any new errors pop up in CI, it's probably because I fixed test_gen_locale and test_set_locale.  Previously, those tests weren't actually asserting anything

### Commits signed with GPG?
Yes