### PR TITLE
Fix cached osrelease_info grain type

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -688,6 +688,17 @@ def grain_funcs(opts, proxy=None):
     return ret
 
 
+def _format_cached_grains(cached_grains):
+    """
+    Returns cached grains with fixed types, like tuples.
+    """
+    if cached_grains.get('osrelease_info'):
+        osrelease_info = cached_grains['osrelease_info']
+        if isinstance(osrelease_info, list):
+            cached_grains['osrelease_info'] = tuple(osrelease_info)
+    return cached_grains
+
+
 def _load_cached_grains(opts, cfn):
     '''
     Returns the grains cached in cfn, or None if the cache is too old or is
@@ -720,7 +731,7 @@ def _load_cached_grains(opts, cfn):
             log.debug('Cached grains are empty, cache might be corrupted. Refreshing.')
             return None
 
-        return cached_grains
+        return _format_cached_grains(cached_grains)
     except (IOError, OSError):
         return None
 

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -1353,3 +1353,31 @@ class LazyLoaderOptimizationOrderTest(TestCase):
         basename = os.path.basename(filename)
         expected = 'lazyloadertest.py' if six.PY3 else 'lazyloadertest.pyc'
         assert basename == expected, basename
+
+
+class LoaderLoadCachedGrainsTest(TestCase):
+    '''
+    Test how the loader works with cached grains
+    '''
+
+    @classmethod
+    def setUpClass(cls):
+        cls.opts = salt.config.minion_config(None)
+        if not os.path.isdir(RUNTIME_VARS.TMP):
+            os.makedirs(RUNTIME_VARS.TMP)
+
+    def setUp(self):
+        self.cache_dir = tempfile.mkdtemp(dir=RUNTIME_VARS.TMP)
+        self.addCleanup(shutil.rmtree, self.cache_dir, ignore_errors=True)
+
+        self.opts['cachedir'] = self.cache_dir
+        self.opts['grains_cache'] = True
+        self.opts['grains'] = salt.loader.grains(self.opts)
+
+    def test_osrelease_info_has_correct_type(self):
+        '''
+        Make sure osrelease_info is tuple after caching
+        '''
+        grains = salt.loader.grains(self.opts)
+        osrelease_info = grains['osrelease_info']
+        assert isinstance(osrelease_info, tuple), osrelease_info


### PR DESCRIPTION
### What does this PR do?
This pull-request fixes problems with operating on `osrelease_info` grain if it was loaded from cache. Now it loads correctly as `tuple`.

### What issues does this PR fix or reference?
I found the one: #54908

### Previous Behavior
`loader.py` loads grain `osrelease_info` as `list`.
It broke modules like `aptpkg.info_installed` and similar.

### New Behavior
Now `osrelease_info` loads as tuple 

### Tests written?
Yes, `unit.test_loader.LoaderLoadCachedGrainsTest`

### Commits signed with GPG?
No