### PR TITLE
[master] Handle exceptions for pymysql

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -431,7 +431,7 @@ def _connect(**kwargs):
         __context__["mysql.error"] = err
         log.error(err)
         return None
-    except pymysql.err.InternalError as exc:
+    except MySQLdb.err.InternalError as exc:
         err = "MySQL Error {0}: {1}".format(*exc.args)
         __context__["mysql.error"] = err
         log.error(err)

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -431,6 +431,11 @@ def _connect(**kwargs):
         __context__["mysql.error"] = err
         log.error(err)
         return None
+    except pymysql.err.InternalError as exc:
+        err = "MySQL Error {0}: {1}".format(*exc.args)
+        __context__["mysql.error"] = err
+        log.error(err)
+        return None
 
     dbc.autocommit(True)
     return dbc

--- a/tests/unit/modules/test_mysql.py
+++ b/tests/unit/modules/test_mysql.py
@@ -25,13 +25,13 @@ NO_MYSQL = False
 NO_PyMYSQL = False
 try:
     import MySQLdb  # pylint: disable=W0611
-except ImportError:  # pylint: disable=broad-except
+except ImportError:
     NO_MYSQL = True
 
 try:
     # MySQLdb import failed, try to import PyMySQL
     import pymysql
-except ImportError:  # pylint: disable=broad-except
+except ImportError:
     NO_PyMYSQL = True
 
 __all_privileges__ = [


### PR DESCRIPTION
### What does this PR do?
Catch and handle pymysql.err.InternalError in mysql module _connect.
Adding a test for the _connect function to ensure exceptions for both MySQL and pymysql connection failures are handled.

### What issues does this PR fix or reference?
#56570 

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.
Yes

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
