### PR TITLE
enable_fqdns_grains default to false on Windows

### DIFF
--- a/changelog/57529.changed
+++ b/changelog/57529.changed
@@ -1,0 +1,2 @@
+Change the ``enable_fqdns_grains`` setting to default to ``False`` on Windows
+to addresses some issues with slowness.

--- a/changelog/57529.changed
+++ b/changelog/57529.changed
@@ -1,2 +1,2 @@
 Change the ``enable_fqdns_grains`` setting to default to ``False`` on Windows
-to addresses some issues with slowness.
+to address some issues with slowness.

--- a/changelog/57529.fixed
+++ b/changelog/57529.fixed
@@ -1,2 +1,0 @@
-Set ``enable_fqdns_grains`` to default to ``False`` on Windows. This addresses
-some of the slowness we're seeing.

--- a/changelog/57529.fixed
+++ b/changelog/57529.fixed
@@ -1,0 +1,2 @@
+Set ``enable_fqdns_grains`` to default to ``False`` on Windows. This addresses
+some of the slowness we're seeing.

--- a/conf/minion
+++ b/conf/minion
@@ -157,6 +157,16 @@
 # Set the directory used to hold unix sockets.
 #sock_dir: /var/run/salt/minion
 
+# In order to calculate the fqdns grain, all the IP addresses from the minion
+# are processed with underlying calls to `socket.gethostbyaddr` which can take
+# 5 seconds to be released (after reaching `socket.timeout`) when there is no
+# fqdn for that IP. These calls to `socket.gethostbyaddr` are processed
+# asynchronously, however, it still adds 5 seconds every time grains are
+# generated if an IP does not resolve. In Windows grains are regenerated each
+# time a new process is spawned. Therefore, the default for Windows is `False`.
+# All other OSes default to `True`
+# enable_fqdn_grains: True
+
 # The minion can take a while to start up when lspci and/or dmidecode is used
 # to populate the grains for the minion. Set this to False if you do not need
 # GPU hardware grains for your minion.

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -1053,6 +1053,26 @@ The directory where Unix sockets will be kept.
 
     sock_dir: /var/run/salt/minion
 
+.. conf_minion:: enable_fqdns_grains
+
+``enable_fqdns_grains``
+-----------------------
+
+Default: ``True``
+
+In order to calculate the fqdns grain, all the IP addresses from the minion are
+processed with underlying calls to ``socket.gethostbyaddr`` which can take 5 seconds
+to be released (after reaching ``socket.timeout``) when there is no fqdn for that IP.
+These calls to ``socket.gethostbyaddr`` are processed asynchronously, however, it still
+adds 5 seconds every time grains are generated if an IP does not resolve. In Windows
+grains are regenerated each time a new process is spawned. Therefore, the default for
+Windows is ``False``. All other OSes default to ``True``. This options was
+added `here <https://github.com/saltstack/salt/pull/55581>`_.
+
+.. code-block:: yaml
+
+    enable_fqdns_grains: False
+
 .. conf_minion:: enable_gpu_grains
 
 ``enable_gpu_grains``

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -66,12 +66,14 @@ if salt.utils.platform.is_windows():
     # support in ZeroMQ, we want the default to be something that has a
     # chance of working.
     _DFLT_IPC_MODE = "tcp"
+    _DFLT_FQDNS_GRAINS = False
     _MASTER_TRIES = -1
     # This needs to be SYSTEM in order for salt-master to run as a Service
     # Otherwise, it will not respond to CLI calls
     _MASTER_USER = "SYSTEM"
 else:
     _DFLT_IPC_MODE = "ipc"
+    _DFLT_FQDNS_GRAINS = True
     _MASTER_TRIES = 1
     _MASTER_USER = salt.utils.user.get_user()
 
@@ -352,6 +354,8 @@ VALID_OPTS = immutabletypes.freeze(
         "test": bool,
         # Tell the loader to attempt to import *.pyx cython files if cython is available
         "cython_enable": bool,
+        # Whether or not to load grains for FQDNs
+        "enable_fqdns_grains": bool,
         # Whether or not to load grains for the GPU
         "enable_gpu_grains": bool,
         # Tell the loader to attempt to import *.zip archives
@@ -1133,6 +1137,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze(
         "test": False,
         "ext_job_cache": "",
         "cython_enable": False,
+        "enable_fqdns_grains": _DFLT_FQDNS_GRAINS,
         "enable_gpu_grains": True,
         "enable_zip_modules": False,
         "state_verbose": True,

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2352,7 +2352,9 @@ def fqdns():
     # Provides:
     # fqdns
     opt = {"fqdns": []}
-    if __opts__.get("enable_fqdns_grains", False if salt.utils.platform.is_windows() else True):
+    if __opts__.get(
+        "enable_fqdns_grains", False if salt.utils.platform.is_windows() else True
+    ):
         opt = __salt__["network.fqdns"]()
     return opt
 

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2352,7 +2352,7 @@ def fqdns():
     # Provides:
     # fqdns
     opt = {"fqdns": []}
-    if __opts__.get("enable_fqdns_grains", True):
+    if __opts__.get("enable_fqdns_grains", False if salt.utils.platform.is_windows() else True):
         opt = __salt__["network.fqdns"]()
     return opt
 

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -1193,14 +1193,14 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         ):
             assert core.dns() == ret
 
-    def test_enablefqdnsFalse(self):
+    def test_enable_fqdns_false(self):
         """
         tests enable_fqdns_grains is set to False
         """
         with patch.dict("salt.grains.core.__opts__", {"enable_fqdns_grains": False}):
             assert core.fqdns() == {"fqdns": []}
 
-    def test_enablefqdnsTrue(self):
+    def test_enable_fqdns_true(self):
         """
         testing that grains uses network.fqdns module
         """
@@ -1211,14 +1211,14 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
             with patch.dict("salt.grains.core.__opts__", {"enable_fqdns_grains": True}):
                 assert core.fqdns() == "my.fake.domain"
 
-    def test_enablefqdnsNone(self):
+    def test_enable_fqdns_none(self):
         """
         testing default fqdns grains is returned when enable_fqdns_grains is None
         """
         with patch.dict("salt.grains.core.__opts__", {"enable_fqdns_grains": None}):
             assert core.fqdns() == {"fqdns": []}
 
-    def test_enablefqdnswithoutpaching(self):
+    def test_enable_fqdns_without_patching(self):
         """
         testing fqdns grains is enabled by default
         """
@@ -1226,7 +1226,11 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
             "salt.grains.core.__salt__",
             {"network.fqdns": MagicMock(return_value="my.fake.domain")},
         ):
-            assert core.fqdns() == "my.fake.domain"
+            # fqdns is disabled by default on Windows
+            if salt.utils.platform.is_windows():
+                assert core.fqdns() == {"fqdns": []}
+            else:
+                assert core.fqdns() == "my.fake.domain"
 
     @skipIf(not salt.utils.platform.is_linux(), "System is not Linux")
     @patch(


### PR DESCRIPTION
### What does this PR do?
Sets `enable_fqdns_grains` to `False` by default on Windows. Brings the minion config option into the docs and the minion config file. `enable_fqdns_grains` was introduced here: https://github.com/saltstack/salt/pull/55581

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/57529

### Previous Behavior
Salt commands take an additional 5 seconds due to IP resolution to FQDN timeout on Windows.

### New Behavior
Salt is peppy...

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
