### PR TITLE
Add new ssh_pre_flight roster option

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -506,6 +506,12 @@
 # Boolean to run command via sudo.
 #ssh_sudo: False
 
+# Boolean to run ssh_pre_flight script defined in roster. By default
+# the script will only run if the thin_dir does not exist on the targeted
+# minion. This forces the script to run regardless of the thin dir existing
+# or not.
+#ssh_run_pre_flight: True
+
 # Number of seconds to wait for a response when establishing an SSH connection.
 #ssh_timeout: 60
 

--- a/doc/ref/cli/salt-ssh.rst
+++ b/doc/ref/cli/salt-ssh.rst
@@ -105,6 +105,14 @@ Options
 
    Pass a JID to be used instead of generating one.
 
+.. option:: --pre-flight
+
+   Run the ssh_pre_flight script defined in the roster.
+   By default this script will only run if the thin dir
+   does not exist on the target minion. This option will
+   force the script to run regardless of the thin dir
+   existing or not.
+
 Authentication Options
 ----------------------
 

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -1341,6 +1341,15 @@ salt-ssh.
       groupA: minion1,minion2
       groupB: minion1,minion3
 
+.. conf_master:: ssh_run_pre_flight
+
+Default: False
+
+Run the ssh_pre_flight script defined in the salt-ssh roster. Be default
+the script will only run when the thin dir does not exist on the targeted
+minion. This will force the script to run and not check if the thin dir
+exists first.
+
 .. conf_master:: thin_extra_mods
 
 ``thin_extra_mods``

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -1345,7 +1345,7 @@ salt-ssh.
 
 Default: False
 
-Run the ssh_pre_flight script defined in the salt-ssh roster. Be default
+Run the ssh_pre_flight script defined in the salt-ssh roster. By default
 the script will only run when the thin dir does not exist on the targeted
 minion. This will force the script to run and not check if the thin dir
 exists first.

--- a/doc/topics/releases/sodium.rst
+++ b/doc/topics/releases/sodium.rst
@@ -16,3 +16,31 @@ also support the syntax used in :py:mod:`module.run <salt.states.module.run>`.
 The old syntax for the mine_function - as a dict, or as a list with dicts that
 contain more than exactly one key - is still supported but discouraged in favor
 of the more uniform syntax of module.run.
+
+Salt-SSH updates
+================
+
+A new Salt-SSH roster option `ssh_pre_flight` has been added. This enables you to run a
+script before Salt-SSH tries to run any commands. You can set this option in the roster
+for a specific minion or use the `roster_defaults` to set it for all minions.
+
+Example for setting `ssh_pre_flight` for specific host in roster file
+
+.. code-block:: yaml
+
+  minion1:
+    host: localhost
+    user: root
+    passwd: P@ssword
+    ssh_pre_flight: /srv/salt/pre_flight.sh
+
+Example for setting `ssh_pre_flight` using roster_defaults, so all minions
+run this script.
+
+.. code-block:: yaml
+
+  roster_defaults:
+    ssh_pre_flight: /srv/salt/pre_flight.sh
+
+The `ssh_pre_flight` script will only run if the thin dir is not currently on the
+minion.

--- a/doc/topics/releases/sodium.rst
+++ b/doc/topics/releases/sodium.rst
@@ -44,6 +44,7 @@ run this script.
 
 The `ssh_pre_flight` script will only run if the thin dir is not currently on the
 minion. If you want to force the script to run you have the following options:
-  - Wipe the thin dir on the targeted minion using the -w arg.
-  - Set ssh_run_pre_flight to True in the config.
-  - Run salt-ssh with the --pre-flight arg.
+
+* Wipe the thin dir on the targeted minion using the -w arg.
+* Set ssh_run_pre_flight to True in the config.
+* Run salt-ssh with the --pre-flight arg.

--- a/doc/topics/releases/sodium.rst
+++ b/doc/topics/releases/sodium.rst
@@ -43,4 +43,7 @@ run this script.
     ssh_pre_flight: /srv/salt/pre_flight.sh
 
 The `ssh_pre_flight` script will only run if the thin dir is not currently on the
-minion.
+minion. If you want to force the script to run you have the following options:
+  - Wipe the thin dir on the targeted minion using the -w arg.
+  - Set ssh_run_pre_flight to True in the config.
+  - Run salt-ssh with the --pre-flight arg.

--- a/doc/topics/ssh/roster.rst
+++ b/doc/topics/ssh/roster.rst
@@ -63,7 +63,9 @@ The information which can be stored in a roster ``target`` is the following:
                      # octal (so for 0o077 in YAML you would do 0077, or 63)
         ssh_pre_flight: # Path to a script that will run before all other salt-ssh
                         # commands. Will only run the first time when the thin dir
-                        # does not exist. Added in Sodium Release.
+                        # does not exist, unless --pre-flight is passed to salt-ssh
+                        # command or ssh_run_pre_flight is set to true in the config
+                        # Added in Sodium Release.
 
 .. _ssh_pre_flight:
 
@@ -74,7 +76,11 @@ A Salt-SSH roster option `ssh_pre_flight` was added in the Sodium release. This 
 you to run a script before Salt-SSH tries to run any commands. You can set this option
 in the roster for a specific minion or use the `roster_defaults` to set it for all minions.
 This script will only run if the thin dir is not currently on the minion. This means it will
-only run on the first run of salt-ssh or if you have recently wiped out your thin dir.
+only run on the first run of salt-ssh or if you have recently wiped out your thin dir. If
+you want to intentionally run the script again you have a couple of options:
+  - Wipe out your thin dir by using the -w salt-ssh arg.
+  - Set ssh_run_pre_flight to True in the config
+  - Run salt-ssh with the --pre-flight arg.
 
 .. _roster_defaults:
 

--- a/doc/topics/ssh/roster.rst
+++ b/doc/topics/ssh/roster.rst
@@ -61,6 +61,20 @@ The information which can be stored in a roster ``target`` is the following:
                      # components. Defaults to /tmp/salt-<hash>.
         cmd_umask:   # umask to enforce for the salt-call command. Should be in
                      # octal (so for 0o077 in YAML you would do 0077, or 63)
+        ssh_pre_flight: # Path to a script that will run before all other salt-ssh
+                        # commands. Will only run the first time when the thin dir
+                        # does not exist. Added in Sodium Release.
+
+.. _ssh_pre_flight:
+
+ssh_pre_flight
+--------------
+
+A Salt-SSH roster option `ssh_pre_flight` was added in the Sodium release. This enables
+you to run a script before Salt-SSH tries to run any commands. You can set this option
+in the roster for a specific minion or use the `roster_defaults` to set it for all minions.
+This script will only run if the thin dir is not currently on the minion. This means it will
+only run on the first run of salt-ssh or if you have recently wiped out your thin dir.
 
 .. _roster_defaults:
 

--- a/doc/topics/ssh/roster.rst
+++ b/doc/topics/ssh/roster.rst
@@ -78,9 +78,10 @@ in the roster for a specific minion or use the `roster_defaults` to set it for a
 This script will only run if the thin dir is not currently on the minion. This means it will
 only run on the first run of salt-ssh or if you have recently wiped out your thin dir. If
 you want to intentionally run the script again you have a couple of options:
-  - Wipe out your thin dir by using the -w salt-ssh arg.
-  - Set ssh_run_pre_flight to True in the config
-  - Run salt-ssh with the --pre-flight arg.
+
+* Wipe out your thin dir by using the -w salt-ssh arg.
+* Set ssh_run_pre_flight to True in the config
+* Run salt-ssh with the --pre-flight arg.
 
 .. _roster_defaults:
 

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -991,6 +991,15 @@ class Single(object):
 
         return self.execute_script(script)
 
