### PR TITLE
Enable port modification in state selinux.port_policy_present

### DIFF
--- a/changelog/55687.fixed.md
+++ b/changelog/55687.fixed.md
@@ -1,0 +1,1 @@
+Fix the ability of the 'selinux.port_policy_present' state to modify.

--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -10,7 +10,6 @@ Execute calls on selinux
     proper packages are installed.
 """
 
-
 import os
 import re
 
@@ -807,10 +806,45 @@ def port_add_policy(name, sel_type=None, protocol=None, port=None, sel_range=Non
 
     .. code-block:: bash
 
-        salt '*' selinux.port_add_policy add tcp/8080 http_port_t
-        salt '*' selinux.port_add_policy add foobar http_port_t protocol=tcp port=8091
+        salt '*' selinux.port_add_policy tcp/8080 http_port_t
+        salt '*' selinux.port_add_policy foobar http_port_t protocol=tcp port=8091
     """
     return _port_add_or_delete_policy("add", name, sel_type, protocol, port, sel_range)
+
+
+def port_modify_policy(name, sel_type=None, protocol=None, port=None, sel_range=None):
+    """
+    .. versionadded:: 2019.2.0
+
+    Modifies the SELinux policy for a given protocol and port.
+
+    Returns the result of the call to semanage.
+
+    name
+        The protocol and port spec. Can be formatted as ``(tcp|udp)/(port|port-range)``.
+
+    sel_type
+        The SELinux Type. Required.
+
+    protocol
+        The protocol for the port, ``tcp`` or ``udp``. Required if name is not formatted.
+
+    port
+        The port or port range. Required if name is not formatted.
+
+    sel_range
+        The SELinux MLS/MCS Security Range.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' selinux.port_modify_policy tcp/8080 http_port_t
+        salt '*' selinux.port_modify_policy foobar http_port_t protocol=tcp port=8091
+    """
+    return _port_add_or_delete_policy(
+        "modify", name, sel_type, protocol, port, sel_range
+    )
 
 
 def port_delete_policy(name, protocol=None, port=None):
@@ -846,13 +880,13 @@ def _port_add_or_delete_policy(
     """
     .. versionadded:: 2019.2.0
 
-    Performs the action as called from ``port_add_policy`` or ``port_delete_policy``.
+    Performs the action as called from ``port_add_policy``, ``port_modify_policy`` or ``port_delete_policy``.
 
     Returns the result of the call to semanage.
     """
-    if action not in ["add", "delete"]:
+    if action not in ["add", "modify", "delete"]:
         raise SaltInvocationError(
-            f'Actions supported are "add" and "delete", not "{action}".'
+            f'Actions supported are "add", "modify" and "delete", not "{action}".'
         )
     if action == "add" and not sel_type:
         raise SaltInvocationError("SELinux Type is required to add a policy")

--- a/salt/states/selinux.py
+++ b/salt/states/selinux.py
@@ -88,7 +88,7 @@ def mode(name):
     ret = {"name": name, "result": False, "comment": "", "changes": {}}
     tmode = _refine_mode(name)
     if tmode == "unknown":
-        ret["comment"] = "{} is not an accepted mode".format(name)
+        ret["comment"] = f"{name} is not an accepted mode"
         return ret
     # Either the current mode in memory or a non-matching config value
     # will trigger setenforce
@@ -100,11 +100,11 @@ def mode(name):
 
     if mode == tmode:
         ret["result"] = True
-        ret["comment"] = "SELinux is already in {} mode".format(tmode)
+        ret["comment"] = f"SELinux is already in {tmode} mode"
         return ret
     # The mode needs to change...
     if __opts__["test"]:
-        ret["comment"] = "SELinux mode is set to be changed to {}".format(tmode)
+        ret["comment"] = f"SELinux mode is set to be changed to {tmode}"
         ret["result"] = None
         ret["changes"] = {"old": mode, "new": tmode}
         return ret
@@ -114,10 +114,10 @@ def mode(name):
         tmode == "Disabled" and __salt__["selinux.getconfig"]() == tmode
     ):
         ret["result"] = True
