### PR TITLE
Improve dpkg_lowpkg

### DIFF
--- a/salt/modules/dpkg_lowpkg.py
+++ b/salt/modules/dpkg_lowpkg.py
@@ -202,11 +202,8 @@ def file_list(*packages):
         if 'No packages found' in line:
             errors.append(line)
     for pkg in pkgs:
-        files = []
-        cmd = 'dpkg -L {0}'.format(pkg)
-        for line in __salt__['cmd.run'](cmd, python_shell=False).splitlines():
-            files.append(line)
-        fileset = set(files)
+        output = __salt__["cmd.run"](["dpkg", "-L", pkg], python_shell=False)
+        fileset = set(output.splitlines())
         ret = ret.union(fileset)
     return {'errors': errors, 'files': list(ret)}
 
@@ -244,11 +241,8 @@ def file_dict(*packages):
         if 'No packages found' in line:
             errors.append(line)
     for pkg in pkgs:
-        files = []
-        cmd = 'dpkg -L {0}'.format(pkg)
-        for line in __salt__['cmd.run'](cmd, python_shell=False).splitlines():
-            files.append(line)
-        ret[pkg] = files
+        cmd = ["dpkg", "-L", pkg]
+        ret[pkg] = __salt__["cmd.run"](cmd, python_shell=False).splitlines()
     return {'errors': errors, 'packages': ret}
 
 

--- a/salt/modules/dpkg_lowpkg.py
+++ b/salt/modules/dpkg_lowpkg.py
@@ -153,19 +153,20 @@ def list_pkgs(*packages):
         salt '*' lowpkg.list_pkgs
         salt '*' lowpkg.list_pkgs httpd
     '''
-    pkgs = {}
-    cmd = 'dpkg -l {0}'.format(' '.join(packages))
+    cmd = [
+        "dpkg-query",
+        "-f=${db:Status-Status}\t${binary:Package}\t${Version}\n",
+        "-W",
+    ] + list(packages)
     out = __salt__['cmd.run_all'](cmd, python_shell=False)
     if out['retcode'] != 0:
         msg = 'Error:  ' + out['stderr']
         log.error(msg)
         return msg
-    out = out['stdout']
 
-    for line in out.splitlines():
-        if line.startswith('ii '):
-            comps = line.split()
-            pkgs[comps[1]] = comps[2]
+    lines = [line.split("\t", 1) for line in out["stdout"].splitlines()]
+    pkgs = dict([line.split("\t") for status, line in lines if status == "installed"])
+
     return pkgs
 
 
@@ -185,22 +186,16 @@ def file_list(*packages):
     '''
     errors = []
     ret = set([])
-    pkgs = {}
-    cmd = 'dpkg -l {0}'.format(' '.join(packages))
+    cmd = ["dpkg-query", "-f=${db:Status-Status}\t${binary:Package}\n", "-W"] + list(packages)
     out = __salt__['cmd.run_all'](cmd, python_shell=False)
     if out['retcode'] != 0:
         msg = 'Error:  ' + out['stderr']
         log.error(msg)
         return msg
-    out = out['stdout']
 
-    for line in out.splitlines():
-        if line.startswith('ii '):
-            comps = line.split()
-            pkgs[comps[1]] = {'version': comps[2],
-                              'description': ' '.join(comps[3:])}
-        if 'No packages found' in line:
-            errors.append(line)
+    lines = [line.split("\t") for line in out["stdout"].splitlines()]
+    pkgs = [package for (status, package) in lines if status == "installed"]
+
     for pkg in pkgs:
         output = __salt__["cmd.run"](["dpkg", "-L", pkg], python_shell=False)
         fileset = set(output.splitlines())
