### PR TITLE
Fix pip state regression when pip 18.0.0 is installed

### DIFF
--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -121,7 +121,7 @@ if HAS_PIP is True:
         purge_pip.__pip_ver__ = pip.__version__
     if salt.utils.versions.compare(ver1=pip.__version__,
                                    oper='>=',
-                                   ver2='18.1'):
+                                   ver2='10.0'):
         from pip._internal.exceptions import InstallationError  # pylint: disable=E0611,E0401
     elif salt.utils.versions.compare(ver1=pip.__version__,
                                      oper='>=',

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -43,6 +43,7 @@ from pytestsalt.utils import get_unused_localhost_port
 from tests.support.unit import skip, _id, SkipTest
 from tests.support.mock import patch
 from tests.support.runtests import RUNTIME_VARS
+from tests.support.sminion import create_sminion
 
 # Import Salt libs
 import salt.utils.files
@@ -1674,11 +1675,5 @@ class VirtualEnv(object):
             return sys.executable
 
     def _create_virtualenv(self):
-        subprocess.check_call(
-            [
-                sys.executable,
-                '-m', 'virtualenv',
-                '-p', self._get_real_python(),
-                self.venv_dir
-            ]
-        )
+        sminion = create_sminion()
+        sminion.functions.virtualenv.create(self.venv_dir, python=self._get_real_python())

--- a/tests/unit/states/test_pip_state.py
+++ b/tests/unit/states/test_pip_state.py
@@ -11,14 +11,19 @@
 from __future__ import absolute_import, print_function, unicode_literals
 import logging
 import sys
+import subprocess
 
 # Import Salt Testing libs
 from tests.support.mixins import LoaderModuleMockMixin, SaltReturnAssertsMixin
 from tests.support.unit import skipIf, TestCase
 from tests.support.mock import MagicMock, patch
+from tests.support.helpers import dedent, VirtualEnv
 
 # Import salt libs
+import salt.version
+import salt.utils.path
 import salt.states.pip_state as pip_state
+from salt.modules.virtualenv_mod import KNOWN_BINARY_NAMES
 
 # Import 3rd-party libs
 try:
@@ -309,3 +314,72 @@ class PipStateUtilsTest(TestCase):
         mock_modules.pop('pip', None)
         with patch('sys.modules', mock_modules):
             pip_state.purge_pip()
+
+
+@skipIf(salt.utils.path.which_bin(KNOWN_BINARY_NAMES) is None, 'virtualenv not installed')
+class PipStateInstallationErrorTest(TestCase):
+
+    def test_importable_installation_error(self):
+        extra_requirements = []
+        for name, version in salt.version.dependency_information():
+            if name in ['PyYAML']:
+                extra_requirements.append('{}=={}'.format(name, version))
+        failures = {}
+        pip_version_requirements = [
+            # Latest pip 8
+            '<9.0',
+            # Latest pip 9
+            '<10.0',
+            # Latest pip 18
+            '<19.0',
+            # Latest pip 19
+            '<20.0',
+            # Latest pip 20
+            '<21.0',
+            # Latest pip
+            None,
+        ]
+        code = dedent('''\
+        import sys
+        import traceback
+        try:
+            import salt.states.pip_state
+            salt.states.pip_state.InstallationError
+        except ImportError as exc:
+            traceback.print_exc(exc, file=sys.stdout)
+            sys.stdout.flush()
+            sys.exit(1)
+        except AttributeError as exc:
+            traceback.print_exc(exc, file=sys.stdout)
+            sys.stdout.flush()
+            sys.exit(2)
+        except Exception as exc:
+            traceback.print_exc(exc, file=sys.stdout)
+            sys.stdout.flush()
+            sys.exit(3)
+        sys.exit(0)
+        ''')
+        for requirement in list(pip_version_requirements):
+            try:
+                with VirtualEnv() as venv:
+                    venv.install(*extra_requirements)
+                    if requirement:
+                        venv.install('pip{}'.format(requirement))
+                    try:
+                        subprocess.check_output([venv.venv_python, '-c', code])
+                    except subprocess.CalledProcessError as exc:
+                        if exc.returncode == 1:
+                            failures[requirement] = 'Failed to import pip:\n{}'.format(exc.output)
+                        elif exc.returncode == 2:
+                            failures[requirement] = 'Failed to import InstallationError from pip:\n{}'.format(exc.output)
+                        else:
+                            failures[requirement] = exc.output
+            except Exception as exc:  # pylint: disable=broad-except
+                failures[requirement] = str(exc)
+        if failures:
+            errors = ''
+            for requirement, exception in failures.items():
+                errors += 'pip{}: {}\n\n'.format(requirement or '', exception)
+            self.fail(
+                'Failed to get InstallationError exception under at least one pip version:\n{}'.format(errors)
+            )


### PR DESCRIPTION
### What does this PR do?
Fixes regression seen in salt 3000rc2.

Closes https://github.com/saltstack/salt/issues/55917

### What issues does this PR fix or reference?
#55917

### Previous Behavior
With pip version 18.0 installed the pip state would fail to load

### New Behavior
pip state now loads properly with all pep versions released at this time

### Tests written?

Yes

### Commits signed with GPG?

Yes