### PR TITLE
Only change mine data if using new allow_tgt feature

### DIFF
--- a/doc/topics/releases/3000.rst
+++ b/doc/topics/releases/3000.rst
@@ -592,6 +592,19 @@ Enhancements to chroot
   :py:func:`highstate<salt.modules.chroot.highstate>` that allow executing
   states in sls files or running apply/highstate inside of a chroot.
 
+Minion-side ACL
+---------------
+
+Salt has had master-side ACL for the salt mine for some time, where the master
+configuration contained `mine_get` that specified which minions could request
+which functions. However, now you can specify which minions can access a function
+in the salt mine function definition itself (or when calling :py:func:`mine.send <salt.modules.mine.send>`).
+This targeting works the same as the generic minion targeting as specified
+:ref:`here <targeting>`. The parameters used are ``allow_tgt`` and ``allow_tgt_type``.
+See also :ref:`the documentation of the Salt Mine <mine_minion-side-acl>`. Please
+note that if you want to use this new feature both your minion and masters will need
+to be on atleast version 3000.
+
 Deprecations
 ============
 

--- a/doc/topics/releases/sodium.rst
+++ b/doc/topics/releases/sodium.rst
@@ -16,14 +16,3 @@ also support the syntax used in :py:mod:`module.run <salt.states.module.run>`.
 The old syntax for the mine_function - as a dict, or as a list with dicts that
 contain more than exactly one key - is still supported but discouraged in favor
 of the more uniform syntax of module.run.
-
-Minion-side ACL
----------------
-
-Salt has had master-side ACL for the salt mine for some time, where the master
-configuration contained `mine_get` that specified which minions could request
-which functions. However, now you can specify which minions can access a function
-in the salt mine function definition itself (or when calling :py:func:`mine.send <salt.modules.mine.send>`).
-This targeting works the same as the generic minion targeting as specified
-:ref:`here <targeting>`. The parameters used are ``allow_tgt`` and ``allow_tgt_type``.
-See also :ref:`the documentation of the Salt Mine <mine_minion-side-acl>`.

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -617,14 +617,17 @@ class RemoteFuncs(object):
                         if 'allow_tgt' in mine_entry:
                             # Only determine allowed targets if any have been specified.
                             # This prevents having to add a list of all minions as allowed targets.
+                            get_minion = checker.check_minions(
+                                         mine_entry['allow_tgt'],
+                                         mine_entry.get('allow_tgt_type', 'glob'))['minions']
+                            # the minion in allow_tgt does not exist
+                            if not get_minion:
+                                continue
                             salt.utils.dictupdate.set_dict_key_value(
                                 minion_side_acl,
                                 '{}:{}'.format(minion, function),
-                                checker.check_minions(
-                                    mine_entry['allow_tgt'],
-                                    mine_entry.get('allow_tgt_type', 'glob')
-                                )['minions']
-                            )
+                                get_minion
+                           )
                 if salt.utils.mine.minion_side_acl_denied(minion_side_acl, minion, function, load['id']):
                     continue
                 if _ret_dict:

--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -217,11 +217,11 @@ def send(name, *args, **kwargs):
         and whose value will be stored in the salt mine. Defaults to ``name``.
     :param str allow_tgt: Targeting specification for ACL. Specifies which minions
         are allowed to access this function. Please note both your master and
-        minion need to be on atleast version 3000 for this to work properly.
+        minion need to be on, at least, version 3000 for this to work properly.
 
     :param str allow_tgt_type: Type of the targeting specification. This value will
         be ignored if ``allow_tgt`` is not specified. Please note both your
-        master and minion need to be on atleast version 3000 for this to work
+        master and minion need to be on, at least, version 3000 for this to work
         properly.
 
     Remaining args and kwargs will be passed on to the function to run.

--- a/tests/integration/files/conf/minion
+++ b/tests/integration/files/conf/minion
@@ -95,6 +95,9 @@ config_test:
 
 mine_functions:
   test.ping: []
+  test.arg:
+    - isn't
+    - allow_tgt: 'sub_minion'
 
 # sdb env module
 osenv:

