### PR TITLE
Virt init disks

### DIFF
--- a/changelog/57005.added
+++ b/changelog/57005.added
@@ -1,0 +1,1 @@
+Add support for disks volumes in virt.running state

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -665,15 +665,28 @@ def _gen_xml(
     return template.render(**context)
 
 
-def _gen_vol_xml(name, format, size):
+def _gen_vol_xml(
+    name,
+    size,
+    format=None,
+    allocation=0,
+    type=None,
+    permissions=None,
+    backing_store=None,
+    nocow=False,
+):
     """
     Generate the XML string to define a libvirt storage volume
     """
     size = int(size) * 1024  # MB
     context = {
+        "type": type,
         "name": name,
+        "target": {"permissions": permissions, "nocow": nocow},
         "format": format,
         "size": six.text_type(size),
+        "allocation": six.text_type(int(allocation) * 1024),
+        "backingStore": backing_store,
     }
     fn_ = "libvirt_volume.jinja"
     try:
@@ -1561,7 +1574,7 @@ def init(
                 log.debug("Generating libvirt XML for %s", _disk)
                 volume_name = "{0}/{1}".format(name, _disk["name"])
                 filename = "{0}.{1}".format(volume_name, _disk["format"])
-                vol_xml = _gen_vol_xml(filename, _disk["format"], _disk["size"])
+                vol_xml = _gen_vol_xml(filename, _disk["size"], format=_disk["format"])
                 define_vol_xml_str(vol_xml, pool=_disk.get("pool"))
 
         elif virt_hypervisor in ["qemu", "kvm", "xen"]:

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -6233,6 +6233,18 @@ def volume_infos(pool=None, volume=None, **kwargs):
             types = ["file", "block", "dir", "network", "netdir", "ploop"]
             infos = vol.info()
 
+            vol_xml = ElementTree.fromstring(vol.XMLDesc())
+            backing_store_path = vol_xml.find("./backingStore/path")
+            backing_store_format = vol_xml.find("./backingStore/format")
+            backing_store = None
+            if backing_store_path is not None:
+                backing_store = {
+                    "path": backing_store_path.text,
+                    "format": backing_store_format.get("type")
+                    if backing_store_format is not None
+                    else None,
+                }
+
             # If we have a path, check its use.
             used_by = []
             if vol.path():
@@ -6254,6 +6266,7 @@ def volume_infos(pool=None, volume=None, **kwargs):
                 "capacity": infos[1],
                 "allocation": infos[2],
                 "used_by": used_by,
+                "backing_store": backing_store,
             }
 
         pools = [

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -4938,14 +4938,14 @@ def network_define(name, bridge, forward, ipv4_config=None, ipv6_config=None, **
     )
     try:
         conn.networkDefineXML(net_xml)
-    except libvirtError as err:
+    except libvirt.libvirtError as err:
         log.warning(err)
         conn.close()
         raise err  # a real error we should report upwards
 
     try:
         network = conn.networkLookupByName(name)
-    except libvirtError as err:
+    except libvirt.libvirtError as err:
         log.warning(err)
         conn.close()
         raise err  # a real error we should report upwards
@@ -5570,7 +5570,7 @@ def pool_define(
             pool = conn.storagePoolDefineXML(pool_xml)
             if start:
                 pool.create()
-    except libvirtError as err:
+    except libvirt.libvirtError as err:
         raise err  # a real error we should report upwards
     finally:
         conn.close()

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -6245,6 +6245,8 @@ def volume_infos(pool=None, volume=None, **kwargs):
                     else None,
                 }
 
+            format_node = vol_xml.find("./target/format")
+
             # If we have a path, check its use.
             used_by = []
             if vol.path():
@@ -6267,6 +6269,7 @@ def volume_infos(pool=None, volume=None, **kwargs):
                 "allocation": infos[2],
                 "used_by": used_by,
                 "backing_store": backing_store,
+                "format": format_node.get("type") if format_node is not None else None,
             }
 
         pools = [

--- a/salt/templates/virt/libvirt_domain.jinja
+++ b/salt/templates/virt/libvirt_domain.jinja
@@ -28,16 +28,19 @@
         </os>
         <devices>
                 {% for disk in disks %}
-                <disk type='file' device='{{ disk.device }}'>
-                        {% if 'source_file' in disk %}
+                <disk type='{{ disk.type }}' device='{{ disk.device }}'>
+                        {% if disk.type == 'file' and 'source_file' in disk -%}
                         <source file='{{ disk.source_file }}' />
+                        {% endif %}
+                        {% if disk.type == 'volume' and 'pool' in disk -%}
+                        <source pool='{{ disk.pool }}' volume='{{ disk.volume }}' />
                         {% endif %}
                         <target dev='{{ disk.target_dev }}' bus='{{ disk.disk_bus }}' />
                         {% if disk.address -%}
                         <address type='drive' controller='0' bus='0' target='0' unit='{{ disk.index }}' />
                         {% endif %}
                         {% if disk.driver -%}
-                        <driver name='qemu' type='{{ disk.type }}' cache='none' io='native'/>
+                        <driver name='qemu' type='{{ disk.format}}' cache='none' io='native'/>
                         {% endif %}
                 </disk>
                 {% endfor %}

--- a/salt/templates/virt/libvirt_domain.jinja
+++ b/salt/templates/virt/libvirt_domain.jinja
@@ -36,7 +36,7 @@
                         <source pool='{{ disk.pool }}' volume='{{ disk.volume }}' />
                         {% endif %}
                         {%- if disk.type == 'network' %}
-                        <source protocol='{{ disk.protocol }}' name='{{ disk.volume }}'>
+                        <source protocol='{{ disk.protocol }}' name='{{ disk.volume }}'{% if disk.get('query') %} query='{{ disk.query }}'{% endif %}>
                           {%- for host in disk.get('hosts') %}
                           <host name='{{ host.name }}'{% if host.get("port") %} port='{{ host.port }}'{% endif %}/>
                           {%- endfor %}

--- a/salt/templates/virt/libvirt_domain.jinja
+++ b/salt/templates/virt/libvirt_domain.jinja
@@ -52,7 +52,9 @@
                 {% for nic in nics %}
                 <interface type='{{ nic.type }}'>
                     <source {{ nic.type }}='{{ nic.source }}'/>
+                    {% if nic.get('mac') -%}
                     <mac address='{{ nic.mac }}'/>
+                    {%- endif %}
                     {% if nic.model %}<model type='{{ nic.model }}'/>{% endif %}
                 </interface>
                 {% endfor %}

--- a/salt/templates/virt/libvirt_domain.jinja
+++ b/salt/templates/virt/libvirt_domain.jinja
@@ -35,6 +35,18 @@
                         {% if disk.type == 'volume' and 'pool' in disk -%}
                         <source pool='{{ disk.pool }}' volume='{{ disk.volume }}' />
                         {% endif %}
+                        {%- if disk.type == 'network' %}
+                        <source protocol='{{ disk.protocol }}' name='{{ disk.volume }}'>
+                          {%- for host in disk.get('hosts') %}
+                          <host name='{{ host.name }}'{% if host.get("port") %} port='{{ host.port }}'{% endif %}/>
+                          {%- endfor %}
+                          {%- if disk.get("auth") %}
+                          <auth username='{{ disk.auth.username }}'>
+                            <secret type='{{ disk.auth.type }}' usage='{{ disk.auth.usage}}'/>
+                          </auth>
+                          {%- endif %}
+                        </source>
+                        {%- endif %}
                         <target dev='{{ disk.target_dev }}' bus='{{ disk.disk_bus }}' />
                         {% if disk.address -%}
                         <address type='drive' controller='0' bus='0' target='0' unit='{{ disk.index }}' />

--- a/salt/templates/virt/libvirt_volume.jinja
+++ b/salt/templates/virt/libvirt_volume.jinja
@@ -1,17 +1,10 @@
 <volume>
-  <name>{{ name }}/{{ filename }}</name>
-  <key>{{ name }}/{{ volname }}</key>
+  <name>{{ name }}</name>
   <source>
   </source>
   <capacity unit='KiB'>{{ size }}</capacity>
   <allocation unit='KiB'>0</allocation>
   <target>
-    <path>{{ pool }}{{ name }}/{{ filename }}</path>
-    <format type='{{ disktype }}'/>
-    <permissions>
-      <mode>00</mode>
-      <owner>0</owner>
-      <group>0</group>
-    </permissions>
+    <format type='{{ format }}'/>
   </target>
 </volume>

--- a/salt/templates/virt/libvirt_volume.jinja
+++ b/salt/templates/virt/libvirt_volume.jinja
@@ -1,10 +1,39 @@
-<volume>
+<volume{% if type %} type='{{ type }}'{% endif %}>
   <name>{{ name }}</name>
   <source>
   </source>
   <capacity unit='KiB'>{{ size }}</capacity>
-  <allocation unit='KiB'>0</allocation>
+  <allocation unit='KiB'>{{ allocation }}</allocation>
   <target>
+    {%- if format %}
     <format type='{{ format }}'/>
+    {%- endif %}
+    {%- if target.permissions -%}
+    <permissions>
+      {%- if target.permissions.get('mode') %}
+      <mode>{{ target.permissions.mode }}</mode>
+      {%- endif %}
+      {%- if target.permissions.get('owner') %}
+      <owner>{{ target.permissions.owner }}</owner>
+      {%- endif %}
+      {%- if target.permissions.get('group') %}
+      <group>{{ target.permissions.group }}</group>
+      {%- endif %}
+      {%- if target.permissions.get('label') %}
+      <label>{{ target.permissions.label }}</label>
+      {%- endif %}
+    </permissions>
+    {%- endif %}
+    {%- if target.nocow %}
+    <nocow/>
+    {%- endif %}
   </target>
+  {%- if backingStore %}
+  <backingStore>
+    <path>{{ backingStore.path }}</path>
+    {%- if backingStore.format %}
+    <format type='{{ backingStore.format }}'/>
+    {%- endif %}
+  </backingStore>
+  {%- endif %}
 </volume>

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -10,7 +10,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import datetime
 import os
-import re
 import shutil
 import tempfile
 
@@ -634,9 +633,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(iface.find("source").attrib["bridge"], "br0")
         self.assertEqual(iface.find("model").attrib["type"], "virtio")
 
-        mac = iface.find("mac").attrib["address"]
-        self.assertTrue(re.match("^([0-9A-F]{2}[:-]){5}([0-9A-F]{2})$", mac, re.I))
-
     def test_gen_xml_for_esxi_default_profile(self):
         """
         Test virt._gen_xml(), ESXi/vmware default profile case
@@ -667,9 +663,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(iface.attrib["type"], "bridge")
         self.assertEqual(iface.find("source").attrib["bridge"], "DEFAULT")
         self.assertEqual(iface.find("model").attrib["type"], "e1000")
-
-        mac = iface.find("mac").attrib["address"]
-        self.assertTrue(re.match("^([0-9A-F]{2}[:-]){5}([0-9A-F]{2})$", mac, re.I))
 
     def test_gen_xml_for_xen_default_profile(self):
         """
@@ -915,8 +908,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         controllers = root.findall(".//devices/controller")
         # There should be no controller
         self.assertTrue(len(controllers) == 0)
-        # kvm mac address shoud start with 52:54:00
-        self.assertTrue("mac address='52:54:00" in xml_data)
 
     def test_diff_disks(self):
         """
@@ -1751,12 +1742,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                         "source": "default",
                         "mac": "52:54:00:39:02:b1",
                     },
-                    {
-                        "name": "eth1",
-                        "type": "network",
-                        "source": "oldnet",
-                        "mac": "52:54:00:39:02:b2",
-                    },
+                    {"name": "eth1", "type": "network", "source": "oldnet"},
                 ],
                 graphics={
                     "type": "spice",
@@ -1995,14 +1981,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 self.assertIn("name", interface_attrs)
                 self.assertIn("model", interface_attrs)
                 self.assertEqual(interface_attrs["model"], "virtio")
-                self.assertIn("mac", interface_attrs)
-                self.assertTrue(
-                    re.match(
-                        "^([0-9A-F]{2}[:-]){5}([0-9A-F]{2})$",
-                        interface_attrs["mac"],
-                        re.I,
-                    )
-                )
 
     def test_get_xml(self):
         """

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -534,18 +534,17 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             self.assertEqual(eth0["source"], "br0")
             self.assertFalse(eth0["model"])
 
-    def test_gen_vol_xml(self):
+    def test_gen_vol_xml_esx(self):
         """
-        Test virt._get_vol_xml()
+        Test virt._get_vol_xml() for the ESX case
         """
-        xml_data = virt._gen_vol_xml(
-            "vmname", "system", "qcow2", 8192, "/path/to/image/"
-        )
+        xml_data = virt._gen_vol_xml("vmname/system.vmdk", "vmdk", 8192)
         root = ET.fromstring(xml_data)
-        self.assertEqual(root.find("name").text, "vmname/system.qcow2")
-        self.assertEqual(root.find("key").text, "vmname/system")
+        self.assertIsNone(root.get("type"))
+        self.assertEqual(root.find("name").text, "vmname/system.vmdk")
         self.assertEqual(root.find("capacity").attrib["unit"], "KiB")
         self.assertEqual(root.find("capacity").text, six.text_type(8192 * 1024))
+        self.assertEqual(root.find("target/format").get("type"), "vmdk")
 
     def test_gen_xml_for_kvm_default_profile(self):
         """

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -70,6 +70,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         self.mock_libvirt = LibvirtMock()
         self.mock_conn = MagicMock()
+        self.mock_conn.getStoragePoolCapabilities.return_value = (
+            "<storagepoolCapabilities/>"
+        )
         self.mock_libvirt.openAuth.return_value = self.mock_conn
         self.mock_popen = MagicMock()
         self.addCleanup(delattr, self, "mock_libvirt")
@@ -124,7 +127,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             {"name": "data", "size": 16384, "format": "raw"},
         ]
 
-        disks = virt._disk_profile("default", "kvm", userdisks, "myvm")
+        disks = virt._disk_profile(self.mock_conn, "default", "kvm", userdisks, "myvm")
         self.assertEqual(
             [
                 {
@@ -154,7 +157,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         Test virt._gen_xml() default boot device
         """
-        diskp = virt._disk_profile("default", "kvm", [], "hello")
+        diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml("hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64")
         root = ET.fromstring(xml_data)
@@ -166,7 +169,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         Test virt._gen_xml() custom boot device
         """
-        diskp = virt._disk_profile("default", "kvm", [], "hello")
+        diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml(
             "hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64", boot_dev="cdrom"
@@ -178,7 +181,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         Test virt._gen_xml() multiple boot devices
         """
-        diskp = virt._disk_profile("default", "kvm", [], "hello")
+        diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml(
             "hello",
@@ -199,7 +202,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         Test virt._gen_xml() serial console
         """
-        diskp = virt._disk_profile("default", "kvm", [], "hello")
+        diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml(
             "hello",
@@ -221,7 +224,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         Test virt._gen_xml() serial console
         """
-        diskp = virt._disk_profile("default", "kvm", [], "hello")
+        diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml(
             "hello",
@@ -243,7 +246,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         Test virt._gen_xml() telnet console
         """
-        diskp = virt._disk_profile("default", "kvm", [], "hello")
+        diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml(
             "hello",
@@ -267,7 +270,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         Test virt._gen_xml() telnet console without any specified port
         """
-        diskp = virt._disk_profile("default", "kvm", [], "hello")
+        diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml(
             "hello",
@@ -292,7 +295,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         Test virt._gen_xml() with no serial console
         """
-        diskp = virt._disk_profile("default", "kvm", [], "hello")
+        diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml(
             "hello",
@@ -314,7 +317,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         Test virt._gen_xml() with no telnet console
         """
-        diskp = virt._disk_profile("default", "kvm", [], "hello")
+        diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml(
             "hello",
@@ -336,7 +339,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         Test virt._gen_xml() with default no graphics device
         """
-        diskp = virt._disk_profile("default", "kvm", [], "hello")
+        diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml("hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64")
         root = ET.fromstring(xml_data)
@@ -346,7 +349,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         Test virt._gen_xml() with default no loader
         """
-        diskp = virt._disk_profile("default", "kvm", [], "hello")
+        diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml("hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64")
         root = ET.fromstring(xml_data)
@@ -356,7 +359,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         Test virt._gen_xml() with default vnc graphics device
         """
-        diskp = virt._disk_profile("default", "kvm", [], "hello")
+        diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml(
             "hello",
@@ -389,7 +392,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         Test virt._gen_xml() with default spice graphics device
         """
-        diskp = virt._disk_profile("default", "kvm", [], "hello")
+        diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml(
             "hello",
@@ -415,7 +418,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         Test virt._gen_xml() with spice graphics device
         """
-        diskp = virt._disk_profile("default", "kvm", [], "hello")
+        diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml(
             "hello",
@@ -450,7 +453,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(
             virt.__salt__, {"config.get": mock}  # pylint: disable=no-member
         ):
-            ret = virt._disk_profile("nonexistent", "vmware", None, "test-vm")
+            ret = virt._disk_profile(
+                self.mock_conn, "nonexistent", "vmware", None, "test-vm"
+            )
             self.assertTrue(len(ret) == 1)
             found = [disk for disk in ret if disk["name"] == "system"]
             self.assertTrue(bool(found))
@@ -467,7 +472,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(
             virt.__salt__, {"config.get": mock}  # pylint: disable=no-member
         ):
-            ret = virt._disk_profile("nonexistent", "kvm", None, "test-vm")
+            ret = virt._disk_profile(
+                self.mock_conn, "nonexistent", "kvm", None, "test-vm"
+            )
             self.assertTrue(len(ret) == 1)
             found = [disk for disk in ret if disk["name"] == "system"]
             self.assertTrue(bool(found))
@@ -484,7 +491,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(
             virt.__salt__, {"config.get": mock}  # pylint: disable=no-member
         ):
-            ret = virt._disk_profile("nonexistent", "xen", None, "test-vm")
+            ret = virt._disk_profile(
+                self.mock_conn, "nonexistent", "xen", None, "test-vm"
+            )
             self.assertTrue(len(ret) == 1)
             found = [disk for disk in ret if disk["name"] == "system"]
             self.assertTrue(bool(found))
@@ -598,7 +607,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         Test virt._gen_xml(), KVM default profile case
         """
-        diskp = virt._disk_profile("default", "kvm", [], "hello")
+        diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml("hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64",)
         root = ET.fromstring(xml_data)
@@ -632,7 +641,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         Test virt._gen_xml(), ESXi/vmware default profile case
         """
-        diskp = virt._disk_profile("default", "vmware", [], "hello")
+        diskp = virt._disk_profile(self.mock_conn, "default", "vmware", [], "hello")
         nicp = virt._nic_profile("default", "vmware")
         xml_data = virt._gen_xml(
             "hello", 1, 512, diskp, nicp, "vmware", "hvm", "x86_64",
@@ -666,7 +675,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         Test virt._gen_xml(), XEN PV default profile case
         """
-        diskp = virt._disk_profile("default", "xen", [], "hello")
+        diskp = virt._disk_profile(self.mock_conn, "default", "xen", [], "hello")
         nicp = virt._nic_profile("default", "xen")
         with patch.dict(
             virt.__grains__, {"os_family": "Suse"}  # pylint: disable=no-member
@@ -721,7 +730,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             virt.__salt__,  # pylint: disable=no-member
             {"config.get": MagicMock(side_effect=[disks, nics])},
         ):
-            diskp = virt._disk_profile("noeffect", "vmware", [], "hello")
+            diskp = virt._disk_profile(
+                self.mock_conn, "noeffect", "vmware", [], "hello"
+            )
             nicp = virt._nic_profile("noeffect", "vmware")
             xml_data = virt._gen_xml(
                 "hello", 1, 512, diskp, nicp, "vmware", "hvm", "x86_64",
@@ -754,7 +765,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             virt.__salt__,  # pylint: disable=no-member
             {"config.get": MagicMock(side_effect=[disks, nics])},
         ):
-            diskp = virt._disk_profile("noeffect", "kvm", [], "hello")
+            diskp = virt._disk_profile(self.mock_conn, "noeffect", "kvm", [], "hello")
             nicp = virt._nic_profile("noeffect", "kvm")
             xml_data = virt._gen_xml(
                 "hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64",
@@ -767,17 +778,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             self.assertTrue(len(root.findall(".//disk")) == 2)
             self.assertTrue(len(root.findall(".//interface")) == 2)
 
-    @patch(
-        "salt.modules.virt.pool_info",
-        return_value={
-            "mypool": {
-                "target_path": os.path.join(salt.syspaths.ROOT_DIR, "pools", "mypool")
-            }
-        },
-    )
-    def test_disk_profile_kvm_disk_pool(self, mock_poolinfo):
+    def test_disk_profile_kvm_disk_pool(self):
         """
-        Test virt._gen_xml(), KVM case with pools defined.
+        Test virt._disk_profile(), KVM case with pools defined.
         """
         disks = {
             "noeffect": [
@@ -799,7 +802,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             },
         ):
 
-            diskp = virt._disk_profile("noeffect", "kvm", [], "hello")
+            diskp = virt._disk_profile(self.mock_conn, "noeffect", "kvm", [], "hello")
 
             pools_path = (
                 os.path.join(salt.syspaths.ROOT_DIR, "pools", "mypool") + os.sep
@@ -809,7 +812,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             )
 
             self.assertEqual(len(diskp), 2)
-            self.assertTrue(diskp[0]["source_file"].startswith(pools_path))
             self.assertTrue(diskp[1]["source_file"].startswith(default_path))
         # pylint: enable=no-member
 
@@ -817,49 +819,56 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         Test virt._gen_xml(), KVM case with an external image.
         """
+        with patch.dict(os.path.__dict__, {"exists": MagicMock(return_value=True)}):
+            diskp = virt._disk_profile(
+                self.mock_conn,
+                None,
+                "kvm",
+                [{"name": "mydisk", "source_file": "/path/to/my/image.qcow2"}],
+                "hello",
+            )
+
+            self.assertEqual(len(diskp), 1)
+            self.assertEqual(diskp[0]["source_file"], ("/path/to/my/image.qcow2"))
+
+    def test_gen_xml_volume(self):
+        """
+        Test virt._gen_xml(), generating a disk of volume type
+        """
+        self.mock_conn.listStoragePools.return_value = ["default"]
+        self.mock_conn.storagePoolLookupByName.return_value.XMLDesc.return_value = (
+            "<pool type='dir'/>"
+        )
+        self.mock_conn.storagePoolLookupByName.return_value.listVolumes.return_value = [
+            "myvolume"
+        ]
         diskp = virt._disk_profile(
+            self.mock_conn,
             None,
             "kvm",
-            [{"name": "mydisk", "source_file": "/path/to/my/image.qcow2"}],
+            [
+                {"name": "system", "pool": "default"},
+                {"name": "data", "pool": "default", "source_file": "myvolume"},
+            ],
             "hello",
         )
-
-        self.assertEqual(len(diskp), 1)
-        self.assertEqual(diskp[0]["source_file"], ("/path/to/my/image.qcow2"))
-
-    @patch("salt.modules.virt.pool_info", return_value={})
-    def test_disk_profile_kvm_disk_pool_notfound(self, mock_poolinfo):
-        """
-        Test virt._gen_xml(), KVM case with pools defined.
-        """
-        disks = {"noeffect": [{"first": {"size": 8192, "pool": "default"}}]}
-        with patch.dict(
-            virt.__salt__,  # pylint: disable=no-member
-            {"config.get": MagicMock(side_effect=[disks, "/default/path/"])},
-        ):
-            with self.assertRaises(CommandExecutionError):
-                virt._disk_profile("noeffect", "kvm", [], "hello")
-
-    @patch(
-        "salt.modules.virt.pool_info", return_value={"target_path": "/dev/disk/by-path"}
-    )
-    def test_disk_profile_kvm_disk_pool_invalid(self, mock_poolinfo):
-        """
-        Test virt._gen_xml(), KVM case with pools defined.
-        """
-        disks = {"noeffect": [{"first": {"size": 8192, "pool": "default"}}]}
-        with patch.dict(
-            virt.__salt__,  # pylint: disable=no-member
-            {"config.get": MagicMock(side_effect=[disks, "/default/path/"])},
-        ):
-            with self.assertRaises(CommandExecutionError):
-                virt._disk_profile("noeffect", "kvm", [], "hello")
+        nicp = virt._nic_profile(None, "kvm")
+        xml_data = virt._gen_xml("hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64",)
+        root = ET.fromstring(xml_data)
+        disk = root.findall(".//disk")[0]
+        self.assertEqual(disk.attrib["device"], "disk")
+        self.assertEqual(disk.attrib["type"], "volume")
+        source = disk.find("source")
+        self.assertEqual("default", source.attrib["pool"])
+        self.assertEqual("hello_system", source.attrib["volume"])
+        self.assertEqual("myvolume", root.find(".//disk[2]/source").get("volume"))
 
     def test_gen_xml_cdrom(self):
         """
         Test virt._gen_xml(), generating a cdrom device (different disk type, no source)
         """
         diskp = virt._disk_profile(
+            self.mock_conn,
             None,
             "kvm",
             [
@@ -876,6 +885,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         xml_data = virt._gen_xml("hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64",)
         root = ET.fromstring(xml_data)
         disk = root.findall(".//disk")[0]
+        self.assertEqual(disk.get("type"), "file")
         self.assertEqual(disk.attrib["device"], "cdrom")
         self.assertIsNone(disk.find("source"))
 
@@ -883,7 +893,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         Test virt._gen_xml() generated device controller for ESXi/vmware
         """
-        diskp = virt._disk_profile("default", "vmware", [], "hello")
+        diskp = virt._disk_profile(self.mock_conn, "default", "vmware", [], "hello")
         nicp = virt._nic_profile("default", "vmware")
         xml_data = virt._gen_xml(
             "hello", 1, 512, diskp, nicp, "vmware", "hvm", "x86_64",
@@ -898,7 +908,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         Test virt._gen_xml() generated device controller for KVM
         """
-        diskp = virt._disk_profile("default", "kvm", [], "hello")
+        diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml("hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64",)
         root = ET.fromstring(xml_data)
@@ -1286,6 +1296,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 # Test case creating disks
                 defineMock.reset_mock()
                 mock_run.reset_mock()
+                pool_mock = MagicMock()
+                pool_mock.XMLDesc.return_value = '<pool type="dir"/>'
+                self.mock_conn.storagePoolLookupByName.return_value = pool_mock
                 virt.init(
                     "test vm",
                     2,
@@ -1305,19 +1318,94 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                     start=False,
                 )
                 definition = ET.fromstring(defineMock.call_args_list[0][0][0])
-                disk_sources = [
-                    disk.find("source").get("file")
-                    if disk.find("source") is not None
-                    else None
-                    for disk in definition.findall("./devices/disk")
-                ]
                 expected_disk_path = os.path.join(root_dir, "test vm_system.qcow2")
-                self.assertEqual(disk_sources, [expected_disk_path, None])
+                self.assertEqual(
+                    expected_disk_path,
+                    definition.find("./devices/disk[1]/source").get("file"),
+                )
+                self.assertIsNone(definition.find("./devices/disk[2]/source"))
                 self.assertEqual(
                     mock_run.call_args[0][0],
                     'qemu-img create -f qcow2 "{0}" 10240M'.format(expected_disk_path),
                 )
                 self.assertEqual(mock_chmod.call_args[0][0], expected_disk_path)
+
+                # Test case creating disks volumes
+                defineMock.reset_mock()
+                mock_run.reset_mock()
+                vol_mock = MagicMock()
+                pool_mock.storageVolLookupByName.return_value = vol_mock
+                pool_mock.listVolumes.return_value = ["test vm_data"]
+                stream_mock = MagicMock()
+                self.mock_conn.newStream.return_value = stream_mock
+                self.mock_conn.listStoragePools.return_value = ["default", "test"]
+                with patch.dict(
+                    os.__dict__, {"open": MagicMock(), "close": MagicMock()}
+                ):
+                    cache_mock = MagicMock()
+                    with patch.dict(virt.__salt__, {"cp.cache_file": cache_mock}):
+                        virt.init(
+                            "test vm",
+                            2,
+                            1234,
+                            nic=None,
+                            disk=None,
+                            disks=[
+                                {
+                                    "name": "system",
+                                    "size": 10240,
+                                    "image": "/path/to/image",
+                                    "pool": "test",
+                                },
+                                {"name": "data", "size": 10240, "pool": "default"},
+                                {
+                                    "name": "test",
+                                    "size": 1024,
+                                    "pool": "default",
+                                    "format": "qcow2",
+                                    "backing_store_path": "/backing/path",
+                                    "backing_store_format": "raw",
+                                },
+                            ],
+                            seed=False,
+                            start=False,
+                        )
+                        definition = ET.fromstring(defineMock.call_args_list[0][0][0])
+                        self.assertTrue(
+                            all(
+                                [
+                                    disk.get("type") == "volume"
+                                    for disk in definition.findall("./devices/disk")
+                                ]
+                            )
+                        )
+                        self.assertEqual(
+                            ["test", "default", "default"],
+                            [
+                                src.get("pool")
+                                for src in definition.findall("./devices/disk/source")
+                            ],
+                        )
+                        self.assertEqual(
+                            ["test vm_system", "test vm_data", "test vm_test"],
+                            [
+                                src.get("volume")
+                                for src in definition.findall("./devices/disk/source")
+                            ],
+                        )
+
+                        create_calls = pool_mock.createXML.call_args_list
+                        vol_names = [
+                            ET.fromstring(call[0][0]).find("name").text
+                            for call in create_calls
+                        ]
+                        self.assertEqual(
+                            ["test vm_system", "test vm_test"], vol_names,
+                        )
+
+                        stream_mock.sendAll.assert_called_once()
+                        stream_mock.finish.assert_called_once()
+                        vol_mock.upload.assert_called_once_with(stream_mock, 0, 0, 0)
 
     def test_update(self):
         """

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -443,7 +443,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(
             virt.__salt__, {"config.get": mock}  # pylint: disable=no-member
         ):
-            ret = virt._disk_profile("nonexistent", "vmware")
+            ret = virt._disk_profile("nonexistent", "vmware", None, "test-vm")
             self.assertTrue(len(ret) == 1)
             found = [disk for disk in ret if disk["name"] == "system"]
             self.assertTrue(bool(found))
@@ -456,11 +456,11 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         Test virt._disk_profile() default KVM profile
         """
-        mock = MagicMock(return_value={})
+        mock = MagicMock(side_effect=[{}, "/images/dir"])
         with patch.dict(
             virt.__salt__, {"config.get": mock}  # pylint: disable=no-member
         ):
-            ret = virt._disk_profile("nonexistent", "kvm")
+            ret = virt._disk_profile("nonexistent", "kvm", None, "test-vm")
             self.assertTrue(len(ret) == 1)
             found = [disk for disk in ret if disk["name"] == "system"]
             self.assertTrue(bool(found))
@@ -473,11 +473,11 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         Test virt._disk_profile() default XEN profile
         """
-        mock = MagicMock(return_value={})
+        mock = MagicMock(side_effect=[{}, "/images/dir"])
         with patch.dict(
             virt.__salt__, {"config.get": mock}  # pylint: disable=no-member
         ):
-            ret = virt._disk_profile("nonexistent", "xen")
+            ret = virt._disk_profile("nonexistent", "xen", None, "test-vm")
             self.assertTrue(len(ret) == 1)
             found = [disk for disk in ret if disk["name"] == "system"]
             self.assertTrue(bool(found))

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -4013,7 +4013,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                     backing_store = (
                         """
                         <backingStore>
-                          <format>qcow2</format>
+                          <format type="qcow2"/>
                           <path>{0}</path>
                         </backingStore>
                     """.format(
@@ -4026,7 +4026,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                         <volume type='file'>
                           <name>{0}</name>
                           <target>
-                            <format>qcow2</format>
+                            <format type="qcow2"/>
                             <path>/path/to/{0}.qcow2</path>
                           </target>
                           {1}
@@ -4082,6 +4082,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                             "capacity": 12345,
                             "allocation": 1234,
                             "used_by": [],
+                            "backing_store": None,
                         },
                         "vol2": {
                             "type": "file",
@@ -4090,6 +4091,10 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                             "capacity": 12345,
                             "allocation": 1234,
                             "used_by": ["vm2"],
+                            "backing_store": {
+                                "path": "/path/to/vol0.qcow2",
+                                "format": "qcow2",
+                            },
                         },
                     }
                 },
@@ -4106,6 +4111,10 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                             "capacity": 12345,
                             "allocation": 1234,
                             "used_by": ["vm2"],
+                            "backing_store": {
+                                "path": "/path/to/vol0.qcow2",
+                                "format": "qcow2",
+                            },
                         }
                     }
                 },
@@ -4136,6 +4145,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                             "capacity": 12345,
                             "allocation": 1234,
                             "used_by": [],
+                            "backing_store": None,
                         },
                         "vol2": {
                             "type": "file",
@@ -4144,6 +4154,10 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                             "capacity": 12345,
                             "allocation": 1234,
                             "used_by": [],
+                            "backing_store": {
+                                "path": "/path/to/vol0.qcow2",
+                                "format": "qcow2",
+                            },
                         },
                     }
                 },
@@ -4160,6 +4174,10 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                             "capacity": 12345,
                             "allocation": 1234,
                             "used_by": [],
+                            "backing_store": {
+                                "path": "/path/to/vol0.qcow2",
+                                "format": "qcow2",
+                            },
                         }
                     }
                 },
