### PR TITLE
[Test Fix] integration.shell.test_auth.UserAuthTest.test_pam_auth_valid_user

### DIFF
--- a/tests/integration/shell/test_auth.py
+++ b/tests/integration/shell/test_auth.py
@@ -42,7 +42,11 @@ def gen_password():
     password = "".join(
         random.choice(string.ascii_letters + string.digits) for _ in range(20)
     )
-    hashed_pwd = gen_hash("salt", password, "sha512")
+    hashed_pwd = (
+        password
+        if salt.utils.platform.is_darwin()
+        else gen_hash("salt", password, "sha512")
+    )
 
     return password, hashed_pwd
 
@@ -77,9 +81,7 @@ class UserAuthTest(ModuleCase, SaltReturnAssertsMixin, ShellCase):
         password, hashed_pwd = gen_password()
 
         # set user password
-        set_pw_cmd = "shadow.set_password {0} '{1}'".format(
-            self.user, password if salt.utils.platform.is_darwin() else hashed_pwd
-        )
+        set_pw_cmd = "shadow.set_password {0} '{1}'".format(self.user, hashed_pwd)
         stdout, stderr, retcode = self.run_call(
             set_pw_cmd, catch_stderr=True, with_retcode=True
         )
@@ -150,9 +152,7 @@ class GroupAuthTest(ModuleCase, SaltReturnAssertsMixin, ShellCase):
         password, hashed_pwd = gen_password()
 
         # set user password
-        set_pw_cmd = "shadow.set_password {0} '{1}'".format(
-            self.user, password if salt.utils.platform.is_darwin() else hashed_pwd
-        )
+        set_pw_cmd = "shadow.set_password {0} '{1}'".format(self.user, hashed_pwd)
         stdout, stderr, retcode = self.run_call(
             set_pw_cmd, catch_stderr=True, with_retcode=True
         )


### PR DESCRIPTION
Fixes MacOS test failure: integration.shell.test_auth.UserAuthTest.test_pam_auth_valid_user
```
salt.exceptions.SaltInvocationError: Algorithm 'sha512' is not natively supported by this platform, use force=True with passlib installed to override.
```

Don't generate redundant hash on MacOS

This also resolves the integrathion/shell/test_auth issue on Darwin
having no sha512 algorithm natively supported.

Fixes #57272