### PR TITLE
Rabbitmq additions master

### DIFF
--- a/doc/ref/states/all/index.rst
+++ b/doc/ref/states/all/index.rst
@@ -244,6 +244,7 @@ state modules
     rabbitmq_cluster
     rabbitmq_plugin
     rabbitmq_policy
+    rabbitmq_upstream
     rabbitmq_user
     rabbitmq_vhost
     rbac_solaris

--- a/doc/ref/states/all/salt.states.rabbitmq_upstream.rst
+++ b/doc/ref/states/all/salt.states.rabbitmq_upstream.rst
@@ -1,0 +1,6 @@
+=============================
+salt.states.rabbitmq_upstream
+=============================
+
+.. automodule:: salt.states.rabbitmq_upstream
+    :members:

--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -1136,7 +1136,7 @@ def disable_plugin(name, runas=None):
     return _format_response(ret, 'Disabled')
 
 
-def add_upstream(
+def set_upstream(
         name,
         uri,
         prefetch_count=None,
@@ -1151,10 +1151,10 @@ def add_upstream(
         queue=None,
         runas=None):
     '''
-    Adds an upstream via rabbitmqctl set_parameter. This can be an exchange-upstream,
+    Configures an upstream via rabbitmqctl set_parameter. This can be an exchange-upstream,
     a queue-upstream or both.
 
-    :param str name: The name of the upstream to add.
+    :param str name: The name of the upstream to configure.
     The following parameters apply to federated exchanges and federated queues:
     :param str uri: The AMQP URI(s) for the upstream.
     :param int prefetch_count: The maximum number of unacknowledged messages copied
@@ -1208,7 +1208,7 @@ def add_upstream(
 
     CLI Example:
     .. code-block:: bash
-        salt '*' rabbitmq.add_upstream upstream_name ack_mode=on-confirm max_hops=1 \
+        salt '*' rabbitmq.set_upstream upstream_name ack_mode=on-confirm max_hops=1 \
             trust_user_id=True uri=amqp://hostname
 
     .. version-added:: Neon

--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -264,7 +264,9 @@ def list_upstreams(runas=None):
     :param str runas: The name of the user to run this command as.
 
     CLI Example:
+
     .. code-block:: bash
+
         salt '*' rabbitmq.list_upstreams
 
     .. versionadded:: Neon
@@ -322,7 +324,9 @@ def upstream_exists(name, runas=None):
     :param str runas: The name of the user to run the command as.
 
     CLI Example:
+
     .. code-block:: bash
+
         salt '*' rabbitmq.upstream_exists rabbit_upstream
 
     .. versionadded:: Neon
@@ -1037,14 +1041,14 @@ def policy_exists(vhost, name, runas=None):
 
 def list_available_plugins(runas=None):
     '''
-        Returns a list of the names of all available plugins (enabled and disabled).
+    Returns a list of the names of all available plugins (enabled and disabled).
 
-        CLI Example:
+    CLI Example:
 
-        .. code-block:: bash
+    .. code-block:: bash
 
-            salt '*' rabbitmq.list_available_plugins
-        '''
+        salt '*' rabbitmq.list_available_plugins
+    '''
     if runas is None and not salt.utils.platform.is_windows():
         runas = salt.utils.user.get_user()
     cmd = [_get_rabbitmq_plugin(), 'list', '-m']
@@ -1059,14 +1063,14 @@ def list_available_plugins(runas=None):
 
 def list_enabled_plugins(runas=None):
     '''
-        Returns a list of the names of the enabled plugins.
+    Returns a list of the names of the enabled plugins.
 
-        CLI Example:
+    CLI Example:
 
-        .. code-block:: bash
+    .. code-block:: bash
 
-            salt '*' rabbitmq.list_enabled_plugins
-        '''
+        salt '*' rabbitmq.list_enabled_plugins
+    '''
     if runas is None and not salt.utils.platform.is_windows():
         runas = salt.utils.user.get_user()
     cmd = [_get_rabbitmq_plugin(), 'list', '-m', '-e']
@@ -1207,7 +1211,9 @@ def set_upstream(
     :param str runas: The name of the user to run the command as.
 
     CLI Example:
+
     .. code-block:: bash
+
         salt '*' rabbitmq.set_upstream upstream_name ack_mode=on-confirm max_hops=1 \
             trust_user_id=True uri=amqp://hostname
 
@@ -1243,6 +1249,12 @@ def delete_upstream(name, runas=None):
 
     :param str name: The name of the upstream to delete.
     :param str runas: The name of the user to run the command as.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' rabbitmq.delete_upstream upstream_name
 
     .. versionadded:: Neon
     '''

--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -267,7 +267,7 @@ def list_upstreams(runas=None):
     .. code-block:: bash
         salt '*' rabbitmq.list_upstreams
 
-    .. version-added:: Neon
+    .. versionadded:: Neon
     '''
     if runas is None and not salt.utils.platform.is_windows():
         runas = salt.utils.user.get_user()
@@ -325,7 +325,7 @@ def upstream_exists(name, runas=None):
     .. code-block:: bash
         salt '*' rabbitmq.upstream_exists rabbit_upstream
 
-    .. version-added:: Neon
+    .. versionadded:: Neon
     '''
     if runas is None and not salt.utils.platform.is_windows():
         runas = salt.utils.user.get_user()
@@ -1211,7 +1211,7 @@ def set_upstream(
         salt '*' rabbitmq.set_upstream upstream_name ack_mode=on-confirm max_hops=1 \
             trust_user_id=True uri=amqp://hostname
 
-    .. version-added:: Neon
+    .. versionadded:: Neon
     '''
     if runas is None and not salt.utils.platform.is_windows():
         runas = salt.utils.user.get_user()
@@ -1244,7 +1244,7 @@ def delete_upstream(name, runas=None):
     :param str name: The name of the upstream to delete.
     :param str runas: The name of the user to run the command as.
 
-    .. version-added:: Neon
+    .. versionadded:: Neon
     '''
     if runas is None and not salt.utils.platform.is_windows():
         runas = salt.utils.user.get_user()

--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -1159,7 +1159,9 @@ def set_upstream(
     a queue-upstream or both.
 
     :param str name: The name of the upstream to configure.
+
     The following parameters apply to federated exchanges and federated queues:
+
     :param str uri: The AMQP URI(s) for the upstream.
     :param int prefetch_count: The maximum number of unacknowledged messages copied
         over a link at any one time. Default: 1000
@@ -1181,7 +1183,9 @@ def set_upstream(
         it itself. If set to false or not set, it will clear any validated user-id
         it encounters. You should only set this to true if you trust the upstream
         server (and by extension, all its upstreams) not to forge user-ids.
+
     The following parameters apply to federated exchanges only:
+
     :param str exchange: The name of the upstream exchange. Default is to use the
         same name as the federated exchange.
     :param int max_hops: The maximum number of federation links that a message
@@ -1204,7 +1208,9 @@ def set_upstream(
         queue for a federated exchange (see expires). This is only of interest
         when connecting to old brokers which determine queue HA mode using this
         argument. Default is ``None``, meaning the queue is not HA.
+
     The following parameter applies to federated queues only:
+
     :param str queue: The name of the upstream queue. Default is to use the same
         name as the federated queue.
 

--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -261,9 +261,13 @@ def list_upstreams(runas=None):
     '''
     Returns a dict of upstreams based on rabbitmqctl list_parameters.
 
+    :param str runas: The name of the user to run this command as.
+
     CLI Example:
     .. code-block:: bash
         salt '*' rabbitmq.list_upstreams
+
+    .. version-added:: Neon
     '''
     if runas is None and not salt.utils.platform.is_windows():
         runas = salt.utils.user.get_user()
@@ -314,9 +318,14 @@ def upstream_exists(name, runas=None):
     '''
     Return whether the upstreamexists based on rabbitmqctl list_parameters.
 
+    :param str name: The name of the upstream to check for.
+    :param str runas: The name of the user to run the command as.
+
     CLI Example:
     .. code-block:: bash
         salt '*' rabbitmq.upstream_exists rabbit_upstream
+
+    .. version-added:: Neon
     '''
     if runas is None and not salt.utils.platform.is_windows():
         runas = salt.utils.user.get_user()
@@ -1133,10 +1142,16 @@ def add_upstream(name, definition, runas=None):
     Definition can be passed as (JSON) string or as dict, which will be converted
     to a JSON string.
 
+    :param str name: The name of the upstream to add.
+    :param str definition: The JSON string that contains the upstream configuration.
+    :param str runas: The name of the user to run the command as.
+
     CLI Example:
     .. code-block:: bash
         salt '*' rabbitmq.add_upstream upstream_name \
         '{"ack-mode":"on-confirm","max-hops":1,"trust-user-id":true,"uri":"amqp://hostname"}'
+
+    .. version-added:: Neon
     '''
     if runas is None and not salt.utils.platform.is_windows():
         runas = salt.utils.user.get_user()
@@ -1153,6 +1168,11 @@ def add_upstream(name, definition, runas=None):
 def delete_upstream(name, runas=None):
     '''
     Deletes an upstream via rabbitmqctl clear_parameter.
+
+    :param str name: The name of the upstream to delete.
+    :param str runas: The name of the user to run the command as.
+
+    .. version-added:: Neon
     '''
     if runas is None and not salt.utils.platform.is_windows():
         runas = salt.utils.user.get_user()

--- a/salt/states/rabbitmq_upstream.py
+++ b/salt/states/rabbitmq_upstream.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
 Manage RabbitMQ Upstreams
-=====================
+=========================
 
 Example:
 
@@ -80,15 +80,15 @@ def present(name,
         be in flight over a federation link at one time. Default: 1000
     :param int reconnect_delay: Time in seconds to wait after a network link
         goes down before attempting reconnection. Default: 5
-    :param str ack_mode:
+    :param str ack_mode: The following values are allowed:
         on-confirm: Messages are acknowledged to the upstream broker after they
-            have been confirmed downstream. Handles network errors and broker failures
-            without losing messages. The slowest option, and the default.
+        have been confirmed downstream. Handles network errors and broker failures
+        without losing messages. The slowest option, and the default.
         on-publish: Messages are acknowledged to the upstream broker after they
-            have been published downstream. Handles network errors without losing
-            messages, but may lose messages in the event of broker failures.
+        have been published downstream. Handles network errors without losing
+        messages, but may lose messages in the event of broker failures.
         no-ack: Message acknowledgements are not used. The fastest option, but
-            you may lose messages in the event of network or broker failures.
+        you may lose messages in the event of network or broker failures.
     :param bool trust_user_id: Set ``True`` to preserve the "user-id" field across
         a federation link, even if the user-id does not match that used to republish
         the message. Set to ``False`` to clear the "user-id" field when messages
@@ -107,10 +107,11 @@ def present(name,
     :param str ha_policy: Determines the "x-ha-policy"-argument for the upstream
         queue for a federated exchange. Default is "none" meaning the queue is
         not HA.
-    param str queue: The name of the upstream queue. Default is to use the same
+    :param str queue: The name of the upstream queue. Default is to use the same
         name as the federated queue.
 
     .. versionadded:: Neon
+
     '''
     ret = {'name': name, 'result': False, 'comment': '', 'changes': {}}
     action = None

--- a/salt/states/rabbitmq_upstream.py
+++ b/salt/states/rabbitmq_upstream.py
@@ -14,6 +14,8 @@ Example:
       - trust_user_id: True
       - ack_mode: on-confirm
       - max_hops: 1
+
+.. version-added:: Neon
 '''
 
 # Import python libs
@@ -107,6 +109,8 @@ def present(name,
         not HA.
     param str queue: The name of the upstream queue. Default is to use the same
         name as the federated queue.
+
+    .. version-added:: Neon
     '''
     ret = {'name': name, 'result': False, 'comment': '', 'changes': {}}
 
@@ -115,7 +119,7 @@ def present(name,
     except CommandExecutionError as err:
         ret['comment'] = 'Error: {0}'.format(err)
         return ret
-    new_config = salt.utils.dicttrim.remove_empty_values({
+    new_config = salt.utils.data.filter_falsey({
         'uri': uri,
         'prefetch-count': prefetch_count,
         'reconnect-delay': reconnect_delay,
@@ -166,10 +170,10 @@ def absent(name,
     '''
     Ensure the named upstream is absent.
 
-    name
-        The name of the upstream to remove
-    runas
-        User to run the command
+    :param str name: The name of the upstream to remove
+    :param str runas: User to run the command
+
+    .. version-added:: Neon
     '''
     ret = {'name': name, 'result': False, 'comment': '', 'changes': {}}
 

--- a/salt/states/rabbitmq_upstream.py
+++ b/salt/states/rabbitmq_upstream.py
@@ -15,7 +15,7 @@ Example:
       - ack_mode: on-confirm
       - max_hops: 1
 
-.. version-added:: Neon
+.. versionadded:: Neon
 '''
 
 # Import python libs
@@ -110,7 +110,7 @@ def present(name,
     param str queue: The name of the upstream queue. Default is to use the same
         name as the federated queue.
 
-    .. version-added:: Neon
+    .. versionadded:: Neon
     '''
     ret = {'name': name, 'result': False, 'comment': '', 'changes': {}}
     action = None
@@ -181,7 +181,7 @@ def absent(name, runas=None):
     :param str name: The name of the upstream to remove
     :param str runas: User to run the command
 
-    .. version-added:: Neon
+    .. versionadded:: Neon
     '''
     ret = {'name': name, 'result': False, 'comment': '', 'changes': {}}
 

--- a/salt/states/rabbitmq_upstream.py
+++ b/salt/states/rabbitmq_upstream.py
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+'''
+Manage RabbitMQ Upstreams
+=====================
+
+Example:
+
+.. code-block:: yaml
+
+    rabbit_upstream:
+      rabbitmq_upstream.present:
+      - name: upstream_1
+      - uri: amqp://my_user:my_password@rabbitmq_host
+      - trust_user_id: True
+      - ack_mode: on-confirm
+      - max_hops: 1
+'''
+
+# Import python libs
+from __future__ import absolute_import
+import logging
+import json
+
+# Import salt libs
+import salt.utils.path
+import salt.utils.dictdiffer
+from salt.exceptions import CommandExecutionError
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Only load if the appropriate rabbitmq module functions are loaded.
+    '''
+    requirements = ['rabbitmq.list_upstreams',
+                    'rabbitmq.upstream_exists',
+                    'rabbitmq.add_upstream',
+                    'rabbitmq.delete_upstream']
+    return all(req in __salt__ for req in requirements)
+
+
+def present(name,
+            uri,
+            prefetch_count=None,
+            reconnect_delay=None,
+            ack_mode=None,
+            trust_user_id=None,
+            exchange=None,
+            max_hops=None,
+            expires=None,
+            message_ttl=None,
+            ha_policy=None,
+            queue=None,
+            runas=None):
+    '''
+    Ensure the RabbitMQ upstream exists.
+
+    :param str name: The name of the upstream connection
+    :param str uri: The URI to connect to. If upstream is a cluster and can have
+        several URIs, you can enter them here separated by spaces.
+        Examples:
+        - amqp://user:password@server_name
+        - amqp://user:password@server_name/vhost
+        When connecting with SSL, several URI-parameters need also be specified:
+        - cacertfile = /path/to/cacert.pem
+        - certfile = /path/to/cert.pem
+        - keyfile = /part/to/key.pem
+        - verity = verify_peer
+        - fail_if_no_peer_cert = true | false
+        - auth_mechanism = external
+        Example (these should be one line each):
+        - amqp://user:password@server_name?cacertfile=/path/to/cacert.pem&certfile=/path/to/cert.pem
+            &keyfile=/path/to/key.pem&verify=verify_peer
+        - amqp://server-name?cacertfile=/path/to/cacert.pem&certfile=/path/to/cert.pem
+            &keyfile=/path/to/key.pem&verify=verify_peer&fail_if_no_peer_cert=true&auth_mechanism=external
+    :param int prefetch_count: Maximum number of unacknowledged messages that may
+        be in flight over a federation link at one time. Default: 1000
+    :param int reconnect_delay: Time in seconds to wait after a network link
+        goes down before attempting reconnection. Default: 5
+    :param str ack_mode:
+        on-confirm: Messages are acknowledged to the upstream broker after they
+            have been confirmed downstream. Handles network errors and broker failures
+            without losing messages. The slowest option, and the default.
+        on-publish: Messages are acknowledged to the upstream broker after they
+            have been published downstream. Handles network errors without losing
+            messages, but may lose messages in the event of broker failures.
+        no-ack: Message acknowledgements are not used. The fastest option, but
+            you may lose messages in the event of network or broker failures.
+    :param bool trust_user_id: Set ``True`` to preserve the "user-id" field across
+        a federation link, even if the user-id does not match that used to republish
+        the message. Set to ``False`` to clear the "user-id" field when messages
+        are federated. Only set this to ``True`` if you trust the upstream broker
+        not to forge user-ids.
+    :param str exchange: The name of the upstream exchange. Default is to use the
+        same name as the federated exchange.
+    :param int max_hops: Maximum number of federation links that messages can
+        traverse before being dropped. Defaults to 1 if not set.
+    :param int expires: Time in milliseconds that the upstream should remember
+        about this node for. After this time all upstream state will be removed.
+        Set to ``None`` (Default) to mean "forever".
+    :param int message_ttl: Time in milliseconds that undelivered messages should
+        be held upstream when there is a network outage or backlog.
+        Set to ``None`` (default) to mean "forever".
+    :param str ha_policy: Determines the "x-ha-policy"-argument for the upstream
+        queue for a federated exchange. Default is "none" meaning the queue is
+        not HA.
+    param str queue: The name of the upstream queue. Default is to use the same
+        name as the federated queue.
+    '''
+    ret = {'name': name, 'result': False, 'comment': '', 'changes': {}}
+
+    try:
+        current = __salt__['rabbitmq.list_upstreams'](runas=runas)
+    except CommandExecutionError as err:
+        ret['comment'] = 'Error: {0}'.format(err)
+        return ret
+    new_config = salt.utils.dicttrim.remove_empty_values({
+        'uri': uri,
+        'prefetch-count': prefetch_count,
+        'reconnect-delay': reconnect_delay,
+        'ack-mode': ack_mode,
+        'trust-user-id': trust_user_id,
+        'exchange': exchange,
+        'max-hops': max_hops,
+        'expires': expires,
+        'message-ttl': message_ttl,
+        'ha-policy': ha_policy,
+        'queue': queue,
+    })
+    if name in current:
+        current_config = json.loads(current.get(name, ''))
+        diff_config = salt.utils.dictdiffer.deep_diff(current_config, new_config)
+        if diff_config:
+            if __opts__['test']:
+                ret['result'] = None
+                ret['comment'] = 'Upstream "{}" would have been updated.'.format(name)
+            else:
+                try:
+                    res = __salt__['rabbitmq.add_upstream'](name, new_config, runas=runas)
+                    ret['result'] = res
+                    ret['comment'] = 'Upstream "{}" updated.'.format(name)
+                    ret['changes'] = diff_config
+                except CommandExecutionError as exp:
+                    ret['comment'] = 'Error: {}'.format(exp)
+        else:
+            ret['result'] = True
+            ret['comment'] = 'Upstream "{}" already present as specified.'.format(name)
+    else:
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'Upstream "{}" would have been created.'.format(name)
+        else:
+            try:
+                res = __salt__['rabbitmq.add_upstream'](name, new_config, runas=runas)
+                ret['result'] = res
+                ret['comment'] = 'Upstream "{}" updated.'.format(name)
+                ret['changes'] = {'old': None, 'new': new_config}
+            except CommandExecutionError as exp:
+                ret['comment'] = 'Error: {}'.format(exp)
+    return ret
+
+
+def absent(name,
+           runas=None):
+    '''
+    Ensure the named upstream is absent.
+
+    name
+        The name of the upstream to remove
+    runas
+        User to run the command
+    '''
+    ret = {'name': name, 'result': False, 'comment': '', 'changes': {}}
+
+    try:
+        upstream_exists = __salt__['rabbitmq.upstream_exists'](name, runas=runas)
+    except CommandExecutionError as err:
+        ret['comment'] = 'Error: {0}'.format(err)
+        return ret
+
+    if upstream_exists:
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'Upstream "{}" would have been deleted.'.format(name)
+        else:
+            try:
+                res = __salt__['rabbitmq.delete_upstream'](name, runas=runas)
+                if res:
+                    ret['result'] = True
+                    ret['comment'] = 'Upstream "{}" has been deleted.'.format(name)
+                    ret['changes'] = {'old': name, 'new': None}
+            except CommandExecutionError as err:
+                ret['comment'] = 'Error: {0}'.format(err)
+    else:
+        ret['result'] = True
+        ret['comment'] = 'The upstream "{}" is already absent.'.format(name)
+    return ret


### PR DESCRIPTION
Master port of https://github.com/saltstack/salt/pull/53123

### What does this PR do?
It adds states (in `states/rabbitmq_upstream.py` and functions (in `modules/rabbitmq.py`) to manipulate rabbitMQ upstream definitions.

### What issues does this PR fix or reference?
None that I'm aware of

### Previous Behavior
Unable to add/remove/modify rabbitMQ upstreams.

### New Behavior
RabbitMQ upstream definitions can be made `_present` or `_absent` or manipulated via execution functions.

### Tests written?
Yes

### Commits signed with GPG?
Yes