### PR TITLE
Fix detection of swap on OpenBSD systems

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -560,7 +560,7 @@ def _bsd_memdata(osdata):
         if osdata["kernel"] in ["OpenBSD", "NetBSD"]:
             swapctl = salt.utils.path.which("swapctl")
             swap_data = __salt__["cmd.run"]("{0} -sk".format(swapctl))
-            if swap_data == "no swap devices configured":
+            if swap_data.endswith("no swap devices configured"):
                 swap_total = 0
             else:
                 swap_total = swap_data.split(" ")[1]


### PR DESCRIPTION
The original logic worked until [this commit](https://github.com/openbsd/src/commit/940f496417b8c0d47943cf066390120c9e78f8a7) which wraps the 'no swap devices configured' error in the program name. Now, the output of 'swapctl -sk' on an OpenBSD system with no swap configured looks like this:

swapctl: no swap devices configured

This change supports both [NetBSD's](https://ftp.netbsd.org/pub/NetBSD/NetBSD-current/src/sbin/swapctl/swaplist.c) message and OpenBSD's message by looking for the key phrase at the end of the command's output

### What does this PR do?

Fixes incorrect behavior of the core grain on OpenBSD systems with no swap configured. Without this change, all salt binaries and calls fail when run locally or from a master. Here's an example stacktrace with minimal repro:

```
# salt-call --local grains.get swap_total
Traceback (most recent call last):
  File "/usr/local/bin/salt-call", line 11, in <module>
    salt_call()
  File "/usr/local/lib/python2.7/site-packages/salt/scripts.py", line 405, in salt_call
    import salt.cli.call
  File "/usr/local/lib/python2.7/site-packages/salt/cli/call.py", line 5, in <module>
    import salt.utils.parsers
  File "/usr/local/lib/python2.7/site-packages/salt/utils/parsers.py", line 27, in <module>
    import salt.config as config
  File "/usr/local/lib/python2.7/site-packages/salt/config/__init__.py", line 98, in <module>
    _DFLT_IPC_WBUFFER = _gather_buffer_space() * .5
  File "/usr/local/lib/python2.7/site-packages/salt/config/__init__.py", line 91, in _gather_buffer_space
    grains = salt.grains.core._memdata(os_data)
  File "/usr/local/lib/python2.7/site-packages/salt/grains/core.py", line 570, in _memdata
    grains.update(_bsd_memdata(osdata))
  File "/usr/local/lib/python2.7/site-packages/salt/grains/core.py", line 491, in _bsd_memdata
    grains['swap_total'] = int(swap_total) // 1024 // 1024
ValueError: invalid literal for int() with base 10: 'no'
```

### What issues does this PR fix or reference?

I cannot find an issue filed for this behavior.

### Previous Behavior

All salt calls on an OpenBSD system without swap configured resulted in an exception.

### New Behavior

Salt works properly.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/latest/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
