### PR TITLE
Fix a couple arg parsing issues

### DIFF
--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -181,6 +181,15 @@ def yamlify_arg(arg):
         # loaded as an int. We don't want that, so return the original value.
         return arg
 
+    else:
+        if any(np_char in arg for np_char in ("\t", "\r", "\n")):
+            # Don't mess with this CLI arg, since it has one or more
+            # non-printable whitespace char. Since the CSafeLoader will
+            # sanitize these chars rather than raise an exception, just
+            # skip YAML loading of this argument and keep the argument as
+            # passed on the CLI.
+            return arg
+
     try:
         # Explicit late import to avoid circular import. DO NOT MOVE THIS.
         import salt.utils.yaml

--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -158,14 +158,21 @@ def yamlify_arg(arg):
     if not isinstance(arg, six.string_types):
         return arg
 
+    # YAML loads empty (or all whitespace) strings as None:
+    #
+    # >>> import yaml
+    # >>> yaml.load('') is None
+    # True
+    # >>> yaml.load('      ') is None
+    # True
+    #
+    # Similarly, YAML document start/end markers would not load properly if
+    # passed through PyYAML, as loading '---' results in None and '...' raises
+    # an exception.
+    #
+    # Therefore, skip YAML loading for these cases and just return the string
+    # that was passed in.
     if arg.strip() in ("", "---", "..."):
-        # Because YAML loads empty (or all whitespace) strings as None, we
-        # return the original string
-        # >>> import yaml
-        # >>> yaml.load('') is None
-        # True
-        # >>> yaml.load('      ') is None
-        # True
         return arg
 
     elif "_" in arg and all([x in "0123456789_" for x in arg.strip()]):

--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -158,7 +158,7 @@ def yamlify_arg(arg):
     if not isinstance(arg, six.string_types):
         return arg
 
-    if arg.strip() == "":
+    if arg.strip() in ("", "---", "..."):
         # Because YAML loads empty (or all whitespace) strings as None, we
         # return the original string
         # >>> import yaml

--- a/tests/unit/utils/test_args.py
+++ b/tests/unit/utils/test_args.py
@@ -321,6 +321,16 @@ class ArgsTestCase(TestCase):
         self.assertEqual(_yamlify_arg('["foo", "bar"]'), ["foo", "bar"])
         self.assertEqual(_yamlify_arg('{"foo": "bar"}'), {"foo": "bar"})
 
+        # Make sure that an empty string is loaded properly.
+        self.assertEqual(_yamlify_arg('   '), '   ')
+
+        # Make sure that we don't improperly load strings that would be
+        # interpreted by PyYAML as YAML document start/end.
+        self.assertEqual(_yamlify_arg('---'), '---')
+        self.assertEqual(_yamlify_arg('--- '), '--- ')
+        self.assertEqual(_yamlify_arg('...'), '...')
+        self.assertEqual(_yamlify_arg(' ...'), ' ...')
+
 
 class KwargRegexTest(TestCase):
     def test_arguments_regex(self):

--- a/tests/unit/utils/test_args.py
+++ b/tests/unit/utils/test_args.py
@@ -331,6 +331,9 @@ class ArgsTestCase(TestCase):
         self.assertEqual(_yamlify_arg('...'), '...')
         self.assertEqual(_yamlify_arg(' ...'), ' ...')
 
+        # Make sure that non-printable whitespace is not YAML-loaded
+        self.assertEqual(_yamlify_arg('foo\t\nbar'), 'foo\t\nbar')
+
 
 class KwargRegexTest(TestCase):
     def test_arguments_regex(self):

--- a/tests/unit/utils/test_args.py
+++ b/tests/unit/utils/test_args.py
@@ -322,17 +322,17 @@ class ArgsTestCase(TestCase):
         self.assertEqual(_yamlify_arg('{"foo": "bar"}'), {"foo": "bar"})
 
         # Make sure that an empty string is loaded properly.
-        self.assertEqual(_yamlify_arg('   '), '   ')
+        self.assertEqual(_yamlify_arg("   "), "   ")
 
         # Make sure that we don't improperly load strings that would be
         # interpreted by PyYAML as YAML document start/end.
-        self.assertEqual(_yamlify_arg('---'), '---')
-        self.assertEqual(_yamlify_arg('--- '), '--- ')
-        self.assertEqual(_yamlify_arg('...'), '...')
-        self.assertEqual(_yamlify_arg(' ...'), ' ...')
+        self.assertEqual(_yamlify_arg("---"), "---")
+        self.assertEqual(_yamlify_arg("--- "), "--- ")
+        self.assertEqual(_yamlify_arg("..."), "...")
+        self.assertEqual(_yamlify_arg(" ..."), " ...")
 
         # Make sure that non-printable whitespace is not YAML-loaded
-        self.assertEqual(_yamlify_arg('foo\t\nbar'), 'foo\t\nbar')
+        self.assertEqual(_yamlify_arg("foo\t\nbar"), "foo\t\nbar")
 
 
 class KwargRegexTest(TestCase):


### PR DESCRIPTION
Since we use PyYAML to separately load each CLI argument, document
start/end markers are not loaded properly. The document start ("---") is
loaded as None, while the document end ("...") raises an exception. This
commit fixes both, and adds unit tests to confirm correct loading, while
also adding a test case to confirm proper loading of an argument that is
all whitespace.

Resolves #56067. 