### PR TITLE
fix macOS failed service stop.

### DIFF
--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -314,6 +314,12 @@ def launchctl(sub_cmd, *args, **kwargs):
     cmd = ["launchctl", sub_cmd]
     cmd.extend(args)
 
+    # fix for https://github.com/saltstack/salt/issues/57436
+    if sub_cmd == "bootout":
+        kwargs["success_retcodes"] = [
+            36,
+        ]
+
     # Run command
     kwargs["python_shell"] = False
     kwargs = salt.utils.args.clean_kwargs(**kwargs)

--- a/tests/unit/utils/test_mac_utils.py
+++ b/tests/unit/utils/test_mac_utils.py
@@ -480,6 +480,31 @@ class MacUtilsTestCase(TestCase, LoaderModuleMockMixin):
                 except CommandExecutionError as exc:
                     self.assertEqual(exc.message, error)
 
+    def test_not_bootout_retcode_36_fail(self):
+        """
+        Make sure that if we get a retcode 36 on non bootout cmds
+        that we still get a failure.
+        """
+        error = (
+            "Failed to bootstrap service:\n"
+            "stdout: failure\n"
+            "stderr: test failure\n"
+            "retcode: 36"
+        )
+        proc = MagicMock(
+            return_value=MockTimedProc(
+                stdout=b"failure", stderr=b"test failure", returncode=36
+            )
+        )
+        with patch("salt.utils.timed_subprocess.TimedProc", proc):
+            with patch(
+                "salt.utils.mac_utils.__salt__", {"cmd.run_all": cmd._run_all_quiet}
+            ):
+                try:
+                    mac_utils.launchctl("bootstrap", "org.salt.minion")
+                except CommandExecutionError as exc:
+                    self.assertEqual(exc.message, error)
+
 
 def _get_walk_side_effects(results):
     """

--- a/tests/unit/utils/test_mac_utils.py
+++ b/tests/unit/utils/test_mac_utils.py
@@ -10,6 +10,8 @@ import os
 import plistlib
 import xml.parsers.expat
 
+import salt.modules.cmdmod as cmd
+
 # Import Salt libs
 import salt.utils.mac_utils as mac_utils
 import salt.utils.platform
@@ -19,7 +21,7 @@ from salt.ext import six
 # Import 3rd-party libs
 from salt.ext.six.moves import range
 from tests.support.mixins import LoaderModuleMockMixin
-from tests.support.mock import MagicMock, call, mock_open, patch
+from tests.support.mock import MagicMock, MockTimedProc, call, mock_open, patch
 
 # Import Salt Testing Libs
 from tests.support.unit import TestCase, skipIf
@@ -437,6 +439,46 @@ class MacUtilsTestCase(TestCase, LoaderModuleMockMixin):
             mock_run.assert_has_calls(calls, any_order=True)
 
         self.assertEqual(len(ret), 0)
+
+    def test_bootout_retcode_36_success(self):
+        """
+        Make sure that if we run a `launchctl bootout` cmd and it returns
+        36 that we treat it as a success.
+        """
+        proc = MagicMock(
+            return_value=MockTimedProc(stdout=None, stderr=None, returncode=36)
+        )
+        with patch("salt.utils.timed_subprocess.TimedProc", proc):
+            with patch(
+                "salt.utils.mac_utils.__salt__", {"cmd.run_all": cmd._run_all_quiet}
+            ):
+                ret = mac_utils.launchctl("bootout", "org.salt.minion")
+        self.assertEqual(ret, True)
+
+    def test_bootout_retcode_99_fail(self):
+        """
+        Make sure that if we run a `launchctl bootout` cmd and it returns
+        something other than 0 or 36 that we treat it as a fail.
+        """
+        error = (
+            "Failed to bootout service:\n"
+            "stdout: failure\n"
+            "stderr: test failure\n"
+            "retcode: 99"
+        )
+        proc = MagicMock(
+            return_value=MockTimedProc(
+                stdout=b"failure", stderr=b"test failure", returncode=99
+            )
+        )
+        with patch("salt.utils.timed_subprocess.TimedProc", proc):
+            with patch(
+                "salt.utils.mac_utils.__salt__", {"cmd.run_all": cmd._run_all_quiet}
+            ):
+                try:
+                    mac_utils.launchctl("bootout", "org.salt.minion")
+                except CommandExecutionError as exc:
+                    self.assertEqual(exc.message, error)
 
 
 def _get_walk_side_effects(results):


### PR DESCRIPTION
# What does this PR do?

Starting on macOS Catalina when trying to stop an active PID process `launchctl bootout` will return an exit code of 36 causing the service.dead state to fail, or even a `service.restart` to fail. This fix ignores retcode 36 on `launchctl bootout` calls.

### What issues does this PR fix or reference?
fixes #57436

### Previous Behavior
Receive an error like below when trying to stop some services.

```
Error running 'service.stop': Failed to bootout service:
stdout: 
stderr: /Library/LaunchDaemons/com.launcher.launcher.plist: Operation now in progress
retcode: 36
```
### New Behavior
No fails, all green :) 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
