### PR TITLE
[RC1 Sodium] Skip proxy minion grains on Windows

### DIFF
--- a/changelog/57529.fixes
+++ b/changelog/57529.fixes
@@ -1,0 +1,1 @@
+Skips proxy related grains on Windows

--- a/salt/grains/chronos.py
+++ b/salt/grains/chronos.py
@@ -17,12 +17,15 @@ __virtualname__ = "chronos"
 
 
 def __virtual__():
-    if salt.utils.platform.is_windows():
-        return False, "chronos: Not available on Windows"
-    if not salt.utils.platform.is_proxy() or "proxy" not in __opts__:
-        return False
-    else:
-        return __virtualname__
+    if not salt.utils.platform.is_proxy():
+        return False, "chronos: Not a proxy minion"
+    try:
+        if not __opts__["proxy"]["proxytype"] == "chronos":
+            return False, "chronos: Missing proxy configuration"
+    except KeyError:
+        return False, "chronos: Missing proxy configuration"
+
+    return __virtualname__
 
 
 def kernel():

--- a/salt/grains/chronos.py
+++ b/salt/grains/chronos.py
@@ -17,6 +17,8 @@ __virtualname__ = "chronos"
 
 
 def __virtual__():
+    if salt.utils.platform.is_windows():
+        return False, "chronos: Not available on Windows"
     if not salt.utils.platform.is_proxy() or "proxy" not in __opts__:
         return False
     else:

--- a/salt/grains/cimc.py
+++ b/salt/grains/cimc.py
@@ -23,6 +23,8 @@ GRAINS_CACHE = {"os_family": "Cisco UCS"}
 
 
 def __virtual__():
+    if salt.utils.platform.is_windows():
+        return False, "cimc: Not available on Windows"
     try:
         if salt.utils.platform.is_proxy() and __opts__["proxy"]["proxytype"] == "cimc":
             return __virtualname__

--- a/salt/grains/cimc.py
+++ b/salt/grains/cimc.py
@@ -23,15 +23,15 @@ GRAINS_CACHE = {"os_family": "Cisco UCS"}
 
 
 def __virtual__():
-    if salt.utils.platform.is_windows():
-        return False, "cimc: Not available on Windows"
+    if not salt.utils.platform.is_proxy():
+        return False, "cimc: Not a proxy minion"
     try:
-        if salt.utils.platform.is_proxy() and __opts__["proxy"]["proxytype"] == "cimc":
-            return __virtualname__
+        if not __opts__["proxy"]["proxytype"] == "cimc":
+            return False, "cimc: Missing proxy configuration"
     except KeyError:
-        pass
+        return False, "cimc: Missing proxy configuration"
 
-    return False
+    return __virtualname__
 
 
 def cimc(proxy=None):

--- a/salt/grains/esxi.py
+++ b/salt/grains/esxi.py
@@ -27,15 +27,16 @@ GRAINS_CACHE = {}
 
 def __virtual__():
 
-    if salt.utils.platform.is_windows():
-        return False, "esxi: Not available on Windows"
+    if not salt.utils.platform.is_proxy():
+        return False, "ESXi: Not a proxy minion"
     try:
-        if salt.utils.platform.is_proxy() and __opts__["proxy"]["proxytype"] == "esxi":
-            return __virtualname__
+        if not __opts__["proxy"]["proxytype"] == "esxi":
+            return False, "ESXi: Missing proxy configuration"
     except KeyError:
-        pass
+        return False, "ESXi: Missing proxy configuration"
 
-    return False
+    return __virtualname__
+
 
 
 def esxi():

--- a/salt/grains/esxi.py
+++ b/salt/grains/esxi.py
@@ -27,6 +27,8 @@ GRAINS_CACHE = {}
 
 def __virtual__():
 
+    if salt.utils.platform.is_windows():
+        return False, "esxi: Not available on Windows"
     try:
         if salt.utils.platform.is_proxy() and __opts__["proxy"]["proxytype"] == "esxi":
             return __virtualname__

