### PR TITLE
Disk grains should not show virtual devices fix issue 57612

### DIFF
--- a/changelog/57612.changed
+++ b/changelog/57612.changed
@@ -1,0 +1,2 @@
+Changes the 'SSDs' grain name to 'ssds' as all grains needs to be 
+resolved in lowered case.

--- a/changelog/57612.fixed
+++ b/changelog/57612.fixed
@@ -1,0 +1,2 @@
+Fixes issue with virtual block devices, like loopbacks and LVMs, wrongly
+populating the "disks" or "SSDs" grains.

--- a/changelog/57612.fixed
+++ b/changelog/57612.fixed
@@ -1,2 +1,2 @@
 Fixes issue with virtual block devices, like loopbacks and LVMs, wrongly
-populating the "disks" or "SSDs" grains.
+populating the "disks" or "ssds" grains.

--- a/salt/grains/disks.py
+++ b/salt/grains/disks.py
@@ -133,23 +133,25 @@ def _linux_disks():
     """
     ret = {"disks": [], "SSDs": []}
 
-    for entry in glob.glob("/sys/block/*/queue/rotational"):
+    for entry in glob.glob("/sys/block/*"):
+        virtual = salt.utils.path.readlink(entry).startswith("../devices/virtual/")
         try:
-            with salt.utils.files.fopen(entry) as entry_fp:
-                device = entry.split("/")[3]
-                flag = entry_fp.read(1)
-                if flag == "0":
-                    ret["SSDs"].append(device)
-                    log.trace("Device %s reports itself as an SSD", device)
-                elif flag == "1":
-                    ret["disks"].append(device)
-                    log.trace("Device %s reports itself as an HDD", device)
-                else:
-                    log.trace(
-                        "Unable to identify device %s as an SSD or HDD. It does "
-                        "not report 0 or 1",
-                        device,
-                    )
+            if not virtual:
+                with salt.utils.files.fopen(entry + "/queue/rotational") as entry_fp:
+                    device = entry.split("/")[3]
+                    flag = entry_fp.read(1)
+                    if flag == "0":
+                        ret["SSDs"].append(device)
+                        log.trace("Device %s reports itself as an SSD", device)
+                    elif flag == "1":
+                        ret["disks"].append(device)
+                        log.trace("Device %s reports itself as an HDD", device)
+                    else:
+                        log.trace(
+                            "Unable to identify device %s as an SSD or HDD. It does "
+                            "not report 0 or 1",
+                            device,
+                        )
         except IOError:
             pass
     return ret

--- a/salt/grains/disks.py
+++ b/salt/grains/disks.py
@@ -94,7 +94,7 @@ _geom_attribs = [
 
 def _freebsd_geom():
     geom = salt.utils.path.which("geom")
-    ret = {"disks": {}, "SSDs": []}
+    ret = {"disks": {}, "ssds": []}
 
     devices = __salt__["cmd.run"]("{0} disk list".format(geom))
     devices = devices.split("\n\n")
@@ -119,7 +119,7 @@ def _freebsd_geom():
         ret["disks"][name] = tmp
         if tmp.get(_geomconsts.ROTATIONRATE) == 0:
             log.trace("Device %s reports itself as an SSD", device)
-            ret["SSDs"].append(name)
+            ret["ssds"].append(name)
 
     for device in devices:
         parse_geom_attribs(device)
@@ -131,7 +131,7 @@ def _linux_disks():
     """
     Return list of disk devices and work out if they are SSD or HDD.
     """
-    ret = {"disks": [], "SSDs": []}
+    ret = {"disks": [], "ssds": []}
 
     for entry in glob.glob("/sys/block/*"):
         virtual = salt.utils.path.readlink(entry).startswith("../devices/virtual/")
@@ -141,7 +141,7 @@ def _linux_disks():
                     device = entry.split("/")[3]
                     flag = entry_fp.read(1)
                     if flag == "0":
-                        ret["SSDs"].append(device)
+                        ret["ssds"].append(device)
                         log.trace("Device %s reports itself as an SSD", device)
                     elif flag == "1":
                         ret["disks"].append(device)
@@ -164,7 +164,7 @@ def _windows_disks():
     path = "MSFT_PhysicalDisk"
     get = "DeviceID,MediaType"
 
-    ret = {"disks": [], "SSDs": []}
+    ret = {"disks": [], "ssds": []}
 
     cmdret = __salt__["cmd.run_all"](
         "{0} /namespace:{1} path {2} get {3} /format:table".format(
@@ -186,7 +186,7 @@ def _windows_disks():
                 ret["disks"].append(device)
             elif mediatype == "4":
                 log.trace("Device %s reports itself as an SSD", device)
-                ret["SSDs"].append(device)
+                ret["ssds"].append(device)
                 ret["disks"].append(device)
             elif mediatype == "5":
                 log.trace("Device %s reports itself as an SCM", device)

--- a/tests/unit/grains/test_disks.py
+++ b/tests/unit/grains/test_disks.py
@@ -117,9 +117,13 @@ class DisksGrainsTestCase(TestCase, LoaderModuleMockMixin):
             "1",
             "1",
         ]
-        with patch("glob.glob", MagicMock(return_value=files)), patch(
-            "salt.utils.path.readlink", MagicMock(side_effect=links)
-        ), patch("salt.utils.files.fopen", mock_open(read_data=contents)):
+
+        patch_glob = patch("glob.glob", autospec=True, return_value=files)
+        patch_readlink = patch(
+            "salt.utils.path.readlink", autospec=True, side_effect=links
+        )
+        patch_fopen = patch("salt.utils.files.fopen", mock_open(read_data=contents))
+        with patch_glob, patch_readlink, patch_fopen:
             ret = disks._linux_disks()
 
         assert ret == {"disks": ["sda", "sdb", "vda"], "SSDs": []}, ret

--- a/tests/unit/grains/test_disks.py
+++ b/tests/unit/grains/test_disks.py
@@ -12,13 +12,13 @@ import salt.grains.disks as disks
 
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
-from tests.support.mock import MagicMock, patch
+from tests.support.mock import MagicMock, mock_open, patch
 from tests.support.unit import TestCase
 
 
-class IscsiGrainsTestCase(TestCase, LoaderModuleMockMixin):
+class DisksGrainsTestCase(TestCase, LoaderModuleMockMixin):
     """
