### PR TITLE
Upgrade to boto3>=1.13.5

### DIFF
--- a/requirements/static/darwin.in
+++ b/requirements/static/darwin.in
@@ -1,5 +1,5 @@
 # This is a compilation of requirements installed on salt-jenkins git.salt state run
-boto3
+boto3>=1.13.5
 boto>=2.46.0
 clustershell
 croniter>=0.3.0,!=0.3.22

--- a/requirements/static/linux.in
+++ b/requirements/static/linux.in
@@ -1,5 +1,5 @@
 apache-libcloud==2.0.0
-boto3
+boto3>=1.13.5
 boto>=2.46.0
 certifi
 cffi

--- a/requirements/static/py3.5/darwin.txt
+++ b/requirements/static/py3.5/darwin.txt
@@ -14,9 +14,9 @@ aws-xray-sdk==0.95        # via moto
 backports.functools-lru-cache==1.5  # via cheroot
 backports.ssl_match_hostname==3.7.0.1
 bcrypt==3.1.6             # via paramiko
-boto3==1.9.132
+boto3==1.13.5
 boto==2.49.0
-botocore==1.12.132        # via boto3, moto, s3transfer
+botocore==1.16.5          # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
 certifi==2019.3.9
 certvalidator==0.11.1     # via vcert
@@ -105,7 +105,7 @@ requests==2.21.0
 responses==0.10.6         # via moto
 rfc3987==1.3.8
 rsa==4.0                  # via google-auth
-s3transfer==0.2.0         # via boto3
+s3transfer==0.3.3         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10

--- a/requirements/static/py3.5/linux.txt
+++ b/requirements/static/py3.5/linux.txt
@@ -12,9 +12,9 @@ attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
 backports.functools-lru-cache==1.5  # via cheroot
 bcrypt==3.1.6             # via paramiko
-boto3==1.9.132
+boto3==1.13.5
 boto==2.49.0
-botocore==1.12.132        # via boto3, moto, s3transfer
+botocore==1.16.5          # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
 certifi==2019.3.9
 certvalidator==0.11.1     # via vcert
@@ -101,7 +101,7 @@ requests==2.21.0
 responses==0.10.6         # via moto
 rfc3987==1.3.8
 rsa==4.0                  # via google-auth
-s3transfer==0.2.0         # via boto3
+s3transfer==0.3.3         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10

--- a/requirements/static/py3.5/windows.txt
+++ b/requirements/static/py3.5/windows.txt
@@ -11,9 +11,9 @@ attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
 backports.functools-lru-cache==1.5  # via cheroot
 backports.ssl-match-hostname==3.7.0.1 ; python_version < "3.7"
-boto3==1.9.132
+boto3==1.13.5
 boto==2.49.0
-botocore==1.12.132        # via boto3, moto, s3transfer
+botocore==1.16.5          # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
 certifi==2019.3.9
 cffi==1.12.2
@@ -97,7 +97,7 @@ requests==2.21.0
 responses==0.10.6         # via moto
 rfc3987==1.3.8
 rsa==4.0                  # via google-auth
-s3transfer==0.2.0         # via boto3
+s3transfer==0.3.3         # via boto3
 salttesting==2017.6.1
 sed==0.3.1
 setproctitle==1.1.10

--- a/requirements/static/py3.6/darwin.txt
+++ b/requirements/static/py3.6/darwin.txt
@@ -14,9 +14,9 @@ aws-xray-sdk==0.95        # via moto
 backports.functools-lru-cache==1.5  # via cheroot
 backports.ssl_match_hostname==3.7.0.1
 bcrypt==3.1.6             # via paramiko
-boto3==1.9.132
+boto3==1.13.5
 boto==2.49.0
-botocore==1.12.132        # via boto3, moto, s3transfer
+botocore==1.16.5          # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
 certifi==2019.3.9
 certvalidator==0.11.1     # via vcert
@@ -104,7 +104,7 @@ requests==2.21.0
 responses==0.10.6         # via moto
 rfc3987==1.3.8
 rsa==4.0                  # via google-auth
-s3transfer==0.2.0         # via boto3
+s3transfer==0.3.3         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10

