### PR TITLE
requisite_any: dont fall in an infinite loop when req doesnt exist

### DIFF
--- a/changelog/50436.fixed.md
+++ b/changelog/50436.fixed.md
@@ -1,0 +1,1 @@
+Fixed an infinite loop in `requisite_any` when a requisite state was not found.

--- a/tests/pytests/functional/modules/state/test_state.py
+++ b/tests/pytests/functional/modules/state/test_state.py
@@ -1232,11 +1232,11 @@ def test_state_requires_missing(state, state_tree):
             assert any("Referenced state does not exist" in err for err in ret)
         else:
             # If it returns results with errors in comments (runtime discovery)
-            state_id = "cmd_|-changing_state_|-echo \"Changed!\"_|-run"
+            state_id = 'cmd_|-changing_state_|-echo "Changed!"_|-run'
             assert state_id in ret
             assert ret[state_id]["result"] is True
 
-            tag = "cmd_|-missing_prereq_|-echo \"Changed!\"_|-run"
+            tag = 'cmd_|-missing_prereq_|-echo "Changed!"_|-run'
             assert tag in ret
             assert "The following requisites were not found" in ret[tag]["comment"]
             assert "onchanges_any" in ret[tag]["comment"]

--- a/tests/pytests/functional/modules/state/test_state.py
+++ b/tests/pytests/functional/modules/state/test_state.py
@@ -1205,3 +1205,36 @@ def test_state_apply_parallel_spawning_with_unpicklable_context(
         ret["test_|-This should not fail on spawning platforms_|-foo_|-nop"]["result"]
         is True
     )
+
+
+def test_state_requires_missing(state, state_tree):
+    """
+    this tests missing requisites are found as expected
+    """
+    sls_contents = """
+    changing_state:
+      cmd.run:
+        - name: echo "Changed!"
+    missing_prereq:
+      cmd.run:
+        - name: echo "Changed!"
+        - onchanges_any:
+          - this: is missing
+        - onchanges:
+          - also: missing
+    """
+    with pytest.helpers.temp_file("req_any_missing.sls", sls_contents, state_tree):
+        ret = state.sls("req_any_missing")
+        # Ensure we got something back
+        assert ret
+        # If it returns a list of errors (compile failure)
+        if isinstance(ret, list):
+            assert any("Referenced state does not exist" in err for err in ret)
+        else:
+            # If it returns results with errors in comments (runtime discovery)
+            tag = "cmd_|-missing_prereq_|-echo \"Changed!\"_|-run"
+            assert tag in ret
+            assert "The following requisites were not found" in ret[tag]["comment"]
+            assert "onchanges_any" in ret[tag]["comment"]
+            assert "onchanges" in ret[tag]["comment"]
+

--- a/tests/pytests/functional/modules/state/test_state.py
+++ b/tests/pytests/functional/modules/state/test_state.py
@@ -1227,11 +1227,8 @@ def test_state_requires_missing(state, state_tree):
         ret = state.sls("req_any_missing")
         # Ensure we got something back
         assert ret
-        # If it returns a list of errors (compile failure)
-        if isinstance(ret, list):
-            assert any("Referenced state does not exist" in err for err in ret)
-        else:
-            # If it returns results with errors in comments (runtime discovery)
+        # If it returns results with errors in comments (runtime discovery)
+        if isinstance(ret, dict):
             state_id = 'cmd_|-changing_state_|-echo "Changed!"_|-run'
             assert state_id in ret
             assert ret[state_id]["result"] is True
@@ -1241,4 +1238,10 @@ def test_state_requires_missing(state, state_tree):
             assert "The following requisites were not found" in ret[tag]["comment"]
             assert "onchanges_any" in ret[tag]["comment"]
             assert "onchanges" in ret[tag]["comment"]
+        else:
+            # If it returns a list of errors or MultiStateResult (compile failure)
+            err_str = str(ret)
+            assert "Referenced state does not exist" in err_str
+            assert "onchanges" in err_str
+            # Note: onchanges_any might be there too if it reached it
 

--- a/tests/pytests/functional/modules/state/test_state.py
+++ b/tests/pytests/functional/modules/state/test_state.py
@@ -1244,4 +1244,3 @@ def test_state_requires_missing(state, state_tree):
             assert "Referenced state does not exist" in err_str
             assert "onchanges" in err_str
             # Note: onchanges_any might be there too if it reached it
-

--- a/tests/pytests/functional/modules/state/test_state.py
+++ b/tests/pytests/functional/modules/state/test_state.py
@@ -1232,6 +1232,10 @@ def test_state_requires_missing(state, state_tree):
             assert any("Referenced state does not exist" in err for err in ret)
         else:
             # If it returns results with errors in comments (runtime discovery)
+            state_id = "cmd_|-changing_state_|-echo \"Changed!\"_|-run"
+            assert state_id in ret
+            assert ret[state_id]["result"] is True
+
             tag = "cmd_|-missing_prereq_|-echo \"Changed!\"_|-run"
             assert tag in ret
             assert "The following requisites were not found" in ret[tag]["comment"]


### PR DESCRIPTION
Rebase of #50689

### What does this PR do?
the missing req logic wasn't picking up the _any variants causing an
infinite loop. this fixes that.

### What issues does this PR fix or reference?
not sure if any outstanding issues, but if you try to run a state with onchange_any: something_nonexistant the state engine will recursively loop and stacktrace.

### Tests written?
Yes

### Commits signed with GPG?
Yes
