### PR TITLE
Fix issue with overly long names in the LGPO module

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -5651,33 +5651,15 @@ def _getAdmlPresentationRefId(adml_data, ref_id):
     helper function to check for a presentation label for a policy element
     '''
     search_results = adml_data.xpath('//*[@*[local-name() = "refId"] = "{0}"]'.format(ref_id))
-    prepended_text = ''
     if search_results:
         for result in search_results:
             the_localname = etree.QName(result.tag).localname
-            presentation_element = PRESENTATION_ANCESTOR_XPATH(result)
-            if presentation_element:
-                presentation_element = presentation_element[0]
-                if TEXT_ELEMENT_XPATH(presentation_element):
-                    for p_item in presentation_element.getchildren():
-                        if p_item == result:
-                            break
-                        else:
-                            if etree.QName(p_item.tag).localname == 'text':
-                                if prepended_text:
-                                    prepended_text = ' '.join((text for text in (prepended_text, getattr(p_item, 'text', '').rstrip()) if text))
-                                else:
-                                    prepended_text = getattr(p_item, 'text', '').rstrip() if getattr(p_item, 'text', '') else ''
-                            else:
-                                prepended_text = ''
-                    if prepended_text.endswith('.'):
-                        prepended_text = ''
             if the_localname == 'textBox' \
                     or the_localname == 'comboBox':
                 label_items = result.xpath('.//*[local-name() = "label"]')
                 for label_item in label_items:
                     if label_item.text:
-                        return (prepended_text + ' ' + label_item.text.rstrip().rstrip(':')).lstrip()
+                        return label_item.text.rstrip().rstrip(':').strip()
             elif the_localname == 'decimalTextBox' \
                     or the_localname == 'longDecimalTextBox' \
                     or the_localname == 'dropdownList' \
@@ -5686,7 +5668,7 @@ def _getAdmlPresentationRefId(adml_data, ref_id):
                     or the_localname == 'text' \
                     or the_localname == 'multiTextBox':
                 if result.text:
-                    return (prepended_text + ' ' + result.text.rstrip().rstrip(':')).lstrip()
+                    return result.text.rstrip().rstrip(':').strip()
     return None
 
 

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -8217,10 +8217,8 @@ def _get_policy_adm_setting(admx_policy,
                                 configured_elements[this_element_name] = True
                                 log.trace('element %s is configured true',
                                           child_item.attrib['id'])
-                    elif etree.QName(child_item).localname == 'decimal' \
-                        or etree.QName(child_item).localname == 'text' \
-                        or etree.QName(child_item).localname == 'longDecimal' \
-                        or etree.QName(child_item).localname == 'multiText':
+                    elif etree.QName(child_item).localname in [
+                            'decimal', 'text', 'longDecimal', 'multiText']:
                         # https://msdn.microsoft.com/en-us/library/dn605987(v=vs.85).aspx
                         if _regexSearchRegPolData(
                                 re.escape(_processValueItem(
@@ -8292,10 +8290,12 @@ def _get_policy_adm_setting(admx_policy,
                                             configured_elements[this_element_name] = _getAdmlDisplayName(
                                                 adml_xml_data=adml_policy_resources,
                                                 display_name=enum_item.attrib['displayName'])
+                                            break
                                     else:
                                         configured_elements[this_element_name] = _getAdmlDisplayName(
                                             adml_xml_data=adml_policy_resources,
                                             display_name=enum_item.attrib['displayName'])
+                                        break
                     elif etree.QName(child_item).localname == 'list':
                         return_value_name = False
                         if 'explicitValue' in child_item.attrib \

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -5662,25 +5662,6 @@ def _getAdmlPresentationRefId(adml_data, ref_id):
     if search_results:
         for result in search_results:
             the_localname = etree.QName(result.tag).localname
-            # presentation_element = PRESENTATION_ANCESTOR_XPATH(result)
-            # if presentation_element:
-            #     presentation_element = presentation_element[0]
-            #     if TEXT_ELEMENT_XPATH(presentation_element):
-            #         for p_item in presentation_element.getchildren():
-            #             if p_item == result:
-            #                 break
-            #             else:
-            #                 if etree.QName(p_item.tag).localname == 'text':
-            #                     if prepended_text:
-            #                         if getattr(p_item, 'text'):
-            #                             prepended_text = ' '.join((text for text in (prepended_text, getattr(p_item, 'text', '').rstrip()) if text))
-            #                     else:
-            #                         if getattr(p_item, 'text'):
-            #                             prepended_text = getattr(p_item, 'text', '').rstrip()
-            #                 else:
-            #                     prepended_text = ''
-            #         if prepended_text.endswith(('.', ':')):
-            #             prepended_text = ''
             if the_localname == 'textBox' \
                     or the_localname == 'comboBox':
                 label_items = result.xpath('.//*[local-name() = "label"]')

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -4918,7 +4918,7 @@ def _parse_xml(adm_file):
         for file_path in file_list:
             os.remove(file_path)
 
-        # Load the file
+        # Lowercase all the keys
         with salt.utils.files.fopen(adm_file, 'rb') as rfh:
 
             encoding = 'utf-8'
@@ -4937,6 +4937,13 @@ def _parse_xml(adm_file):
                     line = line.replace(line[start:q2], line[start:q2].lower())
                     found_key = True
                 modified_xml += line + '\r\n'
+
+        # Convert smart quotes to regular quotes
+        modified_xml = modified_xml.replace('\u201c', '"').replace('\u201d', '"')
+        modified_xml = modified_xml.replace('\u2018', '\'').replace('\u2019', '\'')
+
+        # Convert em dash and en dash to dash
+        modified_xml = modified_xml.replace('\u2013', '-').replace('\u2014', '-')
 
         with salt.utils.files.fopen(out_file, 'wb') as wfh:
             wfh.write(modified_xml.encode(encoding))

--- a/salt/states/win_lgpo.py
+++ b/salt/states/win_lgpo.py
@@ -297,7 +297,7 @@ def set_(name,
                                 # new
                                 if new_e_name in valid_names:
                                     salt.utils.versions.warn_until(
-                                        'Magnesium',
+                                        'Phosphorus',
                                         'The LGPO module changed the way it '
                                         'gets policy element names.\n'
                                         '"{0}" is no longer valid.\n'

--- a/salt/version.py
+++ b/salt/version.py
@@ -109,9 +109,9 @@ class SaltStackVersion(object):
         'Sodium'        : (MAX_SIZE - 98, 0),
         'Magnesium'     : (MAX_SIZE - 97, 0),
         'Aluminium'     : (MAX_SIZE - 96, 0),
+        'Silicon'      : (MAX_SIZE - 95, 0),
+        'Phosphorus'   : (MAX_SIZE - 94, 0),
         # pylint: disable=E8265
-        #'Silicon'      : (MAX_SIZE - 95, 0),
-        #'Phosphorus'   : (MAX_SIZE - 94, 0),
         #'Sulfur'       : (MAX_SIZE - 93, 0),
         #'Chlorine'     : (MAX_SIZE - 92, 0),
         #'Argon'        : (MAX_SIZE - 91, 0),

--- a/tests/integration/modules/test_win_lgpo.py
+++ b/tests/integration/modules/test_win_lgpo.py
@@ -215,7 +215,7 @@ class WinLgpoTest(ModuleCase):
                 'Users can only point and print to these servers': True,
                 'Enter fully qualified server names separated by semicolons': 'fakeserver1;fakeserver2',
                 'Users can only point and print to machines in their forest': True,
-                'Security Prompts: When installing drivers for a new connection': 'Show warning and elevation prompt',
+                'When installing drivers for a new connection': 'Show warning and elevation prompt',
                 'When updating drivers for an existing connection': 'Show warning only',
             },
             [

--- a/tests/unit/modules/test_win_lgpo.py
+++ b/tests/unit/modules/test_win_lgpo.py
@@ -585,8 +585,7 @@ class WinLGPOGetPointAndPrintENTestCase(TestCase, LoaderModuleMockMixin):
                     'Users can only point and print to machines in their '
                     'forest':
                         True,
-                    'Security Prompts: When installing drivers for a new '
-                    'connection':
+                    'When installing drivers for a new connection':
                         'Show warning and elevation prompt',
                     'When updating drivers for an existing connection':
                         'Show warning only',
@@ -671,8 +670,7 @@ class WinLGPOGetPointAndPrintENTestCase(TestCase, LoaderModuleMockMixin):
             'Printers\\Point and Print Restrictions': {
                 'Enter fully qualified server names separated by semicolons':
                     'fakeserver1;fakeserver2',
-                'Security Prompts: When installing drivers for a new '
-                'connection':
+                'When installing drivers for a new connection':
                     'Show warning and elevation prompt',
                 'Users can only point and print to machines in their forest':
                     True,
@@ -696,8 +694,7 @@ class WinLGPOGetPointAndPrintENTestCase(TestCase, LoaderModuleMockMixin):
                             'Enter fully qualified server names separated by '
                             'semicolons':
                                 'fakeserver1;fakeserver2',
-                            'Security Prompts: When installing drivers for a '
-                            'new connection':
+                            'When installing drivers for a new connection':
                                 'Show warning and elevation prompt',
                             'Users can only point and print to machines in '
                             'their forest':

--- a/tests/unit/states/test_win_lgpo.py
+++ b/tests/unit/states/test_win_lgpo.py
@@ -269,4 +269,7 @@ class WinLGPOPolicyElementNames(TestCase, LoaderModuleMockMixin):
                        'Invalid element name: Invalid element spongebob',
             'name': 'test_state',
             'result': False}
-        self.assertDictEqual(result, expected)
+        self.assertDictEqual(result['changes'], expected['changes'])
+        self.assertIn('Invalid element squidward', result['comment'])
+        self.assertIn('Invalid element spongebob', result['comment'])
+        self.assertFalse(expected['result'])

--- a/tests/unit/states/test_win_lgpo.py
+++ b/tests/unit/states/test_win_lgpo.py
@@ -247,6 +247,12 @@ class WinLGPOPolicyElementNames(TestCase, LoaderModuleMockMixin):
                     'Show warning only'}}
         self.assertDictEqual(
             result['changes']['new']['Computer Configuration'], expected)
+        expected = 'The LGPO module changed the way it gets policy element names.\n' \
+                   '"Security Prompts: When installing drivers for a new connection" is no longer valid.\n' \
+                   'Please use "When installing drivers for a new connection" instead.\n' \
+                   'The following policies changed:\n' \
+                   'Point and Print Restrictions'
+        self.assertEqual(result['comment'], expected)
 
     def test_invalid_elements(self):
         computer_policy = {

--- a/tests/unit/states/test_win_lgpo.py
+++ b/tests/unit/states/test_win_lgpo.py
@@ -7,19 +7,50 @@
 from __future__ import absolute_import, unicode_literals, print_function
 
 # Import Salt Testing Libs
+from tests.support.helpers import destructiveTest
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.mock import patch
 from tests.support.unit import TestCase, skipIf
-import salt.utils.platform
 
 # Import Salt Libs
+import salt.config
+import salt.modules.cmdmod
+import salt.modules.file
+import salt.modules.win_file as win_file
+import salt.modules.win_lgpo as win_lgpo_mod
 import salt.states.win_lgpo as win_lgpo
+import salt.utils.platform
+import salt.utils.win_dacl
+import salt.utils.win_lgpo_auditpol
+import salt.utils.win_reg
+
+LOADER_DICTS = {
+    win_lgpo: {
+        '__salt__': {
+            'lgpo.get_policy': win_lgpo_mod.get_policy,
+            'lgpo.get_policy_info': win_lgpo_mod.get_policy_info,
+            'lgpo.set': win_lgpo_mod.set_}},
+    win_lgpo_mod: {
+        '__salt__': {
+            'cmd.run': salt.modules.cmdmod.run,
+            'file.file_exists': salt.modules.file.file_exists,
+            'file.makedirs': win_file.makedirs_,
+            'file.remove': win_file.remove,
+            'file.write': salt.modules.file.write,},
+        '__opts__': salt.config.DEFAULT_MINION_OPTS.copy(),
+        '__utils__': {
+            'reg.read_value': salt.utils.win_reg.read_value,
+            'auditpol.get_auditpol_dump':
+                salt.utils.win_lgpo_auditpol.get_auditpol_dump}},
+    win_file: {
+        '__utils__': {
+            'dacl.set_perms': salt.utils.win_dacl.set_perms}}}
 
 
-@skipIf(not salt.utils.platform.is_windows(), 'LGPO not applicable')
-class WinSystemTestCase(TestCase):
+class WinLGPOComparePoliciesTestCase(TestCase):
     '''
     Test cases for the win_lgpo state
     '''
-
     def test__compare_policies_string(self):
         '''
         ``_compare_policies`` should only return ``True`` when the string values
