### PR TITLE
fix syntax errors on code-block sections in docs

### DIFF
--- a/salt/cache/consul.py
+++ b/salt/cache/consul.py
@@ -15,7 +15,7 @@ The related documentation can be found in the `Consul documentation`_.
 To enable this cache plugin, the master will need the python client for
 Consul installed. This can be easily installed with pip:
 
-.. code-block: bash
+.. code-block:: bash
 
     pip install python-consul
 

--- a/salt/cache/etcd_cache.py
+++ b/salt/cache/etcd_cache.py
@@ -13,7 +13,7 @@ The related documentation can be found in the `Etcd documentation`_.
 To enable this cache plugin, the master will need the python client for
 Etcd installed. This can be easily installed with pip:
 
-.. code-block: bash
+.. code-block:: bash
 
     pip install python-etcd
 

--- a/salt/cache/mysql_cache.py
+++ b/salt/cache/mysql_cache.py
@@ -13,7 +13,7 @@ table if needed. The keys are indexed using the `bank` and `etcd_key` columns.
 To enable this cache plugin, the master will need the python client for
 MySQL installed. This can be easily installed with pip:
 
-.. code-block: bash
+.. code-block:: bash
 
     pip install python-mysql
 

--- a/salt/modules/bamboohr.py
+++ b/salt/modules/bamboohr.py
@@ -6,7 +6,7 @@ Support for BambooHR
 
 Requires a ``subdomain`` and an ``apikey`` in ``/etc/salt/minion``:
 
-.. code-block: yaml
+.. code-block:: yaml
 
     bamboohr:
       apikey: 012345678901234567890

--- a/salt/modules/ifttt.py
+++ b/salt/modules/ifttt.py
@@ -6,7 +6,7 @@ Support for IFTTT
 
 Requires an ``api_key`` in ``/etc/salt/minion``:
 
-.. code-block: yaml
+.. code-block:: yaml
 
     ifttt:
       secret_key: '280d4699-a817-4719-ba6f-ca56e573e44f'