-        ret["comment"] = "SELinux has been set to {} mode".format(tmode)
+        ret["comment"] = f"SELinux has been set to {tmode} mode"
         ret["changes"] = {"old": oldmode, "new": mode}
         return ret
-    ret["comment"] = "Failed to set SELinux to {} mode".format(tmode)
+    ret["comment"] = f"Failed to set SELinux to {tmode} mode"
     return ret
 
 
@@ -138,12 +138,12 @@ def boolean(name, value, persist=False):
     ret = {"name": name, "result": True, "comment": "", "changes": {}}
     bools = __salt__["selinux.list_sebool"]()
     if name not in bools:
-        ret["comment"] = "Boolean {} is not available".format(name)
+        ret["comment"] = f"Boolean {name} is not available"
         ret["result"] = False
         return ret
     rvalue = _refine_value(value)
     if rvalue is None:
-        ret["comment"] = "{} is not a valid value for the boolean".format(value)
+        ret["comment"] = f"{value} is not a valid value for the boolean"
         ret["result"] = False
         return ret
     state = bools[name]["State"] == rvalue
@@ -158,19 +158,19 @@ def boolean(name, value, persist=False):
             return ret
     if __opts__["test"]:
         ret["result"] = None
-        ret["comment"] = "Boolean {} is set to be changed to {}".format(name, rvalue)
+        ret["comment"] = f"Boolean {name} is set to be changed to {rvalue}"
         return ret
 
     ret["result"] = __salt__["selinux.setsebool"](name, rvalue, persist)
     if ret["result"]:
-        ret["comment"] = "Boolean {} has been set to {}".format(name, rvalue)
+        ret["comment"] = f"Boolean {name} has been set to {rvalue}"
         ret["changes"].update({"State": {"old": bools[name]["State"], "new": rvalue}})
         if persist and not default:
             ret["changes"].update(
                 {"Default": {"old": bools[name]["Default"], "new": rvalue}}
             )
         return ret
-    ret["comment"] = "Failed to set the boolean {} to {}".format(name, rvalue)
+    ret["comment"] = f"Failed to set the boolean {name} to {rvalue}"
     return ret
 
 
@@ -213,7 +213,7 @@ def module(name, module_state="Enabled", version="any", **opts):
         return module_remove(name)
     modules = __salt__["selinux.list_semod"]()
     if name not in modules:
-        ret["comment"] = "Module {} is not available".format(name)
+        ret["comment"] = f"Module {name} is not available"
         ret["result"] = False
         return ret
     rmodule_state = _refine_module_state(module_state)
@@ -235,7 +235,7 @@ def module(name, module_state="Enabled", version="any", **opts):
             return ret
     current_module_state = _refine_module_state(modules[name]["Enabled"])
     if rmodule_state == current_module_state:
-        ret["comment"] = "Module {} is in the desired state".format(name)
+        ret["comment"] = f"Module {name} is in the desired state"
         return ret
     if __opts__["test"]:
         ret["result"] = None
@@ -245,10 +245,10 @@ def module(name, module_state="Enabled", version="any", **opts):
         return ret
 
     if __salt__["selinux.setsemod"](name, rmodule_state):
-        ret["comment"] = "Module {} has been set to {}".format(name, module_state)
+        ret["comment"] = f"Module {name} has been set to {module_state}"
         return ret
     ret["result"] = False
-    ret["comment"] = "Failed to set the Module {} to {}".format(name, module_state)
+    ret["comment"] = f"Failed to set the Module {name} to {module_state}"
     return ret
 
 
