### PR TITLE
use full option name instead of undocumented abbreviation

### DIFF
--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -2244,7 +2244,7 @@ def list_products(all=False, refresh=False):
     OEM_PATH = "/var/lib/suseRegister/OEM"
     cmd = list()
     if not all:
-        cmd.append("--disable-repos")
+        cmd.append("--disable-repositories")
     cmd.append("products")
     if not all:
         cmd.append("-i")

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -304,9 +304,18 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
 
             ref_out = {"retcode": 0, "stdout": get_test_data(filename)}
 
-            with patch.dict(
-                zypper.__salt__, {"cmd.run_all": MagicMock(return_value=ref_out)}
-            ):
+            cmd_run_all = MagicMock(return_value=ref_out)
+            mock_call = call(["zypper",
+                              "--non-interactive",
+                              "--xmlout",
+                              "--no-refresh",
+                              "--disable-repositories",
+                              "products", u"-i"],
+                              env={"ZYPP_READONLY_HACK": "1"},
+                              output_loglevel="trace",
+                              python_shell=False)
+
+            with patch.dict(zypper.__salt__, {"cmd.run_all": cmd_run_all}):
                 products = zypper.list_products()
                 self.assertEqual(len(products), 7)
                 self.assertIn(
@@ -329,6 +338,8 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                         self.assertEqual(
                             test_data[kwd], sorted([prod.get(kwd) for prod in products])
                         )
+                cmd_run_all.assert_has_calls([mock_call])
+
 
     def test_refresh_db(self):
         """

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -305,15 +305,20 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
             ref_out = {"retcode": 0, "stdout": get_test_data(filename)}
 
             cmd_run_all = MagicMock(return_value=ref_out)
-            mock_call = call(["zypper",
-                              "--non-interactive",
-                              "--xmlout",
-                              "--no-refresh",
-                              "--disable-repositories",
-                              "products", u"-i"],
-                              env={"ZYPP_READONLY_HACK": "1"},
-                              output_loglevel="trace",
-                              python_shell=False)
+            mock_call = call(
+                [
+                    "zypper",
+                    "--non-interactive",
+                    "--xmlout",
+                    "--no-refresh",
+                    "--disable-repositories",
+                    "products",
+                    u"-i",
+                ],
+                env={"ZYPP_READONLY_HACK": "1"},
+                output_loglevel="trace",
+                python_shell=False,
+            )
 
             with patch.dict(zypper.__salt__, {"cmd.run_all": cmd_run_all}):
                 products = zypper.list_products()
@@ -339,7 +344,6 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                             test_data[kwd], sorted([prod.get(kwd) for prod in products])
                         )
                 cmd_run_all.assert_has_calls([mock_call])
-
 
     def test_refresh_db(self):
         """


### PR DESCRIPTION
### What does this PR do?

Change an option name when call zypper. We used an undocumented abbreviation which will be removed in future versions of zypper. Use the full option name instead.

Prevents:
```
"Module function pkg.list_products threw an exception. Exception: Zypper command failure: The flag --disable-repos is not known.",
```
errors.

### Tests written?

No

Behaviour did not change, we just use the documented option now.

### Commits signed with GPG?

No
