### PR TITLE
Ensure version.py included before we install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -745,6 +745,12 @@ class Install(install):
             self.distribution.salt_download_windows_dlls = True
             self.run_command('download-windows-dlls')
             self.distribution.salt_download_windows_dlls = None
+        # need to ensure _version.py is created in build dir before install
+        if not os.path.exists(os.path.join(self.build_lib)):
+            if not self.skip_build:
+                self.run_command('build')
+        else:
+            self.run_command('write_salt_version')
         # Run install.run
         install.run(self)
 

--- a/tests/integration/setup/test_egg.py
+++ b/tests/integration/setup/test_egg.py
@@ -28,6 +28,22 @@ class EggSetupTest(ModuleCase):
     '''
     Tests for building and installing egg packages
     '''
+
+    def setUp(self):
+        # ensure we have a clean build dir
+        self._clean_build()
+
+    def _clean_build(self):
+        '''
+        helper method to clean the build dir
+        '''
+        dirs = [os.path.join(RUNTIME_VARS.CODE_DIR, 'build'),
+                os.path.join(RUNTIME_VARS.CODE_DIR, 'salt.egg-info'),
+                os.path.join(RUNTIME_VARS.CODE_DIR, 'dist')]
+        for _dir in dirs:
+            if os.path.exists(_dir):
+                shutil.rmtree(_dir)
+
     def test_egg_install(self):
         '''
         test installing an egg package
@@ -37,6 +53,7 @@ class EggSetupTest(ModuleCase):
             ret = self.run_function('cmd.run', ['{0} setup.py install --prefix={1}'.format(venv.venv_python,
                                                                                            venv.venv_dir)],
                                                cwd=RUNTIME_VARS.CODE_DIR)
+            self._clean_build()
             lib_dir = os.path.join(venv.venv_dir, 'lib')
             for _dir in os.listdir(lib_dir):
                 site_pkg = os.path.join(lib_dir, _dir, 'site-packages')
@@ -50,9 +67,3 @@ class EggSetupTest(ModuleCase):
             pip_ver = self.run_function('pip.list', bin_env=venv.venv_dir).get('salt')
             egg_ver = [x for x in egg.split('/')[-1:][0].split('-') if re.search(r'^\d.\d*', x)][0]
             assert pip_ver == egg_ver.replace('_', '-')
-            assert self.run_function('cmd.run', ['salt --version']).split()[1] == pip_ver
-
-    def tearDown(self):
-        build_dir = os.path.join(RUNTIME_VARS.CODE_DIR, 'build')
-        if os.path.exists(build_dir):
-            shutil.rmtree(build_dir)

--- a/tests/integration/setup/test_egg.py
+++ b/tests/integration/setup/test_egg.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+'''
+tests.integration.setup.test_egg
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+'''
+
+# Import python libs
+from __future__ import absolute_import, print_function, unicode_literals
+import os
+import re
+import shutil
+
+# Import Salt Testing libs
+from tests.support.runtests import RUNTIME_VARS
+from tests.support.unit import skipIf
+from tests.support.helpers import VirtualEnv, destructiveTest
+from tests.support.case import ModuleCase
+
+# Import salt libs
+import salt.utils.path
+import salt.utils.platform
+from salt.modules.virtualenv_mod import KNOWN_BINARY_NAMES
+
+
+@destructiveTest
+@skipIf(salt.utils.path.which_bin(KNOWN_BINARY_NAMES) is None, 'virtualenv not installed')
+class EggSetupTest(ModuleCase):
+    '''
+    Tests for building and installing egg packages
+    '''
+    def test_egg_install(self):
+        '''
+        test installing an egg package
+        '''
+        # Let's create the testing virtualenv
+        with VirtualEnv() as venv:
+            ret = self.run_function('cmd.run', ['{0} setup.py install --prefix={1}'.format(venv.venv_python,
+                                                                                           venv.venv_dir)],
+                                               cwd=RUNTIME_VARS.CODE_DIR)
+            lib_dir = os.path.join(venv.venv_dir, 'lib')
+            for _dir in os.listdir(lib_dir):
+                site_pkg = os.path.join(lib_dir, _dir, 'site-packages')
+                for _file in os.listdir(site_pkg):
+                    if _file.startswith('salt-'):
+                        egg = os.path.join(venv.venv_dir, _file)
+                        assert os.path.exists(os.path.join(site_pkg, _file, 'salt', '_version.py'))
+                        break
+
+            # Let's ensure the version is correct
+            pip_ver = self.run_function('pip.list', bin_env=venv.venv_dir).get('salt')
+            egg_ver = [x for x in egg.split('/')[-1:][0].split('-') if re.search(r'^\d.\d*', x)][0]
+            assert pip_ver == egg_ver.replace('_', '-')
+            assert self.run_function('cmd.run', ['salt --version']).split()[1] == pip_ver
+
+    def tearDown(self):
+        build_dir = os.path.join(RUNTIME_VARS.CODE_DIR, 'build')
+        if os.path.exists(build_dir):
+            shutil.rmtree(build_dir)

--- a/tests/unit/test_module_names.py
+++ b/tests/unit/test_module_names.py
@@ -160,6 +160,7 @@ class BadTestModuleNamesTestCase(TestCase):
             'integration.scheduler.test_helpers',
             'integration.scheduler.test_run_job',
             'integration.setup.test_bdist',
+            'integration.setup.test_egg',
             'integration.shell.test_spm',
             'integration.shell.test_cp',
             'integration.shell.test_syndic',


### PR DESCRIPTION
### What does this PR do?
Ensures _version.py included before we run install when running `python setup.py install`

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/56415

### Previous Behavior
`_version.py` would not be included in the build if you run `python setup.py install`. This is because setuptools does not call `run_command('build')`, whereas distutils did when we did an install and we recently migrated to setuptools.

### New Behavior
`_version.py` included and `salt --version` reporting correctly.

### Tests written?
Yes

### Commits signed with GPG?

Yes