### PR TITLE
Ensure errors are returned for missing pillars

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -926,6 +926,9 @@ class Pillar(object):
                                     ]
                                 )
                                 matched_pstates = [sub_sls]
+                            # If matched_pstates is empty, set to sub_sls
+                            if len(matched_pstates) < 1:
+                                matched_pstates = [sub_sls]
                             for m_sub_sls in matched_pstates:
                                 if m_sub_sls not in mods:
                                     nstate, mods, err = self.render_pstate(


### PR DESCRIPTION
### What does this PR do?
Ensures that errors are returned when including from a pillar like this:
```
include:
- pillar_name
````

### What issues does this PR fix or reference?
Fixes: This PR


### Previous Behavior
Salt 2018.3.5 returns errors when a pillar is not found.
Newer versions currently do not.

### New Behavior
Salt returns errors when pillars fail to render

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
