### PR TITLE
Replace log.warn by log.warning and deprecated ElementTree.getchildren()

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -4944,7 +4944,7 @@ def get_password_data(
 
     if not HAS_M2 and not HAS_PYCRYPTO:
         if "key" in kwargs or "key_file" in kwargs:
-            log.warn("No crypto library is installed, can not decrypt password")
+            log.warning("No crypto library is installed, can not decrypt password")
         return ret
 
     if "key" not in kwargs:

--- a/salt/modules/bamboohr.py
+++ b/salt/modules/bamboohr.py
@@ -70,14 +70,13 @@ def list_employees(order_by="id"):
     ret = {}
     status, result = _query(action="employees", command="directory")
     root = ET.fromstring(result)
-    directory = root.getchildren()
-    for cat in directory:
+    for cat in root:
         if cat.tag != "employees":
             continue
         for item in cat:
             emp_id = item.items()[0][1]
             emp_ret = {"id": emp_id}
-            for details in item.getchildren():
+            for details in item:
                 emp_ret[details.items()[0][1]] = details.text
             ret[emp_ret[order_by]] = emp_ret
     return ret
@@ -144,10 +143,9 @@ def show_employee(emp_id, fields=None):
     status, result = _query(action="employees", command=emp_id, args={"fields": fields})
 
     root = ET.fromstring(result)
-    items = root.getchildren()
 
     ret = {"id": emp_id}
-    for item in items:
+    for item in root:
         ret[item.items()[0][1]] = item.text
     return ret
 
@@ -206,15 +204,14 @@ def list_users(order_by="id"):
     ret = {}
     status, result = _query(action="meta", command="users")
     root = ET.fromstring(result)
-    users = root.getchildren()
-    for user in users:
+    for user in root:
         user_id = None
         user_ret = {}
         for item in user.items():
             user_ret[item[0]] = item[1]
             if item[0] == "id":
                 user_id = item[1]
-        for item in user.getchildren():
+        for item in user:
             user_ret[item.tag] = item.text
         ret[user_ret[order_by]] = user_ret
     return ret
@@ -231,8 +228,7 @@ def list_meta_fields():
     ret = {}
     status, result = _query(action="meta", command="fields")
     root = ET.fromstring(result)
-    fields = root.getchildren()
-    for field in fields:
+    for field in root:
         field_id = None
         field_ret = {"name": field.text}
         for item in field.items():

--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -1107,7 +1107,7 @@ def verify(
         msg = "Invalid trustmodel defined: {}. Use one of: {}".format(
             trustmodel, ", ".join(trustmodels)
         )
-        log.warn(msg)
+        log.warning(msg)
         return {"res": False, "message": msg}
 
     extra_args = []

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -1053,7 +1053,7 @@ def traceroute(host):
 
         ret.append(result)
         if not result:
-            log.warn("Cannot parse traceroute output line: %s", line)
+            log.warning("Cannot parse traceroute output line: %s", line)
     return ret
 
 

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -1153,7 +1153,7 @@ def refresh_pillar(wait=False, timeout=30):
             tag="/salt/minion/minion_pillar_refresh_complete", wait=timeout
         )
         if not event_ret or event_ret["complete"] is False:
-            log.warn("Pillar refresh did not complete within timeout %s", timeout)
+            log.warning("Pillar refresh did not complete within timeout %s", timeout)
     return ret
 
 

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -5576,7 +5576,7 @@ def _getAdmlPresentationRefId(adml_data, ref_id):
                 if presentation_element:
                     presentation_element = presentation_element[0]
                     if TEXT_ELEMENT_XPATH(presentation_element):
-                        for p_item in presentation_element.getchildren():
+                        for p_item in presentation_element:
                             if p_item == result:
                                 break
                             if etree.QName(p_item.tag).localname == "text":
@@ -5738,7 +5738,7 @@ def _checkListItem(
     for list_element in xpath_object(policy_element):
         configured_items = 0
         required_items = 0
-        for item in list_element.getchildren():
+        for item in list_element:
             required_items = required_items + 1
             if "key" in item.attrib:
                 item_key = item.attrib["key"]
@@ -5808,7 +5808,7 @@ def _checkValueItemParent(
 
     """
     for element in xpath_object(policy_element):
-        for value_item in element.getchildren():
+        for value_item in element:
             search_string = _processValueItem(
                 value_item,
                 policy_key,
@@ -6541,7 +6541,7 @@ def _checkAllAdmxPolicies(
                     configured_elements = {}
                     policy_disabled_elements = 0
                     for elements_item in ELEMENTS_XPATH(admx_policy):
-                        for child_item in elements_item.getchildren():
+                        for child_item in elements_item:
                             this_element_name = _getFullPolicyName(
                                 policy_item=child_item,
                                 policy_name=child_item.attrib["id"],
@@ -6556,7 +6556,7 @@ def _checkAllAdmxPolicies(
 
                             if etree.QName(child_item).localname == "boolean":
                                 # https://msdn.microsoft.com/en-us/library/dn605978(v=vs.85).aspx
-                                if child_item.getchildren():
+                                if child_item:
                                     if (
                                         TRUE_VALUE_XPATH(child_item)
                                         and this_element_name not in configured_elements
@@ -6764,7 +6764,7 @@ def _checkAllAdmxPolicies(
                                         policy_disabled_elements + 1
                                     )
                                 else:
-                                    for enum_item in child_item.getchildren():
+                                    for enum_item in child_item:
                                         if _checkValueItemParent(
                                             enum_item,
                                             child_item.attrib["id"],
@@ -7500,7 +7500,7 @@ def _writeAdminTemplateRegPolFile(
                             if ELEMENTS_XPATH(this_policy):
                                 log.trace("checking elements of %s", admPolicy)
                                 for elements_item in ELEMENTS_XPATH(this_policy):
-                                    for child_item in elements_item.getchildren():
+                                    for child_item in elements_item:
                                         child_key = this_key
                                         child_valuename = this_valuename
                                         if "key" in child_item.attrib:
@@ -7668,7 +7668,7 @@ def _writeAdminTemplateRegPolFile(
                                 )
                             if ELEMENTS_XPATH(this_policy):
                                 for elements_item in ELEMENTS_XPATH(this_policy):
-                                    for child_item in elements_item.getchildren():
+                                    for child_item in elements_item:
                                         child_key = this_key
                                         child_valuename = this_valuename
                                         if "key" in child_item.attrib:
@@ -7790,9 +7790,7 @@ def _writeAdminTemplateRegPolFile(
                                                 etree.QName(child_item).localname
                                                 == "enum"
                                             ):
-                                                for (
-                                                    enum_item
-                                                ) in child_item.getchildren():
+                                                for enum_item in child_item:
                                                     if (
                                                         base_policy_settings[
                                                             adm_namespace
@@ -8431,7 +8429,7 @@ def get_policy_info(policy_name, policy_class, adml_language="en-US"):
     )
     if success:
         for elements_item in ELEMENTS_XPATH(policy_xml_item):
-            for child_item in elements_item.getchildren():
+            for child_item in elements_item:
                 this_element_name = _getFullPolicyName(
                     policy_item=child_item,
                     policy_name=child_item.attrib["id"],
@@ -8878,7 +8876,7 @@ def _get_policy_adm_setting(
             configured_elements = {}
             policy_disabled_elements = 0
             for elements_item in ELEMENTS_XPATH(admx_policy):
-                for child_item in elements_item.getchildren():
+                for child_item in elements_item:
                     this_element_name = _getFullPolicyName(
                         policy_item=child_item,
                         policy_name=child_item.attrib["id"],
@@ -8892,7 +8890,7 @@ def _get_policy_adm_setting(
                     )
                     if etree.QName(child_item).localname == "boolean":
                         # https://msdn.microsoft.com/en-us/library/dn605978(v=vs.85).aspx
-                        if child_item.getchildren():
+                        if child_item:
                             if (
                                 TRUE_VALUE_XPATH(child_item)
                                 and this_element_name not in configured_elements
@@ -9080,7 +9078,7 @@ def _get_policy_adm_setting(
                             configured_elements[this_element_name] = "Disabled"
                             policy_disabled_elements = policy_disabled_elements + 1
                         else:
-                            for enum_item in child_item.getchildren():
+                            for enum_item in child_item:
                                 if _checkValueItemParent(
                                     policy_element=enum_item,
                                     policy_name=child_item.attrib["id"],
@@ -9787,9 +9785,7 @@ def set_(
                                         dict,
                                     ):
                                         for elements_item in ELEMENTS_XPATH(the_policy):
-                                            for (
-                                                child_item
-                                            ) in elements_item.getchildren():
+                                            for child_item in elements_item:
                                                 # check each element
                                                 log.trace(
                                                     "checking element %s",
@@ -9922,9 +9918,7 @@ def set_(
                                                 ):
                                                     # make sure the value is in the enumeration
                                                     found = False
-                                                    for (
-                                                        enum_item
-                                                    ) in child_item.getchildren():
+                                                    for enum_item in child_item:
                                                         if (
                                                             _admTemplateData[
                                                                 policy_namespace

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -1166,7 +1166,7 @@ class SaltMessageClient(object):
                 self._connecting_future.set_result(True)
                 break
             except Exception as exc:  # pylint: disable=broad-except
-                log.warn("TCP Message Client encountered an exception %r", exc)
+                log.warning("TCP Message Client encountered an exception %r", exc)
                 yield salt.ext.tornado.gen.sleep(1)  # TODO: backoff
                 # self._connecting_future.set_exception(e)
 

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -127,7 +127,7 @@ def dup2(file1, file2):
         try:
             fno1 = file1.fileno()
         except io.UnsupportedOperation:
-            log.warn("Unsupported operation on file: %r", file1)
+            log.warning("Unsupported operation on file: %r", file1)
             return
     if isinstance(file2, int):
         fno2 = file2
@@ -135,7 +135,7 @@ def dup2(file1, file2):
         try:
             fno2 = file2.fileno()
         except io.UnsupportedOperation:
-            log.warn("Unsupported operation on file: %r", file2)
+            log.warning("Unsupported operation on file: %r", file2)
             return
     os.dup2(fno1, fno2)
 
@@ -847,14 +847,14 @@ class SignalHandlingProcess(Process):
                             if child.is_running():
                                 child.terminate()
                         except psutil.NoSuchProcess:
-                            log.warn(
+                            log.warning(
                                 "Unable to kill child of process %d, it does "
                                 "not exist. My pid is %d",
                                 self.pid,
                                 os.getpid(),
                             )
             except psutil.NoSuchProcess:
-                log.warn(
+                log.warning(
                     "Unable to kill children of process %d, it does not exist."
                     "My pid is %d",
                     self.pid,

--- a/salt/utils/xmlutil.py
+++ b/salt/utils/xmlutil.py
@@ -27,7 +27,7 @@ def _to_dict(xmltree):
     """
     # If this object has no children, the for..loop below will return nothing
     # for it, so just return a single dict representing it.
-    if len(xmltree.getchildren()) < 1:
+    if not xmltree:
         name = _conv_name(xmltree.tag)
         return {name: xmltree.text}
 
@@ -36,7 +36,7 @@ def _to_dict(xmltree):
         name = _conv_name(item.tag)
 
         if name not in xmldict:
-            if len(item.getchildren()) > 0:
+            if item:
                 xmldict[name] = _to_dict(item)
             else:
                 xmldict[name] = item.text
@@ -59,7 +59,7 @@ def _to_full_dict(xmltree):
     for attrName, attrValue in xmltree.attrib.items():
         xmldict[attrName] = attrValue
 
-    if len(xmltree.getchildren()) < 1:
+    if not xmltree:
         if len(xmldict) == 0:
             # If we don't have attributes, we should return the value as a string
             # ex: <entry>test</entry>


### PR DESCRIPTION
When running the test suite, following deprecation warnings appear:

* DeprecationWarning: The `warn` method is deprecated, use `warning` instead.
* DeprecationWarning: This method will be removed in future versions. Use `list(elem)` or iteration over elem instead.

Replace `log.warn` by `log.warning` and deprecated `ElementTree.getchildren()`.