### PR TITLE
Implicitly ignore epoch when no epoch in desired version, and ignore_epoch not passed

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1722,7 +1722,7 @@ def install(
             cmd.extend(targets)
             out = _call_yum(cmd, ignore_retcode=False, redirect_stderr=True)
             if out["retcode"] != 0:
-                errors.append(out["stdout"])
+                errors.append(out["stderr"])
 
     targets = []
     with _temporarily_unhold(to_downgrade, targets):
@@ -1733,7 +1733,7 @@ def install(
             cmd.extend(targets)
             out = _call_yum(cmd)
             if out["retcode"] != 0:
-                errors.append(out["stdout"])
+                errors.append(out["stderr"])
 
     targets = []
     with _temporarily_unhold(to_reinstall, targets):
@@ -1744,7 +1744,7 @@ def install(
             cmd.extend(targets)
             out = _call_yum(cmd)
             if out["retcode"] != 0:
-                errors.append(out["stdout"])
+                errors.append(out["stderr"])
 
     __context__.pop("pkg.list_pkgs", None)
     new = (

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -160,6 +160,20 @@ def _get_comparison_spec(pkgver):
     return oper, verstr
 
 
+def _check_ignore_epoch(oper, desired_version, ignore_epoch=None):
+    """
+    Conditionally ignore epoch, but only under all of the following
+    circumstances:
+
+    1. No value for ignore_epoch passed to state
+    2. desired_version has no epoch
+    3. oper does not contain a "<" or ">"
+    """
+    if ignore_epoch is not None:
+        return ignore_epoch
+    return "<" not in oper and ">" not in oper and ":" not in desired_version
+
+
 def _parse_version_string(version_conditions_string):
     """
     Returns a list of two-tuples containing (operator, version).
@@ -177,7 +191,7 @@ def _parse_version_string(version_conditions_string):
 def _fulfills_version_string(
     installed_versions,
     version_conditions_string,
-    ignore_epoch=False,
+    ignore_epoch=None,
     allow_updates=False,
 ):
     """
@@ -194,11 +208,16 @@ def _fulfills_version_string(
         >=1.2.3-4, <2.3.4-5
         >=1.2.3-4, <2.3.4-5, !=1.2.4-1
 
-    ignore_epoch : False
+    ignore_epoch : None
         When a package version contains an non-zero epoch (e.g.
-        ``1:3.14.159-2.el7``, and a specific version of a package is desired,
+        ``1:3.14.159-2.el7``), and a specific version of a package is desired,
         set this option to ``True`` to ignore the epoch when comparing
         versions.
+
+        .. versionchanged:: Sodium
+            If no value for this argument is passed to the state that calls
+            this helper function, and ``version_conditions_string`` contains no
+            epoch or greater-than/less-than, then the epoch will be ignored.
 
     allow_updates : False
         Allow the package to be updated outside Salt's control (e.g. auto updates on Windows).
@@ -220,7 +239,7 @@ def _fulfills_version_string(
     return False
 
 
-def _fulfills_version_spec(versions, oper, desired_version, ignore_epoch=False):
+def _fulfills_version_spec(versions, oper, desired_version, ignore_epoch=None):
     """
     Returns True if any of the installed versions match the specified version,
     otherwise returns False
@@ -238,7 +257,7 @@ def _fulfills_version_spec(versions, oper, desired_version, ignore_epoch=False):
             oper=oper,
             ver2=desired_version,
             cmp_func=cmp_func,
-            ignore_epoch=ignore_epoch,
+            ignore_epoch=_check_ignore_epoch(oper, desired_version, ignore_epoch),
         ):
             return True
     return False
@@ -260,7 +279,7 @@ def _find_download_targets(
     pkgs=None,
     normalize=True,
     skip_suggestions=False,
-    ignore_epoch=False,
+    ignore_epoch=None,
     **kwargs
 ):
     """
@@ -421,7 +440,7 @@ def _find_advisory_targets(name=None, advisory_ids=None, **kwargs):
 
 
 def _find_remove_targets(
-    name=None, version=None, pkgs=None, normalize=True, ignore_epoch=False, **kwargs
+    name=None, version=None, pkgs=None, normalize=True, ignore_epoch=None, **kwargs
 ):
     """
     Inspect the arguments to pkg.removed and discover what packages need to
@@ -509,7 +528,7 @@ def _find_install_targets(
     skip_suggestions=False,
     pkg_verify=False,
     normalize=True,
-    ignore_epoch=False,
+    ignore_epoch=None,
     reinstall=False,
     refresh=False,
     **kwargs
@@ -670,7 +689,9 @@ def _find_install_targets(
                         name in cur_pkgs
                         and (
                             version is None
-                            or _fulfills_version_string(cur_pkgs[name], version)
+                            or _fulfills_version_string(
+                                cur_pkgs[name], version, ignore_epoch=ignore_epoch
+                            )
                         )
                     )
                 ]
@@ -878,7 +899,7 @@ def _find_install_targets(
     )
 
 
-def _verify_install(desired, new_pkgs, ignore_epoch=False, new_caps=None):
+def _verify_install(desired, new_pkgs, ignore_epoch=None, new_caps=None):
     """
     Determine whether or not the installed packages match what was requested in
     the SLS file.
@@ -998,7 +1019,7 @@ def installed(
     allow_updates=False,
     pkg_verify=False,
     normalize=True,
-    ignore_epoch=False,
+    ignore_epoch=None,
     reinstall=False,
     update_holds=False,
     **kwargs
@@ -1334,32 +1355,16 @@ def installed(
                 - normalize: False
 
     :param bool ignore_epoch:
-        When a package version contains an non-zero epoch (e.g.
-        ``1:3.14.159-2.el7``, and a specific version of a package is desired,
-        set this option to ``True`` to ignore the epoch when comparing
-        versions. This allows for the following SLS to be used:
-
-        .. code-block:: yaml
-
-            # Actual vim-enhanced version: 2:7.4.160-1.el7
-            vim-enhanced:
-              pkg.installed:
-                - version: 7.4.160-1.el7
-                - ignore_epoch: True
-
-        Without this option set to ``True`` in the above example, the package
-        would be installed, but the state would report as failed because the
-        actual installed version would be ``2:7.4.160-1.el7``. Alternatively,
-        this option can be left as ``False`` and the full version string (with
-        epoch) can be specified in the SLS file:
-
-        .. code-block:: yaml
-
-            vim-enhanced:
-              pkg.installed:
-                - version: 2:7.4.160-1.el7
+        If this option is not explicitly set, and there is no epoch in the
+        desired package version, the epoch will be implicitly ignored. Set this
+        argument to ``True`` to explicitly ignore the epoch, and ``False`` to
+        strictly enforce it.
 
         .. versionadded:: 2015.8.9
+
+        .. versionchanged:: Sodium
+            In prior releases, the default behavior was to strictly enforce
+            epochs unless this argument was set to ``True``.
 
     |
 
@@ -2775,7 +2780,7 @@ def _uninstall(
     version=None,
     pkgs=None,
     normalize=True,
-    ignore_epoch=False,
+    ignore_epoch=None,
     **kwargs
 ):
     """
@@ -2893,9 +2898,7 @@ def _uninstall(
     }
 
 
-def removed(
-    name, version=None, pkgs=None, normalize=True, ignore_epoch=False, **kwargs
-):
+def removed(name, version=None, pkgs=None, normalize=True, ignore_epoch=None, **kwargs):
     """
     Verify that a package is not installed, calling ``pkg.remove`` if necessary
     to remove the package.
@@ -2941,33 +2944,17 @@ def removed(
 
         .. versionadded:: 2015.8.0
 
-    ignore_epoch : False
-        When a package version contains an non-zero epoch (e.g.
-        ``1:3.14.159-2.el7``, and a specific version of a package is desired,
-        set this option to ``True`` to ignore the epoch when comparing
-        versions. This allows for the following SLS to be used:
-
-        .. code-block:: yaml
-
-            # Actual vim-enhanced version: 2:7.4.160-1.el7
-            vim-enhanced:
-              pkg.removed:
-                - version: 7.4.160-1.el7
-                - ignore_epoch: True
-
-        Without this option set to ``True`` in the above example, the state
-        would falsely report success since the actual installed version is
-        ``2:7.4.160-1.el7``. Alternatively, this option can be left as
-        ``False`` and the full version string (with epoch) can be specified in
-        the SLS file:
-
-        .. code-block:: yaml
-
-            vim-enhanced:
-              pkg.removed:
-                - version: 2:7.4.160-1.el7
+    ignore_epoch : None
+        If this option is not explicitly set, and there is no epoch in the
+        desired package version, the epoch will be implicitly ignored. Set this
+        argument to ``True`` to explicitly ignore the epoch, and ``False`` to
+        strictly enforce it.
 
         .. versionadded:: 2015.8.9
+
+        .. versionchanged:: Sodium
+            In prior releases, the default behavior was to strictly enforce
+            epochs unless this argument was set to ``True``.
 
     Multiple Package Options:
 
@@ -3003,7 +2990,7 @@ def removed(
         return ret
 
 
-def purged(name, version=None, pkgs=None, normalize=True, ignore_epoch=False, **kwargs):
+def purged(name, version=None, pkgs=None, normalize=True, ignore_epoch=None, **kwargs):
     """
     Verify that a package is not installed, calling ``pkg.purge`` if necessary
     to purge the package. All configuration files are also removed.
@@ -3049,33 +3036,17 @@ def purged(name, version=None, pkgs=None, normalize=True, ignore_epoch=False, **
 
         .. versionadded:: 2015.8.0
 
-    ignore_epoch : False
-        When a package version contains an non-zero epoch (e.g.
-        ``1:3.14.159-2.el7``, and a specific version of a package is desired,
-        set this option to ``True`` to ignore the epoch when comparing
-        versions. This allows for the following SLS to be used:
-
-        .. code-block:: yaml
-
-            # Actual vim-enhanced version: 2:7.4.160-1.el7
-            vim-enhanced:
-              pkg.purged:
-                - version: 7.4.160-1.el7
-                - ignore_epoch: True
-
-        Without this option set to ``True`` in the above example, the state
-        would falsely report success since the actual installed version is
-        ``2:7.4.160-1.el7``. Alternatively, this option can be left as
-        ``False`` and the full version string (with epoch) can be specified in
-        the SLS file:
-
-        .. code-block:: yaml
-
-            vim-enhanced:
-              pkg.purged:
-                - version: 2:7.4.160-1.el7
+    ignore_epoch : None
+        If this option is not explicitly set, and there is no epoch in the
+        desired package version, the epoch will be implicitly ignored. Set this
+        argument to ``True`` to explicitly ignore the epoch, and ``False`` to
+        strictly enforce it.
 
         .. versionadded:: 2015.8.9
+
+        .. versionchanged:: Sodium
+            In prior releases, the default behavior was to strictly enforce
+            epochs unless this argument was set to ``True``.
 
     Multiple Package Options:
 
@@ -3084,7 +3055,7 @@ def purged(name, version=None, pkgs=None, normalize=True, ignore_epoch=False, **
         ``name`` parameter will be ignored if this option is passed. It accepts
         version numbers as well.
 
-    .. versionadded:: 0.16.0
+        .. versionadded:: 0.16.0
     """
     kwargs["saltenv"] = __env__
     try:

--- a/tests/integration/states/test_pkg.py
+++ b/tests/integration/states/test_pkg.py
@@ -31,7 +31,6 @@ from tests.support.helpers import (
     runs_on,
 )
 from tests.support.mixins import SaltReturnAssertsMixin
-from tests.support.unit import skipIf
 
 log = logging.getLogger(__name__)
 
@@ -73,6 +72,9 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
             elif grains["osmajorrelease"] == 7:
                 cls._PKG_DOT_TARGETS = ["tomcat-el-2.2-api"]
                 cls._PKG_EPOCH_TARGETS = ["comps-extras"]
+            elif grains["osmajorrelease"] == 8:
+                cls._PKG_DOT_TARGETS = ["vid.stab"]
+                cls._PKG_EPOCH_TARGETS = ["traceroute"]
         elif grains["os_family"] == "Suse":
             cls._PKG_TARGETS = ["lynx", "htop"]
             if grains["os"] == "SUSE":
@@ -143,12 +145,14 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.run_state("pkg.removed", name=target)
         self.assertSaltTrueReturn(ret)
 
-    @skipIf(not _VERSION_SPEC_SUPPORTED, "Version specification not supported")
     @requires_salt_states("pkg.installed", "pkg.removed")
     def test_pkg_002_installed_with_version(self):
         """
         This is a destructive test as it installs and then removes a package
         """
+        if not self._VERSION_SPEC_SUPPORTED:
+            self.skipTest("Version specification not supported")
+
         target = self._PKG_TARGETS[0]
         version = self.latest_version(target)
 
@@ -188,12 +192,14 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
             ret = self.run_state("pkg.removed", name=None, pkgs=self._PKG_TARGETS)
             self.assertSaltTrueReturn(ret)
 
-    @skipIf(not _VERSION_SPEC_SUPPORTED, "Version specification not supported")
     @requires_salt_states("pkg.installed", "pkg.removed")
     def test_pkg_004_installed_multipkg_with_version(self):
         """
         This is a destructive test as it installs and then removes two packages
         """
+        if not self._VERSION_SPEC_SUPPORTED:
+            self.skipTest("Version specification not supported")
+
         version = self.latest_version(self._PKG_TARGETS[0])
 
         # If this assert fails, we need to find new targets, this test needs to
@@ -210,13 +216,15 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
             ret = self.run_state("pkg.removed", name=None, pkgs=self._PKG_TARGETS)
             self.assertSaltTrueReturn(ret)
 
-    @skipIf(not _PKG_32_TARGETS, "No 32 bit packages have been specified for testing")
     @requires_salt_modules("pkg.version")
     @requires_salt_states("pkg.installed", "pkg.removed")
     def test_pkg_005_installed_32bit(self):
         """
         This is a destructive test as it installs and then removes a package
         """
+        if not self._PKG_32_TARGETS:
+            self.skipTest("No 32 bit packages have been specified for testing")
+
         target = self._PKG_32_TARGETS[0]
 
         # _PKG_TARGETS_32 is only populated for platforms for which Salt has to
@@ -235,12 +243,14 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.run_state("pkg.removed", name=target)
         self.assertSaltTrueReturn(ret)
 
-    @skipIf(not _PKG_32_TARGETS, "No 32 bit packages have been specified for testing")
     @requires_salt_states("pkg.installed", "pkg.removed")
     def test_pkg_006_installed_32bit_with_version(self):
         """
         This is a destructive test as it installs and then removes a package
         """
+        if not self._PKG_32_TARGETS:
+            self.skipTest("No 32 bit packages have been specified for testing")
+
         target = self._PKG_32_TARGETS[0]
 
         # _PKG_TARGETS_32 is only populated for platforms for which Salt has to
@@ -261,10 +271,6 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.run_state("pkg.removed", name=target)
         self.assertSaltTrueReturn(ret)
 
-    @skipIf(
-        not _PKG_DOT_TARGETS,
-        'No packages with "." in their name have been configured for',
-    )
     @requires_salt_states("pkg.installed", "pkg.removed")
     def test_pkg_007_with_dot_in_pkgname(self=None):
         """
@@ -273,6 +279,9 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
 
         This is a destructive test as it installs a package
         """
+        if not self._PKG_DOT_TARGETS:
+            self.skipTest('No packages with "." in their name have been specified',)
+
         target = self._PKG_DOT_TARGETS[0]
 
         version = self.latest_version(target)
@@ -286,10 +295,6 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         ret = self.run_state("pkg.removed", name=target)
         self.assertSaltTrueReturn(ret)
 
-    @skipIf(
-        not _PKG_EPOCH_TARGETS,
-        'No targets have been configured with "epoch" in the version',
-    )
     @requires_salt_states("pkg.installed", "pkg.removed")
     def test_pkg_008_epoch_in_version(self):
         """
@@ -298,6 +303,9 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
 
         This is a destructive test as it installs a package
         """
+        if not self._PKG_EPOCH_TARGETS:
+            self.skipTest('No targets have been configured with "epoch" in the version')
+
         target = self._PKG_EPOCH_TARGETS[0]
 
         version = self.latest_version(target)
@@ -407,13 +415,15 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
                 "Package {0} is already up-to-date".format(target),
             )
 
-    @skipIf(not _WILDCARDS_SUPPORTED, "Wildcards in pkg.install are not supported")
     @requires_salt_modules("pkg.version")
     @requires_salt_states("pkg.installed", "pkg.removed")
     def test_pkg_012_installed_with_wildcard_version(self):
         """
         This is a destructive test as it installs and then removes a package
         """
+        if not self._WILDCARDS_SUPPORTED:
+            self.skipTest("Wildcards in pkg.install are not supported")
+
         target = self._PKG_TARGETS[0]
         version = self.run_function("pkg.version", [target])
 
@@ -577,13 +587,51 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
                 ret = self.run_state("pkg.removed", name=versionlock_pkg)
                 self.assertSaltTrueReturn(ret)
 
-    @skipIf(not _PKG_CAP_TARGETS, "Capability not provided")
+    @requires_salt_states("pkg.installed", "pkg.removed")
+    def test_pkg_016_conditionally_ignore_epoch(self):
+        """
+        See
+        https://github.com/saltstack/salt/issues/56654#issuecomment-615034952
+
+        This is a destructive test as it installs a package
+        """
+        if not self._PKG_EPOCH_TARGETS:
+            self.skipTest('No targets have been configured with "epoch" in the version')
+
+        target = self._PKG_EPOCH_TARGETS[0]
+
+        # Strip the epoch from the latest available version
+        version = self.latest_version(target).split(":", 1)[-1]
+        # If this assert fails, we need to find a new target. This test
+        # needs to be able to test successful installation of the package, so
+        # the target needs to not be installed before we run the
+        # pkg.installed state below
+        self.assertTrue(version)
+
+        # CASE 1: package name passed in "name" param
+        ret = self.run_state(
+            "pkg.installed", name=target, version=version, refresh=False
+        )
+        self.assertSaltTrueReturn(ret)
+        ret = self.run_state("pkg.removed", name=target)
+        self.assertSaltTrueReturn(ret)
+
+        # CASE 2: same as case 1 but with "pkgs"
+        ret = self.run_state(
+            "pkg.installed", name="foo", pkgs=[{target: version}], refresh=False
+        )
+        self.assertSaltTrueReturn(ret)
+        ret = self.run_state("pkg.removed", name=target)
+        self.assertSaltTrueReturn(ret)
+
     @requires_salt_modules("pkg.version")
     @requires_salt_states("pkg.installed", "pkg.removed")
     def test_pkg_cap_001_installed(self):
         """
         This is a destructive test as it installs and then removes a package
         """
+        if not self._PKG_CAP_TARGETS:
+            self.skipTest("Capability not provided")
 
         target, realpkg = self._PKG_CAP_TARGETS[0]
         version = self.run_function("pkg.version", [target])
@@ -617,12 +665,14 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
             ret = self.run_state("pkg.removed", name=realpkg)
             self.assertSaltTrueReturn(ret)
 
-    @skipIf(not _PKG_CAP_TARGETS, "Capability not available")
     @requires_salt_states("pkg.installed", "pkg.removed")
     def test_pkg_cap_002_already_installed(self):
         """
         This is a destructive test as it installs and then removes a package
         """
+        if not self._PKG_CAP_TARGETS:
+            self.skipTest("Capability not provided")
+
         target, realpkg = self._PKG_CAP_TARGETS[0]
         version = self.run_function("pkg.version", [target])
         realver = self.run_function("pkg.version", [realpkg])
@@ -660,13 +710,17 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
             ret = self.run_state("pkg.removed", name=realpkg)
             self.assertSaltTrueReturn(ret)
 
-    @skipIf(not _PKG_CAP_TARGETS, "Capability not available")
-    @skipIf(not _VERSION_SPEC_SUPPORTED, "Version specification not supported")
     @requires_salt_states("pkg.installed", "pkg.removed")
     def test_pkg_cap_003_installed_multipkg_with_version(self):
         """
         This is a destructive test as it installs and then removes two packages
         """
+        if not self._PKG_CAP_TARGETS:
+            self.skipTest("Capability not provided")
+
+        if not self._VERSION_SPEC_SUPPORTED:
+            self.skipTest("Version specification not supported")
+
         target, realpkg = self._PKG_CAP_TARGETS[0]
         version = self.latest_version(target)
         realver = self.latest_version(realpkg)
@@ -720,7 +774,6 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
             )
             self.assertSaltTrueReturn(ret)
 
-    @skipIf(not _PKG_CAP_TARGETS, "Capability not available")
     @requires_salt_modules("pkg.version")
     @requires_salt_states("pkg.latest", "pkg.removed")
     def test_pkg_cap_004_latest(self):
@@ -728,6 +781,9 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         This tests pkg.latest with a package that has no epoch (or a zero
         epoch).
         """
+        if not self._PKG_CAP_TARGETS:
+            self.skipTest("Capability not provided")
+
         target, realpkg = self._PKG_CAP_TARGETS[0]
         version = self.run_function("pkg.version", [target])
         realver = self.run_function("pkg.version", [realpkg])
@@ -766,13 +822,15 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
             ret = self.run_state("pkg.removed", name=realpkg)
             self.assertSaltTrueReturn(ret)
 
-    @skipIf(not _PKG_CAP_TARGETS, "Capability not available")
     @requires_salt_modules("pkg.version")
     @requires_salt_states("pkg.installed", "pkg.removed", "pkg.downloaded")
     def test_pkg_cap_005_downloaded(self):
         """
         This is a destructive test as it installs and then removes a package
         """
+        if not self._PKG_CAP_TARGETS:
+            self.skipTest("Capability not provided")
+
         target, realpkg = self._PKG_CAP_TARGETS[0]
         version = self.run_function("pkg.version", [target])
         realver = self.run_function("pkg.version", [realpkg])
@@ -802,13 +860,15 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         )
         self.assertSaltTrueReturn(ret)
 
-    @skipIf(not _PKG_CAP_TARGETS, "Capability not available")
     @requires_salt_modules("pkg.version")
     @requires_salt_states("pkg.installed", "pkg.removed", "pkg.uptodate")
     def test_pkg_cap_006_uptodate(self):
         """
         This is a destructive test as it installs and then removes a package
         """
+        if not self._PKG_CAP_TARGETS:
+            self.skipTest("Capability not provided")
+
         target, realpkg = self._PKG_CAP_TARGETS[0]
         version = self.run_function("pkg.version", [target])
         realver = self.run_function("pkg.version", [realpkg])


### PR DESCRIPTION
### What does this PR do?

A usability tweak for `pkg` states on platforms that support pkg epochs.

In the process of adding a test case for this, I encountered a major testing oversight that was merged on Jan 9th in https://github.com/saltstack/salt/pull/55707. By moving the lists of package targets into the class, they weren't defined until _after_ the decorators had already ran. This means that most of these decorated tests were being skipped all the time, on all platforms. Not great, Bob!

I've moved the skip logic back within the actual tests, where they were before the decorators were added last autumn in 291579c02b630e453a4ec90936218964bd5c5f89.

### What issues does this PR fix or reference?

#56654 

https://github.com/saltstack/salt/pull/55707

### Previous Behavior

Epochs were strictly enforced in package comparisons (i.e. `2.3-4` would not be a match if the actual version of the package was `1:2.3-4`), unless `ignore_epoch` was set to `True`.

### New Behavior

Now, when no value is explicitly passed this argument, the epoch will be implicitly skipped if the desired version does not itself contain an epoch. This will allow for much more natural version handling, instead of requiring the user to always know beforehand when they are dealing with a package that has an epoch in the version.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [ ] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
No