### PR TITLE
[PyTest] Resolve paths when checking from filenames functionality.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -682,7 +682,7 @@ def from_filenames_collection_modifyitems(config, items):
     selected = []
     deselected = []
     for item in items:
-        itempath = pathlib.Path(str(item.fspath)).relative_to(CODE_DIR)
+        itempath = pathlib.Path(str(item.fspath)).resolve().relative_to(CODE_DIR)
         if itempath in test_module_paths:
             selected.append(item)
         else:


### PR DESCRIPTION
### What does this PR do?

This change fixes the following error seen on windows:
```
Traceback (most recent call last):
  File "C:\Users\ADMINI~1\AppData\Local\Temp\kitchen\testing\.nox\pytest-parametrized-3-coverage-true-crypto-none-transport-zeromq\lib\site-packages\_pytest\main.py", line 206, in wrap_session
    session.exitstatus = doit(config, session) or 0
  File "C:\Users\ADMINI~1\AppData\Local\Temp\kitchen\testing\.nox\pytest-parametrized-3-coverage-true-crypto-none-transport-zeromq\lib\site-packages\_pytest\main.py", line 249, in _main
    config.hook.pytest_collection(session=session)
  File "C:\Users\ADMINI~1\AppData\Local\Temp\kitchen\testing\.nox\pytest-parametrized-3-coverage-true-crypto-none-transport-zeromq\lib\site-packages\pluggy\hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "C:\Users\ADMINI~1\AppData\Local\Temp\kitchen\testing\.nox\pytest-parametrized-3-coverage-true-crypto-none-transport-zeromq\lib\site-packages\pluggy\manager.py", line 92, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "C:\Users\ADMINI~1\AppData\Local\Temp\kitchen\testing\.nox\pytest-parametrized-3-coverage-true-crypto-none-transport-zeromq\lib\site-packages\pluggy\manager.py", line 86, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "C:\Users\ADMINI~1\AppData\Local\Temp\kitchen\testing\.nox\pytest-parametrized-3-coverage-true-crypto-none-transport-zeromq\lib\site-packages\pluggy\callers.py", line 208, in _multicall
    return outcome.get_result()
  File "C:\Users\ADMINI~1\AppData\Local\Temp\kitchen\testing\.nox\pytest-parametrized-3-coverage-true-crypto-none-transport-zeromq\lib\site-packages\pluggy\callers.py", line 80, in get_result
    raise ex[1].with_traceback(ex[2])
  File "C:\Users\ADMINI~1\AppData\Local\Temp\kitchen\testing\.nox\pytest-parametrized-3-coverage-true-crypto-none-transport-zeromq\lib\site-packages\pluggy\callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "C:\Users\ADMINI~1\AppData\Local\Temp\kitchen\testing\.nox\pytest-parametrized-3-coverage-true-crypto-none-transport-zeromq\lib\site-packages\_pytest\main.py", line 259, in pytest_collection
    return session.perform_collect()
  File "C:\Users\ADMINI~1\AppData\Local\Temp\kitchen\testing\.nox\pytest-parametrized-3-coverage-true-crypto-none-transport-zeromq\lib\site-packages\_pytest\main.py", line 498, in perform_collect
    session=self, config=self.config, items=items
  File "C:\Users\ADMINI~1\AppData\Local\Temp\kitchen\testing\.nox\pytest-parametrized-3-coverage-true-crypto-none-transport-zeromq\lib\site-packages\pluggy\hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "C:\Users\ADMINI~1\AppData\Local\Temp\kitchen\testing\.nox\pytest-parametrized-3-coverage-true-crypto-none-transport-zeromq\lib\site-packages\pluggy\manager.py", line 92, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "C:\Users\ADMINI~1\AppData\Local\Temp\kitchen\testing\.nox\pytest-parametrized-3-coverage-true-crypto-none-transport-zeromq\lib\site-packages\pluggy\manager.py", line 86, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "C:\Users\ADMINI~1\AppData\Local\Temp\kitchen\testing\.nox\pytest-parametrized-3-coverage-true-crypto-none-transport-zeromq\lib\site-packages\pluggy\callers.py", line 203, in _multicall
    gen.send(outcome)
  File "C:\Users\ADMINI~1\AppData\Local\Temp\kitchen\testing\tests\conftest.py", line 317, in pytest_collection_modifyitems
    from_filenames_collection_modifyitems(config, items)
  File "C:\Users\ADMINI~1\AppData\Local\Temp\kitchen\testing\tests\conftest.py", line 685, in from_filenames_collection_modifyitems
    itempath = pathlib.Path(str(item.fspath)).relative_to(CODE_DIR)
  File "c:\python37\lib\pathlib.py", line 883, in relative_to
    .format(str(self), str(formatted)))
ValueError: 'C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\kitchen\\testing\\tests\\integration\\cli\\test_batch.py' does not start with 'C:\\Users\\Administrator\\AppData\\Local\\Temp\\kitchen\\testing'
```