### PR TITLE
fix cloud tests

### DIFF
--- a/tests/integration/cloud/clouds/test_digitalocean.py
+++ b/tests/integration/cloud/clouds/test_digitalocean.py
@@ -37,7 +37,7 @@ class DigitalOceanTest(CloudTest):
         Tests the return of running the --list-images command for digitalocean
         """
         image_list = self.run_cloud("--list-images {0}".format(self.PROVIDER))
-        self.assertIn("14.04.5 x64", [i.strip() for i in image_list])
+        self.assertIn("ubuntu-18-04-x64", [i.strip() for i in image_list])
 
     def test_list_locations(self):
         """

--- a/tests/integration/files/conf/cloud.profiles.d/digitalocean.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/digitalocean.conf
@@ -1,5 +1,5 @@
 digitalocean-test:
   provider: digitalocean-config
-  image: 14.04.5 x64
+  image: ubuntu-18-04-x64
   size: 2GB
   script_args: '-P'


### PR DESCRIPTION
### What does this PR do?
ubuntu 14.04 no longer exists as an image in digitalocean, this updates the cloudtests to use ubuntu 18.04