### PR TITLE
Make the Salt Proxy environment aware

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -3669,6 +3669,6 @@ class SProxyMinion(SMinion):
         self.opts['grains'] = salt.loader.grains(self.opts, proxy=self.proxy)
 
         #  Sync the grains here so the proxy can communicate them to the master
-        self.functions['saltutil.sync_grains'](saltenv='base')
+        self.functions['saltutil.sync_grains'](saltenv=self.opts['saltenv'])
         self.grains_cache = self.opts['grains']
         self.ready = True


### PR DESCRIPTION
The Salt proxy minion is looking for proxy minion modules in
salt://_proxy/. It does so however only in the default "base"
environment. On setups which do not use "base" or shall be executed in a
different environment this breaks:

/etc/salt/master:
...
file_roots:
  noc:
    - /srv/salt
...

$ grep "proxyenabled" /srv/salt/_proxy/junos_manager.py
__proxyenabled__ = ['junos_manager']

$ salt-proxy --proxyid=dev1 -l debug
...
[DEBUG   ] rest_sample proxy __virtual__() called...
[INFO    ] ssh_sample proxy __virtual__() called...
[DEBUG   ] Could not LazyLoad junos_manager.grains
[DEBUG   ] Could not LazyLoad junos_manager.init
[ERROR   ] Proxymodule junos_manager is missing an init() or a
shutdown() or both. Check your proxymodule.  Salt-proxy aborted.
[WARNING ] Stopping the Salt Proxy Minion
[ERROR   ] -1
[INFO    ] The proxy minion is shutting down..
[INFO    ] The Salt ProxyMinion is shut down

This is because the loader only looks for _proxy modules in the "base"
environment. This commit fixes this (but might possibly break other
things, though I did not find side-effects)

The initial pull request https://github.com/saltstack/salt/pull/36704 were merged quite some time ago, but one part of it is missing in the 2019.2 release (again?).