### PR TITLE
Fix mac softwareupdate for catalina

### DIFF
--- a/salt/modules/mac_softwareupdate.py
+++ b/salt/modules/mac_softwareupdate.py
@@ -34,7 +34,7 @@ def __virtual__():
     return __virtualname__
 
 
-def _get_available(recommended=False, restart=False):
+def _get_available(recommended=False, restart=False, shut_down=False):
     """
     Utility function to get all available update packages.
 
@@ -44,48 +44,74 @@ def _get_available(recommended=False, restart=False):
     cmd = ["softwareupdate", "--list"]
     out = salt.utils.mac_utils.execute_return_result(cmd)
 
-    # rexp parses lines that look like the following:
-    #    * Safari6.1.2MountainLion-6.1.2
-    #         Safari (6.1.2), 51679K [recommended]
-    #    - iCal-1.0.2
-    #         iCal, 1.0.2, 6520K
-    rexp = re.compile("(?m)^   [*|-] " r"([^ ].*)[\r\n].*\(([^\)]+)")
+    if __grains__["osrelease_info"][1] >= 15:
+        # Example output:
+        # Software Update Tool
+        #
+        # Finding available software
+        # Software Update found the following new or updated software:
+        # * Label: Command Line Tools beta 5 for Xcode-11.0
+        #     Title: Command Line Tools beta 5 for Xcode, Version: 11.0, Size: 224804K, Recommended: YES,
+        # * Label: macOS Catalina Developer Beta-6
+        #     Title: macOS Catalina Public Beta, Version: 5, Size: 3084292K, Recommended: YES, Action: restart,
+        # * Label: BridgeOSUpdateCustomer
+        #     Title: BridgeOSUpdateCustomer, Version: 10.15.0.1.1.1560926689, Size: 390674K, Recommended: YES, Action: shut down,
+        # - Label: iCal-1.0.2
+        #     Title: iCal, Version: 1.0.2, Size: 6520K,
+        rexp = re.compile(
+            r"(?m)"  # Turn on multiline matching
+            r"^\s*[*-] Label: "  # Name lines start with * or - and "Label: "
+            r"(?P<name>[^ ].*)[\r\n]"  # Capture the rest of that line; this is the update name.
+            r".*Version: (?P<version>[^,]*), "  # Grab the version number.
+            r"Size: (?P<size>[^,]*),\s*"  # Grab the size; unused at this time.
+            r"(?P<recommended>Recommended: YES,)?\s*"  # Optionally grab the recommended flag.
+            r"(?P<action>Action: (?:restart|shut down),)?"  # Optionally grab an action.
+        )
+    else:
+        # Example output:
+        # Software Update Tool
+        #
+        # Finding available software
+        # Software Update found the following new or updated software:
+        #    * Command Line Tools (macOS Mojave version 10.14) for Xcode-10.3
+        #        Command Line Tools (macOS Mojave version 10.14) for Xcode (10.3), 199140K [recommended]
+        #    * macOS 10.14.1 Update
+        #        macOS 10.14.1 Update (10.14.1), 199140K [recommended] [restart]
+        #    * BridgeOSUpdateCustomer
+        #        BridgeOSUpdateCustomer (10.14.4.1.1.1555388607), 328394K, [recommended] [shut down]
+        #    - iCal-1.0.2
+        #        iCal, (1.0.2), 6520K
+        rexp = re.compile(
+            r"(?m)"  # Turn on multiline matching
+            r"^\s+[*-] "  # Name lines start with 3 spaces and either a * or a -.
+            r"(?P<name>.*)[\r\n]"  # The rest of that line is the name.
+            r".*\((?P<version>[^ \)]*)"  # Capture the last parenthesized value on the next line.
+            r"[^\r\n\[]*(?P<recommended>\[recommended\])?\s?"  # Capture [recommended] if there.
+            r"(?P<action>\[(?:restart|shut down)\])?"  # Capture an action if present.
+        )
 
+    # Build a list of lambda funcs to apply to matches to filter based
+    # on our args.
+    conditions = []
     if salt.utils.data.is_true(recommended):
-        # rexp parses lines that look like the following:
-        #    * Safari6.1.2MountainLion-6.1.2
-        #         Safari (6.1.2), 51679K [recommended]
-        rexp = re.compile("(?m)^   [*] " r"([^ ].*)[\r\n].*\(([^\)]+)")
+        conditions.append(lambda m: m.group("recommended"))
+    if salt.utils.data.is_true(restart):
+        conditions.append(
+            lambda m: "restart" in (m.group("action") or "")
+        )  # pylint: disable=superfluous-parens
+    if salt.utils.data.is_true(shut_down):
+        conditions.append(
+            lambda m: "shut down" in (m.group("action") or "")
+        )  # pylint: disable=superfluous-parens
 
-    keys = ["name", "version"]
-    _get = lambda l, k: l[keys.index(k)]
-
-    updates = rexp.findall(out)
-
-    ret = {}
-    for line in updates:
-        name = _get(line, "name")
-        version_num = _get(line, "version")
-        ret[name] = version_num
-
-    if not salt.utils.data.is_true(restart):
-        return ret
-
-    # rexp parses lines that look like the following:
-    #    * Safari6.1.2MountainLion-6.1.2
-    #         Safari (6.1.2), 51679K [recommended] [restart]
-    rexp1 = re.compile("(?m)^   [*|-] " r"([^ ].*)[\r\n].*restart*")
-
-    restart_updates = rexp1.findall(out)
-    ret_restart = {}
-    for update in ret:
-        if update in restart_updates:
-            ret_restart[update] = ret[update]
-
-    return ret_restart
+    return {
+        m.group("name"): m.group("version")
+        for m in rexp.finditer(out)
+        if all(f(m) for f in conditions)
+    }
 
 
-def list_available(recommended=False, restart=False):
+def list_available(recommended=False, restart=False, shut_down=False):
     """
     List all available updates.
 
