### PR TITLE
re-applied changes

### DIFF
--- a/salt/modules/match.py
+++ b/salt/modules/match.py
@@ -248,7 +248,7 @@ def list_(tgt, minion_id=None):
         opts = __opts__
     matchers = salt.loader.matchers(opts)
     try:
-        return matchers["list_match.match"](tgt, opts=__opts__)
+        return matchers["list_match.match"](tgt, opts=opts)
     except Exception as exc:  # pylint: disable=broad-except
         log.exception(exc)
         return False
@@ -278,7 +278,7 @@ def pcre(tgt, minion_id=None):
         opts = __opts__
     matchers = salt.loader.matchers(opts)
     try:
-        return matchers["pcre_match.match"](tgt, opts=__opts__)
+        return matchers["pcre_match.match"](tgt, opts=opts)
     except Exception as exc:  # pylint: disable=broad-except
         log.exception(exc)
         return False
@@ -309,7 +309,7 @@ def glob(tgt, minion_id=None):
     matchers = salt.loader.matchers(opts)
 
     try:
-        return matchers["glob_match.match"](tgt, opts=__opts__)
+        return matchers["glob_match.match"](tgt, opts=opts)
     except Exception as exc:  # pylint: disable=broad-except
         log.exception(exc)
         return False

--- a/tests/unit/modules/test_match.py
+++ b/tests/unit/modules/test_match.py
@@ -10,6 +10,7 @@ import salt.loader
 import salt.matchers.compound_match as compound_match
 import salt.matchers.glob_match as glob_match
 import salt.matchers.list_match as list_match
+import salt.matchers.pcre_match as pcre_match
 import salt.modules.match as match
 
 # Import Salt Libs
@@ -24,6 +25,7 @@ MATCHERS_DICT = {
     "compound_match.match": compound_match.match,
     "glob_match.match": glob_match.match,
     "list_match.match": list_match.match,
+    "pcre_match.match": pcre_match.match,
 }
 
 # the name of the minion to be used for tests
@@ -210,3 +212,36 @@ class MatchTestCase(TestCase, LoaderModuleMockMixin):
         mdict = "notadict"
 
         self.assertRaises(SaltException, match.filter_by, lookup, merge=mdict)
+
+    def test_glob_match_different_minon_id(self):
+        """
+        Tests for situations where the glob matcher is called with a different
+        minion_id than what is found in __opts__
+        """
+        # not passing minion_id, should return False
+        self.assertFalse(match.glob("bar04"))
+
+        # passing minion_id, should return True
+        self.assertTrue(match.glob("bar04", "bar04"))
+
+    def test_pcre_match_different_minion_id(self):
+        """
+        Tests for situations where the glob matcher is called with a different
+        minion_id than what is found in __opts__
+        """
+        # not passing minion_id, should return False
+        self.assertFalse(match.pcre("bar.*04"))
+
+        # passing minion_id, should return True
+        self.assertTrue(match.pcre("bar.*04", "bar04"))
+
+    def test_list_match_different_minion_id(self):
+        """
+        Tests for situations where the list matcher is called with a different
+        minion_id than what is found in __opts__
+        """
+        # not passing minion_id, should return False
+        self.assertFalse(match.list_("bar02,bar04"))
+
+        # passing minion_id, should return True
+        self.assertTrue(match.list_("bar02,bar04", "bar04"))


### PR DESCRIPTION
Signed-off-by: Oliver Isaac <oisaac@gmail.com>

### What does this PR do?

### What issues does this PR fix or reference?
saltstack#55032 : Fixed issue introduced by saltstack#54001 which default to using __opts__ for the matches when a local variable opts had already been defined.

### Previous Behavior
When using x509.managed_certs with a specified minions attribute the globbing fails to match the minion correctly. It displays an error like:

hostname.net is not permitted to use signing policy signing-policy-name

### New Behavior
Signing policy is globbed correctly

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
