### PR TITLE
Update version.py for new versioning scheme

### DIFF
--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -388,6 +388,7 @@ execution modules
     s3
     s6
     salt_proxy
+    salt_version
     saltcheck
     saltcloudmod
     saltutil

--- a/doc/ref/modules/all/salt.modules.salt_version.rst
+++ b/doc/ref/modules/all/salt.modules.salt_version.rst
@@ -1,0 +1,6 @@
+=========================
+salt.modules.salt_version
+=========================
+
+.. automodule:: salt.modules.salt_version
+    :members:

--- a/doc/topics/releases/3000.rst
+++ b/doc/topics/releases/3000.rst
@@ -5,6 +5,21 @@
 Salt 3000 Release Notes - Codename Neon
 =======================================
 
+New Versioning
+==============
+The neon release has removed the date versioning. Going forward we will
+use a non-date based version schema beginning at 3000. The version will
+be MAJOR.PATCH. For a planned release containing features and/or bug fixes
+the MAJOR version will be incremented. Please review the approved
+`SEP <https://github.com/saltstack/salt-enhancement-proposals/pull/20>`_
+for further details.
+
+The new versioning scheme is PEP 440 compliant, but distutils.StrictVersion
+will result in an error ``invalid version number``. If using StrictVersion to
+compare Salt's versions, please use LooseVersion. There is also the packaging
+library you can use to compare versions. Another alternative is using the
+:py:func:`salt version module<salt.modules.salt_version>`
+
 Saltcheck Updates
 =================
 

--- a/salt/modules/glance.py
+++ b/salt/modules/glance.py
@@ -51,12 +51,6 @@ from salt.version import (
 
 from salt.ext import six
 
-# is there not SaltStackVersion.current() to get
-# the version of the salt running this code??
-_version_ary = __version__.split('.')
-CUR_VER = SaltStackVersion(_version_ary[0], _version_ary[1])
-BORON = SaltStackVersion.from_name('Boron')
-
 # pylint: disable=import-error
 HAS_GLANCE = False
 try:
@@ -399,7 +393,7 @@ def image_list(id=None, profile=None, name=None):  # pylint: disable=C0103
                 _add_image(ret, image)
                 return ret
             if name == image.name:
-                if name in ret and CUR_VER < BORON:
+                if name in ret and __salt__['salt_version.less_than']('Boron'):
                     # Not really worth an exception
                     return {
                         'result': False,

--- a/salt/modules/glance.py
+++ b/salt/modules/glance.py
@@ -43,12 +43,6 @@ import re
 from salt.exceptions import (
     SaltInvocationError
     )
-
-from salt.version import (
-    __version__,
-    SaltStackVersion
-    )
-
 from salt.ext import six
 
 # pylint: disable=import-error

--- a/salt/modules/salt_version.py
+++ b/salt/modules/salt_version.py
@@ -78,10 +78,14 @@ def get_release_number(name):
         log.info('Version {} not found.'.format(name))
         return None
 
-    if version[1] == 0:
-        log.info('Version {} found, but no release number has been assigned '
-                 'yet.'.format(name))
-        return 'No version assigned.'
+    try:
+        if version[1] == 0:
+            log.info('Version {} found, but no release number has been assigned '
+                     'yet.'.format(name))
+            return 'No version assigned.'
+    except IndexError:
+        # The new versioning scheme does not include minor version
+        pass
 
     return '.'.join(str(item) for item in version)
 

--- a/salt/version.py
+++ b/salt/version.py
@@ -33,6 +33,7 @@ if sys.version_info[0] == 3:
 else:
     MAX_SIZE = sys.maxint
     string_types = (six.string_types,)
+VERSION_LIMIT = MAX_SIZE - 200
 # pylint: enable=invalid-name,redefined-builtin
 
 # ----- ATTENTION --------------------------------------------------------------------------------------------------->
@@ -69,7 +70,7 @@ class SaltStackVersion(object):
 
     git_describe_regex = re.compile(
         r'(?:[^\d]+)?(?P<major>[\d]{1,4})'
-        r'\.(?P<minor>[\d]{1,2})'
+        r'(?:\.(?P<minor>[\d]{1,2}))?'
         r'(?:\.(?P<bugfix>[\d]{0,2}))?'
         r'(?:\.(?P<mbugfix>[\d]{0,2}))?'
         r'(?:(?P<pre_type>rc|a|b|alpha|beta|nb)(?P<pre_num>[\d]{1}))?'
@@ -105,7 +106,7 @@ class SaltStackVersion(object):
         'Nitrogen'      : (2017, 7),
         'Oxygen'        : (2018, 3),
         'Fluorine'      : (2019, 2),
-        'Neon'          : (3000, 0),
+        'Neon'          : (3000,),
         'Sodium'        : (MAX_SIZE - 98, 0),
         'Magnesium'     : (MAX_SIZE - 97, 0),
         'Aluminium'     : (MAX_SIZE - 96, 0),
@@ -216,8 +217,8 @@ class SaltStackVersion(object):
 
     def __init__(self,              # pylint: disable=C0103
                  major,
-                 minor,
-                 bugfix=0,
+                 minor=None,
+                 bugfix=None,
                  mbugfix=0,
                  pre_type=None,
                  pre_num=None,
@@ -230,7 +231,7 @@ class SaltStackVersion(object):
         if isinstance(minor, string_types):
             minor = int(minor)
 
-        if bugfix is None:
+        if bugfix is None and not self.new_version(major=major):
             bugfix = 0
         elif isinstance(bugfix, string_types):
             bugfix = int(bugfix)
@@ -264,6 +265,12 @@ class SaltStackVersion(object):
         self.noc = noc
         self.sha = sha
 
+    def new_version(self, major):
+        '''
+        determine if using new versioning scheme
+        '''
+        return bool(int(major) >= 3000 and int(major) < VERSION_LIMIT)
+
     @classmethod
     def parse(cls, version_string):
         if version_string.lower() in cls.LNAMES:
@@ -290,7 +297,7 @@ class SaltStackVersion(object):
             cls.VNAMES[
                 max([version_info for version_info in
                      cls.VNAMES if
-                     version_info[0] < (MAX_SIZE - 200)])
+                     version_info[0] < (VERSION_LIMIT)])
             ]
         )
 
@@ -356,11 +363,16 @@ class SaltStackVersion(object):
 
     @property
     def string(self):
-        version_string = '{0}.{1}.{2}'.format(
-            self.major,
-            self.minor,
-            self.bugfix
-        )
+        if self.new_version(self.major):
+            version_string = '{0}'.format(self.major)
+            if self.minor:
+                version_string = '{0}.{1}'.format(self.major, self.minor)
+        else:
+            version_string = '{0}.{1}.{2}'.format(
+                self.major,
+                self.minor,
+                self.bugfix
+            )
         if self.mbugfix:
             version_string += '.{0}'.format(self.mbugfix)
         if self.pre_type:
@@ -403,21 +415,25 @@ class SaltStackVersion(object):
                     )
                 )
 
