### PR TITLE
[master] Updating fail_with and succeed_with functions to use comment argument

### DIFF
--- a/salt/states/test.py
+++ b/salt/states/test.py
@@ -77,7 +77,9 @@ def succeed_without_changes(name, **kwargs):  # pylint: disable=unused-argument
     name
         A unique string.
     """
-    ret = {"name": name, "changes": {}, "result": True, "comment": "Success!"}
+    comment = kwargs.get("comment", "Success!")
+
+    ret = {"name": name, "changes": {}, "result": True, "comment": comment}
     return ret
 
 
@@ -90,7 +92,9 @@ def fail_without_changes(name, **kwargs):  # pylint: disable=unused-argument
     name:
         A unique string.
     """
-    ret = {"name": name, "changes": {}, "result": False, "comment": "Failure!"}
+    comment = kwargs.get("comment", "Failure!")
+
+    ret = {"name": name, "changes": {}, "result": False, "comment": comment}
 
     if __opts__["test"]:
         ret["result"] = False
@@ -108,7 +112,9 @@ def succeed_with_changes(name, **kwargs):  # pylint: disable=unused-argument
     name:
         A unique string.
     """
-    ret = {"name": name, "changes": {}, "result": True, "comment": "Success!"}
+    comment = kwargs.get("comment", "Success!")
+
+    ret = {"name": name, "changes": {}, "result": True, "comment": comment}
 
     # Following the docs as written here
     # http://docs.saltstack.com/ref/states/writing.html#return-data
@@ -134,6 +140,8 @@ def fail_with_changes(name, **kwargs):  # pylint: disable=unused-argument
     name:
         A unique string.
     """
+    comment = kwargs.get("comment", "Failure!")
+
     ret = {"name": name, "changes": {}, "result": False, "comment": "Failure!"}
 
     # Following the docs as written here

--- a/tests/unit/states/test_test.py
+++ b/tests/unit/states/test_test.py
@@ -36,6 +36,12 @@ class TestTestCase(TestCase, LoaderModuleMockMixin):
             ret.update({"comment": "Success!"})
             self.assertDictEqual(test.succeed_without_changes("salt"), ret)
 
+        with patch.dict(test.__opts__, {"test": False}):
+            ret.update({"comment": "A success comment!"})
+            self.assertDictEqual(
+                test.succeed_without_changes("salt", comment="A success comment!"), ret
+            )
+
     def test_fail_without_changes(self):
         """
             Test to returns failure.
@@ -44,6 +50,12 @@ class TestTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(test.__opts__, {"test": False}):
             ret.update({"comment": "Failure!"})
             self.assertDictEqual(test.fail_without_changes("salt"), ret)
+
+        with patch.dict(test.__opts__, {"test": False}):
+            ret.update({"comment": "A failure comment!"})
+            self.assertDictEqual(
+                test.fail_without_changes("salt", comment="A failure comment!"), ret
+            )
 
     def test_succeed_with_changes(self):
         """
@@ -65,6 +77,23 @@ class TestTestCase(TestCase, LoaderModuleMockMixin):
             )
             self.assertDictEqual(test.succeed_with_changes("salt"), ret)
 
+        with patch.dict(test.__opts__, {"test": False}):
+            ret.update(
+                {
+                    "changes": {
+                        "testing": {
+                            "new": "Something pretended" " to change",
+                            "old": "Unchanged",
+                        }
+                    },
+                    "comment": "A success comment!",
+                    "result": True,
+                }
+            )
+            self.assertDictEqual(
+                test.succeed_with_changes("salt", comment="A success comment!"), ret
+            )
+
     def test_fail_with_changes(self):
         """
             Test to returns failure and changes is not empty.
@@ -84,6 +113,23 @@ class TestTestCase(TestCase, LoaderModuleMockMixin):
                 }
             )
             self.assertDictEqual(test.succeed_with_changes("salt"), ret)
+
+        with patch.dict(test.__opts__, {"test": False}):
+            ret.update(
+                {
+                    "changes": {
+                        "testing": {
+                            "new": "Something pretended" " to change",
+                            "old": "Unchanged",
+                        }
+                    },
+                    "comment": "A failure comment!",
+                    "result": True,
+                }
+            )
+            self.assertDictEqual(
+                test.succeed_with_changes("salt", comment="A failure comment!"), ret
+            )
 
     def test_configurable_test_state(self):
         """


### PR DESCRIPTION
### What does this PR do?
Update the various succeed_with and fail_with functions to use comment when passed.

### What issues does this PR fix or reference?
Fixes: #51821 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ Yes] Docs
- [ No] Changelog
- [ Yes] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
