### PR TITLE
[master] Update is_enabled function to show global status

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -831,11 +831,27 @@ Default: ``False``
 
 The minion can locally cache grain data instead of refreshing the data
 each time the grain is referenced. By default this feature is disabled,
-to enable set grains_cache to ``True``.
+to enable set ``grains_cache`` to ``True``.
 
 .. code-block:: yaml
 
     grains_cache: False
+
+.. conf_minion:: grains_cache_expiration
+
+``grains_cache_expiration``
+---------------------------
+
+Default: ``300``
+
+Grains cache expiration, in seconds. If the cache file is older than this number
+of seconds then the grains cache will be dumped and fully re-populated with
+fresh data. Defaults to 5 minutes. Will have no effect if
+:conf_minion:`grains_cache` is not enabled.
+
+.. code-block:: yaml
+
+    grains_cache_expiration: 300
 
 .. conf_minion:: grains_deep_merge
 

--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -157,9 +157,12 @@ def list_(show_all=False, show_disabled=True, where=None, return_yaml=True):
         return {"schedule": {}}
 
 
-def is_enabled(name):
+def is_enabled(name=None):
     """
     List a Job only if its enabled
+
+    If not job is specified, indicate
+    if the scheduler is enabled or disabled.
 
     .. versionadded:: 2015.5.3
 
@@ -168,13 +171,18 @@ def is_enabled(name):
     .. code-block:: bash
 
         salt '*' schedule.is_enabled name=job_name
+
+        salt '*' schedule.is_enabled
     """
 
     current_schedule = __salt__["schedule.list"](show_all=False, return_yaml=False)
-    if name in current_schedule:
-        return current_schedule[name]
+    if not name:
+        return current_schedule.get("enabled", True)
     else:
-        return {}
+        if name in current_schedule:
+            return current_schedule[name]
+        else:
+            return {}
 
 
 def purge(**kwargs):

--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -161,7 +161,7 @@ def is_enabled(name=None):
     """
     List a Job only if its enabled
 
-    If not job is specified, indicate
+    If job is not specified, indicate
     if the scheduler is enabled or disabled.
 
     .. versionadded:: 2015.5.3

--- a/tests/unit/modules/test_schedule.py
+++ b/tests/unit/modules/test_schedule.py
@@ -6,6 +6,7 @@
 # Import Python Libs
 from __future__ import absolute_import, print_function, unicode_literals
 
+import logging
 import os
 
 # Import Salt Libs
@@ -17,6 +18,8 @@ from tests.support.mock import MagicMock, patch
 # Import Salt Testing Libs
 from tests.support.runtests import RUNTIME_VARS
 from tests.support.unit import TestCase
+
+log = logging.getLogger(__name__)
 
 JOB1 = {
     "function": "test.ping",
@@ -526,3 +529,32 @@ class ScheduleTestCase(TestCase, LoaderModuleMockMixin):
                 with patch.object(SaltEvent, "get_event", return_value=_ret_value):
                     ret = schedule.modify("job2", function="test.version", test=True)
                     self.assertDictEqual(ret, expected5)
+
+    # 'is_enabled' function tests: 1
+
+    def test_is_enabled(self):
+        """
+        Test is_enabled
+        """
+        job1 = {"function": "salt", "seconds": 3600}
+
+        comm1 = "Modified job: job1 in schedule."
+
+        mock_schedule = {"enabled": True, "job1": job1}
+
+        mock_lst = MagicMock(return_value=mock_schedule)
+
+        with patch.dict(
+            schedule.__opts__, {"schedule": {"job1": job1}, "sock_dir": self.sock_dir}
+        ):
+            mock = MagicMock(return_value=True)
+            with patch.dict(
+                schedule.__salt__, {"event.fire": mock, "schedule.list": mock_lst}
+            ):
+                _ret_value = {"complete": True, "schedule": {"job1": job1}}
+                with patch.object(SaltEvent, "get_event", return_value=_ret_value):
+                    ret = schedule.is_enabled("job1")
+                    self.assertDictEqual(ret, job1)
+
+                    ret = schedule.is_enabled()
+                    self.assertEqual(ret, True)


### PR DESCRIPTION
### What does this PR do?
Update is_enabled to make name argument optional, when empty is_enabled will indicate if the scheduler is enabled or disabled.  Add test for is_enabled.

### What issues does this PR fix or reference?
#51823

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
