### PR TITLE
Grains cache refresh

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2642,30 +2642,6 @@ class Minion(MinionBase):
 
             self.add_periodic_callback('schedule', handle_schedule)
 
-    def add_periodic_callback(self, name, method, interval=1):
-        '''
-        Add a periodic callback to the event loop and call it's start method.
-        If a callback by the given name exists this method returns False
-        '''
-        if name in self.periodic_callbacks:
-            return False
-        self.periodic_callbacks[name] = salt.ext.tornado.ioloop.PeriodicCallback(
-            method, interval * 1000,
-        )
-        self.periodic_callbacks[name].start()
-        return True
-
-    def remove_periodic_callback(self, name):
-        '''
-        Remove a periodic callback.
-        If a callback by the given name does not exist this method returns False
-        '''
-        callback = self.periodic_callbacks.pop(name, None)
-        if callback is None:
-            return False
-        callback.stop()
-        return True
-
     def setup_grains_cache_refresh(self, before_connect=False):
         '''
         Setup the grains cache refresher.
@@ -2695,6 +2671,30 @@ class Minion(MinionBase):
                 periodic_cb.start()
 
             self.periodic_callbacks.update(new_periodic_callbacks)
+
+    def add_periodic_callback(self, name, method, interval=1):
+        '''
+        Add a periodic callback to the event loop and call it's start method.
+        If a callback by the given name exists this method returns False
+        '''
+        if name in self.periodic_callbacks:
+            return False
+        self.periodic_callbacks[name] = salt.ext.tornado.ioloop.PeriodicCallback(
+            method, interval * 1000,
+        )
+        self.periodic_callbacks[name].start()
+        return True
+
+    def remove_periodic_callback(self, name):
+        '''
+        Remove a periodic callback.
+        If a callback by the given name does not exist this method returns False
+        '''
+        callback = self.periodic_callbacks.pop(name, None)
+        if callback is None:
+            return False
+        callback.stop()
+        return True
 
     # Main Minion Tune In
     def tune_in(self, start=True):

--- a/tests/unit/test_minion.py
+++ b/tests/unit/test_minion.py
@@ -416,7 +416,7 @@ class MinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         with patch('salt.minion.Minion.ctx', MagicMock(return_value={})), \
                 patch('salt.utils.process.MultiprocessingProcess', MagicMock(return_value=True)):
             mock_opts = self.get_config('minion', from_scratch=True)
-            io_loop = tornado.ioloop.IOLoop()
+            io_loop = salt.ext.tornado.ioloop.IOLoop()
             io_loop.make_current()
             try:
                 for (grains_cache, refresh_every, expected) in [
@@ -436,7 +436,6 @@ class MinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                         self.assertTrue('grains_cache_refresh' not in minion.periodic_callbacks)
             finally:
                 minion.destroy()
-
 
 
 class MinionAsyncTestCase(TestCase, AdaptedConfigurationTestCaseMixin, salt.ext.tornado.testing.AsyncTestCase):


### PR DESCRIPTION
### What does this PR do?

This PR replaces the `grains_refresh_every` mechanism with a new multiprocessing process that will update the grain cache without blocking the main salt-minion process. 

### Previous Behavior

Refreshing grains on the minion was a blocking process. This was causing sporadic timeouts for us when running jobs on some minions if that job initiated a grain refresh, particularly on Solaris minions.

### New Behavior

This feature will be disabled by default. To enable the grains cache refresh, set `grains_cache` to `True` and set `grains_refresh_every` to a positive integer. When enabled, the grains will be refreshed by a non-blocking process on a periodic basis. By setting `grains_refresh_every` less than or equal to `grains_cache_expiration`, the minion will never need to refresh its grains as part of a job initiated on the minion, which will prevent the timeouts seen as a result.

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

Yes

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