--- a/salt/modules/pushbullet.py
+++ b/salt/modules/pushbullet.py
@@ -6,7 +6,7 @@ Module for sending messages to Pushbullet (https://www.pushbullet.com)
 
 Requires an ``api_key`` in ``/etc/salt/minion``:
 
-.. code-block: yaml
+.. code-block:: yaml
 
     pushbullet:
       api_key: 'ABC123abc123ABC123abc123ABC123ab'

--- a/salt/modules/rallydev.py
+++ b/salt/modules/rallydev.py
@@ -6,7 +6,7 @@ Support for RallyDev
 
 Requires a ``username`` and a ``password`` in ``/etc/salt/minion``:
 
-.. code-block: yaml
+.. code-block:: yaml
 
     rallydev:
       username: myuser@example.com

--- a/salt/modules/vault.py
+++ b/salt/modules/vault.py
@@ -74,7 +74,7 @@ Functions to interact with Hashicorp Vault.
         You can still use the token auth via a OS environment variable via this
         config example:
 
-        .. code-block: yaml
+        .. code-block:: yaml
 
            vault:
              url: https://vault.service.domain:8200
@@ -86,7 +86,8 @@ Functions to interact with Hashicorp Vault.
 
         And then export the VAULT_TOKEN variable in your OS:
 
-        .. code-block: bash
+        .. code-block:: bash
+
            export VAULT_TOKEN=11111111-1111-1111-1111-1111111111111
 
     policies
@@ -100,7 +101,7 @@ Functions to interact with Hashicorp Vault.
         expanded into multiple policies. For example, given the template
         ``saltstack/by-role/{grains[roles]}``, and a minion having these grains:
 
-        .. code-block: yaml
+        .. code-block:: yaml
 
             grains:
                 roles:

--- a/salt/modules/vboxmanage.py
+++ b/salt/modules/vboxmanage.py
@@ -7,7 +7,7 @@ Support for VirtualBox using the VBoxManage command
 If the ``vboxdrv`` kernel module is not loaded, this module can automatically
 load it by configuring ``autoload_vboxdrv`` in ``/etc/salt/minion``:
 
-.. code-block: yaml
+.. code-block:: yaml
 
     autoload_vboxdrv: True
 

--- a/salt/modules/victorops.py
+++ b/salt/modules/victorops.py
@@ -6,7 +6,7 @@ Support for VictorOps
 
 Requires an ``api_key`` in ``/etc/salt/minion``:
 
-.. code-block: yaml
+.. code-block:: yaml
 
     victorops:
       api_key: '280d4699-a817-4719-ba6f-ca56e573e44f'

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -7906,7 +7906,7 @@ def _apply_scsi_controller(adapter, adapter_type, bus_sharing, key,
         Describes the operation which should be done on the object,
         the possibles values: 'add' and 'edit', the default value is 'add'
 
-    .. code-block: bash
+    .. code-block:: bash
 
         scsi:
           adapter: 'SCSI controller 0'
@@ -8097,7 +8097,7 @@ def _apply_cd_drive(drive_label, key, device_type, operation,
     parent_ref
         Parent object
 
-    .. code-block: bash
+    .. code-block:: bash
 
         cd:
             adapter: "CD/DVD drive 1"
@@ -8278,7 +8278,7 @@ def _create_disks(service_instance, disks, scsi_controllers=None, parent=None):
     parent
         Parent object reference
 
-    .. code-block: bash
+    .. code-block:: bash
 
         disk:
           adapter: 'Hard disk 1'
@@ -8389,7 +8389,7 @@ def _create_network_adapters(network_interfaces, parent=None):
     parent
         Parent object reference
 
-    .. code-block: bash
+    .. code-block:: bash
 
         interfaces:
           adapter: 'Network adapter 1'

--- a/salt/modules/zk_concurrency.py
+++ b/salt/modules/zk_concurrency.py
@@ -185,7 +185,7 @@ def lock_holders(path,
 
     Example:
 
-    .. code-block: bash
+    .. code-block:: bash
 
         salt minion zk_concurrency.lock_holders /lock/path host1:1234,host2:1234
     '''
@@ -237,7 +237,7 @@ def lock(path,
 
     Example:
 
-    .. code-block: bash
+    .. code-block:: bash
 
         salt minion zk_concurrency.lock /lock/path host1:1234,host2:1234
     '''
@@ -298,7 +298,7 @@ def unlock(path,
 
     Example:
 
-    .. code-block: bash
+    .. code-block:: bash
 
         salt minion zk_concurrency.unlock /lock/path host1:1234,host2:1234
     '''
@@ -348,7 +348,7 @@ def party_members(path,
 
     Example:
 
-    .. code-block: bash
+    .. code-block:: bash
 
         salt minion zk_concurrency.party_members /lock/path host1:1234,host2:1234
         salt minion zk_concurrency.party_members /lock/path host1:1234,host2:1234 min_nodes=3 blocking=True

--- a/salt/proxy/nxos.py
+++ b/salt/proxy/nxos.py
@@ -163,7 +163,7 @@ def ping():
     '''
     Ping the device on the other end of the connection
 
-    .. code-block: bash
+    .. code-block:: bash
 
         salt '*' nxos.cmd ping
     '''
@@ -187,7 +187,7 @@ def sendline(command):
     '''
     Run command through switch's cli
 
-    .. code-block: bash
+    .. code-block:: bash
 
         salt '*' nxos.cmd sendline 'show run | include "^username admin password"'
     '''
@@ -203,7 +203,7 @@ def grains():
     '''
     Get grains for proxy minion
 
-    .. code-block: bash
+    .. code-block:: bash
 
         salt '*' nxos.cmd grains
     '''
@@ -218,7 +218,7 @@ def grains_refresh():
     '''
     Refresh the grains from the proxy device.
 
-    .. code-block: bash
+    .. code-block:: bash
 
         salt '*' nxos.cmd grains_refresh
     '''
@@ -230,7 +230,7 @@ def get_user(username):
     '''
     Get username line from switch
 
-    .. code-block: bash
+    .. code-block:: bash
 
         salt '*' nxos.cmd get_user username=admin
     '''
@@ -241,7 +241,7 @@ def get_roles(username):
     '''
     Get roles that the username is assigned from switch
 
-    .. code-block: bash
+    .. code-block:: bash
 
         salt '*' nxos.cmd get_roles username=admin
     '''
@@ -258,7 +258,7 @@ def check_password(username, password, encrypted=False):
     '''
     Check if passed password is the one assigned to user
 
-    .. code-block: bash
+    .. code-block:: bash
 
         salt '*' nxos.cmd check_password username=admin password=admin
         salt '*' nxos.cmd check_password username=admin \\

--- a/salt/runners/drac.py
+++ b/salt/runners/drac.py
@@ -5,7 +5,7 @@ Manage Dell DRAC from the Master
 The login credentials need to be configured in the Salt master
 configuration file.
 
-.. code-block: yaml
+.. code-block:: yaml
 
     drac:
       username: admin

--- a/salt/sdb/sqlite3.py
+++ b/salt/sdb/sqlite3.py
@@ -31,7 +31,7 @@ Advanced Usage:
 Instead of a table name, it is possible to provide custom SQL statements to
 create the table(s) and get and set values.
 
-.. code-block: yaml
+.. code-block:: yaml
 
     myadvanced
       driver: sqlite3

--- a/salt/states/chocolatey.py
+++ b/salt/states/chocolatey.py
@@ -215,7 +215,7 @@ def uninstalled(name, version=None, uninstall_args=None, override_args=False):
       When this is set to False uninstall_args will be appended to the end of
       the default arguments
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
       Removemypackage:
         chocolatey.uninstalled:

--- a/salt/states/lxd_image.py
+++ b/salt/states/lxd_image.py
@@ -70,7 +70,7 @@ def present(name,
 
         For an LXD to LXD copy:
 
-        .. code-block: yaml
+        .. code-block:: yaml
 
             source:
                 type: lxd
@@ -89,7 +89,7 @@ def present(name,
 
         From file:
 
-        .. code-block: yaml
+        .. code-block:: yaml
 
             source:
                 type: file
@@ -98,7 +98,7 @@ def present(name,
 
         From simplestreams:
 
-        .. code-block: yaml
+        .. code-block:: yaml
 
             source:
                 type: simplestreams
@@ -107,7 +107,7 @@ def present(name,
 
         From an URL:
 
-        .. code-block: yaml
+        .. code-block:: yaml
 
             source:
                 type: url

--- a/salt/thorium/file.py
+++ b/salt/thorium/file.py
@@ -5,14 +5,14 @@ Writes matches to disk to verify activity, helpful when testing
 Normally this is used by giving the name of the file (without a path) that the
 data will be saved to. If for instance you use ``foo`` as the name:
 
-.. code-block: yaml
+.. code-block:: yaml
 
     foo:
       file.save
 
 Then the file will be saved to:
 
-.. code-block: bash
+.. code-block:: bash
 
     <salt cachedir>/thorium/saves/foo
 

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -383,7 +383,7 @@ def query(params=None, setname=None, requesturl=None, location=None,
 
     Default ``product`` is ``ec2``. Valid ``product`` names are:
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
         - autoscaling (Auto Scaling)
         - cloudformation (CloudFormation)

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -3137,7 +3137,7 @@ def _strip_cache_events(data, opts):
     are configured in the main Salt Cloud configuration file, usually
     ``/etc/salt/cloud``.
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
         cache_event_strip_fields:
           - password


### PR DESCRIPTION
### What does this PR do?
It fixes missing code-block sections in docs due to missing second colon

### Previous Behavior
Many code-block sections were missing

### New Behavior
code-block sections now show up