### PR TITLE
Fixes minion returning list in chocolatey module

### DIFF
--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -16,12 +16,12 @@ import tempfile
 # Import salt libs
 import salt.utils.data
 import salt.utils.platform
-from requests.structures import CaseInsensitiveDict
 from salt.exceptions import (
     CommandExecutionError,
     CommandNotFoundError,
     SaltInvocationError,
 )
+from salt.utils.data import CaseInsensitiveDict
 from salt.utils.versions import LooseVersion as _LooseVersion
 
 log = logging.getLogger(__name__)

--- a/tests/integration/modules/test_chocolatey.py
+++ b/tests/integration/modules/test_chocolatey.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+import pytest
+import salt.modules.chocolatey as choco
+import salt.utils.platform
+from tests.support.case import ModuleCase
+from tests.support.helpers import destructiveTest
+from tests.support.unit import skipIf
+
+
+@skipIf(not salt.utils.platform.is_windows(), "Tests for only Windows")
+@pytest.mark.windows_whitelisted
+class ChocolateyModuleTest(ModuleCase):
+    """
+    Validate Chocolatey module
+    """
+
+    @destructiveTest
+    def setUp(self):
+        """
+        Ensure that Chocolatey is installed
+        """
+        self._chocolatey_bin = choco._find_chocolatey()
+        if "ERROR" in self._chocolatey_bin:
+            #    self.fail("Chocolatey is not installed")
+            self.run_function("chocolatey.bootstrap")
+        super(ChocolateyModuleTest, self).setUp()
+
+    def test_list_(self):
+        ret = self.run_function("chocolatey.list", narrow="adobereader", exact=True)
+        self.assertTrue("adobereader" in ret)


### PR DESCRIPTION
### What does this PR do?
Changes CaseInsensitiveDict implementation from requests to salt's implementation in utils.data

### What issues does this PR fix or reference?
Fixes: #54899

### Previous Behavior
The CaseInsensitiveDict cannot be serialized by msgpack. The minion would encounter a TypeError and nothing would be returned to the master.

### New Behavior
msgpack is able to serialize the output from list and the minion successfully returns the response to the master.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/latest/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes
