### PR TITLE
Add Securing Salt Master section to Master Config topic

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -13,9 +13,26 @@ of the Salt system each have a respective configuration file. The
 
     :ref:`Example master configuration file <configuration-examples-master>`.
 
-The configuration file for the salt-master is located at ``/etc/salt/master``
-by default. Atomic included configuration files can be placed in 
-``/etc/salt/master.d/*.conf``. Warning: files with other suffixes than .conf will 
+Securing the Salt Master
+========================
+The Salt Master is the most critical piece of your Salt implementation because
+it has the ability to reach every part of your infrastructure. For the most
+part, ensure that your Salt Master is secure. For example, you could run Salt
+Masters in a private network, unaccessible to the internet, with no public IP
+address.
+
+However, there are a few scenarios where the Salt Master reasonably needs to be
+accessible to the Internet. In those scenarios, strict firewall rules should be
+used. One option is to avoid allowing large ranges in your firewall rules.
+Another option is to use a hardened bastion server or a VPN to restrict direct
+access to the Salt Master from the Internet.
+
+
+Configuring the Salt Master
+===========================
+The configuration file for the Salt Master is located at ``/etc/salt/master``
+by default. Atomic included configuration files can be placed in
+``/etc/salt/master.d/*.conf``. Warning: files with other suffixes than .conf will
 not be included. A notable exception is FreeBSD, where the configuration file is
 located at ``/usr/local/etc/salt``. The available options are as follows:
 


### PR DESCRIPTION
### What does this PR do?
DOCS CHANGE ONLY. I'm putting this PR in at Sage Robin's request. As a result of the CVE, some users said they had misinterpreted the documentation to suggest that Salt Masters should be public facing on the Internet. This PR adds a section to the Master Configuration topic that incorporates some hardening recommendations for the Salt Master.

### What issues does this PR fix or reference?
Fixes misconceptions about the Salt Master.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ X ] Docs
- [ N/A ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ N/A ] Tests written/updated

### Commits signed with GPG?
I tried to do this, but I probably failed. I had difficulties adding the GPG I generated to Github and I'm hoping that an SSH I set up earlier this year compensates for that. Sorry!

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
