### PR TITLE
consistent file location handling across APIs

### DIFF
--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -94,8 +94,10 @@ class HandleFileCopy:
                 proxy_hash = __salt__["file.get_hash"](local_cache_path)
                 # check if hash is same, else copy newly
                 if master_hash.get("hsum") == proxy_hash:
+                    # kwargs will have values when path is a template
                     if self._kwargs:
                         self._cached_file = salt.utils.files.mkstemp()
+                        # local copy is a template, hence need to render
                         with salt.utils.files.fopen(self._cached_file, "w") as fp:
                             template_string = __salt__["slsutil.renderer"](
                                 path=local_cache_path,

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -71,6 +71,23 @@ __virtualname__ = "junos"
 __proxyenabled__ = ["junos"]
 
 
+def __virtual__():
+    """
+    We need the Junos adapter libraries for this
+    module to work.  We also need a proxymodule entry in __opts__
+    in the opts dictionary
+    """
+    if HAS_JUNOS and "proxy" in __opts__:
+        return __virtualname__
+    else:
+        return (
+            False,
+            "The junos or dependent module could not be loaded: "
+            "junos-eznc or jxmlease or yamlordereddictloader or "
+            "proxy could not be loaded.",
+        )
+
+
 class HandleFileCopy:
     """
     To figure out proper path either from proxy local file system
@@ -146,23 +163,6 @@ class HandleFileCopy:
         if self._cached_folder is not None:
             __salt__["file.rmdir"](self._cached_folder)
             log.debug("Deleted cached folder: {0}".format(self._cached_folder))
-
-
-def __virtual__():
-    """
-    We need the Junos adapter libraries for this
-    module to work.  We also need a proxymodule entry in __opts__
-    in the opts dictionary
-    """
-    if HAS_JUNOS and "proxy" in __opts__:
-        return __virtualname__
-    else:
-        return (
-            False,
-            "The junos or dependent module could not be loaded: "
-            "junos-eznc or jxmlease or yamlordereddictloader or "
-            "proxy could not be loaded.",
-        )
 
 
 def timeoutDecorator(function):

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -21,6 +21,7 @@ import copy
 import json
 import logging
 import os
+import tempfile
 import traceback
 from functools import wraps
 
@@ -31,7 +32,6 @@ import salt.utils.json
 import salt.utils.stringutils
 import yaml
 from salt.ext import six
-import tempfile
 
 try:
     from lxml import etree

--- a/salt/states/junos.py
+++ b/salt/states/junos.py
@@ -195,7 +195,7 @@ def rollback(name, id, **kwargs):
 
 
 @resultdecorator
-def diff(name, d_id, **kwargs):
+def diff(name, d_id=0, **kwargs):
     """
     .. versionchanged:: Sodium
 

--- a/tests/unit/modules/test_junos.py
+++ b/tests/unit/modules/test_junos.py
@@ -13,7 +13,7 @@ from salt.ext import six
 
 # Import test libs
 from tests.support.mixins import LoaderModuleMockMixin, XMLEqualityMixin
-from tests.support.mock import ANY, PropertyMock, call, mock_open, patch
+from tests.support.mock import ANY, PropertyMock, call, mock_open, patch, MagicMock
 from tests.support.unit import TestCase, skipIf
 
 # Import 3rd-party libs
@@ -47,6 +47,10 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 "__salt__": {
                     "cp.get_template": self.mock_cp,
                     "cp.get_file": self.mock_cp,
+                    "file.file_exists": MagicMock(return_value=True),
+                    "slsutil.renderer": MagicMock(
+                        return_value="set system host-name dummy"
+                    ),
                 },
             }
         }
@@ -1120,234 +1124,301 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         self.assertEqual(junos.install_config(), ret)
 
     def test_install_config_cp_fails(self):
-        with patch("os.path.isfile") as mock_isfile:
-            mock_isfile.return_value = False
+        with patch.dict(
+            junos.__salt__, {"file.file_exists": MagicMock(return_value=False)}
+        ):
+            ret = dict()
             ret = dict()
             ret["message"] = "Invalid file path."
             ret["out"] = False
             self.assertEqual(junos.install_config("path"), ret)
 
     def test_install_config_file_cp_fails(self):
-        with patch("os.path.isfile") as mock_isfile, patch(
-            "os.path.getsize"
-        ) as mock_getsize:
-            mock_isfile.return_value = True
-            mock_getsize.return_value = 0
+        with patch.dict(
+            junos.__salt__, {"file.file_exists": MagicMock(return_value=False)}
+        ):
             ret = dict()
