### PR TITLE
Only import ABCs from collections.abc

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -12,6 +12,7 @@ import logging
 import signal
 import traceback
 import weakref
+from collections.abc import Mapping, MutableMapping
 
 # Import Salt libs
 import salt.exceptions
@@ -34,13 +35,6 @@ import salt.utils.state
 import salt.utils.user
 import salt.utils.versions
 from salt.ext import six
-
-try:
-    from collections.abc import Mapping, MutableMapping
-except ImportError:
-    # pylint: disable=no-name-in-module
-    from collections import Mapping, MutableMapping
-
 
 log = logging.getLogger(__name__)
 

--- a/salt/daemons/__init__.py
+++ b/salt/daemons/__init__.py
@@ -9,18 +9,10 @@ import logging
 
 # Import Python Libs
 import sys
+from collections.abc import Iterable, Mapping, Sequence
 
 # Import Salt Libs
 from salt.ext import six
-
-try:
-    from collections.abc import Iterable, Sequence, Mapping
-except ImportError:
-    # pylint: disable=no-name-in-module
-    from collections import Iterable, Sequence, Mapping
-
-    # pylint: enable=no-name-in-module
-
 
 log = logging.getLogger(__name__)
 

--- a/salt/ext/tornado/httputil.py
+++ b/salt/ext/tornado/httputil.py
@@ -31,17 +31,11 @@ import email.utils
 import numbers
 import re
 import time
+from collections.abc import MutableMapping
 
 from salt.ext.tornado.escape import native_str, parse_qs_bytes, utf8
 from salt.ext.tornado.log import gen_log
-from salt.ext.tornado.util import ObjectDict, PY3
-
-try:
-    from collections.abc import MutableMapping
-except ImportError:
-    # pylint: disable=no-name-in-module
-    from collections import MutableMapping
-
+from salt.ext.tornado.util import PY3, ObjectDict
 
 if PY3:
     import http.cookies as Cookie
@@ -64,6 +58,7 @@ except ImportError:
     # ssl is unavailable on app engine.
     class _SSLError(Exception):
         pass
+
     # Hack around a mypy limitation. We can't simply put "type: ignore"
     # on the class definition itself; must go through an assignment.
     SSLError = _SSLError  # type: ignore
@@ -76,7 +71,7 @@ except ImportError:
 
 # RFC 7230 section 3.5: a recipient MAY recognize a single LF as a line
 # terminator and ignore any preceding CR.
-_CRLF_RE = re.compile(r'\r?\n')
+_CRLF_RE = re.compile(r"\r?\n")
 
 
 class _NormalizedHeaderCache(dict):
@@ -90,6 +85,7 @@ class _NormalizedHeaderCache(dict):
     >>> normalized_headers["coNtent-TYPE"]
     'Content-Type'
     """
+
     def __init__(self, size):
         super(_NormalizedHeaderCache, self).__init__()
         self.size = size
@@ -139,12 +135,12 @@ class HTTPHeaders(MutableMapping):
     Set-Cookie: A=B
     Set-Cookie: C=D
     """
+
     def __init__(self, *args, **kwargs):
         self._dict = {}  # type: typing.Dict[str, str]
         self._as_list = {}  # type: typing.Dict[str, typing.List[str]]
         self._last_key = None
-        if (len(args) == 1 and len(kwargs) == 0 and
-                isinstance(args[0], HTTPHeaders)):
+        if len(args) == 1 and len(kwargs) == 0 and isinstance(args[0], HTTPHeaders):
             # Copy constructor
             for k, v in args[0].get_all():
                 self.add(k, v)
@@ -160,8 +156,9 @@ class HTTPHeaders(MutableMapping):
         norm_name = _normalized_headers[name]
         self._last_key = norm_name
         if norm_name in self:
-            self._dict[norm_name] = (native_str(self[norm_name]) + ',' +
-                                     native_str(value))
+            self._dict[norm_name] = (
+                native_str(self[norm_name]) + "," + native_str(value)
+            )
             self._as_list[norm_name].append(value)
         else:
             self[norm_name] = value
