### PR TITLE
msgpack: support versions >= 1.0.0

### DIFF
--- a/salt/utils/msgpack.py
+++ b/salt/utils/msgpack.py
@@ -75,13 +75,29 @@ def _sanitize_msgpack_kwargs(kwargs):
     return kwargs
 
 
+def _sanitize_msgpack_unpack_kwargs(kwargs):
+    """
+    Clean up msgpack keyword arguments for unpack operations, based on
+    the version
+    https://github.com/msgpack/msgpack-python/blob/master/ChangeLog.rst
+    """
+    assert isinstance(kwargs, dict)
+    if version >= (1, 0, 0) and kwargs.get("raw", None) is None:
+        log.info("adding `raw=True` argument to msgpack call")
+        kwargs["raw"] = True
+
+    return _sanitize_msgpack_kwargs(kwargs)
+
+
 class Unpacker(msgpack.Unpacker):
     """
     Wraps the msgpack.Unpacker and removes non-relevant arguments
     """
 
     def __init__(self, *args, **kwargs):
-        msgpack.Unpacker.__init__(self, *args, **_sanitize_msgpack_kwargs(kwargs))
+        msgpack.Unpacker.__init__(
+            self, *args, **_sanitize_msgpack_unpack_kwargs(kwargs)
+        )
 
 
 def pack(o, stream, **kwargs):
@@ -120,7 +136,7 @@ def unpack(stream, **kwargs):
     By default, this function uses the msgpack module and falls back to
     msgpack_pure, if the msgpack is not available.
     """
-    return msgpack.unpack(stream, **_sanitize_msgpack_kwargs(kwargs))
+    return msgpack.unpack(stream, **_sanitize_msgpack_unpack_kwargs(kwargs))
 
 
 def unpackb(packed, **kwargs):
@@ -132,7 +148,7 @@ def unpackb(packed, **kwargs):
     By default, this function uses the msgpack module and falls back to
     msgpack_pure.
     """
-    return msgpack.unpackb(packed, **_sanitize_msgpack_kwargs(kwargs))
+    return msgpack.unpackb(packed, **_sanitize_msgpack_unpack_kwargs(kwargs))
 
 
 # alias for compatibility to simplejson/marshal/pickle.

--- a/tests/unit/utils/test_msgpack.py
+++ b/tests/unit/utils/test_msgpack.py
@@ -194,6 +194,75 @@ class TestMsgpack(TestCase):
             "msgpack functions with no alias in `salt.utils.msgpack`",
         )
 
+    def test_sanitize_msgpack_kwargs(self):
+        """
+        Test helper function _sanitize_msgpack_kwargs
+        """
+        version = salt.utils.msgpack.version
+
+        kwargs = {"strict_map_key": True, "raw": True, "use_bin_type": True}
+        salt.utils.msgpack.version = (0, 6, 0)
+        self.assertEqual(
+            salt.utils.msgpack._sanitize_msgpack_kwargs(kwargs),
+            {"raw": True, "strict_map_key": True, "use_bin_type": True},
+        )
+
+        kwargs = {"strict_map_key": True, "raw": True, "use_bin_type": True}
+        salt.utils.msgpack.version = (0, 5, 2)
+        self.assertEqual(
+            salt.utils.msgpack._sanitize_msgpack_kwargs(kwargs),
+            {"raw": True, "use_bin_type": True},
+        )
+
+        kwargs = {"strict_map_key": True, "raw": True, "use_bin_type": True}
+        salt.utils.msgpack.version = (0, 4, 0)
+        self.assertEqual(
+            salt.utils.msgpack._sanitize_msgpack_kwargs(kwargs), {"use_bin_type": True}
+        )
+
+        kwargs = {"strict_map_key": True, "raw": True, "use_bin_type": True}
+        salt.utils.msgpack.version = (0, 3, 0)
+        self.assertEqual(salt.utils.msgpack._sanitize_msgpack_kwargs(kwargs), {})
+        salt.utils.msgpack.version = version
+
+    def test_sanitize_msgpack_unpack_kwargs(self):
+        """
+        Test helper function _sanitize_msgpack_unpack_kwargs
+        """
+        version = salt.utils.msgpack.version
+
+        kwargs = {"strict_map_key": True, "use_bin_type": True}
+        salt.utils.msgpack.version = (1, 0, 0)
+        self.assertEqual(
+            salt.utils.msgpack._sanitize_msgpack_unpack_kwargs(kwargs),
+            {"raw": True, "strict_map_key": True, "use_bin_type": True},
+        )
+
+        kwargs = {"strict_map_key": True, "use_bin_type": True}
+        salt.utils.msgpack.version = (0, 6, 0)
+        self.assertEqual(
+            salt.utils.msgpack._sanitize_msgpack_unpack_kwargs(kwargs),
+            {"strict_map_key": True, "use_bin_type": True},
+        )
+
+        kwargs = {"strict_map_key": True, "use_bin_type": True}
+        salt.utils.msgpack.version = (0, 5, 2)
+        self.assertEqual(
+            salt.utils.msgpack._sanitize_msgpack_unpack_kwargs(kwargs),
+            {"use_bin_type": True},
+        )
+
+        kwargs = {"strict_map_key": True, "use_bin_type": True}
+        salt.utils.msgpack.version = (0, 4, 0)
+        self.assertEqual(
+            salt.utils.msgpack._sanitize_msgpack_unpack_kwargs(kwargs),
+            {"use_bin_type": True},
+        )
+        kwargs = {"strict_map_key": True, "use_bin_type": True}
+        salt.utils.msgpack.version = (0, 3, 0)
+        self.assertEqual(salt.utils.msgpack._sanitize_msgpack_unpack_kwargs(kwargs), {})
+        salt.utils.msgpack.version = version
+
     def _test_base(self, pack_func, unpack_func):
         """
         In msgpack, 'dumps' is an alias for 'packb' and 'loads' is an alias for 'unpackb'.


### PR DESCRIPTION
### What does this PR do?

A recent change in msgpack >= 1.0.0, update the default value for the
parameter `raw` to False.  This change breaks Salt for those versions.

This patch add the parameter `raw=True` to all the unpack operations,
restoring the old default.
