### PR TITLE
Fix matching of integer keys in nested subdicts

### DIFF
--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -772,12 +772,21 @@ def traverse_dict_and_list(data, key, default=None, delimiter=DEFAULT_TARGET_DEL
                 # Late import to avoid circular import
                 import salt.utils.args
 
-                # YAML-load the current key (catches integer dict keys)
+                # YAML-load the current key (catches integer/float dict keys)
                 try:
                     loaded_key = salt.utils.args.yamlify_arg(each)
                 except Exception:  # pylint: disable=broad-except
                     return default
-                if loaded_key != each:
+                if loaded_key == each:
+                    # After YAML-loading, the desired key is unchanged. This
+                    # means that the KeyError caught above is a legitimate
+                    # failure to match the desired key. Therefore, return the
+                    # default.
+                    return default
+                else:
+                    # YAML-loading the key changed its value, so re-check with
+                    # the loaded key. This is how we can match a numeric key
+                    # with a string-based expression.
                     try:
                         ptr = ptr[loaded_key]
                     except (KeyError, TypeError):

--- a/tests/unit/utils/test_data.py
+++ b/tests/unit/utils/test_data.py
@@ -226,6 +226,14 @@ class DataTestCase(TestCase):
                 {"not_found": "not_found"},
             ),
         )
+        # Traverse and match integer key in a nested dict
+        # https://github.com/saltstack/salt/issues/56444
+        self.assertEqual(
+            "it worked",
+            salt.utils.data.traverse_dict_and_list(
+                {"foo": {1234: "it worked"}}, "foo:1234", "it didn't work",
+            ),
+        )
 
     def test_compare_dicts(self):
         ret = salt.utils.data.compare_dicts(old={"foo": "bar"}, new={"foo": "bar"})

--- a/tests/unit/utils/test_data.py
+++ b/tests/unit/utils/test_data.py
@@ -226,12 +226,22 @@ class DataTestCase(TestCase):
                 {"not_found": "not_found"},
             ),
         )
+
         # Traverse and match integer key in a nested dict
         # https://github.com/saltstack/salt/issues/56444
         self.assertEqual(
             "it worked",
             salt.utils.data.traverse_dict_and_list(
                 {"foo": {1234: "it worked"}}, "foo:1234", "it didn't work",
+            ),
+        )
+        # Make sure that we properly return the default value when the initial
+        # attempt fails and YAML-loading the target key doesn't change its
+        # value.
+        self.assertEqual(
+            "default",
+            salt.utils.data.traverse_dict_and_list(
+                {"foo": {"baz": "didn't work"}}, "foo:bar", "default",
             ),
         )
 


### PR DESCRIPTION
This fixes https://github.com/saltstack/salt/issues/56444. It is an alternative solution to https://github.com/saltstack/salt/pull/56552 which doesn't require iteration.