### PR TITLE
Fix literal comparison

### DIFF
--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -158,7 +158,7 @@ def _changes(
     elif "shadow.info" in __salt__ and salt.utils.platform.is_windows():
         if (
             expire
-            and expire is not -1
+            and expire != -1
             and salt.utils.dateutils.strftime(lshad["expire"])
             != salt.utils.dateutils.strftime(expire)
         ):


### PR DESCRIPTION
When building the documentation, sphinx prints following error message:

```
salt/states/user.py:161: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  and expire is not -1
```

Fix the literal comparison.