### PR TITLE
x509.certificate_managed: always call file.managed even when cert contents haven't changed

### DIFF
--- a/salt/states/x509.py
+++ b/salt/states/x509.py
@@ -686,14 +686,15 @@ def certificate_managed(
 
     ret = _certificate_file_managed(ret, file_args)
 
-    ret["changes"]["Certificate"] = {
-        "Old": current_cert_info,
-        "New": __salt__["x509.read_certificate"](certificate=name),
-    }
-    ret["changes"]["Status"] = {
-        "Old": invalid_reason,
-        "New": "Certificate is valid and up to date",
-    }
+    if ret["result"]:
+        ret["changes"]["Certificate"] = {
+            "Old": current_cert_info,
+            "New": __salt__["x509.read_certificate"](certificate=name),
+        }
+        ret["changes"]["Status"] = {
+            "Old": invalid_reason,
+            "New": "Certificate is valid and up to date",
+        }
 
     return ret
 

--- a/salt/states/x509.py
+++ b/salt/states/x509.py
@@ -643,6 +643,16 @@ def certificate_managed(
         return _certificate_file_managed(ret, file_args)
 
     if __opts__["test"]:
+        file_args, extra_args = _get_file_args(name, **kwargs)
+        # Use empty contents for file.managed in test mode.
+        # We don't want generate a new certificate, even in memory,
+        # for security reasons.
+        # Using an empty string instead of omitting it will at least
+        # show the old certificate in the diff.
+        file_args["contents"] = ""
+
+        ret = _certificate_file_managed(ret, file_args)
+
         ret["result"] = None
         ret["comment"] = "Certificate {0} will be created".format(name)
         ret["changes"]["Status"] = {

--- a/tests/integration/files/file/base/x509/self_signed_different_properties.sls
+++ b/tests/integration/files/file/base/x509/self_signed_different_properties.sls
@@ -1,6 +1,7 @@
 {% set keyfile = pillar['keyfile'] %}
 {% set crtfile = pillar['crtfile'] %}
-{% set subjectAltName = pillar['subjectAltName'] %}
+{% set subjectAltName = pillar['subjectAltName']|default('DNS:alt.service.local') %}
+{% set fileMode = pillar['fileMode']|default('0600') %}
 
 private_key:
   x509.private_key_managed:
@@ -9,6 +10,7 @@ private_key:
 self_signed_cert:
   x509.certificate_managed:
     - name: {{ crtfile }}
+    - mode: {{ fileMode }}
     - signing_private_key: {{ keyfile }}
     - CN: service.local
     - subjectAltName: {{ subjectAltName }}

--- a/tests/integration/files/file/base/x509/self_signed_file_error.sls
+++ b/tests/integration/files/file/base/x509/self_signed_file_error.sls
@@ -1,0 +1,20 @@
+{% set keyfile = pillar['keyfile'] %}
+{% set crtfile = pillar['crtfile'] %}
+{% set user = pillar['user'] %}
+
+private_key:
+  x509.private_key_managed:
+    - name: {{ keyfile }}
+
+self_signed_cert:
+  x509.certificate_managed:
+    - name: {{ crtfile }}
+    # crtfile is many folders deep, so this line will cause
+    # file.managed to fail
+    - makedirs: False
+    - signing_private_key: {{ keyfile }}
+    - CN: localhost
+    - days_valid: 90
+    - days_remaining: 30
+    - require:
+      - x509: private_key


### PR DESCRIPTION
### What does this PR do?

Fixes a bug I introduced when rewriting `x509.certificate.managed`.

The state now always calls `file.managed`, even if the certificate contents don't need to change. This allows the user to change the user / group / mode of an existing certificate.

Both file and certificate changes are properly shown in the state output:

![Screen Shot 2020-04-21 at 18 26 33](https://user-images.githubusercontent.com/578458/79901243-745b4f00-8407-11ea-93bc-0a1e82b6b4cd.png)
![Screen Shot 2020-04-21 at 18 20 30](https://user-images.githubusercontent.com/578458/79901244-74f3e580-8407-11ea-86e4-a7e00baaf059.png)
![Screen Shot 2020-04-21 at 18 27 08](https://user-images.githubusercontent.com/578458/79901240-72918b80-8407-11ea-88b8-7979c03af222.png)


Ping @Ch3LL and @waynew, since you worked on #52935.

### What issues does this PR fix or reference?

See https://github.com/saltstack/salt/pull/52935#issuecomment-616732463

### Merge requirements satisfied?
- [x] Tests written/updated

### Commits signed with GPG?
Yes
