### PR TITLE
[RC1 Sodium] Uncap msgpack version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 Jinja2
-msgpack>=0.5,!=0.5.5,<1.0.0
+msgpack>=0.5,!=0.5.5
 PyYAML
 MarkupSafe
 requests>=1.0.0


### PR DESCRIPTION
### What does this PR do?

After merging PR#57122 we can install `msgpack` versions equal or bigger than 1.0.0

fixes #57536 