### PR TITLE
port #52212 to master - suggested for Neon

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -5792,19 +5792,23 @@ def prepend(name,
 
     if makedirs is True:
         dirname = os.path.dirname(name)
-        if not __salt__['file.directory_exists'](dirname):
-            try:
-                _makedirs(name=name)
-            except CommandExecutionError as exc:
-                return _error(ret, 'Drive {0} is not mapped'.format(exc.message))
+        if __opts__['test']:
+            ret['comment'] = 'Directory {0} is set to be updated'.format(dirname)
+            ret['result'] = None
+        else:
+            if not __salt__['file.directory_exists'](dirname):
+                try:
+                    _makedirs(name=name)
+                except CommandExecutionError as exc:
+                    return _error(ret, 'Drive {0} is not mapped'.format(exc.message))
 
-            check_res, check_msg, check_changes = _check_directory_win(dirname) \
-                if salt.utils.platform.is_windows() \
-                else _check_directory(dirname)
+                check_res, check_msg, check_changes = _check_directory_win(dirname) \
+                    if salt.utils.platform.is_windows() \
+                    else _check_directory(dirname)
 
-            if not check_res:
-                ret['changes'] = check_changes
-                return _error(ret, check_msg)
+                if not check_res:
+                    ret['changes'] = check_changes
+                    return _error(ret, check_msg)
 
     check_res, check_msg = _check_file(name)
     if not check_res:


### PR DESCRIPTION
### What does this PR do?
Ports #52212 to master
This change has been backported to 2018.3, so it should really be fixed for Neon as well.

### What issues does this PR fix or reference?
Continues to close #49329 and ports #52212 to master

### Previous Behavior
Previous behavior mistakenly made changes when `test=True` was passed.

### New Behavior
Wrap changes with a test check

### Tests written?
No
Previous behavior mistakenly made changes when `test=True` was passed. This PR corrects that behavior, and it seems silly to create tests for expected behavior or to check accidently broken bits.

### Commits signed with GPG?
No