@@ -4191,6 +4209,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                             "capacity": 12345,
                             "allocation": 1234,
                             "used_by": [],
+                            "backing_store": None,
                         },
                         "vol2": {
                             "type": "file",
@@ -4199,6 +4218,10 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                             "capacity": 12345,
                             "allocation": 1234,
                             "used_by": [],
+                            "backing_store": {
+                                "path": "/path/to/vol0.qcow2",
+                                "format": "qcow2",
+                            },
                         },
                     }
                 },
@@ -4215,6 +4238,10 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                             "capacity": 12345,
                             "allocation": 1234,
                             "used_by": [],
+                            "backing_store": {
+                                "path": "/path/to/vol0.qcow2",
+                                "format": "qcow2",
+                            },
                         }
                     }
                 },

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -4083,6 +4083,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                             "allocation": 1234,
                             "used_by": [],
                             "backing_store": None,
+                            "format": "qcow2",
                         },
                         "vol2": {
                             "type": "file",
@@ -4095,6 +4096,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                                 "path": "/path/to/vol0.qcow2",
                                 "format": "qcow2",
                             },
+                            "format": "qcow2",
                         },
                     }
                 },
@@ -4115,6 +4117,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                                 "path": "/path/to/vol0.qcow2",
                                 "format": "qcow2",
                             },
