### PR TITLE
Fix file.get_selinux_context with directories

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3929,11 +3929,11 @@ def get_selinux_context(path):
 
         salt '*' file.get_selinux_context /etc/hosts
     """
-    out = __salt__["cmd.run"](["ls", "-Z", path], python_shell=False)
+    cmd_ret = __salt__["cmd.run_all"](["stat", "-c", "%C", path], python_shell=False)
 
-    try:
-        ret = re.search(r"\w+:\w+:\w+:\w+", out).group(0)
-    except AttributeError:
+    if cmd_ret["retcode"] == 0:
+        ret = cmd_ret["stdout"]
+    else:
         ret = "No selinux context information is available for {0}".format(path)
 
     return ret

--- a/tests/integration/modules/test_file.py
+++ b/tests/integration/modules/test_file.py
@@ -11,9 +11,10 @@ import sys
 # Import salt libs
 import salt.utils.files
 import salt.utils.platform
-from tests.support.case import ModuleCase
 
 # Import Salt Testing libs
+from tests.support.case import ModuleCase
+from tests.support.helpers import requires_system_grains
 from tests.support.runtests import RUNTIME_VARS
 from tests.support.unit import skipIf
 
@@ -73,6 +74,52 @@ class FileModuleTest(ModuleCase):
             os.remove(self.mybadsymlink)
         shutil.rmtree(self.mydir, ignore_errors=True)
         super(FileModuleTest, self).tearDown()
+
+    @skipIf(salt.utils.platform.is_windows(), "No security context on Windows")
+    @requires_system_grains
+    def test_get_selinux_context(self, grains):
+        if grains.get("selinux", {}).get("enabled", False):
+            NEW_CONTEXT = "system_u:object_r:system_conf_t:s0"
+            self.run_function(
+                "file.set_selinux_context", arg=[self.myfile, *(NEW_CONTEXT.split(":"))]
+            )
+            ret_file = self.run_function("file.get_selinux_context", arg=[self.myfile])
+            self.assertEqual(ret_file, NEW_CONTEXT)
+
+            # Issue #56557.  Ensure that the context of the directory
+            # containing one file is the context of the directory itself, and
+            # not the context of the first file in the directory.
+            self.run_function(
+                "file.set_selinux_context", arg=[self.mydir, *(NEW_CONTEXT.split(":"))]
+            )
+            ret_dir = self.run_function("file.get_selinux_context", arg=[self.mydir])
+            self.assertEqual(ret_dir, NEW_CONTEXT)
+            ret_updir = self.run_function(
+                "file.get_selinux_context",
+                arg=[os.path.abspath(os.path.join(self.mydir, ".."))],
+            )
+            self.assertNotEqual(ret_updir, NEW_CONTEXT)
+        else:
+            ret_file = self.run_function("file.get_selinux_context", arg=[self.myfile])
+            self.assertIn("No selinux context information is available", ret_file)
+
+    @skipIf(salt.utils.platform.is_windows(), "No security context on Windows")
+    @requires_system_grains
+    def test_set_selinux_context(self, grains):
+        if not grains.get("selinux", {}).get("enabled", False):
+            self.skipTest("selinux not available")
+
+        FILE_CONTEXT = "system_u:object_r:system_conf_t:s0"
+        ret_file = self.run_function(
+            "file.set_selinux_context", arg=[self.myfile, *(FILE_CONTEXT.split(":"))]
+        )
+        self.assertEqual(ret_file, FILE_CONTEXT)
+
+        DIR_CONTEXT = "system_u:object_r:user_home_t:s0"
+        ret_dir = self.run_function(
+            "file.set_selinux_context", arg=[self.mydir, *(DIR_CONTEXT.split(":"))]
+        )
+        self.assertEqual(ret_dir, DIR_CONTEXT)
 
     @skipIf(salt.utils.platform.is_windows(), "No chgrp on Windows")
     def test_chown(self):


### PR DESCRIPTION
### What does this PR do?

Refactors `file.get_selinux_context` so that it works with directories.  It now gets the context more directly with `stat` instead of indirectly (and incorrectly, for directories) extracting it from `ls -Z`.

### What issues does this PR fix or reference?

Fixes #56557.

### Tests written?

~No.  Needs some.~
Yes.

TODO:

* [x] Add tests

### Commits signed with GPG?

No