@@ -192,7 +189,7 @@ class HTTPHeaders(MutableMapping):
         """
         if line[0].isspace():
             # continuation of a multi-line header
-            new_part = ' ' + line.lstrip()
+            new_part = " " + line.lstrip()
             self._as_list[self._last_key][-1] += new_part
             self._dict[self._last_key] += new_part
         else:
@@ -345,9 +342,20 @@ class HTTPServerRequest(object):
     .. versionchanged:: 4.0
        Moved from ``tornado.httpserver.HTTPRequest``.
     """
-    def __init__(self, method=None, uri=None, version="HTTP/1.0", headers=None,
-                 body=None, host=None, files=None, connection=None,
-                 start_line=None, server_connection=None):
+
+    def __init__(
+        self,
+        method=None,
+        uri=None,
+        version="HTTP/1.0",
+        headers=None,
+        body=None,
+        host=None,
+        files=None,
+        connection=None,
+        start_line=None,
+        server_connection=None,
+    ):
         if start_line is not None:
             method, uri, version = start_line
         self.method = method
@@ -357,9 +365,9 @@ class HTTPServerRequest(object):
         self.body = body or b""
 
         # set remote IP and protocol
-        context = getattr(connection, 'context', None)
-        self.remote_ip = getattr(context, 'remote_ip', None)
-        self.protocol = getattr(context, 'protocol', "http")
+        context = getattr(connection, "context", None)
+        self.remote_ip = getattr(context, "remote_ip", None)
+        self.protocol = getattr(context, "protocol", "http")
 
         self.host = host or self.headers.get("Host") or "127.0.0.1"
         self.host_name = split_host_and_port(self.host.lower())[0]
@@ -369,7 +377,7 @@ class HTTPServerRequest(object):
         self._start_time = time.time()
         self._finish_time = None
 
-        self.path, sep, self.query = uri.partition('?')
+        self.path, sep, self.query = uri.partition("?")
         self.arguments = parse_qs_bytes(self.query, keep_blank_values=True)
         self.query_arguments = copy.deepcopy(self.arguments)
         self.body_arguments = {}
@@ -413,8 +421,9 @@ class HTTPServerRequest(object):
            to write the response.
         """
         assert isinstance(chunk, bytes)
-        assert self.version.startswith("HTTP/1."), \
-            "deprecated interface only supported in HTTP/1.x"
+        assert self.version.startswith(
+            "HTTP/1."
+        ), "deprecated interface only supported in HTTP/1.x"
         self.connection.write(chunk, callback=callback)
 
     def finish(self):
@@ -458,16 +467,18 @@ class HTTPServerRequest(object):
         http://docs.python.org/library/ssl.html#sslsocket-objects
         """
         try:
-            return self.connection.stream.socket.getpeercert(
-                binary_form=binary_form)
+            return self.connection.stream.socket.getpeercert(binary_form=binary_form)
         except SSLError:
             return None
 
     def _parse_body(self):
         parse_body_arguments(
-            self.headers.get("Content-Type", ""), self.body,
-            self.body_arguments, self.files,
-            self.headers)
+            self.headers.get("Content-Type", ""),
+            self.body,
+            self.body_arguments,
+            self.files,
+            self.headers,
+        )
 
         for k, v in self.body_arguments.items():
             self.arguments.setdefault(k, []).extend(v)
@@ -476,7 +487,10 @@ class HTTPServerRequest(object):
         attrs = ("protocol", "host", "method", "uri", "version", "remote_ip")
         args = ", ".join(["%s=%r" % (n, getattr(self, n)) for n in attrs])
         return "%s(%s, headers=%s)" % (
-            self.__class__.__name__, args, dict(self.headers))
+            self.__class__.__name__,
+            args,
+            dict(self.headers),
+        )
 
 
 class HTTPInputError(Exception):
