### PR TITLE
Update links to Jinja docs

### DIFF
--- a/doc/topics/jinja/index.rst
+++ b/doc/topics/jinja/index.rst
@@ -696,7 +696,7 @@ Return of examples #2 and #3:
 
   [[web01, example.com], [db01, example.com]]
 
-.. _`map filter`: http://jinja.pocoo.org/docs/2.10/templates/#map
+.. _`map filter`: https://jinja.palletsprojects.com/en/2.11.x/templates/#map
 
 
 .. jinja_ref:: is_sorted

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -883,7 +883,7 @@ class SerializerExtension(Extension, object):
 
         unique = ['foo', 'bar']
 
-    .. _`import tag`: http://jinja.pocoo.org/docs/templates/#import
+    .. _`import tag`: https://jinja.palletsprojects.com/en/2.11.x/templates/#import
     '''
 
     tags = {

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -289,7 +289,7 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
     newline = False
 
     if tmplstr and not isinstance(tmplstr, six.text_type):
-        # http://jinja.pocoo.org/docs/api/#unicode
+        # https://jinja.palletsprojects.com/en/2.11.x/api/#unicode
         tmplstr = tmplstr.decode(SLS_ENCODING)
 
     if tmplstr.endswith(os.linesep):


### PR DESCRIPTION
### What does this PR do?
Fixes a few remaining URLs still pointing to the old Jinja domain (pocoo.org) instead of the new one (palletsprojects.com)

### What issues does this PR fix or reference?
None

### Merge requirements satisfied?
- [N/A] Docs
- [N/A] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [N/A] Tests written/updated

### Commits signed with GPG?
Yes