### PR TITLE
Rewrite PY3-specific code that uses argspec functions from inspect module

### DIFF
--- a/salt/modules/napalm_mod.py
+++ b/salt/modules/napalm_mod.py
@@ -10,7 +10,6 @@ Helpers for the NAPALM modules.
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python stdlib
-import inspect
 import logging
 
 # import NAPALM utils
@@ -103,7 +102,9 @@ def _get_netmiko_args(optional_args):
     # Older version don't have the netmiko_helpers module, the following code is
     # simply a port from the NAPALM code base, for backwards compatibility:
     # https://github.com/napalm-automation/napalm/blob/develop/napalm/base/netmiko_helpers.py
-    netmiko_args, _, _, netmiko_defaults = inspect.getargspec(BaseConnection.__init__)
+    netmiko_args, _, _, netmiko_defaults = __utils__["args.get_function_argspec"](
+        BaseConnection.__init__
+    )
     check_self = netmiko_args.pop(0)
     if check_self != "self":
         raise ValueError("Error processing Netmiko arguments")

--- a/salt/modules/netmiko_mod.py
+++ b/salt/modules/netmiko_mod.py
@@ -184,8 +184,6 @@ outside a ``netmiko`` Proxy, e.g.:
 """
 from __future__ import absolute_import
 
-import inspect
-
 # Import python stdlib
 import logging
 
@@ -251,7 +249,7 @@ def _prepare_connection(**kwargs):
     fun_kwargs = {}
     netmiko_kwargs = __salt__["config.get"]("netmiko", {})
     netmiko_kwargs.update(kwargs)  # merge the CLI args with the opts/pillar
-    netmiko_init_args, _, _, netmiko_defaults = inspect.getargspec(
+    netmiko_init_args, _, _, netmiko_defaults = __utils__["args.get_function_argspec"](
         BaseConnection.__init__
     )
     check_self = netmiko_init_args.pop(0)

--- a/salt/modules/scp_mod.py
+++ b/salt/modules/scp_mod.py
@@ -9,8 +9,6 @@ Module to copy files via `SCP <https://man.openbsd.org/scp>`_
 """
 from __future__ import absolute_import, print_function, unicode_literals
 
-import inspect
-
 # Import python libs
 import logging
 
@@ -40,17 +38,17 @@ def __virtual__():
 def _select_kwargs(**kwargs):
     paramiko_kwargs = {}
     scp_kwargs = {}
-    PARAMIKO_KWARGS, _, _, _ = inspect.getargspec(paramiko.SSHClient.connect)
-    PARAMIKO_KWARGS.pop(0)  # strip self
-    PARAMIKO_KWARGS.append("auto_add_policy")
-    SCP_KWARGS, _, _, _ = inspect.getargspec(scp.SCPClient.__init__)
-    SCP_KWARGS.pop(0)  # strip self
-    SCP_KWARGS.pop(0)  # strip transport arg (it is passed in _prepare_connection)
-    for karg, warg in six.iteritems(kwargs):
-        if karg in PARAMIKO_KWARGS and warg is not None:
-            paramiko_kwargs[karg] = warg
-        if karg in SCP_KWARGS and warg is not None:
-            scp_kwargs[karg] = warg
+    paramiko_args = __utils__["args.get_function_argspec"](paramiko.SSHClient.connect)[
+        0
+    ]
+    paramiko_args.append("auto_add_policy")
+    scp_args = __utils__["args.get_function_argspec"](scp.SCPClient.__init__)[0]
+    scp_args.pop(0)  # strip transport arg (it is passed in _prepare_connection)
+    for key, val in six.iteritems(kwargs):
+        if key in paramiko_args and val is not None:
+            paramiko_kwargs[key] = val
+        if key in scp_args and val is not None:
+            scp_kwargs[key] = val
     return paramiko_kwargs, scp_kwargs
 
 

--- a/salt/modules/testinframod.py
+++ b/salt/modules/testinframod.py
@@ -218,9 +218,9 @@ def _copy_function(module_name, name=None):
             parameters = mod_sig.parameters
         else:
             if isinstance(mod.__init__, types.MethodType):
-                mod_sig = inspect.getargspec(mod.__init__)
+                mod_sig = __utils__["args.get_function_argspec"](mod.__init__)
             elif hasattr(mod, "__call__"):
-                mod_sig = inspect.getargspec(mod.__call__)
+                mod_sig = __utils__["args.get_function_argspec"](mod.__call__)
             parameters = mod_sig.args
         log.debug("Parameters accepted by module %s: %s", module_name, parameters)
         additional_args = {}

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -186,7 +186,6 @@ connection credentials are used instead of vCenter credentials, the ``host_names
 from __future__ import absolute_import
 
 import datetime
-import inspect
 import logging
 import sys
 from functools import wraps
