### PR TITLE
highstate_doc: Fix spelling mistake of process

### DIFF
--- a/salt/modules/highstate_doc.py
+++ b/salt/modules/highstate_doc.py
@@ -6,8 +6,8 @@ This module renders highstate configuration into a more human readable format.
 
 How it works:
 
-`highstate or lowstate` data is parsed with a `proccesser` this defaults to `highstate_doc.proccesser_markdown`.
-The proccessed data is passed to a `jinja` template that builds up the document content.
+`highstate or lowstate` data is parsed with a `processor` this defaults to `highstate_doc.processor_markdown`.
+The processed data is passed to a `jinja` template that builds up the document content.
 
 
 configuration: Pillar
@@ -17,11 +17,11 @@ configuration: Pillar
     # the following defaults can be overrided
     highstate_doc.config:
 
-        # list of regex of state names to ignore in `highstate_doc.proccess_lowstates`
+        # list of regex of state names to ignore in `highstate_doc.process_lowstates`
         filter_id_regex:
             - '.*!doc_skip$'
 
-        # list of regex of state functions to ignore in `highstate_doc.proccess_lowstates`
+        # list of regex of state functions to ignore in `highstate_doc.process_lowstates`
         filter_state_function_regex:
             - 'file.accumulated'
 
@@ -32,8 +32,8 @@ configuration: Pillar
         # limit size of files that can be included in doc (10000 bytes)
         max_render_file_size: 10000
 
-        # advanced option to set a custom lowstate proccesser
-        proccesser: highstate_doc.proccesser_markdown
+        # advanced option to set a custom lowstate processor
+        processor: highstate_doc.processor_markdown
 
 
 State example
@@ -47,7 +47,7 @@ State example
             - contents: |
                 example `highstate_doc.note`
                 ------------------
-                This state does not do anything to the system! It is only used by a `proccesser`
+                This state does not do anything to the system! It is only used by a `processor`
                 you can use `requisites` and `order` to move your docs around the rendered file.
 
     {{sls}} a file we don't want in the doc !doc_skip:
@@ -118,14 +118,14 @@ You can use pandoc to create HTML versions of the markdown.
 
 .. code-block:: bash
 
