### PR TITLE
Install KB2999226 from .cab instead of .msu

### DIFF
--- a/pkg/windows/build_env.ps1
+++ b/pkg/windows/build_env.ps1
@@ -169,7 +169,7 @@ If (Test-Path "$($ini[$bitPaths]['VCppBuildToolsDir'])\vcbuildtools.bat") {
 #------------------------------------------------------------------------------
 Write-Output " - Checking for Python 3 installation . . ."
 If (Test-Path "$($ini['Settings']['Python3Dir'])\python.exe") {
-    # Found Python 3.5, do nothing
+    # Found Python 3, do nothing
     Write-Output " - Python 3 Found . . ."
 } Else {
     Write-Output " - Downloading $($ini[$bitPrograms]['Python3']) . . ."

--- a/pkg/windows/build_pkg.bat
+++ b/pkg/windows/build_pkg.bat
@@ -143,21 +143,27 @@ set Url=http://repo.saltstack.com/windows/dependencies/64/ucrt/Windows6.0-KB2999
 set Name=Windows6.0-KB2999226-x64.msu
 @echo - Downloading %Name%
 powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url% -file "%PreDir%\%Name%"
+Expand -F:*KB2999226*.cab "%PreDir%\%Name%" "%PreDir%"
 
 set Url=http://repo.saltstack.com/windows/dependencies/64/ucrt/Windows6.1-KB2999226-x64.msu
 set Name=Windows6.1-KB2999226-x64.msu
 @echo - Downloading %Name%
 powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url% -file "%PreDir%\%Name%"
+Expand -F:*KB2999226*.cab "%PreDir%\%Name%" "%PreDir%"
 
 set Url=http://repo.saltstack.com/windows/dependencies/64/ucrt/Windows8-RT-KB2999226-x64.msu
 set Name=Windows8-RT-KB2999226-x64.msu
 @echo - Downloading %Name%
 powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url% -file "%PreDir%\%Name%"
+Expand -F:*KB2999226*.cab "%PreDir%\%Name%" "%PreDir%"
 
 set Url=http://repo.saltstack.com/windows/dependencies/64/ucrt/Windows8.1-KB2999226-x64.msu
 set Name=Windows8.1-KB2999226-x64.msu
 @echo - Downloading %Name%
 powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url% -file "%PreDir%\%Name%"
+Expand -F:*KB2999226*.cab "%PreDir%\%Name%" "%PreDir%"
+
+del /q "%PreDir%\*.msu"
 
 :: 32 bit binaries only needed for x86 installer
 :: ProgramFiles(x86) is defined on AMD64 systems
@@ -169,21 +175,27 @@ set Url=http://repo.saltstack.com/windows/dependencies/32/ucrt/Windows6.0-KB2999
 set Name=Windows6.0-KB2999226-x86.msu
 @echo - Downloading %Name%
 powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url% -file "%PreDir%\%Name%"
+Expand -F:*KB2999226*.cab "%PreDir%\%Name%" "%PreDir%"
 
 set Url=http://repo.saltstack.com/windows/dependencies/32/ucrt/Windows6.1-KB2999226-x86.msu
 set Name=Windows6.1-KB2999226-x86.msu
 @echo - Downloading %Name%
 powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url% -file "%PreDir%\%Name%"
+Expand -F:*KB2999226*.cab "%PreDir%\%Name%" "%PreDir%"
 
 set Url=http://repo.saltstack.com/windows/dependencies/32/ucrt/Windows8-RT-KB2999226-x86.msu
 set Name=Windows8-RT-KB2999226-x86.msu
 @echo - Downloading %Name%
 powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url% -file "%PreDir%\%Name%"
+Expand -F:*KB2999226*.cab "%PreDir%\%Name%" "%PreDir%"
 
 set Url=http://repo.saltstack.com/windows/dependencies/32/ucrt/Windows8.1-KB2999226-x86.msu
 set Name=Windows8.1-KB2999226-x86.msu
 @echo - Downloading %Name%
 powershell -ExecutionPolicy RemoteSigned -File download_url_file.ps1 -url %Url% -file "%PreDir%\%Name%"
+Expand -F:*KB2999226*.cab "%PreDir%\%Name%" "%PreDir%"
+
+del /q "%PreDir%\*.msu"
 
 :vcredist_2013_x86
 @echo.


### PR DESCRIPTION
### What does this PR do?

This fixes the installation of update (KB2999226) when the Windows Update service is disabled.

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
If the Windows Update service is disabled, then the update (KB2999226) will not be installed, as in the current version this is done in `wusa`.

### New Behavior
Update (KB2999226) will be installed regardless of the status of the Windows Update service.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
