### PR TITLE
[master] Only set createhome to False on Windows

### DIFF
--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -334,7 +334,7 @@ def present(
         databases.
 
         .. note::
-            Not supported on Windows or Mac OS.
+            Not supported on Windows.
 
     password
         A password hash to set for the user. This field is only supported on
@@ -497,8 +497,8 @@ def present(
     if other is not None:
         other = salt.utils.data.decode(other)
 
-    # createhome not supported on Windows or Mac
-    if __grains__["kernel"] in ("Darwin", "Windows"):
+    # createhome not supported on Windows
+    if __grains__["kernel"] == "Windows":
         createhome = False
 
     ret = {

--- a/tests/integration/states/test_user.py
+++ b/tests/integration/states/test_user.py
@@ -288,6 +288,21 @@ class UserTest(ModuleCase, SaltReturnAssertsMixin):
             self.assertEqual("", ret["workphone"])
             self.assertEqual("", ret["homephone"])
 
+    @skipIf(
+        salt.utils.platform.is_windows(), "windows minon does not support createhome"
+    )
+    def test_user_present_home_directory_created(self):
+        """
+        This is a DESTRUCTIVE TEST it creates a new user on the minion.
+
+        It ensures that the home directory is created.
+        """
+        ret = self.run_state("user.present", name=self.user_name, createhome=True)
+        self.assertSaltTrueReturn(ret)
+
+        user_info = self.run_function("user.info", [self.user_name])
+        self.assertTrue(os.path.exists(user_info["home"]))
+
     def tearDown(self):
         if salt.utils.platform.is_darwin():
             check_user = self.run_function("user.list_users")


### PR DESCRIPTION
### What does this PR do?
createhome is supported on OS X, removing the documentation and if statement that block it.

### What issues does this PR fix or reference?
#54288 

### Previous Behavior
The createhome parameter was documented that it was not available when running on OS X.

### New Behavior
Remove documentation mentioning OS X and change if statement to only set createhome to False when running on Windows.

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.
Yes.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
