### PR TITLE
Use salt.utils.http.query for checksum download

### DIFF
--- a/salt/modules/nexus.py
+++ b/salt/modules/nexus.py
@@ -455,11 +455,11 @@ def __save_artifact(artifact_url, target_file, headers):
             if checksum_response['body'] == file_sum:
                 result['status'] = True
                 result['target_file'] = target_file
-                result['comment'] = 'File {0} already exists, checksum matches with Artifactory.\n' \
+                result['comment'] = 'File {0} already exists, checksum matches with Nexus.\n' \
                                     'Checksum URL: {1}'.format(target_file, checksum_url)
                 return result
             else:
-                result['comment'] = 'File {0} already exists, checksum does not match with Artifactory!\n'\
+                result['comment'] = 'File {0} already exists, checksum does not match with Nexus!\n'\
                                     'Checksum URL: {1}'.format(target_file, checksum_url)
 
         else:

--- a/salt/modules/nexus.py
+++ b/salt/modules/nexus.py
@@ -446,25 +446,25 @@ def __save_artifact(artifact_url, target_file, headers):
         log.debug("File %s already exists, checking checksum...", target_file)
         checksum_url = artifact_url + ".sha1"
 
-        checksum_success, artifact_sum, checksum_comment = __download(checksum_url, headers)
-        if checksum_success:
-            log.debug("Downloaded SHA1 SUM: %s", artifact_sum)
+        checksum_response = salt.utils.http.query(checksum_url, header_dict=headers)
+        if checksum_response['body']:
+            log.debug("Downloaded SHA1 SUM: %s", checksum_response['body'])
             file_sum = __salt__['file.get_hash'](path=target_file, form='sha1')
             log.debug("Target file (%s) SHA1 SUM: %s", target_file, file_sum)
 
-            if artifact_sum == file_sum:
+            if checksum_response['body'] == file_sum:
                 result['status'] = True
                 result['target_file'] = target_file
-                result['comment'] = 'File {0} already exists, checksum matches with nexus.\n' \
+                result['comment'] = 'File {0} already exists, checksum matches with Artifactory.\n' \
                                     'Checksum URL: {1}'.format(target_file, checksum_url)
                 return result
             else:
-                result['comment'] = 'File {0} already exists, checksum does not match with nexus!\n'\
+                result['comment'] = 'File {0} already exists, checksum does not match with Artifactory!\n'\
                                     'Checksum URL: {1}'.format(target_file, checksum_url)
 
         else:
             result['status'] = False
-            result['comment'] = checksum_comment
+            result['comment'] = checksum_response['error']
             return result
 
     log.debug('Downloading: %s -> %s', artifact_url, target_file)
@@ -495,23 +495,6 @@ def __get_group_id_subpath(group_id):
 def __get_classifier_url(classifier):
     has_classifier = classifier is not None and classifier != ""
     return "-" + classifier if has_classifier else ""
-
-
-def __download(request_url, headers):
-    log.debug('Downloading content from %s', request_url)
-
-    success = False
-    content = None
-    comment = None
-    try:
-        request = urllib.request.Request(request_url, None, headers)
-        url = urllib.request.urlopen(request)
-        content = url.read()
-        success = True
-    except HTTPError as e:
-        comment = __get_error_comment(e, request_url)
-
-    return success, content, comment
 
 
 def __get_error_comment(http_error, request_url):


### PR DESCRIPTION
Use the built in http query to download the file checksum from a maven repo.  Resolves issues with comparing raw byte data to a string in previous code.

This PR resolves issues raised in #54644 (PR to merge #49507) by using the built in (and hopefully well tested) http utils, addresses issues in both nexus and artifactory modules (which used identical code.)

