### PR TITLE
Replace pycryptodome with pycrypto

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,6 @@ repos:
           - --include=requirements/base.txt
           - --include=requirements/zeromq.txt
           - --include=requirements/pytest.txt
-          - --remove-line=^pycrypto==(.*)$
 
       - id: pip-tools-compile
         alias: compile-darwin-py2.7-zmq-requirements
@@ -30,7 +29,6 @@ repos:
           - --include=requirements/base.txt
           - --include=requirements/zeromq.txt
           - --include=requirements/pytest.txt
-          - --remove-line=^pycrypto==(.*)$
           - --passthrough-line-from-input=^pyobjc(.*)$
 
       - id: pip-tools-compile
@@ -46,7 +44,6 @@ repos:
           - --include=requirements/base.txt
           - --include=requirements/zeromq.txt
           - --include=requirements/pytest.txt
-          - --remove-line=^pycrypto==(.*)$
 
       - id: pip-tools-compile
         alias: compile-cloud-py2.7-requirements
@@ -99,7 +96,6 @@ repos:
           - --include=requirements/base.txt
           - --include=requirements/zeromq.txt
           - --include=requirements/pytest.txt
-          - --remove-line=^pycrypto==(.*)$
 
       - id: pip-tools-compile
         alias: compile-cloud-py3.4-requirements
@@ -132,7 +128,6 @@ repos:
           - --include=requirements/base.txt
           - --include=requirements/zeromq.txt
           - --include=requirements/pytest.txt
-          - --remove-line=^pycrypto==(.*)$
 
       - id: pip-tools-compile
         alias: compile-darwin-py3.5-zmq-requirements
@@ -147,7 +142,6 @@ repos:
           - --include=requirements/base.txt
           - --include=requirements/zeromq.txt
           - --include=requirements/pytest.txt
-          - --remove-line=^pycrypto==(.*)$
           - --passthrough-line-from-input=^pyobjc(.*)$
 
       - id: pip-tools-compile
@@ -163,7 +157,6 @@ repos:
           - --include=requirements/base.txt
           - --include=requirements/zeromq.txt
           - --include=requirements/pytest.txt
-          - --remove-line=^pycrypto==(.*)$
 
       - id: pip-tools-compile
         alias: compile-cloud-py3.5-requirements
@@ -234,7 +227,6 @@ repos:
           - --include=requirements/base.txt
           - --include=requirements/zeromq.txt
           - --include=requirements/pytest.txt
-          - --remove-line=^pycrypto==(.*)$
 
       - id: pip-tools-compile
         alias: compile-darwin-py3.6-zmq-requirements
@@ -249,7 +241,6 @@ repos:
           - --include=requirements/base.txt
           - --include=requirements/zeromq.txt
           - --include=requirements/pytest.txt
-          - --remove-line=^pycrypto==(.*)$
           - --passthrough-line-from-input=^pyobjc(.*)$
 
       - id: pip-tools-compile
@@ -265,7 +256,6 @@ repos:
           - --include=requirements/base.txt
           - --include=requirements/zeromq.txt
           - --include=requirements/pytest.txt
-          - --remove-line=^pycrypto==(.*)$
 
       - id: pip-tools-compile
         alias: compile-cloud-py3.6-requirements
@@ -336,7 +326,6 @@ repos:
           - --include=requirements/base.txt
           - --include=requirements/zeromq.txt
           - --include=requirements/pytest.txt
-          - --remove-line=^pycrypto==(.*)$
 
       - id: pip-tools-compile
         alias: compile-darwin-py3.7-zmq-requirements
@@ -351,7 +340,6 @@ repos:
           - --include=requirements/base.txt
           - --include=requirements/zeromq.txt
           - --include=requirements/pytest.txt
-          - --remove-line=^pycrypto==(.*)$
           - --passthrough-line-from-input=^pyobjc(.*)$
 
       - id: pip-tools-compile
@@ -367,7 +355,6 @@ repos:
           - --include=requirements/base.txt
           - --include=requirements/zeromq.txt
           - --include=requirements/pytest.txt
-          - --remove-line=^pycrypto==(.*)$
 
       - id: pip-tools-compile
         alias: compile-cloud-py3.7-requirements

--- a/requirements/crypto.txt
+++ b/requirements/crypto.txt
@@ -1,2 +1,2 @@
-pycryptodome; sys.platform != 'win32'
+pycrypto>=2.6.1; sys.platform not in 'win32,darwin'
 pycryptodomex; sys.platform == 'win32'

--- a/requirements/static/linux.in
+++ b/requirements/static/linux.in
@@ -23,9 +23,6 @@ more-itertools==5.0.0
 moto
 paramiko>=2.1.6
 psutil
-# Let's install pycryptodome instead of pycrypto because of pycrypto's outstanding security issues
-# PyCrypto, if pulled, will be removed from the generated static requirements
-pycryptodome
 pygit2
 pyinotify
 pyopenssl

--- a/requirements/static/py2.7/darwin.txt
+++ b/requirements/static/py2.7/darwin.txt
@@ -87,7 +87,7 @@ pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5
 pycparser==2.19
-pycryptodome==3.8.1 ; sys_platform != "win32"
+pycryptodome==3.8.1
 pynacl==1.3.0             # via paramiko
 pyopenssl==19.0.0
 pyparsing==2.4.5          # via packaging

--- a/requirements/static/py2.7/linux.txt
+++ b/requirements/static/py2.7/linux.txt
@@ -85,7 +85,8 @@ pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5             # via paramiko, pyasn1-modules, rsa
 pycparser==2.19           # via cffi
-pycryptodome==3.8.1 ; sys_platform != "win32"
+pycrypto==2.6.1 ; sys_platform not in "win32,darwin"
+pycryptodome==3.8.1       # via python-jose
 pygit2==0.28.2
 pyinotify==0.9.6
 pynacl==1.3.0             # via paramiko

--- a/requirements/static/py3.4/linux.txt
+++ b/requirements/static/py3.4/linux.txt
@@ -75,7 +75,8 @@ pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5             # via paramiko, pyasn1-modules, rsa
 pycparser==2.19           # via cffi
-pycryptodome==3.8.1 ; sys_platform != "win32"
+pycrypto==2.6.1 ; sys_platform not in "win32,darwin"
+pycryptodome==3.8.1       # via python-jose
 pygit2==0.28.2
 pyinotify==0.9.6
 pynacl==1.3.0             # via paramiko

--- a/requirements/static/py3.5/darwin.txt
+++ b/requirements/static/py3.5/darwin.txt
@@ -78,7 +78,7 @@ pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5
 pycparser==2.19
-pycryptodome==3.8.1 ; sys_platform != "win32"
+pycryptodome==3.8.1
 pynacl==1.3.0             # via paramiko
 pyopenssl==19.0.0
 pyparsing==2.4.5          # via packaging

--- a/requirements/static/py3.5/linux.txt
+++ b/requirements/static/py3.5/linux.txt
@@ -75,7 +75,8 @@ pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5             # via paramiko, pyasn1-modules, rsa
 pycparser==2.19           # via cffi
-pycryptodome==3.8.1 ; sys_platform != "win32"
+pycrypto==2.6.1 ; sys_platform not in "win32,darwin"
+pycryptodome==3.8.1       # via python-jose
 pygit2==0.28.2
 pyinotify==0.9.6
 pynacl==1.3.0             # via paramiko

--- a/requirements/static/py3.6/darwin.txt
+++ b/requirements/static/py3.6/darwin.txt
@@ -77,7 +77,7 @@ pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5
 pycparser==2.19
-pycryptodome==3.8.1 ; sys_platform != "win32"
+pycryptodome==3.8.1
 pynacl==1.3.0             # via paramiko
 pyopenssl==19.0.0
 pyparsing==2.4.5          # via packaging

--- a/requirements/static/py3.6/linux.txt
+++ b/requirements/static/py3.6/linux.txt
@@ -74,7 +74,8 @@ pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5             # via paramiko, pyasn1-modules, rsa
 pycparser==2.19           # via cffi
-pycryptodome==3.8.1 ; sys_platform != "win32"
+pycrypto==2.6.1 ; sys_platform not in "win32,darwin"
+pycryptodome==3.8.1       # via python-jose
 pygit2==0.28.2
 pyinotify==0.9.6
 pynacl==1.3.0             # via paramiko

--- a/requirements/static/py3.7/darwin.txt
+++ b/requirements/static/py3.7/darwin.txt
@@ -77,7 +77,7 @@ pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5
 pycparser==2.19
-pycryptodome==3.8.1 ; sys_platform != "win32"
+pycryptodome==3.8.1
 pynacl==1.3.0             # via paramiko
 pyopenssl==19.0.0
 pyparsing==2.4.5          # via packaging

--- a/requirements/static/py3.7/linux.txt
+++ b/requirements/static/py3.7/linux.txt
@@ -11,6 +11,7 @@ atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
 backports.functools-lru-cache==1.5  # via cheroot
+backports.ssl-match-hostname==3.7.0.1  # via websocket-client
 bcrypt==3.1.6             # via paramiko
 boto3==1.9.132
 boto==2.49.0
@@ -73,7 +74,8 @@ pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5             # via paramiko, pyasn1-modules, rsa
 pycparser==2.19           # via cffi
-pycryptodome==3.8.1 ; sys_platform != "win32"
+pycrypto==2.6.1 ; sys_platform not in "win32,darwin"
+pycryptodome==3.8.1       # via python-jose
 pygit2==0.28.2
 pyinotify==0.9.6
 pynacl==1.3.0             # via paramiko

--- a/setup.py
+++ b/setup.py
@@ -206,7 +206,7 @@ def _parse_requirements_file(requirements_file):
             except ValueError:
                 pkg, pyverspec = line, ''
             pyverspec = pyverspec.strip()
-            if pyverspec:
+            if pyverspec and (not pkg.startswith('pycrypto') or pkg.startswith('pycryptodome')):
                 _, op, ver = pyverspec.split(' ', 2)
                 if not _check_ver(platform.python_version(), _parse_op(op), _parse_ver(ver)):
                     continue


### PR DESCRIPTION
### What does this PR do?

Due to issues found during package testing for the several supported
linux distributions, we're switching back our crypto depencency to
pycrypto.

Security concerned users are still advised to install the latest m2crypto
or pycryptodome library after pip installing salt since salt is prepared
to work with whatever is available.
