### PR TITLE
Fallback to disabled LG_INCLUDE_INDIRECT when DC is unavailable

### DIFF
--- a/salt/utils/win_functions.py
+++ b/salt/utils/win_functions.py
@@ -88,9 +88,10 @@ def get_user_groups(name, sid=False):
         try:
             groups = win32net.NetUserGetLocalGroups(None, name)
         except win32net.error as exc:
-            if exc.winerror == 5:
+            # ERROR_ACCESS_DENIED, NERR_DCNotFound, RPC_S_SERVER_UNAVAILABLE
+            if exc.winerror in (5, 1722, 2453):
                 # Try without LG_INCLUDE_INDIRECT flag, because the user might
-                # not have permissions for it
+                # not have permissions for it or something is wrong with DC
                 groups = win32net.NetUserGetLocalGroups(None, name, 0)
             else:
                 raise

--- a/tests/unit/utils/test_win_functions.py
+++ b/tests/unit/utils/test_win_functions.py
@@ -96,6 +96,30 @@ class WinFunctionsTestCase(TestCase):
     @skipIf(not salt.utils.platform.is_windows(),
             'WinDLL only available on Windows')
     @skipIf(not HAS_WIN32, 'Requires pywin32 libraries')
+    def test_get_user_groups_unavailable_dc(self):
+        groups = ['Administrators', 'Users']
+        win_error = WinError()
+        win_error.winerror = 1722
+        effect = [win_error, groups]
+        with patch('win32net.NetUserGetLocalGroups', side_effect=effect):
+            ret = win_functions.get_user_groups('Administrator')
+            self.assertListEqual(groups, ret)
+
+    @skipIf(not salt.utils.platform.is_windows(),
+            'WinDLL only available on Windows')
+    @skipIf(not HAS_WIN32, 'Requires pywin32 libraries')
+    def test_get_user_groups_unknown_dc(self):
+        groups = ['Administrators', 'Users']
+        win_error = WinError()
+        win_error.winerror = 2453
+        effect = [win_error, groups]
+        with patch('win32net.NetUserGetLocalGroups', side_effect=effect):
+            ret = win_functions.get_user_groups('Administrator')
+            self.assertListEqual(groups, ret)
+
+    @skipIf(not salt.utils.platform.is_windows(),
+            'WinDLL only available on Windows')
+    @skipIf(not HAS_WIN32, 'Requires pywin32 libraries')
     def test_get_user_groups_missing_permission(self):
         groups = ['Administrators', 'Users']
         win_error = WinError()


### PR DESCRIPTION
### What does this PR do?
Fixes issue when DC is unavailable and Salt Minion tries to retrieve list of groups the running user is member of. 

### What issues does this PR fix or reference?
#54809

### Previous Behavior
Minion also tries to resolve indirect groups, which causes minion to fail with exception which causes the service to restart indefinitely.

### New Behavior
Minion tries to resolve only direct groups if indirect resolving fails, causing service to start properly if there is any issue with DC

### Tests written?
Yes

### Commits signed with GPG?
Yes