### PR TITLE
Fix Zabbix API "configuration.import" invocation

### DIFF
--- a/salt/modules/zabbix.py
+++ b/salt/modules/zabbix.py
@@ -2550,14 +2550,11 @@ def configuration_import(config_file, rules=None, file_format="xml", **connectio
         salt '*' zabbix.configuration_import salt://zabbix/config/zabbix_templates.xml \
         "{'screens': {'createMissing': True, 'updateExisting': True}}"
     """
+    zabbix_version = apiinfo_version(**connection_args)
+
     if rules is None:
         rules = {}
     default_rules = {
-        "applications": {
-            "createMissing": True,
-            "updateExisting": False,
-            "deleteMissing": False,
-        },
         "discoveryRules": {
             "createMissing": True,
             "updateExisting": True,
@@ -2592,6 +2589,22 @@ def configuration_import(config_file, rules=None, file_format="xml", **connectio
         },
         "valueMaps": {"createMissing": True, "updateExisting": False},
     }
+    if _LooseVersion(zabbix_version) >= _LooseVersion("3.2"):
+        # rules/httptests added
+        default_rules["httptests"] = {
+            "createMissing": True,
+            "updateExisting": True,
+            "deleteMissing": False,
+        }
+    if _LooseVersion(zabbix_version) >= _LooseVersion("3.4"):
+        # rules/applications/upateExisting deprecated
+        default_rules["applications"] = {"createMissing": True, "deleteMissing": False}
+    else:
+        default_rules["applications"] = {
+            "createMissing": True,
+            "updateExisting": True,
+            "deleteMissing": False,
+        }
     new_rules = dict(default_rules)
 
     if rules:


### PR DESCRIPTION
- Added a apiinfo_version call to check the API version when
  importing a configuration xml or json.
- Added default rules for httptests when API version is greater or
  equals 3.2
- Removed rules/applications/updateExisting property when API
  version is greater or equals 3.4

### What does this PR do?
Changes the default rules used for configuration_import by Zabbix API version

### What issues does this PR fix or reference?
Fixes: #54020

### Previous Behavior
Always send the same set of rules, causing:

Zabbix API: Invalid params. (Invalid parameter "/rules/applications": unexpected parameter "updateExisting".)

When Zabbix version >= 3.4

### New Behavior
Send a different set of default rules for:
- Zabbix version < 3.2
- Zabbix version between 3.2 and 3.4
- Zabbix version >= 3.4

### Commits signed with GPG?
No