@@ -224,22 +219,16 @@ def file_dict(*packages):
     '''
     errors = []
     ret = {}
-    pkgs = {}
-    cmd = 'dpkg -l {0}'.format(' '.join(packages))
+    cmd = ["dpkg-query", "-f=${db:Status-Status}\t${binary:Package}\n", "-W"] + list(packages)
     out = __salt__['cmd.run_all'](cmd, python_shell=False)
     if out['retcode'] != 0:
         msg = 'Error:  ' + out['stderr']
         log.error(msg)
         return msg
-    out = out['stdout']
 
-    for line in out.splitlines():
-        if line.startswith('ii '):
-            comps = line.split()
-            pkgs[comps[1]] = {'version': comps[2],
-                              'description': ' '.join(comps[3:])}
-        if 'No packages found' in line:
-            errors.append(line)
+    lines = [line.split("\t") for line in out["stdout"].splitlines()]
+    pkgs = [package for (status, package) in lines if status == "installed"]
+
     for pkg in pkgs:
         cmd = ["dpkg", "-L", pkg]
         ret[pkg] = __salt__["cmd.run"](cmd, python_shell=False).splitlines()

--- a/salt/modules/dpkg_lowpkg.py
+++ b/salt/modules/dpkg_lowpkg.py
@@ -205,7 +205,7 @@ def file_list(*packages):
         output = __salt__["cmd.run"](["dpkg", "-L", pkg], python_shell=False)
         fileset = set(output.splitlines())
         ret = ret.union(fileset)
-    return {'errors': errors, 'files': list(ret)}
+    return {'errors': errors, 'files': sorted(ret)}
 
 
 def file_dict(*packages):

--- a/salt/modules/dpkg_lowpkg.py
+++ b/salt/modules/dpkg_lowpkg.py
@@ -213,9 +213,9 @@ def file_dict(*packages):
 
     .. code-block:: bash
 
-        salt '*' lowpkg.file_list httpd
-        salt '*' lowpkg.file_list httpd postfix
-        salt '*' lowpkg.file_list
+        salt '*' lowpkg.file_dict httpd
+        salt '*' lowpkg.file_dict httpd postfix
+        salt '*' lowpkg.file_dict
     '''
     errors = []
     ret = {}

--- a/salt/modules/dpkg_lowpkg.py
+++ b/salt/modules/dpkg_lowpkg.py
@@ -151,7 +151,8 @@ def list_pkgs(*packages):
     .. code-block:: bash
 
         salt '*' lowpkg.list_pkgs
-        salt '*' lowpkg.list_pkgs httpd
+        salt '*' lowpkg.list_pkgs hostname
+        salt '*' lowpkg.list_pkgs hostname mount
     '''
     cmd = [
         "dpkg-query",
@@ -180,8 +181,8 @@ def file_list(*packages):
 
     .. code-block:: bash
 
-        salt '*' lowpkg.file_list httpd
-        salt '*' lowpkg.file_list httpd postfix
+        salt '*' lowpkg.file_list hostname
+        salt '*' lowpkg.file_list hostname mount
         salt '*' lowpkg.file_list
     '''
     errors = []
@@ -213,8 +214,8 @@ def file_dict(*packages):
 
     .. code-block:: bash
 
-        salt '*' lowpkg.file_dict httpd
-        salt '*' lowpkg.file_dict httpd postfix
+        salt '*' lowpkg.file_dict hostname
+        salt '*' lowpkg.file_dict hostname mount
         salt '*' lowpkg.file_dict
     '''
     errors = []

--- a/tests/unit/modules/test_dpkg_lowpkg.py
+++ b/tests/unit/modules/test_dpkg_lowpkg.py
@@ -5,6 +5,7 @@
 
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
+import logging
 import os
 
 # Import Salt Testing Libs
@@ -19,10 +20,54 @@ from tests.support.mock import (
 import salt.modules.dpkg_lowpkg as dpkg
 
 
+DPKG_ERROR_MSG = """dpkg-query: package 'httpd' is not installed
+Use dpkg --contents (= dpkg-deb --contents) to list archive files contents.
+"""
+
+DPKG_L_OUTPUT = {
+    "hostname": """\
+/.
+/bin
+/bin/hostname
+/usr
+/usr/share
+/usr/share/doc
+/usr/share/doc/hostname
+/usr/share/doc/hostname/changelog.gz
+/usr/share/doc/hostname/copyright
+/usr/share/man
+/usr/share/man/man1
+/usr/share/man/man1/hostname.1.gz
+/bin/dnsdomainname
+/bin/domainname
+/bin/nisdomainname
+/bin/ypdomainname
+/usr/share/man/man1/dnsdomainname.1.gz
+/usr/share/man/man1/domainname.1.gz
+/usr/share/man/man1/nisdomainname.1.gz
+/usr/share/man/man1/ypdomainname.1.gz
+"""
+}
+
+
 class DpkgTestCase(TestCase, LoaderModuleMockMixin):
     '''
     Test cases for salt.modules.dpkg
     '''
+
+    def setUp(self):
+        dpkg_lowpkg_logger = logging.getLogger("salt.modules.dpkg_lowpkg")
+        self.level = dpkg_lowpkg_logger.level
+        dpkg_lowpkg_logger.setLevel(logging.FATAL)
+
+    def tearDown(self):
+        logging.getLogger("salt.modules.dpkg_lowpkg").setLevel(self.level)
+
+    def dpkg_L_side_effect(self, cmd, **kwargs):
+        self.assertEqual(cmd[:2], ["dpkg", "-L"])
+        package = cmd[2]
+        return DPKG_L_OUTPUT[package]
+
     def setup_loader_modules(self):
         return {dpkg: {}}
 
@@ -51,17 +96,26 @@ class DpkgTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test if it lists the packages currently installed
         '''
-        mock = MagicMock(return_value={'retcode': 0,
-                                       'stderr': '',
-                                       'stdout': 'Salt'})
+        mock = MagicMock(
+            return_value={
+                "retcode": 0,
+                "stderr": "",
+                "stdout": "installed\thostname\t3.21",
+            }
+        )
         with patch.dict(dpkg.__salt__, {'cmd.run_all': mock}):
-            self.assertDictEqual(dpkg.list_pkgs('httpd'), {})
+            self.assertDictEqual(dpkg.list_pkgs("hostname"), {"hostname": "3.21"})
 
-        mock = MagicMock(return_value={'retcode': 1,
-                                       'stderr': 'error',
-                                       'stdout': 'Salt'})
+        mock = MagicMock(
+            return_value={
+                "retcode": 1,
+                "stderr": "dpkg-query: no packages found matching httpd",
+                "stdout": "",
+            }
+        )
         with patch.dict(dpkg.__salt__, {'cmd.run_all': mock}):
-            self.assertEqual(dpkg.list_pkgs('httpd'), 'Error:  error')
+            self.assertEqual(dpkg.list_pkgs("httpd"),
+                             "Error:  dpkg-query: no packages found matching httpd")
 
     # 'file_list' function tests: 1
 
@@ -69,18 +123,47 @@ class DpkgTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test if it lists the files that belong to a package.
         '''
-        mock = MagicMock(return_value={'retcode': 0,
-                                       'stderr': '',
-                                       'stdout': 'Salt'})
-        with patch.dict(dpkg.__salt__, {'cmd.run_all': mock}):
-            self.assertDictEqual(dpkg.file_list('httpd'),
-                                 {'errors': [], 'files': []})
+        dpkg_query_mock = MagicMock(
+            return_value={"retcode": 0, "stderr": "", "stdout": "installed\thostname"}
+        )
+        dpkg_L_mock = MagicMock(side_effect=self.dpkg_L_side_effect)
+        with patch.dict(
+            dpkg.__salt__, {"cmd.run_all": dpkg_query_mock, "cmd.run": dpkg_L_mock}
+        ):
+            self.assertDictEqual(
+                dpkg.file_list("hostname"),
+                {
+                    "errors": [],
+                    "files": [
+                        "/.",
+                        "/bin",
+                        "/bin/dnsdomainname",
+                        "/bin/domainname",
+                        "/bin/hostname",
+                        "/bin/nisdomainname",
+                        "/bin/ypdomainname",
+                        "/usr",
+                        "/usr/share",
+                        "/usr/share/doc",
+                        "/usr/share/doc/hostname",
+                        "/usr/share/doc/hostname/changelog.gz",
+                        "/usr/share/doc/hostname/copyright",
+                        "/usr/share/man",
+                        "/usr/share/man/man1",
+                        "/usr/share/man/man1/dnsdomainname.1.gz",
+                        "/usr/share/man/man1/domainname.1.gz",
+                        "/usr/share/man/man1/hostname.1.gz",
+                        "/usr/share/man/man1/nisdomainname.1.gz",
+                        "/usr/share/man/man1/ypdomainname.1.gz",
+                    ],
+                },
+            )
 
-        mock = MagicMock(return_value={'retcode': 1,
-                                       'stderr': 'error',
-                                       'stdout': 'Salt'})
+        mock = MagicMock(
+            return_value={"retcode": 1, "stderr": DPKG_ERROR_MSG, "stdout": ""}
+        )
         with patch.dict(dpkg.__salt__, {'cmd.run_all': mock}):
-            self.assertEqual(dpkg.file_list('httpd'), 'Error:  error')
+            self.assertEqual(dpkg.file_list("httpd"), "Error:  " + DPKG_ERROR_MSG)
 
     # 'file_dict' function tests: 1
 
@@ -88,18 +171,47 @@ class DpkgTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test if it lists the files that belong to a package, grouped by package
         '''
