### PR TITLE
Fix several tests that fail on FreeBSD

### DIFF
--- a/tests/integration/modules/test_disk.py
+++ b/tests/integration/modules/test_disk.py
@@ -18,8 +18,9 @@ from salt.ext import six
 
 
 @destructiveTest
-@skipIf(salt.utils.platform.is_windows(), 'No mtab on Windows')
 @skipIf(salt.utils.platform.is_darwin(), 'No mtab on Darwin')
+@skipIf(salt.utils.platform.is_freebsd(), 'No mtab on FreeBSD')
+@skipIf(salt.utils.platform.is_windows(), 'No mtab on Windows')
 class DiskModuleVirtualizationTest(ModuleCase):
     '''
     Test to make sure we return a clean result under Docker. Refs #8976

--- a/tests/integration/modules/test_pkg.py
+++ b/tests/integration/modules/test_pkg.py
@@ -352,6 +352,8 @@ class PkgModuleTest(ModuleCase, SaltReturnAssertsMixin):
             cmd_pkg = self.run_function('cmd.run', ['apt list {0}'.format(self.pkg)])
         elif grains['os_family'] == 'Arch':
             cmd_pkg = self.run_function('cmd.run', ['pacman -Si {0}'.format(self.pkg)])
+        elif grains['os_family'] == 'FreeBSD':
+            cmd_pkg = self.run_function('cmd.run', ['pkg search -S name -qQ version -e {0}'.format(self.pkg)])
         elif grains['os_family'] == 'Suse':
             cmd_pkg = self.run_function('cmd.run', ['zypper info {0}'.format(self.pkg)])
         elif grains['os_family'] == 'MacOS':

--- a/tests/integration/modules/test_pkg.py
+++ b/tests/integration/modules/test_pkg.py
@@ -143,6 +143,16 @@ class PkgModuleTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.run_function(func, ['/bin/ls'])
         self.assertNotEqual(len(ret), 0)
 
+    # Similar to pkg.owner, but for FreeBSD's pkgng
+    @requires_salt_modules('pkg.which')
+    def test_which(self):
+        '''
+        test finding the package owning a file
+        '''
+        func = 'pkg.which'
+        ret = self.run_function(func, ['/usr/local/bin/salt-call'])
+        self.assertNotEqual(len(ret), 0)
+
     @destructiveTest
     @requires_salt_modules('pkg.version', 'pkg.install', 'pkg.remove')
     @requires_network()

--- a/tests/integration/modules/test_status.py
+++ b/tests/integration/modules/test_status.py
@@ -27,7 +27,7 @@ class StatusModuleTest(ModuleCase):
         status_pid = self.run_function('status.pid', ['salt'])
         grab_pids = status_pid.split()[:10]
         random_pid = random.choice(grab_pids)
-        grep_salt = self.run_function('cmd.run', ['ps aux | grep salt'])
+        grep_salt = self.run_function('cmd.run', ['pgrep -f salt'])
         self.assertIn(random_pid, grep_salt)
 
     @skipIf(not salt.utils.platform.is_windows(), 'windows only test')

--- a/tests/integration/modules/test_sysctl.py
+++ b/tests/integration/modules/test_sysctl.py
@@ -30,7 +30,7 @@ class SysctlModuleTest(ModuleCase):
     def test_show_freebsd(self):
         ret = self.run_function('sysctl.show')
         self.assertIn('vm.vmtotal', ret, 'Multiline variable absent')
-        self.assertGreater(ret.get('vm.vmtotal').splitlines(),
+        self.assertGreater(len(ret.get('vm.vmtotal').splitlines()),
                            1,
                            'Multiline value was parsed wrong')
 


### PR DESCRIPTION
### What does this PR do?
Fixes several miscellaneous test failures on FreeBSD, and adds a test for `pkg.which`.  There are no changes to the actual Salt code, just to the tests.  See individual commit messages for details.

### What issues does this PR fix or reference?
none

### Tests written?
One new test for pkg.which.  Fixes for several other existing tests

### Commits signed with GPG?
Yes