### PR TITLE
Do not allow msgpack 1.0.0rc1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,5 @@
 Jinja2
-# This should be changed to msgpack-python for Packages
-# msgpack-python>0.3,!=0.5.5
-msgpack>=0.5,!=0.5.5
+msgpack>=0.5,!=0.5.5,<1.0.0
 PyYAML
 MarkupSafe
 requests>=1.0.0


### PR DESCRIPTION
This pins msgpack to lower than 1.0.0 until we can address #56007

### Tests written?

No

### Commits signed with GPG?

Yes