### PR TITLE
Fix unit test on Python 3.8

### DIFF
--- a/.ci/kitchen-archlts-py3
+++ b/.ci/kitchen-archlts-py3
@@ -8,7 +8,7 @@ runTestSuite(
     golden_images_branch: 'master',
     jenkins_slave_label: 'kitchen-slave',
     nox_env_name: 'runtests-zeromq',
-    nox_passthrough_opts: '-n integration.modules.test_pkg',
+    nox_passthrough_opts: '',
     python_version: 'py3',
     testrun_timeout: 6,
     use_spot_instances: true)

--- a/requirements/pytest.txt
+++ b/requirements/pytest.txt
@@ -1,7 +1,7 @@
 mock >= 3.0.0
 # PyTest
 pytest >=4.6.6,<4.7   # PyTest 4.6.x are the last Py2 and Py3 releases
-pytest-salt >= 2019.12.27
+pytest-salt >= 2020.1.27
 pytest-tempdir >= 2019.10.12
 pytest-helpers-namespace >= 2019.1.8
 pytest-salt-runtests-bridge >= 2019.7.10

--- a/requirements/static/py3.5/darwin.txt
+++ b/requirements/static/py3.5/darwin.txt
@@ -89,7 +89,7 @@ pyparsing==2.4.5          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.12.27
+pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==4.6.6
 python-dateutil==2.8.0

--- a/requirements/static/py3.5/linux.txt
+++ b/requirements/static/py3.5/linux.txt
@@ -84,7 +84,7 @@ pyparsing==2.4.5          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.12.27
+pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==4.6.6
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, vcert

--- a/requirements/static/py3.5/windows.txt
+++ b/requirements/static/py3.5/windows.txt
@@ -78,7 +78,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via packaging
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.12.27
+pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==4.6.6
 python-dateutil==2.8.0

--- a/requirements/static/py3.6/darwin.txt
+++ b/requirements/static/py3.6/darwin.txt
@@ -88,7 +88,7 @@ pyparsing==2.4.5          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.12.27
+pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==4.6.6
 python-dateutil==2.8.0

--- a/requirements/static/py3.6/linux.txt
+++ b/requirements/static/py3.6/linux.txt
@@ -83,7 +83,7 @@ pyparsing==2.4.5          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.12.27
+pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==4.6.6
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, vcert

--- a/requirements/static/py3.6/windows.txt
+++ b/requirements/static/py3.6/windows.txt
@@ -77,7 +77,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via packaging
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.12.27
+pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==4.6.6
 python-dateutil==2.8.0

--- a/requirements/static/py3.7/darwin.txt
+++ b/requirements/static/py3.7/darwin.txt
@@ -87,7 +87,7 @@ pyparsing==2.4.5          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.12.27
+pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==4.6.6
 python-dateutil==2.8.0

--- a/requirements/static/py3.7/linux.txt
+++ b/requirements/static/py3.7/linux.txt
@@ -83,7 +83,7 @@ pyparsing==2.4.5          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.12.27
+pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==4.6.6
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, vcert

--- a/requirements/static/py3.7/windows.txt
+++ b/requirements/static/py3.7/windows.txt
@@ -76,7 +76,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via packaging
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.12.27
+pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==4.6.6
 python-dateutil==2.8.0

--- a/requirements/static/py3.8/darwin.txt
+++ b/requirements/static/py3.8/darwin.txt
@@ -86,7 +86,7 @@ pyparsing==2.4.5          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.12.27
+pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==4.6.6
 python-dateutil==2.8.0

--- a/requirements/static/py3.8/linux.txt
+++ b/requirements/static/py3.8/linux.txt
@@ -82,7 +82,7 @@ pyparsing==2.4.5          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.12.27
+pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==4.6.6
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, vcert

--- a/requirements/static/py3.9/darwin.txt
+++ b/requirements/static/py3.9/darwin.txt
@@ -86,7 +86,7 @@ pyparsing==2.4.5          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.12.27
+pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==4.6.6
 python-dateutil==2.8.0

--- a/requirements/static/py3.9/linux.txt
+++ b/requirements/static/py3.9/linux.txt
@@ -82,7 +82,7 @@ pyparsing==2.4.5          # via packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
 pytest-salt-runtests-bridge==2019.7.10
-pytest-salt==2019.12.27
+pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==4.6.6
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, vcert

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -6,7 +6,6 @@ A collection of mixins useful for the various *Client interfaces
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals, with_statement
 
-import collections
 import copy as pycopy
 import fnmatch
 import logging
@@ -36,6 +35,13 @@ import salt.utils.user
 import salt.utils.versions
 from salt.ext import six
 
