### PR TITLE
Add efi parameter GSoC

### DIFF
--- a/salt/templates/virt/libvirt_domain.jinja
+++ b/salt/templates/virt/libvirt_domain.jinja
@@ -3,7 +3,7 @@
         <vcpu>{{ cpu }}</vcpu>
         <memory unit='KiB'>{{ mem }}</memory>
         <currentMemory unit='KiB'>{{ mem }}</currentMemory>
-        <os>
+        <os {{boot.os_attrib}}>
                 <type arch='{{ arch }}'>{{ os_type }}</type>
                 {% if boot %}
                   {% if 'kernel' in boot %}


### PR DESCRIPTION
### What does this PR do?
Allows user to specify `efi` parameter so that `uefi` firmware can be auto selected. 
This PR also fix a bug on removing `loader` and `nvram` path. Previous code will not work because `None` is handled as a string in sls file.  We need to use `boot_tag_value == "None"` to check that.
### What issues does this PR fix or reference?
In response to feature request #57397
Fixes: a bug on changing back to BIOS boot. 

### Previous Behavior
Removing UEFI firmware path will not work.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
