### PR TITLE
Fix incorrect list of installed packages via dpkg

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -1330,7 +1330,7 @@ def list_pkgs(versions_as_list=False,
                 name += ':{0}'.format(arch)
         if cols:
             if ('install' in linetype or 'hold' in linetype) and \
-                    'installed' in status:
+                    ('installed' in status or 'triggers-pending' in status):
                 __salt__['pkg_resource.add_pkg'](ret['installed'],
                                                  name,
                                                  version_num)


### PR DESCRIPTION
### What does this PR do?
Fix incorrect list of installed packages (dpkg) with status "hold" and sub-status "triggers-pending"

### What issues does this PR fix or reference?
**usual situation:**
`root@test ~ # dpkg-query --showformat '${Status} ${Package} ${Version} ${Architecture}' -W vim`
`install ok installed vim 2:8.0.1453-1ubuntu1.1 amd64`

**trouble case:**
`root@test ~ # dpkg-query --showformat '${Status} ${Package} ${Version} ${Architecture}' -W systemd`
`hold ok triggers-pending systemd 237-3ubuntu10.38 amd64`
In trouble case systemd is already installed but has status "triggers-pending" and will be skipped by function list_pkgs so the Salt will try to install it again.

### Previous Behavior
Utility apt tried to repeatedly install target held package because function list_pkgs return its incorrect status

### New Behavior
Packages with a state "hold triggers-pending" will handle correctly

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
