### PR TITLE
Add arpcheck to RH8 IP

### DIFF
--- a/changelog/57047.fixed
+++ b/changelog/57047.fixed
@@ -1,0 +1,1 @@
+Added ARPCHECK to the template for RHEL8 networking.

--- a/salt/templates/rh_ip/rh8_eth.jinja
+++ b/salt/templates/rh_ip/rh8_eth.jinja
@@ -26,6 +26,7 @@ IPADDR{{loop.index}}="{{i['ipaddr']}}"
 PREFIX{{loop.index}}="{{i['prefix']}}"
 {% endfor -%}
 {%endif%}{% if gateway %}GATEWAY="{{gateway}}"
+{%endif%}{% if arpcheck %}ARPCHECK="{{arpcheck}}"
 {%endif%}{% if enable_ipv6 %}IPV6INIT="yes"
 {% if ipv6_autoconf %}IPV6_AUTOCONF="{{ipv6_autoconf}}"
 {%endif%}{% if dhcpv6c %}DHCPV6C="{{dhcpv6c}}"


### PR DESCRIPTION
In #20602 we added the ability to change ARPCHECK in network settings.
This was missing and later added in RH7, but was missing from RH8, since
RH8 support was added before we updated the RH7 support.

This fixes #57047

### Previous Behavior

Missing the ARPCHECK seems to trigger some strange behavior (see #57047)

### New Behavior

The behavior should not be triggered

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] ~Docs~
- [x] Changelog
- [ ] ~Tests written/updated~

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
