### PR TITLE
set `up` in alive function

### DIFF
--- a/salt/proxy/netmiko_px.py
+++ b/salt/proxy/netmiko_px.py
@@ -262,7 +262,8 @@ def alive(opts):
     if not netmiko_device['always_alive']:
         return True
     if ping() and initialized():
-        return netmiko_device['connection'].remote_conn.transport.is_alive()
+        netmiko_device['up'] = netmiko_device['connection'].remote_conn.transport.is_alive()
+        return netmiko_device['up']
     return False
 
 


### PR DESCRIPTION
### What does this PR do?
fix persistent connection to ssh connection lost

### What issues does this PR fix or reference?
ping checks for `up` status, so alive should set that

### Previous Behavior
When ssh connection was broken, it was taking huge time to come back

### New Behavior
next keep-alive will make sure new connection is established.

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
