### PR TITLE
Repair template_vars functionality and allow for dest keyword in rpc on Junos

### DIFF
--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -296,8 +296,9 @@ def rpc(cmd=None, dest=None, **kwargs):
         return ret
 
     format_ = op.pop("format", "xml")
-    # when called from state, dest becomes part of op via __pub_arg
-    dest = dest or op.pop("dest", None)
+    # dest becomes part of op via __pub_arg if not None
+    # rpc commands objecting to dest as part of op
+    op.pop("dest", dest)
 
     if cmd in ["get-config", "get_config"]:
         filter_reply = None

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -297,9 +297,8 @@ def rpc(cmd=None, dest=None, **kwargs):
 
     format_ = op.pop("format", "xml")
     # dest becomes part of op via __pub_arg if not None
-    # rpc commands opjecting to dest as part of op
-    if dest:
-        op.pop("dest", None)
+    # rpc commands objecting to dest as part of op
+    op.pop("dest", dest)
 
     if cmd in ["get-config", "get_config"]:
         filter_reply = None

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -946,7 +946,11 @@ def install_config(path=None, **kwargs):
 
     test = op.pop("test", False)
 
-    with HandleFileCopy(path, **op) as template_cached_path:
+    kwargs = {}
+    if "template_vars" in op:
+        kwargs.update({"template_vars": op["template_vars"]})
+
+    with HandleFileCopy(path, **kwargs) as template_cached_path:
         if template_cached_path is None:
             ret["message"] = "Invalid file path."
             ret["out"] = False
@@ -1430,7 +1434,11 @@ def load(path=None, **kwargs):
     else:
         op.update(kwargs)
 
-    with HandleFileCopy(path, **op) as template_cached_path:
+    kwargs = {}
+    if "template_vars" in op:
+        kwargs.update({"template_vars": op["template_vars"]})
+
+    with HandleFileCopy(path, **kwargs) as template_cached_path:
         if template_cached_path is None:
             ret["message"] = "Invalid file path."
             ret["out"] = False

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -953,7 +953,9 @@ def install_config(path=None, **kwargs):
 
     try:
         template_cached_path = salt.utils.files.mkstemp()
-        __salt__['cp.get_template']( path, template_cached_path, template_vars=template_vars)
+        __salt__["cp.get_template"](
+            path, template_cached_path, template_vars=template_vars
+        )
     except Exception as ex:  # pylint: disable=broad-except
         ret["message"] = (
             "Salt failed to render the template, please check file path and syntax."
@@ -1456,7 +1458,9 @@ def load(path=None, **kwargs):
 
     try:
         template_cached_path = salt.utils.files.mkstemp()
-        __salt__['cp.get_template']( path, template_cached_path, template_vars=template_vars)
+        __salt__["cp.get_template"](
+            path, template_cached_path, template_vars=template_vars
+        )
     except Exception as ex:  # pylint: disable=broad-except
         ret["message"] = (
             "Salt failed to render the template, please check file path and syntax."

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -296,9 +296,8 @@ def rpc(cmd=None, dest=None, **kwargs):
         return ret
 
     format_ = op.pop("format", "xml")
-    # dest becomes part of op via __pub_arg if not None
-    # rpc commands objecting to dest as part of op
-    op.pop("dest", dest)
+    # when called from state, dest becomes part of op via __pub_arg
+    dest = dest or op.pop("dest", None)
 
     if cmd in ["get-config", "get_config"]:
         filter_reply = None
@@ -946,32 +945,11 @@ def install_config(path=None, **kwargs):
 
     test = op.pop("test", False)
 
-    template_vars = {}
-    if "template_vars" in op:
-        template_vars = op["template_vars"]
-
-    try:
-        template_cached_path = salt.utils.files.mkstemp()
-        __salt__["cp.get_template"](
-            path, template_cached_path, template_vars=template_vars
-        )
-    except Exception as ex:  # pylint: disable=broad-except
-        ret["message"] = (
-            "Salt failed to render the template, please check file path and syntax."
-            "\nError: {0}".format(str(ex))
-        )
-        ret["out"] = False
-        return ret
-
-    if not os.path.isfile(template_cached_path):
-        ret["message"] = "Invalid file path."
-        ret["out"] = False
-        return ret
-
-    if os.path.getsize(template_cached_path) == 0:
-        ret["message"] = "Template failed to render"
-        ret["out"] = False
-        return ret
+    with HandleFileCopy(path, **op) as template_cached_path:
+        if template_cached_path is None:
+            ret["message"] = "Invalid file path."
+            ret["out"] = False
+            return ret
 
         if os.path.getsize(template_cached_path) == 0:
             ret["message"] = "Template failed to render"
@@ -1451,22 +1429,11 @@ def load(path=None, **kwargs):
     else:
         op.update(kwargs)
 
-    template_vars = {}
-    if "template_vars" in op:
-        template_vars = op["template_vars"]
-
-    try:
-        template_cached_path = salt.utils.files.mkstemp()
-        __salt__["cp.get_template"](
-            path, template_cached_path, template_vars=template_vars
-        )
-    except Exception as ex:  # pylint: disable=broad-except
-        ret["message"] = (
-            "Salt failed to render the template, please check file path and syntax."
-            "\nError: {0}".format(str(ex))
-        )
-        ret["out"] = False
-        return ret
+    with HandleFileCopy(path, **op) as template_cached_path:
+        if template_cached_path is None:
+            ret["message"] = "Invalid file path."
+            ret["out"] = False
+            return ret
 
         if os.path.getsize(template_cached_path) == 0:
             ret["message"] = "Template failed to render"


### PR DESCRIPTION
### What does this PR do?
Repairs template_vars functionality on Junos and compensates for dest keyword in rpc commands

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/57388

### Previous Behavior
load and certain rpc's on Junos would fail, see https://github.com/saltstack/salt/issues/57388

### New Behavior
load and rpc commands with dest parameters now function correctly, see https://github.com/saltstack/salt/issues/57388

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [X] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