--- a/requirements/static/py3.6/linux.txt
+++ b/requirements/static/py3.6/linux.txt
@@ -12,9 +12,9 @@ attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
 backports.functools-lru-cache==1.5  # via cheroot
 bcrypt==3.1.6             # via paramiko
-boto3==1.9.132
+boto3==1.13.5
 boto==2.49.0
-botocore==1.12.132        # via boto3, moto, s3transfer
+botocore==1.16.5          # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
 certifi==2019.3.9
 certvalidator==0.11.1     # via vcert
@@ -100,7 +100,7 @@ requests==2.21.0
 responses==0.10.6         # via moto
 rfc3987==1.3.8
 rsa==4.0                  # via google-auth
-s3transfer==0.2.0         # via boto3
+s3transfer==0.3.3         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10

--- a/requirements/static/py3.6/windows.txt
+++ b/requirements/static/py3.6/windows.txt
@@ -11,9 +11,9 @@ attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
 backports.functools-lru-cache==1.5  # via cheroot
 backports.ssl-match-hostname==3.7.0.1 ; python_version < "3.7"
-boto3==1.9.132
+boto3==1.13.5
 boto==2.49.0
-botocore==1.12.132        # via boto3, moto, s3transfer
+botocore==1.16.5          # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
 certifi==2019.3.9
 cffi==1.12.2
@@ -96,7 +96,7 @@ requests==2.21.0
 responses==0.10.6         # via moto
 rfc3987==1.3.8
 rsa==4.0                  # via google-auth
-s3transfer==0.2.0         # via boto3
+s3transfer==0.3.3         # via boto3
 salttesting==2017.6.1
 sed==0.3.1
 setproctitle==1.1.10

--- a/requirements/static/py3.7/darwin.txt
+++ b/requirements/static/py3.7/darwin.txt
@@ -14,9 +14,9 @@ aws-xray-sdk==0.95        # via moto
 backports.functools-lru-cache==1.5  # via cheroot
 backports.ssl_match_hostname==3.7.0.1
 bcrypt==3.1.6             # via paramiko
-boto3==1.9.132
+boto3==1.13.5
 boto==2.49.0
-botocore==1.12.132        # via boto3, moto, s3transfer
+botocore==1.16.5          # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
 certifi==2019.3.9
 certvalidator==0.11.1     # via vcert
@@ -103,7 +103,7 @@ requests==2.21.0
 responses==0.10.6         # via moto
 rfc3987==1.3.8
 rsa==4.0                  # via google-auth
-s3transfer==0.2.0         # via boto3
+s3transfer==0.3.3         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10

--- a/requirements/static/py3.7/linux.txt
+++ b/requirements/static/py3.7/linux.txt
@@ -12,9 +12,9 @@ attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
 backports.functools-lru-cache==1.5  # via cheroot
 bcrypt==3.1.6             # via paramiko
-boto3==1.9.132
+boto3==1.13.5
 boto==2.49.0
-botocore==1.12.132        # via boto3, moto, s3transfer
+botocore==1.16.5          # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
 certifi==2019.3.9
 certvalidator==0.11.1     # via vcert
@@ -100,7 +100,7 @@ requests==2.21.0
 responses==0.10.6         # via moto
 rfc3987==1.3.8
 rsa==4.0                  # via google-auth
-s3transfer==0.2.0         # via boto3
+s3transfer==0.3.3         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10

--- a/requirements/static/py3.7/windows.txt
+++ b/requirements/static/py3.7/windows.txt
@@ -10,9 +10,9 @@ atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
 backports.functools-lru-cache==1.5  # via cheroot
-boto3==1.9.132
+boto3==1.13.5
 boto==2.49.0
-botocore==1.12.132        # via boto3, moto, s3transfer
+botocore==1.16.5          # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
 certifi==2019.3.9
 cffi==1.12.2
@@ -95,7 +95,7 @@ requests==2.21.0
 responses==0.10.6         # via moto
 rfc3987==1.3.8
 rsa==4.0                  # via google-auth
-s3transfer==0.2.0         # via boto3
+s3transfer==0.3.3         # via boto3
 salttesting==2017.6.1
 sed==0.3.1
 setproctitle==1.1.10

