### PR TITLE
Refactor SyncWrapper

### DIFF
--- a/salt/transport/client.py
+++ b/salt/transport/client.py
@@ -24,8 +24,9 @@ class ReqChannel(object):
     @staticmethod
     def factory(opts, **kwargs):
         # All Sync interfaces are just wrappers around the Async ones
-        sync = SyncWrapper(AsyncReqChannel.factory, (opts,), kwargs)
-        return sync
+        return SyncWrapper(
+            AsyncReqChannel.factory, (opts,), kwargs, loop_kwarg="io_loop",
+        )
 
     def close(self):
         """
@@ -62,8 +63,9 @@ class PushChannel(object):
 
     @staticmethod
     def factory(opts, **kwargs):
-        sync = SyncWrapper(AsyncPushChannel.factory, (opts,), kwargs)
-        return sync
+        return SyncWrapper(
+            AsyncPushChannel.factory, (opts,), kwargs, loop_kwarg="io_loop",
+        )
 
     def send(self, load, tries=3, timeout=60):
         """
@@ -79,8 +81,9 @@ class PullChannel(object):
 
     @staticmethod
     def factory(opts, **kwargs):
-        sync = SyncWrapper(AsyncPullChannel.factory, (opts,), kwargs)
-        return sync
+        return SyncWrapper(
+            AsyncPullChannel.factory, (opts,), kwargs, loop_kwarg="io_loop",
+        )
 
 
 # TODO: better doc strings

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -91,6 +91,13 @@ class IPCServer(object):
     but using either UNIX domain sockets or TCP sockets
     """
 
+    async_methods = [
+        "handle_stream",
+    ]
+    close_methods = [
+        "close",
+    ]
+
     def __init__(self, socket_path, io_loop=None, payload_handler=None):
         """
         Create a new Tornado IPC server
@@ -414,6 +421,15 @@ class IPCMessageClient(IPCClient):
     # Send some data
     ipc_client.send('Hello world')
     """
+
+    async_methods = [
+        "send",
+        "connect",
+        "_connect",
+    ]
+    close_methods = [
+        "close",
+    ]
 
     # FIXME timeout unimplemented
     # FIXME tries unimplemented

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -240,6 +240,15 @@ class AsyncTCPReqChannel(salt.transport.client.ReqChannel):
     # This class is only a singleton per minion/master pair
     # mapping of io_loop -> {key -> channel}
     instance_map = weakref.WeakKeyDictionary()
+    async_methods = [
+        "crypted_transfer_decode_dictentry",
+        "_crypted_transfer",
+        "_uncrypted_transfer",
+        "send",
+    ]
+    close_methods = [
+        "close",
+    ]
 
     def __new__(cls, opts, **kwargs):
         """
@@ -446,6 +455,15 @@ class AsyncTCPReqChannel(salt.transport.client.ReqChannel):
 class AsyncTCPPubChannel(
     salt.transport.mixins.auth.AESPubClientMixin, salt.transport.client.AsyncPubChannel
 ):
+    async_methods = [
+        "send_id",
+        "connect_callback",
+        "connect",
+    ]
+    close_methods = [
+        "close",
+    ]
+
     def __init__(self, opts, **kwargs):
         self.opts = opts
 
@@ -545,7 +563,7 @@ class AsyncTCPPubChannel(
                 "tag": tag,
             }
             req_channel = salt.utils.asynchronous.SyncWrapper(
-                AsyncTCPReqChannel, (self.opts,)
+                AsyncTCPReqChannel, (self.opts,), loop_kwarg="io_loop",
             )
             try:
                 req_channel.send(load, timeout=60)
@@ -1660,7 +1678,7 @@ class TCPPubServerChannel(salt.transport.server.PubServerChannel):
         # TODO: switch to the actual asynchronous interface
         # pub_sock = salt.transport.ipc.IPCMessageClient(self.opts, io_loop=self.io_loop)
         pub_sock = salt.utils.asynchronous.SyncWrapper(
-            salt.transport.ipc.IPCMessageClient, (pull_uri,)
+            salt.transport.ipc.IPCMessageClient, (pull_uri,), loop_kwarg="io_loop",
         )
         pub_sock.connect()
 

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -142,6 +142,16 @@ class AsyncZeroMQReqChannel(salt.transport.client.ReqChannel):
     # This class is only a singleton per minion/master pair
     # mapping of io_loop -> {key -> channel}
     instance_map = weakref.WeakKeyDictionary()
