### PR TITLE
Do not list files for all available saltenvs until it's necessary

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -40,6 +40,7 @@ import salt.utils.event
 import salt.utils.files
 import salt.utils.hashutils
 import salt.utils.immutabletypes as immutabletypes
+import salt.utils.lazy
 import salt.utils.msgpack
 import salt.utils.platform
 import salt.utils.process
@@ -3043,6 +3044,41 @@ class State(object):
         return self.call_high(high)
 
 
+class AvailableStates(salt.utils.lazy.LazyDict):
+    def __init__(self, envs, gather_func):
+        self._envs = set(envs)
+        self._gather_func = gather_func
+        super(AvailableStates, self).__init__()
+
+    def __setitem__(self, key, val):
+        raise AttributeError('setitem not supported for {}'.format(self.__class__.__name__))
+
+    def __delitem__(self, key):
+        del self._dict[key]
+        self._envs.remove(key)
+
+    def _missing(self, key):
+        return key not in self._envs
+
+    def _load(self, key):
+        if key in self._envs:
+            self._dict[key] = self._gather_func(key)
+        return True
+
+    def _load_all(self):
+        for key in self._envs:
+            self._load(key)
+
+    def __len__(self):
+        return len(self._envs)
+
+    def __iter__(self):
+        return iter(self._envs)
+
+    def __contains__(self, key):
+        return key in self._envs
+
+
 class BaseHighState(object):
     '''
     The BaseHighState is an abstract base class that is the foundation of
@@ -3054,18 +3090,9 @@ class BaseHighState(object):
     def __init__(self, opts):
         self.opts = self.__gen_opts(opts)
         self.iorder = 10000
-        self.avail = self.__gather_avail()
+        self.avail = AvailableStates(self._get_envs(), self.client.list_states)
         self.serial = salt.payload.Serial(self.opts)
         self.building_highstate = OrderedDict()
-
-    def __gather_avail(self):
-        '''
-        Gather the lists of available sls data from the master
-        '''
-        avail = {}
-        for saltenv in self._get_envs():
-            avail[saltenv] = self.client.list_states(saltenv)
-        return avail
 
     def __gen_opts(self, opts):
         '''

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import os
 import shutil
 import tempfile
+from collections import Counter
 
 # Import Salt Testing libs
 from tests.support.unit import TestCase, skipIf
@@ -25,6 +26,7 @@ from salt.utils.odict import OrderedDict
 from salt.utils.decorators import state as statedecorators
 import salt.utils.files
 import salt.utils.platform
+from salt.ext.six.moves import range
 
 try:
     import pytest
@@ -599,3 +601,65 @@ class StateFormatSlotsTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             self.state_obj.format_slots(cdata)
         mock.assert_called_once_with('fun_arg', fun_key='fun_val')
         self.assertEqual(cdata, {'args': ['arg'], 'kwargs': {'key': 'value1thing~'}})
+
+
+class AvailableStatesTestCase(TestCase):
+    '''
+    Test cases for AvailableStates class
+    '''
+
+    def setUp(self):
+        self.calls_counter = Counter()
+        self.envs = ('base', 'some')
+        self.available_states = salt.state.AvailableStates(self.envs, self.gather_states)
+
+    def tearDown(self):
+        del self.calls_counter
+        del self.envs
+        del self.available_states
+
+    @staticmethod
+    def make_file_list(key):
+        return ['{}-{}'.format(key, i) for i in range(3)]
+
+    def gather_states(self, key):
+        self.calls_counter[key] += 1
+        return self.make_file_list(key)
+
+    def test_gather_called(self):
+        '''
+        test gather_func called once when key accessed
+        '''
+        for env in self.envs:
+            self.assertEqual(self.calls_counter[env], 0)
+            self.available_states.get(env)
+            self.assertEqual(self.calls_counter[env], 1)
+            self.available_states.get(env)
+            self.assertEqual(self.calls_counter[env], 1)
+
+    def test_gather_not_called(self):
+        '''
+        test gather_func not called if key not accessed
+        '''
+        for env in self.envs:
+            self.assertTrue(env in self.available_states)
+            self.assertEqual(self.calls_counter[env], 0)
+
+    def test_looks_like_dict(self):
+        '''
+        test AvailableStates behaves like dict
+        '''
+        self.assertSequenceEqual(self.envs, self.available_states.keys())
+        self.assertSequenceEqual(self.envs, [k for k in self.available_states])
+        self.assertSequenceEqual(self.envs, list(self.available_states))
+        self.assertFalse('nonexistent_key' in self.available_states)
+        for env in self.envs:
+            file_list = self.make_file_list(env)
+            self.assertSequenceEqual(file_list, self.available_states.get(env))
+            self.assertSequenceEqual(file_list, self.available_states[env])
+            self.assertTrue(env in self.available_states)
+        original_dict = {k: self.make_file_list(k) for k in self.envs}
+        self.assertDictEqual(original_dict, dict(self.available_states))
+        self.assertEqual(original_dict, self.available_states)
+        with self.assertRaises(AttributeError):
+            self.available_states['any'] = 'some'


### PR DESCRIPTION
Porting #51826 to master

Improve performance of state.apply in case of many saltenvs.

### What does this PR do?
Replace listing files for each available saltenv on BaseHighState init with LazyDict which calls list_files only if given saltenv used somewhere in states.

### Previous Behavior
Minion calls list_states for every available saltenv on every highstate

### New Behavior
Minion calls list_states only for actually used saltenvs

### Tests written?

No

### Commits signed with GPG?

Yes
