### PR TITLE
Update `noxfile.py` to work with upstream nox

### DIFF
--- a/changelog/57583.fixed
+++ b/changelog/57583.fixed
@@ -1,0 +1,1 @@
+Allow running nox sessions either using our `nox-py2 fork <https://github.com/s0undt3ch/nox/tree/hotfix/py2-release>`_ or upstream `nox <https://github.com/theacodes/nox>`_.

--- a/doc/topics/development/tests/index.rst
+++ b/doc/topics/development/tests/index.rst
@@ -28,6 +28,11 @@ nox will create a virtualenv with the specified interpreter. Once the virtualenv
 is created it will also install all of the required python dependencies required for
 that session and run the tests.
 
+.. warning::
+    Please note that you need to ensure to install `nox-py2` and not `nox` regardles of
+    installing Python 2 or Python 3 as these two libraries are incompatibile. Salt needs
+    to use `nox-py2` to ensure Python 2 support.
+
 For example if you want to run all of the tests using the zeromq transport on python3
 you would need to specify the zeromq transport and python3.
 
@@ -67,10 +72,10 @@ kitchen-salt `getting started`_ for instructions on how to install and set it up
 `Kitchen Salt`_ uses Test Kitchen to spin up the VM or container in the configured
 provider. Once the VM is spun up, `Kitchen Salt`_ can install salt and run a particular
 set of states. In the case of our branch and PR tests we create "Golden Images" which
-run the `salt-jenkins`_ states and install salt beforehand. We only update these "Golden
-Images" when we need to upgrade or install a system dependency. You can view the
-`kitchen-salt jenkins setup`_ docs for instructions on how to set up `Kitchen Salt`_ similar
-to the jenkins environment we use to run branch and PR tests.
+run the `salt-jenkins`_ states and install salt system dependencies beforehand. We only
+update these "Golden Images" when we need to upgrade or install a system dependency. You can
+view the `kitchen-salt jenkins setup`_ docs for instructions on how to set up `Kitchen Salt`_
+similar to the jenkins environment we use to run branch and PR tests.
 
 Test Directory Structure
 ========================
@@ -144,7 +149,7 @@ running salt's test suite: ``nox-py2``.
 
     pip install nox-py2
 
-Once this requirement is installed, you can use ``nox`` binary to run
+Once this requirement is installed, you can use the ``nox`` binary to run
 all of the tests included in Salt's test suite:
 
 .. code-block:: bash
@@ -167,7 +172,7 @@ Instead of running the entire test suite all at once, which can take a long time
 there are several ways to run only specific groups of tests or individual tests:
 
 * Run :ref:`unit tests only<running-unit-tests-no-daemons>`: ``nox -e 'pytest-zeromq-3(coverage=False)' -- tests/unit/``
