### PR TITLE
Fix issues with setuptools in conjunction with spawn

### DIFF
--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -94,6 +94,13 @@ def salt_master():
     Start the salt master.
     '''
     import salt.cli.daemons
+
+    # Fix for setuptools generated scripts, so that it will
+    # work with multiprocessing fork emulation.
+    # (see multiprocessing.forking.get_preparation_data())
+    if __name__ != '__main__':
+        sys.modules['__main__'] = sys.modules[__name__]
+
 # REMOVEME after Python 2.7 support is dropped (also the six import)
     if six.PY2:
         from salt.utils.versions import warn_until
@@ -183,6 +190,13 @@ def salt_minion():
 
     import salt.cli.daemons
     import multiprocessing
+
+    # Fix for setuptools generated scripts, so that it will
+    # work with multiprocessing fork emulation.
+    # (see multiprocessing.forking.get_preparation_data())
+    if __name__ != '__main__':
+        sys.modules['__main__'] = sys.modules[__name__]
+
     if '' in sys.path:
         sys.path.remove('')
 


### PR DESCRIPTION
### What does this PR do?

The switch to setuptools caused the following tracebacks on windows when Salt is installed via the installer. This change addresses the issue.

```
Traceback (most recent call last):
  File "C:\salt\bin\Scripts\salt-minion", line 4, in <module>
    __import__('pkg_resources').run_script('salt==3000', 'salt-minion')
  File "C:\salt\bin\lib\site-packages\pkg_resources\__init__.py", line 750, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "C:\salt\bin\lib\site-packages\pkg_resources\__init__.py", line 1527, in run_script
    exec(code, namespace, namespace)
  File "c:\salt\bin\lib\site-packages\salt-3000-py3.5.egg\EGG-INFO\scripts\salt-minion", line 26, in <module>
    salt_minion()
  File "C:\salt\bin\lib\site-packages\salt-3000-py3.5.egg\salt\scripts.py", line 191, in salt_minion
    minion.start()
  File "C:\salt\bin\lib\site-packages\salt-3000-py3.5.egg\salt\cli\daemons.py", line 323, in start
    super(Minion, self).start()
  File "C:\salt\bin\lib\site-packages\salt-3000-py3.5.egg\salt\utils\parsers.py", line 1073, in start
    self.prepare()
  File "C:\salt\bin\lib\site-packages\salt-3000-py3.5.egg\salt\cli\daemons.py", line 241, in prepare
    super(Minion, self).prepare()
  File "C:\salt\bin\lib\site-packages\salt-3000-py3.5.egg\salt\utils\parsers.py", line 1070, in prepare
    self.parse_args()
  File "C:\salt\bin\lib\site-packages\salt-3000-py3.5.egg\salt\utils\parsers.py", line 238, in parse_args
    mixin_after_parsed_func, traceback.format_exc(err)
  File "C:\salt\bin\lib\traceback.py", line 163, in format_exc
    return "".join(format_exception(*sys.exc_info(), limit=limit, chain=chain))
  File "C:\salt\bin\lib\traceback.py", line 117, in format_exception
    type(value), value, tb, limit=limit).format(chain=chain))
  File "C:\salt\bin\lib\traceback.py", line 474, in __init__
    capture_locals=capture_locals)
  File "C:\salt\bin\lib\traceback.py", line 332, in extract
    if limit >= 0:
TypeError: unorderable types: AttributeError() >= int()
```

```
Traceback (most recent call last):
  File "C:\salt\bin\lib\site-packages\salt-3000-py3.5.egg\salt\utils\parsers.py", line 233, in parse_args
    mixin_after_parsed_func(self)
  File "C:\salt\bin\lib\site-packages\salt-3000-py3.5.egg\salt\utils\parsers.py", line 881, in _setup_mp_logging_listener
    self._get_mp_logging_listener_queue()
  File "C:\salt\bin\lib\site-packages\salt-3000-py3.5.egg\salt\log\setup.py", line 558, in setup_multiprocessing_logging_listener
    __MP_LOGGING_QUEUE_PROCESS.start()
  File "C:\salt\bin\lib\multiprocessing\process.py", line 105, in start
    self._popen = self._Popen(self)
  File "C:\salt\bin\lib\multiprocessing\context.py", line 212, in _Popen
    return _default_context.get_context().Process._Popen(process_obj)
  File "C:\salt\bin\lib\multiprocessing\context.py", line 313, in _Popen
    return Popen(process_obj)
  File "C:\salt\bin\lib\multiprocessing\popen_spawn_win32.py", line 34, in __init__
    prep_data = spawn.get_preparation_data(process_obj._name)
  File "C:\salt\bin\lib\multiprocessing\spawn.py", line 173, in get_preparation_data
    main_mod_name = getattr(main_module.__spec__, "name", None)
AttributeError: module '__main__' has no attribute '__spec__'
```

Note: We sourced this from https://docs.celeryproject.org/en/3.1/_modules/celery/bin/celery.html

### Tests written?

No - :( This should be covered by testing our artifacts which we currently do manually. Though we are moving towards a day when it will be automated.

### Commits signed with GPG?

Yes