### PR TITLE
Fix section header for listen/listen_in

### DIFF
--- a/doc/ref/states/requisites.rst
+++ b/doc/ref/states/requisites.rst
@@ -1039,8 +1039,8 @@ if the gluster commands return a 0 ret value.
                 - /etc/crontab
                 - 'entry1'
 
-runas
-~~~~~
+Listen/Listen_in
+----------------
 
 .. versionadded:: 2014.7.0
 


### PR DESCRIPTION
### What does this PR do?

Minor fix to documentation. This seems to have been corrupted by a bad merge when merging #51846. See https://github.com/saltstack/salt/commit/1dfcb2755ae98d1e194ad3706e771519a481f46b#diff-a4cee24ecb1fc3e59865895c11641dfbL965

### What issues does this PR fix or reference?

Section title/nesting was incorrect in the documentation.

### Tests written?

N/A

### Commits signed with GPG?

No

---

This bug is present in the 3000 docs branch (but not 2019.2.3). I'm not entirely sure what are the appropriate branches I should backport it to? The contributor documentation is unclear on this.
