### PR TITLE
Added dnf support on Centos > 7 #55898

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -148,7 +148,7 @@ def _yum():
            and int(__grains__['osrelease']) >= 22):
             __context__[contextkey] = 'dnf'
         elif ('centos' in __grains__['os'].lower()
-           and int(float(__grains__['osrelease'])) > 7):
+           and int(__grains__['osrelease'].split('.')[0]) > 7):
             __context__[contextkey] = 'dnf'
         else:
             __context__[contextkey] = 'yum'

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -147,6 +147,9 @@ def _yum():
         if ('fedora' in __grains__['os'].lower()
            and int(__grains__['osrelease']) >= 22):
             __context__[contextkey] = 'dnf'
+        elif ('centos' in __grains__['os'].lower()
+           and int(__grains__['osrelease']) > 7):
+            __context__[contextkey] = 'dnf'
         else:
             __context__[contextkey] = 'yum'
     return __context__[contextkey]

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -148,7 +148,7 @@ def _yum():
            and int(__grains__['osrelease']) >= 22):
             __context__[contextkey] = 'dnf'
         elif ('centos' in __grains__['os'].lower()
-           and int(__grains__['osrelease']) > 7):
+           and int(float(__grains__['osrelease'])) > 7):
             __context__[contextkey] = 'dnf'
         else:
             __context__[contextkey] = 'yum'


### PR DESCRIPTION
### What does this PR do?

Enables dnf support for CentOS 8 systems.

### What issues does this PR fix or reference?

Fixes #55898 

### Previous Behavior

If you tried to use pkg.installed this error appears:
```
          ID: timezone
    Function: pkg.installed
      Result: False
     Comment: Error occurred installing package(s). Additional info follows:

              errors:
                  - Failed to find executable yum: No such file or directory
```

### Tests written?

No

### Commits signed with GPG?

Yes
