### PR TITLE
Prevent logging deadlock on "salt-api" subprocesses dealing with SSH minions

### DIFF
--- a/salt/_logging/impl.py
+++ b/salt/_logging/impl.py
@@ -245,7 +245,7 @@ class SaltLoggingClass(
             finally:
                 try:
                     handler.release()
-                except:
+                except Exception:  # pylint: disable=broad-except
                     pass
         return instance
 
@@ -323,7 +323,7 @@ class SaltLoggingClass(
                     stack_info=stack_info,
                     stacklevel=stacklevel,
                 )
-        except:
+        except Exception:  # pylint: disable=broad-except
             pass
         finally:
             logging._releaseLock()

--- a/salt/_logging/impl.py
+++ b/salt/_logging/impl.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
     salt._logging.impl
     ~~~~~~~~~~~~~~~~~~
@@ -6,16 +5,11 @@
     Salt's logging implementation classes/functionality
 """
 
-# Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 import re
 import sys
 import types
-
-# Import 3rd-party libs
-import salt.ext.six as six
 
 # Let's define these custom logging levels before importing the salt._logging.mixins
 # since they will be used there
@@ -25,7 +19,6 @@ GARBAGE = logging.GARBAGE = 1
 QUIET = logging.QUIET = 1000
 DEBUG = logging.DEBUG = 10
 
-# Import Salt libs
 from salt._logging.handlers import StreamHandler  # isort:skip
 
 # from salt._logging.handlers import SysLogHandler  # isort:skip
@@ -53,7 +46,7 @@ LOG_LEVELS = {
     "warning": logging.WARNING,
 }
 
-LOG_VALUES_TO_LEVELS = dict((v, k) for (k, v) in LOG_LEVELS.items())
+LOG_VALUES_TO_LEVELS = {v: k for (k, v) in LOG_LEVELS.items()}
 
 LOG_COLORS = {
     "levels": {
@@ -97,9 +90,7 @@ LOG_COLORS = {
 }
 
 # Make a list of log level names sorted by log level
-SORTED_LEVEL_NAMES = [
-    l[0] for l in sorted(six.iteritems(LOG_LEVELS), key=lambda x: x[1])
-]
+SORTED_LEVEL_NAMES = [l[0] for l in sorted(LOG_LEVELS.items(), key=lambda x: x[1])]
 
 MODNAME_PATTERN = re.compile(r"(?P<name>%%\(name\)(?:\-(?P<digits>[\d]+))?s)")
 
@@ -169,8 +160,7 @@ def set_log_record_factory(factory):
     Set the logging  log record factory
     """
     get_log_record_factory.__factory__ = factory
-    if not six.PY2:
-        logging.setLogRecordFactory(factory)
+    logging.setLogRecordFactory(factory)
 
 
 set_log_record_factory(SaltLogRecord)
@@ -181,7 +171,7 @@ LOGGING_LOGGER_CLASS = logging.getLoggerClass()
 
 
 class SaltLoggingClass(
-    six.with_metaclass(LoggingMixinMeta, LOGGING_LOGGER_CLASS, NewStyleClassMixin)
+    LOGGING_LOGGER_CLASS, NewStyleClassMixin, metaclass=LoggingMixinMeta
 ):
     def __new__(cls, *args):
         """
@@ -195,7 +185,7 @@ class SaltLoggingClass(
             logging.getLogger(__name__)
 
         """
-        instance = super(SaltLoggingClass, cls).__new__(cls)
+        instance = super().__new__(cls)
 
         max_logger_length = len(max(list(logging.Logger.manager.loggerDict), key=len))
         for handler in logging.root.handlers:
@@ -280,7 +270,7 @@ class SaltLoggingClass(
                 "Only one of 'exc_info' and 'exc_info_on_loglevel' is " "permitted"
             )
         if exc_info_on_loglevel is not None:
-            if isinstance(exc_info_on_loglevel, six.string_types):
+            if isinstance(exc_info_on_loglevel, str):
                 exc_info_on_loglevel = LOG_LEVELS.get(
                     exc_info_on_loglevel, logging.ERROR
                 )
@@ -364,7 +354,7 @@ class SaltLoggingClass(
         except NameError:
             salt_system_encoding = "utf-8"
 
-        if isinstance(msg, six.string_types) and not isinstance(msg, six.text_type):
+        if isinstance(msg, str) and not isinstance(msg, str):
             try:
                 _msg = msg.decode(salt_system_encoding, "replace")
             except UnicodeDecodeError:
@@ -374,9 +364,7 @@ class SaltLoggingClass(
 
         _args = []
         for item in args:
-            if isinstance(item, six.string_types) and not isinstance(
-                item, six.text_type
-            ):
+            if isinstance(item, str) and not isinstance(item, str):
                 try:
                     _args.append(item.decode(salt_system_encoding, "replace"))
                 except UnicodeDecodeError:
@@ -385,24 +373,9 @@ class SaltLoggingClass(
                 _args.append(item)
         _args = tuple(_args)
 
-        if six.PY2:
-            # Recreate what's done for Py >= 3.5
-            _log_record_factory = get_log_record_factory()
-            logrecord = _log_record_factory(
-                name, level, fn, lno, _msg, _args, exc_info, func
-            )
-
-            if extra is not None:
-                for key in extra:
-                    if (key in ["message", "asctime"]) or (key in logrecord.__dict__):
-                        raise KeyError(
-                            "Attempt to overwrite '{}' in LogRecord".format(key)
-                        )
-                    logrecord.__dict__[key] = extra[key]
-        else:
-            logrecord = LOGGING_LOGGER_CLASS.makeRecord(
-                self, name, level, fn, lno, _msg, _args, exc_info, func, sinfo
-            )
+        logrecord = LOGGING_LOGGER_CLASS.makeRecord(
+            self, name, level, fn, lno, _msg, _args, exc_info, func, sinfo
+        )
 
         if exc_info_on_loglevel is not None:
             # Let's add some custom attributes to the LogRecord class in order

--- a/salt/_logging/impl.py
+++ b/salt/_logging/impl.py
@@ -197,9 +197,7 @@ class SaltLoggingClass(
         """
         instance = super(SaltLoggingClass, cls).__new__(cls)
 
-        max_logger_length = len(
-            max(list(logging.Logger.manager.loggerDict), key=len)
-        )
+        max_logger_length = len(max(list(logging.Logger.manager.loggerDict), key=len))
         for handler in logging.root.handlers:
             try:
                 if handler in (

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -606,7 +606,7 @@ class SSH:
                     logging._acquireLock()
                     routine = Process(target=self.handle_routine, args=args)
                     routine.start()
-                except:
+                except Exception:  # pylint: disable=broad-except
                     pass
                 finally:
                     logging._releaseLock()

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -532,7 +532,9 @@ class SSH:
             **target
         )
         ret = {"id": single.id}
+        logging._acquireLock()
         stdout, stderr, retcode = single.run()
+        logging._releaseLock()
         # This job is done, yield
         try:
             data = salt.utils.json.find_json(stdout)
@@ -600,8 +602,16 @@ class SSH:
                     self.targets[host],
                     mine,
                 )
-                routine = Process(target=self.handle_routine, args=args)
-                routine.start()
+                try:
+                    logging._acquireLock()
+                    routine = Process(
+                                    target=self.handle_routine,
+                                    args=args)
+                    routine.start()
+                except:
+                    pass
+                finally:
+                    logging._releaseLock()
                 running[host] = {"thread": routine}
                 continue
             ret = {}

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -604,9 +604,7 @@ class SSH:
                 )
                 try:
                     logging._acquireLock()
-                    routine = Process(
-                                    target=self.handle_routine,
-                                    args=args)
+                    routine = Process(target=self.handle_routine, args=args)
                     routine.start()
                 except:
                     pass

--- a/salt/client/ssh/client.py
+++ b/salt/client/ssh/client.py
@@ -1,7 +1,9 @@
 import copy
 import logging
+import multiprocessing
 import os
 import random
+import time
 
 import salt.config
 import salt.syspaths
@@ -10,6 +12,7 @@ from salt.exceptions import SaltClientError
 
 log = logging.getLogger(__name__)
 
+_LOCK = multiprocessing.Lock()
 
 class SSHClient:
     """
@@ -54,7 +57,11 @@ class SSHClient:
         opts["selected_target_option"] = tgt_type
         opts["tgt"] = tgt
         opts["arg"] = arg
-        return salt.client.ssh.SSH(opts)
+        _LOCK.acquire()
+        ret = salt.client.ssh.SSH(opts)
+        time.sleep(0.01)
+        _LOCK.release()
+        return ret
 
     def cmd_iter(
         self,

--- a/salt/client/ssh/client.py
+++ b/salt/client/ssh/client.py
@@ -14,6 +14,7 @@ log = logging.getLogger(__name__)
 
 _LOCK = multiprocessing.Lock()
 
+
 class SSHClient:
     """
     Create a client object for executing routines via the salt-ssh backend

--- a/salt/client/ssh/wrapper/cp.py
+++ b/salt/client/ssh/wrapper/cp.py
@@ -2,10 +2,10 @@
 Wrap the cp module allowing for managed ssh file transfers
 """
 
-import logging
 import os
 
 import salt.client.ssh
+import salt.log.setup as logging
 import salt.utils.files
 import salt.utils.stringutils
 import salt.utils.templates

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -10,7 +10,6 @@ import functools
 import importlib.machinery  # pylint: disable=no-name-in-module,import-error
 import importlib.util  # pylint: disable=no-name-in-module,import-error
 import inspect
-import logging
 import os
 import re
 import sys
@@ -26,6 +25,7 @@ import salt.config
 import salt.defaults.events
 import salt.defaults.exitcodes
 import salt.loader_context
+import salt.log.setup as logging
 import salt.syspaths
 import salt.utils.args
 import salt.utils.context

--- a/salt/utils/lazy.py
+++ b/salt/utils/lazy.py
@@ -9,8 +9,8 @@ from __future__ import absolute_import, unicode_literals
 from collections.abc import MutableMapping
 import time
 
-import salt.log.setup as logging
 import salt.exceptions
+import salt.log.setup as logging
 
 log = logging.getLogger(__name__)
 

--- a/salt/utils/lazy.py
+++ b/salt/utils/lazy.py
@@ -1,13 +1,10 @@
-# -*- coding: utf-8 -*-
 """
 Lazily-evaluated data structures, primarily used by Salt's loader
 """
 
-# Import Python Libs
-from __future__ import absolute_import, unicode_literals
 
-from collections.abc import MutableMapping
 import time
+from collections.abc import MutableMapping
 
 import salt.exceptions
 import salt.log.setup as logging
@@ -82,7 +79,7 @@ class LazyDict(MutableMapping):
 
         Override this to return a more meaningfull error message if possible
         """
-        return "'{0}' is not available.".format(function_name)
+        return "'{}' is not available.".format(function_name)
 
     def __setitem__(self, key, val):
         self._dict[key] = val

--- a/salt/utils/lazy.py
+++ b/salt/utils/lazy.py
@@ -6,9 +6,10 @@ Lazily-evaluated data structures, primarily used by Salt's loader
 # Import Python Libs
 from __future__ import absolute_import, unicode_literals
 
-import logging
 from collections.abc import MutableMapping
+import time
 
+import salt.log.setup as logging
 import salt.exceptions
 
 log = logging.getLogger(__name__)
@@ -100,11 +101,13 @@ class LazyDict(MutableMapping):
             # load the item
             if self._load(key):
                 log.debug("LazyLoaded %s", key)
+                time.sleep(0.0001)
                 return self._dict[key]
             else:
                 log.debug(
                     "Could not LazyLoad %s: %s", key, self.missing_fun_string(key)
                 )
+                time.sleep(0.0001)
                 raise KeyError(key)
         else:
             return self._dict[key]


### PR DESCRIPTION
### What does this PR do?

This PR fixes a deadlock that sometimes happens under heavy load (lot of parallel requests to Salt API) performing operations with SSH minions. This situation gets even worse when "DEBUG" logging is enabled on the master.

Let say we have an environment with 5 ssh minions, (we use a "roster file"), and we execute multiple `curl` requests to "salt-api" `/run` endpoint, i.a. running: `cmd.run date`, in parallel.

The "salt-api" starts processing the requests, most of the requests eventually finish but for some of them, the `salt-api` subprocesses created for handling those requests get into a deadlock during the very beginning of the process' bootstrapping, at Python's `logging._acquireLock()`. Before the "ssh" call is even executed.

Those processes are stuck forever.

This PR fixes the deadlock by doing some refactors on how Salt handles the Python's logging locks in order to manage them properly and avoid the deadlock.

Sorry for not attaching any dump or debugging information at this moment.

(I would need to think how this could be to tested)

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog
- [ ] Tests written/updated

### Commits signed with GPG?
Yes