### PR TITLE
Fix `ps.top()` when iterating through a zombie process.

### DIFF
--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -150,7 +150,10 @@ def top(num_processes=5, interval=3):
         except psutil.NoSuchProcess:
             continue
         else:
-            user, system = process.cpu_times()[:2]
+            try:
+                user, system = process.cpu_times()[:2]
+            except psutil.ZombieProcess:
+                user = system = 0.0
         start_usage[process] = user + system
     time.sleep(interval)
     usage = set()

--- a/tests/unit/modules/test_ps.py
+++ b/tests/unit/modules/test_ps.py
@@ -321,8 +321,27 @@ class PsTestCase(TestCase):
         result = ps.top(num_processes=1, interval=0)
         assert len(result) == 1
 
-        ## This is commented out pending discussion on https://github.com/saltstack/salt/commit/2e5c3162ef87cca8a2c7b12ade7c7e1b32028f0a
-        # @skipIf(not HAS_UTMP, "The utmp module must be installed to run test_get_users_utmp()")
-        # @patch('salt.utils.psutil_compat.get_users', new=MagicMock(return_value=None))  # This will force the function to use utmp
-        # def test_get_users_utmp(self):
-        #     pass
+    def test_top_zombie_process(self):
+        # Get 3 pids that are currently running on the system
+        pids = psutil.pids()[:3]
+        # The a process instance for each of the pids
+        processes = [psutil.Process(pid) for pid in pids]
+
+        # Patch the middle process to raise ZombieProcess when .cpu_times is called
+        def raise_exception():
+            raise psutil.ZombieProcess(processes[1].pid)
+
+        processes[1].cpu_times = raise_exception
+
+        # Make sure psutil.pids only returns the above 3 pids
+        with patch("salt.utils.psutil_compat.pids", return_value=pids):
+            # Make sure we use our process list from above
+            with patch("salt.utils.psutil_compat.Process", side_effect=processes):
+                result = ps.top(num_processes=1, interval=0)
+                assert len(result) == 1
+
+    ## This is commented out pending discussion on https://github.com/saltstack/salt/commit/2e5c3162ef87cca8a2c7b12ade7c7e1b32028f0a
+    # @skipIf(not HAS_UTMP, "The utmp module must be installed to run test_get_users_utmp()")
+    # @patch('salt.utils.psutil_compat.get_users', new=MagicMock(return_value=None))  # This will force the function to use utmp
+    # def test_get_users_utmp(self):
+    #     pass


### PR DESCRIPTION
### What does this PR do?

Fix `ps.top()` when iterating through a zombie process.

At least on macOS High Sierra, when Salt's `ps.top()` iterates through a
zombie process, we get the following traceback:

```
Traceback (most recent call last):
  File "/private/tmp/kitchen/testing/.nox/runtests-parametrized-3-coverage-true-crypto-none-transport-zeromq/lib/python3.7/site-packages/psutil/_common.py", line 340, in wrapper
    ret = self._cache[fun]
AttributeError: 'Process' object has no attribute '_cache'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/private/tmp/kitchen/testing/.nox/runtests-parametrized-3-coverage-true-crypto-none-transport-zeromq/lib/python3.7/site-packages/psutil/_common.py", line 340, in wrapper
    ret = self._cache[fun]
AttributeError: _cache

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/private/tmp/kitchen/testing/.nox/runtests-parametrized-3-coverage-true-crypto-none-transport-zeromq/lib/python3.7/site-packages/psutil/_psosx.py", line 356, in catch_zombie
    yield
  File "/private/tmp/kitchen/testing/.nox/runtests-parametrized-3-coverage-true-crypto-none-transport-zeromq/lib/python3.7/site-packages/psutil/_psosx.py", line 397, in _get_pidtaskinfo
    ret = cext.proc_pidtaskinfo_oneshot(self.pid)
ProcessLookupError: [Errno 3] No such process

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/private/tmp/kitchen/testing/tests/unit/modules/test_ps.py", line 321, in test_top
    result = ps.top(num_processes=1, interval=0)
  File "/private/tmp/kitchen/testing/salt/modules/ps.py", line 153, in top
    user, system = process.cpu_times()[:2]
  File "/private/tmp/kitchen/testing/.nox/runtests-parametrized-3-coverage-true-crypto-none-transport-zeromq/lib/python3.7/site-packages/psutil/_common.py", line 343, in wrapper
    return fun(self)
  File "/private/tmp/kitchen/testing/.nox/runtests-parametrized-3-coverage-true-crypto-none-transport-zeromq/lib/python3.7/site-packages/psutil/__init__.py", line 1160, in cpu_times
    return self._proc.cpu_times()
  File "/private/tmp/kitchen/testing/.nox/runtests-parametrized-3-coverage-true-crypto-none-transport-zeromq/lib/python3.7/site-packages/psutil/_psosx.py", line 338, in wrapper
    return fun(self, *args, **kwargs)
  File "/private/tmp/kitchen/testing/.nox/runtests-parametrized-3-coverage-true-crypto-none-transport-zeromq/lib/python3.7/site-packages/psutil/_psosx.py", line 482, in cpu_times
    rawtuple = self._get_pidtaskinfo()
  File "/private/tmp/kitchen/testing/.nox/runtests-parametrized-3-coverage-true-crypto-none-transport-zeromq/lib/python3.7/site-packages/psutil/_psosx.py", line 338, in wrapper
    return fun(self, *args, **kwargs)
  File "/private/tmp/kitchen/testing/.nox/runtests-parametrized-3-coverage-true-crypto-none-transport-zeromq/lib/python3.7/site-packages/psutil/_common.py", line 343, in wrapper
    return fun(self)
  File "/private/tmp/kitchen/testing/.nox/runtests-parametrized-3-coverage-true-crypto-none-transport-zeromq/lib/python3.7/site-packages/psutil/_psosx.py", line 397, in _get_pidtaskinfo
    ret = cext.proc_pidtaskinfo_oneshot(self.pid)
  File "/usr/local/opt/python/Frameworks/Python.framework/Versions/3.7/lib/python3.7/contextlib.py", line 130, in __exit__
    self.gen.throw(type, value, traceback)
  File "/private/tmp/kitchen/testing/.nox/runtests-parametrized-3-coverage-true-crypto-none-transport-zeromq/lib/python3.7/site-packages/psutil/_psosx.py", line 367, in catch_zombie
    raise ZombieProcess(proc.pid, proc._name, proc._ppid)
psutil.ZombieProcess: psutil.ZombieProcess process still exists but it's a zombie (pid=26805)
```

Since on that code we're only interested in the data for sorting, catch
the `ZombieProcess` exception and set `user` and `system` to `0.0`.

### Merge requirements satisfied?
- [x] Tests written/updated - No, fixes a broken test

### Commits signed with GPG?
Yes