### PR TITLE
Fix issue with venv_dir path on Windows

### DIFF
--- a/tests/integration/states/test_pip_state.py
+++ b/tests/integration/states/test_pip_state.py
@@ -411,8 +411,10 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
             # of the system drive. Otherwise the path is too long and the pip
             # upgrade will fail. Also, I don't know why salt.utils.platform
             # doesn't work in this function, that's why I used sys.platform
-            venv_dir = os.path.join(
-                os.environ["SystemDrive"], "tmp-6833-pip-upgrade-pip"
+            # Need to use os.sep.join here instead of os.path.join because of
+            # the colon in SystemDrive
+            venv_dir = os.sep.join(
+                [os.environ["SystemDrive"], "tmp-6833-pip-upgrade-pip"]
             )
         else:
             venv_dir = os.path.join(RUNTIME_VARS.TMP, "6833-pip-upgrade-pip")

--- a/tests/integration/states/test_pip_state.py
+++ b/tests/integration/states/test_pip_state.py
@@ -313,7 +313,7 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
         venv_create = self._create_virtualenv(
             venv_dir, user=username, password="PassWord1!"
         )
-        if venv_create["retcode"] > 0:
+        if venv_create.get("retcode", 1) > 0:
             self.skipTest(
                 "Failed to create testcase virtual environment: {0}"
                 "".format(venv_create)
@@ -366,7 +366,7 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
         venv_create = self._create_virtualenv(
             venv_dir, user=username, password="PassWord1!"
         )
-        if venv_create["retcode"] > 0:
+        if venv_create.get("retcode", 1) > 0:
             self.skipTest(
                 "failed to create testcase virtual environment: {0}"
                 "".format(venv_create)
@@ -539,7 +539,7 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
         # the state internal keywords
         venv_dir = os.path.join(RUNTIME_VARS.TMP, "pip-installed-unless")
         venv_create = self._create_virtualenv(venv_dir)
-        if venv_create["retcode"] > 0:
+        if venv_create.get("retcode", 1) > 0:
             self.skipTest(
                 "Failed to create testcase virtual environment: {0}".format(venv_create)
             )


### PR DESCRIPTION
### What does this PR do?
The new temp path was missing the backslash `\` after the c: for the temp path
Also uses get to retrieve the retcode... this should give a more descriptive error in the test.

### What issues does this PR fix or reference?
https://jenkinsci.saltstack.com/job/pr-windows2019-py3-slow/job/master/13/testReport/junit/integration.states.test_pip_state/PipStateTest/test_issue_6833_pip_upgrade_pip/

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
