### PR TITLE
saltnado: don't use gather_job_timeout as a timeout signal in job_not_running

### DIFF
--- a/changelog/49572.fixed
+++ b/changelog/49572.fixed
@@ -1,0 +1,1 @@
+fix frequent rest_tornado non-fatal tracebacks

--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -1120,7 +1120,8 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
         Return a future which will complete once jid (passed in) is no longer
         running on tgt
         """
-        ping_pub_data = yield self.saltclients["local"](
+        local_client = self.saltclients["local"]
+        ping_pub_data = yield local_client(
             tgt, "saltutil.find_job", [jid], tgt_type=tgt_type
         )
         ping_tag = tagify([ping_pub_data["jid"], "ret"], "job")
@@ -1141,7 +1142,7 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
                 if not minion_running:
                     raise salt.ext.tornado.gen.Return(True)
                 else:
-                    ping_pub_data = yield self.saltclients["local"](
+                    ping_pub_data = yield local_client(
                         tgt, "saltutil.find_job", [jid], tgt_type=tgt_type
                     )
                     ping_tag = tagify([ping_pub_data["jid"], "ret"], "job")

--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -1,4 +1,3 @@
-# encoding: utf-8
 """
 A non-blocking REST API for Salt
 ================================
@@ -186,7 +185,6 @@ a return like::
 .. |500| replace:: internal server error
 """
 # Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 # pylint: disable=import-error
 import cgi
@@ -200,7 +198,6 @@ import salt.auth
 import salt.client
 
 # salt imports
-import salt.ext.six as six
 import salt.ext.tornado.escape
 import salt.ext.tornado.gen
 import salt.ext.tornado.httpserver
@@ -264,7 +261,7 @@ class Any(Future):
     """
 
     def __init__(self, futures):
-        super(Any, self).__init__()
+        super().__init__()
         for future in futures:
             future.add_done_callback(self.done_callback)
 
@@ -274,7 +271,7 @@ class Any(Future):
             self.set_result(future)
 
 