--- a/salt/grains/fx2.py
+++ b/salt/grains/fx2.py
@@ -26,15 +26,15 @@ GRAINS_CACHE = {}
 
 
 def __virtual__():
-    if salt.utils.platform.is_windows():
-        return False, "fx2: Not available on Windows"
-    if (
-        salt.utils.platform.is_proxy()
-        and "proxy" in __opts__
-        and __opts__["proxy"].get("proxytype") == "fx2"
-    ):
-        return __virtualname__
-    return False
+    if not salt.utils.platform.is_proxy():
+        return False, "fx2: Not a proxy minion"
+    try:
+        if not __opts__["proxy"]["proxytype"] == "fx2":
+            return False, "fx2: Missing proxy configuration"
+    except KeyError:
+        return False, "fx2: Missing proxy configuration"
+
+    return __virtualname__
 
 
 def _find_credentials():

--- a/salt/grains/fx2.py
+++ b/salt/grains/fx2.py
@@ -26,6 +26,8 @@ GRAINS_CACHE = {}
 
 
 def __virtual__():
+    if salt.utils.platform.is_windows():
+        return False, "fx2: Not available on Windows"
     if (
         salt.utils.platform.is_proxy()
         and "proxy" in __opts__

--- a/salt/grains/junos.py
+++ b/salt/grains/junos.py
@@ -23,12 +23,15 @@ log = logging.getLogger(__name__)
 
 
 def __virtual__():
-    if salt.utils.platform.is_windows():
-        return False, "junos: Not available on Windows"
-    if "proxy" not in __opts__:
-        return False
-    else:
-        return __virtualname__
+    if not salt.utils.platform.is_proxy():
+        return False, "junos: Not a proxy minion"
+    try:
+        if not __opts__["proxy"]["proxytype"] == "junos":
+            return False, "junos: Missing proxy configuration"
+    except KeyError:
+        return False, "junos: Missing proxy configuration"
+
+    return __virtualname__
 
 
 def _remove_complex_types(dictionary):

--- a/salt/grains/junos.py
+++ b/salt/grains/junos.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import logging
 
 # Import Salt libs
+import salt.utils.platform
 from salt.ext import six
 
 __proxyenabled__ = ["junos"]
@@ -22,6 +23,8 @@ log = logging.getLogger(__name__)
 
 
 def __virtual__():
+    if salt.utils.platform.is_windows():
+        return False, "junos: Not available on Windows"
     if "proxy" not in __opts__:
         return False
     else:

--- a/salt/grains/marathon.py
+++ b/salt/grains/marathon.py
@@ -15,6 +15,8 @@ __virtualname__ = "marathon"
 
 
 def __virtual__():
+    if salt.utils.platform.is_windows():
+        return False, "marathon: Not available on Windows"
     if (
         salt.utils.platform.is_proxy()
         and "proxy" in __opts__

--- a/salt/grains/marathon.py
+++ b/salt/grains/marathon.py
@@ -15,15 +15,15 @@ __virtualname__ = "marathon"
 
 
 def __virtual__():
-    if salt.utils.platform.is_windows():
-        return False, "marathon: Not available on Windows"
-    if (
-        salt.utils.platform.is_proxy()
-        and "proxy" in __opts__
-        and __opts__["proxy"].get("proxytype") == "marathon"
-    ):
-        return __virtualname__
-    return False
+    if not salt.utils.platform.is_proxy():
+        return False, "marathon: Not a proxy minion"
+    try:
+        if not __opts__["proxy"]["proxytype"] == "marathon":
+            return False, "marathon: Missing proxy configuration"
+    except KeyError:
+        return False, "marathon: Missing proxy configuration"
+
+    return __virtualname__
 
 
 def kernel():

--- a/salt/grains/mdadm.py
+++ b/salt/grains/mdadm.py
@@ -9,8 +9,15 @@ import logging
 
 # Import salt libs
 import salt.utils.files
+import salt.utils.platform
 
 log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    if salt.utils.platform.is_windows():
+        return False, "mdadm: Not available on Windows"
+    return True
 
 
 def mdadm():

--- a/salt/grains/napalm.py
+++ b/salt/grains/napalm.py
@@ -56,8 +56,14 @@ def __virtual__():
     """
     NAPALM library must be installed for this module to work and run in a (proxy) minion.
     """
-    if salt.utils.platform.is_windows():
-        return False, "napalm: Not available on Windows"
+    if not salt.utils.platform.is_proxy():
+        return False, "napalm: Not a proxy minion"
+    try:
+        if not __opts__["proxy"]["proxytype"] == "napalm":
+            return False, "napalm: Missing proxy configuration"
+    except KeyError:
+        return False, "napalm: Missing proxy configuration"
+
     return salt.utils.napalm.virtual(__opts__, __virtualname__, __file__)
 
 

--- a/salt/grains/napalm.py
+++ b/salt/grains/napalm.py
@@ -23,6 +23,7 @@ import logging
 # Salt lib
 import salt.utils.dns
 import salt.utils.napalm
+import salt.utils.platform
 
 log = logging.getLogger(__name__)
 
@@ -55,6 +56,8 @@ def __virtual__():
     """
     NAPALM library must be installed for this module to work and run in a (proxy) minion.
     """
+    if salt.utils.platform.is_windows():
+        return False, "napalm: Not available on Windows"
     return salt.utils.napalm.virtual(__opts__, __virtualname__, __file__)
 
 

--- a/salt/grains/nvme.py
+++ b/salt/grains/nvme.py
@@ -28,6 +28,8 @@ log = logging.getLogger(__name__)
 
 
 def __virtual__():
+    if salt.utils.platform.is_windows():
+        return False, "nvme: Not available on Windows"
     if __opts__.get("nvme_grains", False) is False:
         return False
     return __virtualname__

--- a/salt/grains/nxos.py
+++ b/salt/grains/nxos.py
@@ -24,8 +24,14 @@ __virtualname__ = "nxos"
 
 
 def __virtual__():
-    if salt.utils.platform.is_windows():
-        return False, "nxos: Not available on Windows"
+    if not salt.utils.platform.is_proxy():
+        return False, "nvme: Not a proxy minion"
+    try:
+        if not __opts__["proxy"]["proxytype"] == "nvme":
+            return False, "nvme: Missing proxy configuration"
+    except KeyError:
+        return False, "nvme: Missing proxy configuration"
+
     try:
         salt.utils.nxos.version_info()
     except NxosClientError as err:

--- a/salt/grains/nxos.py
+++ b/salt/grains/nxos.py
@@ -24,6 +24,8 @@ __virtualname__ = "nxos"
 
 
 def __virtual__():
+    if salt.utils.platform.is_windows():
+        return False, "nxos: Not available on Windows"
     try:
         salt.utils.nxos.version_info()
     except NxosClientError as err:

--- a/salt/grains/panos.py
+++ b/salt/grains/panos.py
@@ -23,15 +23,15 @@ GRAINS_CACHE = {"os_family": "panos"}
 
 
 def __virtual__():
-    if salt.utils.platform.is_windows():
-        return False, "panos: Not available on Windows"
+    if not salt.utils.platform.is_proxy():
+        return False, "panos: Not a proxy minion"
     try:
-        if salt.utils.platform.is_proxy() and __opts__["proxy"]["proxytype"] == "panos":
-            return __virtualname__
+        if not __opts__["proxy"]["proxytype"] == "panos":
+            return False, "panos: Missing proxy configuration"
     except KeyError:
-        pass
+        return False, "panos: Missing proxy configuration"
 
-    return False
+    return __virtualname__
 
 
 def panos(proxy=None):

--- a/salt/grains/panos.py
+++ b/salt/grains/panos.py
@@ -23,6 +23,8 @@ GRAINS_CACHE = {"os_family": "panos"}
 
 
 def __virtual__():
+    if salt.utils.platform.is_windows():
+        return False, "panos: Not available on Windows"
     try:
         if salt.utils.platform.is_proxy() and __opts__["proxy"]["proxytype"] == "panos":
             return __virtualname__

--- a/salt/grains/philips_hue.py
+++ b/salt/grains/philips_hue.py
@@ -19,6 +19,8 @@ Static grains for the Philips HUE lamps
 
 .. versionadded:: 2015.8.3
 """
+# Import Salt Libs
+import salt.utils.platform
 
 __proxyenabled__ = ["philips_hue"]
 
@@ -26,6 +28,8 @@ __virtualname__ = "hue"
 
 
 def __virtual__():
+    if salt.utils.platform.is_windows():
+        return False, "hue: Not available on Windows"
     if "proxy" not in __opts__:
         return False
     else:

--- a/salt/grains/philips_hue.py
+++ b/salt/grains/philips_hue.py
@@ -28,12 +28,15 @@ __virtualname__ = "hue"
 
 
 def __virtual__():
-    if salt.utils.platform.is_windows():
-        return False, "hue: Not available on Windows"
-    if "proxy" not in __opts__:
-        return False
-    else:
-        return __virtualname__
+    if not salt.utils.platform.is_proxy():
+        return False, "hue: Not a proxy minion"
+    try:
+        if not __opts__["proxy"]["proxytype"] == "hue":
+            return False, "hue: Missing proxy configuration"
+    except KeyError:
+        return False, "hue: Missing proxy configuration"
+
+    return __virtualname__
 
 
 def kernel():

--- a/salt/grains/rest_sample.py
+++ b/salt/grains/rest_sample.py
@@ -12,18 +12,15 @@ __virtualname__ = "rest_sample"
 
 
 def __virtual__():
-    if salt.utils.platform.is_windows():
-        return False, "rest_sample: Not available on Windows"
+    if not salt.utils.platform.is_proxy():
+        return False, "rest_sample: Not a proxy minion"
     try:
-        if (
-            salt.utils.platform.is_proxy()
-            and __opts__["proxy"]["proxytype"] == "rest_sample"
-        ):
-            return __virtualname__
+        if not __opts__["proxy"]["proxytype"] == "rest_sample":
+            return False, "rest_sample: Missing proxy configuration"
     except KeyError:
-        pass
+        return False, "rest_sample: Missing proxy configuration"
 
-    return False
+    return __virtualname__
 
 
 def kernel():

--- a/salt/grains/rest_sample.py
+++ b/salt/grains/rest_sample.py
@@ -12,6 +12,8 @@ __virtualname__ = "rest_sample"
 
 
 def __virtual__():
+    if salt.utils.platform.is_windows():
+        return False, "rest_sample: Not available on Windows"
     try:
         if (
             salt.utils.platform.is_proxy()

--- a/salt/grains/ssh_sample.py
+++ b/salt/grains/ssh_sample.py
@@ -12,18 +12,15 @@ __virtualname__ = "ssh_sample"
 
 
 def __virtual__():
-    if salt.utils.platform.is_windows():
-        return False, "ssh_sample: Not available on Windows"
+    if not salt.utils.platform.is_proxy():
+        return False, "ssh_sample: Not a proxy minion"
     try:
-        if (
-            salt.utils.platform.is_proxy()
-            and __opts__["proxy"]["proxytype"] == "ssh_sample"
-        ):
-            return __virtualname__
+        if not __opts__["proxy"]["proxytype"] == "ssh_sample":
+            return False, "ssh_sample: Missing proxy configuration"
     except KeyError:
-        pass
+        return False, "ssh_sample: Missing proxy configuration"
 
-    return False
+    return __virtualname__
 
 
 def kernel():

--- a/salt/grains/ssh_sample.py
+++ b/salt/grains/ssh_sample.py
@@ -12,6 +12,8 @@ __virtualname__ = "ssh_sample"
 
 
 def __virtual__():
+    if salt.utils.platform.is_windows():
+        return False, "ssh_sample: Not available on Windows"
     try:
         if (
             salt.utils.platform.is_proxy()


### PR DESCRIPTION
### What does this PR do?
Salt-Proxy is not a thing in Windows, yet cpu time is being spent on some of the grains modules that deal with proxy. This PR gates those grains with a `salt.utils.platform.is_windows()` command within the `__virtual__` function for proxy related grains.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/57529

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
