### PR TITLE
Fix broken ps.top

### DIFF
--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -155,7 +155,10 @@ def top(num_processes=5, interval=3):
     time.sleep(interval)
     usage = set()
     for process, start in six.iteritems(start_usage):
-        user, system = process.cpu_times()[:2]
+        try:
+            user, system = process.cpu_times()[:2]
+        except psutil.NoSuchProcess:
+            continue
         now = user + system
         diff = now - start
         usage.add((diff, process))

--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -163,11 +163,7 @@ def top(num_processes=5, interval=3):
         diff = now - start
         usage.add((diff, process))
 
-    for idx, (diff, process) in enumerate(
-        sorted(usage, key=lambda x: x[0], reverse=True)
-    ):
-        if num_processes and idx >= num_processes:
-            break
+    for diff, process in sorted(usage, key=lambda x: x[0], reverse=True):
         info = {
             "cmd": _get_proc_cmdline(process) or _get_proc_name(process),
             "user": _get_proc_username(process),
@@ -187,7 +183,12 @@ def top(num_processes=5, interval=3):
             # function. Ignore this process and do not include this process in
             # the return data.
             continue
+
         result.append(info)
+
+        # Stop gathering process info since we've reached the desired number
+        if len(result) >= num_processes:
+            break
 
     return result
 

--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -178,10 +178,16 @@ def top(num_processes=5, interval=3):
             "cpu": {},
             "mem": {},
         }
-        for key, value in six.iteritems(process.cpu_times()._asdict()):
-            info["cpu"][key] = value
-        for key, value in six.iteritems(process.memory_info()._asdict()):
-            info["mem"][key] = value
+        try:
+            for key, value in six.iteritems(process.cpu_times()._asdict()):
+                info["cpu"][key] = value
+            for key, value in six.iteritems(process.memory_info()._asdict()):
+                info["mem"][key] = value
+        except psutil.NoSuchProcess:
+            # Process ended since psutil.pids() was run earlier in this
+            # function. Ignore this process and do not include this process in
+            # the return data.
+            continue
         result.append(info)
 
     return result

--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -147,26 +147,22 @@ def top(num_processes=5, interval=3):
     for pid in psutil.pids():
         try:
             process = psutil.Process(pid)
-            user, system = process.cpu_times()
-        except ValueError:
-            user, system, _, _ = process.cpu_times()
         except psutil.NoSuchProcess:
             continue
+        else:
+            user, system = process.cpu_times()[:2]
         start_usage[process] = user + system
     time.sleep(interval)
     usage = set()
     for process, start in six.iteritems(start_usage):
-        try:
-            user, system = process.cpu_times()
-        except ValueError:
-            user, system, _, _ = process.cpu_times()
-        except psutil.NoSuchProcess:
-            continue
+        user, system = process.cpu_times()[:2]
         now = user + system
         diff = now - start
         usage.add((diff, process))
 
-    for idx, (diff, process) in enumerate(reversed(sorted(usage))):
+    for idx, (diff, process) in enumerate(
+        sorted(usage, key=lambda x: x[1].pid, reverse=True)
+    ):
         if num_processes and idx >= num_processes:
             break
         if len(_get_proc_cmdline(process)) == 0:

--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -168,12 +168,8 @@ def top(num_processes=5, interval=3):
     ):
         if num_processes and idx >= num_processes:
             break
-        if len(_get_proc_cmdline(process)) == 0:
-            cmdline = _get_proc_name(process)
-        else:
-            cmdline = _get_proc_cmdline(process)
         info = {
-            "cmd": cmdline,
+            "cmd": _get_proc_cmdline(process) or _get_proc_name(process),
             "user": _get_proc_username(process),
             "status": _get_proc_status(process),
             "pid": _get_proc_pid(process),

--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -164,7 +164,7 @@ def top(num_processes=5, interval=3):
         usage.add((diff, process))
 
     for idx, (diff, process) in enumerate(
-        sorted(usage, key=lambda x: x[1].pid, reverse=True)
+        sorted(usage, key=lambda x: x[0], reverse=True)
     ):
         if num_processes and idx >= num_processes:
             break

--- a/tests/unit/modules/test_ps.py
+++ b/tests/unit/modules/test_ps.py
@@ -312,12 +312,14 @@ class PsTestCase(TestCase):
 
     def test_top(self):
         """
-        There's no need to do any asserts here. Merely running the function
-        should not raise a traceback. See the following issue:
+        See the following issue:
 
         https://github.com/saltstack/salt/issues/56942
         """
-        ps.top()
+        # Limiting to one process because the test suite might be running as
+        # PID 1 under docker and there may only *be* one process running.
+        result = ps.top(num_processes=1, interval=0)
+        assert len(result) == 1
 
         ## This is commented out pending discussion on https://github.com/saltstack/salt/commit/2e5c3162ef87cca8a2c7b12ade7c7e1b32028f0a
         # @skipIf(not HAS_UTMP, "The utmp module must be installed to run test_get_users_utmp()")

--- a/tests/unit/modules/test_ps.py
+++ b/tests/unit/modules/test_ps.py
@@ -310,6 +310,15 @@ class PsTestCase(TestCase):
                 ps.get_users()[0],
             )
 
+    def test_top(self):
+        """
+        There's no need to do any asserts here. Merely running the function
+        should not raise a traceback. See the following issue:
+
+        https://github.com/saltstack/salt/issues/56942
+        """
+        ps.top()
+
         ## This is commented out pending discussion on https://github.com/saltstack/salt/commit/2e5c3162ef87cca8a2c7b12ade7c7e1b32028f0a
         # @skipIf(not HAS_UTMP, "The utmp module must be installed to run test_get_users_utmp()")
         # @patch('salt.utils.psutil_compat.get_users', new=MagicMock(return_value=None))  # This will force the function to use utmp


### PR DESCRIPTION
This fixes two problems:

1. Poorly-designed handling of unpacking selective items from a `psutil.Process` instance, leading to a `ValueError`. This is fixed by slicing.

2. `psutil.Process` objects are not sortable on Python 3. Fixed by using a key lambda to sort on the `pid` attribute.

Resolves #56942