### PR TITLE
Doc: 2018.3.0 availability for sdb yaml gpg render

### DIFF
--- a/salt/sdb/yaml.py
+++ b/salt/sdb/yaml.py
@@ -35,8 +35,11 @@ Optional configuration:
         merge_list: false
       gpg: true
 
-Setting the ``gpg`` option to ``true`` (default is ``false``) will decrypt embedded
-GPG-encrypted data using the :py:mod:`GPG renderer <salt.renderers.gpg>`.
+.. versionadded:: 2018.3.0
+
+Setting the ``gpg`` option to ``true`` (default is ``false``) will decrypt
+embedded GPG-encrypted data using the :py:mod:`GPG renderer
+<salt.renderers.gpg>`.
 """
 
 # import python libs


### PR DESCRIPTION
### What does this PR do?

Make clear that gpg rendering support was not availabilty until 2018.3.0.  It was added in https://github.com/saltstack/salt/pull/43710.

### What issues does this PR fix or reference?

Incomplete documentation, leading to confusion of availability of feature when using a legacy version.

### Tests written?

No, docs-only change.

### Commits signed with GPG?

No.