### PR TITLE
Master port #50773: zypper's locks to holds

### DIFF
--- a/changelog/56922.fixed
+++ b/changelog/56922.fixed
@@ -1,0 +1,1 @@
+zypperpkg add_lock and remove_lock examples do not work

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -404,7 +404,7 @@ def _get_yum_config():
                     conf[opt] = cp.get("main", opt)
         else:
             log.warning(
-                "Could not find [main] section in %s, using internal " "defaults", fn
+                "Could not find [main] section in %s, using internal defaults", fn
             )
 
     return conf
@@ -1691,9 +1691,7 @@ def install(
         holds = list_holds(full=False)
     except SaltInvocationError:
         holds = []
-        log.debug(
-            "Failed to get holds, versionlock plugin is probably not " "installed"
-        )
+        log.debug("Failed to get holds, versionlock plugin is probably not installed")
     unhold_prevented = []
 
     @contextlib.contextmanager
@@ -2346,7 +2344,7 @@ def unhold(name=None, pkgs=None, sources=None, **kwargs):  # pylint: disable=W06
                 else:
                     ret[target][
                         "comment"
-                    ] = "Package {} was unable to be " "unheld.".format(target)
+                    ] = "Package {} was unable to be unheld.".format(target)
         else:
             ret[target].update(result=True)
             ret[target]["comment"] = "Package {} is not being held.".format(target)

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -2111,10 +2111,10 @@ def unhold(name=None, pkgs=None, **kwargs):
     for pkg in pkgs:
         if locks.get(pkg):
             removed.append(pkg)
-            ret[pkg]["comment"] = "Package {0} is no longer held.".format(pkg)
+            ret[pkg]["comment"] = "Package {} is no longer held.".format(pkg)
         else:
             missing.append(pkg)
-            ret[pkg]["comment"] = "Package {0} unable to be unheld.".format(pkg)
+            ret[pkg]["comment"] = "Package {} unable to be unheld.".format(pkg)
 
     if removed:
         __zypper__.call("rl", *removed)
@@ -2200,9 +2200,9 @@ def hold(name=None, pkgs=None, **kwargs):
         ret[pkg] = {"name": pkg, "changes": {}, "result": False, "comment": ""}
         if not locks.get(pkg):
             added.append(pkg)
-            ret[pkg]["comment"] = "Package {0} is now being held.".format(pkg)
+            ret[pkg]["comment"] = "Package {} is now being held.".format(pkg)
         else:
-            ret[pkg]["comment"] = "Package {0} is already set to be held.".format(pkg)
+            ret[pkg]["comment"] = "Package {} is already set to be held.".format(pkg)
 
     if added:
         __zypper__.call("al", *added)

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -2112,6 +2112,50 @@ def remove_lock(packages, root=None, **kwargs):  # pylint: disable=unused-argume
     return {"removed": len(removed), "not_found": missing}
 
 
+def hold(name=None, pkgs=None, **kwargs):
+    """
+    Add a package lock. Specify packages to lock by exact name.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.add_lock <package name>
+        salt '*' pkg.add_lock <package1>,<package2>,<package3>
+        salt '*' pkg.add_lock pkgs='["foo", "bar"]'
+
+    :param name:
+    :param pkgs:
+    :param kwargs:
+    :return:
+    """
+    ret = {}
+    if (not name and not pkgs) or (name and pkgs):
+        raise CommandExecutionError("Name or packages must be specified.")
+    elif name:
+        pkgs = [name]
+
+    locks = list_locks()
+    added = []
+    try:
+        pkgs = list(__salt__["pkg_resource.parse_targets"](pkgs)[0].keys())
+    except MinionError as exc:
+        raise CommandExecutionError(exc)
+
+    for pkg in pkgs:
+        ret[pkg] = {"name": pkg, "changes": {}, "result": False, "comment": ""}
+        if not locks.get(pkg):
+            added.append(pkg)
+            ret[pkg]["comment"] = "Package {0} is now being held.".format(pkg)
+        else:
+            ret[pkg]["comment"] = "Package {0} is already set to be held.".format(pkg)
+
+    if added:
+        __zypper__.call("al", *added)
+
+    return ret
+
+
 def add_lock(packages, root=None, **kwargs):  # pylint: disable=unused-argument
     """
     Add a package lock. Specify packages to lock by exact name.

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -2079,6 +2079,8 @@ def clean_locks(root=None):
 
 def unhold(name=None, pkgs=None, **kwargs):
     """
+    .. versionadded:: 3003
+
     Remove a package hold.
 
     name
@@ -2169,6 +2171,8 @@ def remove_lock(name, root=None, **kwargs):
 
 def hold(name=None, pkgs=None, **kwargs):
     """
+    .. versionadded:: 3003
+
     Add a package hold.  Specify one of ``name`` and ``pkgs``.
 
     name

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -2079,25 +2079,30 @@ def clean_locks(root=None):
 
 def unhold(name=None, pkgs=None, **kwargs):
     """
-    Remove specified package lock.
+    Remove a package hold.
+
+    name
+        A package name, or a comma-separated list of package names.  Specify
+        one of ``name`` or ``pkgs``.
+
+    pkgs
+        A list of packages.  Specify one of ``name`` or ``pkgs``.
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' pkg.remove_lock <package name>
-        salt '*' pkg.remove_lock <package1>,<package2>,<package3>
-        salt '*' pkg.remove_lock pkgs='["foo", "bar"]'
+        salt '*' pkg.unhold <package name>
+        salt '*' pkg.unhold <package1>,<package2>,<package3>
+        salt '*' pkg.unhold pkgs='["foo", "bar"]'
     """
     ret = {}
     if (not name and not pkgs) or (name and pkgs):
         raise CommandExecutionError("Name or packages must be specified.")
-    elif name:
-        pkgs = [name]
 
     locks = list_locks()
     try:
-        pkgs = list(__salt__["pkg_resource.parse_targets"](pkgs)[0].keys())
+        pkgs = list(__salt__["pkg_resource.parse_targets"](name, pkgs)[0].keys())
     except MinionError as exc:
         raise CommandExecutionError(exc)
 
@@ -2117,9 +2122,15 @@ def unhold(name=None, pkgs=None, **kwargs):
     return ret
 
 
-def remove_lock(packages, root=None, **kwargs):  # pylint: disable=unused-argument
+def remove_lock(name, root=None, **kwargs):
     """
