### PR TITLE
On start, update git_pillar on second loop

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -244,7 +244,8 @@ class Maintenance(salt.utils.process.SignalHandlingProcess):
 
         # Make Start Times
         last = int(time.time())
-        last_git_pillar_update = last
+        # update git_pillar on first loop
+        last_git_pillar_update = 0
 
         git_pillar_update_interval = self.opts.get("git_pillar_update_interval", 0)
         old_present = set()

--- a/salt/master.py
+++ b/salt/master.py
@@ -1,11 +1,9 @@
-# -*- coding: utf-8 -*-
 """
 This module contains all of the routines needed to set up a master server, this
 involves preparing the three listeners and the workers needed by the master.
 """
 
 # Import python libs
-from __future__ import absolute_import, print_function, unicode_literals, with_statement
 
 import collections
 import copy
@@ -103,7 +101,7 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 
-class SMaster(object):
+class SMaster:
     """
     Create a simple salt-master, this will generate the top-level master
     """
@@ -160,7 +158,7 @@ class Maintenance(salt.utils.process.SignalHandlingProcess):
 
         :param dict opts: The salt options
         """
-        super(Maintenance, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.opts = opts
         # How often do we perform the maintenance tasks
         self.loop_interval = int(self.opts["loop_interval"])
@@ -286,16 +284,10 @@ class Maintenance(salt.utils.process.SignalHandlingProcess):
                     keys.append(fn_)
             log.debug("Writing master key cache")
             # Write a temporary file securely
-            if six.PY2:
-                with salt.utils.atomicfile.atomic_open(
-                    os.path.join(self.opts["pki_dir"], acc, ".key_cache")
-                ) as cache_file:
-                    self.serial.dump(keys, cache_file)
-            else:
-                with salt.utils.atomicfile.atomic_open(
-                    os.path.join(self.opts["pki_dir"], acc, ".key_cache"), mode="wb"
-                ) as cache_file:
-                    self.serial.dump(keys, cache_file)
+            with salt.utils.atomicfile.atomic_open(
+                os.path.join(self.opts["pki_dir"], acc, ".key_cache"), mode="wb"
+            ) as cache_file:
+                self.serial.dump(keys, cache_file)
 
     def handle_key_rotate(self, now):
         """
@@ -325,14 +317,14 @@ class Maintenance(salt.utils.process.SignalHandlingProcess):
 
         if to_rotate:
             log.info("Rotating master AES key")
-            for secret_key, secret_map in six.iteritems(SMaster.secrets):
+            for secret_key, secret_map in SMaster.secrets.items():
                 # should be unnecessary-- since no one else should be modifying
                 with secret_map["secret"].get_lock():
                     secret_map["secret"].value = salt.utils.stringutils.to_bytes(
                         secret_map["reload"]()
                     )
                 self.event.fire_event(
-                    {"rotate_{0}_key".format(secret_key): True}, tag="key"
+                    {"rotate_{}_key".format(secret_key): True}, tag="key"
                 )
             self.rotate = now
             if self.opts.get("ping_on_rotate"):
@@ -390,7 +382,7 @@ class FileserverUpdate(salt.utils.process.SignalHandlingProcess):
     """
 
     def __init__(self, opts, **kwargs):
-        super(FileserverUpdate, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.opts = opts
         self.update_threads = {}
         # Avoid circular import
@@ -422,7 +414,7 @@ class FileserverUpdate(salt.utils.process.SignalHandlingProcess):
         update_intervals = self.fileserver.update_intervals()
         self.buckets = {}
         for backend in self.fileserver.backends():
-            fstr = "{0}.update".format(backend)
+            fstr = "{}.update".format(backend)
             try:
                 update_func = self.fileserver.servers[fstr]
             except KeyError:
@@ -430,7 +422,7 @@ class FileserverUpdate(salt.utils.process.SignalHandlingProcess):
                 continue
             if backend in update_intervals:
                 # Variable intervals are supported for this backend
-                for id_, interval in six.iteritems(update_intervals[backend]):
+                for id_, interval in update_intervals[backend].items():
                     if not interval:
                         # Don't allow an interval of 0
                         interval = DEFAULT_INTERVAL
@@ -452,7 +444,7 @@ class FileserverUpdate(salt.utils.process.SignalHandlingProcess):
                 # nothing to pass to the backend's update func, so we'll just
                 # set the value to None.
                 try:
-                    interval_key = "{0}_update_interval".format(backend)
+                    interval_key = "{}_update_interval".format(backend)
                     interval = self.opts[interval_key]
                 except KeyError:
                     interval = DEFAULT_INTERVAL
@@ -477,7 +469,7 @@ class FileserverUpdate(salt.utils.process.SignalHandlingProcess):
                 "interval of %d",
                 interval,
             )
-            for backend, update_args in six.iteritems(backends):
+            for backend, update_args in backends.items():
                 backend_name, update_func = backend
                 try:
                     if update_args:
@@ -623,7 +615,7 @@ class Master(SMaster):
         try:
             os.chdir("/")
         except OSError as err:
-            errors.append("Cannot change to root directory ({0})".format(err))
+            errors.append("Cannot change to root directory ({})".format(err))
 
         if self.opts.get("fileserver_verify_config", True):
             # Avoid circular import
@@ -633,7 +625,7 @@ class Master(SMaster):
             if not fileserver.servers:
                 errors.append(
                     "Failed to load fileserver backends, the configured backends "
-                    "are: {0}".format(", ".join(self.opts["fileserver_backend"]))
+                    "are: {}".format(", ".join(self.opts["fileserver_backend"]))
                 )
             else:
                 # Run init() for all backends which support the function, to
@@ -641,7 +633,7 @@ class Master(SMaster):
                 try:
                     fileserver.init()
                 except salt.exceptions.FileserverConfigError as exc:
-                    critical_errors.append("{0}".format(exc))
+                    critical_errors.append("{}".format(exc))
 
         if not self.opts["fileserver_backend"]:
             errors.append("No fileserver backends are configured")
@@ -661,7 +653,7 @@ class Master(SMaster):
                 git_pillars = [
                     x
                     for x in self.opts.get("ext_pillar", [])
-                    if "git" in x and not isinstance(x["git"], six.string_types)
+                    if "git" in x and not isinstance(x["git"], str)
                 ]
             except TypeError:
                 git_pillars = []
@@ -863,7 +855,7 @@ class Halite(salt.utils.process.SignalHandlingProcess):
 
         :param dict hopts: The halite options
         """
-        super(Halite, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.hopts = hopts
 
     # __setstate__ and __getstate__ are only used on Windows.
@@ -908,7 +900,7 @@ class ReqServer(salt.utils.process.SignalHandlingProcess):
         :rtype: ReqServer
         :returns: Request server
         """
-        super(ReqServer, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.opts = opts
         self.master_key = mkey
         # Prepare the AES key
@@ -940,7 +932,7 @@ class ReqServer(salt.utils.process.SignalHandlingProcess):
 
     def _handle_signals(self, signum, sigframe):  # pylint: disable=unused-argument
         self.destroy(signum)
-        super(ReqServer, self)._handle_signals(signum, sigframe)
+        super()._handle_signals(signum, sigframe)
 
     def __bind(self):
         """
@@ -1004,7 +996,7 @@ class ReqServer(salt.utils.process.SignalHandlingProcess):
         # signal handlers
         with salt.utils.process.default_signals(signal.SIGINT, signal.SIGTERM):
             for ind in range(int(self.opts["worker_threads"])):
-                name = "MWorker-{0}".format(ind)
+                name = "MWorker-{}".format(ind)
                 self.process_manager.add_process(
                     MWorker,
                     args=(self.opts, self.master_key, self.key, req_channels, name),
@@ -1051,7 +1043,7 @@ class MWorker(salt.utils.process.SignalHandlingProcess):
         """
         kwargs["name"] = name
         self.name = name
-        super(MWorker, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.opts = opts
         self.req_channels = req_channels
 
@@ -1067,7 +1059,7 @@ class MWorker(salt.utils.process.SignalHandlingProcess):
     # These methods are only used when pickling so will not be used on
     # non-Windows platforms.
     def __setstate__(self, state):
-        super(MWorker, self).__init__(
+        super().__init__(
             log_queue=state["log_queue"], log_queue_level=state["log_queue_level"]
         )
         self.opts = state["opts"]
@@ -1092,7 +1084,7 @@ class MWorker(salt.utils.process.SignalHandlingProcess):
     def _handle_signals(self, signum, sigframe):
         for channel in getattr(self, "req_channels", ()):
             channel.close()
-        super(MWorker, self)._handle_signals(signum, sigframe)
+        super()._handle_signals(signum, sigframe)
 
     def __bind(self):
         """
@@ -1252,7 +1244,7 @@ class MWorker(salt.utils.process.SignalHandlingProcess):
         self.__bind()
 
 
-class TransportMethods(object):
+class TransportMethods:
     """
     Expose methods to the transport layer, methods with their names found in
     the class attribute 'expose_methods' will be exposed to the transport layer
@@ -1370,7 +1362,7 @@ class AESFuncs(TransportMethods):
 
         try:
             pub = salt.crypt.get_rsa_pub_key(pub_path)
-        except (IOError, OSError):
+        except OSError:
             log.warning(
                 "Salt minion claiming to be %s attempted to communicate with "
                 "master, but key could not be read and verification was denied.",
@@ -1716,7 +1708,7 @@ class AESFuncs(TransportMethods):
         self.fs_.update_opts()
         if self.opts.get("minion_data_cache", False):
             self.masterapi.cache.store(
-                "minions/{0}".format(load["id"]),
+                "minions/{}".format(load["id"]),
                 "data",
                 {"grains": load["grains"], "pillar": data},
             )
@@ -1791,7 +1783,7 @@ class AESFuncs(TransportMethods):
             log.trace("Verifying signed event publish from minion")
             sig = load.pop("sig")
             this_minion_pubkey = os.path.join(
-                self.opts["pki_dir"], "minions/{0}".format(load["id"])
+                self.opts["pki_dir"], "minions/{}".format(load["id"])
             )
             serialized_load = salt.serializers.msgpack.serialize(load)
             if not salt.crypt.verify_signature(
@@ -1834,7 +1826,7 @@ class AESFuncs(TransportMethods):
                 continue
             # if we have a load, save it
             if load.get("load"):
-                fstr = "{0}.save_load".format(self.opts["master_job_cache"])
+                fstr = "{}.save_load".format(self.opts["master_job_cache"])
                 self.mminion.returners[fstr](load["jid"], load["load"])
 
             # Register the syndic
@@ -1849,7 +1841,7 @@ class AESFuncs(TransportMethods):
                     wfh.write("")
 
             # Format individual return loads
-            for key, item in six.iteritems(load["return"]):
+            for key, item in load["return"].items():
                 ret = {"jid": load["jid"], "id": key}
                 ret.update(item)
                 if "master_id" in load:
@@ -1896,7 +1888,7 @@ class AESFuncs(TransportMethods):
         auth_cache = os.path.join(self.opts["cachedir"], "publish_auth")
         if not os.path.isdir(auth_cache):
             os.makedirs(auth_cache)
-        jid_fn = os.path.join(auth_cache, six.text_type(load["jid"]))
+        jid_fn = os.path.join(auth_cache, str(load["jid"]))
         with salt.utils.files.fopen(jid_fn, "r") as fp_:
             if not load["id"] == fp_.read():
                 return {}
@@ -2112,8 +2104,8 @@ class ClearFuncs(TransportMethods):
                 return {
                     "error": {
                         "name": err_name,
-                        "message": 'Authentication failure of type "{0}" occurred for '
-                        "user {1}.".format(auth_type, username),
+                        "message": 'Authentication failure of type "{}" occurred for '
+                        "user {}.".format(auth_type, username),
                     }
                 }
             elif isinstance(runner_check, dict) and "error" in runner_check:
@@ -2144,7 +2136,7 @@ class ClearFuncs(TransportMethods):
                 "error": {
                     "name": exc.__class__.__name__,
                     "args": exc.args,
-                    "message": six.text_type(exc),
+                    "message": str(exc),
                 }
             }
 
@@ -2175,8 +2167,8 @@ class ClearFuncs(TransportMethods):
                 return {
                     "error": {
                         "name": err_name,
-                        "message": 'Authentication failure of type "{0}" occurred for '
-                        "user {1}.".format(auth_type, username),
+                        "message": 'Authentication failure of type "{}" occurred for '
+                        "user {}.".format(auth_type, username),
                     }
                 }
             elif isinstance(wheel_check, dict) and "error" in wheel_check:
@@ -2200,7 +2192,7 @@ class ClearFuncs(TransportMethods):
             fun = clear_load.pop("fun")
             tag = tagify(jid, prefix="wheel")
             data = {
-                "fun": "wheel.{0}".format(fun),
+                "fun": "wheel.{}".format(fun),
                 "jid": jid,
                 "tag": tag,
                 "user": username,
@@ -2214,7 +2206,7 @@ class ClearFuncs(TransportMethods):
             return {"tag": tag, "data": data}
         except Exception as exc:  # pylint: disable=broad-except
             log.error("Exception occurred while introspecting %s: %s", fun, exc)
-            data["return"] = "Exception occurred in wheel {0}: {1}: {2}".format(
+            data["return"] = "Exception occurred in wheel {}: {}: {}".format(
                 fun, exc.__class__.__name__, exc,
             )
             data["success"] = False
@@ -2286,7 +2278,7 @@ class ClearFuncs(TransportMethods):
 
         # Setup authorization list variable and error information
         auth_list = auth_check.get("auth_list", [])
-        err_msg = 'Authentication failure of type "{0}" occurred.'.format(auth_type)
+        err_msg = 'Authentication failure of type "{}" occurred.'.format(auth_type)
 
         if auth_check.get("error"):
             # Authentication error occurred: do not continue.
@@ -2352,7 +2344,7 @@ class ClearFuncs(TransportMethods):
                     "load": {
                         "jid": None,
                         "minions": minions,
-                        "error": "Master could not resolve minions for target {0}".format(
+                        "error": "Master could not resolve minions for target {}".format(
                             clear_load["tgt"]
                         ),
                     },
@@ -2399,14 +2391,14 @@ class ClearFuncs(TransportMethods):
         nocache = extra.get("nocache", False)
 
         # Retrieve the jid
-        fstr = "{0}.prep_jid".format(self.opts["master_job_cache"])
+        fstr = "{}.prep_jid".format(self.opts["master_job_cache"])
         try:
             # Retrieve the jid
             jid = self.mminion.returners[fstr](nocache=nocache, passed_jid=passed_jid)
         except (KeyError, TypeError):
             # The returner is not present
             msg = (
-                "Failed to allocate a jid. The requested returner '{0}' "
+                "Failed to allocate a jid. The requested returner '{}' "
                 "could not be loaded.".format(fstr.split(".")[0])
             )
             log.error(msg)
@@ -2463,7 +2455,7 @@ class ClearFuncs(TransportMethods):
         self.event.fire_event(new_job_load, tagify([clear_load["jid"], "new"], "job"))
 
         if self.opts["ext_job_cache"]:
-            fstr = "{0}.save_load".format(self.opts["ext_job_cache"])
+            fstr = "{}.save_load".format(self.opts["ext_job_cache"])
             save_load_func = True
 
             # Get the returner's save_load arg_spec.
@@ -2501,7 +2493,7 @@ class ClearFuncs(TransportMethods):
 
         # always write out to the master job caches
         try:
-            fstr = "{0}.save_load".format(self.opts["master_job_cache"])
+            fstr = "{}.save_load".format(self.opts["master_job_cache"])
             self.mminion.returners[fstr](clear_load["jid"], clear_load, minions)
         except KeyError:
             log.critical(

--- a/tests/unit/test_master.py
+++ b/tests/unit/test_master.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-
 import time
 
 import salt.config

--- a/tests/unit/test_master.py
+++ b/tests/unit/test_master.py
@@ -2,9 +2,12 @@
 
 from __future__ import absolute_import
 
+import time
+
 import salt.config
 import salt.master
 from tests.support.helpers import slowTest
+from tests.support.mixins import AdaptedConfigurationTestCaseMixin
 from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase
 
@@ -659,3 +662,96 @@ class ClearFuncsTestCase(TestCase):
             "salt.utils.minions.CkMinions.auth_check", MagicMock(return_value=False)
         ):
             self.assertEqual(mock_ret, self.clear_funcs.publish(load))
+
+
+class MaintenanceTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
+    """
+    TestCase for salt.master.Maintenance class
+    """
+
+    def setUp(self):
+        self.opts = self.get_temp_config("master", git_pillar_update_interval=180)
+        self.main_class = salt.master.Maintenance(self.opts)
+
+    def tearDown(self):
+        del self.main_class
+
+    def test_run_func(self):
+        """
+        Test the run function inside Maintenance class.
+        """
+
+        class MockTime:
+            def __init__(self, max_duration):
+                self._start_time = time.time()
+                self._current_duration = 0
+                self._max_duration = max_duration
+                self._calls = []
+
+            def time(self):
+                return self._start_time + self._current_duration
+
+            def sleep(self, secs):
+                self._calls += [secs]
+                self._current_duration += secs
+                if self._current_duration >= self._max_duration:
+                    raise RuntimeError("Time passes")
+
+        mocked_time = MockTime(60 * 4)
+
+        class MockTimedFunc:
+            def __init__(self):
+                self.call_times = []
+
+            def __call__(self, *args, **kwargs):
+                self.call_times += [mocked_time._current_duration]
+
+        mocked__post_fork_init = MockTimedFunc()
+        mocked_clean_old_jobs = MockTimedFunc()
+        mocked_clean_expired_tokens = MockTimedFunc()
+        mocked_clean_pub_auth = MockTimedFunc()
+        mocked_handle_git_pillar = MockTimedFunc()
+        mocked_handle_schedule = MockTimedFunc()
+        mocked_handle_key_cache = MockTimedFunc()
+        mocked_handle_presence = MockTimedFunc()
+        mocked_handle_key_rotate = MockTimedFunc()
+        mocked_check_max_open_files = MockTimedFunc()
+
+        with patch("salt.master.time", mocked_time), patch(
+            "salt.utils.process", autospec=True
+        ), patch(
+            "salt.master.Maintenance._post_fork_init", mocked__post_fork_init
+        ), patch(
+            "salt.daemons.masterapi.clean_old_jobs", mocked_clean_old_jobs
+        ), patch(
+            "salt.daemons.masterapi.clean_expired_tokens", mocked_clean_expired_tokens
+        ), patch(
+            "salt.daemons.masterapi.clean_pub_auth", mocked_clean_pub_auth
+        ), patch(
+            "salt.master.Maintenance.handle_git_pillar", mocked_handle_git_pillar
+        ), patch(
+            "salt.master.Maintenance.handle_schedule", mocked_handle_schedule
+        ), patch(
+            "salt.master.Maintenance.handle_key_cache", mocked_handle_key_cache
+        ), patch(
+            "salt.master.Maintenance.handle_presence", mocked_handle_presence
+        ), patch(
+            "salt.master.Maintenance.handle_key_rotate", mocked_handle_key_rotate
+        ), patch(
+            "salt.utils.verify.check_max_open_files", mocked_check_max_open_files
+        ):
+            try:
+                self.main_class.run()
+            except RuntimeError as exc:
+                self.assertEqual(str(exc), "Time passes")
+            self.assertEqual(mocked_time._calls, [60] * 4)
+            self.assertEqual(mocked__post_fork_init.call_times, [0])
+            self.assertEqual(mocked_clean_old_jobs.call_times, [60, 120, 180])
+            self.assertEqual(mocked_clean_expired_tokens.call_times, [60, 120, 180])
+            self.assertEqual(mocked_clean_pub_auth.call_times, [60, 120, 180])
+            self.assertEqual(mocked_handle_git_pillar.call_times, [0, 180])
+            self.assertEqual(mocked_handle_schedule.call_times, [0, 60, 120, 180])
+            self.assertEqual(mocked_handle_key_cache.call_times, [0, 60, 120, 180])
+            self.assertEqual(mocked_handle_presence.call_times, [0, 60, 120, 180])
+            self.assertEqual(mocked_handle_key_rotate.call_times, [0, 60, 120, 180])
+            self.assertEqual(mocked_check_max_open_files.call_times, [0, 60, 120, 180])


### PR DESCRIPTION
### What does this PR do?

Before this patch, the master would wait `git_pillar_update_interval` before doing the first update. When this setting is big (we set it to one week at work), this can lead to unfetched repositories.

### What issues does this PR fix or reference?

PR #53621

Fixes #56356.

### Previous Behavior
The first `git_pillar` update would run at _start time_ + `git_pillar_update_interval`.

### New Behavior
The first git_pillar update would run at _start time_.

### Tests written?

No

### Commits signed with GPG?

No