### PR TITLE
Add http engine

### DIFF
--- a/doc/ref/engines/all/index.rst
+++ b/doc/ref/engines/all/index.rst
@@ -12,6 +12,7 @@ engine modules
 
     docker_events
     fluent
+    http
     http_logstash
     ircbot
     junos_syslog

--- a/doc/ref/engines/all/salt.engines.http.rst
+++ b/doc/ref/engines/all/salt.engines.http.rst
@@ -1,0 +1,2 @@
+.. automodule:: salt.engines.http
+    :members:

--- a/salt/engines/http.py
+++ b/salt/engines/http.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+"""
+HTTP - engine
+==========================
+
+An engine that reads messages from the salt event bus and pushes
+them onto a desired endpoint via HTTP requests.
+
+.. note::
+    By default, this engine take everything from the Salt bus and exports into
+    defined http endpoint.
+
+:configuration: Example configuration
+
+    .. code-block:: yaml
+
+        engines:
+          - http:
+              urls:
+                  - http://automation.example.com/saltevent
+                  - http://localhost:9000/api/v1/events
+              headers:
+                  X-AUTH-TOKEN: saltapiusertoken
+                  AnotherCustomToken: loremipsum
+              tags:
+                  - salt/job/*/new
+                  - salt/job/*/ret/*
+              funs:
+                  - probes.results
+                  - bgp.config
+"""
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import python lib
+import fnmatch
+
+# Import salt libs
+import salt.config
+import salt.utils.event
+import salt.utils.http
+import salt.utils.json
+
+# ----------------------------------------------------------------------------------------------------------------------
+# module properties
+# ----------------------------------------------------------------------------------------------------------------------
+
+_HEADERS = {"Content-Type": "application/json"}
+
+# ----------------------------------------------------------------------------------------------------------------------
+# module properties
+# ----------------------------------------------------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------------------------------------------------
+# helpers
+# ----------------------------------------------------------------------------------------------------------------------
+
+
+def _http_endpoint(url, data):
+    """
+    Issues HTTP queries to defined server.
+    """
+    result = salt.utils.http.query(
+        url,
+        "POST",
+        header_dict=_HEADERS,
+        data=salt.utils.json.dumps(data),
+        decode=False,
+        status=True,
+        opts=__opts__,
+    )
+    return result
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+# main
+# ----------------------------------------------------------------------------------------------------------------------
+
+
+def start(urls, headers=None, tags=None, funs=None):
+    """
+    Listen to salt events and forward them to desired endpoint.
+
+    url
+        The endpoint.
+    headers
+        headers which will be included in http headers
+    """
+
+    if headers is None:
+        headers = {}
+
+    for k, v in headers.items():
+        _HEADERS[k] = v
+
+    if __opts__.get("id").endswith("_master"):
+        instance = "master"
+    else:
+        instance = "minion"
+
+    event_bus = salt.utils.event.get_event(
+        instance,
+        sock_dir=__opts__["sock_dir"],
+        transport=__opts__["transport"],
+        opts=__opts__,
+    )
+    while True:
+        event = event_bus.get_event(full=True)
+        if event:
+            publish = True
+            if tags and isinstance(tags, list):
+                found_match = False
+                for tag in tags:
+                    if fnmatch.fnmatch(event["tag"], tag):
+                        found_match = True
+                publish = found_match
+            if funs and "fun" in event["data"]:
+                if not event["data"]["fun"] in funs:
+                    publish = False
+            if publish:
+                for url in urls:
+                    _http_endpoint(url, event)

--- a/salt/engines/http.py
+++ b/salt/engines/http.py
@@ -87,11 +87,9 @@ def start(urls, headers=None, tags=None, funs=None):
         headers which will be included in http headers
     """
 
-    if headers is None:
-        headers = {}
-
-    for k, v in headers.items():
-        _HEADERS[k] = v
+    if headers is not None:
+        for k, v in headers.items():
+            _HEADERS[k] = v
 
     if __opts__.get("id").endswith("_master"):
         instance = "master"


### PR DESCRIPTION
Thanks to this engine You're able to send all or filtered events from salt event bus onto one or multiple defined http endpoints with custom headers (authorization purposes)

### What does this PR do?
Add ability to use http engine with all advantages it brings

### What issues does this PR fix or reference?
Fixes: uncapability to send all or filtered events from salt event bus onto various endpoints with custom headers

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

I was not able to find any test cases for any engine. I'm sorry but I'm not capable to write any test.

### Commits signed with GPG?
No