@@ -485,6 +499,7 @@ class HTTPInputError(Exception):
 
     .. versionadded:: 4.0
     """
+
     pass
 
 
@@ -493,6 +508,7 @@ class HTTPOutputError(Exception):
 
     .. versionadded:: 4.0
     """
+
     pass
 
 
@@ -501,6 +517,7 @@ class HTTPServerConnectionDelegate(object):
 
     .. versionadded:: 4.0
     """
+
     def start_request(self, server_conn, request_conn):
         """This method is called by the server when a new request has started.
 
@@ -527,6 +544,7 @@ class HTTPMessageDelegate(object):
 
     .. versionadded:: 4.0
     """
+
     def headers_received(self, start_line, headers):
         """Called when the HTTP headers have been received and parsed.
 
@@ -567,6 +585,7 @@ class HTTPConnection(object):
 
     .. versionadded:: 4.0
     """
+
     def write_headers(self, start_line, headers, chunk=None, callback=None):
         """Write an HTTP header block.
 
@@ -622,16 +641,20 @@ def url_concat(url, args):
         parsed_query.extend(args)
     else:
         err = "'args' parameter should be dict, list or tuple. Not {0}".format(
-            type(args))
+            type(args)
+        )
         raise TypeError(err)
     final_query = urlencode(parsed_query)
-    url = urlunparse((
-        parsed_url[0],
-        parsed_url[1],
-        parsed_url[2],
-        parsed_url[3],
-        final_query,
-        parsed_url[5]))
+    url = urlunparse(
+        (
+            parsed_url[0],
+            parsed_url[1],
+            parsed_url[2],
+            parsed_url[3],
+            final_query,
+            parsed_url[5],
+        )
+    )
     return url
 
 
@@ -645,6 +668,7 @@ class HTTPFile(ObjectDict):
     * ``body``
     * ``content_type``
     """
+
     pass
 
 
@@ -728,15 +752,14 @@ def parse_body_arguments(content_type, body, arguments, files, headers=None):
     and ``files`` parameters are dictionaries that will be updated
     with the parsed contents.
     """
-    if headers and 'Content-Encoding' in headers:
-        gen_log.warning("Unsupported Content-Encoding: %s",
-                        headers['Content-Encoding'])
+    if headers and "Content-Encoding" in headers:
+        gen_log.warning("Unsupported Content-Encoding: %s", headers["Content-Encoding"])
         return
     if content_type.startswith("application/x-www-form-urlencoded"):
         try:
             uri_arguments = parse_qs_bytes(native_str(body), keep_blank_values=True)
         except Exception as e:
-            gen_log.warning('Invalid x-www-form-urlencoded body: %s', e)
+            gen_log.warning("Invalid x-www-form-urlencoded body: %s", e)
             uri_arguments = {}
         for name, values in uri_arguments.items():
             if values:
@@ -787,16 +810,18 @@ def parse_multipart_form_data(boundary, data, arguments, files):
         if disposition != "form-data" or not part.endswith(b"\r\n"):
             gen_log.warning("Invalid multipart/form-data")
             continue
-        value = part[eoh + 4:-2]
+        value = part[eoh + 4 : -2]
         if not disp_params.get("name"):
             gen_log.warning("multipart/form-data value missing name")
             continue
         name = disp_params["name"]
         if disp_params.get("filename"):
             ctype = headers.get("Content-Type", "application/unknown")
-            files.setdefault(name, []).append(HTTPFile(  # type: ignore
-                filename=disp_params["filename"], body=value,
-                content_type=ctype))
+            files.setdefault(name, []).append(
+                HTTPFile(  # type: ignore
+                    filename=disp_params["filename"], body=value, content_type=ctype
+                )
+            )
         else:
             arguments.setdefault(name, []).append(value)
 
@@ -823,7 +848,8 @@ def format_timestamp(ts):
 
 
 RequestStartLine = collections.namedtuple(
-    'RequestStartLine', ['method', 'path', 'version'])
+    "RequestStartLine", ["method", "path", "version"]
+)
 
 
 def parse_request_start_line(line):
