### PR TITLE
Add vcredist 2013

### DIFF
--- a/pkg/windows/build_pkg.bat
+++ b/pkg/windows/build_pkg.bat
@@ -139,45 +139,72 @@ mkdir "%PreDir%"
 @echo ----------------------------------------------------------------------
 :: 64 bit binaries required for AMD64 and x86
 :: Copy down the 64 bit binaries
-set Url60=http://repo.saltstack.com/windows/dependencies/64/ucrt/Windows6.0-KB2999226-x64.msu
-set Name60=Windows6.0-KB2999226-x64.msu
-set Url61=http://repo.saltstack.com/windows/dependencies/64/ucrt/Windows6.1-KB2999226-x64.msu
-set Name61=Windows6.1-KB2999226-x64.msu
-set Url80=http://repo.saltstack.com/windows/dependencies/64/ucrt/Windows8-RT-KB2999226-x64.msu
-set Name80=Windows8-RT-KB2999226-x64.msu
-set Url81=http://repo.saltstack.com/windows/dependencies/64/ucrt/Windows8.1-KB2999226-x64.msu
-set Name81=Windows8.1-KB2999226-x64.msu
-@echo - Downloading %Name60%
-powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url60% -file "%PreDir%\%Name60%"
-@echo - Downloading %Name61%
-powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url61% -file "%PreDir%\%Name61%"
-@echo - Downloading %Name80%
-powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url80% -file "%PreDir%\%Name80%"
-@echo - Downloading %Name81%
-powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url81% -file "%PreDir%\%Name81%"
+set Url=http://repo.saltstack.com/windows/dependencies/64/ucrt/Windows6.0-KB2999226-x64.msu
+set Name=Windows6.0-KB2999226-x64.msu
+@echo - Downloading %Name%
+powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url% -file "%PreDir%\%Name%"
+
+set Url=http://repo.saltstack.com/windows/dependencies/64/ucrt/Windows6.1-KB2999226-x64.msu
+set Name=Windows6.1-KB2999226-x64.msu
+@echo - Downloading %Name%
+powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url% -file "%PreDir%\%Name%"
+
+set Url=http://repo.saltstack.com/windows/dependencies/64/ucrt/Windows8-RT-KB2999226-x64.msu
+set Name=Windows8-RT-KB2999226-x64.msu
+@echo - Downloading %Name%
+powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url% -file "%PreDir%\%Name%"
+
+set Url=http://repo.saltstack.com/windows/dependencies/64/ucrt/Windows8.1-KB2999226-x64.msu
+set Name=Windows8.1-KB2999226-x64.msu
+@echo - Downloading %Name%
+powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url% -file "%PreDir%\%Name%"
 
 :: 32 bit binaries only needed for x86 installer
 :: ProgramFiles(x86) is defined on AMD64 systems
 :: If it's defined, skip the x86 binaries
-If Defined ProgramFiles(x86) goto prereq_end
+If Defined ProgramFiles(x86) goto vcredist_2013_x64
 
 :: Copy down the 32 bit binaries
