### PR TITLE
Add support for disperse sets for gluster

### DIFF
--- a/salt/states/glusterfs.py
+++ b/salt/states/glusterfs.py
@@ -124,6 +124,8 @@ def volume_present(
     start=False,
     force=False,
     arbiter=False,
+    disperse=False,
+    redundancy=False,
 ):
     """
     Ensure that the volume exists
@@ -141,6 +143,16 @@ def volume_present(
         use every third brick as arbiter (metadata only)
 
         .. versionadded:: 2019.2.0
+
+    disperse
+        brick count for disperse set
+
+        .. versionadded:: neon
+
+    redundancy
+        number of redundant bricks for disperse set
+
+        .. versionadded:: neon
 
     start
         ensure that the volume is also started
@@ -173,6 +185,17 @@ def volume_present(
             - arbiter: True
             - start: True
 
+        Disperse Volume with specified redundancy:
+          glusterfs.volume_present:
+            - name: volume4
+            - bricks:
+              - host1:/srv/gluster/drive5
+              - host2:/srv/gluster/drive6
+              - host3:/srv/gluster/drive7
+            - disperse: 3
+            - redundancy: 1
+            - start: True
+
     """
     ret = {"name": name, "changes": {}, "comment": "", "result": False}
 
@@ -191,7 +214,7 @@ def volume_present(
             return ret
 
         vol_created = __salt__["glusterfs.create_volume"](
-            name, bricks, stripe, replica, device_vg, transport, start, force, arbiter
+            name, bricks, stripe, replica, device_vg, transport, start, force, arbiter, disperse, redundancy
         )
 
         if not vol_created:


### PR DESCRIPTION
### What does this PR do?
It adds support for [disperse volumes](https://docs.gluster.org/en/latest/Administrator%20Guide/Setting%20Up%20Volumes/#creating-dispersed-volumes) for GlusterFS.

Please note that I added "neon" as the `versionadded` docstring, unsure what if I'm supposed to do anything with this, just saw it elsewhere in the code.

### What issues does this PR fix or reference?
#55854

### New Behavior
Disperse sets can now be created with states or module.
If `disperse` is set and `redundancy` is not, redundancy is calculated by Gluster.
If `redundancy` is set and `disperse` is not, all specified bricks will be used for the disperse set.
This is based on the GlusterFS documentation on disperse sets, and is handled by GlusterFS itself.

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

No, I would like some help with this.

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
