### PR TITLE
Add fetchonly aka '-F' to pkg.upgrade module.

### DIFF
--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -1198,6 +1198,16 @@ def upgrade(*names, **kwargs):
         .. code-block:: bash
 
             salt '*' pkg.upgrade <package name> fromrepo=repo
+
+    fetchonly
+        Do not perform installation of packages, merely fetch
+        packages that should be upgraded and detect possible conflicts.
+
+        CLI Example:
+
+        .. code-block:: bash
+
+            salt '*' pkg.upgrade <package name> fetchonly=True
     """
     jail = kwargs.pop("jail", None)
     chroot = kwargs.pop("chroot", None)
@@ -1206,12 +1216,15 @@ def upgrade(*names, **kwargs):
     force = kwargs.pop("force", False)
     local = kwargs.pop("local", False)
     dryrun = kwargs.pop("dryrun", False)
+    fetchonly = kwargs.pop("fetchonly", False)
     pkgs = kwargs.pop("pkgs", [])
     opts = ""
     if force:
         opts += "f"
     if local:
         opts += "L"
+    if fetchonly:
+        opts += "F"
     if dryrun:
         opts += "n"
     if not dryrun:

--- a/tests/unit/modules/test_pkgng.py
+++ b/tests/unit/modules/test_pkgng.py
@@ -232,3 +232,23 @@ class PkgNgTestCase(TestCase, LoaderModuleMockMixin):
                     output_loglevel="trace",
                     python_shell=False,
                 )
+
+    def test_upgrade_with_fetchonly(self):
+        """
+        Test pkg upgrade to fetch packages only
+        """
+        pkg_cmd = MagicMock(return_value={"retcode": 0})
+
+        with patch.dict(pkgng.__salt__, {"cmd.run_all": pkg_cmd}):
+            with patch("salt.modules.pkgng.list_pkgs", ListPackages()):
+                result = pkgng.upgrade(fetchonly=True)
+                expected = {
+                    "gettext-runtime": {"new": "0.20.1", "old": ""},
+                    "p5-Mojolicious": {"new": "8.40", "old": ""},
+                }
+                self.assertDictEqual(result, expected)
+                pkg_cmd.assert_called_with(
+                    ["pkg", "upgrade", "-Fy"],
+                    output_loglevel="trace",
+                    python_shell=False,
+                )


### PR DESCRIPTION
It fetches packages to detect possible conflicts but doesn't perform
installation.

### What does this PR do?

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