-set Url60=http://repo.saltstack.com/windows/dependencies/32/ucrt/Windows6.0-KB2999226-x86.msu
-set Name60=Windows6.0-KB2999226-x86.msu
-set Url61=http://repo.saltstack.com/windows/dependencies/32/ucrt/Windows6.1-KB2999226-x86.msu
-set Name61=Windows6.1-KB2999226-x86.msu
-set Url80=http://repo.saltstack.com/windows/dependencies/32/ucrt/Windows8-RT-KB2999226-x86.msu
-set Name80=Windows8-RT-KB2999226-x86.msu
-set Url81=http://repo.saltstack.com/windows/dependencies/32/ucrt/Windows8.1-KB2999226-x86.msu
-set Name81=Windows8.1-KB2999226-x86.msu
-@echo - Downloading %Name60%
-powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url60% -file "%PreDir%\%Name60%"
-@echo - Downloading %Name61%
-powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url61% -file "%PreDir%\%Name61%"
-@echo - Downloading %Name80%
-powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url80% -file "%PreDir%\%Name80%"
-@echo - Downloading %Name81%
-powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url81% -file "%PreDir%\%Name81%"
+set Url=http://repo.saltstack.com/windows/dependencies/32/ucrt/Windows6.0-KB2999226-x86.msu
+set Name=Windows6.0-KB2999226-x86.msu
+@echo - Downloading %Name%
+powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url% -file "%PreDir%\%Name%"
+
+set Url=http://repo.saltstack.com/windows/dependencies/32/ucrt/Windows6.1-KB2999226-x86.msu
+set Name=Windows6.1-KB2999226-x86.msu
+@echo - Downloading %Name%
+powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url% -file "%PreDir%\%Name%"
+
+set Url=http://repo.saltstack.com/windows/dependencies/32/ucrt/Windows8-RT-KB2999226-x86.msu
+set Name=Windows8-RT-KB2999226-x86.msu
+@echo - Downloading %Name%
+powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url% -file "%PreDir%\%Name%"
+
+set Url=http://repo.saltstack.com/windows/dependencies/32/ucrt/Windows8.1-KB2999226-x86.msu
+set Name=Windows8.1-KB2999226-x86.msu
+@echo - Downloading %Name%
+powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url% -file "%PreDir%\%Name%"
+
+goto vcredist_2013_x86
+
+:vcredist_2013_x64
+@echo.
+@echo Copying VCRedist 2013 X64 to Prerequisites
+@echo ----------------------------------------------------------------------
+set Url=http://repo.saltstack.com/windows/dependencies/64/vcredist_x64_2013.exe
+set Name=vcredist_x64_2013.exe
+@echo - Downloading %Name%
+powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url% -file "%PreDir%\%Name%"
+
+:vcredist_2013_x86
+@echo.
+@echo Copying VCRedist 2013 X86 to Prerequisites
+@echo ----------------------------------------------------------------------
+set Url=http://repo.saltstack.com/windows/dependencies/32/vcredist_x86_2013.exe
+set Name=vcredist_x86_2013.exe
+@echo - Downloading %Name%
+powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url% -file "%PreDir%\%Name%"
+
 
 :prereq_end
 

--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -501,6 +501,87 @@ Section -install_ucrt
 SectionEnd
 
 
+# Check and install Visual C++ redist 2013 packages
+# Hidden section (-) to install VCRedist
+Section -install_vcredist_2013
+
+    Var /GLOBAL VcRedistName
+    Var /GLOBAL VcRedistGuid
+    Var /GLOBAL NeedVcRedist
+
+    # GUIDs can be found by installing them and then running the following command:
+    # wmic product where "Name like '%2013%minimum runtime%'" get Name, Version, IdentifyingNumber
+    !define VCREDIST_X86_NAME "vcredist_x86_2013"
+    !define VCREDIST_X86_GUID "{8122DAB1-ED4D-3676-BB0A-CA368196543E}"
+    !define VCREDIST_X64_NAME "vcredist_x64_2013"
+    !define VCREDIST_X64_GUID "{53CF6934-A98D-3D84-9146-FC4EDF3D5641}"
+
+    # Only install 64bit VCRedist on 64bit machines
+    ${If} ${CPUARCH} == "AMD64"
+        StrCpy $VcRedistName ${VCREDIST_X64_NAME}
+        StrCpy $VcRedistGuid ${VCREDIST_X64_GUID}
+        Call InstallVCRedist
+    ${EndIf}
+
+    # Install 32bit VCRedist on all machines
+    StrCpy $VcRedistName ${VCREDIST_X86_NAME}
+    StrCpy $VcRedistGuid ${VCREDIST_X86_GUID}
+    Call InstallVCRedist
+
+SectionEnd
+
+
+Function InstallVCRedist
+    # Check to see if it's already installed
+    Call MsiQueryProductState
+    ${If} $NeedVcRedist == "True"
+        detailPrint "System requires $VcRedistName"
+        MessageBox MB_ICONQUESTION|MB_YESNO|MB_DEFBUTTON2 \
+            "$VcRedistName is currently not installed. Would you like to install?" \
+            /SD IDYES IDYES installVCRedist
+        detailPrint "Aborted by user"
+        Abort
+
+        # If an output variable is specified ($0 in the case below),
+        # ExecWait sets the variable with the exit code (and only sets the
+        # error flag if an error occurs; if an error occurs, the contents
+        # of the user variable are undefined).
+        # http://nsis.sourceforge.net/Reference/ExecWait
+        installVCRedist:
+        ClearErrors
+        detailPrint "Installing $VcRedistName..."
+        ExecWait '"$PLUGINSDIR\$VcRedistName.exe" /install /quiet /norestart' $0
+        IfErrors 0 CheckVcRedistErrorCode
+            MessageBox MB_OK \
+                "$VcRedistName failed to install. Try installing the package manually." \
+                /SD IDOK
+            detailPrint "An error occurred during installation of $VcRedistName"
+            Abort
+
+        CheckVcRedistErrorCode:
+        # Check for Reboot Error Code (3010)
+        ${If} $0 == 3010
+            MessageBox MB_OK \
+                "$VcRedistName installed but requires a restart to complete." \
+                /SD IDOK
+            detailPrint "Reboot and run Salt install again"
+            Abort
+
+        # Check for any other errors
+        ${ElseIfNot} $0 == 0
+            MessageBox MB_OK \
+                "$VcRedistName failed with ErrorCode: $0. Try installing the package manually." \
+                /SD IDOK
+            detailPrint "An error occurred during installation of $VcRedistName"
+            detailPrint "Error: $0"
+            Abort
+        ${EndIf}
+
+    ${EndIf}
+
+FunctionEnd
+
+
 Section "MainSection" SEC01
 
     SetOutPath "$INSTDIR\"
