### PR TITLE
Fix type error in TornadoImporter

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -12,7 +12,7 @@ import importlib
 
 class TornadoImporter(object):
 
-    def find_module(self, module_name, package_path):
+    def find_module(self, module_name, package_path=None):
         if module_name.startswith('tornado'):
             return self
         return None

--- a/tests/unit/test_ext.py
+++ b/tests/unit/test_ext.py
@@ -14,6 +14,7 @@ from tests.support.runtests import RUNTIME_VARS
 import tests.support.helpers
 
 # Import Salt libs
+import salt
 import salt.ext.six
 import salt.modules.cmdmod
 import salt.utils.platform
@@ -95,3 +96,10 @@ class VendorTornadoTest(TestCase):
             log.error("Test found bad line: %s", line)
             valid_lines.append(line)
         assert valid_lines == [], len(valid_lines)
+
+    def test_regression_56063(self):
+        importer = salt.TornadoImporter()
+        try:
+            importer.find_module('tornado')
+        except TypeError:
+            assert False, 'TornadoImporter raised type error when one argument passed'


### PR DESCRIPTION
### What does this PR do?

Fixes tracebacks in salt loader because the find_module method of TornadoImporter required 3 arguments, path should default to None.

```
Traceback (most recent call last):
  File "/tmp/kitchen/testing/salt/loader.py", line 1607, in _load_module
    mod = imp.load_module(mod_namespace, fn_, fpath, desc)
  File "/tmp/kitchen/testing/salt/grains/esxi.py", line 16, in <module>
    import salt.modules.vsphere
  File "/tmp/kitchen/testing/salt/modules/vsphere.py", line 222, in <module>
    import jsonschema
  File "/tmp/kitchen/testing/.nox/runtests-parametrized-2-7-coverage-true-crypto-none-transport-zeromq/lib/python2.7/site-packages/jsonschema/__init__.py", line 18, in <module>
    from jsonschema.validators import (
  File "/tmp/kitchen/testing/.nox/runtests-parametrized-2-7-coverage-true-crypto-none-transport-zeromq/lib/python2.7/site-packages/jsonschema/validators.py", line 170, in <module>
    meta_schema=_utils.load_schema("draft3"),
  File "/tmp/kitchen/testing/.nox/runtests-parametrized-2-7-coverage-true-crypto-none-transport-zeromq/lib/python2.7/site-packages/jsonschema/_utils.py", line 57, in load_schema
    data = pkgutil.get_data('jsonschema', "schemas/{0}.json".format(name))
  File "/usr/lib64/python2.7/pkgutil.py", line 578, in get_data
    loader = get_loader(package)
  File "/usr/lib64/python2.7/pkgutil.py", line 464, in get_loader
    return find_loader(fullname)
  File "/usr/lib64/python2.7/pkgutil.py", line 475, in find_loader
    loader = importer.find_module(fullname)
TypeError: find_module() takes exactly 3 arguments (2 given)
```

### What issues does this PR fix or reference?

#56063 


### Tests written?

Yes

### Commits signed with GPG?

Yes