### PR TITLE
Changes for BUG opened: 56995

### DIFF
--- a/salt/modules/zabbix.py
+++ b/salt/modules/zabbix.py
@@ -2307,9 +2307,9 @@ def mediatype_get(name=None, mediatypeids=None, **connection_args):
             if name:
                 # since zabbix API 4.4, mediatype has new attribute: name
                 if _LooseVersion(zabbix_version) >= _LooseVersion("4.4"):
-                    params['filter'].setdefault('name', name)
+                    params['filter'].setdefault("name", name)
                 else:
-                    params['filter'].setdefault('description', name)
+                    params['filter'].setdefault("description", name)
             if mediatypeids:
                 params.setdefault("mediatypeids", mediatypeids)
             params = _params_extend(params, **connection_args)

--- a/salt/modules/zabbix.py
+++ b/salt/modules/zabbix.py
@@ -2307,9 +2307,9 @@ def mediatype_get(name=None, mediatypeids=None, **connection_args):
             if name:
                 # since zabbix API 4.4, mediatype has new attribute: name
                 if _LooseVersion(zabbix_version) >= _LooseVersion("4.4"):
-                    params['filter'].setdefault("name", name)
+                    params["filter"].setdefault("name", name)
                 else:
-                    params['filter'].setdefault("description", name)
+                    params["filter"].setdefault("description", name)
             if mediatypeids:
                 params.setdefault("mediatypeids", mediatypeids)
             params = _params_extend(params, **connection_args)

--- a/salt/modules/zabbix.py
+++ b/salt/modules/zabbix.py
@@ -2362,10 +2362,10 @@ def mediatype_create(name, mediatype, **connection_args):
             # since zabbix 4.4 api, mediatype has new attribute: name
             if _LooseVersion(zabbix_version) >= _LooseVersion("4.4"):
                 params = {"name": name}
-                _ignore_name=False
+                _ignore_name = False
             else:
                 params = {"description": name}
-                _ignore_name=True
+                _ignore_name = True
             params["type"] = mediatype
             params = _params_extend(params, _ignore_name, **connection_args)
             ret = _query(method, params, conn_args["url"], conn_args["auth"])

--- a/salt/modules/zabbix.py
+++ b/salt/modules/zabbix.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Support for Zabbix
 
@@ -23,7 +22,6 @@ Support for Zabbix
 
 :codeauthor: Jiri Kotlin <jiri.kotlin@ultimum.io>
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Python libs
 import logging
@@ -35,9 +33,6 @@ import salt.utils.files
 import salt.utils.http
 import salt.utils.json
 from salt.exceptions import SaltException
-
-# Import Salt libs
-from salt.ext import six
 
 # pylint: disable=import-error,no-name-in-module,unused-import
 from salt.ext.six.moves.urllib.error import HTTPError, URLError
@@ -134,7 +129,7 @@ def _frontend_url():
             response = salt.utils.http.query(frontend_url)
             error = response["error"]
         except HTTPError as http_e:
-            error = six.text_type(http_e)
+            error = str(http_e)
         if error.find("412: Precondition Failed"):
             return frontend_url
         else:
@@ -172,9 +167,7 @@ def _query(method, params, url, auth=None):
 
     data = salt.utils.json.dumps(data)
 
-    log.info(
-        "_QUERY input:\nurl: %s\ndata: %s", six.text_type(url), six.text_type(data)
-    )
+    log.info("_QUERY input:\nurl: %s\ndata: %s", str(url), str(data))
 
     try:
         result = salt.utils.http.query(
@@ -187,12 +180,10 @@ def _query(method, params, url, auth=None):
             status=True,
             headers=True,
         )
-        log.info("_QUERY result: %s", six.text_type(result))
+        log.info("_QUERY result: %s", str(result))
         if "error" in result:
             raise SaltException(
-                "Zabbix API: Status: {0} ({1})".format(
-                    result["status"], result["error"]
-                )
+                "Zabbix API: Status: {} ({})".format(result["status"], result["error"])
             )
         ret = result.get("dict", {})
         if "error" in ret:
@@ -206,7 +197,7 @@ def _query(method, params, url, auth=None):
         raise SaltException(
             "URL or HTTP headers are probably not correct! ({})".format(err)
         )
-    except socket.error as err:
+    except OSError as err:
         raise SaltException("Check hostname in URL! ({})".format(err))
 
 
@@ -246,7 +237,7 @@ def _login(**kwargs):
                     name = name[len(prefix) :]
                 except IndexError:
                     return
-            val = __salt__["config.option"]("zabbix.{0}".format(name), None)
+            val = __salt__["config.option"]("zabbix.{}".format(name), None)
             if val is not None:
                 connargs[key] = val
 
@@ -355,7 +346,7 @@ def substitute_params(input_object, extend_params=None, filter_key="name", **kwa
             except KeyError:
                 raise SaltException(
                     "Qyerying object ID requested "
-                    "but object name not provided: {0}".format(input_object)
+                    "but object name not provided: {}".format(input_object)
                 )
         else:
             return {
@@ -364,7 +355,7 @@ def substitute_params(input_object, extend_params=None, filter_key="name", **kwa
             }
     else:
         # Zabbix response is always str, return everything in str as well
-        return six.text_type(input_object)
+        return str(input_object)
 
 
 # pylint: disable=too-many-return-statements,too-many-nested-blocks
@@ -383,18 +374,18 @@ def compare_params(defined, existing, return_old_value=False):
     # Comparison of data types
     if not isinstance(defined, type(existing)):
         raise SaltException(
-            "Zabbix object comparison failed (data type mismatch). Expecting {0}, got {1}. "
-            'Existing value: "{2}", defined value: "{3}").'.format(
+            "Zabbix object comparison failed (data type mismatch). Expecting {}, got {}. "
+            'Existing value: "{}", defined value: "{}").'.format(
                 type(existing), type(defined), existing, defined
             )
         )
 
     # Comparison of values
     if not salt.utils.data.is_iter(defined):
-        if six.text_type(defined) != six.text_type(existing) and return_old_value:
-            return {"new": six.text_type(defined), "old": six.text_type(existing)}
-        elif six.text_type(defined) != six.text_type(existing) and not return_old_value:
-            return six.text_type(defined)
+        if str(defined) != str(existing) and return_old_value:
+            return {"new": str(defined), "old": str(existing)}
+        elif str(defined) != str(existing) and not return_old_value:
+            return str(defined)
 
     # Comparison of lists of values or lists of dicts
     if isinstance(defined, list):
@@ -441,8 +432,8 @@ def compare_params(defined, existing, return_old_value=False):
 
         except TypeError:
             raise SaltException(
-                "Zabbix object comparison failed (data type mismatch). Expecting {0}, got {1}. "
-                'Existing value: "{2}", defined value: "{3}").'.format(
+                "Zabbix object comparison failed (data type mismatch). Expecting {}, got {}. "
+                'Existing value: "{}", defined value: "{}").'.format(
                     type(existing), type(defined), existing, defined
                 )
             )
@@ -466,12 +457,12 @@ def get_object_id_by_params(obj, params=None, **connection_args):
         params = {}
     res = run_query(obj + ".get", params, **connection_args)
     if res and len(res) == 1:
-        return six.text_type(res[0][ZABBIX_ID_MAPPER[obj]])
+        return str(res[0][ZABBIX_ID_MAPPER[obj]])
     else:
         raise SaltException(
             "Zabbix API: Object does not exist or bad Zabbix user permissions or other unexpected "
-            "result. Called method {0} with params {1}. "
-            "Result: {2}".format(obj + ".get", params, res)
+            "result. Called method {} with params {}. "
+            "Result: {}".format(obj + ".get", params, res)
         )
 
 
@@ -2023,7 +2014,7 @@ def usermacro_get(
             if macro:
                 # Python mistakenly interprets macro names starting and ending with '{' and '}' as a dict
                 if isinstance(macro, dict):
-                    macro = "{" + six.text_type(next(iter(macro))) + "}"
+                    macro = "{" + str(next(iter(macro))) + "}"
                 if not macro.startswith("{") and not macro.endswith("}"):
                     macro = "{" + macro + "}"
                 params["filter"].setdefault("macro", macro)
@@ -2075,7 +2066,7 @@ def usermacro_create(macro, value, hostid, **connection_args):
             if macro:
                 # Python mistakenly interprets macro names starting and ending with '{' and '}' as a dict
                 if isinstance(macro, dict):
-                    macro = "{" + six.text_type(next(iter(macro))) + "}"
+                    macro = "{" + str(next(iter(macro))) + "}"
                 if not macro.startswith("{") and not macro.endswith("}"):
                     macro = "{" + macro + "}"
                 params["macro"] = macro
@@ -2117,7 +2108,7 @@ def usermacro_createglobal(macro, value, **connection_args):
             if macro:
                 # Python mistakenly interprets macro names starting and ending with '{' and '}' as a dict
                 if isinstance(macro, dict):
-                    macro = "{" + six.text_type(next(iter(macro))) + "}"
+                    macro = "{" + str(next(iter(macro))) + "}"
                 if not macro.startswith("{") and not macro.endswith("}"):
                     macro = "{" + macro + "}"
                 params["macro"] = macro
@@ -2650,7 +2641,7 @@ def configuration_import(config_file, rules=None, file_format="xml", **connectio
         salt.utils.files.safe_rm(cfile)
 
     params = {"format": file_format, "rules": new_rules, "source": xml}
-    log.info("CONFIGURATION IMPORT: rules: %s", six.text_type(params["rules"]))
+    log.info("CONFIGURATION IMPORT: rules: %s", str(params["rules"]))
     try:
         run_query("configuration.import", params, **connection_args)
         return {
@@ -2660,4 +2651,4 @@ def configuration_import(config_file, rules=None, file_format="xml", **connectio
             "called successfully.",
         }
     except SaltException as exc:
-        return {"name": config_file, "result": False, "message": six.text_type(exc)}
+        return {"name": config_file, "result": False, "message": str(exc)}

--- a/tests/unit/modules/test_zabbix.py
+++ b/tests/unit/modules/test_zabbix.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 """
     :codeauthor: :email:`Christian McHugh <christian.mchugh@gmail.com>`
 """
 
 # Import Python Libs
-from __future__ import absolute_import, unicode_literals
 
 import salt.modules.zabbix as zabbix
 from salt.exceptions import SaltException

--- a/tests/unit/modules/test_zabbix.py
+++ b/tests/unit/modules/test_zabbix.py
@@ -232,6 +232,46 @@ class ZabbixTestCase(TestCase, LoaderModuleMockMixin):
             with patch.object(zabbix, "_login", return_value=CONN_ARGS):
                 self.assertEqual(zabbix.apiinfo_version(**CONN_ARGS), module_return)
 
+    def test_get_mediatype(self):
+        """
+        query_submitted = { "params": {"filter": {"description": 10}, "output": "extend"}, 
+        "id": 0, "auth": "251feb98e3c25b6b7fb984b6c7a79817", "method": "mediatype.get"}
+        """
+
+        module_return = [
+            {
+                "mediatypeid":"10",
+                "type":"0",
+                "name":"Testing",
+                "smtp_server":"mail.example.com",
+                "smtp_helo":"example.com",
+                "smtp_email":"zabbix@example.com"
+            }
+        ]
+
+        query_return = {
+            "jsonrpc": "2.0",
+            "result": [
+                {
+                    "mediatypeid":"10",
+                    "type":"0",
+                    "name":"Testing",
+                    "smtp_server":"mail.example.com",
+                    "smtp_helo":"example.com",
+                    "smtp_email":"zabbix@example.com"
+                }
+            ],
+            "id": 0,
+        }
+        zabbix_version_return_list = ["3.4", "4.4.5"]
+        for zabbix_version_return in zabbix_version_return_list:
+          patch_apiinfo_version = patch.object(zabbix, "apiinfo_version", autospec=True, return_value=zabbix_version_return)
+          patch_query = patch.object(zabbix, "_query", autospec=True, return_value=query_return)
+          patch_login = patch.object(zabbix, "_login", autospec=True, return_value=CONN_ARGS)
+
+          with patch_apiinfo_version, patch_query, patch_login:
+            self.assertEqual(zabbix.mediatype_get("10", **CONN_ARGS), module_return)
+
     def test_user_create(self):
         """
         query_submitted = {"params": {"passwd": "password007", "alias": "james",

--- a/tests/unit/modules/test_zabbix.py
+++ b/tests/unit/modules/test_zabbix.py
@@ -234,18 +234,18 @@ class ZabbixTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_get_mediatype(self):
         """
-        query_submitted = { "params": {"filter": {"description": 10}, "output": "extend"}, 
+        query_submitted = { "params": {"filter": {"description": 10}, "output": "extend"},
         "id": 0, "auth": "251feb98e3c25b6b7fb984b6c7a79817", "method": "mediatype.get"}
         """
 
         module_return = [
             {
-                "mediatypeid":"10",
-                "type":"0",
-                "name":"Testing",
-                "smtp_server":"mail.example.com",
-                "smtp_helo":"example.com",
-                "smtp_email":"zabbix@example.com"
+                "mediatypeid": "10",
+                "type": "0",
+                "name": "Testing",
+                "smtp_server": "mail.example.com",
+                "smtp_helo": "example.com",
+                "smtp_email": "zabbix@example.com",
             }
         ]
 
@@ -253,24 +253,32 @@ class ZabbixTestCase(TestCase, LoaderModuleMockMixin):
             "jsonrpc": "2.0",
             "result": [
                 {
-                    "mediatypeid":"10",
-                    "type":"0",
-                    "name":"Testing",
-                    "smtp_server":"mail.example.com",
-                    "smtp_helo":"example.com",
-                    "smtp_email":"zabbix@example.com"
+                    "mediatypeid": "10",
+                    "type": "0",
+                    "name": "Testing",
+                    "smtp_server": "mail.example.com",
+                    "smtp_helo": "example.com",
+                    "smtp_email": "zabbix@example.com",
                 }
             ],
             "id": 0,
         }
         zabbix_version_return_list = ["3.4", "4.4.5"]
         for zabbix_version_return in zabbix_version_return_list:
-          patch_apiinfo_version = patch.object(zabbix, "apiinfo_version", autospec=True, return_value=zabbix_version_return)
-          patch_query = patch.object(zabbix, "_query", autospec=True, return_value=query_return)
-          patch_login = patch.object(zabbix, "_login", autospec=True, return_value=CONN_ARGS)
-
-          with patch_apiinfo_version, patch_query, patch_login:
-            self.assertEqual(zabbix.mediatype_get("10", **CONN_ARGS), module_return)
+            patch_apiinfo_version = patch.object(
+                zabbix,
+                "apiinfo_version",
+                autospec=True,
+                return_value=zabbix_version_return,
+            )
+            patch_query = patch.object(
+                zabbix, "_query", autospec=True, return_value=query_return
+            )
+            patch_login = patch.object(
+                zabbix, "_login", autospec=True, return_value=CONN_ARGS
+            )
+            with patch_apiinfo_version, patch_query, patch_login:
+                self.assertEqual(zabbix.mediatype_get("10", **CONN_ARGS), module_return)
 
     def test_user_create(self):
         """


### PR DESCRIPTION
### What does this PR do?
Fix mediatype_create and mediatype_get usage since new API 4.4.

- Added a apiinfo_version call to check the API version when
  dealing with mediatype_create and get.
- Changed the attribute called from "description" to "name",
  when API version is greater or equal to 4.4. changed both
  mediatype_create and mediatype_get.

### What issues does this PR fix or reference?
Fixes #56995 

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