+    def check_thin_dir(self):
+        '''
+        check if the thindir exists on the remote machine
+        '''
+        stdout, stderr, retcode = self.shell.exec_cmd('test -d {0}'.format(self.thin_dir))
+        if retcode != 0:
+            return False
+        return True
+
     def deploy(self):
         """
         Deploy salt-thin
@@ -1026,8 +1035,8 @@ class Single(object):
         stdout = stderr = retcode = None
 
         if self.ssh_pre_flight:
-            if os.path.exists(self.thin_dir):
-                log.debug('{0} thin dir already exists. Not running ssh_pre_flight script'.format(self.thin_dir))
+            if self.check_thin_dir() and not self.opts.get('ssh_run_pre_flight', False):
+                log.info('{0} thin dir already exists. Not running ssh_pre_flight script'.format(self.thin_dir))
             elif not os.path.exists(self.ssh_pre_flight):
                 log.error('The ssh_pre_flight script {0} does not exist'.format(self.ssh_pre_flight))
             else:
@@ -1035,7 +1044,7 @@ class Single(object):
                 if stderr:
                     log.error('Error running ssh_pre_flight script {0}'.format(self.ssh_pre_file))
                     return stdout, stderr, retcode
-                log.debug('Successfully ran the ssh_pre_flight script: {0}'.format(self.ssh_pre_file))
+                log.info('Successfully ran the ssh_pre_flight script: {0}'.format(self.ssh_pre_file))
 
         if self.opts.get("raw_shell", False):
             cmd_str = " ".join([self._escape_arg(arg) for arg in self.argv])

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -895,6 +895,11 @@ class Single(object):
         self.fsclient = fsclient
         self.context = {"master_opts": self.opts, "fileclient": self.fsclient}
 
+        self.ssh_pre_flight = kwargs.get('ssh_pre_flight', None)
+
+        if self.ssh_pre_flight:
+            self.ssh_pre_file = os.path.basename(self.ssh_pre_flight)
+
         if isinstance(argv, six.string_types):
             self.argv = [argv]
         else:
@@ -974,6 +979,18 @@ class Single(object):
             return arg
         return "".join(["\\" + char if re.match(r"\W", char) else char for char in arg])
 
+    def run_ssh_pre_flight(self):
+        '''
+        Run our pre_flight script before running any ssh commands
+        '''
+        script = os.path.join(tempfile.gettempdir(), self.ssh_pre_file)
+
+        self.shell.send(
+             self.ssh_pre_flight,
+             script)
+
+        return self.execute_script(script)
+
     def deploy(self):
         """
         Deploy salt-thin
@@ -1007,6 +1024,18 @@ class Single(object):
         Returns tuple of (stdout, stderr, retcode)
         """
         stdout = stderr = retcode = None
+
+        if self.ssh_pre_flight:
+            if os.path.exists(self.thin_dir):
+                log.debug('{0} thin dir already exists. Not running ssh_pre_flight script'.format(self.thin_dir))
+            elif not os.path.exists(self.ssh_pre_flight):
+                log.error('The ssh_pre_flight script {0} does not exist'.format(self.ssh_pre_flight))
+            else:
+                stdout, stderr, retcode = self.run_ssh_pre_flight()
+                if stderr:
+                    log.error('Error running ssh_pre_flight script {0}'.format(self.ssh_pre_file))
+                    return stdout, stderr, retcode
+                log.debug('Successfully ran the ssh_pre_flight script: {0}'.format(self.ssh_pre_file))
 
         if self.opts.get("raw_shell", False):
             cmd_str = " ".join([self._escape_arg(arg) for arg in self.argv])
@@ -1263,6 +1292,26 @@ ARGS = {arguments}\n'''.format(
 
         return cmd
 
+    def execute_script(self, script, extension='py', pre_dir=''):
+        '''
+        execute a script on the minion then delete
+        '''
+        if extension == 'ps1':
+            ret = self.shell.exec_cmd('"powershell {0}"'.format(script))
+        else:
+            if not self.winrm:
+                ret = self.shell.exec_cmd('/bin/sh \'{0}{1}\''.format(pre_dir, script))
+            else:
+                ret = saltwinshell.call_python(self, script)
+
+        # Remove file from target system
+        if not self.winrm:
+            self.shell.exec_cmd('rm \'{0}{1}\''.format(pre_dir, script))
+        else:
+            self.shell.exec_cmd('del {0}'.format(script))
+
+        return ret
+
     def shim_cmd(self, cmd_str, extension="py"):
         """
         Run a shim command.
@@ -1293,22 +1342,9 @@ ARGS = {arguments}\n'''.format(
         except IOError:
             pass
 
-        # Execute shim
-        if extension == "ps1":
-            ret = self.shell.exec_cmd('"powershell {0}"'.format(target_shim_file))
-        else:
-            if not self.winrm:
-                ret = self.shell.exec_cmd(
-                    "/bin/sh '$HOME/{0}'".format(target_shim_file)
-                )
-            else:
-                ret = saltwinshell.call_python(self, target_shim_file)
-
-        # Remove shim from target system
-        if not self.winrm:
-            self.shell.exec_cmd("rm '$HOME/{0}'".format(target_shim_file))
-        else:
-            self.shell.exec_cmd("del {0}".format(target_shim_file))
+        ret = self.execute_script(script=target_shim_file,
+                                  extension=extension,
+                                  pre_dir='$HOME/')
 
         return ret
 

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1035,7 +1035,7 @@ class Single(object):
         stdout = stderr = retcode = None
 
         if self.ssh_pre_flight:
-            if self.check_thin_dir() and not self.opts.get("ssh_run_pre_flight", False):
+            if not self.opts.get("ssh_run_pre_flight", False) and self.check_thin_dir():
                 log.info(
                     "{0} thin dir already exists. Not running ssh_pre_flight script".format(
                         self.thin_dir

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -895,7 +895,7 @@ class Single(object):
         self.fsclient = fsclient
         self.context = {"master_opts": self.opts, "fileclient": self.fsclient}
 
-        self.ssh_pre_flight = kwargs.get('ssh_pre_flight', None)
+        self.ssh_pre_flight = kwargs.get("ssh_pre_flight", None)
 
         if self.ssh_pre_flight:
             self.ssh_pre_file = os.path.basename(self.ssh_pre_flight)
@@ -980,22 +980,22 @@ class Single(object):
         return "".join(["\\" + char if re.match(r"\W", char) else char for char in arg])
 
     def run_ssh_pre_flight(self):
-        '''
+        """
         Run our pre_flight script before running any ssh commands
-        '''
+        """
         script = os.path.join(tempfile.gettempdir(), self.ssh_pre_file)
 
-        self.shell.send(
-             self.ssh_pre_flight,
-             script)
+        self.shell.send(self.ssh_pre_flight, script)
 
         return self.execute_script(script)
 
     def check_thin_dir(self):
