### PR TITLE
Revert "Don't remove one directory level from slspath"

### DIFF
--- a/doc/ref/states/vars.rst
+++ b/doc/ref/states/vars.rst
@@ -96,10 +96,11 @@ include option.
 slspath
 =======
 
-The `slspath` variable contains the path to the current sls file. The value
-of `slspath` in files referenced in the current sls depends on the reference
-method. For jinja includes `slspath` is the path to the current file. For
-salt includes `slspath` is the path to the included file.
+The `slspath` variable contains the path to the directory of the current sls
+file. The value of `slspath` in files referenced in the current sls depends on
+the reference method. For jinja includes `slspath` is the path to the current
+directory of the file. For salt includes `slspath` is the path to the directory
+of the included file.
 
 .. code-block:: jinja
 

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -122,6 +122,8 @@ def wrap_tmpl_func(render_str):
             slspath = context['sls'].replace('.', '/')
             if tmplpath is not None:
                 context['tplpath'] = tmplpath
+                if not tmplpath.lower().replace('\\', '/').endswith('/init.sls'):
+                    slspath = os.path.dirname(slspath)
                 template = tmplpath.replace('\\', '/')
                 i = template.rfind(slspath.replace('.', '/'))
                 if i != -1:

--- a/tests/unit/utils/test_templates.py
+++ b/tests/unit/utils/test_templates.py
@@ -209,8 +209,8 @@ class WrapRenderTestCase(TestCase):
             context=context,
             tmplpath='/tmp/foo/bar/init.sls'
         )
-        assert render.context['slspath'] == 'foo/bar'
-        assert render.context['tpldir'] == 'foo/bar'
+        assert render.context['slspath'] == 'foo/bar', render.context['slspath']
+        assert render.context['tpldir'] == 'foo/bar', render.context['tpldir']
 
     @with_tempdir()
     def test_wrap_issue_56119_b(self, tempdir):
@@ -225,5 +225,5 @@ class WrapRenderTestCase(TestCase):
             context=context,
             tmplpath='/tmp/foo/bar/bang.sls'
         )
-        assert render.context['slspath'] == 'foo/bar'
-        assert render.context['tpldir'] == 'foo/bar'
+        assert render.context['slspath'] == 'foo/bar', render.context['slspath']
+        assert render.context['tpldir'] == 'foo/bar', render.context['tpldir']

--- a/tests/unit/utils/test_templates.py
+++ b/tests/unit/utils/test_templates.py
@@ -8,10 +8,10 @@ from __future__ import absolute_import, print_function, unicode_literals
 import os
 import sys
 import logging
-import shutil
 
 # Import Salt libs
 import salt.utils.templates
+import salt.utils.files
 
 # Import Salt Testing Libs
 from tests.support.helpers import with_tempdir
@@ -198,9 +198,8 @@ class WrapRenderTestCase(TestCase):
 
     @with_tempdir()
     def test_wrap_issue_56119_a(self, tempdir):
-        assert os.path.exists(tempdir)
         slsfile = os.path.join(tempdir, 'foo')
-        with open(slsfile, 'w') as fp:
+        with salt.utils.files.fopen(slsfile, 'w') as fp:
             fp.write('{{ slspath }}')
         context = {'opts': {}, 'saltenv': 'base', 'sls': 'foo.bar'}
         render = MockRender()
@@ -210,14 +209,13 @@ class WrapRenderTestCase(TestCase):
             context=context,
             tmplpath='/tmp/foo/bar/init.sls'
         )
-        assert render.context['slspath']  == 'foo/bar'
-        assert render.context['tpldir']  == 'foo/bar'
+        assert render.context['slspath'] == 'foo/bar'
+        assert render.context['tpldir'] == 'foo/bar'
 
     @with_tempdir()
     def test_wrap_issue_56119_b(self, tempdir):
-        assert os.path.exists(tempdir)
         slsfile = os.path.join(tempdir, 'foo')
-        with open(slsfile, 'w') as fp:
+        with salt.utils.files.fopen(slsfile, 'w') as fp:
             fp.write('{{ slspath }}')
         context = {'opts': {}, 'saltenv': 'base', 'sls': 'foo.bar.bang'}
         render = MockRender()
@@ -227,5 +225,5 @@ class WrapRenderTestCase(TestCase):
             context=context,
             tmplpath='/tmp/foo/bar/bang.sls'
         )
-        assert render.context['slspath']  == 'foo/bar'
-        assert render.context['tpldir']  == 'foo/bar'
+        assert render.context['slspath'] == 'foo/bar'
+        assert render.context['tpldir'] == 'foo/bar'


### PR DESCRIPTION
This reverts commit 7c28995a0a535f4db2f76db39f09754c7ceda2f5.

This change is being reverted because it broke states without going through any kind of deprecation path.

### What issues does this PR fix or reference?

#56119

### Tests written?

Yes

### Commits signed with GPG?

Yes
