### PR TITLE
[master] Fixes to logic behind ipv6 filter

### DIFF
--- a/salt/_compat.py
+++ b/salt/_compat.py
@@ -215,7 +215,8 @@ class IPv6InterfaceScoped(ipaddress.IPv6Interface, IPv6AddressScoped):
     Update
     '''
     def __init__(self, address):
-        if isinstance(address, (bytes, int)):
+        if PY3 and isinstance(address, (bytes, int)) or \
+           not PY3 and isinstance(address, int):
             IPv6AddressScoped.__init__(self, address)
             self.network = ipaddress.IPv6Network(self._ip)
             self._prefixlen = self._max_prefixlen

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -224,6 +224,15 @@ class NetworkTestCase(TestCase):
         # https://github.com/saltstack/salt/issues/51258
         self.assertFalse(network.is_ipv6('sixteen-char-str'))
 
+    def test_ipv6(self):
+        self.assertTrue(network.ipv6('2001:db8:0:1:1:1:1:1'))
+        self.assertTrue(network.ipv6('0:0:0:0:0:0:0:1'))
+        self.assertTrue(network.ipv6('::1'))
+        self.assertTrue(network.ipv6('::'))
+        self.assertTrue(network.ipv6('2001:0db8:85a3:0000:0000:8a2e:0370:7334'))
+        self.assertTrue(network.ipv6('2001:0db8:85a3::8a2e:0370:7334'))
+        self.assertTrue(network.ipv6('2001:67c:2e8::/48'))
+
     def test_parse_host_port(self):
         _ip = ipaddress.ip_address
         good_host_ports = {


### PR DESCRIPTION
### What does this PR do?
Updating the logic in IPv6InterfaceScoped to handle situation when this code is running on Python 2 where bytes & strings are treated as the same. Previously when an IPv6 network with a netmask was included it would be treated as a string and handled in the wrong block, which would result in the passed string as invalid.

### What issues does this PR fix or reference?
#52518

### Previous Behavior
ipv6 filter did not work as expected

### New Behavior
ipv6 works again as expected

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
