### PR TITLE
Port #48907 to master

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -248,7 +248,7 @@ def get_fqhostname():
         for info in addrinfo:
             # info struct [family, socktype, proto, canonname, sockaddr]
             if len(info) >= 4:
-                l.append(info[3])
+                l = [info[3]]
     except socket.gaierror:
         pass
 

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -247,7 +247,7 @@ def get_fqhostname():
         )
         for info in addrinfo:
             # info struct [family, socktype, proto, canonname, sockaddr]
-            if len(info) >= 4:
+            if len(info) >= 4 and info[3]:
                 l = [info[3]]
     except socket.gaierror:
         pass

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -1247,3 +1247,22 @@ class NetworkTestCase(TestCase):
             MagicMock(return_value=[(2, 3, 0, "hostname", ("127.0.1.1", 0))]),
         ):
             self.assertEqual(network.get_fqhostname(), "hostname")
+
+    def test_get_fqhostname_return_empty_hostname(self):
+        """
+        Test if proper hostname is used when hostname returns empty string
+        """
+        host = "hostname"
+        with patch("socket.gethostname", MagicMock(return_value=host)), patch(
+            "socket.getfqdn",
+            MagicMock(return_value="very.long.and.complex.domain.name"),
+        ), patch(
+            "socket.getaddrinfo",
+            MagicMock(
+                return_value=[
+                    (2, 3, 0, host, ("127.0.1.1", 0)),
+                    (2, 3, 0, "", ("127.0.1.1", 0)),
+                ]
+            ),
+        ):
+            self.assertEqual(network.get_fqhostname(), host)

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -1232,3 +1232,18 @@ class NetworkTestCase(TestCase):
             interface_data=interface_data,
         )
         assert ret == {}, ret
+
+    def test_get_fqhostname_return(self):
+        """
+        Test if proper hostname is used when RevDNS differ from hostname
+
+        :return:
+        """
+        with patch("socket.gethostname", MagicMock(return_value="hostname")), patch(
+            "socket.getfqdn",
+            MagicMock(return_value="very.long.and.complex.domain.name"),
+        ), patch(
+            "socket.getaddrinfo",
+            MagicMock(return_value=[(2, 3, 0, "hostname", ("127.0.1.1", 0))]),
+        ):
+            self.assertEqual(network.get_fqhostname(), "hostname")


### PR DESCRIPTION
Port #48907 to master

Also fixes an issue the windows ssh tests found. If `cannonname` is empty that would get added to the list. This ensures we ensure there is not an empty string before we add to the list. You can see the added test `test_get_fqhostname_return_empty_hostname` for an example of this. 