### PR TITLE
Update scripts/* to explicitly reference Python 3

### DIFF
--- a/scripts/salt
+++ b/scripts/salt
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Publish commands to the salt system from the command line on the master.
 """

--- a/scripts/salt-api
+++ b/scripts/salt-api
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Import salt libs
 from salt.scripts import salt_api

--- a/scripts/salt-call
+++ b/scripts/salt-call
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Directly call a salt command in the modules, does not require a running salt
 minion to run.

--- a/scripts/salt-cloud
+++ b/scripts/salt-cloud
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Publish commands to the salt system from the command line on the master.
 """

--- a/scripts/salt-cp
+++ b/scripts/salt-cp
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Publish commands to the salt system from the command line on the master.
 """

--- a/scripts/salt-extend
+++ b/scripts/salt-extend
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Quickstart for creating an/or extending the functionality of your SaltStack installation
 

--- a/scripts/salt-key
+++ b/scripts/salt-key
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Manage the authentication keys with salt-key
 """

--- a/scripts/salt-master
+++ b/scripts/salt-master
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Start the salt-master
 """

--- a/scripts/salt-minion
+++ b/scripts/salt-minion
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This script is used to kick off a salt minion daemon
 """

--- a/scripts/salt-proxy
+++ b/scripts/salt-proxy
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 This script is used to kick off a salt proxy minion daemon

--- a/scripts/salt-run
+++ b/scripts/salt-run
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Execute a salt convenience routine
 """

--- a/scripts/salt-ssh
+++ b/scripts/salt-ssh
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Execute the salt ssh system
 """

--- a/scripts/salt-syndic
+++ b/scripts/salt-syndic
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This script is used to kick off a salt syndic daemon
 """

--- a/scripts/salt-unity
+++ b/scripts/salt-unity
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from salt.scripts import salt_unity
 

--- a/scripts/spm
+++ b/scripts/spm
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Publish commands to the salt system from the command line on the master.
 


### PR DESCRIPTION
Since the master branch no longer supports Python 2, and many distros
still default /usr/bin/python to Python 2, this commit changes the
scripts to explicitly call Python 3.