### PR TITLE
virt._get_domain: don't raise an exception if there is no VM

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -288,7 +288,7 @@ def _get_domain(conn, *vms, **kwargs):
         for id_ in conn.listDefinedDomains():
             all_vms.append(id_)
 
-    if not all_vms:
+    if vms and not all_vms:
         raise CommandExecutionError("No virtual machines found.")
 
     if vms:

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -18,14 +18,18 @@ import salt.config
 import salt.modules.config as config
 import salt.modules.virt as virt
 import salt.syspaths
+
 # Import salt libs
 import salt.utils.yaml
 from salt._compat import ElementTree as ET
 from salt.exceptions import CommandExecutionError
+
 # Import third party libs
 from salt.ext import six
+
 # pylint: disable=import-error
 from salt.ext.six.moves import range  # pylint: disable=redefined-builtin
+
 # Import Salt Testing libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch
@@ -4007,7 +4011,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         )
         self.assertRaisesRegex(
             CommandExecutionError,
-            "The VM 'vm2' is not present",
+            'The VM "vm2" is not present',
             virt._get_domain,
             self.mock_conn,
             "vm2",


### PR DESCRIPTION
### What does this PR do?

Raising an exception if there is no VM in `virt._get_domain` makes sense if
looking for some VMs, but not when listing all VMs.

### What issues does this PR fix or reference?

### Previous Behavior

Running this on a hypervisor minion without any VM raises an exception:

```
salt 'kvm' virt.list_domains
```

### New Behavior

Running the same command without any VM only returns an empty list

### Tests written?

Yes

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