-            ret["message"] = "Template failed to render"
+            ret = dict()
+            ret["message"] = "Invalid file path."
             ret["out"] = False
             self.assertEqual(junos.install_config("path"), ret)
 
     def test_install_config(self):
-        with patch("jnpr.junos.utils.config.Config.commit") as mock_commit, patch(
-            "jnpr.junos.utils.config.Config.commit_check"
-        ) as mock_commit_check, patch(
-            "jnpr.junos.utils.config.Config.diff"
-        ) as mock_diff, patch(
-            "jnpr.junos.utils.config.Config.load"
-        ) as mock_load, patch(
-            "salt.utils.files.safe_rm"
-        ) as mock_safe_rm, patch(
-            "salt.utils.files.mkstemp"
-        ) as mock_mkstemp, patch(
-            "os.path.isfile"
-        ) as mock_isfile, patch(
-            "os.path.getsize"
-        ) as mock_getsize:
-            mock_isfile.return_value = True
-            mock_getsize.return_value = 10
-            mock_mkstemp.return_value = "test/path/config"
-            mock_diff.return_value = "diff"
-            mock_commit_check.return_value = True
+        with patch.dict(
+            junos.__salt__,
+            {
+                "cp.is_cached": MagicMock(return_value="test/path/config"),
+                "cp.hash_file": MagicMock(
+                    return_value={"hash_type": "sha256", "hsum": "a386e49c17"}
+                ),
+                "file.get_hash": MagicMock(return_value="a386e49c17"),
+            },
+        ):
+            with patch("jnpr.junos.utils.config.Config.commit") as mock_commit, patch(
+                "jnpr.junos.utils.config.Config.commit_check"
+            ) as mock_commit_check, patch(
+                "jnpr.junos.utils.config.Config.diff"
+            ) as mock_diff, patch(
+                "jnpr.junos.utils.config.Config.load"
+            ) as mock_load, patch(
+                "salt.utils.files.safe_rm"
+            ) as mock_safe_rm, patch(
+                "salt.utils.files.mkstemp"
+            ) as mock_mkstemp, patch(
+                "os.path.isfile"
+            ) as mock_isfile, patch(
+                "os.path.getsize"
+            ) as mock_getsize:
+                mock_isfile.return_value = True
+                mock_getsize.return_value = 10
+                mock_mkstemp.return_value = "test/path/config"
+                mock_diff.return_value = "diff"
+                mock_commit_check.return_value = True
 
-            ret = dict()
-            ret["message"] = "Successfully loaded and committed!"
-            ret["out"] = True
-            self.assertEqual(junos.install_config("actual/path/config.set"), ret)
-            mock_load.assert_called_with(path="test/path/config", format="set")
+                ret = dict()
+                ret["message"] = "Successfully loaded and committed!"
+                ret["out"] = True
+                self.assertEqual(
+                    junos.install_config("salt://actual/path/config.set"), ret
+                )
+                mock_load.assert_called_with(path="test/path/config", format="set")
 
     def test_install_config_xml_file(self):
-        with patch("jnpr.junos.utils.config.Config.commit") as mock_commit, patch(
-            "jnpr.junos.utils.config.Config.commit_check"
-        ) as mock_commit_check, patch(
-            "jnpr.junos.utils.config.Config.diff"
-        ) as mock_diff, patch(
-            "jnpr.junos.utils.config.Config.load"
-        ) as mock_load, patch(
-            "salt.utils.files.safe_rm"
-        ) as mock_safe_rm, patch(
-            "salt.utils.files.mkstemp"
-        ) as mock_mkstemp, patch(
-            "os.path.isfile"
-        ) as mock_isfile, patch(
-            "os.path.getsize"
-        ) as mock_getsize:
-            mock_isfile.return_value = True
-            mock_getsize.return_value = 10
-            mock_mkstemp.return_value = "test/path/config"
-            mock_diff.return_value = "diff"
-            mock_commit_check.return_value = True
+        with patch.dict(
+            junos.__salt__,
+            {
+                "cp.is_cached": MagicMock(return_value="test/path/config"),
+                "cp.hash_file": MagicMock(
+                    return_value={"hash_type": "sha256", "hsum": "a386e49c17"}
+                ),
+                "file.get_hash": MagicMock(return_value="a386e49c17"),
+            },
+        ):
+            with patch("jnpr.junos.utils.config.Config.commit") as mock_commit, patch(
+                "jnpr.junos.utils.config.Config.commit_check"
+            ) as mock_commit_check, patch(
+                "jnpr.junos.utils.config.Config.diff"
+            ) as mock_diff, patch(
+                "jnpr.junos.utils.config.Config.load"
+            ) as mock_load, patch(
+                "salt.utils.files.safe_rm"
+            ) as mock_safe_rm, patch(
+                "salt.utils.files.mkstemp"
+            ) as mock_mkstemp, patch(
+                "os.path.isfile"
+            ) as mock_isfile, patch(
+                "os.path.getsize"
+            ) as mock_getsize:
+                mock_isfile.return_value = True
+                mock_getsize.return_value = 10
+                mock_mkstemp.return_value = "test/path/config"
+                mock_diff.return_value = "diff"
+                mock_commit_check.return_value = True
 
-            ret = dict()
-            ret["message"] = "Successfully loaded and committed!"
-            ret["out"] = True
-            self.assertEqual(junos.install_config("actual/path/config.xml"), ret)
-            mock_load.assert_called_with(path="test/path/config", format="xml")
+                ret = dict()
+                ret["message"] = "Successfully loaded and committed!"
+                ret["out"] = True
+                self.assertEqual(
+                    junos.install_config("salt://actual/path/config.xml"), ret
+                )
+                mock_load.assert_called_with(path="test/path/config", format="xml")
 
     def test_install_config_text_file(self):
-        with patch("jnpr.junos.utils.config.Config.commit") as mock_commit, patch(
-            "jnpr.junos.utils.config.Config.commit_check"
-        ) as mock_commit_check, patch(
-            "jnpr.junos.utils.config.Config.diff"
-        ) as mock_diff, patch(
-            "jnpr.junos.utils.config.Config.load"
-        ) as mock_load, patch(
-            "salt.utils.files.safe_rm"
-        ) as mock_safe_rm, patch(
-            "salt.utils.files.mkstemp"
-        ) as mock_mkstemp, patch(
-            "os.path.isfile"
-        ) as mock_isfile, patch(
-            "os.path.getsize"
-        ) as mock_getsize:
-            mock_isfile.return_value = True
-            mock_getsize.return_value = 10
-            mock_mkstemp.return_value = "test/path/config"
-            mock_diff.return_value = "diff"
-            mock_commit_check.return_value = True
+        with patch.dict(
+            junos.__salt__,
+            {
+                "cp.is_cached": MagicMock(return_value="test/path/config"),
+                "cp.hash_file": MagicMock(
+                    return_value={"hash_type": "sha256", "hsum": "a386e49c17"}
+                ),
+                "file.get_hash": MagicMock(return_value="a386e49c17"),
+            },
+        ):
+            with patch("jnpr.junos.utils.config.Config.commit") as mock_commit, patch(
+                "jnpr.junos.utils.config.Config.commit_check"
+            ) as mock_commit_check, patch(
+                "jnpr.junos.utils.config.Config.diff"
+            ) as mock_diff, patch(
+                "jnpr.junos.utils.config.Config.load"
+            ) as mock_load, patch(
+                "salt.utils.files.safe_rm"
+            ) as mock_safe_rm, patch(
+                "salt.utils.files.mkstemp"
+            ) as mock_mkstemp, patch(
+                "os.path.isfile"
+            ) as mock_isfile, patch(
+                "os.path.getsize"
+            ) as mock_getsize:
+                mock_isfile.return_value = True
+                mock_getsize.return_value = 10
+                mock_mkstemp.return_value = "test/path/config"
+                mock_diff.return_value = "diff"
+                mock_commit_check.return_value = True
 
-            ret = dict()
-            ret["message"] = "Successfully loaded and committed!"
-            ret["out"] = True
-            self.assertEqual(junos.install_config("actual/path/config"), ret)
-            mock_load.assert_called_with(path="test/path/config", format="text")
+                ret = dict()
+                ret["message"] = "Successfully loaded and committed!"
+                ret["out"] = True
+                self.assertEqual(junos.install_config("salt://actual/path/config"), ret)
+                mock_load.assert_called_with(path="test/path/config", format="text")
 
     def test_install_config_replace(self):