-        '''
+        """
         check if the thindir exists on the remote machine
-        '''
-        stdout, stderr, retcode = self.shell.exec_cmd('test -d {0}'.format(self.thin_dir))
+        """
+        stdout, stderr, retcode = self.shell.exec_cmd(
+            "test -d {0}".format(self.thin_dir)
+        )
         if retcode != 0:
             return False
         return True
@@ -1035,16 +1035,32 @@ class Single(object):
         stdout = stderr = retcode = None
 
         if self.ssh_pre_flight:
-            if self.check_thin_dir() and not self.opts.get('ssh_run_pre_flight', False):
-                log.info('{0} thin dir already exists. Not running ssh_pre_flight script'.format(self.thin_dir))
+            if self.check_thin_dir() and not self.opts.get("ssh_run_pre_flight", False):
+                log.info(
+                    "{0} thin dir already exists. Not running ssh_pre_flight script".format(
+                        self.thin_dir
+                    )
+                )
             elif not os.path.exists(self.ssh_pre_flight):
-                log.error('The ssh_pre_flight script {0} does not exist'.format(self.ssh_pre_flight))
+                log.error(
+                    "The ssh_pre_flight script {0} does not exist".format(
+                        self.ssh_pre_flight
+                    )
+                )
             else:
                 stdout, stderr, retcode = self.run_ssh_pre_flight()
                 if stderr:
-                    log.error('Error running ssh_pre_flight script {0}'.format(self.ssh_pre_file))
+                    log.error(
+                        "Error running ssh_pre_flight script {0}".format(
+                            self.ssh_pre_file
+                        )
+                    )
                     return stdout, stderr, retcode
-                log.info('Successfully ran the ssh_pre_flight script: {0}'.format(self.ssh_pre_file))
+                log.info(
+                    "Successfully ran the ssh_pre_flight script: {0}".format(
+                        self.ssh_pre_file
+                    )
+                )
 
         if self.opts.get("raw_shell", False):
             cmd_str = " ".join([self._escape_arg(arg) for arg in self.argv])
@@ -1301,23 +1317,23 @@ ARGS = {arguments}\n'''.format(
 
         return cmd
 
-    def execute_script(self, script, extension='py', pre_dir=''):
-        '''
+    def execute_script(self, script, extension="py", pre_dir=""):
+        """
         execute a script on the minion then delete