--- a/requirements/static/py3.8/darwin.txt
+++ b/requirements/static/py3.8/darwin.txt
@@ -14,9 +14,9 @@ aws-xray-sdk==0.95        # via moto
 backports.functools-lru-cache==1.5  # via cheroot
 backports.ssl_match_hostname==3.7.0.1
 bcrypt==3.1.6             # via paramiko
-boto3==1.9.132
+boto3==1.13.5
 boto==2.49.0
-botocore==1.12.132        # via boto3, moto, s3transfer
+botocore==1.16.5          # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
 certifi==2019.3.9
 certvalidator==0.11.1     # via vcert
@@ -102,7 +102,7 @@ requests==2.21.0
 responses==0.10.6         # via moto
 rfc3987==1.3.8
 rsa==4.0                  # via google-auth
-s3transfer==0.2.0         # via boto3
+s3transfer==0.3.3         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10

--- a/requirements/static/py3.8/linux.txt
+++ b/requirements/static/py3.8/linux.txt
@@ -12,9 +12,9 @@ attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
 backports.functools-lru-cache==1.5  # via cheroot
 bcrypt==3.1.6             # via paramiko
-boto3==1.9.132
+boto3==1.13.5
 boto==2.49.0
-botocore==1.12.132        # via boto3, moto, s3transfer
+botocore==1.16.5          # via boto3, moto, s3transfer
 cached-property==1.5.1    # via pygit2
 cachetools==3.1.0         # via google-auth
 certifi==2019.3.9
@@ -100,7 +100,7 @@ requests==2.21.0
 responses==0.10.6         # via moto
 rfc3987==1.3.8
 rsa==4.0                  # via google-auth
-s3transfer==0.2.0         # via boto3
+s3transfer==0.3.3         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10

--- a/requirements/static/py3.9/darwin.txt
+++ b/requirements/static/py3.9/darwin.txt
@@ -14,9 +14,9 @@ aws-xray-sdk==0.95        # via moto
 backports.functools-lru-cache==1.5  # via cheroot
 backports.ssl_match_hostname==3.7.0.1
 bcrypt==3.1.6             # via paramiko
-boto3==1.9.132
+boto3==1.13.5
 boto==2.49.0
-botocore==1.12.132        # via boto3, moto, s3transfer
+botocore==1.16.5          # via boto3, moto, s3transfer
 cachetools==3.1.0         # via google-auth
 certifi==2019.3.9
 certvalidator==0.11.1     # via vcert
@@ -102,7 +102,7 @@ requests==2.21.0
 responses==0.10.6         # via moto
 rfc3987==1.3.8
 rsa==4.0                  # via google-auth
-s3transfer==0.2.0         # via boto3
+s3transfer==0.3.3         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10

--- a/requirements/static/py3.9/linux.txt
+++ b/requirements/static/py3.9/linux.txt
@@ -12,9 +12,9 @@ attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
 backports.functools-lru-cache==1.5  # via cheroot
 bcrypt==3.1.6             # via paramiko
-boto3==1.9.132
+boto3==1.13.5
 boto==2.49.0
-botocore==1.12.132        # via boto3, moto, s3transfer
+botocore==1.16.5          # via boto3, moto, s3transfer
 cached-property==1.5.1    # via pygit2
 cachetools==3.1.0         # via google-auth
 certifi==2019.3.9
@@ -100,7 +100,7 @@ requests==2.21.0
 responses==0.10.6         # via moto
 rfc3987==1.3.8
 rsa==4.0                  # via google-auth
-s3transfer==0.2.0         # via boto3
+s3transfer==0.3.3         # via boto3
 salttesting==2017.6.1
 scp==0.13.2               # via junos-eznc
 setproctitle==1.1.10

--- a/requirements/static/windows.in
+++ b/requirements/static/windows.in
@@ -1,6 +1,6 @@
 # This is a compilation of requirements installed on salt-jenkins git.salt state run
 #apache-libcloud==2.0.0
-boto3
+boto3>=1.13.5
 boto>=2.46.0
 dmidecode
 dnspython


### PR DESCRIPTION
### What does this PR do?
Upgrade to boto3>=1.13.5

While testing running the test suite under Py3.7 on windows we hit an
issue installing botocore at the version it was at.
With this newer version of boto3 which also pulls in a newer version of
botocore we got past the issue.
