### PR TITLE
`__getstate__` and `__setstate__` consolidation

### DIFF
--- a/salt/client/netapi.py
+++ b/salt/client/netapi.py
@@ -21,25 +21,6 @@ class RunNetapi(salt.utils.process.SignalHandlingProcess):
         self.opts = opts
         self.fname = fname
 
-    # __setstate__ and __getstate__ are only used on Windows.
-    # We do this so that __init__ will be invoked on Windows in the child
-    # process so that a register_after_fork() equivalent will work on Windows.
-    def __setstate__(self, state):
-        self.__init__(
-            state["opts"],
-            state["fname"],
-            log_queue=state["log_queue"],
-            log_queue_level=state["log_queue_level"],
-        )
-
-    def __getstate__(self):
-        return {
-            "opts": self.opts,
-            "fname": self.fname,
-            "log_queue": self.log_queue,
-            "log_queue_level": self.log_queue_level,
-        }
-
     def run(self):
         netapi = salt.loader.netapi(self.opts)
         netapi_func = netapi[self.fname]

--- a/salt/engines/__init__.py
+++ b/salt/engines/__init__.py
@@ -2,7 +2,6 @@
 Initialize the engines system. This plugin system allows for
 complex services to be encapsulated within the salt plugin environment
 """
-
 import logging
 
 import salt
@@ -82,35 +81,6 @@ class Engine(salt.utils.process.SignalHandlingProcess):
         self.funcs = funcs
         self.runners = runners
         self.proxy = proxy
-
-    # __setstate__ and __getstate__ are only used on Windows.
-    # We do this so that __init__ will be invoked on Windows in the child
-    # process so that a register_after_fork() equivalent will work on Windows.
-    def __setstate__(self, state):
-        self.__init__(
-            state["name"],
-            state["opts"],
-            state["fun"],
-            state["config"],
-            state["funcs"],
-            state["runners"],
-            state["proxy"],
-            log_queue=state["log_queue"],
-            log_queue_level=state["log_queue_level"],
-        )
-
-    def __getstate__(self):
-        return {
-            "name": self.name,
-            "opts": self.opts,
-            "fun": self.fun,
-            "config": self.config,
-            "funcs": self.funcs,
-            "runners": self.runners,
-            "proxy": self.proxy,
-            "log_queue": self.log_queue,
-            "log_queue_level": self.log_queue_level,
-        }
 
     def run(self):
         """

--- a/salt/master.py
+++ b/salt/master.py
@@ -2,7 +2,6 @@
 This module contains all of the routines needed to set up a master server, this
 involves preparing the three listeners and the workers needed by the master.
 """
-
 import collections
 import copy
 import ctypes
@@ -106,18 +105,21 @@ class SMaster:
     # These methods are only used when pickling so will not be used on
     # non-Windows platforms.
     def __setstate__(self, state):
-        self.opts = state["opts"]
+        super().__setstate__(state)
         self.master_key = state["master_key"]
         self.key = state["key"]
         SMaster.secrets = state["secrets"]
 
     def __getstate__(self):
-        return {
-            "opts": self.opts,
-            "master_key": self.master_key,
-            "key": self.key,
-            "secrets": SMaster.secrets,
-        }
+        state = super().__getstate__()
+        state.update(
+            {
+                "key": self.key,
+                "master_key": self.master_key,
+                "secrets": SMaster.secrets,
+            }
+        )
+        return state
 
     def __prep_key(self):
         """
@@ -146,23 +148,6 @@ class Maintenance(salt.utils.process.SignalHandlingProcess):
         self.rotate = int(time.time())
         # A serializer for general maint operations
         self.serial = salt.payload.Serial(self.opts)
-
-    # __setstate__ and __getstate__ are only used on Windows.
-    # We do this so that __init__ will be invoked on Windows in the child
-    # process so that a register_after_fork() equivalent will work on Windows.
-    def __setstate__(self, state):
-        self.__init__(
-            state["opts"],
-            log_queue=state["log_queue"],
-            log_queue_level=state["log_queue_level"],
-        )
-
-    def __getstate__(self):
-        return {
-            "opts": self.opts,
-            "log_queue": self.log_queue,
-            "log_queue_level": self.log_queue_level,
-        }
 
     def _post_fork_init(self):
         """
@@ -370,21 +355,6 @@ class FileserverUpdate(salt.utils.process.SignalHandlingProcess):
 
         self.fileserver = salt.fileserver.Fileserver(self.opts)
         self.fill_buckets()
-
-    # __setstate__ and __getstate__ are only used on Windows.
-    # We do this so that __init__ will be invoked on Windows in the child
-    # process so that a register_after_fork() equivalent will work on Windows.
-    def __setstate__(self, state):
-        self.__init__(
-            state["opts"],
-            log_queue=state["log_queue"],
-        )
-
-    def __getstate__(self):
-        return {
-            "opts": self.opts,
-            "log_queue": self.log_queue,
-        }
 
     def fill_buckets(self):
         """