@@ -840,12 +866,14 @@ def parse_request_start_line(line):
         raise HTTPInputError("Malformed HTTP request line")
     if not re.match(r"^HTTP/1\.[0-9]$", version):
         raise HTTPInputError(
-            "Malformed HTTP version in HTTP Request-Line: %r" % version)
+            "Malformed HTTP version in HTTP Request-Line: %r" % version
+        )
     return RequestStartLine(method, path, version)
 
 
 ResponseStartLine = collections.namedtuple(
-    'ResponseStartLine', ['version', 'code', 'reason'])
+    "ResponseStartLine", ["version", "code", "reason"]
+)
 
 
 def parse_response_start_line(line):
@@ -860,8 +888,8 @@ def parse_response_start_line(line):
     match = re.match("(HTTP/1.[0-9]) ([0-9]+) ([^\r]*)", line)
     if not match:
         raise HTTPInputError("Error parsing response start line")
-    return ResponseStartLine(match.group(1), int(match.group(2)),
-                             match.group(3))
+    return ResponseStartLine(match.group(1), int(match.group(2)), match.group(3))
+
 
 # _parseparam and _parse_header are copied and modified from python2.7's cgi.py
 # The original 2.7 version of this code did not correctly support some
@@ -871,11 +899,11 @@ def parse_response_start_line(line):
 
 
 def _parseparam(s):
-    while s[:1] == ';':
+    while s[:1] == ";":
         s = s[1:]
-        end = s.find(';')
+        end = s.find(";")
         while end > 0 and (s.count('"', 0, end) - s.count('\\"', 0, end)) % 2:
-            end = s.find(';', end + 1)
+            end = s.find(";", end + 1)
         if end < 0:
             end = len(s)
         f = s[:end]
@@ -889,17 +917,17 @@ def _parse_header(line):
     Return the main content-type and a dictionary of options.
 
     """
-    parts = _parseparam(';' + line)
+    parts = _parseparam(";" + line)
     key = next(parts)
     pdict = {}
     for p in parts:
-        i = p.find('=')
+        i = p.find("=")
         if i >= 0:
             name = p[:i].strip().lower()
-            value = p[i + 1:].strip()
+            value = p[i + 1 :].strip()
             if len(value) >= 2 and value[0] == value[-1] == '"':
                 value = value[1:-1]
-                value = value.replace('\\\\', '\\').replace('\\"', '"')
+                value = value.replace("\\\\", "\\").replace('\\"', '"')
             pdict[name] = value
         else:
             pdict[p] = None
@@ -922,12 +950,13 @@ def _encode_header(key, pdict):
             out.append(k)
         else:
             # TODO: quote if necessary.
-            out.append('%s=%s' % (k, v))
-    return '; '.join(out)
+            out.append("%s=%s" % (k, v))
+    return "; ".join(out)
 
 
 def doctests():
     import doctest
+
     return doctest.DocTestSuite()
 
 
@@ -938,7 +967,7 @@ def split_host_and_port(netloc):
 
     .. versionadded:: 4.1
     """
-    match = re.match(r'^(.+):(\d+)$', netloc)
+    match = re.match(r"^(.+):(\d+)$", netloc)
     if match:
         host = match.group(1)
         port = int(match.group(2))
@@ -950,7 +979,7 @@ def split_host_and_port(netloc):
 
 _OctalPatt = re.compile(r"\\[0-3][0-7][0-7]")
 _QuotePatt = re.compile(r"[\\].")
-_nulljoin = ''.join
+_nulljoin = "".join
 
 
 def _unquote_cookie(str):
@@ -983,7 +1012,7 @@ def _unquote_cookie(str):
     while 0 <= i < n:
         o_match = _OctalPatt.search(str, i)
         q_match = _QuotePatt.search(str, i)
-        if not o_match and not q_match:              # Neither matched
+        if not o_match and not q_match:  # Neither matched
             res.append(str[i:])
             break
         # else:
