### PR TITLE
states/svn: set ret[comment] appropriately for 'svn export'

### DIFF
--- a/salt/states/svn.py
+++ b/salt/states/svn.py
@@ -300,6 +300,7 @@ def export(
     out = __salt__[svn_cmd](cwd, name, basename, user, username, password, rev, *opts)
     ret["changes"]["new"] = name
     ret["changes"]["comment"] = name + " was Exported to " + target
+    ret["comment"] = out
 
     return ret
 

--- a/tests/unit/states/test_svn.py
+++ b/tests/unit/states/test_svn.py
@@ -113,7 +113,7 @@ class SvnTestCase(TestCase, LoaderModuleMockMixin):
                                 "new": "salt",
                                 "comment": "salt was Exported to c://salt",
                             },
-                            "comment": "",
+                            "comment": True,
                             "name": "salt",
                             "result": True,
                         },


### PR DESCRIPTION
A value "out" is computed but never used inside export(). Per similar
code in latest() (ie 'svn update'), this "out" should be assigned to
ret[comment].

### What does this PR do?

Set ret[comment] appropriately for the case of 'svn export'

### What issues does this PR fix or reference?
Fixes: non

### Merge requirements satisfied?

- [ ] Docs
- [ ] Changelog
- [X] Tests written/updated

### Commits signed with GPG?
No