### PR TITLE
Only trim output, don't modify test files

### DIFF
--- a/tests/integration/states/test_archive.py
+++ b/tests/integration/states/test_archive.py
@@ -56,6 +56,13 @@ class ArchiveTest(ModuleCase, SaltReturnAssertsMixin):
 
     def tearDown(self):
         self._clear_archive_dir()
+        try:
+            salt.utils.files.rm_rf(
+                os.path.join(RUNTIME_VARS.TMP_ROOT_DIR, "cache", "archive_hash")
+            )
+        except OSError:
+            # some tests do notcreate the archive_hash directory
+            pass
 
     @staticmethod
     def _clear_archive_dir():
@@ -363,7 +370,7 @@ class ArchiveTest(ModuleCase, SaltReturnAssertsMixin):
             name=ARCHIVE_DIR,
             source=self.archive_local_tar_source,
             archive_format="tar",
-            skip_files_list_verify=False,
+            skip_files_list_verify=True,
             source_hash_update=True,
             source_hash=ARCHIVE_TAR_SHA_HASH,
             trim_output=1,

--- a/tests/integration/states/test_archive.py
+++ b/tests/integration/states/test_archive.py
@@ -363,7 +363,7 @@ class ArchiveTest(ModuleCase, SaltReturnAssertsMixin):
             name=ARCHIVE_DIR,
             source=self.archive_local_tar_source,
             archive_format="tar",
-            skip_files_list_verify=True,
+            skip_files_list_verify=False,
             source_hash_update=True,
             source_hash=ARCHIVE_TAR_SHA_HASH,
             trim_output=1,


### PR DESCRIPTION
### What does this PR do?
"Skip_files_list_verify" is tested in a different function use the default value here to not mangle the test files unnecessarily

### What issues does this PR fix or reference?
closes: #57326