-        with patch("jnpr.junos.utils.config.Config.commit") as mock_commit, patch(
-            "jnpr.junos.utils.config.Config.commit_check"
-        ) as mock_commit_check, patch(
-            "jnpr.junos.utils.config.Config.diff"
-        ) as mock_diff, patch(
-            "jnpr.junos.utils.config.Config.load"
-        ) as mock_load, patch(
-            "salt.utils.files.safe_rm"
-        ) as mock_safe_rm, patch(
-            "salt.utils.files.mkstemp"
-        ) as mock_mkstemp, patch(
-            "os.path.isfile"
-        ) as mock_isfile, patch(
-            "os.path.getsize"
-        ) as mock_getsize:
-            mock_isfile.return_value = True
-            mock_getsize.return_value = 10
-            mock_mkstemp.return_value = "test/path/config"
-            mock_diff.return_value = "diff"
-            mock_commit_check.return_value = True
+        with patch.dict(
+            junos.__salt__,
+            {
+                "cp.is_cached": MagicMock(return_value="test/path/config"),
+                "cp.hash_file": MagicMock(
+                    return_value={"hash_type": "sha256", "hsum": "a386e49c17"}
+                ),
+                "file.get_hash": MagicMock(return_value="a386e49c17"),
+            },
+        ):
+            with patch("jnpr.junos.utils.config.Config.commit") as mock_commit, patch(
+                "jnpr.junos.utils.config.Config.commit_check"
+            ) as mock_commit_check, patch(
+                "jnpr.junos.utils.config.Config.diff"
+            ) as mock_diff, patch(
+                "jnpr.junos.utils.config.Config.load"
+            ) as mock_load, patch(
+                "salt.utils.files.safe_rm"
+            ) as mock_safe_rm, patch(
+                "salt.utils.files.mkstemp"
+            ) as mock_mkstemp, patch(
+                "os.path.isfile"
+            ) as mock_isfile, patch(
+                "os.path.getsize"
+            ) as mock_getsize:
+                mock_isfile.return_value = True
+                mock_getsize.return_value = 10
+                mock_mkstemp.return_value = "test/path/config"
+                mock_diff.return_value = "diff"
+                mock_commit_check.return_value = True
 
-            args = {
-                "__pub_user": "root",
-                "__pub_arg": [{"replace": True}],
-                "replace": True,
-                "__pub_fun": "junos.install_config",
-                "__pub_jid": "20170222213858582619",
-                "__pub_tgt": "mac_min",
-                "__pub_tgt_type": "glob",
-                "__pub_ret": "",
-            }
+                args = {
+                    "__pub_user": "root",
+                    "__pub_arg": [{"replace": True}],
+                    "replace": True,
+                    "__pub_fun": "junos.install_config",
+                    "__pub_jid": "20170222213858582619",
+                    "__pub_tgt": "mac_min",
+                    "__pub_tgt_type": "glob",
+                    "__pub_ret": "",
+                }
 
-            ret = dict()
-            ret["message"] = "Successfully loaded and committed!"
-            ret["out"] = True
-            self.assertEqual(
-                junos.install_config("actual/path/config.set", **args), ret
-            )
-            mock_load.assert_called_with(
-                path="test/path/config", format="set", merge=False
-            )
+                ret = dict()
+                ret["message"] = "Successfully loaded and committed!"
+                ret["out"] = True
+                self.assertEqual(
+                    junos.install_config("salt://actual/path/config.set", **args), ret
+                )
+                mock_load.assert_called_with(
+                    path="test/path/config", format="set", merge=False
+                )
 
     def test_install_config_overwrite(self):