+                            "format": "qcow2",
                         }
                     }
                 },
@@ -4146,6 +4149,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                             "allocation": 1234,
                             "used_by": [],
                             "backing_store": None,
+                            "format": "qcow2",
                         },
                         "vol2": {
                             "type": "file",
@@ -4158,6 +4162,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                                 "path": "/path/to/vol0.qcow2",
                                 "format": "qcow2",
                             },
+                            "format": "qcow2",
                         },
                     }
                 },
@@ -4178,6 +4183,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                                 "path": "/path/to/vol0.qcow2",
                                 "format": "qcow2",
                             },
+                            "format": "qcow2",
                         }
                     }
                 },
@@ -4210,6 +4216,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                             "allocation": 1234,
                             "used_by": [],
                             "backing_store": None,
+                            "format": "qcow2",
                         },
                         "vol2": {
                             "type": "file",
@@ -4222,6 +4229,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                                 "path": "/path/to/vol0.qcow2",
                                 "format": "qcow2",
                             },
+                            "format": "qcow2",
                         },
                     }
                 },
@@ -4242,6 +4250,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                                 "path": "/path/to/vol0.qcow2",
                                 "format": "qcow2",
                             },
+                            "format": "qcow2",
                         }
                     }
                 },

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -441,8 +441,8 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         mock = MagicMock(return_value={})
         with patch.dict(
-            virt.__salt__, {"config.get": mock}
-        ):  # pylint: disable=no-member
+            virt.__salt__, {"config.get": mock}  # pylint: disable=no-member
+        ):
             ret = virt._disk_profile("nonexistent", "vmware")
             self.assertTrue(len(ret) == 1)
             found = [disk for disk in ret if disk["name"] == "system"]
