### PR TITLE
Add pkg.upgrade fromrepo=repository functionality

### DIFF
--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -1167,10 +1167,19 @@ def upgrade(*names, **kwargs):
         .. code-block:: bash
 
             salt '*' pkg.upgrade <package name> dryrun=True
+
+    fromrepo
+        In multi-repo mode, override the pkg.conf ordering and only attempt
+        to upgrade packages from the named repository.
+
+        CLI Example:
+        .. code-block:: bash
+            salt '*' pkg.upgrade <package name> fromrepo=repo
     '''
     jail = kwargs.pop('jail', None)
     chroot = kwargs.pop('chroot', None)
     root = kwargs.pop('root', None)
+    fromrepo = kwargs.pop('fromrepo', None)
     force = kwargs.pop('force', False)
     local = kwargs.pop('local', False)
     dryrun = kwargs.pop('dryrun', False)
@@ -1193,6 +1202,8 @@ def upgrade(*names, **kwargs):
         cmd.extend(names)
     if pkgs:
         cmd.extend(pkgs)
+    if fromrepo:
+        cmd.extend(['--repository', fromrepo])
 
     old = list_pkgs()
     result = __salt__['cmd.run_all'](cmd,


### PR DESCRIPTION
Add pkg.upgrade fromrepo=repository functionality to allow upgrades only from specific repositories.

### What does this PR do?

Add salt '*' pkg.upgrade fromrepo=my_repo functionality, for whatever reasons this was missing for pkg.upgrade

### Commits signed with GPG?

No