@@ -850,29 +820,6 @@ class ReqServer(salt.utils.process.SignalHandlingProcess):
         self.key = key
         self.secrets = secrets
 
-    # __setstate__ and __getstate__ are only used on Windows.
-    # We do this so that __init__ will be invoked on Windows in the child
-    # process so that a register_after_fork() equivalent will work on Windows.
-    def __setstate__(self, state):
-        self.__init__(
-            state["opts"],
-            state["key"],
-            state["mkey"],
-            secrets=state["secrets"],
-            log_queue=state["log_queue"],
-            log_queue_level=state["log_queue_level"],
-        )
-
-    def __getstate__(self):
-        return {
-            "opts": self.opts,
-            "key": self.key,
-            "mkey": self.master_key,
-            "secrets": self.secrets,
-            "log_queue": self.log_queue,
-            "log_queue_level": self.log_queue_level,
-        }
-
     def _handle_signals(self, signum, sigframe):  # pylint: disable=unused-argument
         self.destroy(signum)
         super()._handle_signals(signum, sigframe)
@@ -993,27 +940,14 @@ class MWorker(salt.utils.process.SignalHandlingProcess):
     # These methods are only used when pickling so will not be used on
     # non-Windows platforms.
     def __setstate__(self, state):
-        super().__init__(
-            log_queue=state["log_queue"], log_queue_level=state["log_queue_level"]
-        )
-        self.opts = state["opts"]
-        self.req_channels = state["req_channels"]
-        self.mkey = state["mkey"]
-        self.key = state["key"]
+        super().__setstate__(state)
         self.k_mtime = state["k_mtime"]
         SMaster.secrets = state["secrets"]
 
     def __getstate__(self):
-        return {
-            "opts": self.opts,
-            "req_channels": self.req_channels,
-            "mkey": self.mkey,
-            "key": self.key,
-            "k_mtime": self.k_mtime,
-            "secrets": SMaster.secrets,
-            "log_queue": self.log_queue,
-            "log_queue_level": self.log_queue_level,
-        }
+        state = super().__getstate__()
+        state.update({"k_mtime": self.k_mtime, "secrets": SMaster.secrets})
+        return state
 
     def _handle_signals(self, signum, sigframe):
         for channel in getattr(self, "req_channels", ()):

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -12,7 +12,7 @@ import socket
 import threading
 import time
 import traceback
-import urllib.parse as urlparse
+import urllib.parse
 import weakref
 
 import salt.crypt
@@ -149,26 +149,6 @@ if USE_LOAD_BALANCER:
             self.socket_queue = socket_queue
             self._socket = None
 
-        # __setstate__ and __getstate__ are only used on Windows.
-        # We do this so that __init__ will be invoked on Windows in the child
-        # process so that a register_after_fork() equivalent will work on
-        # Windows.
-        def __setstate__(self, state):
-            self.__init__(
-                state["opts"],
-                state["socket_queue"],
-                log_queue=state["log_queue"],
-                log_queue_level=state["log_queue_level"],
-            )
-
-        def __getstate__(self):
-            return {
-                "opts": self.opts,
-                "socket_queue": self.socket_queue,
-                "log_queue": self.log_queue,
-                "log_queue_level": self.log_queue_level,
-            }
-
         def close(self):
             if self._socket is not None:
                 self._socket.shutdown(socket.SHUT_RDWR)
@@ -304,7 +284,7 @@ class AsyncTCPReqChannel(salt.transport.client.ReqChannel):
 
         resolver = kwargs.get("resolver")
 
-        parse = urlparse.urlparse(self.opts["master_uri"])
+        parse = urllib.parse.urlparse(self.opts["master_uri"])
         master_host, master_port = parse.netloc.rsplit(":", 1)
         self.master_addr = (master_host, int(master_port))
         self._closing = False

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -1145,23 +1145,6 @@ class EventPublisher(salt.utils.process.SignalHandlingProcess):
         self.puller = None
         self.publisher = None
 
