### PR TITLE
Port #49886 and #52709 to master

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -340,7 +340,7 @@ class LocalClient(object):
             >>> local.run_job('*', 'test.sleep', [300])
             {'jid': '20131219215650131543', 'minions': ['jerry']}
         """
-        arg = salt.utils.args.condition_input(arg, kwarg)
+        arg = salt.utils.args.parse_input(arg, kwargs=kwarg)
 
         try:
             pub_data = self.pub(
@@ -404,7 +404,7 @@ class LocalClient(object):
             >>> local.run_job_async('*', 'test.sleep', [300])
             {'jid': '20131219215650131543', 'minions': ['jerry']}
         """
-        arg = salt.utils.args.condition_input(arg, kwarg)
+        arg = salt.utils.args.parse_input(arg, kwargs=kwarg)
 
         try:
             pub_data = yield self.pub_async(
@@ -450,7 +450,7 @@ class LocalClient(object):
             >>> local.cmd_async('*', 'test.sleep', [300])
             '20131219215921857715'
         """
-        arg = salt.utils.args.condition_input(arg, kwarg)
+        arg = salt.utils.args.parse_input(arg, kwargs=kwarg)
         pub_data = self.run_job(
             tgt, fun, arg, tgt_type, ret, jid=jid, listen=False, **kwargs
         )
@@ -551,7 +551,7 @@ class LocalClient(object):
         # Late import - not used anywhere else in this file
         import salt.cli.batch
 
-        arg = salt.utils.args.condition_input(arg, kwarg)
+        arg = salt.utils.args.parse_input(arg, kwargs=kwarg)
         opts = {
             "tgt": tgt,
             "fun": fun,
@@ -583,6 +583,7 @@ class LocalClient(object):
         for key, val in six.iteritems(self.opts):
             if key not in opts:
                 opts[key] = val
+
         batch = salt.cli.batch.Batch(opts, eauth=eauth, quiet=True)
         for ret in batch.run():
             yield ret
@@ -703,7 +704,7 @@ class LocalClient(object):
             minion ID. A compound command will return a sub-dictionary keyed by
             function name.
         """
-        arg = salt.utils.args.condition_input(arg, kwarg)
+        arg = salt.utils.args.parse_input(arg, kwargs=kwarg)
         was_listening = self.event.cpub
 
         try:
@@ -758,7 +759,7 @@ class LocalClient(object):
         :param verbose: Print extra information about the running command
         :returns: A generator
         """
-        arg = salt.utils.args.condition_input(arg, kwarg)
+        arg = salt.utils.args.parse_input(arg, kwargs=kwarg)
         was_listening = self.event.cpub
 
         try:
@@ -832,7 +833,7 @@ class LocalClient(object):
             {'dave': {'ret': True}}
             {'stewart': {'ret': True}}
         """
-        arg = salt.utils.args.condition_input(arg, kwarg)
+        arg = salt.utils.args.parse_input(arg, kwargs=kwarg)
         was_listening = self.event.cpub
 
         try:
@@ -896,7 +897,7 @@ class LocalClient(object):
             None
             {'stewart': {'ret': True}}
         """
-        arg = salt.utils.args.condition_input(arg, kwarg)
+        arg = salt.utils.args.parse_input(arg, kwargs=kwarg)
         was_listening = self.event.cpub
 
         try:
@@ -941,7 +942,7 @@ class LocalClient(object):
         """
         Execute a salt command and return
         """
-        arg = salt.utils.args.condition_input(arg, kwarg)
+        arg = salt.utils.args.parse_input(arg, kwargs=kwarg)
         was_listening = self.event.cpub
 
         try:
@@ -2105,7 +2106,7 @@ class Caller(object):
         """
         func = self.sminion.functions[fun]
         args, kwargs = salt.minion.load_args_and_kwargs(
-            func, salt.utils.args.parse_input(args), kwargs
+            func, salt.utils.args.parse_input(args, kwargs=kwargs),
         )
         return func(*args, **kwargs)
 

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -450,9 +450,8 @@ class LocalClient(object):
             >>> local.cmd_async('*', 'test.sleep', [300])
             '20131219215921857715'
         """
-        arg = salt.utils.args.parse_input(arg, kwargs=kwarg)
         pub_data = self.run_job(
-            tgt, fun, arg, tgt_type, ret, jid=jid, listen=False, **kwargs
+            tgt, fun, arg, tgt_type, ret, jid=jid, kwarg=kwarg, listen=False, **kwargs
         )
         try:
             return pub_data["jid"]
@@ -704,12 +703,20 @@ class LocalClient(object):
             minion ID. A compound command will return a sub-dictionary keyed by
             function name.
         """
-        arg = salt.utils.args.parse_input(arg, kwargs=kwarg)
         was_listening = self.event.cpub
 
         try:
             pub_data = self.run_job(
-                tgt, fun, arg, tgt_type, ret, timeout, jid, listen=True, **kwargs
+                tgt,
+                fun,
+                arg,
+                tgt_type,
+                ret,
+                timeout,
+                jid,
+                kwarg=kwarg,
+                listen=True,
+                **kwargs
             )
 
             if not pub_data:
@@ -759,12 +766,19 @@ class LocalClient(object):
         :param verbose: Print extra information about the running command
         :returns: A generator
         """
-        arg = salt.utils.args.parse_input(arg, kwargs=kwarg)
         was_listening = self.event.cpub
 
         try:
             self.pub_data = self.run_job(
-                tgt, fun, arg, tgt_type, ret, timeout, listen=True, **kwargs
+                tgt,
+                fun,
+                arg,
+                tgt_type,
+                ret,
+                timeout,
+                kwarg=kwarg,
+                listen=True,
+                **kwargs
             )
 
             if not self.pub_data:
@@ -833,12 +847,19 @@ class LocalClient(object):
             {'dave': {'ret': True}}
             {'stewart': {'ret': True}}
         """
-        arg = salt.utils.args.parse_input(arg, kwargs=kwarg)
         was_listening = self.event.cpub
 
         try:
             pub_data = self.run_job(
-                tgt, fun, arg, tgt_type, ret, timeout, listen=True, **kwargs
+                tgt,
+                fun,
+                arg,
+                tgt_type,
+                ret,
+                timeout,
+                kwarg=kwarg,
+                listen=True,
+                **kwargs
             )
 
             if not pub_data:
@@ -897,12 +918,19 @@ class LocalClient(object):
             None
             {'stewart': {'ret': True}}
         """
-        arg = salt.utils.args.parse_input(arg, kwargs=kwarg)
         was_listening = self.event.cpub
 
         try:
             pub_data = self.run_job(
-                tgt, fun, arg, tgt_type, ret, timeout, listen=True, **kwargs
+                tgt,
+                fun,
+                arg,
+                tgt_type,
+                ret,
+                timeout,
+                kwarg=kwarg,
+                listen=True,
+                **kwargs
             )
 
             if not pub_data:
@@ -942,12 +970,19 @@ class LocalClient(object):
         """
         Execute a salt command and return
         """
-        arg = salt.utils.args.parse_input(arg, kwargs=kwarg)
         was_listening = self.event.cpub
 
         try:
             pub_data = self.run_job(
-                tgt, fun, arg, tgt_type, ret, timeout, listen=True, **kwargs
+                tgt,
+                fun,
+                arg,
+                tgt_type,
+                ret,
+                timeout,
+                kwarg=kwarg,
+                listen=True,
+                **kwargs
             )
 
             if not pub_data:

--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -96,7 +96,7 @@ def condition_input(args, kwargs):
     return ret
 
 
-def parse_input(args, condition=True, no_parse=None):
+def parse_input(args, kwargs=None, condition=True, no_parse=None):
     """
     Parse out the args and kwargs from a list of input values. Optionally,
     return the args and kwargs without passing them to condition_input().
@@ -105,6 +105,8 @@ def parse_input(args, condition=True, no_parse=None):
     """
     if no_parse is None:
         no_parse = ()
+    if kwargs is None:
+        kwargs = {}
     _args = []
     _kwargs = {}
     for arg in args:
@@ -126,6 +128,7 @@ def parse_input(args, condition=True, no_parse=None):
                 _args.append(arg)
         else:
             _args.append(arg)
+    _kwargs.update(kwargs)
     if condition:
         return condition_input(_args, _kwargs)
     return _args, _kwargs

--- a/tests/integration/modules/test_cmdmod.py
+++ b/tests/integration/modules/test_cmdmod.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 import os
 import sys
 import tempfile
-import textwrap
 from contextlib import contextmanager
 
 import pytest
@@ -285,11 +284,11 @@ class CMDModuleTest(ModuleCase):
         """
         cmd.exec_code
         """
-        code = textwrap.dedent(
-            """\
-               import sys
-               sys.stdout.write('cheese')"""
-        )
+        # `code` is a multiline YAML text. Formatting it as a YAML block scalar.
+        code = """|
+                   import sys
+                   sys.stdout.write('cheese')
+               """
         self.assertEqual(
             self.run_function(
                 "cmd.exec_code", [AVAILABLE_PYTHON_EXECUTABLE, code]
@@ -302,11 +301,11 @@ class CMDModuleTest(ModuleCase):
         """
         cmd.exec_code
         """
-        code = textwrap.dedent(
-            """\
-               import sys
-               sys.stdout.write(sys.argv[1])"""
-        )
+        # `code` is a multiline YAML text. Formatting it as a YAML block scalar.
+        code = """|
+                   import sys
+                   sys.stdout.write(sys.argv[1])
+               """
         arg = "cheese"
         self.assertEqual(
             self.run_function(
@@ -320,11 +319,11 @@ class CMDModuleTest(ModuleCase):
         """
         cmd.exec_code
         """
-        code = textwrap.dedent(
-            """\
-               import sys
-               sys.stdout.write(sys.argv[1])"""
-        )
+        # `code` is a multiline YAML text. Formatting it as a YAML block scalar.
+        code = """|
+                   import sys
+                   sys.stdout.write(sys.argv[1])
+               """
         arg = "cheese"
         self.assertEqual(
             self.run_function(

--- a/tests/integration/shell/test_enabled.py
+++ b/tests/integration/shell/test_enabled.py
@@ -21,7 +21,7 @@ class EnabledTest(ModuleCase):
     """
 
     cmd = (
-        "printf '%s\n' first second third | wc -l ; "
+        "printf '%s\\n' first second third | wc -l ; "
         "export SALTY_VARIABLE='saltines' && echo $SALTY_VARIABLE ; "
         "echo duh &> /dev/null"
     )

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -16,6 +16,7 @@ from salt.exceptions import (
     SaltInvocationError,
     SaltReqTimeoutError,
 )
+from salt.ext.tornado.concurrent import Future
 
 # Import Salt Testing libs
 from tests.support.mixins import SaltClientTestCaseMixin
@@ -244,3 +245,68 @@ class LocalClientTestCase(TestCase, SaltClientTestCaseMixin):
                     "test.ping",
                     tgt_type="nodegroup",
                 )
