### PR TITLE
Skip 2 tests on FreeBSD.

### DIFF
--- a/tests/unit/beacons/test_inotify.py
+++ b/tests/unit/beacons/test_inotify.py
@@ -111,6 +111,7 @@ class INotifyBeaconTestCase(TestCase, LoaderModuleMockMixin):
         ret = inotify.beacon(config)
         self.assertEqual(ret, [])
 
+    @skipIf(salt.utils.platform.is_freebsd(), "Skip on FreeBSD")
     def test_dir_auto_add(self):
         config = [
             {"files": {self.tmpdir: {"mask": ["create", "open"], "auto_add": True}}}
@@ -136,6 +137,7 @@ class INotifyBeaconTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(ret[0]["path"], fp)
         self.assertEqual(ret[0]["change"], "IN_OPEN")
 
+    @skipIf(salt.utils.platform.is_freebsd(), "Skip on FreeBSD")
     def test_dir_recurse(self):
         dp1 = os.path.join(self.tmpdir, "subdir1")
         os.mkdir(dp1)


### PR DESCRIPTION
### What does this PR do?
Skip 2 tests on FreeBSD.

Currently IN_OPEN, IN_CLOSE_WRITE and IN_CLOSE_NOWRITE events are not
implemented into libinotify and not available on FreeBSD, hence disable
2 affected tests [1]

[1]: https://github.com/dmatveev/libinotify-kqueue