### PR TITLE
Remove salt/utils/vt.py duplication from filename map.

### DIFF
--- a/tests/filename_map.yml
+++ b/tests/filename_map.yml
@@ -243,16 +243,6 @@ salt/utils/vt.py:
   - integration.ssh.test_raw
   - integration.ssh.test_state
 
-salt/utils/vt.py:
-  - integration.cli.test_custom_module
-  - integration.cli.test_grains
-  - integration.ssh.test_grains
-  - integration.ssh.test_jinja_filters
-  - integration.ssh.test_mine
-  - integration.ssh.test_pillar
-  - integration.ssh.test_raw
-  - integration.ssh.test_state
-
 salt/wheel/*:
   - integration.wheel.test_client
 

--- a/tests/filename_map.yml
+++ b/tests/filename_map.yml
@@ -1,6 +1,6 @@
 '*':
   - unit.test_module_names
-  - unit.test_doc
+  - unit.utils.test_doc
   - unit.test_virtualname
   - integration.modules.test_sysmod
 


### PR DESCRIPTION
### What does this PR do?
`tests/filename_map.yml` contains a duplicated record for `salt/utils/vt.py` that breaks tests if running with `runtests --from-filenames`.
Also corrected path to the `test_doc` test that was moved to `utils` subfolder.

This should fix the tests pass for #56723

### What issues does this PR fix or reference?
Fixes: N/A

### Previous Behavior
```
$ nox -e 'runtests-zeromq-3(coverage=False)' -- --from-filenames=salt/modules/test.py
<...CUT...>
RuntimeError: Failed to load filename map: while constructing a mapping
  in "/home/dimm/projects/salt/git/salt/tests/filename_map.yml", line 1, column 1
found conflicting ID 'salt/utils/vt.py'
  in "/home/dimm/projects/salt/git/salt/tests/filename_map.yml", line 246, column 1
```

### New Behavior
```
$ nox -e 'runtests-zeromq-3(coverage=False)' -- --from-filenames=salt/modules/test.py
<...CUT...>
Test suite execution finalized with exit code: 0
```

### Merge requirements satisfied?
N/A

### Commits signed with GPG?
Yes