### PR TITLE
Add test framework for pdbedit and state smartos tests

### DIFF
--- a/salt/states/smartos.py
+++ b/salt/states/smartos.py
@@ -373,6 +373,9 @@ def config_present(name, value):
     if not __opts__['test'] and ret['changes']:
         ret['result'] = _write_config(config)
 
+        if not ret['result']:
+            ret['comment'] = 'Could not add property {0} with value "{1}" to config'.format(name, value)
+
     return ret
 
 

--- a/tests/unit/modules/test_pdbedit.py
+++ b/tests/unit/modules/test_pdbedit.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+# Import python libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import Salt Libs
+import salt.modules.pdbedit as pdbedit
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase
+
+
+class PdbeditTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    TestCase for salt.modules.pdbedit module
+    '''
+
+    def setup_loader_modules(self):
+        return {pdbedit: {}}
+
+    def test_generate_nt_hash(self):
+        '''
+        Test salt.modules.pdbedit.generate_nt_hash
+        '''
+        ret = pdbedit.generate_nt_hash('supersecret')
+        assert b'43239E3A0AF748020D5B426A4977D7E5' == ret

--- a/tests/unit/states/test_pdbedit.py
+++ b/tests/unit/states/test_pdbedit.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Libs
 import salt.states.pdbedit as pdbedit
+import salt.modules.pdbedit as pdbedit_mod
 
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
@@ -18,7 +19,8 @@ class PdbeditTestCase(TestCase, LoaderModuleMockMixin):
     '''
 
     def setup_loader_modules(self):
-        return {pdbedit: {}}
+        return {pdbedit: {},
+                pdbedit_mod: {}}
 
     def test_generate_absent(self):
         '''
@@ -26,6 +28,10 @@ class PdbeditTestCase(TestCase, LoaderModuleMockMixin):
         user is already absent
         '''
         name = 'testname'
-        with patch.object(pdbedit, '__salt__', return_value=MagicMock()):
-            ret = pdbedit.absent(name)
+        cmd_ret = {'pid': 13172, 'retcode': 0, 'stdout': '', 'stderr': ''}
+        with patch.dict(pdbedit.__salt__, {'pdbedit.list':
+                                           pdbedit_mod.list_users}):
+            with patch.dict(pdbedit_mod.__salt__, {'cmd.run_all':
+                                                   MagicMock(return_value=cmd_ret)}):
+                ret = pdbedit.absent(name)
         assert ret['comment'] == 'account {0} is absent'.format(name)

--- a/tests/unit/states/test_pdbedit.py
+++ b/tests/unit/states/test_pdbedit.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+# Import python libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import Salt Libs
+import salt.states.pdbedit as pdbedit
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase
+from tests.support.mock import patch, MagicMock
+
+
+class PdbeditTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    TestCase for salt.states.pdbedit module
+    '''
+
+    def setup_loader_modules(self):
+        return {pdbedit: {}}
+
+    def test_generate_absent(self):
+        '''
+        Test salt.states.pdbedit.absent when
+        user is already absent
+        '''
+        name = 'testname'
+        with patch.object(pdbedit, '__salt__', return_value=MagicMock()):
+            ret = pdbedit.absent(name)
+        assert ret['comment'] == 'account {0} is absent'.format(name)

--- a/tests/unit/states/test_smartos.py
+++ b/tests/unit/states/test_smartos.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+# Import python libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import Salt Libs
+import salt.states.smartos as smartos
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase
+from tests.support.mock import patch
+
+
+class SmartOsTestCase(TestCase, LoaderModuleMockMixin):
+    '''
+    TestCase for salt.states.smartos
+    '''
+
+    def setup_loader_modules(self):
+        return {smartos: {
+                  '__opts__': {'test': False}}
+        }
+
+    def test_config_present_does_not_exist(self):
+        '''
+        Test salt.states.smartos.config_present
+        when the config files does not exist
+        '''
+        name = 'test'
+        value = 'test_value'
+        with patch('os.path.isfile', return_value=False):
+            with patch('salt.utils.atomicfile.atomic_open', side_effect=IOError):
+                ret = smartos.config_present(name=name, value=value)
+        assert not ret['result']
+        assert ret['comment'] == 'Could not add property {0} with value "{1}" to config'.format(name, value)


### PR DESCRIPTION
### What does this PR do?
Add test framework for smartos module and pdbedit state/execution modules.

Also ensure we add a comment in `config_present` when we cannot write to the config file.

fyi @sjorge 