-        if (self.pre_type and other.pre_type) or (not self.pre_type and not other.pre_type):
-            # Both either have or don't have pre-release information, regular compare is ok
-            return method(self.noc_info, other.noc_info)
+        other_noc_info = list(other.noc_info)
+        noc_info = list(self.noc_info)
+
+        if self.new_version(self.major):
+            if isinstance(self.minor, int) and not isinstance(other.minor, int):
+                other_noc_info[1] = 0
+
+            if not isinstance(self.minor, int) and isinstance(other.minor, int):
+                noc_info[1] = 0
 
         if self.pre_type and not other.pre_type:
             # We have pre-release information, the other side doesn't
-            other_noc_info = list(other.noc_info)
             other_noc_info[4] = 'zzzzz'
-            return method(self.noc_info, tuple(other_noc_info))
 
         if not self.pre_type and other.pre_type:
             # The other side has pre-release informatio, we don't
-            noc_info = list(self.noc_info)
             noc_info[4] = 'zzzzz'
-            return method(tuple(noc_info), other.noc_info)
+
+        return method(tuple(noc_info), tuple(other_noc_info))
 
     def __lt__(self, other):
         return self.__compare__(other, lambda _self, _other: _self < _other)

--- a/tests/unit/modules/test_glance.py
+++ b/tests/unit/modules/test_glance.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+# Import Python libs
+from __future__ import absolute_import, unicode_literals, print_function
+
+# Import Salt Testing libs
+from tests.support.unit import TestCase
+from tests.support.mock import MagicMock, patch
+from tests.support.mixins import LoaderModuleMockMixin
+
+# Import Salt libs
+import salt.modules.glance as glance
+import salt.modules.salt_version
+
+
+class GlanceTestCase(TestCase, LoaderModuleMockMixin):
+    def setup_loader_modules(self):
+        return {glance:
+                {'__salt__': {'salt_version.less_than':
+                    salt.modules.salt_version.less_than}},
+                }
+
+    def test_image_list(self):
+        '''
+        test salt.modles.glance
+        '''
+        name = 'test'
+        image = MagicMock()
+        image.name = name
+        attrs = {'images.list.return_value': [image], }
+        mock_auth = MagicMock(**attrs)
+        patch_auth = patch('salt.modules.glance._auth', return_value=mock_auth)
+
+        with patch_auth:
+            ret = glance.image_list(id='test_id', name=name)
+            assert ret[0]['name'] == name

