### PR TITLE
Resolve paths passed directly with `--files`

### DIFF
--- a/tasks/docs.py
+++ b/tasks/docs.py
@@ -136,7 +136,7 @@ def build_file_list(files, extension):
     if not _files:
         _files = CODE_DIR.rglob("*{}".format(extension))
     else:
-        _files = [pathlib.Path(fname) for fname in _files]
+        _files = [pathlib.Path(fname).resolve() for fname in _files]
     _files = [path.relative_to(CODE_DIR) for path in _files]
     return _files
 


### PR DESCRIPTION
### What does this PR do?
See title

### What issues does this PR fix or reference?
Fixes issue not caught on https://github.com/saltstack/salt/pull/56727

### Previous Behavior
Didn't resolve to absolute paths any path passed in by `--files`

### New Behavior
Resolves to absolute paths any path passed in by `--files`