### PR TITLE
Skip TOMLRendererTestCase if toml is missing

### DIFF
--- a/tests/unit/renderers/test_toml.py
+++ b/tests/unit/renderers/test_toml.py
@@ -5,12 +5,14 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt libs
 import salt.renderers.toml as toml
+import salt.serializers.toml
 
 # Import Salt Testing libs
 from tests.support.mixins import LoaderModuleMockMixin
-from tests.support.unit import TestCase
+from tests.support.unit import TestCase, skipIf
 
 
+@skipIf(not salt.serializers.toml.available, "The 'toml' library is missing")
 class TOMLRendererTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         return {toml: {}}


### PR DESCRIPTION
If the toml library is missing, `TOMLRendererTestCase` will fail:

```
======================================================================
ERROR: test_toml_render_string (unit.renderers.test_toml.TOMLRendererTestCase)
[CPU:0.0%|MEM:26.0%]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "salt/serializers/toml.py", line 46, in deserialize
    return toml.loads(stream_or_string)
NameError: name 'toml' is not defined

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "tests/unit/renderers/test_toml.py", line 38, in test_toml_render_string
    result = toml.render(data)
  File "salt/renderers/toml.py", line 23, in render
    data = deserialize(sls_data) or {}
  File "salt/serializers/toml.py", line 48, in deserialize
    raise DeserializationError(error)
salt.serializers.DeserializationError: name 'toml' is not defined
```