### PR TITLE
Fixing State 'apache_module' __virtual__ returned False.

### DIFF
--- a/salt/modules/suse_apache.py
+++ b/salt/modules/suse_apache.py
@@ -23,7 +23,7 @@ def __virtual__():
     '''
     Only load the module if apache is installed.
     '''
-    if salt.utils.path.which('apache2ctl') and __grains__['os_family'] == 'SUSE':
+    if salt.utils.path.which('apache2ctl') and __grains__['os_family'] == 'Suse':
         return __virtualname__
     return (False, 'apache execution module not loaded: apache not installed.')
 


### PR DESCRIPTION
#46946
#26284
#19090
#14045

### What does this PR do?
It fixes "State 'apache_module.enable' was not found in SLS. Reason: 'apache_module' \_\_virtual\_\_ returned False." error that appears on SLES systems when using apache_module.enable. There is a typo: os_family grain is "Suse" but not "SUSE" on at least SLES12 and SLES15.

### What issues does this PR fix or reference?
For sure: #46946
Probably (wasn't tested): #26284, #19090, #14045


### Tests written?
No

### Commits signed with GPG?
No
