### PR TITLE
Remove buggy start parameter from virt.pool_running docstring

### DIFF
--- a/changelog/57275.fixed
+++ b/changelog/57275.fixed
@@ -1,0 +1,1 @@
+Remove buggy start parameter from virt.pool_running docstring

--- a/salt/states/virt.py
+++ b/salt/states/virt.py
@@ -1322,8 +1322,6 @@ def pool_running(
         when set to ``True``, the pool will be automatically undefined after being stopped. (Default: ``False``)
     :param autostart:
         Whether to start the pool when booting the host. (Default: ``True``)
-    :param start:
-        When ``True``, define and start the pool, otherwise the pool will be left stopped.
     :param connection: libvirt connection URI, overriding defaults
     :param username: username to connect with, overriding defaults
     :param password: password to connect with, overriding defaults


### PR DESCRIPTION
### What does this PR do?

As mentioned by issue #57275, the start parameter in virt.pool_running
documentation is not implemented at all. Remove it from the doc.

### What issues does this PR fix or reference?
Fixes: #57275 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [X] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated: Documentation-only change

### Commits signed with GPG?
Yes