-        mock = MagicMock(return_value={'retcode': 0,
-                                       'stderr': '',
-                                       'stdout': 'Salt'})
-        with patch.dict(dpkg.__salt__, {'cmd.run_all': mock}):
-            self.assertDictEqual(dpkg.file_dict('httpd'),
-                                 {'errors': [], 'packages': {}})
+        dpkg_query_mock = MagicMock(
+            return_value={"retcode": 0, "stderr": "", "stdout": "installed\thostname"}
+        )
+        dpkg_L_mock = MagicMock(side_effect=self.dpkg_L_side_effect)
+        with patch.dict(
+            dpkg.__salt__, {"cmd.run_all": dpkg_query_mock, "cmd.run": dpkg_L_mock}
+        ):
+            expected = {
+                "errors": [],
+                "packages": {
+                    "hostname": [
+                        "/.",
+                        "/bin",
+                        "/bin/hostname",
+                        "/usr",
+                        "/usr/share",
+                        "/usr/share/doc",
+                        "/usr/share/doc/hostname",
+                        "/usr/share/doc/hostname/changelog.gz",
+                        "/usr/share/doc/hostname/copyright",
+                        "/usr/share/man",
+                        "/usr/share/man/man1",
+                        "/usr/share/man/man1/hostname.1.gz",
+                        "/bin/dnsdomainname",
+                        "/bin/domainname",
+                        "/bin/nisdomainname",
+                        "/bin/ypdomainname",
+                        "/usr/share/man/man1/dnsdomainname.1.gz",
+                        "/usr/share/man/man1/domainname.1.gz",
+                        "/usr/share/man/man1/nisdomainname.1.gz",
+                        "/usr/share/man/man1/ypdomainname.1.gz",
+                    ]
+                },
+            }
+            self.assertDictEqual(dpkg.file_dict("hostname"), expected)
 
-        mock = MagicMock(return_value={'retcode': 1,
-                                       'stderr': 'error',
-                                       'stdout': 'Salt'})
+        mock = MagicMock(
+            return_value={"retcode": 1, "stderr": DPKG_ERROR_MSG, "stdout": ""}
+        )
         with patch.dict(dpkg.__salt__, {'cmd.run_all': mock}):
-            self.assertEqual(dpkg.file_dict('httpd'), 'Error:  error')
+            self.assertEqual(dpkg.file_dict("httpd"), "Error:  " + DPKG_ERROR_MSG)
 
     def test_info(self):
         '''


### PR DESCRIPTION
While trying to work on fixing #52605, I stumbled over some code in `dpkg_lowpkg` that could be improved. This pull requests changes the code to use `dpkg-query` for listing packages instead of `dpkg -L`, because the output is easier to parse. Also remove some useless loop iterations and improve the documentation. Please have a look at the individual commits for details.