### PR TITLE
Document __env__ for pillar_roots

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -3793,6 +3793,10 @@ Default:
 Set the environments and directories used to hold pillar sls data. This
 configuration is the same as :conf_master:`file_roots`:
 
+As of 2017.7.5 and 2018.3.1, it is possible to have `__env__` as a catch-all environment.
+
+Example:
+
 .. code-block:: yaml
 
     pillar_roots:
@@ -3802,6 +3806,8 @@ configuration is the same as :conf_master:`file_roots`:
         - /srv/pillar/dev
       prod:
         - /srv/pillar/prod
+      __env__:
+        - /srv/pillar/others
 
 .. conf_master:: on_demand_ext_pillar
 


### PR DESCRIPTION
### What does this PR do?

Document `__env__` for pillar_roots. Caught by @morgana2313 in #55747.