### PR TITLE
don't overwrite rst files with autodoc

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -343,6 +343,7 @@ else:
 modindex_common_prefix = ["salt."]
 
 autosummary_generate = True
+autosummary_generate_overwrite = False
 
 # strip git rev as there won't necessarily be a release based on it
 stripped_release = re.sub(r"-\d+-g[0-9a-f]+$", "", release)

--- a/doc/ref/modules/all/salt.modules.nxos_upgrade.rst
+++ b/doc/ref/modules/all/salt.modules.nxos_upgrade.rst
@@ -1,5 +1,5 @@
 salt.modules.nxos_upgrade module
-============================
+================================
 
 .. automodule:: salt.modules.nxos_upgrade
     :members:

--- a/doc/ref/states/all/salt.states.nxos_upgrade.rst
+++ b/doc/ref/states/all/salt.states.nxos_upgrade.rst
@@ -1,5 +1,5 @@
 salt.states.nxos_upgrade module
-=======================
+===============================
 
 .. automodule:: salt.states.nxos_upgrade
     :members:


### PR DESCRIPTION
### What does this PR do?
Fixes https://github.com/saltstack/salt/issues/57508

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/57508

### Previous Behavior
Sphinx auto-generated rst stub files

### New Behavior
Sphinx uses the pre version 3 behavior of requiring and using manually generated rst stub files.


See https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html#confval-autosummary_generate_overwrite for more information.