--- a/tests/unit/modules/test_salt_version.py
+++ b/tests/unit/modules/test_salt_version.py
@@ -29,12 +29,16 @@ class SaltVersionTestCase(TestCase):
         salt.version.SaltStackVersion.LNAMES dict using upper-case indexes
         '''
         assert isinstance(salt.version.SaltStackVersion.LNAMES, dict)
+        sv = salt.version.SaltStackVersion(*salt.version.__version_info__)
         for k, v in salt.version.SaltStackVersion.LNAMES.items():
             assert k == k.lower()
             assert isinstance(v, tuple)
-            assert len(v) == 2
+            if sv.new_version(major=v[0]):
+                assert len(v) == 1
+            else:
+                assert len(v) == 2
 
-        sv = salt.version.SaltStackVersion(*salt.version.__version_info__).__str__()
+        sv = sv.__str__()
         assert isinstance(sv, six.string_types)
 
         with patch('salt.version.SaltStackVersion.LNAMES', {'neon': (2019, 8)}):
@@ -63,6 +67,12 @@ class SaltVersionTestCase(TestCase):
         '''
         assert salt_version.get_release_number('Oxygen') == '2018.3'
 
+    def test_get_release_number_success_new_version(self):
+        '''
+        Test that a version is returned for new versioning (3000)
+        '''
+        assert salt_version.get_release_number('Neon') == '3000'
+
     # equal tests: 3
 
     @patch('salt.version.SaltStackVersion.LNAMES', {'foo': (1900, 5)})
@@ -73,12 +83,31 @@ class SaltVersionTestCase(TestCase):
         '''
         assert salt_version.equal('foo') is True
 
+    @patch('salt.version.SaltStackVersion.LNAMES', {'foo': (3000, )})
+    @patch('salt.version.SaltStackVersion', MagicMock(return_value='3000.1'))
+    def test_equal_success_new_version(self):
+        '''
+        Test that the current version is equal to the codename
+        while using the new versioning
+        '''
+        assert salt_version.equal('foo') is True
+
     @patch('salt.version.SaltStackVersion.LNAMES', {'oxygen': (2018, 3),
                                                     'nitrogen': (2017, 7)})
     @patch('salt.version.SaltStackVersion', MagicMock(return_value='2018.3.2'))
     def test_equal_older_codename(self):
         '''
         Test that when an older codename is passed in, the function returns False.
+        '''
+        assert salt_version.equal('Nitrogen') is False
+
+    @patch('salt.version.SaltStackVersion.LNAMES', {'neon': (3000),
+                                                    'nitrogen': (2017, 7)})
+    @patch('salt.version.SaltStackVersion', MagicMock(return_value='2018.3.2'))
+    def test_equal_older_codename_new_version(self):
+        '''
+        Test that when an older codename is passed in, the function returns False.
+        while also testing with the new versioning.
         '''
         assert salt_version.equal('Nitrogen') is False
 
@@ -95,6 +124,14 @@ class SaltVersionTestCase(TestCase):
     @patch('salt.modules.salt_version.get_release_number', MagicMock(return_value='2017.7'))
     @patch('salt.version.SaltStackVersion', MagicMock(return_value='2018.3.2'))
     def test_greater_than_success(self):
+        '''
+        Test that the current version is newer than the codename
+        '''
+        assert salt_version.greater_than('Nitrogen') is True
+
+    @patch('salt.modules.salt_version.get_release_number', MagicMock(return_value='2017.7'))
+    @patch('salt.version.SaltStackVersion', MagicMock(return_value='3000'))
+    def test_greater_than_success_new_version(self):
         '''
         Test that the current version is newer than the codename
         '''
@@ -132,6 +169,15 @@ class SaltVersionTestCase(TestCase):
     def test_less_than_success(self):
         '''
         Test that when a newer codename is passed in, the function returns True.
+        '''
+        assert salt_version.less_than('Fluorine') is True
+
+    @patch('salt.modules.salt_version.get_release_number', MagicMock(return_value='3000'))
+    @patch('salt.version.SaltStackVersion', MagicMock(return_value='2018.3.2'))
+    def test_less_than_success_new_version(self):
+        '''
+        Test that when a newer codename is passed in, the function returns True
+        using new version
         '''
         assert salt_version.less_than('Fluorine') is True
 

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -175,7 +175,8 @@ class VersionTestCase(TestCase):
                          'returncode.return_value': 0}
                 proc_ret = MagicMock(**attrs)
                 proc_mock = patch('subprocess.Popen', return_value=proc_ret)
+                patch_os = patch('os.path.exists', return_value=True)
 
-                with proc_mock:
+                with proc_mock, patch_os:
                     ret = getattr(salt.version, '__discover_version')(salt_ver)
                 assert ret == exp

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -33,9 +33,10 @@ class VersionTestCase(TestCase):
             ('0.17.0rc1', (0, 17, 0, 0, 'rc', 1, 0, None), None),
             ('v0.17.0rc1-1-g52ebdfd', (0, 17, 0, 0, 'rc', 1, 1, 'g52ebdfd'), None),
             ('v2014.1.4.1', (2014, 1, 4, 1, '', 0, 0, None), None),
-            ('v2014.1.4.1rc3-n/a-abcdefgh', (2014, 1, 4, 1, 'rc', 3, -1, 'abcdefgh'), None),
+            ('v2014.1.4.1rc3-n/a-abcdefff', (2014, 1, 4, 1, 'rc', 3, -1, 'abcdefff'), None),
             ('v3.4.1.1', (3, 4, 1, 1, '', 0, 0, None), None),
-            ('v3000', (3000, None, None, 0, '', 0, 0, None), None)
+            ('v3000', (3000, None, None, 0, '', 0, 0, None), '3000'),
+            ('v3000rc1', (3000, None, None, 0, 'rc', 1, 0, None), '3000rc1'),
 
         )
 
@@ -56,8 +57,8 @@ class VersionTestCase(TestCase):
             ('v0.17.0', 'v0.17.0rc1'),
             ('Hydrogen', '0.17.0'),
             ('Helium', 'Hydrogen'),
-            ('v2014.1.4.1-n/a-abcdefgh', 'v2014.1.4.1rc3-n/a-abcdefgh'),
-            ('v2014.1.4.1-1-abcdefgh', 'v2014.1.4.1-n/a-abcdefgh'),
+            ('v2014.1.4.1-n/a-abcdefff', 'v2014.1.4.1rc3-n/a-abcdefff'),
+            ('v2014.1.4.1-1-abcdefff', 'v2014.1.4.1-n/a-abcdefff'),
             ('v2016.12.0rc1', 'v2016.12.0b1'),
             ('v2016.12.0beta1', 'v2016.12.0alpha1'),
             ('v2016.12.0alpha1', 'v2016.12.0alpha0'),
@@ -85,6 +86,23 @@ class VersionTestCase(TestCase):
 
         with self.assertRaises(ValueError):
             SaltStackVersion.parse('Drunk')
+
+    def test_sha(self):
+        '''
+        test matching sha's
+        '''
+        exp_ret = (
+            ('d6cd1e2bd19e03a81132a23b2025920577f84e37', True),
+            ('2880105', True),
+            ('v3000.0.1', False),
+            ('v0.12.0-85-g2880105', False)
+        )
+        for commit, exp in exp_ret:
+            ret = SaltStackVersion.git_sha_regex.match(commit)
+            if exp:
+                assert ret
+            else:
+                assert not ret
 
     def test_version_report_lines(self):
         '''


### PR DESCRIPTION
### What does this PR do?
Updates `version.py` to work with new versioning scheme -> `v3000`, `v3000.1` etc.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/55896 

### Previous Behavior
Would only work with date versioning (Major, Minor, Bugfix)

### New Behavior
Now works with both date versioning and new versioning (3000, 3000.1, etc)

### Tests written?
Yes

### Commits signed with GPG?

Yes