@@ -127,3 +158,110 @@ class WinSystemTestCase(TestCase):
         self.assertFalse(
             win_lgpo._compare_policies(compare_integer, None)
         )
+
+
+@destructiveTest
+@skipIf(not salt.utils.platform.is_windows(), 'System is not Windows')
+class WinLGPOPolicyElementNames(TestCase, LoaderModuleMockMixin):
+    '''
+    Test variations of the Point and Print Restrictions policy when Not
+    Configured (NC)
+    '''
+    def setup_loader_modules(self):
+        return LOADER_DICTS
+
+    def setUp(self):
+        computer_policy = {'Point and Print Restrictions': 'Not Configured'}
+        with patch.dict(win_lgpo.__opts__, {'test': False}):
+            win_lgpo.set_(name='nc_state', computer_policy=computer_policy)
+
+    def test_current_element_naming_style(self):
+        computer_policy = {
+            'Point and Print Restrictions': {
+                'Users can only point and print to these servers':
+                    True,
+                'Enter fully qualified server names separated by '
+                'semicolons':
+                    'fakeserver1;fakeserver2',
+                'Users can only point and print to machines in their '
+                'forest':
+                    True,
+                'When installing drivers for a new connection':
+                    'Show warning and elevation prompt',
+                'When updating drivers for an existing connection':
+                    'Show warning only',
+            }}
+        with patch.dict(win_lgpo.__opts__, {'test': False}):
+            result = win_lgpo.set_(name='test_state',
+                                   computer_policy=computer_policy)
+        expected = {
+            'Point and Print Restrictions': {
+                'Enter fully qualified server names separated by '
+                'semicolons':
+                    'fakeserver1;fakeserver2',
+                'When installing drivers for a new connection':
+                    'Show warning and elevation prompt',
+                'Users can only point and print to machines in '
+                'their forest':
+                    True,
+                u'Users can only point and print to these servers':
+                    True,
+                u'When updating drivers for an existing connection':
+                    'Show warning only'}}
+        self.assertDictEqual(
+            result['changes']['new']['Computer Configuration'], expected)
+
+    def test_old_element_naming_style(self):
+        computer_policy = {
+            'Point and Print Restrictions': {
+                'Users can only point and print to these servers':
+                    True,
+                'Enter fully qualified server names separated by '
+                'semicolons':
+                    'fakeserver1;fakeserver2',
+                'Users can only point and print to machines in their '
+                'forest':
+                    True,
+                # Here's the old one
+                'Security Prompts: When installing drivers for a new connection':
+                    'Show warning and elevation prompt',
+                'When updating drivers for an existing connection':
+                    'Show warning only',
+            }}
+
+        with patch.dict(win_lgpo.__opts__, {'test': False}):
+            result = win_lgpo.set_(name='test_state',
+                                   computer_policy=computer_policy)
+        expected = {
+            'Point and Print Restrictions': {
+                'Enter fully qualified server names separated by '
+                'semicolons':
+                    'fakeserver1;fakeserver2',
+                'When installing drivers for a new connection':
+                    'Show warning and elevation prompt',
+                'Users can only point and print to machines in '
+                'their forest':
+                    True,
+                u'Users can only point and print to these servers':
+                    True,
+                u'When updating drivers for an existing connection':
+                    'Show warning only'}}
+        self.assertDictEqual(
+            result['changes']['new']['Computer Configuration'], expected)
+
+    def test_invalid_elements(self):
+        computer_policy = {
+            'Point and Print Restrictions': {
+                'Invalid element spongebob': True,
+                'Invalid element squidward': False}}
+
+        with patch.dict(win_lgpo.__opts__, {'test': False}):
+            result = win_lgpo.set_(name='test_state',
+                                   computer_policy=computer_policy)
+        expected = {
+            'changes': {},
+            'comment': 'Invalid element name: Invalid element squidward\n'
+                       'Invalid element name: Invalid element spongebob',
+            'name': 'test_state',
+            'result': False}
+        self.assertDictEqual(result, expected)

