### PR TITLE
improve boot parameter documentation GSoC

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1364,21 +1364,48 @@ def init(
 
                      .. versionadded:: 2019.2.0
     :param boot:
-        Specifies kernel for the virtual machine, as well as boot parameters
-        for the virtual machine. This is an optionl parameter, and all of the
-        keys are optional within the dictionary. If a remote path is provided
-        to kernel or initrd, salt will handle the downloading of the specified
-        remote fild, and will modify the XML accordingly.
+        Specifies kernel, initial ramdisk and kernel command line parameters for the virtual machine.
+        This is an optional parameter, all of the keys are optional within the dictionary. The structure of
+        the dictionary is documented in :ref:`init-boot-def`. If a remote path is provided to kernel or initrd,
+        salt will handle the downloading of the specified remote file and modify the XML accordingly.
+        To boot VM with UEFI, specify loader and nvram path.
+
+        .. versionadded:: 3000
 
         .. code-block:: python
 
             {
                 'kernel': '/root/f8-i386-vmlinuz',
                 'initrd': '/root/f8-i386-initrd',
-                'cmdline': 'console=ttyS0 ks=http://example.com/f8-i386/os/'
+                'cmdline': 'console=ttyS0 ks=http://example.com/f8-i386/os/',
+                'loader': '/usr/share/OVMF/OVMF_CODE.fd',
+                'nvram': '/usr/share/OVMF/OVMF_VARS.ms.fd'
             }
 
-        .. versionadded:: 3000
+    .. _init-boot-def:
+
+    .. rubric:: Boot parameters definition
+
+    The boot parameters dictionary can contains the following properties:
+
+    kernel
+        The URL or path to the kernel to run the virtual machine with.
+
+    initrd
+        The URL or path to the initrd file to run the virtual machine with.
+
+    cmdline
+        The parameters to pass to the kernel provided in the `kernel` property.
+
+    loader
+        The path to the UEFI binary loader to use.
+
+        .. versionadded:: sodium
+
+    nvram
+        The path to the UEFI data template. The file will be copied when creating the virtual machine.
+
+        .. versionadded:: sodium
 
     .. _init-nic-def:
 
@@ -1878,23 +1905,13 @@ def update(
     :param password: password to connect with, overriding defaults
 
     :param boot:
-        Specifies kernel for the virtual machine, as well as boot parameters
-        for the virtual machine. This is an optionl parameter, and all of the
-        keys are optional within the dictionary. If a remote path is provided
-        to kernel or initrd, salt will handle the downloading of the specified
-        remote fild, and will modify the XML accordingly.Boot vm with UEFI,
-        loader and nvram can be specified to achieve the goal. To remove any
-        boot parameters, pass an None object to the relevant parameter, for instance: "kernel": None
+        Specifies kernel, initial ramdisk and kernel command line parameters for the virtual machine.
+        This is an optional parameter, all of the keys are optional within the dictionary.
 
-        .. code-block:: python
+        Refer to :ref:`init-boot-def` for the complete boot parameter description.
 
-            {
-                'kernel': '/root/f8-i386-vmlinuz',
-                'initrd': '/root/f8-i386-initrd',
-                'cmdline': 'console=ttyS0 ks=http://example.com/f8-i386/os/'
-                'loader': /usr/share/OVMF/OVMF_CODE.fd
-                'nvram': /usr/share/OVMF/OVMF_VARS.ms.fd
-            }
+        To update any boot parameters, specify the new path for each. To remove any boot parameters,
+        pass a None object, for instance: 'kernel': ``None``.
 
         .. versionadded:: 3000
 

--- a/salt/states/virt.py
+++ b/salt/states/virt.py
@@ -337,19 +337,15 @@ def defined(
         but ``x86_64`` is prefed over ``i686``. Only used when creating a new virtual machine.
 
     :param boot:
-        Specifies kernel for the virtual machine, as well as boot parameters
-        for the virtual machine. This is an optionl parameter, and all of the
-        keys are optional within the dictionary. If a remote path is provided
-        to kernel or initrd, salt will handle the downloading of the specified
-        remote fild, and will modify the XML accordingly.
+        Specifies kernel, initial ramdisk and kernel command line parameters for the virtual machine.
+        This is an optional parameter, all of the keys are optional within the dictionary.
 
-        .. code-block:: python
+        Refer to :ref:`init-boot-def` for the complete boot parameters description.
 
-            {
-                'kernel': '/root/f8-i386-vmlinuz',
-                'initrd': '/root/f8-i386-initrd',
-                'cmdline': 'console=ttyS0 ks=http://example.com/f8-i386/os/'
-            }
+        To update any boot parameters, specify the new path for each. To remove any boot parameters,
+        pass a None object, for instance: 'kernel': ``None``.
+
+        .. versionadded:: 3000
 
     :param update: set to ``False`` to prevent updating a defined domain. (Default: ``True``)
 
@@ -567,19 +563,13 @@ def running(
         .. versionadded:: 3000
 
     :param boot:
-        Specifies kernel for the virtual machine, as well as boot parameters
-        for the virtual machine. This is an optionl parameter, and all of the
-        keys are optional within the dictionary. If a remote path is provided
-        to kernel or initrd, salt will handle the downloading of the specified
-        remote fild, and will modify the XML accordingly.
+        Specifies kernel, initial ramdisk and kernel command line parameters for the virtual machine.
+        This is an optional parameter, all of the keys are optional within the dictionary.
 
-        .. code-block:: python
+        Refer to :ref:`init-boot-def` for the complete boot parameters description.
 
-            {
-                'kernel': '/root/f8-i386-vmlinuz',
-                'initrd': '/root/f8-i386-initrd',
-                'cmdline': 'console=ttyS0 ks=http://example.com/f8-i386/os/'
-            }
+        To update any boot parameters, specify the new path for each. To remove any boot parameters,
+        pass a None object, for instance: 'kernel': ``None``.
 
         .. versionadded:: 3000
 


### PR DESCRIPTION
### What does this PR do?
This PR improves the boot parameter documentation.  Parameter definitions are linked to virt.init function. 

### What issues does this PR fix or reference?
Fixes:
Fix some typos and spelling error in the doc.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
