### PR TITLE
Add new salt-ssh set_path option

### DIFF
--- a/.ci/kitchen-macosxhighsierra-py3
+++ b/.ci/kitchen-macosxhighsierra-py3
@@ -11,7 +11,7 @@ runTestSuite(
     kitchen_platforms_file: '/var/jenkins/workspace/pre-golden-nox-platforms.yml',
     kitchen_verifier_file: '/var/jenkins/workspace/nox-verifier.yml',
     nox_env_name: 'runtests-zeromq',
-    nox_passthrough_opts: '',
+    nox_passthrough_opts: '--ssh-tests',
     python_version: 'py3',
     run_full: params.runFull,
     testrun_timeout: 6,

--- a/.ci/kitchen-macosxmojave-py3
+++ b/.ci/kitchen-macosxmojave-py3
@@ -11,7 +11,7 @@ runTestSuite(
     kitchen_platforms_file: '/var/jenkins/workspace/pre-golden-nox-platforms.yml',
     kitchen_verifier_file: '/var/jenkins/workspace/nox-verifier.yml',
     nox_env_name: 'runtests-zeromq',
-    nox_passthrough_opts: '',
+    nox_passthrough_opts: '--ssh-tests',
     python_version: 'py3',
     run_full: params.runFull,
     testrun_timeout: 6,

--- a/.ci/kitchen-macosxsierra-py3
+++ b/.ci/kitchen-macosxsierra-py3
@@ -11,7 +11,7 @@ runTestSuite(
     kitchen_platforms_file: '/var/jenkins/workspace/pre-golden-nox-platforms.yml',
     kitchen_verifier_file: '/var/jenkins/workspace/nox-verifier.yml',
     nox_env_name: 'runtests-zeromq',
-    nox_passthrough_opts: '',
+    nox_passthrough_opts: '--ssh-tests',
     python_version: 'py3',
     run_full: params.runFull,
     testrun_timeout: 6,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ This project versioning is _similar_ to [Semantic Versioning](https://semver.org
 Versions are `MAJOR.PATCH`.
 
 ## 3001 - Sodium
-## Sodium
 
 ### Removed
 
@@ -16,23 +15,11 @@ Versions are `MAJOR.PATCH`.
 ### Changed
 
 ### Fixed
+- [#56237](https://github.com/saltstack/salt/pull/56237) - Fix alphabetical ordering and remove duplicates across all documentation indexes - [@myii](https://github.com/myii)
+- [#56325](https://github.com/saltstack/salt/pull/56325) - Fix hyperlinks to `salt.serializers` and other documentation issues - [@myii](https://github.com/myii)
 
 ### Added
 - [#56627](https://github.com/saltstack/salt/pull/56627) - Add new salt-ssh set_path option
-
-
-## 3000.1
-
-### Removed
-
-### Deprecated
-
-### Changed
-
-### Fixed
-
-- [#56237](https://github.com/saltstack/salt/pull/56237) - Fix alphabetical ordering and remove duplicates across all documentation indexes - [@myii](https://github.com/myii)
-- [#56325](https://github.com/saltstack/salt/pull/56325) - Fix hyperlinks to `salt.serializers` and other documentation issues - [@myii](https://github.com/myii)
 
 ## 3000.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ This project versioning is _similar_ to [Semantic Versioning](https://semver.org
 Versions are `MAJOR.PATCH`.
 
 ## 3001 - Sodium
+## Sodium
+
+### Removed
+
+### Deprecated
+
+### Changed
+
+### Fixed
+
+### Added
+- [#56627](https://github.com/saltstack/salt/pull/56627) - Add new salt-ssh set_path option
+
+
+## 3000.1
 
 ### Removed
 

--- a/doc/topics/releases/sodium.rst
+++ b/doc/topics/releases/sodium.rst
@@ -28,9 +28,11 @@ This grain provides the same information as the ``path`` grain, only formatted
 as a list of directories.
 
 
-================
 Salt-SSH updates
 ================
+
+ssh_pre_flight
+--------------
 
 A new Salt-SSH roster option `ssh_pre_flight` has been added. This enables you to run a
 script before Salt-SSH tries to run any commands. You can set this option in the roster
@@ -60,3 +62,18 @@ minion. If you want to force the script to run you have the following options:
 * Wipe the thin dir on the targeted minion using the -w arg.
 * Set ssh_run_pre_flight to True in the config.
 * Run salt-ssh with the --pre-flight arg.
+
+set_path
+--------
+
+A new salt-ssh roster option `set_path` has been added. This allows you to set
+the path environment variable used to run the salt-ssh command on the target minion.
+You can set this setting in your roster file like so:
+
+.. code-block:: yaml
+
+  minion1:
+    host: localhost
+    user: root
+    passwd: P@ssword
+    set_path: '$PATH:/usr/local/bin/'

--- a/doc/topics/ssh/roster.rst
+++ b/doc/topics/ssh/roster.rst
@@ -66,6 +66,10 @@ The information which can be stored in a roster ``target`` is the following:
                         # does not exist, unless --pre-flight is passed to salt-ssh
                         # command or ssh_run_pre_flight is set to true in the config
                         # Added in Sodium Release.
+        set_path:    # Set the path environment variable, to ensure the expected python
+                     # binary is in the salt-ssh path, when running the command.
+                     # Example: '$PATH:/usr/local/bin/'. Added in Sodium Release.
+
 
 .. _ssh_pre_flight:
 

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -139,6 +139,10 @@ DEBUG="{{DEBUG}}"
 if [ -n "$DEBUG" ]
     then set -x
 fi
+SET_PATH="{{SET_PATH}}"
+if [ -n "$SET_PATH" ]
+    then export PATH={{SET_PATH}}
+fi
 SUDO=""
 if [ -n "{{SUDO}}" ]
     then SUDO="sudo "
@@ -907,6 +911,7 @@ class Single(object):
 
         self.fun, self.args, self.kwargs = self.__arg_comps()
         self.id = id_
+        self.set_path = kwargs.get("set_path", "")
 
         self.mods = mods if isinstance(mods, dict) else {}
         args = {
@@ -1311,6 +1316,7 @@ ARGS = {arguments}\n'''.format(
                 SUDO_USER=sudo_user,
                 SSH_PY_CODE=py_code_enc,
                 HOST_PY_MAJOR=sys.version_info[0],
+                SET_PATH=self.set_path,
             )
         else:
             cmd = saltwinshell.gen_shim(py_code_enc)

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -755,8 +755,10 @@ class TestDaemon(object):
         ) as roster:
             roster.write("  user: {0}\n".format(RUNTIME_VARS.RUNNING_TESTS_USER))
             roster.write(
-                "  priv: {0}/{1}".format(RUNTIME_VARS.TMP_CONF_DIR, "key_test")
+                "  priv: {0}/{1}\n".format(RUNTIME_VARS.TMP_CONF_DIR, "key_test")
             )
+            if salt.utils.platform.is_darwin():
+                roster.write("  set_path: $PATH:/usr/local/bin/\n")
         sys.stdout.write(" {LIGHT_GREEN}STARTED!\n{ENDC}".format(**self.colors))
 
     @classmethod

--- a/tests/integration/ssh/test_deploy.py
+++ b/tests/integration/ssh/test_deploy.py
@@ -10,6 +10,7 @@ import shutil
 
 # Import salt testing libs
 from tests.support.case import SSHCase
+from tests.support.runtests import RUNTIME_VARS
 
 
 class SSHTest(SSHCase):
@@ -33,6 +34,18 @@ class SSHTest(SSHCase):
         os.path.isdir(thin_dir)
         os.path.exists(os.path.join(thin_dir, "salt-call"))
         os.path.exists(os.path.join(thin_dir, "running_data"))
+
+    def test_set_path(self):
+        """
+        test setting the path env variable
+        """
+        path = "/pathdoesnotexist/"
+        roster = os.path.join(RUNTIME_VARS.TMP, "roster-set-path")
+        self.custom_roster(
+            roster, data={"set_path": "$PATH:/usr/local/bin/:{0}".format(path)}
+        )
+        ret = self.run_function("environ.get", ["PATH"], roster_file=roster)
+        assert path in ret
 
     def tearDown(self):
         """

--- a/tests/integration/ssh/test_master.py
+++ b/tests/integration/ssh/test_master.py
@@ -37,6 +37,7 @@ class SSHMasterTestCase(SSHCase):
             service = "org.ntp.ntpd"
             if int(os_release.split(".")[1]) >= 13:
                 service = "com.apple.AirPlayXPCHelper"
+        self.run_function("service.enable", [service])
         ret = self.run_function("service.get_all")
         self.assertIn(service, ret)
         self.run_function("service.stop", [service])

--- a/tests/unit/client/test_ssh.py
+++ b/tests/unit/client/test_ssh.py
@@ -7,6 +7,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import os
+import re
 import shutil
 import tempfile
 
@@ -392,3 +393,42 @@ class SSHSingleTests(TestCase):
                 call("/bin/sh '{0}'".format(exp_tmp)),
                 call("rm '{0}'".format(exp_tmp)),
             ] == mock_cmd.call_args_list
+
+    def test_cmd_run_set_path(self):
+        """
+        test when set_path is set
+        """
+        target = self.target
+        target["set_path"] = "$PATH:/tmp/path/"
+        single = ssh.Single(
+            self.opts,
+            self.opts["argv"],
+            "localhost",
+            mods={},
+            fsclient=None,
+            thin=salt.utils.thin.thin_path(self.opts["cachedir"]),
+            mine=False,
+            **self.target
+        )
+
+        ret = single._cmd_str()
+        assert re.search("\\" + target["set_path"], ret)
+
+    def test_cmd_run_not_set_path(self):
+        """
+        test when set_path is not set
+        """
+        target = self.target
+        single = ssh.Single(
+            self.opts,
+            self.opts["argv"],
+            "localhost",
+            mods={},
+            fsclient=None,
+            thin=salt.utils.thin.thin_path(self.opts["cachedir"]),
+            mine=False,
+            **self.target
+        )
+
+        ret = single._cmd_str()
+        assert re.search('SET_PATH=""', ret)

--- a/tests/unit/client/test_ssh.py
+++ b/tests/unit/client/test_ssh.py
@@ -394,6 +394,7 @@ class SSHSingleTests(TestCase):
                 call("rm '{0}'".format(exp_tmp)),
             ] == mock_cmd.call_args_list
 
+    @skipIf(salt.utils.platform.is_windows(), "SSH_PY_SHIM not set on windows")
     def test_cmd_run_set_path(self):
         """
         test when set_path is set
@@ -414,6 +415,7 @@ class SSHSingleTests(TestCase):
         ret = single._cmd_str()
         assert re.search("\\" + target["set_path"], ret)
 
+    @skipIf(salt.utils.platform.is_windows(), "SSH_PY_SHIM not set on windows")
     def test_cmd_run_not_set_path(self):
         """
         test when set_path is not set


### PR DESCRIPTION
### What does this PR do?
Adds new `set_path` option for salt-ssh to set the PATH environment variable used in the salt-ssh shim.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/56599 - the mac tests are failing because python is not in the path. 

### Previous Behavior
Could not set the PATH when running salt-ssh. 

### New Behavior
Can set the PATH environment variable when running salt-ssh. This helps solve problems associated when python is not in your current path setting. 

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
Yes