-        '''
-        if extension == 'ps1':
+        """
+        if extension == "ps1":
             ret = self.shell.exec_cmd('"powershell {0}"'.format(script))
         else:
             if not self.winrm:
-                ret = self.shell.exec_cmd('/bin/sh \'{0}{1}\''.format(pre_dir, script))
+                ret = self.shell.exec_cmd("/bin/sh '{0}{1}'".format(pre_dir, script))
             else:
                 ret = saltwinshell.call_python(self, script)
 
         # Remove file from target system
         if not self.winrm:
-            self.shell.exec_cmd('rm \'{0}{1}\''.format(pre_dir, script))
+            self.shell.exec_cmd("rm '{0}{1}'".format(pre_dir, script))
         else:
-            self.shell.exec_cmd('del {0}'.format(script))
+            self.shell.exec_cmd("del {0}".format(script))
 
         return ret
 
@@ -1351,9 +1367,9 @@ ARGS = {arguments}\n'''.format(
         except IOError:
             pass
 
-        ret = self.execute_script(script=target_shim_file,
-                                  extension=extension,
-                                  pre_dir='$HOME/')
+        ret = self.execute_script(
+            script=target_shim_file, extension=extension, pre_dir="$HOME/"
+        )
 
         return ret
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -786,6 +786,7 @@ VALID_OPTS = immutabletypes.freeze(
         "ssh_log_file": six.string_types,
         "ssh_config_file": six.string_types,
         "ssh_merge_pillar": bool,
+        "ssh_run_pre_flight": bool,
         "cluster_mode": bool,
         "sqlite_queue_dir": six.string_types,
         "queue_dirs": list,

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -3268,6 +3268,14 @@ class SaltSSHOptionParser(
             help="Pass a JID to be used instead of generating one.",
         )
 
+        self.add_option(
+            '--pre-flight',
+            default=False,
+            action='store_true',
+            dest='ssh_run_pre_flight',
+            help='Run the defined ssh_pre_flight script in the roster'
+        )
+
         ssh_group = optparse.OptionGroup(
             self, "SSH Options", "Parameters for the SSH client."
         )

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -3269,11 +3269,11 @@ class SaltSSHOptionParser(
         )
 
         self.add_option(
-            '--pre-flight',
+            "--pre-flight",
             default=False,
-            action='store_true',
-            dest='ssh_run_pre_flight',
-            help='Run the defined ssh_pre_flight script in the roster'
+            action="store_true",
+            dest="ssh_run_pre_flight",
+            help="Run the defined ssh_pre_flight script in the roster",
         )
 
         ssh_group = optparse.OptionGroup(

--- a/tests/integration/ssh/test_deploy.py
+++ b/tests/integration/ssh/test_deploy.py
@@ -10,10 +10,6 @@ import shutil
 
 # Import salt testing libs
 from tests.support.case import SSHCase
-from tests.support.runtests import RUNTIME_VARS
-
-# Import salt libs
-import salt.utils.yaml
 
 
 class SSHTest(SSHCase):
@@ -37,26 +33,6 @@ class SSHTest(SSHCase):
         os.path.isdir(thin_dir)
         os.path.exists(os.path.join(thin_dir, "salt-call"))
         os.path.exists(os.path.join(thin_dir, "running_data"))
-
-    def test_ssh_pre_flight(self):
-        '''
-        test ssh when ssh_pre_flight is set
-        ensure the script runs successfully
-        '''
-        roster = os.path.join(RUNTIME_VARS.TMP, 'pre_flight_roster')
-
-        data = {'ssh_pre_flight': os.path.join(RUNTIME_VARS.TMP, 'ssh_pre_flight.sh')}
-        self.custom_roster(roster, data)
-
-        test_script = os.path.join(RUNTIME_VARS.TMP,
-                'test-pre-flight-script-worked.txt')
-
-        with salt.utils.files.fopen(data['ssh_pre_flight'], 'w') as fp_:
-            fp_.write('touch {0}'.format(test_script))
-
-        ret = self.run_function('test.ping', roster_file=roster)
-
-        assert os.path.exists(test_script)
 
     def tearDown(self):
         """

--- a/tests/integration/ssh/test_deploy.py
+++ b/tests/integration/ssh/test_deploy.py
@@ -10,6 +10,10 @@ import shutil
 
 # Import salt testing libs
 from tests.support.case import SSHCase
+from tests.support.runtests import RUNTIME_VARS
+
+# Import salt libs
+import salt.utils.yaml
 
 
 class SSHTest(SSHCase):
@@ -33,6 +37,26 @@ class SSHTest(SSHCase):
         os.path.isdir(thin_dir)
         os.path.exists(os.path.join(thin_dir, "salt-call"))
         os.path.exists(os.path.join(thin_dir, "running_data"))
+
+    def test_ssh_pre_flight(self):
+        '''
+        test ssh when ssh_pre_flight is set
+        ensure the script runs successfully
+        '''
+        roster = os.path.join(RUNTIME_VARS.TMP, 'pre_flight_roster')
+
+        data = {'ssh_pre_flight': os.path.join(RUNTIME_VARS.TMP, 'ssh_pre_flight.sh')}
+        self.custom_roster(roster, data)
+
+        test_script = os.path.join(RUNTIME_VARS.TMP,
+                'test-pre-flight-script-worked.txt')
+
+        with salt.utils.files.fopen(data['ssh_pre_flight'], 'w') as fp_:
+            fp_.write('touch {0}'.format(test_script))
+
+        ret = self.run_function('test.ping', roster_file=roster)
+
+        assert os.path.exists(test_script)
 
     def tearDown(self):
         """

--- a/tests/integration/ssh/test_pre_flight.py
+++ b/tests/integration/ssh/test_pre_flight.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+'''
+Test for ssh_pre_flight roster option
+'''
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
+import os
+import shutil
+
+# Import salt testing libs
+from tests.support.case import SSHCase
+from tests.support.runtests import RUNTIME_VARS
+
+# import salt libs
+import salt.utils.files
+
+
+class SSHPreFlightTest(SSHCase):
+    '''
+    Test ssh_pre_flight roster option
+    '''
+    def setUp(self):
+        self.roster = os.path.join(RUNTIME_VARS.TMP, 'pre_flight_roster')
+        self.data = {'ssh_pre_flight': os.path.join(RUNTIME_VARS.TMP, 'ssh_pre_flight.sh')}
+        self.test_script = os.path.join(RUNTIME_VARS.TMP,
+                'test-pre-flight-script-worked.txt')
+
+    def _create_roster(self):
+        self.custom_roster(self.roster, self.data)
+
+        with salt.utils.files.fopen(self.data['ssh_pre_flight'], 'w') as fp_:
+            fp_.write('touch {0}'.format(self.test_script))
+
+    def test_ssh_pre_flight(self):
+        '''
+        test ssh when ssh_pre_flight is set
+        ensure the script runs successfully
+        '''
+        self._create_roster()
+        ret = self.run_function('test.ping', roster_file=self.roster)
+
+        assert os.path.exists(self.test_script)
+
+    def test_ssh_run_pre_flight(self):
+        '''
+        test ssh when --pre-flight is passed to salt-ssh
+        to ensure the script runs successfully
+        '''
+        self._create_roster()
+        # make sure we previously ran a command so the thin dir exists
+        self.run_function('test.ping', wipe=False)
+        assert not os.path.exists(self.test_script)
+
+        ret = self.run_function('test.ping', ssh_opts='--pre-flight',
+                roster_file=self.roster, wipe=False)
+        assert os.path.exists(self.test_script)
+
+    def tearDown(self):
+        '''
+        make sure to clean up any old ssh directories
+        '''
+        files = [self.roster, self.data['ssh_pre_flight'], self.test_script]
+        for fp_ in files:
+            if os.path.exists(fp_):
+                os.remove(fp_)

--- a/tests/integration/ssh/test_pre_flight.py
+++ b/tests/integration/ssh/test_pre_flight.py
@@ -21,6 +21,7 @@ class SSHPreFlightTest(SSHCase):
     """
 
     def setUp(self):
+        super(SSHPreFlightTest, self).setUp()
         self.roster = os.path.join(RUNTIME_VARS.TMP, "pre_flight_roster")
         self.data = {
             "ssh_pre_flight": os.path.join(RUNTIME_VARS.TMP, "ssh_pre_flight.sh")

--- a/tests/integration/ssh/test_pre_flight.py
+++ b/tests/integration/ssh/test_pre_flight.py
@@ -1,64 +1,70 @@
 # -*- coding: utf-8 -*-
-'''
+"""
 Test for ssh_pre_flight roster option
-'''
+"""
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
+
 import os
+
+# import salt libs
+import salt.utils.files
 
 # Import salt testing libs
 from tests.support.case import SSHCase
 from tests.support.runtests import RUNTIME_VARS
 
-# import salt libs
-import salt.utils.files
-
 
 class SSHPreFlightTest(SSHCase):
-    '''
+    """
     Test ssh_pre_flight roster option
-    '''
+    """
+
     def setUp(self):
-        self.roster = os.path.join(RUNTIME_VARS.TMP, 'pre_flight_roster')
-        self.data = {'ssh_pre_flight': os.path.join(RUNTIME_VARS.TMP, 'ssh_pre_flight.sh')}
-        self.test_script = os.path.join(RUNTIME_VARS.TMP,
-                'test-pre-flight-script-worked.txt')
+        self.roster = os.path.join(RUNTIME_VARS.TMP, "pre_flight_roster")
+        self.data = {
+            "ssh_pre_flight": os.path.join(RUNTIME_VARS.TMP, "ssh_pre_flight.sh")
+        }
+        self.test_script = os.path.join(
+            RUNTIME_VARS.TMP, "test-pre-flight-script-worked.txt"
+        )
 
     def _create_roster(self):
         self.custom_roster(self.roster, self.data)
 
-        with salt.utils.files.fopen(self.data['ssh_pre_flight'], 'w') as fp_:
-            fp_.write('touch {0}'.format(self.test_script))
+        with salt.utils.files.fopen(self.data["ssh_pre_flight"], "w") as fp_:
+            fp_.write("touch {0}".format(self.test_script))
 
     def test_ssh_pre_flight(self):
-        '''
+        """
         test ssh when ssh_pre_flight is set
         ensure the script runs successfully
-        '''
+        """
         self._create_roster()
-        ret = self.run_function('test.ping', roster_file=self.roster)
+        ret = self.run_function("test.ping", roster_file=self.roster)
 
         assert os.path.exists(self.test_script)
 
     def test_ssh_run_pre_flight(self):
-        '''
+        """
         test ssh when --pre-flight is passed to salt-ssh
         to ensure the script runs successfully
-        '''
+        """
         self._create_roster()
         # make sure we previously ran a command so the thin dir exists
-        self.run_function('test.ping', wipe=False)
+        self.run_function("test.ping", wipe=False)
         assert not os.path.exists(self.test_script)
 
-        ret = self.run_function('test.ping', ssh_opts='--pre-flight',
-                roster_file=self.roster, wipe=False)
+        ret = self.run_function(
+            "test.ping", ssh_opts="--pre-flight", roster_file=self.roster, wipe=False
+        )
         assert os.path.exists(self.test_script)
 
     def tearDown(self):
-        '''
+        """
         make sure to clean up any old ssh directories
-        '''
-        files = [self.roster, self.data['ssh_pre_flight'], self.test_script]
+        """
+        files = [self.roster, self.data["ssh_pre_flight"], self.test_script]
         for fp_ in files:
             if os.path.exists(fp_):
                 os.remove(fp_)

--- a/tests/integration/ssh/test_pre_flight.py
+++ b/tests/integration/ssh/test_pre_flight.py
@@ -5,7 +5,6 @@ Test for ssh_pre_flight roster option
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
 import os
-import shutil
 
 # Import salt testing libs
 from tests.support.case import SSHCase

--- a/tests/support/case.py
+++ b/tests/support/case.py
@@ -85,19 +85,21 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixin
         )
 
     def run_ssh(self, arg_str, with_retcode=False, timeout=25,
-                catch_stderr=False, wipe=False, raw=False, roster_file=None, **kwargs):
+                catch_stderr=False, wipe=False, raw=False, roster_file=None,
+                ssh_opts='', **kwargs):
         '''
         Execute salt-ssh
         '''
         if not roster_file:
             roster_file = os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'roster')
 
-        arg_str = '{0} {1} -c {2} -i --priv {3} --roster-file {4} localhost {5} --out=json'.format(
+        arg_str = '{0} {1} -c {2} -i --priv {3} --roster-file {4} {5} localhost {6} --out=json'.format(
             ' -W' if wipe else '',
             ' -r' if raw else '',
             self.config_dir,
             os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'key_test'),
             roster_file,
+            ssh_opts,
             arg_str
         )
         return self.run_script(
@@ -524,19 +526,21 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
         return ret
 
     def run_ssh(self, arg_str, with_retcode=False, catch_stderr=False,  # pylint: disable=W0221
-                timeout=RUN_TIMEOUT, wipe=True, raw=False, roster_file=None, **kwargs):
+                timeout=RUN_TIMEOUT, wipe=True, raw=False, roster_file=None,
+                ssh_opts='', **kwargs):
         '''
         Execute salt-ssh
         '''
         if not roster_file:
             roster_file = os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'roster')
 