-    # __setstate__ and __getstate__ are only used on Windows.
-    # We do this so that __init__ will be invoked on Windows in the child
-    # process so that a register_after_fork() equivalent will work on Windows.
-    def __setstate__(self, state):
-        self.__init__(
-            state["opts"],
-            log_queue=state["log_queue"],
-            log_queue_level=state["log_queue_level"],
-        )
-
-    def __getstate__(self):
-        return {
-            "opts": self.opts,
-            "log_queue": self.log_queue,
-            "log_queue_level": self.log_queue_level,
-        }
-
     def run(self):
         """
         Bind the pub and pull sockets for events
@@ -1277,23 +1260,6 @@ class EventReturn(salt.utils.process.SignalHandlingProcess):
         self.minion = salt.minion.MasterMinion(local_minion_opts)
         self.event_queue = []
         self.stop = False
-
-    # __setstate__ and __getstate__ are only used on Windows.
-    # We do this so that __init__ will be invoked on Windows in the child
-    # process so that a register_after_fork() equivalent will work on Windows.
-    def __setstate__(self, state):
-        self.__init__(
-            state["opts"],
-            log_queue=state["log_queue"],
-            log_queue_level=state["log_queue_level"],
-        )
-
-    def __getstate__(self):
-        return {
-            "opts": self.opts,
-            "log_queue": self.log_queue,
-            "log_queue_level": self.log_queue_level,
-        }
 
     def _handle_signals(self, signum, sigframe):
         # Flush and terminate

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -5,8 +5,6 @@
     Utilities that can only be used on a salt master.
 
 """
-
-
 import logging
 import os
 import signal
@@ -595,23 +593,6 @@ class CacheWorker(Process):
         super().__init__(**kwargs)
         self.opts = opts
 
-    # __setstate__ and __getstate__ are only used on Windows.
-    # We do this so that __init__ will be invoked on Windows in the child
-    # process so that a register_after_fork() equivalent will work on Windows.
-    def __setstate__(self, state):
-        self.__init__(
-            state["opts"],
-            log_queue=state["log_queue"],
-            log_queue_level=state["log_queue_level"],
-        )
-
-    def __getstate__(self):
-        return {
-            "opts": self.opts,
-            "log_queue": self.log_queue,
-            "log_queue_level": self.log_queue_level,
-        }
-
     def run(self):
         """
         Gather currently connected minions and update the cache
@@ -656,23 +637,6 @@ class ConnectedCache(Process):
         self.timer = CacheTimer(self.opts, self.timer_stop)
         self.timer.start()
         self.running = True
-
-    # __setstate__ and __getstate__ are only used on Windows.
-    # We do this so that __init__ will be invoked on Windows in the child
-    # process so that a register_after_fork() equivalent will work on Windows.
-    def __setstate__(self, state):
-        self.__init__(
-            state["opts"],
-            log_queue=state["log_queue"],
-            log_queue_level=state["log_queue_level"],
-        )
-
-    def __getstate__(self):
-        return {
-            "opts": self.opts,
-            "log_queue": self.log_queue,
-            "log_queue_level": self.log_queue_level,
-        }
 
     def signal_handler(self, sig, frame):
         """

--- a/salt/utils/platform.py
+++ b/salt/utils/platform.py
@@ -2,6 +2,7 @@
 Functions for identifying which platform a machine is
 """
 
+import multiprocessing
 import os
 import platform
 import subprocess
@@ -209,3 +210,12 @@ def is_aarch64():
     Simple function to return if host is AArch64 or not
     """
     return platform.machine().startswith("aarch64")
+
+
+def spawning_platform():
+    """
+    Returns True if multiprocessing.get_start_method(allow_none=False) returns "spawn"
+
+    This is the default for Windows Python >= 3.4 and macOS on Python >= 3.8.
+    """
+    return multiprocessing.get_start_method(allow_none=False) == "spawn"

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -1,8 +1,6 @@
 """
 Functions for daemonizing and otherwise modifying running processes
 """
-
-
 import contextlib
 import copy
 import errno
@@ -29,11 +27,9 @@ import salt.utils.path
 import salt.utils.platform
 import salt.utils.versions
 from salt.ext.tornado import gen