-* Run unit and integration tests for states: ``nox -e 'pytest-zeromq-3(coverage=False)' -- tests/unit/states/ tests/unit/modules/``
+* Run unit and integration tests for states: ``nox -e 'pytest-zeromq-3(coverage=False)' -- tests/unit/states/ tests/integration/states/``
 * Run integration tests for an individual module: ``nox -e 'pytest-zeromq-3(coverage=False)' -- tests/integration/modules/test_virt.py``
 * Run unit tests for an individual module: ``nox -e 'pytest-zeromq-3(coverage=False)' -- tests/unit/modules/test_virt.py``
 * Run an individual test by using the class and test name (this example is for the
@@ -272,7 +277,7 @@ cloud provider tests can be run by setting the ``--cloud-provider-tests`` flag:
 
 .. code-block:: bash
 
-    nox -e 'pytest-zeromq-3(coverage=False)' -- tests/integration/cloud/
+    nox -e 'pytest-cloud-3(coverage=False)'
 
 Automated Test Runs
 ===================

--- a/doc/topics/development/tests/index.rst
+++ b/doc/topics/development/tests/index.rst
@@ -55,7 +55,7 @@ repo or you can manually install the dependency yourself.
 
 System Dependencies
 ===================
-The system dependencies are installed from the `salt-jenkins`_ repo. The ``git.salt``
+The system dependencies are installed from the `salt-jenkins`_ repo. The ``git.minimal``
 states are what is run to determine what dependencies to install on which platform.
 We run these states only when we want to update our current VM images with new
 dependencies.

--- a/doc/topics/development/tests/index.rst
+++ b/doc/topics/development/tests/index.rst
@@ -6,12 +6,71 @@ Salt's Test Suite
 
 Salt comes with a powerful integration and unit test suite allowing for
 the fully automated run of integration and/or unit tests from a single
-interface.
+interface. It uses the combination of pytest, nox and `Kitchen Salt`_ to
+run these tests. Nox is used to manage all of the test python dependencies.
+When you run the test runner with nox, you will be installing the same
+python dependencies that we use to run our test suite on PRs and branch tests.
+`Kitchen Salt`_ is used to spin up our virtual machines based off of golden
+images. These virtual machines use the `salt-jenkins` sls states to configure
+any system dependencies.
 
 To learn the basics of how Salt's test suite works, be sure to check
 out the :ref:`Salt's Test Suite: An Introduction <tutorial-salt-testing>`
 tutorial.
 
+Nox
+===
+Nox is used to manage all of the python dependencies used in the test suite
+and spins up the different nox sessions. You can look at the ``noxfile.py``
+in the salt repo to view all of the current nox configurations. In that file
+you will notice various nox sessions. When creating each of these sessions,
+nox will create a virtualenv with the specified interpreter. Once the virtualenv
+is created it will also install all of the required python dependencies required for
+that session and run the tests.
+
+For example if you want to run all of the tests using the zeromq transport on python3
+you would need to specify the zeromq transport and python3.
+
+.. code-block:: bash
+
+    nox -e 'pytest-zeromq-3(coverage=False)'
+
+To run all the tests but on the tcp transport, you would need to specify the tcp session.
+
+.. code-block:: bash
+
+    nox -e 'pytest-tcp-3(coverage=False)'
+
+You can view all available sessions by running:
+
+.. code-block:: bash
+
+    nox --list-sessions
+
+For the most part you will only need nox to run the test suite, as this tool
+will install the exact same python dependencies we use to run on our test runs.
+The exception to this is when a system dependency is required, for example ``mysql``.
+These system dependencies are installed with sls states managed in the `salt-jenkins`_
+repo or you can manually install the dependency yourself.
+
+System Dependencies
+===================
+The system dependencies are installed from the `salt-jenkins`_ repo. The ``git.salt``
+states are what is run to determine what dependencies to install on which platform.
+We run these states only when we want to update our current VM images with new
+dependencies.
+
+Kitchen Salt
+============
+We also use `Kitchen Salt`_ to spin up the VM's used for testing. You can view the
+kitchen-salt `getting started`_ for instructions on how to install and set it up.
+`Kitchen Salt`_ uses Test Kitchen to spin up the VM or container in the configured
+provider. Once the VM is spun up, `Kitchen Salt`_ can install salt and run a particular
+set of states. In the case of our branch and PR tests we create "Golden Images" which
+run the `salt-jenkins`_ states and install salt beforehand. We only update these "Golden
+Images" when we need to upgrade or install a system dependency. You can view the
+`kitchen-salt jenkins setup`_ docs for instructions on how to set up `Kitchen Salt`_ similar
+to the jenkins environment we use to run branch and PR tests.
 
 Test Directory Structure
 ========================
@@ -30,47 +89,6 @@ group.
 The files that are housed in the ``modules`` directory of either the unit
 or the integration testing factions contain respective integration or unit
 test files for Salt execution modules.
-
-
-.. note::
-    Salt's test framework provides for the option to only run tests which
-    correspond to a given file (or set of files), via the ``--from-filenames``
-    argument to ``runtests.py``:
-
-    .. code-block:: bash
-
-        python /path/to/runtests.py --from-filenames=salt/modules/foo.py
-
-    Therefore, where possible, test files should be named to match the source
-    files they are testing. For example, when writing tests for
-    ``salt/modules/foo.py``, unit tests should go into
-    ``tests/unit/modules/test_foo.py``, and integration tests should go into
-    ``tests/integration/modules/test_foo.py``.
-
-    However, integration tests are organized differently from unit tests, and
-    this may not always be plausible. In these cases, to ensure that the proper
-    tests are run for these files, they must be mapped in
-    `tests/filename_map.yml`__.
-
-    The filename map is used to supplement the test framework's filename
-    matching logic. This allows one to ensure that states correspnding to an
-    execution module are also tested when ``--from-filenames`` includes that
-    execution module. It can also be used for those cases where the path to a
-    test file doesn't correspond directly to the file which is being tested
-    (e.g. the ``shell``, ``spm``, and ``ssh`` integration tests, among others).
-    Both glob expressions and regular expressions are permitted in the filename
-    map.
-
-
-    .. important::
-        Test modules which don't map directly to the source file they are
-        testing (using the naming convention described above), **must** be
-        added to the ``ignore`` tuple in ``tests/unit/test_module_names.py``,
-        in the ``test_module_name_source_match`` function. This unit test
-        ensures that we maintain the naming convention for test files.
-
-    .. __: https://github.com/saltstack/salt/blob/|repo_primary_branch|/tests/filename_map.yml
-
 
 Integration Tests
 -----------------
@@ -119,57 +137,26 @@ or in addition to, integration tests when contributing to Salt.
 Running The Tests
 =================
 
-There are requirements, in addition to Salt's requirements, which
-need to be installed in order to run the test suite. Install one of
-the lines below, depending on the relevant Python version:
+There is only one requirement to install, to quickly get started
+running salt's test suite: ``nox-py2``.
 
 .. code-block:: bash
 
-    pip install -r requirements/dev_python27.txt
-    pip install -r requirements/dev_python34.txt
+    pip install nox-py2
 
-To be able to run integration tests which utilizes ZeroMQ transport, you also
-need to install additional requirements for it. Make sure you have installed
-the C/C++ compiler and development libraries and header files needed for your
-Python version.
-
-This is an example for RedHat-based operating systems:
+Once this requirement is installed, you can use ``nox`` binary to run
+all of the tests included in Salt's test suite:
 
 .. code-block:: bash
 
-    yum install gcc gcc-c++ python-devel
-    pip install -r requirements/zeromq.txt
-
-On Debian, Ubuntu or their derivatives run the following commands:
-
-.. code-block:: bash
-
-    apt-get install build-essential python-dev
-    pip install -r requirements/zeromq.txt
-
-This will install the latest ``pycrypto`` and ``pyzmq`` (with bundled
-``libzmq``) Python modules required for running integration tests suite.
-
-Once all requirements are installed, use ``runtests.py`` script to run all of
-the tests included in Salt's test suite:
-
-.. code-block:: bash
-
-    python tests/runtests.py
+    nox -e 'pytest-zeromq-3(coverage=False)'
 
 For more information about options you can pass the test runner, see the
 ``--help`` option:
 
 .. code-block:: bash
 
-    python tests/runtests.py --help
-
-An alternative way of invoking the test suite is available in ``setup.py``:
-
-.. code-block:: bash
-
-    ./setup.py test
-
+    nox -e 'pytest-zeromq-3(coverage=False)' -- --help
 
 .. _running-test-subsections:
 
@@ -179,17 +166,17 @@ Running Test Subsections
 Instead of running the entire test suite all at once, which can take a long time,
 there are several ways to run only specific groups of tests or individual tests:
 
-* Run :ref:`unit tests only<running-unit-tests-no-daemons>`: ``python tests/runtests.py --unit-tests``
-* Run unit and integration tests for states: ``python tests/runtests.py --state``
-* Run integration tests for an individual module: ``python tests/runtests.py -n integration.modules.virt``
-* Run unit tests for an individual module: ``python tests/runtests.py -n unit.modules.virt_test``
+* Run :ref:`unit tests only<running-unit-tests-no-daemons>`: ``nox -e 'pytest-zeromq-3(coverage=False)' -- tests/unit/``
+* Run unit and integration tests for states: ``nox -e 'pytest-zeromq-3(coverage=False)' -- tests/unit/states/ tests/unit/modules/``
+* Run integration tests for an individual module: ``nox -e 'pytest-zeromq-3(coverage=False)' -- tests/integration/modules/test_virt.py``
+* Run unit tests for an individual module: ``nox -e 'pytest-zeromq-3(coverage=False)' -- tests/unit/modules/test_virt.py``
 * Run an individual test by using the class and test name (this example is for the
-  ``test_default_kvm_profile`` test in the ``integration.module.virt``):
-  ``python tests/runtests.py -n integration.module.virt.VirtTest.test_default_kvm_profile``
+  ``test_default_kvm_profile`` test in the ``tests/integration/module/test_virt.py``):
+  ``nox -e 'pytest-zeromq-3(coverage=False)' -- tests/integration/modules/test_virt.py::VirtTest::test_default_kvm_profile``
 
 For more specific examples of how to run various test subsections or individual
