### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[Bug]"
+labels: Bug
+assignees: ''
+
+---
+
+**Description of the bug**
+A clear and concise description of what the bug is.
+<!-- Note: Please direct questions to the salt-users google group, IRC and Slack. Only post issues/bugs and feature requests here -->
+
+**Setup**
+(Please provide relevant configs and/or SLS files (Be sure to remove sensitive info).)
+
+**To Reproduce**
+Steps to reproduce the behavior: (Include debug logs if possible and relevant)
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Versions Report**
+(Provided by running `salt --versions-report`. Please also mention any differences in master/minion versions.)
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[Feature Request]"
+labels: Feature
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Updating to use the GitHub templates that will allow titles to be uniform as well as add labels to bugs and feature requests. Fixes: #55853 