@@ -402,19 +401,12 @@ def gets_service_instance_via_proxy(fn):
         None, this is a decorator
     """
     fn_name = fn.__name__
-    try:
-        (
-            arg_names,
-            args_name,
-            kwargs_name,
-            default_values,
-            _,
-            _,
-            _,
-        ) = inspect.getfullargspec(fn)
-    except AttributeError:
-        # Fallback to Python 2.7
-        arg_names, args_name, kwargs_name, default_values = inspect.getargspec(fn)
+    (
+        arg_names,
+        args_name,
+        kwargs_name,
+        default_values,
+    ) = salt.utils.args.get_function_argspec(fn)
     default_values = default_values if default_values is not None else []
 
     @wraps(fn)

--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -290,6 +290,8 @@ def get_function_argspec(func, is_class_method=None):
                     varargs = param.name
                 elif param.kind == param.VAR_KEYWORD:
                     keywords = param.name
+            if is_class_method:
+                del args[0]
             aspec = _ArgSpec(args, varargs, keywords, tuple(defaults) or None)
 
     return aspec

--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -268,7 +268,30 @@ def get_function_argspec(func, is_class_method=None):
         aspec = _getargspec(func.__call__)
         del aspec.args[0]  # self
     else:
-        raise TypeError("Cannot inspect argument list for '{0}'".format(func))
+        try:
+            sig = inspect.signature(func)
+        except TypeError:
+            raise TypeError("Cannot inspect argument list for '{0}'".format(func))
+        else:
+            # argspec-related functions are deprecated in Python 3 in favor of
+            # the new inspect.Signature class, and will be removed at some
+            # point in the Python 3 lifecycle. So, build a namedtuple which
+            # looks like the result of a Python 2 argspec.
+            _ArgSpec = namedtuple("ArgSpec", "args varargs keywords defaults")
+            args = []
+            defaults = []
+            varargs = keywords = None
+            for param in sig.parameters.values():
+                if param.kind == param.POSITIONAL_OR_KEYWORD:
+                    args.append(param.name)
+                    if param.default is not inspect._empty:
+                        defaults.append(param.default)
+                elif param.kind == param.VAR_POSITIONAL:
+                    varargs = param.name
+                elif param.kind == param.VAR_KEYWORD:
+                    keywords = param.name
+            aspec = _ArgSpec(args, varargs, keywords, tuple(defaults) or None)
+
     return aspec
 
 

--- a/tests/unit/utils/test_args.py
+++ b/tests/unit/utils/test_args.py
@@ -42,17 +42,70 @@ class ArgsTestCase(TestCase):
         )
 
     def test_get_function_argspec(self):
-        def dummy_func(first, second, third, fourth="fifth"):
+        class DummyClass(object):
+            def __init__(self, first):
+                pass
+
+            def __call__(self, first):
+                pass
+
+        dummy_class = DummyClass("foo")
+
+        def dummy_func_nodefault(first, second, third):
             pass
 
-        expected_argspec = namedtuple("ArgSpec", "args varargs keywords defaults")(
-            args=["first", "second", "third", "fourth"],
+        def dummy_func_default(first, second, third="fourth"):
+            pass
+
+        def dummy_func_varargs_keywords(*args, **kwargs):
+            pass
+
+        _ArgSpec = namedtuple("ArgSpec", "args varargs keywords defaults")
+
+        # Callable class instance
+        expected_argspec = _ArgSpec(
+            args=["first"], varargs=None, keywords=None, defaults=None,
+        )
+        ret = salt.utils.args.get_function_argspec(dummy_class)
+        self.assertEqual(ret, expected_argspec)
+
+        # Function with no varargs, no keywords, and no defaults
+        expected_argspec = _ArgSpec(
+            args=["first", "second", "third"],
             varargs=None,
             keywords=None,
-            defaults=("fifth",),
+            defaults=None,
         )
-        ret = salt.utils.args.get_function_argspec(dummy_func)
+        ret = salt.utils.args.get_function_argspec(dummy_func_nodefault)
+        self.assertEqual(ret, expected_argspec)
 
+        # Function with no varargs, no keywords, and one default
+        expected_argspec = _ArgSpec(
+            args=["first", "second", "third"],
+            varargs=None,
+            keywords=None,
+            defaults=("fourth",),
+        )
+        ret = salt.utils.args.get_function_argspec(dummy_func_default)
+        self.assertEqual(ret, expected_argspec)
+
+        # Function with both varargs and keywords
+        expected_argspec = _ArgSpec(
+            args=[], varargs="args", keywords="kwargs", defaults=None,
+        )
+        ret = salt.utils.args.get_function_argspec(dummy_func_varargs_keywords)
+        self.assertEqual(ret, expected_argspec)
+
+        # Test that is_class_method=True is respected. Note that we don't
+        # actually have a decorated function from rest_tornado here to test
+        # this case, but we're testing for the behavior we expect, which is
+        # that the first argument is popped off of the args.
+        expected_argspec = _ArgSpec(
+            args=["second", "third"], varargs=None, keywords=None, defaults=None,
+        )
+        ret = salt.utils.args.get_function_argspec(
+            dummy_func_nodefault, is_class_method=True
+        )
         self.assertEqual(ret, expected_argspec)
 
     def test_parse_kwarg(self):


### PR DESCRIPTION
*This pull request was inspired by https://github.com/saltstack/salt/pull/56027.*

### What does this PR do?

[`inspect.getargspec()`](https://docs.python.org/3/library/inspect.html#inspect.getargspec) and [`inspect.getfullargspec()`](https://docs.python.org/3/library/inspect.html#inspect.getfullargspec) are deprecated in Python 3 in favor of [`inspect.Signature`](https://docs.python.org/3/library/inspect.html#inspect.Signature).

To ensure consistent behavior moving forward with Python 3, this PR does the following:

1. Modifies `salt.utils.args` such that the PY3-specific code to build the namedtuple now uses [`inspect.signature()`](https://docs.python.org/3/library/inspect.html#inspect.signature).

2. Updates all calls to [`inspect.getargspec()`](https://docs.python.org/3/library/inspect.html#inspect.getargspec) and [`inspect.getfullargspec()`](https://docs.python.org/3/library/inspect.html#inspect.getfullargspec) elsewhere in the code to ensure that they use the proper PY3-specific code when running under PY3.

### What issues does this PR fix or reference?

Refs: https://github.com/saltstack/salt/pull/56027

### Merge requirements satisfied?

Docs are unnecessary, as this doesn't change how one uses Salt.

Additionally, new tests are not needed because there are already unit tests that confirm proper operation of `salt.utils.args.get_function_argspec()`, and these tests pass with the new code.

### Commits signed with GPG?
No