### PR TITLE
Fix test under PyTest.

### DIFF
--- a/tests/integration/modules/test_chocolatey.py
+++ b/tests/integration/modules/test_chocolatey.py
@@ -3,30 +3,30 @@
 from __future__ import absolute_import
 
 import pytest
-import salt.modules.chocolatey as choco
+import salt.utils.path
 import salt.utils.platform
 from tests.support.case import ModuleCase
 from tests.support.helpers import destructiveTest
+from tests.support.sminion import create_sminion
 from tests.support.unit import skipIf
 
 
 @skipIf(not salt.utils.platform.is_windows(), "Tests for only Windows")
+@destructiveTest
 @pytest.mark.windows_whitelisted
 class ChocolateyModuleTest(ModuleCase):
     """
     Validate Chocolatey module
     """
 
-    @destructiveTest
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         """
         Ensure that Chocolatey is installed
         """
-        self._chocolatey_bin = choco._find_chocolatey()
-        if "ERROR" in self._chocolatey_bin:
-            #    self.fail("Chocolatey is not installed")
-            self.run_function("chocolatey.bootstrap")
-        super(ChocolateyModuleTest, self).setUp()
+        if salt.utils.path.which("chocolatey.exe") is None:
+            sminion = create_sminion()
+            sminion.functions.chocolatey.bootstrap()
 
     def test_list_(self):
         ret = self.run_function("chocolatey.list", narrow="adobereader", exact=True)

--- a/tests/whitelist.txt
+++ b/tests/whitelist.txt
@@ -16,6 +16,7 @@ integration.minion.test_timeout
 integration.modules.test_aliases
 integration.modules.test_archive
 integration.modules.test_beacons
+integration.modules.test_chocolatey
 integration.modules.test_cmdmod
 integration.modules.test_config
 integration.modules.test_cp
@@ -66,8 +67,8 @@ integration.returners.test_librato_return
 integration.runners.test_fileserver
 integration.runners.test_jobs
 integration.runners.test_manage
-integration.runners.test_runner_returns
 integration.runners.test_nacl
+integration.runners.test_runner_returns
 integration.runners.test_salt
 integration.sdb.test_env
 integration.shell.test_arguments
@@ -92,12 +93,12 @@ integration.spm.test_info
 integration.spm.test_install
 integration.spm.test_remove
 integration.spm.test_repo
+integration.states.test_file
 integration.states.test_host
 integration.states.test_pip_state
 integration.states.test_pkg
 integration.states.test_reg
 integration.states.test_renderers
-integration.states.test_file
 integration.states.test_service
 integration.states.test_user
 integration.utils.testprogram


### PR DESCRIPTION
### What does this PR do?
The `setUp` function relied on a module function which used
`__context__` which is only available when the module is loaded
through Salt's loader.
The test should have, in fact, failed when running under
`runtests.py` but it didn't, which suggests the module's global
scope is _dirty_.

This PR stops the test case from relying on the `__context__` dunder.

### What issues does this PR fix or reference?
https://jenkinsci.saltstack.com/view/Master%20Branch%20Pytest%20Jobs/job/pr-windows2016-py3-pytest/job/master/215/testReport/tests.integration.modules.test_chocolatey/ChocolateyModuleTest/test_list_/