-from salt.log.mixins import NewStyleClassMixIn
 
 log = logging.getLogger(__name__)
 
-# pylint: disable=import-error
 HAS_PSUTIL = False
 try:
     import psutil
@@ -824,36 +820,114 @@ class ProcessManager:
                 )
 
 
-class Process(multiprocessing.Process, NewStyleClassMixIn):
+class Process(multiprocessing.Process):
+    """
+    Salt relies on this custom implementation of :py:class:`~multiprocessing.Process` to
+    simplify/automate some common procedures, for example, logging in the new process is
+    configured for "free" for every new process.
+    This is most important in platforms which default to ``spawn` instead of ``fork`` for
+    new processes.
+
+    This is achieved by some dunder methods in the class:
+
+    * ``__new__``:
+
+        This method ensures that any arguments and/or keyword arguments that are passed to
+        ``__init__`` are captured.
+
+        By having this information captured, we can define ``__setstate__`` and ``__getstate__``
+        to automatically take care of reconstructing the object state on spawned processes.
+
+    * ``__getstate__``:
+
+        This method should return a dictionary which will be used as the ``state`` argument to
+        :py:method:`salt.utils.process.Process.__setstate__`.
+        Usually, when subclassing, this method does not need to be implemented, however,
+        if implemented, `super()` **must** be called.
+
+    * ``__setstate__``:
+
+        This method reconstructs the object on the spawned process.
+        The ``state`` argument is constructed by the
+        :py:method:`salt.utils.process.Process.__getstate__` method.
+        Usually, when subclassing, this method does not need to be implemented, however,
+        if implemented, `super()` **must** be called.
+
+
+    An example of where ``__setstate__`` and ``__getstate__`` needed to be subclassed can be
+    seen in :py:class:`salt.master.MWorker`.
+
+    The gist of it is something like, if there are internal attributes which need to maintain
+    their state on spawned processes, then, subclasses must implement ``__getstate__`` and
+    ``__setstate__`` to ensure that.
+
+
+    For example:
+
+
+    .. code-block:: python
+
+        import salt.utils.process
+
+        class MyCustomProcess(salt.utils.process.Process):
+
+            def __init__(self, opts, **kwargs):
+                super().__init__(**kwargs)
+                self.opts = opts
+
+                # This attribute, counter, should only start at 0 on the initial(parent) process.
+                # Any child processes, need to carry the current value of the counter(instead of
+                # starting at zero).
+                self.counter = 0
+
+            def __getstate__(self):
+                state = super().__getstate__()
+                state.update(
+                    {
+                        "counter": self.counter,
+                    }
+                )
+                return state
+
+            def __setstate__(self, state):
+                super().__setstate__(state)
+                self.counter = state["counter"]
+    """
+
+    def __new__(cls, *args, **kwargs):
+        """
+        This method ensures that any arguments and/or keyword arguments that are passed to
+        ``__init__`` are captured.
+
+        By having this information captured, we can define ``__setstate__`` and ``__getstate__``
+        to automatically take care of object pickling which is required for platforms that
+        spawn processes instead of forking them.
+        """
+        # We implement __new__ because we want to capture the passed in *args and **kwargs
+        # in order to remove the need for each class to implement __getstate__ and __setstate__
+        # which is required on spawning platforms
+        instance = super().__new__(cls)
+        instance._after_fork_methods = []
+        instance._finalize_methods = []
+
+        if salt.utils.platform.spawning_platform():
+            # On spawning platforms, subclasses should call super if they define
+            # __setstate__ and/or __getstate__
+            instance._args_for_getstate = copy.copy(args)
+            instance._kwargs_for_getstate = copy.copy(kwargs)
+        return instance
+
     def __init__(self, *args, **kwargs):
         log_queue = kwargs.pop("log_queue", None)
         log_queue_level = kwargs.pop("log_queue_level", None)
         super().__init__(*args, **kwargs)
-        if salt.utils.platform.is_windows():
-            # On Windows, subclasses should call super if they define
-            # __setstate__ and/or __getstate__
-            self._args_for_getstate = copy.copy(args)
-            self._kwargs_for_getstate = copy.copy(kwargs)
         self.log_queue = log_queue
         if self.log_queue is None:
             self.log_queue = salt.log.setup.get_multiprocessing_logging_queue()
