### PR TITLE
Fix broken symlink in test_symlink_list

### DIFF
--- a/tests/unit/fileserver/test_roots.py
+++ b/tests/unit/fileserver/test_roots.py
@@ -62,6 +62,12 @@ class RootsTest(TestCase, AdaptedConfigurationTestCaseMixin, LoaderModuleMockMix
                 os.chdir(cwd)
             cls.test_symlink_list_file_roots = {"base": [root_dir]}
         else:
+            dest_sym = os.path.join(RUNTIME_VARS.BASE_FILES, "dest_sym")
+            if not os.path.islink(dest_sym):
+                # Fix broken symlink by recreating it
+                if os.path.exists(dest_sym):
+                    os.remove(dest_sym)
+                os.symlink("source_sym", dest_sym)
             cls.test_symlink_list_file_roots = None
         cls.tmp_dir = tempfile.mkdtemp(dir=RUNTIME_VARS.TMP)
         full_path_to_file = os.path.join(RUNTIME_VARS.BASE_FILES, "testfile")


### PR DESCRIPTION
Running the unit tests on the release tarball fails on Linux:

```
======================================================================
FAIL: test_symlink_list (unit.fileserver.test_roots.RootsTest)
[CPU:0.0%|MEM:76.1%]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/unit/fileserver/test_roots.py", line 174, in test_symlink_list
    self.assertDictEqual(ret, {'dest_sym': 'source_sym'})
AssertionError: {} != {'dest_sym': 'source_sym'}
- {}
+ {'dest_sym': 'source_sym'}

----------------------------------------------------------------------
```

The file `tests/integration/files/file/base/dest_sym` is a symlink to `source_sym` in the git repository, but it is a normal file in the release tarball. Therefore just restore the symlink in that case.