### PR TITLE
Fix pycrypto.gen_hash and update the test.

### DIFF
--- a/salt/utils/pycrypto.py
+++ b/salt/utils/pycrypto.py
@@ -103,6 +103,7 @@ def gen_hash(crypt_salt=None, password=None, algorithm=None, force=False):
     """
     Generate /etc/shadow hash
     """
+    log.debug("gen_hash start with: %s", (crypt_salt, password, algorithm, force))
     if password is None:
         password = secure_password()
 
@@ -112,8 +113,10 @@ def gen_hash(crypt_salt=None, password=None, algorithm=None, force=False):
 
     if algorithm not in methods:
         if force and HAS_PASSLIB:
+            log.debug("gen_hash return fallback")
             return _fallback_gen_hash(crypt_salt, password, algorithm)
         else:
+            log.debug("gen_hash raise SaltInvocationError")
             raise SaltInvocationError(
                 "Algorithm '{}' is not natively supported by this platform, use force=True with passlib installed to override.".format(
                     algorithm
@@ -126,8 +129,10 @@ def gen_hash(crypt_salt=None, password=None, algorithm=None, force=False):
         crypt_salt = "${}${}".format(methods[algorithm].ident, crypt_salt)
     else:  # method is crypt (DES)
         if len(crypt_salt) != 2:
+            log.debug("gen_hash raise ValueError")
             raise ValueError(
                 "Invalid salt for hash, 'crypt' salt must be 2 characters."
             )
 
+    log.debug("gen_hash returning crypt for: %s, %s", password, crypt_salt)
     return crypt.crypt(password, crypt_salt)

--- a/salt/utils/pycrypto.py
+++ b/salt/utils/pycrypto.py
@@ -106,6 +106,10 @@ def gen_hash(crypt_salt=None, password=None, algorithm=None, force=False):
     if password is None:
         password = secure_password()
 
+    if algorithm is None:
+        # use the most secure natively supported method
+        algorithm = crypt.methods[0].name.lower() if HAS_CRYPT else known_methods[0]
+
     if algorithm not in methods:
         if force and HAS_PASSLIB:
             return _fallback_gen_hash(crypt_salt, password, algorithm)
@@ -115,10 +119,6 @@ def gen_hash(crypt_salt=None, password=None, algorithm=None, force=False):
                     algorithm
                 )
             )
-
-    if algorithm is None:
-        # use the most secure natively supported method
-        algorithm = crypt.methods[0].name.lower()
 
     if crypt_salt is None:
         crypt_salt = methods[algorithm]

--- a/salt/utils/pycrypto.py
+++ b/salt/utils/pycrypto.py
@@ -87,9 +87,6 @@ def _fallback_gen_hash(crypt_salt=None, password=None, algorithm=None):
     """
     Generate a /etc/shadow-compatible hash for a non-local system
     """
-    if algorithm is None:
-        algorithm = 0
-
     # these are the passlib equivalents to the 'known_methods' defined in crypt
     schemes = ["sha512_crypt", "sha256_crypt", "bcrypt", "md5_crypt", "des_crypt"]
 
@@ -103,7 +100,6 @@ def gen_hash(crypt_salt=None, password=None, algorithm=None, force=False):
     """
     Generate /etc/shadow hash
     """
-    log.debug("gen_hash start with: %s", (crypt_salt, password, algorithm, force))
     if password is None:
         password = secure_password()
 
@@ -113,10 +109,8 @@ def gen_hash(crypt_salt=None, password=None, algorithm=None, force=False):
 
     if algorithm not in methods:
         if force and HAS_PASSLIB:
-            log.debug("gen_hash return fallback")
             return _fallback_gen_hash(crypt_salt, password, algorithm)
         else:
-            log.debug("gen_hash raise SaltInvocationError")
             raise SaltInvocationError(
                 "Algorithm '{}' is not natively supported by this platform, use force=True with passlib installed to override.".format(
                     algorithm
@@ -129,10 +123,8 @@ def gen_hash(crypt_salt=None, password=None, algorithm=None, force=False):
         crypt_salt = "${}${}".format(methods[algorithm].ident, crypt_salt)
     else:  # method is crypt (DES)
         if len(crypt_salt) != 2:
-            log.debug("gen_hash raise ValueError")
             raise ValueError(
                 "Invalid salt for hash, 'crypt' salt must be 2 characters."
             )
 
-    log.debug("gen_hash returning crypt for: %s, %s", password, crypt_salt)
     return crypt.crypt(password, crypt_salt)

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -751,9 +751,7 @@ def with_system_user(
                 if salt.utils.platform.is_darwin():
                     hashed_password = password
                 else:
-                    hashed_password = salt.utils.pycrypto.gen_hash(
-                        crypt_salt="SALTsalt", password=password
-                    )
+                    hashed_password = salt.utils.pycrypto.gen_hash(password=password)
                 hashed_password = "'{0}'".format(hashed_password)
                 add_pwd = cls.run_function(
                     "shadow.set_password", [username, hashed_password]

--- a/tests/unit/utils/test_pycrypto.py
+++ b/tests/unit/utils/test_pycrypto.py
@@ -32,7 +32,8 @@ class PycryptoTestCase(TestCase):
         },
         "blowfish": {
             "hashed": "$2b$12$goodsaltgoodsaltgoodsOaeGcaoZ.j.ugFo3vJZv5uk3W2zf2166",
-            "salt": "goodsaltgoodsaltgoodsa",
+            "salt_crypt": "12$goodsaltgoodsaltgoodsa",
+            "salt_passlib": "goodsaltgoodsaltgoodsa",
             "badsalt": "badsaltbadsaltbadsaltb",
         },
         "md5": {
@@ -86,7 +87,8 @@ class PycryptoTestCase(TestCase):
         default_algorithm = salt.utils.pycrypto.crypt.methods[0].name.lower()
         expected = self.expecteds[default_algorithm]
         ret = salt.utils.pycrypto.gen_hash(
-            crypt_salt=expected["salt_crypt"], password=self.passwd,
+            crypt_salt=expected.get("salt") or expected["salt_crypt"],
+            password=self.passwd,
         )
         self.assertEqual(ret, expected["hashed"])
 

--- a/tests/unit/utils/test_pycrypto.py
+++ b/tests/unit/utils/test_pycrypto.py
@@ -1,20 +1,14 @@
 # -*- coding: utf-8 -*-
 
-# Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
 
-import logging
 import re
 
-# Import Salt Libs
 import salt.utils.platform
 import salt.utils.pycrypto
 from salt.exceptions import SaltInvocationError
-
-# Import Salt Testing Libs
+from tests.support.mock import patch
 from tests.support.unit import TestCase, skipIf
-
-log = logging.getLogger(__name__)
 
 
 class PycryptoTestCase(TestCase):
@@ -22,70 +16,65 @@ class PycryptoTestCase(TestCase):
     TestCase for salt.utils.pycrypto module
     """
 
-    @skipIf(not salt.utils.pycrypto.HAS_CRYPT, "crypt not available")
-    def test_gen_hash(self):
-        """
-        Test gen_hash
-        """
-        passwd = "test_password"
-        expecteds = {
-            "sha512": {
-                "hashed": "$6$rounds=656000$goodsalt$25xEV0IAcghzQbu8TF5KdDMYk3b4u9nR/38xYU/26xvPgirDavreGhtLfYRYW.RngLmRtD9i8S8XP3dPx4.PV.",
-                "salt": "rounds=656000$goodsalt",
-                "badsalt": "rounds=656000$badsalt",
-            },
-            "sha256": {
-                "hashed": "$5$rounds=535000$goodsalt$2tSwAugenFhj2sHC1EHyGo.7razFvRhlK0c11k4.xG7",
-                "salt": "rounds=535000$goodsalt",
-                "badsalt": "rounds=656000$badsalt",
-            },
-            "blowfish": {
-                "hashed": "$2b$12$goodsaltgoodsaltgoodsOaeGcaoZ.j.ugFo3vJZv5uk3W2zf2166",
-                "salt": "goodsaltgoodsaltgoodsa",
-                "badsalt": "badsaltbadsaltbadsaltb",
-            },
-            "md5": {
-                "hashed": "$1$goodsalt$4XQMx4a4e1MpBB8xzz.TQ0",
-                "salt": "goodsalt",
-                "badsalt": "badsalt",
-            },
-            "crypt": {"hashed": "goVHulDpuGA7w", "salt": "go", "badsalt": "ba"},
-        }
-        invalid_salt = "thissaltistoolongthissaltistoolongthissaltistoolongthissaltistoolongthissaltistoolong"
+    passwd = "test_password"
+    expecteds = {
+        "sha512": {
+            "hashed": "$6$rounds=656000$goodsalt$25xEV0IAcghzQbu8TF5KdDMYk3b4u9nR/38xYU/26xvPgirDavreGhtLfYRYW.RngLmRtD9i8S8XP3dPx4.PV.",
+            "salt_crypt": "rounds=656000$goodsalt",
+            "salt_passlib": "goodsalt",
+            "badsalt": "badsalt",
+        },
+        "sha256": {
+            "hashed": "$5$rounds=535000$goodsalt$2tSwAugenFhj2sHC1EHyGo.7razFvRhlK0c11k4.xG7",
+            "salt_crypt": "rounds=535000$goodsalt",
+            "salt_passlib": "goodsalt",
+            "badsalt": "badsalt",
+        },
+        "blowfish": {
+            "hashed": "$2b$12$goodsaltgoodsaltgoodsOaeGcaoZ.j.ugFo3vJZv5uk3W2zf2166",
+            "salt": "goodsaltgoodsaltgoodsa",
+            "badsalt": "badsaltbadsaltbadsaltb",
+        },
+        "md5": {
+            "hashed": "$1$goodsalt$4XQMx4a4e1MpBB8xzz.TQ0",
+            "salt": "goodsalt",
+            "badsalt": "badsalt",
+        },
+        "crypt": {"hashed": "goVHulDpuGA7w", "salt": "go", "badsalt": "ba"},
+    }
+    invalid_salt = "thissaltistoolongthissaltistoolongthissaltistoolongthissaltistoolongthissaltistoolong"
 
-        if salt.utils.pycrypto.HAS_PASSLIB:
-            methods = salt.utils.pycrypto.known_methods
-            force = True
-        else:
-            methods = salt.utils.pycrypto.methods
-            force = False
+    @skipIf(not salt.utils.pycrypto.HAS_CRYPT, "crypt not available")
+    def test_gen_hash_crypt(self):
+        """
+        Test gen_hash with crypt library
+        """
+        methods = salt.utils.pycrypto.methods
 
         for algorithm in methods:
-            expected = expecteds[algorithm]
+            expected = self.expecteds[algorithm]
             ret = salt.utils.pycrypto.gen_hash(
-                crypt_salt=expected["salt"],
-                password=passwd,
+                crypt_salt=expected.get("salt") or expected["salt_crypt"],
+                password=self.passwd,
                 algorithm=algorithm,
-                force=force,
             )
             self.assertEqual(ret, expected["hashed"])
 
             ret = salt.utils.pycrypto.gen_hash(
                 crypt_salt=expected["badsalt"],
-                password=passwd,
+                password=self.passwd,
                 algorithm=algorithm,
-                force=force,
             )
             self.assertNotEqual(ret, expected["hashed"])
 
             ret = salt.utils.pycrypto.gen_hash(
-                crypt_salt=None, password=passwd, algorithm=algorithm, force=force
+                crypt_salt=None, password=self.passwd, algorithm=algorithm
             )
             self.assertNotEqual(ret, expected["hashed"])
 
         with self.assertRaises(ValueError):
             ret = salt.utils.pycrypto.gen_hash(
-                crypt_salt="long", password=passwd, algorithm="crypt", force=force,
+                crypt_salt="long", password=self.passwd, algorithm="crypt"
             )
 
         with self.assertRaises(SaltInvocationError):
@@ -94,12 +83,74 @@ class PycryptoTestCase(TestCase):
         # Assert it works without arguments passed
         self.assertIsNotNone(salt.utils.pycrypto.gen_hash())
         # Assert it works without algorithm passed
-        default_algorithm = salt.utils.pycrypto.crypt.methods[0]
-        if default_algorithm in expecteds:
+        default_algorithm = salt.utils.pycrypto.crypt.methods[0].name.lower()
+        expected = self.expecteds[default_algorithm]
+        ret = salt.utils.pycrypto.gen_hash(
+            crypt_salt=expected["salt_crypt"], password=self.passwd,
+        )
+        self.assertEqual(ret, expected["hashed"])
+
+    @skipIf(not salt.utils.pycrypto.HAS_PASSLIB, "passlib not available")
+    @patch("salt.utils.pycrypto.methods", {})
+    @patch("salt.utils.pycrypto.HAS_CRYPT", False)
+    def test_gen_hash_passlib(self):
+        """
+        Test gen_hash with passlib
+        """
+        methods = salt.utils.pycrypto.known_methods
+
+        for algorithm in methods:
+            expected = self.expecteds[algorithm]
             ret = salt.utils.pycrypto.gen_hash(
-                crypt_salt=expected["salt"], password=passwd,
+                crypt_salt=expected.get("salt") or expected["salt_passlib"],
+                password=self.passwd,
+                algorithm=algorithm,
+                force=True,
             )
             self.assertEqual(ret, expected["hashed"])
+
+            ret = salt.utils.pycrypto.gen_hash(
+                crypt_salt=expected["badsalt"],
+                password=self.passwd,
+                algorithm=algorithm,
+                force=True,
+            )
+            self.assertNotEqual(ret, expected["hashed"])
+
+            ret = salt.utils.pycrypto.gen_hash(
+                crypt_salt=None, password=self.passwd, algorithm=algorithm, force=True
+            )
+            self.assertNotEqual(ret, expected["hashed"])
+
+            with self.assertRaises(ValueError):
+                ret = salt.utils.pycrypto.gen_hash(
+                    crypt_salt=self.invalid_salt,
+                    password=self.passwd,
+                    algorithm=algorithm,
+                    force=True,
+                )
+
+        with self.assertRaises(SaltInvocationError):
+            salt.utils.pycrypto.gen_hash(algorithm="garbage")
+
+        # Assert it works without arguments passed
+        self.assertIsNotNone(salt.utils.pycrypto.gen_hash(force=True))
+        # Assert it works without algorithm passed
+        default_algorithm = salt.utils.pycrypto.known_methods[0]
+        expected = self.expecteds[default_algorithm]
+        if default_algorithm in self.expecteds:
+            ret = salt.utils.pycrypto.gen_hash(
+                crypt_salt=expected["salt_passlib"], password=self.passwd, force=True,
+            )
+            self.assertEqual(ret, expected["hashed"])
+
+    @patch("salt.utils.pycrypto.methods", {})
+    def test_gen_hash_no_lib(self):
+        """
+        test gen_hash with no crypt library available
+        """
+        with self.assertRaises(SaltInvocationError):
+            salt.utils.pycrypto.gen_hash()
 
     def test_secure_password(self):
         """


### PR DESCRIPTION
### What does this PR do?
Make `salt.utils.pycrypto.gen_hash` work again `algorithm=None` setting it to the strongest one of available if possible.
Update the corresponding test to actually run the `gen_hash` test, to pass it and to check this particular case.
This is needed for #50544 to pass the key tests.

### What issues does this PR fix or reference?
Fixes salt_key tests for https://github.com/saltstack/salt/issues/50544
Fixes https://github.com/saltstack/salt/issues/57269
Fixes https://github.com/saltstack/salt/issues/57268

### Previous Behavior
Before https://github.com/saltstack/salt/pull/54931 the `gen_hash` worked without the `algorithm` argument passing using the strongest available algorithm.
After #54931 it stopped to work raising an error.

### New Behavior
Works again.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes