### PR TITLE
Change pip version from 8.0 to 9.0.1

### DIFF
--- a/tests/integration/states/test_pip_state.py
+++ b/tests/integration/states/test_pip_state.py
@@ -431,7 +431,7 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
         # Let's install a fixed version pip over whatever pip was
         # previously installed
         ret = self.run_function(
-            "pip.install", ["pip==8.0"], upgrade=True, bin_env=venv_dir
+            "pip.install", ["pip==9.0.1"], upgrade=True, bin_env=venv_dir
         )
 
         if not isinstance(ret, dict):
@@ -444,14 +444,14 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertEqual(ret["retcode"], 0)
         self.assertIn("Successfully installed pip", ret["stdout"])
 
-        # Let's make sure we have pip 8.0 installed
+        # Let's make sure we have pip 9.0.1 installed
         self.assertEqual(
-            self.run_function("pip.list", ["pip"], bin_env=venv_dir), {"pip": "8.0.0"}
+            self.run_function("pip.list", ["pip"], bin_env=venv_dir), {"pip": "9.0.1"}
         )
 
         # Now the actual pip upgrade pip test
         ret = self.run_state(
-            "pip.installed", name="pip==8.0.1", upgrade=True, bin_env=venv_dir
+            "pip.installed", name="pip==20.0.1", upgrade=True, bin_env=venv_dir
         )
 
         if not isinstance(ret, dict):
@@ -462,7 +462,7 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
             )
 
         self.assertSaltTrueReturn(ret)
-        self.assertSaltStateChangesEqual(ret, {"pip==8.0.1": "Installed"})
+        self.assertSaltStateChangesEqual(ret, {"pip==20.0.1": "Installed"})
 
     @slowTest
     def test_pip_installed_specific_env(self):


### PR DESCRIPTION
### What does this PR do?
Change version of pip from 8.0 to 9.0.1 to address `pip._vendor.distlib.DistlibException: Unable to locate finder for 'pip._vendor.distlib'`

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/57248

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
