### PR TITLE
Mock kubernetes when building the documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -163,6 +163,8 @@ MOCK_MODULES = [
     "jnpr.junos.utils.config",
     "jnpr.junos.utils.sw",
     "keyring",
+    "kubernetes",
+    "kubernetes.config",
     "libvirt",
     "lxml",
     "lxml.etree",


### PR DESCRIPTION
Importing kubernetesmod fails, when building the documentation:

```
doc/ref/modules/all/index.rst:20: WARNING: failed to import kubernetesmod
doc/ref/modules/all/index.rst:20: WARNING: toctree references unknown document 'ref/modules/all/kubernetesmod'
WARNING: autodoc: failed to import module 'kubernetesmod' from module
'salt.modules'; the following exception was raised:
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/sphinx/ext/autodoc/importer.py", line 154, in import_module
    __import__(modname)
  File "salt/modules/kubernetesmod.py", line 71, in <module>
    import kubernetes  # pylint: disable=import-self
  File "/usr/lib/python3/dist-packages/kubernetes/__init__.py", line 20, in <module>
    import kubernetes.config
  File "/usr/lib/python3/dist-packages/kubernetes/config/__init__.py", line 17, in <module>
    from .kube_config import (list_kube_config_contexts, load_kube_config,
  File "/usr/lib/python3/dist-packages/kubernetes/config/kube_config.py", line 27, in <module>
    from requests_oauthlib import OAuth2Session
  File "/usr/lib/python3/dist-packages/requests_oauthlib/__init__.py", line 11, in <module>
    if requests.__version__ < '2.0.0':
TypeError: '<' not supported between instances of 'module' and 'str'
```

Therefore also mock `kubernetes` and `kubernetes.config`.