### PR TITLE
Add gitfs and git_pillar fallback branch

### DIFF
--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -532,7 +532,7 @@ would only fetch branches and tags (the default).
 Global Remotes
 ==============
 
-.. versionadded:: 2018.3.0
+.. versionadded:: 2018.3.0 for all_saltenvs, sodium for fallback
 
 The ``all_saltenvs`` per-remote configuration parameter overrides the logic
 Salt uses to map branches/tags to fileserver environments (i.e. saltenvs). This
@@ -543,6 +543,8 @@ allows a single branch/tag to appear in *all* GitFS saltenvs.
    configured using ``all_saltenvs`` will *not* show up in a fileserver
    environment defined via some other fileserver backend (e.g.
    :conf_master:`file_roots`).
+
+The ``fallback`` global or per-remote configuration can also be used.
 
 This is very useful in particular when working with :ref:`salt formulas
 <conventions-formula>`. Prior to the addition of this feature, it was necessary
@@ -559,6 +561,15 @@ single branch.
     gitfs_remotes:
       - http://foo.com/quux.git:
         - all_saltenvs: anything
+
+If you want to also test working branches of the formula repository, use
+``fallback``:
+
+.. code-block:: yaml
+
+    gitfs_remotes:
+      - http://foo.com/quux.git:
+        - fallback: anything
 
 .. _gitfs-update-intervals:
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -513,11 +513,11 @@ VALID_OPTS = immutabletypes.freeze(
         "minionfs_update_interval": int,
         "s3fs_update_interval": int,
         "svnfs_update_interval": int,
-        # NOTE: git_pillar_base, git_pillar_branch, git_pillar_env, and
-        # git_pillar_root omitted here because their values could conceivably be
-        # loaded as non-string types, which is OK because git_pillar will normalize
-        # them to strings. But rather than include all the possible types they
-        # could be, we'll just skip type-checking.
+        # NOTE: git_pillar_base, git_pillar_fallback, git_pillar_branch,
+        # git_pillar_env, and git_pillar_root omitted here because their values
+        # could conceivably be loaded as non-string types, which is OK because
+        # git_pillar will normalize them to strings. But rather than include all the
+        # possible types they could be, we'll just skip type-checking.
         "git_pillar_ssl_verify": bool,
         "git_pillar_global_lock": bool,
         "git_pillar_user": six.string_types,
@@ -529,10 +529,10 @@ VALID_OPTS = immutabletypes.freeze(
         "git_pillar_refspecs": list,
         "git_pillar_includes": bool,
         "git_pillar_verify_config": bool,
-        # NOTE: gitfs_base, gitfs_mountpoint, and gitfs_root omitted here because
-        # their values could conceivably be loaded as non-string types, which is OK
-        # because gitfs will normalize them to strings. But rather than include all
-        # the possible types they could be, we'll just skip type-checking.
+        # NOTE: gitfs_base, gitfs_fallback, gitfs_mountpoint, and gitfs_root omitted
+        # here because their values could conceivably be loaded as non-string types,
+        # which is OK because gitfs will normalize them to strings. But rather than
+        # include all the possible types they could be, we'll just skip type-checking.
         "gitfs_remotes": list,
         "gitfs_insecure_auth": bool,
         "gitfs_privkey": six.string_types,
@@ -1033,6 +1033,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze(
         "git_pillar_base": "master",
         "git_pillar_branch": "master",
         "git_pillar_env": "",
+        "git_pillar_fallback": "",
         "git_pillar_root": "",
         "git_pillar_ssl_verify": True,
         "git_pillar_global_lock": True,
@@ -1048,6 +1049,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze(
         "gitfs_mountpoint": "",
         "gitfs_root": "",
         "gitfs_base": "master",
+        "gitfs_fallback": "",
         "gitfs_user": "",
         "gitfs_password": "",
         "gitfs_insecure_auth": False,
@@ -1272,6 +1274,7 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze(
         "git_pillar_base": "master",
         "git_pillar_branch": "master",
         "git_pillar_env": "",
+        "git_pillar_fallback": "",
         "git_pillar_root": "",
         "git_pillar_ssl_verify": True,
         "git_pillar_global_lock": True,
@@ -1288,6 +1291,7 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze(
         "gitfs_mountpoint": "",
         "gitfs_root": "",
         "gitfs_base": "master",
+        "gitfs_fallback": "",
         "gitfs_user": "",
         "gitfs_password": "",
         "gitfs_insecure_auth": False,

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -59,6 +59,7 @@ from salt.exceptions import FileserverConfigError
 
 PER_REMOTE_OVERRIDES = (
     "base",
+    "fallback",
     "mountpoint",
     "root",
     "ssl_verify",

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -365,6 +365,28 @@ remotes. The update is handled within the global loop, hence
 
     git_pillar_update_interval: 120
 
+.. _git-pillar-fallback:
+
+fallback
+~~~~~~~~
+
+.. versionadded:: sodium
+
+Setting ``fallback`` per-remote or global configuration parameter will map non-existing environments to a default branch. Example:
+
+.. code-block:: yaml
+
+    ext_pillar:
+      - git:
+        - __env__ https://mydomain.tld/top.git
+          - all_saltenvs: master
+        - __env__ https://mydomain.tld/pillar-nginx.git:
+          - mountpoint: web/server/
+          - fallback: master
+        - __env__ https://mydomain.tld/pillar-appdata.git:
+          - mountpoint: web/server/
+          - fallback: master
+
 """
 from __future__ import absolute_import, print_function, unicode_literals
 
@@ -384,7 +406,7 @@ from salt.exceptions import FileserverConfigError
 from salt.ext import six
 from salt.pillar import Pillar
 
-PER_REMOTE_OVERRIDES = ("env", "root", "ssl_verify", "refspecs")
+PER_REMOTE_OVERRIDES = ("env", "root", "ssl_verify", "refspecs", "fallback")
 PER_REMOTE_ONLY = ("name", "mountpoint", "all_saltenvs")
 GLOBAL_ONLY = ("base", "branch")
 

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -1073,6 +1073,22 @@ class GitProvider(object):
                 if candidate is not None:
                     return candidate
 
+        if self.fallback:
+            for ref_type in self.ref_types:
+                try:
+                    func_name = "get_tree_from_{0}".format(ref_type)
+                    func = getattr(self, func_name)
+                except AttributeError:
+                    log.error(
+                        "%s class is missing function '%s'",
+                        self.__class__.__name__,
+                        func_name,
+                    )
+                else:
+                    candidate = func(self.fallback)
+                    if candidate is not None:
+                        return candidate
+
         # No matches found
         return None
 
@@ -1192,12 +1208,18 @@ class GitPython(GitProvider):
 
         # 'origin/' + tgt_ref ==> matches a branch head
         # 'tags/' + tgt_ref + '@{commit}' ==> matches tag's commit
-        for rev_parse_target, checkout_ref in (
-            ("origin/" + tgt_ref, "origin/" + tgt_ref),
-            ("tags/" + tgt_ref, "tags/" + tgt_ref),
-        ):
+        checkout_refs = [
+            ("origin/" + tgt_ref, False),
+            ("tags/" + tgt_ref, False),
+        ]
+        if self.fallback:
+            checkout_refs += [
+                ("origin/" + self.fallback, True),
+                ("tags/" + self.fallback, True),
+            ]
+        for checkout_ref, fallback in checkout_refs:
             try:
-                target_sha = self.repo.rev_parse(rev_parse_target).hexsha
+                target_sha = self.repo.rev_parse(checkout_ref).hexsha
             except Exception:  # pylint: disable=broad-except
                 # ref does not exist
                 continue
@@ -1210,10 +1232,11 @@ class GitPython(GitProvider):
                 with self.gen_lock(lock_type="checkout"):
                     self.repo.git.checkout(checkout_ref)
                     log.debug(
-                        "%s remote '%s' has been checked out to %s",
+                        "%s remote '%s' has been checked out to %s%s",
                         self.role,
                         self.id,
                         checkout_ref,
+                        " as fallback" if fallback else "",
                     )
             except GitLockError as exc:
                 if exc.errno == errno.EEXIST:
@@ -1559,6 +1582,11 @@ class Pygit2(GitProvider):
             return False
 
         try:
+            if remote_ref not in refs and tag_ref not in refs and self.fallback:
+                tgt_ref = self.fallback
+                local_ref = "refs/heads/" + tgt_ref
+                remote_ref = "refs/remotes/origin/" + tgt_ref
+                tag_ref = "refs/tags/" + tgt_ref
             if remote_ref in refs:
                 # Get commit id for the remote ref
                 oid = self.peel(self.repo.lookup_reference(remote_ref)).id
@@ -2890,9 +2918,7 @@ class GitFS(GitBase):
         and send the path to the newly cached file
         """
         fnd = {"path": "", "rel": ""}
-        if os.path.isabs(path) or (
-            not salt.utils.stringutils.is_hex(tgt_env) and tgt_env not in self.envs()
-        ):
+        if os.path.isabs(path):
             return fnd
 
         dest = salt.utils.path.join(self.cache_root, "refs", tgt_env, path)
@@ -2923,6 +2949,12 @@ class GitFS(GitBase):
         for repo in self.remotes:
             if repo.mountpoint(tgt_env) and not path.startswith(
                 repo.mountpoint(tgt_env) + os.sep
+            ):
+                continue
+            if (
+                not salt.utils.stringutils.is_hex(tgt_env)
+                and tgt_env not in self.envs()
+                and not repo.fallback
             ):
                 continue
             repo_path = path[len(repo.mountpoint(tgt_env)) :].lstrip(os.sep)
@@ -3082,11 +3114,12 @@ class GitFS(GitBase):
         if refresh_cache:
             log.trace("Start rebuilding gitfs file_list cache")
             ret = {"files": set(), "symlinks": {}, "dirs": set()}
-            if (
-                salt.utils.stringutils.is_hex(load["saltenv"])
-                or load["saltenv"] in self.envs()
-            ):
-                for repo in self.remotes:
+            for repo in self.remotes:
+                if (
+                    salt.utils.stringutils.is_hex(load["saltenv"])
+                    or load["saltenv"] in self.envs()
+                    or repo.fallback
+                ):
                     start = time.time()
                     repo_files, repo_symlinks = repo.file_list(load["saltenv"])
                     ret["files"].update(repo_files)

--- a/tests/integration/pillar/test_git_pillar.py
+++ b/tests/integration/pillar/test_git_pillar.py
@@ -583,6 +583,41 @@ class GitPythonMixin(object):
             },
         )
 
+    def test_fallback(self):
+        """
+        Test fallback parameter.
+        """
+        ret = self.get_pillar(
+            """\
+            file_ignore_regex: []
+            file_ignore_glob: []
+            git_pillar_provider: gitpython
+            cachedir: {cachedir}
+            extension_modules: {extmods}
+            pillarenv: nonexisting
+            ext_pillar:
+              - git:
+                - __env__ {url_extra_repo}:
+                  - fallback: master
+                - __env__ {url}:
+                  - mountpoint: nowhere
+                  - fallback: dev
+            """
+        )
+        self.assertEqual(
+            ret,
+            {
+                "branch": "dev",
+                "motd": "The force will be with you. Always.",
+                "mylist": ["dev"],
+                "mydict": {
+                    "dev": True,
+                    "nested_list": ["dev"],
+                    "nested_dict": {"dev": True},
+                },
+            },
+        )
+
 
 @destructiveTest
 @skipIf(_windows_or_mac(), "minion is windows or mac")
@@ -2059,6 +2094,121 @@ class TestPygit2SSH(GitPillarSSHTestBase):
         )
         self.assertEqual(ret, expected)
 
+    @requires_system_grains
+    def test_fallback(self, grains):
+        """
+        Test fallback parameter.
+        """
+        expected = {
+            "branch": "dev",
+            "motd": "The force will be with you. Always.",
+            "mylist": ["dev"],
+            "mydict": {
+                "dev": True,
+                "nested_list": ["dev"],
+                "nested_dict": {"dev": True},
+            },
+        }
+
+        # Test with passphraseless key and global credential options
+        ret = self.get_pillar(
+            """\
+            file_ignore_regex: []
+            file_ignore_glob: []
+            git_pillar_provider: pygit2
+            git_pillar_pubkey: {pubkey_nopass}
+            git_pillar_privkey: {privkey_nopass}
+            cachedir: {cachedir}
+            extension_modules: {extmods}
+            pillarenv: nonexisting
+            ext_pillar:
+              - git:
+                - __env__ {url_extra_repo}:
+                  - fallback: master
+                - __env__ {url}:
+                  - mountpoint: nowhere
+                  - fallback: dev
+            """
+        )
+        self.assertEqual(ret, expected)
+
+        # Test with passphraseless key and per-repo credential options
+        ret = self.get_pillar(
+            """\
+            file_ignore_regex: []
+            file_ignore_glob: []
+            git_pillar_provider: pygit2
+            cachedir: {cachedir}
+            extension_modules: {extmods}
+            pillarenv: nonexisting
+            ext_pillar:
+              - git:
+                - __env__ {url_extra_repo}:
+                  - fallback: master
+                  - pubkey: {pubkey_nopass}
+                  - privkey: {privkey_nopass}
+                - __env__ {url}:
+                  - mountpoint: nowhere
+                  - fallback: dev
+                  - pubkey: {pubkey_nopass}
+                  - privkey: {privkey_nopass}
+            """
+        )
+        self.assertEqual(ret, expected)
+
+        if grains["os_family"] == "Debian":
+            # passphrase-protected currently does not work here
+            return
+
+        # Test with passphrase-protected key and global credential options
+        ret = self.get_pillar(
+            """\
+            file_ignore_regex: []
+            file_ignore_glob: []
+            git_pillar_provider: pygit2
+            git_pillar_pubkey: {pubkey_withpass}
+            git_pillar_privkey: {privkey_withpass}
+            git_pillar_passphrase: {passphrase}
+            cachedir: {cachedir}
+            extension_modules: {extmods}
+            pillarenv: nonexisting
+            ext_pillar:
+              - git:
+                - __env__ {url_extra_repo}:
+                  - fallback: master
+                - __env__ {url}:
+                  - mountpoint: nowhere
+                  - fallback: dev
+            """
+        )
+        self.assertEqual(ret, expected)
+
+        # Test with passphrase-protected key and per-repo credential options
+        ret = self.get_pillar(
+            """\
+            file_ignore_regex: []
+            file_ignore_glob: []
+            git_pillar_provider: pygit2
+            cachedir: {cachedir}
+            extension_modules: {extmods}
+            pillarenv: nonexisting
+            ext_pillar:
+              - git:
+                - __env__ {url_extra_repo}:
+                  - fallback: master
+                  - pubkey: {pubkey_nopass}
+                  - privkey: {privkey_nopass}
+                  - passphrase: {passphrase}
+                - __env__ {url}:
+                  - mountpoint: nowhere
+                  - fallback: dev
+                  - pubkey: {pubkey_nopass}
+                  - privkey: {privkey_nopass}
+                  - passphrase: {passphrase}
+            """
+        )
+        self.assertEqual(ret, expected)
+
 
 @skipIf(_windows_or_mac(), "minion is windows or mac")
 @skip_if_not_root
@@ -2514,6 +2664,41 @@ class TestPygit2HTTP(GitPillarHTTPTestBase):
                     "master": True,
                     "nested_list": ["master"],
                     "nested_dict": {"master": True},
+                },
+            },
+        )
+
+    def test_fallback(self):
+        """
+        Test fallback parameter.
+        """
+        ret = self.get_pillar(
+            """\
+            file_ignore_regex: []
+            file_ignore_glob: []
+            git_pillar_provider: pygit2
+            cachedir: {cachedir}
+            extension_modules: {extmods}
+            pillarenv: nonexisting
+            ext_pillar:
+              - git:
+                - __env__ {url_extra_repo}:
+                  - fallback: master
+                - __env__ {url}:
+                  - mountpoint: nowhere
+                  - fallback: dev
+            """
+        )
+        self.assertEqual(
+            ret,
+            {
+                "branch": "dev",
+                "motd": "The force will be with you. Always.",
+                "mylist": ["dev"],
+                "mydict": {
+                    "dev": True,
+                    "nested_list": ["dev"],
+                    "nested_dict": {"dev": True},
                 },
             },
         )
@@ -3216,6 +3401,44 @@ class TestPygit2AuthenticatedHTTP(GitPillarHTTPTestBase):
                     "master": True,
                     "nested_list": ["master"],
                     "nested_dict": {"master": True},
+                },
+            },
+        )
+
+    def test_fallback(self):
+        """
+        Test fallback parameter.
+        """
+        ret = self.get_pillar(
+            """\
+            file_ignore_regex: []
+            file_ignore_glob: []
+            git_pillar_provider: pygit2
+            git_pillar_user: {user}
+            git_pillar_password: {password}
+            git_pillar_insecure_auth: True
+            cachedir: {cachedir}
+            extension_modules: {extmods}
+            pillarenv: nonexisting
+            ext_pillar:
+              - git:
+                - __env__ {url_extra_repo}:
+                  - fallback: master
+                - __env__ {url}:
+                  - mountpoint: nowhere
+                  - fallback: dev
+            """
+        )
+        self.assertEqual(
+            ret,
+            {
+                "branch": "dev",
+                "motd": "The force will be with you. Always.",
+                "mylist": ["dev"],
+                "mydict": {
+                    "dev": True,
+                    "nested_list": ["dev"],
+                    "nested_dict": {"dev": True},
                 },
             },
         )

