### PR TITLE
Open cache_file in binary format

### DIFF
--- a/salt/fileserver/s3fs.py
+++ b/salt/fileserver/s3fs.py
@@ -573,7 +573,7 @@ def _refresh_buckets_cache_file(cache_file):
 
     log.debug("Writing buckets cache file")
 
-    with salt.utils.files.fopen(cache_file, "w") as fp_:
+    with salt.utils.files.fopen(cache_file, "wb") as fp_:
         pickle.dump(metadata, fp_)
 
     return metadata


### PR DESCRIPTION
Open cache_file in binary format, as bytes are returned.
Could be placed inside a try statement, if desired.

WIP

### What does this PR do?
Opens the cache_file in binary format, as bytes are returned in Python3.
Referenced: https://github.com/saltstack/salt/blob/5949f05e23d91622c0fd9f239af58a8f3abd1044/salt/pillar/s3.py#L409

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/53244

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
