### PR TITLE
Only process ADMX files when loading policies

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -4987,6 +4987,8 @@ def _load_policy_definitions(path='c:\\Windows\\PolicyDefinitions',
         if root == path:
             for t_admx_file in files:
                 admx_file_name, admx_file_ext = os.path.splitext(t_admx_file)
+                # Only process ADMX files, any other file will cause a
+                # stacktrace later on
                 if not admx_file_ext == '.admx':
                     log.debug('{0} is not an ADMX file'.format(t_admx_file))
                     continue
@@ -5005,9 +5007,6 @@ def _load_policy_definitions(path='c:\\Windows\\PolicyDefinitions',
                     namespaces['None'] = namespaces[None]
                     namespaces.pop(None)
                     namespace_string = 'None:'
-                this_prefix = xml_tree.xpath(
-                        '/{0}policyDefinitions/{0}policyNamespaces/{0}target/@prefix'.format(namespace_string),
-                        namespaces=namespaces)[0]
                 this_namespace = xml_tree.xpath(
                         '/{0}policyDefinitions/{0}policyNamespaces/{0}target/@namespace'.format(namespace_string),
                         namespaces=namespaces)[0]

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -4986,6 +4986,10 @@ def _load_policy_definitions(path='c:\\Windows\\PolicyDefinitions',
     for root, dirs, files in salt.utils.path.os_walk(path):
         if root == path:
             for t_admx_file in files:
+                admx_file_name, admx_file_ext = os.path.splitext(t_admx_file)
+                if not admx_file_ext == '.admx':
+                    log.debug('{0} is not an ADMX file'.format(t_admx_file))
+                    continue
                 admx_file = os.path.join(root, t_admx_file)
                 # Parse xml for the ADMX file
                 try:
@@ -5038,7 +5042,7 @@ def _load_policy_definitions(path='c:\\Windows\\PolicyDefinitions',
                 adml_file = os.path.join(
                     root,
                     language,
-                    os.path.splitext(t_admx_file)[0] + '.adml')
+                    admx_file_name + '.adml')
                 if not __salt__['file.file_exists'](adml_file):
                     log.info('An ADML file in the specified ADML language '
                              '"%s" does not exist for the ADMX "%s", the '
@@ -5048,7 +5052,7 @@ def _load_policy_definitions(path='c:\\Windows\\PolicyDefinitions',
                     adml_file = os.path.join(
                         root,
                         language.split('-')[0],
-                        os.path.splitext(t_admx_file)[0] + '.adml')
+                        admx_file_name + '.adml')
                     if not __salt__['file.file_exists'](adml_file):
                         log.info('An ADML file in the specified ADML language '
                                  'code %s does not exist for the ADMX "%s", '
@@ -5058,7 +5062,7 @@ def _load_policy_definitions(path='c:\\Windows\\PolicyDefinitions',
                         adml_file = os.path.join(
                             root,
                             display_language_fallback,
-                            os.path.splitext(t_admx_file)[0] + '.adml')
+                            admx_file_name + '.adml')
                         if not __salt__['file.file_exists'](adml_file):
                             log.info('An ADML file in the specified ADML '
                                      'fallback language "%s" '
@@ -5070,7 +5074,7 @@ def _load_policy_definitions(path='c:\\Windows\\PolicyDefinitions',
                             adml_file = os.path.join(
                                 root,
                                 display_language_fallback.split('-')[0],
-                                os.path.splitext(t_admx_file)[0] + '.adml')
+                                admx_file_name + '.adml')
                             if not __salt__['file.file_exists'](adml_file):
                                 msg = ('An ADML file in the specified ADML language '
                                        '"{0}" and the fallback language "{1}" do not '

--- a/tests/unit/modules/test_win_lgpo.py
+++ b/tests/unit/modules/test_win_lgpo.py
@@ -19,6 +19,7 @@ import salt.config
 import salt.loader
 import salt.modules.win_lgpo as win_lgpo
 import salt.states.win_lgpo
+import salt.utils.files
 import salt.utils.platform
 import salt.utils.stringutils
 
@@ -352,7 +353,7 @@ class WinLGPOGetPolicyADMXTestCase(TestCase, LoaderModuleMockMixin):
             'lgpo',
             'policy_defs')
         try:
-            with open(bogus_fle, 'w+') as fh:
+            with salt.utils.files.fopen(bogus_fle, 'w+') as fh:
                 fh.write('<junk></junk>')
             # This function doesn't return anything (None), it just loads
             # the XPath structures into __context__. We're just making sure it

--- a/tests/unit/modules/test_win_lgpo.py
+++ b/tests/unit/modules/test_win_lgpo.py
@@ -333,6 +333,7 @@ class WinLGPOGetPolicyADMXTestCase(TestCase, LoaderModuleMockMixin):
                             'Allow Telemetry': 'Not Configured'}}}}}
         self.assertDictEqual(result, expected)
 
+    @destructiveTest
     def test__load_policy_definitions(self):
         '''
         Test that unexpected files in the PolicyDefinitions directory won't

--- a/tests/unit/modules/test_win_lgpo.py
+++ b/tests/unit/modules/test_win_lgpo.py
@@ -5,6 +5,7 @@
 
 # Import Python Libs
 from __future__ import absolute_import, unicode_literals, print_function
+import glob
 import os
 
 # Import Salt Testing Libs
@@ -331,6 +332,38 @@ class WinLGPOGetPolicyADMXTestCase(TestCase, LoaderModuleMockMixin):
                         'Data Collection and Preview Builds': {
                             'Allow Telemetry': 'Not Configured'}}}}}
         self.assertDictEqual(result, expected)
+
+    def test__load_policy_definitions(self):
+        '''
+        Test that unexpected files in the PolicyDefinitions directory won't
+        cause the _load_policy_definitions function to explode
+        https://gitlab.com/saltstack/enterprise/lock/issues/3826
+        '''
+        # The PolicyDefinitions directory should only contain ADMX files. We
+        # want to make sure the `_load_policy_definitions` function skips non
+        # ADMX files in this directory.
+        # Create a bogus ADML file in PolicyDefinitions directory
+        bogus_fle = os.path.join(
+            'c:\\Windows\\PolicyDefinitions',
+            '_bogus.adml')
+        cache_dir = os.path.join(
+            win_lgpo.__opts__['cachedir'],
+            'lgpo',
+            'policy_defs')
+        try:
+            with open(bogus_fle, 'w+') as fh:
+                fh.write('<junk></junk>')
+            # This function doesn't return anything (None), it just loads
+            # the XPath structures into __context__. We're just making sure it
+            # doesn't stack trace here
+            self.assertIsNone(win_lgpo._load_policy_definitions())
+        finally:
+            # Remove source file
+            os.remove(bogus_fle)
+            # Remove cached file
+            search_string = '{0}\\_bogus*.adml'.format(cache_dir)
+            for file_name in glob.glob(search_string):
+                os.remove(file_name)
 
 
 @skipIf(not salt.utils.platform.is_windows(), 'System is not Windows')


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with processing non ADMX files in the Policy Definitions directory.

### What issues does this PR fix or reference?
https://gitlab.com/saltstack/enterprise/lock/issues/3826

### Previous Behavior
`lgpo.get_policy_info` would fail with the following stacktrace
```
  File "c:\salt\bin\site-packages\salt-3000-py3.5.egg\salt\utils\templates.py", line 392, in render_jinja_tmpl
    output = template.render(**decoded_context)
  File "c:\salt\bin\lib\site-packages\jinja2\environment.py",line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "c:\salt\bin\lib\site-packages\jinja2\environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "c:\salt\bin\lib\site-packages\jinja2\_compat.py", line 37, in reraise
    raise value.with_traceback(tb)
  File "<template>", line 16, in top-level template code
  File "c:\salt\bin\lib\site-packages\salt-3000-py3.5.egg\salt\modules\win_lgpo.py", line 7759, in get_policy_info
    adml_language=adml_language)
  File "c:\salt\bin\lib\site-packages\salt-3000-py3.5.egg\salt\modules\win_lgpo.py", line 7398, in _lookup_admin_template
    admx_policy_definitions = _get_policy_definitions(language=adml_language)
  Files "c:\salt\bin\lib\site-packages\salt-3000-py3.5.egg\salt\modules\win_lgpo.py", line 5105, in _get_policy_definitions
    _load_policy_definitions(path=path,language=language)
  File "c:\salt\bin\lib\site-packages\salt-3000-py3.5.egg\salt\modules\win_lgpo.py, line 5006, in _load_policy_definitions
    namespaces=namespaces)[0]
```

### New Behavior
Non-ADMX files are skipped, no stacktrace

### Tests written?
Oui

### Commits signed with GPG?
Yes