### PR TITLE
Correct firewalld.reload_rules docstring

### DIFF
--- a/salt/modules/firewalld.py
+++ b/salt/modules/firewalld.py
@@ -82,7 +82,7 @@ def reload_rules():
 
     .. code-block:: bash
 
-        salt '*' firewalld.reload
+        salt '*' firewalld.reload_rules
     """
     return __firewall_cmd("--reload")
 


### PR DESCRIPTION
### What does this PR do?

Correct example section in the docstring of `firewalld.reload_rules`.
The function is called `reload_rules`, not `reload`.

### What issues does this PR fix or reference?
None

### Previous Behavior
The example claimed the function is called `reload`, which did not work.
<details><pre>
`salt-call --local firewalld.reload` produces following output:

    local:
        ----------
        firewalld.reload:
            'firewalld.reload' is not available.
        firewalld.reload_rules:

                Reload the firewall rules, which makes the permanent configuration the new
                runtime configuration without losing state information.

                New in version 2016.11.0

                CLI Example:

                    salt '*' firewalld.reload
</pre></details>
### New Behavior
The example correctly shows `salt '*' firewalld.reload_rules`.

### Commits signed with GPG?
Yes