+    .. deprecated:: 3003
+        This function is deprecated. Please use ``unhold()`` instead.
+
     Remove specified package lock.
+
+    name
+        A package name, or a comma-separated list of package names.
 
     root
         operate on a different root directory.
@@ -2130,15 +2141,14 @@ def remove_lock(packages, root=None, **kwargs):  # pylint: disable=unused-argume
 
         salt '*' pkg.remove_lock <package name>
         salt '*' pkg.remove_lock <package1>,<package2>,<package3>
-        salt '*' pkg.remove_lock pkgs='["foo", "bar"]'
     """
 
     salt.utils.versions.warn_until(
-        "Sodium", "This function is deprecated. Please use unhold() instead."
+        "Phosphorus", "This function is deprecated. Please use unhold() instead."
     )
     locks = list_locks(root)
     try:
-        packages = list(__salt__["pkg_resource.parse_targets"](packages)[0].keys())
+        packages = list(__salt__["pkg_resource.parse_targets"](name)[0].keys())
     except MinionError as exc:
         raise CommandExecutionError(exc)
 
@@ -2158,31 +2168,31 @@ def remove_lock(packages, root=None, **kwargs):  # pylint: disable=unused-argume
 
 def hold(name=None, pkgs=None, **kwargs):
     """
-    Add a package lock. Specify packages to lock by exact name.
+    Add a package hold.  Specify one of ``name`` and ``pkgs``.
+
+    name
+        A package name, or a comma-separated list of package names.  Specify
+        one of ``name`` or ``pkgs``.
+
+    pkgs
+        A list of packages.  Specify one of ``name`` or ``pkgs``.
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' pkg.add_lock <package name>
-        salt '*' pkg.add_lock <package1>,<package2>,<package3>
-        salt '*' pkg.add_lock pkgs='["foo", "bar"]'
-
-    :param name:
-    :param pkgs:
-    :param kwargs:
-    :return:
+        salt '*' pkg.hold <package name>
+        salt '*' pkg.hold <package1>,<package2>,<package3>
+        salt '*' pkg.hold pkgs='["foo", "bar"]'
     """
     ret = {}
     if (not name and not pkgs) or (name and pkgs):
         raise CommandExecutionError("Name or packages must be specified.")
-    elif name:
-        pkgs = [name]
 
     locks = list_locks()
     added = []
     try:
-        pkgs = list(__salt__["pkg_resource.parse_targets"](pkgs)[0].keys())
+        pkgs = list(__salt__["pkg_resource.parse_targets"](name, pkgs)[0].keys())
     except MinionError as exc:
         raise CommandExecutionError(exc)
 
@@ -2200,8 +2210,11 @@ def hold(name=None, pkgs=None, **kwargs):
     return ret
 
 
-def add_lock(packages, root=None, **kwargs):  # pylint: disable=unused-argument
+def add_lock(name, root=None, **kwargs):
     """
+    .. deprecated:: 3003
+        This function is deprecated. Please use ``hold()`` instead.
+
     Add a package lock. Specify packages to lock by exact name.
 
     root
@@ -2213,15 +2226,14 @@ def add_lock(packages, root=None, **kwargs):  # pylint: disable=unused-argument
 
         salt '*' pkg.add_lock <package name>
         salt '*' pkg.add_lock <package1>,<package2>,<package3>
-        salt '*' pkg.add_lock pkgs='["foo", "bar"]'
     """
     salt.utils.versions.warn_until(
-        "Sodium", "This function is deprecated. Please use hold() instead."
+        "Phosphorus", "This function is deprecated. Please use hold() instead."
     )
     locks = list_locks(root)
     added = []
     try:
-        packages = list(__salt__["pkg_resource.parse_targets"](packages)[0].keys())
+        packages = list(__salt__["pkg_resource.parse_targets"](name)[0].keys())
     except MinionError as exc:
         raise CommandExecutionError(exc)
 

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -2109,12 +2109,13 @@ def unhold(name=None, pkgs=None, **kwargs):
     removed = []
     missing = []
     for pkg in pkgs:
+        ret[pkg] = {"name": pkg, "changes": {}, "result": True, "comment": ""}
         if locks.get(pkg):
             removed.append(pkg)
             ret[pkg]["comment"] = "Package {} is no longer held.".format(pkg)
         else:
             missing.append(pkg)
-            ret[pkg]["comment"] = "Package {} unable to be unheld.".format(pkg)
+            ret[pkg]["comment"] = "Package {} was already unheld.".format(pkg)
 
     if removed:
         __zypper__.call("rl", *removed)
@@ -2197,7 +2198,7 @@ def hold(name=None, pkgs=None, **kwargs):
         raise CommandExecutionError(exc)
 
     for pkg in pkgs:
-        ret[pkg] = {"name": pkg, "changes": {}, "result": False, "comment": ""}
+        ret[pkg] = {"name": pkg, "changes": {}, "result": True, "comment": ""}
         if not locks.get(pkg):
             added.append(pkg)
             ret[pkg]["comment"] = "Package {} is now being held.".format(pkg)

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -33,6 +33,7 @@ import salt.utils.pkg
 import salt.utils.pkg.rpm
 import salt.utils.stringutils
 import salt.utils.systemd
+import salt.utils.versions
 from salt.exceptions import CommandExecutionError, MinionError, SaltInvocationError
 from salt.utils.versions import LooseVersion
 
@@ -2132,6 +2133,9 @@ def remove_lock(packages, root=None, **kwargs):  # pylint: disable=unused-argume
         salt '*' pkg.remove_lock pkgs='["foo", "bar"]'
     """
 
+    salt.utils.versions.warn_until(
+        "Sodium", "This function is deprecated. Please use unhold() instead."
+    )
     locks = list_locks(root)
     try:
         packages = list(__salt__["pkg_resource.parse_targets"](packages)[0].keys())
@@ -2211,6 +2215,9 @@ def add_lock(packages, root=None, **kwargs):  # pylint: disable=unused-argument
         salt '*' pkg.add_lock <package1>,<package2>,<package3>
         salt '*' pkg.add_lock pkgs='["foo", "bar"]'
     """
+    salt.utils.versions.warn_until(
+        "Sodium", "This function is deprecated. Please use hold() instead."
+    )
     locks = list_locks(root)
     added = []
     try:

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Installation of packages using OS package managers such as yum or apt-get
 =========================================================================
@@ -71,22 +70,16 @@ state module
     used. This will be addressed in a future release of Salt.
 """
 
-# Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import fnmatch
 import logging
 import os
 import re
 
-# Import Salt libs
 import salt.utils.pkg
 import salt.utils.platform
 import salt.utils.versions
 from salt.exceptions import CommandExecutionError, MinionError, SaltInvocationError
-
-# Import 3rd-party libs
-from salt.ext import six
 from salt.modules.pkg_resource import _repack_pkgs
 from salt.output import nested
 from salt.utils.functools import namespaced_function as _namespaced_function
@@ -323,7 +316,7 @@ def _find_download_targets(
                     "name": name,
                     "changes": {},
                     "result": True,
-                    "comment": "Version {0} of package '{1}' is already "
+                    "comment": "Version {} of package '{}' is already "
                     "downloaded".format(version, name),
                 }
 
@@ -334,7 +327,7 @@ def _find_download_targets(
                     "name": name,
                     "changes": {},
                     "result": True,
-                    "comment": "Package {0} is already " "downloaded".format(name),
+                    "comment": "Package {} is already " "downloaded".format(name),
                 }
 
     version_spec = False
