### PR TITLE
Fix s3fs cache byte/str mismatch

### DIFF
--- a/changelog/53244.fixed
+++ b/changelog/53244.fixed
@@ -1,0 +1,1 @@
+Fix s3fs cache byte/str mismatch

--- a/salt/fileserver/s3fs.py
+++ b/salt/fileserver/s3fs.py
@@ -568,15 +568,22 @@ def _refresh_buckets_cache_file(cache_file):
                     metadata[saltenv].append({bucket_name: env_files})
 
     # write the metadata to disk
+    _write_buckets_cache_file(metadata, cache_file)
+
+    return metadata
+
+
+def _write_buckets_cache_file(metadata, cache_file):
+    """
+    Write the contents of the buckets cache file
+    """
     if os.path.isfile(cache_file):
         os.remove(cache_file)
 
     log.debug("Writing buckets cache file")
 
-    with salt.utils.files.fopen(cache_file, "w") as fp_:
+    with salt.utils.files.fopen(cache_file, "wb") as fp_:
         pickle.dump(metadata, fp_)
-
-    return metadata
 
 
 def _read_buckets_cache_file(cache_file):

--- a/tests/unit/fileserver/test_s3fs.py
+++ b/tests/unit/fileserver/test_s3fs.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+import tempfile
+
+# Import Salt libs
+import salt.fileserver.s3fs as s3fs
+
+# Import Salt Testing libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.runtests import RUNTIME_VARS
+from tests.support.unit import TestCase
+
+
+class S3fsFileTest(TestCase, LoaderModuleMockMixin):
+    def setup_loader_modules(self):
+        opts = {
+            "cachedir": self.tmp_cachedir,
+        }
+        return {s3fs: {"__opts__": opts}}
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp_cachedir = tempfile.mkdtemp(dir=RUNTIME_VARS.TMP)
+
+    def test_cache_round_trip(self):
+        metadata = {"foo": "bar"}
+        cache_file = s3fs._get_cached_file_name("base", "fake_bucket", "some_file")
+
+        s3fs._write_buckets_cache_file(metadata, cache_file)
+        assert s3fs._read_buckets_cache_file(cache_file) == metadata


### PR DESCRIPTION
### What does this PR do?

Fixes a broken str/bytes mismatch in the S3 Fileserver, with unit test.  HT @natemellendorf @jerem991 for the fixes in #57232 and #57241, respectively.

### What issues does this PR fix or reference?

Fixes: #53244.

### Merge requirements satisfied?

- (n/a) Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?

No.