@@ -992,13 +1021,13 @@ def _unquote_cookie(str):
             j = o_match.start(0)
         if q_match:
             k = q_match.start(0)
-        if q_match and (not o_match or k < j):     # QuotePatt matched
+        if q_match and (not o_match or k < j):  # QuotePatt matched
             res.append(str[i:k])
             res.append(str[k + 1])
             i = k + 2
-        else:                                      # OctalPatt matched
+        else:  # OctalPatt matched
             res.append(str[i:j])
-            res.append(chr(int(str[j + 1:j + 4], 8)))
+            res.append(chr(int(str[j + 1 : j + 4], 8)))
             i = j + 4
     return _nulljoin(res)
 
@@ -1015,13 +1044,13 @@ def parse_cookie(cookie):
     .. versionadded:: 4.4.2
     """
     cookiedict = {}
-    for chunk in cookie.split(str(';')):
-        if str('=') in chunk:
-            key, val = chunk.split(str('='), 1)
+    for chunk in cookie.split(str(";")):
+        if str("=") in chunk:
+            key, val = chunk.split(str("="), 1)
         else:
             # Assume an empty name per
             # https://bugzilla.mozilla.org/show_bug.cgi?id=169091
-            key, val = str(''), chunk
+            key, val = str(""), chunk
         key, val = key.strip(), val.strip()
         if key or val:
             # unquote using Python's algorithm.

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -13,6 +13,7 @@ import os
 import re
 import sys
 import time
+from collections.abc import Sequence
 
 # Import salt libs
 import salt.loader
@@ -26,15 +27,6 @@ import salt.utils.versions
 from salt.ext import six
 from salt.utils.args import get_function_argspec as _argspec
 from salt.utils.decorators import ensure_unicode_args
-
-try:
-    from collections.abc import Sequence
-except ImportError:
-    # pylint: disable=no-name-in-module
-    from collections import Sequence
-
-    # pylint: enable=no-name-in-module
-
 
 log = logging.getLogger(__name__)
 

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -19,6 +19,7 @@ import threading
 import time
 import traceback
 import types
+from collections.abc import MutableMapping
 from zipimport import zipimporter
 
 # Import salt libs
@@ -54,13 +55,6 @@ else:
 
     USE_IMPORTLIB = False
 
-try:
-    from collections.abc import MutableMapping
-except ImportError:
-    # pylint: disable=no-name-in-module
-    from collections import MutableMapping
-
-    # pylint: enable=no-name-in-module
 
 try:
     import pkg_resources

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -30,6 +30,7 @@ import sys
 import tempfile
 import time
 from collections import namedtuple
+from collections.abc import Iterable, Mapping
 from functools import reduce  # pylint: disable=redefined-builtin
 
 # Import salt libs
@@ -57,12 +58,6 @@ from salt.ext import six
 from salt.ext.six.moves import range, zip
 from salt.ext.six.moves.urllib.parse import urlparse as _urlparse
 from salt.utils.files import HASHES, HASHES_REVMAP
-
-try:
-    from collections.abc import Iterable, Mapping
-except ImportError:
-    from collections import Iterable, Mapping
-
 
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
 

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -33,6 +33,7 @@ import stat
 import string  # do not remove, used in imported file.py functions
 import sys  # do not remove, used in imported file.py functions
 import tempfile  # do not remove. Used in salt.modules.file.__clean_tmp
+from collections.abc import Iterable, Mapping
 from functools import reduce  # do not remove
 
 import salt.utils.atomicfile  # do not remove, used in imported file.py functions
@@ -121,14 +122,6 @@ from salt.modules.file import (
     write,
 )
 from salt.utils.functools import namespaced_function as _namespaced_function
-
-# pylint: disable=no-name-in-module
-try:
-    from collections.abc import Iterable, Mapping
-except ImportError:
-    from collections import Iterable, Mapping
-# pylint: enable=no-name-in-module
-
 
 HAS_WINDOWS_MODULES = False
 try:

--- a/salt/output/nested.py
+++ b/salt/output/nested.py
@@ -25,6 +25,8 @@ Example output::
 """
 from __future__ import absolute_import, print_function, unicode_literals
 
