### PR TITLE
Code is a string not yaml

### DIFF
--- a/tests/integration/modules/test_cmdmod.py
+++ b/tests/integration/modules/test_cmdmod.py
@@ -13,6 +13,7 @@ import salt.utils.platform
 from salt.ext import six
 from tests.support.case import ModuleCase
 from tests.support.helpers import (
+    dedent,
     destructiveTest,
     skip_if_binaries_missing,
     skip_if_not_root,
@@ -286,11 +287,12 @@ class CMDModuleTest(ModuleCase):
         """
         cmd.exec_code
         """
-        # `code` is a multiline YAML text. Formatting it as a YAML block scalar.
-        code = """|
+        code = dedent(
+            """
                    import sys
                    sys.stdout.write('cheese')
                """
+        )
         self.assertEqual(
             self.run_function(
                 "cmd.exec_code", [AVAILABLE_PYTHON_EXECUTABLE, code]
@@ -303,11 +305,12 @@ class CMDModuleTest(ModuleCase):
         """
         cmd.exec_code
         """
-        # `code` is a multiline YAML text. Formatting it as a YAML block scalar.
-        code = """|
+        code = dedent(
+            """
                    import sys
                    sys.stdout.write(sys.argv[1])
                """
+        )
         arg = "cheese"
         self.assertEqual(
             self.run_function(
@@ -321,11 +324,12 @@ class CMDModuleTest(ModuleCase):
         """
         cmd.exec_code
         """
-        # `code` is a multiline YAML text. Formatting it as a YAML block scalar.
-        code = """|
+        code = dedent(
+            """
                    import sys
                    sys.stdout.write(sys.argv[1])
                """
+        )
         arg = "cheese"
         self.assertEqual(
             self.run_function(


### PR DESCRIPTION
### What does this PR do?

Fixing test failures that show up running slow tests. The documentation for cmdmod.exec_code show that 'code' should be a string.

### What issues does this PR fix or reference?

Fixes #57244

### Merge requirements satisfied?

- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes