### PR TITLE
salt.serializers.toml: use maintained toml library

### DIFF
--- a/salt/serializers/toml.py
+++ b/salt/serializers/toml.py
@@ -10,9 +10,9 @@
 
 from __future__ import absolute_import
 
-# Import pytoml
+# Import toml lib
 try:
-    import pytoml as toml
+    import toml
     available = True
 except ImportError:
     available = False


### PR DESCRIPTION
### What does this PR do?

The `pytoml` library is not maintained any more since 2018-12-30 and
recommend to use `toml`.

* salt/serializers/toml.py: switch from `pytoml` to `toml` library.

### What issues does this PR fix or reference?

https://github.com/avakar/pytoml/commit/cd2a62e1444cda2c517b02d36b97151acf379b88

### Tests written?

No

### Commits signed with GPG?

Yes