### PR TITLE
Add virt.*defined states

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1701,6 +1701,7 @@ def update(
     graphics=None,
     live=True,
     boot=None,
+    test=False,
     **kwargs
 ):
     """
@@ -1757,6 +1758,10 @@ def update(
             }
 
         .. versionadded:: 3000
+
+    :param test: run in dry-run mode if set to True
+
+        .. versionadded:: sodium
 
     :return:
 
@@ -1927,11 +1932,15 @@ def update(
                     item in changes["disk"]["new"]
                     and source_file
                     and not os.path.isfile(source_file)
+                    and not test
                 ):
                     _qemu_image_create(all_disks[idx])
 
         try:
-            conn.defineXML(salt.utils.stringutils.to_str(ElementTree.tostring(desc)))
+            if not test:
+                conn.defineXML(
+                    salt.utils.stringutils.to_str(ElementTree.tostring(desc))
+                )
             status["definition"] = True
         except libvirt.libvirtError as err:
             conn.close()
@@ -1988,7 +1997,7 @@ def update(
 
         for cmd in commands:
             try:
-                ret = getattr(domain, cmd["cmd"])(*cmd["args"])
+                ret = getattr(domain, cmd["cmd"])(*cmd["args"]) if not test else 0
                 device_type = cmd["device"]
                 if device_type in ["cpu", "mem"]:
                     status[device_type] = not bool(ret)

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1810,8 +1810,8 @@ def update(
     new_desc = ElementTree.fromstring(
         _gen_xml(
             name,
-            cpu,
-            mem,
+            cpu or 0,
+            mem or 0,
             all_disks,
             _get_merged_nics(hypervisor, nic_profile, interfaces),
             hypervisor,

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -1336,6 +1336,40 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         define_mock = MagicMock(return_value=True)
         self.mock_conn.defineXML = define_mock
 
+        # No parameter passed case
+        self.assertEqual(
+            {
+                "definition": False,
+                "disk": {"attached": [], "detached": []},
+                "interface": {"attached": [], "detached": []},
+            },
+            virt.update("my_vm"),
+        )
+
+        # Same parameters passed than in default virt.defined state case
+        self.assertEqual(
+            {
+                "definition": False,
+                "disk": {"attached": [], "detached": []},
+                "interface": {"attached": [], "detached": []},
+            },
+            virt.update(
+                "my_vm",
+                cpu=None,
+                mem=None,
+                disk_profile=None,
+                disks=None,
+                nic_profile=None,
+                interfaces=None,
+                graphics=None,
+                live=True,
+                connection=None,
+                username=None,
+                password=None,
+                boot=None,
+            ),
+        )
+
         # Update vcpus case
         setvcpus_mock = MagicMock(return_value=0)
         domain_mock.setVcpusFlags = setvcpus_mock


### PR DESCRIPTION
### What does this PR do?

This PR extracts the code defining and/or updating the VM, storage pool or network from the corresponding `virt.*running` state into `virt.*defined` states.

This allows ensuring a VM, storage pool or network is defined without needing to care about it's status.

While at it, implement the `__opts__['test']` support for those states. The returned values from the running states have been keep intact as much as possible.

Since the running states are using the new defined ones, the existing running tests are enough to ensure the defined states are working fine.

### What issues does this PR fix or reference?

### Tests written?

Yes

### Commits signed with GPG?

Yes