### PR TITLE
Move all PR requirements under same heading

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,19 +9,14 @@ Remove this section if not relevant
 ### New Behavior
 Remove this section if not relevant
 
-### Docs & changelog written?
-Yes/No 
+### Merge requirements satisfied?
+**[NOTICE] Bug fixes or features added to Salt require tests.**
+<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
 - [ ] Docs
 - [ ] Changelog
-
-### Tests written?
-**[NOTICE] Bug fixes or features added to Salt require tests.**
-Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.
-
-Yes/No
+- [ ] Tests written/updated
 
 ### Commits signed with GPG?
-
 Yes/No
 
 Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.


### PR DESCRIPTION
List all major requirements together as checkboxes.

It would be really helpful to have subheadings at the top of https://docs.saltstack.com/en/master/topics/development/contributing.html for the docs, changelog, and testing requirements to make clear what is expected, how to start, and list examples.

### What does this PR do?
Combines the doc/changelog and test sections.