### PR TITLE
virt.init: fix the name of volumes reused in disk-types pools

### DIFF
--- a/changelog/57497.fixed
+++ b/changelog/57497.fixed
@@ -1,0 +1,1 @@
+Fix volume name for disk-typed pools in virt.defined

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1323,6 +1323,23 @@ def _fill_disk_filename(conn, vm_name, disk, hypervisor, pool_caps):
             pool_xml = ElementTree.fromstring(pool_obj.XMLDesc())
             pool_type = pool_xml.get("type")
 
+            # Disk pools volume names are partition names, they need to be named based on the device name
+            if pool_type == "disk":
+                device = pool_xml.find("./source/device").get("path")
+                all_volumes = pool_obj.listVolumes()
+                if disk.get("source_file") not in all_volumes:
+                    indexes = [
+                        int(re.sub("[a-z]+", "", vol_name)) for vol_name in all_volumes
+                    ] or [0]
+                    index = min(
+                        [
+                            idx
+                            for idx in range(1, max(indexes) + 2)
+                            if idx not in indexes
+                        ]
+                    )
+                    disk["filename"] = "{}{}".format(os.path.basename(device), index)
+
             # Is the user wanting to reuse an existing volume?
             if disk.get("source_file"):
                 if not disk.get("source_file") in pool_obj.listVolumes():
@@ -1349,18 +1366,6 @@ def _fill_disk_filename(conn, vm_name, disk, hypervisor, pool_caps):
                     disk["format"] = "qcow2"
                 else:
                     disk["format"] = volume_options.get("default_format", None)
-
-            # Disk pools volume names are partition names, they need to be named based on the device name
-            if pool_type == "disk":
-                device = pool_xml.find("./source/device").get("path")
-                indexes = [
-                    int(re.sub("[a-z]+", "", vol_name))
-                    for vol_name in pool_obj.listVolumes()
-                ] or [0]
-                index = min(
-                    [idx for idx in range(1, max(indexes) + 2) if idx not in indexes]
-                )
-                disk["filename"] = "{}{}".format(os.path.basename(device), index)
 
     elif hypervisor == "bhyve" and vm_name:
         disk["filename"] = "{}.{}".format(vm_name, disk["name"])

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -929,6 +929,16 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         )
         self.assertEqual(diskp[0]["filename"], ("vdb2"))
 
+        # Reuse existing volume case
+        diskp = virt._disk_profile(
+            self.mock_conn,
+            None,
+            "kvm",
+            [{"name": "mydisk", "pool": "test-vdb", "source_file": "vdb1"}],
+            "hello",
+        )
+        self.assertEqual(diskp[0]["filename"], ("vdb1"))
+
     def test_gen_xml_volume(self):
         """
         Test virt._gen_xml(), generating a disk of volume type


### PR DESCRIPTION
### What does this PR do?

Only compute the partition name if no source_file was provided by the
user for a pool of disk type.

### What issues does this PR fix or reference?
Fixes: #57497 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes