### PR TITLE
Fix virt.get_profiles

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1895,6 +1895,8 @@ def init(
                     for x in y
                 }
             )
+            if len(hypervisors) == 0:
+                raise SaltInvocationError("No supported hypervisors were found")
             virt_hypervisor = "kvm" if "kvm" in hypervisors else hypervisors[0]
 
         # esxi used to be a possible value for the hypervisor: map it to vmware since it's the same
@@ -3238,24 +3240,21 @@ def get_profiles(hypervisor=None, **kwargs):
             for x in y
         }
     )
-    default_hypervisor = "kvm" if "kvm" in hypervisors else hypervisors[0]
+    if len(hypervisors) == 0:
+        raise SaltInvocationError("No supported hypervisors were found")
 
     if not hypervisor:
-        hypervisor = default_hypervisor
+        hypervisor = "kvm" if "kvm" in hypervisors else hypervisors[0]
     virtconf = __salt__["config.get"]("virt", {})
     for typ in ["disk", "nic"]:
         _func = getattr(sys.modules[__name__], "_{0}_profile".format(typ))
         ret[typ] = {
-            "default": _func(
-                "default", hypervisor if hypervisor else default_hypervisor
-            )
+            "default": _func("default", hypervisor)
         }
         if typ in virtconf:
             ret.setdefault(typ, {})
             for prf in virtconf[typ]:
-                ret[typ][prf] = _func(
-                    prf, hypervisor if hypervisor else default_hypervisor
-                )
+                ret[typ][prf] = _func(prf, hypervisor)
     return ret
 
 

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -90,18 +90,14 @@ from xml.etree import ElementTree
 from xml.sax import saxutils
 
 # Import third party libs
-import jinja2
 import jinja2.exceptions
 
 # Import salt libs
 import salt.utils.files
 import salt.utils.json
-import salt.utils.network
 import salt.utils.path
 import salt.utils.stringutils
 import salt.utils.templates
-import salt.utils.validate.net
-import salt.utils.versions
 import salt.utils.xmlutil as xmlutil
 import salt.utils.yaml
 from salt._compat import ipaddress

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -98,6 +98,7 @@ import salt.utils.json
 import salt.utils.path
 import salt.utils.stringutils
 import salt.utils.templates
+import salt.utils.virt
 import salt.utils.xmlutil as xmlutil
 import salt.utils.yaml
 from salt._compat import ipaddress
@@ -105,7 +106,6 @@ from salt.exceptions import CommandExecutionError, SaltInvocationError
 from salt.ext import six
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 from salt.ext.six.moves.urllib.parse import urlparse, urlunparse
-from salt.utils.virt import check_remote, download_remote
 
 try:
     import libvirt  # pylint: disable=import-error
@@ -1532,13 +1532,15 @@ def _handle_remote_boot_params(orig_boot):
             for key in keys:
                 if key == "efi" and type(orig_boot.get(key)) == bool:
                     new_boot[key] = orig_boot.get(key)
