### PR TITLE
aptpkg: Fix installing 32-bit packages on 64-bit OS

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -212,10 +212,12 @@ def normalize_name(name):
         salt '*' pkg.normalize_name zsh:amd64
     """
     try:
-        name, arch = name.rsplit(PKG_ARCH_SEPARATOR, 1)
+        pkgname, pkgarch = name.rsplit(PKG_ARCH_SEPARATOR, 1)
     except ValueError:
-        return name
-    return name
+        pkgname = name
+        pkgarch = __grains__["osarch"]
+
+    return pkgname if pkgarch in (__grains__["osarch"], "any") else name
 
 
 def parse_arch(name):

--- a/tests/unit/modules/test_aptpkg.py
+++ b/tests/unit/modules/test_aptpkg.py
@@ -173,7 +173,7 @@ class AptPkgTestCase(TestCase, LoaderModuleMockMixin):
     """
 
     def setup_loader_modules(self):
-        return {aptpkg: {}}
+        return {aptpkg: {"__grains__": {}}}
 
     def test_version(self):
         """
@@ -643,6 +643,20 @@ class AptPkgTestCase(TestCase, LoaderModuleMockMixin):
 
         ret = aptpkg._skip_source(mock_source)
         self.assertFalse(ret)
+
+    def test_normalize_name(self):
+        """
+        Test that package is normalized only when it should be
+        """
+        with patch.dict(aptpkg.__grains__, {"osarch": "amd64"}):
+            result = aptpkg.normalize_name("foo")
+            assert result == "foo", result
+            result = aptpkg.normalize_name("foo:amd64")
+            assert result == "foo", result
+            result = aptpkg.normalize_name("foo:any")
+            assert result == "foo", result
+            result = aptpkg.normalize_name("foo:i386")
+            assert result == "foo:i386", result
 
 
 @skipIf(pytest is None, "PyTest is missing")


### PR DESCRIPTION
This was broken because a `normalize_name` function was added to aptpkg.py, which was incorrectly written. The pkg states use this function, if present, to figure out whether or not the package architecture needs to be stripped from the package name. However, this recently-added function was *always* stripping the architecture, causing 32-bit suffixes to be stripped.

This commit fixes the incorrect implementation of `normalize_name` and adds a unit test.

Fixes #49637.