### PR TITLE
Update `libnacl` to 1.7.1

### DIFF
--- a/pkg/windows/req.txt
+++ b/pkg/windows/req.txt
@@ -11,7 +11,7 @@ idna==2.8
 ioloop==0.1a0
 ipaddress==1.0.22
 jinja2==2.10.1
-libnacl==1.6.1
+libnacl==1.7.1
 lxml==4.3.0
 Mako==1.0.7
 markupsafe==1.1.1

--- a/requirements/static/linux.in
+++ b/requirements/static/linux.in
@@ -17,7 +17,7 @@ jxmlease
 kazoo
 keyring==5.7.1
 kubernetes<4.0
-libnacl==1.6.0
+libnacl>=1.7.1
 mock>=3.0.5
 more-itertools==5.0.0
 moto

--- a/requirements/static/py2.7/linux.txt
+++ b/requirements/static/py2.7/linux.txt
@@ -61,7 +61,7 @@ jxmlease==1.0.1
 kazoo==2.6.1
 keyring==5.7.1
 kubernetes==3.0.0
-libnacl==1.6.0
+libnacl==1.7.1
 lxml==4.3.3               # via junos-eznc, ncclient
 mako==1.1.0
 markupsafe==1.1.1

--- a/requirements/static/py2.7/windows.txt
+++ b/requirements/static/py2.7/windows.txt
@@ -56,7 +56,7 @@ jsonpickle==1.1           # via aws-xray-sdk
 jsonschema==2.6.0
 keyring==5.7.1
 kubernetes==3.0.0
-libnacl==1.6.1
+libnacl==1.7.1
 lxml==4.3.0
 mako==1.0.7
 markupsafe==1.1.1

--- a/requirements/static/py3.4/linux.txt
+++ b/requirements/static/py3.4/linux.txt
@@ -52,7 +52,7 @@ jxmlease==1.0.1
 kazoo==2.6.1
 keyring==5.7.1
 kubernetes==3.0.0
-libnacl==1.6.0
+libnacl==1.7.1
 lxml==4.3.3               # via junos-eznc, ncclient
 mako==1.1.0
 markupsafe==1.1.1

--- a/requirements/static/py3.5/linux.txt
+++ b/requirements/static/py3.5/linux.txt
@@ -52,7 +52,7 @@ jxmlease==1.0.1
 kazoo==2.6.1
 keyring==5.7.1
 kubernetes==3.0.0
-libnacl==1.6.0
+libnacl==1.7.1
 lxml==4.3.3               # via junos-eznc, ncclient
 mako==1.1.0
 markupsafe==1.1.1

--- a/requirements/static/py3.5/windows.txt
+++ b/requirements/static/py3.5/windows.txt
@@ -47,7 +47,7 @@ jsonpickle==1.1           # via aws-xray-sdk
 jsonschema==2.6.0
 keyring==5.7.1
 kubernetes==3.0.0
-libnacl==1.6.1
+libnacl==1.7.1
 lxml==4.3.0
 mako==1.0.7
 markupsafe==1.1.1

--- a/requirements/static/py3.6/linux.txt
+++ b/requirements/static/py3.6/linux.txt
@@ -52,7 +52,7 @@ jxmlease==1.0.1
 kazoo==2.6.1
 keyring==5.7.1
 kubernetes==3.0.0
-libnacl==1.6.0
+libnacl==1.7.1
 lxml==4.3.3               # via junos-eznc, ncclient
 mako==1.1.0
 markupsafe==1.1.1

--- a/requirements/static/py3.6/windows.txt
+++ b/requirements/static/py3.6/windows.txt
@@ -47,7 +47,7 @@ jsonpickle==1.1           # via aws-xray-sdk
 jsonschema==2.6.0
 keyring==5.7.1
 kubernetes==3.0.0
-libnacl==1.6.1
+libnacl==1.7.1
 lxml==4.3.0
 mako==1.0.7
 markupsafe==1.1.1

--- a/requirements/static/py3.7/linux.txt
+++ b/requirements/static/py3.7/linux.txt
@@ -52,7 +52,7 @@ jxmlease==1.0.1
 kazoo==2.6.1
 keyring==5.7.1
 kubernetes==3.0.0
-libnacl==1.6.0
+libnacl==1.7.1
 lxml==4.3.3               # via junos-eznc, ncclient
 mako==1.1.0
 markupsafe==1.1.1

--- a/requirements/static/py3.7/windows.txt
+++ b/requirements/static/py3.7/windows.txt
@@ -47,7 +47,7 @@ jsonpickle==1.1           # via aws-xray-sdk
 jsonschema==2.6.0
 keyring==5.7.1
 kubernetes==3.0.0
