### PR TITLE
Late import `salt.client.ssh.client`

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -22,7 +22,6 @@ import time
 import salt.acl
 import salt.auth
 import salt.client
-import salt.client.ssh.client
 
 # Import salt libs
 import salt.crypt
@@ -2416,6 +2415,9 @@ class ClearFuncs(TransportMethods):
     @property
     def ssh_client(self):
         if not hasattr(self, "_ssh_client"):
+            # Late import
+            import salt.client.ssh.client
+
             self._ssh_client = salt.client.ssh.client.SSHClient(mopts=self.opts)
         return self._ssh_client
 


### PR DESCRIPTION
### What does this PR do?

The reason behind this late import is that Salt's thin generation, if
Python 2 is available, tries to get the required dependencies, as such,
it tries to import `concurrent` provided by the `futures` package.
Having that import at the module scope will try to import `concurrent`,
if not available, the master will fail to start, even if the user is not
working with salt-ssh at all.

See also:
* https://github.com/saltstack/salt-bootstrap/pull/1466/checks?check_run_id=700200552
* https://github.com/saltstack/salt-bootstrap/pull/1466/checks?check_run_id=700200628