### PR TITLE
Iis redact password

### DIFF
--- a/changelog/57285.fixed
+++ b/changelog/57285.fixed
@@ -1,0 +1,2 @@
+Redact passwords in the return when setting credentials using
+``win_iis.container_setting``

--- a/salt/states/win_iis.py
+++ b/salt/states/win_iis.py
@@ -562,7 +562,7 @@ def container_setting(name, container, settings=None):
 
     if ret_settings["failures"]:
         ret["comment"] = "Some settings failed to change."
-        ret["changes"] = ret_settings['changes']
+        ret["changes"] = ret_settings
         ret["result"] = False
     else:
         ret["comment"] = "Set settings to contain the provided values."

--- a/salt/states/win_iis.py
+++ b/salt/states/win_iis.py
@@ -530,7 +530,7 @@ def container_setting(name, container, settings=None):
         return ret
     elif __opts__["test"]:
         ret["comment"] = "Settings will be changed."
-        ret["changes"] = ret_settings
+        ret["changes"] = ret_settings['changes']
         return ret
 
     __salt__["win_iis.set_container_setting"](
@@ -562,7 +562,7 @@ def container_setting(name, container, settings=None):
 
     if ret_settings["failures"]:
         ret["comment"] = "Some settings failed to change."
-        ret["changes"] = ret_settings
+        ret["changes"] = ret_settings['changes']
         ret["result"] = False
     else:
         ret["comment"] = "Set settings to contain the provided values."

--- a/salt/states/win_iis.py
+++ b/salt/states/win_iis.py
@@ -530,7 +530,7 @@ def container_setting(name, container, settings=None):
         return ret
     elif __opts__["test"]:
         ret["comment"] = "Settings will be changed."
-        ret["changes"] = ret_settings['changes']
+        ret["changes"] = ret_settings["changes"]
         return ret
 
     __salt__["win_iis.set_container_setting"](

--- a/salt/states/win_iis.py
+++ b/salt/states/win_iis.py
@@ -514,10 +514,16 @@ def container_setting(name, container, settings=None):
             settings[setting] = identityType_map2string[settings[setting]]
 
         if str(settings[setting]) != str(current_settings[setting]):
-            ret_settings["changes"][setting] = {
-                "old": current_settings[setting],
-                "new": settings[setting],
-            }
+            if setting == "processModel.password":
+                ret_settings["changes"][setting] = {
+                    "old": "XXX-REDACTED-XXX",
+                    "new": "XXX-REDACTED-XXX",
+                }
+            else:
+                ret_settings["changes"][setting] = {
+                    "old": current_settings[setting],
+                    "new": settings[setting],
+                }
     if not ret_settings["changes"]:
         ret["comment"] = "Settings already contain the provided values."
         ret["result"] = True
@@ -536,11 +542,23 @@ def container_setting(name, container, settings=None):
     )
     for setting in settings:
         if str(settings[setting]) != str(new_settings[setting]):
-            ret_settings["failures"][setting] = {
-                "old": current_settings[setting],
-                "new": new_settings[setting],
-            }
+            if setting == "processModel.password":
+                ret_settings["failures"][setting] = {
+                    "old": "XXX-REDACTED-XXX",
+                    "new": "XXX-REDACTED-XXX",
+                }
+            else:
+                ret_settings["failures"][setting] = {
+                    "old": current_settings[setting],
+                    "new": new_settings[setting],
+                }
             ret_settings["changes"].pop(setting, None)
+        else:
+            if setting == "processModel.password":
+                ret_settings["changes"][setting] = {
+                    "old": "XXX-REDACTED-XXX",
+                    "new": "XXX-REDACTED-XXX",
+                }
 
     if ret_settings["failures"]:
         ret["comment"] = "Some settings failed to change."

--- a/tests/unit/states/test_win_iis.py
+++ b/tests/unit/states/test_win_iis.py
@@ -152,20 +152,17 @@ class WinIisTestCase(TestCase, LoaderModuleMockMixin):
             "processModel.password": "Sup3rS3cr3tP@ssW0rd",
             "processModel.identityType": "SpecificUser"
         }
