### PR TITLE
Adding functionality to CIMC modules

### DIFF
--- a/salt/modules/cimc.py
+++ b/salt/modules/cimc.py
@@ -129,6 +129,74 @@ def create_user(uid=None, username=None, password=None, priv=None):
     return ret
 
 
+def http_update_bios(server=None, path=None):
+    '''
+    Update the BIOS firmware through HTTP.
+
+    Args:
+        server(str): The IP address or hostname of the HTTP server.
+
+        path(str): The HTTP path and filename for the BIOS image.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cimc.http_update_bios foo.bar.com /path/HP-SL2.cap
+
+    '''
+
+    if not server:
+        raise salt.exceptions.CommandExecutionError("The server name must be specified.")
+
+    if not path:
+        raise salt.exceptions.CommandExecutionError("The HTTP path must be specified.")
+
+    dn = "sys/rack-unit-1/bios/fw-updatable"
+
+    inconfig = """<firmwareUpdatable adminState='trigger' dn='sys/rack-unit-1/bios/fw-updatable'
+    protocol='http' remoteServer='{0}' remotePath='{1}'
+    type='blade-bios' />""".format(server, path)
+
+    ret = __proxy__['cimc.set_config_modify'](dn, inconfig, False)
+
+    return ret
+
+
+def http_update_cimc(server=None, path=None):
+    '''
+    Update the CIMC firmware through HTTP.
+
+    Args:
+        server(str): The IP address or hostname of the HTTP server.
+
+        path(str): The HTTP path and filename for the CIMC image.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cimc.http_update_cimc foo.bar.com /path/HP-SL2.cap
+
+    '''
+
+    if not server:
+        raise salt.exceptions.CommandExecutionError("The server name must be specified.")
+
+    if not path:
+        raise salt.exceptions.CommandExecutionError("The HTTP path must be specified.")
+
+    dn = "sys/rack-unit-1/mgmt/fw-updatable"
+
+    inconfig = """<firmwareUpdatable adminState='trigger' dn='sys/rack-unit-1/mgmt/fw-updatable'
+    protocol='http' remoteServer='{0}' remotePath='{1}'
+    type='blade-controller' />""".format(server, path)
+
+    ret = __proxy__['cimc.set_config_modify'](dn, inconfig, False)
+
+    return ret
+
+
 def get_bios_defaults():
     '''
     Get the default values of BIOS tokens.
@@ -159,6 +227,27 @@ def get_bios_settings():
     ret = __proxy__['cimc.get_config_resolver_class']('biosSettings', True)
 
     return ret
+
+
+def get_bios_running():
+    '''
+    Returns the current bios version that is running.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cimc.get_bios_running
+
+    '''
+    ret = __proxy__['cimc.get_config_resolver_class']('firmwareRunning', False)
+
+    if 'outConfigs' in ret and 'firmwareRunning' in ret['outConfigs']:
+        for version in ret['outConfigs']['firmwareRunning']:
+            if 'dn' in version and version['dn'] == 'sys/rack-unit-1/bios/fw-boot-loader':
+                return version['version']
+
+    return "Unable to retrieve version."
 
 
 def get_boot_order():
@@ -209,6 +298,29 @@ def get_disks():
     return ret
 
 
+def get_dns_servers():
+    '''
+    Retrieves the DNS servers from the device.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cimc.get_dns_servers
+
+    '''
+    ret = __proxy__['cimc.get_config_resolver_class']('mgmtIf', True)
+
+    response = {'preferred': None, 'alternate': None}
+
+    try:
+        response['preferred'] = ret['outConfigs']['mgmtIf'][0]['dnsPreferred']
+        response['alternate'] = ret['outConfigs']['mgmtIf'][0]['dnsAlternate']
+        return response
+    except Exception:
+        return "Unable to retrieve DNS Servers"
+
+
 def get_ethernet_interfaces():
     '''
     Get the adapter Ethernet interface details.
@@ -257,6 +369,43 @@ def get_firmware():
     return ret
 
 
+def get_firmware_available():
+    '''
+    Retrieves the list of firmware on the device that is available for upgrade.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cimc.get_firmware_available
+
+    '''
+    ret = __proxy__['cimc.get_config_resolver_class']('firmwareUpdatable', False)
+
+    return ret
+
+
+def get_firmware_running():
+    '''
+    Returns the current firmware version that is running.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cimc.get_firmware_running
+
+    '''
+    ret = __proxy__['cimc.get_config_resolver_class']('firmwareRunning', False)
+
+    if 'outConfigs' in ret and 'firmwareRunning' in ret['outConfigs']:
+        for version in ret['outConfigs']['firmwareRunning']:
+            if 'dn' in version and version['dn'] == 'sys/rack-unit-1/mgmt/fw-system':
+                return version['version']
+
+    return "Unable to retrieve version."
+
+
 def get_hostname():
     '''
     Retrieves the hostname from the device.
@@ -274,7 +423,7 @@ def get_hostname():
 
     try:
         return ret['outConfigs']['mgmtIf'][0]['hostname']
-    except Exception as err:
+    except Exception:
         return "Unable to retrieve hostname"
 
 
@@ -437,6 +586,38 @@ def get_snmp_config():
 
     '''
     ret = __proxy__['cimc.get_config_resolver_class']('commSnmp', False)
