### PR TITLE
Return only targeted minion in cache.pillar runner when using tgt

### DIFF
--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -80,7 +80,8 @@ def pillar(tgt=None, tgt_type='glob', **kwargs):
         The ``expr_form`` argument has been renamed to ``tgt_type``, earlier
         releases must use ``expr_form``.
 
-    Return cached pillars of the targeted minions
+    Return cached pillars of the targeted minions if tgt is set.
+    If tgt is not set will return cached pillars for all minions.
 
     CLI Example:
 

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -352,6 +352,8 @@ class MasterPillarUtil(object):
         minion_pillars = {}
         minion_grains = {}
         minion_ids = self._tgt_to_list()
+        if self.tgt and not minion_ids:
+            return {}
         if any(arg for arg in [self.use_cached_grains, self.use_cached_pillar, self.grains_fallback, self.pillar_fallback]):
             log.debug('Getting cached minion data')
             cached_minion_grains, cached_minion_pillars = self._get_cached_minion_data(*minion_ids)

--- a/tests/integration/runners/test_cache.py
+++ b/tests/integration/runners/test_cache.py
@@ -72,7 +72,46 @@ class ManageTest(ShellCase):
             tgt='minion'
         )
 
-        self.assertIn('minion', ret['return'])
+        assert 'minion' in ret['return']
+        assert 'sub_minion' not in ret['return']
+
+    def test_pillar_no_tgt(self):
+        '''
+        Test cache.pillar when no tgt is
+        supplied. This should return pillar
+        data for all minions
+        '''
+        # Store the data
+        ret = self.run_run_plus(
+            'cache.pillar',
+        )
+
+        assert all(x in ret['return'] for x in ['minion', 'sub_minion'])
+
+    def test_pillar_minion_noexist(self):
+        '''
+        Test cache.pillar when the target does not exist
+        '''
+        ret = self.run_run_plus(
+            'cache.pillar',
+            tgt='doesnotexist'
+        )
+
+        assert 'minion' not in ret['return']
+        assert 'sub_minion' not in ret['return']
+
+    def test_pillar_minion_tgt_type_pillar(self):
+        '''
+        Test cache.pillar when the target exists
+        and tgt_type is pillar
+        '''
+        ret = self.run_run_plus(
+            'cache.pillar',
+            tgt='monty:python',
+            tgt_type='pillar',
+        )
+
+        assert all(x in ret['return'] for x in ['minion', 'sub_minion'])
 
     def test_mine(self):
         '''

--- a/tests/unit/utils/test_master.py
+++ b/tests/unit/utils/test_master.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+
+# Import python libs
+from __future__ import absolute_import, unicode_literals
+
+# Import Salt Libs
+import salt.utils.master
+
+# Import Salt Testing Libs
+from tests.support.unit import TestCase
+from tests.support.mock import patch
+
+
+class MasterPillarUtilTestCase(TestCase):
+    '''
+    TestCase for salt.utils.master.MasterPillarUtil methods
+    '''
+    def test_get_minion_pillar(self):
+        '''
+        test get_minion_pillar when
+        target exists
+        '''
+        opts = {'test': False}
+        minion = 'minion'
+        pillar = salt.utils.master.MasterPillarUtil(tgt=minion,
+                                                    tgt_type='glob',
+                                                    opts=opts)
+        grains_data = {minion: {'domain': ''}}
+        pillar_data = {minion: {'test_pillar': 'foo'}}
+
+        patch_grain = patch('salt.utils.master.MasterPillarUtil._get_minion_grains',
+                            return_value=grains_data)
+        patch_pillar = patch('salt.utils.master.MasterPillarUtil._get_minion_pillar',
+                             return_value=pillar_data)
+        patch_tgt_list = patch('salt.utils.master.MasterPillarUtil._tgt_to_list',
+                               return_value=[minion])
+
+        with patch_grain, patch_pillar, patch_tgt_list:
+            ret = pillar.get_minion_pillar()
+        assert ret[minion] == pillar_data[minion]
+
+    def test_get_minion_pillar_doesnotexist(self):
+        '''
+        test get_minion_pillar when
+        target does not exist
+        '''
+        opts = {'test': False}
+        minion = 'minion'
+        pillar = salt.utils.master.MasterPillarUtil(tgt='doesnotexist',
+                                                    tgt_type='glob',
+                                                    opts=opts)
+        grains_data = {minion: {'domain': ''}}
+        pillar_data = {minion: {'test_pillar': 'foo'}}
+
+        patch_grain = patch('salt.utils.master.MasterPillarUtil._get_minion_grains',
+                            return_value=grains_data)
+        patch_pillar = patch('salt.utils.master.MasterPillarUtil._get_minion_pillar',
+                             return_value=pillar_data)
+        patch_tgt_list = patch('salt.utils.master.MasterPillarUtil._tgt_to_list',
+                               return_value=[])
+
+        with patch_grain, patch_pillar, patch_tgt_list:
+            ret = pillar.get_minion_pillar()
+        assert minion not in ret
+
+    def test_get_minion_pillar_notgt(self):
+        '''
+        test get_minion_pillar when
+        passing target None
+        '''
+        opts = {'test': False}
+        minion = 'minion'
+        pillar = salt.utils.master.MasterPillarUtil(tgt=None,
+                                                    tgt_type='glob',
+                                                    opts=opts)
+        grains_data = {minion: {'domain': ''}}
+        pillar_data = {minion: {'test_pillar': 'foo'}}
+
+        patch_grain = patch('salt.utils.master.MasterPillarUtil._get_minion_grains',
+                            return_value=grains_data)
+        patch_pillar = patch('salt.utils.master.MasterPillarUtil._get_minion_pillar',
+                             return_value=pillar_data)
+        patch_tgt_list = patch('salt.utils.master.MasterPillarUtil._tgt_to_list',
+                               return_value=[])
+
+        with patch_grain, patch_pillar, patch_tgt_list:
+            ret = pillar.get_minion_pillar()
+        assert minion in ret


### PR DESCRIPTION
### What does this PR do?
Only return cached pillar data for minion that is passed with `tgt`.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/53039

### Previous Behavior
If you run `salt-run --out=json cache.pillar tgt='doesnotexist'` with a target that does not exist it still returns all the cached pilllar data for ALL minions. 

### New Behavior
If you run `salt-run --out=json cache.pillar tgt='doesnotexist'` with a target that does not exist will not return anything.

Also as you can see I updated the docs to state: `If tgt is not set will return cached pillars for all minions.` The reason I did this is this is the current behavior that a user can run `cache.pillar` without a tgt set and all pillar data would be returned,and the other reason is `tgt` is an not required as its currently a kwarg. For these reasons I kept this behavior as its expected. If we want to eventually require the `tgt` argument for some reason then we would need to set it on a deprecation path, but I believe this change is best path for now.


### Tests written?
Yes

### Commits signed with GPG?

Yes