### PR TITLE
Skip test_drift_detector if required test file is missing

### DIFF
--- a/tests/unit/test_zypp_plugins.py
+++ b/tests/unit/test_zypp_plugins.py
@@ -36,6 +36,8 @@ class ZyppPluginsTestCase(TestCase):
     '''
     Test shipped libzypp plugins.
     '''
+    @skipIf(not os.path.exists(ZYPPNOTIFY_FILE),
+            'Required file {} does not exist.'.format(ZYPPNOTIFY_FILE))
     def test_drift_detector(self):
         '''
         Test drift detector for a correct cookie file.


### PR DESCRIPTION
The release tarball does not contain the file
`scripts/suse/zypper/plugins/commit/zyppnotify`. Therefore skip
`ZyppPluginsTestCase.test_drift_detector`, because it will fail
otherwise:

```
ERROR: test_drift_detector (unit.test_zypp_plugins.ZyppPluginsTestCase)
[CPU:0.0%|MEM:5.5%]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/unit/test_zypp_plugins.py", line 45, in test_drift_detector
    zyppnotify = imp.load_source('zyppnotify', ZYPPNOTIFY_FILE)
  File "/usr/lib/python3.7/imp.py", line 171, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 696, in _load
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 724, in exec_module
  File "<frozen importlib._bootstrap_external>", line 859, in get_code
  File "/usr/lib/python3.7/imp.py", line 157, in get_data
    return super().get_data(path)
  File "<frozen importlib._bootstrap_external>", line 916, in get_data
FileNotFoundError: [Errno 2] No such file or directory: 'scripts/suse/zypper/plugins/commit/zyppnotify'
```