### PR TITLE
Correct : AttributeError: 'str' object has no attribute 'name'

### DIFF
--- a/salt/spm/pkgfiles/local.py
+++ b/salt/spm/pkgfiles/local.py
@@ -136,7 +136,7 @@ def install_file(package, formula_tar, member, formula_def, conn=None):
     if member.name.startswith('{0}/_'.format(package)):
         if node_type in ('master', 'minion'):
             # Module files are distributed via extmods directory
-            member.name = new_name.name.replace('{0}/_'.format(package), '')
+            member.name = new_name.replace('{0}/_'.format(package), '')
             out_path = os.path.join(
                 salt.syspaths.CACHE_DIR,
                 node_type,
@@ -144,7 +144,7 @@ def install_file(package, formula_tar, member, formula_def, conn=None):
             )
         else:
             # Module files are distributed via _modules, _states, etc
-            member.name = new_name.name.replace('{0}/'.format(package), '')
+            member.name = new_name.replace('{0}/'.format(package), '')
     elif member.name == '{0}/pillar.example'.format(package):
         # Pillars are automatically put in the pillar_path
         member.name = '{0}.sls.orig'.format(package)


### PR DESCRIPTION
### What does this PR do?
Correct error when using SPM with local File. 
The error was there for 2 years !!

### What issues does this PR fix or reference?
None

### Previous Behavior
Python Error when: 

```bash
[root@master ~]# spm local install /srv/spm_build/spm-1.0.0-1.spm --force
Installing packages:
        spm

Proceed? [N/y] y
... installing spm
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
AttributeError: 'str' object has no attribute 'name'
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/salt/spm/__init__.py", line 159, in _pkgfiles_fun
    return getattr(getattr(self.pkgfiles, self.files_prov), func)(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/spm/pkgfiles/local.py", line 147, in install_file
    member.name = new_name.name.replace('{0}/'.format(package), '')
AttributeError: 'str' object has no attribute 'name'
```

### New Behavior
No error

### Tests written?
No

### Commits signed with GPG?
No