-    # proccess all the readme.md files to readme.html
+    # process all the readme.md files to readme.html
     if which pandoc; then echo "Found pandoc"; else echo "** Missing pandoc"; exit 1; fi
     if which gs; then echo "Found gs"; else echo "** Missing gs(ghostscript)"; exit 1; fi
     readme_files=$(find $dest -type f -path "*/README.md" -print)
     for f in $readme_files ; do
         ff=${f#$dest/}
         minion=${ff%%/*}
-        echo "proccess: $dest/${minion}/$(basename $f)"
+        echo "process: $dest/${minion}/$(basename $f)"
         cat $dest/${minion}/$(basename $f) | \
             pandoc --standalone --from markdown_github --to html \
             --include-in-header $dest/style.html \
@@ -147,9 +147,9 @@ If you wish to customize the document format:
 
 .. code-block:: none
 
-    # you could also create a new `proccesser` for perhaps reStructuredText
+    # you could also create a new `processor` for perhaps reStructuredText
     # highstate_doc.config:
-    #     proccesser: doc_custom.proccesser_rst
+    #     processor: doc_custom.processor_rst
 
     # example `salt://makereadme.jinja`
     """
@@ -157,7 +157,7 @@ If you wish to customize the document format:
     ==========================================
 
     {# lowstates is set from highstate_doc.render() #}
-    {# if lowstates is missing use salt.highstate_doc.proccess_lowstates() #}
+    {# if lowstates is missing use salt.highstate_doc.process_lowstates() #}
     {% for s in lowstates %}
     {{s.id}}
     -----------------------------------------------------------------
@@ -388,7 +388,7 @@ def _get_config(**kwargs):
         "filter_id_regex": [".*!doc_skip"],
         "filter_function_regex": [],
         "replace_text_regex": {},
-        "proccesser": "highstate_doc.proccesser_markdown",
+        "processor": "highstate_doc.processor_markdown",
         "max_render_file_size": 10000,
         "note": None,
     }
@@ -459,7 +459,7 @@ def render(
 
     """
     config = _get_config(**kwargs)
-    lowstates = proccess_lowstates(**kwargs)
+    lowstates = process_lowstates(**kwargs)
     # TODO: __env__,
     context = {
         "saltenv": None,
@@ -478,7 +478,7 @@ def render(
         raise Exception("No jinja template text")
 
     txt = tpl.render_jinja_tmpl(template_text, context, tmplpath=None)
-    # after proccessing the template replace passwords or other data.
+    # after processing the template replace passwords or other data.
     rt = config.get("replace_text_regex")
     for r in rt:
         txt = re.sub(r, rt[r], txt)
@@ -498,16 +498,16 @@ def _blacklist_filter(s, config):
     return False
 
 
-def proccess_lowstates(**kwargs):
+def process_lowstates(**kwargs):
     """
-    return proccessed lowstate data that was not blacklisted
+    return processed lowstate data that was not blacklisted
 
     render_module_function is used to provide your own.
     defaults to from_lowstate
     """
     states = []
     config = _get_config(**kwargs)
-    proccesser = config.get("proccesser")
+    processor = config.get("processor")
     ls = __salt__["state.show_lowstate"]()
 
     if not isinstance(ls, list):
@@ -524,7 +524,7 @@ def proccess_lowstates(**kwargs):
     for s in ls:
         if _blacklist_filter(s, config):
             continue
-        doc = __salt__[proccesser](s, config, **kwargs)
+        doc = __salt__[processor](s, config, **kwargs)
         states.append(doc)
     return states
 
@@ -624,16 +624,16 @@ def _format_markdown_requisite(state, stateid, makelink=True):
         return " * `{0}`\n".format(fmt_id)
 
 
-def proccesser_markdown(lowstate_item, config, **kwargs):
+def processor_markdown(lowstate_item, config, **kwargs):
     """
-    Takes low state data and returns a dict of proccessed data
+    Takes low state data and returns a dict of processed data
     that is by default used in a jinja template when rendering a markdown highstate_doc.
 
     This `lowstate_item_markdown` given a lowstate item, returns a dict like:
 
     .. code-block:: none
 
-        vars:       # the raw lowstate_item that was proccessed
+        vars:       # the raw lowstate_item that was processed
         id:         # the 'id' of the state.
         id_full:    # combo of the state type and id "state: id"
         state:      # name of the salt state module

--- a/salt/states/highstate_doc.py
+++ b/salt/states/highstate_doc.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-To be used with proccessors in module `highstate_doc`.
+To be used with processors in module `highstate_doc`.
 """
 
 # Import Python libs
@@ -13,7 +13,7 @@ def note(name, source=None, contents=None, **kwargs):
     """
     Add content to a document generated using `highstate_doc.render`.
 
-    This state does not preform any tasks on the host. It only is used in highstate_doc lowstate proccessers
+    This state does not preform any tasks on the host. It only is used in highstate_doc lowstate processors
     to include extra documents.
 
     .. code-block:: yaml
@@ -26,7 +26,7 @@ def note(name, source=None, contents=None, **kwargs):
                 - contents: |
                     example `highstate_doc.note`
                     ------------------
-                    This state does not do anything to the system! It is only used by a `proccesser`
+                    This state does not do anything to the system! It is only used by a `processor`
                     you can use `requisites` and `order` to move your docs around the rendered file.
                     .. this message appare aboce the `pkg: somepackage` state.
                 - source: salt://{{tpldir}}/also_include_a_file.md


### PR DESCRIPTION
The word `process` and variants of it is mispelled. Fix the spelling mistakes which includes changing the configuration option from `proccesser` to `processor` in `highstate_doc`.