### PR TITLE
Restrict the 'start_event_grains' only to the start events

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1431,7 +1431,7 @@ class Minion(MinionBase):
             ret = yield channel.send(load, timeout=timeout)
             raise tornado.gen.Return(ret)
 
-    def _fire_master(self, data=None, tag=None, events=None, pretag=None, timeout=60, sync=True, timeout_handler=None):
+    def _fire_master(self, data=None, tag=None, events=None, pretag=None, timeout=60, sync=True, timeout_handler=None, include_startup_grains=False):
         '''
         Fire an event on the master, or drop message if unable to send.
         '''
@@ -1450,7 +1450,7 @@ class Minion(MinionBase):
         else:
             return
 
-        if self.opts['start_event_grains']:
+        if include_startup_grains :
             grains_to_add = dict(
                 [(k, v) for k, v in six.iteritems(self.opts.get('grains', {})) if k in self.opts['start_event_grains']])
             load['grains'] = grains_to_add
@@ -2146,6 +2146,9 @@ class Minion(MinionBase):
             })
 
     def _fire_master_minion_start(self):
+        include_grains = False
+        if self.opts['start_event_grains']:
+            include_grains = True
         # Send an event to the master that the minion is live
         if self.opts['enable_legacy_startup_events']:
             # Old style event. Defaults to False in Sodium release.
@@ -2154,7 +2157,8 @@ class Minion(MinionBase):
                 self.opts['id'],
                 time.asctime()
                 ),
-                'minion_start'
+                'minion_start',
+                include_startup_grains = include_grains
             )
         # send name spaced event
         self._fire_master(
@@ -2163,6 +2167,7 @@ class Minion(MinionBase):
             time.asctime()
             ),
             tagify([self.opts['id'], 'start'], 'minion'),
+            include_startup_grains=include_grains
         )
 
     def module_refresh(self, force_refresh=False, notify=False):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1450,7 +1450,7 @@ class Minion(MinionBase):
         else:
             return
 
-        if include_startup_grains :
+        if include_startup_grains:
             grains_to_add = dict(
                 [(k, v) for k, v in six.iteritems(self.opts.get('grains', {})) if k in self.opts['start_event_grains']])
             load['grains'] = grains_to_add
@@ -2158,7 +2158,7 @@ class Minion(MinionBase):
                 time.asctime()
                 ),
                 'minion_start',
-                include_startup_grains = include_grains
+                include_startup_grains=include_grains
             )
         # send name spaced event
         self._fire_master(

--- a/tests/unit/test_minion.py
+++ b/tests/unit/test_minion.py
@@ -341,6 +341,22 @@ class MinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         finally:
             minion.destroy()
 
+    def test_when_other_events_fired_and_start_event_grains_are_set(self):
+        mock_opts = self.get_config('minion', from_scratch=True)
+        mock_opts['start_event_grains'] = ["os"]
+        io_loop = tornado.ioloop.IOLoop()
+        io_loop.make_current()
+        minion = salt.minion.Minion(mock_opts, io_loop=io_loop)
+        try:
+            minion.tok = MagicMock()
+            minion._send_req_sync = MagicMock()
+            minion._fire_master('Custm_event_fired', 'custom_event')
+            load = minion._send_req_sync.call_args[0][0]
+
+            self.assertTrue('grains' not in load)
+        finally:
+            minion.destroy()
+
     def test_minion_retry_dns_count(self):
         '''
         Tests that the resolve_dns will retry dns look ups for a maximum of

--- a/tests/unit/test_minion.py
+++ b/tests/unit/test_minion.py
@@ -318,7 +318,7 @@ class MinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         try:
             minion.tok = MagicMock()
             minion._send_req_sync = MagicMock()
-            minion._fire_master('Minion has started', 'minion_start')
+            minion._fire_master('Minion has started', 'minion_start', include_startup_grains=True)
             load = minion._send_req_sync.call_args[0][0]
 
             self.assertTrue('grains' in load)


### PR DESCRIPTION
### What does this PR do?
https://github.com/saltstack/salt/pull/54948 introduced an unintended effect where `start_event_grains` were being passed to events other than start event, which wasn't the idea. This PR restrict these grains to startup events.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/55870
### Previous Behavior
Grains defined against `start_event_grains` were being passed to events other that start events.

### New Behavior
Grains defined against `start_event_grains` are being passed to only start events

### Tests written?
The existing test has been modified 

Yes

### Commits signed with GPG?

No


