### PR TITLE
WIP: Use the repo symlink to the latest version of the win_installer

### DIFF
--- a/tests/support/win_installer.py
+++ b/tests/support/win_installer.py
@@ -12,66 +12,16 @@
 from __future__ import absolute_import
 import hashlib
 import requests
-import re
 
 PREFIX = 'Salt-Minion-'
 REPO = "https://repo.saltstack.com/windows"
 
 
-def iter_installers(content):
-    '''
-    Parse a list of windows installer links and their corresponding md5
-    checksum links.
-    '''
-    HREF_RE = "<a href=\"(.*?)\">"
-    installer, md5 = None, None
-    for m in re.finditer(HREF_RE, content):
-        x = m.groups()[0]
-        if not x.startswith(PREFIX):
-            continue
-        if x.endswith(('zip', 'sha256')):
-            continue
-        if installer:
-            if x != installer + '.md5':
-                raise Exception("Unable to parse response")
-            md5 = x
-            yield installer, md5
-            installer, md5 = None, None
-        else:
-            installer = x
-
-
-def split_installer(name):
-    '''
-    Return a tuple of the salt version, python verison and architecture from an
-    installer name.
-    '''
-    x = name[len(PREFIX):]
-    return x.split('-')[:3]
-
-
-def latest_version(repo=REPO):
-    '''
-    Return the latest version found on the salt repository webpage.
-    '''
-    content = requests.get(repo).content.decode('utf-8')
-    for name, md5 in iter_installers(content):
-        pass
-    return split_installer(name)[0]
-
-
-def installer_name(salt_ver, py_ver='Py2', arch='AMD64'):
+def latest_installer_name(py_ver='Py3', arch='AMD64'):
     '''
     Create an installer file name
     '''
-    return "Salt-Minion-{}-{}-{}-Setup.exe".format(salt_ver, py_ver, arch)
-
-
-def latest_installer_name(repo=REPO, **kwargs):
-    '''
-    Fetch the latest installer name
-    '''
-    return installer_name(latest_version(repo), **kwargs)
+    return "Salt-Minion-Latest-{}-{}-Setup.exe".format(py_ver, arch)
 
 
 def download_and_verify(fp, name, repo=REPO):

--- a/tests/support/win_installer.py
+++ b/tests/support/win_installer.py
@@ -17,7 +17,7 @@ PREFIX = 'Salt-Minion-'
 REPO = "https://repo.saltstack.com/windows"
 
 
-def latest_installer_name(py_ver='Py3', arch='AMD64'):
+def latest_installer_name(py_ver='Py2', arch='AMD64'):
     '''
     Create an installer file name
     '''


### PR DESCRIPTION
### What does this PR do?
Fixes failing EC2 tests on windows by using the repo symlink to the latest version of the win_installer instead of parsing the url