### PR TITLE
Return a more meaningful error on unmapped accounts

### DIFF
--- a/salt/modules/win_groupadd.py
+++ b/salt/modules/win_groupadd.py
@@ -36,9 +36,11 @@ def __virtual__():
     """
     Set the group module if the kernel is Windows
     """
-    if salt.utils.platform.is_windows() and HAS_DEPENDENCIES:
-        return __virtualname__
-    return (False, "Module win_groupadd: module only works on Windows systems")
+    if not salt.utils.platform.is_windows():
+        return False, "win_groupadd: only works on Windows systems"
+    if not HAS_DEPENDENCIES:
+        return False, "win_groupadd: missing dependencies"
+    return __virtualname__
 
 
 def _get_computer_object():
@@ -283,7 +285,7 @@ def adduser(name, username, **kwargs):
             return False
     except pywintypes.com_error as exc:
         msg = "Failed to add {0} to group {1}. {2}".format(
-            username, name, win32api.FormatMessage(exc.excepinfo[5])
+            username, name, exc.excepinfo[2]
         )
         log.error(msg)
         return False

--- a/salt/states/group.py
+++ b/salt/states/group.py
@@ -180,9 +180,9 @@ def present(name, gid=None, system=False, addusers=None, delusers=None, members=
         # -- if trying to add and delete the same user(s) at the same time.
         if not set(addusers).isdisjoint(set(delusers)):
             ret["result"] = None
-            ret["comment"] = (
-                "Error. Same user(s) can not be added and deleted" " simultaneously"
-            )
+            ret[
+                "comment"
+            ] = "Error. Same user(s) can not be added and deleted simultaneously"
             return ret
 
     changes = _changes(name, gid, addusers, delusers, members)


### PR DESCRIPTION
### What does this PR do?
Fixes an issue in win_groupadd where an unmapped account would throw a double stacktrace. One for the error and another when it tried to look up the error code to get the message. Since pywintypes.com_error returns a good text string, we'll just use that instead of trying to look it up
again.

This code is being covered by an existing test.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/56903

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
