### PR TITLE
Import vsphere only on esxi hosts

### DIFF
--- a/changelog/57529.fixed
+++ b/changelog/57529.fixed
@@ -1,0 +1,3 @@
+Improves performance. Pofiling `test.ping` on Windows shows that 13 of 17 
+seconds are wasted when the esxi grain loads vsphere before noting that
+the OS is not a esxi host.

--- a/changelog/57529.fixed
+++ b/changelog/57529.fixed
@@ -1,3 +1,3 @@
-Improves performance. Pofiling `test.ping` on Windows shows that 13 of 17 
+Improves performance. Profiling `test.ping` on Windows shows that 13 of 17 
 seconds are wasted when the esxi grain loads vsphere before noting that
 the OS is not a esxi host.

--- a/salt/grains/esxi.py
+++ b/salt/grains/esxi.py
@@ -11,8 +11,9 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
-import salt.modules.vsphere
 import salt.utils.platform
+if salt.utils.platform.is_proxy() and __opts__["proxy"]["proxytype"] == "esxi":
+    import salt.modules.vsphere
 
 # Import Salt Libs
 from salt.exceptions import SaltSystemExit

--- a/salt/grains/esxi.py
+++ b/salt/grains/esxi.py
@@ -11,12 +11,13 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
+# Import Salt Libs
 import salt.utils.platform
+from salt.exceptions import SaltSystemExit
+
 if salt.utils.platform.is_proxy() and __opts__["proxy"]["proxytype"] == "esxi":
     import salt.modules.vsphere
 
-# Import Salt Libs
-from salt.exceptions import SaltSystemExit
 
 __proxyenabled__ = ["esxi"]
 __virtualname__ = "esxi"


### PR DESCRIPTION
### What does this PR do?
`import vsphere` only on esxi hosts.

### What issues does this PR fix?
#57529

### Current Behavior
The esxi grains attempt to load vsphere before testing if the minion is an esxi hosts.
On Windows, this attempt wastes 3/4 of a `test.ping` command (13 of 16 profiled seconds) by busy polling (100%CPU).

### Merge requirements satisfied?
- [x] No docs
- [x] Changelog
- [x] Tests exist

