### PR TITLE
Uses correct zero value for lgpo LockoutDuration

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -2615,12 +2615,18 @@ class _policy_info(object):
                         "lgpo_section": self.account_lockout_policy_gpedit_path,
                         "Settings": {
                             "Function": "_in_range_inclusive",
-                            "Args": {"min": 0, "max": 6000000},
+                            "Args": {
+                                "min": 0,
+                                "max": 6000000,
+                                "zero_value": 0xFFFFFFFF,
+                            },
                         },
                         "NetUserModal": {"Modal": 3, "Option": "lockout_duration"},
                         "Transform": {
                             "Get": "_seconds_to_minutes",
                             "Put": "_minutes_to_seconds",
+                            "GetArgs": {"zero_value": 0xFFFFFFFF},
+                            "PutArgs": {"zero_value": 0xFFFFFFFF},
                         },
                     },
                     "LockoutThreshold": {
@@ -4252,7 +4258,10 @@ class _policy_info(object):
         """
         converts a number of seconds to minutes
         """
+        zero_value = kwargs.get("zero_value", 0)
         if val is not None:
+            if val == zero_value:
+                return 0
             return val / 60
         else:
             return "Not Defined"
@@ -4262,7 +4271,10 @@ class _policy_info(object):
         """
         converts number of minutes to seconds
         """
+        zero_value = kwargs.get("zero_value", 0)
         if val is not None:
+            if val == 0:
+                return zero_value
             return val * 60
         else:
             return "Not Defined"

--- a/tests/integration/modules/test_win_lgpo.py
+++ b/tests/integration/modules/test_win_lgpo.py
@@ -560,6 +560,27 @@ class WinLgpoTest(ModuleCase):
         )
 
     @destructiveTest
+    def test_set_computer_policy_LockoutDuration(self):
+        """
+        Test setting LockoutDuration
+        """
+        # For LockoutDuration to be meaningful, first configure
+        # LockoutThreshold
+        self._testSeceditPolicy("LockoutThreshold", 3, [r"^LockoutBadCount = 3"])
+
+        # Next set the LockoutDuration non-zero value, as this is required
+        # before setting LockoutWindow
+        self._testSeceditPolicy("LockoutDuration", 60, [r"^LockoutDuration = 60"])
+
+        # Now set LockoutWindow to a valid value <= LockoutDuration. If this
+        # is not set, then the LockoutDuration zero value is ignored by the
+        # Windows API (leading to a false sense of accomplishment)
+        self._testSeceditPolicy("LockoutWindow", 60, [r"^ResetLockoutCount = 60"])
+
+        # set LockoutDuration zero value, the secedit zero value is -1
+        self._testSeceditPolicy("LockoutDuration", 0, [r"^LockoutDuration = -1"])
+
+    @destructiveTest
     def test_set_computer_policy_GuestAccountStatus(self):
         """
         Test setting/unsetting/changing GuestAccountStatus


### PR DESCRIPTION
### What does this PR do?

Updates win_lgpo execution module to use the correct zero value for `LockoutDuration`

### What issues does this PR fix or reference?

Fixes #56406

### Previous Behavior
Setting the `LockoutDuration` to 0 with certain combinations of `LockoutThreshold` and `LockoutWindow` would throw a CommandExecutionError.

### New Behavior
The `LockoutDuration` zero value is set correctly.

### Tests written?

Yes

### Commits signed with GPG?

Yes
