### PR TITLE
Fixed the skip_files_list_verify in archive.extracted state

### DIFF
--- a/tests/integration/states/test_archive.py
+++ b/tests/integration/states/test_archive.py
@@ -329,6 +329,12 @@ class ArchiveTest(ModuleCase, SaltReturnAssertsMixin):
             "skip_files_list_verify argument was set to True. "
             "Extraction is not needed"
         )
+
+        # Clearing the minion cache at the start to ensure that different tests of
+        # skip_files_list_verify won't affect each other
+        self.run_function("saltutil.clear_cache")
+        self.run_function("saltutil.sync_all")
+
         ret = self.run_state(
             "archive.extracted",
             name=ARCHIVE_DIR,
@@ -336,6 +342,7 @@ class ArchiveTest(ModuleCase, SaltReturnAssertsMixin):
             archive_format="tar",
             skip_files_list_verify=True,
             source_hash_update=True,
+            keep_source=True,
             source_hash=ARCHIVE_TAR_SHA_HASH,
         )
 
@@ -350,6 +357,53 @@ class ArchiveTest(ModuleCase, SaltReturnAssertsMixin):
             archive_format="tar",
             skip_files_list_verify=True,
             source_hash_update=True,
+            keep_source=True,
+            source_hash=ARCHIVE_TAR_SHA_HASH,
+        )
+
+        self.assertSaltTrueReturn(ret)
+        self.assertInSaltComment(expected_comment, ret)
+
+    def test_local_archive_extracted_with_skip_files_list_verify_and_keep_source_is_false(
+        self,
+    ):
+        """
+        test archive.extracted with local file and skip_files_list_verify set to True
+        and keep_source is set to False.
+        """
+        expected_comment = (
+            "existing source sum is the same as the expected one and "
+            "skip_files_list_verify argument was set to True. "
+            "Extraction is not needed"
+        )
+        # Clearing the minion cache at the start to ensure that different tests of
+        # skip_files_list_verify won't affect each other
+        self.run_function("saltutil.clear_cache")
+        self.run_function("saltutil.sync_all")
+
+        ret = self.run_state(
+            "archive.extracted",
+            name=ARCHIVE_DIR,
+            source=self.archive_local_tar_source,
+            archive_format="tar",
+            skip_files_list_verify=True,
+            source_hash_update=True,
+            keep_source=False,
+            source_hash=ARCHIVE_TAR_SHA_HASH,
+        )
+
+        self.assertSaltTrueReturn(ret)
+
+        self._check_extracted(self.untar_file)
+
+        ret = self.run_state(
+            "archive.extracted",
+            name=ARCHIVE_DIR,
+            source=self.archive_local_tar_source,
+            archive_format="tar",
+            skip_files_list_verify=True,
+            source_hash_update=True,
+            keep_source=False,
             source_hash=ARCHIVE_TAR_SHA_HASH,
         )
 


### PR DESCRIPTION
### What does this PR do?
It fixes the `skip_files_list_verify` logic in `archive.extracted`state for the case if `keep_source` is set to `False`.

### What issues does this PR fix or reference?
#55443

### Previous Behavior
Before that this logic only worked if we keep the source which is not how I originally intended to implement this. See #55443

### New Behavior
Now, this logic works for both cases of `keep_source`, yet there is a bunch of limitations that has to be taken into account.

### Implementation details
I don't fancy current implementation. There is a lot of magic going on in this state, especially regarding caching. 

Also, there is a huge edge case that I highlighted in the warning section of the `skip_files_list_verify` argument. To properly fix that we need to introduce some smart Minion cache controls, see https://github.com/saltstack/salt/issues/34369

### Tests written?

Yes

### Commits signed with GPG?

Yes