### PR TITLE
Fix LGPO.GET with Unicode Hostname

### DIFF
--- a/changelog/57591.fixed
+++ b/changelog/57591.fixed
@@ -1,0 +1,1 @@
+Fixes issue with lgpo.get when there are unicode characters in the hostname

--- a/salt/utils/win_lgpo_netsh.py
+++ b/salt/utils/win_lgpo_netsh.py
@@ -116,7 +116,7 @@ def _netsh_file(content):
         str: The text returned by the netsh command
     """
     with tempfile.NamedTemporaryFile(
-        mode="w", prefix="salt-", suffix=".netsh", delete=False
+        mode="w", prefix="salt-", suffix=".netsh", delete=False, encoding="utf-8"
     ) as fp:
         fp.write(content)
     try:

--- a/tests/unit/utils/test_win_lgpo_netsh.py
+++ b/tests/unit/utils/test_win_lgpo_netsh.py
@@ -10,6 +10,7 @@ from salt.exceptions import CommandExecutionError
 
 # Import Salt Testing Libs
 from tests.support.helpers import destructiveTest
+from tests.support.mock import patch
 from tests.support.unit import TestCase, skipIf
 
 
@@ -26,6 +27,17 @@ class WinLgpoNetshTestCase(TestCase):
         ret = win_lgpo_netsh.get_settings(
             profile="domain", section="firewallpolicy", store="lgpo"
         )
+        self.assertIn("Inbound", ret)
+        self.assertIn("Outbound", ret)
+
+    def test_get_settings_firewallpolicy_lgpo_issue_57591(self):
+        """
+        Should not stacktrace when the hostname contains unicode characters
+        """
+        with patch.object(win_lgpo_netsh, "__hostname__", return_value="kомпьютер"):
+            ret = win_lgpo_netsh.get_settings(
+                profile="domain", section="firewallpolicy", store="lgpo"
+            )
         self.assertIn("Inbound", ret)
         self.assertIn("Outbound", ret)
 


### PR DESCRIPTION
### What does this PR do?
Adds `encoding="utf-8"` to the tempfile.NamedTemporaryFile command. It attempts to write contents to the file containing unicode characters. Without it, it uses the system default (`cp-1252`) which does not handle special characters.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/57591

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
