### PR TITLE
zypperpkg: filter patterns that start with dot

### DIFF
--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -2334,11 +2334,14 @@ def _get_installed_patterns(root=None):
     # a real error.
     output = __salt__["cmd.run"](cmd, ignore_retcode=True)
 
-    installed_patterns = [
+    # On <= SLE12SP4 we have patterns that have multiple names (alias)
+    # and that are duplicated.  The alias start with ".", so we filter
+    # them.
+    installed_patterns = {
         _pattern_name(line)
         for line in output.splitlines()
-        if line.startswith("pattern() = ")
-    ]
+        if line.startswith("pattern() = ") and not _pattern_name(line).startswith(".")
+    }
 
     patterns = {
         k: v for k, v in _get_visible_patterns(root=root).items() if v["installed"]

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -1954,6 +1954,28 @@ pattern() = package-c"""
             }
 
     @patch("salt.modules.zypperpkg._get_visible_patterns")
+    def test__get_installed_patterns_with_alias(self, get_visible_patterns):
+        """Test installed patterns in the system if they have alias"""
+        get_visible_patterns.return_value = {
+            "package-a": {"installed": True, "summary": "description a"},
+            "package-b": {"installed": False, "summary": "description b"},
+        }
+
+        salt_mock = {
+            "cmd.run": MagicMock(
+                return_value="""pattern() = .package-a-alias
+pattern() = package-a
+pattern-visible()
+pattern() = package-c"""
+            ),
+        }
+        with patch.dict("salt.modules.zypperpkg.__salt__", salt_mock):
+            assert zypper._get_installed_patterns() == {
+                "package-a": {"installed": True, "summary": "description a"},
+                "package-c": {"installed": True, "summary": "Non-visible pattern"},
+            }
+
+    @patch("salt.modules.zypperpkg._get_visible_patterns")
     def test_list_patterns(self, get_visible_patterns):
         """Test available patterns in the repo"""
         get_visible_patterns.return_value = {


### PR DESCRIPTION
### What does this PR do?

For versions <=SLE12SP4 some patterns can contain alias, and can appear
duplicated.  The alias start with ".", so they can be filtered.

If the module try to search by the alias name (pattern:.basename, for
example), zypper will not be able to find it and the operation will
fail.

This patch detect and filter the alias, and remove duplicates.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [X] Tests written/updated
