### PR TITLE
fix: grains virtual on AWS

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -873,20 +873,26 @@ def _virtual(osdata):
                 break
         elif command == "virt-what":
             try:
-                output = output.splitlines()[-1]
+                lines = output.splitlines()
             except IndexError:
-                pass
-            if output in ("kvm", "qemu", "uml", "xen", "lxc"):
-                grains["virtual"] = output
-                break
-            elif "vmware" in output:
-                grains["virtual"] = "VMware"
-                break
-            elif "parallels" in output:
-                grains["virtual"] = "Parallels"
-                break
-            elif "hyperv" in output:
-                grains["virtual"] = "HyperV"
+                lines = [output]
+            found = True
+            for line in lines:
+                if line in ("kvm", "qemu", "uml", "xen", "lxc"):
+                    grains["virtual"] = line
+                    break
+                elif "vmware" in line:
+                    grains["virtual"] = "VMware"
+                    break
+                elif "parallels" in line:
+                    grains["virtual"] = "Parallels"
+                    break
+                elif "hyperv" in line:
+                    grains["virtual"] = "HyperV"
+                    break
+            else:
+                found = False
+            if found:
                 break
         elif command == "dmidecode":
             # Product Name: VirtualBox


### PR DESCRIPTION
virt-what detects `kvm` and `aws`.

Properly detects `kvm` as `virtual`.

### What does this PR do?

Fix the `virtual` detection via `virt-what`

### What issues does this PR fix or reference?

On AWS, Debian/buster, I noticed `virtual` grain was set to `physical`.

Fixed it to proprely detect `kvm`.

```
# dpkg -l virt-what
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name           Version      Architecture Description
+++-==============-============-============-=============================================
ii  virt-what      1.19-1       amd64        detect if we are running in a virtual machine
# virt-what 
kvm
aws
# 
```


### Previous Behavior

```
# salt-call grains.item virtual
local:
    ----------
    virtual:
        physical
```

### New Behavior


```
# salt-call grains.item virtual
local:
    ----------
    virtual:
        kvm
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [ ] Docs
- [ ] Changelog
- [ ] Tests written/updated

Not sure how to add tests, as they would require a specific EC2 instance, and if there were already such, it might have been detected earlier.

### Commits signed with GPG?
Yes