-class EventListener(object):
+class EventListener:
     """
     Class responsible for listening to the salt master event bus and updating
     futures. This is the core of what makes this asynchronous, this allows us to do
@@ -392,7 +389,7 @@ class EventListener(object):
         mtag, data = self.event.unpack(raw, self.event.serial)
 
         # see if we have any futures that need this info:
-        for (tag, matcher), futures in six.iteritems(self.tag_map):
+        for (tag, matcher), futures in self.tag_map.items():
             try:
                 is_matched = matcher(mtag, tag)
             except Exception:  # pylint: disable=broad-except
@@ -771,12 +768,10 @@ class SaltAuthHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
 
             if "groups" in token and token["groups"]:
                 user_groups = set(token["groups"])
-                eauth_groups = set(
-                    [i.rstrip("%") for i in eauth.keys() if i.endswith("%")]
-                )
+                eauth_groups = {i.rstrip("%") for i in eauth.keys() if i.endswith("%")}
 
                 for group in user_groups & eauth_groups:
-                    perms.extend(eauth["{0}%".format(group)])
+                    perms.extend(eauth["{}%".format(group)])
 
             perms = sorted(list(set(perms)))
         # If we can't find the creds, then they aren't authorized
@@ -958,7 +953,7 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
 
             # disbatch to the correct handler
             try:
-                chunk_ret = yield getattr(self, "_disbatch_{0}".format(low["client"]))(
+                chunk_ret = yield getattr(self, "_disbatch_{}".format(low["client"]))(
                     low
                 )
                 ret.append(chunk_ret)
@@ -966,9 +961,7 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
                 ret.append("Failed to authenticate")
                 break
             except Exception as ex:  # pylint: disable=broad-except
-                ret.append(
-                    "Unexpected exception while handling request: {0}".format(ex)
-                )
+                ret.append("Unexpected exception while handling request: {}".format(ex))
                 log.error("Unexpected exception while handling request:", exc_info=True)
 
         self.write(self.serialize({"return": ret}))
@@ -1065,7 +1058,7 @@ class SaltAPIHandler(BaseSaltAPIHandler):  # pylint: disable=W0223
             """
             Check if there are any more minions we are waiting on returns from
             """
-            return any(x is False for x in six.itervalues(minions))
+            return any(x is False for x in minions.values())
 
         # here we want to follow the behavior of LocalClient.get_iter_returns
         # namely we want to wait at least syndic_wait (assuming we are a syndic)
@@ -1611,15 +1604,15 @@ class EventsSaltAPIHandler(SaltAPIHandler):  # pylint: disable=W0223
         self.set_header("Cache-Control", "no-cache")
         self.set_header("Connection", "keep-alive")
 
-        self.write("retry: {0}\n".format(400))
+        self.write("retry: {}\n".format(400))
         self.flush()
 
         while True:
             try:
                 event = yield self.application.event_listener.get_event(self)
-                self.write("tag: {0}\n".format(event.get("tag", "")))
+                self.write("tag: {}\n".format(event.get("tag", "")))
                 self.write(
-                    str("data: {0}\n\n").format(_json_dumps(event))
+                    "data: {}\n\n".format(_json_dumps(event))
                 )  # future lint: disable=blacklisted-function
                 self.flush()
             except TimeoutException:

--- a/tests/integration/netapi/rest_tornado/test_app.py
+++ b/tests/integration/netapi/rest_tornado/test_app.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, print_function, unicode_literals
-
 import os
 import threading
 import time
@@ -8,7 +5,6 @@ import time
 import pytest
 import salt.utils.json
 import salt.utils.stringutils
-from salt.ext import six
 from salt.netapi.rest_tornado import saltnado
 from salt.utils.versions import StrictVersion
 from salt.utils.zeromq import ZMQDefaultLoop as ZMQIOLoop
@@ -38,7 +34,7 @@ class _SaltnadoIntegrationTestCase(SaltnadoTestCase):  # pylint: disable=abstrac
 @pytest.mark.usefixtures("salt_sub_minion")
 class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
     def setUp(self):
-        super(TestSaltAPIHandler, self).setUp()
+        super().setUp()
         os.environ["ASYNC_TEST_TIMEOUT"] = "300"
 
     def get_app(self):
@@ -459,7 +455,7 @@ class TestMinionSaltAPIHandler(_SaltnadoIntegrationTestCase):
         # one per minion
         self.assertEqual(len(response_obj["return"][0]), 2)
         # check a single grain
-        for minion_id, grains in six.iteritems(response_obj["return"][0]):
+        for minion_id, grains in response_obj["return"][0].items():
             self.assertEqual(minion_id, grains["id"])
 
     @slowTest
@@ -564,7 +560,7 @@ class TestJobsSaltAPIHandler(_SaltnadoIntegrationTestCase):
         response = self.wait(timeout=30)
         response_obj = salt.utils.json.loads(response.body)["return"][0]
         try:
-            for jid, ret in six.iteritems(response_obj):
+            for jid, ret in response_obj.items():
                 self.assertIn("Function", ret)
                 self.assertIn("Target", ret)
                 self.assertIn("Target-type", ret)
@@ -576,9 +572,9 @@ class TestJobsSaltAPIHandler(_SaltnadoIntegrationTestCase):
             raise
 
         # test with a specific JID passed in
-        jid = next(six.iterkeys(response_obj))
+        jid = next(iter(response_obj.keys()))
         self.http_client.fetch(
-            self.get_url("/jobs/{0}".format(jid)),
+            self.get_url("/jobs/{}".format(jid)),
             self.stop,
             method="GET",
             headers={saltnado.AUTH_TOKEN_HEADER: self.token["token"]},
@@ -650,8 +646,7 @@ class TestEventsSaltAPIHandler(_SaltnadoIntegrationTestCase):
         self.stop()
 
     def on_event(self, event):
-        if six.PY3:
-            event = event.decode("utf-8")
+        event = event.decode("utf-8")
         if self.events_to_fire > 0:
             self.application.event_listener.event.fire_event(
                 {"foo": "bar", "baz": "qux"}, "salt/netapi/test"

--- a/tests/integration/netapi/rest_tornado/test_app.py
+++ b/tests/integration/netapi/rest_tornado/test_app.py
@@ -84,7 +84,6 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
 
     # Local client tests
 
-    @skipIf(True, "to be re-enabled when #23623 is merged")
     def test_simple_local_post(self):
         """
         Test a basic API of /
@@ -138,7 +137,6 @@ class TestSaltAPIHandler(_SaltnadoIntegrationTestCase):
 
     # local client request body test
 