-tests, please see the :ref:`Test Selection Options <test-selection-options>`
-documentation or the :ref:`Running Specific Tests <running-specific-tests>`
+tests, please see the `pytest`_ documentation on how to run specific tests or
+the :ref:`Running Specific Tests <running-specific-tests>`
 section of the :ref:`Salt's Test Suite: An Introduction <tutorial-salt-testing>`
 tutorial.
 
@@ -203,11 +190,11 @@ Since the unit tests do not require a master or minion to execute, it is often u
 run unit tests individually, or as a whole group, without having to start up the integration testing
 daemons. Starting up the master, minion, and syndic daemons takes a lot of time before the tests can
 even start running and is unnecessary to run unit tests. To run unit tests without invoking the
-integration test daemons, simply run the ``runtests.py`` script with ``--unit`` argument:
+integration test daemons, simply add the unit directory as an argument:
 
 .. code-block:: bash
 
-    python tests/runtests.py --unit
+    nox -e 'pytest-zeromq-3(coverage=False)' -- tests/unit/
 
 All of the other options to run individual tests, entire classes of tests, or
 entire test modules still apply.
@@ -238,7 +225,7 @@ To run tests marked as destructive, set the ``--run-destructive`` flag:
 
 .. code-block:: bash
 
-    python tests/runtests.py --run-destructive
+    nox -e 'pytest-zeromq-3(coverage=False)' -- --run-destructive
 
 
 Running Cloud Provider Tests
@@ -285,45 +272,7 @@ cloud provider tests can be run by setting the ``--cloud-provider-tests`` flag:
 
 .. code-block:: bash
 
-    ./tests/runtests.py --cloud-provider-tests
-
-
-Running The Tests In A Docker Container
----------------------------------------
-
-The test suite can be executed under a `docker`_ container using the
-``--docked`` option flag. The `docker`_ container must be properly configured
-on the system invoking the tests and the container must have access to the
-internet.
-
-Here's a simple usage example:
-
-.. code-block:: bash
-
-    python tests/runtests.py --docked=ubuntu-12.04 -v
-
-The full `docker`_ container repository can also be provided:
-
-.. code-block:: bash
-
-    python tests/runtests.py --docked=salttest/ubuntu-12.04 -v
-
-
-The SaltStack team is creating some containers which will have the necessary
-dependencies pre-installed. Running the test suite on a container allows
-destructive tests to run without making changes to the main system. It also
-enables the test suite to run under a different distribution than the one
-the main system is currently using.
-
-The current list of test suite images is on Salt's `docker repository`_.
-
-Custom `docker`_ containers can be provided by submitting a pull request
-against Salt's `docker Salt test containers`_ repository.
-
-.. _`docker`: https://www.docker.com/
-.. _`docker repository`: https://index.docker.io/u/salttest/
-.. _`docker Salt test containers`: https://github.com/saltstack/docker-containers
-
+    nox -e 'pytest-zeromq-3(coverage=False)' -- tests/integration/cloud/
 
 Automated Test Runs
 ===================
@@ -500,3 +449,10 @@ See implementation details in `tests.support.helpers` for details.
 
 `@with_system_user_and_group` -- Creates and optionally destroys a system user and group
 within a test case.  See implementation details in `tests.support.helpers` for details.
+
+
+.. _kitchen-salt jenkins setup: https://kitchen.saltstack.com/docs/file/docs/jenkins.md
+.. _getting started: https://kitchen.saltstack.com/docs/file/docs/gettingstarted.md
+.. _salt-jenkins: https://github.com/saltstack/salt-jenkins
+.. _Kitchen Salt: https://kitchen.saltstack.com/
+.. _pytest: https://docs.pytest.org/en/latest/usage.html#specifying-tests-selecting-tests

--- a/doc/topics/development/tests/index.rst
+++ b/doc/topics/development/tests/index.rst
@@ -11,7 +11,7 @@ run these tests. Nox is used to manage all of the test python dependencies.
 When you run the test runner with nox, you will be installing the same
 python dependencies that we use to run our test suite on PRs and branch tests.
 `Kitchen Salt`_ is used to spin up our virtual machines based off of golden
-images. These virtual machines use the `salt-jenkins` sls states to configure
+images. These virtual machines use the `salt-jenkins`_ sls states to configure
 any system dependencies.
 
 To learn the basics of how Salt's test suite works, be sure to check
@@ -25,16 +25,11 @@ and spins up the different nox sessions. You can look at the ``noxfile.py``
 in the salt repo to view all of the current nox configurations. In that file
 you will notice various nox sessions. When creating each of these sessions,
 nox will create a virtualenv with the specified interpreter. Once the virtualenv
-is created it will also install all of the required python dependencies required for
-that session and run the tests.
+is created it will also install all of the required python dependencies
+required for that session and run the tests.
 
-.. warning::
-    Please note that you need to ensure to install `nox-py2` and not `nox` regardles of
-    installing Python 2 or Python 3 as these two libraries are incompatibile. Salt needs
-    to use `nox-py2` to ensure Python 2 support.
-
-For example if you want to run all of the tests using the zeromq transport on python3
-you would need to specify the zeromq transport and python3.
+For example if you want to run all of the tests using the zeromq transport on
+python3 you would need to specify the zeromq transport and python3.
 
 .. code-block:: bash
 
@@ -60,9 +55,10 @@ repo or you can manually install the dependency yourself.
 
 System Dependencies
 ===================
-The system dependencies are installed from the `salt-jenkins`_ repo. The ``git.minimal``
-states are what is run to determine what dependencies to install on which platform.
-We run these states only when we want to update our current VM images with new
+The system dependencies are installed from the `salt-jenkins`_ repo. The
+``golden-images-provision`` state is what is run to determine what dependencies
+to install on which platform.
+We run this state only when we want to update our current VM images with new
 dependencies.
 
 Kitchen Salt
@@ -80,8 +76,14 @@ similar to the jenkins environment we use to run branch and PR tests.
 Test Directory Structure
 ========================
 
-Salt's test suite is located in the ``tests`` directory in the root of
-Salt's codebase. The test suite is divided into two main groups:
+Salt's test suite is located in the ``tests/`` directory in the root of
+Salt's codebase.
+
+With the migration to PyTest, Salt has created a separate directory for tests
+that are written taking advantage of the full pottential of PyTest. These are
+located under ``tests/pytests``.
+
+As for the old test suite, it is divided into two main groups:
 
 * :ref:`Integration Tests <integration-tests>`
 * :ref:`Unit Tests <unit-tests>`
@@ -94,6 +96,10 @@ group.
 The files that are housed in the ``modules`` directory of either the unit
 or the integration testing factions contain respective integration or unit
 test files for Salt execution modules.
+
+The PyTest only tests under ``tests/pytests`` should, more or less, follow the
+same grouping as the old test suite.
+
 
 Integration Tests
 -----------------
@@ -143,11 +149,11 @@ Running The Tests
 =================
 
 There is only one requirement to install, to quickly get started
-running salt's test suite: ``nox-py2``.
+running salt's test suite: ``nox``.
 
 .. code-block:: bash
 
-    pip install nox-py2
+    pip install nox
 
 Once this requirement is installed, you can use the ``nox`` binary to run
 all of the tests included in Salt's test suite:

--- a/doc/topics/tutorials/writing_tests.rst
+++ b/doc/topics/tutorials/writing_tests.rst
@@ -393,7 +393,11 @@ Therefore, the example above is a good illustration of a unit test "blocking
 the exits" via the ``@patch`` decorator, as well as testing logic via asserting
 against the ``return`` statement in the ``if`` clause. In this example we used the
 python ``assert`` to verify the return from ``cp.get_file``. Pytest allows you to use
-these `asserts`_ when writing your tests.
+these `asserts`_ when writing your tests and, in fact, plain `asserts`_ is the preferred
+way to assert anything in your tests. As Salt dives deeper into Pytest, the use of
+`unittest.TestClass` will be replaced by plain test functions, or test functions grouped
+in a class, which **does not** subclass `unittest.TestClass`, which, of course, doesn't
+work with unittest assert functions.
 
 There are more examples of writing unit tests of varying complexities available
 in the following docs:

--- a/doc/topics/tutorials/writing_tests.rst
+++ b/doc/topics/tutorials/writing_tests.rst
@@ -32,37 +32,13 @@ where the majority of Salt's test cases are housed.
 Getting Set Up For Tests
 ========================
 
-There are a couple of requirements, in addition to Salt's requirements, that need
-to be installed in order to run Salt's test suite. You can install these additional
-requirements using the files located in the ``salt/requirements`` directory,
-depending on your relevant version of Python:
+First of all you will need to ensure you install ``nox-py2``. This version of nox,
+allows the tests to run on both python2 and python3. Ensure you install ``nox-py2``
+and not ``nox`` as this will prevent you from running all the tests.
 
 .. code-block:: bash
 
-    pip install -r requirements/dev_python27.txt
-    pip install -r requirements/dev_python34.txt
-
-To be able to run integration tests which utilizes ZeroMQ transport, you also
-need to install additional requirements for it. Make sure you have installed
-the C/C++ compiler and development libraries and header files needed for your
-Python version.
-
-This is an example for RedHat-based operating systems:
-
-.. code-block:: bash
-
-    yum install gcc gcc-c++ python-devel
-    pip install -r requirements/zeromq.txt
-
-On Debian, Ubuntu or their derivatives run the following commands:
-
-.. code-block:: bash
-
-    apt-get install build-essential python-dev
-    pip install -r requirements/zeromq.txt
-
-This will install the latest ``pycrypto`` and ``pyzmq`` (with bundled
-``libzmq``) Python modules required for running integration tests suite.
+    pip install nox-py2
 
 
 Test Directory Structure
@@ -119,12 +95,11 @@ Running the Test Suite
 ======================
 
 Once all of the :ref:`requirements <getting_set_up_for_tests>` are installed, the
-``runtests.py`` file in the ``salt/tests`` directory is used to instantiate
-Salt's test suite:
+``nox`` command is used to instantiate Salt's test suite:
 
 .. code-block:: bash
 
-    python tests/runtests.py [OPTIONS]
+    nox -e 'pytest-zeromq-3(coverage=False)'
 
 The command above, if executed without any options, will run the entire suite of
 integration and unit tests. Some tests require certain flags to run, such as
@@ -134,19 +109,14 @@ perform the tests that don't require special attention.
 At the end of the test run, you will see a summary output of the tests that passed,
 failed, or were skipped.
 
-The test runner also includes a ``--help`` option that lists all of the various
-command line options:
+You can pass any pytest options after the nox command like so:
 
 .. code-block:: bash
 