--- a/tests/integration/files/conf/sub_minion
+++ b/tests/integration/files/conf/sub_minion
@@ -62,3 +62,8 @@ grains:
     keystone.password: demopass
     keystone.tenant: demo
     keystone.auth_url: http://127.0.0.1:5000/v3/
+
+mine_functions:
+  test.arg:
+    - isn't
+    - allow_tgt: 'sub_minion'

--- a/tests/integration/modules/test_mine.py
+++ b/tests/integration/modules/test_mine.py
@@ -8,10 +8,11 @@ import time
 import pprint
 
 # Import Salt Testing libs
-from tests.support.case import ModuleCase
+from tests.support.case import ModuleCase, ShellCase
+from tests.support.runtests import RUNTIME_VARS
 
 
-class MineTest(ModuleCase):
+class MineTest(ModuleCase, ShellCase):
     '''
     Test the mine system
     '''
@@ -22,15 +23,8 @@ class MineTest(ModuleCase):
         '''
         test mine.get and mine.update
         '''
-        self.assertTrue(self.run_function('mine.update', minion_tgt='minion'))
-        # The sub_minion does not have mine_functions defined in its configuration
-        # In this case, mine.update returns None
-        self.assertIsNone(
-            self.run_function(
-                'mine.update',
-                minion_tgt='sub_minion'
-            )
-        )
+        assert self.run_function('mine.update', minion_tgt='minion')
+        assert self.run_function('mine.update', minion_tgt='sub_minion')
         # Since the minion has mine_functions defined in its configuration,
         # mine.update will return True
         self.assertTrue(
@@ -39,6 +33,78 @@ class MineTest(ModuleCase):
                 ['minion', 'test.ping']
             )
         )
