### PR TITLE
Upgrade `psutil` to v5.6.6 because of CVE-2019-18874

### DIFF
--- a/pkg/osx/req.txt
+++ b/pkg/osx/req.txt
@@ -16,7 +16,7 @@ linode-python==1.1.1
 Mako==1.0.7
 markupsafe==1.1.1
 msgpack-python==0.5.6
-psutil==5.6.1
+psutil==5.6.6
 pyasn1==0.4.5
 pycparser==2.19
 pycryptodome==3.8.1

--- a/pkg/windows/req.txt
+++ b/pkg/windows/req.txt
@@ -16,7 +16,7 @@ lxml==4.3.0
 Mako==1.0.7
 markupsafe==1.1.1
 msgpack-python==0.5.6
-psutil==5.6.1
+psutil==5.6.6
 pyasn1==0.4.5
 pycparser==2.19
 pycryptodomex==3.8.1

--- a/requirements/static/py2.7/darwin.txt
+++ b/requirements/static/py2.7/darwin.txt
@@ -84,7 +84,7 @@ pathlib2==2.3.3           # via importlib-metadata, importlib-resources, pytest,
 pathtools==0.1.2          # via watchdog
 pluggy==0.13.1            # via pytest
 portend==2.4              # via cherrypy
-psutil==5.6.1
+psutil==5.6.6
 py==1.8.0                 # via pytest
 pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth

--- a/requirements/static/py2.7/linux.txt
+++ b/requirements/static/py2.7/linux.txt
@@ -79,7 +79,7 @@ pathlib2==2.3.3           # via importlib-metadata, pytest
 pathtools==0.1.2          # via watchdog
 pluggy==0.13.0            # via pytest
 portend==2.4              # via cherrypy
-psutil==5.6.1
+psutil==5.6.6
 py==1.8.0                 # via pytest
 pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth

--- a/requirements/static/py2.7/windows.txt
+++ b/requirements/static/py2.7/windows.txt
@@ -72,7 +72,7 @@ pathlib2==2.3.3           # via importlib-metadata, pytest
 pathtools==0.1.2          # via watchdog
 pluggy==0.13.0            # via pytest
 portend==2.4              # via cherrypy
-psutil==5.6.1
+psutil==5.6.6
 py==1.8.0                 # via pytest
 pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth

--- a/requirements/static/py3.4/linux.txt
+++ b/requirements/static/py3.4/linux.txt
@@ -69,7 +69,7 @@ pathlib2==2.3.3           # via importlib-metadata, pytest
 pathtools==0.1.2          # via watchdog
 pluggy==0.13.0            # via pytest
 portend==2.4              # via cherrypy
-psutil==5.6.1
+psutil==5.6.6
 py==1.8.0                 # via pytest
 pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth

--- a/requirements/static/py3.5/darwin.txt
+++ b/requirements/static/py3.5/darwin.txt
@@ -75,7 +75,7 @@ pathlib2==2.3.3           # via pytest
 pathtools==0.1.2          # via watchdog
 pluggy==0.13.1            # via pytest
 portend==2.4              # via cherrypy
-psutil==5.6.1
+psutil==5.6.6
 py==1.8.0                 # via pytest
 pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth

--- a/requirements/static/py3.5/linux.txt
+++ b/requirements/static/py3.5/linux.txt
@@ -69,7 +69,7 @@ pathlib2==2.3.3           # via pytest
 pathtools==0.1.2          # via watchdog
 pluggy==0.13.0            # via pytest
 portend==2.4              # via cherrypy
-psutil==5.6.1
+psutil==5.6.6
 py==1.8.0                 # via pytest
 pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth

--- a/requirements/static/py3.5/windows.txt
+++ b/requirements/static/py3.5/windows.txt
@@ -62,7 +62,7 @@ pathlib2==2.3.3           # via pytest
 pathtools==0.1.2          # via watchdog
 pluggy==0.13.0            # via pytest
 portend==2.4              # via cherrypy
-psutil==5.6.1
+psutil==5.6.6
 py==1.8.0                 # via pytest
 pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth

--- a/requirements/static/py3.6/darwin.txt
+++ b/requirements/static/py3.6/darwin.txt
@@ -74,7 +74,7 @@ paramiko==2.4.2           # via junos-eznc, ncclient, scp
 pathtools==0.1.2          # via watchdog
 pluggy==0.13.1            # via pytest
 portend==2.4              # via cherrypy
-psutil==5.6.1
+psutil==5.6.6
 py==1.8.0                 # via pytest
 pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth

--- a/requirements/static/py3.6/linux.txt
+++ b/requirements/static/py3.6/linux.txt
@@ -68,7 +68,7 @@ paramiko==2.4.2
 pathtools==0.1.2          # via watchdog
 pluggy==0.13.0            # via pytest
 portend==2.4              # via cherrypy
-psutil==5.6.1
+psutil==5.6.6
 py==1.8.0                 # via pytest
 pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth

--- a/requirements/static/py3.6/windows.txt
+++ b/requirements/static/py3.6/windows.txt
@@ -61,7 +61,7 @@ patch==1.16
 pathtools==0.1.2          # via watchdog
 pluggy==0.13.0            # via pytest
 portend==2.4              # via cherrypy
-psutil==5.6.1
+psutil==5.6.6
 py==1.8.0                 # via pytest
 pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth

--- a/requirements/static/py3.7/darwin.txt
+++ b/requirements/static/py3.7/darwin.txt
@@ -73,7 +73,7 @@ paramiko==2.4.2           # via junos-eznc, ncclient, scp
 pathtools==0.1.2          # via watchdog
 pluggy==0.13.1            # via pytest
 portend==2.4              # via cherrypy
-psutil==5.6.1
+psutil==5.6.6
 py==1.8.0                 # via pytest
 pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth

--- a/requirements/static/py3.7/linux.txt
+++ b/requirements/static/py3.7/linux.txt
@@ -68,7 +68,7 @@ paramiko==2.4.2
 pathtools==0.1.2          # via watchdog
 pluggy==0.13.0            # via pytest
 portend==2.4              # via cherrypy
-psutil==5.6.1
+psutil==5.6.6
 py==1.8.0                 # via pytest
 pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth

--- a/requirements/static/py3.7/windows.txt
+++ b/requirements/static/py3.7/windows.txt
@@ -61,7 +61,7 @@ patch==1.16
 pathtools==0.1.2          # via watchdog
 pluggy==0.13.0            # via pytest
 portend==2.4              # via cherrypy
-psutil==5.6.1
+psutil==5.6.6
 py==1.8.0                 # via pytest
 pyaml==19.4.1             # via moto
 pyasn1-modules==0.2.4     # via google-auth

--- a/requirements/static/windows.in
+++ b/requirements/static/windows.in
@@ -19,7 +19,6 @@ patch
 pygit2
 python-etcd>0.4.2
 msgpack-python >= 0.4.2, != 0.5.5
-psutil
 pyopenssl
 python-gnupg
 pyvmomi


### PR DESCRIPTION
### What does this PR do?
See title.

### What issues does this PR fix or reference?
https://github.com/advisories/GHSA-qfc5-mcwq-26q8