### PR TITLE
correct formatting issue with highstate output module

### DIFF
--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -186,7 +186,7 @@ def _format_host(host, data, indent_level=1):
     nchanges = 0
     strip_colors = __opts__.get("strip_colors", True)
 
-    if data is None or data is True or data is False:
+    if isinstance(data, int) or data is None:
         nchanges = 1
         hstrs.append(('{0}    {1}{2[ENDC]}'.format(hcolor, data, colors)))
         hcolor = colors["CYAN"]  # Print the minion name in cyan

--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -190,7 +190,7 @@ def _format_host(host, data, indent_level=1):
         nchanges = 1
         hstrs.append(('{0}    {1}{2[ENDC]}'.format(hcolor, data, colors)))
         hcolor = colors["CYAN"]  # Print the minion name in cyan
-    elif isinstance(data, int) or isinstance(data, six.string_types):
+    elif isinstance(data, six.string_types):
         # Data in this format is from saltmod.function,
         # so it is always a 'change'
         nchanges = 1

--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -188,15 +188,15 @@ def _format_host(host, data, indent_level=1):
 
     if isinstance(data, int):
         nchanges = 1
-        hcolor = colors["CYAN"]  # Print the minion name in cyan
         hstrs.append(('{0}    {1}{2[ENDC]}'.format(hcolor, data, colors)))
+        hcolor = colors["CYAN"]  # Print the minion name in cyan
     elif isinstance(data, six.string_types):
         # Data in this format is from saltmod.function,
         # so it is always a 'change'
         nchanges = 1
-        hcolor = colors["CYAN"]  # Print the minion name in cyan
         for data in data.splitlines():
             hstrs.append(('{0}    {1}{2[ENDC]}'.format(hcolor, data, colors)))
+        hcolor = colors["CYAN"]  # Print the minion name in cyan
     elif isinstance(data, list):
         # Errors have been detected, list them in RED!
         hcolor = colors["LIGHT_RED"]

--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -188,15 +188,15 @@ def _format_host(host, data, indent_level=1):
 
     if isinstance(data, int):
         nchanges = 1
-        hstrs.append(('{0}    {1}{2[ENDC]}'.format(hcolor, data, colors)))
         hcolor = colors["CYAN"]  # Print the minion name in cyan
+        hstrs.append(('{0}    {1}{2[ENDC]}'.format(hcolor, data, colors)))
     elif isinstance(data, six.string_types):
         # Data in this format is from saltmod.function,
         # so it is always a 'change'
         nchanges = 1
+        hcolor = colors["CYAN"]  # Print the minion name in cyan
         for data in data.splitlines():
             hstrs.append(('{0}    {1}{2[ENDC]}'.format(hcolor, data, colors)))
-        hcolor = colors["CYAN"]  # Print the minion name in cyan
     elif isinstance(data, list):
         # Errors have been detected, list them in RED!
         hcolor = colors["LIGHT_RED"]

--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -190,7 +190,6 @@ def _format_host(host, data, indent_level=1):
         nchanges = 1
         hstrs.append(('{0}    {1}{2[ENDC]}'.format(hcolor, data, colors)))
         hcolor = colors["CYAN"]  # Print the minion name in cyan
-
     elif isinstance(data, int) or isinstance(data, six.string_types):
         # Data in this format is from saltmod.function,
         # so it is always a 'change'

--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -186,14 +186,19 @@ def _format_host(host, data, indent_level=1):
     nchanges = 0
     strip_colors = __opts__.get("strip_colors", True)
 
-    if isinstance(data, int) or isinstance(data, six.string_types):
+    if data is None or data is True or data is False:
+        nchanges = 1
+        hstrs.append(('{0}    {1}{2[ENDC]}'.format(hcolor, data, colors)))
+        hcolor = colors["CYAN"]  # Print the minion name in cyan
+
+    elif isinstance(data, int) or isinstance(data, six.string_types):
         # Data in this format is from saltmod.function,
         # so it is always a 'change'
         nchanges = 1
         for data in data.splitlines():
             hstrs.append(('{0}    {1}{2[ENDC]}'.format(hcolor, data, colors)))
         hcolor = colors["CYAN"]  # Print the minion name in cyan
-    if isinstance(data, list):
+    elif isinstance(data, list):
         # Errors have been detected, list them in RED!
         hcolor = colors["LIGHT_RED"]
         hstrs.append(("    {0}Data failed to compile:{1[ENDC]}".format(hcolor, colors)))
@@ -203,7 +208,7 @@ def _format_host(host, data, indent_level=1):
             hstrs.append(
                 ("{0}----------\n    {1}{2[ENDC]}".format(hcolor, err, colors))
             )
-    if isinstance(data, dict):
+    elif isinstance(data, dict):
         # Verify that the needed data is present
         data_tmp = {}
         for tname, info in six.iteritems(data):

--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -186,7 +186,7 @@ def _format_host(host, data, indent_level=1):
     nchanges = 0
     strip_colors = __opts__.get("strip_colors", True)
 
-    if isinstance(data, int) or data is None:
+    if isinstance(data, int):
         nchanges = 1
         hstrs.append(('{0}    {1}{2[ENDC]}'.format(hcolor, data, colors)))
         hcolor = colors["CYAN"]  # Print the minion name in cyan

--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -190,7 +190,8 @@ def _format_host(host, data, indent_level=1):
         # Data in this format is from saltmod.function,
         # so it is always a 'change'
         nchanges = 1
-        hstrs.append(("{0}    {1}{2[ENDC]}".format(hcolor, data, colors)))
+        for data in data.splitlines():
+            hstrs.append(('{0}    {1}{2[ENDC]}'.format(hcolor, data, colors)))
         hcolor = colors["CYAN"]  # Print the minion name in cyan
     if isinstance(data, list):
         # Errors have been detected, list them in RED!


### PR DESCRIPTION
### What does this PR do?
Corrects a formatting issue when ```cmd.run``` is run from an orchestration and returns multiple lines of output. This PR ensures every line of output under ```Changes``` is indented properly.

### What issues does this PR fix or reference?
#56554

### Previous Behavior

given the orchestration state

```
command_1:
  salt.function:
    - name: cmd.run
    - tgt: 'server'
    - arg:
      - ls /tmp
```
the files listed under ```Changes``` would not be indented properly
```
[root@server ~]# salt-run state.orch orch.test --out highstate
server.example.com_master:
----------
          ID: command_1
    Function: salt.function
        Name: cmd.run
      Result: True
     Comment: Function ran successfully. Function cmd.run ran on server.
     Started: 19:02:44.195687
    Duration: 413.993 ms
     Changes:   
              server:
                  file1
              file2
              file3
```

### New Behavior
```
[root@server ~]# salt-run state.orch orch.test --out highstate
server.example.com_master:
----------
          ID: command_1
    Function: salt.function
        Name: cmd.run
      Result: True
     Comment: Function ran successfully. Function cmd.run ran on server.
     Started: 19:03:19.668603
    Duration: 418.08 ms
     Changes:   
              server:
                  file1
                  file2
                  file3
```