@@ -102,7 +128,7 @@ def list_available(recommended=False, restart=False):
 
        salt '*' softwareupdate.list_available
     """
-    return _get_available(recommended, restart)
+    return _get_available(recommended, restart, shut_down)
 
 
 def ignore(name):

--- a/tests/unit/modules/test_mac_softwareupdate.py
+++ b/tests/unit/modules/test_mac_softwareupdate.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+
+
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import salt modules
+import salt.modules.mac_softwareupdate as mac_softwareupdate
+
+# Import Salt Testing libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.mock import patch
+from tests.support.unit import TestCase
+
+# These examples include 'recommended' and 'regular' updates. It's
+# believed that only 'recommended' updates will ever have an "action", so
+# included are examples of 'recommended' updates that have no action, the
+# 'restart' action, and the 'shut down' action.
+
+# This may need to be revised as we gather more example output.
+MOJAVE_LIST_OUTPUT = """Software Update Tool
+
+Finding available software
+Software Update found the following new or updated software:
+   * Command Line Tools (macOS Mojave version 10.14) for Xcode-10.3
+    Command Line Tools (macOS Mojave version 10.14) for Xcode (10.3), 199140K [recommended]
+   * macOS 10.14.1 Update
+    macOS 10.14.1 Update (10.14.1), 199140K [recommended] [restart]
+   * BridgeOSUpdateCustomer
+    BridgeOSUpdateCustomer (10.14.4.1.1.1555388607), 328394K, [recommended] [shut down]
+   - iCal-1.0.2
+    iCal, (1.0.2), 6520K"""
+
+CATALINA_LIST_OUTPUT = """Software Update Tool
+
+Finding available software
+Software Update found the following new or updated software:
+* Label: Command Line Tools beta 5 for Xcode-11.0
+    Title: Command Line Tools beta 5 for Xcode, Version: 11.0, Size: 224804K, Recommended: YES,
+* Label: macOS Catalina Developer Beta-6
+    Title: macOS Catalina Public Beta, Version: 5, Size: 3084292K, Recommended: YES, Action: restart,
+* Label: BridgeOSUpdateCustomer
+    Title: BridgeOSUpdateCustomer, Version: 10.15.0.1.1.1560926689, Size: 390674K, Recommended: YES, Action: shut down,
+- Label: iCal-1.0.2
+    Title: iCal, Version: 1.0.2, Size: 6520K,"""
+
+
+class MacSoftwareUpdatePreCatalinaTestCase(TestCase, LoaderModuleMockMixin):
+    def setup_loader_modules(self):
+        return {mac_softwareupdate: {"__grains__": {"osrelease_info": [10, 14, 6]}}}
+
+    @patch("salt.utils.mac_utils.execute_return_result")
+    def test_list_available(self, mock_execute):
+        mock_execute.return_value = MOJAVE_LIST_OUTPUT
+        result = mac_softwareupdate.list_available()
+        expected = {
+            "Command Line Tools (macOS Mojave version 10.14) for Xcode-10.3": "10.3",
+            "macOS 10.14.1 Update": "10.14.1",
+            "BridgeOSUpdateCustomer": "10.14.4.1.1.1555388607",
+            "iCal-1.0.2": "1.0.2",
+        }
+        self.assertEqual(result, expected)
+
+    @patch("salt.utils.mac_utils.execute_return_result")
+    def test_list_available_trailing_ws(self, mock_execute):
+        """Ensure the regex works with trailing whitespace in labels"""
+        # This also tests for no version number returning an empty str.
+        # This example's label will not install without the trailing space.
+        mock_execute.return_value = (
+            "Software Update Tool\n\nFinding available software\n"
+            "Software Update found the following new or updated software:\n"
+            "   * macOS Mojave 10.14.6 Supplemental Update- \n"
+            "    macOS Mojave 10.14.6 Supplemental Update ( ), 1581834K [recommended] [restart]"
+        )
+        result = mac_softwareupdate.list_available()
+        expected = {"macOS Mojave 10.14.6 Supplemental Update- ": ""}
+        self.assertEqual(result, expected)
+
+    @patch("salt.utils.mac_utils.execute_return_result")
+    def test_list_recommended(self, mock_execute):
+        mock_execute.return_value = MOJAVE_LIST_OUTPUT
+        result = mac_softwareupdate.list_available(recommended=True)
+        expected = {
+            "Command Line Tools (macOS Mojave version 10.14) for Xcode-10.3": "10.3",
+            "macOS 10.14.1 Update": "10.14.1",
+            "BridgeOSUpdateCustomer": "10.14.4.1.1.1555388607",
+        }
+        self.assertEqual(result, expected)
+
+    @patch("salt.utils.mac_utils.execute_return_result")
+    def test_list_restart(self, mock_execute):
+        mock_execute.return_value = MOJAVE_LIST_OUTPUT
+        result = mac_softwareupdate.list_available(restart=True)
+        expected = {"macOS 10.14.1 Update": "10.14.1"}
+        self.assertEqual(result, expected)
+
+    @patch("salt.utils.mac_utils.execute_return_result")
+    def test_list_shut_down(self, mock_execute):
+        mock_execute.return_value = MOJAVE_LIST_OUTPUT
+        result = mac_softwareupdate.list_available(shut_down=True)
+        expected = {"BridgeOSUpdateCustomer": "10.14.4.1.1.1555388607"}
+        self.assertEqual(result, expected)
+
+
+class MacSoftwareUpdateCatalinaTestCase(TestCase, LoaderModuleMockMixin):
+    def setup_loader_modules(self):
+        return {mac_softwareupdate: {"__grains__": {"osrelease_info": [10, 15]}}}
+
+    @patch("salt.utils.mac_utils.execute_return_result")
+    def test_list_available(self, mock_execute):
+        mock_execute.return_value = CATALINA_LIST_OUTPUT
+        result = mac_softwareupdate.list_available()
+        expected = {
+            "Command Line Tools beta 5 for Xcode-11.0": "11.0",
+            "macOS Catalina Developer Beta-6": "5",
+            "BridgeOSUpdateCustomer": "10.15.0.1.1.1560926689",
+            "iCal-1.0.2": "1.0.2",
+        }
+        self.assertEqual(result, expected)
+
+    @patch("salt.utils.mac_utils.execute_return_result")
+    def test_list_recommended(self, mock_execute):
+        mock_execute.return_value = CATALINA_LIST_OUTPUT
+        result = mac_softwareupdate.list_available(recommended=True)
+        expected = {
+            "Command Line Tools beta 5 for Xcode-11.0": "11.0",
+            "macOS Catalina Developer Beta-6": "5",
+            "BridgeOSUpdateCustomer": "10.15.0.1.1.1560926689",
+        }
+        self.assertEqual(result, expected)
+
+    @patch("salt.utils.mac_utils.execute_return_result")
+    def test_list_restart(self, mock_execute):
+        mock_execute.return_value = CATALINA_LIST_OUTPUT
+        result = mac_softwareupdate.list_available(restart=True)
+        expected = {"macOS Catalina Developer Beta-6": "5"}
+        self.assertEqual(result, expected)
+
+    @patch("salt.utils.mac_utils.execute_return_result")
+    def test_list_shut_down(self, mock_execute):
+        mock_execute.return_value = CATALINA_LIST_OUTPUT
+        result = mac_softwareupdate.list_available(shut_down=True)
+        expected = {"BridgeOSUpdateCustomer": "10.15.0.1.1.1560926689"}
+        self.assertEqual(result, expected)


### PR DESCRIPTION
### What does this PR do?
This PR fixes the `mac_softwareupdate.list_available` func to address changes in the output of the macOS `/usr/sbin/softwareupdate` tool. It handles two issues:
1. macOS Catalina changes the structure of the output.
2. At some point Apple added a "shut down" action to some updates (as opposed to "restart").

This PR switches on OS version to determine which regular expression to use, while adding the ability to filter updates by the new "shut down" action.

This PR was already accepted as #54281, but I was asked to rebase against master. So here we are!

### What issues does this PR fix or reference?
#54220

### Previous Behavior
`mac_softwareupdate.list_available` would not find any available updates on Catalina.
`mac_softwareupdate.list_available` was not able to filter for `shut down` type updates.

### New Behavior
`mac_softwareupdate.list_available` has functional parity for the newer output format on Catalina.
`mac_softwareupdate.list_available` now has an arg to filter for `shut down` type updates.

### Tests written?
Yes

### Commits signed with GPG?
No