### PR TITLE
Fix proxy shell tests

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1218,6 +1218,7 @@ class TestDaemon(object):
                 minion_opts["extension_modules"],
                 sub_minion_opts["extension_modules"],
                 sub_minion_opts["pki_dir"],
+                proxy_opts["pki_dir"],
                 master_opts["sock_dir"],
                 syndic_master_opts["sock_dir"],
                 sub_minion_opts["sock_dir"],

--- a/tests/support/paths.py
+++ b/tests/support/paths.py
@@ -78,7 +78,7 @@ TMP_MM_CONF_DIR = TMP_MM_MINION_CONF_DIR = os.path.join(TMP_CONF_DIR, "multimast
 TMP_MM_SUB_CONF_DIR = TMP_MM_SUB_MINION_CONF_DIR = os.path.join(
     TMP_CONF_DIR, "sub-multimaster"
 )
-TMP_PROXY_CONF_DIR = os.path.join(TMP_CONF_DIR, "proxy")
+TMP_PROXY_CONF_DIR = TMP_CONF_DIR
 CONF_DIR = os.path.join(INTEGRATION_TEST_DIR, "files", "conf")
 PILLAR_DIR = os.path.join(FILES, "pillar")
 TMP_SCRIPT_DIR = os.path.join(TMP, "scripts")


### PR DESCRIPTION
Fixes these tests failures:
```
integration.proxy.test_shell.ProxyCallerSimpleTestCase.test_can_it_ping
integration.proxy.test_shell.ProxyCallerSimpleTestCase.test_grains_items
integration.proxy.test_shell.ProxyCallerSimpleTestCase.test_list_pkgs
integration.proxy.test_shell.ProxyCallerSimpleTestCase.test_service_get_all
integration.proxy.test_shell.ProxyCallerSimpleTestCase.test_service_list
integration.proxy.test_shell.ProxyCallerSimpleTestCase.test_service_start
integration.proxy.test_shell.ProxyCallerSimpleTestCase.test_upgrade
```
https://jenkinsci.saltstack.com/job/pr-centos7-py3-proxy-slow/job/master/13/

Create 'pki' directory for proxy minion.
Fixed path to proxy config dir.

Still fail on pytest. I'm checking this.