@@ -458,8 +458,8 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         mock = MagicMock(return_value={})
         with patch.dict(
-            virt.__salt__, {"config.get": mock}
-        ):  # pylint: disable=no-member
+            virt.__salt__, {"config.get": mock}  # pylint: disable=no-member
+        ):
             ret = virt._disk_profile("nonexistent", "kvm")
             self.assertTrue(len(ret) == 1)
             found = [disk for disk in ret if disk["name"] == "system"]
@@ -475,8 +475,8 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         mock = MagicMock(return_value={})
         with patch.dict(
-            virt.__salt__, {"config.get": mock}
-        ):  # pylint: disable=no-member
+            virt.__salt__, {"config.get": mock}  # pylint: disable=no-member
+        ):
             ret = virt._disk_profile("nonexistent", "xen")
             self.assertTrue(len(ret) == 1)
             found = [disk for disk in ret if disk["name"] == "system"]
@@ -492,8 +492,8 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         mock = MagicMock(return_value={})
         with patch.dict(
-            virt.__salt__, {"config.get": mock}
-        ):  # pylint: disable=no-member
+            virt.__salt__, {"config.get": mock}  # pylint: disable=no-member
+        ):
             ret = virt._nic_profile("nonexistent", "vmware")
             self.assertTrue(len(ret) == 1)
             eth0 = ret[0]