-libnacl==1.6.1
+libnacl==1.7.1
 lxml==4.3.0
 mako==1.0.7
 markupsafe==1.1.1

--- a/requirements/static/windows.in
+++ b/requirements/static/windows.in
@@ -11,7 +11,6 @@ jmespath
 jsonschema
 keyring==5.7.1
 kubernetes<4.0
-libnacl
 mock>=3.0.5; python_version < '3.6'
 more-itertools==5.0.0
 moto<=1.3.7


### PR DESCRIPTION
### What does this PR do?
Update `libnacl` to 1.7.1

```
Failed to import utils nacl, this is due most likely to a syntax error:
20:27:00         Traceback (most recent call last):
20:27:00           File "/tmp/kitchen/testing/salt/loader.py", line 1607, in _load_module
20:27:00             mod = imp.load_module(mod_namespace, fn_, fpath, desc)
20:27:00           File "/tmp/kitchen/testing/salt/utils/nacl.py", line 26, in <module>
20:27:00             import libnacl.secret
20:27:00           File "/tmp/kitchen/testing/.nox/runtests-parametrized-2-7-coverage-true-crypto-none-transport-zeromq/local/lib/python2.7/site-packages/libnacl/__init__.py", line 119, in <module>
20:27:00             crypto_box_SEEDBYTES = nacl.crypto_box_seedbytes()
20:27:00           File "/usr/lib64/python2.7/ctypes/__init__.py", line 374, in __getattr__
20:27:00             func = self.__getitem__(name)
20:27:00           File "/usr/lib64/python2.7/ctypes/__init__.py", line 379, in __getitem__
20:27:00             func = self._FuncPtr((name_or_ordinal, self))
20:27:00         AttributeError: /usr/lib64/libsodium.so.4: undefined symbol: crypto_box_seedbytes

20:27:13         20:27:12,714 [salt.loader                                               :1624][ERROR   ] Failed to import module nacl, this is due most likely to a syntax error:
20:27:13         Traceback (most recent call last):
20:27:13           File "/tmp/kitchen/testing/salt/loader.py", line 1607, in _load_module
20:27:13             mod = imp.load_module(mod_namespace, fn_, fpath, desc)
20:27:13           File "/tmp/kitchen/testing/salt/modules/nacl.py", line 157, in <module>
20:27:13             import salt.utils.nacl
20:27:13           File "/tmp/kitchen/testing/salt/utils/nacl.py", line 26, in <module>
20:27:13             import libnacl.secret
20:27:13           File "/tmp/kitchen/testing/.nox/runtests-parametrized-2-7-coverage-true-crypto-none-transport-zeromq/local/lib/python2.7/site-packages/libnacl/__init__.py", line 119, in <module>
20:27:13             crypto_box_SEEDBYTES = nacl.crypto_box_seedbytes()
20:27:13           File "/usr/lib64/python2.7/ctypes/__init__.py", line 374, in __getattr__
20:27:13             func = self.__getitem__(name)
20:27:13           File "/usr/lib64/python2.7/ctypes/__init__.py", line 379, in __getitem__
20:27:13             func = self._FuncPtr((name_or_ordinal, self))
20:27:13         AttributeError: /usr/lib64/libsodium.so.4: undefined symbol: crypto_box_seedbytes

20:27:15         20:27:15,353 [salt.loader                                               :1624][ERROR   ] Failed to import utils nacl, this is due most likely to a syntax error:
20:27:15         Traceback (most recent call last):
20:27:15           File "/tmp/kitchen/testing/salt/loader.py", line 1607, in _load_module
20:27:15             mod = imp.load_module(mod_namespace, fn_, fpath, desc)
20:27:15           File "/tmp/kitchen/testing/salt/utils/nacl.py", line 26, in <module>
20:27:15             import libnacl.secret
20:27:15           File "/tmp/kitchen/testing/.nox/runtests-parametrized-2-7-coverage-true-crypto-none-transport-zeromq/local/lib/python2.7/site-packages/libnacl/__init__.py", line 119, in <module>
20:27:15             crypto_box_SEEDBYTES = nacl.crypto_box_seedbytes()
20:27:15           File "/usr/lib64/python2.7/ctypes/__init__.py", line 374, in __getattr__
20:27:15             func = self.__getitem__(name)
20:27:15           File "/usr/lib64/python2.7/ctypes/__init__.py", line 379, in __getitem__
20:27:15             func = self._FuncPtr((name_or_ordinal, self))
20:27:15         AttributeError: /usr/lib64/libsodium.so.4: undefined symbol: crypto_box_seedbytes
```