### PR TITLE
salt/runner: respect `--timeout` argument when using `eauth`

### DIFF
--- a/salt/runner.py
+++ b/salt/runner.py
@@ -292,7 +292,7 @@ class Runner(RunnerClient):
                     print(f"jid: {self.jid}")
 
                 if self.opts.get("eauth"):
-                    ret = self.cmd_sync(low)
+                    ret = self.cmd_sync(low, timeout=self.opts.get("timeout"))
                     if isinstance(ret, dict) and set(ret) == {"data", "outputter"}:
                         outputter = ret["outputter"]
                         ret = ret["data"]


### PR DESCRIPTION
When using external authentication, the `--timeout` argument for `salt-run` had no effect.

### What does this PR do?
It makes the `--timeout` argument for `salt-run` work once again in setups using external authentication.

### What issues does this PR fix or reference?
None

### Previous Behavior
Specifying `--timeout` on the CLI when using `salt-run` had no effect at all.

### New Behavior
`--timeout` is now respected again

### Tests written?
Yes

### Commits signed with GPG?
Yes