### PR TITLE
Port #49492 to master

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -280,7 +280,7 @@ def _linux_gpu_data():
 
     gpus = []
     for gpu in devs:
-        vendor_strings = gpu["Vendor"].lower().split()
+        vendor_strings = re.split("[^A-Za-z0-9]", gpu["Vendor"].lower())
         # default vendor to 'unknown', overwrite if we match a known one
         vendor = "unknown"
         for name in known_vendors:

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -1832,3 +1832,75 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         exists.return_value = True
         with patch("salt.utils.files.fopen", _fopen):
             self.assertEqual(core._hw_data({"kernel": "Linux"}), {})
+
+    @patch("salt.utils.path.which", MagicMock(return_value="/usr/sbin/lspci"))
+    def test_linux_gpus(self):
+        """
+        Test GPU detection on Linux systems
+        """
+
+        def _cmd_side_effect(cmd):
+            ret = ""
+            for device in devices:
+                ret += textwrap.dedent(
+                    """
+                                          Class:	{0}
+                                          Vendor:	{1}
+                                          Device:	{2}
+                                          SVendor:	Evil Corp.
+                                          SDevice:	Graphics XXL
+                                          Rev:	c1
+                                          NUMANode:	0"""
+                ).format(*device)
+                ret += "\n"
+            return ret.strip()
+
+        devices = [
+            [
+                "VGA compatible controller",
+                "Advanced Micro Devices, Inc. [AMD/ATI]",
+                "Vega [Radeon RX Vega]]",
+                "amd",
+            ],  # AMD
+            [
+                "Audio device",
+                "Advanced Micro Devices, Inc. [AMD/ATI]",
+                "Device aaf8",
+                None,
+            ],  # non-GPU device
+            [
+                "VGA compatible controller",
+                "NVIDIA Corporation",
+                "GK208 [GeForce GT 730]",
+                "nvidia",
+            ],  # Nvidia
+            [
+                "VGA compatible controller",
+                "Intel Corporation",
+                "Device 5912",
+                "intel",
+            ],  # Intel
+            [
+                "VGA compatible controller",
+                "ATI Technologies Inc",
+                "RC410 [Radeon Xpress 200M]",
+                "ati",
+            ],  # ATI
+            [
+                "3D controller",
+                "NVIDIA Corporation",
+                "GeForce GTX 950M",
+                "nvidia",
+            ],  # 3D controller
+        ]
+        with patch.dict(
+            core.__salt__, {"cmd.run": MagicMock(side_effect=_cmd_side_effect)}
+        ):
+            ret = core._linux_gpu_data()["gpus"]
+            count = 0
+            for device in devices:
+                if device[3] is None:
+                    continue
+                assert ret[count]["model"] == device[2]
+                assert ret[count]["vendor"] == device[3]
+                count += 1


### PR DESCRIPTION
Port #49492 to master

Fix AMD GPU vendor detection
It fixes the detection of the vendor of AMD GPUs for the GPU grains.
Previously the vendor would be reported as unknown.