### PR TITLE
Fix linux acl.present for defaults and recursion

### DIFF
--- a/salt/states/linux_acl.py
+++ b/salt/states/linux_acl.py
@@ -152,18 +152,36 @@ def present(name, acl_type, acl_name="", perms="", recurse=False, force=False):
         if user:
             octal_sum = sum([_octal.get(i, i) for i in perms])
             need_refresh = False
-            for path in __current_perms:
-                acl_found = False
-                for user_acl in __current_perms[path].get(_acl_type, []):
-                    if (
-                        _search_name in user_acl
-                        and user_acl[_search_name]["octal"] == octal_sum
-                    ):
-                        acl_found = True
+            # If recursive check all paths retrieved via acl.getfacl
+            if recurse:
+                for path in __current_perms:
+                    acl_found = False
+                    if _default:
+                        # Recusive default acls only apply to directories
+                        if not os.path.isdir(path):
+                            continue
+                        _current_perms_path = __current_perms[path].get("defaults", {})
+                    else:
+                        _current_perms_path = __current_perms[path]
+                    for user_acl in _current_perms_path.get(_acl_type, []):
+                        if (
+                            _search_name in user_acl
+                            and user_acl[_search_name]["octal"] == octal_sum
+                        ):
+                            acl_found = True
+                    if not acl_found:
+                        need_refresh = True
                         break
+
                 if not acl_found:
                     need_refresh = True
-                    break
+            # Check the permissions from the already located file
+            elif user[_search_name]['octal'] == sum([_octal.get(i, i) for i in perms]):
+                need_refresh = False
+            # If they don't match then refresh
+            else:
+                need_refresh = True
+
             if not need_refresh:
                 ret["comment"] = "Permissions are in the desired state"
             else:

--- a/salt/states/linux_acl.py
+++ b/salt/states/linux_acl.py
@@ -174,7 +174,7 @@ def present(name, acl_type, acl_name="", perms="", recurse=False, force=False):
                         break
 
             # Check the permissions from the already located file
-            elif user[_search_name]['octal'] == sum([_octal.get(i, i) for i in perms]):
+            elif user[_search_name]["octal"] == sum([_octal.get(i, i) for i in perms]):
                 need_refresh = False
             # If they don't match then refresh
             else:

--- a/salt/states/linux_acl.py
+++ b/salt/states/linux_acl.py
@@ -173,8 +173,6 @@ def present(name, acl_type, acl_name="", perms="", recurse=False, force=False):
                         need_refresh = True
                         break
 
-                if not acl_found:
-                    need_refresh = True
             # Check the permissions from the already located file
             elif user[_search_name]['octal'] == sum([_octal.get(i, i) for i in perms]):
                 need_refresh = False

--- a/tests/unit/states/test_linux_acl.py
+++ b/tests/unit/states/test_linux_acl.py
@@ -56,17 +56,17 @@ class LinuxAclTestCase(TestCase, LoaderModuleMockMixin):
                 },
                 {name: {acl_type: ""}},
                 {
-                    name: { "defaults": { "users": [{acl_name: {"octal": 7}}]}},
-                    name + "/foo": { "defaults": { "users": [{acl_name: {"octal": 7}}]}}
+                    name: {"defaults": {"users": [{acl_name: {"octal": 7}}]}},
+                    name + "/foo": {"defaults": {"users": [{acl_name: {"octal": 7}}]}},
                 },
                 {
-                    name: { "defaults": { "users": [{acl_name: {"octal": 7}}]}},
-                    name + "/foo": { "defaults": { "users": [{acl_name: {"octal": 7}}]}}
+                    name: {"defaults": {"users": [{acl_name: {"octal": 7}}]}},
+                    name + "/foo": {"defaults": {"users": [{acl_name: {"octal": 7}}]}},
                 },
                 {
-                    name: { "defaults": { "users": [{acl_name: {"octal": 7}}]}},
-                    name + "/foo": { "defaults": { "users": [{acl_name: {"octal": 7}}]}}
-                }
+                    name: {"defaults": {"users": [{acl_name: {"octal": 7}}]}},
+                    name + "/foo": {"defaults": {"users": [{acl_name: {"octal": 7}}]}},
+                },
             ]
         )
         mock_modfacl = MagicMock(return_value=True)
