### PR TITLE
Fix saltversioninfo grain for new version

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -319,8 +319,7 @@ class SaltStackVersion(object):
         # Higher than 0.17, lower than first date based
         return 0 < self.major < 2014
 
-    @property
-    def info(self):
+    def min_info(self):
         info = [self.major]
         if self.new_version(self.major):
             if self.minor:
@@ -329,43 +328,35 @@ class SaltStackVersion(object):
             info.extend([self.minor,
                         self.bugfix,
                         self.mbugfix])
-        return tuple(info)
+        return info
+
+    @property
+    def info(self):
+        return tuple(self.min_info())
 
     @property
     def pre_info(self):
-        return (
-            self.major,
-            self.minor,
-            self.bugfix,
-            self.mbugfix,
-            self.pre_type,
-            self.pre_num
-        )
+        info = self.min_info()
+        info.extend([self.pre_type,
+                     self.pre_num])
+        return tuple(info)
 
     @property
     def noc_info(self):
-        return (
-            self.major,
-            self.minor,
-            self.bugfix,
-            self.mbugfix,
-            self.pre_type,
-            self.pre_num,
-            self.noc
-        )
+        info = self.min_info()
+        info.extend([self.pre_type,
+                     self.pre_num,
+                     self.noc])
+        return tuple(info)
 
     @property
     def full_info(self):
-        return (
-            self.major,
-            self.minor,
-            self.bugfix,
-            self.mbugfix,
-            self.pre_type,
-            self.pre_num,
-            self.noc,
-            self.sha
-        )
+        info = self.min_info()
+        info.extend([self.pre_type,
+                     self.pre_num,
+                     self.noc,
+                     self.sha])
+        return tuple(info)
 
     @property
     def string(self):
@@ -405,6 +396,16 @@ class SaltStackVersion(object):
             version_string += ' ({0})'.format(self.RMATCH[(self.major, self.minor)])
         return version_string
 
+    @property
+    def pre_index(self):
+        if self.new_version(self.major):
+            pre_type = 2
+            if not isinstance(self.minor, int):
+                pre_type = 1
+        else:
+            pre_type = 4
+        return pre_type
+
     def __str__(self):
         return self.string
 
@@ -421,23 +422,29 @@ class SaltStackVersion(object):
                     )
                 )
 
+        pre_type = self.pre_index
+        other_pre_type = other.pre_index
         other_noc_info = list(other.noc_info)
         noc_info = list(self.noc_info)
 
         if self.new_version(self.major):
-            if isinstance(self.minor, int) and not isinstance(other.minor, int):
-                other_noc_info[1] = 0
+            if self.minor and not other.minor:
+                # We have minor information, the other side does not
+                if self.minor > 0:
+                    other_noc_info[1] = 0
 
-            if not isinstance(self.minor, int) and isinstance(other.minor, int):
-                noc_info[1] = 0
+            if not self.minor and other.minor:
+                # The other side has minor information, we don't
+                if other.minor > 0:
+                    noc_info[1] = 0
 
         if self.pre_type and not other.pre_type:
             # We have pre-release information, the other side doesn't
-            other_noc_info[4] = 'zzzzz'
+            other_noc_info[other_pre_type] = 'zzzzz'
 
         if not self.pre_type and other.pre_type:
-            # The other side has pre-release informatio, we don't
-            noc_info[4] = 'zzzzz'
+            # The other side has pre-release information, we don't
+            noc_info[pre_type] = 'zzzzz'
 
         return method(tuple(noc_info), tuple(other_noc_info))
 

--- a/salt/version.py
+++ b/salt/version.py
@@ -321,12 +321,15 @@ class SaltStackVersion(object):
 
     @property
     def info(self):
-        return (
-            self.major,
-            self.minor,
-            self.bugfix,
-            self.mbugfix
-        )
+        info = [self.major]
+        if self.new_version(self.major):
+            if self.minor:
+                info.append(self.minor)
+        else:
+            info.extend([self.minor,
+                        self.bugfix,
+                        self.mbugfix])
+        return tuple(info)
 
     @property
     def pre_info(self):

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -1485,3 +1485,19 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
 
         self.assertIn('osfullname', os_grains)
         self.assertEqual(os_grains.get('osfullname'), 'FreeBSD')
+
+    def test_saltversioninfo(self):
+        '''
+        test saltversioninfo core grain.
+        '''
+        ret = core.saltversioninfo()
+        info = ret['saltversioninfo']
+        assert isinstance(ret, dict)
+        assert isinstance(info, list)
+        try:
+            assert len(info) == 1
+        except AssertionError:
+            # We have a minor version we need to test
+            assert len(info) == 2
+        assert all([x is not None for x in info])
+        assert all([isinstance(x, int) for x in info])

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -37,8 +37,11 @@ class VersionTestCase(TestCase):
             ('v2014.1.4.1', (2014, 1, 4, 1, '', 0, 0, None), None),
             ('v2014.1.4.1rc3-n/a-abcdefff', (2014, 1, 4, 1, 'rc', 3, -1, 'abcdefff'), None),
             ('v3.4.1.1', (3, 4, 1, 1, '', 0, 0, None), None),