+try:
+    from collections.abc import Mapping, MutableMapping
+except ImportError:
+    # pylint: disable=no-name-in-module
+    from collections import Mapping, MutableMapping
+
+
 log = logging.getLogger(__name__)
 
 CLIENT_INTERNAL_KEYWORDS = frozenset(
@@ -58,7 +64,7 @@ CLIENT_INTERNAL_KEYWORDS = frozenset(
 )
 
 
-class ClientFuncsDict(collections.MutableMapping):
+class ClientFuncsDict(MutableMapping):
     """
     Class to make a read-only dict for accessing runner funcs "directly"
     """
@@ -148,7 +154,7 @@ class SyncClientMixin(object):
             self.opts, crypt="clear", usage="master_call"
         ) as channel:
             ret = channel.send(load)
-            if isinstance(ret, collections.Mapping):
+            if isinstance(ret, Mapping):
                 if "error" in ret:
                     salt.utils.error.raise_error(**ret["error"])
             return ret

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2950,7 +2950,9 @@ def apply_cloud_providers_config(overrides, defaults=None):
         # Merge provided extends
         keep_looping = False
         for alias, entries in six.iteritems(providers.copy()):
-            for driver, details in six.iteritems(entries):
+            for driver in list(six.iterkeys(entries)):
+                # Don't use iteritems, because the values of the dictionary will be changed
+                details = entries[driver]
 
                 if "extends" not in details:
                     # Extends resolved or non existing, continue!

--- a/salt/ext/tornado/httputil.py
+++ b/salt/ext/tornado/httputil.py
@@ -36,6 +36,13 @@ from salt.ext.tornado.escape import native_str, parse_qs_bytes, utf8
 from salt.ext.tornado.log import gen_log
 from salt.ext.tornado.util import ObjectDict, PY3
 
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    # pylint: disable=no-name-in-module
+    from collections import MutableMapping
+
+
 if PY3:
     import http.cookies as Cookie
     from http.client import responses
@@ -104,7 +111,7 @@ class _NormalizedHeaderCache(dict):
 _normalized_headers = _NormalizedHeaderCache(1000)
 
 
-class HTTPHeaders(collections.MutableMapping):
+class HTTPHeaders(MutableMapping):
     """A dictionary that maintains ``Http-Header-Case`` for all keys.
 
     Supports multiple values per key via a pair of new methods,

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -60,29 +60,34 @@ except ImportError:
 __proxyenabled__ = ["*"]
 __FQDN__ = None
 
-
-_supported_dists += (
-    "arch",
-    "mageia",
-    "meego",
-    "vmware",
-    "bluewhite64",
-    "slamd64",
-    "ovs",
-    "system",
-    "mint",
-    "oracle",
-    "void",
-)
-
 # linux_distribution deprecated in py3.7
 try:
     from platform import linux_distribution as _deprecated_linux_distribution
 
+    # Extend the default list of supported distros. This will be used for the
+    # /etc/DISTRO-release checking that is part of linux_distribution()
+    from platform import _supported_dists
+
+    _supported_dists += (
+        "arch",
+        "mageia",
+        "meego",
+        "vmware",
+        "bluewhite64",
+        "slamd64",
+        "ovs",
+        "system",
+        "mint",
+        "oracle",
+        "void",
+    )
+
     def linux_distribution(**kwargs):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            return _deprecated_linux_distribution(**kwargs)
+            return _deprecated_linux_distribution(
+                supported_dists=_supported_dists, **kwargs
+            )
 
 
 except ImportError:
@@ -2067,8 +2072,7 @@ def os_data():
             "platform.linux_distribution()"
         )
         (osname, osrelease, oscodename) = [
-            x.strip('"').strip("'")
-            for x in linux_distribution(supported_dists=_supported_dists)
+            x.strip('"').strip("'") for x in linux_distribution()
         ]
         # Try to assign these three names based on the lsb info, they tend to
         # be more accurate than what python gets from /etc/DISTRO-release.

--- a/salt/renderers/stateconf.py
+++ b/salt/renderers/stateconf.py
@@ -225,10 +225,10 @@ def render(input, saltenv="base", sls="", argline="", **kws):
             tmplctx = STATE_CONF.copy()
             if tmplctx:
                 prefix = sls + "::"
-                for k in six.iterkeys(tmplctx):  # iterate over a copy of keys
-                    if k.startswith(prefix):
-                        tmplctx[k[len(prefix) :]] = tmplctx[k]
-                        del tmplctx[k]
+                tmplctx = {
+                    k[len(prefix) :] if k.startswith(prefix) else k: v
+                    for k, v in six.iteritems(tmplctx)
+                }
         else:
             tmplctx = {}
 

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -7,7 +7,6 @@ Jinja loading utils to enable a more powerful backend for jinja templates
 from __future__ import absolute_import, unicode_literals
 
 import atexit
-import collections
 import logging
 import os.path
 import pipes
@@ -37,6 +36,13 @@ from salt.exceptions import TemplateError
 from salt.ext import six
 from salt.utils.decorators.jinja import jinja_filter, jinja_global, jinja_test
 from salt.utils.odict import OrderedDict
+
+try:
+    from collections.abc import Hashable
+except ImportError:
+    # pylint: disable=no-name-in-module
+    from collections import Hashable
+
 
 log = logging.getLogger(__name__)
 
@@ -342,7 +348,7 @@ def to_bool(val):
         return val.lower() in ("yes", "1", "true")
     if isinstance(val, six.integer_types):
         return val > 0
-    if not isinstance(val, collections.Hashable):
+    if not isinstance(val, Hashable):
         return len(val) > 0
     return False
 
@@ -507,7 +513,7 @@ def unique(values):
         ['a', 'b', 'c']
     """
     ret = None
