### PR TITLE
Fix bad RST in consul_pillar docstring

### DIFF
--- a/salt/pillar/consul_pillar.py
+++ b/salt/pillar/consul_pillar.py
@@ -22,9 +22,9 @@ All parameters are optional.
 
 The ``consul.token`` requires python-consul >= 0.4.7.
 
-If you have a multi-datacenter Consul cluster you can map your ``pillarenv``s
-to your data centers by providing a dictionary of mappings in ``consul.dc``
-field:
+If you have a multi-datacenter Consul cluster you can map your ``pillarenv``
+entries to your data centers by providing a dictionary of mappings in
+``consul.dc`` field:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
### What does this PR do?

Fixes some broken RST in the consul_pillar docs.  I couldn't find a way to simultaneously satisfy RST and lint to actually render "`pillarenv`s", so I rephrased the problem away.

Before:

![image](https://user-images.githubusercontent.com/170730/76258060-9fac2500-6231-11ea-9d4b-538816869879.png)

After:

![image](https://user-images.githubusercontent.com/170730/78789020-f3ba3e80-7982-11ea-81d7-75650e5a2543.png)


### What issues does this PR fix or reference?

No open issues.

### Tests written?

No.  Docs-only change.

### Commits signed with GPG?

No.