### PR TITLE
Refactor import of tornado

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -69,7 +69,7 @@ except ImportError:
 # pylint: enable=import-error
 
 # Import tornado
-import tornado.gen  # pylint: disable=F0401
+import tornado.gen as tornado_gen  # pylint: disable=F0401
 
 log = logging.getLogger(__name__)
 
@@ -352,7 +352,7 @@ class LocalClient(object):
         _res = salt.utils.minions.CkMinions(self.opts).check_minions(tgt, tgt_type=expr_form)
         return _res['minions']
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def run_job_async(
             self,
             tgt,
@@ -407,7 +407,7 @@ class LocalClient(object):
             # Convert to generic client error and pass along message
             raise SaltClientError(general_exception)
 
-        raise tornado.gen.Return(self._check_pub_data(pub_data, listen=listen))
+        raise tornado_gen.Return(self._check_pub_data(pub_data, listen=listen))
 
     def cmd_async(
             self,
@@ -1776,7 +1776,7 @@ class LocalClient(object):
         return {'jid': payload['load']['jid'],
                 'minions': payload['load']['minions']}
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def pub_async(self,
                   tgt,
                   fun,
@@ -1858,7 +1858,7 @@ class LocalClient(object):
                 # and try again if the key has changed
                 key = self.__read_master_key()
                 if key == self.key:
-                    raise tornado.gen.Return(payload)
+                    raise tornado_gen.Return(payload)
                 self.key = key
                 payload_kwargs['key'] = self.key
                 payload = yield channel.send(payload_kwargs)
@@ -1876,9 +1876,9 @@ class LocalClient(object):
                 raise PublishError(error)
 
             if not payload:
-                raise tornado.gen.Return(payload)
+                raise tornado_gen.Return(payload)
 
-        raise tornado.gen.Return({'jid': payload['load']['jid'],
+        raise tornado_gen.Return({'jid': payload['load']['jid'],
                                   'minions': payload['load']['minions']})
 
     # pylint: disable=W1701

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -33,7 +33,7 @@ import salt.log.setup
 from salt.ext import six
 
 # Import 3rd-party libs
-import tornado.stack_context
+from tornado.stack_context import StackContext
 
 log = logging.getLogger(__name__)
 
@@ -368,7 +368,7 @@ class SyncClientMixin(object):
                 func_globals['__jid_event__'].fire_event(data, 'new')
 
                 # Initialize a context for executing the method.
-                with tornado.stack_context.StackContext(self.functions.context_dict.clone):
+                with StackContext(self.functions.context_dict.clone):
                     func = self.functions[fun]
                     try:
                         data['return'] = func(*args, **kwargs)

--- a/salt/engines/ircbot.py
+++ b/salt/engines/ircbot.py
@@ -64,8 +64,8 @@ import socket
 import ssl
 from collections import namedtuple
 
-import tornado.ioloop
-import tornado.iostream
+from tornado.ioloop import IOLoop
+from tornado.iostream import IOStream, SSLIOStream
 
 import logging
 log = logging.getLogger(__name__)
@@ -96,16 +96,16 @@ class IRCClient(object):
         self.allow_hosts = allow_hosts
         self.allow_nicks = allow_nicks
         self.disable_query = disable_query
-        self.io_loop = tornado.ioloop.IOLoop(make_current=False)
+        self.io_loop = IOLoop(make_current=False)
         self.io_loop.make_current()
         self._connect()
 
     def _connect(self):
         _sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
         if self.ssl is True:
-            self._stream = tornado.iostream.SSLIOStream(_sock, ssl_options={'cert_reqs': ssl.CERT_NONE})
+            self._stream = SSLIOStream(_sock, ssl_options={'cert_reqs': ssl.CERT_NONE})
         else:
-            self._stream = tornado.iostream.IOStream(_sock)
+            self._stream = IOStream(_sock)
         self._stream.set_close_callback(self.on_closed)
         self._stream.connect((self.host, self.port), self.on_connect)
 
@@ -184,9 +184,9 @@ class IRCClient(object):
         event = self._event(raw)
 
         if event.code == "PING":
-            tornado.ioloop.IOLoop.current().spawn_callback(self.send_message, "PONG {0}".format(event.line))
+            IOLoop.current().spawn_callback(self.send_message, "PONG {0}".format(event.line))
         elif event.code == 'PRIVMSG':
-            tornado.ioloop.IOLoop.current().spawn_callback(self._privmsg, event)
+            IOLoop.current().spawn_callback(self._privmsg, event)
         self.read_messages()
 
     def join_channel(self, channel):

--- a/salt/engines/webhook.py
+++ b/salt/engines/webhook.py
@@ -5,9 +5,9 @@ Send events from webhook api
 from __future__ import absolute_import, print_function, unicode_literals
 
 # import tornado library
-import tornado.httpserver
-import tornado.ioloop
-import tornado.web
+from tornado.httpserver import HTTPServer
+from tornado.ioloop import IOLoop
+from tornado.web import Application, RequestHandler
 
 # import salt libs
 import salt.utils.event
@@ -66,7 +66,7 @@ def start(address=None, port=5000, ssl_crt=None, ssl_key=None):
         else:
             __salt__['event.send'](tag, msg)
 
-    class WebHook(tornado.web.RequestHandler):  # pylint: disable=abstract-method
+    class WebHook(RequestHandler):  # pylint: disable=abstract-method
         def post(self, tag):  # pylint: disable=arguments-differ
             body = self.request.body
             headers = self.request.headers
@@ -76,12 +76,12 @@ def start(address=None, port=5000, ssl_crt=None, ssl_key=None):
             }
             fire('salt/engines/hook/' + tag, payload)
 
-    application = tornado.web.Application([(r"/(.*)", WebHook), ])
+    application = Application([(r"/(.*)", WebHook), ])
     ssl_options = None
     if all([ssl_crt, ssl_key]):
         ssl_options = {"certfile": ssl_crt, "keyfile": ssl_key}
-    io_loop = tornado.ioloop.IOLoop(make_current=False)
+    io_loop = IOLoop(make_current=False)
     io_loop.make_current()
-    http_server = tornado.httpserver.HTTPServer(application, ssl_options=ssl_options)
+    http_server = HTTPServer(application, ssl_options=ssl_options)
     http_server.listen(port, address=address)
     io_loop.start()

--- a/salt/master.py
+++ b/salt/master.py
@@ -27,7 +27,7 @@ from salt.ext.six.moves import range
 from salt.utils.zeromq import zmq, ZMQDefaultLoop, install_zmq, ZMQ_VERSION_INFO
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
 
-import tornado.gen  # pylint: disable=F0401
+import tornado.gen as tornado_gen  # pylint: disable=F0401
 
 # Import salt libs
 import salt.crypt
@@ -1037,7 +1037,7 @@ class MWorker(salt.utils.process.SignalHandlingProcess):
             # Tornado knows what to do
             pass
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _handle_payload(self, payload):
         '''
         The _handle_payload method is the key method used to figure out what
@@ -1063,7 +1063,7 @@ class MWorker(salt.utils.process.SignalHandlingProcess):
         load = payload['load']
         ret = {'aes': self._handle_aes,
                'clear': self._handle_clear}[key](load)
-        raise tornado.gen.Return(ret)
+        raise tornado_gen.Return(ret)
 
     def _post_stats(self, start, cmd):
         '''

--- a/salt/metaproxy/proxy.py
+++ b/salt/metaproxy/proxy.py
@@ -64,6 +64,7 @@ from salt.utils.process import (default_signals,
 
 import tornado.gen as tornado_gen  # pylint: disable=F0401
 import tornado.ioloop  # pylint: disable=F0401
+from tornado.stack_context import StackContext
 
 log = logging.getLogger(__name__)
 
@@ -321,7 +322,7 @@ def target(cls, minion_instance, opts, data, connected):
                 salt.minion.get_proc_dir(opts['cachedir'], uid=uid)
             )
 
-    with tornado.stack_context.StackContext(minion_instance.ctx):
+    with StackContext(minion_instance.ctx):
         if isinstance(data['fun'], tuple) or isinstance(data['fun'], list):
             ProxyMinion._thread_multi_return(minion_instance, opts, data)
         else:

--- a/salt/metaproxy/proxy.py
+++ b/salt/metaproxy/proxy.py
@@ -62,7 +62,7 @@ from salt.utils.process import (default_signals,
                                 SignalHandlingProcess)
 
 
-import tornado.gen  # pylint: disable=F0401
+import tornado.gen as tornado_gen  # pylint: disable=F0401
 import tornado.ioloop  # pylint: disable=F0401
 
 log = logging.getLogger(__name__)
@@ -710,7 +710,7 @@ def handle_decoded_payload(self, data):
         process_count = len(salt.utils.minion.running(self.opts))
         while process_count >= process_count_max:
             log.warning("Maximum number of processes reached while executing jid {0}, waiting...".format(data['jid']))
-            yield tornado.gen.sleep(10)
+            yield tornado_gen.sleep(10)
             process_count = len(salt.utils.minion.running(self.opts))
 
     # We stash an instance references to allow for the socket

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -110,7 +110,7 @@ from salt.exceptions import (
 )
 
 
-import tornado.gen  # pylint: disable=F0401
+import tornado.gen as tornado_gen  # pylint: disable=F0401
 import tornado.ioloop  # pylint: disable=F0401
 
 log = logging.getLogger(__name__)
@@ -488,7 +488,7 @@ class MinionBase(object):
                 return self.beacons.process(b_conf, self.opts['grains'])  # pylint: disable=no-member
         return []
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def eval_master(self,
                     opts,
                     timeout=60,
@@ -514,7 +514,7 @@ class MinionBase(object):
         if opts['master_type'] == 'disable':
             log.warning('Master is set to disable, skipping connection')
             self.connected = False
-            raise tornado.gen.Return((None, None))
+            raise tornado_gen.Return((None, None))
 
         # Run masters discovery over SSDP. This may modify the whole configuration,
         # depending of the networking and sets of masters.
@@ -650,7 +650,7 @@ class MinionBase(object):
                 if attempts != 0:
                     # Give up a little time between connection attempts
                     # to allow the IOLoop to run any other scheduled tasks.
-                    yield tornado.gen.sleep(opts['acceptance_wait_time'])
+                    yield tornado_gen.sleep(opts['acceptance_wait_time'])
                 attempts += 1
                 if tries > 0:
                     log.debug(
@@ -712,7 +712,7 @@ class MinionBase(object):
                 else:
                     self.tok = pub_channel.auth.gen_token(b'salt')
                     self.connected = True
-                    raise tornado.gen.Return((opts['master'], pub_channel))
+                    raise tornado_gen.Return((opts['master'], pub_channel))
 
         # single master sign in
         else:
@@ -723,7 +723,7 @@ class MinionBase(object):
                 if attempts != 0:
                     # Give up a little time between connection attempts
                     # to allow the IOLoop to run any other scheduled tasks.
-                    yield tornado.gen.sleep(opts['acceptance_wait_time'])
+                    yield tornado_gen.sleep(opts['acceptance_wait_time'])
                 attempts += 1
                 if tries > 0:
                     log.debug(
@@ -755,7 +755,7 @@ class MinionBase(object):
                         yield pub_channel.connect()
                     self.tok = pub_channel.auth.gen_token(b'salt')
                     self.connected = True
-                    raise tornado.gen.Return((opts['master'], pub_channel))
+                    raise tornado_gen.Return((opts['master'], pub_channel))
                 except SaltClientError:
                     if attempts == tries:
                         # Exhausted all attempts. Return exception.
@@ -967,7 +967,7 @@ class MinionManager(MinionBase):
         self.event.subscribe('')
         self.event.set_event_handler(self.handle_event)
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def handle_event(self, package):
         for minion in self.minions:
             minion.handle_event(package)
@@ -1019,7 +1019,7 @@ class MinionManager(MinionBase):
             self.io_loop.spawn_callback(self._connect_minion, minion)
         self.io_loop.call_later(timeout, self._check_minions)
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _connect_minion(self, minion):
         '''
         Create a minion, and asynchronously connect it to a master
@@ -1046,7 +1046,7 @@ class MinionManager(MinionBase):
                 last = time.time()
                 if auth_wait < self.max_auth_wait:
                     auth_wait += self.auth_wait
-                yield tornado.gen.sleep(auth_wait)  # TODO: log?
+                yield tornado_gen.sleep(auth_wait)  # TODO: log?
             except SaltMasterUnresolvableError:
                 err = 'Master address: \'{0}\' could not be resolved. Invalid or unresolveable address. ' \
                       'Set \'master\' value in minion config.'.format(minion.opts['master'])
@@ -1226,7 +1226,7 @@ class Minion(MinionBase):
         if timeout and self._sync_connect_master_success is False:
             raise SaltDaemonNotRunning('Failed to connect to the salt-master')
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def connect_master(self, failed=False):
         '''
         Return a future which will complete when you are connected to a master
@@ -1235,7 +1235,7 @@ class Minion(MinionBase):
         yield self._post_master_init(master)
 
     # TODO: better name...
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _post_master_init(self, master):
         '''
         Function to finish init after connecting to a master
@@ -1418,7 +1418,7 @@ class Minion(MinionBase):
         with salt.transport.client.ReqChannel.factory(self.opts) as channel:
             return channel.send(load, timeout=timeout)
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _send_req_async(self, load, timeout):
 
         if self.opts['minion_sign_messages']:
@@ -1429,7 +1429,7 @@ class Minion(MinionBase):
 
         with salt.transport.client.AsyncReqChannel.factory(self.opts) as channel:
             ret = yield channel.send(load, timeout=timeout)
-            raise tornado.gen.Return(ret)
+            raise tornado_gen.Return(ret)
 
     def _fire_master(self, data=None, tag=None, events=None, pretag=None, timeout=60, sync=True, timeout_handler=None, include_startup_grains=False):
         '''
@@ -1475,7 +1475,7 @@ class Minion(MinionBase):
                 self._send_req_async(load, timeout, callback=lambda f: None)  # pylint: disable=unexpected-keyword-arg
         return True
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _handle_decoded_payload(self, data):
         '''
         Override this method if you wish to handle the decoded data
@@ -1517,7 +1517,7 @@ class Minion(MinionBase):
             process_count = len(salt.utils.minion.running(self.opts))
             while process_count >= process_count_max:
                 log.warning("Maximum number of processes reached while executing jid %s, waiting...", data['jid'])
-                yield tornado.gen.sleep(10)
+                yield tornado_gen.sleep(10)
                 process_count = len(salt.utils.minion.running(self.opts))
 
         # We stash an instance references to allow for the socket
@@ -2197,7 +2197,7 @@ class Minion(MinionBase):
         self.matchers = salt.loader.matchers(self.opts)
 
     # TODO: only allow one future in flight at a time?
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def pillar_refresh(self, force_refresh=False):
         '''
         Refresh the pillar
@@ -2363,13 +2363,13 @@ class Minion(MinionBase):
                 log.warning('Unable to send mine data to master.')
                 return None
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def handle_event(self, package):
         '''
         Handle an event from the epull_sock (all local minion events)
         '''
         if not self.ready:
-            raise tornado.gen.Return()
+            raise tornado_gen.Return()
         tag, data = salt.utils.event.SaltEvent.unpack(package)
         log.debug(
             'Minion of \'%s\' is handling event tag \'%s\'',
@@ -2409,7 +2409,7 @@ class Minion(MinionBase):
             # if the master disconnect event is for a different master, raise an exception
             if tag.startswith(master_event(type='disconnected')) and data['master'] != self.opts['master']:
                 # not mine master, ignore
-                raise tornado.gen.Return()
+                raise tornado_gen.Return()
             if tag.startswith(master_event(type='failback')):
                 # if the master failback event is not for the top master, raise an exception
                 if data['master'] != self.opts['master_list'][0]:
@@ -2938,7 +2938,7 @@ class Syndic(Minion):
         # In the future, we could add support for some clearfuncs, but
         # the syndic currently has no need.
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def reconnect(self):
         if hasattr(self, 'pub_channel'):
             self.pub_channel.on_recv(None)
@@ -2955,7 +2955,7 @@ class Syndic(Minion):
             self.pub_channel.on_recv(self._process_cmd_socket)
             log.info('Minion is ready to receive requests!')
 
-        raise tornado.gen.Return(self)
+        raise tornado_gen.Return(self)
 
     def destroy(self):
         '''
@@ -3038,7 +3038,7 @@ class SyndicManager(MinionBase):
             s_opts['master'] = master
             self._syndics[master] = self._connect_syndic(s_opts)
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _connect_syndic(self, opts):
         '''
         Create a syndic, and asynchronously connect it to a master
@@ -3078,7 +3078,7 @@ class SyndicManager(MinionBase):
                 last = time.time()
                 if auth_wait < self.max_auth_wait:
                     auth_wait += self.auth_wait
-                yield tornado.gen.sleep(auth_wait)  # TODO: log?
+                yield tornado_gen.sleep(auth_wait)  # TODO: log?
             except (KeyboardInterrupt, SystemExit):  # pylint: disable=try-except-raise
                 raise
             except Exception:  # pylint: disable=broad-except
@@ -3088,7 +3088,7 @@ class SyndicManager(MinionBase):
                     opts['master'], exc_info=True
                 )
 
-        raise tornado.gen.Return(syndic)
+        raise tornado_gen.Return(syndic)
 
     def _mark_master_dead(self, master):
         '''
@@ -3346,7 +3346,7 @@ class ProxyMinion(Minion):
     '''
 
     # TODO: better name...
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _post_master_init(self, master):
         '''
         Function to finish init after connecting to a master
@@ -3375,7 +3375,7 @@ class ProxyMinion(Minion):
         mp_call = _metaproxy_call(self.opts, 'handle_payload')
         return mp_call(self, payload)
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _handle_decoded_payload(self, data):
         mp_call = _metaproxy_call(self.opts, 'handle_decoded_payload')
         return mp_call(self, data)

--- a/salt/netapi/rest_tornado/__init__.py
+++ b/salt/netapi/rest_tornado/__init__.py
@@ -18,11 +18,13 @@ log = logging.getLogger(__virtualname__)
 min_tornado_version = '4.0'
 has_tornado = False
 try:
-    import tornado
-    if _StrictVersion(tornado.version) >= _StrictVersion(min_tornado_version):
+    from tornado import version as tornado_version
+    if _StrictVersion(tornado_version) >= _StrictVersion(min_tornado_version):
         has_tornado = True
     else:
         log.error('rest_tornado requires at least tornado %s', min_tornado_version)
+    from tornado.ioloop import IOLoop
+    from tornado.web import Application
 except (ImportError, TypeError) as err:
     has_tornado = False
     log.error('ImportError! %s', err)
@@ -76,7 +78,7 @@ def get_application(opts):
             (formatted_events_pattern, saltnado_websockets.FormattedEventsHandler),
         ]
 
-    application = tornado.web.Application(paths, debug=mod_opts.get('debug', False))
+    application = Application(paths, debug=mod_opts.get('debug', False))
 
     application.opts = opts
     application.mod_opts = mod_opts
@@ -115,8 +117,8 @@ def start():
             ssl_opts.update({'keyfile': mod_opts['ssl_key']})
         kwargs['ssl_options'] = ssl_opts
 
-    import tornado.httpserver
-    http_server = tornado.httpserver.HTTPServer(get_application(__opts__), **kwargs)
+    from tornado.httpserver import HTTPServer
+    http_server = HTTPServer(get_application(__opts__), **kwargs)
     try:
         http_server.bind(mod_opts['port'],
                          address=mod_opts.get('address'),
@@ -128,6 +130,6 @@ def start():
         raise SystemExit(1)
 
     try:
-        tornado.ioloop.IOLoop.current().start()
+        IOLoop.current().start()
     except KeyboardInterrupt:
         raise SystemExit(0)

--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -199,7 +199,7 @@ import tornado.escape
 import tornado.httpserver
 import tornado.ioloop
 import tornado.web
-import tornado.gen
+import tornado.gen as tornado_gen
 from tornado.concurrent import Future
 # pylint: enable=import-error
 
@@ -904,7 +904,7 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
 
         self.disbatch()
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def disbatch(self):
         '''
         Disbatch all lowstates to the appropriate clients
@@ -940,7 +940,7 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
         self.write(self.serialize({'return': ret}))
         self.finish()
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _disbatch_local(self, chunk):
         '''
         Dispatch local client commands
@@ -979,7 +979,7 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
                     future.set_result(None)
                 except Exception:  # pylint: disable=broad-except
                     pass
-            raise tornado.gen.Return('No minions matched the target. No command was sent, no jid was assigned.')
+            raise tornado_gen.Return('No minions matched the target. No command was sent, no jid was assigned.')
 
         # get_event for missing minion
         for minion in list(set(pub_data['minions']) - set(minions)):
@@ -997,10 +997,10 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
 
         # wait syndic a while to avoid missing published events
         if self.application.opts['order_masters']:
-            min_wait_time = tornado.gen.sleep(self.application.opts['syndic_wait'])
+            min_wait_time = tornado_gen.sleep(self.application.opts['syndic_wait'])
 
         # To ensure job_not_running and all_return are terminated by each other, communicate using a future
-        is_finished = tornado.gen.sleep(self.application.opts['gather_job_timeout'])
+        is_finished = tornado_gen.sleep(self.application.opts['gather_job_timeout'])
 
         # ping until the job is not running, while doing so, if we see new minions returning
         # that they are running the job, add them to the list
@@ -1035,11 +1035,11 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
                 # When finished entire routine, cleanup other futures and return result
                 if f is is_finished:
                     cancel_inflight_futures()
-                    raise tornado.gen.Return(chunk_ret)
+                    raise tornado_gen.Return(chunk_ret)
                 elif f is min_wait_time:
                     if not more_todo():
                         cancel_inflight_futures()
-                        raise tornado.gen.Return(chunk_ret)
+                        raise tornado_gen.Return(chunk_ret)
                     continue
 
                 f_result = f.result()
@@ -1057,12 +1057,12 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
                     # if there are no more minions to wait for, then we are done
                     if not more_todo() and min_wait_time.done():
                         cancel_inflight_futures()
-                        raise tornado.gen.Return(chunk_ret)
+                        raise tornado_gen.Return(chunk_ret)
 
             except TimeoutException:
                 pass
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def job_not_running(self, jid, tgt, tgt_type, minions, is_finished):
         '''
         Return a future which will complete once jid (passed in) is no longer
@@ -1085,11 +1085,11 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
                 if f is is_finished:
                     if not event.done():
                         event.set_result(None)
-                    raise tornado.gen.Return(True)
+                    raise tornado_gen.Return(True)
                 event = f.result()
             except TimeoutException:
                 if not minion_running:
-                    raise tornado.gen.Return(True)
+                    raise tornado_gen.Return(True)
                 else:
                     ping_pub_data = yield self.saltclients['local'](tgt,
                                                                     'saltutil.find_job',
@@ -1106,7 +1106,7 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
                 minions[event['data']['id']] = False
             minion_running = True
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _disbatch_local_async(self, chunk):
         '''
         Disbatch local client_async commands
@@ -1115,9 +1115,9 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
         # fire a job off
         pub_data = yield self.saltclients['local_async'](*f_call.get('args', ()), **f_call.get('kwargs', {}))
 
-        raise tornado.gen.Return(pub_data)
+        raise tornado_gen.Return(pub_data)
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _disbatch_runner(self, chunk):
         '''
         Disbatch runner client commands
@@ -1130,20 +1130,20 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
 
             # only return the return data
             ret = event if full_return else event['data']['return']
-            raise tornado.gen.Return(ret)
+            raise tornado_gen.Return(ret)
         except TimeoutException:
-            raise tornado.gen.Return('Timeout waiting for runner to execute')
+            raise tornado_gen.Return('Timeout waiting for runner to execute')
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _disbatch_runner_async(self, chunk):
         '''
         Disbatch runner client_async commands
         '''
         pub_data = self.saltclients['runner'](chunk)
-        raise tornado.gen.Return(pub_data)
+        raise tornado_gen.Return(pub_data)
 
     # salt.utils.args.format_call doesn't work for functions having the
-    # annotation tornado.gen.coroutine
+    # annotation tornado_gen.coroutine
     def _format_call_run_job_async(self, chunk):
         f_call = salt.utils.args.format_call(
             salt.client.LocalClient.run_job,
@@ -1463,7 +1463,7 @@ class EventsSaltAPIHandler(SaltAPIHandler):  # pylint: disable=W0223
 
     .. seealso:: :ref:`events`
     '''
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def get(self):
         r'''
         An HTTP stream of the Salt master event bus

--- a/salt/netapi/rest_tornado/saltnado_websockets.py
+++ b/salt/netapi/rest_tornado/saltnado_websockets.py
@@ -291,7 +291,7 @@ Setup
 '''
 from __future__ import absolute_import, print_function, unicode_literals
 
-import tornado.websocket
+from tornado.websocket import WebSocketHandler
 from . import event_processor
 from .saltnado import _check_cors_origin
 
@@ -306,7 +306,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class AllEventsHandler(tornado.websocket.WebSocketHandler):  # pylint: disable=W0223,W0232
+class AllEventsHandler(WebSocketHandler):  # pylint: disable=W0223,W0232
     '''
     Server side websocket handler.
     '''

--- a/salt/netapi/rest_tornado/saltnado_websockets.py
+++ b/salt/netapi/rest_tornado/saltnado_websockets.py
@@ -295,7 +295,7 @@ import tornado.websocket
 from . import event_processor
 from .saltnado import _check_cors_origin
 
-import tornado.gen
+import tornado.gen as tornado_gen
 
 import salt.utils.json
 import salt.netapi
@@ -334,7 +334,7 @@ class AllEventsHandler(tornado.websocket.WebSocketHandler):  # pylint: disable=W
         '''
         self.connected = False
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def on_message(self, message):
         """Listens for a "websocket client ready" message.
         Once that message is received an asynchronous job
@@ -387,7 +387,7 @@ class AllEventsHandler(tornado.websocket.WebSocketHandler):  # pylint: disable=W
 
 class FormattedEventsHandler(AllEventsHandler):  # pylint: disable=W0223,W0232
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def on_message(self, message):
         """Listens for a "websocket client ready" message.
         Once that message is received an asynchronous job

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -10,7 +10,7 @@ import fnmatch
 import os
 import collections
 import logging
-import tornado.gen
+import tornado.gen as tornado_gen
 import sys
 import traceback
 import inspect
@@ -158,7 +158,7 @@ class AsyncRemotePillar(RemotePillarMixin):
                                      merge_lists=True)
         self._closing = False
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def compile_pillar(self):
         '''
         Return a future which will contain the pillar data from the master
@@ -188,7 +188,7 @@ class AsyncRemotePillar(RemotePillarMixin):
             log.error(msg)
             # raise an exception! Pillar isn't empty, we can't sync it!
             raise SaltClientError(msg)
-        raise tornado.gen.Return(ret_pillar)
+        raise tornado_gen.Return(ret_pillar)
 
     def destroy(self):
         if self._closing:
@@ -1135,7 +1135,7 @@ class Pillar(object):
 # TODO: actually migrate from Pillar to AsyncPillar to allow for futures in
 # ext_pillar etc.
 class AsyncPillar(Pillar):
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def compile_pillar(self, ext=True):
         ret = super(AsyncPillar, self).compile_pillar(ext=ext)
-        raise tornado.gen.Return(ret)
+        raise tornado_gen.Return(ret)

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -13,7 +13,7 @@ import time
 
 # Import Tornado libs
 import tornado
-import tornado.gen
+import tornado.gen as tornado_gen
 import tornado.netutil
 import tornado.concurrent
 from tornado.locks import Lock
@@ -136,7 +136,7 @@ class IPCServer(object):
             )
         self._started = True
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def handle_stream(self, stream):
         '''
         Override this to handle the streams as they arrive
@@ -146,13 +146,13 @@ class IPCServer(object):
         See https://tornado.readthedocs.io/en/latest/iostream.html#tornado.iostream.IOStream
         for additional details.
         '''
-        @tornado.gen.coroutine
+        @tornado_gen.coroutine
         def _null(msg):
-            raise tornado.gen.Return(None)
+            raise tornado_gen.Return(None)
 
         def write_callback(stream, header):
             if header.get('mid'):
-                @tornado.gen.coroutine
+                @tornado_gen.coroutine
                 def return_message(msg):
                     pack = salt.transport.frame.frame_msg_ipc(
                         msg,
@@ -296,7 +296,7 @@ class IPCClient(object):
 
         return future
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _connect(self, timeout=None):
         '''
         Connect to a running IPCServer
@@ -337,7 +337,7 @@ class IPCClient(object):
                     self._connecting_future.set_exception(e)
                     break
 
-                yield tornado.gen.sleep(1)
+                yield tornado_gen.sleep(1)
 
     # pylint: disable=W1701
     def __del__(self):
@@ -403,7 +403,7 @@ class IPCMessageClient(IPCClient):
     '''
     # FIXME timeout unimplemented
     # FIXME tries unimplemented
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def send(self, msg, timeout=None, tries=None):
         '''
         Send a message to an IPC socket
@@ -507,7 +507,7 @@ class IPCMessagePublisher(object):
             )
         self._started = True
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _write(self, stream, pack):
         try:
             yield stream.write(pack)
@@ -619,12 +619,12 @@ class IPCMessageSubscriber(IPCClient):
         self._saved_data = []
         self._read_in_progress = Lock()
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _read(self, timeout, callback=None):
         try:
             yield self._read_in_progress.acquire(timeout=0.00000001)
-        except tornado.gen.TimeoutError:
-            raise tornado.gen.Return(None)
+        except tornado_gen.TimeoutError:
+            raise tornado_gen.Return(None)
 
         exc_to_raise = None
         ret = None
@@ -676,7 +676,7 @@ class IPCMessageSubscriber(IPCClient):
 
         if exc_to_raise is not None:
             raise exc_to_raise  # pylint: disable=E0702
-        raise tornado.gen.Return(ret)
+        raise tornado_gen.Return(ret)
 
     def read_sync(self, timeout=None):
         '''
@@ -692,7 +692,7 @@ class IPCMessageSubscriber(IPCClient):
             return self._saved_data.pop(0)
         return self.io_loop.run_sync(lambda: self._read(timeout))
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def read_async(self, callback):
         '''
         Asynchronously read messages and invoke a callback when they are ready.
@@ -704,10 +704,10 @@ class IPCMessageSubscriber(IPCClient):
                 yield self.connect(timeout=5)
             except StreamClosedError:
                 log.trace('Subscriber closed stream on IPC %s before connect', self.socket_path)
-                yield tornado.gen.sleep(1)
+                yield tornado_gen.sleep(1)
             except Exception as exc:  # pylint: disable=broad-except
                 log.error('Exception occurred while Subscriber connecting: %s', exc)
-                yield tornado.gen.sleep(1)
+                yield tornado_gen.sleep(1)
         yield self._read(None, callback)
 
     def close(self):

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -12,11 +12,10 @@ import socket
 import time
 
 # Import Tornado libs
-import tornado
 import tornado.gen as tornado_gen
-import tornado.netutil
-import tornado.concurrent
+from tornado.concurrent import Future as TornadoFuture
 from tornado.locks import Lock
+from tornado.netutil import add_accept_handler, bind_unix_socket
 from tornado.ioloop import IOLoop, TimeoutError as TornadoTimeoutError
 from tornado.iostream import IOStream, StreamClosedError
 # Import Salt libs
@@ -37,7 +36,7 @@ def future_with_timeout_callback(future):
         future._future_with_timeout._done_callback(future)
 
 
-class FutureWithTimeout(tornado.concurrent.Future):
+class FutureWithTimeout(TornadoFuture):
     def __init__(self, io_loop, future, timeout):
         super(FutureWithTimeout, self).__init__()
         self.io_loop = io_loop
@@ -127,10 +126,10 @@ class IPCServer(object):
             # Based on default used in tornado.netutil.bind_sockets()
             self.sock.listen(128)
         else:
-            self.sock = tornado.netutil.bind_unix_socket(self.socket_path)
+            self.sock = bind_unix_socket(self.socket_path)
 
         with salt.utils.asynchronous.current_ioloop(self.io_loop):
-            tornado.netutil.add_accept_handler(
+            add_accept_handler(
                 self.sock,
                 self.handle_connection,
             )
@@ -256,7 +255,7 @@ class IPCClient(object):
         to the server.
 
         '''
-        self.io_loop = io_loop or tornado.ioloop.IOLoop.current()
+        self.io_loop = io_loop or IOLoop.current()
         self.socket_path = socket_path
         self._closing = False
         self.stream = None
@@ -284,7 +283,7 @@ class IPCClient(object):
             if hasattr(self, '_connecting_future'):
                 # read previous future result to prevent the "unhandled future exception" error
                 self._connecting_future.exception()  # pylint: disable=E0203
-            future = tornado.concurrent.Future()
+            future = TornadoFuture()
             self._connecting_future = future
             self._connect(timeout=timeout)
 
@@ -498,10 +497,10 @@ class IPCMessagePublisher(object):
             # Based on default used in tornado.netutil.bind_sockets()
             self.sock.listen(128)
         else:
-            self.sock = tornado.netutil.bind_unix_socket(self.socket_path)
+            self.sock = bind_unix_socket(self.socket_path)
 
         with salt.utils.asynchronous.current_ioloop(self.io_loop):
-            tornado.netutil.add_accept_handler(
+            add_accept_handler(
                 self.sock,
                 self.handle_connection,
             )

--- a/salt/transport/mixins/auth.py
+++ b/salt/transport/mixins/auth.py
@@ -24,7 +24,7 @@ from salt.utils.cache import CacheCli
 
 # Import Third Party Libs
 from salt.ext import six
-import tornado.gen
+import tornado.gen as tornado_gen
 try:
     from M2Crypto import RSA
     HAS_M2 = True
@@ -51,7 +51,7 @@ class AESPubClientMixin(object):
             if not salt.crypt.verify_signature(master_pubkey_path, payload['load'], payload.get('sig')):
                 raise salt.crypt.AuthenticationError('Message signature failed to validate.')
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _decode_payload(self, payload):
         # we need to decrypt it
         log.trace('Decoding payload: %s', payload)
@@ -63,7 +63,7 @@ class AESPubClientMixin(object):
                 yield self.auth.authenticate()
                 payload['load'] = self.auth.crypticle.loads(payload['load'])
 
-        raise tornado.gen.Return(payload)
+        raise tornado_gen.Return(payload)
 
 
 # TODO: rename?

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -42,7 +42,7 @@ from salt.transport import iter_transport_opts
 # Import Tornado Libs
 import tornado
 import tornado.tcpserver
-import tornado.gen
+import tornado.gen as tornado_gen
 import tornado.concurrent
 import tornado.tcpclient
 import tornado.netutil
@@ -343,7 +343,7 @@ class AsyncTCPReqChannel(salt.transport.client.ReqChannel):
             'load': load,
         }
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def crypted_transfer_decode_dictentry(self, load, dictkey=None, tries=3, timeout=60):
         if not self.auth.authenticated:
             yield self.auth.authenticate()
@@ -358,9 +358,9 @@ class AsyncTCPReqChannel(salt.transport.client.ReqChannel):
         data = pcrypt.loads(ret[dictkey])
         if six.PY3:
             data = salt.transport.frame.decode_embedded_strs(data)
-        raise tornado.gen.Return(data)
+        raise tornado_gen.Return(data)
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _crypted_transfer(self, load, tries=3, timeout=60):
         '''
         In case of authentication errors, try to renegotiate authentication
@@ -368,7 +368,7 @@ class AsyncTCPReqChannel(salt.transport.client.ReqChannel):
         Indeed, we can fail too early in case of a master restart during a
         minion state execution call
         '''
-        @tornado.gen.coroutine
+        @tornado_gen.coroutine
         def _do_transfer():
             data = yield self.message_client.send(self._package_load(self.auth.crypticle.dumps(load)),
                                                   timeout=timeout,
@@ -381,24 +381,24 @@ class AsyncTCPReqChannel(salt.transport.client.ReqChannel):
                 data = self.auth.crypticle.loads(data)
                 if six.PY3:
                     data = salt.transport.frame.decode_embedded_strs(data)
-            raise tornado.gen.Return(data)
+            raise tornado_gen.Return(data)
 
         if not self.auth.authenticated:
             yield self.auth.authenticate()
         try:
             ret = yield _do_transfer()
-            raise tornado.gen.Return(ret)
+            raise tornado_gen.Return(ret)
         except salt.crypt.AuthenticationError:
             yield self.auth.authenticate()
             ret = yield _do_transfer()
-            raise tornado.gen.Return(ret)
+            raise tornado_gen.Return(ret)
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _uncrypted_transfer(self, load, tries=3, timeout=60):
         ret = yield self.message_client.send(self._package_load(load), timeout=timeout)
-        raise tornado.gen.Return(ret)
+        raise tornado_gen.Return(ret)
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def send(self, load, tries=3, timeout=60, raw=False):
         '''
         Send a request, return a future which will complete when we send the message
@@ -412,7 +412,7 @@ class AsyncTCPReqChannel(salt.transport.client.ReqChannel):
             # Convert to 'SaltClientError' so that clients can handle this
             # exception more appropriately.
             raise SaltClientError('Connection to master lost')
-        raise tornado.gen.Return(ret)
+        raise tornado_gen.Return(ret)
 
 
 class AsyncTCPPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.transport.client.AsyncPubChannel):
@@ -452,7 +452,7 @@ class AsyncTCPPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.tran
             'load': load,
         }
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def send_id(self, tok, force_auth):
         '''
         Send the minion id to the master so that the master may better
@@ -462,12 +462,12 @@ class AsyncTCPPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.tran
         '''
         load = {'id': self.opts['id'], 'tok': tok}
 
-        @tornado.gen.coroutine
+        @tornado_gen.coroutine
         def _do_transfer():
             msg = self._package_load(self.auth.crypticle.dumps(load))
             package = salt.transport.frame.frame_msg(msg, header=None)
             yield self.message_client.write_to_stream(package)
-            raise tornado.gen.Return(True)
+            raise tornado_gen.Return(True)
 
         if force_auth or not self.auth.authenticated:
             count = 0
@@ -480,13 +480,13 @@ class AsyncTCPPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.tran
                     count += 1
         try:
             ret = yield _do_transfer()
-            raise tornado.gen.Return(ret)
+            raise tornado_gen.Return(ret)
         except salt.crypt.AuthenticationError:
             yield self.auth.authenticate()
             ret = yield _do_transfer()
-            raise tornado.gen.Return(ret)
+            raise tornado_gen.Return(ret)
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def connect_callback(self, result):
         if self._closing:
             return
@@ -549,7 +549,7 @@ class AsyncTCPPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.tran
             '__master_disconnected'
         )
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def connect(self):
         try:
             self.auth = salt.crypt.AsyncAuth(self.opts, io_loop=self.io_loop)
@@ -588,7 +588,7 @@ class AsyncTCPPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.tran
         if callback is None:
             return self.message_client.on_recv(callback)
 
-        @tornado.gen.coroutine
+        @tornado_gen.coroutine
         def wrap_callback(body):
             if not isinstance(body, dict):
                 # TODO: For some reason we need to decode here for things
@@ -690,7 +690,7 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
                 self._socket.listen(self.backlog)
         salt.transport.mixins.auth.AESReqServerMixin.post_fork(self, payload_handler, io_loop)
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def handle_message(self, stream, header, payload):
         '''
         Handle incoming messages from underylying tcp streams
@@ -700,31 +700,31 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
                 payload = self._decode_payload(payload)
             except Exception:  # pylint: disable=broad-except
                 stream.write(salt.transport.frame.frame_msg('bad load', header=header))
-                raise tornado.gen.Return()
+                raise tornado_gen.Return()
 
             # TODO helper functions to normalize payload?
             if not isinstance(payload, dict) or not isinstance(payload.get('load'), dict):
                 yield stream.write(salt.transport.frame.frame_msg(
                     'payload and load must be a dict', header=header))
-                raise tornado.gen.Return()
+                raise tornado_gen.Return()
 
             try:
                 id_ = payload['load'].get('id', '')
                 if str('\0') in id_:
                     log.error('Payload contains an id with a null byte: %s', payload)
                     stream.send(self.serial.dumps('bad load: id contains a null byte'))
-                    raise tornado.gen.Return()
+                    raise tornado_gen.Return()
             except TypeError:
                 log.error('Payload contains non-string id: %s', payload)
                 stream.send(self.serial.dumps('bad load: id {0} is not a string'.format(id_)))
-                raise tornado.gen.Return()
+                raise tornado_gen.Return()
 
             # intercept the "_auth" commands, since the main daemon shouldn't know
             # anything about our key auth
             if payload['enc'] == 'clear' and payload.get('load', {}).get('cmd') == '_auth':
                 yield stream.write(salt.transport.frame.frame_msg(
                     self._auth(payload['load']), header=header))
-                raise tornado.gen.Return()
+                raise tornado_gen.Return()
 
             # TODO: test
             try:
@@ -734,7 +734,7 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
                 stream.write('Some exception handling minion payload')
                 log.error('Some exception handling a payload from minion', exc_info=True)
                 stream.close()
-                raise tornado.gen.Return()
+                raise tornado_gen.Return()
 
             req_fun = req_opts.get('fun', 'send')
             if req_fun == 'send_clear':
@@ -751,7 +751,7 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
                 # always attempt to return an error to the minion
                 stream.write('Server-side exception handling payload')
                 stream.close()
-        except tornado.gen.Return:
+        except tornado_gen.Return:
             raise
         except tornado.iostream.StreamClosedError:
             # Stream was closed. This could happen if the remote side
@@ -762,7 +762,7 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
             # Absorb any other exceptions
             log.error('Unexpected exception occurred: %s', exc, exc_info=True)
 
-        raise tornado.gen.Return()
+        raise tornado_gen.Return()
 
 
 class SaltMessageServer(tornado.tcpserver.TCPServer, object):
@@ -778,7 +778,7 @@ class SaltMessageServer(tornado.tcpserver.TCPServer, object):
         self.message_handler = message_handler
         self._shutting_down = False
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def handle_stream(self, stream, address):
         '''
         Handle incoming streams and add messages to the incoming queue
@@ -913,14 +913,14 @@ class SaltMessageClientPool(salt.transport.MessageClientPool):
             message_client.close()
         self.message_clients = []
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def connect(self):
         futures = []
         for message_client in self.message_clients:
             futures.append(message_client.connect())
         for future in futures:
             yield future
-        raise tornado.gen.Return(None)
+        raise tornado_gen.Return(None)
 
     def on_recv(self, *args, **kwargs):
         for message_client in self.message_clients:
@@ -1046,7 +1046,7 @@ class SaltMessageClient(object):
         return future
 
     # TODO: tcp backoff opts
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _connect(self):
         '''
         Try to connect for the rest of time!
@@ -1074,10 +1074,10 @@ class SaltMessageClient(object):
                 break
             except Exception as exc:  # pylint: disable=broad-except
                 log.warn('TCP Message Client encountered an exception %r', exc)
-                yield tornado.gen.sleep(1)  # TODO: backoff
+                yield tornado_gen.sleep(1)  # TODO: backoff
                 #self._connecting_future.set_exception(e)
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _stream_return(self):
         try:
             while not self._closing and (
@@ -1143,7 +1143,7 @@ class SaltMessageClient(object):
         finally:
             self._stream_return_future.set_result(True)
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _stream_send(self):
         while not self._connecting_future.done() or self._connecting_future.result() is not True:
             yield self._connecting_future
@@ -1362,7 +1362,7 @@ class PubServer(tornado.tcpserver.TCPServer, object):
                     salt.utils.event.tagify('present', 'presence')
                 )
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _stream_read(self, client):
         unpacker = salt.utils.msgpack.Unpacker()
         while not self._closing:
@@ -1404,7 +1404,7 @@ class PubServer(tornado.tcpserver.TCPServer, object):
         self.io_loop.spawn_callback(self._stream_read, client)
 
     # TODO: ACK the publish through IPC
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def publish_payload(self, package, _):
         log.debug('TCP PubServer sending payload: %s', package)
         payload = salt.transport.frame.frame_msg(package['payload'])

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -40,11 +40,13 @@ from salt.exceptions import SaltReqTimeoutError, SaltClientError
 from salt.transport import iter_transport_opts
 
 # Import Tornado Libs
-import tornado
-import tornado.tcpserver
+from tornado import version_info as tornado_version_info
+from tornado.tcpserver import TCPServer
 import tornado.gen as tornado_gen
-import tornado.concurrent
-import tornado.tcpclient
+from tornado.concurrent import Future as TornadoFuture
+from tornado.ioloop import IOLoop
+from tornado.iostream import IOStream, StreamClosedError
+from tornado.tcpclient import TCPClient
 import tornado.netutil
 import tornado.iostream
 
@@ -74,7 +76,7 @@ else:
 if USE_LOAD_BALANCER:
     import threading
     import multiprocessing
-    import tornado.util
+    from tornado.util import errno_from_exception
     from salt.utils.process import SignalHandlingProcess
 
 log = logging.getLogger(__name__)
@@ -209,7 +211,7 @@ if USE_LOAD_BALANCER:
                     # ECONNABORTED indicates that there was a connection
                     # but it was closed while still in the accept queue.
                     # (observed on FreeBSD).
-                    if tornado.util.errno_from_exception(e) == errno.ECONNABORTED:
+                    if errno_from_exception(e) == errno.ECONNABORTED:
                         continue
                     raise
 
@@ -230,7 +232,7 @@ class AsyncTCPReqChannel(salt.transport.client.ReqChannel):
         Only create one instance of channel per __key()
         '''
         # do we have any mapping for this io_loop
-        io_loop = kwargs.get('io_loop') or tornado.ioloop.IOLoop.current()
+        io_loop = kwargs.get('io_loop') or IOLoop.current()
         if io_loop not in cls.instance_map:
             cls.instance_map[io_loop] = weakref.WeakValueDictionary()
         loop_instance_map = cls.instance_map[io_loop]
@@ -277,7 +279,7 @@ class AsyncTCPReqChannel(salt.transport.client.ReqChannel):
         # crypt defaults to 'aes'
         self.crypt = kwargs.get('crypt', 'aes')
 
-        self.io_loop = kwargs.get('io_loop') or tornado.ioloop.IOLoop.current()
+        self.io_loop = kwargs.get('io_loop') or IOLoop.current()
 
         if self.crypt != 'clear':
             self.auth = salt.crypt.AsyncAuth(self.opts, io_loop=self.io_loop)
@@ -408,7 +410,7 @@ class AsyncTCPReqChannel(salt.transport.client.ReqChannel):
                 ret = yield self._uncrypted_transfer(load, tries=tries, timeout=timeout)
             else:
                 ret = yield self._crypted_transfer(load, tries=tries, timeout=timeout)
-        except tornado.iostream.StreamClosedError:
+        except StreamClosedError:
             # Convert to 'SaltClientError' so that clients can handle this
             # exception more appropriately.
             raise SaltClientError('Connection to master lost')
@@ -424,7 +426,7 @@ class AsyncTCPPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.tran
         self.serial = salt.payload.Serial(self.opts)
 
         self.crypt = kwargs.get('crypt', 'aes')
-        self.io_loop = kwargs.get('io_loop') or tornado.ioloop.IOLoop.current()
+        self.io_loop = kwargs.get('io_loop') or IOLoop.current()
         self.connected = False
         self._closing = False
         self._reconnected = False
@@ -753,7 +755,7 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
                 stream.close()
         except tornado_gen.Return:
             raise
-        except tornado.iostream.StreamClosedError:
+        except StreamClosedError:
             # Stream was closed. This could happen if the remote side
             # closed the connection on its end (eg in a timeout or shutdown
             # situation).
@@ -765,13 +767,13 @@ class TCPReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin, salt.tra
         raise tornado_gen.Return()
 
 
-class SaltMessageServer(tornado.tcpserver.TCPServer, object):
+class SaltMessageServer(TCPServer, object):
     '''
     Raw TCP server which will receive all of the TCP streams and re-assemble
     messages that are sent through to us
     '''
     def __init__(self, message_handler, *args, **kwargs):
-        io_loop = kwargs.pop('io_loop', None) or tornado.ioloop.IOLoop.current()
+        io_loop = kwargs.pop('io_loop', None) or IOLoop.current()
         super(SaltMessageServer, self).__init__(*args, **kwargs)
         self.io_loop = io_loop
         self.clients = []
@@ -798,7 +800,7 @@ class SaltMessageServer(tornado.tcpserver.TCPServer, object):
                     header = framed_msg['head']
                     self.io_loop.spawn_callback(self.message_handler, stream, header, framed_msg['body'])
 
-        except tornado.iostream.StreamClosedError:
+        except StreamClosedError:
             log.trace('req client disconnected %s', address)
             self.remove_client((stream, address))
         except Exception as e:  # pylint: disable=broad-except
@@ -868,7 +870,7 @@ if USE_LOAD_BALANCER:
                 pass
 
 
-class TCPClientKeepAlive(tornado.tcpclient.TCPClient):
+class TCPClientKeepAlive(TCPClient):
     '''
     Override _create_stream() in TCPClient to enable keep alive support.
     '''
@@ -888,10 +890,10 @@ class TCPClientKeepAlive(tornado.tcpclient.TCPClient):
         # after one connection has completed.
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         _set_tcp_keepalive(sock, self.opts)
-        stream = tornado.iostream.IOStream(
+        stream = IOStream(
             sock,
             max_buffer_size=max_buffer_size)
-        if tornado.version_info < (5,):
+        if tornado_version_info < (5,):
             return stream.connect(addr)
         return stream, stream.connect(addr)
 
@@ -953,7 +955,7 @@ class SaltMessageClient(object):
         self.connect_callback = connect_callback
         self.disconnect_callback = disconnect_callback
 
-        self.io_loop = io_loop or tornado.ioloop.IOLoop.current()
+        self.io_loop = io_loop or IOLoop.current()
 
         with salt.utils.asynchronous.current_ioloop(self.io_loop):
             self._tcp_client = TCPClientKeepAlive(opts, resolver=resolver)
@@ -970,7 +972,7 @@ class SaltMessageClient(object):
         self._on_recv = None
         self._closing = False
         self._connecting_future = self.connect()
-        self._stream_return_future = tornado.concurrent.Future()
+        self._stream_return_future = TornadoFuture()
         self.io_loop.spawn_callback(self._stream_return)
 
     def _stop_io_loop(self):
@@ -989,7 +991,7 @@ class SaltMessageClient(object):
             # _stream_return() completes by restarting the IO Loop.
             # This will prevent potential errors on shutdown.
             try:
-                orig_loop = tornado.ioloop.IOLoop.current()
+                orig_loop = IOLoop.current()
                 self.io_loop.make_current()
                 self._stream.close()
                 if self._read_until_future is not None:
@@ -1001,7 +1003,7 @@ class SaltMessageClient(object):
                     # 'StreamClosedError' when the stream is closed.
                     if self._read_until_future.done():
                         self._read_until_future.exception()
-                    if (self.io_loop != tornado.ioloop.IOLoop.current(instance=False)
+                    if (self.io_loop != IOLoop.current(instance=False)
                             or not self._stream_return_future.done()):
                         self.io_loop.add_future(
                             self._stream_return_future,
@@ -1032,7 +1034,7 @@ class SaltMessageClient(object):
         if hasattr(self, '_connecting_future') and not self._connecting_future.done():
             future = self._connecting_future
         else:
-            future = tornado.concurrent.Future()
+            future = TornadoFuture()
             self._connecting_future = future
             self.io_loop.add_callback(self._connect)
 
@@ -1057,7 +1059,7 @@ class SaltMessageClient(object):
             try:
                 kwargs = {}
                 if self.source_ip or self.source_port:
-                    if tornado.version_info >= (4, 5):
+                    if tornado_version_info >= (4, 5):
                         ### source_ip and source_port are supported only in Tornado >= 4.5
                         # See http://www.tornadoweb.org/en/stable/releases/v4.5.0.html
                         # Otherwise will just ignore these args
@@ -1107,7 +1109,7 @@ class SaltMessageClient(object):
                                 self.io_loop.spawn_callback(self._on_recv, header, body)
                             else:
                                 log.error('Got response for message_id %s that we are not tracking', message_id)
-                except tornado.iostream.StreamClosedError as e:
+                except StreamClosedError as e:
                     log.debug('tcp stream to %s:%s closed, unable to recv', self.host, self.port)
                     for future in six.itervalues(self.send_future_map):
                         future.set_exception(e)
@@ -1154,7 +1156,7 @@ class SaltMessageClient(object):
                 del self.send_queue[0]
             # if the connection is dead, lets fail this send, and make sure we
             # attempt to reconnect
-            except tornado.iostream.StreamClosedError as e:
+            except StreamClosedError as e:
                 if message_id in self.send_future_map:
                     self.send_future_map.pop(message_id).set_exception(e)
                 self.remove_message_timeout(message_id)
@@ -1215,7 +1217,7 @@ class SaltMessageClient(object):
         message_id = self._message_id()
         header = {'mid': message_id}
 
-        future = tornado.concurrent.Future()
+        future = TornadoFuture()
         if callback is not None:
             def handle_future(future):
                 response = future.result()
@@ -1270,7 +1272,7 @@ class Subscriber(object):
     # pylint: enable=W1701
 
 
-class PubServer(tornado.tcpserver.TCPServer, object):
+class PubServer(TCPServer, object):
     '''
     TCP publisher
     '''
@@ -1387,7 +1389,7 @@ class PubServer(tornado.tcpserver.TCPServer, object):
                         continue
                     client.id_ = load['id']
                     self._add_client_present(client)
-            except tornado.iostream.StreamClosedError as e:
+            except StreamClosedError as e:
                 log.debug('tcp stream to %s closed, unable to recv', client.address)
                 client.close()
                 self._remove_client_present(client)
@@ -1424,7 +1426,7 @@ class PubServer(tornado.tcpserver.TCPServer, object):
                             # Write the packed str
                             f = client.stream.write(payload)
                             self.io_loop.add_future(f, lambda f: True)
-                        except tornado.iostream.StreamClosedError:
+                        except StreamClosedError:
                             to_remove.append(client)
                 else:
                     log.debug('Publish target %s not connected', topic)
@@ -1434,7 +1436,7 @@ class PubServer(tornado.tcpserver.TCPServer, object):
                     # Write the packed str
                     f = client.stream.write(payload)
                     self.io_loop.add_future(f, lambda f: True)
-                except tornado.iostream.StreamClosedError:
+                except StreamClosedError:
                     to_remove.append(client)
         for client in to_remove:
             log.debug('Subscriber at %s has disconnected from publisher', client.address)
@@ -1479,7 +1481,7 @@ class TCPPubServerChannel(salt.transport.server.PubServerChannel):
 
         # Check if io_loop was set outside
         if self.io_loop is None:
-            self.io_loop = tornado.ioloop.IOLoop.current()
+            self.io_loop = IOLoop.current()
 
         # Spin up the publisher
         pub_server = PubServer(self.opts, io_loop=self.io_loop)

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -50,7 +50,7 @@ except ImportError:
 
 # Import Tornado Libs
 import tornado
-import tornado.gen
+import tornado.gen as tornado_gen
 import tornado.concurrent
 
 # Import third party libs
@@ -281,7 +281,7 @@ class AsyncZeroMQReqChannel(salt.transport.client.ReqChannel):
             'load': load,
         }
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def crypted_transfer_decode_dictentry(self, load, dictkey=None, tries=3, timeout=60):
         if not self.auth.authenticated:
             # Return control back to the caller, continue when authentication succeeds
@@ -311,9 +311,9 @@ class AsyncZeroMQReqChannel(salt.transport.client.ReqChannel):
         data = pcrypt.loads(ret[dictkey])
         if six.PY3:
             data = salt.transport.frame.decode_embedded_strs(data)
-        raise tornado.gen.Return(data)
+        raise tornado_gen.Return(data)
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _crypted_transfer(self, load, tries=3, timeout=60, raw=False):
         '''
         Send a load across the wire, with encryption
@@ -328,7 +328,7 @@ class AsyncZeroMQReqChannel(salt.transport.client.ReqChannel):
         :param int tries: The number of times to make before failure
         :param int timeout: The number of seconds on a response before failing
         '''
-        @tornado.gen.coroutine
+        @tornado_gen.coroutine
         def _do_transfer():
             # Yield control to the caller. When send() completes, resume by populating data with the Future.result
             data = yield self.message_client.send(
@@ -344,7 +344,7 @@ class AsyncZeroMQReqChannel(salt.transport.client.ReqChannel):
                 data = self.auth.crypticle.loads(data, raw)
             if six.PY3 and not raw:
                 data = salt.transport.frame.decode_embedded_strs(data)
-            raise tornado.gen.Return(data)
+            raise tornado_gen.Return(data)
         if not self.auth.authenticated:
             # Return control back to the caller, resume when authentication succeeds
             yield self.auth.authenticate()
@@ -355,9 +355,9 @@ class AsyncZeroMQReqChannel(salt.transport.client.ReqChannel):
             # If auth error, return control back to the caller, continue when authentication succeeds
             yield self.auth.authenticate()
             ret = yield _do_transfer()
-        raise tornado.gen.Return(ret)
+        raise tornado_gen.Return(ret)
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _uncrypted_transfer(self, load, tries=3, timeout=60):
         '''
         Send a load across the wire in cleartext
@@ -372,9 +372,9 @@ class AsyncZeroMQReqChannel(salt.transport.client.ReqChannel):
             tries=tries,
         )
 
-        raise tornado.gen.Return(ret)
+        raise tornado_gen.Return(ret)
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def send(self, load, tries=3, timeout=60, raw=False):
         '''
         Send a request, return a future which will complete when we send the message
@@ -383,7 +383,7 @@ class AsyncZeroMQReqChannel(salt.transport.client.ReqChannel):
             ret = yield self._uncrypted_transfer(load, tries=tries, timeout=timeout)
         else:
             ret = yield self._crypted_transfer(load, tries=tries, timeout=timeout, raw=raw)
-        raise tornado.gen.Return(ret)
+        raise tornado_gen.Return(ret)
 
 
 class AsyncZeroMQPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.transport.client.AsyncPubChannel):
@@ -505,7 +505,7 @@ class AsyncZeroMQPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.t
     # pylint: enable=W1701
 
     # TODO: this is the time to see if we are connected, maybe use the req channel to guess?
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def connect(self):
         if not self.auth.authenticated:
             yield self.auth.authenticate()
@@ -530,7 +530,7 @@ class AsyncZeroMQPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.t
                                source_ip=self.opts.get('source_ip'),
                                source_port=self.opts.get('source_publish_port'))
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _decode_messages(self, messages):
         '''
         Take the zmq messages, decrypt/decode them into a payload
@@ -547,7 +547,7 @@ class AsyncZeroMQPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.t
             if (self.opts.get('__role') != 'syndic' and message_target not in ('broadcast', self.hexid)) or \
                 (self.opts.get('__role') == 'syndic' and message_target not in ('broadcast', 'syndic')):
                 log.debug('Publish received for not this minion: %s', message_target)
-                raise tornado.gen.Return(None)
+                raise tornado_gen.Return(None)
             payload = self.serial.loads(messages[1])
         else:
             raise Exception(('Invalid number of messages ({0}) in zeromq pub'
@@ -555,7 +555,7 @@ class AsyncZeroMQPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.t
         # Yield control back to the caller. When the payload has been decoded, assign
         # the decoded payload to 'ret' and resume operation
         ret = yield self._decode_payload(payload)
-        raise tornado.gen.Return(ret)
+        raise tornado_gen.Return(ret)
 
     @property
     def stream(self):
@@ -575,7 +575,7 @@ class AsyncZeroMQPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.t
         if callback is None:
             return self.stream.on_recv(None)
 
-        @tornado.gen.coroutine
+        @tornado_gen.coroutine
         def wrap_callback(messages):
             payload = yield self._decode_messages(messages)
             if payload is not None:
@@ -715,7 +715,7 @@ class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin,
         self.stream = zmq.eventloop.zmqstream.ZMQStream(self._socket, io_loop=self.io_loop)
         self.stream.on_recv_stream(self.handle_message)
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def handle_message(self, stream, payload):
         '''
         Handle incoming messages from underlying TCP streams
@@ -740,30 +740,30 @@ class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin,
             else:
                 log.error('Bad load from minion: %s: %s', exc_type, exc)
             stream.send(self.serial.dumps('bad load'))
-            raise tornado.gen.Return()
+            raise tornado_gen.Return()
 
         # TODO helper functions to normalize payload?
         if not isinstance(payload, dict) or not isinstance(payload.get('load'), dict):
             log.error('payload and load must be a dict. Payload was: %s and load was %s', payload, payload.get('load'))
             stream.send(self.serial.dumps('payload and load must be a dict'))
-            raise tornado.gen.Return()
+            raise tornado_gen.Return()
 
         try:
             id_ = payload['load'].get('id', '')
             if str('\0') in id_:
                 log.error('Payload contains an id with a null byte: %s', payload)
                 stream.send(self.serial.dumps('bad load: id contains a null byte'))
-                raise tornado.gen.Return()
+                raise tornado_gen.Return()
         except TypeError:
             log.error('Payload contains non-string id: %s', payload)
             stream.send(self.serial.dumps('bad load: id {0} is not a string'.format(id_)))
-            raise tornado.gen.Return()
+            raise tornado_gen.Return()
 
         # intercept the "_auth" commands, since the main daemon shouldn't know
         # anything about our key auth
         if payload['enc'] == 'clear' and payload.get('load', {}).get('cmd') == '_auth':
             stream.send(self.serial.dumps(self._auth(payload['load'])))
-            raise tornado.gen.Return()
+            raise tornado_gen.Return()
 
         # TODO: test
         try:
@@ -774,7 +774,7 @@ class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin,
             # always attempt to return an error to the minion
             stream.send('Some exception handling minion payload')
             log.error('Some exception handling a payload from minion', exc_info=True)
-            raise tornado.gen.Return()
+            raise tornado_gen.Return()
 
         req_fun = req_opts.get('fun', 'send')
         if req_fun == 'send_clear':
@@ -790,7 +790,7 @@ class ZeroMQReqServerChannel(salt.transport.mixins.auth.AESReqServerMixin,
             log.error('Unknown req_fun %s', req_fun)
             # always attempt to return an error to the minion
             stream.send('Server-side exception handling payload')
-        raise tornado.gen.Return()
+        raise tornado_gen.Return()
 
     def __setup_signals(self):
         signal.signal(signal.SIGINT, self._handle_signals)
@@ -853,7 +853,7 @@ class ZeroMQPubServerChannel(salt.transport.server.PubServerChannel):
         self.ckminions = salt.utils.minions.CkMinions(self.opts)
 
     def connect(self):
-        return tornado.gen.sleep(5)
+        return tornado_gen.sleep(5)
 
     def _publish_daemon(self, log_queue=None):
         '''
@@ -1205,7 +1205,7 @@ class AsyncReqMessageClient(object):
         self.socket.connect(self.addr)
         self.stream = zmq.eventloop.zmqstream.ZMQStream(self.socket, io_loop=self.io_loop)
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _internal_send_recv(self):
         while len(self.send_queue) > 0:
             message = self.send_queue[0]

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -51,7 +51,7 @@ except ImportError:
 # Import Tornado Libs
 import tornado
 import tornado.gen as tornado_gen
-import tornado.concurrent
+from tornado.concurrent import Future as TornadoFuture
 
 # Import third party libs
 try:
@@ -1272,7 +1272,7 @@ class AsyncReqMessageClient(object):
         Return a future which will be completed when the message has a response
         '''
         if future is None:
-            future = tornado.concurrent.Future()
+            future = TornadoFuture()
             future.tries = tries
             future.attempts = 0
             future.timeout = timeout

--- a/salt/utils/asynchronous.py
+++ b/salt/utils/asynchronous.py
@@ -7,8 +7,8 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import sys
 
-import tornado.ioloop
-import tornado.concurrent
+from tornado.ioloop import IOLoop
+from tornado.concurrent import Future as TornadoFuture
 import contextlib
 from salt.ext import six
 from salt.utils import zeromq
@@ -19,7 +19,7 @@ def current_ioloop(io_loop):
     '''
     A context manager that will set the current ioloop to io_loop for the context
     '''
-    orig_loop = tornado.ioloop.IOLoop.current()
+    orig_loop = IOLoop.current()
     io_loop.make_current()
     try:
         yield
@@ -63,7 +63,7 @@ class SyncWrapper(object):
                 # Overload the ioloop for the func call-- since it might call .current()
                 with current_ioloop(self.io_loop):
                     ret = attr(*args, **kwargs)
-                    if isinstance(ret, tornado.concurrent.Future):
+                    if isinstance(ret, TornadoFuture):
                         ret = self._block_future(ret)
                     return ret
             return wrap

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -70,8 +70,8 @@ from salt.ext.six.moves import range
 
 # Import third party libs
 from salt.ext import six
-import tornado.ioloop
-import tornado.iostream
+from tornado.ioloop import IOLoop
+from tornado.iostream import StreamClosedError
 
 # Import salt libs
 import salt.config
@@ -226,7 +226,7 @@ class SaltEvent(object):
             self.io_loop = io_loop
             self._run_io_loop_sync = False
         else:
-            self.io_loop = tornado.ioloop.IOLoop()
+            self.io_loop = IOLoop()
             self._run_io_loop_sync = True
         self.cpub = False
         self.cpush = False
@@ -548,7 +548,7 @@ class SaltEvent(object):
                 ret = {'data': data, 'tag': mtag}
             except KeyboardInterrupt:
                 return {'tag': 'salt/event/exit', 'data': {}}
-            except tornado.iostream.StreamClosedError:
+            except StreamClosedError:
                 if self.raise_errors:
                     raise
                 else:
@@ -637,7 +637,7 @@ class SaltEvent(object):
                         try:
                             ret = self._get_event(wait, tag, match_func, no_block)
                             break
-                        except tornado.iostream.StreamClosedError:
+                        except StreamClosedError:
                             self.close_pub()
                             self.connect_pub(timeout=wait)
                             continue
@@ -966,7 +966,7 @@ class AsyncEventPublisher(object):
         default_minion_sock_dir = self.opts['sock_dir']
         self.opts.update(opts)
 
-        self.io_loop = io_loop or tornado.ioloop.IOLoop.current()
+        self.io_loop = io_loop or IOLoop.current()
         self._closing = False
 
         hash_type = getattr(hashlib, self.opts['hash_type'])
@@ -1098,7 +1098,7 @@ class EventPublisher(salt.utils.process.SignalHandlingProcess):
         Bind the pub and pull sockets for events
         '''
         salt.utils.process.appendproctitle(self.__class__.__name__)
-        self.io_loop = tornado.ioloop.IOLoop()
+        self.io_loop = IOLoop()
         with salt.utils.asynchronous.current_ioloop(self.io_loop):
             if self.opts['ipc_mode'] == 'tcp':
                 epub_uri = int(self.opts['tcp_master_pub_port'])

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -19,7 +19,7 @@ import stat
 import subprocess
 import sys
 import time
-import tornado.ioloop
+from tornado.ioloop import IOLoop
 import weakref
 from datetime import datetime
 
@@ -2676,7 +2676,7 @@ class GitFS(GitBase):
         exited.
         '''
         # No need to get the ioloop reference if we're not initializing remotes
-        io_loop = tornado.ioloop.IOLoop.current() if init_remotes else None
+        io_loop = IOLoop.current() if init_remotes else None
         if not init_remotes or io_loop not in cls.instance_map:
             # We only evaluate the second condition in this if statement if
             # we're initializing remotes, so we won't get here unless io_loop

--- a/salt/utils/zeromq.py
+++ b/salt/utils/zeromq.py
@@ -6,7 +6,8 @@ ZMQ-specific functions
 from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
-import tornado.ioloop
+from tornado import version_info as tornado_version_info
+from tornado.ioloop import IOLoop
 from salt.exceptions import SaltSystemExit
 from salt._compat import ipaddress
 
@@ -27,7 +28,7 @@ try:
         ZMQ_VERSION_INFO = tuple([int(v_el) for v_el in zmq.__version__.split('.')])
         LIBZMQ_VERSION_INFO = tuple([int(v_el) for v_el in zmq.zmq_version().split('.')])
         if ZMQ_VERSION_INFO[0] > 16:  # 17.0.x+ deprecates zmq's ioloops
-            ZMQDefaultLoop = tornado.ioloop.IOLoop
+            ZMQDefaultLoop = IOLoop
 except Exception:  # pylint: disable=broad-except
     log.exception('Error while getting LibZMQ/PyZMQ library version')
 
@@ -37,12 +38,12 @@ if ZMQDefaultLoop is None:
         # Support for ZeroMQ 13.x
         if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
             zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
-        if tornado.version_info < (5,):
+        if tornado_version_info < (5,):
             ZMQDefaultLoop = zmq.eventloop.ioloop.ZMQIOLoop
     except ImportError:
         ZMQDefaultLoop = None
     if ZMQDefaultLoop is None:
-        ZMQDefaultLoop = tornado.ioloop.IOLoop
+        ZMQDefaultLoop = IOLoop
 
 
 def install_zmq():
@@ -56,7 +57,7 @@ def install_zmq():
     # instead of checking the first element of ZMQ_VERSION_INFO will prevent an
     # IndexError when this function is invoked during the docs build.
     if zmq and ZMQ_VERSION_INFO < (17,):
-        if tornado.version_info < (5,):
+        if tornado_version_info < (5,):
             zmq.eventloop.ioloop.install()
 
 

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -30,8 +30,8 @@ import tempfile
 import textwrap
 import threading
 import time
-import tornado.ioloop
-import tornado.web
+from tornado.ioloop import IOLoop
+from tornado.web import Application, RequestHandler, StaticFileHandler
 import types
 
 # Import 3rd-party libs
@@ -1449,20 +1449,20 @@ class Webserver(object):
         self.wait = wait
         self.handler = handler \
             if handler is not None \
-            else tornado.web.StaticFileHandler
+            else StaticFileHandler
         self.web_root = None
 
     def target(self):
         '''
         Threading target which stands up the tornado application
         '''
-        self.ioloop = tornado.ioloop.IOLoop()
+        self.ioloop = IOLoop()
         self.ioloop.make_current()
-        if self.handler == tornado.web.StaticFileHandler:
-            self.application = tornado.web.Application(
+        if self.handler == StaticFileHandler:
+            self.application = Application(
                 [(r'/(.*)', self.handler, {'path': self.root})])
         else:
-            self.application = tornado.web.Application(
+            self.application = Application(
                 [(r'/(.*)', self.handler)])
         self.application.listen(self.port)
         self.ioloop.start()
@@ -1526,7 +1526,7 @@ class Webserver(object):
         self.server_thread.join()
 
 
-class SaveRequestsPostHandler(tornado.web.RequestHandler):
+class SaveRequestsPostHandler(RequestHandler):
     '''
     Save all requests sent to the server.
     '''
@@ -1545,7 +1545,7 @@ class SaveRequestsPostHandler(tornado.web.RequestHandler):
         raise NotImplementedError()
 
 
-class MirrorPostHandler(tornado.web.RequestHandler):
+class MirrorPostHandler(RequestHandler):
     '''
     Mirror a POST body back to the client
     '''

--- a/tests/unit/fileserver/test_gitfs.py
+++ b/tests/unit/fileserver/test_gitfs.py
@@ -10,13 +10,14 @@ import os
 import shutil
 import tempfile
 import textwrap
-import tornado.ioloop
 import logging
 import stat
 try:
     import pwd  # pylint: disable=unused-import
 except ImportError:
     pass
+
+from tornado.ioloop import IOLoop
 
 # Import Salt Testing Libs
 from tests.support.runtests import RUNTIME_VARS
@@ -73,7 +74,7 @@ def _rmtree_error(func, path, excinfo):
 
 def _clear_instance_map():
     try:
-        del salt.utils.gitfs.GitFS.instance_map[tornado.ioloop.IOLoop.current()]
+        del salt.utils.gitfs.GitFS.instance_map[IOLoop.current()]
     except KeyError:
         pass
 

--- a/tests/unit/netapi/test_rest_tornado.py
+++ b/tests/unit/netapi/test_rest_tornado.py
@@ -28,11 +28,11 @@ except ImportError:
 # Import 3rd-party libs
 # pylint: disable=import-error
 try:
-    import tornado.escape
-    import tornado.testing
-    import tornado.concurrent
+    from tornado.escape import native_str
+    from tornado.concurrent import Future
     from tornado.testing import AsyncTestCase, AsyncHTTPTestCase, gen_test
     from tornado.httpclient import HTTPRequest, HTTPError
+    from tornado.web import Application
     from tornado.websocket import websocket_connect
     import salt.netapi.rest_tornado as rest_tornado
     from salt.netapi.rest_tornado import saltnado
@@ -125,7 +125,7 @@ class SaltnadoTestCase(TestCase, AdaptedConfigurationTestCaseMixin, AsyncHTTPTes
             del self.application
 
     def build_tornado_app(self, urls):
-        application = tornado.web.Application(urls, debug=True)
+        application = Application(urls, debug=True)
 
         application.auth = self.auth
         application.opts = self.opts
@@ -143,7 +143,7 @@ class SaltnadoTestCase(TestCase, AdaptedConfigurationTestCaseMixin, AsyncHTTPTes
             if response.headers.get('Content-Type') == 'application/json':
                 response._body = response.body.decode('utf-8')
             else:
-                response._body = tornado.escape.native_str(response.body)
+                response._body = native_str(response.body)
         return response
 
     def fetch(self, path, **kwargs):
@@ -779,7 +779,7 @@ class TestSaltnadoUtils(AsyncTestCase):
         # create a few futures
         futures = []
         for x in range(0, 3):
-            future = tornado.concurrent.Future()
+            future = Future()
             future.add_done_callback(self.stop)
             futures.append(future)
 

--- a/tests/unit/test_minion.py
+++ b/tests/unit/test_minion.py
@@ -19,6 +19,7 @@ import salt.utils.event as event
 from salt.exceptions import SaltSystemExit, SaltMasterUnresolvableError
 import salt.syspaths
 import tornado
+import tornado.gen as tornado_gen
 import tornado.testing
 from salt.ext.six.moves import range
 import salt.utils.crypt
@@ -212,7 +213,7 @@ class MinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                 class SleepCalledException(Exception):
                     """Thrown when sleep is called"""
 
-                tornado.gen.sleep.return_value.set_exception(SleepCalledException())
+                tornado_gen.sleep.return_value.set_exception(SleepCalledException())
 
                 # up until process_count_max: gen.sleep does not get called, processes are started normally
                 for i in range(process_count_max):

--- a/tests/unit/test_proxy_minion.py
+++ b/tests/unit/test_proxy_minion.py
@@ -9,6 +9,7 @@ import copy
 
 import logging
 import tornado
+from tornado.ioloop import IOLoop
 import tornado.testing
 
 # Import Salt Testing libs
@@ -31,7 +32,7 @@ class ProxyMinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         '''
         mock_opts = salt.config.DEFAULT_MINION_OPTS.copy()
         mock_jid_queue = [123]
-        proxy_minion = salt.minion.ProxyMinion(mock_opts, jid_queue=copy.copy(mock_jid_queue), io_loop=tornado.ioloop.IOLoop())
+        proxy_minion = salt.minion.ProxyMinion(mock_opts, jid_queue=copy.copy(mock_jid_queue), io_loop=IOLoop())
         try:
             ret = proxy_minion._post_master_init('dummy_master')
             self.assert_called_once(salt.minion._metaproxy_call)
@@ -46,7 +47,7 @@ class ProxyMinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         mock_data = {'fun': 'foo.bar',
                      'jid': 123}
         mock_jid_queue = [123]
-        proxy_minion = salt.minion.ProxyMinion(mock_opts, jid_queue=copy.copy(mock_jid_queue), io_loop=tornado.ioloop.IOLoop())
+        proxy_minion = salt.minion.ProxyMinion(mock_opts, jid_queue=copy.copy(mock_jid_queue), io_loop=IOLoop())
         try:
             ret = proxy_minion._handle_decoded_payload(mock_data).result()
             self.assertEqual(proxy_minion.jid_queue, mock_jid_queue)
@@ -63,7 +64,7 @@ class ProxyMinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         mock_data = {'fun': 'foo.bar',
                      'jid': 123}
         mock_jid_queue = [123]
-        proxy_minion = salt.minion.ProxyMinion(mock_opts, jid_queue=copy.copy(mock_jid_queue), io_loop=tornado.ioloop.IOLoop())
+        proxy_minion = salt.minion.ProxyMinion(mock_opts, jid_queue=copy.copy(mock_jid_queue), io_loop=IOLoop())
         try:
             ret = proxy_minion._handle_decoded_payload(mock_data).result()
             self.assertEqual(proxy_minion.jid_queue, mock_jid_queue)

--- a/tests/unit/transport/mixins.py
+++ b/tests/unit/transport/mixins.py
@@ -8,7 +8,7 @@ import salt.transport.client
 
 # Import 3rd-party libs
 from salt.ext import six
-import tornado.gen
+import tornado.gen as tornado_gen
 
 
 def run_loop_in_thread(loop, evt):
@@ -16,13 +16,13 @@ def run_loop_in_thread(loop, evt):
     Run the provided loop until an event is set
     '''
     loop.make_current()
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def stopper():
         while True:
             if evt.is_set():
                 loop.stop()
                 break
-            yield tornado.gen.sleep(.3)
+            yield tornado_gen.sleep(.3)
     loop.add_callback(stopper)
     try:
         loop.start()

--- a/tests/unit/transport/test_ipc.py
+++ b/tests/unit/transport/test_ipc.py
@@ -11,7 +11,7 @@ import socket
 import threading
 import logging
 
-import tornado.gen
+import tornado.gen as tornado_gen
 import tornado.ioloop
 import tornado.testing
 
@@ -72,7 +72,7 @@ class BaseIPCReqCase(tornado.testing.AsyncTestCase):
         del self.server_channel
         #del self._start_handlers
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _handle_payload(self, payload, reply_func):
         self.payloads.append(payload)
         yield reply_func(payload)

--- a/tests/unit/transport/test_ipc.py
+++ b/tests/unit/transport/test_ipc.py
@@ -13,7 +13,7 @@ import logging
 
 import tornado.gen as tornado_gen
 import tornado.ioloop
-import tornado.testing
+from tornado.testing import AsyncTestCase
 
 import salt.config
 import salt.exceptions
@@ -34,7 +34,7 @@ log = logging.getLogger(__name__)
 
 
 @skipIf(salt.utils.platform.is_windows(), 'Windows does not support Posix IPC')
-class BaseIPCReqCase(tornado.testing.AsyncTestCase):
+class BaseIPCReqCase(AsyncTestCase):
     '''
     Test the req server/client pair
     '''
@@ -174,7 +174,7 @@ class IPCMessageClient(BaseIPCReqCase):
 
 
 @skipIf(salt.utils.platform.is_windows(), 'Windows does not support Posix IPC')
-class IPCMessagePubSubCase(tornado.testing.AsyncTestCase):
+class IPCMessagePubSubCase(AsyncTestCase):
     '''
     Test all of the clear msg stuff
     '''

--- a/tests/unit/transport/test_tcp.py
+++ b/tests/unit/transport/test_tcp.py
@@ -9,7 +9,7 @@ import threading
 import socket
 import logging
 
-import tornado.gen
+import tornado.gen as tornado_gen
 import tornado.ioloop
 import tornado.concurrent
 from tornado.testing import AsyncTestCase, gen_test
@@ -90,12 +90,12 @@ class BaseTCPReqCase(TestCase, AdaptedConfigurationTestCaseMixin):
         del cls.server_channel
 
     @classmethod
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _handle_payload(cls, payload):
         '''
         TODO: something besides echo
         '''
-        raise tornado.gen.Return((payload, {'fun': 'send_clear'}))
+        raise tornado_gen.Return((payload, {'fun': 'send_clear'}))
 
 
 @skipIf(salt.utils.platform.is_darwin(), 'hanging test suite on MacOS')
@@ -111,12 +111,12 @@ class ClearReqTestCases(BaseTCPReqCase, ReqChannelMixin):
         del self.channel
 
     @classmethod
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _handle_payload(cls, payload):
         '''
         TODO: something besides echo
         '''
-        raise tornado.gen.Return((payload, {'fun': 'send_clear'}))
+        raise tornado_gen.Return((payload, {'fun': 'send_clear'}))
 
 
 @skipIf(salt.utils.platform.is_darwin(), 'hanging test suite on MacOS')
@@ -129,12 +129,12 @@ class AESReqTestCases(BaseTCPReqCase, ReqChannelMixin):
         del self.channel
 
     @classmethod
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _handle_payload(cls, payload):
         '''
         TODO: something besides echo
         '''
-        raise tornado.gen.Return((payload, {'fun': 'send'}))
+        raise tornado_gen.Return((payload, {'fun': 'send'}))
 
     # TODO: make failed returns have a specific framing so we can raise the same exception
     # on encrypted channels

--- a/tests/unit/transport/test_zeromq.py
+++ b/tests/unit/transport/test_zeromq.py
@@ -24,7 +24,7 @@ import zmq.eventloop.ioloop
 if not hasattr(zmq.eventloop.ioloop, 'ZMQIOLoop'):
     zmq.eventloop.ioloop.ZMQIOLoop = zmq.eventloop.ioloop.IOLoop
 from tornado.testing import AsyncTestCase
-import tornado.gen
+import tornado.gen as tornado_gen
 
 # Import Salt libs
 import salt.config
@@ -137,12 +137,12 @@ class ClearReqTestCases(BaseZMQReqCase, ReqChannelMixin):
         del self.channel
 
     @classmethod
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _handle_payload(cls, payload):
         '''
         TODO: something besides echo
         '''
-        raise tornado.gen.Return((payload, {'fun': 'send_clear'}))
+        raise tornado_gen.Return((payload, {'fun': 'send_clear'}))
 
     def test_master_uri_override(self):
         '''
@@ -167,12 +167,12 @@ class AESReqTestCases(BaseZMQReqCase, ReqChannelMixin):
         del self.channel
 
     @classmethod
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def _handle_payload(cls, payload):
         '''
         TODO: something besides echo
         '''
-        raise tornado.gen.Return((payload, {'fun': 'send'}))
+        raise tornado_gen.Return((payload, {'fun': 'send'}))
 
     # TODO: make failed returns have a specific framing so we can raise the same exception
     # on encrypted channels

--- a/tests/unit/utils/test_asynchronous.py
+++ b/tests/unit/utils/test_asynchronous.py
@@ -4,7 +4,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Import 3rd-party libs
-import tornado.testing
+from tornado.testing import gen_test
 import tornado.gen as tornado_gen
 from tornado.testing import AsyncTestCase
 
@@ -35,7 +35,7 @@ class HelperB(object):
 
 
 class TestSyncWrapper(AsyncTestCase):
-    @tornado.testing.gen_test
+    @gen_test
     def test_helpers(self):
         '''
         Test that the helper classes do what we expect within a regular asynchronous env

--- a/tests/unit/utils/test_asynchronous.py
+++ b/tests/unit/utils/test_asynchronous.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 # Import 3rd-party libs
 import tornado.testing
-import tornado.gen
+import tornado.gen as tornado_gen
 from tornado.testing import AsyncTestCase
 
 import salt.utils.asynchronous as asynchronous
@@ -15,10 +15,10 @@ class HelperA(object):
     def __init__(self, io_loop=None):
         pass
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def sleep(self):
-        yield tornado.gen.sleep(0.5)
-        raise tornado.gen.Return(True)
+        yield tornado_gen.sleep(0.5)
+        raise tornado_gen.Return(True)
 
 
 class HelperB(object):
@@ -27,11 +27,11 @@ class HelperB(object):
             a = asynchronous.SyncWrapper(HelperA)
         self.a = a
 
-    @tornado.gen.coroutine
+    @tornado_gen.coroutine
     def sleep(self):
-        yield tornado.gen.sleep(0.5)
+        yield tornado_gen.sleep(0.5)
         self.a.sleep()
-        raise tornado.gen.Return(False)
+        raise tornado_gen.Return(False)
 
 
 class TestSyncWrapper(AsyncTestCase):

--- a/tests/unit/utils/test_context.py
+++ b/tests/unit/utils/test_context.py
@@ -5,7 +5,7 @@
 '''
 # Import python libs
 from __future__ import absolute_import
-import tornado.stack_context
+from tornado.stack_context import StackContext, run_with_stack_context
 import tornado.gen as tornado_gen
 from tornado.testing import AsyncTestCase, gen_test
 import threading
@@ -95,8 +95,8 @@ class ContextDictTests(AsyncTestCase):
             s = self.num_concurrent_tasks - x
             over = self.cd.clone()
 
-            f = tornado.stack_context.run_with_stack_context(
-                tornado.stack_context.StackContext(lambda: over),  # pylint: disable=W0640
+            f = run_with_stack_context(
+                StackContext(lambda: over),  # pylint: disable=W0640
                 lambda: tgt(x, s/5.0, over),  # pylint: disable=W0640
             )
             futures.append(f)

--- a/tests/unit/utils/test_context.py
+++ b/tests/unit/utils/test_context.py
@@ -6,7 +6,7 @@
 # Import python libs
 from __future__ import absolute_import
 import tornado.stack_context
-import tornado.gen
+import tornado.gen as tornado_gen
 from tornado.testing import AsyncTestCase, gen_test
 import threading
 import time
@@ -66,11 +66,11 @@ class ContextDictTests(AsyncTestCase):
     def test_coroutines(self):
         '''Verify that ContextDict overrides properly within coroutines
         '''
-        @tornado.gen.coroutine
+        @tornado_gen.coroutine
         def secondary_coroutine(over):
-            raise tornado.gen.Return(over.get('foo'))
+            raise tornado_gen.Return(over.get('foo'))
 
-        @tornado.gen.coroutine
+        @tornado_gen.coroutine
         def tgt(x, s, over):
             inner_ret = []
             # first grab the global
@@ -81,13 +81,13 @@ class ContextDictTests(AsyncTestCase):
             over['foo'] = x
             inner_ret.append(over.get('foo'))
             # sleep for some time to let other coroutines do this section of code
-            yield tornado.gen.sleep(s)
+            yield tornado_gen.sleep(s)
             # get the value of the global again.
             inner_ret.append(over.get('foo'))
             # Call another coroutine to verify that we keep our context
             r = yield secondary_coroutine(over)
             inner_ret.append(r)
-            raise tornado.gen.Return(inner_ret)
+            raise tornado_gen.Return(inner_ret)
 
         futures = []
 
@@ -101,7 +101,7 @@ class ContextDictTests(AsyncTestCase):
             )
             futures.append(f)
 
-        wait_iterator = tornado.gen.WaitIterator(*futures)
+        wait_iterator = tornado_gen.WaitIterator(*futures)
         while not wait_iterator.done():
             r = yield wait_iterator.next()  # pylint: disable=incompatible-py3-code
             self.assertEqual(r[0], r[1])  # verify that the global value remails


### PR DESCRIPTION
salt requires tornado 4 and does not work with tornado >= 5. Debian/Ubuntu ships newer versions of tornado, but renamed the old version to `tornado4`. So we changed the import statements for the Debian package.

Here I am propose to merge the two of the three commits that changes the way the tornado import is used.
