### PR TITLE
Get GID from staff as int instead of user_name

### DIFF
--- a/tests/integration/states/test_user.py
+++ b/tests/integration/states/test_user.py
@@ -169,7 +169,7 @@ class UserTest(ModuleCase, SaltReturnAssertsMixin):
         group_name = grp.getgrgid(ret["gid"]).gr_name
         if not salt.utils.platform.is_darwin():
             self.assertTrue(os.path.isdir(self.user_home))
-        self.assertEqual(group_name, self.user_name)
+            self.assertEqual(group_name, self.user_name)
         ret = self.run_state("user.absent", name=self.user_name)
         self.assertSaltTrueReturn(ret)
         ret = self.run_state("group.absent", name=self.user_name)

--- a/tests/integration/states/test_user.py
+++ b/tests/integration/states/test_user.py
@@ -152,10 +152,14 @@ class UserTest(ModuleCase, SaltReturnAssertsMixin):
         # user
         ret = self.run_state("group.present", name=self.user_name)
         self.assertSaltTrueReturn(ret)
+        if salt.utils.platform.is_darwin():
+            gid = grp.getgrnam("staff").gr_gid
+        else:
+            gid = self.user_name
         ret = self.run_state(
             "user.present",
             name=self.user_name,
-            gid=self.user_name,
+            gid=gid,
             usergroup=False,
             home=self.user_home,
         )


### PR DESCRIPTION
### What does this PR do?
Under OSX get the GID from staff instead of using user_name.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/57315

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
