### PR TITLE
Allow set higher priority failhard on the client-side

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -3145,13 +3145,15 @@ class BaseHighState(object):
         if not isinstance(mopts, dict):
             # An error happened on the master
             opts['renderer'] = 'jinja|yaml'
-            opts['failhard'] = False
+            if 'failhard' not in opts:
+                opts['failhard'] = False
             opts['state_top'] = salt.utils.url.create('top.sls')
             opts['nodegroups'] = {}
             opts['file_roots'] = {'base': [syspaths.BASE_FILE_ROOTS_DIR]}
         else:
             opts['renderer'] = mopts['renderer']
-            opts['failhard'] = mopts.get('failhard', False)
+            if 'failhard' not in opts:
+                opts['failhard'] = mopts.get('failhard', False)
             if mopts['state_top'].startswith('salt://'):
                 opts['state_top'] = mopts['state_top']
             elif mopts['state_top'].startswith('/'):


### PR DESCRIPTION
### What does this PR do?
Allow set higher priority failhard on the client-side.
Failhard is a cool feature, because in many case fast fail is better.
Global failhard control is hard to use, client-side can control itself seems better.

### What issues does this PR fix or reference?
Fixes: No

### Previous Behavior
Server-side can set global failhard.

### New Behavior
Client-side can set higher priority failhard.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