--- a/tests/unit/states/test_win_lgpo.py
+++ b/tests/unit/states/test_win_lgpo.py
@@ -2,7 +2,6 @@
 '''
 :codeauthor: Shane Lee <slee@saltstack.com>
 '''
-
 # Import Python Libs
 from __future__ import absolute_import, unicode_literals, print_function
 
@@ -36,7 +35,7 @@ LOADER_DICTS = {
             'file.file_exists': salt.modules.file.file_exists,
             'file.makedirs': win_file.makedirs_,
             'file.remove': win_file.remove,
-            'file.write': salt.modules.file.write,},
+            'file.write': salt.modules.file.write},
         '__opts__': salt.config.DEFAULT_MINION_OPTS.copy(),
         '__utils__': {
             'reg.read_value': salt.utils.win_reg.read_value,

--- a/tests/unit/states/test_win_lgpo.py
+++ b/tests/unit/states/test_win_lgpo.py
@@ -273,3 +273,113 @@ class WinLGPOPolicyElementNames(TestCase, LoaderModuleMockMixin):
         self.assertIn('Invalid element squidward', result['comment'])
         self.assertIn('Invalid element spongebob', result['comment'])
         self.assertFalse(expected['result'])
+
+
+@destructiveTest
+@skipIf(not salt.utils.platform.is_windows(), 'System is not Windows')
+class WinLGPOPolicyElementNamesTestTrue(TestCase, LoaderModuleMockMixin):
+    '''
+    Test variations of the Point and Print Restrictions policy when Not
+    Configured (NC)
+    '''
+    configured = False
+
+    def setup_loader_modules(self):
+        return LOADER_DICTS
+
+    def setUp(self):
+        if not self.configured:
+            computer_policy = {
+                'Point and Print Restrictions': {
+                    'Users can only point and print to these servers':
+                        True,
+                    'Enter fully qualified server names separated by '
+                    'semicolons':
+                        'fakeserver1;fakeserver2',
+                    'Users can only point and print to machines in their '
+                    'forest':
+                        True,
+                    'When installing drivers for a new connection':
+                        'Show warning and elevation prompt',
+                    'When updating drivers for an existing connection':
+                        'Show warning only',
+                }}
+            with patch.dict(win_lgpo.__opts__, {'test': False}):
+                win_lgpo.set_(name='nc_state', computer_policy=computer_policy)
+            self.configured = True
+
+    def test_current_element_naming_style(self):
+        computer_policy = {
+            'Point and Print Restrictions': {
+                'Users can only point and print to these servers':
+                    True,
+                'Enter fully qualified server names separated by '
+                'semicolons':
+                    'fakeserver1;fakeserver2',
+                'Users can only point and print to machines in their '
+                'forest':
+                    True,
+                'When installing drivers for a new connection':
+                    'Show warning and elevation prompt',
+                'When updating drivers for an existing connection':
+                    'Show warning only',
+            }}
+        with patch.dict(win_lgpo.__opts__, {'test': True}):
+            result = win_lgpo.set_(name='test_state',
+                                   computer_policy=computer_policy)
+        expected = {
+            'changes': {},
+            'comment': 'All specified policies are properly configured'}
+        self.assertDictEqual(result['changes'], expected['changes'])
+        self.assertTrue(result['result'])
+        self.assertEqual(result['comment'], result['comment'])
+
+    def test_old_element_naming_style(self):
+        computer_policy = {
+            'Point and Print Restrictions': {
+                'Users can only point and print to these servers':
+                    True,
+                'Enter fully qualified server names separated by '
+                'semicolons':
+                    'fakeserver1;fakeserver2',
+                'Users can only point and print to machines in their '
+                'forest':
+                    True,
+                # Here's the old one
+                'Security Prompts: When installing drivers for a new connection':
+                    'Show warning and elevation prompt',
+                'When updating drivers for an existing connection':
+                    'Show warning only',
+            }}
+        with patch.dict(win_lgpo.__opts__, {'test': True}):
+            result = win_lgpo.set_(name='test_state',
+                                   computer_policy=computer_policy)
+        expected = {
+            'changes': {},
+            'comment': 'The LGPO module changed the way it gets policy element names.\n'
+                       '"Security Prompts: When installing drivers for a new connection" is no longer valid.\n'
+                       'Please use "When installing drivers for a new connection" instead.\n'
+                       'All specified policies are properly configured'}
+        self.assertDictEqual(result['changes'], expected['changes'])
+        self.assertTrue(result['result'])
+        self.assertEqual(result['comment'], result['comment'])
+
+    def test_invalid_elements(self):
+        computer_policy = {
+            'Point and Print Restrictions': {
+                'Invalid element spongebob': True,
+                'Invalid element squidward': False}}
+
+        with patch.dict(win_lgpo.__opts__, {'test': True}):
+            result = win_lgpo.set_(name='test_state',
+                                   computer_policy=computer_policy)
+        expected = {
+            'changes': {},
+            'comment': 'Invalid element name: Invalid element squidward\n'
+                       'Invalid element name: Invalid element spongebob',
+            'name': 'test_state',
+            'result': False}
+        self.assertDictEqual(result['changes'], expected['changes'])
+        self.assertIn('Invalid element squidward', result['comment'])
+        self.assertIn('Invalid element spongebob', result['comment'])
+        self.assertFalse(expected['result'])


### PR DESCRIPTION
### What does this PR do?
Fixes an issue in the LGPO module where policy parameters are extremely long. Some policy names were entire sentences pull from the adml file and prepended to the actual policy name.

This change does not affect ALL policies, only those that had prepended additional text. I estimate that to be 5 to 10 percent of policies. I added some logic to the state that will attempt to replace the old element name with the new element name. If this occurs, a Deprecation warning will be displayed in the comments. The warning will be displayed until Phosphorus.

This PR also replaces smart quotes, smart single quotes, em-dashes, and en-dashes with normal quotes and dashes. The unrecognized characters in the `Previous Behavior` section below contains smart quotes and an em dash. Those will be replaced and display properly. It will also make it so you don't have to add em dashes and smart quotes when setting policies. You will be able to use standard characters.

### Previous Behavior
 A recent update to the Windows Update Config policy recently gives us this as a policy setting:
```
            If you have selected ΓÇ£4 ΓÇô Auto download and schedule the installΓÇ¥ for your scheduled install day and specified a schedule, you also have the option to limit updating to a weekly, bi-weekly or monthly occurrence, using the options below: Every week:
                True
```

### New Behavior
With this PR the above policy setting becomes:
```
            Every week:
                True
```

### Tests written?
Yes

### Commits signed with GPG?
Yes