### PR TITLE
Work around upstream bug in Jinja2 indent filter

### DIFF
--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -14,6 +14,7 @@ import pipes
 import pprint
 import re
 import uuid
+import warnings
 from functools import wraps
 from xml.dom import minidom
 from xml.etree.ElementTree import Element, SubElement, tostring
@@ -37,12 +38,14 @@ from salt.exceptions import TemplateError
 from salt.ext import six
 from salt.utils.decorators.jinja import jinja_filter, jinja_global, jinja_test
 from salt.utils.odict import OrderedDict
+from salt.utils.versions import LooseVersion
 
 log = logging.getLogger(__name__)
 
 __all__ = ["SaltCacheLoader", "SerializerExtension"]
 
 GLOBAL_UUID = uuid.UUID("91633EBF-1C86-5E33-935A-28061F4B480E")
+JINJA_VERSION = LooseVersion(jinja2.__version__)
 
 
 class SaltCacheLoader(BaseLoader):
@@ -345,6 +348,48 @@ def to_bool(val):
     if not isinstance(val, collections.Hashable):
         return len(val) > 0
     return False
+
+
+@jinja_filter("indent")
+def indent(s, width=4, first=False, blank=False, indentfirst=None):
+    """
+    A ported version of the "indent" filter containing a fix for indenting Markup
+    objects. If the minion has Jinja version 2.11 or newer, the "indent" filter
+    from upstream will be used, and this one will be ignored.
+    """
+    if indentfirst is not None:
+        warnings.warn(
+            "The 'indentfirst' argument is renamed to 'first' and will"
+            " be removed in Jinja 3.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        first = indentfirst
+
+    indention = " " * width
+    newline = "\n"
+
+    if isinstance(s, Markup):
+        indention = Markup(indention)
+        newline = Markup(newline)
+
+    s += newline  # this quirk is necessary for splitlines method
+
+    if blank:
+        rv = (newline + indention).join(s.splitlines())
+    else:
+        lines = s.splitlines()
+        rv = lines.pop(0)
+
+        if lines:
+            rv += newline + newline.join(
+                indention + line if line else line for line in lines
+            )
+
+    if first:
+        rv = indention + rv
+
+    return rv
 
 
 @jinja_filter("tojson")

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -33,6 +33,7 @@ from salt.exceptions import CommandExecutionError, SaltInvocationError, SaltRend
 from salt.ext import six
 from salt.utils.decorators.jinja import JinjaFilter, JinjaGlobal, JinjaTest
 from salt.utils.odict import OrderedDict
+from salt.utils.versions import LooseVersion
 
 if sys.version_info[:2] >= (3, 5):
     import importlib.machinery  # pylint: disable=no-name-in-module,import-error
@@ -359,11 +360,15 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
         jinja_env = jinja2.Environment(undefined=jinja2.StrictUndefined, **env_args)
 
     tojson_filter = jinja_env.filters.get("tojson")
+    indent_filter = jinja_env.filters.get("indent")
     jinja_env.tests.update(JinjaTest.salt_jinja_tests)
     jinja_env.filters.update(JinjaFilter.salt_jinja_filters)
     if tojson_filter is not None:
         # Use the existing tojson filter, if present (jinja2 >= 2.9)
         jinja_env.filters["tojson"] = tojson_filter
+    if salt.utils.jinja.JINJA_VERSION >= LooseVersion("2.11"):
+        # Use the existing indent filter on Jinja versions where it's not broken
+        jinja_env.filters["indent"] = indent_filter
     jinja_env.globals.update(JinjaGlobal.salt_jinja_globals)
 
     # globals

--- a/tests/unit/utils/test_jinja.py
+++ b/tests/unit/utils/test_jinja.py
@@ -21,7 +21,7 @@ import salt.utils.files
 import salt.utils.json
 import salt.utils.stringutils
 import salt.utils.yaml
-from jinja2 import DictLoader, Environment, exceptions
+from jinja2 import DictLoader, Environment, Markup, exceptions
 from salt.exceptions import SaltRenderError
 from salt.ext import six
 from salt.ext.six.moves import builtins
@@ -30,6 +30,7 @@ from salt.utils.jinja import (
     SaltCacheLoader,
     SerializerExtension,
     ensure_sequence_filter,
+    indent,
     tojson,
 )
 from salt.utils.odict import OrderedDict
@@ -53,8 +54,8 @@ BLINESEP = salt.utils.stringutils.to_bytes(os.linesep)
 class JinjaTestCase(TestCase):
     def test_tojson(self):
         """
-        Test the tojson filter for those using Jinja < 2.9. Non-ascii unicode
-        content should be dumped with ensure_ascii=True.
+        Test the ported tojson filter. Non-ascii unicode content should be
+        dumped with ensure_ascii=True.
         """
         data = {"Non-ascii words": ["süß", "спам", "яйца"]}
         result = tojson(data)
@@ -63,6 +64,16 @@ class JinjaTestCase(TestCase):
             '"\\u0441\\u043f\\u0430\\u043c", '
             '"\\u044f\\u0439\\u0446\\u0430"]}'
         )
+        assert result == expected, result
+
+    def test_indent(self):
+        """
+        Test the indent filter with Markup object as input. Double-quotes
+        should not be URL-encoded.
+        """
+        data = Markup('foo:\n  "bar"')
+        result = indent(data)
+        expected = Markup('foo:\n      "bar"')
         assert result == expected, result
 
 


### PR DESCRIPTION
### What does this PR do?

This conditionally uses a port of the upstream version of the filter with the fix in place. The minion will only get this filter if it has Jinja < 2.11 installed.

### What issues does this PR fix or reference?

Fixes https://github.com/saltstack/salt/issues/56833

### Previous Behavior

Piping content that has gone through the `yaml` filter (or any other one which returns a `Markup` object) into the `indent` filter would result in some characters (`<`, `>`, `"`, `&`, and maybe others) being encoded (example in the linked issue).

### New Behavior

This content is properly handled by Jinja.

### Merge requirements satisfied?
- [x] Tests written/updated

### Commits signed with GPG?
No