### PR TITLE
Allow skipping test cases that need Internet access

### DIFF
--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -622,6 +622,9 @@ def requires_network(only_local_network=False):
                     cls.skipTest("No local network was detected")
                 return func(cls)
 
+            if os.environ.get("NO_INTERNET"):
+                cls.skipTest("Environment variable NO_INTERNET is set.")
+
             # We are using the google.com DNS records as numerical IPs to avoid
             # DNS lookups which could greatly slow down this check
             for addr in (

--- a/tests/unit/modules/test_zcbuildout.py
+++ b/tests/unit/modules/test_zcbuildout.py
@@ -145,8 +145,8 @@ class Base(TestCase, LoaderModuleMockMixin):
     salt.utils.path.which_bin(KNOWN_VIRTUALENV_BINARY_NAMES) is None,
     "The 'virtualenv' packaged needs to be installed",
 )
+@requires_network()
 class BuildoutTestCase(Base):
-    @requires_network()
     @skipIf(True, "SLOWTEST skip")
     def test_onlyif_unless(self):
         b_dir = os.path.join(self.tdir, "b")
@@ -157,7 +157,6 @@ class BuildoutTestCase(Base):
         self.assertTrue(ret["comment"] == "unless condition is true")
         self.assertTrue(ret["status"] is True)
 
-    @requires_network()
     @skipIf(True, "SLOWTEST skip")
     def test_salt_callback(self):
         @buildout._salt_callback
@@ -215,7 +214,6 @@ class BuildoutTestCase(Base):
             self.assertTrue(0 == len(buildout.LOG.by_level[l]))
         # pylint: enable=invalid-sequence-index
 
-    @requires_network()
     @skipIf(True, "SLOWTEST skip")
     def test_get_bootstrap_url(self):
         for path in [
@@ -240,7 +238,6 @@ class BuildoutTestCase(Base):
                 "b2 url for {0}".format(path),
             )
 
-    @requires_network()
     @skipIf(True, "SLOWTEST skip")
     def test_get_buildout_ver(self):
         for path in [
@@ -261,7 +258,6 @@ class BuildoutTestCase(Base):
                 2, buildout._get_buildout_ver(path), "2 for {0}".format(path)
             )
 
-    @requires_network()
     @skipIf(True, "SLOWTEST skip")
     def test_get_bootstrap_content(self):
         self.assertEqual(
@@ -277,7 +273,6 @@ class BuildoutTestCase(Base):
             buildout._get_bootstrap_content(os.path.join(self.tdir, "var", "tb", "2")),
         )
 
-    @requires_network()
     @skipIf(True, "SLOWTEST skip")
     def test_logger_clean(self):
         buildout.LOG.clear()
@@ -296,7 +291,6 @@ class BuildoutTestCase(Base):
             not in [len(buildout.LOG.by_level[a]) > 0 for a in buildout.LOG.by_level]
         )
 
-    @requires_network()
     @skipIf(True, "SLOWTEST skip")
     def test_logger_loggers(self):
         buildout.LOG.clear()
@@ -309,7 +303,6 @@ class BuildoutTestCase(Base):
             self.assertEqual(buildout.LOG.by_level[i][0], "foo")
             self.assertEqual(buildout.LOG.by_level[i][-1], "moo")
 
-    @requires_network()
     @skipIf(True, "SLOWTEST skip")
     def test__find_cfgs(self):
         result = sorted(
@@ -329,7 +322,6 @@ class BuildoutTestCase(Base):
         )
         self.assertEqual(result, assertlist)
 
-    @requires_network()
     def skip_test_upgrade_bootstrap(self):
         b_dir = os.path.join(self.tdir, "b")
         bpy = os.path.join(b_dir, "bootstrap.py")
@@ -357,6 +349,7 @@ class BuildoutTestCase(Base):
     salt.utils.path.which_bin(KNOWN_VIRTUALENV_BINARY_NAMES) is None,
     "The 'virtualenv' packaged needs to be installed",
 )
+@requires_network()
 class BuildoutOnlineTestCase(Base):
     @classmethod
     def setUpClass(cls):
@@ -426,7 +419,6 @@ class BuildoutOnlineTestCase(Base):
                 ]
             )
 
-    @requires_network()
     @skipIf(True, "TODO this test should probably be fixed")
     def test_buildout_bootstrap(self):
         b_dir = os.path.join(self.tdir, "b")
@@ -477,7 +469,6 @@ class BuildoutOnlineTestCase(Base):
             or ("setuptools>=0.7" in comment)
         )
 
-    @requires_network()
     @skipIf(True, "SLOWTEST skip")
     def test_run_buildout(self):
         if salt.modules.virtualenv_mod.virtualenv_ver(self.ppy_st) >= (20, 0, 0):
