### PR TITLE
GNU patch 2.7.6 always needs a strip option

### DIFF
--- a/changelog/57205.fixed.md
+++ b/changelog/57205.fixed.md
@@ -1,0 +1,1 @@
+Fix `file.patch` state failing to detect an already-applied patch when the patch file contains absolute or prefixed paths and GNU patch 2.7.6+ is used. The reverse-apply dry-run now correctly passes `-p0` so the reject file is matched against the target without path stripping.

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -7375,8 +7375,8 @@ def patch(
             # Try to reverse-apply hunks from rejects file using a dry-run.
             # If this returns a retcode of 0, we know that the patch was
             # already applied. Rejects are written from the base of the
-            # directory, so the strip option doesn't apply here.
-            reverse_pass = _patch(patch_rejects, ["-R", "-f"], dry_run=True)
+            # directory, so the required strip level is 0.
+            reverse_pass = _patch(patch_rejects, ["-R", "-f", "-p0"], dry_run=True)
             already_applied = reverse_pass["retcode"] == 0
 
             # Check if the patch command threw an error upon execution

--- a/tests/pytests/functional/states/file/test_patch.py
+++ b/tests/pytests/functional/states/file/test_patch.py
@@ -188,6 +188,53 @@ def test_patch_single_file(file, files, patches):
     assert ret.comment == "Patch was already applied"
 
 
+def test_patch_single_file_absolute_paths(file, state_tree, tmp_path):
+    """
+    Regression test for issue #52329: file.patch must detect an already-applied
+    patch when the patch file uses absolute paths (GNU patch 2.7.6+ behaviour).
+
+    Without the ``-p0`` flag on the reverse-apply dry-run, GNU patch cannot
+    match the absolute path in the reject file against the target file and
+    returns a non-zero exit code, causing the state to report
+    "Patch would not apply cleanly" instead of "Patch was already applied".
+    """
+    target = tmp_path / "target.txt"
+    target.write_text("line one\nline two\nline three\n")
+
+    # Construct a patch with the absolute path of the target file as the
+    # header (mirrors the real-world zeromq.patch from issue #52329).
+    abs_path = str(target)
+    patch_content = textwrap.dedent(
+        f"""\
+        --- {abs_path}
+        +++ {abs_path}
+        @@ -1,3 +1,3 @@
+        -line one
+        +LINE ONE
+         line two
+         line three
+        """
+    )
+    patch_file = tmp_path / "absolute.patch"
+    patch_file.write_text(patch_content)
+
+    patch_source = "salt://absolute.patch"
+    patch_dest = state_tree / "absolute.patch"
+    patch_dest.write_text(patch_content)
+
+    # First run: apply the patch.
+    ret = file.patch(name=abs_path, source=patch_source)
+    assert ret.result is True
+    assert ret.changes
+    assert ret.comment == "Patch successfully applied"
+
+    # Second run: must detect the patch was already applied, not fail.
+    ret = file.patch(name=abs_path, source=patch_source)
+    assert ret.result is True
+    assert not ret.changes
+    assert ret.comment == "Patch was already applied"
+
+
 @pytest.mark.skip_on_freebsd(
     reason="Previously skipped on FreeBSD. Needs investigation as to why it currently False"
 )

--- a/tests/pytests/functional/states/file/test_patch.py
+++ b/tests/pytests/functional/states/file/test_patch.py
@@ -215,9 +215,6 @@ def test_patch_single_file_absolute_paths(file, state_tree, tmp_path):
          line three
         """
     )
-    patch_file = tmp_path / "absolute.patch"
-    patch_file.write_text(patch_content)
-
     patch_source = "salt://absolute.patch"
     patch_dest = state_tree / "absolute.patch"
     patch_dest.write_text(patch_content)


### PR DESCRIPTION
### What does this PR do?
When checking whether a patch applies in reverse, add the `-p0` option.
Without this, you get errors such as

>No file to patch.  Skipping patch.
>1 out of 1 hunk ignored
>can't find file to patch at input line 857
>Perhaps you should have used the -p or --strip option?

There may be additional bugs like this if the target is not a directory. The solution should be to default `strip=0`.

### What issues does this PR fix or reference?
Fixes: #52329

### Previous Behavior
Once a patch has been applied, all further runs fail.

### New Behavior
State now correctly detects whether the patch has been applied,

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
