### PR TITLE
Fix issue with whitespace in ADML data

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -5639,7 +5639,9 @@ def _getAdmlDisplayName(adml_xml_data, display_name):
                                                  displayNameId=displayname_id)
         if search_results:
             for result in search_results:
-                return result.text
+                # Needs the `strip()` because some adml data has an extra space
+                # at the end
+                return result.text.strip()
 
     return None
 

--- a/tests/unit/modules/test_win_lgpo.py
+++ b/tests/unit/modules/test_win_lgpo.py
@@ -10,6 +10,7 @@ import os
 # Import Salt Testing Libs
 from tests.support.helpers import destructiveTest
 from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.mock import MagicMock, Mock, patch
 from tests.support.unit import TestCase, skipIf
 
 # Import Salt Libs
@@ -46,6 +47,18 @@ class WinLGPOTestCase(TestCase):
     Test cases for salt.modules.win_lgpo
     '''
     encoded_null = chr(0).encode('utf-16-le')
+
+    def test__getAdmlDisplayName(self):
+        display_name = '$(string.KeepAliveTime1)'
+        adml_xml_data = 'junk, we are mocking the return'
+        obj_xpath = Mock()
+        obj_xpath.text = '300000 or 5 minutes (recommended) '
+        mock_xpath_obj = MagicMock(return_value=[obj_xpath])
+        with patch.object(win_lgpo, 'ADML_DISPLAY_NAME_XPATH', mock_xpath_obj):
+            result = win_lgpo._getAdmlDisplayName(adml_xml_data=adml_xml_data,
+                                                  display_name=display_name)
+        expected = '300000 or 5 minutes (recommended)'
+        self.assertEqual(result, expected)
 
     def test__encode_string(self):
         '''


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with the text field in ADML data containing an extra space at the end.

This happens with the Legacy Templates from Microsoft. The `KeepAliveTime` value of `300000 or 5 minutes (recommended)` has a space at the end. This causes states to report that a change is needed when in fact it the policy is already set.

```
MSS_KeepAliveTime:
  lgpo.set:
    - computer_policy:
        "MSS: (KeepAliveTime) How often keep-alive packets are sent in milliseconds":
          "KeepAliveTime": '300000 or 5 minutes (recommended)'
```

When the state does the comparison it is comparing the requested dict:
```
{'KeepAliveTime': '300000 or 5 minutes (recommended)'}
```
with the current setting
```
{'KeepAliveTime': '300000 or 5 minutes (recommended) '}
```

### What issues does this PR fix or reference?
Found in Enterprise

### Previous Behavior
`test=True` will always report a change is necessary.

### New Behavior
`test=True` reports no changes needed

### Tests written?
Yes

### Commits signed with GPG?
Yes