@@ -508,8 +508,8 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         mock = MagicMock(return_value={})
         with patch.dict(
-            virt.__salt__, {"config.get": mock}
-        ):  # pylint: disable=no-member
+            virt.__salt__, {"config.get": mock}  # pylint: disable=no-member
+        ):
             ret = virt._nic_profile("nonexistent", "kvm")
             self.assertTrue(len(ret) == 1)
             eth0 = ret[0]
@@ -524,8 +524,8 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         mock = MagicMock(return_value={})
         with patch.dict(
-            virt.__salt__, {"config.get": mock}
-        ):  # pylint: disable=no-member
+            virt.__salt__, {"config.get": mock}  # pylint: disable=no-member
+        ):
             ret = virt._nic_profile("nonexistent", "xen")
             self.assertTrue(len(ret) == 1)
             eth0 = ret[0]
@@ -621,7 +621,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         diskp = virt._disk_profile("default", "xen", [], "hello")
         nicp = virt._nic_profile("default", "xen")
-        with patch.dict(virt.__grains__, {"os_family": "Suse"}):
+        with patch.dict(
+            virt.__grains__, {"os_family": "Suse"}  # pylint: disable=no-member
+        ):
             xml_data = virt._gen_xml(
                 "hello", 1, 512, diskp, nicp, "xen", "xen", "x86_64", boot=None
             )
@@ -702,12 +704,8 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             ]
         }
         with patch.dict(
-            virt.__salt__,
-            {
-                "config.get": MagicMock(
-                    side_effect=[disks, nics]  # pylint: disable=no-member
-                )
-            },
+            virt.__salt__,  # pylint: disable=no-member
+            {"config.get": MagicMock(side_effect=[disks, nics])},
         ):
             diskp = virt._disk_profile("noeffect", "kvm", [], "hello")
             nicp = virt._nic_profile("noeffect", "kvm")
@@ -789,12 +787,8 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         disks = {"noeffect": [{"first": {"size": 8192, "pool": "default"}}]}
         with patch.dict(
-            virt.__salt__,
-            {
-                "config.get": MagicMock(
-                    side_effect=[disks, "/default/path/"]  # pylint: disable=no-member
-                )
-            },
+            virt.__salt__,  # pylint: disable=no-member
+            {"config.get": MagicMock(side_effect=[disks, "/default/path/"])},
         ):
             with self.assertRaises(CommandExecutionError):
                 virt._disk_profile("noeffect", "kvm", [], "hello")
@@ -808,12 +802,8 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         disks = {"noeffect": [{"first": {"size": 8192, "pool": "default"}}]}
         with patch.dict(
-            virt.__salt__,
-            {
-                "config.get": MagicMock(
-                    side_effect=[disks, "/default/path/"]  # pylint: disable=no-member
-                )
-            },
+            virt.__salt__,  # pylint: disable=no-member
+            {"config.get": MagicMock(side_effect=[disks, "/default/path/"])},
         ):
             with self.assertRaises(CommandExecutionError):
                 virt._disk_profile("noeffect", "kvm", [], "hello")
@@ -1543,8 +1533,8 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         devattach_mock.reset_mock()
         devdetach_mock.reset_mock()
         with patch.dict(
-            salt.modules.config.__opts__, mock_config
-        ):  # pylint: disable=no-member
+            salt.modules.config.__opts__, mock_config  # pylint: disable=no-member
+        ):
             ret = virt.update(
                 "my_vm",
                 nic_profile="myprofile",
@@ -1857,8 +1847,8 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         mock_config = salt.utils.yaml.safe_load(yaml_config)
         with patch.dict(
-            salt.modules.config.__opts__, mock_config
-        ):  # pylint: disable=no-member
+            salt.modules.config.__opts__, mock_config  # pylint: disable=no-member
+        ):
 
             for name in six.iterkeys(mock_config["virt"]["nic"]):
                 profile = salt.modules.virt._nic_profile(name, "kvm")

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -1125,7 +1125,13 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                     "device": "cdrom",
                     "source_file": None,
                     "model": "ide",
-                }
+                },
+                {
+                    "name": "remote",
+                    "device": "cdrom",
+                    "source_file": "http://myhost:8080/url/to/image?query=foo&filter=bar",
+                    "model": "ide",
+                },
             ],
             "hello",
         )
@@ -1138,6 +1144,19 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(disk.get("type"), "file")
         self.assertEqual(disk.attrib["device"], "cdrom")
         self.assertIsNone(disk.find("source"))
