### PR TITLE
Remove isoformat argument

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -3719,7 +3719,7 @@ def _parse_snapshot_description(vm_snapshot, unix_time=False):
         if node.tag == 'name':
             ret['name'] = node.text
         elif node.tag == 'creationTime':
-            ret['created'] = datetime.datetime.fromtimestamp(float(node.text)).isoformat(' ') \
+            ret['created'] = datetime.datetime.fromtimestamp(float(node.text)).isoformat() \
                                 if not unix_time else float(node.text)
         elif node.tag == 'state':
             ret['running'] = node.text == 'running'


### PR DESCRIPTION
### What does this PR do?

Bugfixes module virt.list_snapshots in file salt/modules/virt.py

### What issues does this PR fix or reference?

None

### Previous Behavior

```
[root@myminion ~]# salt-call virt.list_snapshots domain-logstash
...
[DEBUG   ] LazyLoaded yaml.render
[DEBUG   ] LazyLoaded virt.list_snapshots
[DEBUG   ] LazyLoaded direct_call.execute
[DEBUG   ] LazyLoaded config.get
[DEBUG   ] key: virt.connect, ret: _|-
[DEBUG   ] key: libvirt:connection, ret: _|-
[DEBUG   ] key: virt:connection:uri, ret: _|-
[DEBUG   ] key: libvirt:hypervisor, ret: _|-

Passed invalid arguments: isoformat() argument 1 must be char, not unicode.

Usage:

    List available snapshots for certain vm or for all.

    :param domain: domain name
    :param connection: libvirt connection URI, overriding defaults

        .. versionadded:: 2019.2.0
    :param username: username to connect with, overriding defaults

        .. versionadded:: 2019.2.0
    :param password: password to connect with, overriding defaults

        .. versionadded:: 2019.2.0

    .. versionadded:: 2016.3.0

    CLI Example:

    .. code-block:: bash

        salt '*' virt.list_snapshots
        salt '*' virt.list_snapshots <domain>

Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/cli/caller.py", line 237, in call
    ret['return'] = self.minion.executors[fname](self.opts, data, func, args, kwargs)
  File "/usr/lib/python2.7/site-packages/salt/executors/direct_call.py", line 12, in execute
    return func(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/salt/modules/virt.py", line 3599, in list_snapshots
    ret[vm_domain.name()] = [_parse_snapshot_description(snap) for snap in vm_domain.listAllSnapshots()] or 'N/A'
  File "/usr/lib/python2.7/site-packages/salt/modules/virt.py", line 3563, in _parse_snapshot_description
    if not unix_time else float(node.text)
TypeError: isoformat() argument 1 must be char, not unicode
```

The creation time is correct:
```
[root@myminion ~]# virsh snapshot-dumpxml --domain domain --snapshotname domain-20200109-155338 | grep creationTime
  <creationTime>1578581618</creationTime>
```

Simulate this in python:
```
>>> datetime.datetime.fromtimestamp(float('1578581618')).isoformat(' ')
'2020-01-09 15:53:38'
>>> datetime.datetime.fromtimestamp(float('1578581618')).isoformat()
'2020-01-09T15:53:38'
>>>
```

### New Behavior
```
[root@myminion ~]# salt-call virt.list_snapshots mydomain-logstash
local:
    ----------
    mydomain-logstash:
        |_
          ----------
          created:
              2020-01-09T15:53:38
          current:
              True
          name:
              mydomain-logstash-20200109-155338
          running:
              True
```


### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
