### PR TITLE
Port #50168 to master

### DIFF
--- a/salt/defaults/events.py
+++ b/salt/defaults/events.py
@@ -9,5 +9,5 @@ as this may result in circular imports.
 """
 
 # Constants for events on the minion bus
-MINION_PILLAR_COMPLETE = "/salt/minion/minion_pillar_complete"
-MINION_MOD_COMPLETE = "/salt/minion/minion_mod_complete"
+MINION_PILLAR_REFRESH_COMPLETE = "/salt/minion/minion_pillar_refresh_complete"
+MINION_MOD_REFRESH_COMPLETE = "/salt/minion/minion_mod_refresh_complete"

--- a/salt/defaults/events.py
+++ b/salt/defaults/events.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+"""
+Event constants used by listeners and servers, to be imported elsewhere in Salt code.
+
+Do NOT, import any salt modules (salt.utils, salt.config, etc.) into this file,
+as this may result in circular imports.
+
+.. versionadded:: Neon
+"""
+
+# Constants for events on the minion bus
+MINION_PILLAR_COMPLETE = "/salt/minion/minion_pillar_complete"
+MINION_MOD_COMPLETE = "/salt/minion/minion_mod_complete"

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -24,6 +24,7 @@ from zipimport import zipimporter
 
 # Import salt libs
 import salt.config
+import salt.defaults.events
 import salt.defaults.exitcodes
 import salt.syspaths
 import salt.utils.args
@@ -283,7 +284,9 @@ def minion_mods(
 
     if notify:
         with salt.utils.event.get_event("minion", opts=opts, listen=False) as evt:
-            evt.fire_event({"complete": True}, tag="/salt/minion/minion_mod_complete")
+            evt.fire_event(
+                {"complete": True}, tag=salt.defaults.events.MINION_MOD_COMPLETE
+            )
 
     return ret
 

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -285,7 +285,7 @@ def minion_mods(
     if notify:
         with salt.utils.event.get_event("minion", opts=opts, listen=False) as evt:
             evt.fire_event(
-                {"complete": True}, tag=salt.defaults.events.MINION_MOD_COMPLETE
+                {"complete": True}, tag=salt.defaults.events.MINION_MOD_REFRESH_COMPLETE
             )
 
     return ret

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -1150,15 +1150,18 @@ def refresh_pillar(wait=False, timeout=30):
             with salt.utils.event.get_event(
                 "minion", opts=__opts__, listen=True
             ) as eventer:
-                ret = __salt__["event.fire"]({"notify": True}, "pillar_refresh")
+                ret = __salt__["event.fire"]({}, "pillar_refresh")
                 # Wait for the finish event to fire
                 log.trace("refresh_pillar waiting for pillar refresh to complete")
                 # Blocks until we hear this event or until the timeout expires
                 event_ret = eventer.get_event(
-                    tag=salt.defaults.events.MINION_PILLAR_COMPLETE, wait=timeout
+                    tag=salt.defaults.events.MINION_PILLAR_REFRESH_COMPLETE,
+                    wait=timeout,
                 )
                 if not event_ret or event_ret["complete"] is False:
-                    log.warn("Pillar refresh did not complete within timeout %s", timeout)
+                    log.warn(
+                        "Pillar refresh did not complete within timeout %s", timeout
+                    )
         else:
             ret = __salt__["event.fire"]({}, "pillar_refresh")
     except KeyError:
@@ -1197,7 +1200,9 @@ def refresh_modules(**kwargs):
                 # Wait for the finish event to fire
                 log.trace("refresh_modules waiting for module refresh to complete")
                 # Blocks until we hear this event or until the timeout expires
-                eventer.get_event(tag=salt.defaults.events.MINION_MOD_COMPLETE, wait=30)
+                eventer.get_event(
+                    tag=salt.defaults.events.MINION_MOD_REFRESH_COMPLETE, wait=30
+                )
     except KeyError:
         log.error("Event module not available. Module refresh failed.")
         ret = False  # Effectively a no-op, since we can't really return without an event system

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -23,6 +23,7 @@ import salt
 import salt.client
 import salt.client.ssh.client
 import salt.config
+import salt.defaults.events
 import salt.payload
 import salt.runner
 import salt.state
@@ -1141,19 +1142,28 @@ def refresh_pillar(wait=False, timeout=30):
     .. code-block:: bash
 
         salt '*' saltutil.refresh_pillar
+        salt '*' saltutil.refresh_pillar wait=True timeout=60
     """
     try:
-        ret = __salt__["event.fire"]({}, "pillar_refresh")
+        if wait:
+            #  If we're going to block, first setup a listener
+            with salt.utils.event.get_event(
+                "minion", opts=__opts__, listen=True
+            ) as eventer:
+                ret = __salt__["event.fire"]({"notify": True}, "pillar_refresh")
+                # Wait for the finish event to fire
+                log.trace("refresh_pillar waiting for pillar refresh to complete")
+                # Blocks until we hear this event or until the timeout expires
+                event_ret = eventer.get_event(
+                    tag=salt.defaults.events.MINION_PILLAR_COMPLETE, wait=timeout
+                )
+                if not event_ret or event_ret["complete"] is False:
+                    log.warn("Pillar refresh did not complete within timeout %s", timeout)
+        else:
+            ret = __salt__["event.fire"]({}, "pillar_refresh")
     except KeyError:
-        log.error("Event module not available. Module refresh failed.")
+        log.error("Event module not available. Pillar refresh failed.")
         ret = False  # Effectively a no-op, since we can't really return without an event system
-    if wait:
-        eventer = salt.utils.event.get_event("minion", opts=__opts__, listen=True)
-        event_ret = eventer.get_event(
-            tag="/salt/minion/minion_pillar_refresh_complete", wait=timeout
-        )
-        if not event_ret or event_ret["complete"] is False:
-            log.warning("Pillar refresh did not complete within timeout %s", timeout)
     return ret
 
 
@@ -1177,17 +1187,17 @@ def refresh_modules(**kwargs):
     asynchronous = bool(kwargs.get("async", True))
     try:
         if asynchronous:
-            #  If we're going to block, first setup a listener
             ret = __salt__["event.fire"]({}, "module_refresh")
         else:
+            #  If we're going to block, first setup a listener
             with salt.utils.event.get_event(
                 "minion", opts=__opts__, listen=True
-            ) as event_bus:
+            ) as eventer:
                 ret = __salt__["event.fire"]({"notify": True}, "module_refresh")
                 # Wait for the finish event to fire
                 log.trace("refresh_modules waiting for module refresh to complete")
                 # Blocks until we hear this event or until the timeout expires
-                event_bus.get_event(tag="/salt/minion/minion_mod_complete", wait=30)
+                eventer.get_event(tag=salt.defaults.events.MINION_MOD_COMPLETE, wait=30)
     except KeyError:
         log.error("Event module not available. Module refresh failed.")
         ret = False  # Effectively a no-op, since we can't really return without an event system

--- a/tests/integration/modules/test_saltutil.py
+++ b/tests/integration/modules/test_saltutil.py
@@ -354,7 +354,9 @@ class SaltUtilSyncPillarTest(ModuleCase):
             )
 
         opts = self.run_function("test.get_opts")
-        wait = self.WaitForEvent(opts, salt.defaults.events.MINION_PILLAR_COMPLETE)
+        wait = self.WaitForEvent(
+            opts, salt.defaults.events.MINION_PILLAR_REFRESH_COMPLETE
+        )
         wait.start()
         self.run_function("saltutil.refresh_pillar", wait=True)
         while wait.is_alive():

--- a/tests/integration/modules/test_saltutil.py
+++ b/tests/integration/modules/test_saltutil.py
@@ -8,9 +8,13 @@ from __future__ import absolute_import, print_function, unicode_literals
 import os
 import shutil
 import textwrap
