### PR TITLE
Fix stacktrace in return from win_pkg

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1651,7 +1651,7 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
                     try:
                         cached_file = __salt__["cp.cache_file"](cache_file, saltenv)
                     except MinionError as exc:
-                        msg = "Failed to cache {0}".foromat(cache_file)
+                        msg = "Failed to cache {0}".format(cache_file)
                         log.exception(msg, exc_info=exc)
                         return "{0}\n{1}".format(msg, exc)
 

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1024,7 +1024,7 @@ def refresh_db(**kwargs):
         )
     except MinionError as exc:
         log.exception(
-            "Failed to cache %s" % repo_details.winrepo_source_dir, exc_info=exc
+            "Failed to cache %s", repo_details.winrepo_source_dir, exc_info=exc
         )
     return genrepo(saltenv=saltenv, verbose=verbose, failhard=failhard)
 
@@ -1308,11 +1308,13 @@ def _get_source_sum(source_hash, file_path, saltenv):
         try:
             cached_hash_file = __salt__["cp.cache_file"](source_hash, saltenv)
         except MinionError as exc:
-            log.exception("Failed to cache %s" % source_hash, exc_info=exc)
+            log.exception("Failed to cache %s", source_hash, exc_info=exc)
             raise
 
         if not cached_hash_file:
-            raise CommandExecutionError("Source hash file %s not found" % source_hash)
+            raise CommandExecutionError(
+                "Source hash file {0} not found".format(source_hash)
+            )
 
         ret = __salt__["file.extract_hash"](cached_hash_file, "", file_path)
         if ret is None:
@@ -1625,9 +1627,9 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
                         exclude_pat="E@init.sls$",
                     )
                 except MinionError as exc:
-                    msg = "Failed to cache %s" % path
+                    msg = "Failed to cache {0}".format(path)
                     log.exception(msg, exc_info=exc)
-                    return "%s\n%s" % (msg, exc)
+                    return "{0}\n{1}".format(msg, exc)
 
             # Check to see if the cache_file is cached... if passed
             if cache_file and cache_file.startswith("salt:"):
@@ -1638,9 +1640,9 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
                     try:
                         cached_file = __salt__["cp.cache_file"](cache_file, saltenv)
                     except MinionError as exc:
-                        msg = "Failed to cache %s" % cache_file
+                        msg = "Failed to cache {0}".format(cache_file)
                         log.exception(msg, exc_info=exc)