--- a/tests/support/gitfs.py
+++ b/tests/support/gitfs.py
@@ -68,6 +68,7 @@ _OPTS = {
     "git_pillar_base": "master",
     "git_pillar_branch": "master",
     "git_pillar_env": "",
+    "git_pillar_fallback": "",
     "git_pillar_root": "",
     "git_pillar_ssl_verify": True,
     "git_pillar_global_lock": True,

--- a/tests/unit/fileserver/test_gitfs.py
+++ b/tests/unit/fileserver/test_gitfs.py
@@ -92,6 +92,7 @@ class GitfsConfigTestCase(TestCase, LoaderModuleMockMixin):
             "gitfs_root": "",
             "fileserver_backend": ["gitfs"],
             "gitfs_base": "master",
+            "gitfs_fallback": "",
             "fileserver_events": True,
             "transport": "zeromq",
             "gitfs_mountpoint": "",
@@ -265,6 +266,75 @@ class GitFSTestFuncs(object):
         ret = gitfs.dir_list(LOAD)
         self.assertIn("grail", ret)
         self.assertIn(UNICODE_DIRNAME, ret)
+
+    def test_find_and_serve_file(self):
+        with patch.dict(gitfs.__opts__, {"file_buffer_size": 262144}):
+            gitfs.update()
+
+            # find_file
+            ret = gitfs.find_file("testfile")
+            self.assertEqual("testfile", ret["rel"])
+
+            full_path_to_file = salt.utils.path.join(
+                gitfs.__opts__["cachedir"], "gitfs", "refs", "base", "testfile"
+            )
+            self.assertEqual(full_path_to_file, ret["path"])
+
+            # serve_file
+            load = {"saltenv": "base", "path": full_path_to_file, "loc": 0}
+            fnd = {"path": full_path_to_file, "rel": "testfile"}
+            ret = gitfs.serve_file(load, fnd)
+
+            with salt.utils.files.fopen(
+                os.path.join(RUNTIME_VARS.BASE_FILES, "testfile"), "r"
+            ) as fp_:  # NB: Why not 'rb'?
+                data = fp_.read()
+
+            self.assertDictEqual(ret, {"data": data, "dest": "testfile"})
+
+    def test_file_list_fallback(self):
+        with patch.dict(gitfs.__opts__, {"gitfs_fallback": "master"}):
+            gitfs.update()
+            ret = gitfs.file_list({"saltenv": "notexisting"})
+            self.assertIn("testfile", ret)
+            self.assertIn(UNICODE_FILENAME, ret)
+            # This function does not use os.sep, the Salt fileserver uses the
+            # forward slash, hence it being explicitly used to join here.
+            self.assertIn("/".join((UNICODE_DIRNAME, "foo.txt")), ret)
+
+    def test_dir_list_fallback(self):
+        with patch.dict(gitfs.__opts__, {"gitfs_fallback": "master"}):
+            gitfs.update()
+            ret = gitfs.dir_list({"saltenv": "notexisting"})
+            self.assertIn("grail", ret)
+            self.assertIn(UNICODE_DIRNAME, ret)
+
+    def test_find_and_serve_file_fallback(self):
+        with patch.dict(
+            gitfs.__opts__, {"file_buffer_size": 262144, "gitfs_fallback": "master"}
+        ):
+            gitfs.update()
+
+            # find_file
+            ret = gitfs.find_file("testfile", tgt_env="notexisting")
+            self.assertEqual("testfile", ret["rel"])
+
+            full_path_to_file = salt.utils.path.join(
+                gitfs.__opts__["cachedir"], "gitfs", "refs", "notexisting", "testfile"
+            )
+            self.assertEqual(full_path_to_file, ret["path"])
+
+            # serve_file
+            load = {"saltenv": "notexisting", "path": full_path_to_file, "loc": 0}
+            fnd = {"path": full_path_to_file, "rel": "testfile"}
+            ret = gitfs.serve_file(load, fnd)
+
+            with salt.utils.files.fopen(
+                os.path.join(RUNTIME_VARS.BASE_FILES, "testfile"), "r"
+            ) as fp_:  # NB: Why not 'rb'?
+                data = fp_.read()
+
+            self.assertDictEqual(ret, {"data": data, "dest": "testfile"})
 
     def test_envs(self):
         gitfs.update()
@@ -566,6 +636,7 @@ class GitPythonTest(GitFSTestBase, GitFSTestFuncs, TestCase, LoaderModuleMockMix
             "gitfs_root": "",
             "fileserver_backend": ["gitfs"],
             "gitfs_base": "master",
+            "gitfs_fallback": "",
             "fileserver_events": True,
             "transport": "zeromq",
             "gitfs_mountpoint": "",
@@ -614,6 +685,7 @@ class Pygit2Test(GitFSTestBase, GitFSTestFuncs, TestCase, LoaderModuleMockMixin)
             "gitfs_root": "",
             "fileserver_backend": ["gitfs"],
             "gitfs_base": "master",
+            "gitfs_fallback": "",
             "fileserver_events": True,
             "transport": "zeromq",
             "gitfs_mountpoint": "",


### PR DESCRIPTION
### What does this PR do?

Add a fallback branch when no matching branch is found. This is a forward port of pull request #51971.

### New Behavior

Example:

```yaml
gitfs_remotes:
  - http://foo.com/states/top.git:
    - all_saltenvs: master
  - http://foo.com/states/apache.git:
    - fallback: master
  - http://foo.com/states/nginx.git:
    - fallback: master
  - http://foo.com/states/webapp.git:
    - fallback: develop
```

Where a state in `webapp` includes a state of `apache`.

With this PR, one can test a feature branch of `webapp` without needing to create the same branch in `apache`. Similarly, one can test a feature branch of `apache` without needing to create the same branch in `webapp`.

### Merge requirements satisfied?
- [x] Docs
- [ ] Changelog
- [x] Tests written/updated