### PR TITLE
the note only applies to SALT and SALT_SSH commands

### DIFF
--- a/doc/ref/cli/_includes/output-options.rst
+++ b/doc/ref/cli/_includes/output-options.rst
@@ -13,13 +13,6 @@ Output Options
     Salt will fall back on the ``pprint`` outputter and display the return data
     using the Python ``pprint`` standard library module.
 
-    .. note::
-        If using ``--out=json``, you will probably want ``--static`` as well.
-        Without the static option, you will get a separate JSON string per minion
-        which makes JSON output invalid as a whole.
-        This is due to using an iterative outputter. So if you want to feed it
-        to a JSON parser, use ``--static`` as well.
-
 .. option:: --out-indent OUTPUT_INDENT, --output-indent OUTPUT_INDENT
 
     Print the output indented by the provided value in spaces. Negative values

--- a/doc/ref/cli/salt-ssh.rst
+++ b/doc/ref/cli/salt-ssh.rst
@@ -174,6 +174,12 @@ Scan Roster Options
 
 .. include:: _includes/output-options.rst
 
+.. note::
+    If using ``--out=json``, you will probably want ``--static`` as well.
+    Without the static option, you will get a separate JSON string per minion
+    which makes JSON output invalid as a whole.
+    This is due to using an iterative outputter. So if you want to feed it
+    to a JSON parser, use ``--static`` as well.
 
 See also
 ========

--- a/doc/ref/cli/salt.rst
+++ b/doc/ref/cli/salt.rst
@@ -111,6 +111,12 @@ Options
 
 .. include:: _includes/output-options.rst
 
+.. note::
+    If using ``--out=json``, you will probably want ``--static`` as well.
+    Without the static option, you will get a separate JSON string per minion
+    which makes JSON output invalid as a whole.
+    This is due to using an iterative outputter. So if you want to feed it
+    to a JSON parser, use ``--static`` as well.
 
 See also
 ========


### PR DESCRIPTION
What does this PR do?

Removes a NOTE which does not apply to several CLI commands
What issues does this PR fix or reference?

#40888

Old Behavior

Note was included with salt-call, salt-key, and salt-cloud commands, which do not have a --static option. Attempt to add the option suggested by the Note would give an error.
New Behavior

Note is only included in docs for salt and salt-ssh commands.
Tests written?

No. PR addresses documentation only.

make html was run and correct results appear on the appropriate pages.

Commits signed with GPG?

Apparently not. Commits from my MacBook seem to be broken, now, But the GPG key is present. Will debug now that I see it is no longer working.

This is a re-issue of #55856 which was applied to the 2019.2.3 branch (as instructed by https://docs.saltstack.com/en/latest/topics/development/contributing.html#which-salt-branch) rather than master. My attempt to rebase failed in git hell.
