### PR TITLE
centos-7-py3-tcp takes too long, don't use spot for it

### DIFF
--- a/.ci/kitchen-centos7-py3-tcp
+++ b/.ci/kitchen-centos7-py3-tcp
@@ -10,7 +10,7 @@ runTestSuite(
     nox_env_name: 'runtests-tcp',
     nox_passthrough_opts: '--ssh-tests',
     python_version: 'py3',
-    testrun_timeout: 6,
-    use_spot_instances: true)
+    testrun_timeout: 7,
+    use_spot_instances: false)
 
 // vim: ft=groovy


### PR DESCRIPTION
### What does this PR do?
centos-7-py3-tcp gets really close to the 6 hour mark, extending the timeout so we can still use m5.large instances.