### PR TITLE
Run `pre-commit run -av pip-tools-compile` against the changes from #55749

### DIFF
--- a/requirements/static/py2.7/darwin.txt
+++ b/requirements/static/py2.7/darwin.txt
@@ -53,7 +53,7 @@ importlib-metadata==0.23  # via pluggy, pytest
 ipaddress==1.0.22
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
-jmespath==0.9.4           # via boto3, botocore
+jmespath==0.9.4
 jsondiff==1.1.1           # via moto
 jsonpickle==1.1           # via aws-xray-sdk
 jsonschema==2.6.0

--- a/requirements/static/py2.7/linux.txt
+++ b/requirements/static/py2.7/linux.txt
@@ -51,7 +51,7 @@ importlib-metadata==0.23  # via pluggy, pytest
 ipaddress==1.0.22         # via cryptography, docker, kubernetes
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
-jmespath==0.9.4           # via boto3, botocore
+jmespath==0.9.4
 jsondiff==1.1.1           # via moto
 jsonpickle==1.1           # via aws-xray-sdk
 jsonschema==2.6.0

--- a/requirements/static/py2.7/windows.txt
+++ b/requirements/static/py2.7/windows.txt
@@ -51,7 +51,7 @@ ioloop==0.1a0
 ipaddress==1.0.22
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
-jmespath==0.9.4           # via boto3, botocore
+jmespath==0.9.4
 jsondiff==1.1.1           # via moto
 jsonpickle==1.1           # via aws-xray-sdk
 jsonschema==2.6.0

--- a/requirements/static/py3.4/linux.txt
+++ b/requirements/static/py3.4/linux.txt
@@ -43,7 +43,7 @@ importlib-metadata==0.23  # via pluggy, pytest
 ipaddress==1.0.22         # via kubernetes
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
-jmespath==0.9.4           # via boto3, botocore
+jmespath==0.9.4
 jsondiff==1.1.1           # via moto
 jsonpickle==1.1           # via aws-xray-sdk
 jsonschema==2.6.0

--- a/requirements/static/py3.5/darwin.txt
+++ b/requirements/static/py3.5/darwin.txt
@@ -46,7 +46,7 @@ importlib-metadata==0.23  # via pluggy, pytest
 ipaddress==1.0.22
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
-jmespath==0.9.4           # via boto3, botocore
+jmespath==0.9.4
 jsondiff==1.1.1           # via moto
 jsonpickle==1.1           # via aws-xray-sdk
 jsonschema==2.6.0

--- a/requirements/static/py3.5/linux.txt
+++ b/requirements/static/py3.5/linux.txt
@@ -43,7 +43,7 @@ importlib-metadata==0.23  # via pluggy, pytest
 ipaddress==1.0.22         # via kubernetes
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
-jmespath==0.9.4           # via boto3, botocore
+jmespath==0.9.4
 jsondiff==1.1.1           # via moto
 jsonpickle==1.1           # via aws-xray-sdk
 jsonschema==2.6.0

--- a/requirements/static/py3.5/windows.txt
+++ b/requirements/static/py3.5/windows.txt
@@ -44,7 +44,7 @@ ioloop==0.1a0
 ipaddress==1.0.22
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
-jmespath==0.9.4           # via boto3, botocore
+jmespath==0.9.4
 jsondiff==1.1.1           # via moto
 jsonpickle==1.1           # via aws-xray-sdk
 jsonschema==2.6.0

--- a/requirements/static/py3.6/darwin.txt
+++ b/requirements/static/py3.6/darwin.txt
@@ -46,7 +46,7 @@ importlib-metadata==0.23  # via pluggy, pytest
 ipaddress==1.0.22
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
-jmespath==0.9.4           # via boto3, botocore
+jmespath==0.9.4
 jsondiff==1.1.1           # via moto
 jsonpickle==1.1           # via aws-xray-sdk
 jsonschema==2.6.0

--- a/requirements/static/py3.6/linux.txt
+++ b/requirements/static/py3.6/linux.txt
@@ -43,7 +43,7 @@ importlib-metadata==0.23  # via pluggy, pytest
 ipaddress==1.0.22         # via kubernetes
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
-jmespath==0.9.4           # via boto3, botocore
+jmespath==0.9.4
 jsondiff==1.1.1           # via moto
 jsonpickle==1.1           # via aws-xray-sdk
 jsonschema==2.6.0

--- a/requirements/static/py3.6/windows.txt
+++ b/requirements/static/py3.6/windows.txt
@@ -44,7 +44,7 @@ ioloop==0.1a0
 ipaddress==1.0.22
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
-jmespath==0.9.4           # via boto3, botocore
+jmespath==0.9.4
 jsondiff==1.1.1           # via moto
 jsonpickle==1.1           # via aws-xray-sdk
 jsonschema==2.6.0

--- a/requirements/static/py3.7/darwin.txt
+++ b/requirements/static/py3.7/darwin.txt
@@ -46,7 +46,7 @@ importlib-metadata==0.23  # via pluggy, pytest
 ipaddress==1.0.22
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
-jmespath==0.9.4           # via boto3, botocore
+jmespath==0.9.4
 jsondiff==1.1.1           # via moto
 jsonpickle==1.1           # via aws-xray-sdk
 jsonschema==2.6.0

--- a/requirements/static/py3.7/linux.txt
+++ b/requirements/static/py3.7/linux.txt
@@ -43,7 +43,7 @@ importlib-metadata==0.23  # via pluggy, pytest
 ipaddress==1.0.22         # via kubernetes
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
-jmespath==0.9.4           # via boto3, botocore
+jmespath==0.9.4
 jsondiff==1.1.1           # via moto
 jsonpickle==1.1           # via aws-xray-sdk
 jsonschema==2.6.0

--- a/requirements/static/py3.7/windows.txt
+++ b/requirements/static/py3.7/windows.txt
@@ -44,7 +44,7 @@ ioloop==0.1a0
 ipaddress==1.0.22
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
-jmespath==0.9.4           # via boto3, botocore
+jmespath==0.9.4
 jsondiff==1.1.1           # via moto
 jsonpickle==1.1           # via aws-xray-sdk
 jsonschema==2.6.0


### PR DESCRIPTION
### What does this PR do?
This change doesn't really update any requirements files, just it's comments because `jmespath` is now a primary dependency, not a secondary.

### What issues does this PR fix or reference?
#55749 
