### PR TITLE
Fix win_dns_client when used with scheduler

### DIFF
--- a/salt/modules/win_dns_client.py
+++ b/salt/modules/win_dns_client.py
@@ -12,8 +12,10 @@ import salt.utils.platform
 
 try:
     import wmi
+    import salt.utils.winapi
+    HAS_LIBS = True
 except ImportError:
-    pass
+    HAS_LIBS = False
 
 log = logging.getLogger(__name__)
 
@@ -22,14 +24,24 @@ def __virtual__():
     '''
     Only works on Windows systems
     '''
-    if salt.utils.platform.is_windows():
-        return 'win_dns_client'
-    return (False, "Module win_dns_client: module only works on Windows systems")
+    if not salt.utils.platform.is_windows():
+        return False, 'Module win_dns_client: module only works on Windows ' \
+                      'systems'
+    if not HAS_LIBS:
+        return False, 'Module win_dns_client: missing required libraries'
+    return 'win_dns_client'
 
 
 def get_dns_servers(interface='Local Area Connection'):
     '''
     Return a list of the configured DNS servers of the specified interface
+
+    Args:
+        interface (str): The name of the network interface. This is the name as
+        it appears in the Control Panel under Network Connections
+
+    Returns:
+        list: A list of dns servers
 
     CLI Example:
 
@@ -121,7 +133,14 @@ def dns_dhcp(interface='Local Area Connection'):
 
 def get_dns_config(interface='Local Area Connection'):
     '''
-    Get the type of DNS configuration (dhcp / static)
+    Get the type of DNS configuration (dhcp / static).
+
+    Args:
+        interface (str): The name of the network interface. This is the
+        Description in the Network Connection Details for the device
+
+    Returns:
+        bool: ``True`` if DNS is configured, otherwise ``False``
 
     CLI Example:
 

--- a/tests/unit/modules/test_win_dns_client.py
+++ b/tests/unit/modules/test_win_dns_client.py
@@ -10,11 +10,7 @@ import types
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import TestCase, skipIf
-from tests.support.mock import (
-    MagicMock,
-    patch,
-    Mock,
-)
+from tests.support.mock import MagicMock, patch, Mock
 
 # Import Salt Libs
 import salt.modules.win_dns_client as win_dns_client
@@ -89,8 +85,7 @@ class WinDnsClientTestCase(TestCase, LoaderModuleMockMixin):
         Test if it return a list of the configured DNS servers
         of the specified interface.
         '''
-        with patch('salt.utils', Mockwinapi), \
-                patch('salt.utils.winapi.Com', MagicMock()), \
+        with patch('salt.utils.winapi.Com', MagicMock()), \
                 patch.object(self.WMI, 'Win32_NetworkAdapter',
                              return_value=[Mockwmi()]), \
                 patch.object(self.WMI, 'Win32_NetworkAdapterConfiguration',

--- a/tests/unit/modules/test_win_dns_client.py
+++ b/tests/unit/modules/test_win_dns_client.py
@@ -162,21 +162,13 @@ class WinDnsClientTestCase(TestCase, LoaderModuleMockMixin):
                            'Windows systems')
         self.assertEqual(result, expected)
 
-    def test___virtual__(self):
-        result = win_dns_client.__virtual__()
-        expected = 'win_dns_client'
-        self.assertEqual(result, expected)
-
-
-class WinDnsClientTestCaseMissingLibs(TestCase):
-    '''
-    Test cases for salt.modules.win_dns_client. This was the only way I could
-    mock HAS_LIBS = False
-    '''
-    def setUp(self):
-        win_dns_client.HAS_LIBS = False
-
+    @patch.object(win_dns_client, 'HAS_LIBS', False)
     def test___virtual__missing_libs(self):
         result = win_dns_client.__virtual__()
         expected = (False, 'Module win_dns_client: missing required libraries')
+        self.assertEqual(result, expected)
+
+    def test___virtual__(self):
+        result = win_dns_client.__virtual__()
+        expected = 'win_dns_client'
         self.assertEqual(result, expected)

--- a/tests/unit/modules/test_win_dns_client.py
+++ b/tests/unit/modules/test_win_dns_client.py
@@ -64,7 +64,6 @@ class WinDnsClientTestCase(TestCase, LoaderModuleMockMixin):
     '''
     Test cases for salt.modules.win_dns_client
     '''
-
     def setup_loader_modules(self):
         # wmi and pythoncom modules are platform specific...
         mock_pythoncom = types.ModuleType(
@@ -154,3 +153,30 @@ class WinDnsClientTestCase(TestCase, LoaderModuleMockMixin):
                              return_value=[Mockwmi()]), \
                 patch.object(wmi, 'WMI', Mock(return_value=self.WMI)):
             self.assertTrue(win_dns_client.get_dns_config())
+
+    @patch('salt.utils.platform.is_windows')
+    def test___virtual__non_windows(self, mock):
+        mock.return_value = False
+        result = win_dns_client.__virtual__()
+        expected = (False, 'Module win_dns_client: module only works on '
+                           'Windows systems')
+        self.assertEqual(result, expected)
+
+    def test___virtual__(self):
+        result = win_dns_client.__virtual__()
+        expected = 'win_dns_client'
+        self.assertEqual(result, expected)
+
+
+class WinDnsClientTestCaseMissingLibs(TestCase):
+    '''
+    Test cases for salt.modules.win_dns_client. This was the only way I could
+    mock HAS_LIBS = False
+    '''
+    def setUp(self):
+        win_dns_client.HAS_LIBS = False
+
+    def test___virtual__missing_libs(self):
+        result = win_dns_client.__virtual__()
+        expected = (False, 'Module win_dns_client: missing required libraries')
+        self.assertEqual(result, expected)


### PR DESCRIPTION
### What does this PR do?
Add missing import to `modules\win_dns_client.py`
Improve docs for a couple functions.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/56320

### Tests written?
Yes

### Commits signed with GPG?
Yes