@@ -493,7 +484,6 @@ class BuildoutOnlineTestCase(Base):
         self.assertTrue("Installing a" in out)
         self.assertTrue("Installing b" in out)
 
-    @requires_network()
     @skipIf(True, "SLOWTEST skip")
     def test_buildout(self):
         if salt.modules.virtualenv_mod.virtualenv_ver(self.ppy_st) >= (20, 0, 0):

--- a/tests/unit/states/test_pip_state.py
+++ b/tests/unit/states/test_pip_state.py
@@ -21,7 +21,7 @@ import salt.utils.path
 # Import salt libs
 import salt.version
 from salt.modules.virtualenv_mod import KNOWN_BINARY_NAMES
-from tests.support.helpers import VirtualEnv, dedent
+from tests.support.helpers import VirtualEnv, dedent, requires_network
 
 # Import Salt Testing libs
 from tests.support.mixins import LoaderModuleMockMixin, SaltReturnAssertsMixin
@@ -419,6 +419,7 @@ class PipStateUtilsTest(TestCase):
 @skipIf(
     salt.utils.path.which_bin(KNOWN_BINARY_NAMES) is None, "virtualenv not installed"
 )
+@requires_network()
 class PipStateInstallationErrorTest(TestCase):
     @skipIf(True, "SLOWTEST skip")
     def test_importable_installation_error(self):

--- a/tests/unit/states/test_zcbuildout.py
+++ b/tests/unit/states/test_zcbuildout.py
@@ -24,6 +24,7 @@ from tests.unit.modules.test_zcbuildout import KNOWN_VIRTUALENV_BINARY_NAMES, Ba
     salt.utils.path.which_bin(KNOWN_VIRTUALENV_BINARY_NAMES) is None,
     "The 'virtualenv' packaged needs to be installed",
 )
+@requires_network()
 class BuildoutTestCase(Base):
     def setup_loader_modules(self):
         module_globals = {
@@ -41,7 +42,6 @@ class BuildoutTestCase(Base):
     # I don't have the time to invest in learning more about buildout,
     # and given we don't have support yet, and there are other priorities
     # I'm going to punt on this for now - WW
-    @requires_network()
     @skipIf(True, "Buildout is still in beta. Test needs fixing.")
     def test_quiet(self):
         c_dir = os.path.join(self.tdir, "c")
@@ -52,7 +52,6 @@ class BuildoutTestCase(Base):
         self.assertFalse("Log summary:" in cret["comment"], cret["comment"])
         self.assertTrue(cret["result"], cret["comment"])
 
-    @requires_network()
     @skipIf(True, "SLOWTEST skip")
     def test_error(self):
         b_dir = os.path.join(self.tdir, "e")
@@ -62,7 +61,6 @@ class BuildoutTestCase(Base):
         )
         self.assertFalse(ret["result"])
 
-    @requires_network()
     @skipIf(True, "SLOWTEST skip")
     def test_installed(self):
         if salt.modules.virtualenv_mod.virtualenv_ver(self.ppy_st) >= (20, 0, 0):

--- a/tests/unit/utils/test_dns.py
+++ b/tests/unit/utils/test_dns.py
@@ -28,9 +28,10 @@ from salt.utils.dns import (
     lookup,
 )
 from salt.utils.odict import OrderedDict
-from tests.support.mock import MagicMock, patch
 
 # Testing
+from tests.support.helpers import requires_network
+from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase, skipIf
 
 
@@ -311,6 +312,7 @@ class DNSlookupsCase(TestCase):
                     )
 
     @skipIf(not salt.utils.dns.HAS_NSLOOKUP, "nslookup is not available")
+    @requires_network()
     def test_lookup_with_servers(self):
         rights = {
             "A": [

--- a/tests/unit/utils/test_jinja.py
+++ b/tests/unit/utils/test_jinja.py
@@ -35,7 +35,7 @@ from salt.utils.jinja import (
 from salt.utils.odict import OrderedDict
 from salt.utils.templates import JINJA, render_jinja_tmpl
 from tests.support.case import ModuleCase
-from tests.support.helpers import flaky
+from tests.support.helpers import requires_network
 from tests.support.mock import MagicMock, Mock, patch
 from tests.support.runtests import RUNTIME_VARS
 from tests.support.unit import TestCase, skipIf
@@ -1358,7 +1358,7 @@ class TestCustomExtensions(TestCase):
         )
         self.assertEqual(rendered, "16777216")
 
-    @flaky
+    @requires_network()
     def test_http_query(self):
         """
         Test the `http_query` Jinja filter.


### PR DESCRIPTION
Mark test cases that need Internet access and allow skipping them by setting the environment variable `NO_INTERNET`.