-        with patch("jnpr.junos.utils.config.Config.commit") as mock_commit, patch(
-            "jnpr.junos.utils.config.Config.commit_check"
-        ) as mock_commit_check, patch(
-            "jnpr.junos.utils.config.Config.diff"
-        ) as mock_diff, patch(
-            "jnpr.junos.utils.config.Config.load"
-        ) as mock_load, patch(
-            "salt.utils.files.safe_rm"
-        ) as mock_safe_rm, patch(
-            "salt.utils.files.mkstemp"
-        ) as mock_mkstemp, patch(
-            "os.path.isfile"
-        ) as mock_isfile, patch(
-            "os.path.getsize"
-        ) as mock_getsize:
-            mock_isfile.return_value = True
-            mock_getsize.return_value = 10
-            mock_mkstemp.return_value = "test/path/config"
-            mock_diff.return_value = "diff"
-            mock_commit_check.return_value = True
+        with patch.dict(
+            junos.__salt__,
+            {
+                "cp.is_cached": MagicMock(return_value="test/path/config"),
+                "cp.hash_file": MagicMock(
+                    return_value={"hash_type": "sha256", "hsum": "a386e49c17"}
+                ),
+                "file.get_hash": MagicMock(return_value="a386e49c17"),
+            },
+        ):
+            with patch("jnpr.junos.utils.config.Config.commit") as mock_commit, patch(
+                "jnpr.junos.utils.config.Config.commit_check"
+            ) as mock_commit_check, patch(
+                "jnpr.junos.utils.config.Config.diff"
+            ) as mock_diff, patch(
+                "jnpr.junos.utils.config.Config.load"
+            ) as mock_load, patch(
+                "salt.utils.files.safe_rm"
+            ) as mock_safe_rm, patch(
+                "salt.utils.files.mkstemp"
+            ) as mock_mkstemp, patch(
+                "os.path.isfile"
+            ) as mock_isfile, patch(
+                "os.path.getsize"
+            ) as mock_getsize:
+                mock_isfile.return_value = True
+                mock_getsize.return_value = 10
+                mock_mkstemp.return_value = "test/path/config"
+                mock_diff.return_value = "diff"
+                mock_commit_check.return_value = True
 
-            args = {
-                "__pub_user": "root",
-                "__pub_arg": [{"overwrite": True}],
-                "overwrite": True,
-                "__pub_fun": "junos.install_config",
-                "__pub_jid": "20170222213858582619",
-                "__pub_tgt": "mac_min",
-                "__pub_tgt_type": "glob",
-                "__pub_ret": "",
-            }
+                args = {
+                    "__pub_user": "root",
+                    "__pub_arg": [{"overwrite": True}],
+                    "overwrite": True,
+                    "__pub_fun": "junos.install_config",
+                    "__pub_jid": "20170222213858582619",
+                    "__pub_tgt": "mac_min",
+                    "__pub_tgt_type": "glob",
+                    "__pub_ret": "",
+                }
 
-            ret = dict()
-            ret["message"] = "Successfully loaded and committed!"
-            ret["out"] = True
-            self.assertEqual(
-                junos.install_config("actual/path/config.xml", **args), ret
-            )
-            mock_load.assert_called_with(
-                path="test/path/config", format="xml", overwrite=True
-            )
+                ret = dict()
+                ret["message"] = "Successfully loaded and committed!"
+                ret["out"] = True
+                self.assertEqual(
+                    junos.install_config("salt://actual/path/config.xml", **args), ret
+                )
+                mock_load.assert_called_with(
+                    path="test/path/config", format="xml", overwrite=True
+                )
 
     def test_install_config_overwrite_false(self):
-        with patch("jnpr.junos.utils.config.Config.commit") as mock_commit, patch(
-            "jnpr.junos.utils.config.Config.commit_check"
-        ) as mock_commit_check, patch(
-            "jnpr.junos.utils.config.Config.diff"
-        ) as mock_diff, patch(
-            "jnpr.junos.utils.config.Config.load"
-        ) as mock_load, patch(
-            "salt.utils.files.safe_rm"
-        ) as mock_safe_rm, patch(
-            "salt.utils.files.mkstemp"
-        ) as mock_mkstemp, patch(
-            "os.path.isfile"
-        ) as mock_isfile, patch(
-            "os.path.getsize"
-        ) as mock_getsize:
-            mock_isfile.return_value = True
-            mock_getsize.return_value = 10
-            mock_mkstemp.return_value = "test/path/config"
-            mock_diff.return_value = "diff"
-            mock_commit_check.return_value = True
+        with patch.dict(
+            junos.__salt__,
+            {
+                "cp.is_cached": MagicMock(return_value="test/path/config"),
+                "cp.hash_file": MagicMock(
+                    return_value={"hash_type": "sha256", "hsum": "a386e49c17"}
+                ),
+                "file.get_hash": MagicMock(return_value="a386e49c17"),
+            },
+        ):
+            with patch("jnpr.junos.utils.config.Config.commit") as mock_commit, patch(
+                "jnpr.junos.utils.config.Config.commit_check"
+            ) as mock_commit_check, patch(
+                "jnpr.junos.utils.config.Config.diff"
+            ) as mock_diff, patch(
+                "jnpr.junos.utils.config.Config.load"
+            ) as mock_load, patch(
+                "salt.utils.files.safe_rm"
+            ) as mock_safe_rm, patch(
+                "salt.utils.files.mkstemp"
+            ) as mock_mkstemp, patch(
+                "os.path.isfile"
+            ) as mock_isfile, patch(
+                "os.path.getsize"
+            ) as mock_getsize:
+                mock_isfile.return_value = True
+                mock_getsize.return_value = 10
+                mock_mkstemp.return_value = "test/path/config"
+                mock_diff.return_value = "diff"
+                mock_commit_check.return_value = True
 
-            args = {
-                "__pub_user": "root",
-                "__pub_arg": [{"overwrite": False}],
-                "overwrite": False,
-                "__pub_fun": "junos.install_config",
-                "__pub_jid": "20170222213858582619",
-                "__pub_tgt": "mac_min",
-                "__pub_tgt_type": "glob",
-                "__pub_ret": "",
-            }
+                args = {
+                    "__pub_user": "root",
+                    "__pub_arg": [{"overwrite": False}],
+                    "overwrite": False,
+                    "__pub_fun": "junos.install_config",
+                    "__pub_jid": "20170222213858582619",
+                    "__pub_tgt": "mac_min",
+                    "__pub_tgt_type": "glob",
+                    "__pub_ret": "",
+                }
 
-            ret = dict()
-            ret["message"] = "Successfully loaded and committed!"
-            ret["out"] = True
-            self.assertEqual(junos.install_config("actual/path/config", **args), ret)
-            mock_load.assert_called_with(
-                path="test/path/config", format="text", merge=True
-            )
+                ret = dict()
+                ret["message"] = "Successfully loaded and committed!"
+                ret["out"] = True
+                self.assertEqual(
+                    junos.install_config("salt://actual/path/config", **args), ret
+                )
+                mock_load.assert_called_with(
+                    path="test/path/config", format="text", merge=True
+                )
 
     def test_install_config_load_causes_exception(self):
         with patch("jnpr.junos.utils.config.Config.diff") as mock_diff, patch(
@@ -1685,24 +1756,33 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         self.assertEqual(junos.install_os(), ret)
 
     def test_install_os_cp_fails(self):
-        with patch("os.path.isfile") as mock_isfile, patch(
-            "os.path.getsize"
-        ) as mock_getsize:
-            mock_getsize.return_value = 10
-            mock_isfile.return_value = False
-            ret = dict()
-            ret["message"] = "Invalid image path."
-            ret["out"] = False
-            self.assertEqual(junos.install_os("/image/path/"), ret)
+        with patch.dict(
+            junos.__salt__,
+            {
+                "cp.is_cached": MagicMock(return_value="/pat/to/tmp/file"),
+                "cp.hash_file": MagicMock(
+                    return_value={"hash_type": "sha256", "hsum": "a386e49c17"}
+                ),
+                "file.get_hash": MagicMock(return_value="xxxx"),
+                "file.rmdir": MagicMock(return_value="True"),
+            },
+        ):
+            with patch("os.path.isfile") as mock_isfile, patch(
+                "os.path.getsize"
+            ) as mock_getsize:
+                mock_getsize.return_value = 10
+                mock_isfile.return_value = False
+                ret = dict()
+                ret["message"] = "Invalid path. Please provide a valid image path"
+                ret["out"] = False
+                self.assertEqual(junos.install_os("salt://image/path/"), ret)
 
     def test_install_os_image_cp_fails(self):
-        with patch("os.path.isfile") as mock_isfile, patch(
-            "os.path.getsize"
-        ) as mock_getsize:
-            mock_getsize.return_value = 0
-            mock_isfile.return_value = True
+        with patch.dict(
+            junos.__salt__, {"file.file_exists": MagicMock(return_value=False)}
+        ):
             ret = dict()
-            ret["message"] = "Failed to copy image"
+            ret["message"] = "Invalid path. Please provide a valid image path"
             ret["out"] = False
             self.assertEqual(junos.install_os("/image/path/"), ret)
 
@@ -1882,28 +1962,24 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             )
 
     def test_file_copy_without_args(self):
-        ret = dict()
-        ret["message"] = "Please provide the absolute path of the file to be copied."
-        ret["out"] = False
-        self.assertEqual(junos.file_copy(), ret)
+        self.assertRaises(TypeError, junos.file_copy)
 
