### PR TITLE
Extend bond hashing algorithms with encaps

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -969,7 +969,7 @@ def _parse_settings_bond_2(opts, iface, bond_def):
         bond.update({'arp_interval': bond_def['arp_interval']})
 
     if 'hashing-algorithm' in opts:
-        valid = ['layer2', 'layer2+3', 'layer3+4']
+        valid = ['layer2', 'layer2+3', 'layer3+4', 'encap2+3', 'encap3+4']
         if opts['hashing-algorithm'] in valid:
             bond.update({'xmit_hash_policy': opts['hashing-algorithm']})
         else:
@@ -1056,7 +1056,7 @@ def _parse_settings_bond_4(opts, iface, bond_def):
         bond.update({'use_carrier': bond_def['use_carrier']})
 
     if 'hashing-algorithm' in opts:
-        valid = ['layer2', 'layer2+3', 'layer3+4']
+        valid = ['layer2', 'layer2+3', 'layer3+4', 'encap2+3', 'encap3+4']
         if opts['hashing-algorithm'] in valid:
             bond.update({'xmit_hash_policy': opts['hashing-algorithm']})
         else:

--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -394,7 +394,7 @@ def _parse_settings_bond_2(opts, iface, bond_def):
         bond.update({'arp_interval': bond_def['arp_interval']})
 
     if 'hashing-algorithm' in opts:
-        valid = ['layer2', 'layer2+3', 'layer3+4']
+        valid = ['layer2', 'layer2+3', 'layer3+4', 'encap2+3', 'encap3+4']
         if opts['hashing-algorithm'] in valid:
             bond.update({'xmit_hash_policy': opts['hashing-algorithm']})
         else:
@@ -481,7 +481,7 @@ def _parse_settings_bond_4(opts, iface, bond_def):
         bond.update({'use_carrier': bond_def['use_carrier']})
 
     if 'hashing-algorithm' in opts:
-        valid = ['layer2', 'layer2+3', 'layer3+4']
+        valid = ['layer2', 'layer2+3', 'layer3+4', 'encap2+3', 'encap3+4']
         if opts['hashing-algorithm'] in valid:
             bond.update({'xmit_hash_policy': opts['hashing-algorithm']})
         else:


### PR DESCRIPTION
### What does this PR do?
This PR adds encap hashing algorithms to bond valid opts

### What issues does this PR fix or reference?
According to https://www.kernel.org/doc/Documentation/networking/bonding.txt encap options are also valid. This PR will remove limitations

### Tests written?
No

### Commits signed with GPG?
No