-        arg_str = '{0} -ldebug{1} -c {2} -i --priv {3} --roster-file {4} --out=json localhost {5}'.format(
+        arg_str = '{0} -ldebug{1} -c {2} -i --priv {3} --roster-file {4} {5} --out=json localhost {6}'.format(
             ' -W' if wipe else '',
             ' -r' if raw else '',
             self.config_dir,
             os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'key_test'),
             roster_file,
+            ssh_opts,
             arg_str)
         ret = self.run_script('salt-ssh',
                               arg_str,

--- a/tests/support/case.py
+++ b/tests/support/case.py
@@ -84,23 +84,32 @@ class ShellTestCase(TestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixin
             timeout=timeout,
         )
 
-    def run_ssh(self, arg_str, with_retcode=False, timeout=25,
-                catch_stderr=False, wipe=False, raw=False, roster_file=None,
-                ssh_opts='', **kwargs):
-        '''
+    def run_ssh(
+        self,
+        arg_str,
+        with_retcode=False,
+        timeout=25,
+        catch_stderr=False,
+        wipe=False,
+        raw=False,
+        roster_file=None,
+        ssh_opts="",
+        **kwargs
+    ):
+        """
         Execute salt-ssh
-        '''
+        """
         if not roster_file:
-            roster_file = os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'roster')
+            roster_file = os.path.join(RUNTIME_VARS.TMP_CONF_DIR, "roster")
 
-        arg_str = '{0} {1} -c {2} -i --priv {3} --roster-file {4} {5} localhost {6} --out=json'.format(
-            ' -W' if wipe else '',
-            ' -r' if raw else '',
+        arg_str = "{0} {1} -c {2} -i --priv {3} --roster-file {4} {5} localhost {6} --out=json".format(
+            " -W" if wipe else "",
+            " -r" if raw else "",
             self.config_dir,
-            os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'key_test'),
+            os.path.join(RUNTIME_VARS.TMP_CONF_DIR, "key_test"),
             roster_file,
             ssh_opts,
-            arg_str
+            arg_str,
         )
         return self.run_script(
             "salt-ssh",
@@ -525,31 +534,43 @@ class ShellCase(ShellTestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixi
         log.debug("Result of run_spm for command '%s': %s", arg_str, ret)
         return ret
 
-    def run_ssh(self, arg_str, with_retcode=False, catch_stderr=False,  # pylint: disable=W0221
-                timeout=RUN_TIMEOUT, wipe=True, raw=False, roster_file=None,
-                ssh_opts='', **kwargs):
-        '''
+    def run_ssh(
+        self,
+        arg_str,
+        with_retcode=False,
+        catch_stderr=False,  # pylint: disable=W0221
+        timeout=RUN_TIMEOUT,
+        wipe=True,
+        raw=False,
+        roster_file=None,
+        ssh_opts="",
+        **kwargs
+    ):
+        """
         Execute salt-ssh
-        '''
+        """
         if not roster_file:
-            roster_file = os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'roster')
+            roster_file = os.path.join(RUNTIME_VARS.TMP_CONF_DIR, "roster")
 
-        arg_str = '{0} -ldebug{1} -c {2} -i --priv {3} --roster-file {4} {5} --out=json localhost {6}'.format(
-            ' -W' if wipe else '',
-            ' -r' if raw else '',
+        arg_str = "{0} -ldebug{1} -c {2} -i --priv {3} --roster-file {4} {5} --out=json localhost {6}".format(
+            " -W" if wipe else "",
+            " -r" if raw else "",
             self.config_dir,
-            os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'key_test'),
+            os.path.join(RUNTIME_VARS.TMP_CONF_DIR, "key_test"),
             roster_file,
             ssh_opts,
-            arg_str)
-        ret = self.run_script('salt-ssh',
-                              arg_str,
-                              with_retcode=with_retcode,
-                              catch_stderr=catch_stderr,
-                              timeout=timeout,
-                              raw=True,
-                              **kwargs)
-        log.debug('Result of run_ssh for command \'%s %s\': %s', arg_str, kwargs, ret)
+            arg_str,
+        )
+        ret = self.run_script(
+            "salt-ssh",
+            arg_str,
+            with_retcode=with_retcode,
+            catch_stderr=catch_stderr,
+            timeout=timeout,
+            raw=True,
+            **kwargs
+        )
+        log.debug("Result of run_ssh for command '%s %s': %s", arg_str, kwargs, ret)
         return ret
 
     # pylint: enable=arguments-differ
@@ -1109,17 +1130,17 @@ class SSHCase(ShellCase):
             return ret
 
     def custom_roster(self, new_roster, data):
-        '''
+        """
         helper method to create a custom roster to use for a ssh test
-        '''
-        roster = os.path.join(RUNTIME_VARS.TMP_CONF_DIR, 'roster')
+        """
+        roster = os.path.join(RUNTIME_VARS.TMP_CONF_DIR, "roster")
 
-        with salt.utils.files.fopen(roster, 'r') as fp_:
+        with salt.utils.files.fopen(roster, "r") as fp_:
             conf = salt.utils.yaml.safe_load(fp_)
 
-        conf['localhost'].update(data)
+        conf["localhost"].update(data)
 
-        with salt.utils.files.fopen(new_roster, 'w') as fp_:
+        with salt.utils.files.fopen(new_roster, "w") as fp_:
             salt.utils.yaml.safe_dump(conf, fp_)
 
 

--- a/tests/unit/client/test_ssh.py
+++ b/tests/unit/client/test_ssh.py
@@ -177,7 +177,7 @@ class SSHSingleTests(TestCase):
         mock_cmd = MagicMock(return_value=cmd_ret)
         patch_flight = patch('salt.client.ssh.Single.run_ssh_pre_flight', mock_flight)
         patch_cmd = patch('salt.client.ssh.Single.cmd_block', mock_cmd)
-        patch_os = patch('os.path.exists', side_effect=[False, True])
+        patch_os = patch('os.path.exists', side_effect=[True])
 
         with patch_os, patch_flight, patch_cmd:
             ret = single.run()
@@ -207,7 +207,7 @@ class SSHSingleTests(TestCase):
         mock_cmd = MagicMock(return_value=cmd_ret)
         patch_flight = patch('salt.client.ssh.Single.run_ssh_pre_flight', mock_flight)
         patch_cmd = patch('salt.client.ssh.Single.cmd_block', mock_cmd)
-        patch_os = patch('os.path.exists', side_effect=[False, True])
+        patch_os = patch('os.path.exists', side_effect=[True])
 
         with patch_os, patch_flight, patch_cmd:
             ret = single.run()
@@ -237,7 +237,7 @@ class SSHSingleTests(TestCase):
         mock_cmd = MagicMock(return_value=cmd_ret)
         patch_flight = patch('salt.client.ssh.Single.run_ssh_pre_flight', mock_flight)
         patch_cmd = patch('salt.client.ssh.Single.cmd_block', mock_cmd)
-        patch_os = patch('os.path.exists', side_effect=[False, False])
+        patch_os = patch('os.path.exists', side_effect=[False])
 
         with patch_os, patch_flight, patch_cmd:
             ret = single.run()
@@ -262,11 +262,11 @@ class SSHSingleTests(TestCase):
                 mine=False,
                 **target)
 
