### PR TITLE
Master port 50763

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -5100,12 +5100,12 @@ def keyvalue(
     if not name:
         return _error(ret, "Must provide name to file.keyvalue")
     if key is not None and value is not None:
-        if type(key_values) is dict:
+        if isinstance(key_values, dict):
             return _error(
                 ret, "file.keyvalue can not combine key_values with key and value"
             )
         key_values = {str(key): value}
-    elif type(key_values) is not dict:
+    elif not isinstance(key_values, dict):
         return _error(
             ret, "file.keyvalue key and value not supplied and key_values empty"
         )

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -3057,6 +3057,16 @@ class FileTest(ModuleCase, SaltReturnAssertsMixin):
 
         self.assertSaltTrueReturn(ret)
 
+        ret = self.run_state('file.keyvalue',
+                name=name, key_values={'logingracetime':'1m'}, separator=" ", uncomment=" #", key_ignore_case=True)
+
+        with salt.utils.files.fopen(name, 'r') as fp_:
+            file_contents = fp_.read()
+            self.assertNotIn('#LoginGraceTime 2m', file_contents)
+            self.assertIn("LoginGraceTime 1m", file_contents)
+
+        self.assertSaltTrueReturn(ret)
+
 
 @pytest.mark.windows_whitelisted
 class BlockreplaceTest(ModuleCase, SaltReturnAssertsMixin):


### PR DESCRIPTION
https://github.com/saltstack/salt/pull/50763
### What does this PR do?
Turns out, when feeding parameters from an .sls file instead of directly to the state module through a test means dicts are actually of type salt.utils.odict.OrderedDict instead of dict. Though still an instance of dict, I believe this is a better way of checking for correct input.

### What issues does this PR fix or reference?
No issue opened for this.

### Previous Behavior
Running the file.keyvalue state with key_values populated with a dictionary would actually complain no key_values where supplied.

### New Behavior
Correctly identifies key_values as being an instance of a dictionary and will continue to process all key/value pairs.

### Tests written?
Yes, additional checks to also check feeding a dictionary instead of just a key and value parameter.

### Commits signed with GPG?
Yes