### PR TITLE
Fix typo (`Minon` → `Minion`)

### DIFF
--- a/doc/spelling_wordlist.txt
+++ b/doc/spelling_wordlist.txt
@@ -443,7 +443,7 @@ Memcached
 metadata
 Metadata
 minionfs
-minon
+minion
 mirrorlist
 mkfile
 mkfs

--- a/doc/topics/cloud/config.rst
+++ b/doc/topics/cloud/config.rst
@@ -57,7 +57,7 @@ settings can be placed in the provider, profile or map configuration files:
           - web
 
 
-When salt cloud creates a new minon, it can automatically add grain information
+When salt cloud creates a new minion, it can automatically add grain information
 to the minion configuration file identifying the sources originally used
 to define it.
 

--- a/doc/topics/installation/nxos.rst
+++ b/doc/topics/installation/nxos.rst
@@ -47,15 +47,15 @@ Using the tables above, select the Salt Minion type.
 
 Choices:
   * ``SSH`` Proxy Minion (See `Salt Proxy Minion Configuration`_ Section)
-  * ``NX-API`` Proxy Minon (See `Salt Proxy Minion Configuration`_ Section)
+  * ``NX-API`` Proxy Minion (See `Salt Proxy Minion Configuration`_ Section)
   * ``GuestShell`` Native Minion (See `GuestShell Salt Minion Installation`_ Section)
-      * Some platforms support a native minon installed directly on the NX-OS device inside the GuestShell
+      * Some platforms support a native minion installed directly on the NX-OS device inside the GuestShell
       * The GuestShell is a secure Linux container environment running CentOS
 
 STEP 3: Network Connectivity
 ----------------------------
 
-Ensure that IP reachability exists between the NX-OS Salt Minon device and the SaltStack Master.
+Ensure that IP reachability exists between the NX-OS Salt Minion device and the SaltStack Master.
 
 **Note:** The management interface exists in a separate VRF context and requires additional configuration as shown.
 
@@ -89,7 +89,7 @@ Here is a sample Proxy Minion directory structure
   ├── n7k-proxy.sls
   └── top.sls
 
-This displays a top sls file and two proxy minon sls files for a Nexus 3k and Nexus 7k device.
+This displays a top sls file and two proxy minion sls files for a Nexus 3k and Nexus 7k device.
 
 Sample contents for the ``top.sls`` file.
 
@@ -105,7 +105,7 @@ Sample contents for the ``top.sls`` file.
 Proxy Minion Pillar Data
 ------------------------
 
-Here is a sample Proxy Minon pillar data file.
+Here is a sample Proxy Minion pillar data file.
 
 All of the data for both ssh and nxapi proxy minion types can be stored in the same pillar data file.  To choose ``ssh`` or ``nxapi``, simply set the ``connection:`` parameter accordingly.
 
@@ -305,7 +305,7 @@ Example:
   - #id: salt
   + id: n3k-guestshell-minion
 
-Start the Minon in the Guestshell and accept the key on the SaltStack Master.
+Start the Minion in the Guestshell and accept the key on the SaltStack Master.
 
   ``[root@guestshell ~]# systemctl start salt-minion``
 
@@ -327,7 +327,7 @@ Start the Minon in the Guestshell and accept the key on the SaltStack Master.
   Proceed? [n/Y] Y
   Key for minion n3k-guestshell-minion accepted.
 
-Ping the SaltStack Minon running in the Guestshell.
+Ping the SaltStack Minion running in the Guestshell.
 
 .. code:: bash
 

--- a/doc/topics/releases/2015.5.4.rst
+++ b/doc/topics/releases/2015.5.4.rst
@@ -517,7 +517,7 @@ Changelog for v2015.5.3..v2015.5.4
 
   * 1e9a850e23 fix autoruns.list looking in wrong directory
 
-* **ISSUE** `saltstack/salt-bootstrap#640`_: (`Deshke`_) salt-minon install bug on ubuntu 14.04 tornado>=4.0 (refs: `#26065`_)
+* **ISSUE** `saltstack/salt-bootstrap#640`_: (`Deshke`_) salt-minion install bug on ubuntu 14.04 tornado>=4.0 (refs: `#26065`_)
 
 * **ISSUE** `saltstack/salt-bootstrap#633`_: (`neilmb`_) Bootstrap install fails on python-requests dependency (refs: `#26065`_)
 

--- a/doc/topics/tutorials/esxi_proxy_minion.rst
+++ b/doc/topics/tutorials/esxi_proxy_minion.rst
@@ -136,7 +136,7 @@ order for the ESXi Proxy Minion to run and connect properly.
 Proxy Config File
 -----------------
 