-        old_settings = [
-            {
-                "processModel.userName": "Administrator",
-                "processModel.password": "0ldP@ssW0rd1!",
-                "processModel.identityType": "SpecificUser",
-            }
-        ]
-        current_settings = [
-            {
-                "processModel.userName": "Administrator",
-                "processModel.password": "Sup3rS3cr3tP@ssW0rd",
-                "processModel.identityType": "SpecificUser",
-            }
-        ]
+        old_settings = {
+            "processModel.userName": "Administrator",
+            "processModel.password": "0ldP@ssW0rd1!",
+            "processModel.identityType": "SpecificUser",
+        }
+        current_settings = {
+            "processModel.userName": "Administrator",
+            "processModel.password": "Sup3rS3cr3tP@ssW0rd",
+            "processModel.identityType": "SpecificUser",
+        }
+
         new_settings = current_settings
         expected_ret = {
             "name": name,
@@ -200,20 +197,16 @@ class WinIisTestCase(TestCase, LoaderModuleMockMixin):
             "processModel.password": "Sup3rS3cr3tP@ssW0rd",
             "processModel.identityType": "SpecificUser"
         }
-        old_settings = [
-            {
-                "processModel.userName": "Administrator",
-                "processModel.password": "0ldP@ssW0rd1!",
-                "processModel.identityType": "SpecificUser",
-            }
-        ]
-        current_settings = [
-            {
-                "processModel.userName": "Administrator",
-                "processModel.password": "Sup3rS3cr3tP@ssW0rd",
-                "processModel.identityType": "SpecificUser",
-            }
-        ]
+        old_settings = {
+            "processModel.userName": "Administrator",
+            "processModel.password": "0ldP@ssW0rd1!",
+            "processModel.identityType": "SpecificUser",
+        }
+        current_settings = {
+            "processModel.userName": "Administrator",
+            "processModel.password": "Sup3rS3cr3tP@ssW0rd",
+            "processModel.identityType": "SpecificUser",
+        }
         new_settings = current_settings
         expected_ret = {
             "name": name,

--- a/tests/unit/states/test_win_iis.py
+++ b/tests/unit/states/test_win_iis.py
@@ -230,3 +230,48 @@ class WinIisTestCase(TestCase, LoaderModuleMockMixin):
         ), patch.dict(win_iis.__opts__, {"test": True}):
             actual_ret = win_iis.container_setting(name=name, container=container, settings=settings)
         self.assertEqual(expected_ret, actual_ret)
+
+    def test_container_settings_password_redacted_failures(self):
+        name = "IIS:\\"
+        container = "AppPools"
+        settings = {
+            "processModel.userName": "Administrator",
+            "processModel.password": "Sup3rS3cr3tP@ssW0rd",
+            "processModel.identityType": "SpecificUser"
+        }
+        old_settings = {
+            "processModel.userName": "Administrator",
+            "processModel.password": "0ldP@ssW0rd1!",
+            "processModel.identityType": "SpecificUser",
+        }
+        current_settings = {
+            "processModel.userName": "Administrator",
+            "processModel.password": "0ldP@ssW0rd1!",
+            "processModel.identityType": "SpecificUser",
+        }
+
+        new_settings = old_settings
+        expected_ret = {
+            "name": name,
+            "changes": {
+                "processModel.password": {
+                    "new": "XXX-REDACTED-XXX",
+                    "old": "XXX-REDACTED-XXX"
+                }
+            },
+            "comment": "Set settings to contain the provided values.",
+            "result": True,
+        }
+        with patch.dict(
+            win_iis.__salt__,
+            {
+                "win_iis.get_container_setting": MagicMock(
+                    side_effect=[old_settings, current_settings, new_settings]
+                ),
+                "win_iis.set_container_setting": MagicMock(return_value=True),
+            },
+        ), patch.dict(win_iis.__opts__, {"test": False}):
+            actual_ret = win_iis.container_setting(name=name,
+                                                   container=container,
+                                                   settings=settings)
+        self.assertEqual(expected_ret, actual_ret)

