### PR TITLE
[PyTest #33 - Extract] There's really no need to setup clear_func for each test.

### DIFF
--- a/tests/unit/test_master.py
+++ b/tests/unit/test_master.py
@@ -17,9 +17,14 @@ class ClearFuncsTestCase(TestCase):
     TestCase for salt.master.ClearFuncs class
     """
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         opts = salt.config.master_config(None)
-        self.clear_funcs = salt.master.ClearFuncs(opts, {})
+        cls.clear_funcs = salt.master.ClearFuncs(opts, {})
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.clear_funcs
 
     # runner tests
 


### PR DESCRIPTION
### What does this PR do?
This makes it so that all tests in this module take ~30 seconds to run
as opposed to ~20s for each test