-    @skipIf(True, "Undetermined race condition in test. Temporarily disabled.")
     def test_simple_local_post_only_dictionary_request(self):
         """
         Test a basic API of /
@@ -417,7 +415,6 @@ class TestMinionSaltAPIHandler(_SaltnadoIntegrationTestCase):
         application.event_listener = saltnado.EventListener({}, self.opts)
         return application
 
-    @skipIf(True, "issue #34753")
     def test_get_no_mid(self):
         response = self.fetch(
             "/minions",
@@ -433,7 +430,6 @@ class TestMinionSaltAPIHandler(_SaltnadoIntegrationTestCase):
         for minion_id, grains in six.iteritems(response_obj["return"][0]):
             self.assertEqual(minion_id, grains["id"])
 
-    @skipIf(True, "to be re-enabled when #23623 is merged")
     @slowTest
     def test_get(self):
         response = self.fetch(
@@ -523,7 +519,6 @@ class TestJobsSaltAPIHandler(_SaltnadoIntegrationTestCase):
         application.event_listener = saltnado.EventListener({}, self.opts)
         return application
 
-    @skipIf(True, "to be re-enabled when #23623 is merged")
     @slowTest
     def test_get(self):
         # test with no JID
@@ -580,7 +575,6 @@ class TestRunSaltAPIHandler(_SaltnadoIntegrationTestCase):
         application.event_listener = saltnado.EventListener({}, self.opts)
         return application
 
-    @skipIf(True, "to be re-enabled when #23623 is merged")
     @slowTest
     def test_get(self):
         low = [{"client": "local", "tgt": "*", "fun": "test.ping"}]
@@ -700,9 +694,7 @@ class TestWebhookSaltAPIHandler(_SaltnadoIntegrationTestCase):
                 )
             self.assertEqual(event["tag"], "salt/netapi/hook")
             self.assertIn("headers", event["data"])
-            self.assertEqual(
-                event["data"]["post"], {"foo": salt.utils.stringutils.to_bytes("bar")}
-            )
+            self.assertEqual(event["data"]["post"], {"foo": "bar"})
         finally:
             self._future_resolved.clear()
             del self._future_resolved

--- a/tests/unit/netapi/test_rest_tornado.py
+++ b/tests/unit/netapi/test_rest_tornado.py
@@ -1,22 +1,13 @@
-# coding: utf-8
-
-from __future__ import absolute_import
-
 import copy
 import hashlib
 import os
 import shutil
+from urllib.parse import urlencode, urlparse
 
 import salt.auth
 import salt.utils.event
 import salt.utils.json
 import salt.utils.yaml
-from salt.ext import six
-from salt.ext.six.moves import map, range  # pylint: disable=import-error
-from salt.ext.six.moves.urllib.parse import (  # pylint: disable=no-name-in-module
-    urlencode,
-    urlparse,
-)
 from tests.support.events import eventpublisher_process
 from tests.support.helpers import patched_environ, slowTest
 from tests.support.mixins import AdaptedConfigurationTestCaseMixin
@@ -45,10 +36,10 @@ except ImportError:
     HAS_TORNADO = False
 
     # Create fake test case classes so we can properly skip the test case
-    class AsyncTestCase(object):
+    class AsyncTestCase:
         pass
 
-    class AsyncHTTPTestCase(object):
+    class AsyncHTTPTestCase:
         pass
 
 
@@ -103,13 +94,13 @@ class SaltnadoTestCase(TestCase, AdaptedConfigurationTestCaseMixin, AsyncHTTPTes
         return self.auth.mk_token(self.auth_creds_dict)
 
     def setUp(self):
-        super(SaltnadoTestCase, self).setUp()
+        super().setUp()
         self.patched_environ = patched_environ(ASYNC_TEST_TIMEOUT="30")
         self.patched_environ.__enter__()
         self.addCleanup(self.patched_environ.__exit__)
 
     def tearDown(self):
-        super(SaltnadoTestCase, self).tearDown()
+        super().tearDown()
         if hasattr(self, "http_server"):
             del self.http_server
         if hasattr(self, "io_loop"):
@@ -145,8 +136,6 @@ class SaltnadoTestCase(TestCase, AdaptedConfigurationTestCaseMixin, AsyncHTTPTes
     def decode_body(self, response):
         if response is None:
             return response
-        if six.PY2:
-            return response
         if response.body:
             # Decode it
             if response.headers.get("Content-Type") == "application/json":
@@ -156,7 +145,7 @@ class SaltnadoTestCase(TestCase, AdaptedConfigurationTestCaseMixin, AsyncHTTPTes
         return response
 
     def fetch(self, path, **kwargs):
-        return self.decode_body(super(SaltnadoTestCase, self).fetch(path, **kwargs))
+        return self.decode_body(super().fetch(path, **kwargs))
 
 
 class TestBaseSaltAPIHandler(SaltnadoTestCase):
@@ -244,7 +233,7 @@ class TestBaseSaltAPIHandler(SaltnadoTestCase):
 
         # send a token as a cookie
         response = self.fetch(
-            "/", headers={"Cookie": "{0}=foo".format(saltnado.AUTH_COOKIE_NAME)}
+            "/", headers={"Cookie": "{}=foo".format(saltnado.AUTH_COOKIE_NAME)}
         )
         token = salt.utils.json.loads(response.body)["token"]
         self.assertEqual(token, "foo")
@@ -254,7 +243,7 @@ class TestBaseSaltAPIHandler(SaltnadoTestCase):
             "/",
             headers={
                 saltnado.AUTH_TOKEN_HEADER: "foo",
-                "Cookie": "{0}=bar".format(saltnado.AUTH_COOKIE_NAME),
+                "Cookie": "{}=bar".format(saltnado.AUTH_COOKIE_NAME),
             },
         )
         token = salt.utils.json.loads(response.body)["token"]
@@ -367,7 +356,7 @@ class TestBaseSaltAPIHandler(SaltnadoTestCase):
         Test transformations low data of the function _get_lowstate
         """
         valid_lowstate = [
-            {u"client": u"local", u"tgt": u"*", u"fun": u"test.fib", u"arg": [u"10"]}
+            {"client": "local", "tgt": "*", "fun": "test.fib", "arg": ["10"]}
         ]
 
         # Case 1. dictionary type of lowstate
