### PR TITLE
smartos.vm_present could not handle nics with vrrp_vrid property

### DIFF
--- a/salt/states/smartos.py
+++ b/salt/states/smartos.py
@@ -246,6 +246,11 @@ def _parse_vmconfig(config, instances):
                     ## some property are lowercase
                     if 'mac' in instance_config:
                         instance_config['mac'] = instance_config['mac'].lower()
+                    ## calculate mac from vrrp_vrid
+                    if 'vrrp_vrid' in instance_config:
+                        instance_config['mac'] = "00:00:5e:00:01:{0}".format(
+                            hex(int(instance_config['vrrp_vrid'])).split('x')[-1].zfill(2),
+                        )
                     vmconfig[prop].append(instance_config)
     else:
         log.error('smartos.vm_present::parse_vmconfig - failed to parse')
@@ -768,7 +773,8 @@ def vm_present(name, vmconfig, config=None):
         'instance': {
             'nics': 'mac',
             'disks': 'path',
-            'filesystems': 'target'
+            'filesystems': 'target',
+            'pci_devices': 'path',
         },
         'create_only': [
             'filesystems'

--- a/tests/unit/states/test_smartos.py
+++ b/tests/unit/states/test_smartos.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Libs
 import salt.states.smartos as smartos
+from salt.utils.odict import OrderedDict
 
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
@@ -34,3 +35,46 @@ class SmartOsTestCase(TestCase, LoaderModuleMockMixin):
                 ret = smartos.config_present(name=name, value=value)
         assert not ret['result']
         assert ret['comment'] == 'Could not add property {0} with value "{1}" to config'.format(name, value)
+
+    def test_parse_vmconfig_vrrp(self):
+        '''
+        Test _parse_vmconfig's vrid -> mac convertor
+
+        SmartOS will always use a mac based on the vrrp_vrid,
+        so we will replace the provided mac with the one based
+        on this value.
+
+        Doing so ensures that 'old' nics are removed and 'new'
+        nics get added as these actions are keyed on the mac
+        property.
+        '''
+        # NOTE: vmconfig is not a full vmadm payload,
+        #       this is not an issue given we are only testing
+        #       the vrrp_vrid to mac conversions
+        ret = smartos._parse_vmconfig(
+            OrderedDict([
+                ('nics', OrderedDict([
+                    ('00:00:5e:00:01:01', OrderedDict([
+                        ('vrrp_vrid', 1),
+                        ('vrrp_primary_ip', '12.34.5.6'),
+                    ])),
+                    ('00:00:5e:00:01:24', OrderedDict([
+                        ('vrrp_vrid', 240),
+                        ('vrrp_primary_ip', '12.34.5.6'),
+                    ])),
+                    ('00:22:06:00:00:01', OrderedDict([
+                        ('ips', ['12.34.5.6/24']),
+                    ]))
+                ]))
+            ]),
+            {'nics': 'mac'},
+        )
+
+        # NOTE: nics.0 is a vrrp nic with correct mac (check mac == vrid based -> unchanged)
+        assert ret['nics'][0]['mac'] == '00:00:5e:00:01:01'
+
+        # NOTE: nics.1 is a vrrp nic with incorrect mac (check mac == vrid based -> changed)
+        assert ret['nics'][1]['mac'] == '00:00:5e:00:01:f0'
+
+        # NOTE: nics.2 was not a vrrp nic (check mac was not changed)
+        assert ret['nics'][2]['mac'] == '00:22:06:00:00:01'


### PR DESCRIPTION
### What does this PR do?
SmartOS will automatically calculate (and override) the mac property of any nics that have `vrrp_vrid` property set.

This causes a lot of issues:
- we keep trying to add a new nic if the mac that was provided is incorrect
- we keep trying to delete the existing nic with the mac based on the vrid
- we keep trying to incorrect update a nic if the vrid was change (cannot be update, remove and add new nic)

### What issues does this PR fix or reference?
n/a

### Previous Behavior
We would try to add/remove/update the incorrect nic when `vrrp_vrid` property was present making the state module fail.

### New Behavior
We now account for this in `_parse_vmconfig()`, this function is used to map unique identifiers for various smartos resource types (nics, disks, ...)

We will use the provided mac address from the resource key **unless* the `vrrp_vrid` property is present, then generate the mac based on the provided vrid.

This results in the nic being correctly added, when the vrid is changes this results in a remove of the old nic and adding of the new nic as is expected by vmadm.

### Tests written?
Yes, I've added tests to test the mac handling of `_parse_vmconfig()`

### Commits signed with GPG?
No