-    python tests/runtests.py --help
+    nox -e 'pytest-zeromq-3(coverage=False)' -- tests/unit/modules/test_ps.py
 
-You can also call the test runner as an executable:
-
-.. code-block:: bash
-
-    ./tests/runtests.py --help
-
+The above command will run the ``test_ps.py`` test with the zeromq transport, python3,
+and pytest. The option after ``--`` can include any pytest options.
 
 Running Integration Tests
 -------------------------
@@ -164,7 +134,7 @@ the test suite, allowing you to write tests to assert against expected or
 unexpected behaviors.
 
 A simple example of a test utilizing a typical master/minion execution module command
-is the test for the ``test_ping`` function in the 
+is the test for the ``test_ping`` function in the
 ``tests/integration/modules/test_test.py``
 file:
 
@@ -186,37 +156,26 @@ with a ``True`` response.
 Test Selection Options
 ~~~~~~~~~~~~~~~~~~~~~~
 
-If you look in the output of the ``--help`` command of the test runner, you will
-see a section called ``Tests Selection Options``. The options under this section
-contain various subsections of the integration test suite such as ``--modules``,
-``--ssh``, or ``--states``. By selecting any one of these options, the test daemons
-will spin up and the integration tests in the named subsection will run.
+If you want to run only a subset of tests, this is easily done with pytest. You only
+need to point the test runner to the directory. For example if you want to run all
+integration module tests:
 
 .. code-block:: bash
 
-    ./tests/runtests.py --modules
-
-.. note::
-
-    The testing subsections listed in the ``Tests Selection Options`` of the
-    ``--help`` output *only* apply to the integration tests. They do not run unit
-    tests.
-
+    nox -e 'pytest-zeromq-3(coverage=False)' -- tests/integration/modules/
 
 Running Unit Tests
 ------------------
 
-While ``./tests/runtests.py`` executes the *entire* test suite (barring any tests
-requiring special flags), the ``--unit`` flag can be used to run *only* Salt's
-unit tests. Salt's unit tests include the tests located in the ``tests/unit``
-directory.
+If you want to run only the unit tests, you can just pass the unit test directory
+as an option to the test runner.
 
 The unit tests do not spin up any Salt testing daemons as the integration tests
 do and execute very quickly compared to the integration tests.
 
 .. code-block:: bash
 
-    ./tests/runtests.py --unit
+    nox -e 'pytest-zeromq-3(coverage=False)' -- tests/unit/
 
 
 .. _running-specific-tests:
@@ -226,16 +185,14 @@ Running Specific Tests
 
 There are times when a specific test file, test class, or even a single,
 individual test need to be executed, such as when writing new tests. In these
-situations, the ``--name`` option should be used.
+situations, you should use the `pytest syntax`_ to select the specific tests.
 
 For running a single test file, such as the pillar module test file in the
-integration test directory, you must provide the file path using ``.`` instead
-of ``/`` as separators and no file extension:
+integration test directory, you must provide the file path.
 
 .. code-block:: bash
 
-    ./tests/runtests.py --name=integration.modules.test_pillar
-    ./tests/runtests.py -n integration.modules.test_pillar
+    nox -e 'pytest-zeromq-3(coverage=False)' -- tests/integration/modules/test_pillar.py
 
 Some test files contain only one test class while other test files contain multiple
 test classes. To run a specific test class within the file, append the name of
@@ -243,28 +200,22 @@ the test class to the end of the file path:
 
 .. code-block:: bash
 
-    ./tests/runtests.py --name=integration.modules.test_pillar.PillarModuleTest
-    ./tests/runtests.py -n integration.modules.test_pillar.PillarModuleTest
+    nox -e 'pytest-zeromq-3(coverage=False)' -- tests/integration/modules/test_pillar.py::PillarModuleTest
 
 To run a single test within a file, append both the name of the test class the
 individual test belongs to, as well as the name of the test itself:
 
 .. code-block:: bash
 
-    ./tests/runtests.py \
-      --name=integration.modules.test_pillar.PillarModuleTest.test_data
-    ./tests/runtests.py \
-      -n integration.modules.test_pillar.PillarModuleTest.test_data
+    nox -e 'pytest-zeromq-3(coverage=False)' -- tests/integration/modules/test_pillar.py::PillarModuleTest::test_data
 
-The ``--name`` and ``-n`` options can be used for unit tests as well as integration
-tests. The following command is an example of how to execute a single test found in
+
+The following command is an example of how to execute a single test found in
 the ``tests/unit/modules/test_cp.py`` file:
 
 .. code-block:: bash
 
-    ./tests/runtests.py \
-      -n unit.modules.test_cp.CpTestCase.test_get_template_success
-
+    nox -e 'pytest-zeromq-3(coverage=False)' -- tests/unit/modules/test_cp.py::CpTestCase::test_get_file_not_found
 
 Writing Tests for Salt
 ======================
