### PR TITLE
Address grain issue with MS Hyper-V 2019

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1327,14 +1327,18 @@ def _windows_os_release_grain(caption, product_type):
     version = "Unknown"
     release = ""
     if "Server" in caption:
-        for item in caption.split(" "):
-            # If it's all digits, then it's version
-            if re.match(r"\d+", item):
-                version = item
-            # If it starts with R and then numbers, it's the release
-            # ie: R2
-            if re.match(r"^R\d+$", item):
-                release = item
+        # Edge case here to handle MS Product that doesn't contain a year
+        if re.match(r"^Microsoft Hyper-V Server$", caption):
+            version = "2019"
+        else:
+            for item in caption.split(" "):
+                # If it's all digits, then it's version
+                if re.match(r"\d+", item):
+                    version = item
+                # If it starts with R and then numbers, it's the release
+                # ie: R2
+                if re.match(r"^R\d+$", item):
+                    release = item
         os_release = "{0}Server{1}".format(version, release)
     else:
         for item in caption.split(" "):

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -869,6 +869,12 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
             version = core._windows_os_release_grain(caption, 1)
             self.assertEqual(version, "7")
 
+        # Microsoft Hyper-V Server 2019
+        # Issue https://github.com/saltstack/salt/issue/55212
+        caption = "Microsoft Hyper-V Server"
+        version = core._windows_os_release_grain(caption, 1)
+        self.assertEqual(version, "2019Server")
+
     @skipIf(not salt.utils.platform.is_linux(), "System is not Linux")
     def test_linux_memdata(self):
         """


### PR DESCRIPTION
### What does this PR do?
Sets a default osrelease grain for MS Hyper-V 2019 because a year isn't provided in system information.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/55212

### Previous Behavior
Crash

### New Behavior
No crash

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
