### PR TITLE
Update pdbedit module for Debian version

### DIFF
--- a/changelog/56553.fixed
+++ b/changelog/56553.fixed
@@ -1,0 +1,1 @@
+Relax version requirements for pdbedit, also handle Debian branding in the version string.

--- a/salt/modules/pdbedit.py
+++ b/salt/modules/pdbedit.py
@@ -49,15 +49,15 @@ def __virtual__():
     if not salt.utils.path.which("pdbedit"):
         return (False, "pdbedit command is not available")
 
-    # NOTE: check version is >= 4.8.x
+    # NOTE: check version is >= 4.5.x
     ver = salt.modules.cmdmod.run("pdbedit -V")
-    ver_regex = re.compile(r"^Version\s(\d+)\.(\d+)\.(\d+)$")
+    ver_regex = re.compile(r"^Version\s(\d+)\.(\d+)\.(\d+).*$")
     ver_match = ver_regex.match(ver)
     if not ver_match:
         return (False, "pdbedit -V returned an unknown version format")
 
-    if not (int(ver_match.group(1)) >= 4 and int(ver_match.group(2)) >= 8):
-        return (False, "pdbedit is to old, 4.8.0 or newer is required")
+    if not (int(ver_match.group(1)) >= 4 and int(ver_match.group(2)) >= 5):
+        return (False, "pdbedit is to old, 4.5.0 or newer is required")
 
     return __virtualname__
 

--- a/tests/unit/modules/test_pdbedit.py
+++ b/tests/unit/modules/test_pdbedit.py
@@ -26,8 +26,9 @@ class PdbeditTestCase(TestCase, LoaderModuleMockMixin):
         """
         mock_bad_ver = MagicMock(return_value="Ver 1.1a")
         mock_old_ver = MagicMock(return_value="Version 1.0.0")
-        mock_exa_ver = MagicMock(return_value="Version 4.8.0")
+        mock_exa_ver = MagicMock(return_value="Version 4.5.0")
         mock_new_ver = MagicMock(return_value="Version 4.9.2")
+        mock_deb_ver = MagicMock(return_value="Version 4.5.16-Debian")
 
         # NOTE: no pdbedit installed
         with patch("salt.utils.path.which", MagicMock(return_value=None)):
@@ -49,17 +50,24 @@ class PdbeditTestCase(TestCase, LoaderModuleMockMixin):
         ), patch("salt.modules.cmdmod.run", mock_old_ver):
             ret = pdbedit.__virtual__()
             self.assertEqual(
-                ret, (False, "pdbedit is to old, 4.8.0 or newer is required")
+                ret, (False, "pdbedit is to old, 4.5.0 or newer is required")
             )
 
-        # NOTE: pdbedit is exactly 4.8.0
+        # NOTE: pdbedit is exactly 4.5.0
         with patch(
             "salt.utils.path.which", MagicMock(return_value="/opt/local/bin/pdbedit")
         ), patch("salt.modules.cmdmod.run", mock_exa_ver):
             ret = pdbedit.__virtual__()
             self.assertEqual(ret, "pdbedit")
 
-        # NOTE: pdbedit is newer than 4.8.0
+        # NOTE: pdbedit is debian version
+        with patch(
+            "salt.utils.path.which", MagicMock(return_value="/opt/local/bin/pdbedit")
+        ), patch("salt.modules.cmdmod.run", mock_deb_ver):
+            ret = pdbedit.__virtual__()
+            self.assertEqual(ret, "pdbedit")
+
+        # NOTE: pdbedit is newer than 4.5.0
         with patch(
             "salt.utils.path.which", MagicMock(return_value="/opt/local/bin/pdbedit")
         ), patch("salt.modules.cmdmod.run", mock_new_ver):


### PR DESCRIPTION
### What does this PR do?
This fixes 2 issues with the version matching:
- Version 4.5.0 is new enough according to this [comment](https://github.com/saltstack/salt/issues/55185#issuecomment-625285808).


### What issues does this PR fix or reference?
Fixes:
- #56553
- #55185 (load on version 4.5.0 and up)

### Previous Behavior
Regex did not deal with junk behind the version number, e.g. debian adds branding there.

### New Behavior
Regex ignores the stuff after the version, relaxes version requirements to 4.5.0.

### Merge requirements satisfied?>
- [ ] Docs
- [x] Changelog
- [X] Tests written/updated

### Commits signed with GPG?
No