### PR TITLE
closed: states/svn: set ret[comment] appropriately

### DIFF
--- a/salt/states/svn.py
+++ b/salt/states/svn.py
@@ -298,6 +298,7 @@ def export(
     out = __salt__[svn_cmd](cwd, name, basename, user, username, password, rev, *opts)
     ret["changes"]["new"] = name
     ret["changes"]["comment"] = name + " was Exported to " + target
+    ret["comment"] = out
 
     return ret
 


### PR DESCRIPTION
### What does this PR do?

Set ret[comment] in states/svn.py

### What issues does this PR fix or reference?

None

### Previous Behavior

Log message for comment was blank

### New Behavior

Log message for comment is not blank

### Tests written?

No

### Commits signed with GPG?

No
