### PR TITLE
Allow minions to return job information to any configured master

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -280,6 +280,28 @@ to the next master in the list if it finds the existing one is dead.
 
     master_alive_interval: 30
 
+.. conf_minion:: master_return_strategy
+
+``master_return_strategy``
+--------------------------
+
+.. versionadded:: 2018.x.x
+
+Default: ``source``
+
+This option controls the master return strategy. Can be ``source`` or ``any``.
+If set to ``source``, then the minion will only attempt to return the job
+results to the master that sent the job. If set to ``any``, then the minion
+will attempt to return the job results to the master that sent the job but if
+that fails, then the minion will attempt to return the job results to the next
+connected master in the configuration. :conf_minion:`master_alive_interval`
+must also be set. This is used to keep track of which masters are currently
+connected.
+
+.. code-block:: yaml
+
+    master_return_strategy: source
+
 .. conf_minion:: master_shuffle
 
 ``master_shuffle``

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -141,6 +141,9 @@ VALID_OPTS = immutabletypes.freeze({
     # is interrupted and try another master in the list.
     'master_alive_interval': int,
 
+    # The strategy to use when returning results back to the master.
+    'master_return_strategy': six.string_types,
+
     # When in multi-master failover mode, fail back to the first master in the list if it's back
     # online.
     'master_failback': bool,
@@ -1208,6 +1211,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze({
     'master_alive_interval': 0,
     'master_failback': False,
     'master_failback_interval': 0,
+    'master_return_strategy: 'source',
     'verify_master_pubkey_sign': False,
     'sign_pub_messages': False,
     'always_verify_signature': False,

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1211,7 +1211,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze({
     'master_alive_interval': 0,
     'master_failback': False,
     'master_failback_interval': 0,
-    'master_return_strategy: 'source',
+    'master_return_strategy': 'source',
     'verify_master_pubkey_sign': False,
     'sign_pub_messages': False,
     'always_verify_signature': False,

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2423,7 +2423,12 @@ class Minion(MinionBase):
                 log.debug('Forwarding master event tag=%s', data['tag'])
                 self._fire_master(data['data'], data['tag'], data['events'], data['pretag'], sync=False)
         elif tag.startswith('master_return'):
-            log.debug('Returning results for jid=%s to %s', data.get('jid'), self.opts['master'])
+            log.debug(
+                'Returning results for jid=%s to %s:%s',
+                data.get('jid'),
+                self.opts['master'],
+                self.opts['master_port']
+            )
             self._return_pub(data)
         elif tag.startswith(master_event(type='disconnected')) or tag.startswith(master_event(type='failback')):
             # if the master disconnect event is for a different master, raise an exception

--- a/tests/integration/files/conf/mm_sub_minion
+++ b/tests/integration/files/conf/mm_sub_minion
@@ -2,6 +2,7 @@ id: mm-sub-minion
 master:
   - localhost:64506
   - localhost:64508
+master_alive_interval: 1
 master_return_strategy: any
 return_retry_timer: 1
 return_retry_timer_max: 0

--- a/tests/integration/files/conf/mm_sub_minion
+++ b/tests/integration/files/conf/mm_sub_minion
@@ -2,3 +2,6 @@ id: mm-sub-minion
 master:
   - localhost:64506
   - localhost:64508
+master_return_strategy: any
+return_retry_timer: 1
+return_retry_timer_max: 0

--- a/tests/multimaster/minion/test_event.py
+++ b/tests/multimaster/minion/test_event.py
@@ -2,13 +2,13 @@
 
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
+import time
 
 # Import Salt Testing libs
 from tests.support.case import MultimasterModuleCase, MultiMasterTestShellCase
 from tests.support.helpers import skip_if_not_root, destructiveTest
 from tests.support.mixins import AdaptedConfigurationTestCaseMixin
 from tests.support.unit import skipIf
-import time
 
 import salt.modules.iptables
 HAS_IPTABLES = salt.modules.iptables.__virtual__()
@@ -124,7 +124,7 @@ class TestHandleEvents(MultimasterModuleCase, MultiMasterTestShellCase, AdaptedC
         # THEN the result from mm-sub-minion with master_return_strategy of any will arrive on
         # mm-master whereas the result from mm-minion with master_return_strategy of source will
         # not
-        tag='salt/job/{0}/ret/mm-sub-minion'.format(return_any_jid)
+        tag = 'salt/job/{0}/ret/mm-sub-minion'.format(return_any_jid)
         try:
             ret_event = self.wait_for_event(
                 self.mm_master_opts,

--- a/tests/support/case.py
+++ b/tests/support/case.py
@@ -753,7 +753,6 @@ class ModuleCase(TestCase, SaltClientTestCaseMixin):
                     break
 
     def wait_for_event(self, opts, wait=5, tag=''):
-        import salt.config
         import salt.utils.event
 
         event = salt.utils.event.get_event('master', sock_dir=opts['sock_dir'], opts=opts)
@@ -767,7 +766,7 @@ class ModuleCase(TestCase, SaltClientTestCaseMixin):
         '''
         return self.run_function(_function, args, **kw)
 
-    def run_function(self, function, arg=(), minion_tgt='minion', timeout=300, master_tgt=None, **kwargs):
+    def run_function(self, function, arg=(), minion_tgt='minion', timeout=300, master_tgt=None, asynchronous=False, **kwargs):
         '''
         Run a single salt function and condition the return down to match the
         behavior of the raw function call

--- a/tests/support/case.py
+++ b/tests/support/case.py
@@ -786,11 +786,17 @@ class ModuleCase(TestCase, SaltClientTestCaseMixin):
         if 'f_timeout' in kwargs:
             kwargs['timeout'] = kwargs.pop('f_timeout')
         client = self.client if master_tgt is None else self.clients[master_tgt]
-        orig = client.cmd(minion_tgt,
-                          function,
-                          arg,
-                          timeout=timeout,
-                          kwarg=kwargs)
+        if asynchronous:
+            orig = client.cmd_async(minion_tgt,
+                                    function,
+                                    arg,
+                                    kwarg=kwargs)
+        else:
+            orig = client.cmd(minion_tgt,
+                              function,
+                              arg,
+                              timeout=timeout,
+                              kwarg=kwargs)
 
         if RUNTIME_VARS.PYTEST_SESSION:
             fail_or_skip_func = self.fail


### PR DESCRIPTION
### What does this PR do?

This PR introduces a new minion configuration option, master_return_strategy. Can be source or any. The default of source preserves the current behavior, namely, the minion will only attempt to return the job results to the master that sent the job. If set to any, then the minion will first attempt to return the job results to the master that sent the job. If that fails then the minion will attempt to return the job results to the other configured masters, one by one, until successful or the master list has been exhausted. master_alive_interval must also be set. This is used to keep track of which masters are currently connected.

### What issues does this PR fix or reference?

### Previous Behavior

When a master becomes unavailable after sending a job but before receiving the return information, that return info will never make it back to the masters. If relying on master_job_cache or event_returns on the master side then the job return information is lost forever.

### New Behavior

When the initiating master becomes unavailable after firing a job to a minion then the minion will attempt to return the job information to another configured master.

### Tests written?

Not yet

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
