### PR TITLE
fix(pkgrepo): fix regression with `refresh_db` warning for `Neon`

### DIFF
--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -311,10 +311,10 @@ def managed(name, ppa=None, **kwargs):
     """
     if "refresh_db" in kwargs:
         salt.utils.versions.warn_until(
-            "Neon",
+            "Sodium",
             "The 'refresh_db' argument to 'pkg.mod_repo' has been "
             "renamed to 'refresh'. Support for using 'refresh_db' will be "
-            "removed in the Neon release of Salt.",
+            "removed in the Sodium release of Salt.",
         )
         kwargs["refresh"] = kwargs.pop("refresh_db")
 


### PR DESCRIPTION
### What does this PR do?

Fix regression introduced recently by a `master` port.

### What issues does this PR fix or reference?

* Regression introduced recently during port of #53537 to `master`:
  - https://github.com/saltstack/salt/blame/master/salt/states/pkgrepo.py#L313-L318

### Previous Behavior

* Regression detected during weekly test of Salt's `master` branch using
  the Formula's CI
  - Both instances now failing:
    https://travis-ci.org/github/myii/apt-formula/builds/681357766
  - Specific error:
    https://travis-ci.org/github/myii/apt-formula/jobs/681357767#L1517-L1530

### New Behavior

* Propose modification `Neon` => `Sodium` since there's been no warning
  given in the state prior to this (checked via. the blame)
* Confirmed this fixes the regression:
  - Both instances now passing:
    https://travis-ci.org/github/myii/apt-formula/builds/682550353
  - Specific warning message for `Sodium` visible:
    https://travis-ci.org/github/myii/apt-formula/jobs/682550354#L1394

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog
- [ ] Tests written/updated

### Commits signed with GPG?

Yes