### PR TITLE
Add grain to list LVM volumes implement issue 57629

### DIFF
--- a/changelog/57629.added
+++ b/changelog/57629.added
@@ -1,0 +1,1 @@
+Added grains to show the LVM Volume Groups and their Logical Volumes.

--- a/doc/ref/grains/all/index.rst
+++ b/doc/ref/grains/all/index.rst
@@ -20,6 +20,7 @@ grains modules
     fx2
     iscsi
     junos
+    lvm
     marathon
     mdadm
     mdata

--- a/doc/ref/grains/all/salt.grains.lvm.rst
+++ b/doc/ref/grains/all/salt.grains.lvm.rst
@@ -1,0 +1,6 @@
+===============
+salt.grains.lvm
+===============
+
+.. automodule:: salt.grains.lvm
+    :members:

--- a/salt/grains/lvm.py
+++ b/salt/grains/lvm.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""
+Detect LVM Volumes
+"""
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import python libs
+import logging
+
+# Import salt libs
+import salt.modules.cmdmod
+import salt.utils.files
+import salt.utils.path
+import salt.utils.platform
+
+__salt__ = {
+    "cmd.run": salt.modules.cmdmod._run_quiet,
+    "cmd.run_all": salt.modules.cmdmod._run_all_quiet,
+}
+
+log = logging.getLogger(__name__)
+
+
+def lvm():
+    """
+    Return list of LVM devices
+    """
+    if salt.utils.platform.is_linux():
+        return _linux_lvm()
+    elif salt.utils.platform.is_aix():
+        return _aix_lvm()
+    else:
+        log.trace("LVM grain does not support OS")
+
+
+def _linux_lvm():
+    ret = {}
+    cmd = salt.utils.path.which("lvm")
+    if cmd:
+        vgs = __salt__["cmd.run"]("{0} vgs -o vg_name --noheadings".format(cmd))
+
+        for vg in vgs.splitlines():
+            vg = vg.strip()
+            ret[vg] = []
+            lvs = __salt__["cmd.run"](
+                "{0} lvs -o lv_name --noheadings {1}".format(cmd, vg)
+            )
+            for lv in lvs.splitlines():
+                ret[vg].append(lv.strip())
+
+        return {"lvm": ret}
+    else:
+        log.trace("No LVM installed")
+
+
+def _aix_lvm():
+    ret = {}
+    cmd = salt.utils.path.which("lsvg")
+    vgs = __salt__["cmd.run"]("{0}".format(cmd))
+
+    for vg in vgs.splitlines():
+        ret[vg] = []
+        lvs = __salt__["cmd.run"]("{0} -l {1}".format(cmd, vg))
+        for lvline in lvs.splitlines()[2:]:
+            lv = lvline.split(" ", 1)[0]
+            ret[vg].append(lv)
+
+    return {"lvm": ret}

--- a/salt/grains/lvm.py
+++ b/salt/grains/lvm.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
 """
 Detect LVM Volumes
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
 import logging
@@ -30,20 +28,20 @@ def lvm():
     elif salt.utils.platform.is_aix():
         return _aix_lvm()
     else:
-        log.trace("LVM grain does not support OS")
+        log.trace("LVM grain does not support this OS")
 
 
 def _linux_lvm():
     ret = {}
     cmd = salt.utils.path.which("lvm")
     if cmd:
-        vgs = __salt__["cmd.run"]("{0} vgs -o vg_name --noheadings".format(cmd))
+        vgs = __salt__["cmd.run"]("{} vgs -o vg_name --noheadings".format(cmd))
 
         for vg in vgs.splitlines():
             vg = vg.strip()
             ret[vg] = []
             lvs = __salt__["cmd.run"](
-                "{0} lvs -o lv_name --noheadings {1}".format(cmd, vg)
+                "{} lvs -o lv_name --noheadings {}".format(cmd, vg)
             )
             for lv in lvs.splitlines():
                 ret[vg].append(lv.strip())
@@ -56,11 +54,11 @@ def _linux_lvm():
 def _aix_lvm():
     ret = {}
     cmd = salt.utils.path.which("lsvg")
-    vgs = __salt__["cmd.run"]("{0}".format(cmd))
+    vgs = __salt__["cmd.run"]("{}".format(cmd))
 
     for vg in vgs.splitlines():
         ret[vg] = []
-        lvs = __salt__["cmd.run"]("{0} -l {1}".format(cmd, vg))
+        lvs = __salt__["cmd.run"]("{} -l {}".format(cmd, vg))
         for lvline in lvs.splitlines()[2:]:
             lv = lvline.split(" ", 1)[0]
             ret[vg].append(lv)

--- a/tests/unit/grains/test_lvm.py
+++ b/tests/unit/grains/test_lvm.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
 """
     :codeauthor: :email:`Shane Lee <slee@saltstack.com>`
 """
 # Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Libs
 import salt.grains.lvm as lvm
@@ -70,7 +68,7 @@ class LvmGrainsTestCase(TestCase, LoaderModuleMockMixin):
 
     def test__linux_lvm_no_logical_volumes(self):
         """
-        Test grains._linux_lvm, lvm installed but no volumes
+        Test grains._linux_lvm, lvm is installed but no volumes
         Should return a dictionary only with the header
         """
 

