### PR TITLE
[master] various netapi fixes and tests

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -1299,3 +1299,9 @@
 # use OS defaults, typically 75 seconds on Linux, see
 # /proc/sys/net/ipv4/tcp_keepalive_intvl.
 #tcp_keepalive_intvl: -1
+
+
+#####         NetAPI settings          #####
+############################################
+# Allow the raw_shell parameter to be used when calling Salt SSH client via API
+#netapi_allow_raw_shell: True

--- a/noxfile.py
+++ b/noxfile.py
@@ -475,7 +475,7 @@ def _runtests(session, coverage, cmd_args):
 @nox.parametrize('crypto', [None, 'm2crypto', 'pycryptodomex'])
 def runtests_parametrized(session, coverage, transport, crypto):
     # Install requirements
-    _install_requirements(session, transport, 'unittest-xml-reporting==2.2.1')
+    _install_requirements(session, transport, 'unittest-xml-reporting==2.5.2')
 
     if crypto:
         if crypto == 'm2crypto':

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1186,6 +1186,10 @@ VALID_OPTS = immutabletypes.freeze({
 
     # Thorium top file location
     'thorium_top': six.string_types,
+
+    # Allow raw_shell option when using the ssh
+    # client via the Salt API
+    'netapi_allow_raw_shell': bool,
 })
 
 # default configurations
@@ -1799,6 +1803,7 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze({
     'auth_events': True,
     'minion_data_cache_events': True,
     'enable_ssh_minions': False,
+    'netapi_allow_raw_shell': False,
 })
 
 

--- a/salt/netapi/__init__.py
+++ b/salt/netapi/__init__.py
@@ -71,9 +71,14 @@ class NetapiClient(object):
             raise salt.exceptions.SaltInvocationError(
                     'Invalid client specified: \'{0}\''.format(low.get('client')))
 
-        if not ('token' in low or 'eauth' in low) and low['client'] != 'ssh':
+        if not ('token' in low or 'eauth' in low):
             raise salt.exceptions.EauthAuthenticationError(
                     'No authentication credentials given')
+
+        if low.get('raw_shell') and \
+                not self.opts.get('netapi_allow_raw_shell'):
+            raise salt.exceptions.EauthAuthenticationError(
+                    'Raw shell option not allowed.')
 
         l_fun = getattr(self, low['client'])
         f_call = salt.utils.args.format_call(l_fun, low)

--- a/tests/integration/netapi/test_client.py
+++ b/tests/integration/netapi/test_client.py
@@ -2,16 +2,31 @@
 
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
+import logging
 import os
 import time
 
 # Import Salt Testing libs
+from tests.support.paths import TMP_CONF_DIR, TMP
 from tests.support.runtests import RUNTIME_VARS
 from tests.support.unit import TestCase, skipIf
+from tests.support.mock import patch
+from tests.support.case import SSHCase
+from tests.support.helpers import (
+    Webserver,
+    SaveRequestsPostHandler,
+    requires_sshd_server
+)
 
 # Import Salt libs
 import salt.config
 import salt.netapi
+
+from salt.exceptions import (
+    EauthAuthenticationError
+)
+
+log = logging.getLogger(__name__)
 
 
 class NetapiClientTest(TestCase):
@@ -74,6 +89,12 @@ class NetapiClientTest(TestCase):
             pass
         self.assertEqual(ret, {'minions': sorted(['minion', 'sub_minion'])})
 
+    def test_local_unauthenticated(self):
+        low = {'client': 'local', 'tgt': '*', 'fun': 'test.ping'}
+
+        with self.assertRaises(EauthAuthenticationError) as excinfo:
+            ret = self.netapi.run(low)
+
     def test_wheel(self):
         low = {'client': 'wheel', 'fun': 'key.list_all'}
         low.update(self.eauth_creds)
@@ -107,6 +128,12 @@ class NetapiClientTest(TestCase):
         self.assertIn('jid', ret)
         self.assertIn('tag', ret)
 
+    def test_wheel_unauthenticated(self):
+        low = {'client': 'wheel', 'tgt': '*', 'fun': 'test.ping'}
+
+        with self.assertRaises(EauthAuthenticationError) as excinfo:
+            ret = self.netapi.run(low)
+
     @skipIf(True, 'This is not testing anything. Skipping for now.')
     def test_runner(self):
         # TODO: fix race condition in init of event-- right now the event class
@@ -125,3 +152,111 @@ class NetapiClientTest(TestCase):
         low.update(self.eauth_creds)
 
         ret = self.netapi.run(low)
+
+    def test_runner_unauthenticated(self):
+        low = {'client': 'runner', 'tgt': '*', 'fun': 'test.ping'}
+
+        with self.assertRaises(EauthAuthenticationError) as excinfo:
+            ret = self.netapi.run(low)
+
+
+@requires_sshd_server
+class NetapiSSHClientTest(SSHCase):
+    eauth_creds = {
+        'username': 'saltdev_auto',
+        'password': 'saltdev',
+        'eauth': 'auto',
+    }
+
+    def setUp(self):
+        '''
+        Set up a NetapiClient instance
+        '''
+        opts = salt.config.client_config(os.path.join(TMP_CONF_DIR, 'master'))
+        self.netapi = salt.netapi.NetapiClient(opts)
+
+        # Initialize salt-ssh
+        self.run_function('test.ping')
+
+    def tearDown(self):
+        del self.netapi
+
+    @classmethod
+    def setUpClass(cls):
+        cls.post_webserver = Webserver(handler=SaveRequestsPostHandler)
+        cls.post_webserver.start()
+        cls.post_web_root = cls.post_webserver.web_root
+        cls.post_web_handler = cls.post_webserver.handler
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.post_webserver.stop()
+        del cls.post_webserver
+
+    def test_ssh(self):
+        low = {'client': 'ssh', 'tgt': 'localhost', 'fun': 'test.ping'}
+        low.update(self.eauth_creds)
+
+        ret = self.netapi.run(low)
+
+        self.assertIn('localhost', ret)
+        self.assertEqual(ret['localhost']['return'], True)
+        self.assertEqual(ret['localhost']['id'], 'localhost')
+        self.assertEqual(ret['localhost']['fun'], 'test.ping')
+
+    def test_ssh_unauthenticated(self):
+        low = {'client': 'ssh', 'tgt': 'localhost', 'fun': 'test.ping'}
+
+        with self.assertRaises(EauthAuthenticationError) as excinfo:
+            ret = self.netapi.run(low)
+
+    def test_ssh_unauthenticated_raw_shell_curl(self):
+
+        fun = '-o ProxyCommand curl {0}'.format(self.post_web_root)
+        low = {'client': 'ssh',
+               'tgt': 'localhost',
+               'fun': fun,
+               'raw_shell': True}
+
+        ret = None
+        with self.assertRaises(EauthAuthenticationError) as excinfo:
+            ret = self.netapi.run(low)
+
+        self.assertEqual(self.post_web_handler.received_requests, [])
+        self.assertEqual(ret, None)
+
+    def test_ssh_unauthenticated_raw_shell_touch(self):
+
+        badfile = os.path.join(TMP, 'badfile.txt')
+        fun = '-o ProxyCommand touch {0}'.format(badfile)
+        low = {'client': 'ssh',
+               'tgt': 'localhost',
+               'fun': fun,
+               'raw_shell': True}
+
+        ret = None
+        with self.assertRaises(EauthAuthenticationError) as excinfo:
+            ret = self.netapi.run(low)
+
+        self.assertEqual(ret, None)
+        self.assertFalse(os.path.exists('badfile.txt'))
+
+    def test_ssh_authenticated_raw_shell_disabled(self):
+
+        badfile = os.path.join(TMP, 'badfile.txt')
+        fun = '-o ProxyCommand touch {0}'.format(badfile)
+        low = {'client': 'ssh',
+               'tgt': 'localhost',
+               'fun': fun,
+               'raw_shell': True}
+
+        low.update(self.eauth_creds)
+
+        ret = None
+        with patch.dict(self.netapi.opts,
+                        {'netapi_allow_raw_shell': False}):
+            with self.assertRaises(EauthAuthenticationError) as excinfo:
+                ret = self.netapi.run(low)
+
+        self.assertEqual(ret, None)
+        self.assertFalse(os.path.exists('badfile.txt'))

--- a/tests/integration/netapi/test_client.py
+++ b/tests/integration/netapi/test_client.py
@@ -175,6 +175,9 @@ class NetapiSSHClientTest(SSHCase):
         opts = salt.config.client_config(os.path.join(TMP_CONF_DIR, 'master'))
         self.netapi = salt.netapi.NetapiClient(opts)
 
+        self.priv_file = os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'key_test')
+        self.rosters = os.path.join(RUNTIME_VARS.TMP_CONF_DIR)
+
         # Initialize salt-ssh
         self.run_function('test.ping')
 
@@ -194,12 +197,20 @@ class NetapiSSHClientTest(SSHCase):
         del cls.post_webserver
 
     def test_ssh(self):
-        low = {'client': 'ssh', 'tgt': 'localhost', 'fun': 'test.ping'}
+        low = {'client': 'ssh',
+               'tgt': 'localhost',
+               'fun': 'test.ping',
+               'ignore_host_keys': True,
+               'roster_file': 'roster',
+               'rosters': [self.rosters],
+               'ssh_priv': self.priv_file}
+
         low.update(self.eauth_creds)
 
         ret = self.netapi.run(low)
 
         self.assertIn('localhost', ret)
+        self.assertIn('return', ret['localhost'])
         self.assertEqual(ret['localhost']['return'], True)
         self.assertEqual(ret['localhost']['id'], 'localhost')
         self.assertEqual(ret['localhost']['fun'], 'test.ping')

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -1526,6 +1526,25 @@ class Webserver(object):
         self.server_thread.join()
 
 
+class SaveRequestsPostHandler(tornado.web.RequestHandler):
+    '''
+    Save all requests sent to the server.
+    '''
+    received_requests = []
+
+    def post(self, *args):  # pylint: disable=arguments-differ
+        '''
+        Handle the post
+        '''
+        self.received_requests.append(self.request)
+
+    def data_received(self):  # pylint: disable=arguments-differ
+        '''
+        Streaming not used for testing
+        '''
+        raise NotImplementedError()
+
+
 class MirrorPostHandler(tornado.web.RequestHandler):
     '''
     Mirror a POST body back to the client

--- a/tests/support/xmlunit.py
+++ b/tests/support/xmlunit.py
@@ -15,11 +15,7 @@
 # Import python libs
 from __future__ import absolute_import
 import io
-import sys
 import logging
-
-# Import 3rd-party libs
-from salt.ext import six
 
 log = logging.getLogger(__name__)
 
@@ -29,46 +25,57 @@ try:
     import xmlrunner.result
     HAS_XMLRUNNER = True
 
-    class _DelegateIO(object):
-        '''
-        This class defines an object that captures whatever is written to
-        a stream or file.
-        '''
+    class _DuplicateWriter(io.TextIOBase):
+        """
+        Duplicate output from the first handle to the second handle
+        The second handle is expected to be a StringIO and not to block.
+        """
 
-        def __init__(self, delegate):
-            self._captured = six.StringIO()
-            self.delegate = delegate
+        def __init__(self, first, second):
+            super(_DuplicateWriter, self).__init__()
+            self._first = first
+            self._second = second
 
-        def write(self, text):
-            if six.PY2 and isinstance(text, six.text_type):
-                text = text.encode(__salt_system_encoding__)
-            self._captured.write(text)
-            self.delegate.write(text)
+        def flush(self):
+            self._first.flush()
+            self._second.flush()
+
+        def writable(self):
+            return True
+
+        def writelines(self, lines):
+            self._first.writelines(lines)
+            self._second.writelines(lines)
+
+        def write(self, b):
+            if isinstance(self._first, io.TextIOBase):
+                wrote = self._first.write(b)
+
+                if wrote is not None:
+                    # expected to always succeed to write
+                    self._second.write(b[:wrote])
+
+                return wrote
+            else:
+                # file-like object in Python2
+                # It doesn't return wrote bytes.
+                self._first.write(b)
+                self._second.write(b)
+                return len(b)
 
         def fileno(self):
-            return self.delegate.fileno()
+            return self._first.fileno()
 
-        def __getattr__(self, attr):
-            try:
-                return getattr(self._captured, attr)
-            except (AttributeError, io.UnsupportedOperation):
-                return getattr(self.delegate, attr)
+    xmlrunner.result._DuplicateWriter = _DuplicateWriter
 
     class _XMLTestResult(xmlrunner.result._XMLTestResult):
         def startTest(self, test):
-            log.debug('>>>>> START >>>>> {0}'.format(test.id()))
+            log.debug('>>>>> START >>>>> %s', test.id())
             # xmlrunner classes are NOT new-style classes
             xmlrunner.result._XMLTestResult.startTest(self, test)
-            if self.buffer:
-                # Let's override the values of self._stdXXX_buffer
-                # We want a similar sys.stdXXX file like behaviour
-                self._stderr_buffer = _DelegateIO(sys.__stderr__)
-                self._stdout_buffer = _DelegateIO(sys.__stdout__)
-                sys.stderr = self._stderr_buffer
-                sys.stdout = self._stdout_buffer
 
         def stopTest(self, test):
-            log.debug('<<<<< END <<<<<<< {0}'.format(test.id()))
+            log.debug('<<<<< END <<<<<<< %s', test.id())
             # xmlrunner classes are NOT new-style classes
             return xmlrunner.result._XMLTestResult.stopTest(self, test)
 


### PR DESCRIPTION
### What does this PR do?
Various netapi fixes and tests.  Updating netapi to 

### Previous Behavior
Authentication was not required when using the Salt API and specifying that the client type should be SSH.  Additionally the ability to pass raw_shell commands with the Salt API was enabled by default, this allowed sending arbitrary commands to the SSH binary when using a client type of SSH.

### New Behavior
Authentication is required when using Salt API and a client type of SSH.  The ability to use raw_shell commands is disabled by default.

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