@@ -615,7 +604,7 @@ class TestSaltAuthHandler(SaltnadoTestCase):
         self.assertEqual(response.code, 200)
         response_obj = salt.utils.json.loads(response.body)["return"][0]
         token = response_obj["token"]
-        self.assertIn("session_id={0}".format(token), cookies)
+        self.assertIn("session_id={}".format(token), cookies)
         self.assertEqual(
             sorted(response_obj["perms"]),
             sorted(
@@ -638,7 +627,7 @@ class TestSaltAuthHandler(SaltnadoTestCase):
         self.assertEqual(response.code, 200)
         response_obj = salt.utils.json.loads(response.body)["return"][0]
         token = response_obj["token"]
-        self.assertIn("session_id={0}".format(token), cookies)
+        self.assertIn("session_id={}".format(token), cookies)
         self.assertEqual(
             sorted(response_obj["perms"]),
             sorted(
@@ -661,7 +650,7 @@ class TestSaltAuthHandler(SaltnadoTestCase):
         self.assertEqual(response.code, 200)
         response_obj = salt.utils.json.loads(response.body)["return"][0]
         token = response_obj["token"]
-        self.assertIn("session_id={0}".format(token), cookies)
+        self.assertIn("session_id={}".format(token), cookies)
         self.assertEqual(
             sorted(response_obj["perms"]),
             sorted(
@@ -677,7 +666,7 @@ class TestSaltAuthHandler(SaltnadoTestCase):
         Test logins with bad/missing passwords
         """
         bad_creds = []
-        for key, val in six.iteritems(self.auth_creds_dict):
+        for key, val in self.auth_creds_dict.items():
             if key == "password":
                 continue
             bad_creds.append((key, val))
@@ -695,7 +684,7 @@ class TestSaltAuthHandler(SaltnadoTestCase):
         Test logins with bad/missing passwords
         """
         bad_creds = []
-        for key, val in six.iteritems(self.auth_creds_dict):
+        for key, val in self.auth_creds_dict.items():
             if key == "username":
                 val = val + "foo"
             if key == "eauth":
@@ -797,7 +786,7 @@ class TestWebsocketSaltAPIHandler(SaltnadoTestCase):
             "token"
         ]
 
-        url = "ws://127.0.0.1:{0}/all_events/{1}".format(self.get_http_port(), token)
+        url = "ws://127.0.0.1:{}/all_events/{}".format(self.get_http_port(), token)
         request = HTTPRequest(
             url, headers={"Origin": "http://example.com", "Host": "example.com"}
         )
@@ -814,7 +803,7 @@ class TestWebsocketSaltAPIHandler(SaltnadoTestCase):
             getattr(hashlib, self.opts.get("hash_type", "md5"))().hexdigest()
         )
 
-        url = "ws://127.0.0.1:{0}/all_events/{1}".format(self.get_http_port(), token)
+        url = "ws://127.0.0.1:{}/all_events/{}".format(self.get_http_port(), token)
         request = HTTPRequest(
             url, headers={"Origin": "http://example.com", "Host": "example.com"}
         )
@@ -837,7 +826,7 @@ class TestWebsocketSaltAPIHandler(SaltnadoTestCase):
             "token"
         ]
 
-        url = "ws://127.0.0.1:{0}/all_events/{1}".format(self.get_http_port(), token)
+        url = "ws://127.0.0.1:{}/all_events/{}".format(self.get_http_port(), token)
         request = HTTPRequest(
             url, headers={"Origin": "http://foo.bar", "Host": "example.com"}
         )
@@ -858,7 +847,7 @@ class TestWebsocketSaltAPIHandler(SaltnadoTestCase):
         token = salt.utils.json.loads(self.decode_body(response).body)["return"][0][
             "token"
         ]
-        url = "ws://127.0.0.1:{0}/all_events/{1}".format(self.get_http_port(), token)
+        url = "ws://127.0.0.1:{}/all_events/{}".format(self.get_http_port(), token)
 
         # Example.com should works
         request = HTTPRequest(
@@ -890,7 +879,7 @@ class TestWebsocketSaltAPIHandler(SaltnadoTestCase):
         token = salt.utils.json.loads(self.decode_body(response).body)["return"][0][
             "token"
         ]
-        url = "ws://127.0.0.1:{0}/all_events/{1}".format(self.get_http_port(), token)
+        url = "ws://127.0.0.1:{}/all_events/{}".format(self.get_http_port(), token)
 
         # Example.com should works
         request = HTTPRequest(
@@ -955,7 +944,7 @@ class TestEventListener(AsyncTestCase):
         if not os.path.exists(self.sock_dir):
             os.makedirs(self.sock_dir)
         self.addCleanup(shutil.rmtree, self.sock_dir, ignore_errors=True)
-        super(TestEventListener, self).setUp()
+        super().setUp()
 
     @slowTest
     def test_simple(self):
@@ -1031,7 +1020,7 @@ class TestEventListener(AsyncTestCase):
         dummy_request_future_2 : will be timeout-ed by clean-by_request(dummy_request)
         """
 
-        class DummyRequest(object):
+        class DummyRequest:
             """
             Dummy request object to simulate the request object
             """

--- a/tests/unit/netapi/test_rest_tornado.py
+++ b/tests/unit/netapi/test_rest_tornado.py
@@ -130,6 +130,8 @@ class SaltnadoTestCase(TestCase, AdaptedConfigurationTestCaseMixin, AsyncHTTPTes
             del self._test_generator
         if hasattr(self, "application"):
             del self.application
+        if hasattr(self, "patched_environ"):
+            del self.patched_environ
 
     def build_tornado_app(self, urls):
         application = salt.ext.tornado.web.Application(urls, debug=True)


### PR DESCRIPTION
(Summary copied from #49567.  This was intended for Neon, but appears to have not made it off of the old `neon` branch?)

because the future was generated from tornado.gen.sleep, its eventual timer
still fires regardless of if the future is manually set with set_result. When
set_result is called twice (once manually by saltnado, once by tornado call_later),
a stacktrace like so is thrown:

```
[ERROR   ] Uncaught exception POST / (::1)
Traceback (most recent call last):
  File "/home/mphillips81/.pyenv/versions/3.6.5/lib/python3.6/site-packages/tornado/web.py", line 1369, in _stack_context_handle_exception
    raise_exc_info((type, value, traceback))
  File "<string>", line 3, in raise_exc_info
  File "/home/mphillips81/.pyenv/versions/3.6.5/lib/python3.6/site-packages/tornado/stack_context.py", line 314, in wrapped
    ret = fn(*args, **kwargs)
  File "/home/mphillips81/.pyenv/versions/3.6.5/lib/python3.6/site-packages/tornado/gen.py", line 771, in later
    f.set_result(None)
  File "/home/mphillips81/.pyenv/versions/3.6.5/lib/python3.6/site-packages/tornado/concurrent.py", line 254, in set_result
    self._set_done()
  File "/home/mphillips81/.pyenv/versions/3.6.5/lib/python3.6/site-packages/tornado/concurrent.py", line 298, in _set_done
    for cb in self._callbacks:
TypeError: 'NoneType' object is not iterable

```
This patch attempts to fix that. @jacksontj would appreciate a review I'm not hugely familiar with the saltnado/tornado code here.

### What does this PR do?
fixes a stack thrown after every call.

fixes https://github.com/saltstack/salt/issues/49572

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.