-        cmd_ret = ('', 'Error running script', 1)
+        cmd_ret = ('', '', 0)
         mock_flight = MagicMock(return_value=cmd_ret)
         mock_cmd = MagicMock(return_value=cmd_ret)
         patch_flight = patch('salt.client.ssh.Single.run_ssh_pre_flight', mock_flight)
-        patch_cmd = patch('salt.client.ssh.Single.cmd_block', mock_cmd)
+        patch_cmd = patch('salt.client.ssh.shell.Shell.exec_cmd', mock_cmd)
         patch_os = patch('os.path.exists', return_value=True)
 
         with patch_os, patch_flight, patch_cmd:

--- a/tests/unit/client/test_ssh.py
+++ b/tests/unit/client/test_ssh.py
@@ -186,9 +186,12 @@ class SSHSingleTests(TestCase):
         mock_cmd = MagicMock(return_value=cmd_ret)
         patch_flight = patch("salt.client.ssh.Single.run_ssh_pre_flight", mock_flight)
         patch_cmd = patch("salt.client.ssh.Single.cmd_block", mock_cmd)
+        patch_exec_cmd = patch(
+            "salt.client.ssh.shell.Shell.exec_cmd", return_value=("", "", 1)
+        )
         patch_os = patch("os.path.exists", side_effect=[True])
 
-        with patch_os, patch_flight, patch_cmd:
+        with patch_os, patch_flight, patch_cmd, patch_exec_cmd:
             ret = single.run()
             mock_cmd.assert_called()
             mock_flight.assert_called()
@@ -217,9 +220,12 @@ class SSHSingleTests(TestCase):
         mock_cmd = MagicMock(return_value=cmd_ret)
         patch_flight = patch("salt.client.ssh.Single.run_ssh_pre_flight", mock_flight)
         patch_cmd = patch("salt.client.ssh.Single.cmd_block", mock_cmd)
+        patch_exec_cmd = patch(
+            "salt.client.ssh.shell.Shell.exec_cmd", return_value=("", "", 1)
+        )
         patch_os = patch("os.path.exists", side_effect=[True])
 
-        with patch_os, patch_flight, patch_cmd:
+        with patch_os, patch_flight, patch_cmd, patch_exec_cmd:
             ret = single.run()
             mock_cmd.assert_not_called()
             mock_flight.assert_called()
@@ -248,9 +254,12 @@ class SSHSingleTests(TestCase):
         mock_cmd = MagicMock(return_value=cmd_ret)
         patch_flight = patch("salt.client.ssh.Single.run_ssh_pre_flight", mock_flight)
         patch_cmd = patch("salt.client.ssh.Single.cmd_block", mock_cmd)
+        patch_exec_cmd = patch(
+            "salt.client.ssh.shell.Shell.exec_cmd", return_value=("", "", 1)
+        )
         patch_os = patch("os.path.exists", side_effect=[False])
 
-        with patch_os, patch_flight, patch_cmd:
+        with patch_os, patch_flight, patch_cmd, patch_exec_cmd:
             ret = single.run()
             mock_cmd.assert_called()
             mock_flight.assert_not_called()
@@ -279,9 +288,10 @@ class SSHSingleTests(TestCase):
         mock_cmd = MagicMock(return_value=cmd_ret)
         patch_flight = patch("salt.client.ssh.Single.run_ssh_pre_flight", mock_flight)
         patch_cmd = patch("salt.client.ssh.shell.Shell.exec_cmd", mock_cmd)
+        patch_cmd_block = patch("salt.client.ssh.Single.cmd_block", mock_cmd)
         patch_os = patch("os.path.exists", return_value=True)
 
-        with patch_os, patch_flight, patch_cmd:
+        with patch_os, patch_flight, patch_cmd, patch_cmd_block:
             ret = single.run()
             mock_cmd.assert_called()
             mock_flight.assert_not_called()
@@ -337,13 +347,13 @@ class SSHSingleTests(TestCase):
         exp_ret = ("Success", "", 0)
         mock_cmd = MagicMock(return_value=exp_ret)
         patch_cmd = patch("salt.client.ssh.shell.Shell.exec_cmd", mock_cmd)
+        patch_send = patch("salt.client.ssh.shell.Shell.send", return_value=("", "", 0))
         patch_rand = patch("os.urandom", return_value=b"5\xd9l\xca\xc2\xff")
 
-        with patch_cmd, patch_rand:
+        with patch_cmd, patch_rand, patch_send:
             ret = single.shim_cmd(cmd_str="echo test")
             assert ret == exp_ret
             assert [
-                call("mkdir -p "),
                 call("/bin/sh '$HOME/.35d96ccac2ff.py'"),
                 call("rm '$HOME/.35d96ccac2ff.py'"),
             ] == mock_cmd.call_args_list

--- a/tests/unit/client/test_ssh.py
+++ b/tests/unit/client/test_ssh.py
@@ -18,12 +18,12 @@ import salt.utils.path
 import salt.utils.thin
 import salt.utils.yaml
 from salt.client import ssh
+from tests.support.case import ShellCase
+from tests.support.mock import MagicMock, call, patch
 
 # Import Salt Testing libs
 from tests.support.runtests import RUNTIME_VARS
 from tests.support.unit import TestCase, skipIf
-from tests.support.case import ShellCase
-from tests.support.mock import MagicMock, patch, call
 
 ROSTER = """
 localhost:
@@ -113,71 +113,80 @@ class SSHRosterDefaults(TestCase):
 class SSHSingleTests(TestCase):
     def setUp(self):
         self.tmp_cachedir = tempfile.mkdtemp(dir=RUNTIME_VARS.TMP)
-        self.argv = ['ssh.set_auth_key', 'root', 'hobn+amNAXSBTiOXEqlBjGB...rsa root@master']
+        self.argv = [
+            "ssh.set_auth_key",
+            "root",
+            "hobn+amNAXSBTiOXEqlBjGB...rsa root@master",
+        ]
         self.opts = {
-            'argv': self.argv,
-            '__role': 'master',
-            'cachedir': self.tmp_cachedir,
-            'extension_modules': os.path.join(self.tmp_cachedir, 'extmods'),
+            "argv": self.argv,
+            "__role": "master",
+            "cachedir": self.tmp_cachedir,
+            "extension_modules": os.path.join(self.tmp_cachedir, "extmods"),
         }
         self.target = {
-            'passwd': 'abc123',
-            'ssh_options': None,
-            'sudo': False,
-            'identities_only': False,
-            'host': 'login1',
-            'user': 'root',
-            'timeout': 65,
-            'remote_port_forwards': None,
-            'sudo_user': '',
-            'port': '22',
-            'priv': '/etc/salt/pki/master/ssh/salt-ssh.rsa'
+            "passwd": "abc123",
+            "ssh_options": None,
+            "sudo": False,
+            "identities_only": False,
+            "host": "login1",
+            "user": "root",
+            "timeout": 65,
+            "remote_port_forwards": None,
+            "sudo_user": "",
+            "port": "22",
+            "priv": "/etc/salt/pki/master/ssh/salt-ssh.rsa",
         }
 
     def test_single_opts(self):
-        ''' Sanity check for ssh.Single options
-        '''
+        """ Sanity check for ssh.Single options
+        """
 
         single = ssh.Single(
-                self.opts,
-                self.opts['argv'],
-                'localhost',
-                mods={},
-                fsclient=None,
-                thin=salt.utils.thin.thin_path(self.opts['cachedir']),
-                mine=False,
-                **self.target)
+            self.opts,
+            self.opts["argv"],
+            "localhost",
+            mods={},
+            fsclient=None,
+            thin=salt.utils.thin.thin_path(self.opts["cachedir"]),
+            mine=False,
+            **self.target
+        )
 
-        self.assertEqual(single.shell._ssh_opts(), '')
-        self.assertEqual(single.shell._cmd_str('date +%s'), 'ssh login1 '
-                         '-o KbdInteractiveAuthentication=no -o '
-                         'PasswordAuthentication=yes -o ConnectTimeout=65 -o Port=22 '
-                         '-o IdentityFile=/etc/salt/pki/master/ssh/salt-ssh.rsa '
-                         '-o User=root  date +%s')
+        self.assertEqual(single.shell._ssh_opts(), "")
+        self.assertEqual(
+            single.shell._cmd_str("date +%s"),
+            "ssh login1 "
+            "-o KbdInteractiveAuthentication=no -o "
+            "PasswordAuthentication=yes -o ConnectTimeout=65 -o Port=22 "
+            "-o IdentityFile=/etc/salt/pki/master/ssh/salt-ssh.rsa "
+            "-o User=root  date +%s",
+        )
 
     def test_run_with_pre_flight(self):
-        '''
+        """
         test Single.run() when ssh_pre_flight is set
         and script successfully runs
