### PR TITLE
Additional fix for proxytests in pytest

### DIFF
--- a/tests/integration/proxy/conftest.py
+++ b/tests/integration/proxy/conftest.py
@@ -31,6 +31,7 @@ def salt_proxy(request, salt_factories, salt_master):
     config_defaults["hosts.file"] = os.path.join(RUNTIME_VARS.TMP, "hosts")
     config_defaults["aliases.file"] = os.path.join(RUNTIME_VARS.TMP, "aliases")
     config_defaults["transport"] = request.config.getoption("--transport")
+    config_defaults["root_dir"] = root_dir
     yield salt_factories.spawn_proxy_minion(
         request, proxy_minion_id, master_id="master", config_defaults=config_defaults
     )


### PR DESCRIPTION
### What does this PR do?
This fixes proxy tests running with pytest in addition to #57307
This is not needed for Sodium and makes no sense for runtests or salt logic. So no need to merge right now.

This prevents of running `salt_factories._get_root_dir_for_daemon(proxy_minion_id)` twice for the same daemon. Running this twice produces 2 different roots: one is set to `RUNTIME_VARS` the second one is used by daemon that breaks tests that use `RUNTIME_VARS`.
