### PR TITLE
Virt disks fixes

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1251,6 +1251,10 @@ def _disk_profile(conn, profile, hypervisor, disks, vm_name):
     pool_caps = _pool_capabilities(conn)
 
     for disk in disklist:
+        # Set default model for cdrom devices before the overlay sets the wrong one
+        if disk.get("device", "disk") == "cdrom" and "model" not in disk:
+            disk["model"] = "ide"
+
         # Add the missing properties that have defaults
         for key, val in six.iteritems(overlay):
             if key not in disk:

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -2373,6 +2373,7 @@ def update(
         # From that point on, failures are not blocking to try to live update as much
         # as possible.
         commands = []
+        removable_changes = []
         if domain.isActive() and live:
             if cpu:
                 commands.append(
@@ -2392,7 +2393,6 @@ def update(
                 )
 
             # Look for removable device source changes
-            removable_changes = []
             new_disks = []
             for new_disk in changes["disk"].get("new", []):
                 device = new_disk.get("device", "disk")

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1968,8 +1968,17 @@ def _disks_equal(disk1, disk2):
         else ElementTree.Element("source")
     )
 
+    source1_dict = xmlutil.to_dict(source1, True)
+    source2_dict = xmlutil.to_dict(source2, True)
+
+    # Remove the index added by libvirt in the source for backing chain
+    if source1_dict:
+        source1_dict.pop("index", None)
+    if source2_dict:
+        source2_dict.pop("index", None)
+
     return (
-        xmlutil.to_dict(source1, True) == xmlutil.to_dict(source2, True)
+        source1_dict == source2_dict
         and target1 is not None
         and target2 is not None
         and target1.get("bus") == target2.get("bus")

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -5398,6 +5398,16 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
               <alias name='virtio-disk0'/>
               <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
             </disk>
+            <disk type='network' device='cdrom'>
+              <driver name='qemu' type='raw' cache='none' io='native'/>
+              <source protocol='http' name='/pub/iso/myimage.iso' query='foo=bar&amp;baz=flurb' index='1'>
+                <host name='dev-srv.tf.local' port='80'/>
+              </source>
+              <target dev='hda' bus='ide'/>
+              <readonly/>
+              <alias name='ide0-0-0'/>
+              <address type='drive' controller='0' bus='0' target='0' unit='0'/>
+            </disk>
           </devices>
         </domain>
         """
@@ -5456,6 +5466,11 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                             "file format": "raw",
                         },
                     },
+                },
+                "hda": {
+                    "type": "cdrom",
+                    "file format": "raw",
+                    "file": "http://dev-srv.tf.local:80/pub/iso/myimage.iso?foo=bar&baz=flurb",
                 },
             },
         )

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -2810,6 +2810,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
           </source>
         </pool>
         """
+        pool_mock.name.return_value = "test-ses"
         pool_mock.storageVolLookupByName.return_value.XMLDesc.return_value = [
             """
             <volume type='network'>
@@ -2827,7 +2828,8 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         ]
         pool_mock.listVolumes.return_value = ["my_vm_data2"]
         self.mock_conn.listAllStoragePools.return_value = [pool_mock]
-        self.mock_conn.listStoragePools.return_value = ["default"]
+        self.mock_conn.listStoragePools.return_value = ["test-ses"]
+        self.mock_conn.storagePoolLookupByName.return_value = pool_mock
 
         with patch.dict(os.path.__dict__, {"exists": MagicMock(return_value=False)}):
             res = virt.purge("test-vm")

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -4226,6 +4226,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         mock_pool = MagicMock()
         mock_pool.delete = MagicMock(return_value=0)
+        mock_pool.XMLDesc.return_value = "<pool type='dir'/>"
         self.mock_conn.storagePoolLookupByName = MagicMock(return_value=mock_pool)
 
         res = virt.pool_delete("test-pool")
@@ -4238,6 +4239,44 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         mock_pool.delete.assert_called_once_with(
             self.mock_libvirt.VIR_STORAGE_POOL_DELETE_NORMAL
         )
+
+    def test_pool_delete_secret(self):
+        """
+        Test virt.pool_delete function where the pool has a secret
+        """
+        mock_pool = MagicMock()
+        mock_pool.delete = MagicMock(return_value=0)
+        mock_pool.XMLDesc.return_value = """
+            <pool type='rbd'>
+              <name>test-ses</name>
+              <source>
+                <host name='myhost'/>
+                <name>libvirt-pool</name>
+                <auth type='ceph' username='libvirt'>
+                  <secret usage='pool_test-ses'/>
+                </auth>
+              </source>
+            </pool>
+        """
+        self.mock_conn.storagePoolLookupByName = MagicMock(return_value=mock_pool)
+        mock_undefine = MagicMock(return_value=0)
+        self.mock_conn.secretLookupByUsage.return_value.undefine = mock_undefine
+
+        res = virt.pool_delete("test-ses")
+        self.assertTrue(res)
+
+        self.mock_conn.storagePoolLookupByName.assert_called_once_with("test-ses")
+
+        # Shouldn't be called with another parameter so far since those are not implemented
+        # and thus throwing exceptions.
+        mock_pool.delete.assert_called_once_with(
+            self.mock_libvirt.VIR_STORAGE_POOL_DELETE_NORMAL
+        )
+
+        self.mock_conn.secretLookupByUsage.assert_called_once_with(
+            self.mock_libvirt.VIR_SECRET_USAGE_TYPE_CEPH, "pool_test-ses"
+        )
+        mock_undefine.assert_called_once()
 
     def test_full_info(self):
         """

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -860,6 +860,22 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             self.assertEqual(len(diskp), 1)
             self.assertEqual(diskp[0]["source_file"], ("/path/to/my/image.qcow2"))
 
+    def test_disk_profile_cdrom_default(self):
+        """
+        Test virt._gen_xml(), KVM case with cdrom.
+        """
+        with patch.dict(os.path.__dict__, {"exists": MagicMock(return_value=True)}):
+            diskp = virt._disk_profile(
+                self.mock_conn,
+                None,
+                "kvm",
+                [{"name": "mydisk", "device": "cdrom"}],
+                "hello",
+            )
+
+            self.assertEqual(len(diskp), 1)
+            self.assertEqual(diskp[0]["model"], "ide")
+
     def test_disk_profile_pool_disk_type(self):
         """
         Test virt._disk_profile(), with a disk pool of disk type


### PR DESCRIPTION
### What does this PR do?

Fixes miscellaneous problems related to the recent PR adding disk volume support in `virt` module and state.

 * Show proper URL for remote CDROMs in `virt.get_disks()`
 * Show libvirt pool name for rbd and gluster volumes in `virt.get_disks()`
 * Remove libvirt secret when removing rbd storage pool

### What issues does this PR fix or reference?
Fixes: #56666 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [ ] Changelog - Actually fixing another PR that hasn't been released yet
- [X] Tests written/updated

### Commits signed with GPG?
Yes
