### PR TITLE
Py3 unicode

### DIFF
--- a/changelog/54447.added
+++ b/changelog/54447.added
@@ -1,0 +1,2 @@
+Adds a ``chcp`` option to all ``cmd.run*`` commands. It defaults to 437, but
+you can now specify 65001 for better unicode support.

--- a/changelog/56028.added
+++ b/changelog/56028.added
@@ -1,0 +1,2 @@
+Adds a ``content`` parameter to the ``@with_tempfile`` helper to create a temp
+file with content. This is used to test file functions with unicode characters

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -286,6 +286,7 @@ def _run(
     bg=False,
     encoded_cmd=False,
     success_retcodes=None,
+    chcp=437,
     **kwargs
 ):
     """
@@ -602,7 +603,7 @@ def _run(
         else:
             # On Windows set the codepage to US English.
             if python_shell:
-                cmd = "chcp 437 > nul & " + cmd
+                cmd = "chcp {0} > nul & {1}".format(chcp, cmd)
 
     if clean_env:
         run_env = env
@@ -1137,6 +1138,12 @@ def run(
 
       .. versionadded:: 2019.2.0
 
+    :param int chcp: 437
+        Sets the codepage for Windows commands. Only applicable on Windows
+        systems. For others the setting will be ignored
+
+        .. versionadded:: Magnesium
+
     CLI Example:
 
     .. code-block:: bash
@@ -1389,6 +1396,12 @@ def shell(
 
       .. versionadded:: 2019.2.0
 
+    :param int chcp: 437
+        Sets the codepage for Windows commands. Only applicable on Windows
+        systems. For others the setting will be ignored
+
+        .. versionadded:: Magnesium
+
     CLI Example:
 
     .. code-block:: bash
@@ -1618,6 +1631,12 @@ def run_stdout(
 
       .. versionadded:: 2019.2.0
 
+    :param int chcp: 437
+        Sets the codepage for Windows commands. Only applicable on Windows
+        systems. For others the setting will be ignored
+
+        .. versionadded:: Magnesium
+
     CLI Example:
 
     .. code-block:: bash
@@ -1828,6 +1847,12 @@ def run_stderr(
         present in the ``stdin`` value to newlines.
 
       .. versionadded:: 2019.2.0
+
+    :param int chcp: 437
+        Sets the codepage for Windows commands. Only applicable on Windows
+        systems. For others the setting will be ignored
+
+        .. versionadded:: Magnesium
 
     CLI Example:
 
@@ -2064,6 +2089,12 @@ def run_all(
 
       .. versionadded:: 2019.2.0
 
+    :param int chcp: 437
+        Sets the codepage for Windows commands. Only applicable on Windows
+        systems. For others the setting will be ignored
+
+        .. versionadded:: Magnesium
+
     CLI Example:
 
     .. code-block:: bash
@@ -2265,6 +2296,12 @@ def retcode(
         present in the ``stdin`` value to newlines.
 
       .. versionadded:: 2019.2.0
+
+    :param int chcp: 437
+        Sets the codepage for Windows commands. Only applicable on Windows
+        systems. For others the setting will be ignored
+
+        .. versionadded:: Magnesium
 
     CLI Example:
 
@@ -2538,6 +2575,12 @@ def script(
 
       .. versionadded:: 2019.2.0
 
+    :param int chcp: 437
+        Sets the codepage for Windows commands. Only applicable on Windows
+        systems. For others the setting will be ignored
+
+        .. versionadded:: Magnesium
+
     CLI Example:
 
     .. code-block:: bash
@@ -2789,6 +2832,12 @@ def script_retcode(
         present in the ``stdin`` value to newlines.
 
       .. versionadded:: 2019.2.0
+
+    :param int chcp: 437
+        Sets the codepage for Windows commands. Only applicable on Windows
+        systems. For others the setting will be ignored
+
+        .. versionadded:: Magnesium
 
     CLI Example:
 
@@ -3653,6 +3702,12 @@ def powershell(
 
       .. versionadded:: 2019.2.0
 
+    :param int chcp: 437
+        Sets the codepage for Windows commands. Only applicable on Windows
+        systems. For others the setting will be ignored
+
+        .. versionadded:: Magnesium
+
     :returns:
         :dict: A dictionary of data returned by the powershell command.
 
@@ -3962,6 +4017,12 @@ def powershell_all(
 
       .. versionadded:: 2019.2.0
 
+    :param int chcp: 437
+        Sets the codepage for Windows commands. Only applicable on Windows
+        systems. For others the setting will be ignored
+
+        .. versionadded:: Magnesium
+
     :return: A dictionary with the following entries:
 
         result
@@ -4230,6 +4291,12 @@ def run_bg(
         present in the ``stdin`` value to newlines.
 
       .. versionadded:: 2019.2.0
+
+    :param int chcp: 437
+        Sets the codepage for Windows commands. Only applicable on Windows
+        systems. For others the setting will be ignored
+
+        .. versionadded:: Magnesium
 
     CLI Example:
 

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -1027,6 +1027,9 @@ def with_system_user_and_group(username, group, on_existing="delete", delete=Tru
 class WithTempfile(object):
     def __init__(self, **kwargs):
         self.create = kwargs.pop("create", True)
+        self.content = kwargs.pop("content", "")
+        if self.content:
+            self.create = True
         if "dir" not in kwargs:
             kwargs["dir"] = RUNTIME_VARS.TMP
         if "prefix" not in kwargs:
@@ -1043,6 +1046,9 @@ class WithTempfile(object):
 
     def wrap(self, testcase, *args, **kwargs):
         name = salt.utils.files.mkstemp(**self.kwargs)
+        if self.content:
+            with salt.utils.files.fopen(name, "w") as fp:
+                fp.write(self.content)
         if not self.create:
             os.remove(name)
         try:

--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -568,7 +568,8 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
         Test that unicode doesn't crash the system
         """
         stdout = "Datenträger"
-        ret = cmdmod.run_all("echo Datenträger")
+        with patch.object(builtins, "__salt_system_encoding__", "utf-8"):
+            ret = cmdmod.run_all("cmd /c echo Datenträger")
         self.assertEqual(ret["stdout"], stdout)
 
     def test_run_all_output_loglevel_quiet(self):

--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -528,6 +528,25 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(ret["stdout"], stdout_unicode)
         self.assertEqual(ret["stderr"], stderr_unicode)
 
+    def test_run_all_unicode(self):
+        """
+        Ensure that unicode stdout and stderr are decoded properly
+        """
+        stdout_unicode = "Here is some unicode: спам"
+        stderr_unicode = "Here is some unicode: яйца"
+        stdout_bytes = stdout_unicode.encode("utf-8")
+        stderr_bytes = stderr_unicode.encode("utf-8")
+
+        proc = MagicMock(
+            return_value=MockTimedProc(stdout=stdout_bytes, stderr=stderr_bytes)
+        )
+
+        with patch("salt.utils.timed_subprocess.TimedProc", proc):
+            ret = cmdmod.run_all("some command", rstrip=False)
+
+        self.assertEqual(ret["stdout"], stdout_unicode)
+        self.assertEqual(ret["stderr"], stderr_unicode)
+
     def test_run_all_output_encoding(self):
         """
         Test that specifying the output encoding works as expected
@@ -541,6 +560,16 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
             builtins, "__salt_system_encoding__", "utf-8"
         ):
             ret = cmdmod.run_all("some command", output_encoding="latin1")
+
+        self.assertEqual(ret["stdout"], stdout)
+
+    def test_run_all_unicode_in_stdout(self):
+        """
+        Test that unicode doesn't crash the system
+        """
+        stdout = "Datenträger"
+
+        ret = cmdmod.run_all("echo Datenträger")
 
         self.assertEqual(ret["stdout"], stdout)
 

--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -507,7 +507,7 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(ret["stdout"], "")
         self.assertEqual(ret["stderr"], "")
 
-    def test_run_all_unicode(self):
+    def test_run_all_unicode_set_system_encoding(self):
         """
         Ensure that unicode stdout and stderr are decoded properly
         """
@@ -568,9 +568,7 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
         Test that unicode doesn't crash the system
         """
         stdout = "Datenträger"
-
         ret = cmdmod.run_all("echo Datenträger")
-
         self.assertEqual(ret["stdout"], stdout)
 
     def test_run_all_output_loglevel_quiet(self):

