### PR TITLE
Fix traceback on win_system module import

### DIFF
--- a/salt/utils/win_system.py
+++ b/salt/utils/win_system.py
@@ -6,6 +6,9 @@ Functions shared with salt.modules.win_system and salt.grains.pending_reboot
 
 .. versionadded:: Sodium
 """
+# NOTE: DO NOT USE RAW STRINGS IN THIS MODULE! UNICODE_LITERALS DOES NOT PLAY
+# NICELY WITH RAW STRINGS CONTAINING \u or \U.
+
 # When production windows installer is using Python 3, Python 2 code can be removed
 from __future__ import absolute_import, print_function, unicode_literals
 
@@ -30,7 +33,7 @@ log = logging.getLogger(__name__)
 
 # Define the module's virtual name
 __virtualname__ = "win_system"
-MINION_VOLATILE_KEY = r"SYSTEM\CurrentControlSet\Services\salt-minion\Volatile-Data"
+MINION_VOLATILE_KEY = "SYSTEM\\CurrentControlSet\\Services\\salt-minion\\Volatile-Data"
 REBOOT_REQUIRED_NAME = "Reboot required"
 
 
@@ -100,7 +103,7 @@ def get_pending_computer_name():
     try:
         pending = salt.utils.win_reg.read_value(
             hive="HKLM",
-            key=r"SYSTEM\CurrentControlSet\Services\Tcpip\Parameters",
+            key="SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters",
             vname="NV Hostname",
         )["vdata"]
     except TypeError:
@@ -112,15 +115,15 @@ def get_pending_computer_name():
 
 
 def get_pending_component_servicing():
-    r"""
+    """
     Determine whether there are pending Component Based Servicing tasks that
     require a reboot.
 
     If any the following registry keys exist then a reboot is pending:
 
-    ``HKLM:\\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending``
-    ``HKLM:\\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootInProgress``
-    ``HKLM:\\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\PackagesPending``
+    ``HKLM:\\\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Component Based Servicing\\RebootPending``
+    ``HKLM:\\\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Component Based Servicing\\RebootInProgress``
+    ``HKLM:\\\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Component Based Servicing\\PackagesPending``
 
     .. versionadded:: Sodium
 
@@ -136,22 +139,22 @@ def get_pending_component_servicing():
     """
     # So long as the registry key exists, a reboot is pending
     key = (
-        r"SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based "
-        r"Servicing\RebootPending"
+        "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Component Based "
+        "Servicing\\RebootPending"
     )
     if salt.utils.win_reg.key_exists(hive="HKLM", key=key):
         return True
 
     key = (
-        r"SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based "
-        r"Servicing\RebootInProgress"
+        "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Component Based "
+        "Servicing\\RebootInProgress"
     )
     if salt.utils.win_reg.key_exists(hive="HKLM", key=key):
         return True
 
     key = (
-        r"SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based "
-        r"Servicing\PackagesPending"
+        "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Component Based "
+        "Servicing\\PackagesPending"
     )
     if salt.utils.win_reg.key_exists(hive="HKLM", key=key):
         return True
@@ -160,14 +163,14 @@ def get_pending_component_servicing():
 
 
 def get_pending_domain_join():
-    r"""
+    """
     Determine whether there is a pending domain join action that requires a
     reboot.
 
     If any the following registry keys exist then a reboot is pending:
 
-    ``HKLM:\\SYSTEM\CurrentControlSet\Services\Netlogon\AvoidSpnSet``
-    ``HKLM:\\SYSTEM\CurrentControlSet\Services\Netlogon\JoinDomain``
+    ``HKLM:\\\\SYSTEM\\CurrentControlSet\\Services\\Netlogon\\AvoidSpnSet``
+    ``HKLM:\\\\SYSTEM\\CurrentControlSet\\Services\\Netlogon\\JoinDomain``
 
     .. versionadded:: Sodium
 
