### PR TITLE
Accept nested namespaces in spacewalk.api

### DIFF
--- a/changelog/57442.fixed
+++ b/changelog/57442.fixed
@@ -1,0 +1,1 @@
+Accept nested namespaces in spacewalk.api runner function.

--- a/salt/runners/spacewalk.py
+++ b/salt/runners/spacewalk.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Spacewalk Runner
 ================
@@ -29,13 +28,10 @@ master configuration at ``/etc/salt/master`` or ``/etc/salt/master.d/spacewalk.c
     not using the defaults. Default is ``protocol: https``.
 
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
-# Import python libs
 import atexit
 import logging
 
-# Import third party libs
 from salt.ext import six
 
 log = logging.getLogger(__name__)
@@ -62,7 +58,7 @@ def _get_spacewalk_configuration(spacewalk_url=""):
 
     if spacewalk_config:
         try:
-            for spacewalk_server, service_config in six.iteritems(spacewalk_config):
+            for spacewalk_server, service_config in spacewalk_config.items():
                 username = service_config.get("username", None)
                 password = service_config.get("password", None)
                 protocol = service_config.get("protocol", "https")
@@ -76,7 +72,7 @@ def _get_spacewalk_configuration(spacewalk_url=""):
                     return False
 
                 ret = {
-                    "api_url": "{0}://{1}/rpc/api".format(protocol, spacewalk_server),
+                    "api_url": "{}://{}/rpc/api".format(protocol, spacewalk_server),
                     "username": username,
                     "password": password,
                 }
@@ -127,7 +123,7 @@ def _get_session(server):
 
     config = _get_spacewalk_configuration(server)
     if not config:
-        raise Exception("No config for '{0}' found on master".format(server))
+        raise Exception("No config for '{}' found on master".format(server))
 
     session = _get_client_and_key(
         config["api_url"], config["username"], config["password"]
@@ -170,11 +166,11 @@ def api(server, command, *args, **kwargs):
     else:
         arguments = args
 
-    call = "{0} {1}".format(command, arguments)
+    call = "{} {}".format(command, arguments)
     try:
         client, key = _get_session(server)
     except Exception as exc:  # pylint: disable=broad-except
-        err_msg = "Exception raised when connecting to spacewalk server ({0}): {1}".format(
+        err_msg = "Exception raised when connecting to spacewalk server ({}): {}".format(
             server, exc
         )
         log.error(err_msg)
@@ -186,7 +182,7 @@ def api(server, command, *args, **kwargs):
     try:
         output = endpoint(key, *arguments)
     except Exception as e:  # pylint: disable=broad-except
-        output = "API call failed: {0}".format(e)
+        output = "API call failed: {}".format(e)
 
     return {call: output}
 
@@ -205,7 +201,7 @@ def addGroupsToKey(server, activation_key, groups):
     try:
         client, key = _get_session(server)
     except Exception as exc:  # pylint: disable=broad-except
-        err_msg = "Exception raised when connecting to spacewalk server ({0}): {1}".format(
+        err_msg = "Exception raised when connecting to spacewalk server ({}): {}".format(
             server, exc
         )
         log.error(err_msg)
@@ -231,7 +227,7 @@ def deleteAllGroups(server):
     try:
         client, key = _get_session(server)
     except Exception as exc:  # pylint: disable=broad-except
-        err_msg = "Exception raised when connecting to spacewalk server ({0}): {1}".format(
+        err_msg = "Exception raised when connecting to spacewalk server ({}): {}".format(
             server, exc
         )
         log.error(err_msg)
@@ -268,7 +264,7 @@ def deleteAllSystems(server):
     try:
         client, key = _get_session(server)
     except Exception as exc:  # pylint: disable=broad-except
-        err_msg = "Exception raised when connecting to spacewalk server ({0}): {1}".format(
+        err_msg = "Exception raised when connecting to spacewalk server ({}): {}".format(
             server, exc
         )
         log.error(err_msg)
@@ -302,7 +298,7 @@ def deleteAllActivationKeys(server):
     try:
         client, key = _get_session(server)
     except Exception as exc:  # pylint: disable=broad-except
-        err_msg = "Exception raised when connecting to spacewalk server ({0}): {1}".format(
+        err_msg = "Exception raised when connecting to spacewalk server ({}): {}".format(
             server, exc
         )
         log.error(err_msg)
@@ -339,7 +335,7 @@ def unregister(name, server_url):
     try:
         client, key = _get_session(server_url)
     except Exception as exc:  # pylint: disable=broad-except
-        err_msg = "Exception raised when connecting to spacewalk server ({0}): {1}".format(
+        err_msg = "Exception raised when connecting to spacewalk server ({}): {}".format(
             server_url, exc
         )
         log.error(err_msg)
@@ -351,10 +347,10 @@ def unregister(name, server_url):
         for system in systems_list:
             out = client.system.deleteSystem(key, system["id"])
             if out == 1:
-                return {name: "Successfully unregistered from {0}".format(server_url)}
+                return {name: "Successfully unregistered from {}".format(server_url)}
             else:
-                return {name: "Failed to unregister from {0}".format(server_url)}
+                return {name: "Failed to unregister from {}".format(server_url)}
     else:
         return {
-            name: "System does not exist in spacewalk server ({0})".format(server_url)
+            name: "System does not exist in spacewalk server ({})".format(server_url)
         }

--- a/salt/runners/spacewalk.py
+++ b/salt/runners/spacewalk.py
@@ -176,7 +176,11 @@ def api(server, command, *args, **kwargs):
         log.error(err_msg)
         return {call: err_msg}
 
-    namespace, method = command.split(".")
+    namespace, _, method = command.rpartition(".")
+    if not namespace:
+        return {
+            call: "Error: command must use the following format: 'namespace.method'"
+        }
     endpoint = getattr(getattr(client, namespace), method)
 
     try:

--- a/tests/pytests/unit/runners/test_spacewalk.py
+++ b/tests/pytests/unit/runners/test_spacewalk.py
@@ -1,0 +1,47 @@
+"""
+Unit tests for Spacewalk runner
+"""
+import salt.runners.spacewalk as spacewalk
+from tests.support.mock import Mock, call, patch
+
+
+def test_api_command_must_have_namespace():
+    _get_session_mock = Mock(return_value=(None, None))
+
+    with patch.object(spacewalk, "_get_session", _get_session_mock):
+        result = spacewalk.api("mocked.server", "badMethod")
+        assert result == {
+            "badMethod ()": "Error: command must use the following format: 'namespace.method'"
+        }
+
+
+def test_api_command_accepts_single_namespace():
+    client_mock = Mock()
+    _get_session_mock = Mock(return_value=(client_mock, "key"))
+    getattr_mock = Mock(return_value="mocked_getattr_return")
+
+    with patch.object(spacewalk, "_get_session", _get_session_mock):
+        with patch.object(spacewalk, "getattr", getattr_mock):
+            spacewalk.api("mocked.server", "system.listSystems")
+            getattr_mock.assert_has_calls(
+                [
+                    call(client_mock, "system"),
+                    call("mocked_getattr_return", "listSystems"),
+                ]
+            )
+
+
+def test_api_command_accepts_nested_namespace():
+    client_mock = Mock()
+    _get_session_mock = Mock(return_value=(client_mock, "key"))
+    getattr_mock = Mock(return_value="mocked_getattr_return")
+
+    with patch.object(spacewalk, "_get_session", _get_session_mock):
+        with patch.object(spacewalk, "getattr", getattr_mock):
+            spacewalk.api("mocked.server", "channel.software.listChildren")
+            getattr_mock.assert_has_calls(
+                [
+                    call(client_mock, "channel.software"),
+                    call("mocked_getattr_return", "listChildren"),
+                ]
+            )


### PR DESCRIPTION
### What does this PR do?
`salt-run $server spacewalk.api` allows users to run arbitrary Spacewalk API functions through Salt. These are passed in a namespace.method notation and may use nested namespaces. Previously only methods in a top-level namespace were supported.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/57442

### Previous Behavior
```
Exception occurred in runner spacewalk.api: Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/salt/client/mixins.py", line 377, in low
    data['return'] = func(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/runners/spacewalk.py", line 175, in api
    namespace, method = command.split('.')
ValueError: too many values to unpack (expected 2)
```

### New Behavior
API gets called as expected, e.g.
```
channel.software.listChildren ('sle-product-sles15-sp1-pool-x86_64',):
    |_
      ----------
      arch_label:
          channel-x86_64
      arch_name:
          x86_64
[...]
```

### Merge requirements satisfied?
- [ ] Docs
- [X] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

Does this need to be documented in addition to the changelog? As there are no spacewalk runner tests yet I will need some time writing them, I opened the PR already to get feedback on the fix.

### Commits signed with GPG?
Yes