### PR TITLE
Pre-commit fixes

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,8 +1,0 @@
-[settings]
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-line_length=88
-ensure_newline_before_comments=True
-use_parentheses=True
-skip=salt/ext/,tests/kitchen/tests/,templates/

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,8 +1,0 @@
-[settings]
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-line_length=88
-ensure_newline_before_comments=True
-use_parentheses=True
-skip=salt/ext/,tests/kitchen/tests/

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,8 @@
+[settings]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+line_length=88
+ensure_newline_before_comments=True
+use_parentheses=True
+skip=salt/ext/,tests/kitchen/tests/,templates/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+default_language_version:
+    python: python3
+
 exclude: ^(doc/_static/.*|doc/_themes/.*)$
 repos:
   - repo: https://github.com/saltstack/pip-tools-compile-impersonate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -423,7 +423,6 @@ repos:
     rev: '1e78a9acf3110e1f9721feb591f89a451fc9876a'
     hooks:
       - id: isort
-        additional_dependencies: ['isort[pyproject]']
         # This tells pre-commit not to pass files to isort.
         # This should be kept in sync with pyproject.toml
         exclude: >

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -425,7 +425,6 @@ repos:
     rev: stable
     hooks:
       - id: black
-        language_version: python3.7
 
   - repo: https://github.com/saltstack/salt-nox-pre-commit
     rev: master

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -423,6 +423,7 @@ repos:
     rev: '1e78a9acf3110e1f9721feb591f89a451fc9876a'
     hooks:
       - id: isort
+        additional_dependencies: ['isort[pyproject]']
         # This tells pre-commit not to pass files to isort.
         # This should be kept in sync with pyproject.toml
         exclude: >

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -423,11 +423,27 @@ repos:
     rev: '1e78a9acf3110e1f9721feb591f89a451fc9876a'
     hooks:
       - id: isort
+        # This tells pre-commit not to pass files to isort.
+        # This should be kept in sync with pyproject.toml
+        exclude: >
+            (?x)^(
+                templates/.*|
+                salt/ext/.*|
+                tests/kitchen/.*
+            )$
 
   - repo: https://github.com/psf/black
     rev: stable
     hooks:
       - id: black
+        # This tells pre-commit not to pass files to black.
+        # This should be kept in sync with pyproject.toml
+        exclude: >
+            (?x)^(
+                templates/.*|
+                salt/ext/.*|
+                tests/kitchen/.*
+            )$
 
   - repo: https://github.com/saltstack/salt-nox-pre-commit
     rev: master

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -423,6 +423,7 @@ repos:
     rev: '1e78a9acf3110e1f9721feb591f89a451fc9876a'
     hooks:
       - id: isort
+        additional_dependencies: ['toml']
         # This tells pre-commit not to pass files to isort.
         # This should be kept in sync with pyproject.toml
         exclude: >

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,12 @@ exclude= '''
   | tests/kitchen
   | templates
 )/
+
+
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+line_length = 88
+skip=salt/ext,tests/kitchen,templates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,3 @@ exclude= '''
   | tests/kitchen
   | templates
 )/
-
-
-[tool.isort]
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-line_length = 88
-skip=salt/ext,tests/kitchen,templates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,18 @@
 [tool.black]
-exclude= '''
-\(
+exclude= """
+/(
     salt/ext
   | tests/kitchen
   | templates
 )/
+"""
+
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+line_length = 88
+ensure_newline_before_comments=true
+skip="salt/ext,tests/kitchen,templates"
+


### PR DESCRIPTION
### What does this PR do?

This is not, strictly speaking, necessary. Removing the language version
allows use of one's default supported python (3.6+).

Also consolidates isort config in pyproject.toml and fixes excludes, because the way pre-commit provides black/isort files  on `pre-commit -a` overrides their default exclude settings

### Previous Behavior

Contributors not using Python3.7 in their dev environment would have to add pyenv or similiar

### New Behavior

Now contributors with Python >=3.6 should be A-OK

### Tests written?

Not relevant

### Commits signed with GPG?

Yes