### PR TITLE
config file can be template using pillar/grains

### DIFF
--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -112,7 +112,7 @@ class HandleFileCopy:
                 # check if hash is same, else copy newly
                 if master_hash.get("hsum") == proxy_hash:
                     # kwargs will have values when path is a template
-                    if self._kwargs is not None:
+                    if self._kwargs:
                         self._cached_file = salt.utils.files.mkstemp()
                         # local copy is a template, hence need to render
                         with salt.utils.files.fopen(self._cached_file, "w") as fp:
@@ -130,7 +130,7 @@ class HandleFileCopy:
             log.debug(
                 "Caching file {0} at {1}".format(self._file_path, self._cached_folder)
             )
-            if self._kwargs is not None:
+            if self._kwargs:
                 self._cached_file = salt.utils.files.mkstemp(dir=self._cached_folder)
                 __salt__["cp.get_template"](
                     self._file_path, self._cached_file, **self._kwargs
@@ -144,7 +144,7 @@ class HandleFileCopy:
         else:
             # check for local location of file
             if __salt__["file.file_exists"](self._file_path):
-                if self._kwargs is not None:
+                if self._kwargs:
                     self._cached_file = salt.utils.files.mkstemp()
                     with salt.utils.files.fopen(self._cached_file, "w") as fp:
                         template_string = __salt__["slsutil.renderer"](

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -112,7 +112,7 @@ class HandleFileCopy:
                 # check if hash is same, else copy newly
                 if master_hash.get("hsum") == proxy_hash:
                     # kwargs will have values when path is a template
-                    if self._kwargs:
+                    if self._kwargs is not None:
                         self._cached_file = salt.utils.files.mkstemp()
                         # local copy is a template, hence need to render
                         with salt.utils.files.fopen(self._cached_file, "w") as fp:
@@ -130,9 +130,10 @@ class HandleFileCopy:
             log.debug(
                 "Caching file {0} at {1}".format(self._file_path, self._cached_folder)
             )
-            if self._kwargs:
-                self._cached_file = __salt__["cp.get_template"](
-                    self._file_path, self._cached_folder, **self._kwargs
+            if self._kwargs is not None:
+                self._cached_file = salt.utils.files.mkstemp(dir=self._cached_folder)
+                __salt__["cp.get_template"](
+                    self._file_path, self._cached_file, **self._kwargs
                 )
             else:
                 self._cached_file = __salt__["cp.get_file"](
@@ -143,7 +144,7 @@ class HandleFileCopy:
         else:
             # check for local location of file
             if __salt__["file.file_exists"](self._file_path):
-                if self._kwargs:
+                if self._kwargs is not None:
                     self._cached_file = salt.utils.files.mkstemp()
                     with salt.utils.files.fopen(self._cached_file, "w") as fp:
                         template_string = __salt__["slsutil.renderer"](


### PR DESCRIPTION
### What does this PR do?
Render config file to parse pillar/grains in it
lets say config file is
```
root@iagent:/srv/salt# cat configs/host.set
{% set proxyid = grains['id'] %}
set system host-name {{ pillar[proxyid]['hostname'] }}
```
This gave error as

```
[ERROR   ] {'out': False, 'message': 'Could not load configuration due to : "ConfigLoadError(severity: error, bad_element: {%, message: error: unknown command\nerror: host-name: \'{{\': Must be a string of alphanumericals, dashes or underscores\nerror: syntax error, expecting [Enter])"', 'format': 'set'}
```

In such a case, state file doesn't need to pass template_vars. We need to render config file in all cases.

When cache is not present, while copy we used cp_get_template, this return folder name and not the file path. Hence we got this error
```
[ERROR   ] {'out': False, 'message': 'Could not load configuration due to : "[Errno 21] Is a directory: \'/tmp/tmpgcohosan\'"', 'format': 'set'}
```
Hence first create tmp file in given dir, and use this file path as location for rendered config file.

### What issues does this PR fix or reference?
Fixes: 57665

### Previous Behavior
It used to work in older salt. With recent code changes in master/sodium, this got broken.

### New Behavior
Works as earlier and as expected.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