--- a/tests/unit/grains/test_lvm.py
+++ b/tests/unit/grains/test_lvm.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+"""
+    :codeauthor: :email:`Shane Lee <slee@saltstack.com>`
+"""
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import Salt Libs
+import salt.grains.lvm as lvm
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.mock import MagicMock, patch
+from tests.support.unit import TestCase
+
+
+class LvmGrainsTestCase(TestCase, LoaderModuleMockMixin):
+    """
+    Test cases for LVM grains
+    """
+
+    def setup_loader_modules(self):
+        return {
+            lvm: {"__salt__": {}},
+        }
+
+    def test__linux_lvm(self):
+        """
+        Test grains._linux_lvm, normal return
+        Should return a populated dictionary
+        """
+
+        vgs_out = "  vg00\n  vg01"
+        lvs_out_vg00 = "  root\n  swap\n  tmp \n  usr \n  var"
+        lvs_out_vg01 = "  opt \n"
+        cmd_out = MagicMock(
+            autospec=True, side_effect=[vgs_out, lvs_out_vg00, lvs_out_vg01]
+        )
+
+        patch_which = patch(
+            "salt.utils.path.which", autospec=True, return_value="/usr/sbin/lvm"
+        )
+        patch_cmd_lvm = patch.dict(lvm.__salt__, {"cmd.run": cmd_out})
+        with patch_which, patch_cmd_lvm:
+            ret = lvm._linux_lvm()
+
+        assert ret == {
+            "lvm": {"vg00": ["root", "swap", "tmp", "usr", "var"], "vg01": ["opt"]}
+        }, ret
+
+    def test__linux_lvm_no_lvm(self):
+        """
+        Test grains._linux_lvm, no lvm installed
+        Should return nothing
+        """
+
+        vgs_out = "  vg00\n  vg01"
+        lvs_out_vg00 = "  root\n  swap\n  tmp \n  usr \n  var"
+        lvs_out_vg01 = "  opt \n"
+        cmd_out = MagicMock(
+            autospec=True, side_effect=[vgs_out, lvs_out_vg00, lvs_out_vg01]
+        )
+
+        patch_which = patch("salt.utils.path.which", autospec=True, return_value="")
+        patch_cmd_lvm = patch.dict(lvm.__salt__, {"cmd.run": cmd_out})
+        with patch_which, patch_cmd_lvm:
+            ret = lvm._linux_lvm()
+
+        assert ret is None, ret
+
+    def test__linux_lvm_no_logical_volumes(self):
+        """
+        Test grains._linux_lvm, lvm installed but no volumes
+        Should return a dictionary only with the header
+        """
+
+        vgs_out = ""
+        cmd_out = MagicMock(autospec=True, side_effect=[vgs_out])
+
+        patch_which = patch(
+            "salt.utils.path.which", autospec=True, return_value="/usr/sbin/lvm"
+        )
+        patch_cmd_lvm = patch.dict(lvm.__salt__, {"cmd.run": cmd_out})
+        with patch_which, patch_cmd_lvm:
+            ret = lvm._linux_lvm()
+
+        assert ret == {"lvm": {}}, ret
+
+    def test__aix_lvm(self):
+        """
+        Test grains._aix_lvm, normal return
+        Should return a populated dictionary
+        """
+
+        lsvg_out = "rootvg\nothervg"
+        lsvg_out_rootvg = "rootvg:\n\
+LV NAME             TYPE       LPs     PPs     PVs  LV STATE      MOUNT POINT\n\
+hd5                 boot       1       1       1    closed/syncd  N/A\n\
+hd6                 paging     32      32      1    open/syncd    N/A\n\
+hd8                 jfs2log    1       1       1    open/syncd    N/A\n\
+hd4                 jfs2       32      32      1    open/syncd    /\n\
+hd2                 jfs2       16      16      1    open/syncd    /usr\n\
+hd9var              jfs2       32      32      1    open/syncd    /var\n\
+hd3                 jfs2       32      32      1    open/syncd    /tmp\n\
+hd1                 jfs2       16      16      1    open/syncd    /home\n\
+hd10opt             jfs2       16      16      1    open/syncd    /opt"
+        lsvg_out_othervg = "othervg:\n\
+LV NAME             TYPE       LPs     PPs     PVs  LV STATE      MOUNT POINT\n\
+loglv01             jfs2log    1       1       1    open/syncd    N/A\n\
+datalv              jfs2       16      16      1    open/syncd    /data"
+        cmd_out = MagicMock(
+            autospec=True, side_effect=[lsvg_out, lsvg_out_rootvg, lsvg_out_othervg]
+        )
+
+        patch_which = patch(
+            "salt.utils.path.which", autospec=True, return_value="/usr/sbin/lsvg"
+        )
+        patch_cmd_lvm = patch.dict(lvm.__salt__, {"cmd.run": cmd_out})
+        with patch_which, patch_cmd_lvm:
+            ret = lvm._aix_lvm()
+
+        assert ret == {
+            "lvm": {
+                "rootvg": [
+                    "hd5",
+                    "hd6",
+                    "hd8",
+                    "hd4",
+                    "hd2",
+                    "hd9var",
+                    "hd3",
+                    "hd1",
+                    "hd10opt",
+                ],
+                "othervg": ["loglv01", "datalv"],
+            }
+        }, ret


### PR DESCRIPTION
### What does this PR do?
This initial support implements a grain called "lvm" which returns a dictionary with the volume groups, each one with a list of their logical volumes inside.

LVM is an important information about a Linux machine. Usually Linux servers have most or all their disk filesystems using a logical volume as mountpoint.

### What issues does this PR fix or reference?
Implements and resolves #57629 

### New Behavior
To have a grain with the list of LVM volumes:
```
root@marvin:~# salt-call grains.get lvm
local:
    ----------
    marvinvg00:
        - opt
        - root
        - swap
        - tmp
        - usr
        - var
    marvinvg01:
        - home
        - srv
        - usrlocal
```

### Merge requirements satisfied?
[salt-runtests-20200610192428.log](https://github.com/saltstack/salt/files/4761571/salt-runtests-20200610192428.log)


### Commits signed with GPG?
No