### PR TITLE
[master] Fix to scheduler for use of when and splay

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -1019,7 +1019,7 @@ class Schedule(object):
 
                 if when < now - loop_interval and \
                         not data.get('_run', False) and \
-                        not data.get('run', False) and \
+                        not run and \
                         not data['_splay']:
                     data['_next_fire_time'] = None
                     data['_continue'] = True

--- a/tests/integration/scheduler/test_eval.py
+++ b/tests/integration/scheduler/test_eval.py
@@ -9,7 +9,12 @@ import os
 import random
 import time
 
-import dateutil.parser as dateutil_parser
+try:
+    import dateutil.parser as dateutil_parser
+    HAS_DATEUTIL_PARSER = True
+except ImportError:
+    HAS_DATEUTIL_PARSER = False
+
 import datetime
 
 # Import Salt Testing libs
@@ -43,6 +48,7 @@ DEFAULT_CONFIG['pki_dir'] = os.path.join(ROOT_DIR, 'pki')
 DEFAULT_CONFIG['cachedir'] = os.path.join(ROOT_DIR, 'cache')
 
 
+@skipIf(HAS_DATEUTIL_PARSER is False, 'The \'dateutil.parser\' library is not available')
 class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
     '''
     Validate the pkg module
@@ -920,6 +926,7 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
         }
         run_time1 = dateutil_parser.parse('11/29/2017 4:00pm')
         run_time2 = run_time1 + datetime.timedelta(seconds=splay)
+        run_time3 = run_time2 + datetime.timedelta(seconds=1)
 
         # Add the job to the scheduler
         self.schedule.opts.update(job)
@@ -939,6 +946,13 @@ class SchedulerEvalTest(ModuleCase, SaltReturnAssertsMixin):
             self.schedule.eval(now=run_time2)
             ret = self.schedule.job_status(job_name)
             self.assertEqual(ret['_last_run'], run_time2)
+
+            # Evaluate at expected runtime3, should not run
+            # _next_fire_time should be None
+            self.schedule.eval(now=run_time3)
+            ret = self.schedule.job_status(job_name)
+            self.assertEqual(ret['_last_run'], run_time2)
+            self.assertEqual(ret['_next_fire_time'], None)
 
     def test_eval_when_splay_in_past(self):
         '''


### PR DESCRIPTION
### What does this PR do?
Fix for when using a combination of when and splay.  Previously comparing the wrong value when determining if the job should be run and next_fire_time updated.  This resulted in multiple job runs when `when` and `splay` were used together.  Code updated and test updated to ensure only one run at the specific time.  Skip eval tests is dateutil.parser is unavailable.

### What issues does this PR fix or reference?
#53152 

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