+from collections.abc import Mapping
+
 # Import python libs
 from numbers import Number
 
@@ -34,14 +36,6 @@ import salt.utils.color
 import salt.utils.odict
 import salt.utils.stringutils
 from salt.ext import six
-
-try:
-    from collections.abc import Mapping
-except ImportError:
-    # pylint: disable=no-name-in-module
-    from collections import Mapping
-
-    # pylint: enable=no-name-in-module
 
 
 class NestDisplay(object):

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -293,6 +293,7 @@ import sys
 import time
 import traceback
 from collections import defaultdict
+from collections.abc import Iterable, Mapping
 from datetime import date, datetime  # python3 problem in the making?
 
 # Import salt libs
@@ -317,14 +318,6 @@ from salt.ext.six.moves import zip_longest
 from salt.ext.six.moves.urllib.parse import urlparse as _urlparse
 from salt.serializers import DeserializationError
 from salt.state import get_accumulator_dir as _get_accumulator_dir
-
-# pylint: disable=no-name-in-module
-try:
-    from collections.abc import Iterable, Mapping
-except ImportError:
-    from collections import Iterable, Mapping
-# pylint: enable=no-name-in-module
-
 
 if salt.utils.platform.is_windows():
     import salt.utils.win_dacl

--- a/salt/utils/context.py
+++ b/salt/utils/context.py
@@ -14,17 +14,10 @@ from __future__ import absolute_import, print_function, unicode_literals
 # Import python libs
 import copy
 import threading
+from collections.abc import MutableMapping
 from contextlib import contextmanager
 
 from salt.ext import six
-
-try:
-    from collections.abc import MutableMapping
-except ImportError:
-    # pylint: disable=no-name-in-module
-    from collections import MutableMapping
-
-    # pylint: enable=no-name-in-module
 
 
 @contextmanager

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -12,6 +12,7 @@ import fnmatch
 import functools
 import logging
 import re
+from collections.abc import Mapping, MutableMapping, Sequence
 
 # Import Salt libs
 import salt.utils.dictupdate
@@ -26,15 +27,6 @@ from salt.ext.six.moves import range  # pylint: disable=redefined-builtin
 from salt.ext.six.moves import zip  # pylint: disable=redefined-builtin
 from salt.utils.decorators.jinja import jinja_filter
 from salt.utils.odict import OrderedDict
-
-try:
-    from collections.abc import Mapping, MutableMapping, Sequence
-except ImportError:
-    # pylint: disable=no-name-in-module
-    from collections import Mapping, MutableMapping, Sequence
-
-    # pylint: enable=no-name-in-module
-
 
 try:
     import jmespath

--- a/salt/utils/dictdiffer.py
+++ b/salt/utils/dictdiffer.py
@@ -14,16 +14,9 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import copy
+from collections.abc import Mapping
 
 from salt.ext import six
-
-try:
-    from collections.abc import Mapping
-except ImportError:
-    # pylint: disable=no-name-in-module
-    from collections import Mapping
-
-    # pylint: enable=no-name-in-module
 
 
 def diff(current_dict, past_dict):

--- a/salt/utils/dictupdate.py
+++ b/salt/utils/dictupdate.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 # Import 3rd-party libs
 import copy
 import logging
+from collections.abc import Mapping
 
 # Import salt libs
 import salt.ext.six as six
@@ -18,15 +19,6 @@ from salt.defaults import DEFAULT_TARGET_DELIM
 from salt.exceptions import SaltInvocationError
 from salt.utils.decorators.jinja import jinja_filter
 from salt.utils.odict import OrderedDict
