### PR TITLE
Fix Tornado 4.5.3 embedded for Python 3.7 support

### DIFF
--- a/salt/ext/tornado/gen.py
+++ b/salt/ext/tornado/gen.py
@@ -484,9 +484,8 @@ class WaitIterator(object):
         self.current_future = done
         self.current_index = self._unfinished.pop(done)
 
-    @coroutine
     def __aiter__(self):
-        raise Return(self)
+        raise self
 
     def __anext__(self):
         if self.done():

--- a/salt/ext/tornado/queues.py
+++ b/salt/ext/tornado/queues.py
@@ -254,7 +254,6 @@ class Queue(object):
         """
         return self._finished.wait(timeout)
 
-    @gen.coroutine
     def __aiter__(self):
         return _QueueIterator(self)
 

--- a/salt/ext/tornado/test/asyncio_test.py
+++ b/salt/ext/tornado/test/asyncio_test.py
@@ -47,7 +47,8 @@ class AsyncIOLoopTest(AsyncTestCase):
         if hasattr(asyncio, 'ensure_future'):
             ensure_future = asyncio.ensure_future
         else:
-            ensure_future = asyncio.async
+            # async is a reserved word in Python 3.7
+            ensure_future = getattr(asyncio, "async")
 
         x = yield ensure_future(
             asyncio.get_event_loop().run_in_executor(None, lambda: 42))


### PR DESCRIPTION
### What does this PR do?
Adjusts for use of reserved keyword async in Python 3.7
Code change as previously utilized by Debian in Debian 10

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/56018

### Previous Behavior
On Python 3.7, would have errors, for example: Amazon Linux 2 Python 3.7, see associated issue

### New Behavior
Code builds and packages cleanly.

### Tests written?
Yes, nightly build script for Amazon Linux 2 Python 3 support

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