+
+    # all of these parse_input test wrapper tests can be replaced by
+    # parameterize if/when we switch to pytest runner
+    # @pytest.mark.parametrize('method', [('run_job', 'cmd', ...)])
+    def _test_parse_input(self, method, asynchronous=False):
+        if asynchronous:
+            target = "salt.client.LocalClient.pub_async"
+            pub_ret = Future()
+            pub_ret.set_result({"jid": "123456789", "minions": ["m1"]})
+        else:
+            target = "salt.client.LocalClient.pub"
+            pub_ret = {"jid": "123456789", "minions": ["m1"]}
+
+        with patch(target, return_value=pub_ret) as pub_mock:
+            with patch(
+                "salt.client.LocalClient.get_cli_event_returns",
+                return_value=[{"m1": {"ret": ["test.arg"]}}],
+            ):
+                with patch(
+                    "salt.client.LocalClient.get_iter_returns",
+                    return_value=[{"m1": {"ret": True}}],
+                ):
+                    ret = getattr(self.client, method)(
+                        "*",
+                        "test.arg",
+                        arg=[
+                            "a",
+                            5,
+                            "yaml_arg={qux: Qux}",
+                            "another_yaml={bax: 12345}",
+                        ],
+                        jid="123456789",
+                    )
+
+                    # iterate generator if needed
+                    if asynchronous:
+                        pass
+                    else:
+                        ret = list(ret)
+
+                    # main test here is that yaml_arg is getting deserialized properly
+                    parsed_args = [
+                        "a",
+                        5,
+                        {
+                            "yaml_arg": {"qux": "Qux"},
+                            "another_yaml": {"bax": 12345},
+                            "__kwarg__": True,
+                        },
+                    ]
+                    self.assertTrue(
+                        any(parsed_args in call[0] for call in pub_mock.call_args_list)
+                    )
+
+    def test_parse_input_is_called(self):
+        self._test_parse_input("run_job")
+        self._test_parse_input("cmd")
+        self._test_parse_input("cmd_subset")
+        self._test_parse_input("cmd_batch")
+        self._test_parse_input("cmd_cli")
+        self._test_parse_input("cmd_full_return")
+        self._test_parse_input("cmd_iter")
+        self._test_parse_input("cmd_iter_no_block")
+        self._test_parse_input("cmd_async")
+        self._test_parse_input("run_job_async", asynchronous=True)


### PR DESCRIPTION
Port #49886 and #52709 to master

### localclient: pass input args/kwargs through salt.utils.args.parse_input #49886

this functionality brings localclient in line with what happens on the
cli, as well as what runnerclient does. this ensures that any foo=bar
kwargs passed in as args are handled accordingly. right now localclient
relies on SaltCMDOptionParser to do this handling for us, but that
leaves a hole when salt-api interactions are brought in.

### LocalClient: don't parse input twice and test fix. #52709

Related to #49886 where passing input args and kwargs through parse_input was inroduced.

I've removed passing the args to parse_input from all functions except run_job because other functions aren't used that args and all are calling run_job. This avoids parsing that args multiple times.

Also I've updated the CMDModuleTest according to parse_input expectations. It yamlifies each text value in arguments so it expects arguments values to be a YAML code. This means that multiline blocks of python code shall be formatted accordingly.
Reference: https://yaml.org/spec/1.2/spec.html#id2795688
Examples and human friendly description: https://yaml-multiline.info/#block-scalars