+
+        disk = root.findall(".//disk")[1]
+        self.assertEqual(disk.get("type"), "network")
+        self.assertEqual(disk.attrib["device"], "cdrom")
+        self.assertEqual(
+            {
+                "protocol": "http",
+                "name": "/url/to/image",
+                "query": "query=foo&filter=bar",
+                "host": {"name": "myhost", "port": "8080"},
+            },
+            salt.utils.xmlutil.to_dict(disk.find("source"), True),
+        )
 
     def test_controller_for_esxi(self):
         """

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -158,7 +158,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
-        xml_data = virt._gen_xml("hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64")
+        xml_data = virt._gen_xml(
+            self.mock_conn, "hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64"
+        )
         root = ET.fromstring(xml_data)
         self.assertEqual(root.find("os/boot").attrib["dev"], "hd")
         self.assertEqual(root.find("os/type").attrib["arch"], "x86_64")
@@ -171,7 +173,16 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml(
-            "hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64", boot_dev="cdrom"
+            self.mock_conn,
+            "hello",
+            1,
+            512,
+            diskp,
+            nicp,
+            "kvm",
+            "hvm",
+            "x86_64",
+            boot_dev="cdrom",
         )
         root = ET.fromstring(xml_data)
         self.assertEqual(root.find("os/boot").attrib["dev"], "cdrom")
@@ -183,6 +194,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml(
+            self.mock_conn,
             "hello",
             1,
             512,
@@ -204,6 +216,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml(
+            self.mock_conn,
             "hello",
             1,
             512,
@@ -226,6 +239,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml(
+            self.mock_conn,
             "hello",
             1,
             512,
@@ -248,6 +262,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml(
+            self.mock_conn,
             "hello",
             1,
             512,
@@ -272,6 +287,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml(
+            self.mock_conn,
             "hello",
             1,
             512,
@@ -297,6 +313,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml(
+            self.mock_conn,
             "hello",
             1,
             512,
@@ -319,6 +336,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml(
+            self.mock_conn,
             "hello",
             1,
             512,
@@ -340,7 +358,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
-        xml_data = virt._gen_xml("hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64")
+        xml_data = virt._gen_xml(
+            self.mock_conn, "hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64"
+        )
         root = ET.fromstring(xml_data)
         self.assertIsNone(root.find("devices/graphics"))
 
@@ -350,7 +370,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
-        xml_data = virt._gen_xml("hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64")
+        xml_data = virt._gen_xml(
+            self.mock_conn, "hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64"
+        )
         root = ET.fromstring(xml_data)
         self.assertIsNone(root.find("os/loader"))
 
@@ -361,6 +383,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml(
+            self.mock_conn,
             "hello",
             1,
             512,
@@ -394,6 +417,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml(
+            self.mock_conn,
             "hello",
             1,
             512,
@@ -420,6 +444,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
         xml_data = virt._gen_xml(
+            self.mock_conn,
             "hello",
             1,
             512,
@@ -608,7 +633,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
-        xml_data = virt._gen_xml("hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64",)
+        xml_data = virt._gen_xml(
+            self.mock_conn, "hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64",
+        )
         root = ET.fromstring(xml_data)
         self.assertEqual(root.attrib["type"], "kvm")
         self.assertEqual(root.find("vcpu").text, "1")
@@ -640,7 +667,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         diskp = virt._disk_profile(self.mock_conn, "default", "vmware", [], "hello")
         nicp = virt._nic_profile("default", "vmware")
         xml_data = virt._gen_xml(
-            "hello", 1, 512, diskp, nicp, "vmware", "hvm", "x86_64",
+            self.mock_conn, "hello", 1, 512, diskp, nicp, "vmware", "hvm", "x86_64",
         )
         root = ET.fromstring(xml_data)
         self.assertEqual(root.attrib["type"], "vmware")
@@ -674,7 +701,16 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             virt.__grains__, {"os_family": "Suse"}  # pylint: disable=no-member
         ):
             xml_data = virt._gen_xml(
-                "hello", 1, 512, diskp, nicp, "xen", "xen", "x86_64", boot=None
+                self.mock_conn,
+                "hello",
+                1,
+                512,
+                diskp,
+                nicp,
+                "xen",
+                "xen",
+                "x86_64",
+                boot=None,
             )
             root = ET.fromstring(xml_data)
             self.assertEqual(root.attrib["type"], "xen")
@@ -728,7 +764,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             )
             nicp = virt._nic_profile("noeffect", "vmware")
             xml_data = virt._gen_xml(
-                "hello", 1, 512, diskp, nicp, "vmware", "hvm", "x86_64",
+                self.mock_conn, "hello", 1, 512, diskp, nicp, "vmware", "hvm", "x86_64",
             )
             root = ET.fromstring(xml_data)
             self.assertEqual(root.attrib["type"], "vmware")
@@ -761,7 +797,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             diskp = virt._disk_profile(self.mock_conn, "noeffect", "kvm", [], "hello")
             nicp = virt._nic_profile("noeffect", "kvm")
             xml_data = virt._gen_xml(
-                "hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64",
+                self.mock_conn, "hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64",
             )
             root = ET.fromstring(xml_data)
             self.assertEqual(root.attrib["type"], "kvm")
@@ -845,8 +881,13 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             ],
             "hello",
         )
+        self.mock_conn.storagePoolLookupByName.return_value.XMLDesc.return_value = (
+            "<pool type='dir'/>"
+        )
         nicp = virt._nic_profile(None, "kvm")
-        xml_data = virt._gen_xml("hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64",)
+        xml_data = virt._gen_xml(
+            self.mock_conn, "hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64",
+        )
         root = ET.fromstring(xml_data)
         disk = root.findall(".//disk")[0]
         self.assertEqual(disk.attrib["device"], "disk")
@@ -855,6 +896,116 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual("default", source.attrib["pool"])
         self.assertEqual("hello_system", source.attrib["volume"])
         self.assertEqual("myvolume", root.find(".//disk[2]/source").get("volume"))
+
+        # RBD volume usage auth test case
+        self.mock_conn.listStoragePools.return_value = ["test-rbd"]
+        self.mock_conn.storagePoolLookupByName.return_value.XMLDesc.return_value = """
+            <pool type='rbd'>
+              <name>test-rbd</name>
+              <uuid>ede33e0a-9df0-479f-8afd-55085a01b244</uuid>
+              <capacity unit='bytes'>526133493760</capacity>
+              <allocation unit='bytes'>589928</allocation>
+              <available unit='bytes'>515081306112</available>
+              <source>
+                <host name='ses2.tf.local'/>
+                <host name='ses3.tf.local' port='1234'/>
+                <name>libvirt-pool</name>
+                <auth type='ceph' username='libvirt'>
+                  <secret usage='pool_test-rbd'/>
+                </auth>
+              </source>
+            </pool>
+        """
+        self.mock_conn.getStoragePoolCapabilities.return_value = """
+            <storagepoolCapabilities>
+              <pool type='rbd' supported='yes'>
+                <volOptions>
+                  <defaultFormat type='raw'/>
+                  <enum name='targetFormatType'>
+                  </enum>
+                </volOptions>
+              </pool>
+            </storagepoolCapabilities>
+        """
+        diskp = virt._disk_profile(
+            self.mock_conn,
+            None,
+            "kvm",
+            [{"name": "system", "pool": "test-rbd"}],
+            "test-vm",
+        )
+        xml_data = virt._gen_xml(
+            self.mock_conn, "hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64",
+        )
+        root = ET.fromstring(xml_data)
+        disk = root.findall(".//disk")[0]
+        self.assertDictEqual(
+            {
+                "type": "network",
+                "device": "disk",
+                "source": {
+                    "protocol": "rbd",
+                    "name": "libvirt-pool/test-vm_system",
+                    "host": [
+                        {"name": "ses2.tf.local"},
+                        {"name": "ses3.tf.local", "port": "1234"},
+                    ],
+                    "auth": {
+                        "username": "libvirt",
+                        "secret": {"type": "ceph", "usage": "pool_test-rbd"},
+                    },
+                },
+                "target": {"dev": "vda", "bus": "virtio"},
+                "driver": {
+                    "name": "qemu",
+                    "type": "raw",
+                    "cache": "none",
+                    "io": "native",
+                },
+            },
+            salt.utils.xmlutil.to_dict(disk, True),
+        )
+
+        # RBD volume UUID auth test case
+        self.mock_conn.storagePoolLookupByName.return_value.XMLDesc.return_value = """
+            <pool type='rbd'>
+              <name>test-rbd</name>
+              <uuid>ede33e0a-9df0-479f-8afd-55085a01b244</uuid>
+              <capacity unit='bytes'>526133493760</capacity>
+              <allocation unit='bytes'>589928</allocation>
+              <available unit='bytes'>515081306112</available>
+              <source>
+                <host name='ses2.tf.local'/>
+                <host name='ses3.tf.local' port='1234'/>
+                <name>libvirt-pool</name>
+                <auth type='ceph' username='libvirt'>
+                  <secret uuid='some-uuid'/>
+                </auth>
+              </source>
+            </pool>
+        """
+        self.mock_conn.secretLookupByUUIDString.return_value.usageID.return_value = (
+            "pool_test-rbd"
+        )
+        diskp = virt._disk_profile(
+            self.mock_conn,
+            None,
+            "kvm",
+            [{"name": "system", "pool": "test-rbd"}],
+            "test-vm",
+        )
+        xml_data = virt._gen_xml(
+            self.mock_conn, "hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64",
+        )
+        root = ET.fromstring(xml_data)
+        self.assertDictEqual(
+            {
+                "username": "libvirt",
+                "secret": {"type": "ceph", "usage": "pool_test-rbd"},
+            },
+            salt.utils.xmlutil.to_dict(root.find(".//disk/source/auth"), True),
+        )
+        self.mock_conn.secretLookupByUUIDString.assert_called_once_with("some-uuid")
 
     def test_gen_xml_cdrom(self):
         """
@@ -875,7 +1026,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             "hello",
         )
         nicp = virt._nic_profile(None, "kvm")
-        xml_data = virt._gen_xml("hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64",)
+        xml_data = virt._gen_xml(
+            self.mock_conn, "hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64",
+        )
         root = ET.fromstring(xml_data)
         disk = root.findall(".//disk")[0]
         self.assertEqual(disk.get("type"), "file")
@@ -889,7 +1042,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         diskp = virt._disk_profile(self.mock_conn, "default", "vmware", [], "hello")
         nicp = virt._nic_profile("default", "vmware")
         xml_data = virt._gen_xml(
-            "hello", 1, 512, diskp, nicp, "vmware", "hvm", "x86_64",
+            self.mock_conn, "hello", 1, 512, diskp, nicp, "vmware", "hvm", "x86_64",
         )
         root = ET.fromstring(xml_data)
         controllers = root.findall(".//devices/controller")