+import threading
 import time
 
 import pytest
+import salt.config
+import salt.defaults.events
+import salt.utils.event
 import salt.utils.files
 import salt.utils.stringutils
 from tests.support.case import ModuleCase
@@ -258,6 +262,23 @@ class SaltUtilSyncPillarTest(ModuleCase):
     Testcase for the saltutil sync pillar module
     """
 
+    class WaitForEvent(threading.Thread):
+        def __init__(self, opts, event_tag):
+            self.__eventer = salt.utils.event.get_event(
+                "minion", opts=opts, listen=True
+            )
+            self.__event_tag = event_tag
+            self.__event_complete = False
+
+            threading.Thread.__init__(self)
+
+        def run(self):
+            if self.__eventer.get_event(tag=self.__event_tag, wait=30):
+                self.__event_complete = True
+
+        def is_complete(self):
+            return self.__event_complete
+
     @flaky
     def test_pillar_refresh(self):
         """
@@ -302,6 +323,62 @@ class SaltUtilSyncPillarTest(ModuleCase):
 
         post_pillar = self.run_function("pillar.raw")
         self.assertIn(pillar_key, post_pillar.get(pillar_key, "didnotwork"))
+
+    def test_pillar_refresh_sync(self):
+        """
+        test pillar refresh module with sync enabled
+        """
+        pillar_key = "itworked_sync"
+
+        pre_pillar = self.run_function("pillar.raw")
+        self.assertNotIn(pillar_key, pre_pillar.get(pillar_key, "didnotwork_sync"))
+
+        with salt.utils.files.fopen(
+            os.path.join(RUNTIME_VARS.TMP_PILLAR_TREE, "add_pillar_sync.sls"), "w"
+        ) as fp:
+            fp.write(
+                salt.utils.stringutils.to_str("{0}: itworked_sync".format(pillar_key))
+            )
+
+        with salt.utils.files.fopen(
+            os.path.join(RUNTIME_VARS.TMP_PILLAR_TREE, "top.sls"), "w"
+        ) as fp:
+            fp.write(
+                textwrap.dedent(
+                    """\
+                     base:
+                       '*':
+                         - add_pillar_sync
+                     """
+                )
+            )
+
+        opts = self.run_function("test.get_opts")
+        wait = self.WaitForEvent(opts, salt.defaults.events.MINION_PILLAR_COMPLETE)
+        wait.start()
+        self.run_function("saltutil.refresh_pillar", wait=True)
+        while wait.is_alive():
+            time.sleep(1)
+        self.assertTrue(wait.is_complete())
+
+        pillar = False
+        timeout = time.time() + 30
+        while not pillar:
+            post_pillar = self.run_function("pillar.raw")
+            try:
+                self.assertIn(
+                    pillar_key, post_pillar.get(pillar_key, "didnotwork_sync")
+                )
+                pillar = True
+            except AssertionError:
+                if time.time() > timeout:
+                    self.assertIn(
+                        pillar_key, post_pillar.get(pillar_key, "didnotwork_sync")
+                    )
+                continue
+
+        post_pillar = self.run_function("pillar.raw")
+        self.assertIn(pillar_key, post_pillar.get(pillar_key, "didnotwork_sync"))
 
     def tearDown(self):
         for filename in os.listdir(RUNTIME_VARS.TMP_PILLAR_TREE):


### PR DESCRIPTION
Port #50168 to master

I've tried to rework it to resolve crossing with functionality added to master by DWoz in #54942.

Original comment:

> Allow to refresh pillar synchronously
> This PR adds the optional ability to run saltutil.refresh_pillar Allow to refresh pillar synchronously, saying saltutil.refresh_pillar async=False. I tried to follow the explanatory comment from @gtmanfred and I believe that this works, still I am not sure about the mentioned use of the _gather_pillar() method. I am happy to rework the PR if something is missing.