### PR TITLE
Put Py3 back

### DIFF
--- a/pkg/windows/build.bat
+++ b/pkg/windows/build.bat
@@ -37,6 +37,7 @@ if %errorLevel%==0 (
 @echo ---------------------------------------------------------------------
 
 set "Version="
+set "Python="
 :: First Parameter
 if not "%~1"=="" (
     echo.%1 | FIND /I "=" > nul && (
@@ -50,9 +51,34 @@ if not "%~1"=="" (
     )
 )
 
+:: Second Parameter
+if not "%~2"=="" (
+    echo.%2 | FIND /I "=" > nul && (
+        :: Named Parameter
+        set "%~2"
+    ) || (
+        :: Positional Parameter
+        set "Python=%~2"
+    )
+)
+
 :: If Version not defined, Get the version from Git
 if "%Version%"=="" (
     for /f "delims=" %%a in ('git describe') do @set "Version=%%a"
+)
+
+:: If Python not defined, Assume Python 3
+if "%Python%"=="" (
+    set Python=3
+)
+
+:: Verify valid Python value (3)
+:: We may need to add Python 4 in the future (delims=34)
+set "x="
+for /f "delims=3" %%i in ("%Python%") do set x=%%i
+if Defined x (
+    echo Invalid Python Version specified. Must be 3. Passed %Python%
+    goto eof
 )
 
 @echo =====================================================================
@@ -61,7 +87,12 @@ if "%Version%"=="" (
 :: Define Variables
 @echo %0 :: Defining Variables...
 @echo ---------------------------------------------------------------------
-Set "PyDir=C:\Python37"
+if %Python%==3 (
+    Set "PyDir=C:\Python37"
+) else (
+    :: Placeholder for future version
+    :: Set "PyDir=C:\Python4"
+)
 Set "PATH=%PATH%;%PyDir%;%PyDir%\Scripts"
 
 Set "CurDir=%~dp0"
@@ -106,7 +137,7 @@ if not %errorLevel%==0 (
 :: Build the Salt Package
 @echo %0 :: Build the Salt Package...
 @echo ---------------------------------------------------------------------
-call "%CurDir%build_pkg.bat" "%Version%"
+call "%CurDir%build_pkg.bat" "%Version%" "%Python%"
 @echo.
 
 :eof

--- a/pkg/windows/build_env.ps1
+++ b/pkg/windows/build_env.ps1
@@ -168,18 +168,18 @@ If (Test-Path "$($ini[$bitPaths]['VCppBuildToolsDir'])\vcbuildtools.bat") {
 # Install Python
 #------------------------------------------------------------------------------
 Write-Output " - Checking for Python 3 installation . . ."
-If (Test-Path "$($ini['Settings']['PythonDir'])\python.exe") {
+If (Test-Path "$($ini['Settings']['Python3Dir'])\python.exe") {
     # Found Python 3.5, do nothing
     Write-Output " - Python 3 Found . . ."
 } Else {
-    Write-Output " - Downloading $($ini[$bitPrograms]['Python']) . . ."
-    $file = "$($ini[$bitPrograms]['Python'])"
+    Write-Output " - Downloading $($ini[$bitPrograms]['Python3']) . . ."
+    $file = "$($ini[$bitPrograms]['Python3'])"
     $url  = "$($ini['Settings']['SaltRepo'])/$bitFolder/$file"
     $file = "$($ini['Settings']['DownloadDir'])\$bitFolder\$file"
     DownloadFileWithProgress $url $file
 
-    Write-Output " - $script_name :: Installing $($ini[$bitPrograms]['Python']) . . ."
-    $p    = Start-Process $file -ArgumentList "/Quiet InstallAllUsers=1 TargetDir=`"$($ini['Settings']['PythonDir'])`" Include_doc=0 Include_tcltk=0 Include_test=0 Include_launcher=1 PrependPath=1 Shortcuts=0" -Wait -NoNewWindow -PassThru
+    Write-Output " - $script_name :: Installing $($ini[$bitPrograms]['Python3']) . . ."
+    $p    = Start-Process $file -ArgumentList "/Quiet InstallAllUsers=1 TargetDir=`"$($ini['Settings']['Python3Dir'])`" Include_doc=0 Include_tcltk=0 Include_test=0 Include_launcher=1 PrependPath=1 Shortcuts=0" -Wait -NoNewWindow -PassThru
 }
 
 #------------------------------------------------------------------------------
@@ -187,8 +187,8 @@ If (Test-Path "$($ini['Settings']['PythonDir'])\python.exe") {
 #------------------------------------------------------------------------------
 Write-Output " - Updating Environment Variables . . ."
 $Path = (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).Path
-If (!($Path.ToLower().Contains("$($ini['Settings']['ScriptsDir'])".ToLower()))) {
-    $newPath  = "$($ini['Settings']['ScriptsDir']);$Path"
+If (!($Path.ToLower().Contains("$($ini['Settings']['Scripts3Dir'])".ToLower()))) {
+    $newPath  = "$($ini['Settings']['Scripts3Dir']);$Path"
     Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath
     $env:Path = $newPath
 }
@@ -199,7 +199,7 @@ If (!($Path.ToLower().Contains("$($ini['Settings']['ScriptsDir'])".ToLower()))) 
 Write-Output " ----------------------------------------------------------------"
 Write-Output " - $script_name :: Updating PIP and SetupTools . . ."
 Write-Output " ----------------------------------------------------------------"
-Start_Process_and_test_exitcode "cmd" "/c $($ini['Settings']['PythonDir'])\python.exe -m pip --disable-pip-version-check --no-cache-dir install -r $($script_path)\req_pip.txt" "python pip"
+Start_Process_and_test_exitcode "cmd" "/c $($ini['Settings']['Python3Dir'])\python.exe -m pip --disable-pip-version-check --no-cache-dir install -r $($script_path)\req_pip.txt" "python pip"
 
 
 #==============================================================================
@@ -208,7 +208,7 @@ Start_Process_and_test_exitcode "cmd" "/c $($ini['Settings']['PythonDir'])\pytho
 Write-Output " ----------------------------------------------------------------"
 Write-Output " - $script_name :: Installing windows specific pypi resources using pip . . ."
 Write-Output " ----------------------------------------------------------------"
-Start_Process_and_test_exitcode "cmd" "/c $($ini['Settings']['PythonDir'])\python.exe -m pip --disable-pip-version-check --no-cache-dir install -r $($script_path)\req_win.txt" "pip install"
+Start_Process_and_test_exitcode "cmd" "/c $($ini['Settings']['Python3Dir'])\python.exe -m pip --disable-pip-version-check --no-cache-dir install -r $($script_path)\req_win.txt" "pip install"
 
 #==============================================================================
 # Install pypi resources using pip
@@ -217,10 +217,10 @@ If ($NoPipDependencies -eq $false) {
   Write-Output " ----------------------------------------------------------------"
   Write-Output " - $script_name :: Installing pypi resources using pip . . ."
   Write-Output " ----------------------------------------------------------------"
-  Start_Process_and_test_exitcode "cmd" "/c $($ini['Settings']['PythonDir'])\python.exe -m pip --disable-pip-version-check --no-cache-dir install -r $($script_path)\req.txt" "pip install"
+  Start_Process_and_test_exitcode "cmd" "/c $($ini['Settings']['Python3Dir'])\python.exe -m pip --disable-pip-version-check --no-cache-dir install -r $($script_path)\req.txt" "pip install"
 }
 
-If (Test-Path "$($ini['Settings']['SitePkgsDir'])\pywin32_system32" -PathType Container )
+If (Test-Path "$($ini['Settings']['SitePkgs3Dir'])\pywin32_system32" -PathType Container )
 {
     #==============================================================================
     # Cleaning Up PyWin32
@@ -232,20 +232,20 @@ If (Test-Path "$($ini['Settings']['SitePkgsDir'])\pywin32_system32" -PathType Co
     # Move DLL's to Python Root
     # The dlls have to be in Python directory and the site-packages\win32 directory
     Write-Output " - $script_name :: Moving PyWin32 DLLs . . ."
-    Copy-Item "$( $ini['Settings']['SitePkgsDir'] )\pywin32_system32\*.dll" "$( $ini['Settings']['PythonDir'] )" -Force
-    Move-Item "$( $ini['Settings']['SitePkgsDir'] )\pywin32_system32\*.dll" "$( $ini['Settings']['SitePkgsDir'] )\win32" -Force
+    Copy-Item "$( $ini['Settings']['SitePkgs3Dir'] )\pywin32_system32\*.dll" "$( $ini['Settings']['Python3Dir'] )" -Force
+    Move-Item "$( $ini['Settings']['SitePkgs3Dir'] )\pywin32_system32\*.dll" "$( $ini['Settings']['SitePkgs3Dir'] )\win32" -Force
 
     # Create gen_py directory
     Write-Output " - $script_name :: Creating gen_py Directory . . ."
-    New-Item -Path "$( $ini['Settings']['SitePkgsDir'] )\win32com\gen_py" -ItemType Directory -Force | Out-Null
+    New-Item -Path "$( $ini['Settings']['SitePkgs3Dir'] )\win32com\gen_py" -ItemType Directory -Force | Out-Null
 
     # Remove pywin32_system32 directory
     Write-Output " - $script_name :: Removing pywin32_system32 Directory . . ."
-    Remove-Item "$( $ini['Settings']['SitePkgsDir'] )\pywin32_system32"
+    Remove-Item "$( $ini['Settings']['SitePkgs3Dir'] )\pywin32_system32"
 
     # Remove PyWin32 PostInstall and testall Scripts
     Write-Output " - $script_name :: Removing PyWin32 scripts . . ."
-    Remove-Item "$( $ini['Settings']['ScriptsDir'] )\pywin32_*" -Force -Recurse
+    Remove-Item "$( $ini['Settings']['Scripts3Dir'] )\pywin32_*" -Force -Recurse
 }
 
 #==============================================================================
@@ -261,7 +261,7 @@ ForEach($key in $ini[$bitDLLs].Keys) {
     $url  = "$($ini['Settings']['SaltRepo'])/$bitFolder/$file"
     $file = "$($ini['Settings']['DownloadDir'])\$bitFolder\$file"
     DownloadFileWithProgress $url $file
-    Copy-Item $file  -destination $($ini['Settings']['PythonDir'])
+    Copy-Item $file  -destination $($ini['Settings']['Python3Dir'])
 }
 
 #------------------------------------------------------------------------------

--- a/pkg/windows/clean_env.bat
+++ b/pkg/windows/clean_env.bat
@@ -16,12 +16,12 @@ if %errorLevel%==0 (
 )
 echo.
 
-:CheckPython2
-if exist "\Python27" goto RemovePython2
+:CheckPython27
+if exist "\Python27" goto RemovePython27
 
-goto CheckPython3
+goto CheckPython35
 
-:RemovePython2
+:RemovePython27
     rem Uninstall Python 2.7
     echo %0 :: Uninstalling Python 2 ...
     echo ---------------------------------------------------------------------
@@ -54,12 +54,12 @@ goto CheckPython3
         echo Failed, please remove manually
     )
 
-:CheckPython3
-if exist "\Python35" goto RemovePython3
+:CheckPython35
+if exist "\Python35" goto RemovePython35
 
 goto CheckPython37
 
-:RemovePython3
+:RemovePython35
     echo %0 :: Uninstalling Python 3 ...
     echo ---------------------------------------------------------------------
     :: 64 bit

--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -11,7 +11,7 @@
 !define PRODUCT_UNINST_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}"
 !define PRODUCT_UNINST_KEY_OTHER "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME_OTHER}"
 !define PRODUCT_UNINST_ROOT_KEY "HKLM"
-!define OUTFILE "Salt-Minion-${PRODUCT_VERSION}-${CPUARCH}-Setup.exe"
+!define OUTFILE "Salt-Minion-${PRODUCT_VERSION}-Py${PYTHON_VERSION}-${CPUARCH}-Setup.exe"
 
 # Import Libraries
 !include "MUI2.nsh"
@@ -29,6 +29,12 @@ ${StrStrAdv}
     !define PRODUCT_VERSION "${SaltVersion}"
 !else
     !define PRODUCT_VERSION "Undefined Version"
+!endif
+
+!ifdef PythonVersion
+    !define PYTHON_VERSION "${PythonVersion}"
+!else
+    !define PYTHON_VERSION "3"
 !endif
 
 !if "$%PROCESSOR_ARCHITECTURE%" == "AMD64"
@@ -389,7 +395,7 @@ FunctionEnd
 ###############################################################################
 # Installation Settings
 ###############################################################################
-Name "${PRODUCT_NAME} ${PRODUCT_VERSION}"
+Name "${PRODUCT_NAME} ${PRODUCT_VERSION} (Python ${PYTHON_VERSION})"
 OutFile "${OutFile}"
 InstallDir "c:\salt"
 InstallDirRegKey HKLM "${PRODUCT_DIR_REGKEY}" ""

--- a/pkg/windows/modules/get-settings.psm1
+++ b/pkg/windows/modules/get-settings.psm1
@@ -16,9 +16,9 @@ Function Get-Settings {
         $Settings = @{
             "SaltRepo"    = "https://repo.saltstack.com/windows/dependencies"
             "SaltDir"     = "C:\salt"
-            "PythonDir"   = "C:\Python37"
-            "ScriptsDir"  = "C:\Python37\Scripts"
-            "SitePkgsDir" = "C:\Python37\Lib\site-packages"
+            "Python3Dir"   = "C:\Python37"
+            "Scripts3Dir"  = "C:\Python37\Scripts"
+            "SitePkgs3Dir" = "C:\Python37\Lib\site-packages"
             "DownloadDir" = "$env:Temp\DevSalt"
             }
 
@@ -50,13 +50,13 @@ Function Get-Settings {
 
         # Filenames for 64 bit Windows
         $64bitPrograms = @{
-            "Python"   = "python-3.7.4-amd64.exe"
+            "Python3"   = "python-3.7.4-amd64.exe"
         }
         $ini.Add("64bitPrograms", $64bitPrograms)
 
         # Filenames for 32 bit Windows
         $32bitPrograms = @{
-            "Python"   = "python-3.7.4.exe"
+            "Python3"   = "python-3.7.4.exe"
         }
         $ini.Add("32bitPrograms", $32bitPrograms)
 


### PR DESCRIPTION
# What does this PR do?
Puts Py3 back in the filename for salt builds so as to not break the current naming convention and to allow for future releases of Python. This will avoid breaking things like WinRepo Package definitions for Salt.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
