### PR TITLE
Fix exception in boto_iam.create_policy_version

### DIFF
--- a/changelog/57376.fixed
+++ b/changelog/57376.fixed
@@ -1,0 +1,2 @@
+Fix bug whereby exception can occur before a version identifier could be resolved,
+resulting in an exception during exception handling.

--- a/changelog/57376.fixed
+++ b/changelog/57376.fixed
@@ -1,2 +1,1 @@
-Fix bug whereby exception can occur before a version identifier could be resolved,
-resulting in an exception during exception handling.
+Fixed UnboundLocalError vid in boto_iam.create_policy_version.

--- a/salt/modules/boto_iam.py
+++ b/salt/modules/boto_iam.py
@@ -1957,7 +1957,7 @@ def create_policy_version(
         log.debug(e)
         log.error("Failed to create IAM policy %s.", policy_name)
         return {"created": False, "error": __utils__["boto.get_error"](e)}
-    try:
+    else:
         vid = (
             ret.get("create_policy_version_response", {})
             .get("create_policy_version_result", {})
@@ -1966,10 +1966,6 @@ def create_policy_version(
         )
         log.info("Created IAM policy %s version %s.", policy_name, vid)
         return {"created": True, "version_id": vid}
-    except boto.exception.BotoServerError as e:
-        log.debug(e)
-        log.error("Failed to create IAM policy %s version %s.", policy_name, vid)
-        return {"created": False, "error": __utils__["boto.get_error"](e)}
 
 
 def delete_policy_version(

--- a/salt/modules/boto_iam.py
+++ b/salt/modules/boto_iam.py
@@ -1953,6 +1953,11 @@ def create_policy_version(
     policy_arn = _get_policy_arn(policy_name, region, key, keyid, profile)
     try:
         ret = conn.create_policy_version(policy_arn, policy_document, **params)
+    except boto.exception.BotoServerError as e:
+        log.debug(e)
+        log.error("Failed to create IAM policy %s.", policy_name)
+        return {"created": False, "error": __utils__["boto.get_error"](e)}
+    try:
         vid = (
             ret.get("create_policy_version_response", {})
             .get("create_policy_version_result", {})

--- a/tests/unit/modules/test_boto_iam.py
+++ b/tests/unit/modules/test_boto_iam.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=confusing-with-statement
+import salt.modules.boto_iam as boto_iam
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.mock import patch
+from tests.support.unit import TestCase
+
+
+class TestBotoIam(TestCase, LoaderModuleMockMixin):
+    def setup_loader_modules(self):
+        return {
+            boto_iam: {"_get_conn": None, "__utils__": {"boto.get_error": lambda x: x}}
+        }
+
+    def test_create_policy_version_should_return_error_if_policy_version_failed_to_create(
+        self,
+    ):
+        expected_error = "This is some fako error message. Not real at all."
+        patch_get_conn = patch.object(boto_iam, "_get_conn")
+        patch_get_error = patch.dict(
+            boto_iam.__utils__, {"boto.get_error": lambda x: expected_error}
+        )
+        with patch_get_conn as mock_conn, patch_get_error:
+            mock_conn.return_value.create_policy_version.side_effect = boto_iam.boto.exception.BotoServerError(
+                "fnord", "fnord"
+            )
+
+            result = boto_iam.create_policy_version(
+                policy_name="fnord", policy_document=None
+            )
+
+            self.assertFalse(result["created"])
+            self.assertEqual(result["error"], expected_error)
+
+    def test_create_policy_version_should_return_provided_policy_name_and_resulting_vid(
+        self,
+    ):
+        expected_version_id = 42
+        patch_get_conn = patch.object(boto_iam, "_get_conn")
+        with patch_get_conn as mock_conn:
+            mock_conn.return_value.create_policy_version.return_value = {
+                "create_policy_version_response": {
+                    "create_policy_version_result": {
+                        "policy_version": {"version_id": expected_version_id}
+                    }
+                }
+            }
+
+            result = boto_iam.create_policy_version(
+                policy_name="fnord", policy_document=None
+            )
+
+            self.assertTrue(result["created"])
+            self.assertEqual(result["version_id"], expected_version_id)


### PR DESCRIPTION
### What issues does this PR fix or reference?

It is currently possible for an exception to occur before a version identifier could be resolved,
resulting in an exception **during exception handling**.

### Previous Behavior
```
local:
----------
          ID: <redacted>
    Function: boto_iam.policy_present
        Name: <redacted>
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/site-packages/salt/state.py", line 1933, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1951, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python2.7/site-packages/salt/states/boto_iam.py", line 1529, in policy_present
                  keyid=keyid, profile=profile)
                File "/usr/lib/python2.7/site-packages/salt/modules/boto_iam.py", line 1850, in create_policy_version
                  log.error('Failed to create IAM policy %s version %s.', policy_name, vid)
              UnboundLocalError: local variable 'vid' referenced before assignment
     Started: 21:15:56.936631
    Duration: 2185.593 ms
     Changes:
```

### New Behavior
```
[ERROR   ] Failed to create IAM policy <redacted>.
...
local:
----------
          ID: aws s3 iam policy rrt-app-instance-policy
    Function: boto_iam.policy_present
        Name: rrt-app-instance-policy
      Result: False
     Comment: Failed to update policy: Bad Request: <reason here>
     Started: 21:17:31.295869
    Duration: 2189.172 ms
     Changes:
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No