### PR TITLE
fixed incorrect git function variable (master branch)

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -261,8 +261,8 @@ def _not_fast_forward(
 
 def latest(
     name,
+    target,
     rev="HEAD",
-    target=None,
     branch=None,
     user=None,
     password=None,
@@ -2195,7 +2195,7 @@ def present(
 def detached(
     name,
     rev,
-    target=None,
+    target,
     remote="origin",
     user=None,
     password=None,
@@ -2685,7 +2685,7 @@ def detached(
 
 def cloned(
     name,
-    target=None,
+    target,
     branch=None,
     user=None,
     password=None,

--- a/tests/unit/states/test_git.py
+++ b/tests/unit/states/test_git.py
@@ -73,3 +73,24 @@ class GitTestCase(TestCase, LoaderModuleMockMixin):
             )
             assert result["result"] is True, result
             git_diff.assert_not_called()
+
+    def test_latest_without_target(self):
+        """
+        Test latest when called without passing target
+        """
+        name = "https://foo.com/bar/baz.git"
+        self.assertRaises(TypeError, git_state.latest, name)
+
+    def test_detached_without_target(self):
+        """
+        Test detached when called without passing target
+        """
+        name = "https://foo.com/bar/baz.git"
+        self.assertRaises(TypeError, git_state.detached, name)
+
+    def test_cloned_without_target(self):
+        """
+        Test cloned when called without passing target
+        """
+        name = "https://foo.com/bar/baz.git"
+        self.assertRaises(TypeError, git_state.cloned, name)


### PR DESCRIPTION
This PR rebases https://github.com/saltstack/salt/pull/52556 on the master branch.

### What does this PR do?
Made the optional argument `target` a required positional arguement for three git functions.

### What issues does this PR fix or reference?
#52364 

### Tests taken
Tested each function without `target` set, all three failed with error: target required.

### Previous Behavior
Docs said you could leave target to default `None,` but @garethgreenaway tested and found this is incorrect, a Target is required.

### New Behavior
Docs function 

### Commits signed with GPG?
Yes