### PR TITLE
Produce correct point version for CentOS 8

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2050,8 +2050,9 @@ def os_data():
             # https://bugs.centos.org/view.php?id=8359
             # /etc/os-release contains no minor distro release number so we fall back to parse
             # /etc/centos-release file instead.
-            # Commit introducing this comment should be reverted after the upstream bug is released.
-            if "CentOS Linux 7" in grains.get("lsb_distrib_codename", ""):
+            # Starting with CentOS 7 this minor release information is intentionally not provided
+            # At the time of this commit, CentOS 6+ is supported and works the same for 6, 7 and 8.
+            if grains.get("lsb_distrib_id", "").lower().startswith("centos linux"):
                 grains.pop("lsb_distrib_release", None)
             grains["osrelease"] = grains.get("lsb_distrib_release", osrelease).strip()
         grains["oscodename"] = (


### PR DESCRIPTION
### What does this PR do?
Includes CentOS 8 when checking for new behavior to determine minor release version. This was previously addressed by https://github.com/saltstack/salt/pull/31539/commits/a3b806d12667d8fe71a2f5f2a1908e9b6996dcd0 and the upstream bug is still "assigned".

### What issues does this PR fix or reference?
Fixes: #57424 

### Previous Behavior
Point release information is not available

### New Behavior
Point release information is available

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.

