### PR TITLE
Add ability to add hwaddr and macaddr

### DIFF
--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -666,6 +666,11 @@ def _parse_settings_eth(opts, iface_type, enabled, iface):
         except ValueError:
             _raise_error_iface(iface, "mtu", ["integer"])
 
+    if "hwaddr" in opts and "macaddr" in opts:
+        msg = "Cannot pass both hwaddr and macaddr. Must use either hwaddr or macaddr"
+        log.error(msg)
+        raise AttributeError(msg)
+
     if iface_type not in ["bridge"]:
         ethtool = _parse_ethtool_opts(opts, iface)
         if ethtool:
@@ -874,6 +879,12 @@ def _parse_settings_eth(opts, iface_type, enabled, iface):
 
     if "clonenum_start" in opts:
         result["clonenum_start"] = opts["clonenum_start"]
+
+    if "hwaddr" in opts:
+        result["hwaddr"] = opts["hwaddr"]
+
+    if "macaddr" in opts:
+        result["macaddr"] = opts["macaddr"]
 
     # If NetworkManager is available, we can control whether we use
     # it or not

--- a/tests/unit/modules/test_rh_ip.py
+++ b/tests/unit/modules/test_rh_ip.py
@@ -227,6 +227,46 @@ class RhipTestCase(TestCase, LoaderModuleMockMixin):
             with patch.object(rh_ip, "_read_file", return_value="A"):
                 self.assertEqual(rh_ip.get_interface("iface"), "A")
 
+    def test__parse_settings_eth_hwaddr_and_macaddr(self):
+        """
+        Test that an AttributeError is thrown when hwaddr and macaddr are
+        passed together. They cannot be used together
+        """
+        opts = {"hwaddr": 1, "macaddr": 2}
+
+        self.assertRaises(
+            AttributeError,
+            rh_ip._parse_settings_eth,
+            opts=opts,
+            iface_type="eth",
+            enabled=True,
+            iface="eth0",
+        )
+
+    def test__parse_settings_eth_hwaddr(self):
+        """
+        Make sure hwaddr gets added when parsing opts
+        """
+        opts = {"hwaddr": "AA:BB:CC:11:22:33"}
+        with patch.dict(rh_ip.__salt__, {"network.interfaces": MagicMock()}):
+            results = rh_ip._parse_settings_eth(
+                opts=opts, iface_type="eth", enabled=True, iface="eth0"
+            )
+        self.assertIn("hwaddr", results)
+        self.assertEqual(results["hwaddr"], opts["hwaddr"])
+
+    def test__parse_settings_eth_macaddr(self):
+        """
+        Make sure macaddr gets added when parsing opts
+        """
+        opts = {"macaddr": "AA:BB:CC:11:22:33"}
+        with patch.dict(rh_ip.__salt__, {"network.interfaces": MagicMock()}):
+            results = rh_ip._parse_settings_eth(
+                opts=opts, iface_type="eth", enabled=True, iface="eth0"
+            )
+        self.assertIn("macaddr", results)
+        self.assertEqual(results["macaddr"], opts["macaddr"])
+
     def test_up(self):
         """
         Test to start up a network interface


### PR DESCRIPTION
### What does this PR do?
Adds the ability to add `hwaddr` and `macaddr` to the network config for Redhat based systems. Adds tests.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/56910

### Previous Behavior
Though added to the state, the `hwaddr` or `macaddr` would not be added to the config.

### New Behavior
They are now added to the config if defined

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