-    def test_file_copy_invalid_src(self):
+    @patch("paramiko.SSHClient")
+    @patch("scp.SCPClient.put")
+    @patch("scp.SCPClient.__init__")
+    def test_file_copy_invalid_src(self, mock_scpclient, mock_put, mock_ssh):
+        mock_scpclient.return_value = None
+        invalid_path = "invalid/file/path"
+        mock_put.side_effect = Exception(invalid_path)
         with patch("os.path.isfile") as mock_isfile:
             mock_isfile.return_value = False
             ret = dict()
-            ret["message"] = "Invalid source file path"
+            ret["message"] = 'Could not copy file : "invalid/file/path"'
             ret["out"] = False
-            self.assertEqual(junos.file_copy("invalid/file/path", "file"), ret)
+            self.assertEqual(junos.file_copy(invalid_path, "file"), ret)
 
     def test_file_copy_without_dest(self):
-        ret = dict()
-        ret[
-            "message"
-        ] = "Please provide the absolute path of the destination where the file is to be copied."
-        ret["out"] = False
-        with patch("salt.modules.junos.os.path.isfile") as mck:
-            mck.return_value = True
-            self.assertEqual(junos.file_copy("/home/user/config.set"), ret)
+        self.assertRaises(TypeError, junos.file_copy, src="/home/user/config.set")
 
     def test_file_copy(self):
         with patch("salt.modules.junos.SCP") as mock_scp, patch(
@@ -2106,16 +2182,28 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         self.assertEqual(ret, ret_exp)
 
     def test_load_wrong_tmp_file(self):
-        ret_exp = {"out": False, "message": "Invalid file path."}
-        with patch("salt.utils.files.mkstemp") as mock_mkstemp:
-            mock_mkstemp.return_value = "/pat/to/tmp/file"
-            ret = junos.load("/path/to/file")
-            self.assertEqual(ret, ret_exp)
+        ret_exp = {
+            "out": False,
+            "message": "Could not load configuration due to : \"[Errno 2] No such file or directory: '/pat/to/tmp/file'\"",
+            "format": "text",
+        }
+        with patch.dict(
+            junos.__salt__,
+            {
+                "cp.is_cached": MagicMock(return_value="/pat/to/tmp/file"),
+                "cp.hash_file": MagicMock(
+                    return_value={"hash_type": "sha256", "hsum": "a386e49c17"}
+                ),
+                "file.get_hash": MagicMock(return_value="a386e49c17"),
+            },
+        ):
+            with patch("os.path.getsize") as mock_getsize:
+                mock_getsize.return_value = 1000
+                ret = junos.load("salt://path/to/file")
+                self.assertEqual(ret, ret_exp)
 
     def test_load_invalid_path(self):
-        ret_exp = {"out": False, "message": "Template failed to render"}
-        ret = junos.load("/path/to/file")
-        self.assertEqual(ret, ret_exp)
+        self.assertRaises(FileNotFoundError, junos.load, path="/path/to/file")
 
     def test_load_no_extension(self):
         ret_exp = {"out": True, "message": "Successfully loaded the configuration."}
@@ -2135,14 +2223,29 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         ret_exp = {"out": True, "message": "Successfully loaded the configuration."}
         with patch("os.path.getsize") as mock_getsize, patch(
             "jnpr.junos.utils.config.Config.load"
+        ) as mock_load, patch("os.path.isfile") as mock_isfile:
+            mock_getsize.return_value = 1000
+            mock_isfile.return_value = True
+            ret = junos.load("/path/to/file.xml")
+            mock_load.assert_called_with(format="xml", path="/path/to/file.xml")
+            self.assertEqual(ret, ret_exp)
+
+    def test_load_xml_extension_with_kwargs(self):
+        ret_exp = {"out": True, "message": "Successfully loaded the configuration."}
+        with patch("os.path.getsize") as mock_getsize, patch(
+            "jnpr.junos.utils.config.Config.load"
         ) as mock_load, patch("salt.utils.files.mkstemp") as mock_mkstmp, patch(
             "os.path.isfile"
-        ) as mock_isfile:
+        ) as mock_isfile, patch(
+            "salt.utils.files.fopen"
+        ) as fopen:
             mock_getsize.return_value = 1000
             mock_mkstmp.return_value = "/path/to/file"
             mock_isfile.return_value = True
