### PR TITLE
Fixed logic around false negative in file.patch state with test=True

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -6852,7 +6852,7 @@ def patch(
             __opts__["test"] = orig_test
             sys.modules[__salt__["file.patch"].__module__].__opts__["test"] = orig_test
 
-        if not result["result"]:
+        if result["result"] is False:
             log.debug(
                 "failed to download %s",
                 salt.utils.url.redact_http_basic_auth(source_match),


### PR DESCRIPTION
### What does this PR do?
Changes one conditional from bool() to if False so that when in test mode salt does not think it needs to make changes that it actually will not make when not in test mode.

I'm not sure this is the correct way to fix this, I can just say it does fix my issue. In fact I do not understand why previous behaviour examples below numbers 2 and 3 have different output so this very well may not be the correct fix.

### What issues does this PR fix or reference?
This is a continuation of https://github.com/saltstack/salt/pull/53858, it got closed when you merged to master.

### Previous Behavior
1. `salt 'myminion' state.apply` will result in no changes
1. `salt 'myminion' state.apply test=True` will show that all file.patched states will have changes, AND that the changes are then entire contents of the patch file, which is quite alarming to look at. IE:
    ```
    ----------
              ID: patch /my-conda-env/lib/python3.6/site-packages/salt/beacons/napalm_beacon.py in 2019.2.0
        Function: file.patch
            Name: /my-conda-env/lib/python3.6/site-packages/salt/beacons/napalm_beacon.py
          Result: None
         Comment: File /tmp/__salt.tmp.4w45xiks updated
         Started: 20:45:21.051892
        Duration: 10.492 ms
         Changes:   
                  ----------
                  diff:
                      --- 
                      +++ 
                      @@ -0,0 +1,24 @@
                      +--- a/salt/beacons/napalm_beacon.py
                      ++++ b/salt/beacons/napalm_beacon.py
                      +@@ -286,8 +286,8 @@ def validate(config):
                      +     if not isinstance(config, list):
                      +         return False, 'Configuration for napalm beacon must be a list.'
                      +     for mod in config:
                      +-        fun = mod.keys()[0]
                      +-        fun_cfg = mod.values()[0]
                      ++        fun = list(mod.keys())[0]
                      ++        fun_cfg = list(mod.values())[0]
                      +         if not isinstance(fun_cfg, dict):
                      +             return False, 'The match structure for the {} execution function output must be a dictionary'.format(fun)
                      +         if fun not in __salt__:
                      +@@ -306,8 +306,8 @@ def beacon(config):
                      +         if not mod:
                      +             continue
                      +         event = {}
                      +-        fun = mod.keys()[0]
                      +-        fun_cfg = mod.values()[0]
                      ++        fun = list(mod.keys())[0]
                      ++        fun_cfg = list(mod.values())[0]
                      +         args = fun_cfg.pop('_args', [])
                      +         kwargs = fun_cfg.pop('_kwargs', {})
                      +         log.debug('Executing %s with %s and %s', fun, args, kwargs)
    ```
    I got here from this log entry when running the minion in debug mode:
    ```
    [DEBUG   ] failed to download salt://patches/2019-2-0/napalm_beacon.patch
    ```
1. `salt 'myminion' state.apply patches test=True` THIS however shows no changes, correctly.

### New Behavior
1. `salt 'myminion' state.apply` will result in no changes
1. `salt 'myminion' state.apply test=True` Shows no changes, correctly.
1. `salt 'myminion' state.apply patches test=True` Shows no changes, correctly.

### Tests written?
No

### Commits signed with GPG?

No