-
-try:
-    from collections.abc import Mapping
-except ImportError:
-    # pylint: disable=no-name-in-module
-    from collections import Mapping
-
-    # pylint: enable=no-name-in-module
-
 
 log = logging.getLogger(__name__)
 

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -60,6 +60,7 @@ import logging
 # Import python libs
 import os
 import time
+from collections.abc import MutableMapping
 from multiprocessing.util import Finalize
 
 # Import salt libs
@@ -83,15 +84,6 @@ import salt.utils.zeromq
 # Import third party libs
 from salt.ext import six
 from salt.ext.six.moves import range
-
-try:
-    from collections.abc import MutableMapping
-except ImportError:
-    # pylint: disable=no-name-in-module
-    from collections import MutableMapping
-
-    # pylint: enable=no-name-in-module
-
 
 log = logging.getLogger(__name__)
 

--- a/salt/utils/immutabletypes.py
+++ b/salt/utils/immutabletypes.py
@@ -11,15 +11,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import copy
-
-# Import python libs
-try:
-    from collections.abc import Mapping, Sequence, Set
-except ImportError:
-    # pylint: disable=no-name-in-module
-    from collections import Mapping, Sequence, Set
-
-    # pylint: enable=no-name-in-module
+from collections.abc import Mapping, Sequence, Set
 
 
 class ImmutableDict(Mapping):

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -14,6 +14,7 @@ import pprint
 import re
 import uuid
 import warnings
+from collections.abc import Hashable
 from functools import wraps
 from xml.dom import minidom
 from xml.etree.ElementTree import Element, SubElement, tostring
@@ -38,13 +39,6 @@ from salt.ext import six
 from salt.utils.decorators.jinja import jinja_filter, jinja_global, jinja_test
 from salt.utils.odict import OrderedDict
 from salt.utils.versions import LooseVersion
-
-try:
-    from collections.abc import Hashable
-except ImportError:
-    # pylint: disable=no-name-in-module
-    from collections import Hashable
-
 
 log = logging.getLogger(__name__)
 

--- a/salt/utils/lazy.py
+++ b/salt/utils/lazy.py
@@ -7,16 +7,9 @@ Lazily-evaluated data structures, primarily used by Salt's loader
 from __future__ import absolute_import, unicode_literals
 
 import logging
+from collections.abc import MutableMapping
 
 import salt.exceptions
-
-try:
-    from collections.abc import MutableMapping
-except ImportError:
-    # pylint: disable=no-name-in-module
-    from collections import MutableMapping
-
-    # pylint: enable=no-name-in-module
 
 log = logging.getLogger(__name__)
 

--- a/salt/utils/odict.py
+++ b/salt/utils/odict.py
@@ -23,17 +23,10 @@
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
 
+from collections.abc import Callable
+
 # Import 3rd-party libs
 from salt.ext import six
-
-try:
-    from collections.abc import Callable
-except ImportError:
-    # pylint: disable=no-name-in-module
-    from collections import Callable
-
-    # pylint: enable=no-name-in-module
-
 
 try:
     # pylint: disable=E0611,minimum-python-version