@@ -542,17 +623,17 @@ Function .onInit
     ${EndIf}
 
     customConfigExists:
-    # Check for existing installation
-    ReadRegStr $R0 HKLM \
-        "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}" \
-        "UninstallString"
-    StrCmp $R0 "" checkOther
-    # Found existing installation, prompt to uninstall
-    MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
-        "${PRODUCT_NAME} is already installed.$\n$\n\
-        Click `OK` to remove the existing installation." \
-        /SD IDOK IDOK uninst
-    Abort
+        # Check for existing installation
+        ReadRegStr $R0 HKLM \
+            "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}" \
+            "UninstallString"
+        StrCmp $R0 "" checkOther
+        # Found existing installation, prompt to uninstall
+        MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
+            "${PRODUCT_NAME} is already installed.$\n$\n\
+            Click `OK` to remove the existing installation." \
+            /SD IDOK IDOK uninst
+        Abort
 
     checkOther:
         # Check for existing installation of full salt
@@ -807,6 +888,16 @@ FunctionEnd
 ###############################################################################
 # Helper Functions
 ###############################################################################
+Function MsiQueryProductState
+    # Used for detecting VCRedist Installation
+    !define INSTALLSTATE_DEFAULT "5"
+
+    StrCpy $NeedVcRedist "False"
+    System::Call "msi::MsiQueryProductStateA(t '$VcRedistGuid') i.r0"
+    StrCmp $0 ${INSTALLSTATE_DEFAULT} +2 0
+    StrCpy $NeedVcRedist "True"
+
+FunctionEnd
 
 #------------------------------------------------------------------------------
 # Trim Function

--- a/pkg/windows/modules/get-settings.psm1
+++ b/pkg/windows/modules/get-settings.psm1
@@ -65,7 +65,6 @@ Function Get-Settings {
             "Libeay"     = "libeay32.dll"
             "SSLeay"     = "ssleay32.dll"
             "OpenSSLLic" = "OpenSSL_License.txt"
-            "msvcr"      = "msvcr120.dll"
             "Libsodium"  = "libsodium.dll"
         }
         $ini.Add("64bitDLLs", $64bitDLLs)
@@ -75,7 +74,6 @@ Function Get-Settings {
             "Libeay"     = "libeay32.dll"
             "SSLeay"     = "ssleay32.dll"
             "OpenSSLLic" = "OpenSSL_License.txt"
-            "msvcr"      = "msvcr120.dll"
             "Libsodium"  = "libsodium.dll"
         }
         $ini.Add("32bitDLLs", $32bitDLLs)

--- a/setup.py
+++ b/setup.py
@@ -485,7 +485,7 @@ class DownloadWindowsDlls(Command):
         url = "https://repo.saltstack.com/windows/dependencies/{bits}/{fname}.dll"
         dest = os.path.join(os.path.dirname(sys.executable), "{fname}.dll")
         with indent_log():
-            for fname in ("libeay32", "ssleay32", "msvcr120"):
+            for fname in ("libeay32", "ssleay32"):
                 # See if the library is already on the system
                 if find_library(fname):
                     continue

--- a/setup.py
+++ b/setup.py
@@ -485,7 +485,7 @@ class DownloadWindowsDlls(Command):
         url = "https://repo.saltstack.com/windows/dependencies/{bits}/{fname}.dll"
         dest = os.path.join(os.path.dirname(sys.executable), "{fname}.dll")
         with indent_log():
-            for fname in ("libeay32", "ssleay32"):
+            for fname in ("libeay32", "ssleay32", "libsodium"):
                 # See if the library is already on the system
                 if find_library(fname):
                     continue


### PR DESCRIPTION
### What does this PR do?
Adds vcredist_2013 which contains `msvcr120.dll` which is a requirement for OpenSSL. It doesn't work to just put the dll in the python root. It needs to be in the system path. OpenSSL is a requirement for M2Crypto. The x509 module requires M2Crypto. This basically fixes the x509 module on Windows.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/57266

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
