### PR TITLE
Fix CMDMODTestCase if home directory does not exist

### DIFF
--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -260,7 +260,7 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
                             MagicMock(side_effect=OSError(expected_error)),
                         ):
                             with self.assertRaises(CommandExecutionError) as error:
-                                cmdmod.run("foo")
+                                cmdmod.run("foo", cwd="/")
                             assert error.exception.args[0].endswith(
                                 expected_error
                             ), repr(error.exception.args[0])
@@ -279,7 +279,7 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
                             MagicMock(side_effect=IOError(expected_error)),
                         ):
                             with self.assertRaises(CommandExecutionError) as error:
-                                cmdmod.run("foo")
+                                cmdmod.run("foo", cwd="/")
                             assert error.exception.args[0].endswith(
                                 expected_error
                             ), repr(error.exception.args[0])


### PR DESCRIPTION
When the home directory points to a directory that does not exist (e.g.
when building salt with sbuild), some test cases will fail:

```
======================================================================
FAIL: test_run_no_vt_io_error (unit.modules.test_cmdmod.CMDMODTestCase)
[CPU:100.0%|MEM:71.6%]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/unit/modules/test_cmdmod.py", line 256, in test_run_no_vt_io_error
    assert error.exception.args[0].endswith(expected_error), repr(error.exception.args[0])
AssertionError: "Specified cwd '/non-existing' either not absolute or does not exist"

======================================================================
FAIL: test_run_no_vt_os_error (unit.modules.test_cmdmod.CMDMODTestCase)
[CPU:0.0%|MEM:71.6%]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/unit/modules/test_cmdmod.py", line 242, in test_run_no_vt_os_error
    assert error.exception.args[0].endswith(expected_error), repr(error.exception.args[0])
AssertionError: "Specified cwd '/non-existing' either not absolute or does not exist"

----------------------------------------------------------------------
```

So change to `/`, because this directory exists on every system.