### PR TITLE
Fix condition for ConfigTestCase.test_datetime_config_validation

### DIFF
--- a/tests/unit/utils/test_schema.py
+++ b/tests/unit/utils/test_schema.py
@@ -45,13 +45,6 @@ try:
     HAS_STRICT_RFC3339 = True
 except ImportError:
     HAS_STRICT_RFC3339 = False
-
-try:
-    import isodate
-
-    HAS_ISODATE = True
-except ImportError:
-    HAS_ISODATE = False
 # pylint: enable=unused-import
 
 
@@ -876,10 +869,7 @@ class ConfigTestCase(TestCase):
         )
 
     @skipIf(HAS_JSONSCHEMA is False, "The 'jsonschema' library is missing")
-    @skipIf(
-        any([HAS_ISODATE, HAS_STRICT_RFC3339]) is False,
-        "The 'strict_rfc3339' or 'isodate' library is missing",
-    )
+    @skipIf(not HAS_STRICT_RFC3339, "The 'strict_rfc3339' library is missing")
     def test_datetime_config_validation(self):
         class TestConf(schema.Schema):
             item = schema.DateTimeItem(title="Item", description="Item description")


### PR DESCRIPTION
The `jsonschema` library only uses `strict_rfc3339` and not `isodate`. The test case `ConfigTestCase.test_datetime_config_validation` will fail if `isodate` is available but not `strict_rfc3339`:

```
======================================================================
FAIL: test_datetime_config_validation (unit.utils.test_schema.ConfigTestCase)
[CPU:0.0%|MEM:26.0%]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/unit/utils/test_schema.py", line 897, in test_datetime_config_validation
    jsonschema.validate(
AssertionError: ValidationError not raised

----------------------------------------------------------------------
```

Therefore require `strict_rfc3339` to be present for running `ConfigTestCase.test_datetime_config_validation`.

fixes #55936