-                        return "%s\n%s" % (msg, exc)
+                        return "{0}\n{1}".format(msg, exc)
 
                 # Make sure the cached file is the same as the source
                 if __salt__["cp.hash_file"](cache_file, saltenv) != __salt__[
@@ -1649,9 +1651,9 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
                     try:
                         cached_file = __salt__["cp.cache_file"](cache_file, saltenv)
                     except MinionError as exc:
-                        msg = "Failed to cache %s" % cache_file
+                        msg = "Failed to cache {0}".foromat(cache_file)
                         log.exception(msg, exc_info=exc)
-                        return "%s\n%s" % (msg, exc)
+                        return "{0}\n{1}".format(msg, exc)
 
                     # Check if the cache_file was cached successfully
                     if not cached_file:
@@ -1666,9 +1668,9 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
                 try:
                     cached_pkg = __salt__["cp.cache_file"](installer, saltenv)
                 except MinionError as exc:
-                    msg = "Failed to cache %s" % installer
+                    msg = "Failed to cache {0}".format(installer)
                     log.exception(msg, exc_info=exc)
-                    return "%s\n%s" % (msg, exc)
+                    return "{0}\n{1}".format(msg, exc)
 
                 # Check if the installer was cached successfully
                 if not cached_pkg:
@@ -1687,9 +1689,9 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
                     try:
                         cached_pkg = __salt__["cp.cache_file"](installer, saltenv)
                     except MinionError as exc:
-                        msg = "Failed to cache %s" % installer
+                        msg = "Failed to cache {0}".format(installer)
                         log.exception(msg, exc_info=exc)
-                        return "%s\n%s" % (msg, exc)
+                        return "{0}\n{1}".format(msg, exc)
 
                     # Check if the installer was cached successfully
                     if not cached_pkg:
@@ -1725,7 +1727,7 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
 
             if source_sum["hsum"] != cached_pkg_sum:
                 raise SaltInvocationError(
-                    ("Source hash '{0}' does not match package hash" " '{1}'").format(
+                    "Source hash '{0}' does not match package hash '{1}'".format(
                         source_sum["hsum"], cached_pkg_sum
                     )
                 )
@@ -2057,9 +2059,9 @@ def remove(name=None, pkgs=None, **kwargs):
                             path, saltenv, False, None, "E@init.sls$"
                         )
                     except MinionError as exc:
-                        msg = "Failed to cache %s" % path
+                        msg = "Failed to cache {0}".format(path)
                         log.exception(msg, exc_info=exc)
-                        return "%s\n%s" % (msg, exc)
+                        return "{0}\n{1}".format(msg, exc)
 
                 # Check to see if the uninstaller is cached
                 cached_pkg = __salt__["cp.is_cached"](uninstaller, saltenv)
@@ -2068,9 +2070,9 @@ def remove(name=None, pkgs=None, **kwargs):
                     try:
                         cached_pkg = __salt__["cp.cache_file"](uninstaller, saltenv)
                     except MinionError as exc:
-                        msg = "Failed to cache %s" % uninstaller
+                        msg = "Failed to cache {0}".format(uninstaller)
                         log.exception(msg, exc_info=exc)
-                        return "%s\n%s" % (msg, exc)
+                        return "{0}\n{1}".format(msg, exc)
 
                     # Check if the uninstaller was cached successfully
                     if not cached_pkg:
@@ -2088,9 +2090,9 @@ def remove(name=None, pkgs=None, **kwargs):
                         try:
                             cached_pkg = __salt__["cp.cache_file"](uninstaller, saltenv)
                         except MinionError as exc:
-                            msg = "Failed to cache %s" % uninstaller
+                            msg = "Failed to cache {0}".format(uninstaller)
                             log.exception(msg, exc_info=exc)
-                            return "%s\n%s" % (msg, exc)
+                            return "{0}\n{1}".format(msg, exc)
 
                         # Check if the installer was cached successfully
                         if not cached_pkg:

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -609,8 +609,9 @@ class GitProvider(object):
         # According to stackoverflow (http://goo.gl/l74GC8), we are setting LANGUAGE as well
         # just to be sure.
         env = os.environ.copy()
-        env[b"LANGUAGE"] = b"C"
-        env[b"LC_ALL"] = b"C"
+        if not salt.utils.platform.is_windows():
+            env[b"LANGUAGE"] = b"C"
+            env[b"LC_ALL"] = b"C"
 
         cmd = subprocess.Popen(
             shlex.split(cmd_str),


### PR DESCRIPTION
### What does this PR do?
Returns a meaningful message without the stacktrace
Adds some tests

Instead of stacktracing, the return will look more like this:
```
C:\dev\salt>salt-call --local state.apply t.pkg.install_salt
[ERROR   ] Failed to cache https://repo.saltstack.com/windows/Salt-Minion-3000.1-Py3-AMD64-Setup.exe
Traceback (most recent call last):
  File "c:\dev\salt\salt\modules\win_pkg.py", line 1667, in install
    cached_pkg = __salt__["cp.cache_file"](installer, saltenv)
  File "c:\dev\salt\salt\modules\cp.py", line 500, in cache_file
    result = _client().cache_file(path, saltenv, source_hash=source_hash)
  File "c:\dev\salt\salt\fileclient.py", line 189, in cache_file
    path, "", True, saltenv, cachedir=cachedir, source_hash=source_hash
  File "c:\dev\salt\salt\fileclient.py", line 738, in get_url
    raise MinionError("Error: {0} reading {1}".format(query["error"], url))
salt.exceptions.MinionError: Error: [Errno 11001] getaddrinfo failed reading https://repo.saltstack.com/windows/Salt-Minion-3000.1-Py3-AMD64-Setup.exe
[ERROR   ] The following packages failed to install/update: salt-minion-py3=3000.1
Failed to cache https://repo.saltstack.com/windows/Salt-Minion-3000.1-Py3-AMD64-Setup.exe
Error: [Errno 11001] getaddrinfo failed reading https://repo.saltstack.com/windows/Salt-Minion-3000.1-Py3-AMD64-Setup.exe
local:
----------
          ID: salt minion installed
    Function: pkg.installed
        Name: salt-minion-py3
      Result: False
     Comment: The following packages failed to install/update: salt-minion-py3=3000.1
              Failed to cache https://repo.saltstack.com/windows/Salt-Minion-3000.1-Py3-AMD64-Setup.exe
              Error: [Errno 11001] getaddrinfo failed reading https://repo.saltstack.com/windows/Salt-Minion-3000.1-Py3-AMD64-Setup.exe
     Started: 16:28:04.761120
    Duration: 8296.503 ms
     Changes:

Summary for local
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time:   8.297 s
```

The stacktrace will be a part of the log and not the return to the master

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/56952

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