+
+    return ret
+
+
+def get_snmp_users():
+    '''
+    Get the SNMPv3 users.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cimc.get_snmp_users
+
+    '''
+    ret = __proxy__['cimc.get_config_resolver_class']('commSnmpUser', False)
+
+    return ret
+
+
+def get_snmp_traps():
+    '''
+    Get the SNMPv3 trap destinations.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cimc.get_snmp_traps
+
+    '''
+    ret = __proxy__['cimc.get_config_resolver_class']('commSnmpTrap', False)
 
     return ret
 
@@ -629,6 +810,43 @@ def reboot():
     return ret
 
 
+def set_dns_servers(preferred=None, alternate=None):
+    '''
+    Sets the DNS servers for the device.
+
+    Args:
+        preferred(str): The preferred DNS server.
+
+        alternate(str): The alternate DNS server.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cimc.set_dns_servers 10.0.0.1 10.0.0.2
+
+        salt '*' cimc.set_dns_servers 10.0.0.1
+
+    '''
+    if not preferred and not alternate:
+        raise salt.exceptions.CommandExecutionError("At least one DNS server must be provided.")
+
+    primary = " dnsPreferred=\"{0}\"".format(preferred) if preferred else ""
+    secondary = " dnsAlternate=\"{0}\"".format(alternate) if alternate else ""
+    dn = "sys/rack-unit-1/mgmt/if-1"
+    inconfig = """<mgmtIf dn="sys/rack-unit-1/mgmt/if-1"{0}{1}></mgmtIf>""".format(primary, secondary)
+
+    ret = __proxy__['cimc.set_config_modify'](dn, inconfig, False)
+
+    try:
+        if ret['outConfig']['mgmtIf'][0]['status'] == 'modified':
+            return True
+        else:
+            return False
+    except Exception:
+        return False
+
+
 def set_hostname(hostname=None):
     '''
     Sets the hostname on the server.
@@ -658,7 +876,7 @@ def set_hostname(hostname=None):
             return True
         else:
             return False
-    except Exception as err:
+    except Exception:
         return False
 
 
@@ -801,7 +1019,7 @@ def set_power_configuration(policy=None, delayType=None, delayValue=None):
             else:
                 raise salt.exceptions.CommandExecutionError("Invalid delay type entered.")
     elif policy == "stay-off":
-        query = ' vpResumeOnACPowerLoss="reset"'
+        query = ' vpResumeOnACPowerLoss="stay-off"'
     elif policy == "last-state":
         query = ' vpResumeOnACPowerLoss="last-state"'
     else:
@@ -811,6 +1029,117 @@ def set_power_configuration(policy=None, delayType=None, delayValue=None):
     inconfig = """<biosVfResumeOnACPowerLoss
     dn="sys/rack-unit-1/board/Resume-on-AC-power-loss"{0}>
     </biosVfResumeOnACPowerLoss>""".format(query)
+
+    ret = __proxy__['cimc.set_config_modify'](dn, inconfig, False)
+
+    return ret
+
+
+def set_snmp_configuration(adminState=None, location=None, contact=None, communityAccess=None, trapCommunity=None, community=None):
+    '''
+    Sets the SNMP configuration on the device. This is only available for some
+    C-Series servers.
+
+    Args:
+        adminState(bool): Controls if the SNMP service is running or not.
+
+        location(str): The SNMP location string.
+
+        contact(str): The SNMP contact address.
+
+        communityAccess(str): Controls if the SNMP community string access is allowed. Valid options are:
+
+            disabled: SNMP community strings are disabled.
+
+            limited: Provides read-only access.
+
+            full: Provides full access.
+
+        trapCommunity(str): The SNMPv2 trap community string.
+
+        community(str): The SNMPv2 community string.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cimc.set_snmp_configuration True
+
+    '''
+
+    options = []
+    if adminState is not None:
+        options.append('adminState="{0}"'.format('enabled' if adminState else 'disabled'))
+    if location:
+        options.append('sysLocation="{0}"'.format(location))
+    if contact:
+        options.append('sysContact="{0}"'.format(contact))
+    if communityAccess:
+        options.append('com2Sec="{0}"'.format(communityAccess))
+    if trapCommunity:
+        options.append('trapCommunity="{0}"'.format(trapCommunity))
+    if community:
+        options.append('community="{0}"'.format(community))
+
+    dn = "sys/svc-ext/snmp-svc"
+    inconfig = """<commSnmp dn="sys/svc-ext/snmp-svc" {0}></commSnmp>""".format(" ".join(options))
+
+    ret = __proxy__['cimc.set_config_modify'](dn, inconfig, False)
+
+    return ret
+
+
+def set_snmp_user(uid=None, username=None, securityLevel=None, auth=None, authPassword=None, privacy=None,
+                  privacyPassword=None):
+    '''
+    Sets a SNMPv3 user.
+
+    Args:
+        uid(int): The SNMPv3 ID slot to create the user account in.
+
+        username(str): The name of the SNMPv3 user.
+
+        securityLevel(str): The SNMPv3 security level to utilize. This contols if SNMPv3 will use the `AUTH` and `PRIV`
+            functions.
+
+        auth(str): The hash function to use for `AUTH`.
+
+        authPassword(str): The `AUTH` password.
+
+        privacy(str): The `PRIV` encryption to use.
+
+        privacyPassword(str): The `PRIV` password.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cimc.set_snmp_user 1 username=foobar securityLevel=authpriv auth=SHA authPassword=foobar privacy=AES
+            privacyPassword=foobar
+
+    '''
+
+    if not uid:
+        raise salt.exceptions.CommandExecutionError("The SNMPv3 user ID must be specified.")
+
+    options = []
+    if username:
+        options.append('name="{0}"'.format(username))
+    if securityLevel:
+        options.append('securityLevel="{0}"'.format(securityLevel))
+    if auth:
+        options.append('auth="{0}"'.format(auth))
+    if authPassword:
+        options.append('authPwd="{0}"'.format(authPassword))
+    if privacy:
+        options.append('privacy="{0}"'.format(privacy))
+    if privacyPassword:
+        options.append('privacyPwd="{0}"'.format(privacyPassword))
+
+    dn = "sys/svc-ext/snmp-svc/snmpv3-user-{0}".format(uid)
+
+    inconfig = """<commSnmpUser id="{0}" dn="sys/svc-ext/snmp-svc/snmpv3-user-{0}" {1}></commSnmpUser>""".format(
+        uid, " ".join(options))
 
     ret = __proxy__['cimc.set_config_modify'](dn, inconfig, False)
 
@@ -855,8 +1184,8 @@ def set_syslog_server(server=None, type="primary"):
     ret = __proxy__['cimc.set_config_modify'](dn, inconfig, False)
 
     return ret
-
-
+    
+    
 def set_user(uid=None, username=None, password=None, priv=None, status=None):
     '''
     Sets a CIMC user with specified configurations.
