### PR TITLE
Fix Issue 52369

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -672,7 +672,7 @@ def _set_network_adapter_mapping(adapter_specs):
     if 'ip' in list(adapter_specs.keys()):
         ip = six.text_type(adapter_specs['ip'])
         subnet_mask = six.text_type(adapter_specs['subnet_mask'])
-        adapter_mapping.adapter.ip = vim.vm.customization.FixedIp(ipAddress=ip)
+        adapter_mapping.adapter.ip.ipAddress = vim.vm.customization.FixedIp(ipAddress=ip)
         adapter_mapping.adapter.subnetMask = subnet_mask
     else:
         adapter_mapping.adapter.ip = vim.vm.customization.DhcpIpGenerator()


### PR DESCRIPTION
### What does this PR do?
Sets static ip address on VMWare virtual machines

### What issues does this PR fix or reference?
#52369

### Previous Behavior
Remove this section if not relevant
Static ip in salt-cloud vmware profile doesn't overwrite vm adapter configuration.

### New Behavior
Remove this section if not relevant
Static ip in salt-cloud vmware profile overwrites vm adapter configuration.

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**  
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
