### PR TITLE
Port #51012 to master

### DIFF
--- a/changelog/.keep
+++ b/changelog/.keep
@@ -1,0 +1,1 @@
+Keep this directory pls, git

--- a/changelog/56779.fixed
+++ b/changelog/56779.fixed
@@ -1,0 +1,1 @@
+cmd.run with runas and cwd now properly sets path on macOS

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -446,9 +446,7 @@ def _run(
         # Ensure the login is simulated correctly (note: su runs sh, not bash,
         # which causes the environment to be initialised incorrectly, which is
         # fixed by the previous line of code)
-        cmd = 'su -l {0} -c "cd {1}; {2}"'.format(
-            _cmd_quote(runas), _cmd_quote(cwd), _cmd_quote(cmd)
-        )
+        cmd = "su -l {0} -c {1}".format(_cmd_quote(runas), _cmd_quote(cmd))
 
         # Set runas to None, because if you try to run `su -l` after changing
         # user, su will prompt for the password of the user and cause salt to

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -446,7 +446,9 @@ def _run(
         # Ensure the login is simulated correctly (note: su runs sh, not bash,
         # which causes the environment to be initialised incorrectly, which is
         # fixed by the previous line of code)
-        cmd = "su -l {0} -c {1}".format(_cmd_quote(runas), _cmd_quote(cmd))
+        cmd = 'su -l {0} -c "cd {1}; {2}"'.format(
+            _cmd_quote(runas), _cmd_quote(cwd), _cmd_quote(cmd)
+        )
 
         # Set runas to None, because if you try to run `su -l` after changing
         # user, su will prompt for the password of the user and cause salt to

--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -452,6 +452,8 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
         else:
             raise RuntimeError
 
+    @skipIf(salt.utils.platform.is_windows(), "Do not run on Windows")
+    @skipIf(salt.utils.platform.is_darwin(), "Do not run on MacOS")
     def test_run_cwd_in_combination_with_runas(self):
         """
         cmd.run executes command in the cwd directory


### PR DESCRIPTION
### What does this PR do?

Ports #51012 to master

When calling cmd.run with cwd in combination
with runas the working directory was not set on macOS

This commit also adds a test to check the expected behaviour

### What issues does this PR fix or reference?

PR #51012

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
Yes