### PR TITLE
Change x509.certficate_managed

### DIFF
--- a/salt/states/x509.py
+++ b/salt/states/x509.py
@@ -718,7 +718,7 @@ def certificate_managed(
             append_file_contents = __salt__["x509.get_pem_entry"](
                 append_file, pem_type="CERTIFICATE"
             )
-            contents += append_file_contents
+            contents += salt.utils.stringutils.to_str(append_file_contents)
         except salt.exceptions.SaltInvocationError as e:
             ret["result"] = False
             ret[


### PR DESCRIPTION
### What does this PR do?
This change decodes a bytes variable to an utf-8 string before concatenating to another string.

### What issues does this PR fix or reference?
On Python 3.7 I get the following error for `x509.certificate_managed`, which is fixed in this PR:
```
An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python3/dist-packages/salt/state.py", line 1919, in call
                  **cdata['kwargs'])
                File "/usr/lib/python3/dist-packages/salt/loader.py", line 1918, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python3/dist-packages/salt/states/x509.py", line 560, in certificate_managed
                  'contents'] += __salt__['x509.get_pem_entry'](append_cert, pem_type='CERTIFICATE')
              TypeError: can only concatenate str (not "bytes") to str
```

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