-            ret = junos.load("/path/to/file.xml")
-            mock_load.assert_called_with(format="xml", path="/path/to/file")
+            ret = junos.load("/path/to/file.xml", template_vars=dict(hostname="test"))
+            mock_load.assert_called_with(
+                format="xml", path="/path/to/file", template_vars={"hostname": "test"}
+            )
             self.assertEqual(ret, ret_exp)
 
     def test_load_set_extension(self):
@@ -2156,7 +2259,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             mock_mkstmp.return_value = "/path/to/file"
             mock_isfile.return_value = True
             ret = junos.load("/path/to/file.set")
-            mock_load.assert_called_with(format="set", path="/path/to/file")
+            mock_load.assert_called_with(format="set", path="/path/to/file.set")
             self.assertEqual(ret, ret_exp)
 
     def test_load_replace_true(self):
@@ -2263,10 +2366,17 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             "tablename": "ModuleTable",
             "message": "Given table file {} cannot be located".format(file),
         }
-        with patch("jnpr.junos.factory.FactoryLoader.load") as mock_load:
-            ret = junos.get_table(table, file, path)
-            self.assertEqual(ret, ret_exp)
-            mock_load.assert_not_called()
+        with patch.dict(
+            junos.__salt__, {"file.file_exists": MagicMock(return_value=False)}
+        ):
+            with patch("jnpr.junos.factory.FactoryLoader.load") as mock_load, patch(
+                "salt.utils.files.fopen"
+            ) as mock_fopen, patch(
+                "jnpr.junos.factory.FactoryLoader.load"
+            ) as mock_load:
+                ret = junos.get_table(table, file, path)
+                self.assertEqual(ret, ret_exp)
+                mock_load.assert_not_called()
 
     def test_get_table_no_path_no_file(self):
         table = "ModuleTable"
@@ -2277,13 +2387,16 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             "tablename": "ModuleTable",
             "message": "Given table file {} cannot be located".format(file),
         }
-        with patch("jnpr.junos.factory.FactoryLoader.load") as mock_load, patch(
-            "glob.glob"
-        ) as mock_fopen:
-            mock_fopen.return_value = []
-            ret = junos.get_table(table, file)
-            self.assertEqual(ret, ret_exp)
-            mock_load.assert_not_called()
+        with patch.dict(
+            junos.__salt__, {"file.file_exists": MagicMock(return_value=False)}
+        ):
+            with patch("jnpr.junos.factory.FactoryLoader.load") as mock_load, patch(
+                "glob.glob"
+            ) as mock_fopen:
+                mock_fopen.return_value = []
+                ret = junos.get_table(table, file)
+                self.assertEqual(ret, ret_exp)
+                mock_load.assert_not_called()
 
     def test_get_table_yaml_load_error(self):
         table = "ModuleTable"

--- a/tests/unit/modules/test_junos.py
+++ b/tests/unit/modules/test_junos.py
@@ -10,6 +10,7 @@ import os
 # Import salt modules
 import salt.modules.junos as junos
 from salt.ext import six
+
 # Import test libs
 from tests.support.mixins import LoaderModuleMockMixin, XMLEqualityMixin
 from tests.support.mock import ANY, MagicMock, PropertyMock, call, mock_open, patch

--- a/tests/unit/modules/test_junos.py
+++ b/tests/unit/modules/test_junos.py
@@ -10,10 +10,9 @@ import os
 # Import salt modules
 import salt.modules.junos as junos
 from salt.ext import six
-
 # Import test libs
 from tests.support.mixins import LoaderModuleMockMixin, XMLEqualityMixin
-from tests.support.mock import ANY, PropertyMock, call, mock_open, patch, MagicMock
+from tests.support.mock import ANY, MagicMock, PropertyMock, call, mock_open, patch
 from tests.support.unit import TestCase, skipIf
 
 # Import 3rd-party libs


### PR DESCRIPTION
### What does this PR do?
Fix https://github.com/Juniper/salt/issues/146

### What issues does this PR fix or reference?
Fixes:
  * all API should have the same behavior for the user-provided file.
  * In case of proxy model, we can have file located either on master or proxy server itself. So we should handle both cases.

### Previous Behavior
* install_os, load, install_config took file from master, file_copy get_table used to take file from proxy. 
* Also if master/proxy running at same machine, install_os would unnecessarily copy huge file to same server to some tmp file. 

### New Behavior
* if master/proxy running at same allocation, file is not copied and can use local file location
* All APIs now can take file from master using salt://

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ y ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
