### PR TITLE
Refresh __salt__ dunder on pip state changes

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1182,7 +1182,7 @@ class State(object):
             elif data["fun"] == "symlink":
                 if "bin" in data["name"]:
                     self.module_refresh()
-        elif data["state"] in ("pkg", "ports"):
+        elif data["state"] in ("pkg", "ports", "pip"):
             self.module_refresh()
 
     def verify_data(self, data):


### PR DESCRIPTION
### What does this PR do?

Adds "pip" to the tuple of state types that trigger a `__salt__` dunder refresh when the state has changes.

### What issues does this PR fix or reference?

See https://github.com/saltstack/salt/issues/56669#issuecomment-618099941

### Previous Behavior

`pip` states required a `reload_modules: True` in order to enable modules/states that require them.

### New Behavior

`reload_modules` no longer needed

### Merge requirements satisfied?

- [ ] Docs
- [ ] Changelog
- [ ] Tests written/updated

### Commits signed with GPG?
No