-        '''
+        """
         target = self.target.copy()
-        target['ssh_pre_flight'] = os.path.join(RUNTIME_VARS.TMP, 'script.sh')
+        target["ssh_pre_flight"] = os.path.join(RUNTIME_VARS.TMP, "script.sh")
         single = ssh.Single(
-                self.opts,
-                self.opts['argv'],
-                'localhost',
-                mods={},
-                fsclient=None,
-                thin=salt.utils.thin.thin_path(self.opts['cachedir']),
-                mine=False,
-                **target)
+            self.opts,
+            self.opts["argv"],
+            "localhost",
+            mods={},
+            fsclient=None,
+            thin=salt.utils.thin.thin_path(self.opts["cachedir"]),
+            mine=False,
+            **target
+        )
 
-        cmd_ret = ('Success', '', 0)
+        cmd_ret = ("Success", "", 0)
         mock_flight = MagicMock(return_value=cmd_ret)
         mock_cmd = MagicMock(return_value=cmd_ret)
-        patch_flight = patch('salt.client.ssh.Single.run_ssh_pre_flight', mock_flight)
-        patch_cmd = patch('salt.client.ssh.Single.cmd_block', mock_cmd)
-        patch_os = patch('os.path.exists', side_effect=[True])
+        patch_flight = patch("salt.client.ssh.Single.run_ssh_pre_flight", mock_flight)
+        patch_cmd = patch("salt.client.ssh.Single.cmd_block", mock_cmd)
+        patch_os = patch("os.path.exists", side_effect=[True])
 
         with patch_os, patch_flight, patch_cmd:
             ret = single.run()
@@ -186,28 +195,29 @@ class SSHSingleTests(TestCase):
             assert ret == cmd_ret
 
     def test_run_with_pre_flight_stderr(self):
-        '''
+        """
         test Single.run() when ssh_pre_flight is set
         and script errors when run
-        '''
+        """
         target = self.target.copy()
-        target['ssh_pre_flight'] = os.path.join(RUNTIME_VARS.TMP, 'script.sh')
+        target["ssh_pre_flight"] = os.path.join(RUNTIME_VARS.TMP, "script.sh")
         single = ssh.Single(
-                self.opts,
-                self.opts['argv'],
-                'localhost',
-                mods={},
-                fsclient=None,
-                thin=salt.utils.thin.thin_path(self.opts['cachedir']),
-                mine=False,
-                **target)
+            self.opts,
+            self.opts["argv"],
+            "localhost",
+            mods={},
+            fsclient=None,
+            thin=salt.utils.thin.thin_path(self.opts["cachedir"]),
+            mine=False,
+            **target
+        )
 
-        cmd_ret = ('', 'Error running script', 1)
+        cmd_ret = ("", "Error running script", 1)
         mock_flight = MagicMock(return_value=cmd_ret)
         mock_cmd = MagicMock(return_value=cmd_ret)
-        patch_flight = patch('salt.client.ssh.Single.run_ssh_pre_flight', mock_flight)
-        patch_cmd = patch('salt.client.ssh.Single.cmd_block', mock_cmd)
-        patch_os = patch('os.path.exists', side_effect=[True])
+        patch_flight = patch("salt.client.ssh.Single.run_ssh_pre_flight", mock_flight)
+        patch_cmd = patch("salt.client.ssh.Single.cmd_block", mock_cmd)
+        patch_os = patch("os.path.exists", side_effect=[True])
 
         with patch_os, patch_flight, patch_cmd:
             ret = single.run()
@@ -216,28 +226,29 @@ class SSHSingleTests(TestCase):
             assert ret == cmd_ret
 
     def test_run_with_pre_flight_script_doesnot_exist(self):
-        '''
+        """
         test Single.run() when ssh_pre_flight is set
         and the script does not exist
-        '''
+        """
         target = self.target.copy()
-        target['ssh_pre_flight'] = os.path.join(RUNTIME_VARS.TMP, 'script.sh')
+        target["ssh_pre_flight"] = os.path.join(RUNTIME_VARS.TMP, "script.sh")
         single = ssh.Single(
-                self.opts,
-                self.opts['argv'],
-                'localhost',
-                mods={},
-                fsclient=None,
-                thin=salt.utils.thin.thin_path(self.opts['cachedir']),
-                mine=False,
-                **target)
+            self.opts,
+            self.opts["argv"],
+            "localhost",
+            mods={},
+            fsclient=None,
+            thin=salt.utils.thin.thin_path(self.opts["cachedir"]),
+            mine=False,
+            **target
+        )
 
-        cmd_ret = ('Success', '', 0)
+        cmd_ret = ("Success", "", 0)
         mock_flight = MagicMock(return_value=cmd_ret)
         mock_cmd = MagicMock(return_value=cmd_ret)
-        patch_flight = patch('salt.client.ssh.Single.run_ssh_pre_flight', mock_flight)
-        patch_cmd = patch('salt.client.ssh.Single.cmd_block', mock_cmd)
-        patch_os = patch('os.path.exists', side_effect=[False])
+        patch_flight = patch("salt.client.ssh.Single.run_ssh_pre_flight", mock_flight)
+        patch_cmd = patch("salt.client.ssh.Single.cmd_block", mock_cmd)
+        patch_os = patch("os.path.exists", side_effect=[False])
 
         with patch_os, patch_flight, patch_cmd:
             ret = single.run()
@@ -246,28 +257,29 @@ class SSHSingleTests(TestCase):
             assert ret == cmd_ret
 
     def test_run_with_pre_flight_thin_dir_exists(self):
-        '''
+        """
         test Single.run() when ssh_pre_flight is set
         and thin_dir already exists
