### PR TITLE
Fix two fileserver runner bugs

### DIFF
--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -387,15 +387,11 @@ class Fileserver(object):
                 for sub in back:
                     if "{0}.envs".format(sub[1:]) in server_funcs:
                         ret.remove(sub[1:])
-                    elif "{0}.envs".format(sub[1:-2]) in server_funcs:
-                        ret.remove(sub[1:-2])
                 return ret
 
         for sub in back:
             if "{0}.envs".format(sub) in server_funcs:
                 ret.append(sub)
-            elif "{0}.envs".format(sub[:-2]) in server_funcs:
-                ret.append(sub[:-2])
         return ret
 
     def master_opts(self, load):

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -717,9 +717,6 @@ class Fileserver(object):
                 )
 
         for back in file_list_backends:
-            # Account for the fact that the file_list cache directory for gitfs
-            # is 'git', hgfs is 'hg', etc.
-            back_virtualname = re.sub("fs$", "", back)
             try:
                 cache_files = os.listdir(os.path.join(list_cachedir, back))
             except OSError as exc:
@@ -736,7 +733,7 @@ class Fileserver(object):
                 if extension != "p":
                     # Filename does not end in ".p". Not a cache file, ignore.
                     continue
-                elif back_virtualname not in fsb or (
+                elif back not in fsb or (
                     saltenv is not None and cache_saltenv not in saltenv
                 ):
                     log.debug(
@@ -757,6 +754,11 @@ class Fileserver(object):
                         cache_saltenv,
                         back,
                     )
+
+        # Ensure reproducible ordering of returns
+        for key in ret:
+            ret[key].sort()
+
         return ret
 
     @ensure_unicode_args

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -81,6 +81,7 @@ log = logging.getLogger(__name__)
 
 # Define the module's virtual name
 __virtualname__ = "gitfs"
+__virtual_aliases__ = ("git",)
 
 
 def _gitfs(init_remotes=True):

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -82,7 +82,8 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 # Define the module's virtual name
-__virtualname__ = "hg"
+__virtualname__ = "hgfs"
+__virtual_aliases__ = ("hg",)
 
 
 def __virtual__():

--- a/salt/fileserver/svnfs.py
+++ b/salt/fileserver/svnfs.py
@@ -78,7 +78,8 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 # Define the module's virtual name
-__virtualname__ = "svn"
+__virtualname__ = "svnfs"
+__virtual_aliases__ = ("svn",)
 
 
 def __virtual__():

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -498,6 +498,23 @@ def fileserver(opts, backends):
     Returns the file server modules
     """
     _utils = utils(opts)
+
+    if backends is not None:
+        if not isinstance(backends, list):
+            backends = [backends]
+        # Make sure that the VCS backends work either with git or gitfs, hg or
+        # hgfs, etc.
+        vcs_re = re.compile("^(git|svn|hg)")
+        fs_re = re.compile("fs$")
+        vcs = []
+        non_vcs = []
+        for back in [fs_re.sub("", x) for x in backends]:
+            if vcs_re.match(back):
+                vcs.extend((back, back + "fs"))
+            else:
+                non_vcs.append(back)
+        backends = vcs + non_vcs
+
     return LazyLoader(
         _module_dirs(opts, "fileserver"),
         opts,

--- a/tests/unit/runners/test_fileserver.py
+++ b/tests/unit/runners/test_fileserver.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+"""
+unit tests for the fileserver runner
+"""
+
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+import os
+
+# Import Salt libs
+import salt.loader
+import salt.runners.fileserver as fileserver
+import salt.utils.files
+
+# Import testing libs
+from tests.support.helpers import with_tempdir
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.mock import MagicMock, patch
+from tests.support.unit import TestCase
+
+
+class DummyFS(object):
+    """
+    Dummy object to provide the attributes needed to run unit tests
+    """
+
+    def __init__(self, backends):
+        self.backends = backends
+
+    def keys(self):
+        return ["{0}.envs".format(x) for x in self.backends]
+
+
+class FileserverTest(TestCase, LoaderModuleMockMixin):
+    """
+    Validate the cache runner
+    """
+
+    def setup_loader_modules(self):
+        return {fileserver: {"__opts__": {"extension_modules": ""}}}
+
+    def _make_file_lists_cache(self, cachedir, backends):
+        """
+        Create some dummy files to represent file list caches, as well as other
+        files that aren't file list caches, so that we can confirm that *only*
+        the cache files are touched. Create a dir for each configured backend,
+        as well as for the roots backend (which is *not* configured as a
+        backend in this test), so that we can ensure that its cache is left
+        alone.
+        """
+        for back in backends:
+            back_cachedir = os.path.join(cachedir, "file_lists", back)
+            # Make file_lists cachedir
+            os.makedirs(os.path.join(back_cachedir))
+            # Touch a couple files
+            for filename in ("base.p", "dev.p", "foo.txt"):
+                with salt.utils.files.fopen(os.path.join(back_cachedir, filename), "w"):
+                    pass
+
+    @with_tempdir()
+    def test_clear_file_list_cache_vcs(self, cachedir):
+        """
+        Test that VCS backends are cleared irrespective of whether they are
+        configured as gitfs/git, hgfs/hg, svnfs/svn.
+        """
+        # Mixture of VCS backends specified with and without "fs" at the end,
+        # to confirm that the correct dirs are cleared.
+        backends = ["gitfs", "hg", "svnfs"]
+        opts = {
+            "fileserver_backend": backends,
+            "cachedir": cachedir,
+        }
+        mock_fs = DummyFS(backends)
+
+        self._make_file_lists_cache(cachedir, backends + ["roots"])
+
+        with patch.dict(fileserver.__opts__, opts), patch.object(
+            salt.loader, "fileserver", MagicMock(return_value=mock_fs)
+        ):
+            cleared = fileserver.clear_file_list_cache()
+
+        # Make sure the return data matches what you'd expect
+        expected = {
+            "gitfs": ["base", "dev"],
+            "hg": ["base", "dev"],
+            "svnfs": ["base", "dev"],
+        }
+        assert cleared == expected, cleared
+
+        # Trust, but verify! Check that the correct files are actually gone
+        assert not os.path.exists(
+            os.path.join(cachedir, "file_lists", "gitfs", "base.p")
+        )
+        assert not os.path.exists(
+            os.path.join(cachedir, "file_lists", "gitfs", "dev.p")
+        )
+        assert not os.path.exists(os.path.join(cachedir, "file_lists", "hg", "base.p"))
+        assert not os.path.exists(
+            os.path.join(cachedir, "file_lists", "gitfs", "dev.p")
+        )
+        assert not os.path.exists(os.path.join(cachedir, "file_lists", "hg", "base.p"))
+        assert not os.path.exists(
+            os.path.join(cachedir, "file_lists", "svnfs", "dev.p")
+        )
+
+        # These files *should* exist and shouldn't have been cleaned
+        assert os.path.exists(os.path.join(cachedir, "file_lists", "gitfs", "foo.txt"))
+        assert os.path.exists(os.path.join(cachedir, "file_lists", "hg", "foo.txt"))
+        assert os.path.exists(os.path.join(cachedir, "file_lists", "svnfs", "foo.txt"))
+        assert os.path.exists(os.path.join(cachedir, "file_lists", "roots", "base.p"))
+        assert os.path.exists(os.path.join(cachedir, "file_lists", "roots", "dev.p"))
+        assert os.path.exists(os.path.join(cachedir, "file_lists", "roots", "foo.txt"))
+
+    @with_tempdir()
+    def test_clear_file_list_cache_vcs_limited(self, cachedir):
+        """
+        Test the arguments to limit what is cleared
+        """
+        # Mixture of VCS backends specified with and without "fs" at the end,
+        # to confirm that the correct dirs are cleared.
+        backends = ["gitfs", "hg", "svnfs"]
+        opts = {
+            "fileserver_backend": backends,
+            "cachedir": cachedir,
+        }
+        mock_fs = DummyFS(backends)
+
+        self._make_file_lists_cache(cachedir, backends + ["roots"])
+
+        with patch.dict(fileserver.__opts__, opts), patch.object(
+            salt.loader, "fileserver", MagicMock(return_value=mock_fs)
+        ):
+            cleared = fileserver.clear_file_list_cache(saltenv="base", backend="gitfs")
+
+        expected = {"gitfs": ["base"]}
+        assert cleared == expected, cleared
+
+        # Trust, but verify! Check that the correct files are actually gone
+        assert not os.path.exists(
+            os.path.join(cachedir, "file_lists", "gitfs", "base.p")
+        )
+
+        # These files *should* exist and shouldn't have been cleaned
+        assert os.path.exists(os.path.join(cachedir, "file_lists", "gitfs", "dev.p"))
+        assert os.path.exists(os.path.join(cachedir, "file_lists", "gitfs", "foo.txt"))
+        assert os.path.exists(os.path.join(cachedir, "file_lists", "hg", "base.p"))
+        assert os.path.exists(os.path.join(cachedir, "file_lists", "hg", "dev.p"))
+        assert os.path.exists(os.path.join(cachedir, "file_lists", "hg", "foo.txt"))
+        assert os.path.exists(os.path.join(cachedir, "file_lists", "svnfs", "base.p"))
+        assert os.path.exists(os.path.join(cachedir, "file_lists", "svnfs", "dev.p"))
+        assert os.path.exists(os.path.join(cachedir, "file_lists", "svnfs", "foo.txt"))
+        assert os.path.exists(os.path.join(cachedir, "file_lists", "roots", "base.p"))
+        assert os.path.exists(os.path.join(cachedir, "file_lists", "roots", "dev.p"))
+        assert os.path.exists(os.path.join(cachedir, "file_lists", "roots", "foo.txt"))

--- a/tests/unit/test_fileserver.py
+++ b/tests/unit/test_fileserver.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 from salt import fileserver
 
 # Import Salt Testing libs
+from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import TestCase
 
 
@@ -28,3 +29,24 @@ class MapDiffTestCase(TestCase):
         map1 = {"file1": 12345}
         map2 = {"file1": 1234}
         assert fileserver.diff_mtime_map(map1, map2) is True
+
+
+class VCSBackendWhitelistCase(TestCase, LoaderModuleMockMixin):
+    def setup_loader_modules(self):
+        return {fileserver: {}}
+
+    def test_whitelist(self):
+        opts = {
+            "fileserver_backend": ["roots", "git", "hgfs", "svn"],
+            "extension_modules": "",
+        }
+        fs = fileserver.Fileserver(opts)
+        assert fs.servers.whitelist == [
+            "git",
+            "gitfs",
+            "hg",
+            "hgfs",
+            "svn",
+            "svnfs",
+            "roots",
+        ], fs.servers.whitelist


### PR DESCRIPTION
## What does this PR do?

In a prior PR, I attempted to make it so that the VCS fileserver backends would work irrespective of whether or not the backend ended in "fs". However, this implementation caused issues with a couple of the fileserver runner functions. This fixes them.

### What issues does this PR fix or reference?

Fixes #55380
Fixes #57008

### Previous Behavior

The `fileserver.update` function would not work when the `gitfs` fileserver backend was specified as ``git``.

The `fileserver.clear_file_list_cache` function would not clean the gitfs file list caches unless the backend was defined in `fileserer_backend` as `git`.

### New Behavior

Both these issues are now fixed.

### Merge requirements satisfied?

- [X] Tests written/updated

### Commits signed with GPG?
No