+
+    def test_get_allow_tgt(self):
+        '''
+        test mine.get and mine.update using allow_tgt
+        '''
+        assert self.run_function('mine.update', minion_tgt='minion')
+        assert self.run_function('mine.update', minion_tgt='sub_minion')
+
+        # sub_minion should be able to view test.arg data
+        sub_min_ret = self.run_call(r'mine.get \* test.arg', config_dir=RUNTIME_VARS.TMP_SUB_MINION_CONF_DIR)
+        assert "            - isn't" in sub_min_ret
+
+        # minion should not be able to view test.arg data
+        min_ret = self.run_call(r'mine.get \* test.arg')
+        assert "            - isn't" not in min_ret
+
+    def test_send_allow_tgt(self):
+        '''
+        test mine.send with allow_tgt set
+        '''
+        mine_name = 'test_this'
+        for minion in ['sub_minion', 'minion']:
+            assert self.run_function('mine.send', [mine_name,
+                'mine_function=test.arg_clean', 'one'], allow_tgt='sub_minion',
+                minion_tgt=minion)
+        min_ret = self.run_call(r'mine.get \* ' + mine_name)
+        sub_ret = self.run_call(r'mine.get \* ' + mine_name,
+                config_dir=RUNTIME_VARS.TMP_SUB_MINION_CONF_DIR)
+
+        # ensure we did get the mine_name mine function for sub_minion
+        assert '            - one' in sub_ret
+        # ensure we did not get the mine_name mine function for minion
+        assert '            - one' not in min_ret
+
+    def test_send_allow_tgt_compound(self):
+        '''
+        test mine.send with allow_tgt set
+        and using compound targeting
+        '''
+        mine_name = 'test_this_comp'
+        for minion in ['sub_minion', 'minion']:
+            assert self.run_function('mine.send', [mine_name,
+                'mine_function=test.arg_clean', 'one'],
+                allow_tgt='L@minion,sub_minion',
+                allow_tgt_type='compound',
+                minion_tgt=minion)
+        min_ret = self.run_call(r'mine.get \* ' + mine_name)
+        sub_ret = self.run_call(r'mine.get \* ' + mine_name,
+                config_dir=RUNTIME_VARS.TMP_SUB_MINION_CONF_DIR)
+
+        # ensure we get the mine_name mine function for both minions
+        for ret in [min_ret, sub_ret]:
+            assert '            - one' in ret
+
+    def test_send_allow_tgt_doesnotexist(self):
+        '''
+        test mine.send with allow_tgt set when
+        the minion defined in allow_tgt does
+        not exist
+        '''
+        mine_name = 'mine_doesnotexist'
+        for minion in ['sub_minion', 'minion']:
+            assert self.run_function('mine.send', [mine_name,
+                'mine_function=test.arg_clean', 'one'], allow_tgt='doesnotexist',
+                minion_tgt=minion)
+        min_ret = self.run_call(r'mine.get \* ' + mine_name)
+        sub_ret = self.run_call(r'mine.get \* ' + mine_name,
+                config_dir=RUNTIME_VARS.TMP_SUB_MINION_CONF_DIR)
+
+        # ensure we did not get the mine_name mine function for both minions
+        for ret in [sub_ret, min_ret]:
+            assert '            - one' not in ret
 
     def test_send(self):
         '''

--- a/tests/integration/modules/test_mine.py
+++ b/tests/integration/modules/test_mine.py
@@ -11,12 +11,18 @@ import pprint
 from tests.support.case import ModuleCase, ShellCase
 from tests.support.runtests import RUNTIME_VARS
 
+# Import Salt libs
+import salt.utils.platform
+
 
 class MineTest(ModuleCase, ShellCase):
     '''
     Test the mine system
     '''
     def setUp(self):
+        self.tgt = r'\*'
+        if salt.utils.platform.is_windows():
+            self.tgt = '*'
         self.wait_for_all_jobs()
 
     def test_get(self):
@@ -42,11 +48,11 @@ class MineTest(ModuleCase, ShellCase):
         assert self.run_function('mine.update', minion_tgt='sub_minion')
 
         # sub_minion should be able to view test.arg data
-        sub_min_ret = self.run_call(r'mine.get \* test.arg', config_dir=RUNTIME_VARS.TMP_SUB_MINION_CONF_DIR)
+        sub_min_ret = self.run_call('mine.get {0} test.arg'.format(self.tgt), config_dir=RUNTIME_VARS.TMP_SUB_MINION_CONF_DIR)
         assert "            - isn't" in sub_min_ret
 
         # minion should not be able to view test.arg data
-        min_ret = self.run_call(r'mine.get \* test.arg')
+        min_ret = self.run_call('mine.get {0} test.arg'.format(self.tgt))
         assert "            - isn't" not in min_ret
 
     def test_send_allow_tgt(self):
@@ -58,8 +64,8 @@ class MineTest(ModuleCase, ShellCase):
             assert self.run_function('mine.send', [mine_name,
                 'mine_function=test.arg_clean', 'one'], allow_tgt='sub_minion',
                 minion_tgt=minion)
-        min_ret = self.run_call(r'mine.get \* ' + mine_name)
-        sub_ret = self.run_call(r'mine.get \* ' + mine_name,
+        min_ret = self.run_call('mine.get {0} {1}'.format(self.tgt, mine_name))
+        sub_ret = self.run_call('mine.get {0} {1}'.format(self.tgt, mine_name),
                 config_dir=RUNTIME_VARS.TMP_SUB_MINION_CONF_DIR)
 
         # ensure we did get the mine_name mine function for sub_minion
@@ -79,8 +85,8 @@ class MineTest(ModuleCase, ShellCase):
                 allow_tgt='L@minion,sub_minion',
                 allow_tgt_type='compound',
                 minion_tgt=minion)
-        min_ret = self.run_call(r'mine.get \* ' + mine_name)
-        sub_ret = self.run_call(r'mine.get \* ' + mine_name,
+        min_ret = self.run_call('mine.get {0} {1}'.format(self.tgt, mine_name))
+        sub_ret = self.run_call('mine.get {0} {1}'.format(self.tgt, mine_name),
                 config_dir=RUNTIME_VARS.TMP_SUB_MINION_CONF_DIR)
 
         # ensure we get the mine_name mine function for both minions
@@ -98,8 +104,8 @@ class MineTest(ModuleCase, ShellCase):
             assert self.run_function('mine.send', [mine_name,
                 'mine_function=test.arg_clean', 'one'], allow_tgt='doesnotexist',
                 minion_tgt=minion)
-        min_ret = self.run_call(r'mine.get \* ' + mine_name)
-        sub_ret = self.run_call(r'mine.get \* ' + mine_name,
+        min_ret = self.run_call('mine.get {0} {1}'.format(self.tgt, mine_name))
+        sub_ret = self.run_call('mine.get {0} {1}'.format(self.tgt, mine_name),
                 config_dir=RUNTIME_VARS.TMP_SUB_MINION_CONF_DIR)
 
         # ensure we did not get the mine_name mine function for both minions

--- a/tests/support/case.py
+++ b/tests/support/case.py
@@ -175,9 +175,12 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixin
         arg_str = '--config-dir {0} {1}'.format(self.config_dir, arg_str)
         return self.run_script('salt-cp', arg_str, with_retcode=with_retcode, catch_stderr=catch_stderr)
 
-    def run_call(self, arg_str, with_retcode=False, catch_stderr=False, local=False, timeout=15):
+    def run_call(self, arg_str, with_retcode=False, catch_stderr=False,
+            local=False, timeout=15, config_dir=None):
+        if not config_dir:
+            config_dir = self.config_dir
         arg_str = '{0} --config-dir {1} {2}'.format('--local' if local else '',
-                                                    self.config_dir, arg_str)
+                                                    config_dir, arg_str)
 
         return self.run_script('salt-call',
                                arg_str,
@@ -582,12 +585,14 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
                                timeout=timeout)
 
     def run_call(self, arg_str, with_retcode=False, catch_stderr=False,  # pylint: disable=W0221
-            local=False, timeout=RUN_TIMEOUT):
+            local=False, timeout=RUN_TIMEOUT, config_dir=None):
         '''
         Execute salt-call.
         '''
+        if not config_dir:
+            config_dir = self.config_dir
         arg_str = '{0} --config-dir {1} {2}'.format('--local' if local else '',
-                                                    self.config_dir, arg_str)
+                                                    config_dir, arg_str)
         ret = self.run_script('salt-call',
                               arg_str,
                               with_retcode=with_retcode,
@@ -772,8 +777,6 @@ class ModuleCase(TestCase, SaltClientTestCaseMixin):
             'ssh.recv_known_host_entries',
             'time.sleep'
         )
-        if minion_tgt == 'sub_minion':
-            known_to_return_none += ('mine.update',)
         if 'f_arg' in kwargs:
             kwargs['arg'] = kwargs.pop('f_arg')
         if 'f_timeout' in kwargs:


### PR DESCRIPTION
### What does this PR do?
With the new `allow_tgt` feature in the mine.get the data structure was changed. This PR ensures we only send this new data structure if we are using the new `allow_tgt` feature. 

Fixes the issue in https://github.com/saltstack/salt/issues/56118

The initial issue made it so a master on <3000 would not  work with a >=3000 minion with mine data. With this PR we only change the data structure if we are using the new feature, so we assume if they are using the new feature they want to use 3000. Also documented that both the master and minion need to be on atleast versions 3000 if using this feature.

This PR also fixes another issue I found. If you set a minion in `allow_tgt` that is a minion that does not actually exist it will return the data regardless. Without this PR given the following config:

```
mine_functions:
  cpu:
    - mine_function: grains.get
    - cpuarch
    - allow_tgt: doesnotexist
```

As you can see above we have defined a minion that does not exist in `allow_tgt`, but I can still gather the data for any minion:

```
[root@localhost ~]# salt-call mine.get \* cpu
local:
    ----------
    master_min:
        x86_64
    thecakeisalie:
        x86_64
```

With this patch, we check to see if the minion even exists, if it does not we do not allow the minion to view the data:

```
[root@localhost ~]# salt-call mine.get \* cpu
local:
    ----------
```


### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/56118

### Previous Behavior
Data returned on a master (<3000) and minion (>=3000), even if not using the new `allow_tgt` feature:

```
    minion_name:
        ----------
        __data__:
            - 10.1.2.3
        __saltmine_acl__:
            1
```

### New Behavior
Data returned on a master (<3000) and minion (>=3000), even if not using the new `allow_tgt` feature:

```
    minion_name:
        - 10.1.2.3
```

To note if one is using the `allow_tgt` feature and they have a master <3000 they will see the wrong data (ex, `__data__`), this feature requires both master and minion are upgraded.

### Tests written?
Yes

### Commits signed with GPG?

Yes