### PR TITLE
Fix cmd.powershell when stdout is empty

### DIFF
--- a/changelog/57493.fixed
+++ b/changelog/57493.fixed
@@ -1,0 +1,4 @@
+Fixes issue with cmd.powershell. Some powershell commands do not return
+anything in stdout. This causes the JSON parser to fail because an empty string
+is not valid JSON. This changes an empty string to `{}` which is valid JSON and
+will not cause the JSON loader to stacktrace.

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -3719,6 +3719,9 @@ def powershell(
         **kwargs
     )
 
+    # Sometimes Powershell returns an empty string, which isn't valid JSON
+    if response == "":
+        response = "{}"
     try:
         return salt.utils.json.loads(response)
     except Exception:  # pylint: disable=broad-except

--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -269,12 +269,7 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
         """
         Tests cmd.powershell with a string value output
         """
-        mock_run = {
-            "pid": 1234,
-            "retcode": 0,
-            "stderr": "",
-            "stdout": '"foo"'
-        }
+        mock_run = {"pid": 1234, "retcode": 0, "stderr": "", "stdout": '"foo"'}
         with patch("salt.modules.cmdmod._run", return_value=mock_run):
             ret = cmdmod.powershell("Set-ExecutionPolicy RemoteSigned")
             self.assertEqual("foo", ret)
@@ -284,12 +279,7 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
         """
         Tests cmd.powershell when the output is an empty string
         """
-        mock_run = {
-            "pid": 1234,
-            "retcode": 0,
-            "stderr": "",
-            "stdout": ""
-        }
+        mock_run = {"pid": 1234, "retcode": 0, "stderr": "", "stdout": ""}
         with patch("salt.modules.cmdmod._run", return_value=mock_run):
             ret = cmdmod.powershell("Set-ExecutionPolicy RemoteSigned")
             self.assertEqual({}, ret)

--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -264,6 +264,36 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
                         )
                         self.assertIn("foo", ret)
 
+    @skipIf(not salt.utils.platform.is_windows(), "Only run on Windows")
+    def test_powershell(self):
+        """
+        Tests cmd.powershell with a string value output
+        """
+        mock_run = {
+            "pid": 1234,
+            "retcode": 0,
+            "stderr": "",
+            "stdout": '"foo"'
+        }
+        with patch("salt.modules.cmdmod._run", return_value=mock_run):
+            ret = cmdmod.powershell("Set-ExecutionPolicy RemoteSigned")
+            self.assertEqual("foo", ret)
+
+    @skipIf(not salt.utils.platform.is_windows(), "Only run on Windows")
+    def test_powershell_empty(self):
+        """
+        Tests cmd.powershell when the output is an empty string
+        """
+        mock_run = {
+            "pid": 1234,
+            "retcode": 0,
+            "stderr": "",
+            "stdout": ""
+        }
+        with patch("salt.modules.cmdmod._run", return_value=mock_run):
+            ret = cmdmod.powershell("Set-ExecutionPolicy RemoteSigned")
+            self.assertEqual({}, ret)
+
     def test_is_valid_shell_windows(self):
         """
         Tests return if running on windows


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with `cmd.powershell` when the stdout is an empty string. This is invalid JSON and causes a stacktrace when it's parsed as JSON.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/57493

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
