### PR TITLE
Move the `salt-unity` implementation to `salt.scripts`

### DIFF
--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -553,3 +553,29 @@ def salt_extend(extension, name, description, salt_dir, merge):
                           description=description,
                           salt_dir=salt_dir,
                           merge=merge)
+
+
+def salt_unity():
+    '''
+    Change the args and redirect to another salt script
+    '''
+    avail = []
+    for fun in dir(sys.modules[__name__]):
+        if fun.startswith('salt'):
+            avail.append(fun[5:])
+    if len(sys.argv) < 2:
+        msg = 'Must pass in a salt command, available commands are:'
+        for cmd in avail:
+            msg += '\n{0}'.format(cmd)
+        print(msg)
+        sys.exit(1)
+    cmd = sys.argv[1]
+    if cmd not in avail:
+        # Fall back to the salt command
+        sys.argv[0] = 'salt'
+        s_fun = salt_main
+    else:
+        sys.argv[0] = 'salt-{0}'.format(cmd)
+        sys.argv.pop(1)
+        s_fun = getattr(sys.modules[__name__], 'salt_{0}'.format(cmd))
+    s_fun()

--- a/scripts/salt-unity
+++ b/scripts/salt-unity
@@ -1,57 +1,7 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
-# Import python libs
-import sys
-
-# Import salt libs
-import salt.scripts
-import salt.utils.platform
-
-
-def get_avail():
-    '''
-    Return the available salt commands
-    '''
-    ret = []
-    for fun in dir(salt.scripts):
-        if fun.startswith('salt'):
-            ret.append(fun[5:])
-    return ret
-
-
-def redirect():
-    '''
-    Change the args and redirect to another salt script
-    '''
-    avail = get_avail()
-    if len(sys.argv) < 2:
-        msg = 'Must pass in a salt command, available commands are:'
-        for cmd in avail:
-            msg += '\n{0}'.format(cmd)
-        print(msg)
-        sys.exit(1)
-    cmd = sys.argv[1]
-    if cmd not in avail:
-        # Fall back to the salt command
-        sys.argv[0] = 'salt'
-        s_fun = salt.scripts.salt_main
-    else:
-        sys.argv[0] = 'salt-{0}'.format(cmd)
-        sys.argv.pop(1)
-        s_fun = getattr(salt.scripts, 'salt_{0}'.format(cmd))
-    s_fun()
+from salt.scripts import salt_unity
 
 
 if __name__ == '__main__':
-    if salt.utils.platform.is_windows():
-        # Since this file does not have a '.py' extension, when running on
-        # Windows, spawning any addional processes will fail due to Python
-        # not being able to load this 'module' in the new process.
-        # Work around this by creating a '.pyc' file which will enable the
-        # spawned process to load this 'module' and proceed.
-        import os.path
-        import py_compile
-        cfile = os.path.splitext(__file__)[0] + '.pyc'
-        if not os.path.exists(cfile):
-            py_compile.compile(__file__, cfile)
-    redirect()
+    salt_unity()


### PR DESCRIPTION
### What does this PR do?
See title.

With the move to setuptools there was still one distutils script `scripts/salt-unity` which wasn't implemented in `salt.scripts`, this PR addresses that.