### PR TITLE
Avoid circular import issue

### DIFF
--- a/salt/utils/files.py
+++ b/salt/utils/files.py
@@ -5,7 +5,6 @@ Functions for working with files
 
 from __future__ import absolute_import, print_function, unicode_literals
 
-# Import Python libs
 import codecs
 import contextlib
 import errno
@@ -18,18 +17,13 @@ import subprocess
 import tempfile
 import time
 
-import salt.modules.selinux
-
-# Import Salt libs
 import salt.utils.path
 import salt.utils.platform
 import salt.utils.stringutils
 from salt.exceptions import CommandExecutionError, FileLockError, MinionError
-
-# Import 3rd-party libs
 from salt.ext import six
 from salt.ext.six.moves import range
-from salt.ext.six.moves.urllib.parse import quote  # pylint: disable=no-name-in-module
+from salt.ext.six.moves.urllib.parse import quote
 from salt.utils.decorators.jinja import jinja_filter
 
 try:
@@ -134,6 +128,9 @@ def copyfile(source, dest, backup_mode="", cachedir=""):
     Copy files from a source to a destination in an atomic way, and if
     specified cache the file.
     """
+    # Late import
+    import salt.modules.selinux
+
     if not os.path.isfile(source):
         raise IOError("[Errno 2] No such file or directory: {0}".format(source))
     if not os.path.isdir(os.path.dirname(dest)):


### PR DESCRIPTION
### What does this PR do?
Avoid circular import issue

```
Traceback (most recent call last):
File "/usr/bin/salt-minion", line 11, in <module>
load_entry_point('salt==3000.1', 'console_scripts', 'salt-minion')()
File "/usr/lib/python3.6/site-packages/salt/scripts.py", line 187, in salt_minion
import salt.utils.platform
File "/usr/lib/python3.6/site-packages/salt/utils/platform.py", line 24, in <module>
from salt.utils.decorators import memoize as real_memoize
File "/usr/lib/python3.6/site-packages/salt/utils/decorators/__init__.py", line 18, in <module>
import salt.utils.args
File "/usr/lib/python3.6/site-packages/salt/utils/args.py", line 19, in <module>
import salt.utils.data
File "/usr/lib/python3.6/site-packages/salt/utils/data.py", line 29, in <module>
from salt.utils.debug import caller_name
File "/usr/lib/python3.6/site-packages/salt/utils/debug.py", line 17, in <module>
import salt.utils.files
File "/usr/lib/python3.6/site-packages/salt/utils/files.py", line 25, in <module>
import salt.modules.selinux
File "/usr/lib/python3.6/site-packages/salt/modules/selinux.py", line 23, in <module>
import salt.utils.decorators as decorators
AttributeError: module 'salt.utils' has no attribute 'decorators'
```
/cc @oeuftete