### PR TITLE
Update kubernetesmod.py to use V1Deployment/V1DeploymentSpec

### DIFF
--- a/salt/modules/kubernetesmod.py
+++ b/salt/modules/kubernetesmod.py
@@ -72,15 +72,7 @@ try:
     import kubernetes.client
     from kubernetes.client.rest import ApiException
     from urllib3.exceptions import HTTPError
-    # pylint: disable=no-name-in-module
-    try:
-        # There is an API change in Kubernetes >= 2.0.0.
-        from kubernetes.client import V1beta1Deployment as AppsV1beta1Deployment
-        from kubernetes.client import V1beta1DeploymentSpec as AppsV1beta1DeploymentSpec
-    except ImportError:
-        from kubernetes.client import AppsV1beta1Deployment
-        from kubernetes.client import AppsV1beta1DeploymentSpec
-    # pylint: enable=no-name-in-module
+    from kubernetes.client import V1Deployment, V1DeploymentSpec
 
     HAS_LIBS = True
 except ImportError:
@@ -439,7 +431,7 @@ def deployments(namespace='default', **kwargs):
     '''
     cfg = _setup_conn(**kwargs)
     try:
-        api_instance = kubernetes.client.ExtensionsV1beta1Api()
+        api_instance = kubernetes.client.AppsV1Api()
         api_response = api_instance.list_namespaced_deployment(namespace)
 
         return [dep['metadata']['name'] for dep in api_response.to_dict().get('items')]
@@ -449,7 +441,7 @@ def deployments(namespace='default', **kwargs):
         else:
             log.exception(
                 'Exception when calling '
-                'ExtensionsV1beta1Api->list_namespaced_deployment'
+                'AppsV1Api->list_namespaced_deployment'
             )
             raise CommandExecutionError(exc)
     finally:
@@ -579,7 +571,7 @@ def show_deployment(name, namespace='default', **kwargs):
     '''
     cfg = _setup_conn(**kwargs)
     try:
-        api_instance = kubernetes.client.ExtensionsV1beta1Api()
+        api_instance = kubernetes.client.AppsV1Api()
         api_response = api_instance.read_namespaced_deployment(name, namespace)
 
         return api_response.to_dict()
@@ -589,7 +581,7 @@ def show_deployment(name, namespace='default', **kwargs):
         else:
             log.exception(
                 'Exception when calling '
-                'ExtensionsV1beta1Api->read_namespaced_deployment'
+                'AppsV1Api->read_namespaced_deployment'
             )
             raise CommandExecutionError(exc)
     finally:
@@ -758,7 +750,7 @@ def delete_deployment(name, namespace='default', **kwargs):
     body = kubernetes.client.V1DeleteOptions(orphan_dependents=True)
 
     try:
-        api_instance = kubernetes.client.ExtensionsV1beta1Api()
+        api_instance = kubernetes.client.AppsV1Api()
         api_response = api_instance.delete_namespaced_deployment(
             name=name,
             namespace=namespace,
@@ -793,7 +785,7 @@ def delete_deployment(name, namespace='default', **kwargs):
         else:
             log.exception(
                 'Exception when calling '
-                'ExtensionsV1beta1Api->delete_namespaced_deployment'
+                'AppsV1Api->delete_namespaced_deployment'
             )
             raise CommandExecutionError(exc)
     finally:
@@ -971,7 +963,7 @@ def create_deployment(
     '''
     body = __create_object_body(
         kind='Deployment',
-        obj_class=AppsV1beta1Deployment,
+        obj_class=V1Deployment,
         spec_creator=__dict_to_deployment_spec,
         name=name,
         namespace=namespace,
@@ -984,7 +976,7 @@ def create_deployment(
     cfg = _setup_conn(**kwargs)
 
     try:
-        api_instance = kubernetes.client.ExtensionsV1beta1Api()
+        api_instance = kubernetes.client.AppsV1Api()
         api_response = api_instance.create_namespaced_deployment(
             namespace, body)
 
@@ -995,7 +987,7 @@ def create_deployment(
         else:
             log.exception(
                 'Exception when calling '
-                'ExtensionsV1beta1Api->create_namespaced_deployment'
+                'AppsV1Api->create_namespaced_deployment'
             )
             raise CommandExecutionError(exc)
     finally:
@@ -1247,7 +1239,7 @@ def replace_deployment(name,
     '''
     body = __create_object_body(
         kind='Deployment',
-        obj_class=AppsV1beta1Deployment,
+        obj_class=V1Deployment,
         spec_creator=__dict_to_deployment_spec,
         name=name,
         namespace=namespace,
@@ -1260,7 +1252,7 @@ def replace_deployment(name,
     cfg = _setup_conn(**kwargs)
 
     try:
-        api_instance = kubernetes.client.ExtensionsV1beta1Api()
+        api_instance = kubernetes.client.AppsV1Api()
         api_response = api_instance.replace_namespaced_deployment(
             name, namespace, body)
 
@@ -1271,7 +1263,7 @@ def replace_deployment(name,
         else:
             log.exception(
                 'Exception when calling '
-                'ExtensionsV1beta1Api->replace_namespaced_deployment'
+                'AppsV1Api->replace_namespaced_deployment'
             )
             raise CommandExecutionError(exc)
     finally:
@@ -1540,9 +1532,9 @@ def __dict_to_object_meta(name, namespace, metadata):
 
 def __dict_to_deployment_spec(spec):
     '''
-    Converts a dictionary into kubernetes AppsV1beta1DeploymentSpec instance.
+    Converts a dictionary into kubernetes V1DeploymentSpec instance.
     '''
-    spec_obj = AppsV1beta1DeploymentSpec(template=spec.get('template', ''))
+    spec_obj = V1DeploymentSpec(selector=spec.get('selector'), template=spec.get('template'))
     for key, value in iteritems(spec):
         if hasattr(spec_obj, key):
             setattr(spec_obj, key, value)


### PR DESCRIPTION
### What does this PR do?

Deployment and DeploymentSpec have been available in the apps/v1 API since Kubernetes v1.9, and were removed from apps/v1beta1 in Kubernetes v1.16. This commit updates the kubernetesmod module to use those instead of the apps/v1beta1 Deployment and DeploymentSpec objects.

Additionally, V1DeploymentSpec also requires a selector object during construction, so that has been added, and the default empty string value of template on construction has been removed.

### What issues does this PR fix or reference?

### Previous Behavior
For Kubernetes clusters of version v1.16 or higher, Deployments would fail to be created.

### New Behavior
For Kubernetes clusters of version v1.9 or higher, Deployments will be created.

### Tests written?
No

### Commits signed with GPG?

Yes