### PR TITLE
doc: Do not mock Python's concurrent module

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -86,7 +86,6 @@ MOCK_MODULES = [
     # Python stdlib
     "user",
     # salt core
-    "concurrent",
     "Crypto",
     "Crypto.Signature",
     "Crypto.Cipher",
@@ -150,7 +149,6 @@ MOCK_MODULES = [
     "OpenSSL",
     "avahi",
     "boto.regioninfo",
-    "concurrent",
     "dbus",
     "django",
     "dns",


### PR DESCRIPTION
Sphinx 2.4 fails to build the documentation:

```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/sphinx/cmd/build.py", line 272, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
  File "/usr/lib/python3/dist-packages/sphinx/application.py", line 272, in __init__
    self._init_builder()
  File "/usr/lib/python3/dist-packages/sphinx/application.py", line 328, in _init_builder
    self.events.emit('builder-inited')
  File "/usr/lib/python3/dist-packages/sphinx/events.py", line 99, in emit
    results.append(callback(self.app, *args))
  File "/usr/lib/python3/dist-packages/sphinx/ext/intersphinx.py", line 233, in load_mappings
    with concurrent.futures.ThreadPoolExecutor() as pool:
AttributeError: __enter__
```

Therefore do not mock Python's concurrent module.

Bug-Debian: https://bugs.debian.org/955057