--- a/tests/unit/states/test_win_iis.py
+++ b/tests/unit/states/test_win_iis.py
@@ -267,7 +267,7 @@ class WinIisTestCase(TestCase, LoaderModuleMockMixin):
                     }
                 },
             },
-            "comment": "Set settings to contain the provided values.",
+            "comment": "Some settings failed to change.",
             "result": False,
         }
         with patch.dict(

--- a/tests/unit/states/test_win_iis.py
+++ b/tests/unit/states/test_win_iis.py
@@ -181,10 +181,10 @@ class WinIisTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(
             win_iis.__salt__,
             {
-                "win_iis.get_container_settings": MagicMock(
+                "win_iis.get_container_setting": MagicMock(
                     side_effect=[old_settings, current_settings, new_settings]
                 ),
-                "win_iis.set_container_settings": MagicMock(return_value=True),
+                "win_iis.set_container_setting": MagicMock(return_value=True),
             },
         ), patch.dict(win_iis.__opts__, {"test": False}):
             actual_ret = win_iis.container_setting(name=name,
@@ -229,10 +229,10 @@ class WinIisTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(
             win_iis.__salt__,
             {
-                "win_iis.get_webconfiguration_settings": MagicMock(
+                "win_iis.get_webconfiguration_setting": MagicMock(
                     side_effect=[old_settings, current_settings, new_settings]
                 ),
-                "win_iis.set_webconfiguration_settings": MagicMock(return_value=True),
+                "win_iis.set_webconfiguration_setting": MagicMock(return_value=True),
             },
         ), patch.dict(win_iis.__opts__, {"test": True}):
             actual_ret = win_iis.container_setting(name=name, container=container, settings=settings)

--- a/tests/unit/states/test_win_iis.py
+++ b/tests/unit/states/test_win_iis.py
@@ -240,7 +240,7 @@ class WinIisTestCase(TestCase, LoaderModuleMockMixin):
             "processModel.identityType": "SpecificUser"
         }
         old_settings = {
-            "processModel.userName": "Administrator",
+            "processModel.userName": "Spongebob",
             "processModel.password": "0ldP@ssW0rd1!",
             "processModel.identityType": "SpecificUser",
         }
@@ -254,7 +254,12 @@ class WinIisTestCase(TestCase, LoaderModuleMockMixin):
         expected_ret = {
             "name": name,
             "changes": {
-                "changes": {},
+                "changes": {
+                    "processModel.userName": {
+                        "new": "Administrator",
+                        "old": "Spongebob"
+                    }
+                },
                 "failures": {
                     "processModel.password": {
                         "new": "XXX-REDACTED-XXX",
@@ -263,7 +268,7 @@ class WinIisTestCase(TestCase, LoaderModuleMockMixin):
                 },
             },
             "comment": "Set settings to contain the provided values.",
-            "result": True,
+            "result": False,
         }
         with patch.dict(
             win_iis.__salt__,

--- a/tests/unit/states/test_win_iis.py
+++ b/tests/unit/states/test_win_iis.py
@@ -143,3 +143,95 @@ class WinIisTestCase(TestCase, LoaderModuleMockMixin):
         ), patch.dict(win_iis.__opts__, {"test": False}):
             actual_ret = win_iis.webconfiguration_settings(name, settings)
         self.assertEqual(expected_ret, actual_ret)
+
+    def test_webconfiguration_settings_password_redacted(self):
+        name = "IIS:\\"
+        container = "AppPools"
+        settings = {
+            "processModel.userName": "Administrator",
+            "processModel.password": "Sup3rS3cr3tP@ssW0rd",
+            "processModel.identityType": "SpecificUser"
+        }
+        old_settings = [
+            {
+                "processModel.userName": "Administrator",
+                "processModel.password": "0ldP@ssW0rd1!",
+                "processModel.identityType": "SpecificUser",
+            }
+        ]
+        current_settings = [
+            {
+                "processModel.userName": "Administrator",
+                "processModel.password": "Sup3rS3cr3tP@ssW0rd",
+                "processModel.identityType": "SpecificUser",
+            }
+        ]
+        new_settings = current_settings
+        expected_ret = self.__base_webconfiguration_ret(
+            name=name,
+            result=True,
+            changes={
+                "processModel.password": {
+                    "new": "XXX-REDACTED-XXX",
+                    "old": "XXX-REDACTED-XXX"
+                }
+            },
+            comment="Set settings to contain the provided values.",
+        )
+        with patch.dict(
+            win_iis.__salt__,
+            {
+                "win_iis.get_webconfiguration_settings": MagicMock(
+                    side_effect=[old_settings, current_settings, new_settings]
+                ),
+                "win_iis.set_webconfiguration_settings": MagicMock(return_value=True),
+            },
+        ), patch.dict(win_iis.__opts__, {"test": False}):
+            actual_ret = win_iis.webconfiguration_settings(name, settings)
+        self.assertEqual(expected_ret, actual_ret)
+
+    def test_webconfiguration_settings_password_redacted_test_true(self):
+        name = "IIS:\\"
+        container = "AppPools"
+        settings = {
+            "processModel.userName": "Administrator",
+            "processModel.password": "Sup3rS3cr3tP@ssW0rd",
+            "processModel.identityType": "SpecificUser"
+        }
+        old_settings = [
+            {
+                "processModel.userName": "Administrator",
+                "processModel.password": "0ldP@ssW0rd1!",
+                "processModel.identityType": "SpecificUser",
+            }
+        ]
+        current_settings = [
+            {
+                "processModel.userName": "Administrator",
+                "processModel.password": "Sup3rS3cr3tP@ssW0rd",
+                "processModel.identityType": "SpecificUser",
+            }
+        ]
+        new_settings = current_settings
+        expected_ret = self.__base_webconfiguration_ret(
+            name=name,
+            result=True,
+            changes={
+                "processModel.password": {
+                    "new": "XXX-REDACTED-XXX",
+                    "old": "XXX-REDACTED-XXX"
+                }
+            },
+            comment="Settings will be changed.",
+        )
+        with patch.dict(
+            win_iis.__salt__,
+            {
+                "win_iis.get_webconfiguration_settings": MagicMock(
+                    side_effect=[old_settings, current_settings, new_settings]
+                ),
+                "win_iis.set_webconfiguration_settings": MagicMock(return_value=True),
+            },
+        ), patch.dict(win_iis.__opts__, {"test": True}):
+            actual_ret = win_iis.webconfiguration_settings(name, settings)
+        self.assertEqual(expected_ret, actual_ret)

--- a/tests/unit/states/test_win_iis.py
+++ b/tests/unit/states/test_win_iis.py
@@ -254,10 +254,13 @@ class WinIisTestCase(TestCase, LoaderModuleMockMixin):
         expected_ret = {
             "name": name,
             "changes": {
-                "processModel.password": {
-                    "new": "XXX-REDACTED-XXX",
-                    "old": "XXX-REDACTED-XXX"
-                }
+                "changes": {},
+                "failures": {
+                    "processModel.password": {
+                        "new": "XXX-REDACTED-XXX",
+                        "old": "XXX-REDACTED-XXX"
+                    }
+                },
             },
             "comment": "Set settings to contain the provided values.",
             "result": True,

--- a/tests/unit/states/test_win_iis.py
+++ b/tests/unit/states/test_win_iis.py
@@ -150,7 +150,7 @@ class WinIisTestCase(TestCase, LoaderModuleMockMixin):
         settings = {
             "processModel.userName": "Administrator",
             "processModel.password": "Sup3rS3cr3tP@ssW0rd",
-            "processModel.identityType": "SpecificUser"
+            "processModel.identityType": "SpecificUser",
         }
         old_settings = {
             "processModel.userName": "Administrator",
@@ -169,7 +169,7 @@ class WinIisTestCase(TestCase, LoaderModuleMockMixin):
             "changes": {
                 "processModel.password": {
                     "new": "XXX-REDACTED-XXX",
-                    "old": "XXX-REDACTED-XXX"
+                    "old": "XXX-REDACTED-XXX",
                 }
             },
             "comment": "Set settings to contain the provided values.",
@@ -184,9 +184,9 @@ class WinIisTestCase(TestCase, LoaderModuleMockMixin):
                 "win_iis.set_container_setting": MagicMock(return_value=True),
             },
         ), patch.dict(win_iis.__opts__, {"test": False}):
-            actual_ret = win_iis.container_setting(name=name,
-                                                   container=container,
-                                                   settings=settings)
+            actual_ret = win_iis.container_setting(
+                name=name, container=container, settings=settings
+            )
         self.assertEqual(expected_ret, actual_ret)
 
     def test_container_settings_password_redacted_test_true(self):
@@ -195,7 +195,7 @@ class WinIisTestCase(TestCase, LoaderModuleMockMixin):
         settings = {
             "processModel.userName": "Administrator",
             "processModel.password": "Sup3rS3cr3tP@ssW0rd",
-            "processModel.identityType": "SpecificUser"
+            "processModel.identityType": "SpecificUser",
         }
         old_settings = {
             "processModel.userName": "Administrator",
@@ -213,7 +213,7 @@ class WinIisTestCase(TestCase, LoaderModuleMockMixin):
             "changes": {
                 "processModel.password": {
                     "new": "XXX-REDACTED-XXX",
-                    "old": "XXX-REDACTED-XXX"
+                    "old": "XXX-REDACTED-XXX",
                 }
             },
             "comment": "Settings will be changed.",
@@ -228,7 +228,9 @@ class WinIisTestCase(TestCase, LoaderModuleMockMixin):
                 "win_iis.set_container_setting": MagicMock(return_value=True),
             },
         ), patch.dict(win_iis.__opts__, {"test": True}):
-            actual_ret = win_iis.container_setting(name=name, container=container, settings=settings)
+            actual_ret = win_iis.container_setting(
+                name=name, container=container, settings=settings
+            )
         self.assertEqual(expected_ret, actual_ret)
 
     def test_container_settings_password_redacted_failures(self):
@@ -237,7 +239,7 @@ class WinIisTestCase(TestCase, LoaderModuleMockMixin):
         settings = {
             "processModel.userName": "Administrator",
             "processModel.password": "Sup3rS3cr3tP@ssW0rd",
-            "processModel.identityType": "SpecificUser"
+            "processModel.identityType": "SpecificUser",
         }
         old_settings = {
             "processModel.userName": "Spongebob",
@@ -257,13 +259,13 @@ class WinIisTestCase(TestCase, LoaderModuleMockMixin):
                 "changes": {
                     "processModel.userName": {
                         "new": "Administrator",
-                        "old": "Spongebob"
+                        "old": "Spongebob",
                     }
                 },
                 "failures": {
                     "processModel.password": {
                         "new": "XXX-REDACTED-XXX",
-                        "old": "XXX-REDACTED-XXX"
+                        "old": "XXX-REDACTED-XXX",
                     }
                 },
             },
@@ -279,7 +281,7 @@ class WinIisTestCase(TestCase, LoaderModuleMockMixin):
                 "win_iis.set_container_setting": MagicMock(return_value=True),
             },
         ), patch.dict(win_iis.__opts__, {"test": False}):
-            actual_ret = win_iis.container_setting(name=name,
-                                                   container=container,
-                                                   settings=settings)
+            actual_ret = win_iis.container_setting(
+                name=name, container=container, settings=settings
+            )
         self.assertEqual(expected_ret, actual_ret)

--- a/tests/unit/states/test_win_iis.py
+++ b/tests/unit/states/test_win_iis.py
@@ -144,7 +144,7 @@ class WinIisTestCase(TestCase, LoaderModuleMockMixin):
             actual_ret = win_iis.webconfiguration_settings(name, settings)
         self.assertEqual(expected_ret, actual_ret)
 
-    def test_webconfiguration_settings_password_redacted(self):
+    def test_container_settings_password_redacted(self):
         name = "IIS:\\"
         container = "AppPools"
         settings = {
@@ -181,16 +181,18 @@ class WinIisTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(
             win_iis.__salt__,
             {
-                "win_iis.get_webconfiguration_settings": MagicMock(
+                "win_iis.get_container_settings": MagicMock(
                     side_effect=[old_settings, current_settings, new_settings]
                 ),
-                "win_iis.set_webconfiguration_settings": MagicMock(return_value=True),
+                "win_iis.set_container_settings": MagicMock(return_value=True),
             },
         ), patch.dict(win_iis.__opts__, {"test": False}):
-            actual_ret = win_iis.webconfiguration_settings(name, settings)
+            actual_ret = win_iis.container_setting(name=name,
+                                                   container=container,
+                                                   settings=settings)
         self.assertEqual(expected_ret, actual_ret)
 
-    def test_webconfiguration_settings_password_redacted_test_true(self):
+    def test_container_settings_password_redacted_test_true(self):
         name = "IIS:\\"
         container = "AppPools"
         settings = {
@@ -233,5 +235,5 @@ class WinIisTestCase(TestCase, LoaderModuleMockMixin):
                 "win_iis.set_webconfiguration_settings": MagicMock(return_value=True),
             },
         ), patch.dict(win_iis.__opts__, {"test": True}):
-            actual_ret = win_iis.webconfiguration_settings(name, settings)
+            actual_ret = win_iis.container_setting(name=name, container=container, settings=settings)
         self.assertEqual(expected_ret, actual_ret)

--- a/tests/unit/states/test_win_iis.py
+++ b/tests/unit/states/test_win_iis.py
@@ -167,17 +167,17 @@ class WinIisTestCase(TestCase, LoaderModuleMockMixin):
             }
         ]
         new_settings = current_settings
