### PR TITLE
Add ShiftLeft Scan to the pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -106,3 +106,14 @@ docs-build-man-pages:
     - pip install -U nox-py2==2019.6.25
     - nox --version
     - nox -e 'docs-man(compress=True, update=False)'
+
+scan:
+  stage: test
+  image: shiftleft/sast-scan
+  script:
+    - scan --src ${CI_PROJECT_DIR} --type python --out_dir ${CI_PROJECT_DIR}/reports
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_REF_NAME"
+    paths:
+      - $CI_PROJECT_DIR/reports/
+    when: always


### PR DESCRIPTION
### What does this PR do?

This PR adds ShiftLeft Scan, a free open-source SAST scanning tool to the GitLab CI pipeline. This tool - which internally uses bandit for python - is detecting a number of flaws/poor security practices in this repo - 70 high and 188 medium.

An example pipeline job: https://gitlab.com/prabhusl/salt/-/jobs/537865815
A report based on the findings: https://prabhusl.gitlab.io/-/salt/-/jobs/537865815/artifacts/reports/source-python-report.html

In light of the recent CVE, I believe it is essential that the findings are triaged and appropriately addressed with either fixes or by flagging false positives.

### What issues does this PR fix or reference?
Fixes:

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
