### PR TITLE
Add missing RST stubs for new helm state/exec module

### DIFF
--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -186,6 +186,7 @@ execution modules
     haproxyconn
     hashutil
     heat
+    helm
     hg
     highstate_doc
     hosts

--- a/doc/ref/modules/all/salt.modules.helm.rst
+++ b/doc/ref/modules/all/salt.modules.helm.rst
@@ -1,0 +1,6 @@
+salt.modules.helm module
+========================
+
+.. automodule:: salt.modules.helm
+    :members:
+    :undoc-members:

--- a/doc/ref/states/all/index.rst
+++ b/doc/ref/states/all/index.rst
@@ -124,6 +124,7 @@ state modules
     grains
     group
     heat
+    helm
     hg
     highstate_doc
     host

--- a/doc/ref/states/all/salt.states.helm.rst
+++ b/doc/ref/states/all/salt.states.helm.rst
@@ -1,0 +1,6 @@
+salt.states.helm module
+=======================
+
+.. automodule:: salt.states.helm
+    :members:
+    :undoc-members:

--- a/salt/modules/helm.py
+++ b/salt/modules/helm.py
@@ -2,7 +2,9 @@
 """
 Interface with Helm
 
-:depends: helm_ package installed on minion's system.
+:depends: pyhelm_ Python package
+
+.. _pyhelm: https://pypi.org/project/pyhelm/
 
 .. note::
     This module use the helm-cli. The helm-cli binary have to be present in your Salt-Minion path.

--- a/salt/modules/helm.py
+++ b/salt/modules/helm.py
@@ -8,7 +8,7 @@ Interface with Helm
     This module use the helm-cli. The helm-cli binary have to be present in your Salt-Minion path.
 
 Helm-CLI vs Salt-Modules
---------------
+------------------------
 
 This module is a wrapper of the helm binary.
 All helm v3.0 command are implemented.


### PR DESCRIPTION
https://github.com/saltstack/salt/pull/56081 was merged several hours ago, breaking the docs checks. This adds the needed RST files to ensure docs files are created for this new module.