@@ -349,13 +342,13 @@ def _find_download_targets(
                 comments.append(
                     "The following package(s) were not found, and no "
                     "possible matches were found in the package db: "
-                    "{0}".format(", ".join(sorted(problems["no_suggest"])))
+                    "{}".format(", ".join(sorted(problems["no_suggest"])))
                 )
             if problems.get("suggest"):
-                for pkgname, suggestions in six.iteritems(problems["suggest"]):
+                for pkgname, suggestions in problems["suggest"].items():
                     comments.append(
-                        "Package '{0}' not found (possible matches: "
-                        "{1})".format(pkgname, ", ".join(suggestions))
+                        "Package '{}' not found (possible matches: "
+                        "{})".format(pkgname, ", ".join(suggestions))
                     )
             if comments:
                 if len(comments) > 1:
@@ -371,7 +364,7 @@ def _find_download_targets(
     # Check current downloaded versions against specified versions
     targets = {}
     problems = []
-    for pkgname, pkgver in six.iteritems(to_download):
+    for pkgname, pkgver in to_download.items():
         cver = cur_pkgs.get(pkgname, {})
         # Package not yet downloaded, so add to targets
         if not cver:
@@ -401,7 +394,7 @@ def _find_download_targets(
 
     if not targets:
         # All specified packages are already downloaded
-        msg = "All specified packages{0} are already downloaded".format(
+        msg = "All specified packages{} are already downloaded".format(
             " (matching specified versions)" if version_spec else ""
         )
         return {"name": name, "changes": {}, "result": True, "comment": msg}
@@ -425,7 +418,7 @@ def _find_advisory_targets(name=None, advisory_ids=None, **kwargs):
                 "name": name,
                 "changes": {},
                 "result": True,
-                "comment": "Advisory patch {0} is already " "installed".format(name),
+                "comment": "Advisory patch {} is already " "installed".format(name),
             }
 
     # Find out which advisory patches will be targeted in the call to pkg.install
@@ -477,12 +470,12 @@ def _find_remove_targets(
     # Check current versions against specified versions
     targets = []
     problems = []
-    for pkgname, pkgver in six.iteritems(to_remove):
+    for pkgname, pkgver in to_remove.items():
         # FreeBSD pkg supports `openjdk` and `java/openjdk7` package names
         origin = bool(re.search("/", pkgname))
 
         if __grains__["os"] == "FreeBSD" and origin:
-            cver = [k for k, v in six.iteritems(cur_pkgs) if v["origin"] == pkgname]
+            cver = [k for k, v in cur_pkgs.items() if v["origin"] == pkgname]
         else:
             cver = cur_pkgs.get(pkgname, [])
 
@@ -518,7 +511,7 @@ def _find_remove_targets(
 
     if not targets:
         # All specified packages are already absent
-        msg = "All specified packages{0} are already absent".format(
+        msg = "All specified packages{} are already absent".format(
             " (matching specified versions)" if version_spec else ""
         )
         return {"name": name, "changes": {}, "result": True, "comment": msg}
@@ -619,7 +612,7 @@ def _find_install_targets(
                 "name": name,
                 "changes": {},
                 "result": False,
-                "comment": "Invalidly formatted '{0}' parameter. See "
+                "comment": "Invalidly formatted '{}' parameter. See "
                 "minion log.".format("pkgs" if pkgs else "sources"),
             }
 
@@ -634,7 +627,7 @@ def _find_install_targets(
                     "name": name,
                     "changes": {},
                     "result": False,
-                    "comment": "Package {0} not found in the "
+                    "comment": "Package {} not found in the "
                     "repository.".format(name),
                 }
             if version is None:
@@ -656,7 +649,7 @@ def _find_install_targets(
         origin = bool(re.search("/", name))
 
         if __grains__["os"] == "FreeBSD" and origin:
-            cver = [k for k, v in six.iteritems(cur_pkgs) if v["origin"] == name]
+            cver = [k for k, v in cur_pkgs.items() if v["origin"] == name]
         else:
             cver = cur_pkgs.get(name, [])
 
@@ -667,7 +660,7 @@ def _find_install_targets(
                     "name": name,
                     "changes": {},
                     "result": True,
-                    "comment": "Version {0} of package '{1}' is already "
+                    "comment": "Version {} of package '{}' is already "
                     "installed".format(version, name),
                 }
 
@@ -678,7 +671,7 @@ def _find_install_targets(
                     "name": name,
                     "changes": {},
                     "result": True,
-                    "comment": "Package {0} is already " "installed".format(name),
+                    "comment": "Package {} is already " "installed".format(name),
                 }
 
     version_spec = False
@@ -687,21 +680,19 @@ def _find_install_targets(
         # enforced. Takes extra time. Disable for improved performance
         if not skip_suggestions:
             # Perform platform-specific pre-flight checks
-            not_installed = dict(
-                [
-                    (name, version)
-                    for name, version in desired.items()
-                    if not (
-                        name in cur_pkgs
-                        and (
-                            version is None
-                            or _fulfills_version_string(
-                                cur_pkgs[name], version, ignore_epoch=ignore_epoch
-                            )
+            not_installed = {
+                name: version
+                for name, version in desired.items()
+                if not (
+                    name in cur_pkgs
+                    and (
+                        version is None
+                        or _fulfills_version_string(
+                            cur_pkgs[name], version, ignore_epoch=ignore_epoch
                         )
                     )
-                ]
-            )
+                )
+            }
             if not_installed:
                 try:
                     problems = _preflight_check(not_installed, **kwargs)
@@ -713,13 +704,13 @@ def _find_install_targets(
                         comments.append(
                             "The following package(s) were not found, and no "
                             "possible matches were found in the package db: "
-                            "{0}".format(", ".join(sorted(problems["no_suggest"])))
+                            "{}".format(", ".join(sorted(problems["no_suggest"])))
                         )
                     if problems.get("suggest"):
-                        for pkgname, suggestions in six.iteritems(problems["suggest"]):
+                        for pkgname, suggestions in problems["suggest"].items():
                             comments.append(
-                                "Package '{0}' not found (possible matches: "
-                                "{1})".format(pkgname, ", ".join(suggestions))
+                                "Package '{}' not found (possible matches: "
+                                "{})".format(pkgname, ", ".join(suggestions))
                             )
                     if comments:
                         if len(comments) > 1:
@@ -733,9 +724,7 @@ def _find_install_targets(
 
     # Resolve the latest package version for any packages with "latest" in the
     # package version
-    wants_latest = (
-        [] if sources else [x for x, y in six.iteritems(desired) if y == "latest"]
-    )
+    wants_latest = [] if sources else [x for x, y in desired.items() if y == "latest"]
     if wants_latest:
         resolved_latest = __salt__["pkg.latest_version"](
             *wants_latest, refresh=refresh, **kwargs
@@ -766,7 +755,7 @@ def _find_install_targets(
     problems = []
     warnings = []
     failed_verify = False
-    for package_name, version_string in six.iteritems(desired):
+    for package_name, version_string in desired.items():
         cver = cur_pkgs.get(package_name, [])
         if resolve_capabilities and not cver and package_name in cur_prov:
             cver = cur_pkgs.get(cur_prov.get(package_name)[0], [])
@@ -795,12 +784,12 @@ def _find_install_targets(
                 problems.append(err.format(version_string, "file not found"))
                 continue
             elif not os.path.exists(cached_path):
-                problems.append("{0} does not exist on minion".format(version_string))
+                problems.append("{} does not exist on minion".format(version_string))
                 continue
             source_info = __salt__["lowpkg.bin_pkg_info"](cached_path)
             if source_info is None:
                 warnings.append(
-                    "Failed to parse metadata for {0}".format(version_string)
+                    "Failed to parse metadata for {}".format(version_string)
                 )
                 continue
             else:
@@ -923,7 +912,7 @@ def _verify_install(desired, new_pkgs, ignore_epoch=None, new_caps=None):
         has_origin = "/" in pkgname
 
         if __grains__["os"] == "FreeBSD" and has_origin:
-            cver = [k for k, v in six.iteritems(new_pkgs) if v["origin"] == pkgname]
+            cver = [k for k, v in new_pkgs.items() if v["origin"] == pkgname]
         elif __grains__["os"] == "MacOS" and has_origin:
             cver = new_pkgs.get(pkgname, new_pkgs.get(pkgname.split("/")[-1]))
         elif __grains__["os"] == "OpenBSD":
@@ -964,7 +953,7 @@ def _get_desired_pkg(name, desired):
         oper = ""
     else:
         oper = "="
-    return "{0}{1}{2}".format(name, oper, "" if not desired[name] else desired[name])
+    return "{}{}{}".format(name, oper, "" if not desired[name] else desired[name])
 
 
 def _preflight_check(desired, fromrepo, **kwargs):
@@ -1718,8 +1707,8 @@ def installed(
             "comment": "pkg.verify not implemented",
         }
 
-    if not isinstance(version, six.string_types) and version is not None:
-        version = six.text_type(version)
+    if not isinstance(version, str) and version is not None:
+        version = str(version)
 
     kwargs["allow_updates"] = allow_updates
 
@@ -1763,7 +1752,7 @@ def installed(
                     "name": name,
                     "changes": {},
                     "result": False,
-                    "comment": six.text_type(exc),
+                    "comment": str(exc),
                 }
 
             if "result" in hold_ret and not hold_ret["result"]:
@@ -1772,7 +1761,7 @@ def installed(
                     "changes": {},
                     "result": False,
                     "comment": "An error was encountered while "
-                    "holding/unholding package(s): {0}".format(hold_ret["comment"]),
+                    "holding/unholding package(s): {}".format(hold_ret["comment"]),
                 }
             else:
                 modified_hold = [
@@ -1788,16 +1777,16 @@ def installed(
                 ]
 
                 for i in modified_hold:
-                    result["comment"] += ".\n{0}".format(i["comment"])
+                    result["comment"] += ".\n{}".format(i["comment"])
                     result["result"] = i["result"]
                     result["changes"][i["name"]] = i["changes"]
 
                 for i in not_modified_hold:
-                    result["comment"] += ".\n{0}".format(i["comment"])
+                    result["comment"] += ".\n{}".format(i["comment"])
                     result["result"] = i["result"]
 
                 for i in failed_hold:
-                    result["comment"] += ".\n{0}".format(i["comment"])
+                    result["comment"] += ".\n{}".format(i["comment"])
                     result["result"] = i["result"]
         return result
 
@@ -1814,8 +1803,8 @@ def installed(
 
     # Remove any targets not returned by _find_install_targets
     if pkgs:
-        pkgs = [dict([(x, y)]) for x, y in six.iteritems(targets)]
-        pkgs.extend([dict([(x, y)]) for x, y in six.iteritems(to_reinstall)])
+        pkgs = [dict([(x, y)]) for x, y in targets.items()]
+        pkgs.extend([dict([(x, y)]) for x, y in to_reinstall.items()])
     elif sources:
         oldsources = sources
         sources = [x for x in oldsources if next(iter(list(x.keys()))) in targets]
@@ -1832,12 +1821,12 @@ def installed(
                 summary = ", ".join([_get_desired_pkg(x, targets) for x in targets])
             comment.append(
                 "The following packages would be "
-                "installed/updated: {0}".format(summary)
+                "installed/updated: {}".format(summary)
             )
         if to_unpurge:
             comment.append(
                 "The following packages would have their selection status "
-                "changed from 'purge' to 'install': {0}".format(", ".join(to_unpurge))
+                "changed from 'purge' to 'install': {}".format(", ".join(to_unpurge))
             )
         if to_reinstall:
             # Add a comment for each package in to_reinstall with its
@@ -1861,7 +1850,7 @@ def installed(
                     else:
                         pkgstr = _get_desired_pkg(reinstall_pkg, to_reinstall)
                     comment.append(
-                        "Package '{0}' would be reinstalled because the "
+                        "Package '{}' would be reinstalled because the "
                         "following files have been altered:".format(pkgstr)
                     )
                     comment.append(_nested_output(altered_files[reinstall_pkg]))
@@ -1905,7 +1894,7 @@ def installed(
                 ret["changes"] = {}
                 ret["comment"] = (
                     "An error was encountered while installing "
-                    "package(s): {0}".format(exc)
+                    "package(s): {}".format(exc)
                 )
             if warnings:
                 ret.setdefault("warnings", []).extend(warnings)
@@ -1916,7 +1905,7 @@ def installed(
 
         if isinstance(pkg_ret, dict):
             changes["installed"].update(pkg_ret)
-        elif isinstance(pkg_ret, six.string_types):
+        elif isinstance(pkg_ret, str):
             comment.append(pkg_ret)
             # Code below will be looking for a dictionary. If this is a string
             # it means that there was an exception raised and that no packages
@@ -1930,7 +1919,7 @@ def installed(
             action = "pkg.hold" if kwargs["hold"] else "pkg.unhold"
             hold_ret = __salt__[action](name=name, pkgs=desired)
         except (CommandExecutionError, SaltInvocationError) as exc:
-            comment.append(six.text_type(exc))
+            comment.append(str(exc))
             ret = {
                 "name": name,
                 "changes": changes,
@@ -1947,7 +1936,7 @@ def installed(
                     "changes": {},
                     "result": False,
                     "comment": "An error was encountered while "
-                    "holding/unholding package(s): {0}".format(hold_ret["comment"]),
+                    "holding/unholding package(s): {}".format(hold_ret["comment"]),
                 }
                 if warnings:
                     ret.setdefault("warnings", []).extend(warnings)
@@ -2005,11 +1994,11 @@ def installed(
             summary = ", ".join([_get_desired_pkg(x, desired) for x in modified])
         if len(summary) < 20:
             comment.append(
-                "The following packages were installed/updated: " "{0}".format(summary)
+                "The following packages were installed/updated: " "{}".format(summary)
             )
         else:
             comment.append(
-                "{0} targeted package{1} {2} installed/updated.".format(
+                "{} targeted package{} {} installed/updated.".format(
                     len(modified),
                     "s" if len(modified) > 1 else "",
                     "were" if len(modified) > 1 else "was",
@@ -2023,14 +2012,14 @@ def installed(
                 comment.append(i["comment"])
                 if len(changes[change_name]["new"]) > 0:
                     changes[change_name]["new"] += "\n"
-                changes[change_name]["new"] += "{0}".format(i["changes"]["new"])
+                changes[change_name]["new"] += "{}".format(i["changes"]["new"])
                 if len(changes[change_name]["old"]) > 0:
                     changes[change_name]["old"] += "\n"
-                changes[change_name]["old"] += "{0}".format(i["changes"]["old"])
+                changes[change_name]["old"] += "{}".format(i["changes"]["old"])
             else:
                 comment.append(i["comment"])
                 changes[change_name] = {}
-                changes[change_name]["new"] = "{0}".format(i["changes"]["new"])
+                changes[change_name]["new"] = "{}".format(i["changes"]["new"])
 
     # Any requested packages that were not targeted for install or reinstall
     if not_modified:
@@ -2040,11 +2029,11 @@ def installed(
             summary = ", ".join([_get_desired_pkg(x, desired) for x in not_modified])
         if len(not_modified) <= 20:
             comment.append(
-                "The following packages were already installed: " "{0}".format(summary)
+                "The following packages were already installed: " "{}".format(summary)
             )
         else:
             comment.append(
-                "{0} targeted package{1} {2} already installed".format(
+                "{} targeted package{} {} already installed".format(
                     len(not_modified),
                     "s" if len(not_modified) > 1 else "",
                     "were" if len(not_modified) > 1 else "was",
@@ -2063,7 +2052,7 @@ def installed(
         else:
             summary = ", ".join([_get_desired_pkg(x, desired) for x in failed])
         comment.insert(
-            0, "The following packages failed to " "install/update: {0}".format(summary)
+            0, "The following packages failed to " "install/update: {}".format(summary)
         )
         result = False
 
@@ -2127,7 +2116,7 @@ def installed(
                 pkgstr = modified_pkg
             else:
                 pkgstr = _get_desired_pkg(modified_pkg, desired)
-            msg = "Package {0} was reinstalled.".format(pkgstr)
+            msg = "Package {} was reinstalled.".format(pkgstr)
             if modified_pkg in altered_files:
                 msg += " The following files were remediated:"
                 comment.append(msg)
@@ -2142,7 +2131,7 @@ def installed(
                 pkgstr = failed_pkg
             else:
                 pkgstr = _get_desired_pkg(failed_pkg, desired)
-            msg = "Reinstall was not successful for package {0}.".format(pkgstr)
+            msg = "Reinstall was not successful for package {}.".format(pkgstr)
             if failed_pkg in altered_files:
                 msg += " The following files could not be remediated:"
                 comment.append(msg)
@@ -2283,12 +2272,12 @@ def downloaded(
         ret["result"] = False
         ret[
             "comment"
-        ] = "An error was encountered while checking targets: " "{0}".format(targets)
+        ] = "An error was encountered while checking targets: " "{}".format(targets)
         return ret
 
     if __opts__["test"]:
         summary = ", ".join(targets)
-        ret["comment"] = "The following packages would be " "downloaded: {0}".format(
+        ret["comment"] = "The following packages would be " "downloaded: {}".format(
             summary
         )
         return ret
@@ -2315,7 +2304,7 @@ def downloaded(
             ret["changes"] = {}
             ret["comment"] = (
                 "An error was encountered while downloading "
-                "package(s): {0}".format(exc)
+                "package(s): {}".format(exc)
             )
         return ret
 
@@ -2325,13 +2314,13 @@ def downloaded(
     if failed:
         summary = ", ".join([_get_desired_pkg(x, targets) for x in failed])
         ret["result"] = False
-        ret["comment"] = "The following packages failed to " "download: {0}".format(
+        ret["comment"] = "The following packages failed to " "download: {}".format(
             summary
         )
 
     if not ret["changes"] and not ret["comment"]:
         ret["result"] = True
-        ret["comment"] = "Packages downloaded: " "{0}".format(", ".join(targets))
+        ret["comment"] = "Packages downloaded: " "{}".format(", ".join(targets))
 
     return ret
 
@@ -2391,14 +2380,14 @@ def patch_installed(name, advisory_ids=None, downloadonly=None, **kwargs):
         ret["result"] = False
         ret[
             "comment"
-        ] = "An error was encountered while checking targets: " "{0}".format(targets)
+        ] = "An error was encountered while checking targets: " "{}".format(targets)
         return ret
 
     if __opts__["test"]:
         summary = ", ".join(targets)
         ret[
             "comment"
-        ] = "The following advisory patches would be " "downloaded: {0}".format(summary)
+        ] = "The following advisory patches would be " "downloaded: {}".format(summary)
         return ret
 
     try:
@@ -2417,7 +2406,7 @@ def patch_installed(name, advisory_ids=None, downloadonly=None, **kwargs):
             ret["changes"] = {}
             ret["comment"] = (
                 "An error was encountered while downloading "
-                "package(s): {0}".format(exc)
+                "package(s): {}".format(exc)
             )
         return ret
 
@@ -2426,7 +2415,7 @@ def patch_installed(name, advisory_ids=None, downloadonly=None, **kwargs):
         ret["result"] = True
         ret["comment"] = (
             "Advisory patch is not needed or related packages "
-            "are already {0}".format(status)
+            "are already {}".format(status)
         )
 
     return ret
@@ -2683,7 +2672,7 @@ def latest(
             "changes": {},
             "result": False,
             "comment": "An error was encountered while checking the "
-            "newest available version of package(s): {0}".format(exc),
+            "newest available version of package(s): {}".format(exc),
         }
 
     try:
@@ -2692,9 +2681,9 @@ def latest(
         return {"name": name, "changes": {}, "result": False, "comment": exc.strerror}
 
     # Repack the cur/avail data if only a single package is being checked
-    if isinstance(cur, six.string_types):
+    if isinstance(cur, str):
         cur = {desired_pkgs[0]: cur}
-    if isinstance(avail, six.string_types):
+    if isinstance(avail, str):
         avail = {desired_pkgs[0]: avail}
 
     targets = {}
@@ -2704,7 +2693,7 @@ def latest(
             # Package either a) is up-to-date, or b) does not exist
             if not cur.get(pkg):
                 # Package does not exist
-                msg = "No information found for '{0}'.".format(pkg)
+                msg = "No information found for '{}'.".format(pkg)
                 log.error(msg)
                 problems.append(msg)
             elif (
@@ -2750,12 +2739,12 @@ def latest(
                     comments.append(
                         "The following packages are already up-to-date: "
                         + ", ".join(
-                            ["{0} ({1})".format(x, cur[x]) for x in sorted(up_to_date)]
+                            ["{} ({})".format(x, cur[x]) for x in sorted(up_to_date)]
                         )
                     )
                 else:
                     comments.append(
-                        "{0} packages are already up-to-date".format(up_to_date_count)
+                        "{} packages are already up-to-date".format(up_to_date_count)
                     )
 
             return {
@@ -2793,7 +2782,7 @@ def latest(
                 "changes": {},
                 "result": False,
                 "comment": "An error was encountered while installing "
-                "package(s): {0}".format(exc),
+                "package(s): {}".format(exc),
             }
 
         if changes:
@@ -2809,7 +2798,7 @@ def latest(
 
             comments = []
             if failed:
-                msg = "The following packages failed to update: " "{0}".format(
+                msg = "The following packages failed to update: " "{}".format(
                     ", ".join(sorted(failed))
                 )
                 comments.append(msg)
@@ -2817,19 +2806,17 @@ def latest(
                 msg = (
                     "The following packages were successfully "
                     "installed/upgraded: "
-                    "{0}".format(", ".join(sorted(successful)))
+                    "{}".format(", ".join(sorted(successful)))
                 )
                 comments.append(msg)
             if up_to_date:
                 if len(up_to_date) <= 10:
                     msg = (
                         "The following packages were already up-to-date: "
-                        "{0}".format(", ".join(sorted(up_to_date)))
+                        "{}".format(", ".join(sorted(up_to_date)))
                     )
                 else:
-                    msg = "{0} packages were already up-to-date ".format(
-                        len(up_to_date)
-                    )
+                    msg = "{} packages were already up-to-date ".format(len(up_to_date))
                 comments.append(msg)
 
             return {
@@ -2841,18 +2828,18 @@ def latest(
         else:
             if len(targets) > 10:
                 comment = (
-                    "{0} targeted packages failed to update. "
+                    "{} targeted packages failed to update. "
                     "See debug log for details.".format(len(targets))
                 )
             elif len(targets) > 1:
                 comment = (
                     "The following targeted packages failed to update. "
-                    "See debug log for details: ({0}).".format(
+                    "See debug log for details: ({}).".format(
                         ", ".join(sorted(targets))
                     )
                 )
             else:
-                comment = "Package {0} failed to " "update.".format(
+                comment = "Package {} failed to " "update.".format(
                     next(iter(list(targets.keys())))
                 )
             if up_to_date:
@@ -2860,10 +2847,10 @@ def latest(
                     comment += (
                         " The following packages were already "
                         "up-to-date: "
-                        "{0}".format(", ".join(sorted(up_to_date)))
+                        "{}".format(", ".join(sorted(up_to_date)))
                     )
                 else:
-                    comment += "{0} packages were already " "up-to-date".format(
+                    comment += "{} packages were already " "up-to-date".format(
                         len(up_to_date)
                     )
 
@@ -2875,13 +2862,13 @@ def latest(
             }
     else:
         if len(desired_pkgs) > 10:
-            comment = "All {0} packages are up-to-date.".format(len(desired_pkgs))
+            comment = "All {} packages are up-to-date.".format(len(desired_pkgs))
         elif len(desired_pkgs) > 1:
-            comment = "All packages are up-to-date " "({0}).".format(
+            comment = "All packages are up-to-date " "({}).".format(
                 ", ".join(sorted(desired_pkgs))
             )
         else:
-            comment = "Package {0} is already " "up-to-date".format(desired_pkgs[0])
+            comment = "Package {} is already " "up-to-date".format(desired_pkgs[0])
 
         return {"name": name, "changes": {}, "result": True, "comment": comment}
 
@@ -2903,8 +2890,7 @@ def _uninstall(
             "name": name,
             "changes": {},
             "result": False,
-            "comment": "Invalid action '{0}'. "
-            "This is probably a bug.".format(action),
+            "comment": "Invalid action '{}'. " "This is probably a bug.".format(action),
         }
 
     try:
@@ -2917,7 +2903,7 @@ def _uninstall(
             "changes": {},
             "result": False,
             "comment": "An error was encountered while parsing targets: "
-            "{0}".format(exc),
+            "{}".format(exc),
         }
     targets = _find_remove_targets(
         name, version, pkgs, normalize, ignore_epoch=ignore_epoch, **kwargs
@@ -2930,7 +2916,7 @@ def _uninstall(
             "changes": {},
             "result": False,
             "comment": "An error was encountered while checking targets: "
-            "{0}".format(targets),
+            "{}".format(targets),
         }
     if action == "purge":
         old_removed = __salt__["pkg.list_pkgs"](
@@ -2945,7 +2931,7 @@ def _uninstall(
             "changes": {},
             "result": True,
             "comment": "None of the targeted packages are installed"
-            "{0}".format(" or partially installed" if action == "purge" else ""),
+            "{}".format(" or partially installed" if action == "purge" else ""),
         }
 
     if __opts__["test"]:
@@ -2953,11 +2939,11 @@ def _uninstall(
             "name": name,
             "changes": {},
             "result": None,
-            "comment": "The following packages will be {0}d: "
-            "{1}.".format(action, ", ".join(targets)),
+            "comment": "The following packages will be {}d: "
+            "{}.".format(action, ", ".join(targets)),
         }
 
-    changes = __salt__["pkg.{0}".format(action)](
+    changes = __salt__["pkg.{}".format(action)](
         name, pkgs=pkgs, version=version, **kwargs
     )
     new = __salt__["pkg.list_pkgs"](versions_as_list=True, **kwargs)
@@ -2984,8 +2970,8 @@ def _uninstall(
             "name": name,
             "changes": changes,
             "result": False,
-            "comment": "The following packages failed to {0}: "
-            "{1}.".format(action, ", ".join(failed)),
+            "comment": "The following packages failed to {}: "
+            "{}.".format(action, ", ".join(failed)),
         }
 
     comments = []
@@ -2993,14 +2979,13 @@ def _uninstall(
     if not_installed:
         comments.append(
             "The following packages were not installed: "
-            "{0}".format(", ".join(not_installed))
+            "{}".format(", ".join(not_installed))
         )
         comments.append(
-            "The following packages were {0}d: "
-            "{1}.".format(action, ", ".join(targets))
+            "The following packages were {}d: " "{}.".format(action, ", ".join(targets))
         )
     else:
-        comments.append("All targeted packages were {0}d.".format(action))
+        comments.append("All targeted packages were {}d.".format(action))
 
     return {
         "name": name,
@@ -3098,7 +3083,7 @@ def removed(name, version=None, pkgs=None, normalize=True, ignore_epoch=None, **
             ret["changes"] = {}
             ret[
                 "comment"
-            ] = "An error was encountered while removing " "package(s): {0}".format(exc)
+            ] = "An error was encountered while removing " "package(s): {}".format(exc)
         return ret
 
 
@@ -3190,7 +3175,7 @@ def purged(name, version=None, pkgs=None, normalize=True, ignore_epoch=None, **k
             ret["changes"] = {}
             ret[
                 "comment"
-            ] = "An error was encountered while purging " "package(s): {0}".format(exc)
+            ] = "An error was encountered while purging " "package(s): {}".format(exc)
         return ret
 
 
@@ -3256,17 +3241,17 @@ def uptodate(name, refresh=False, pkgs=None, **kwargs):
                     "new": pkgver,
                     "old": __salt__["pkg.version"](pkgname, **kwargs),
                 }
-                for pkgname, pkgver in six.iteritems(packages)
+                for pkgname, pkgver in packages.items()
             }
             if isinstance(pkgs, list):
                 packages = [pkg for pkg in packages if pkg in pkgs]
                 expected = {
                     pkgname: pkgver
-                    for pkgname, pkgver in six.iteritems(expected)
+                    for pkgname, pkgver in expected.items()
                     if pkgname in pkgs
                 }
         except Exception as exc:  # pylint: disable=broad-except
-            ret["comment"] = six.text_type(exc)
+            ret["comment"] = str(exc)
             return ret
     else:
         ret["comment"] = "refresh must be either True or False"
@@ -3293,16 +3278,16 @@ def uptodate(name, refresh=False, pkgs=None, **kwargs):
             ret["changes"] = {}
             ret[
                 "comment"
-            ] = "An error was encountered while updating " "packages: {0}".format(exc)
+            ] = "An error was encountered while updating " "packages: {}".format(exc)
         return ret
 
     # If a package list was provided, ensure those packages were updated
     missing = []
     if isinstance(pkgs, list):
-        missing = [pkg for pkg in six.iterkeys(expected) if pkg not in ret["changes"]]
+        missing = [pkg for pkg in expected.keys() if pkg not in ret["changes"]]
 
     if missing:
-        ret["comment"] = "The following package(s) failed to update: {0}".format(
+        ret["comment"] = "The following package(s) failed to update: {}".format(
             ", ".join(missing)
         )
         ret["result"] = False
@@ -3371,8 +3356,8 @@ def group_installed(name, skip=None, include=None, **kwargs):
             ret["comment"] = "skip must be formatted as a list"
             return ret
         for idx, item in enumerate(skip):
-            if not isinstance(item, six.string_types):
-                skip[idx] = six.text_type(item)
+            if not isinstance(item, str):
+                skip[idx] = str(item)
 
     if include is None:
         include = []
@@ -3381,15 +3366,15 @@ def group_installed(name, skip=None, include=None, **kwargs):
             ret["comment"] = "include must be formatted as a list"
             return ret
         for idx, item in enumerate(include):
-            if not isinstance(item, six.string_types):
-                include[idx] = six.text_type(item)
+            if not isinstance(item, str):
+                include[idx] = str(item)
 
     try:
         diff = __salt__["pkg.group_diff"](name)
     except CommandExecutionError as err:
         ret["comment"] = (
             "An error was encountered while installing/updating "
-            "group '{0}': {1}.".format(name, err)
+            "group '{}': {}.".format(name, err)
         )
         return ret
 
@@ -3399,7 +3384,7 @@ def group_installed(name, skip=None, include=None, **kwargs):
     if invalid_skip:
         ret[
             "comment"
-        ] = "The following mandatory packages cannot be skipped: {0}".format(
+        ] = "The following mandatory packages cannot be skipped: {}".format(
             ", ".join(invalid_skip)
         )
         return ret
@@ -3410,7 +3395,7 @@ def group_installed(name, skip=None, include=None, **kwargs):
 
     if not targets:
         ret["result"] = True
-        ret["comment"] = "Group '{0}' is already installed".format(name)
+        ret["comment"] = "Group '{}' is already installed".format(name)
         return ret
 
     partially_installed = (
@@ -3424,9 +3409,9 @@ def group_installed(name, skip=None, include=None, **kwargs):
         if partially_installed:
             ret[
                 "comment"
-            ] = "Group '{0}' is partially installed and will be updated".format(name)
+            ] = "Group '{}' is partially installed and will be updated".format(name)
         else:
-            ret["comment"] = "Group '{0}' will be installed".format(name)
+            ret["comment"] = "Group '{}' will be installed".format(name)
         return ret
 
     try:
@@ -3441,19 +3426,19 @@ def group_installed(name, skip=None, include=None, **kwargs):
             ret["changes"] = {}
             ret["comment"] = (
                 "An error was encountered while "
-                "installing/updating group '{0}': {1}".format(name, exc)
+                "installing/updating group '{}': {}".format(name, exc)
             )
         return ret
 
     failed = [x for x in targets if x not in __salt__["pkg.list_pkgs"](**kwargs)]
     if failed:
-        ret["comment"] = "Failed to install the following packages: {0}".format(
+        ret["comment"] = "Failed to install the following packages: {}".format(
             ", ".join(failed)
         )
         return ret
 
     ret["result"] = True
-    ret["comment"] = "Group '{0}' was {1}".format(
+    ret["comment"] = "Group '{}' was {}".format(
         name, "updated" if partially_installed else "installed"
     )
     return ret
@@ -3570,6 +3555,6 @@ def mod_watch(name, **kwargs):
     return {
         "name": name,
         "changes": {},
-        "comment": "pkg.{0} does not work with the watch requisite".format(sfun),
+        "comment": "pkg.{} does not work with the watch requisite".format(sfun),
         "result": False,
     }

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1488,9 +1488,14 @@ def installed(
 
     :param bool hold:
         Force the package to be held at the current installed version.
-        Currently works with YUM/DNF & APT based systems.
+
+        Supported on YUM/DNF & APT based systems.
 
         .. versionadded:: 2014.7.0
+
+        Supported on Zypper-based systems.
+
+        .. versionadded:: 3003
 
     :param bool update_holds:
         If ``True``, and this function would update the package version, any
@@ -1499,9 +1504,13 @@ def installed(
         package, the held package(s) will be skipped and the state will fail.
         By default, this parameter is set to ``False``.
 
-        Currently works with YUM/DNF & APT based systems.
+        Supported on YUM/DNF & APT based systems.
 
         .. versionadded:: 2016.11.0
+
+        Supported on Zypper-based systems.
+
+        .. versionadded:: 3003
 
     :param list names:
         A list of packages to install from a software repository. Each package

--- a/tests/integration/states/test_pkg.py
+++ b/tests/integration/states/test_pkg.py
@@ -556,7 +556,11 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
 
         # changes from pkg.hold for Red Hat family are different
         target_changes = {}
-        if grains["os_family"] == "RedHat" or grains["os"] == "FreeBSD":
+        if (
+            grains["os_family"] == "RedHat"
+            or grains["os"] == "FreeBSD"
+            or grains["os_family"] == "Suse"
+        ):
             target_changes = {"new": "hold", "old": ""}
         elif grains["os_family"] == "Debian":
             target_changes = {"new": "hold", "old": "install"}


### PR DESCRIPTION
Port of #50773.

----

### What does this PR do?

Deprecates `add_lock` and `remove_lock` in favour of `hold` and `unhold` functions.

### What issues does this PR fix or reference?

Fixes: #56922 (as part of making the original PR work)

### Merge requirements satisfied?

- [x] Docs
- [x] Changelog
- [x] Tests written/updated*: There are no new tests, but moving the functionality here to `hold`/`unhold` activated a handful of package integration tests (which flushed out some bugs)

### Commits signed with GPG?

No