### PR TITLE
Fix deprecation warnings for imports from collections

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -59,9 +59,9 @@ from salt.ext.six.moves.urllib.parse import urlparse as _urlparse
 from salt.utils.files import HASHES, HASHES_REVMAP
 
 try:
-    from collections import Iterable, Mapping
-except ImportError:
     from collections.abc import Iterable, Mapping
+except ImportError:
+    from collections import Iterable, Mapping
 
 
 # pylint: enable=import-error,no-name-in-module,redefined-builtin

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -124,9 +124,9 @@ from salt.utils.functools import namespaced_function as _namespaced_function
 
 # pylint: disable=no-name-in-module
 try:
-    from collections import Iterable, Mapping
-except ImportError:
     from collections.abc import Iterable, Mapping
+except ImportError:
+    from collections import Iterable, Mapping
 # pylint: enable=no-name-in-module
 
 

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -320,9 +320,9 @@ from salt.state import get_accumulator_dir as _get_accumulator_dir
 
 # pylint: disable=no-name-in-module
 try:
-    from collections import Iterable, Mapping
-except ImportError:
     from collections.abc import Iterable, Mapping
+except ImportError:
+    from collections import Iterable, Mapping
 # pylint: enable=no-name-in-module
 
 


### PR DESCRIPTION
DeprecationWarning: Using or importing the ABCs from `collections` instead of from `collections.abc` is deprecated since Python 3.3, and in 3.9 it will stop working.

Therefore try to import the abstract base classes from `collections.abc` before falling back to `collections`.

In the merged commit 420bbe8c087b7fe8a57b7c075fc1ca86b409c8d6 I missed the import order for some files.