### PR TITLE
win_lgpo - additional delvals fixes and string value fix

### DIFF
--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -5658,7 +5658,7 @@ def _getDataFromRegPolData(search_string, policy_data, return_value_name=False):
                     match.start() : (
                         policy_data.index("]".encode("utf-16-le"), match.end())
                     )
-                ].split(encoded_semicolon)
+                ].split(encoded_semicolon, 4)
                 if len(pol_entry) >= 2:
                     valueName = pol_entry[1].decode("utf-16-le").rstrip(chr(0))
                 if len(pol_entry) >= 5:
@@ -9100,6 +9100,11 @@ def _get_policy_adm_setting(
                         ):
                             log.trace("explicitValue list, we will return value names")
                             return_value_name = True
+                        regex_str = [r'(?!\*', r'\*',
+                                     'D', 'e', 'l', 'V', 'a', 'l', 's',
+                                     r'\.', ')']
+                        delvals_regex = '\x00'.join(regex_str)
+                        delvals_regex = salt.utils.stringutils.to_bytes(delvals_regex)
                         if _regexSearchRegPolData(
                             re.escape(
                                 _processValueItem(
@@ -9111,7 +9116,7 @@ def _get_policy_adm_setting(
                                     check_deleted=False,
                                 )
                             )
-                            + salt.utils.stringutils.to_bytes(r"(?!\*\*delvals\.)"),
+                            + delvals_regex,
                             policy_data=policy_file_data,
                         ):
                             configured_value = _getDataFromRegPolData(

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -55,7 +55,7 @@ import salt.utils.platform
 import salt.utils.stringutils
 import salt.utils.win_lgpo_netsh
 from salt.exceptions import CommandExecutionError, SaltInvocationError
-rom salt.ext import six
+from salt.ext import six
 from salt.ext.six.moves import range
 from salt.serializers.configparser import deserialize
 
@@ -92,11 +92,13 @@ PRESENTATION_ANCESTOR_XPATH = None
 TEXT_ELEMENT_XPATH = None
 
 try:
+    import struct
+
+    import lxml
     import win32net
     import win32security
-    import lxml
-    import struct
     from lxml import etree
+
     from salt.utils.win_reg import Registry
 
     HAS_WINDOWS_MODULES = True

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -6794,6 +6794,7 @@ def _checkAllAdmxPolicies(
                                              'D', 'e', 'l', 'V', 'a', 'l', 's',
                                              r'\.', ')']
                                 delvals_regex = '\x00'.join(regex_str)
+                                delvals_regex = salt.utils.stringutils.to_bytes(delvals_regex)
                                 if _regexSearchRegPolData(
                                     re.escape(
                                         _processValueItem(

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -6790,6 +6790,10 @@ def _checkAllAdmxPolicies(
                                         "explicitValue list, we will return value names"
                                     )
                                     return_value_name = True
+                                regex_str = [r'(?!\*', r'\*',
+                                             'D', 'e', 'l', 'V', 'a', 'l', 's',
+                                             r'\.', ')']
+                                delvals_regex = '\x00'.join(regex_str)
                                 if _regexSearchRegPolData(
                                     re.escape(
                                         _processValueItem(
@@ -6801,8 +6805,7 @@ def _checkAllAdmxPolicies(
                                             check_deleted=False,
                                         )
                                     )
-                                    + salt.utils.stringutils.to_bytes(
-                                        r"(?!\*\*delvals\.)"
+                                    + delvals_regex
                                     ),
                                     policy_file_data,
                                 ):

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -6790,11 +6790,23 @@ def _checkAllAdmxPolicies(
                                         "explicitValue list, we will return value names"
                                     )
                                     return_value_name = True
-                                regex_str = [r'(?!\*', r'\*',
-                                             'D', 'e', 'l', 'V', 'a', 'l', 's',
-                                             r'\.', ')']
-                                delvals_regex = '\x00'.join(regex_str)
-                                delvals_regex = salt.utils.stringutils.to_bytes(delvals_regex)
+                                regex_str = [
+                                    r"(?!\*",
+                                    r"\*",
+                                    "D",
+                                    "e",
+                                    "l",
+                                    "V",
+                                    "a",
+                                    "l",
+                                    "s",
+                                    r"\.",
+                                    ")",
+                                ]
+                                delvals_regex = "\x00".join(regex_str)
+                                delvals_regex = salt.utils.stringutils.to_bytes(
+                                    delvals_regex
+                                )
                                 if _regexSearchRegPolData(
                                     re.escape(
                                         _processValueItem(
@@ -6806,8 +6818,7 @@ def _checkAllAdmxPolicies(
                                             check_deleted=False,
                                         )
                                     )
-                                    + delvals_regex
-                                    ),
+                                    + delvals_regex,
                                     policy_file_data,
                                 ):
                                     configured_value = _getDataFromRegPolData(
@@ -9104,10 +9115,20 @@ def _get_policy_adm_setting(
                         ):
                             log.trace("explicitValue list, we will return value names")
                             return_value_name = True
-                        regex_str = [r'(?!\*', r'\*',
-                                     'D', 'e', 'l', 'V', 'a', 'l', 's',
-                                     r'\.', ')']
-                        delvals_regex = '\x00'.join(regex_str)
+                        regex_str = [
+                            r"(?!\*",
+                            r"\*",
+                            "D",
+                            "e",
+                            "l",
+                            "V",
+                            "a",
+                            "l",
+                            "s",
+                            r"\.",
+                            ")",
+                        ]
+                        delvals_regex = "\x00".join(regex_str)
                         delvals_regex = salt.utils.stringutils.to_bytes(delvals_regex)
                         if _regexSearchRegPolData(
                             re.escape(

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -55,7 +55,7 @@ import salt.utils.platform
 import salt.utils.stringutils
 import salt.utils.win_lgpo_netsh
 from salt.exceptions import CommandExecutionError, SaltInvocationError
-from salt.ext import six
+rom salt.ext import six
 from salt.ext.six.moves import range
 from salt.serializers.configparser import deserialize
 

--- a/tests/integration/modules/test_win_lgpo.py
+++ b/tests/integration/modules/test_win_lgpo.py
@@ -165,7 +165,7 @@ class WinLgpoTest(ModuleCase):
             lgpo_top_level = "User Configuration"
 
         ret = self.run_function(
-            "lgpo.{0}".format(lgpo_function), (policy_name, policy_config)
+            "lgpo.{}".format(lgpo_function), (policy_name, policy_config)
         )
         log.debug("lgpo set_computer_policy ret == %s", ret)
         cmd = [

--- a/tests/integration/modules/test_win_lgpo.py
+++ b/tests/integration/modules/test_win_lgpo.py
@@ -155,23 +155,22 @@ class WinLgpoTest(ModuleCase):
             the policy class this policy belongs to, either Machine or User
         """
         lgpo_function = "set_computer_policy"
-        lgpo_class = "/m"
-        lgpo_folder = "Machine"
-        if policy_class.lower() == "user":
-            lgpo_function = "set_user_policy"
-            lgpo_class = "/u"
-            lgpo_folder = "User"
+        lgpo_class = '/m'
+        lgpo_folder = 'Machine'
+        lgpo_top_level = 'Computer Configuration'
+        if policy_class.lower() == 'user':
+            lgpo_function = 'set_user_policy'
+            lgpo_class = '/u'
+            lgpo_folder = 'User'
+            lgpo_top_level = 'User Configuration'
 
-        ret = self.run_function(
-            "lgpo.{}".format(lgpo_function), (policy_name, policy_config)
-        )
-        log.debug("lgpo set_computer_policy ret == %s", ret)
-        cmd = [
-            "lgpo.exe",
-            "/parse",
-            lgpo_class,
-            r"c:\Windows\System32\GroupPolicy\{}\Registry.pol".format(lgpo_folder),
-        ]
+        ret = self.run_function('lgpo.{}'.format(lgpo_function),
+                                (policy_name, policy_config))
+        log.debug('lgpo set_computer_policy ret == %s', ret)
+        cmd = ['lgpo.exe',
+               '/parse',
+               lgpo_class,
+               r'c:\Windows\System32\GroupPolicy\{}\Registry.pol'.format(lgpo_folder)]
         if assert_true:
             self.assertTrue(ret)
             lgpo_output = self.run_function("cmd.run", (), cmd=" ".join(cmd))
@@ -186,9 +185,51 @@ class WinLgpoTest(ModuleCase):
                 self.assertIsNotNone(
                     match,
                     msg='Failed validating policy "{}" configuration, regex '
-                    '"{}" not found in lgpo output:\n{}'
-                    "".format(policy_name, expected_regex, lgpo_output),
-                )
+                        '"{}" not found in lgpo output:\n{}'
+                        ''.format(policy_name, expected_regex, lgpo_output))
+            # validate the lgpo also sees the right setting
+            this_policy_info = self.run_function('lgpo.get_policy_info',
+                                                 (),
+                                                 policy_name=policy_name,
+                                                 policy_class=policy_class)
+            ret = self.run_function('lgpo.get', (), policy_class=policy_class, return_not_configured=True)
+            self.assertTrue(lgpo_top_level in ret, msg='lgpo did not return the expected entries')
+            found_policy = False
+            output_policy_name = None
+            if 'policy_aliases' in this_policy_info:
+                for policy_alias in this_policy_info['policy_aliases']:
+                    if policy_alias in ret[lgpo_top_level]:
+                        found_policy = True
+                        output_policy_name = policy_alias
+                        break
+            else:
+                found_policy = policy_name in ret[lgpo_top_level]
+            self.assertTrue(found_policy, msg='The configured policy is not in the lgpo.get output')
+            if isinstance(policy_config, list):
+                for this_item in policy_config:
+                    self.assertTrue(this_item in ret[lgpo_top_level][output_policy_name], msg='Item {} not found in policy configuration'.format(this_item))
+            elif isinstance(policy_config, dict):
+                for this_item, this_val in policy_config.items():
+                    item_correct = False
+                    actual_val = None
+                    if 'policy_elements' in this_policy_info and this_policy_info['policy_elements']:
+                        for policy_element in this_policy_info['policy_elements']:
+                            if item_correct:
+                                break
+                            if 'element_aliases' in policy_element and policy_element['element_aliases']:
+                                if this_item in policy_element['element_aliases']:
+                                    for element_alias in policy_element['element_aliases']:
+                                        if element_alias in ret[lgpo_top_level][output_policy_name]:
+                                            actual_val = ret[lgpo_top_level][output_policy_name][element_alias]
+                                            if ret[lgpo_top_level][output_policy_name][element_alias] == this_val:
+                                                item_correct = True
+                                                break
+                    self.assertTrue(item_correct,
+                                    msg='Item "{}" does not have the expected value of "{}"{}'.format(this_item,
+                                                                                                         this_val,
+                                                                                                         ' value found: "{}"'.format(actual_val) if actual_val else ''))
+            else:
+                self.assertEqual(ret[lgpo_top_level][output_policy_name], policy_config, msg='lgpo did not return the expected value for the policy')
         else:
             # expecting it to fail
             self.assertNotEqual(ret, True)
@@ -347,9 +388,8 @@ class WinLgpoTest(ModuleCase):
         self._testAdmxPolicy(
             "RA_Unsolicit",
             {
-                "Configure Offer Remote Access": "Enabled",
-                "Permit remote control of this computer": "Allow helpers to remotely control the computer",
-                "Helpers": ["administrators", "user1"],
+                'Permit remote control of this computer': 'Allow helpers to remotely control the computer',
+                'Helpers': ['administrators', 'user1']
             },
             [
                 r"Computer[\s]*Software\\policies\\Microsoft\\Windows NT\\Terminal Services\\RAUnsolicit[\s]*user1[\s]*SZ:user1[\s]*",
@@ -669,9 +709,9 @@ class WinLgpoTest(ModuleCase):
         self._testAdmxPolicy(
             "RA_Unsolicit",
             {
-                "Configure Offer Remote Access": "Enabled",
-                "Permit remote control of this computer": "Allow helpers to remotely control the computer",
-                "Helpers": ["administrators", "user1"],
+                'Permit remote control of this computer': 'Allow helpers to remotely control the computer',
+                'Helpers': ['administrators', 'user1']
+
             },
             [
                 r"Computer[\s]*Software\\Policies\\Microsoft\\Windows NT\\Terminal Services[\s]*fDisableClip[\s]*DWORD:0",
@@ -978,6 +1018,52 @@ class WinLgpoTest(ModuleCase):
             None,
             False,
         )
+
+    @destructiveTest
+    def test_set_sxs_servicing_policy(self):
+        '''
+        Test setting/unsetting/changing sxs-servicing policy
+        '''
+
+        # Disable sxs-servicing
+        log.debug('Attempting to disable sxs-servicing')
+        self._testAdmxPolicy('Specify settings for optional component installation and component repair',
+                             'Disabled',
+                             [
+                                 r'Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*LocalSourcePath[\s]*DELETE',
+                                 r'Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*UseWindowsUpdate[\s]*DELETE',
+                                 r'Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*RepairContentServerSource[\s]*DELETE',
+                             ])
+        # configure sxs-servicing
+        log.debug('Attempting to enable sxs-servicing')
+        self._testAdmxPolicy('Specify settings for optional component installation and component repair',
+                             {
+                                'Alternate source file path': '',
+                                'Never attempt to download payload from Windows Update': True,
+                                'CheckBox_SidestepWSUS': False,
+                             },
+                             [
+                                 r'Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*LocalSourcePath[\s]*EXSZ:',
+                                 r'Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*UseWindowsUpdate[\s]*DWORD:2',
+                                 r'Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*RepairContentServerSource[\s]*DELETE',
+                             ])
+        log.debug('Attempting to set different values on sxs-servicing')
+        self._testAdmxPolicy('Specify settings for optional component installation and component repair',
+                             {
+                                'Alternate source file path': r'\\some\fake\server',
+                                'Never attempt to download payload from Windows Update': True,
+                                'CheckBox_SidestepWSUS': False,
+                             },
+                             [
+                                 r'Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*LocalSourcePath[\s]*EXSZ:\\\\\\\\some\\\\fake\\\\server',
+                                 r'Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*UseWindowsUpdate[\s]*DWORD:2',
+                                 r'Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*RepairContentServerSource[\s]*DELETE',
+                             ])
+        # Not Configure sxs-servicing
+        log.debug('Attempting to set sxs-servicing to Not Configured')
+        self._testAdmxPolicy('Specify settings for optional component installation and component repair',
+                             'Not Configured',
+                             [r'; Source file:  c:\\windows\\system32\\grouppolicy\\machine\\registry.pol[\s]*; PARSING COMPLETED.'])
 
     def tearDown(self):
         """

--- a/tests/integration/modules/test_win_lgpo.py
+++ b/tests/integration/modules/test_win_lgpo.py
@@ -188,8 +188,9 @@ class WinLgpoTest(ModuleCase):
                 self.assertIsNotNone(
                     match,
                     msg='Failed validating policy "{}" configuration, regex '
-                        '"{}" not found in lgpo output:\n{}'
-                        ''.format(policy_name, expected_regex, lgpo_output))
+                    '"{}" not found in lgpo output:\n{}'
+                    "".format(policy_name, expected_regex, lgpo_output),
+                )
             # validate the lgpo also sees the right setting
             this_policy_info = self.run_function(
                 "lgpo.get_policy_info",
@@ -218,7 +219,12 @@ class WinLgpoTest(ModuleCase):
             )
             if isinstance(policy_config, list):
                 for this_item in policy_config:
-                    self.assertTrue(this_item in ret[lgpo_top_level][output_policy_name], msg='Item {} not found in policy configuration'.format(this_item))
+                    self.assertTrue(
+                        this_item in ret[lgpo_top_level][output_policy_name],
+                        msg="Item {} not found in policy configuration".format(
+                            this_item
+                        ),
+                    )
             elif isinstance(policy_config, dict):
                 for this_item, this_val in policy_config.items():
                     item_correct = False
@@ -253,10 +259,16 @@ class WinLgpoTest(ModuleCase):
                                             ):
                                                 item_correct = True
                                                 break
-                    self.assertTrue(item_correct,
-                                    msg='Item "{}" does not have the expected value of "{}"{}'.format(this_item,
-                                                                                                         this_val,
-                                                                                                         ' value found: "{}"'.format(actual_val) if actual_val else ''))
+                    self.assertTrue(
+                        item_correct,
+                        msg='Item "{}" does not have the expected value of "{}"{}'.format(
+                            this_item,
+                            this_val,
+                            ' value found: "{}"'.format(actual_val)
+                            if actual_val
+                            else "",
+                        ),
+                    )
             else:
                 self.assertEqual(
                     ret[lgpo_top_level][output_policy_name],

--- a/tests/integration/modules/test_win_lgpo.py
+++ b/tests/integration/modules/test_win_lgpo.py
@@ -155,22 +155,25 @@ class WinLgpoTest(ModuleCase):
             the policy class this policy belongs to, either Machine or User
         """
         lgpo_function = "set_computer_policy"
-        lgpo_class = '/m'
-        lgpo_folder = 'Machine'
-        lgpo_top_level = 'Computer Configuration'
-        if policy_class.lower() == 'user':
-            lgpo_function = 'set_user_policy'
-            lgpo_class = '/u'
-            lgpo_folder = 'User'
-            lgpo_top_level = 'User Configuration'
+        lgpo_class = "/m"
+        lgpo_folder = "Machine"
+        lgpo_top_level = "Computer Configuration"
+        if policy_class.lower() == "user":
+            lgpo_function = "set_user_policy"
+            lgpo_class = "/u"
+            lgpo_folder = "User"
+            lgpo_top_level = "User Configuration"
 
-        ret = self.run_function('lgpo.{}'.format(lgpo_function),
-                                (policy_name, policy_config))
-        log.debug('lgpo set_computer_policy ret == %s', ret)
-        cmd = ['lgpo.exe',
-               '/parse',
-               lgpo_class,
-               r'c:\Windows\System32\GroupPolicy\{}\Registry.pol'.format(lgpo_folder)]
+        ret = self.run_function(
+            "lgpo.{0}".format(lgpo_function), (policy_name, policy_config)
+        )
+        log.debug("lgpo set_computer_policy ret == %s", ret)
+        cmd = [
+            "lgpo.exe",
+            "/parse",
+            lgpo_class,
+            r"c:\Windows\System32\GroupPolicy\{}\Registry.pol".format(lgpo_folder),
+        ]
         if assert_true:
             self.assertTrue(ret)
             lgpo_output = self.run_function("cmd.run", (), cmd=" ".join(cmd))
@@ -188,23 +191,31 @@ class WinLgpoTest(ModuleCase):
                         '"{}" not found in lgpo output:\n{}'
                         ''.format(policy_name, expected_regex, lgpo_output))
             # validate the lgpo also sees the right setting
-            this_policy_info = self.run_function('lgpo.get_policy_info',
-                                                 (),
-                                                 policy_name=policy_name,
-                                                 policy_class=policy_class)
-            ret = self.run_function('lgpo.get', (), policy_class=policy_class, return_not_configured=True)
-            self.assertTrue(lgpo_top_level in ret, msg='lgpo did not return the expected entries')
+            this_policy_info = self.run_function(
+                "lgpo.get_policy_info",
+                (),
+                policy_name=policy_name,
+                policy_class=policy_class,
+            )
+            ret = self.run_function(
+                "lgpo.get", (), policy_class=policy_class, return_not_configured=True
+            )
+            self.assertTrue(
+                lgpo_top_level in ret, msg="lgpo did not return the expected entries"
+            )
             found_policy = False
             output_policy_name = None
-            if 'policy_aliases' in this_policy_info:
-                for policy_alias in this_policy_info['policy_aliases']:
+            if "policy_aliases" in this_policy_info:
+                for policy_alias in this_policy_info["policy_aliases"]:
                     if policy_alias in ret[lgpo_top_level]:
                         found_policy = True
                         output_policy_name = policy_alias
                         break
             else:
                 found_policy = policy_name in ret[lgpo_top_level]
-            self.assertTrue(found_policy, msg='The configured policy is not in the lgpo.get output')
+            self.assertTrue(
+                found_policy, msg="The configured policy is not in the lgpo.get output"
+            )
             if isinstance(policy_config, list):
                 for this_item in policy_config:
                     self.assertTrue(this_item in ret[lgpo_top_level][output_policy_name], msg='Item {} not found in policy configuration'.format(this_item))
@@ -212,16 +223,34 @@ class WinLgpoTest(ModuleCase):
                 for this_item, this_val in policy_config.items():
                     item_correct = False
                     actual_val = None
-                    if 'policy_elements' in this_policy_info and this_policy_info['policy_elements']:
-                        for policy_element in this_policy_info['policy_elements']:
+                    if (
+                        "policy_elements" in this_policy_info
+                        and this_policy_info["policy_elements"]
+                    ):
+                        for policy_element in this_policy_info["policy_elements"]:
                             if item_correct:
                                 break
-                            if 'element_aliases' in policy_element and policy_element['element_aliases']:
-                                if this_item in policy_element['element_aliases']:
-                                    for element_alias in policy_element['element_aliases']:
-                                        if element_alias in ret[lgpo_top_level][output_policy_name]:
-                                            actual_val = ret[lgpo_top_level][output_policy_name][element_alias]
-                                            if ret[lgpo_top_level][output_policy_name][element_alias] == this_val:
+                            if (
+                                "element_aliases" in policy_element
+                                and policy_element["element_aliases"]
+                            ):
+                                if this_item in policy_element["element_aliases"]:
+                                    for element_alias in policy_element[
+                                        "element_aliases"
+                                    ]:
+                                        if (
+                                            element_alias
+                                            in ret[lgpo_top_level][output_policy_name]
+                                        ):
+                                            actual_val = ret[lgpo_top_level][
+                                                output_policy_name
+                                            ][element_alias]
+                                            if (
+                                                ret[lgpo_top_level][output_policy_name][
+                                                    element_alias
+                                                ]
+                                                == this_val
+                                            ):
                                                 item_correct = True
                                                 break
                     self.assertTrue(item_correct,
@@ -229,7 +258,11 @@ class WinLgpoTest(ModuleCase):
                                                                                                          this_val,
                                                                                                          ' value found: "{}"'.format(actual_val) if actual_val else ''))
             else:
-                self.assertEqual(ret[lgpo_top_level][output_policy_name], policy_config, msg='lgpo did not return the expected value for the policy')
+                self.assertEqual(
+                    ret[lgpo_top_level][output_policy_name],
+                    policy_config,
+                    msg="lgpo did not return the expected value for the policy",
+                )
         else:
             # expecting it to fail
             self.assertNotEqual(ret, True)
@@ -388,8 +421,8 @@ class WinLgpoTest(ModuleCase):
         self._testAdmxPolicy(
             "RA_Unsolicit",
             {
-                'Permit remote control of this computer': 'Allow helpers to remotely control the computer',
-                'Helpers': ['administrators', 'user1']
+                "Permit remote control of this computer": "Allow helpers to remotely control the computer",
+                "Helpers": ["administrators", "user1"],
             },
             [
                 r"Computer[\s]*Software\\policies\\Microsoft\\Windows NT\\Terminal Services\\RAUnsolicit[\s]*user1[\s]*SZ:user1[\s]*",
@@ -709,9 +742,8 @@ class WinLgpoTest(ModuleCase):
         self._testAdmxPolicy(
             "RA_Unsolicit",
             {
-                'Permit remote control of this computer': 'Allow helpers to remotely control the computer',
-                'Helpers': ['administrators', 'user1']
-
+                "Permit remote control of this computer": "Allow helpers to remotely control the computer",
+                "Helpers": ["administrators", "user1"],
             },
             [
                 r"Computer[\s]*Software\\Policies\\Microsoft\\Windows NT\\Terminal Services[\s]*fDisableClip[\s]*DWORD:0",
@@ -1021,49 +1053,59 @@ class WinLgpoTest(ModuleCase):
 
     @destructiveTest
     def test_set_sxs_servicing_policy(self):
-        '''
+        """
         Test setting/unsetting/changing sxs-servicing policy
-        '''
+        """
 
         # Disable sxs-servicing
-        log.debug('Attempting to disable sxs-servicing')
-        self._testAdmxPolicy('Specify settings for optional component installation and component repair',
-                             'Disabled',
-                             [
-                                 r'Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*LocalSourcePath[\s]*DELETE',
-                                 r'Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*UseWindowsUpdate[\s]*DELETE',
-                                 r'Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*RepairContentServerSource[\s]*DELETE',
-                             ])
+        log.debug("Attempting to disable sxs-servicing")
+        self._testAdmxPolicy(
+            "Specify settings for optional component installation and component repair",
+            "Disabled",
+            [
+                r"Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*LocalSourcePath[\s]*DELETE",
+                r"Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*UseWindowsUpdate[\s]*DELETE",
+                r"Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*RepairContentServerSource[\s]*DELETE",
+            ],
+        )
         # configure sxs-servicing
-        log.debug('Attempting to enable sxs-servicing')
-        self._testAdmxPolicy('Specify settings for optional component installation and component repair',
-                             {
-                                'Alternate source file path': '',
-                                'Never attempt to download payload from Windows Update': True,
-                                'CheckBox_SidestepWSUS': False,
-                             },
-                             [
-                                 r'Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*LocalSourcePath[\s]*EXSZ:',
-                                 r'Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*UseWindowsUpdate[\s]*DWORD:2',
-                                 r'Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*RepairContentServerSource[\s]*DELETE',
-                             ])
-        log.debug('Attempting to set different values on sxs-servicing')
-        self._testAdmxPolicy('Specify settings for optional component installation and component repair',
-                             {
-                                'Alternate source file path': r'\\some\fake\server',
-                                'Never attempt to download payload from Windows Update': True,
-                                'CheckBox_SidestepWSUS': False,
-                             },
-                             [
-                                 r'Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*LocalSourcePath[\s]*EXSZ:\\\\\\\\some\\\\fake\\\\server',
-                                 r'Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*UseWindowsUpdate[\s]*DWORD:2',
-                                 r'Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*RepairContentServerSource[\s]*DELETE',
-                             ])
+        log.debug("Attempting to enable sxs-servicing")
+        self._testAdmxPolicy(
+            "Specify settings for optional component installation and component repair",
+            {
+                "Alternate source file path": "",
+                "Never attempt to download payload from Windows Update": True,
+                "CheckBox_SidestepWSUS": False,
+            },
+            [
+                r"Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*LocalSourcePath[\s]*EXSZ:",
+                r"Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*UseWindowsUpdate[\s]*DWORD:2",
+                r"Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*RepairContentServerSource[\s]*DELETE",
+            ],
+        )
+        log.debug("Attempting to set different values on sxs-servicing")
+        self._testAdmxPolicy(
+            "Specify settings for optional component installation and component repair",
+            {
+                "Alternate source file path": r"\\some\fake\server",
+                "Never attempt to download payload from Windows Update": True,
+                "CheckBox_SidestepWSUS": False,
+            },
+            [
+                r"Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*LocalSourcePath[\s]*EXSZ:\\\\\\\\some\\\\fake\\\\server",
+                r"Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*UseWindowsUpdate[\s]*DWORD:2",
+                r"Computer[\s]*Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Servicing[\s]*RepairContentServerSource[\s]*DELETE",
+            ],
+        )
         # Not Configure sxs-servicing
-        log.debug('Attempting to set sxs-servicing to Not Configured')
-        self._testAdmxPolicy('Specify settings for optional component installation and component repair',
-                             'Not Configured',
-                             [r'; Source file:  c:\\windows\\system32\\grouppolicy\\machine\\registry.pol[\s]*; PARSING COMPLETED.'])
+        log.debug("Attempting to set sxs-servicing to Not Configured")
+        self._testAdmxPolicy(
+            "Specify settings for optional component installation and component repair",
+            "Not Configured",
+            [
+                r"; Source file:  c:\\windows\\system32\\grouppolicy\\machine\\registry.pol[\s]*; PARSING COMPLETED."
+            ],
+        )
 
     def tearDown(self):
         """


### PR DESCRIPTION
### What does this PR do?
Ports fixes from #56060 to other places where the delvals regex was searched.

Corrects an issue where a string value with a semicolon in it would only show the first value in the setting

Adds testing of policy returned from lgpo.get for each ADMX policy test

### What issues does this PR fix or reference?
#56062

### Previous Behavior
Some delvals items would show "**delvals" as the configuration instead of "Disabled"
Items with a semicolon in them (such as the "Enter fully qualified server names separated by semicolons" of "Point and Print Restrictions") would only show the entry up to the semicolon - subsequent runs of lgpo may then reset the value to the shortened string.

### New Behavior
Delval items correctly display the policy setting in lgpo.get
Items with a semicolon show all entries

### Tests written?
Yes

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
