### PR TITLE
Fix idempotency in reg with None REG_SZ

### DIFF
--- a/salt/utils/win_reg.py
+++ b/salt/utils/win_reg.py
@@ -96,7 +96,7 @@ def _to_unicode(vdata):
     """
     # None does not convert to Unicode
     if vdata is None:
-        return None
+        vdata = ""
     if isinstance(vdata, int):
         vdata = str(vdata)
     return salt.utils.stringutils.to_unicode(vdata, "utf-8")

--- a/tests/unit/states/test_reg.py
+++ b/tests/unit/states/test_reg.py
@@ -155,6 +155,22 @@ class RegTestCase(TestCase, LoaderModuleMockMixin):
         ret = reg.present(self.name, vname=self.vname, vdata=self.vdata)
         self.assertDictEqual(ret, expected)
 
+    def test_present_existing_key_only(self):
+        """
+        Test setting only a key with no value name
+        """
+        # Create the reg key for testing
+        salt.utils.win_reg.set_value(hive=self.hive, key=self.key)
+
+        expected = {
+            "comment": "(Default) in {0} is already present".format(self.name),
+            "changes": {},
+            "name": self.name,
+            "result": True,
+        }
+        ret = reg.present(self.name)
+        self.assertDictEqual(ret, expected)
+
     def test_present_existing_test_true(self):
         # Create the reg key for testing
         salt.utils.win_reg.set_value(

--- a/tests/unit/utils/test_win_reg.py
+++ b/tests/unit/utils/test_win_reg.py
@@ -731,6 +731,11 @@ class WinFunctionsTestCase(TestCase):
         result = win_reg.cast_vdata(vdata=vdata, vtype="REG_SZ")
         self.assertTrue(isinstance(result, six.text_type))
 
+        vdata = None
+        result = win_reg.cast_vdata(vdata=vdata, vtype="REG_SZ")
+        self.assertTrue(isinstance(result, six.text_type))
+        self.assertEqual(result, "")
+
     @destructiveTest
     def test_delete_value(self):
         """


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with `reg.present` where you create a key but do not set a value. In that case, the `(Default)` is a REG_SZ value of empty string `''`. Running the state a second time, however, was comparing the default value to be set (`None`) with the current value (`''`) and thus attempting to set the value again.

### What issues does this PR fix or reference?
Fixes: #56959

### Previous Behavior
The `cast_vdata` function in the `win_reg` salt util was returning `None` as `None` when it was a `REG_SZ` type.

### New Behavior
The `cast_vdata` function now returns an empty string when `None` is passed for a `REG_SZ` type.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