--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -569,7 +569,7 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
         Test that unicode doesn't crash the system
         """
         stdout = "Datenträger"
-        ret = cmdmod.run_all("cmd /c echo Datenträger", chcp=65001)
+        ret = cmdmod.run_all("cmd /c echo Datenträger", python_shell=True, chcp=65001)
         self.assertEqual(ret["stdout"], stdout)
 
     def test_run_all_output_loglevel_quiet(self):

--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -563,13 +563,13 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
 
         self.assertEqual(ret["stdout"], stdout)
 
+    @skipIf(not salt.utils.platform.is_windows(), "Only run on Windows")
     def test_run_all_unicode_in_stdout(self):
         """
         Test that unicode doesn't crash the system
         """
         stdout = "Datenträger"
-        with patch.object(builtins, "__salt_system_encoding__", "utf-8"):
-            ret = cmdmod.run_all("cmd /c echo Datenträger")
+        ret = cmdmod.run_all("cmd /c echo Datenträger", chcp=65001)
         self.assertEqual(ret["stdout"], stdout)
 
     def test_run_all_output_loglevel_quiet(self):

--- a/tests/unit/modules/test_reg.py
+++ b/tests/unit/modules/test_reg.py
@@ -20,8 +20,9 @@ except ImportError:
 
 UNICODE_KEY = "Unicode Key \N{TRADE MARK SIGN}"
 UNICODE_VALUE = (
-    "Unicode Value " "\N{COPYRIGHT SIGN},\N{TRADE MARK SIGN},\N{REGISTERED SIGN}"
+    "Unicode Value \N{COPYRIGHT SIGN},\N{TRADE MARK SIGN},\N{REGISTERED SIGN}"
 )
+UNICODE_VALUE_EXTENDED = "发~送时\\间1™自动/化平台"
 FAKE_KEY = "SOFTWARE\\{}".format(random_string("SaltTesting-", lowercase=False))
 
 
@@ -488,6 +489,32 @@ class WinFunctionsTestCase(TestCase, LoaderModuleMockMixin):
                 "key": FAKE_KEY,
                 "success": True,
                 "vdata": UNICODE_VALUE,
+                "vname": "fake_unicode",
+                "vtype": "REG_SZ",
+            }
+            self.assertEqual(
+                reg.read_value(hive="HKLM", key=FAKE_KEY, vname="fake_unicode"),
+                expected,
+            )
+        finally:
+            reg.delete_key_recursive(hive="HKLM", key=FAKE_KEY)
+
+    @destructiveTest
+    def test_set_value_unicode_extended_value(self):
+        """
+        Test the set_value function on a unicode value
+        """
+        try:
+            self.assertTrue(
+                reg.set_value(
+                    hive="HKLM", key=FAKE_KEY, vname="fake_unicode", vdata=UNICODE_VALUE_EXTENDED
+                )
+            )
+            expected = {
+                "hive": "HKLM",
+                "key": FAKE_KEY,
+                "success": True,
+                "vdata": UNICODE_VALUE_EXTENDED,
                 "vname": "fake_unicode",
                 "vtype": "REG_SZ",
             }

--- a/tests/unit/modules/test_reg.py
+++ b/tests/unit/modules/test_reg.py
@@ -22,6 +22,7 @@ UNICODE_KEY = "Unicode Key \N{TRADE MARK SIGN}"
 UNICODE_VALUE = (
     "Unicode Value \N{COPYRIGHT SIGN},\N{TRADE MARK SIGN},\N{REGISTERED SIGN}"
 )
+UNICODE_KEY_EXTENDED = "Unicode Key 间1™自动/化平台"
 UNICODE_VALUE_EXTENDED = "发~送时\\间1™自动/化平台"
 FAKE_KEY = "SOFTWARE\\{}".format(random_string("SaltTesting-", lowercase=False))
 
@@ -466,6 +467,39 @@ class WinFunctionsTestCase(TestCase, LoaderModuleMockMixin):
                 reg.read_value(
                     hive="HKLM",
                     key="\\".join([FAKE_KEY, UNICODE_KEY]),
+                    vname="fake_name",
+                ),
+                expected,
+            )
+        finally:
+            reg.delete_key_recursive(hive="HKLM", key=FAKE_KEY)
+
+    @destructiveTest
+    def test_set_value_unicode_extended_key(self):
+        """
+        Test the set_value function on a unicode key
+        """
+        try:
+            self.assertTrue(
+                reg.set_value(
+                    hive="HKLM",
+                    key="\\".join([FAKE_KEY, UNICODE_KEY_EXTENDED]),
+                    vname="fake_name",
+                    vdata="fake_value",
+                )
+            )
+            expected = {
+                "hive": "HKLM",
+                "key": "\\".join([FAKE_KEY, UNICODE_KEY_EXTENDED]),
+                "success": True,
+                "vdata": "fake_value",
+                "vname": "fake_name",
+                "vtype": "REG_SZ",
+            }
+            self.assertEqual(
+                reg.read_value(
+                    hive="HKLM",
+                    key="\\".join([FAKE_KEY, UNICODE_KEY_EXTENDED]),
                     vname="fake_name",
                 ),
                 expected,

--- a/tests/unit/modules/test_reg.py
+++ b/tests/unit/modules/test_reg.py
@@ -541,7 +541,10 @@ class WinFunctionsTestCase(TestCase, LoaderModuleMockMixin):
         try:
             self.assertTrue(
                 reg.set_value(
-                    hive="HKLM", key=FAKE_KEY, vname="fake_unicode", vdata=UNICODE_VALUE_EXTENDED
+                    hive="HKLM",
+                    key=FAKE_KEY,
+                    vname="fake_unicode",
+                    vdata=UNICODE_VALUE_EXTENDED,
                 )
             )
             expected = {

--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -1233,11 +1233,9 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
                 # Group argument is ignored on Windows systems. Group is set to
                 # user
                 if salt.utils.platform.is_windows():
-                    comt = "User salt is not available Group salt" " is not available"
+                    comt = "User salt is not available Group salt is not available"
                 else:
-                    comt = (
-                        "User salt is not available Group saltstack" " is not available"
-                    )
+                    comt = "User salt is not available Group saltstack is not available"
                 ret.update({"comment": comt, "result": False})
                 self.assertDictEqual(
                     filestate.managed(name, user=user, group=group), ret


### PR DESCRIPTION
### What does this PR do?
Adds some tests for Unicode Support with Py3
Adds the ability to pass file content to the `@with_tempfile` helper
Adds the ability to pass the code page to use with run commands on Windows (`chcp`)

### What issues does this PR fix or reference?
Ref https://github.com/saltstack/salt/pull/56028
fixes https://github.com/saltstack/salt/issues/54447
fixes https://github.com/saltstack/salt/issues/36031

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