-    if isinstance(values, collections.Hashable):
+    if isinstance(values, Hashable):
         ret = set(values)
     else:
         ret = []
@@ -571,7 +577,7 @@ def lst_avg(lst):
 
         2.5
     """
-    if not isinstance(lst, collections.Hashable):
+    if not isinstance(lst, Hashable):
         return float(sum(lst) / len(lst))
     return float(lst)
 
@@ -592,9 +598,7 @@ def union(lst1, lst2):
 
         [1, 2, 3, 4, 6]
     """
-    if isinstance(lst1, collections.Hashable) and isinstance(
-        lst2, collections.Hashable
-    ):
+    if isinstance(lst1, Hashable) and isinstance(lst2, Hashable):
         return set(lst1) | set(lst2)
     return unique(lst1 + lst2)
 
@@ -615,9 +619,7 @@ def intersect(lst1, lst2):
 
         [2, 4]
     """
-    if isinstance(lst1, collections.Hashable) and isinstance(
-        lst2, collections.Hashable
-    ):
+    if isinstance(lst1, Hashable) and isinstance(lst2, Hashable):
         return set(lst1) & set(lst2)
     return unique([ele for ele in lst1 if ele in lst2])
 
@@ -638,9 +640,7 @@ def difference(lst1, lst2):
 
         [1, 3, 6]
     """
-    if isinstance(lst1, collections.Hashable) and isinstance(
-        lst2, collections.Hashable
-    ):
+    if isinstance(lst1, Hashable) and isinstance(lst2, Hashable):
         return set(lst1) - set(lst2)
     return unique([ele for ele in lst1 if ele not in lst2])
 
@@ -661,9 +661,7 @@ def symmetric_difference(lst1, lst2):
 
         [1, 3]
     """
-    if isinstance(lst1, collections.Hashable) and isinstance(
-        lst2, collections.Hashable
-    ):
+    if isinstance(lst1, Hashable) and isinstance(lst2, Hashable):
         return set(lst1) ^ set(lst2)
     return unique(
         [ele for ele in union(lst1, lst2) if ele not in intersect(lst1, lst2)]

--- a/salt/utils/oset.py
+++ b/salt/utils/oset.py
@@ -23,7 +23,11 @@ Rob Speer's changes are as follows:
 """
 from __future__ import absolute_import, print_function, unicode_literals
 
-import collections
+try:
+    from collections.abc import MutableSet
+except ImportError:
+    # pylint: disable=no-name-in-module
+    from collections import MutableSet
 
 SLICE_ALL = slice(None)
 __version__ = "2.0.1"
@@ -49,7 +53,7 @@ def is_iterable(obj):
     )
 
 
-class OrderedSet(collections.MutableSet):
+class OrderedSet(MutableSet):
     """
     An OrderedSet is a custom MutableSet that remembers its order, so that
     every entry has an index that can be looked up.

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -1318,7 +1318,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                   <alias name='net1'/>
                   <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x1'/>
                 </interface>
-                <graphics type='spice' port='5900' autoport='yes' listen='127.0.0.1'>
+                <graphics type='spice' listen='127.0.0.1' autoport='yes'>
                   <listen type='address' address='127.0.0.1'/>
                 </graphics>
                 <video>


### PR DESCRIPTION
Salt fails on Python 3.8:

```
======================================================================
ERROR: unit.grains.test_core (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: unit.grains.test_core
Traceback (most recent call last):
  File "/usr/lib/python3.8/unittest/loader.py", line 436, in _find_test_path
    module = self._get_module_from_name(name)
  File "/usr/lib/python3.8/unittest/loader.py", line 377, in _get_module_from_name
    __import__(name)
  File "tests/unit/grains/test_core.py", line 37, in <module>
    import salt.grains.core as core
  File "salt/grains/core.py", line 40, in <module>
    from platform import _supported_dists
ImportError: cannot import name '_supported_dists' from 'platform' (/usr/lib/python3.8/platform.py)
```

So only try to import `_supported_dists` from `platform` for Python <=
3.7. Otherwise rely on the external `distro` module to  not need any
special handling.

Addresses parts of #55835