### PR TITLE
enum34 is no longer a requirement now that Sodium is Py >= 3.5

### DIFF
--- a/pkg/osx/req.txt
+++ b/pkg/osx/req.txt
@@ -5,7 +5,6 @@ cffi==1.12.2
 CherryPy==17.4.1
 click==7.0
 cryptography==2.6.1
-enum34==1.1.6
 gitpython==2.1.15
 idna==2.8
 ipaddress==1.0.22

--- a/pkg/windows/readme.md
+++ b/pkg/windows/readme.md
@@ -9,7 +9,6 @@ salt for Windows with their corresponding licenses:
 | cffi | MIT |
 | CherryPy | BSD |
 | cryptography | BSD |
-| enum34 | BSD |
 | gitdb | BSD |
 | GitPython | BSD |
 | idna | BSD-like |

--- a/pkg/windows/req.txt
+++ b/pkg/windows/req.txt
@@ -5,7 +5,6 @@ cffi==1.12.2
 CherryPy==17.4.1
 cryptography==2.6.1
 distro==1.4.0
-enum34==1.1.6; python_version < '3.4'
 idna==2.8
 ioloop==0.1a0
 ipaddress==1.0.22

--- a/requirements/static/py3.5/darwin.txt
+++ b/requirements/static/py3.5/darwin.txt
@@ -36,7 +36,6 @@ docker-pycreds==0.4.0     # via docker
 docker==3.7.2
 docutils==0.14            # via botocore
 ecdsa==0.13.3             # via python-jose
-enum34==1.1.6
 filelock==3.0.12          # via virtualenv
 future==0.17.1            # via python-jose
 genshi==0.7.3

--- a/requirements/static/py3.6/darwin.txt
+++ b/requirements/static/py3.6/darwin.txt
@@ -36,7 +36,6 @@ docker-pycreds==0.4.0     # via docker
 docker==3.7.2
 docutils==0.14            # via botocore
 ecdsa==0.13.3             # via python-jose
-enum34==1.1.6
 filelock==3.0.12          # via virtualenv
 future==0.17.1            # via python-jose
 genshi==0.7.3

--- a/requirements/static/py3.7/darwin.txt
+++ b/requirements/static/py3.7/darwin.txt
@@ -36,7 +36,6 @@ docker-pycreds==0.4.0     # via docker
 docker==3.7.2
 docutils==0.14            # via botocore
 ecdsa==0.13.3             # via python-jose
-enum34==1.1.6
 filelock==3.0.12          # via virtualenv
 future==0.17.1            # via python-jose
 genshi==0.7.3

--- a/requirements/static/py3.8/darwin.txt
+++ b/requirements/static/py3.8/darwin.txt
@@ -36,7 +36,6 @@ docker-pycreds==0.4.0     # via docker
 docker==3.7.2
 docutils==0.14            # via botocore
 ecdsa==0.13.3             # via python-jose
-enum34==1.1.6
 filelock==3.0.12          # via virtualenv
 future==0.17.1            # via python-jose
 genshi==0.7.3

--- a/requirements/static/py3.9/darwin.txt
+++ b/requirements/static/py3.9/darwin.txt
@@ -36,7 +36,6 @@ docker-pycreds==0.4.0     # via docker
 docker==3.7.2
 docutils==0.14            # via botocore
 ecdsa==0.13.3             # via python-jose
-enum34==1.1.6
 filelock==3.0.12          # via virtualenv
 future==0.17.1            # via python-jose
 genshi==0.7.3


### PR DESCRIPTION
### What does this PR do?
See title
### What issues does this PR fix or reference?
Fixes #56603