@@ -182,9 +185,9 @@ def get_pending_domain_join():
         import salt.utils.win_system
         salt.utils.win_system.get_pending_domain_join()
     """
-    base_key = r"SYSTEM\CurrentControlSet\Services\Netlogon"
-    avoid_key = r"{0}\AvoidSpnSet".format(base_key)
-    join_key = r"{0}\JoinDomain".format(base_key)
+    base_key = "SYSTEM\\CurrentControlSet\\Services\\Netlogon"
+    avoid_key = "{0}\\AvoidSpnSet".format(base_key)
+    join_key = "{0}\\JoinDomain".format(base_key)
 
     # If either the avoid_key or join_key is present,
     # then there is a reboot pending.
@@ -198,7 +201,7 @@ def get_pending_domain_join():
 
 
 def get_pending_file_rename():
-    r"""
+    """
     Determine whether there are pending file rename operations that require a
     reboot.
 
@@ -210,7 +213,7 @@ def get_pending_file_rename():
 
     in the following registry key:
 
-    ``HKLM:\\SYSTEM\CurrentControlSet\Control\Session Manager``
+    ``HKLM:\\\\SYSTEM\\CurrentControlSet\\Control\\Session Manager``
 
     .. versionadded:: Sodium
 
@@ -226,7 +229,7 @@ def get_pending_file_rename():
         salt.utils.win_system.get_pending_file_rename()
     """
     vnames = ("PendingFileRenameOperations", "PendingFileRenameOperations2")
-    key = r"SYSTEM\CurrentControlSet\Control\Session Manager"
+    key = "SYSTEM\\CurrentControlSet\\Control\\Session Manager"
     for vname in vnames:
         reg_ret = salt.utils.win_reg.read_value(hive="HKLM", key=key, vname=vname)
         if reg_ret["success"]:
@@ -236,14 +239,14 @@ def get_pending_file_rename():
 
 
 def get_pending_servermanager():
-    r"""
+    """
     Determine whether there are pending Server Manager tasks that require a
     reboot.
 
     A reboot is pending if the ``CurrentRebootAttempts`` value name exists and
     has an integer value. The value name resides in the following registry key:
 
-    ``HKLM:\\SOFTWARE\Microsoft\ServerManager``
+    ``HKLM:\\\\SOFTWARE\\Microsoft\\ServerManager``
 
     .. versionadded:: Sodium
 
@@ -259,7 +262,7 @@ def get_pending_servermanager():
         salt.utils.win_system.get_pending_servermanager()
     """
     vname = "CurrentRebootAttempts"
-    key = r"SOFTWARE\Microsoft\ServerManager"
+    key = "SOFTWARE\\Microsoft\\ServerManager"
 
     # There are situations where it's possible to have '(value not set)' as
     # the value data, and since an actual reboot won't be pending in that
@@ -276,13 +279,13 @@ def get_pending_servermanager():
 
 
 def get_pending_dvd_reboot():
-    r"""
+    """
     Determine whether the DVD Reboot flag is set.
 
     The system requires a reboot if the ``DVDRebootSignal`` value name exists
     at the following registry location:
 
-    ``HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce``
+    ``HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\RunOnce``
 
     .. versionadded:: Sodium
 
@@ -299,24 +302,24 @@ def get_pending_dvd_reboot():
     # So long as the registry key exists, a reboot is pending.
     return salt.utils.win_reg.value_exists(
         hive="HKLM",
-        key=r"SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce",
+        key="SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\RunOnce",
         vname="DVDRebootSignal",
     )
 
 
 def get_pending_update():
-    r"""
+    """
     Determine whether there are pending updates that require a reboot.
 
     If either of the following registry keys exists, a reboot is pending:
 
-    ``HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired``
-    ``HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\PostRebootReporting``
+    ``HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\WindowsUpdate\\Auto Update\\RebootRequired``
+    ``HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\WindowsUpdate\\Auto Update\\PostRebootReporting``
 
     If there are any subkeys under the following registry key, a reboot is
     pending:
 
-    ``HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Services\Pending``
+    ``HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\WindowsUpdate\\Services\\Pending``
 
     .. versionadded:: Sodium
 
@@ -333,22 +336,23 @@ def get_pending_update():
     """
     # So long as the registry key exists, a reboot is pending.
     key = (
-        r"SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto "
-        r"Update\RebootRequired"
+        "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\WindowsUpdate\\Auto "
+        "Update\\RebootRequired"
     )
     if salt.utils.win_reg.key_exists(hive="HKLM", key=key):
         return True
 
     key = (
-        r"SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto "
-        r"Update\PostRebootReporting"
+        "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\WindowsUpdate\\Auto "
+        "Update\\PostRebootReporting"
     )
     if salt.utils.win_reg.key_exists(hive="HKLM", key=key):
         return True
 
     # So long as the registry key has subkeys, a reboot is pending.
     key = (
-        r"SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Services" r"\Pending"
+        "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\WindowsUpdate\\Services"
+        "\\Pending"
     )
     list_keys = salt.utils.win_reg.list_keys(hive="HKLM", key=key)
     if len(list_keys) > 0:
@@ -358,7 +362,7 @@ def get_pending_update():
 
 
 def get_reboot_required_witnessed():
-    r"""
+    """
     Determine if at any time during the current boot session the salt minion
     witnessed an event indicating that a reboot is required.
 
@@ -369,7 +373,7 @@ def get_reboot_required_witnessed():
     If the ``Reboot required`` value name exists in the following location and
     has a value of ``1`` then the system is pending reboot:
 
-    ``HKLM:\\SYSTEM\CurrentControlSet\Services\salt-minion\Volatile-Data``
+    ``HKLM:\\\\SYSTEM\\CurrentControlSet\\Services\\salt-minion\\Volatile-Data``
 
     .. versionadded:: Sodium
 
@@ -392,7 +396,7 @@ def get_reboot_required_witnessed():
 
 
 def set_reboot_required_witnessed():
-    r"""
+    """
     This function is used to remember that an event indicating that a reboot is
     required was witnessed. This function relies on the salt-minion's ability to
     create the following volatile registry key in the *HKLM* hive:
@@ -430,10 +434,10 @@ def set_reboot_required_witnessed():
 
 
 def get_pending_update_exe_volatile():
-    r"""
+    """
     Determine whether there is a volatile update exe that requires a reboot.
 
-    Checks ``HKLM:\Microsoft\Updates``. If the ``UpdateExeVolatile`` value name
+    Checks ``HKLM:\\Microsoft\\Updates``. If the ``UpdateExeVolatile`` value name
     is anything other than 0 there is a reboot pending
 
     .. versionadded:: Sodium
@@ -448,7 +452,7 @@ def get_pending_update_exe_volatile():
         import salt.utils.win_system
         salt.utils.win_system.get_pending_update_exe_volatile()
     """
-    key = r"SOFTWARE\Microsoft\Updates"
+    key = "SOFTWARE\\Microsoft\\Updates"
     reg_ret = salt.utils.win_reg.read_value(
         hive="HKLM", key=key, vname="UpdateExeVolatile"
     )

--- a/tests/unit/utils/test_win_system.py
+++ b/tests/unit/utils/test_win_system.py
@@ -7,11 +7,27 @@ import os
 
 # Import Salt Libs
 import salt.utils.platform
-import salt.utils.win_system as win_system
 
 # Import Salt Testing Libs
 from tests.support.mock import patch
 from tests.support.unit import TestCase, skipIf
+
+try:
+    import salt.utils.win_system as win_system
+except Exception as exc:  # pylint: disable=broad-except
+    win_system = exc
+
+
+class WinSystemImportTestCase(TestCase):
+    """
+    Simply importing should not raise an error, especially on Linux
+    """
+
+    def test_import(self):
+        if isinstance(win_system, Exception):
+            raise Exception(
+                "Importing win_system caused traceback: {0}".format(win_system)
+            )
 
 
 @skipIf(not salt.utils.platform.is_windows(), "Only test on Windows systems")


### PR DESCRIPTION
`unicode_literals` does not play nicely with `\u` or `\U`.

```
>>> r'C:\users'
'C:\\users'
>>> r'C:\Users'
'C:\\Users'
>>> from __future__ import unicode_literals
>>> r'C:\users'
  File "<stdin>", line 1
SyntaxError: (unicode error) 'rawunicodeescape' codec can't decode bytes in position 2-3: truncated \uXXXX
>>> r'C:\Users'
  File "<stdin>", line 1
SyntaxError: (unicode error) 'rawunicodeescape' codec can't decode bytes in position 2-3: truncated \uXXXX
```