### PR TITLE
update windows python 3.7 pycurl version

### DIFF
--- a/requirements/static/py3.7/windows.txt
+++ b/requirements/static/py3.7/windows.txt
@@ -68,7 +68,7 @@ pyasn1==0.4.5
 pycparser==2.19
 pycryptodome==3.8.1       # via python-jose
 pycryptodomex==3.8.1 ; sys_platform == "win32"
-pycurl==7.43.0.5
+pycurl==7.43.1
 pygit2==0.28.2
 pymssql==2.1.4
 pymysql==0.9.3


### PR DESCRIPTION
### What does this PR do?
Updates windows python 3.7 dependency to newer pycurl  7.43.1.
I am a little confused by this new version since it is what gets installed on windows with python 3.7 from `pip install pycurl`. However, this version doesn't seem to exist: 
https://pypi.org/project/pycurl/#history
http://pycurl.io/docs/latest/release-notes.html

I do not know if python windows installs other than 3.7 need to be updated.

### What issues does this PR fix or reference?
Fixes: #56873

### Previous Behavior
Salt not able to be installed from pip because of missing pycurl dependency

### New Behavior
Pip untested, but hopefully allows salt to install

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog
- [ ] Tests written/updated

### Commits signed with GPG?
No

@s0undt3ch 