### PR TITLE
[master] check kwargs for expected arguments in salt.utils.functools.call_function

### DIFF
--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -450,7 +450,7 @@ def run(**kwargs):
     return ret
 
 
-def _call_function(name, returner=None, func_args=None):
+def _call_function(name, returner=None, func_args=None, func_kwargs=None):
     """
     Calls a function from the specified module.
 
@@ -462,7 +462,11 @@ def _call_function(name, returner=None, func_args=None):
     """
     if func_args is None:
         func_args = []
-    mret = salt.utils.functools.call_function(__salt__[name], *func_args)
+
+    if func_kwargs is None:
+        func_kwargs = {}
+
+    mret = salt.utils.functools.call_function(__salt__[name], *func_args, **func_kwargs)
     if returner is not None:
         returners = salt.loader.returners(__opts__, __salt__)
         if returner in returners:

--- a/salt/utils/functools.py
+++ b/salt/utils/functools.py
@@ -144,6 +144,10 @@ def call_function(salt_function, *args, **kwargs):
         for arg in argspec.args[_passed_prm:]:
             if arg not in function_kwargs:
                 missing.append(arg)
+            else:
+                # Found the expected argument as a keyword
+                # increase the _passed_prm count
+                _passed_prm += 1
     if missing:
         raise SaltInvocationError("Missing arguments: {0}".format(", ".join(missing)))
     elif _exp_prm > _passed_prm:

--- a/tests/unit/states/test_module.py
+++ b/tests/unit/states/test_module.py
@@ -375,6 +375,26 @@ class ModuleStateTest(TestCase, LoaderModuleMockMixin):
                 (1, 2, 3, (), {}),
             )
 
+            self.assertEqual(
+                module._call_function("testfunc", func_kwargs={"a": 1, "b": 2, "c": 3}),
+                (1, 2, 3, (), {}),
+            )
+
+            self.assertEqual(
+                module._call_function("testfunc", func_kwargs={"c": 3, "a": 1, "b": 2}),
+                (1, 2, 3, (), {}),
+            )
+
+            self.assertEqual(
+                module._call_function("testfunc", func_kwargs={"b": 2, "a": 1, "c": 3}),
+                (1, 2, 3, (), {}),
+            )
+
+            self.assertEqual(
+                module._call_function("testfunc", func_kwargs={"a": 1, "c": 3, "b": 2}),
+                (1, 2, 3, (), {}),
+            )
+
         with patch.dict(
             module.__salt__,
             {"testfunc": lambda c, a, b, *args, **kwargs: (a, b, c, args, kwargs)},
@@ -390,6 +410,26 @@ class ModuleStateTest(TestCase, LoaderModuleMockMixin):
                 module._call_function(
                     "testfunc", func_args=[{"c": 3}, {"a": 1}, {"b": 2}]
                 ),
+                (1, 2, 3, (), {}),
+            )
+
+            self.assertEqual(
+                module._call_function("testfunc", func_kwargs={"a": 1, "b": 2, "c": 3}),
+                (1, 2, 3, (), {}),
+            )
+
+            self.assertEqual(
+                module._call_function("testfunc", func_kwargs={"c": 3, "a": 1, "b": 2}),
+                (1, 2, 3, (), {}),
+            )
+
+            self.assertEqual(
+                module._call_function("testfunc", func_kwargs={"b": 2, "a": 1, "c": 3}),
+                (1, 2, 3, (), {}),
+            )
+
+            self.assertEqual(
+                module._call_function("testfunc", func_kwargs={"a": 1, "c": 3, "b": 2}),
                 (1, 2, 3, (), {}),
             )
 
@@ -411,4 +451,29 @@ class ModuleStateTest(TestCase, LoaderModuleMockMixin):
             self.assertEqual(
                 module._call_function("testfunc", func_args=[3, 1, 2]),
                 (3, 1, 2, (), {}),
+            )
+
+    def test_call_function_ordered_and_named_args(self):
+        """
+        Test _call_function routine when params are not named. Their position should matter.
+
+        :return:
+        """
+        with patch.dict(
+            module.__salt__,
+            {"testfunc": lambda a, b, c, *args, **kwargs: (a, b, c, args, kwargs)},
+            clear=True,
+        ):
+            self.assertEqual(
+                module._call_function(
+                    "testfunc", func_args=[1], func_kwargs={"b": 2, "c": 3}
+                ),
+                (1, 2, 3, (), {}),
+            )
+
+            self.assertEqual(
+                module._call_function(
+                    "testfunc", func_args=[1, 2], func_kwargs={"c": 3}
+                ),
+                (1, 2, 3, (), {}),
             )


### PR DESCRIPTION
### What does this PR do?
Update salt.utils.functools.call_functions to check kwargs for expected arguments.

### What issues does this PR fix or reference?
Fixes: #56584 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