@@ -320,7 +271,7 @@ Args can be passed in to the ``run_function`` method as well:
         '''
         self.assertEqual(self.run_function('test.echo', ['text']), 'text')
 
-The next example is taken from the 
+The next example is taken from the
 ``tests/integration/modules/test_aliases.py`` file and
 demonstrates how to pass kwargs to the ``run_function`` call. Also note that this
 test uses another salt function to ensure the correct data is present (via the
@@ -430,7 +381,7 @@ testing the call to ``cp.hash_file``, which is used in ``cp.get_file``.
             path = 'salt://saltines'
             dest = '/srv/salt/cheese'
             ret = ''
-            self.assertEqual(cp.get_file(path, dest), ret)
+            assert cp.get_file(path, dest) == ret
 
 Note that Salt's ``cp`` module is imported at the top of the file, along with all
 of the other necessary testing imports. The ``get_file`` function is then called
@@ -440,7 +391,9 @@ the integration test examples do above.
 The call to ``cp.get_file`` returns an empty string when a ``hash_file`` isn't found.
 Therefore, the example above is a good illustration of a unit test "blocking
 the exits" via the ``@patch`` decorator, as well as testing logic via asserting
-against the ``return`` statement in the ``if`` clause.
+against the ``return`` statement in the ``if`` clause. In this example we used the
+python ``assert`` to verify the return from ``cp.get_file``. Pytest allows you to use
+these `asserts`_ when writing your tests.
 
 There are more examples of writing unit tests of varying complexities available
 in the following docs:
@@ -502,6 +455,8 @@ Python testing documentation. Please see the follow references for more informat
 * `Python Unittest`_
 * `Python's Assert Functions`_
 
+.. _asserts: https://docs.pytest.org/en/latest/assert.html
+.. _pytest syntax: https://docs.pytest.org/en/latest/usage.html#specifying-tests-selecting-tests
 .. _MagicMock: https://docs.python.org/3/library/unittest.mock.html
 .. _Python Unittest: https://docs.python.org/2/library/unittest.html
 .. _Python's Assert Functions: https://docs.python.org/2/library/unittest.html#assert-methods

--- a/doc/topics/tutorials/writing_tests.rst
+++ b/doc/topics/tutorials/writing_tests.rst
@@ -415,6 +415,25 @@ in the following docs:
     in a poor and fragile unit test.
 
 
+Add a python module dependency to the test run
+----------------------------------------------
+
+The test dependencies for python modules are managed under the ``requirements/static``
+directory. You will need to add your module to the appropriate file under ``requirements/static``.
+When ``pre-commit`` is run it will create all of the needed requirement files
+under ``requirements/static/py3{5,6,7}``. Nox will then use these files to install
+the requirements for the tests.
+
+Add a system dependency to the test run
+---------------------------------------
+
+If you need to add a system dependency for the test run, this will need to be added in
+the `salt jenkins`_ repo. This repo uses salt states to install system dependencies.
+You need to update the ``git/minimal.sls`` file with your dependency to ensure
+it is installed. Once your PR is merged the core team will need to promote the new images
+with your new dependency installed.
+
+
 Checking for Log Messages
 =========================
 
@@ -464,3 +483,4 @@ Python testing documentation. Please see the follow references for more informat
 .. _MagicMock: https://docs.python.org/3/library/unittest.mock.html
 .. _Python Unittest: https://docs.python.org/2/library/unittest.html
 .. _Python's Assert Functions: https://docs.python.org/2/library/unittest.html#assert-methods
+.. _salt jenkins: https://github.com/saltstack/salt-jenkins

--- a/doc/topics/tutorials/writing_tests.rst
+++ b/doc/topics/tutorials/writing_tests.rst
@@ -32,13 +32,11 @@ where the majority of Salt's test cases are housed.
 Getting Set Up For Tests
 ========================
 
-First of all you will need to ensure you install ``nox-py2``. This version of nox,
-allows the tests to run on both python2 and python3. Ensure you install ``nox-py2``
-and not ``nox`` as this will prevent you from running all the tests.
+First of all you will need to ensure you install ``nox``.
 
 .. code-block:: bash
 
-    pip install nox-py2
+    pip install nox
 
 
 Test Directory Structure
@@ -429,9 +427,9 @@ Add a system dependency to the test run
 
 If you need to add a system dependency for the test run, this will need to be added in
 the `salt jenkins`_ repo. This repo uses salt states to install system dependencies.
-You need to update the ``git/minimal.sls`` file with your dependency to ensure
-it is installed. Once your PR is merged the core team will need to promote the new images
-with your new dependency installed.
+You need to update the ``state-tree/golden-images-provision.sls`` file with
+your dependency to ensure it is installed. Once your PR is merged the core team
+will need to promote the new images with your new dependency installed.
 
 
 Checking for Log Messages

--- a/noxfile.py
+++ b/noxfile.py
@@ -68,6 +68,28 @@ RUNTESTS_LOGFILE = os.path.join(
 os.environ[str("PYTHONDONTWRITEBYTECODE")] = str("1")
 
 
+def find_session_runner(session, name, **kwargs):
+    for s, _ in session._runner.manifest.list_all_sessions():
+        if name not in s.signatures:
+            continue
+        for signature in s.signatures:
+            for key, value in kwargs.items():
+                param = "{}={!r}".format(key, value)
+                if IS_PY3:
+                    # Under Python2 repr unicode string are always "u" prefixed, ie, u'a string'.
+                    param = param.replace("u'", "'")
+                if param not in signature:
+                    break
+            else:
+                return s
+            continue
+    session.error(
+        "Could not find a nox session by the name {!r} with the following keyword arguments: {!r}".format(
+            name, kwargs
+        )
+    )
+
+
 def _create_ci_directories():
     for dirname in ("logs", "coverage", "xml-unittests-output"):
         path = os.path.join("artifacts", dirname)
@@ -415,6 +437,9 @@ def _runtests(session, coverage, cmd_args):
 @nox.parametrize("transport", ["zeromq", "tcp"])
 @nox.parametrize("crypto", [None, "m2crypto", "pycryptodome"])
 def runtests_parametrized(session, coverage, transport, crypto):
+    """
+    DO NOT CALL THIS NOX SESSION DIRECTLY
+    """
     # Install requirements
     _install_requirements(session, transport, "unittest-xml-reporting==2.5.2")
 
@@ -451,8 +476,12 @@ def runtests(session, coverage):
     runtests.py session with zeromq transport and default crypto
     """
     session.notify(
-        "runtests-parametrized-{}(coverage={}, crypto=None, transport='zeromq')".format(
-            session.python, coverage
+        find_session_runner(
+            session,
+            "runtests-parametrized-{}".format(session.python),
+            coverage=coverage,
+            crypto=None,
+            transport="zeromq",
         )
     )
 
@@ -464,8 +493,12 @@ def runtests_tcp(session, coverage):
     runtests.py session with TCP transport and default crypto
     """
     session.notify(
-        "runtests-parametrized-{}(coverage={}, crypto=None, transport='tcp')".format(
-            session.python, coverage
+        find_session_runner(
+            session,
+            "runtests-parametrized-{}".format(session.python),
+            coverage=coverage,
+            crypto=None,
+            transport="tcp",
         )
     )
 
@@ -477,8 +510,12 @@ def runtests_zeromq(session, coverage):
     runtests.py session with zeromq transport and default crypto
     """
     session.notify(
-        "runtests-parametrized-{}(coverage={}, crypto=None, transport='zeromq')".format(
-            session.python, coverage
+        find_session_runner(
+            session,
+            "runtests-parametrized-{}".format(session.python),
+            coverage=coverage,
+            crypto=None,
+            transport="zeromq",
         )
     )
 
@@ -490,8 +527,12 @@ def runtests_m2crypto(session, coverage):
     runtests.py session with zeromq transport and m2crypto
     """
     session.notify(
-        "runtests-parametrized-{}(coverage={}, crypto='m2crypto', transport='zeromq')".format(
-            session.python, coverage
+        find_session_runner(
+            session,
+            "runtests-parametrized-{}".format(session.python),
+            coverage=coverage,
+            crypto="m2crypto",
+            transport="zeromq",
         )
     )
 
@@ -503,8 +544,12 @@ def runtests_tcp_m2crypto(session, coverage):
     runtests.py session with TCP transport and m2crypto
     """
     session.notify(
-        "runtests-parametrized-{}(coverage={}, crypto='m2crypto', transport='tcp')".format(
-            session.python, coverage
+        find_session_runner(
+            session,
+            "runtests-parametrized-{}".format(session.python),
+            coverage=coverage,
+            crypto="m2crypto",
+            transport="tco",
         )
     )
 
@@ -516,8 +561,12 @@ def runtests_zeromq_m2crypto(session, coverage):
     runtests.py session with zeromq transport and m2crypto
     """
     session.notify(
-        "runtests-parametrized-{}(coverage={}, crypto='m2crypto', transport='zeromq')".format(
-            session.python, coverage
+        find_session_runner(
+            session,
+            "runtests-parametrized-{}".format(session.python),
+            coverage=coverage,
+            crypto="m2crypto",
+            transport="zeromq",
         )
     )
 
@@ -529,8 +578,12 @@ def runtests_pycryptodome(session, coverage):
     runtests.py session with zeromq transport and pycryptodome
     """
     session.notify(
-        "runtests-parametrized-{}(coverage={}, crypto='pycryptodome', transport='zeromq')".format(
-            session.python, coverage
+        find_session_runner(
+            session,
+            "runtests-parametrized-{}".format(session.python),
+            coverage=coverage,
+            crypto="pycryptodome",
+            transport="zeromq",
         )
     )
 
@@ -542,8 +595,12 @@ def runtests_tcp_pycryptodome(session, coverage):
     runtests.py session with TCP transport and pycryptodome
     """
     session.notify(
-        "runtests-parametrized-{}(coverage={}, crypto='pycryptodome', transport='tcp')".format(
-            session.python, coverage
+        find_session_runner(
+            session,
+            "runtests-parametrized-{}".format(session.python),
+            coverage=coverage,
+            crypto="pycryptodome",
+            transport="tcp",
         )
     )
 
@@ -555,8 +612,12 @@ def runtests_zeromq_pycryptodome(session, coverage):
     runtests.py session with zeromq transport and pycryptodome
     """
     session.notify(
-        "runtests-parametrized-{}(coverage={}, crypto='pycryptodome', transport='zeromq')".format(
-            session.python, coverage
+        find_session_runner(
+            session,
+            "runtests-parametrized-{}".format(session.python),
+            coverage=coverage,
+            crypto="pycryptodome",
+            transport="zeromq",
         )
     )
 
@@ -564,6 +625,9 @@ def runtests_zeromq_pycryptodome(session, coverage):
 @nox.session(python=_PYTHON_VERSIONS, name="runtests-cloud")
 @nox.parametrize("coverage", [False, True])
 def runtests_cloud(session, coverage):
+    """
+    runtests.py cloud tests session
+    """
     # Install requirements
     _install_requirements(session, "zeromq", "unittest-xml-reporting==2.2.1")
 
@@ -584,6 +648,9 @@ def runtests_cloud(session, coverage):
 @nox.session(python=_PYTHON_VERSIONS, name="runtests-tornado")
 @nox.parametrize("coverage", [False, True])
 def runtests_tornado(session, coverage):
+    """
+    runtests.py tornado tests session
+    """
     # Install requirements
     _install_requirements(session, "zeromq", "unittest-xml-reporting==2.2.1")
     session.install("--progress-bar=off", "tornado==5.0.2", silent=PIP_INSTALL_SILENT)
@@ -598,6 +665,9 @@ def runtests_tornado(session, coverage):
 @nox.parametrize("transport", ["zeromq", "tcp"])
 @nox.parametrize("crypto", [None, "m2crypto", "pycryptodome"])
 def pytest_parametrized(session, coverage, transport, crypto):
+    """
+    DO NOT CALL THIS NOX SESSION DIRECTLY
+    """
     # Install requirements
     _install_requirements(session, transport)
 
@@ -640,8 +710,12 @@ def pytest(session, coverage):
     pytest session with zeromq transport and default crypto
     """
     session.notify(
-        "pytest-parametrized-{}(coverage={}, crypto=None, transport='zeromq')".format(
-            session.python, coverage
+        find_session_runner(
+            session,
+            "pytest-parametrized-{}".format(session.python),
+            coverage=coverage,
+            crypto=None,
+            transport="zeromq",
         )
     )
 
@@ -653,8 +727,12 @@ def pytest_tcp(session, coverage):
     pytest session with TCP transport and default crypto
     """
     session.notify(
-        "pytest-parametrized-{}(coverage={}, crypto=None, transport='tcp')".format(
-            session.python, coverage
+        find_session_runner(
+            session,
+            "pytest-parametrized-{}".format(session.python),
+            coverage=coverage,
+            crypto=None,
+            transport="tcp",
         )
     )
 
@@ -666,8 +744,12 @@ def pytest_zeromq(session, coverage):
     pytest session with zeromq transport and default crypto
     """
     session.notify(
-        "pytest-parametrized-{}(coverage={}, crypto=None, transport='zeromq')".format(
-            session.python, coverage
+        find_session_runner(
+            session,
+            "pytest-parametrized-{}".format(session.python),
+            coverage=coverage,
+            crypto=None,
+            transport="zeromq",
         )
     )
 
@@ -679,8 +761,12 @@ def pytest_m2crypto(session, coverage):
     pytest session with zeromq transport and m2crypto
     """
     session.notify(
-        "pytest-parametrized-{}(coverage={}, crypto='m2crypto', transport='zeromq')".format(
-            session.python, coverage
+        find_session_runner(
+            session,
+            "pytest-parametrized-{}".format(session.python),
+            coverage=coverage,
+            crypto="m2crypto",
+            transport="zeromq",
         )
     )
 
@@ -692,8 +778,12 @@ def pytest_tcp_m2crypto(session, coverage):
     pytest session with TCP transport and m2crypto
     """
     session.notify(
-        "pytest-parametrized-{}(coverage={}, crypto='m2crypto', transport='tcp')".format(
-            session.python, coverage
+        find_session_runner(
+            session,
+            "pytest-parametrized-{}".format(session.python),
+            coverage=coverage,
+            crypto="m2crypto",
+            transport="tcp",
         )
     )
 
@@ -705,8 +795,12 @@ def pytest_zeromq_m2crypto(session, coverage):
     pytest session with zeromq transport and m2crypto
     """
     session.notify(
-        "pytest-parametrized-{}(coverage={}, crypto='m2crypto', transport='zeromq')".format(
-            session.python, coverage
+        find_session_runner(
+            session,
+            "pytest-parametrized-{}".format(session.python),
+            coverage=coverage,
+            crypto="m2crypto",
+            transport="zeromq",
         )
     )
 
@@ -718,8 +812,12 @@ def pytest_pycryptodome(session, coverage):
     pytest session with zeromq transport and pycryptodome
     """
     session.notify(
-        "pytest-parametrized-{}(coverage={}, crypto='pycryptodome', transport='zeromq')".format(
-            session.python, coverage
+        find_session_runner(
+            session,
+            "pytest-parametrized-{}".format(session.python),
+            coverage=coverage,
+            crypto="pycryptodome",
+            transport="zeromq",
         )
     )
 
@@ -731,8 +829,12 @@ def pytest_tcp_pycryptodome(session, coverage):
     pytest session with TCP transport and pycryptodome
     """
     session.notify(
-        "pytest-parametrized-{}(coverage={}, crypto='pycryptodome', transport='tcp')".format(
-            session.python, coverage
+        find_session_runner(
+            session,
+            "pytest-parametrized-{}".format(session.python),
+            coverage=coverage,
+            crypto="pycryptodome",
+            transport="tcp",
         )
     )
 
@@ -744,8 +846,12 @@ def pytest_zeromq_pycryptodome(session, coverage):
     pytest session with zeromq transport and pycryptodome
     """
     session.notify(
-        "pytest-parametrized-{}(coverage={}, crypto='pycryptodome', transport='zeromq')".format(
-            session.python, coverage
+        find_session_runner(
+            session,
+            "pytest-parametrized-{}".format(session.python),
+            coverage=coverage,
+            crypto="pycryptodome",
+            transport="zeromq",
         )
     )
 
@@ -753,6 +859,9 @@ def pytest_zeromq_pycryptodome(session, coverage):
 @nox.session(python=_PYTHON_VERSIONS, name="pytest-cloud")
 @nox.parametrize("coverage", [False, True])
 def pytest_cloud(session, coverage):
+    """
+    pytest cloud tests session
+    """
     # Install requirements
     _install_requirements(session, "zeromq")
     requirements_file = os.path.join(
@@ -780,6 +889,9 @@ def pytest_cloud(session, coverage):
 @nox.session(python=_PYTHON_VERSIONS, name="pytest-tornado")
 @nox.parametrize("coverage", [False, True])
 def pytest_tornado(session, coverage):
+    """
+    pytest tornado tests session
+    """
     # Install requirements
     _install_requirements(session, "zeromq")
     session.install("--progress-bar=off", "tornado==5.0.2", silent=PIP_INSTALL_SILENT)
@@ -1012,8 +1124,15 @@ def docs(session, compress, update):
     """
     Build Salt's Documentation
     """
-    session.notify("docs-html(compress={})".format(compress))
-    session.notify("docs-man(compress={}, update={})".format(compress, update))
+    session.notify("docs-html-{}(compress={})".format(session.python, compress))
+    session.notify(
+        find_session_runner(
+            session,
+            "docs-man-{}".format(session.python),
+            compress=compress,
+            update=update,
+        )
+    )
 
 
 @nox.session(name="docs-html", python="3")
@@ -1089,11 +1208,19 @@ def _invoke(session):
 
 @nox.session(name="invoke", python="3")
 def invoke(session):
+    """
+    Run an invoke target
+    """
     _invoke(session)
 
 
 @nox.session(name="invoke-pre-commit", python="3")
 def invoke_pre_commit(session):
+    """
+    DO NOT CALL THIS NOX SESSION DIRECTLY
+
+    This session is called from a pre-commit hook
+    """
     if "VIRTUAL_ENV" not in os.environ:
         session.error(
             "This should be running from within a virtualenv and "


### PR DESCRIPTION
### What does this PR do?
Allows running nox sessions either using our [`nox-py2` fork](https://github.com/s0undt3ch/nox/tree/hotfix/py2-release) or [upstream `nox`](https://github.com/theacodes/nox)

Fixes #57583