### PR TITLE
Remove deprecated bits for Sodium in virt

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -212,26 +212,6 @@ def __get_conn(**kwargs):
     if not conn_str:
         conn_str = __salt__["config.get"]("virt:connection:uri", conn_str)
 
-    hypervisor = __salt__["config.get"]("libvirt:hypervisor", None)
-    if hypervisor is not None:
-        salt.utils.versions.warn_until(
-            "Sodium",
-            "'libvirt.hypervisor' configuration property has been deprecated. "
-            "Rather use the 'virt:connection:uri' to properly define the libvirt "
-            "URI or alias of the host to connect to. 'libvirt:hypervisor' will "
-            "stop being used in {version}.",
-        )
-
-    if hypervisor == "esxi" and conn_str is None:
-        salt.utils.versions.warn_until(
-            "Sodium",
-            "esxi hypervisor default with no default connection URI detected, "
-            "please set 'virt:connection:uri' to 'esx' for keep the legacy "
-            "behavior. Will default to libvirt guess once 'libvirt:hypervisor' "
-            "configuration is removed in {version}.",
-        )
-        conn_str = "esx"
-
     try:
         auth_types = [
             libvirt.VIR_CRED_AUTHNAME,
@@ -1535,34 +1515,24 @@ def init(
     caps = capabilities(**kwargs)
     os_types = sorted({guest["os_type"] for guest in caps["guests"]})
     arches = sorted({guest["arch"]["name"] for guest in caps["guests"]})
-    if not hypervisor:
-        hypervisor = __salt__["config.get"]("libvirt:hypervisor", hypervisor)
-        if hypervisor is not None:
-            salt.utils.versions.warn_until(
-                "Sodium",
-                "'libvirt:hypervisor' configuration property has been deprecated. "
-                "Rather use the 'virt:connection:uri' to properly define the libvirt "
-                "URI or alias of the host to connect to. 'libvirt:hypervisor' will "
-                "stop being used in {version}.",
-            )
-        else:
-            # Use the machine types as possible values
-            # Prefer 'kvm' over the others if available
-            hypervisors = sorted(
-                {
-                    x
-                    for y in [
-                        guest["arch"]["domains"].keys() for guest in caps["guests"]
-                    ]
-                    for x in y
-                }
-            )
-            hypervisor = "kvm" if "kvm" in hypervisors else hypervisors[0]
 
-    # esxi used to be a possible value for the hypervisor: map it to vmware since it's the same
-    hypervisor = "vmware" if hypervisor == "esxi" else hypervisor
+    virt_hypervisor = hypervisor
+    if not virt_hypervisor:
+        # Use the machine types as possible values
+        # Prefer "kvm" over the others if available
+        hypervisors = sorted(
+            {
+                x
+                for y in [guest["arch"]["domains"].keys() for guest in caps["guests"]]
+                for x in y
+            }
+        )
+        virt_hypervisor = "kvm" if "kvm" in hypervisors else hypervisors[0]
 
-    log.debug("Using hypervisor %s", hypervisor)
+    # esxi used to be a possible value for the hypervisor: map it to vmware since it"s the same
+    virt_hypervisor = "vmware" if virt_hypervisor == "esxi" else virt_hypervisor
+
+    log.debug("Using hypervisor %s", virt_hypervisor)
 
     # the NICs are computed as follows:
     # 1 - get the default NICs from the profile
@@ -1575,7 +1545,7 @@ def init(
             "'dmac' parameter has been deprecated. Rather use the 'interfaces' parameter "
             "to properly define the desired MAC address. 'dmac' will be removed in {version}.",
         )
-    nicp = _get_merged_nics(hypervisor, nic, interfaces, dmac=dmac)
+    nicp = _get_merged_nics(virt_hypervisor, nic, interfaces, dmac=dmac)
 
     # the disks are computed as follows:
     # 1 - get the disks defined in the profile
@@ -1597,14 +1567,14 @@ def init(
         )
 
     diskp = _disk_profile(
-        disk, hypervisor, disks, name, image=image, pool=pool, **kwargs
+        disk, virt_hypervisor, disks, name, image=image, pool=pool, **kwargs
     )
 
     # Create multiple disks, empty or from specified images.
     for _disk in diskp:
         log.debug("Creating disk for VM [ %s ]: %s", name, _disk)
 
-        if hypervisor == "vmware":
+        if virt_hypervisor == "vmware":
             if "image" in _disk:
                 # TODO: we should be copying the image file onto the ESX host
                 raise SaltInvocationError(
@@ -1619,7 +1589,7 @@ def init(
                 )
                 define_vol_xml_str(vol_xml)
 
-        elif hypervisor in ["qemu", "kvm", "xen"]:
+        elif virt_hypervisor in ["qemu", "kvm", "xen"]:
 
             create_overlay = enable_qcow
             if create_overlay:
@@ -1656,7 +1626,7 @@ def init(
             # Unknown hypervisor
             raise SaltInvocationError(
                 "Unsupported hypervisor when handling disk image: {0}".format(
-                    hypervisor
+                    virt_hypervisor
                 )
             )
 
@@ -1680,7 +1650,17 @@ def init(
         boot = _handle_remote_boot_params(boot)
 
     vm_xml = _gen_xml(
-        name, cpu, mem, diskp, nicp, hypervisor, os_type, arch, graphics, boot, **kwargs
+        name,
+        cpu,
+        mem,
+        diskp,
+        nicp,
+        virt_hypervisor,
+        os_type,
+        arch,
+        graphics,
+        boot,
+        **kwargs
     )
     conn = __get_conn(**kwargs)
     try:
@@ -2810,6 +2790,8 @@ def get_profiles(hypervisor=None, **kwargs):
     """
     ret = {}
 
+    # Use the machine types as possible values
+    # Prefer 'kvm' over the others if available
     caps = capabilities(**kwargs)
     hypervisors = sorted(
         {
@@ -2821,27 +2803,21 @@ def get_profiles(hypervisor=None, **kwargs):
     default_hypervisor = "kvm" if "kvm" in hypervisors else hypervisors[0]
 
     if not hypervisor:
-        hypervisor = __salt__["config.get"]("libvirt:hypervisor")
-        if hypervisor is not None:
-            salt.utils.versions.warn_until(
-                "Sodium",
-                "'libvirt:hypervisor' configuration property has been deprecated. "
-                "Rather use the 'virt:connection:uri' to properly define the libvirt "
-                "URI or alias of the host to connect to. 'libvirt:hypervisor' will "
-                "stop being used in {version}.",
-            )
-        else:
-            # Use the machine types as possible values
-            # Prefer 'kvm' over the others if available
-            hypervisor = default_hypervisor
+        hypervisor = default_hypervisor
     virtconf = __salt__["config.get"]("virt", {})
     for typ in ["disk", "nic"]:
         _func = getattr(sys.modules[__name__], "_{0}_profile".format(typ))
-        ret[typ] = {"default": _func("default", hypervisor)}
+        ret[typ] = {
+            "default": _func(
+                "default", hypervisor if hypervisor else default_hypervisor
+            )
+        }
         if typ in virtconf:
             ret.setdefault(typ, {})
             for prf in virtconf[typ]:
-                ret[typ][prf] = _func(prf, hypervisor)
+                ret[typ][prf] = _func(
+                    prf, hypervisor if hypervisor else default_hypervisor
+                )
     return ret
 
 

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1194,7 +1194,6 @@ def init(
     priv_key=None,
     seed_cmd="seed.apply",
     enable_vnc=False,
-    enable_qcow=False,
     graphics=None,
     os_type=None,
     arch=None,
@@ -1259,22 +1258,6 @@ def init(
         but ``x86_64`` is prefed over ``i686``.
 
         .. versionadded:: 2019.2.0
-    :param enable_qcow:
-        ``True`` to create a QCOW2 overlay image, rather than copying the image
-        (Default: ``False``).
-
-        Deprecated in favor of ``disks`` parameter. Add the following to the disks
-        definitions to create an overlay image of a template disk image with an
-        image set:
-
-        .. code-block:: python
-
-            {
-                'name': 'name_of_disk_to_change',
-                'overlay_image': True
-            }
-
-        .. deprecated:: 2019.2.0
     :param config: minion configuration to use when seeding.
                    See :mod:`seed module for more details <salt.modules.seed>`
     :param boot_dev: String of space-separated devices to boot from (Default: ``'hd'``)
@@ -1466,18 +1449,7 @@ def init(
                 define_vol_xml_str(vol_xml)
 
         elif virt_hypervisor in ["qemu", "kvm", "xen"]:
-
-            create_overlay = enable_qcow
-            if create_overlay:
-                salt.utils.versions.warn_until(
-                    "Sodium",
-                    "'enable_qcow' parameter has been deprecated. Rather use the 'disks' "
-                    "parameter to override or define the image. 'enable_qcow' will be removed "
-                    "in {version}.",
-                )
-            else:
-                create_overlay = _disk.get("overlay_image", False)
-
+            create_overlay = _disk.get("overlay_image", False)
             if _disk["source_file"]:
                 if os.path.exists(_disk["source_file"]):
                     img_dest = _disk["source_file"]

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -3016,17 +3016,7 @@ def define_vol_xml_str(xml, **kwargs):  # pylint: disable=redefined-outer-name
         virt:
             storagepool: mine
     """
-    poolname = __salt__["config.get"]("libvirt:storagepool", None)
-    if poolname is not None:
-        salt.utils.versions.warn_until(
-            "Sodium",
-            "'libvirt:storagepool' has been deprecated in favor of "
-            "'virt:storagepool'. 'libvirt:storagepool' will stop "
-            "being used in {version}.",
-        )
-    else:
-        poolname = __salt__["config.get"]("virt:storagepool", "default")
-
+    poolname = __salt__["config.get"]("virt:storagepool", "default")
     conn = __get_conn(**kwargs)
     pool = conn.storagePoolLookupByName(six.text_type(poolname))
     ret = pool.createXML(xml, 0) is not None

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1092,20 +1092,9 @@ def _nic_profile(profile_name, hypervisor, dmac=None):
     """
     Compute NIC data based on profile
     """
-
-    default = [{"eth0": {}}]
-
-    # support old location
-    config_data = __salt__["config.option"]("virt.nic", {}).get(profile_name, None)
-
-    if config_data is not None:
-        salt.utils.versions.warn_until(
-            "Sodium",
-            "'virt.nic' has been deprecated in favor of 'virt:nic'. "
-            "'virt.nic' will stop being used in {version}.",
-        )
-    else:
-        config_data = __salt__["config.get"]("virt:nic", {}).get(profile_name, default)
+    config_data = __salt__["config.get"]("virt:nic", {}).get(
+        profile_name, [{"eth0": {}}]
+    )
 
     interfaces = []
 

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -210,24 +210,6 @@ def __get_conn(**kwargs):
     password = kwargs.get("password", None)
     conn_str = kwargs.get("connection", None)
     if not conn_str:
-        conn_str = __salt__["config.get"]("virt.connect", None)
-        if conn_str is not None:
-            salt.utils.versions.warn_until(
-                "Sodium",
-                "'virt.connect' configuration property has been deprecated in favor "
-                "of 'virt:connection:uri'. 'virt.connect' will stop being used in "
-                "{version}.",
-            )
-        else:
-            conn_str = __salt__["config.get"]("libvirt:connection", None)
-            if conn_str is not None:
-                salt.utils.versions.warn_until(
-                    "Sodium",
-                    "'libvirt.connection' configuration property has been deprecated in favor "
-                    "of 'virt:connection:uri'. 'libvirt.connection' will stop being used in "
-                    "{version}.",
-                )
-
         conn_str = __salt__["config.get"]("virt:connection:uri", conn_str)
 
     hypervisor = __salt__["config.get"]("libvirt:hypervisor", None)

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -782,17 +782,7 @@ def _get_images_dir():
     Extract the images dir from the configuration. First attempts to
     find legacy virt.images, then tries virt:images.
     """
-    img_dir = __salt__["config.option"]("virt.images")
-    if img_dir:
-        salt.utils.versions.warn_until(
-            "Sodium",
-            "'virt.images' has been deprecated in favor of "
-            "'virt:images'. 'virt.images' will stop "
-            "being used in {version}.",
-        )
-    else:
-        img_dir = __salt__["config.get"]("virt:images")
-
+    img_dir = __salt__["config.get"]("virt:images")
     log.debug("Image directory from config option `virt:images`" " is %s", img_dir)
     return img_dir
 

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -521,16 +521,7 @@ def _get_migrate_command():
     """
     Returns the command shared by the different migration types
     """
-    tunnel = __salt__["config.option"]("virt.tunnel")
-    if tunnel:
-        salt.utils.versions.warn_until(
-            "Sodium",
-            "'virt.tunnel' has been deprecated in favor of "
-            "'virt:tunnel'. 'virt.tunnel' will stop "
-            "being used in {version}.",
-        )
-    else:
-        tunnel = __salt__["config.get"]("virt:tunnel")
+    tunnel = __salt__["config.get"]("virt:tunnel")
     if tunnel:
         return (
             "virsh migrate --p2p --tunnelled --live --persistent " "--undefinesource "

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1193,7 +1193,6 @@ def init(
     pub_key=None,
     priv_key=None,
     seed_cmd="seed.apply",
-    enable_vnc=False,
     graphics=None,
     os_type=None,
     arch=None,
@@ -1232,17 +1231,6 @@ def init(
     :param pub_key: public key to seed with (Default: ``None``)
     :param priv_key: public key to seed with (Default: ``None``)
     :param seed_cmd: Salt command to execute to seed the image. (Default: ``'seed.apply'``)
-    :param enable_vnc:
-        ``True`` to setup a vnc display for the VM (Default: ``False``)
-
-        Deprecated in favor of the ``graphics`` parameter. Could be replaced with
-        the following:
-
-        .. code-block:: python
-
-            graphics={'type': 'vnc'}
-
-        .. deprecated:: 2019.2.0
     :param graphics:
         Dictionary providing details on the graphics device to create. (Default: ``None``)
         See :ref:`init-graphics-def` for more details on the possible values.
@@ -1479,16 +1467,6 @@ def init(
             )
 
     log.debug("Generating VM XML")
-
-    if enable_vnc:
-        salt.utils.versions.warn_until(
-            "Sodium",
-            "'enable_vnc' parameter has been deprecated in favor of "
-            "'graphics'. Use graphics={'type': 'vnc'} for the same behavior. "
-            "'enable_vnc' will be removed in {version}. ",
-        )
-        graphics = {"type": "vnc"}
-
     if os_type is None:
         os_type = "hvm" if "hvm" in os_types else os_types[0]
     if arch is None:

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -877,9 +877,7 @@ def _qemu_image_create(disk, create_overlay=False, saltenv="base"):
     return img_dest
 
 
-def _disk_profile(
-    profile, hypervisor, disks=None, vm_name=None, image=None, pool=None, **kwargs
-):
+def _disk_profile(profile, hypervisor, disks=None, vm_name=None, image=None, **kwargs):
     """
     Gather the disk profile from the config or apply the default based
     on the active hypervisor
@@ -924,7 +922,7 @@ def _disk_profile(
             "format": "vmdk",
             "model": "scsi",
             "device": "disk",
-            "pool": "[{0}] ".format(pool if pool else "0"),
+            "pool": "[0] ",
         }
     elif hypervisor in ["qemu", "kvm"]:
         overlay = {"format": "qcow2", "device": "disk", "model": "virtio"}
@@ -1302,20 +1300,6 @@ def init(
             }
 
         .. deprecated:: 2019.2.0
-    :param pool:
-        Path of the folder where the image files are located for vmware/esx hypervisors.
-
-        Deprecated in favor of ``disks`` parameter. Add the following to the disks
-        definitions to set the vmware datastore of a disk image:
-
-        .. code-block:: python
-
-            {
-                'name': 'name_of_disk_to_change',
-                'pool': 'mydatastore'
-            }
-
-        .. deprecated:: Flurorine
     :param config: minion configuration to use when seeding.
                    See :mod:`seed module for more details <salt.modules.seed>`
     :param boot_dev: String of space-separated devices to boot from (Default: ``'hd'``)
@@ -1486,14 +1470,6 @@ def init(
     # 1 - get the disks defined in the profile
     # 2 - set the image on the first disk (will be removed later)
     # 3 - update the disks from the profile with the ones from the user. The matching key is the name.
-    pool = kwargs.get("pool", None)
-    if pool:
-        salt.utils.versions.warn_until(
-            "Sodium",
-            "'pool' parameter has been deprecated. Rather use the 'disks' parameter "
-            "to properly define the vmware datastore of disks. 'pool' will be removed in {version}.",
-        )
-
     if image:
         salt.utils.versions.warn_until(
             "Sodium",
@@ -1501,9 +1477,7 @@ def init(
             "to override or define the image. 'image' will be removed in {version}.",
         )
 
-    diskp = _disk_profile(
-        disk, virt_hypervisor, disks, name, image=image, pool=pool, **kwargs
-    )
+    diskp = _disk_profile(disk, virt_hypervisor, disks, name, image=image, **kwargs)
 
     # Create multiple disks, empty or from specified images.
     for _disk in diskp:

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -3269,15 +3269,11 @@ def undefine(vm_, **kwargs):
     return ret
 
 
-def purge(vm_, dirs=False, removables=None, **kwargs):
+def purge(vm_, dirs=False, removables=False, **kwargs):
     """
     Recursively destroy and delete a persistent virtual machine, pass True for
     dir's to also delete the directories containing the virtual machine disk
     images - USE WITH EXTREME CAUTION!
-
-    Pass removables=False to avoid deleting cdrom and floppy images. To avoid
-    disruption, the default but dangerous value is True. This will be changed
-    to the safer False default value in Sodium.
 
     :param vm_: domain name
     :param dirs: pass True to remove containing directories
@@ -3298,19 +3294,11 @@ def purge(vm_, dirs=False, removables=None, **kwargs):
 
     .. code-block:: bash
 
-        salt '*' virt.purge <domain> removables=False
+        salt '*' virt.purge <domain>
     """
     conn = __get_conn(**kwargs)
     dom = _get_domain(conn, vm_)
     disks = _get_disks(dom)
-    if removables is None:
-        salt.utils.versions.warn_until(
-            "Sodium",
-            "removables argument default value is True, but will be changed "
-            "to False by default in {version}. Please set to True to maintain "
-            "the current behavior in the future.",
-        )
-        removables = True
     if (
         VIRT_STATE_NAME_MAP.get(dom.info()[0], "unknown") != "shutdown"
         and dom.destroy() != 0

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -3352,26 +3352,6 @@ def _is_kvm_hyper():
     return "libvirtd" in __salt__["cmd.run"](__grains__["ps"])
 
 
-def is_kvm_hyper():
-    """
-    Returns a bool whether or not this node is a KVM hypervisor
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' virt.is_kvm_hyper
-
-    .. deprecated:: 2019.2.0
-    """
-    salt.utils.versions.warn_until(
-        "Sodium",
-        "'is_kvm_hyper' function has been deprecated. Use the 'get_hypervisor' == \"kvm\" instead. "
-        "'is_kvm_hyper' will be removed in {version}.",
-    )
-    return _is_kvm_hyper()
-
-
 def _is_xen_hyper():
     """
     Returns a bool whether or not this node is a XEN hypervisor
@@ -3390,26 +3370,6 @@ def _is_xen_hyper():
         # No /proc/modules? Are we on Windows? Or Solaris?
         return False
     return "libvirtd" in __salt__["cmd.run"](__grains__["ps"])
-
-
-def is_xen_hyper():
-    """
-    Returns a bool whether or not this node is a XEN hypervisor
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' virt.is_xen_hyper
-
-    .. deprecated:: 2019.2.0
-    """
-    salt.utils.versions.warn_until(
-        "Sodium",
-        "'is_xen_hyper' function has been deprecated. Use the 'get_hypervisor' == \"xen\" instead. "
-        "'is_xen_hyper' will be removed in {version}.",
-    )
-    return _is_xen_hyper()
 
 
 def get_hypervisor():
@@ -3452,7 +3412,7 @@ def is_hyper():
         salt '*' virt.is_hyper
     """
     if HAS_LIBVIRT:
-        return is_xen_hyper() or is_kvm_hyper()
+        return _is_xen_hyper() or _is_kvm_hyper()
     return False
 
 

--- a/salt/states/virt.py
+++ b/salt/states/virt.py
@@ -275,7 +275,6 @@ def running(
     name,
     cpu=None,
     mem=None,
-    image=None,
     vm_type=None,
     disk_profile=None,
     disks=None,
@@ -302,9 +301,6 @@ def running(
     :param name: name of the virtual machine to run
     :param cpu: number of CPUs for the virtual machine to create
     :param mem: amount of memory in MiB for the new virtual machine
-    :param image: disk image to use for the first disk of the new VM
-
-        .. deprecated:: 2019.2.0
     :param vm_type: force virtual machine type for the new VM. The default value is taken from
         the host capabilities. This could be useful for example to use ``'qemu'`` type instead
         of the ``'kvm'`` one.
@@ -503,19 +499,12 @@ def running(
                 else:
                     ret["comment"] = "Domain {0} exists and is running".format(name)
         except CommandExecutionError:
-            if image:
-                salt.utils.versions.warn_until(
-                    "Sodium",
-                    "'image' parameter has been deprecated. Rather use the 'disks' parameter "
-                    "to override or define the image. 'image' will be removed in {version}.",
-                )
             __salt__["virt.init"](
                 name,
                 cpu=cpu,
                 mem=mem,
                 os_type=os_type,
                 arch=arch,
-                image=image,
                 hypervisor=vm_type,
                 disk=disk_profile,
                 disks=disks,

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -3581,7 +3581,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.mock_conn.storagePoolLookupByName = MagicMock(return_value=mocked_pool)
         self.mock_conn.storagePoolDefineXML = MagicMock()
 
-        self.assertTrue(
+        self.assertFalse(
             virt.pool_update(
                 "default",
                 "rbd",
@@ -3590,7 +3590,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 source_auth={"username": "libvirt", "password": "c2VjcmV0"},
             )
         )
-        self.mock_conn.storagePoolDefineXML.assert_called_once_with(expected_xml)
+        self.mock_conn.storagePoolDefineXML.assert_not_called()
         mock_secret.setValue.assert_called_once_with(b"secret")
 
     def test_pool_update_password_create(self):

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -2026,17 +2026,17 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
 
         res = virt.purge("test-vm")
         self.assertTrue(res)
+        mock_remove.assert_called_once()
         mock_remove.assert_any_call("/disks/test.qcow2")
-        mock_remove.assert_any_call("/disks/test-cdrom.iso")
 
     @patch("salt.modules.virt.stop", return_value=True)
     @patch("salt.modules.virt.undefine")
     @patch("os.remove")
-    def test_purge_noremovable(self, mock_remove, mock_undefine, mock_stop):
+    def test_purge_removable(self, mock_remove, mock_undefine, mock_stop):
         """
-        Test virt.purge(removables=False)
+        Test virt.purge(removables=True)
         """
-        xml = """<domain type='kvm' id='7'>
+        xml = """<domain type="kvm" id="7">
               <name>test-vm</name>
               <devices>
                 <disk type='file' device='disk'>
@@ -2083,10 +2083,10 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             qemu_infos
         ]  # pylint: disable=no-member
 
-        res = virt.purge("test-vm", removables=False)
+        res = virt.purge("test-vm", removables=True)
         self.assertTrue(res)
-        mock_remove.assert_called_once()
         mock_remove.assert_any_call("/disks/test.qcow2")
+        mock_remove.assert_any_call("/disks/test-cdrom.iso")
 
     def test_capabilities(self):
         """

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -111,11 +111,12 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         Test virt._disk_profile() when merging with user-defined disks
         """
         root_dir = os.path.join(salt.syspaths.ROOT_DIR, "srv", "salt-images")
-        userdisks = [{"name": "data", "size": 16384, "format": "raw"}]
+        userdisks = [
+            {"name": "system", "image": "/path/to/image"},
+            {"name": "data", "size": 16384, "format": "raw"},
+        ]
 
-        disks = virt._disk_profile(
-            "default", "kvm", userdisks, "myvm", image="/path/to/image"
-        )
+        disks = virt._disk_profile("default", "kvm", userdisks, "myvm")
         self.assertEqual(
             [
                 {

--- a/tests/unit/states/test_virt.py
+++ b/tests/unit/states/test_virt.py
@@ -315,18 +315,23 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                 }
             )
             self.assertDictEqual(
-                virt.running("myvm", cpu=2, mem=2048, image="/path/to/img.qcow2"), ret
+                virt.running(
+                    "myvm",
+                    cpu=2,
+                    mem=2048,
+                    disks=[{"name": "system", "image": "/path/to/img.qcow2"}],
+                ),
+                ret,
             )
             init_mock.assert_called_with(
                 "myvm",
                 cpu=2,
                 mem=2048,
-                image="/path/to/img.qcow2",
                 os_type=None,
                 arch=None,
                 boot=None,
                 disk=None,
-                disks=None,
+                disks=[{"name": "system", "image": "/path/to/img.qcow2"}],
                 nic=None,
                 interfaces=None,
                 graphics=None,
@@ -403,7 +408,6 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                 mem=2048,
                 os_type="linux",
                 arch="i686",
-                image=None,
                 disk="prod",
                 disks=disks,
                 nic="prod",


### PR DESCRIPTION
### What does this PR do?

Removes all the deprecated parameters, configuration and functions that are to be removed in Sodium for the virt module.

### What issues does this PR fix or reference?

### Tests written?

Yes: tests adapted where needed

### Commits signed with GPG?

Yes