### PR TITLE
Allows use of inline powershell for cmd.script args

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -344,7 +344,7 @@ def _run(cmd,
         # The last item in the list [-1] is the current method.
         # The third item[2] in each tuple is the name of that method.
         if stack[-2][2] == 'script':
-            cmd = 'Powershell -NonInteractive -NoProfile -ExecutionPolicy Bypass -File ' + cmd
+            cmd = 'Powershell -NonInteractive -NoProfile -ExecutionPolicy Bypass {0}'.format(cmd.replace('"', '\\"'))
         elif encoded_cmd:
             cmd = 'Powershell -NonInteractive -EncodedCommand {0}'.format(cmd)
         else:

--- a/tests/integration/files/file/base/issue-56195/test.ps1
+++ b/tests/integration/files/file/base/issue-56195/test.ps1
@@ -1,0 +1,7 @@
+[CmdLetBinding()]
+Param(
+  [SecureString] $SecureString
+)
+
+$Credential = New-Object System.Net.NetworkCredential("DummyId", $SecureString)
+$Credential.Password

--- a/tests/integration/modules/test_cmdmod.py
+++ b/tests/integration/modules/test_cmdmod.py
@@ -491,3 +491,14 @@ class CMDModuleTest(ModuleCase):
         out = self.run_function('cmd.run', ['set'], env={"abc": "123", "ABC": "456"}).splitlines()
         self.assertIn('abc=123', out)
         self.assertIn('ABC=456', out)
+
+    @skipIf(not salt.utils.platform.is_windows(), 'minion is not windows')
+    def test_windows_powershell_script_args(self):
+        '''
+        Ensure that powershell processes inline script in args
+        '''
+        val = 'i like cheese'
+        args = '-SecureString (ConvertTo-SecureString -String "{0}" -AsPlainText -Force) -ErrorAction Stop'.format(val)
+        script = 'salt://issue-56195/test.ps1'
+        ret = self.run_function('cmd.script', [script], args=args, shell='powershell')
+        self.assertEqual(ret['stdout'], val)


### PR DESCRIPTION
### What does this PR do?

Using powershell.exe with `-File` when the source shell is cmd treats all args as literal strings, which prevents usage of inline powershell. This patch just removes the `-File` argument, which still works with a script, but allows powershell to process any inline powershell that may be passed to one of the script args.

### What issues does this PR fix or reference?

Fixes #56195 

### Previous Behavior

Args passed to cmd.script with shell=powershell were treated as literal strings

### New Behavior

Args are processed by powershell

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

Yes

### Commits signed with GPG?

Yes