-    Test cases for _windows_disks grains
+    Test cases for disks grains
     """
 
     def setup_loader_modules(self):
@@ -83,3 +83,43 @@ class IscsiGrainsTestCase(TestCase, LoaderModuleMockMixin):
             result = disks._windows_disks()
             expected = {"SSDs": [], "disks": []}
             self.assertDictEqual(result, expected)
+
+    def test__linux_disks(self):
+        """
+        Test grains._linux_disks, normal return
+        Should return a populated dictionary
+        """
+
+        files = [
+            "/sys/block/asm!.asm_ctl_vbg0",
+            "/sys/block/dm-0",
+            "/sys/block/loop0",
+            "/sys/block/ram0",
+            "/sys/block/sda",
+            "/sys/block/sdb",
+            "/sys/block/vda",
+        ]
+        links = [
+            "../devices/virtual/block/asm!.asm_ctl_vbg0",
+            "../devices/virtual/block/dm-0",
+            "../devices/virtual/block/loop0",
+            "../devices/virtual/block/ram0",
+            "../devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda",
+            "../devices/pci0000:35/0000:35:00.0/0000:36:00.0/host2/target2:1:0/2:1:0:0/block/sdb",
+            "../devices/pci0000L00:0000:00:05.0/virtio2/block/vda",
+        ]
+        contents = [
+            "1",
+            "1",
+            "1",
+            "0",
+            "1",
+            "1",
+            "1",
+        ]
+        with patch("glob.glob", MagicMock(return_value=files)), patch(
+            "salt.utils.path.readlink", MagicMock(side_effect=links)
+        ), patch("salt.utils.files.fopen", mock_open(read_data=contents)):
+            ret = disks._linux_disks()
+
+        assert ret == {"disks": ["sda", "sdb", "vda"], "SSDs": []}, ret

--- a/tests/unit/grains/test_disks.py
+++ b/tests/unit/grains/test_disks.py
@@ -48,7 +48,7 @@ class DisksGrainsTestCase(TestCase, LoaderModuleMockMixin):
         ):
             result = disks._windows_disks()
             expected = {
-                "SSDs": ["\\\\.\\PhysicalDrive0"],
+                "ssds": ["\\\\.\\PhysicalDrive0"],
                 "disks": [
                     "\\\\.\\PhysicalDrive0",
                     "\\\\.\\PhysicalDrive1",
@@ -81,7 +81,7 @@ class DisksGrainsTestCase(TestCase, LoaderModuleMockMixin):
             disks.__salt__, {"cmd.run_all": mock_run_all}
         ):
             result = disks._windows_disks()
-            expected = {"SSDs": [], "disks": []}
+            expected = {"ssds": [], "disks": []}
             self.assertDictEqual(result, expected)
 
     def test__linux_disks(self):
@@ -126,4 +126,4 @@ class DisksGrainsTestCase(TestCase, LoaderModuleMockMixin):
         with patch_glob, patch_readlink, patch_fopen:
             ret = disks._linux_disks()
 
-        assert ret == {"disks": ["sda", "sdb", "vda"], "SSDs": []}, ret
+        assert ret == {"disks": ["sda", "sdb", "vda"], "ssds": []}, ret


### PR DESCRIPTION
### What does this PR do?
Changes the disks.py to populate "disks" and "SSDs" only with real devices, skipping virtual devices like devmaps, loopback and RAM disks.

### What issues does this PR fix or reference?
Fixes: #57612 

### Previous Behavior
In a machine with only one disk the grains shows:

```
# salt-call grains.get disks
local:
    - loop1
    - dm-1
    - loop6
    - dm-6
    - loop4
    - dm-4
    - loop2
    - dm-2
    - loop0
    - dm-0
    - loop7
    - dm-7
    - sda
    - loop5
    - dm-5
    - loop3
    - dm-3
# salt-call grains.get SSDs
local:
    - ram2
    - ram0
    - ram9
    - ram14
    - ram7
    - ram12
    - ram5
    - ram10
    - ram3
    - ram1
    - ram15
    - ram8
    - ram13
    - ram6
    - ram11
    - ram4
```

### New Behavior
Now it shows only the real device:

```
# salt-call grains.get SSDs
local:
# salt-call grains.get disks
local:
    - sda
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
[salt-runtests-20200609201317.log](https://github.com/saltstack/salt/files/4755812/salt-runtests-20200609201317.log)

### Commits signed with GPG?
No