### PR TITLE
Fix deprecation warnings for imports from collections

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -6,7 +6,6 @@ A collection of mixins useful for the various *Client interfaces
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals, with_statement
 
-import collections
 import copy as pycopy
 import fnmatch
 import logging
@@ -36,6 +35,13 @@ import salt.utils.user
 import salt.utils.versions
 from salt.ext import six
 
+try:
+    from collections.abc import Mapping, MutableMapping
+except ImportError:
+    # pylint: disable=no-name-in-module
+    from collections import Mapping, MutableMapping
+
+
 log = logging.getLogger(__name__)
 
 CLIENT_INTERNAL_KEYWORDS = frozenset(
@@ -58,7 +64,7 @@ CLIENT_INTERNAL_KEYWORDS = frozenset(
 )
 
 
-class ClientFuncsDict(collections.MutableMapping):
+class ClientFuncsDict(MutableMapping):
     """
     Class to make a read-only dict for accessing runner funcs "directly"
     """
@@ -148,7 +154,7 @@ class SyncClientMixin(object):
             self.opts, crypt="clear", usage="master_call"
         ) as channel:
             ret = channel.send(load)
-            if isinstance(ret, collections.Mapping):
+            if isinstance(ret, Mapping):
                 if "error" in ret:
                     salt.utils.error.raise_error(**ret["error"])
             return ret

--- a/salt/ext/tornado/httputil.py
+++ b/salt/ext/tornado/httputil.py
@@ -36,6 +36,13 @@ from salt.ext.tornado.escape import native_str, parse_qs_bytes, utf8
 from salt.ext.tornado.log import gen_log
 from salt.ext.tornado.util import ObjectDict, PY3
 
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    # pylint: disable=no-name-in-module
+    from collections import MutableMapping
+
+
 if PY3:
     import http.cookies as Cookie
     from http.client import responses
@@ -104,7 +111,7 @@ class _NormalizedHeaderCache(dict):
 _normalized_headers = _NormalizedHeaderCache(1000)
 
 
-class HTTPHeaders(collections.MutableMapping):
+class HTTPHeaders(MutableMapping):
     """A dictionary that maintains ``Http-Header-Case`` for all keys.
 
     Supports multiple values per key via a pair of new methods,

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -7,7 +7,6 @@ Jinja loading utils to enable a more powerful backend for jinja templates
 from __future__ import absolute_import, unicode_literals
 
 import atexit
-import collections
 import logging
 import os.path
 import pipes
@@ -37,6 +36,13 @@ from salt.exceptions import TemplateError
 from salt.ext import six
 from salt.utils.decorators.jinja import jinja_filter, jinja_global, jinja_test
 from salt.utils.odict import OrderedDict
+
+try:
+    from collections.abc import Hashable
+except ImportError:
+    # pylint: disable=no-name-in-module
+    from collections import Hashable
+
 
 log = logging.getLogger(__name__)
 
@@ -342,7 +348,7 @@ def to_bool(val):
         return val.lower() in ("yes", "1", "true")
     if isinstance(val, six.integer_types):
         return val > 0
-    if not isinstance(val, collections.Hashable):
+    if not isinstance(val, Hashable):
         return len(val) > 0
     return False
 
@@ -507,7 +513,7 @@ def unique(values):
         ['a', 'b', 'c']
     """
     ret = None
-    if isinstance(values, collections.Hashable):
+    if isinstance(values, Hashable):
         ret = set(values)
     else:
         ret = []
@@ -571,7 +577,7 @@ def lst_avg(lst):
 
         2.5
     """
-    if not isinstance(lst, collections.Hashable):
+    if not isinstance(lst, Hashable):
         return float(sum(lst) / len(lst))
     return float(lst)
 
@@ -592,9 +598,7 @@ def union(lst1, lst2):
 
         [1, 2, 3, 4, 6]
     """
-    if isinstance(lst1, collections.Hashable) and isinstance(
-        lst2, collections.Hashable
-    ):
+    if isinstance(lst1, Hashable) and isinstance(lst2, Hashable):
         return set(lst1) | set(lst2)
     return unique(lst1 + lst2)
 
@@ -615,9 +619,7 @@ def intersect(lst1, lst2):
 
         [2, 4]
     """
-    if isinstance(lst1, collections.Hashable) and isinstance(
-        lst2, collections.Hashable
-    ):
+    if isinstance(lst1, Hashable) and isinstance(lst2, Hashable):
         return set(lst1) & set(lst2)
     return unique([ele for ele in lst1 if ele in lst2])
 
@@ -638,9 +640,7 @@ def difference(lst1, lst2):
 
         [1, 3, 6]
     """
-    if isinstance(lst1, collections.Hashable) and isinstance(
-        lst2, collections.Hashable
-    ):
+    if isinstance(lst1, Hashable) and isinstance(lst2, Hashable):
         return set(lst1) - set(lst2)
     return unique([ele for ele in lst1 if ele not in lst2])
 
@@ -661,9 +661,7 @@ def symmetric_difference(lst1, lst2):
 
         [1, 3]
     """
-    if isinstance(lst1, collections.Hashable) and isinstance(
-        lst2, collections.Hashable
-    ):
+    if isinstance(lst1, Hashable) and isinstance(lst2, Hashable):
         return set(lst1) ^ set(lst2)
     return unique(
         [ele for ele in union(lst1, lst2) if ele not in intersect(lst1, lst2)]

--- a/salt/utils/oset.py
+++ b/salt/utils/oset.py
@@ -23,7 +23,11 @@ Rob Speer's changes are as follows:
 """
 from __future__ import absolute_import, print_function, unicode_literals
 
-import collections
+try:
+    from collections.abc import MutableSet
+except ImportError:
+    # pylint: disable=no-name-in-module
+    from collections import MutableSet
 
 SLICE_ALL = slice(None)
 __version__ = "2.0.1"
@@ -49,7 +53,7 @@ def is_iterable(obj):
     )
 
 
-class OrderedSet(collections.MutableSet):
+class OrderedSet(MutableSet):
     """
     An OrderedSet is a custom MutableSet that remembers its order, so that
     every entry has an index that can be looked up.


### PR DESCRIPTION
DeprecationWarning: Using or importing the ABCs from `collections` instead of from `collections.abc` is deprecated since Python 3.3, and in 3.9 it will stop working.

Therefore try to import the abstract base classes from `collections.abc` before falling back to `collections`.