### PR TITLE
Add folder initialization $PLUGINSDIR

### DIFF
--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -592,6 +592,7 @@ SectionEnd
 
 Function .onInit
 
+    InitPluginsDir
     Call parseCommandLineSwitches
 
     # Uninstall msi-installed salt


### PR DESCRIPTION
This fixes the installation of updates (KB2999226) when installing
Salt in silent mode for Windows.