### PR TITLE
modules.schedule: fix `UnboundLocalError` in `show_next_fire_time()`

### DIFF
--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -1228,15 +1228,14 @@ def show_next_fire_time(name, **kwargs):
                     tag='/salt/minion/minion_schedule_next_fire_time_complete',
                     wait=30,
                 )
+                if 'next_fire_time' in event_ret:
+                    ret['next_fire_time'] = event_ret['next_fire_time']
+                else:
+                    ret['comment'] = 'next fire time not available.'
+                return ret
     except KeyError:
         # Effectively a no-op, since we can't really return without an event system
         ret = {}
         ret['comment'] = 'Event module not available. Schedule show next fire time failed.'
         ret['result'] = True
         return ret
-
-    if 'next_fire_time' in event_ret:
-        ret['next_fire_time'] = event_ret['next_fire_time']
-    else:
-        ret['comment'] = 'next fire time not available.'
-    return ret


### PR DESCRIPTION
When querying the next fire time of a scheduled event using the
`salt.cmd` runner, the operation fails with an `UnboundLocalError`
exception:

```
Exception occurred in runner salt.cmd: Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/salt/client/mixins.py", line 377, in low
    data['return'] = func(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/salt/runners/salt.py", line 106, in cmd
    if fun in functions \
  File "/usr/lib/python3/dist-packages/salt/modules/schedule.py", line 1213, in show_next_fire_time
    if 'next_fire_time' in event_ret:
UnboundLocalError: local variable 'event_ret' referenced before assignment
```

This can be reproduced using: `salt-run salt.cmd schedule.show_next_fire_time whatever_job`

Moving the block of code using `event_ret` into the right scope fixes this.

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