-        expected_ret = self.__base_webconfiguration_ret(
-            name=name,
-            result=True,
-            changes={
+        expected_ret = {
+            "name": name,
+            "changes": {
                 "processModel.password": {
                     "new": "XXX-REDACTED-XXX",
                     "old": "XXX-REDACTED-XXX"
                 }
             },
-            comment="Set settings to contain the provided values.",
-        )
+            "comment": "Set settings to contain the provided values.",
+            "result": True,
+        }
         with patch.dict(
             win_iis.__salt__,
             {
@@ -215,24 +215,24 @@ class WinIisTestCase(TestCase, LoaderModuleMockMixin):
             }
         ]
         new_settings = current_settings
-        expected_ret = self.__base_webconfiguration_ret(
-            name=name,
-            result=True,
-            changes={
+        expected_ret = {
+            "name": name,
+            "changes": {
                 "processModel.password": {
                     "new": "XXX-REDACTED-XXX",
                     "old": "XXX-REDACTED-XXX"
                 }
             },
-            comment="Settings will be changed.",
-        )
+            "comment": "Settings will be changed.",
+            "result": None,
+        }
         with patch.dict(
             win_iis.__salt__,
             {
-                "win_iis.get_webconfiguration_setting": MagicMock(
+                "win_iis.get_container_setting": MagicMock(
                     side_effect=[old_settings, current_settings, new_settings]
                 ),
-                "win_iis.set_webconfiguration_setting": MagicMock(return_value=True),
+                "win_iis.set_container_setting": MagicMock(return_value=True),
             },
         ), patch.dict(win_iis.__opts__, {"test": True}):
             actual_ret = win_iis.container_setting(name=name, container=container, settings=settings)


### PR DESCRIPTION
### What does this PR do?
Redacts password in the return when setting credentials using the `win_iis.container_setting` state.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/57285

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
