### PR TITLE
Fix unit.modules.test_virt.VirtTestCase.test_update

### DIFF
--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -1318,7 +1318,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                   <alias name='net1'/>
                   <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x1'/>
                 </interface>
-                <graphics type='spice' port='5900' autoport='yes' listen='127.0.0.1'>
+                <graphics type='spice' listen='127.0.0.1' autoport='yes'>
                   <listen type='address' address='127.0.0.1'/>
                 </graphics>
                 <video>


### PR DESCRIPTION
The test case `unit.modules.test_virt.VirtTestCase.test_update` fails on Ubuntu 20.04 with Python 3.8:

```
======================================================================
FAIL: test_update (unit.modules.test_virt.VirtTestCase)
[CPU:0.0%|MEM:17.0%]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/unit/modules/test_virt.py", line 1313, in test_update
    self.assertEqual({
AssertionError: {'definition': False, 'disk': {'attached': [], 'detached[49 chars] []}} != {'definition': True, 'disk': {'attached': [], 'detached'[74 chars]True}
+ {'cpu': True,
- {'definition': False,
? ^              ^^^^

+  'definition': True,
? ^              ^^^

   'disk': {'attached': [], 'detached': []},
-  'interface': {'attached': [], 'detached': []}}
?                                               ^

+  'interface': {'attached': [], 'detached': []},
?                                               ^

+  'mem': True}

======================================================================
```

`virt.update` falsely detects a change to the graphics setting in the "no diff case". The old XML part specifies:

```xml
<graphics type="spice" port="5900" autoport="yes" listen="127.0.0.1">
    <listen type="address" address="127.0.0.1" />
</graphics>
```

The newly generated XML misses the port setting:

```xml
<graphics type="spice" listen="127.0.0.1" autoport="yes">
    <listen type="address" address="127.0.0.1" />
</graphics>
```

So adjust the initial XML file of the template, because setting the port to the default 5900, will change `autoport` to `no`.