### PR TITLE
57347: Updating rpm_lowpkg:version_cmp warning messages

### DIFF
--- a/changelog/57347.fixed
+++ b/changelog/57347.fixed
@@ -1,0 +1,1 @@
+Updated rpm_lowpkg.version_cmp log messages and unit tests

--- a/salt/modules/rpm_lowpkg.py
+++ b/salt/modules/rpm_lowpkg.py
@@ -679,6 +679,11 @@ def version_cmp(ver1, ver2, ignore_epoch=False):
                     "labelCompare function. Not using rpm.labelCompare for "
                     "version comparison."
                 )
+        else:
+            log.warning(
+                "Please install a package that provides rpm.labelCompare for "
+                "more accurate version comparisons."
+            )
         if cmp_func is None and HAS_RPMUTILS:
             try:
                 cmp_func = rpmUtils.miscutils.compareEVR
@@ -687,6 +692,10 @@ def version_cmp(ver1, ver2, ignore_epoch=False):
 
         if cmp_func is None:
             if salt.utils.path.which("rpmdev-vercmp"):
+                log.warning(
+                    "Installing the rpmdevtools package may surface dev tools in production."
+                )
+
                 # rpmdev-vercmp always uses epochs, even when zero
                 def _ensure_epoch(ver):
                     def _prepend(ver):
@@ -725,10 +734,8 @@ def version_cmp(ver1, ver2, ignore_epoch=False):
                         result["stdout"],
                     )
             else:
-                # We'll need to fall back to salt.utils.versions.version_cmp()
                 log.warning(
-                    "rpmdevtools is not installed, please install it for "
-                    "more accurate version comparisons"
+                    "Falling back on salt.utils.versions.version_cmp() for version comparisons"
                 )
         else:
             # If one EVR is missing a release but not the other and they

--- a/tests/unit/modules/test_rpm_lowpkg.py
+++ b/tests/unit/modules/test_rpm_lowpkg.py
@@ -110,28 +110,82 @@ class RpmTestCase(TestCase, LoaderModuleMockMixin):
                 rpm.checksum("file1.rpm", "file2.rpm", "file3.rpm"), ret
             )
 
-    def test_version_cmp_rpm(self):
+    @patch("salt.modules.rpm_lowpkg.HAS_RPM", True)
+    @patch("salt.modules.rpm_lowpkg.rpm.labelCompare", return_value=-1)
+    @patch("salt.modules.rpm_lowpkg.log")
+    def test_version_cmp_rpm(self, mock_log, mock_labelCompare):
         """
-        Test package version is called RPM version if RPM-Python is installed
+        Test package version if RPM-Python is installed
 
         :return:
         """
-        with patch(
-            "salt.modules.rpm_lowpkg.rpm.labelCompare", MagicMock(return_value=0)
-        ), patch("salt.modules.rpm_lowpkg.HAS_RPM", True):
-            self.assertEqual(
-                0, rpm.version_cmp("1", "2")
-            )  # mock returns 0, which means RPM was called
+        self.assertEqual(-1, rpm.version_cmp("1", "2"))
+        self.assertEqual(mock_log.warning.called, False)
+        self.assertEqual(mock_labelCompare.called, True)
 
-    def test_version_cmp_fallback(self):
+    @patch("salt.modules.rpm_lowpkg.HAS_RPM", False)
+    @patch("salt.modules.rpm_lowpkg.HAS_RPMUTILS", True)
+    @patch("salt.modules.rpm_lowpkg.rpmUtils", create=True)
+    @patch("salt.modules.rpm_lowpkg.log")
+    def test_version_cmp_rpmutils(self, mock_log, mock_rpmUtils):
         """
-        Test package version is called RPM version if RPM-Python is installed
+        Test package version if rpmUtils.miscutils called
 
         :return:
         """
-        with patch(
-            "salt.modules.rpm_lowpkg.rpm.labelCompare", MagicMock(return_value=0)
-        ), patch("salt.modules.rpm_lowpkg.HAS_RPM", False):
+        mock_rpmUtils.miscutils = MagicMock()
+        mock_rpmUtils.miscutils.compareEVR = MagicMock(return_value=-1)
+        self.assertEqual(-1, rpm.version_cmp("1", "2"))
+        self.assertEqual(mock_log.warning.called, True)
+        self.assertEqual(mock_rpmUtils.miscutils.compareEVR.called, True)
+        self.assertEqual(
+            mock_log.warning.mock_calls[0][1][0],
+            "Please install a package that provides rpm.labelCompare for more accurate version comparisons.",
+        )
+
+    @patch("salt.modules.rpm_lowpkg.HAS_RPM", False)
+    @patch("salt.modules.rpm_lowpkg.HAS_RPMUTILS", False)
+    @patch("salt.utils.path.which", return_value=True)
+    @patch("salt.modules.rpm_lowpkg.log")
+    def test_version_cmp_rpmdev_vercmp(self, mock_log, mock_which):
+        """
+        Test package version if rpmdev-vercmp is installed
+
+        :return:
+        """
+        mock__salt__ = MagicMock(return_value={"retcode": 12})
+        with patch.dict(rpm.__salt__, {"cmd.run_all": mock__salt__}):
+            self.assertEqual(-1, rpm.version_cmp("1", "2"))
+            self.assertEqual(mock__salt__.called, True)
+            self.assertEqual(mock_log.warning.called, True)
             self.assertEqual(
-                -1, rpm.version_cmp("1", "2")
-            )  # mock returns -1, a python implementation was called
+                mock_log.warning.mock_calls[0][1][0],
+                "Please install a package that provides rpm.labelCompare for more accurate version comparisons.",
+            )
+            self.assertEqual(
+                mock_log.warning.mock_calls[1][1][0],
+                "Installing the rpmdevtools package may surface dev tools in production.",
+            )
+
+    @patch("salt.modules.rpm_lowpkg.HAS_RPM", False)
+    @patch("salt.modules.rpm_lowpkg.HAS_RPMUTILS", False)
+    @patch("salt.utils.versions.version_cmp", return_value=-1)
+    @patch("salt.utils.path.which", return_value=False)
+    @patch("salt.modules.rpm_lowpkg.log")
+    def test_version_cmp_python(self, mock_log, mock_which, mock_version_cmp):
+        """
+        Test package version if falling back to python
+
+        :return:
+        """
+        self.assertEqual(-1, rpm.version_cmp("1", "2"))
+        self.assertEqual(mock_version_cmp.called, True)
+        self.assertEqual(mock_log.warning.called, True)
+        self.assertEqual(
+            mock_log.warning.mock_calls[0][1][0],
+            "Please install a package that provides rpm.labelCompare for more accurate version comparisons.",
+        )
+        self.assertEqual(
+            mock_log.warning.mock_calls[1][1][0],
+            "Falling back on salt.utils.versions.version_cmp() for version comparisons",
+        )


### PR DESCRIPTION
### What does this PR do?
Updates the rpm_lowpkg.version_cmp warning messages / increases unit tests

### What issues does this PR fix or reference?
Fixes: #57347 

### Previous Behavior
A log message asking to install the rpmdevtools package

### New Behavior
Logs a warning asking to install a package that provides rpm.labelCompare
Logs a warning about surfacing dev tools in production if rpmdev-vercmp is found.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [N/A] Docs
- [X] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes
