### PR TITLE
Stop getting warnings about missing toml library

### DIFF
--- a/requirements/static/lint.in
+++ b/requirements/static/lint.in
@@ -1,3 +1,4 @@
 # Lint requirements
 pylint==2.4.4
 SaltPyLint>=v2019.11.14
+toml

--- a/requirements/static/py3.5/lint.txt
+++ b/requirements/static/py3.5/lint.txt
@@ -13,5 +13,6 @@ pycodestyle==2.5.0        # via saltpylint
 pylint==2.4.4
 saltpylint==2019.11.14
 six==1.12.0               # via astroid
+toml==0.10.0
 typed-ast==1.4.1          # via astroid
 wrapt==1.11.1             # via astroid

--- a/requirements/static/py3.6/lint.txt
+++ b/requirements/static/py3.6/lint.txt
@@ -13,5 +13,6 @@ pycodestyle==2.5.0        # via saltpylint
 pylint==2.4.4
 saltpylint==2019.11.14
 six==1.12.0               # via astroid
+toml==0.10.0
 typed-ast==1.4.1          # via astroid
 wrapt==1.11.1             # via astroid

--- a/requirements/static/py3.7/lint.txt
+++ b/requirements/static/py3.7/lint.txt
@@ -13,5 +13,6 @@ pycodestyle==2.5.0        # via saltpylint
 pylint==2.4.4
 saltpylint==2019.11.14
 six==1.12.0               # via astroid
+toml==0.10.0
 typed-ast==1.4.1          # via astroid
 wrapt==1.11.1             # via astroid

--- a/requirements/static/py3.8/lint.txt
+++ b/requirements/static/py3.8/lint.txt
@@ -13,4 +13,5 @@ pycodestyle==2.5.0        # via saltpylint
 pylint==2.4.4
 saltpylint==2019.11.14
 six==1.12.0               # via astroid
+toml==0.10.0
 wrapt==1.11.1             # via astroid

--- a/requirements/static/py3.9/lint.txt
+++ b/requirements/static/py3.9/lint.txt
@@ -13,4 +13,5 @@ pycodestyle==2.5.0        # via saltpylint
 pylint==2.4.4
 saltpylint==2019.11.14
 six==1.12.0               # via astroid
+toml==0.10.0
 wrapt==1.11.1             # via astroid


### PR DESCRIPTION
### What does this PR do?
See title
```
.nox/lint-salt/lib/python3.7/site-packages/isort/settings.py:295: UserWarning: Found pyproject.toml with [tool.isort] section, but toml package is not installed. To configure isort with pyproject.toml, install with 'isort[pyproject]'.
10:19:57    file_path))
```
