### PR TITLE
Add virt.(pool|network)_get_xml functions

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -4584,6 +4584,30 @@ def network_info(name=None, **kwargs):
     return result
 
 
+def network_get_xml(name, **kwargs):
+    '''
+    Return the XML definition of a virtual network
+
+    :param name: libvirt network name
+    :param connection: libvirt connection URI, overriding defaults
+    :param username: username to connect with, overriding defaults
+    :param password: password to connect with, overriding defaults
+
+    .. versionadded:: Neon
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' virt.network_get_xml default
+    '''
+    conn = __get_conn(**kwargs)
+    try:
+        return conn.networkLookupByName(name).XMLDesc()
+    finally:
+        conn.close()
+
+
 def network_start(name, **kwargs):
     '''
     Start a defined virtual network.

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -5352,6 +5352,30 @@ def pool_info(name=None, **kwargs):
     return result
 
 
+def pool_get_xml(name, **kwargs):
+    '''
+    Return the XML definition of a virtual storage pool
+
+    :param name: libvirt storage pool name
+    :param connection: libvirt connection URI, overriding defaults
+    :param username: username to connect with, overriding defaults
+    :param password: password to connect with, overriding defaults
+
+    .. versionadded:: Neon
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' virt.pool_get_xml default
+    '''
+    conn = __get_conn(**kwargs)
+    try:
+        return conn.storagePoolLookupByName(name).XMLDesc()
+    finally:
+        conn.close()
+
+
 def pool_start(name, **kwargs):
     '''
     Start a defined libvirt storage pool.

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -2348,6 +2348,16 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         net = virt.network_info('foo')
         self.assertEqual({}, net)
 
+    def test_network_get_xml(self):
+        '''
+        Test virt.network_get_xml
+        '''
+        network_mock = MagicMock()
+        network_mock.XMLDesc.return_value = '<net>Raw XML</net>'
+        self.mock_conn.networkLookupByName.return_value = network_mock
+
+        self.assertEqual('<net>Raw XML</net>', virt.network_get_xml('default'))
+
     def test_pool(self):
         '''
         Test virt._gen_pool_xml()

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -2760,6 +2760,16 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             }
         }, pool)
 
+    def test_pool_get_xml(self):
+        '''
+        Test virt.pool_get_xml
+        '''
+        pool_mock = MagicMock()
+        pool_mock.XMLDesc.return_value = '<pool>Raw XML</pool>'
+        self.mock_conn.storagePoolLookupByName.return_value = pool_mock
+
+        self.assertEqual('<pool>Raw XML</pool>', virt.pool_get_xml('default'))
+
     def test_pool_list_volumes(self):
         '''
         Test virt.pool_list_volumes


### PR DESCRIPTION
### What does this PR do?

This PR adds `virt.(pool|network)_get_xml` functions since the user may want to get the XML definition of a virtual storage pool or network.

### What issues does this PR fix or reference?

### Tests written?

Yes

### Commits signed with GPG?

Yes