@@ -903,7 +1056,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         diskp = virt._disk_profile(self.mock_conn, "default", "kvm", [], "hello")
         nicp = virt._nic_profile("default", "kvm")
-        xml_data = virt._gen_xml("hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64",)
+        xml_data = virt._gen_xml(
+            self.mock_conn, "hello", 1, 512, diskp, nicp, "kvm", "hvm", "x86_64",
+        )
         root = ET.fromstring(xml_data)
         controllers = root.findall(".//devices/controller")
         # There should be no controller
@@ -1429,6 +1584,19 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                   <alias name='virtio-disk1'/>
                   <address type='pci' domain='0x0000' bus='0x00' slot='0x07' function='0x1'/>
                 </disk>
+                <disk type="network" device="disk">
+                  <driver name='raw' type='qcow2'/>
+                  <source protocol='rbd' name='libvirt-pool/my_vm_data2'>
+                    <host name='ses2.tf.local'/>
+                    <host name='ses3.tf.local' port='1234'/>
+                    <auth username='libvirt'>
+                      <secret type='ceph' usage='pool_test-rbd'/>
+                    </auth>
+                  </source>
+                  <target dev='vdc' bus='virtio'/>
+                  <alias name='virtio-disk2'/>
+                  <address type='pci' domain='0x0000' bus='0x00' slot='0x07' function='0x2'/>
+                </disk>
                 <interface type='network'>
                   <mac address='52:54:00:39:02:b1'/>
                   <source network='default' bridge='virbr0'/>
@@ -1638,14 +1806,15 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 )
 
                 self.assertListEqual(
-                    ["my_vm_data"],
+                    ["my_vm_data", "libvirt-pool/my_vm_data2"],
                     [
                         ET.fromstring(disk).find("source").get("volume")
+                        or ET.fromstring(disk).find("source").get("name")
                         for disk in ret["disk"]["detached"]
                     ],
                 )
                 self.assertEqual(devattach_mock.call_count, 2)
-                devdetach_mock.assert_called_once()
+                self.assertEqual(devdetach_mock.call_count, 2)
 
         # Update nics case
         yaml_config = """
@@ -1705,7 +1874,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         devdetach_mock.reset_mock()
         ret = virt.update("my_vm", disk_profile=None, disks=[])
         self.assertEqual([], ret["disk"]["attached"])
-        self.assertEqual(2, len(ret["disk"]["detached"]))
+        self.assertEqual(3, len(ret["disk"]["detached"]))
         devattach_mock.assert_not_called()
         devdetach_mock.assert_called()
 
@@ -1723,9 +1892,28 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
 
         # Update with no diff case
         pool_mock = MagicMock()
-        pool_mock.XMLDesc.return_value = "<pool type='dir'></pool>"
+        default_pool_desc = "<pool type='dir'></pool>"
+        rbd_pool_desc = """
+            <pool type='rbd'>
+              <name>test-rbd</name>
+              <source>
+                <host name='ses2.tf.local'/>
+                <host name='ses3.tf.local' port='1234'/>
+                <name>libvirt-pool</name>
+                <auth type='ceph' username='libvirt'>
+                  <secret usage='pool_test-rbd'/>
+                </auth>
+              </source>
+            </pool>
+            """
+        pool_mock.XMLDesc.side_effect = [
+            default_pool_desc,
+            rbd_pool_desc,
+            default_pool_desc,
+            rbd_pool_desc,
+        ]
         self.mock_conn.storagePoolLookupByName.return_value = pool_mock
-        self.mock_conn.listStoragePools.return_value = ["default"]
+        self.mock_conn.listStoragePools.return_value = ["test-rbd", "default"]
         self.assertEqual(
             {
                 "definition": False,
@@ -1737,7 +1925,15 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 cpu=1,
                 mem=1024,
                 disk_profile="default",
-                disks=[{"name": "data", "size": 2048, "pool": "default"}],
+                disks=[
+                    {"name": "data", "size": 2048, "pool": "default"},
+                    {
+                        "name": "data2",
+                        "size": 4096,
+                        "pool": "test-rbd",
+                        "format": "raw",
+                    },
+                ],
                 nic_profile="myprofile",
                 interfaces=[
                     {
@@ -2276,6 +2472,75 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         ]
         pool_mock.listVolumes.return_value = ["vm05_system", "vm04_system.qcow2"]
         self.mock_conn.storagePoolLookupByName.return_value = pool_mock
+        self.mock_conn.listStoragePools.return_value = ["default"]
+
+        with patch.dict(os.path.__dict__, {"exists": MagicMock(return_value=False)}):
+            res = virt.purge("test-vm")
+            self.assertTrue(res)
+            pool_mock.storageVolLookupByName.return_value.delete.assert_called_once()
+
+    @patch("salt.modules.virt.stop", return_value=True)
+    @patch("salt.modules.virt.undefine")
+    def test_purge_rbd(self, mock_undefine, mock_stop):
+        """
+        Test virt.purge() with RBD disks
+        """
+        xml = """<domain type='kvm' id='7'>
+              <name>test-vm</name>
+              <devices>
+                <disk type="network" device="disk">
+                  <driver name='raw' type='qcow2'/>
+                  <source protocol='rbd' name='libvirt-pool/my_vm_data2'>
+                    <host name='ses2.tf.local'/>
+                    <host name='ses3.tf.local' port='1234'/>
+                    <auth username='libvirt'>
+                      <secret type='ceph' usage='pool_test-rbd'/>
+                    </auth>
+                  </source>
+                  <target dev='vdc' bus='virtio'/>
+                  <alias name='virtio-disk2'/>
+                  <address type='pci' domain='0x0000' bus='0x00' slot='0x07' function='0x2'/>
+                </disk>
+              </devices>
+            </domain>
+        """
+        self.set_mock_vm("test-vm", xml)
+
+        pool_mock = MagicMock()
+        pool_mock.storageVolLookupByName.return_value.info.return_value = [
+            0,
+            1234567,
+            12345,
+        ]
+        pool_mock.XMLDesc.return_value = """
+        <pool type='rbd'>
+          <name>test-ses</name>
+          <source>
+            <host name='ses2.tf.local'/>
+            <name>libvirt-pool</name>
+            <auth type='ceph' username='libvirt'>
+              <secret usage='pool_test-ses'/>
+            </auth>
+          </source>
+        </pool>
+        """
+        pool_mock.storageVolLookupByName.return_value.XMLDesc.return_value = [
+            """
+            <volume type='network'>
+              <name>my_vm_data2</name>
+              <source>
+              </source>
+              <capacity unit='bytes'>536870912</capacity>
+              <allocation unit='bytes'>0</allocation>
+              <target>
+                <path>libvirt-pool/my_vm_data2</path>
+                <format type='raw'/>
+              </target>
+            </volume>
+            """,
+        ]
+        pool_mock.listVolumes.return_value = ["my_vm_data2"]
+        self.mock_conn.listAllStoragePools.return_value = [pool_mock]
         self.mock_conn.listStoragePools.return_value = ["default"]
 
         with patch.dict(os.path.__dict__, {"exists": MagicMock(return_value=False)}):


### PR DESCRIPTION
### What does this PR do?

Enables volume support in virt module and states.

### What issues does this PR fix or reference?
Fixes: #57005

### Previous Behavior

`virt.running`, `virt.purge`, etc could only handle file disk images.

### New Behavior

`virt.running`, `virt.purge`, etc can also handle volume disk images. This allows to use RBD, iSCSI, etc volumes in VMs.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**

- [x] Docs
- [x] Changelog
- [X] Tests written/updated

### Commits signed with GPG?
Yes