-        else:
-            # Set the logging queue so that it can be retrieved later with
-            # salt.log.setup.get_multiprocessing_logging_queue().
-            salt.log.setup.set_multiprocessing_logging_queue(self.log_queue)
 
         self.log_queue_level = log_queue_level
         if self.log_queue_level is None:
             self.log_queue_level = salt.log.setup.get_multiprocessing_logging_level()
-        else:
-            salt.log.setup.set_multiprocessing_logging_level(self.log_queue_level)
-
-        self._after_fork_methods = [
-            (Process._setup_process_logging, [self], {}),
-        ]
-        self._finalize_methods = [
-            (salt.log.setup.shutdown_multiprocessing_logging, [], {})
-        ]
 
         # Because we need to enforce our after fork and finalize routines,
         # we must wrap this class run method to allow for these extra steps
@@ -864,16 +938,31 @@ class Process(multiprocessing.Process, NewStyleClassMixIn):
         # overriding run from the subclass here
         setattr(self, "run", self.__decorate_run(self.run))
 
-    # __setstate__ and __getstate__ are only used on Windows.
+    # __setstate__ and __getstate__ are only used on spawning platforms.
     def __setstate__(self, state):
+        """
+        This method reconstructs the object on the spawned process.
+        The ``state`` argument is constructed by :py:method:`salt.utils.process.Process.__getstate__`.
+
+        Usually, when subclassing, this method does not need to be implemented, however,
+        if implemented, `super()` **must** be called.
+        """
         args = state["args"]
         kwargs = state["kwargs"]
         # This will invoke __init__ of the most derived class.
         self.__init__(*args, **kwargs)
-        self._after_fork_methods = self._after_fork_methods
-        self._finalize_methods = self._finalize_methods
+        for (function, args, kwargs) in state["after_fork_methods"]:
+            self.register_after_fork_method(function, *args, **kwargs)
+        for (function, args, kwargs) in state["finalize_methods"]:
+            self.register_finalize_method(function, *args, **kwargs)
 
     def __getstate__(self):
+        """
+        This method should return a dictionary which will be used as the ``state`` argument to
+        :py:method:`salt.utils.process.Process.__setstate__`.
+        Usually, when subclassing, this method does not need to be implemented, however,
+        if implemented, `super()` **must** be called.
+        """
         args = self._args_for_getstate
         kwargs = self._kwargs_for_getstate
         if "log_queue" not in kwargs:
@@ -883,21 +972,18 @@ class Process(multiprocessing.Process, NewStyleClassMixIn):
         return {
             "args": args,
             "kwargs": kwargs,
-            "_after_fork_methods": self._after_fork_methods,
-            "_finalize_methods": self._finalize_methods,
+            "after_fork_methods": self._after_fork_methods,
+            "finalize_methods": self._finalize_methods,
         }
-
-    def join(self, *args, **kwargs):  # pylint: disable=arguments-differ
-        super().join(*args, **kwargs)
-        self._after_fork_methods = None
-        self._finalize_methods = None
-
-    def _setup_process_logging(self):
-        salt.log.setup.setup_multiprocessing_logging(self.log_queue)
 
     def __decorate_run(self, run_func):
         @functools.wraps(run_func)
         def wrapped_run_func():
+            # Static after fork method, always needs to happen first
+            salt.log.setup.set_multiprocessing_logging_queue(self.log_queue)
+            salt.log.setup.set_multiprocessing_logging_level(self.log_queue_level)
+            salt.log.setup.setup_multiprocessing_logging(self.log_queue)
+
             for method, args, kwargs in self._after_fork_methods:
                 method(*args, **kwargs)
             try:
@@ -905,7 +991,7 @@ class Process(multiprocessing.Process, NewStyleClassMixIn):
             except SystemExit:  # pylint: disable=try-except-raise
                 # These are handled by multiprocessing.Process._bootstrap()
                 raise
