### PR TITLE
new feature: add saltenv directory to file_roots, pillar_roots and ext_pillar.stack for dynamic environments 

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -491,7 +491,7 @@ class Pillar(object):
             found = globgrep_environments(opts['pillar_roots'].keys(), pillarenv)
             if found:
                 found = found[0] # first match
-                log.debug("pillar_roots '%s' matches saltenv '%s'", found,pillarenv)
+                log.debug("pillar_roots '%s' matches saltenv '%s'", found, pillarenv)
                 opts['pillar_roots'][pillarenv] = [
                     path.replace("__env__", pillarenv) for path in opts['pillar_roots'].pop(found)]
         return opts

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -490,7 +490,7 @@ class Pillar(object):
             # not found? try (first) wildcard expansion:
             found = globgrep_environments(opts['pillar_roots'].keys(), pillarenv)
             if found:
-                found = found[0] # first match
+                found = found[0]  # first match
                 log.debug("pillar_roots '%s' matches saltenv '%s'", found, pillarenv)
                 opts['pillar_roots'][pillarenv] = [
                     path.replace("__env__", pillarenv) for path in opts['pillar_roots'].pop(found)]

--- a/salt/pillar/stack.py
+++ b/salt/pillar/stack.py
@@ -424,11 +424,12 @@ def ext_pillar(minion_id, pillar, *args, **kwargs):
             cfgs = [cfgs]
         stack_config_files += [cfg.replace("__env__", pillarenv) for cfg in cfgs]
     for cfg in stack_config_files:
-        if not os.path.isfile(cfg):
+        if cfg and os.path.isfile(cfg):
+            stack = _process_stack_cfg(cfg, stack, minion_id, pillar)
+        else:
             log.info(
                 'Ignoring pillar stack cfg "%s": file does not exist', cfg)
             continue
-        stack = _process_stack_cfg(cfg, stack, minion_id, pillar)
     return stack
 
 

--- a/salt/pillar/stack.py
+++ b/salt/pillar/stack.py
@@ -402,7 +402,7 @@ strategies = ('overwrite', 'merge-first', 'merge-last', 'remove')
 def ext_pillar(minion_id, pillar, *args, **kwargs):
     stack = {}
     stack_config_files = list(args)
-    pillarenv = __opts__['pillarenv'] or 'base'
+    pillarenv = __opts__['pillarenv'] or __opts__['saltenv'] or 'base'
     traverse = {
         'pillar': functools.partial(salt.utils.data.traverse_dict_and_list, pillar),
         'grains': functools.partial(salt.utils.data.traverse_dict_and_list, __grains__),

--- a/salt/pillar/stack.py
+++ b/salt/pillar/stack.py
@@ -550,4 +550,3 @@ def _parse_stack_cfg(content):
     except Exception as e:  # pylint: disable=broad-except
         pass
     return content.splitlines()
-

--- a/salt/pillar/stack.py
+++ b/salt/pillar/stack.py
@@ -2,7 +2,7 @@
 '''
 Simple and flexible YAML ext_pillar which can read pillar from within pillar.
 
-.. versionadded:: 2016.3.0
+. versionadded:: 2016.3.0
 
 `PillarStack <https://github.com/bbinet/pillarstack>`_ is a custom saltstack
 ``ext_pillar`` which was inspired by `varstack
@@ -550,4 +550,4 @@ def _parse_stack_cfg(content):
     except Exception as e:  # pylint: disable=broad-except
         pass
     return content.splitlines()
-                                                                                                                                                                                         
+

--- a/salt/utils/environment.py
+++ b/salt/utils/environment.py
@@ -3,6 +3,7 @@
 Environment utilities.
 '''
 from __future__ import absolute_import, print_function, unicode_literals
+from fnmatch import fnmatch
 import os
 
 
@@ -63,3 +64,12 @@ def get_module_environment(env=None, function=None):
                     section, {}).get(m_name, {}).get(function, {}).copy())
 
     return result
+
+
+def globgrep_environments(glob_environments, saltenv):
+    '''
+    Return a list of all environments that match saltenv.
+    Uses glob-style wildcard matching. __env__ matches all for backwards compatibility.
+    '''
+    return [glob_env for glob_env in glob_environments
+                if saltenv is not None and (fnmatch(saltenv, glob_env) or glob_env == '__env__')]

--- a/tests/unit/test_pillar.py
+++ b/tests/unit/test_pillar.py
@@ -383,7 +383,7 @@ class PillarTestCase(TestCase):
         }
         pillar = salt.pillar.Pillar(opts, {}, 'mocked-minion', 'base', pillarenv='dev')
         self.assertEqual(pillar.opts['pillar_roots'],
-                         {'base': ['/srv/pillar/base'], 'dev': ['/srv/pillar/__env__']})
+                         {'base': ['/srv/pillar/base'], 'dev': ['/srv/pillar/dev']})
 
     def test_ignored_dynamic_pillarenv(self):
         opts = {
@@ -397,7 +397,8 @@ class PillarTestCase(TestCase):
             'extension_modules': '',
         }
         pillar = salt.pillar.Pillar(opts, {}, 'mocked-minion', 'base', pillarenv='base')
-        self.assertEqual(pillar.opts['pillar_roots'], {'base': ['/srv/pillar/base']})
+        self.assertEqual(pillar.opts['pillar_roots'],
+            {'__env__': ['/srv/pillar/__env__'], 'base': ['/srv/pillar/base']})
 
     @patch('salt.fileclient.Client.list_states')
     def test_malformed_pillar_sls(self, mock_list_states):


### PR DESCRIPTION
### What does this PR do?

Extends dynamic environments for file_roots, pillar_roots and ext_pillar.stack; the requestor's saltenv/pillarenv can be inserted to a requested file-path with the token `__env__`. Glob-style wildcard matching for environments in file_roots, pillar_roots and ext_pillar.stack.

This allows for file_roots, pillar_roots and ext_pillar.stack variants of the gitfs, svnfs and hgfs behavior where branches and tags are translated into salt environments; salt environments are translated into directories. This allows for adding saltenvs dynamically without restarting the salt-master.

### What issues does this PR fix or reference?

Fixes: #55747. Extends #50784 and #46309

### New Behavior

1. glob-style wildcard matching of saltenv/pillarenv. Backwards compatible; specifying `__env__`  as environment has the same effect as '*' and matches all environments. The first matching saltenv/pillarenv is used.

2. `__env__` in a path is replaced by the requistor's saltenv/pillarenv. 

3. new option for ext_pillar stack: pillarenv
```
file_roots:
  foo*:
    - /path/__env__/salt    # becomes /path/foo-bar/salt for saltenv foo-bar
    - /path2/__env__        # becomes /path2/foo-foo for saltenv foo-foo
  '*':
    - /path/__env__/salt    # becomes /path/bar-bar/salt for saltenv bar-bar
    - /path2/__env__        # becomes /path2/bar-foo for saltenv bar-foo

pillar_roots:
  foo*:
    - /path/__env__/pillar    # becomes /path/foo-bar/pillar for saltenv foo-bar
    - /path2/__env__          # becomes /path2/foo-foo for saltenv foo-foo
  '*':
    - /path/__env__/pillar    # becomes /path/bar-bar/pillar for saltenv bar-bar
    - /path2/__env__          # becomes /path2/bar-foo for saltenv bar-foo

ext_pillar:
  - stack:
      pillarenv:
        foo*: /path/__env__/pillar/stack.cfg
        '*': /path2/__env__/pillar/stack.cfg
```

### Tests written?

Yes: Existing unit tests modified to expect new behavior.

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
