### PR TITLE
Fixed documentation of docker_image.load

### DIFF
--- a/salt/states/docker_image.py
+++ b/salt/states/docker_image.py
@@ -128,8 +128,8 @@ def present(name,
             The ``tag`` must be manually specified using the ``tag`` argument.
 
     load
-        Loads a tar archive created with :py:func:`docker.load
-        <salt.modules.dockermod.load>` (or the ``docker load`` Docker CLI
+        Loads a tar archive created with :py:func:`docker.save
+        <salt.modules.dockermod.save>` (or the ``docker save`` Docker CLI
         command), and assigns it the specified repo and tag.
 
         .. code-block:: yaml


### PR DESCRIPTION
### What does this PR do?
Corrects documentation to reference save instead of load. Loading an image that is created `docker save` not `docker load`.

### What issues does this PR fix or reference?

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