-                elif orig_boot.get(key) is not None and check_remote(
+                elif orig_boot.get(key) is not None and salt.utils.virt.check_remote(
                     orig_boot.get(key)
                 ):
                     if saltinst_dir is None:
                         os.makedirs(CACHE_DIR)
                         saltinst_dir = CACHE_DIR
-                    new_boot[key] = download_remote(orig_boot.get(key), saltinst_dir)
+                    new_boot[key] = salt.utils.virt.download_remote(
+                        orig_boot.get(key), saltinst_dir
+                    )
             return new_boot
         else:
             raise SaltInvocationError(

--- a/tests/integration/modules/test_virt.py
+++ b/tests/integration/modules/test_virt.py
@@ -91,3 +91,13 @@ class VirtTest(ModuleCase):
         self.assertEqual(disk["format"], "raw")
         self.assertEqual(disk["sparse_volume"], False)
         self.assertEqual(disk["size"], 8192)
+
+    def test_all_capabilities(self):
+        """
+        Test virt.all_capabilities
+        """
+        caps = self.run_function("virt.all_capabilities")
+        self.assertIsInstance(caps, dict)
+        self.assertIsInstance(caps["host"]["host"]["uuid"], str)
+        self.assertEqual(36, len(caps["host"]["host"]["uuid"]))
+        self.assertIn("qemu", [domainCaps["domain"] for domainCaps in caps["domains"]])

--- a/tests/integration/modules/test_virt.py
+++ b/tests/integration/modules/test_virt.py
@@ -6,6 +6,7 @@ Validate the virt module
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
 
+from numbers import Number
 from xml.etree import ElementTree
 
 # Import Salt Testing libs
@@ -128,3 +129,20 @@ class VirtTest(ModuleCase):
         cpu_baseline = self.run_function("virt.cpu_baseline", out="salt")
         self.assertIsInstance(cpu_baseline, dict)
         self.assertIn(cpu_baseline["vendor"], vendors)
+
+    def test_freemem(self):
+        """
+        Test virt.freemem
+        """
+        available_memory = self.run_function("virt.freemem")
+        self.assertIsInstance(available_memory, Number)
+        self.assertGreater(available_memory, 0)
+
+    def test_freecpu(self):
+        """
+        Test virt.freecpu
+        """
+        available_cpus = self.run_function("virt.freecpu")
+        self.assertIsInstance(available_cpus, Number)
+        self.assertGreater(available_cpus, 0)
+

--- a/tests/integration/modules/test_virt.py
+++ b/tests/integration/modules/test_virt.py
@@ -6,6 +6,8 @@ Validate the virt module
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
 
+from xml.etree import ElementTree
+
 # Import Salt Testing libs
 from tests.support.case import ModuleCase
 from tests.support.helpers import requires_salt_modules
@@ -112,3 +114,17 @@ class VirtTest(ModuleCase):
         self.assertEqual(36, len(caps["host"]["uuid"]))
         self.assertGreaterEqual(len(caps["guests"]), 1)
         self.assertIn(caps["guests"][0]["os_type"], ["hvm", "xen", "xenpvh", "exe"])
+
+    def test_cpu_baseline(self):
+        """
+        Test virt.cpu_baseline
+        """
+        vendors = ["Intel", "ARM", "AMD"]
+        cpu_baseline = self.run_function("virt.cpu_baseline", out="libvirt")
+        self.assertIsInstance(cpu_baseline, str)
+        cpu_baseline = ElementTree.fromstring(cpu_baseline)
+        self.assertIn(cpu_baseline.find("vendor").text, vendors)
+
+        cpu_baseline = self.run_function("virt.cpu_baseline", out="salt")
+        self.assertIsInstance(cpu_baseline, dict)
+        self.assertIn(cpu_baseline["vendor"], vendors)

--- a/tests/integration/modules/test_virt.py
+++ b/tests/integration/modules/test_virt.py
@@ -22,6 +22,7 @@ class VirtTest(ModuleCase):
         Test virt.get_profiles with the KVM profile
         """
         profiles = self.run_function("virt.get_profiles", ["kvm"])
+        self.assertIsInstance(profiles, dict)
         nicp = profiles["nic"]["default"]
         self.assertTrue(nicp[0].get("model", "") == "virtio")
         self.assertTrue(nicp[0].get("source", "") == "br0")
@@ -35,6 +36,7 @@ class VirtTest(ModuleCase):
         Test virt.get_profiles with the ESX profile
         """
         profiles = self.run_function("virt.get_profiles", ["esxi"])
+        self.assertIsInstance(profiles, dict)
         nicp = profiles["nic"]["default"]
         self.assertTrue(nicp[0].get("model", "") == "e1000")
         self.assertTrue(nicp[0].get("source", "") == "DEFAULT")

--- a/tests/integration/modules/test_virt.py
+++ b/tests/integration/modules/test_virt.py
@@ -20,6 +20,21 @@ class VirtTest(ModuleCase):
     Test virt routines
     """
 
+    cpu_models = [
+        "none",
+        "armv7l",
+        "armv7b",
+        "aarch64",
+        "i686",
+        "ppc64",
+        "ppc64le",
+        "riscv32",
+        "riscv64",
+        "s390",
+        "s390x",
+        "x86_64",
+    ]
+
     def test_default_kvm_profile(self):
         """
         Test virt.get_profiles with the KVM profile
@@ -146,3 +161,39 @@ class VirtTest(ModuleCase):
         self.assertIsInstance(available_cpus, Number)
         self.assertGreater(available_cpus, 0)
 
+    def test_full_info(self):
+        """
+        Test virt.full_info
+        """
+        info = self.run_function("virt.full_info")
+        self.assertIsInstance(info, dict)
+        self.assertIsInstance(info["vm_info"], dict)
+
+        self.assertIsInstance(info["freecpu"], Number)
+        self.assertIsInstance(info["freemem"], Number)
+        self.assertGreater(info["freecpu"], 0)
+        self.assertGreater(info["freemem"], 0)
+
+        self.assertIsInstance(info["node_info"], dict)
+        self.assertIsInstance(info["node_info"]["cpucores"], Number)
+        self.assertIsInstance(info["node_info"]["cpumhz"], Number)
+        self.assertIsInstance(info["node_info"]["cpus"], Number)
+        self.assertIsInstance(info["node_info"]["cputhreads"], Number)
+        self.assertIsInstance(info["node_info"]["numanodes"], Number)
+        self.assertIsInstance(info["node_info"]["phymemory"], Number)
+        self.assertIn(info["node_info"]["cpumodel"], self.cpu_models)
+
+    def test_node_info(self):
+        """
+        Test virt.node_info
+        """
+        info = self.run_function("virt.node_info")
+        self.assertIsInstance(info, dict)
+        self.assertIsInstance(info["cpucores"], Number)
+        self.assertIsInstance(info["cpumhz"], Number)
+        self.assertIsInstance(info["cpus"], Number)
+        self.assertIsInstance(info["cputhreads"], Number)
+        self.assertIsInstance(info["numanodes"], Number)
+        self.assertIsInstance(info["phymemory"], Number)
+        self.assertIsInstance(info["sockets"], Number)
+        self.assertIn(info["cpumodel"], self.cpu_models)

--- a/tests/integration/modules/test_virt.py
+++ b/tests/integration/modules/test_virt.py
@@ -23,24 +23,71 @@ class VirtTest(ModuleCase):
         """
         profiles = self.run_function("virt.get_profiles", ["kvm"])
         self.assertIsInstance(profiles, dict)
-        nicp = profiles["nic"]["default"]
-        self.assertTrue(nicp[0].get("model", "") == "virtio")
-        self.assertTrue(nicp[0].get("source", "") == "br0")
-        diskp = profiles["disk"]["default"]
-        self.assertTrue(diskp[0]["system"].get("model", "") == "virtio")
-        self.assertTrue(diskp[0]["system"].get("format", "") == "qcow2")
-        self.assertTrue(diskp[0]["system"].get("size", "") == "8192")
+        nic = profiles["nic"]["default"][0]
+        disk = profiles["disk"]["default"][0]
 
-    def test_default_esxi_profile(self):
+        self.assertEqual(nic["name"], "eth0")
+        self.assertEqual(nic["type"], "bridge")
+        self.assertEqual(nic["model"], "virtio")
+        self.assertEqual(nic["source"], "br0")
+
+        self.assertEqual(disk["name"], "system")
+        self.assertEqual(disk["model"], "virtio")
+        self.assertEqual(disk["size"], 8192)
+
+    def test_default_vmware_profile(self):
         """
-        Test virt.get_profiles with the ESX profile
+        Test virt.get_profiles with the VMware profile
         """
-        profiles = self.run_function("virt.get_profiles", ["esxi"])
+        profiles = self.run_function("virt.get_profiles", ["vmware"])
         self.assertIsInstance(profiles, dict)
-        nicp = profiles["nic"]["default"]
-        self.assertTrue(nicp[0].get("model", "") == "e1000")
-        self.assertTrue(nicp[0].get("source", "") == "DEFAULT")
-        diskp = profiles["disk"]["default"]
-        self.assertTrue(diskp[0]["system"].get("model", "") == "scsi")
-        self.assertTrue(diskp[0]["system"].get("format", "") == "vmdk")
-        self.assertTrue(diskp[0]["system"].get("size", "") == "8192")
+        nic = profiles["nic"]["default"][0]
+        disk = profiles["disk"]["default"][0]
+
+        self.assertEqual(nic["name"], "eth0")
+        self.assertEqual(nic["type"], "bridge")
+        self.assertEqual(nic["model"], "e1000")
+        self.assertEqual(nic["source"], "DEFAULT")
+
+        self.assertEqual(disk["name"], "system")
+        self.assertEqual(disk["model"], "scsi")
+        self.assertEqual(disk["format"], "vmdk")
+        self.assertEqual(disk["size"], 8192)
+
+    def test_default_xen_profile(self):
+        """
+        Test virt.get_profiles with the XEN profile
+        """
+        profiles = self.run_function("virt.get_profiles", ["xen"])
+        self.assertIsInstance(profiles, dict)
+        nic = profiles["nic"]["default"][0]
+        disk = profiles["disk"]["default"][0]
+
+        self.assertEqual(nic["name"], "eth0")
+        self.assertEqual(nic["type"], "bridge")
+        self.assertEqual(nic["model"], None)
+        self.assertEqual(nic["source"], "br0")
+
+        self.assertEqual(disk["name"], "system")
+        self.assertEqual(disk["model"], "xen")
+        self.assertEqual(disk["size"], 8192)
+
+    def test_default_bhyve_profile(self):
+        """
+        Test virt.get_profiles with the Bhyve profile
+        """
+        profiles = self.run_function("virt.get_profiles", ["bhyve"])
+        self.assertIsInstance(profiles, dict)
+        nic = profiles["nic"]["default"][0]
+        disk = profiles["disk"]["default"][0]
+
+        self.assertEqual(nic["name"], "eth0")
+        self.assertEqual(nic["type"], "bridge")
+        self.assertEqual(nic["model"], "virtio")
+        self.assertEqual(nic["source"], "bridge0")
+
+        self.assertEqual(disk["name"], "system")
+        self.assertEqual(disk["model"], "virtio")
+        self.assertEqual(disk["format"], "raw")
+        self.assertEqual(disk["sparse_volume"], False)
+        self.assertEqual(disk["size"], 8192)

--- a/tests/integration/modules/test_virt.py
+++ b/tests/integration/modules/test_virt.py
@@ -101,3 +101,14 @@ class VirtTest(ModuleCase):
         self.assertIsInstance(caps["host"]["host"]["uuid"], str)
         self.assertEqual(36, len(caps["host"]["host"]["uuid"]))
         self.assertIn("qemu", [domainCaps["domain"] for domainCaps in caps["domains"]])
+
+    def test_capabilities(self):
+        """
+        Test virt.capabilities
+        """
+        caps = self.run_function("virt.capabilities")
+        self.assertIsInstance(caps, dict)
+        self.assertIsInstance(caps["host"]["uuid"], str)
+        self.assertEqual(36, len(caps["host"]["uuid"]))
+        self.assertGreaterEqual(len(caps["guests"]), 1)
+        self.assertIn(caps["guests"][0]["os_type"], ["hvm", "xen", "xenpvh", "exe"])


### PR DESCRIPTION
### What does this PR do?
This PR fixes a bug in virt.get_profiles and updates the integration tests.

### Previous Behavior
```
# salt guest virt.get_profiles hypervisor=kvm
guest:
    Passed invalid arguments to virt.get_profiles: _disk_profile() missing 3 required positional arguments: 'hypervisor', 'disks', and 'vm_name'
    
        Return the virt profiles for hypervisor.
    
        Currently there are profiles for:
    
        - nic
        - disk
    
        :param hypervisor: override the default machine type.
        :param connection: libvirt connection URI, overriding defaults
    
            .. versionadded:: 2019.2.0
        :param username: username to connect with, overriding defaults
    
            .. versionadded:: 2019.2.0
        :param password: password to connect with, overriding defaults
    
            .. versionadded:: 2019.2.0
    
        CLI Example:
    
        .. code-block:: bash
    
            salt '*' virt.get_profiles
            salt '*' virt.get_profiles hypervisor=esxi
        
ERROR: Minions returned with non-zero exit code
```

### New Behavior
```
# salt guest virt.get_profiles hypervisor=kvm
guest:
    ----------
    disk:
        ----------
        default:
            |_
              ----------
              device:
                  disk
              model:
                  virtio
              name:
                  system
              size:
                  8192
    nic:
        ----------
        default:
            |_
              ----------
              model:
                  virtio
              name:
                  eth0
              source:
                  br0
              type:
                  bridge
```