--- a/salt/utils/oset.py
+++ b/salt/utils/oset.py
@@ -23,11 +23,7 @@ Rob Speer's changes are as follows:
 """
 from __future__ import absolute_import, print_function, unicode_literals
 
-try:
-    from collections.abc import MutableSet
-except ImportError:
-    # pylint: disable=no-name-in-module
-    from collections import MutableSet
+from collections.abc import MutableSet
 
 SLICE_ALL = slice(None)
 __version__ = "2.0.1"

--- a/salt/utils/path.py
+++ b/salt/utils/path.py
@@ -14,6 +14,7 @@ import posixpath
 import re
 import string
 import struct
+from collections.abc import Iterable
 
 # Import Salt libs
 import salt.utils.args
@@ -24,15 +25,6 @@ from salt.exceptions import CommandNotFoundError
 # Import 3rd-party libs
 from salt.ext import six
 from salt.utils.decorators.jinja import jinja_filter
-
-try:
-    from collections.abc import Iterable
-except ImportError:
-    # pylint: disable=no-name-in-module
-    from collections import Iterable
-
-    # pylint: enable=no-name-in-module
-
 
 try:
     import win32file

--- a/salt/utils/ssdp.py
+++ b/salt/utils/ssdp.py
@@ -27,10 +27,14 @@ import logging
 import random
 import socket
 import time
-from collections import OrderedDict
 
 import salt.utils.json
 import salt.utils.stringutils
+
+try:
+    from salt.utils.odict import OrderedDict
+except ImportError:
+    from collections import OrderedDict
 
 _json = salt.utils.json.import_json()
 if not hasattr(_json, "dumps"):

--- a/tests/integration/shell/test_syndic.py
+++ b/tests/integration/shell/test_syndic.py
@@ -10,7 +10,6 @@
 from __future__ import absolute_import
 
 import logging
-from collections import OrderedDict
 
 import psutil
 import pytest
@@ -22,6 +21,11 @@ from tests.support.case import ShellCase
 from tests.support.helpers import slowTest
 from tests.support.mixins import ShellCaseCommonTestsMixin
 from tests.support.unit import skipIf
+
+try:
+    from salt.utils.odict import OrderedDict
+except ImportError:
+    from collections import OrderedDict
 
 log = logging.getLogger(__name__)
 

--- a/tests/multimaster/__init__.py
+++ b/tests/multimaster/__init__.py
@@ -15,7 +15,6 @@ import stat
 import sys
 import threading
 import time
-from collections import OrderedDict
 
 import salt.config
 import salt.log.setup as salt_log_setup
@@ -47,6 +46,11 @@ from tests.support.paths import (
 # Import salt tests support libs
 from tests.support.processes import SaltMaster, SaltMinion, start_daemon
 from tests.support.runtests import RUNTIME_VARS
+
+try:
+    from salt.utils.odict import OrderedDict
+except ImportError:
+    from collections import OrderedDict
 
 log = logging.getLogger(__name__)
 

--- a/tests/support/mixins.py
+++ b/tests/support/mixins.py
@@ -22,7 +22,6 @@ import sys
 import tempfile
 import time
 import types
-from collections import OrderedDict
 
 import salt.config
 import salt.exceptions
@@ -43,6 +42,11 @@ from salt.utils.verify import verify_env
 from tests.support.mock import patch
 from tests.support.paths import CODE_DIR
 from tests.support.runtests import RUNTIME_VARS
+
+try:
+    from salt.utils.odict import OrderedDict
+except ImportError:
+    from collections import OrderedDict
 
 log = logging.getLogger(__name__)
 

--- a/tests/unit/modules/test_debian_ip.py
+++ b/tests/unit/modules/test_debian_ip.py
@@ -5,18 +5,22 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import tempfile
-from collections import OrderedDict as odict
 
 import jinja2.exceptions
 import salt.modules.debian_ip as debian_ip
-import salt.utils
 
 # Import Salt Testing Libs
+import salt.utils.files
 import salt.utils.platform
 from tests.support.helpers import slowTest
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase, skipIf
+
+try:
+    from salt.utils.odict import OrderedDict as odict
+except ImportError:
+    from collections import OrderedDict as odict
 
 # Big pile of interface data for unit tests
 #   To skip, search for 'DebianIpTestCase'

--- a/tests/unit/pillar/test_pepa.py
+++ b/tests/unit/pillar/test_pepa.py
@@ -3,13 +3,16 @@
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
 
-from collections import OrderedDict
-
 # Import Salt Libs
 import salt.pillar.pepa as pepa
 
 # Import Salt Testing libs
 from tests.support.unit import TestCase
+
+try:
+    from salt.utils.odict import OrderedDict
+except ImportError:
+    from collections import OrderedDict
 
 
 class PepaPillarTestCase(TestCase):


### PR DESCRIPTION
This prevents Deprecation warnings on Python 3.8. Additionally, code to
make these ABCs successfully import in Python 2 is no longer needed and
has been removed.