### PR TITLE
shadow.set_password: handle case where user has no shadow entry

### DIFF
--- a/salt/modules/linux_shadow.py
+++ b/salt/modules/linux_shadow.py
@@ -376,6 +376,10 @@ def set_password(name, password, use_usermod=False, root=None):
 
         salt '*' shadow.set_password root '$1$UYCIxa628.9qXjpQCjM4a..'
     """
+    if __salt__["cmd.retcode"](["id", name], ignore_retcode=True) != 0:
+        log.warning("user %s does not exist, cannot set password", name)
+        return False
+
     if not salt.utils.data.is_true(use_usermod):
         # Edit the shadow file directly
         # ALT Linux uses tcb to store password hashes. More information found

--- a/salt/modules/linux_shadow.py
+++ b/salt/modules/linux_shadow.py
@@ -12,10 +12,10 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import datetime
 import functools
+import logging
 
 # Import python libs
 import os
-import logging
 
 # Import salt libs
 import salt.utils.data

--- a/tests/unit/modules/test_linux_shadow.py
+++ b/tests/unit/modules/test_linux_shadow.py
@@ -4,7 +4,8 @@
 """
 
 # Import Python libs
-from __future__ import absolute_import, unicode_literals, print_function
+from __future__ import absolute_import, print_function, unicode_literals
+
 import textwrap
 
 # Import Salt Testing libs
@@ -15,7 +16,7 @@ import salt.utils.stringutils
 from salt.ext import six
 from tests.support.helpers import skip_if_not_root
 from tests.support.mixins import LoaderModuleMockMixin
-from tests.support.mock import MagicMock, patch, mock_open, DEFAULT
+from tests.support.mock import DEFAULT, MagicMock, mock_open, patch
 from tests.support.unit import TestCase, skipIf
 
 # Import salt libs

--- a/tests/unit/modules/test_linux_shadow.py
+++ b/tests/unit/modules/test_linux_shadow.py
@@ -81,13 +81,13 @@ class LinuxShadowTest(TestCase, LoaderModuleMockMixin):
         isfile_mock = MagicMock(
             side_effect=lambda x: True if x == "/etc/shadow" else DEFAULT
         )
-        shadow_info_mock = MagicMock(return_value={"passwd": "newhash"})
+        password = "newhash"
+        shadow_info_mock = MagicMock(return_value={"passwd": password})
 
         #
         # CASE 1: Normal password change
         #
         user = "bar"
-        password = "newhash"
         user_exists_mock = MagicMock(
             side_effect=lambda x, **y: 0 if x == ["id", user] else DEFAULT
         )
@@ -125,7 +125,6 @@ class LinuxShadowTest(TestCase, LoaderModuleMockMixin):
         # CASE 2: Corner case: no /etc/shadow entry for user
         #
         user = "baz"
-        password = "newhash"
         user_exists_mock = MagicMock(
             side_effect=lambda x, **y: 0 if x == ["id", user] else DEFAULT
         )

--- a/tests/unit/modules/test_linux_shadow.py
+++ b/tests/unit/modules/test_linux_shadow.py
@@ -3,8 +3,9 @@
     :codeauthor: Erik Johnson <erik@saltstack.com>
 """
 
-# Import Pytohn libs
-from __future__ import absolute_import, print_function, unicode_literals
+# Import Python libs
+from __future__ import absolute_import, unicode_literals, print_function
+import textwrap
 
 # Import Salt Testing libs
 import salt.utils.platform
@@ -13,6 +14,7 @@ import salt.utils.platform
 from salt.ext import six
 from tests.support.helpers import skip_if_not_root
 from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.mock import MagicMock, patch, mock_open, DEFAULT
 from tests.support.unit import TestCase, skipIf
 
 # Import salt libs
@@ -58,6 +60,84 @@ class LinuxShadowTest(TestCase, LoaderModuleMockMixin):
                 ),
                 hash_info["pw_hash"],
             )
+
+    def test_set_password(self):
+        """
+        Test the corner case in which shadow.set_password is called for a user
+        that has an entry in /etc/passwd but not /etc/shadow.
+        """
+        data = {
+            "/etc/shadow": textwrap.dedent(
+                """\
+                foo:orighash:17955::::::
+                bar:somehash:17955::::::
+                """
+            ),
+            "*": Exception("Attempted to open something other than /etc/shadow"),
+        }
+        isfile_mock = MagicMock(
+            side_effect=lambda x: True if x == "/etc/shadow" else DEFAULT
+        )
+        shadow_info_mock = MagicMock(return_value={"passwd": "newhash"})
+
+        #
+        # CASE 1: Normal password change
+        #
+        user = "bar"
+        password = "newhash"
+        with patch(
+            "salt.utils.files.fopen", mock_open(read_data=data)
+        ) as shadow_mock, patch("os.path.isfile", isfile_mock), patch.object(
+            shadow, "info", shadow_info_mock
+        ), patch.dict(
+            shadow.__grains__, {"os": "CentOS"}
+        ):
+            result = shadow.set_password(user, password, use_usermod=False)
+
+        assert result
+        filehandles = shadow_mock.filehandles["/etc/shadow"]
+        # We should only have opened twice, once to read the contents and once
+        # to write.
+        assert len(filehandles) == 2
+        # We're rewriting the entire file
+        assert filehandles[1].mode == "w+"
+        # We should be calling writelines instead of write, to rewrite the
+        # entire file.
+        assert len(filehandles[1].writelines_calls) == 1
+        # Make sure we wrote the correct info
+        lines = filehandles[1].writelines_calls[0]
+        # Should only have the same two users in the file
+        assert len(lines) == 2
+        # The first line should be unchanged
+        assert lines[0] == "foo:orighash:17955::::::\n"
+        # The second line should have the new password hash
+        assert lines[1].split(":")[:2] == [user, password]
+
+        #
+        # CASE 2: Corner case: no /etc/shadow entry for user
+        #
+        user = "baz"
+        password = "newhash"
+        with patch(
+            "salt.utils.files.fopen", mock_open(read_data=data)
+        ) as shadow_mock, patch("os.path.isfile", isfile_mock), patch.object(
+            shadow, "info", shadow_info_mock
+        ), patch.dict(
+            shadow.__grains__, {"os": "CentOS"}
+        ):
+            result = shadow.set_password(user, password, use_usermod=False)
+
+        assert result
+        filehandles = shadow_mock.filehandles["/etc/shadow"]
+        # We should only have opened twice, once to read the contents and once
+        # to write.
+        assert len(filehandles) == 2
+        # We're just appending to the file, not rewriting
+        assert filehandles[1].mode == "a+"
+        # We should only have written to the file once
+        assert len(filehandles[1].write_calls) == 1
+        # Make sure we wrote the correct info
+        assert filehandles[1].write_calls[0].split(":")[:2] == [user, password]
 
     @skip_if_not_root
     def test_list_users(self):


### PR DESCRIPTION
Before this fix, this function would not set the password, because its
method of updating the shadow file is to read all the lines into a list,
iterate over that list and update the line for the desired user, and
rewrite the list of lines to /etc/shadow. The problem with this method
is that in the corner cases where the shadow entry doesn't exist (don't
ask), the password is not set, since there is no line for that user.

This fixes that corner case by appending a shadow entry when no line
exists for the specified user.