### PR TITLE
Fix issue when pillars are integers

### DIFF
--- a/salt/output/nested.py
+++ b/salt/output/nested.py
@@ -141,7 +141,13 @@ class NestDisplay(object):
             if isinstance(ret, salt.utils.odict.OrderedDict):
                 keys = ret.keys()
             else:
-                keys = sorted(ret)
+                try:
+                    keys = sorted(ret)
+                except TypeError:
+                    # Some of the keys must be non-string types
+                    ret = {str(k): v for k, v in ret.items()}
+                    keys = sorted(ret)
+
             color = self.CYAN
             if self.retcode != 0:
                 color = self.RED

--- a/tests/unit/output/test_nested.py
+++ b/tests/unit/output/test_nested.py
@@ -41,7 +41,7 @@ class NestedOutputterTestCase(TestCase, LoaderModuleMockMixin):
         self.addCleanup(delattr, self, "data")
 
     def test_output_with_colors(self):
-        # Should look exacly like that, with the default color scheme:
+        # Should look exactly like that, with the default color scheme:
         #
         # local:
         #    ----------
@@ -123,3 +123,22 @@ class NestedOutputterTestCase(TestCase, LoaderModuleMockMixin):
         )
         ret = nested.output(self.data, nested_indent=2)
         self.assertEqual(ret, expected_output_str)
+
+    def test_display_with_integer_keys(self):
+        """
+        Test display output when ret contains a combination of integer and
+        string keys. See issue #56909
+        """
+        nest = nested.NestDisplay(retcode=0)
+        test_dict = {1: "test int 1", 2: "test int 2", "three": "test text three"}
+        lines = nest.display(ret=test_dict, indent=2, prefix="", out=[])
+        expected = [
+            "  \x1b[0;36m----------\x1b[0;0m",
+            "  \x1b[0;36m1\x1b[0;0m:",
+            "      \x1b[0;32mtest int 1\x1b[0;0m",
+            "  \x1b[0;36m2\x1b[0;0m:",
+            "      \x1b[0;32mtest int 2\x1b[0;0m",
+            "  \x1b[0;36mthree\x1b[0;0m:",
+            "      \x1b[0;32mtest text three\x1b[0;0m",
+        ]
+        self.assertListEqual(lines, expected)


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where some pillar data may have integer keys. This was causing the sorted function to fail. See issue #56909

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/56909

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
