### PR TITLE
[BUG] [RC1 Sodium] Corrected documentation had send_commands, should be run_commands

### DIFF
--- a/salt/modules/arista_pyeapi.py
+++ b/salt/modules/arista_pyeapi.py
@@ -80,7 +80,7 @@ outside a ``pyeapi`` Proxy, e.g.:
 
 .. code-block:: bash
 
-    salt '*' pyeapi.send_commands 'show version' 'show interfaces'
+    salt '*' pyeapi.run_commands 'show version' 'show interfaces'
     salt '*' pyeapi.config 'ntp server 1.2.3.4'
 
 .. note::


### PR DESCRIPTION
### What does this PR do?
Corrected documentation had send_commands, should be run_commands as an example

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/57531

- [X] Docs
- [X] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
