### PR TITLE
Fix `integration.modules.test_cmdmod.CMDModuleTest.test_cmd_run_whoami` on Windows

### DIFF
--- a/tests/integration/modules/test_cmdmod.py
+++ b/tests/integration/modules/test_cmdmod.py
@@ -540,6 +540,8 @@ class CMDModuleTest(ModuleCase):
             user = RUNTIME_VARS.RUNTIME_CONFIGS["master"]["user"]
         else:
             user = salt.utils.user.get_specific_user()
+        if user.startswith("sudo_"):
+            user = user.replace("sudo_", "")
         cmd = self.run_function("cmd.run", ["whoami"])
         self.assertEqual(user.lower(), cmd.lower())
 


### PR DESCRIPTION
### What does this PR do?
See title