### PR TITLE
virt: Convert cpu_baseline ElementTree to string

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -4601,7 +4601,7 @@ def cpu_baseline(full=False, migratable=False, out="libvirt", **kwargs):
             "vendor": cpu.find("vendor").text,
             "features": [feature.get("name") for feature in cpu.findall("feature")],
         }
-    return cpu.toxml()
+    return ElementTree.tostring(cpu)
 
 
 def network_define(name, bridge, forward, ipv4_config=None, ipv6_config=None, **kwargs):

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -31,6 +31,7 @@ from salt.ext import six
 from salt.ext.six.moves import range  # pylint: disable=redefined-builtin
 
 # Import Salt Testing libs
+from tests.support.helpers import dedent
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase
@@ -1911,6 +1912,30 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         loader = virt.get_loader("test-vm")
         self.assertEqual("/foo/bar", loader["path"])
         self.assertEqual("yes", loader["readonly"])
+
+    def test_cpu_baseline(self):
+        """
+        Test virt.cpu_baseline()
+        """
+        capabilities_xml = dedent(
+            """<capabilities>
+                  <host>
+                    <uuid>44454c4c-3400-105a-8033-b3c04f4b344a</uuid>
+                    <cpu>
+                      <arch>x86_64</arch>
+                      <vendor>Intel</vendor>
+                    </cpu>
+                  </host>
+                </capabilities>"""
+        )
+
+        baseline_cpu_xml = b"""<cpu match="exact" mode="custom">
+                                  <vendor>Intel</vendor>
+                                </cpu>"""
+
+        self.mock_conn.getCapabilities.return_value = capabilities_xml
+        self.mock_conn.baselineCPU.return_value = baseline_cpu_xml
+        self.assertMultiLineEqual(str(baseline_cpu_xml), str(virt.cpu_baseline()))
 
     def test_parse_qemu_img_info(self):
         """


### PR DESCRIPTION


### What does this PR do?
This PR fixes an error with `virt.cpu_baseline`.

### What issues does this PR fix or reference?
With commit https://github.com/saltstack/salt/commit/0f5184c45cc962a1961166d9d6ee8c9522cf431b the value of `cpu` become of `xml.etree.ElementTree.Element` object and no longer has `toxml()` method.

### Previous Behavior
```
$ salt '*' virt.cpu_baseline
host2:
    The minion function caused an exception: Traceback (most recent call last):
      File "/usr/lib/python3.7/site-packages/salt/minion.py", line 1675, in _thread_return
        return_data = minion_instance.executors[fname](opts, data, func, args, kwargs)
      File "/usr/lib/python3.7/site-packages/salt/executors/direct_call.py", line 12, in execute
        return func(*args, **kwargs)
      File "/usr/lib/python3.7/site-packages/salt/modules/virt.py", line 4410, in cpu_baseline
        return cpu.toxml()
    AttributeError: 'xml.etree.ElementTree.Element' object has no attribute 'toxml'
```

### New Behavior
```
$ salt '*' virt.cpu_baseline
host2: 
    <cpu match="exact" mode="custom">
      <model fallback="forbid">Broadwell-noTSX-IBRS</model>
      <vendor>Intel</vendor>
      <feature name="vme" policy="require" />
      <feature name="ss" policy="require" />
      <feature name="vmx" policy="require" />
      <feature name="f16c" policy="require" />
      <feature name="rdrand" policy="require" />
      <feature name="hypervisor" policy="require" />
      <feature name="tsc_adjust" policy="require" />
      <feature name="mpx" policy="require" />
      <feature name="avx512f" policy="require" />
      <feature name="avx512dq" policy="require" />
      <feature name="clflushopt" policy="require" />
      <feature name="clwb" policy="require" />
      <feature name="avx512cd" policy="require" />
      <feature name="avx512bw" policy="require" />
      <feature name="avx512vl" policy="require" />
      <feature name="pku" policy="require" />
      <feature name="md-clear" policy="require" />
      <feature name="ssbd" policy="require" />
      <feature name="xsaveopt" policy="require" />
      <feature name="xsavec" policy="require" />
      <feature name="xgetbv1" policy="require" />
      <feature name="pdpe1gb" policy="require" />
      <feature name="abm" policy="require" />
    </cpu>
```