### PR TITLE
Skip test_check_virtualname if source directory is not found

### DIFF
--- a/tests/unit/test_module_names.py
+++ b/tests/unit/test_module_names.py
@@ -17,7 +17,7 @@ import salt.utils.stringutils
 # Import Salt Testing libs
 from tests.support.paths import list_test_mods
 from tests.support.runtests import RUNTIME_VARS
-from tests.support.unit import TestCase
+from tests.support.unit import TestCase, skipIf
 
 EXCLUDED_DIRS = [
     os.path.join("tests", "pkg"),
@@ -101,6 +101,10 @@ class BadTestModuleNamesTestCase(TestCase):
         error_msg += "If it is a tests module, then please rename as suggested."
         self.assertEqual([], bad_names, error_msg)
 
+    @skipIf(
+        not os.path.isdir(os.path.join(RUNTIME_VARS.CODE_DIR, "salt")),
+        "Failed to find salt directory in '{}'.".format(RUNTIME_VARS.CODE_DIR),
+    )
     def test_module_name_source_match(self):
         """
         Check all the test mods and check if they correspond to actual files in

--- a/tests/unit/test_module_names.py
+++ b/tests/unit/test_module_names.py
@@ -13,10 +13,10 @@ import os
 # Import Salt libs
 import salt.utils.path
 import salt.utils.stringutils
-from tests.support.paths import list_test_mods
-from tests.support.runtests import RUNTIME_VARS
 
 # Import Salt Testing libs
+from tests.support.paths import list_test_mods
+from tests.support.runtests import RUNTIME_VARS
 from tests.support.unit import TestCase
 
 EXCLUDED_DIRS = [

--- a/tests/unit/test_virtualname.py
+++ b/tests/unit/test_virtualname.py
@@ -12,9 +12,9 @@ import os
 
 # Import Salt libs
 import salt.ext.six as six
-from tests.support.runtests import RUNTIME_VARS
 
 # Import Salt Testing libs
+from tests.support.runtests import RUNTIME_VARS
 from tests.support.unit import TestCase
 
 try:

--- a/tests/unit/test_virtualname.py
+++ b/tests/unit/test_virtualname.py
@@ -15,7 +15,7 @@ import salt.ext.six as six
 
 # Import Salt Testing libs
 from tests.support.runtests import RUNTIME_VARS
-from tests.support.unit import TestCase
+from tests.support.unit import TestCase, skipIf
 
 try:
     import importlib.util
@@ -84,6 +84,10 @@ class VirtualNameTestCase(TestCase):
                     )
         return ret
 
+    @skipIf(
+        not os.path.isdir(os.path.join(RUNTIME_VARS.CODE_DIR, "salt")),
+        "Failed to find salt directory in '{}'.".format(RUNTIME_VARS.CODE_DIR),
+    )
     def test_check_virtualname(self):
         """
         Test that the virtualname is in __name__ of the module


### PR DESCRIPTION
Running the unittest with autopkgtest against the installed version of
salt fails (log from salt 2019.2.3):

```
======================================================================
ERROR: test_check_virtualname (unit.test_virtualname.VirtualNameTestCase)
[CPU:0.0%|MEM:60.8%]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/autopkgtest.O28A17/autopkgtest_tmp/tests/unit/test_virtualname.py", line 89, in test_check_virtualname
    for entry in os.listdir(os.path.join(CODE_DIR, 'salt/')):
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/autopkgtest.O28A17/autopkgtest_tmp/salt/'

----------------------------------------------------------------------
```

Therefore skip `test_check_virtualname` if the source directory `salt` is not
found.