### PR TITLE
Add auto_detect feature to ssh_ext_alternatives

### DIFF
--- a/doc/topics/releases/sodium.rst
+++ b/doc/topics/releases/sodium.rst
@@ -44,11 +44,11 @@ Salt-SSH updates
 ssh_pre_flight
 --------------
 
-A new Salt-SSH roster option `ssh_pre_flight` has been added. This enables you to run a
+A new Salt-SSH roster option ``ssh_pre_flight`` has been added. This enables you to run a
 script before Salt-SSH tries to run any commands. You can set this option in the roster
-for a specific minion or use the `roster_defaults` to set it for all minions.
+for a specific minion or use the ``roster_defaults`` to set it for all minions.
 
-Example for setting `ssh_pre_flight` for specific host in roster file
+Example for setting ``ssh_pre_flight`` for specific host in roster file
 
 .. code-block:: yaml
 
@@ -58,7 +58,7 @@ Example for setting `ssh_pre_flight` for specific host in roster file
     passwd: P@ssword
     ssh_pre_flight: /srv/salt/pre_flight.sh
 
-Example for setting `ssh_pre_flight` using roster_defaults, so all minions
+Example for setting ``ssh_pre_flight`` using roster_defaults, so all minions
 run this script.
 
 .. code-block:: yaml
@@ -66,7 +66,7 @@ run this script.
   roster_defaults:
     ssh_pre_flight: /srv/salt/pre_flight.sh
 
-The `ssh_pre_flight` script will only run if the thin dir is not currently on the
+The ``ssh_pre_flight`` script will only run if the thin dir is not currently on the
 minion. If you want to force the script to run you have the following options:
 
 * Wipe the thin dir on the targeted minion using the -w arg.
@@ -88,6 +88,31 @@ You can set this setting in your roster file like so:
     passwd: P@ssword
     set_path: '$PATH:/usr/local/bin/'
 
+
+auto_detect
+-----------
+
+You can now auto detect the dependencies to be packed into the salt thin when using
+the ``ssh_ext_alternatives`` feature.
+
+.. code-block:: yaml
+
+       ssh_ext_alternatives:
+           2019.2:                     # Namespace, can be anything.
+               py-version: [2, 7]      # Constraint to specific interpreter version
+               path: /opt/2019.2/salt  # Main Salt installation directory.
+               auto_detect: True       # Auto detect dependencies
+               py_bin: /usr/bin/python2.7 # Python binary path used to auto detect dependencies
+
+This new ``auto_detect`` option needs to be set to True in your ``ssh_ext_alternatives`` configuration.
+Salt-ssh will attempt to auto detect the file paths required for the default dependencies to include
+in the thin. If you have a dependency already set in your configuration, it will not attempt to auto
+detect for that dependency.
+
+You can also set the ``py_bin`` option to set the python binary to be used to auto detect the
+dependencies. If ``py_bin`` is not set, it will attempt to use the major Python version set in
+``py-version``. For example, if you set ``py-version`` to be ``[2, 7]`` it will attempt to find and
+use the ``python2`` binary.
 
 State Changes
 =============

--- a/doc/topics/ssh/index.rst
+++ b/doc/topics/ssh/index.rst
@@ -311,3 +311,13 @@ It is recommended that one modify this command a bit by removing the ``-l quiet`
 .. toctree::
 
     roster
+    ssh_ext_alternatives
+
+Different Python Versions
+=========================
+The Sodium release removed python 2 support in Salt. Even though this python 2 support
+is being dropped we have provided multiple ways to work around this with Salt-SSH. You
+can use the following options:
+
+  * :ref:`ssh_pre_flight <ssh_pre_flight>`
+  * :ref:`SSH ext alternatives <ssh-ext-alternatives>`

--- a/doc/topics/ssh/ssh_ext_alternatives.rst
+++ b/doc/topics/ssh/ssh_ext_alternatives.rst
@@ -1,0 +1,70 @@
+.. _ssh-ext-alternatives:
+
+====================
+SSH Ext Alternatives
+====================
+
+In the 2019.2.0 release the ``ssh_ext_alternatives`` feature was added.
+This allows salt-ssh to work across different python versions. You will
+need to ensure you have the following:
+
+  - Salt is installed, with all required dependnecies for both Python2 and Python3
+  - Everything needs to be importable from the respective Python environment.
+
+To enable using this feature you will need to edit the master configuration similar
+to below:
+
+.. code-block:: yaml
+
+       ssh_ext_alternatives:
+           2019.2:                     # Namespace, can be anything.
+               py-version: [2, 7]      # Constraint to specific interpreter version
+               path: /opt/2019.2/salt  # Main Salt installation directory.
+               dependencies:           # List of dependencies and their installation paths
+                 jinja2: /opt/jinja2
+                 yaml: /opt/yaml
+                 tornado: /opt/tornado
+                 msgpack: /opt/msgpack
+                 certifi: /opt/certifi
+                 singledispatch: /opt/singledispatch.py
+                 singledispatch_helpers: /opt/singledispatch_helpers.py
+                 markupsafe: /opt/markupsafe
+                 backports_abc: /opt/backports_abc.py
+
+auto_detect
+-----------
+
+In the Sodium release the ``auto_detect`` feature was added for ``ssh_ext_alternatives``.
+This allows salt-ssh to automatically detect the path to all of your dependencies and
+does not require you to define them under ``dependencies``.
+
+.. code-block:: yaml
+
+       ssh_ext_alternatives:
+           2019.2:                     # Namespace, can be anything.
+               py-version: [2, 7]      # Constraint to specific interpreter version
+               path: /opt/2019.2/salt  # Main Salt installation directory.
+               auto_detect: True       # Auto detect dependencies
+               py_bin: /usr/bin/python2.7 # Python binary path used to auto detect dependencies
+
+If ``py_bin`` is not set alongside ``auto_detect``, it will attempt to auto detect
+the dependnecies using the major version set in ``py-version``. For example if you
+have ``[2, 7]`` set as your ``py-version``, it will attempt to use the binary ``python2``.
+
+You can also use ``auto_detect`` and ``dependencies`` together.
+
+.. code-block:: yaml
+
+       ssh_ext_alternatives:
+           2019.2:                     # Namespace, can be anything.
+               py-version: [2, 7]      # Constraint to specific interpreter version
+               path: /opt/2019.2/salt  # Main Salt installation directory.
+               auto_detect: True       # Auto detect dependencies
+               py_bin: /usr/bin/python2.7 # Python binary path to auto detect dependencies
+               dependencies:           # List of dependencies and their installation paths
+                 jinja2: /opt/jinja2
+
+If a dependency is defined in the ``dependecies`` list ``ssh_ext_alternatives`` will use
+this dependency, instead of the path that ``auto_detect`` finds. For example, if you define
+``/opt/jinja2`` under your ``dependencies`` for jinja2, it will not try to autodetect the
+file path to the jinja2 module, and will favor ``/opt/jinja2``.


### PR DESCRIPTION
### What does this PR do?
Adds the `auto_detect` feature for `ssh_ext_alternatives`.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/community/issues/46

### Previous Behavior
When using `ssh_ext_alternatives` feature you had to manually define all of the file paths to the dependencies.

### New Behavior
You can now enable `ssh_ext_alternatives` to auto detect the file paths to the dependencies. 

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog (release notes)
- [x] Tests written/updated

### Commits signed with GPG?
Yes