-            ('v3000', (3000, None, None, 0, '', 0, 0, None), '3000'),
-            ('v3000rc1', (3000, None, None, 0, 'rc', 1, 0, None), '3000rc1'),
+            ('v3000', (3000, '', 0, 0, None), '3000'),
+            ('v3000.0', (3000, '', 0, 0, None), '3000'),
+            ('v4518.1', (4518, 1, '', 0, 0, None), '4518.1'),
+            ('v3000rc1', (3000, 'rc', 1, 0, None), '3000rc1'),
+            ('v3000rc1-n/a-abcdefff', (3000, 'rc', 1, -1, 'abcdefff'), None),
 
         )
 
@@ -76,6 +79,9 @@ class VersionTestCase(TestCase):
             # version scheme in the future
             # but still adding test for it
             ('v3000', 'v3000.0rc1'),
+            ('v3000.1rc1', 'v3000.0rc1'),
+            ('v3000', 'v2019.2.1rc1'),
+            ('v3001rc1', 'v2019.2.1rc1'),
         )
         for higher_version, lower_version in examples:
             self.assertTrue(SaltStackVersion.parse(higher_version) > lower_version)
@@ -153,6 +159,45 @@ class VersionTestCase(TestCase):
         ver = SaltStackVersion(major=maj_ver, minor=min_ver)
         assert ver.bugfix == 0
         assert ver.string == '{0}.{1}.0'.format(maj_ver, min_ver)
+
+    def test_noc_info(self):
+        '''
+        Test noc_info property method
+        '''
+        expect = (
+            ('v2014.1.4.1rc3-n/a-abcdefff', (2014, 1, 4, 1, 'rc', 3, -1)),
+            ('v3.4.1.1', (3, 4, 1, 1, '', 0, 0)),
+            ('v3000', (3000, '', 0, 0)),
+            ('v3000.0', (3000, '', 0, 0)),
+            ('v4518.1', (4518, 1, '', 0, 0)),
+            ('v3000rc1', (3000, 'rc', 1, 0)),
+            ('v3000rc1-n/a-abcdefff', (3000, 'rc', 1, -1)),
+        )
+
+        for vstr, noc_info in expect:
+            saltstack_version = SaltStackVersion.parse(vstr)
+            assert saltstack_version.noc_info, noc_info
+            assert len(saltstack_version.noc_info) == len(noc_info)
+
+    def test_full_info(self):
+        '''
+        Test full_Info property method
+        '''
+        expect = (
+            ('v2014.1.4.1rc3-n/a-abcdefff', (2014, 1, 4, 1, 'rc', 3, -1, 'abcdefff')),
+            ('v3.4.1.1', (3, 4, 1, 1, '', 0, 0, None)),
+            ('v3000', (3000, '', 0, 0, None)),
+            ('v3000.0', (3000, '', 0, 0, None)),
+            ('v4518.1', (4518, 1, '', 0, 0, None)),
+            ('v3000rc1', (3000, 'rc', 1, 0, None)),
+            ('v3000rc1-n/a-abcdefff', (3000, 'rc', 1, -1, 'abcdefff')),
+
+        )
+
+        for vstr, full_info in expect:
+            saltstack_version = SaltStackVersion.parse(vstr)
+            assert saltstack_version.full_info, full_info
+            assert len(saltstack_version.full_info) == len(full_info)
 
     def test_discover_version(self):
         '''

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -180,3 +180,31 @@ class VersionTestCase(TestCase):
                 with proc_mock, patch_os:
                     ret = getattr(salt.version, '__discover_version')(salt_ver)
                 assert ret == exp
+
+    def test_info_new_version(self):
+        '''
+        test info property method with new versioning scheme
+        '''
+        vers = ((3000, None, None),
+                (3000, 1, None),
+                (3001, 0, None))
+        for maj_ver, min_ver, bug_fix in vers:
+            ver = SaltStackVersion(major=maj_ver, minor=min_ver, bugfix=bug_fix)
+            if min_ver:
+                assert ver.info == (maj_ver, min_ver)
+            else:
+                assert ver.info == (maj_ver,)
+
+    def test_info_old_version(self):
+        '''
+        test info property method with old versioning scheme
+        '''
+        vers = ((2019, 2, 1),
+                (2018, 3, 0),
+                (2017, 7, None))
+        for maj_ver, min_ver, bug_fix in vers:
+            ver = SaltStackVersion(major=maj_ver, minor=min_ver, bugfix=bug_fix)
+            if bug_fix is None:
+                assert ver.info == (maj_ver, min_ver, 0, 0)
+            else:
+                assert ver.info == (maj_ver, min_ver, bug_fix, 0)


### PR DESCRIPTION
### Previous Behavior

```
(salt)  ch3ll@thecakeisalie  ~/git/salt  ➦ 81eb152643  salt-call --local grains.get saltversioninfo
local:
    - 3000
    - 0
    - None
    - 0
```

### New Behavior

```
(salt)  ch3ll@thecakeisalie  ~/git/salt   ver_grains  salt-call --local grains.get saltversioninfo
local:
    - 3000
```

### Fixes Issue
https://github.com/saltstack/salt/issues/56228

### Tests written?
Yes

### Commits signed with GPG?
Yes