-            except Exception as exc:  # pylint: disable=broad-except
+            except Exception:  # pylint: disable=broad-except
                 log.error(
                     "An un-handled exception from the multiprocessing process "
                     "'%s' was caught:\n",
@@ -917,10 +1003,30 @@ class Process(multiprocessing.Process, NewStyleClassMixIn):
                 # it above.
                 raise
             finally:
-                for method, args, kwargs in self._finalize_methods:
-                    method(*args, **kwargs)
+                try:
+                    for method, args, kwargs in self._finalize_methods:
+                        method(*args, **kwargs)
+                finally:
+                    # Static finalize method, should always run last
+                    salt.log.setup.shutdown_multiprocessing_logging()
 
         return wrapped_run_func
+
+    def register_after_fork_method(self, function, *args, **kwargs):
+        """
+        Register a function to run after the process has forked
+        """
+        after_fork_method_tuple = (function, args, kwargs)
+        if after_fork_method_tuple not in self._after_fork_methods:
+            self._after_fork_methods.append(after_fork_method_tuple)
+
+    def register_finalize_method(self, function, *args, **kwargs):
+        """
+        Register a function to run as process terminates
+        """
+        finalize_method_tuple = (function, args, kwargs)
+        if finalize_method_tuple not in self._finalize_methods:
+            self._finalize_methods.append(finalize_method_tuple)
 
 
 class MultiprocessingProcess(Process):
@@ -943,9 +1049,7 @@ class SignalHandlingProcess(Process):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._signal_handled = multiprocessing.Event()
-        self._after_fork_methods.append(
-            (SignalHandlingProcess._setup_signals, [self], {})
-        )
+        self.register_after_fork_method(SignalHandlingProcess._setup_signals, self)
 
     def signal_handled(self):
         return self._signal_handled.is_set()

--- a/salt/utils/reactor.py
+++ b/salt/utils/reactor.py
@@ -1,8 +1,6 @@
 """
 Functions which implement running reactor jobs
 """
-
-
 import fnmatch
 import glob
 import logging
@@ -48,26 +46,6 @@ class Reactor(salt.utils.process.SignalHandlingProcess, salt.state.Compiler):
         self.minion = salt.minion.MasterMinion(local_minion_opts)
         salt.state.Compiler.__init__(self, opts, self.minion.rend)
         self.is_leader = True
-
-    # We need __setstate__ and __getstate__ to avoid pickling errors since
-    # 'self.rend' (from salt.state.Compiler) contains a function reference
-    # which is not picklable.
-    # These methods are only used when pickling so will not be used on
-    # non-Windows platforms.
-    def __setstate__(self, state):
-        Reactor.__init__(
-            self,
-            state["opts"],
-            log_queue=state["log_queue"],
-            log_queue_level=state["log_queue_level"],
-        )
-
-    def __getstate__(self):
-        return {
-            "opts": self.opts,
-            "log_queue": self.log_queue,
-            "log_queue_level": self.log_queue_level,
-        }
 
     def render_reaction(self, glob_ref, tag, data):
         """

--- a/tests/unit/utils/test_process.py
+++ b/tests/unit/utils/test_process.py
@@ -160,7 +160,6 @@ class TestProcessManager(TestCase):
                 process_manager.stop_restarting()
                 process_manager.kill_children()
 
-    @skipIf(sys.version_info < (2, 7), "Needs > Py 2.7 due to bug in stdlib")
     @incr
     def test_counter(self):
         counter = multiprocessing.Value("i", 0)
@@ -256,7 +255,7 @@ class TestProcessCallbacks(TestCase):
     def test_callbacks(self):
         "Validate Process call after fork and finalize methods"
         teardown_to_mock = "salt.log.setup.shutdown_multiprocessing_logging"
-        log_to_mock = "salt.utils.process.Process._setup_process_logging"
+        log_to_mock = "salt.log.setup.setup_multiprocessing_logging"
         with patch(teardown_to_mock) as ma, patch(log_to_mock) as mb:
             evt = multiprocessing.Event()
             proc = salt.utils.process.Process(target=self.process_target, args=(evt,))
@@ -277,7 +276,7 @@ class TestProcessCallbacks(TestCase):
                 self.evt.set()
 
         teardown_to_mock = "salt.log.setup.shutdown_multiprocessing_logging"
-        log_to_mock = "salt.utils.process.Process._setup_process_logging"
+        log_to_mock = "salt.log.setup.setup_multiprocessing_logging"
         with patch(teardown_to_mock) as ma, patch(log_to_mock) as mb:
             proc = MyProcess()
             proc.run()
@@ -286,6 +285,7 @@ class TestProcessCallbacks(TestCase):
         mb.assert_called()
 
 
+@skipIf(not HAS_PSUTIL, "Missing psutil")
 class TestSignalHandlingProcess(TestCase):
     @classmethod
     def Process(cls, pid):
@@ -431,7 +431,7 @@ class TestSignalHandlingProcessCallbacks(TestCase):
         "Validate SignalHandlingProcess call after fork and finalize methods"
 
         teardown_to_mock = "salt.log.setup.shutdown_multiprocessing_logging"
-        log_to_mock = "salt.utils.process.Process._setup_process_logging"
+        log_to_mock = "salt.log.setup.setup_multiprocessing_logging"
         sig_to_mock = "salt.utils.process.SignalHandlingProcess._setup_signals"
         # Mock _setup_signals so we do not register one for this process.
         evt = multiprocessing.Event()
@@ -457,7 +457,7 @@ class TestSignalHandlingProcessCallbacks(TestCase):
                 self.evt.set()
 
         teardown_to_mock = "salt.log.setup.shutdown_multiprocessing_logging"
-        log_to_mock = "salt.utils.process.Process._setup_process_logging"
+        log_to_mock = "salt.log.setup.setup_multiprocessing_logging"
         sig_to_mock = "salt.utils.process.SignalHandlingProcess._setup_signals"
         # Mock _setup_signals so we do not register one for this process.
         with patch(sig_to_mock):
@@ -776,12 +776,11 @@ class TestGetProcessInfo(TestCase):
             self.assertIsNone(salt.utils.process.get_process_info(pid))
 
 
+@skipIf(not HAS_PSUTIL, "Missing psutil")
 class TestClaimMantleOfResponsibility(TestCase):
-    @skipIf(HAS_PSUTIL, "Has psutil")
     def test_simple_claim_no_psutil(self):
         salt.utils.process.claim_mantle_of_responsibility("CMOR_TEST_FILE")
 
-    @skipIf(not HAS_PSUTIL, "Missing psutil")
     def test_simple_claim(self):
         try:
             for _ in range(5):
@@ -791,7 +790,6 @@ class TestClaimMantleOfResponsibility(TestCase):
         finally:
             os.remove("CMOR_TEST_FILE")
 
-    @skipIf(not HAS_PSUTIL, "Missing psutil")
     def test_multiple_processes(self):
         try:
             with CMORProcessHelper("CMOR_TEST_FILE") as p1:
@@ -817,8 +815,8 @@ class TestClaimMantleOfResponsibility(TestCase):
             os.remove("CMOR_TEST_FILE")
 
 
+@skipIf(not HAS_PSUTIL, "Missing psutil")
 class TestCheckMantleOfResponsibility(TestCase):
-    @skipIf(HAS_PSUTIL, "Has psutil")
     def test_simple_claim_no_psutil(self):
         try:
             self.assertIsNone(
@@ -827,7 +825,6 @@ class TestCheckMantleOfResponsibility(TestCase):
         finally:
             os.remove("CMOR_TEST_FILE")
 
-    @skipIf(not HAS_PSUTIL, "Missing psutil")
     def test_simple_claim(self):
         try:
             self.assertIsNone(
@@ -841,7 +838,6 @@ class TestCheckMantleOfResponsibility(TestCase):
         finally:
             os.remove("CMOR_TEST_FILE")
 
-    @skipIf(not HAS_PSUTIL, "Missing psutil")
     def test_multiple_processes(self):
         try:
             self.assertIsNone(

--- a/tests/unit/utils/test_process.py
+++ b/tests/unit/utils/test_process.py
@@ -818,12 +818,9 @@ class TestClaimMantleOfResponsibility(TestCase):
 @skipIf(not HAS_PSUTIL, "Missing psutil")
 class TestCheckMantleOfResponsibility(TestCase):
     def test_simple_claim_no_psutil(self):
-        try:
-            self.assertIsNone(
-                salt.utils.process.check_mantle_of_responsibility("CMOR_TEST_FILE")
-            )
-        finally:
-            os.remove("CMOR_TEST_FILE")
+        self.assertIsNone(
+            salt.utils.process.check_mantle_of_responsibility("CMOR_TEST_FILE")
+        )
 
     def test_simple_claim(self):
         try:


### PR DESCRIPTION
### What does this PR do?
The `Process` class will now take care of all `__getstate__` and `__setstate__`

This PR will then ensure that any forked process, on windows, and of course all platforms which support forking, will behave properly **without** having to implement their own get and set state functions, unless they need to extend the base functionality provided in out Process class.

### Previous Behavior
All subclasses had to implement `__getstate__` and `__setstate__`

### New Behavior
The `Process` class will now take care of all `__getstate__` and `__setstate__`

### Tests written?

No

### Commits signed with GPG?

Yes