@@ -303,7 +303,6 @@ class LinuxAclTestCase(TestCase, LoaderModuleMockMixin):
                         ),
                         ret,
                     )
-
 
     # 'absent' function tests: 2
 

--- a/tests/unit/states/test_linux_acl.py
+++ b/tests/unit/states/test_linux_acl.py
@@ -55,6 +55,18 @@ class LinuxAclTestCase(TestCase, LoaderModuleMockMixin):
                     name + "/foo": {acl_type: [{acl_name: {"octal": 7}}]},
                 },
                 {name: {acl_type: ""}},
+                {
+                    name: { "defaults": { "users": [{acl_name: {"octal": 7}}]}},
+                    name + "/foo": { "defaults": { "users": [{acl_name: {"octal": 7}}]}}
+                },
+                {
+                    name: { "defaults": { "users": [{acl_name: {"octal": 7}}]}},
+                    name + "/foo": { "defaults": { "users": [{acl_name: {"octal": 7}}]}}
+                },
+                {
+                    name: { "defaults": { "users": [{acl_name: {"octal": 7}}]}},
+                    name + "/foo": { "defaults": { "users": [{acl_name: {"octal": 7}}]}}
+                }
             ]
         )
         mock_modfacl = MagicMock(return_value=True)
@@ -224,7 +236,7 @@ class LinuxAclTestCase(TestCase, LoaderModuleMockMixin):
 
                     self.assertDictEqual(
                         linux_acl.present(
-                            name, acl_type, acl_name, perms, recurse=False
+                            name, acl_type, acl_name, perms, recurse=True
                         ),
                         ret,
                     )
@@ -249,6 +261,49 @@ class LinuxAclTestCase(TestCase, LoaderModuleMockMixin):
             self.assertDictEqual(
                 linux_acl.present(name, acl_type, acl_name, perms), ret
             )
+
+            # default recurse false - nothing to do
+            with patch.dict(linux_acl.__salt__, {"acl.getfacl": mock}):
+                # Update - test=True
+                with patch.dict(linux_acl.__opts__, {"test": True}):
+                    comt = "Permissions are in the desired state"
+                    ret = {"name": name, "comment": comt, "changes": {}, "result": True}
+
+                    self.assertDictEqual(
+                        linux_acl.present(
+                            name, "d:" + acl_type, acl_name, perms, recurse=False
+                        ),
+                        ret,
+                    )
+
+            # default recurse false - nothing to do
+            with patch.dict(linux_acl.__salt__, {"acl.getfacl": mock}):
+                # Update - test=True
+                with patch.dict(linux_acl.__opts__, {"test": True}):
+                    comt = "Permissions are in the desired state"
+                    ret = {"name": name, "comment": comt, "changes": {}, "result": True}
+
+                    self.assertDictEqual(
+                        linux_acl.present(
+                            name, "d:" + acl_type, acl_name, perms, recurse=False
+                        ),
+                        ret,
+                    )
+
+            # default recurse true - nothing to do
+            with patch.dict(linux_acl.__salt__, {"acl.getfacl": mock}):
+                # Update - test=True
+                with patch.dict(linux_acl.__opts__, {"test": True}):
+                    comt = "Permissions are in the desired state"
+                    ret = {"name": name, "comment": comt, "changes": {}, "result": True}
+
+                    self.assertDictEqual(
+                        linux_acl.present(
+                            name, "d:" + acl_type, acl_name, perms, recurse=True
+                        ),
+                        ret,
+                    )
+
 
     # 'absent' function tests: 2
 


### PR DESCRIPTION
### What does this PR do?
This fixes an error where the linux acl.present state would reapply
changes to the acl of "default" acls with each run.

It also now correctly checks all sub folders during a recursive
call for changes as appropriate.

### What issues does this PR fix or reference?
Fixes: #57147

### Previous Behavior
Previously it would alway reapply the acl changes when using defaults

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No