### PR TITLE
Fix shell in CMDMODTestCase.test_run_chroot_runas

### DIFF
--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -630,7 +630,7 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
             cmdmod.__salt__, {"mount.mount": MagicMock(), "mount.umount": MagicMock()}
         ):
             with patch("salt.modules.cmdmod.run_all") as run_all_mock:
-                cmdmod.run_chroot("/mnt", "ls", runas="foobar")
+                cmdmod.run_chroot("/mnt", "ls", runas="foobar", shell="/bin/sh")
         run_all_mock.assert_called_with(
             "chroot --userspec foobar: /mnt /bin/sh -c ls",
             bg=False,
@@ -647,7 +647,7 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
             reset_system_locale=True,
             rstrip=True,
             saltenv="base",
-            shell="/bin/bash",
+            shell="/bin/sh",
             stdin=None,
             success_retcodes=None,
             template=None,


### PR DESCRIPTION
cmdmod.run_chroot uses `DEFAULT_SHELL` which might vary on different systems and causes `CMDMODTestCase.test_run_chroot_runas` to fail:

```
======================================================================
FAIL: test_run_chroot_runas (unit.modules.test_cmdmod.CMDMODTestCase)
[CPU:0.0%|MEM:26.0%] Test run_chroot when a runas parameter is provided
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/unit/modules/test_cmdmod.py", line 634, in test_run_chroot_runas
    run_all_mock.assert_called_with(
  File "/usr/lib/python3.8/unittest/mock.py", line 913, in assert_called_with
    raise AssertionError(_error_message()) from cause
AssertionError: expected call not found.
Expected: run_all('chroot --userspec foobar: /mnt /bin/sh -c ls', bg=False, clean_env=False, cwd=None, env=None, ignore_retcode=False, log_callback=None, output_encoding=None, output_loglevel='quiet', pillar=None, pillarenv=None, python_shell=True, reset_system_locale=True, rstrip=True, saltenv='base', shell='/bin/bash', stdin=None, success_retcodes=None, template=None, timeout=None, umask=None, use_vt=False)
Actual: run_all('chroot --userspec foobar: /mnt /bin/sh -c ls', cwd=None, stdin=None, shell='/bin/sh', python_shell=True, env=None, clean_env=False, template=None, rstrip=True, umask=None, output_encoding=None, output_loglevel='quiet', log_callback=None, timeout=None, reset_system_locale=True, ignore_retcode=False, saltenv='base', pillarenv=None, pillar=None, use_vt=False, success_retcodes=None, bg=False)

----------------------------------------------------------------------
```

This can be easily reproduced by running:

```
env -i python3 ./tests/runtests.py -v --no-report -n unit.modules.test_cmdmod.CMDMODTestCase.test_run_chroot_runas
```

Fix the test case by specifying a shell when calling `cmdmod.run_chroot`.