### PR TITLE
Avoid warning noise in logrotate.get

### DIFF
--- a/changelog/53988.fixed
+++ b/changelog/53988.fixed
@@ -1,0 +1,1 @@
+Avoid warning noise in lograte.get

--- a/salt/modules/logrotate.py
+++ b/salt/modules/logrotate.py
@@ -159,7 +159,7 @@ def get(key, value=None, conf_file=_DEFAULT_CONF):
     if value:
         if stanza:
             return stanza.get(value, False)
-        _LOG.warning("Block '%s' not present or empty.", key)
+        _LOG.debug("Block '%s' not present or empty.", key)
     return stanza
 
 

--- a/tests/unit/modules/test_logrotate.py
+++ b/tests/unit/modules/test_logrotate.py
@@ -76,3 +76,28 @@ class LogrotateTestCase(TestCase, LoaderModuleMockMixin):
         ):
             kwargs = {"key": "rotate", "value": "/var/log/wtmp", "setting": "2"}
             self.assertRaises(SaltInvocationError, logrotate.set_, **kwargs)
+
+    def test_get(self):
+        """
+        Test if get a value for a specific configuration line
+        """
+        with patch(
+            "salt.modules.logrotate._parse_conf", MagicMock(return_value=PARSE_CONF)
+        ):
+            # A single key returns the right value
+            self.assertEqual(logrotate.get("rotate"), 1)
+
+            # A single key returns the wrong value
+            self.assertNotEqual(logrotate.get("rotate"), 2)
+
+            # A single key returns the right stanza value
+            self.assertEqual(logrotate.get("/var/log/wtmp", "rotate"), 1)
+
+            # A single key returns the wrong stanza value
+            self.assertNotEqual(logrotate.get("/var/log/wtmp", "rotate"), 2)
+
+            # Ensure we're logging the message as debug not warn
+            with patch.object(logrotate, "_LOG") as log_mock:
+                res = logrotate.get("/var/log/utmp", "rotate")
+                self.assertTrue(log_mock.debug.called)
+                self.assertFalse(log_mock.warn.called)


### PR DESCRIPTION
# What does this PR do?
There is no guarantee that a lookup failure is necessarily a problem, so presenting a message to this effect as a warning has led to confusion for some (and annoyance for others). This resolves the issue
by showing the message at the debug level.

### What issues does this PR fix or reference?
Fixes #53988

### Previous Behavior
```$ sudo salt-call -l warning state.sls logrotate
[WARNING ] Block '/myapp/log/file/path/*' not present or empty.
[WARNING ] Block '/myapp/log/file/path/*' not present or empty.
[WARNING ] Block '/myapp/log/file/path/*' not present or empty.
[WARNING ] Block '/myapp/log/file/path/*' not present or empty.
[WARNING ] Block '/myapp/log/file/path/*' not present or empty.
[WARNING ] Block '/myapp/log/file/path/*' not present or empty.
```
(full details in the issue linked above)

I have a number of users use Salt to provision their VMs with Vagrant, and most of them have asked me at one point if these warnings mean that provisioning is failing and if they should abort and re-do it.

### New Behavior
We should have beautiful silence (except when running with the `-l debug` argument).

### Tests written?
No

### Commits signed with GPG?
Yes
