### PR TITLE
Make slots work with parallel=true

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1906,6 +1906,7 @@ class State(object):
         # correctly calculate further down the chain
         utc_start_time = datetime.datetime.utcnow()
 
+        self.format_slots(cdata)
         tag = _gen_tag(low)
         try:
             ret = self.states[cdata["full"]](*cdata["args"], **cdata["kwargs"])

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -619,6 +619,11 @@ class StateFormatSlotsTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         mock.assert_called_once_with("fun_arg", fun_key="fun_val")
         self.assertEqual(cdata, {"args": ["arg"], "kwargs": {"key": "value1thing~"}})
 
+    # Skip on windows like integration.modules.test_state.StateModuleTest.test_parallel_state_with_long_tag
+    @skipIf(
+        salt.utils.platform.is_windows(),
+        "Skipped until parallel states can be fixed on Windows",
+    )
     def test_format_slots_parallel(self):
         """
         Test if slots work with "parallel: true".

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -618,3 +618,26 @@ class StateFormatSlotsTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             self.state_obj.format_slots(cdata)
         mock.assert_called_once_with("fun_arg", fun_key="fun_val")
         self.assertEqual(cdata, {"args": ["arg"], "kwargs": {"key": "value1thing~"}})
+
+    def test_format_slots_parallel(self):
+        """
+        Test if slots work with "parallel: true".
+        """
+        high_data = {
+            "always-changes-and-succeeds": {
+                "test": [
+                    {"changes": True},
+                    {"comment": "__slot__:salt:test.echo(fun_return)"},
+                    {"parallel": True},
+                    "configurable_test_state",
+                    {"order": 10000},
+                ],
+                "__env__": "base",
+                "__sls__": "parallel_slots",
+            }
+        }
+        self.state_obj.jid = "123"
+        res = self.state_obj.call_high(high_data)
+        self.state_obj.jid = None
+        [(_, data)] = res.items()
+        self.assertEqual(data["comment"], "fun_return")


### PR DESCRIPTION
### Previous Behavior

Slots were completely ignored when states used [`parallel: true`](https://docs.saltstack.com/en/master/ref/states/parallel.html)

### New Behavior

Slots are expanded as expected

### Tests written?

Yes

### Commits signed with GPG?

No

@DmitryKuzmenko I'm not sure if you had any reasons not to expand slots in parallel mode. Any downsides? Please review the PR if you have some time.