### PR TITLE
Minion maintenance process

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -341,17 +341,13 @@
 # to ``True``.
 #grains_deep_merge: False
 
-# The grains_refresh_every setting allows for a minion to periodically check
-# its grains to see if they have changed and, if so, to inform the master
-# of the new grains. This operation is moderately expensive, therefore
-# care should be taken not to set this value too low.
+# The grains_refresh_every setting allows for a minion to periodically
+# refresh its grains cache. Will have no effect if 'grains_cache' is not enabled.
 #
 # Note: This value is expressed in __minutes__!
 #
-# A value of 10 minutes is a reasonable default.
-#
 # If the value is set to zero, this check is disabled.
-#grains_refresh_every: 1
+#grains_refresh_every: 5
 
 # Cache grains on the minion. Default is False.
 #grains_cache: False

--- a/conf/proxy
+++ b/conf/proxy
@@ -265,17 +265,13 @@
 # often lower this value
 #loop_interval: 60
 
-# The grains_refresh_every setting allows for a minion to periodically check
-# its grains to see if they have changed and, if so, to inform the master
-# of the new grains. This operation is moderately expensive, therefore
-# care should be taken not to set this value too low.
+# The grains_refresh_every setting allows for a minion to periodically
+# refresh its grains cache. Will have no effect if 'grains_cache' is not enabled.
 #
 # Note: This value is expressed in __minutes__!
 #
-# A value of 10 minutes is a reasonable default.
-#
 # If the value is set to zero, this check is disabled.
-#grains_refresh_every: 1
+#grains_refresh_every: 5
 
 # Cache grains on the minion. Default is False.
 #grains_cache: False

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -885,16 +885,12 @@ With ``grains_deep_merge``, the result will be:
 ``grains_refresh_every``
 ------------------------
 
-Default: ``0``
+Default: ``5``
 
 The ``grains_refresh_every`` setting allows for a minion to periodically
-check its grains to see if they have changed and, if so, to inform the master
-of the new grains. This operation is moderately expensive, therefore care
-should be taken not to set this value too low.
+refresh its grains cache. Will have no effect if ``grains_cache`` is not enabled.
 
 Note: This value is expressed in minutes.
-
-A value of 10 minutes is a reasonable default.
 
 .. code-block:: yaml
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1436,7 +1436,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze({
     'tcp_keepalive_cnt': -1,
     'tcp_keepalive_intvl': -1,
     'modules_max_memory': -1,
-    'grains_refresh_every': 0,
+    'grains_refresh_every': 5,
     'minion_id_caching': True,
     'minion_id_lowercase': False,
     'minion_id_remove_domain': False,

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1106,6 +1106,9 @@ class MinionManager(MinionBase):
 
 
 class Maintenance(salt.utils.process.SignalHandlingMultiprocessingProcess):
+    '''
+    A generalized maintenance process which performs maintenance routines.
+    '''
     def __init__(self, opts, log_queue=None):
         super(Maintenance, self).__init__(log_queue=log_queue)
         self.opts = opts
@@ -1123,6 +1126,11 @@ class Maintenance(salt.utils.process.SignalHandlingMultiprocessingProcess):
                 'log_queue': self.log_queue}
 
     def run(self):
+        '''
+        This is the general passive maintenance process controller for the Salt minion.
+
+        This is where any data that needs to be cleanly maintained from the minion is maintained.
+        '''
         salt.utils.process.appendproctitle(self.__class__.__name__)
 
         grains_cache = self.opts.get('grains_cache', False)
@@ -1146,6 +1154,9 @@ class Maintenance(salt.utils.process.SignalHandlingMultiprocessingProcess):
             time.sleep(self.opts['loop_interval'])
 
     def handle_grains_cache(self):
+        '''
+        Refresh the minion grain cache and upload to master
+        '''
         if self.opts.get('grains_cache', False):
             import salt.loader
             salt.loader.grains(self.opts, force_refresh=True)

--- a/tests/unit/test_minion.py
+++ b/tests/unit/test_minion.py
@@ -410,9 +410,14 @@ class MinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             io_loop.run_sync(lambda: minion._handle_decoded_payload(job_data))
 
     def test_maintenance(self):
+        '''
+        Test basic functionality of the maintenance routine
+        '''
         class MaintenanceException(Exception):
-            '''Thrown when handle_grains_cache is called to break out of the while loop'''
-            pass
+            '''
+            Thrown when handle_grains_cache is called to break out of the while loop
+            '''
+
         opts = {'grains_cache': True, 'grains_refresh_every': 1, 'loop_interval': 1}
         with patch('salt.minion.time') as mock_time, \
                 patch.object(salt.minion.Maintenance, 'handle_grains_cache',


### PR DESCRIPTION
### What does this PR do?

This PR replaces the `grains_refresh_every` mechanism with a new sub-process that will manage the cache independently of the main salt-minion process. This process has been modeled after the maintenance process that runs on the master and could be extended with additional features if desired.

### Previous Behavior

Refreshing grains on the minion was a blocking process. This was causing sporadic timeouts for us when running jobs on some minions if that job initiated a grain refresh, particularly on Solaris minions.

### New Behavior

By turning on `grains_cache` and setting `grains_refresh_every` to a value less than `grains_cache_expiration`, the grains will be refreshed by a non-blocking process on a periodic basis. This way, the minion will never need to refresh its grains as part of a job initiated on the minion, which will prevent the timeouts seen as a result.

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

Yes

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
