### PR TITLE
Fix mac brew pkg

### DIFF
--- a/salt/modules/mac_brew_pkg.py
+++ b/salt/modules/mac_brew_pkg.py
@@ -147,9 +147,16 @@ def list_pkgs(versions_as_list=False, **kwargs):
     # Brew Cask doesn't provide a JSON interface, must be parsed the old way.
     try:
         cask_cmd = "cask list --versions"
-        out = _call_brew(cask_cmd)["stdout"]
+        lines = _call_brew(cask_cmd)["stdout"].splitlines()
 
-        for line in out.splitlines():
+        # 1st time that "cask list" is running we have this kind of output:
+        # ==> Tapping homebrew/cask
+        # Tapped 1 command and 3540 casks (3,656 files, 210MB).
+        if len(lines) > 1 and str(lines[0]).startswith("==>"):
+            # Remove the 2 1st lines
+            lines = lines[2:]
+
+        for line in lines:
             try:
                 name_and_versions = line.split(" ")
                 pkg_name = name_and_versions[0]

--- a/salt/modules/mac_brew_pkg.py
+++ b/salt/modules/mac_brew_pkg.py
@@ -494,7 +494,7 @@ def upgrade_available(pkg):
     return pkg in list_upgrades()
 
 
-def upgrade(refresh=True):
+def upgrade(refresh=True, **kwargs):
     """
     Upgrade outdated, unpinned brews.
 

--- a/salt/modules/mac_brew_pkg.py
+++ b/salt/modules/mac_brew_pkg.py
@@ -221,8 +221,12 @@ def latest_version(*names, **kwargs):
         refresh_db()
 
     def get_version(pkg_info):
-        # Perhaps this will need an option to pick devel by default
-        return pkg_info["versions"]["stable"] or pkg_info["versions"]["devel"]
+        # return only outdated packages and not pinned packages
+        if pkg_info["outdated"] is True and pkg_info["pinned"] is False:
+            # Perhaps this will need an option to pick devel by default
+            return pkg_info["versions"]["stable"] or pkg_info["versions"]["devel"]
+        else:
+            return ""
 
     versions_dict = dict(
         (key, get_version(val)) for key, val in six.iteritems(_info(*names))


### PR DESCRIPTION
### What does this PR do?
3 fixes with 3 commits:

- 1st commit: fix **pkg.uptodate** not working (missing __**kwargs__)
- 2nd commit: fix **pkg.latest**. Always detected failed changes because the function returns always results
- 3rd commit: fix brew warning at the 1st run

### What issues does this PR fix or reference?
Fixes: #56609, #56676

### Previous Behavior

- 1st commit: Cf #56609

- 2nd commit: Cf #56676 and https://travis-ci.org/github/gigi206/VSCode-Anywhere/builds/681428247#L22206 (line 22206)

```
[ERROR   ] Package jq failed to update.
local:
----------
          ID: salt:core:misc:update:jq
    Function: pkg.latest
        Name: jq
      Result: False
     Comment: Package jq failed to update.
     Started: 11:16:02.292816
    Duration: 12422.909 ms
     Changes:   
```

- 3rd commit: cf https://travis-ci.org/github/gigi206/VSCode-Anywhere/builds/681428247#L14376 (line 14376)

```
[ERROR   ] Command '['/home/linuxbrew/.linuxbrew/bin/brew', 'cask', 'info', '==>']' failed with return code: 1
[ERROR   ] stderr: Error: Cask '==>' is unavailable: No Cask with this name exists.
[ERROR   ] retcode: 1
```

### Merge requirements satisfied?
- [ ] Docs
- [ ] Changelog
- [ ] Tests written/updated

### Commits signed with GPG?
No