-On the machine that will be running the Proxy Minon process(es), a proxy config
+On the machine that will be running the Proxy Minion process(es), a proxy config
 file must be in place. This file should be located in the ``/etc/salt/`` directory
 and should be named ``proxy``. If the file is not there by default, create it.
 

--- a/salt/modules/nxos.py
+++ b/salt/modules/nxos.py
@@ -37,7 +37,7 @@ This module supports execution using a Proxy Minion or Native Minion:
         nxapi enabled
         HTTPS Listen on port 443
 
-Native minon configuration options:
+Native minion configuration options:
 
 .. code-block:: yaml
 

--- a/salt/netapi/rest_tornado/saltnado_websockets.py
+++ b/salt/netapi/rest_tornado/saltnado_websockets.py
@@ -240,7 +240,7 @@ Minion information is sent in response to the following minion events:
 - connection drops
     - requires running ``manage.present`` periodically every ``loop_interval`` seconds
 - minion addition
-- minon removal
+- minion removal
 
 .. code-block:: python
 

--- a/salt/proxy/nxos.py
+++ b/salt/proxy/nxos.py
@@ -27,7 +27,7 @@ To configure the proxy minion for ssh:
       ssh_args: '-o PubkeyAuthentication=no'
       key_accept: True
 
-To configure the proxy minon for nxapi:
+To configure the proxy minion for nxapi:
 
 .. code-block:: yaml
 

--- a/tests/integration/daemons/test_masterapi.py
+++ b/tests/integration/daemons/test_masterapi.py
@@ -40,7 +40,7 @@ class AutosignGrainsTest(ShellCase):
         self.run_key("-d minion -y")
         self.run_call(
             "test.ping -l quiet"
-        )  # get minon to try to authenticate itself again
+        )  # get minion to try to authenticate itself again
 
         if "minion" in self.run_key("-l acc"):
             self.tearDown()
@@ -59,7 +59,7 @@ class AutosignGrainsTest(ShellCase):
         )
         os.chmod(self.autosign_file_path, self.autosign_file_permissions)
 
-        self.run_call("test.ping -l quiet")  # get minon to authenticate itself again
+        self.run_call("test.ping -l quiet")  # get minion to authenticate itself again
 
         try:
             if os.path.isdir(self.autosign_grains_dir):
@@ -76,7 +76,7 @@ class AutosignGrainsTest(ShellCase):
 
         self.run_call(
             "test.ping -l quiet"
-        )  # get minon to try to authenticate itself again
+        )  # get minion to try to authenticate itself again
         self.assertIn("minion", self.run_key("-l acc"))
 
     @slowTest
@@ -88,6 +88,6 @@ class AutosignGrainsTest(ShellCase):
 
         self.run_call(
             "test.ping -l quiet"
-        )  # get minon to try to authenticate itself again
+        )  # get minion to try to authenticate itself again
         self.assertNotIn("minion", self.run_key("-l acc"))
         self.assertIn("minion", self.run_key("-l un"))

--- a/tests/integration/states/test_user.py
+++ b/tests/integration/states/test_user.py
@@ -241,7 +241,7 @@ class UserTest(ModuleCase, SaltReturnAssertsMixin):
 
     @skipIf(
         salt.utils.platform.is_windows(),
-        "windows minon does not support roomnumber or phone",
+        "windows minion does not support roomnumber or phone",
     )
     @slowTest
     def test_user_present_gecos(self):
@@ -265,7 +265,7 @@ class UserTest(ModuleCase, SaltReturnAssertsMixin):
 
     @skipIf(
         salt.utils.platform.is_windows(),
-        "windows minon does not support roomnumber or phone",
+        "windows minion does not support roomnumber or phone",
     )
     @slowTest
     def test_user_present_gecos_none_fields(self):
@@ -295,7 +295,7 @@ class UserTest(ModuleCase, SaltReturnAssertsMixin):
             self.assertEqual("", ret["homephone"])
 
     @skipIf(
-        salt.utils.platform.is_windows(), "windows minon does not support createhome"
+        salt.utils.platform.is_windows(), "windows minion does not support createhome"
     )
     @slowTest
     def test_user_present_home_directory_created(self):


### PR DESCRIPTION
- Notice the typo while reading docs
- Run `ack -i minon` to notice it's quite common and even made it into `doc/spelling_wordlist.txt`
- Run `ack -li minon | xargs sed -i 's|\([Mm]\)inon|\1inion|g'` to correct it
- Review changes
- Add + Commit

### What does this PR do?
Fixes a common typo (`Minon` → `Minion`)

### What issues does this PR fix or reference?
None


### Merge requirements satisfied?
- [N/A] Docs
- [N/A] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [N/A] Tests written/updated

### Commits signed with GPG?
Yes