### PR TITLE
Added supervisord.status_bool method

### DIFF
--- a/changelog/57049.added
+++ b/changelog/57049.added
@@ -1,0 +1,1 @@
+supervisord.status_bool method

--- a/salt/modules/supervisord.py
+++ b/salt/modules/supervisord.py
@@ -401,3 +401,46 @@ def options(name, conf_file=None):
         # pylint: enable=maybe-no-member
         ret[key] = val
     return ret
+
+
+def status_bool(name, expected_state=None, user=None, conf_file=None, bin_env=None):
+    """
+    Check for status of a specific supervisord process and return boolean result.
+
+    name
+        name of the process to check
+
+    expected_state
+        search for a specific process state. If set to ``None`` - any process state will match.
+
+    user
+        user to run supervisorctl as
+
+    conf_file
+        path to supervisord config file
+
+    bin_env
+        path to supervisorctl bin or path to virtualenv with supervisor
+        installed
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' supervisord.status_bool nginx expected_state='RUNNING'
+    """
+
+    cmd = "status {}".format(name)
+    for line in custom(cmd, user, conf_file, bin_env).splitlines():
+        if len(line.split()) > 2:
+            process, state, reason = line.split(None, 2)
+        else:
+            process, state, reason = line.split() + [""]
+
+    if reason == "(no such process)" or process != name:
+        return False
+
+    if expected_state is None or state == expected_state:
+        return True
+    else:
+        return False

--- a/tests/unit/modules/test_supervisord.py
+++ b/tests/unit/modules/test_supervisord.py
@@ -205,7 +205,7 @@ class SupervisordTestCase(TestCase, LoaderModuleMockMixin):
             MockConfig.flag = 0
             self.assertDictEqual(supervisord.options("salt"), {"salt": True})
 
-    # 'status_bool' function tests: 1
+    # 'status_bool' function tests: 4
 
     def test_status_bool_name_correct(self):
         """

--- a/tests/unit/modules/test_supervisord.py
+++ b/tests/unit/modules/test_supervisord.py
@@ -204,3 +204,61 @@ class SupervisordTestCase(TestCase, LoaderModuleMockMixin):
 
             MockConfig.flag = 0
             self.assertDictEqual(supervisord.options("salt"), {"salt": True})
+
+    # 'status_bool' function tests: 1
+
+    def test_status_bool_name_correct(self):
+        """
+        Tests if it returns bool results for process status check
+        """
+
+        return_str = "salt-minion                     RUNNING   pid 25563, uptime 4 days, 12:39:42"
+        with patch.dict(
+            supervisord.__salt__,
+            {"cmd.run_all": self._m_all(return_str), "cmd.which_bin": self._m_bin()},
+        ):
+            self.assertTrue(
+                supervisord.status_bool(name="salt-minion", expected_state=None)
+            )
+
+    def test_status_bool_name_wrong(self):
+        """
+        Tests if it returns bool results for process status check
+        """
+
+        return_str = "salt-master                     RUNNING   pid 25563, uptime 4 days, 12:39:42"
+        with patch.dict(
+            supervisord.__salt__,
+            {"cmd.run_all": self._m_all(return_str), "cmd.which_bin": self._m_bin()},
+        ):
+            self.assertFalse(
+                supervisord.status_bool(name="salt-minion", expected_state=None)
+            )
+
+    def test_status_bool_expected_state_running_success(self):
+        """
+        Tests if it returns bool results for process status check
+        """
+
+        return_str = "salt-minion                     RUNNING   pid 25563, uptime 4 days, 12:39:42"
+        with patch.dict(
+            supervisord.__salt__,
+            {"cmd.run_all": self._m_all(return_str), "cmd.which_bin": self._m_bin()},
+        ):
+            self.assertTrue(
+                supervisord.status_bool(name="salt-minion", expected_state="RUNNING")
+            )
+
+    def test_status_bool_expected_state_running_fail(self):
+        """
+        Tests if it returns bool results for process status check
+        """
+
+        return_str = "salt-minion                     STOPPED   pid 25563, uptime 4 days, 12:39:42"
+        with patch.dict(
+            supervisord.__salt__,
+            {"cmd.run_all": self._m_all(return_str), "cmd.which_bin": self._m_bin()},
+        ):
+            self.assertFalse(
+                supervisord.status_bool(name="salt-minion", expected_state="RUNNING")
+            )


### PR DESCRIPTION
### What does this PR do?
Adding new `supervisord.status_bool` method. Idea is to use it via `onlyif` with slots to only do something with the process if it's available and in the expected state. 

### What issues does this PR fix or reference?
It's a new feature.

### Previous Behavior
It's a new feature.

### New Behavior
`supervisord.status_bool` method added.

### Merge requirements satisfied?
- [V] Docs
- [V] Changelog
- [V] Tests written/updated

### Commits signed with GPG?
Yes