-        '''
+        """
         target = self.target.copy()
-        target['ssh_pre_flight'] = os.path.join(RUNTIME_VARS.TMP, 'script.sh')
+        target["ssh_pre_flight"] = os.path.join(RUNTIME_VARS.TMP, "script.sh")
         single = ssh.Single(
-                self.opts,
-                self.opts['argv'],
-                'localhost',
-                mods={},
-                fsclient=None,
-                thin=salt.utils.thin.thin_path(self.opts['cachedir']),
-                mine=False,
-                **target)
+            self.opts,
+            self.opts["argv"],
+            "localhost",
+            mods={},
+            fsclient=None,
+            thin=salt.utils.thin.thin_path(self.opts["cachedir"]),
+            mine=False,
+            **target
+        )
 
-        cmd_ret = ('', '', 0)
+        cmd_ret = ("", "", 0)
         mock_flight = MagicMock(return_value=cmd_ret)
         mock_cmd = MagicMock(return_value=cmd_ret)
-        patch_flight = patch('salt.client.ssh.Single.run_ssh_pre_flight', mock_flight)
-        patch_cmd = patch('salt.client.ssh.shell.Shell.exec_cmd', mock_cmd)
-        patch_os = patch('os.path.exists', return_value=True)
+        patch_flight = patch("salt.client.ssh.Single.run_ssh_pre_flight", mock_flight)
+        patch_cmd = patch("salt.client.ssh.shell.Shell.exec_cmd", mock_cmd)
+        patch_os = patch("os.path.exists", return_value=True)
 
         with patch_os, patch_flight, patch_cmd:
             ret = single.run()
@@ -276,85 +288,97 @@ class SSHSingleTests(TestCase):
             assert ret == cmd_ret
 
     def test_execute_script(self):
-        '''
+        """
         test Single.execute_script()
-        '''
+        """
         single = ssh.Single(
-                self.opts,
-                self.opts['argv'],
-                'localhost',
-                mods={},
-                fsclient=None,
-                thin=salt.utils.thin.thin_path(self.opts['cachedir']),
-                mine=False,
-                winrm=False,
-                **self.target)
+            self.opts,
+            self.opts["argv"],
+            "localhost",
+            mods={},
+            fsclient=None,
+            thin=salt.utils.thin.thin_path(self.opts["cachedir"]),
+            mine=False,
+            winrm=False,
+            **self.target
+        )
 
-        exp_ret = ('Success', '', 0)
+        exp_ret = ("Success", "", 0)
         mock_cmd = MagicMock(return_value=exp_ret)
-        patch_cmd = patch('salt.client.ssh.shell.Shell.exec_cmd', mock_cmd)
-        script = os.path.join(RUNTIME_VARS.TMP, 'script.sh')
+        patch_cmd = patch("salt.client.ssh.shell.Shell.exec_cmd", mock_cmd)
+        script = os.path.join(RUNTIME_VARS.TMP, "script.sh")
 
         with patch_cmd:
             ret = single.execute_script(script=script)
             assert ret == exp_ret
             assert mock_cmd.call_count == 2
-            assert [call("/bin/sh '{0}'".format(script)),
-                    call("rm '{0}'".format(script))] == mock_cmd.call_args_list
+            assert [
+                call("/bin/sh '{0}'".format(script)),
+                call("rm '{0}'".format(script)),
+            ] == mock_cmd.call_args_list
 
     def test_shim_cmd(self):
-        '''
+        """
         test Single.shim_cmd()
-        '''
+        """
         single = ssh.Single(
-                self.opts,
-                self.opts['argv'],
-                'localhost',
-                mods={},
-                fsclient=None,
-                thin=salt.utils.thin.thin_path(self.opts['cachedir']),
-                mine=False,
-                winrm=False,
-                tty=True,
-                **self.target)
+            self.opts,
+            self.opts["argv"],
+            "localhost",
+            mods={},
+            fsclient=None,
+            thin=salt.utils.thin.thin_path(self.opts["cachedir"]),
+            mine=False,
+            winrm=False,
+            tty=True,
+            **self.target
+        )
 
-        exp_ret = ('Success', '', 0)
+        exp_ret = ("Success", "", 0)
         mock_cmd = MagicMock(return_value=exp_ret)
-        patch_cmd = patch('salt.client.ssh.shell.Shell.exec_cmd', mock_cmd)
-        patch_rand = patch('os.urandom', return_value=b'5\xd9l\xca\xc2\xff')
+        patch_cmd = patch("salt.client.ssh.shell.Shell.exec_cmd", mock_cmd)
+        patch_rand = patch("os.urandom", return_value=b"5\xd9l\xca\xc2\xff")
 
         with patch_cmd, patch_rand:
-            ret = single.shim_cmd(cmd_str='echo test')
+            ret = single.shim_cmd(cmd_str="echo test")
             assert ret == exp_ret
-            assert [call('mkdir -p '),
-                    call("/bin/sh '$HOME/.35d96ccac2ff.py'"),
-                    call("rm '$HOME/.35d96ccac2ff.py'")] == mock_cmd.call_args_list
+            assert [
+                call("mkdir -p "),
+                call("/bin/sh '$HOME/.35d96ccac2ff.py'"),
+                call("rm '$HOME/.35d96ccac2ff.py'"),
+            ] == mock_cmd.call_args_list
 
     def test_run_ssh_pre_flight(self):
-        '''
+        """
         test Single.run_ssh_pre_flight
-        '''
+        """
         target = self.target.copy()
-        target['ssh_pre_flight'] = os.path.join(RUNTIME_VARS.TMP, 'script.sh')
+        target["ssh_pre_flight"] = os.path.join(RUNTIME_VARS.TMP, "script.sh")
         single = ssh.Single(
-                self.opts,
-                self.opts['argv'],
-                'localhost',
-                mods={},
-                fsclient=None,
-                thin=salt.utils.thin.thin_path(self.opts['cachedir']),
-                mine=False,
-                winrm=False,
-                tty=True,
-                **target)
+            self.opts,
+            self.opts["argv"],
+            "localhost",
+            mods={},
+            fsclient=None,
+            thin=salt.utils.thin.thin_path(self.opts["cachedir"]),
+            mine=False,
+            winrm=False,
+            tty=True,
+            **target
+        )
 
-        exp_ret = ('Success', '', 0)
+        exp_ret = ("Success", "", 0)
         mock_cmd = MagicMock(return_value=exp_ret)
-        patch_cmd = patch('salt.client.ssh.shell.Shell.exec_cmd', mock_cmd)
-        exp_tmp = os.path.join(tempfile.gettempdir(), os.path.basename(target['ssh_pre_flight']))
+        patch_cmd = patch("salt.client.ssh.shell.Shell.exec_cmd", mock_cmd)
+        patch_send = patch("salt.client.ssh.shell.Shell.send", return_value=exp_ret)
+        exp_tmp = os.path.join(
+            tempfile.gettempdir(), os.path.basename(target["ssh_pre_flight"])
+        )
 
-        with patch_cmd:
+        with patch_cmd, patch_send:
             ret = single.run_ssh_pre_flight()
             assert ret == exp_ret
-            assert [call("/bin/sh '{0}'".format(exp_tmp)),
-                    call("rm '{0}'".format(exp_tmp))] == mock_cmd.call_args_list
+            assert [
+                call("/bin/sh '{0}'".format(exp_tmp)),
+                call("rm '{0}'".format(exp_tmp)),
+            ] == mock_cmd.call_args_list

--- a/tests/unit/test_module_names.py
+++ b/tests/unit/test_module_names.py
@@ -197,6 +197,7 @@ class BadTestModuleNamesTestCase(TestCase):
             "integration.ssh.test_raw",
             "integration.ssh.test_saltcheck",
             "integration.ssh.test_state",
+            "integration.ssh.test_pre_flight",
             "integration.states.test_compiler",
             "integration.states.test_handle_error",
             "integration.states.test_handle_iorder",


### PR DESCRIPTION
### What does this PR do?
Add new roster option `ssh_pre_flight`. This will allow a user to run a script before other salt-ssh commands are run. This script will only run if the thin_dir does not exist.

### What issues does this PR fix or reference?
https://github.com/saltstack/community/issues/45

### Tests written?
Yes

### Commits signed with GPG?

Yes