+    async_methods = [
+        "crypted_transfer_decode_dictentry",
+        "_crypted_transfer",
+        "_do_transfer",
+        "_uncrypted_transfer",
+        "send",
+    ]
+    close_methods = [
+        "close",
+    ]
 
     def __new__(cls, opts, **kwargs):
         """
@@ -441,6 +451,14 @@ class AsyncZeroMQPubChannel(
     A transport channel backed by ZeroMQ for a Salt Publisher to use to
     publish commands to connected minions
     """
+
+    async_methods = [
+        "connect",
+        "_decode_messages",
+    ]
+    close_methods = [
+        "close",
+    ]
 
     def __init__(self, opts, **kwargs):
         self.opts = opts

--- a/salt/utils/asynchronous.py
+++ b/salt/utils/asynchronous.py
@@ -6,12 +6,16 @@ Helpers/utils for working with tornado asynchronous stuff
 from __future__ import absolute_import, print_function, unicode_literals
 
 import contextlib
+import logging
 import sys
+import threading
 
 import salt.ext.tornado.concurrent
 import salt.ext.tornado.ioloop
 from salt.ext import six
-from salt.utils import zeromq
+
+
+log = logging.getLogger(__name__)
 
 
 @contextlib.contextmanager
@@ -42,71 +46,99 @@ class SyncWrapper(object):
     ret = sync.async_method()
     """
 
-    def __init__(self, method, args=tuple(), kwargs=None):
+    def __init__(
+        self,
+        cls,
+        args=None,
+        kwargs=None,
+        async_methods=None,
+        close_methods=None,
+        loop_kwarg=None,
+    ):
+        self.io_loop = salt.ext.tornado.ioloop.IOLoop()
+        if args is None:
+            args = []
         if kwargs is None:
             kwargs = {}
+        if async_methods is None:
+            async_methods = []
+        if close_methods is None:
+            close_methods = []
+        self.loop_kwarg = loop_kwarg
+        self.cls = cls
+        if loop_kwarg:
+            kwargs[self.loop_kwarg] = self.io_loop
+        self.obj = cls(*args, **kwargs)
+        self._async_methods = list(
+            set(async_methods + getattr(self.obj, "async_methods", []))
+        )
+        self._close_methods = list(
+            set(close_methods + getattr(self.obj, "close_methods", []))
+        )
 
-        self.io_loop = zeromq.ZMQDefaultLoop()
-        kwargs["io_loop"] = self.io_loop
+    def _populate_async_methods(self):
+        """
+        We need the '_coroutines' attribute on classes until we can depricate
+        tornado<4.5. After that 'is_coroutine_fuction' will always be
+        available.
+        """
+        if hasattr(self.obj, "_coroutines"):
+            self._async_methods += self.obj._coroutines
 
-        with current_ioloop(self.io_loop):
-            self.asynchronous = method(*args, **kwargs)
-
-    def __getattribute__(self, key):
-        try:
-            return object.__getattribute__(self, key)
-        except AttributeError:
-            if key == "asynchronous":
-                six.reraise(*sys.exc_info())
-        attr = getattr(self.asynchronous, key)
-        if hasattr(attr, "__call__"):
-
-            def wrap(*args, **kwargs):
-                # Overload the ioloop for the func call-- since it might call .current()
-                with current_ioloop(self.io_loop):
-                    ret = attr(*args, **kwargs)
-                    if isinstance(ret, salt.ext.tornado.concurrent.Future):
-                        ret = self._block_future(ret)
-                    return ret
-
-            return wrap
-        return attr
-
-    def _block_future(self, future):
-        self.io_loop.add_future(future, lambda future: self.io_loop.stop())
-        self.io_loop.start()
-        return future.result()
+    def __repr__(self):
+        return "<SyncWrapper(cls={})".format(self.cls)
 
     def close(self):
-        if hasattr(self, "asynchronous"):
-            if hasattr(self.asynchronous, "close"):
-                # Certain things such as streams should be closed before
-                # their associated io_loop is closed to allow for proper
-                # cleanup.
-                self.asynchronous.close()
-            elif hasattr(self.asynchronous, "destroy"):
-                # Certain things such as streams should be closed before
-                # their associated io_loop is closed to allow for proper
-                # cleanup.
-                self.asynchronous.destroy()
-            del self.asynchronous
-            self.io_loop.close()
-            del self.io_loop
-        elif hasattr(self, "io_loop"):
-            self.io_loop.close()
-            del self.io_loop
+        for method in self._close_methods:
+            if method in self._async_methods:
+                method = self._wrap(method)
+            else:
+                try:
+                    method = getattr(self.obj, method)
+                except AttributeError:
+                    log.error("No sync method %s on object %r", method, self.obj)
+                    continue
+            try:
+                method()
+            except AttributeError:
+                log.error("No async method %s on object %r", method, self.obj)
+            except Exception:  # pylint: disable=broad-except
+                log.exception("Exception encountered while running stop method")
+        io_loop = self.io_loop
+        io_loop.stop()
+        io_loop.close(all_fds=True)
+
+    def __getattr__(self, key):
+        if key in self._async_methods:
+            return self._wrap(key)
+        return getattr(self.obj, key)
+
+    def _wrap(self, key):
+        def wrap(*args, **kwargs):
+            results = []
+            thread = threading.Thread(
+                target=self._target, args=(key, args, kwargs, results, self.io_loop),
+            )
+            thread.start()
+            thread.join()
+            if results[0]:
+                return results[1]
+            else:
+                six.reraise(*results[1])
+
+        return wrap
+
+    def _target(self, key, args, kwargs, results, io_loop):
+        try:
+            result = io_loop.run_sync(lambda: getattr(self.obj, key)(*args, **kwargs))
+            results.append(True)
+            results.append(result)
+        except Exception as exc:  # pylint: disable=broad-except
+            results.append(False)
+            results.append(sys.exc_info())
 
     def __enter__(self):
         return self
 
-    def __exit__(self, *args):
+    def __exit__(self, exc_type, exc_val, tb):
         self.close()
-
-    # pylint: disable=W1701
-    def __del__(self):
-        """
-        On deletion of the asynchronous wrapper, make sure to clean up the asynchronous stuff
-        """
-        self.close()
-
-    # pylint: enable=W1701

--- a/salt/utils/asynchronous.py
+++ b/salt/utils/asynchronous.py
@@ -14,7 +14,6 @@ import salt.ext.tornado.concurrent
 import salt.ext.tornado.ioloop
 from salt.ext import six
 
-
 log = logging.getLogger(__name__)
 
 

--- a/tests/unit/utils/test_asynchronous.py
+++ b/tests/unit/utils/test_asynchronous.py
@@ -5,20 +5,29 @@ import salt.ext.tornado.gen
 import salt.ext.tornado.testing
 import salt.utils.asynchronous as asynchronous
 from salt.ext.tornado.testing import AsyncTestCase
-from tests.support.helpers import slowTest
 
 
 class HelperA(object):
+
+    async_methods = [
+        "sleep",
+    ]
+
     def __init__(self, io_loop=None):
         pass
 
     @salt.ext.tornado.gen.coroutine
     def sleep(self):
-        yield salt.ext.tornado.gen.sleep(0.5)
+        yield salt.ext.tornado.gen.sleep(0.1)
         raise salt.ext.tornado.gen.Return(True)
 
 
 class HelperB(object):
+
+    async_methods = [
+        "sleep",
+    ]
+
     def __init__(self, a=None, io_loop=None):
         if a is None:
             a = asynchronous.SyncWrapper(HelperA)
@@ -26,14 +35,13 @@ class HelperB(object):
 
     @salt.ext.tornado.gen.coroutine
     def sleep(self):
-        yield salt.ext.tornado.gen.sleep(0.5)
+        yield salt.ext.tornado.gen.sleep(0.1)
         self.a.sleep()
         raise salt.ext.tornado.gen.Return(False)
 
 
 class TestSyncWrapper(AsyncTestCase):
     @salt.ext.tornado.testing.gen_test
-    @slowTest
     def test_helpers(self):
         """
         Test that the helper classes do what we expect within a regular asynchronous env
@@ -54,7 +62,6 @@ class TestSyncWrapper(AsyncTestCase):
         ret = sync.sleep()
         self.assertTrue(ret)
 
-    @slowTest
     def test_double(self):
         """
         Test when the asynchronous wrapper object itself creates a wrap of another thing
@@ -66,7 +73,6 @@ class TestSyncWrapper(AsyncTestCase):
         ret = sync.sleep()
         self.assertFalse(ret)
 
-    @slowTest
     def test_double_sameloop(self):
         """
         Test asynchronous wrappers initiated from the same IOLoop, to ensure that


### PR DESCRIPTION
Refactor SyncWrapper so that it uses an alternate ioloop and runs it in
a thread. This is needed for torando 5.0 and greater on python 3 where
asyncio's event loop is the default. The asyncio default loop can only
have on loop running at a time in any given thread. So, the old
SyncWrapper doesn't work because it tires to run multiple ioloops in the
main execution thread.

### Merge requirements satisfied?

- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes