### PR TITLE
Add new function for comparing package versions

### DIFF
--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -290,6 +290,56 @@ def version_clean(verstr):
     return verstr
 
 
+def version_compare(ver1, oper, ver2, ignore_epoch=False):
+    """
+    .. versionadded:: Sodium
+
+    Perform a version comparison, using (where available) platform-specific
+    version comparison tools to make the comparison.
+
+    ver1
+        The first version to be compared
+
+    oper
+        One of `==`, `!=`, `>=`, `<=`, `>`, `<`
+
+    ver2
+        The second version to be compared
+
+    .. note::
+        To avoid shell interpretation, each of the above values should be
+        quoted when this function is used on the CLI.
+
+    ignore_epoch : False
+        If ``True``, both package versions will have their epoch prefix
+        stripped before comparison.
+
+    This function is useful in Jinja templates, to perform specific actions
+    when a package's version meets certain criteria. For example:
+
+    .. code-block:: jinja
+
+        {%- set postfix_version = salt.pkg.version('postfix') %}
+        {%- if postfix_version and salt.pkg_resource.version_compare(postfix_version, '>=', '3.3', ignore_epoch=True) %}
+          {#- do stuff #}
+        {%- endif %}
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt myminion pkg_resource.version_compare '3.5' '<=' '2.4'
+        salt myminion pkg_resource.version_compare '3.5' '<=' '2.4' ignore_epoch=True
+    """
+    return salt.utils.versions.compare(
+        ver1,
+        oper,
+        ver2,
+        ignore_epoch=ignore_epoch,
+        cmp_func=__salt__.get("version_cmp"),
+    )
+
+
 def check_extra_requirements(pkgname, pkgver):
     """
     Check if the installed package already has the given requirements.

--- a/tests/unit/modules/test_pkg_resource.py
+++ b/tests/unit/modules/test_pkg_resource.py
@@ -6,13 +6,12 @@
 # Import Python Libs
 from __future__ import absolute_import, print_function, unicode_literals
 
-import yaml
-
 import salt.modules.pkg_resource as pkg_resource
 
 # Import Salt Libs
 import salt.utils.data
 import salt.utils.yaml
+import yaml
 from salt.ext import six
 
 # Import Salt Testing Libs

--- a/tests/unit/modules/test_pkg_resource.py
+++ b/tests/unit/modules/test_pkg_resource.py
@@ -6,12 +6,13 @@
 # Import Python Libs
 from __future__ import absolute_import, print_function, unicode_literals
 
+import yaml
+
 import salt.modules.pkg_resource as pkg_resource
 
 # Import Salt Libs
 import salt.utils.data
 import salt.utils.yaml
-import yaml
 from salt.ext import six
 
 # Import Salt Testing Libs
@@ -289,3 +290,16 @@ class PkgresTestCase(TestCase, LoaderModuleMockMixin):
             self.assertEqual(pkg_resource.check_extra_requirements("a", "b"), "A")
 
         self.assertTrue(pkg_resource.check_extra_requirements("a", False))
+
+    def test_version_compare(self):
+        """
+        Test the version_compare function
+
+        TODO: Come up with a good way to test epoch handling across different
+        platforms. This function will look in the ``__salt__`` dunder for a
+        version_cmp function (which not all pkg modules implement) and use that
+        to perform platform-specific handling (including interpretation of
+        epochs), but even an integration test would need to take into account
+        the fact that not all package managers grok epochs.
+        """
+        assert pkg_resource.version_compare("2.0", "<", "3.0") is True


### PR DESCRIPTION
This exposes the functionality from `salt.utils.versions.compare()`, allowing it to be used in places like jinja templates.