@@ -871,7 +1200,7 @@ def set_user(uid=None, username=None, password=None, priv=None, status=None):
         password(str): The clear text password of the user.
 
         priv(str): The privilege level of the user.
-
+        
         status(str): The account status of the user.
 
     CLI Example:
@@ -888,13 +1217,13 @@ def set_user(uid=None, username=None, password=None, priv=None, status=None):
 
     if status:
         conf += ' accountStatus="{0}"'.format(status)
-
+        
     if username:
         conf += ' name="{0}"'.format(username)
 
     if priv:
         conf += ' priv="{0}"'.format(priv)
-
+        
     if password:
         conf += ' pwd="{0}"'.format(password)
 

--- a/salt/modules/cimc.py
+++ b/salt/modules/cimc.py
@@ -1184,8 +1184,8 @@ def set_syslog_server(server=None, type="primary"):
     ret = __proxy__['cimc.set_config_modify'](dn, inconfig, False)
 
     return ret
-    
-    
+
+
 def set_user(uid=None, username=None, password=None, priv=None, status=None):
     '''
     Sets a CIMC user with specified configurations.
@@ -1200,7 +1200,7 @@ def set_user(uid=None, username=None, password=None, priv=None, status=None):
         password(str): The clear text password of the user.
 
         priv(str): The privilege level of the user.
-        
+
         status(str): The account status of the user.
 
     CLI Example:
@@ -1217,13 +1217,13 @@ def set_user(uid=None, username=None, password=None, priv=None, status=None):
 
     if status:
         conf += ' accountStatus="{0}"'.format(status)
-        
+
     if username:
         conf += ' name="{0}"'.format(username)
 
     if priv:
         conf += ' priv="{0}"'.format(priv)
-        
+
     if password:
         conf += ' pwd="{0}"'.format(password)
 

--- a/salt/proxy/cimc.py
+++ b/salt/proxy/cimc.py
@@ -102,7 +102,7 @@ def _validate_response_code(response_code_to_check, cookie_to_logout=None):
     if formatted_response_code not in ['200', '201', '202', '204']:
         if cookie_to_logout:
             logout(cookie_to_logout)
-        log.error("Received error HTTP status code: %s", formatted_response_code)
+        log.warning("Received error HTTP status code: {0}" .format(formatted_response_code))
         raise salt.exceptions.CommandExecutionError(
             "Did not receive a valid response from host.")
 
@@ -134,7 +134,7 @@ def init(opts):
     # Ensure connectivity to the device
     log.debug("Attempting to connect to cimc proxy host.")
     get_config_resolver_class("computeRackUnit")
-    log.debug("Successfully connected to cimc proxy host.")
+    log.info("Successfully connected to cimc proxy host {0}.".format(DETAILS['host']))
 
     DETAILS['initialized'] = True
 
@@ -153,6 +153,7 @@ def set_config_modify(dn=None, inconfig=None, hierarchical=False):
 
     payload = '<configConfMo cookie="{0}" inHierarchical="{1}" dn="{2}">' \
               '<inConfig>{3}</inConfig></configConfMo>'.format(cookie, h, dn, inconfig)
+    log.debug("Sending configConfMo payload: {0}".format(payload))
     r = __utils__['http.query'](DETAILS['url'],
                                 data=payload,
                                 method='POST',
@@ -164,7 +165,7 @@ def set_config_modify(dn=None, inconfig=None, hierarchical=False):
                                 headers=DETAILS['headers'])
 
     _validate_response_code(r['status'], cookie)
-
+    log.debug("Received configConfMo response: {0}".format(r['text']))
     answer = re.findall(r'(<[\s\S.]*>)', r['text'])[0]
     items = ET.fromstring(answer)
     logout(cookie)
@@ -186,6 +187,7 @@ def get_config_resolver_class(cid=None, hierarchical=False):
         h = "true"
 
     payload = '<configResolveClass cookie="{0}" inHierarchical="{1}" classId="{2}"/>'.format(cookie, h, cid)
+    log.debug("Sending configResolveClass payload: {0}".format(payload))
     r = __utils__['http.query'](DETAILS['url'],
                                 data=payload,
                                 method='POST',
@@ -197,7 +199,7 @@ def get_config_resolver_class(cid=None, hierarchical=False):
                                 headers=DETAILS['headers'])
 
     _validate_response_code(r['status'], cookie)
-
+    log.debug("Received configResolveClass response: {0}".format(r['text']))
     answer = re.findall(r'(<[\s\S.]*>)', r['text'])[0]
     items = ET.fromstring(answer)
     logout(cookie)

--- a/salt/states/cimc.py
+++ b/salt/states/cimc.py
@@ -295,10 +295,10 @@ def ntp(name, servers):
         log.error(err)
         return ret
     except Exception as err:
-            ret['result'] = False
-            ret['comment'] = "Error setting NTP configuration."
-            log.error(err)
-            return ret
+        ret['result'] = False
+        ret['comment'] = "Error setting NTP configuration."
+        log.error(err)
+        return ret
 
     if req_change:
         try:


### PR DESCRIPTION
### What does this PR do?

Added:
* salt\modules\cimc - Function to update BIOS through HTTP.
* salt\modules\cimc - Function to update firmware through HTTP.
* salt\modules\cimc - Function to get the running bios.
* salt\modules\cimc - Function to get configured DNS servers.
* salt\modules\cimc - Function to get all available firmware.
* salt\modules\cimc - Function to get the running firmware.
* salt\modules\cimc - Function to get the configured SNMP users.
* salt\modules\cimc - Function to get the SNMP traps.
* salt\modules\cimc - Function to set the DNS servers.
* salt\modules\cimc - Function to set the SNMP configuration.
* salt\modules\cimc - Function to set the SNMP users.
* salt\states\cimc - Added state to set DNS servers

Cleanup:
* salt\proxy\cimc - Changed response validation to use warning log, not error.
* salt\proxy\cimc - Changed connection log to use info log.
* salt\proxy\cimc - Added debug logs for troubleshooting payload.
* salt\states\cimc - Added generic catch all for NTP errors for edge cases.

Bug Fix:
* salt\modules\cimc - Fixed issue improperly setting power configuration for stay-off function.
* salt\proxy\cimc - Fixed issue with state setting logging severity to local logs.

### What issues does this PR fix or reference?
No referenced issue.

### Previous Behavior
* The severity level was not properly set for CIMC devices using the State function.
* The power configuration was not setting to stay-off on the CIMC module.

### New Behavior
* The logging severity is now properly set for remote and local levels.
* The power configuration will now properly set to the stay-off level.

### Tests written?
No

### Commits signed with GPG?
No
