### PR TITLE
Roll back gets, add cmd /c

### DIFF
--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -180,7 +180,12 @@ def create(
     if venv_bin is None:
         venv_bin = __opts__.get("venv_bin") or __pillar__.get("venv_bin")
 
-    cmd = [venv_bin]
+    if salt.utils.platform.is_windows():
+        # This is an attempt to address this issue when called from the test
+        # suite: https://github.com/saltstack/salt/issues/54821#issuecomment-629622472
+        cmd = ['cmd', '/c', venv_bin]
+    else:
+        cmd = [venv_bin]
 
     if "pyvenv" not in venv_bin:
         # ----- Stop the user if pyvenv only options are used --------------->

--- a/tests/integration/states/test_pip_state.py
+++ b/tests/integration/states/test_pip_state.py
@@ -313,7 +313,7 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
         venv_create = self._create_virtualenv(
             venv_dir, user=username, password="PassWord1!"
         )
-        if venv_create.get("retcode", 1) > 0:
+        if venv_create["retcode"] > 0:
             self.skipTest(
                 "Failed to create testcase virtual environment: {0}"
                 "".format(venv_create)
@@ -366,7 +366,7 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
         venv_create = self._create_virtualenv(
             venv_dir, user=username, password="PassWord1!"
         )
-        if venv_create.get("retcode", 1) > 0:
+        if venv_create["retcode"] > 0:
             self.skipTest(
                 "failed to create testcase virtual environment: {0}"
                 "".format(venv_create)
@@ -539,7 +539,7 @@ class PipStateTest(ModuleCase, SaltReturnAssertsMixin):
         # the state internal keywords
         venv_dir = os.path.join(RUNTIME_VARS.TMP, "pip-installed-unless")
         venv_create = self._create_virtualenv(venv_dir)
-        if venv_create.get("retcode", 1) > 0:
+        if venv_create["retcode"] > 0:
             self.skipTest(
                 "Failed to create testcase virtual environment: {0}".format(venv_create)
             )


### PR DESCRIPTION
### What does this PR do?
Rolls back the attempt to use .get, the error was returning a string...
Prepends `cmd /c` to the command on Windows for virtualenv with runas

### What issues does this PR fix or reference?
Fixes:  https://jenkinsci.saltstack.com/job/pr-windows2016-py3-slow/job/master/20/testReport/junit/integration.states.test_pip_state/PipStateTest/test_issue_6912_wrong_owner/

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