@@ -263,10 +263,10 @@ def module_install(name):
     """
     ret = {"name": name, "result": True, "comment": "", "changes": {}}
     if __salt__["selinux.install_semod"](name):
-        ret["comment"] = "Module {} has been installed".format(name)
+        ret["comment"] = f"Module {name} has been installed"
         return ret
     ret["result"] = False
-    ret["comment"] = "Failed to install module {}".format(name)
+    ret["comment"] = f"Failed to install module {name}"
     return ret
 
 
@@ -282,14 +282,14 @@ def module_remove(name):
     ret = {"name": name, "result": True, "comment": "", "changes": {}}
     modules = __salt__["selinux.list_semod"]()
     if name not in modules:
-        ret["comment"] = "Module {} is not available".format(name)
+        ret["comment"] = f"Module {name} is not available"
         ret["result"] = False
         return ret
     if __salt__["selinux.remove_semod"](name):
-        ret["comment"] = "Module {} has been removed".format(name)
+        ret["comment"] = f"Module {name} has been removed"
         return ret
     ret["result"] = False
-    ret["comment"] = "Failed to remove module {}".format(name)
+    ret["comment"] = f"Failed to remove module {name}"
     return ret
 
 
@@ -343,7 +343,7 @@ def fcontext_policy_present(
                 sel_level=sel_level,
             )
             if add_ret["retcode"] != 0:
-                ret.update({"comment": "Error adding new rule: {}".format(add_ret)})
+                ret.update({"comment": f"Error adding new rule: {add_ret}"})
             else:
                 ret.update({"result": True})
     else:
@@ -354,7 +354,7 @@ def fcontext_policy_present(
             ret.update(
                 {
                     "result": True,
-                    "comment": 'SELinux policy for "{}" already present '.format(name)
+                    "comment": f'SELinux policy for "{name}" already present '
                     + 'with specified filetype "{}" and sel_type "{}".'.format(
                         filetype_str, sel_type
                     ),
@@ -375,7 +375,7 @@ def fcontext_policy_present(
                 sel_level=sel_level,
             )
             if change_ret["retcode"] != 0:
-                ret.update({"comment": "Error adding new rule: {}".format(change_ret)})
+                ret.update({"comment": f"Error adding new rule: {change_ret}"})
             else:
                 ret.update({"result": True})
     if ret["result"] and (new_state or old_state):
@@ -423,7 +423,7 @@ def fcontext_policy_absent(
         ret.update(
             {
                 "result": True,
-                "comment": 'SELinux policy for "{}" already absent '.format(name)
+                "comment": f'SELinux policy for "{name}" already absent '
                 + 'with specified filetype "{}" and sel_type "{}".'.format(
                     filetype, sel_type
                 ),
@@ -444,7 +444,7 @@ def fcontext_policy_absent(
             sel_level=sel_level,
         )
         if remove_ret["retcode"] != 0:
-            ret.update({"comment": "Error removing policy: {}".format(remove_ret)})
+            ret.update({"comment": f"Error removing policy: {remove_ret}"})
         else:
             ret.update({"result": True})
     return ret
@@ -516,7 +516,7 @@ def port_policy_present(name, sel_type, protocol=None, port=None, sel_range=None
         ret.update(
             {
                 "result": True,
-                "comment": 'SELinux policy for "{}" already present '.format(name)
+                "comment": f'SELinux policy for "{name}" already present '
                 + 'with specified sel_type "{}", protocol "{}" and port "{}".'.format(
                     sel_type, protocol, port
                 ),
@@ -534,7 +534,7 @@ def port_policy_present(name, sel_type, protocol=None, port=None, sel_range=None
             sel_range=sel_range,
         )
         if add_ret["retcode"] != 0:
-            ret.update({"comment": "Error adding new policy: {}".format(add_ret)})
+            ret.update({"comment": f"Error adding new policy: {add_ret}"})
         else:
             ret.update({"result": True})
             new_state = __salt__["selinux.port_get_policy"](
@@ -577,7 +577,7 @@ def port_policy_absent(name, sel_type=None, protocol=None, port=None):
         ret.update(
             {
                 "result": True,
-                "comment": 'SELinux policy for "{}" already absent '.format(name)
+                "comment": f'SELinux policy for "{name}" already absent '
                 + 'with specified sel_type "{}", protocol "{}" and port "{}".'.format(
                     sel_type, protocol, port
                 ),
@@ -593,7 +593,7 @@ def port_policy_absent(name, sel_type=None, protocol=None, port=None):
             port=port,
         )
         if delete_ret["retcode"] != 0:
-            ret.update({"comment": "Error deleting policy: {}".format(delete_ret)})
+            ret.update({"comment": f"Error deleting policy: {delete_ret}"})
         else:
             ret.update({"result": True})
             new_state = __salt__["selinux.port_get_policy"](

--- a/tests/pytests/unit/states/test_selinux.py
+++ b/tests/pytests/unit/states/test_selinux.py
@@ -1,5 +1,6 @@
 """
     :codeauthor: Jayesh Kariya <jayeshk@saltstack.com>
+    :codeauthor: Jason Woods <devel@jasonwoods.me.uk>
 """
 
 import pytest
@@ -118,3 +119,337 @@ def test_boolean():
             ret.update({"comment": comt, "result": False})
             ret.update({"changes": {}})
             assert selinux.boolean(name, value) == ret
+
+
+def test_port_policy_present():
+    """
+    Test to set up an SELinux port.
+    """
+    name = "tcp/8080"
+    protocol = "tcp"
+    port = "8080"
+    ret = {"name": name, "changes": {}, "result": False, "comment": ""}
+
+    # Test when already present with same sel_type
+    mock_add = MagicMock(return_value={"retcode": 0})
+    mock_modify = MagicMock(return_value={"retcode": 0})
+    mock_get = MagicMock(
+        return_value={
+            "sel_type": "http_cache_port_t",
+            "protocol": "tcp",
+            "port": "8080",
+        }
+    )
+    with patch.dict(
+        selinux.__salt__,
+        {
+            "selinux.port_get_policy": mock_get,
+            "selinux.port_add_policy": mock_add,
+            "selinux.port_modify_policy": mock_modify,
+        },
+    ):
+        with patch.dict(selinux.__opts__, {"test": False}):
+            comt = (
+                f'SELinux policy for "{name}" already present '
+                + f'with specified sel_type "http_cache_port_t", protocol "None" '
+                + f'and port "None".'
+            )
+            ret.update({"comment": comt, "result": True})
+            assert selinux.port_policy_present(name, "http_cache_port_t") == ret
+
+            comt = (
+                f'SELinux policy for "name" already present '
+                + f'with specified sel_type "http_cache_port_t", protocol "{protocol}" '
+                + f'and port "{port}".'
+            )
+            ret.update({"comment": comt, "changes": {}, "result": True, "name": "name"})
+            assert (
+                selinux.port_policy_present("name", "http_cache_port_t", protocol, port)
+                == ret
+            )
+            ret.update({"name": name})
+
+    # Test adding new port policy
+    mock_add = MagicMock(return_value={"retcode": 0})
+    mock_modify = MagicMock(return_value={"retcode": 0})
+    mock_get = MagicMock(
+        side_effect=[
+            None,
+            None,
+            None,
+            {"sel_type": "http_cache_port_t", "protocol": "tcp", "port": "8080"},
+        ]
+    )
+    with patch.dict(
+        selinux.__salt__,
+        {
+            "selinux.port_get_policy": mock_get,
+            "selinux.port_add_policy": mock_add,
+            "selinux.port_modify_policy": mock_modify,
+        },
+    ):
+        with patch.dict(selinux.__opts__, {"test": True}):
+            ret.update({"comment": "", "result": None})
+            assert selinux.port_policy_present(name, "http_cache_port_t") == ret
+
+        with patch.dict(selinux.__opts__, {"test": False}):
+            ret.update(
+                {
+                    "comment": "",
+                    "changes": {
+                        "old": None,
+                        "new": {
+                            "sel_type": "http_cache_port_t",
+                            "protocol": "tcp",
+                            "port": "8080",
+                        },
+                    },
+                    "result": True,
+                }
+            )
+            assert selinux.port_policy_present(name, "http_cache_port_t") == ret
+
+    # Test modifying policy to a new sel_type
+    mock_add = MagicMock(return_value={"retcode": 0})
+    mock_modify = MagicMock(return_value={"retcode": 0})
+    mock_get = MagicMock(
+        side_effect=[
+            None,
+            None,
+            {"sel_type": "http_cache_port_t", "protocol": "tcp", "port": "8080"},
+            {"sel_type": "http_port_t", "protocol": "tcp", "port": "8080"},
+        ]
+    )
+    with patch.dict(
+        selinux.__salt__,
+        {
+            "selinux.port_get_policy": mock_get,
+            "selinux.port_add_policy": mock_add,
+            "selinux.port_modify_policy": mock_modify,
+        },
+    ):
+        with patch.dict(selinux.__opts__, {"test": True}):
+            ret.update({"comment": "", "changes": {}, "result": None})
+            assert selinux.port_policy_present(name, "http_port_t") == ret
+
+        with patch.dict(selinux.__opts__, {"test": False}):
+            ret.update(
+                {
+                    "comment": "",
+                    "changes": {
+                        "old": {
+                            "sel_type": "http_cache_port_t",
+                            "protocol": "tcp",
+                            "port": "8080",
+                        },
+                        "new": {
+                            "sel_type": "http_port_t",
+                            "protocol": "tcp",
+                            "port": "8080",
+                        },
+                    },
+                    "result": True,
+                }
+            )
+            assert selinux.port_policy_present(name, "http_port_t") == ret
+
+    # Test adding new port policy with custom name and using protocol and port parameters
+    mock_add = MagicMock(return_value={"retcode": 0})
+    mock_modify = MagicMock(return_value={"retcode": 0})
+    mock_get = MagicMock(
+        side_effect=[
+            None,
+            None,
+            {"sel_type": "http_cache_port_t", "protocol": "tcp", "port": "8081"},
+        ]
+    )
+    with patch.dict(
+        selinux.__salt__,
+        {
+            "selinux.port_get_policy": mock_get,
+            "selinux.port_add_policy": mock_add,
+            "selinux.port_modify_policy": mock_modify,
+        },
+    ):
+        with patch.dict(selinux.__opts__, {"test": False}):
+            ret.update(
+                {
+                    "name": "required_protocol_port",
+                    "comment": "",
+                    "changes": {
+                        "old": None,
+                        "new": {
+                            "sel_type": "http_cache_port_t",
+                            "protocol": "tcp",
+                            "port": "8081",
+                        },
+                    },
+                    "result": True,
+                }
+            )
+            assert (
+                selinux.port_policy_present(
+                    "required_protocol_port",
+                    "http_cache_port_t",
+                    protocol="tcp",
+                    port="8081",
+                )
+                == ret
+            )
+
+    # Test failure of adding new policy
+    mock_add = MagicMock(return_value={"retcode": 1})
+    mock_modify = MagicMock(return_value={"retcode": 1})
+    mock_get = MagicMock(return_value=None)
+    with patch.dict(
+        selinux.__salt__,
+        {
+            "selinux.port_get_policy": mock_get,
+            "selinux.port_add_policy": mock_add,
+            "selinux.port_modify_policy": mock_modify,
+        },
+    ):
+        with patch.dict(selinux.__opts__, {"test": False}):
+            comt = "Error adding new policy: {'retcode': 1}"
+            ret.update({"name": name, "comment": comt, "changes": {}, "result": False})
+            assert selinux.port_policy_present(name, "http_cache_port_t") == ret
+
+
+def test_port_policy_absent():
+    """
+    Test to delete an SELinux port.
+    """
+    name = "tcp/8080"
+    protocol = "tcp"
+    port = "8080"
+    ret = {"name": name, "changes": {}, "result": False, "comment": ""}
+
+    # Test policy already removed
+    mock_delete = MagicMock(return_value={"retcode": 0})
+    mock_get = MagicMock(return_value=None)
+    with patch.dict(
+        selinux.__salt__,
+        {
+            "selinux.port_get_policy": mock_get,
+            "selinux.port_delete_policy": mock_delete,
+        },
+    ):
+        with patch.dict(selinux.__opts__, {"test": False}):
+            comt = (
+                f'SELinux policy for "{name}" already absent '
+                + f'with specified sel_type "http_cache_port_t", protocol "None" '
+                + f'and port "None".'
+            )
+            ret.update({"comment": comt, "changes": {}, "result": True})
+            assert selinux.port_policy_absent(name, "http_cache_port_t") == ret
+
+            comt = (
+                f'SELinux policy for "name" already absent '
+                + f'with specified sel_type "http_cache_port_t", protocol "{protocol}" '
+                + f'and port "{port}".'
+            )
+            ret.update({"comment": comt, "changes": {}, "result": True, "name": "name"})
+            assert (
+                selinux.port_policy_absent("name", "http_cache_port_t", protocol, port)
+                == ret
+            )
+            ret.update({"name": name})
+
+    # Test removing a policy
+    mock_delete = MagicMock(return_value={"retcode": 0})
+    mock_get = MagicMock(
+        side_effect=[
+            {"sel_type": "http_cache_port_t", "protocol": "tcp", "port": "8080"},
+            {"sel_type": "http_cache_port_t", "protocol": "tcp", "port": "8080"},
+            None,
+        ]
+    )
+    with patch.dict(
+        selinux.__salt__,
+        {
+            "selinux.port_get_policy": mock_get,
+            "selinux.port_delete_policy": mock_delete,
+        },
+    ):
+        with patch.dict(selinux.__opts__, {"test": True}):
+            ret.update({"comment": "", "result": None})
+            assert selinux.port_policy_absent(name, "http_cache_port_t") == ret
+
+        with patch.dict(selinux.__opts__, {"test": False}):
+            ret.update(
+                {
+                    "comment": "",
+                    "changes": {
+                        "old": {
+                            "sel_type": "http_cache_port_t",
+                            "protocol": "tcp",
+                            "port": "8080",
+                        },
+                        "new": None,
+                    },
+                    "result": True,
+                }
+            )
+            assert selinux.port_policy_absent(name, "http_cache_port_t") == ret
+
+    # Test removing a policy using custom name and with protocol and port parameters
+    mock_delete = MagicMock(return_value={"retcode": 0})
+    mock_get = MagicMock(
+        side_effect=[
+            {"sel_type": "http_cache_port_t", "protocol": "tcp", "port": "8081"},
+            None,
+        ]
+    )
+    with patch.dict(
+        selinux.__salt__,
+        {
+            "selinux.port_get_policy": mock_get,
+            "selinux.port_delete_policy": mock_delete,
+        },
+    ):
+        with patch.dict(selinux.__opts__, {"test": False}):
+            ret.update(
+                {
+                    "name": "required_protocol_port",
+                    "comment": "",
+                    "changes": {
+                        "old": {
+                            "sel_type": "http_cache_port_t",
+                            "protocol": "tcp",
+                            "port": "8081",
+                        },
+                        "new": None,
+                    },
+                    "result": True,
+                }
+            )
+            assert (
+                selinux.port_policy_absent(
+                    "required_protocol_port",
+                    "http_cache_port_t",
+                    protocol="tcp",
+                    port="8081",
+                )
+                == ret
+            )
+
+    # Test failure to delete a policy
+    mock_delete = MagicMock(return_value={"retcode": 2})
+    mock_get = MagicMock(
+        return_value={
+            "sel_type": "http_cache_port_t",
+            "protocol": "tcp",
+            "port": "8080",
+        }
+    )
+    with patch.dict(
+        selinux.__salt__,
+        {
+            "selinux.port_get_policy": mock_get,
+            "selinux.port_delete_policy": mock_delete,
+        },
+    ):
+        with patch.dict(selinux.__opts__, {"test": False}):
+            comt = "Error deleting policy: {'retcode': 2}"
+            ret.update({"name": name, "comment": comt, "changes": {}, "result": False})
+            assert selinux.port_policy_absent(name, "http_cache_port_t") == ret


### PR DESCRIPTION
### What does this PR do?

Allow port_policy_present to modify the SELinux type for a port that already has a type, such as a port that exists in the system policy.

### What issues does this PR fix or reference?
#55687

### Previous Behavior
port_policy_present would call port_add_policy even though the port already exists under a different type, which calls semanage -a. This will fail if the port already exists in the policy. Default ports such as 8080 already exist in the system policy so previously you could not set additional types for any default port as it would always fail.

### New Behavior
When a port already exists in the policy, port_modify_policy is used which will call semanage -m and successfully modify the port type.

Because policy modifications results in port_get_policy finding two policies if sel_type is omitted and only returning the first, most likely the default policy and not the modification, there is first a check for an exact matching policy including sel_type, and then if that doesn't find one, it then checks for ANY policy regardless of sel_type, and thus performs a modification. If the second check finds no policy it then performs an addition.

### Tests written?
Yes

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
