### PR TITLE
handle config load error when cache is not available for first time

### DIFF
--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -144,7 +144,7 @@ class HandleFileCopy:
             if self._cached_file != "":
                 return self._cached_file
         else:
-            # check for local location of file
+            # check for local location of the file
             if __salt__["file.file_exists"](self._file_path):
                 if self._kwargs:
                     self._cached_file = salt.utils.files.mkstemp()

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -126,16 +126,18 @@ class HandleFileCopy:
                     else:
                         return local_cache_path
                 # continue for else part
-            self._cached_folder = tempfile.mkdtemp()
-            log.debug(
-                "Caching file {0} at {1}".format(self._file_path, self._cached_folder)
-            )
             if self._kwargs:
-                self._cached_file = salt.utils.files.mkstemp(dir=self._cached_folder)
+                self._cached_file = salt.utils.files.mkstemp()
                 __salt__["cp.get_template"](
                     self._file_path, self._cached_file, **self._kwargs
                 )
             else:
+                self._cached_folder = tempfile.mkdtemp()
+                log.debug(
+                    "Caching file {0} at {1}".format(
+                        self._file_path, self._cached_folder
+                    )
+                )
                 self._cached_file = __salt__["cp.get_file"](
                     self._file_path, self._cached_folder
                 )

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -131,8 +131,9 @@ class HandleFileCopy:
                 "Caching file {0} at {1}".format(self._file_path, self._cached_folder)
             )
             if self._kwargs:
-                self._cached_file = __salt__["cp.get_template"](
-                    self._file_path, self._cached_folder, **self._kwargs
+                self._cached_file = salt.utils.files.mkstemp(dir=self._cached_folder)
+                __salt__["cp.get_template"](
+                    self._file_path, self._cached_file, **self._kwargs
                 )
             else:
                 self._cached_file = __salt__["cp.get_file"](

--- a/tests/unit/modules/test_junos.py
+++ b/tests/unit/modules/test_junos.py
@@ -1298,11 +1298,11 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 ret["out"] = True
                 self.assertEqual(
                     junos.install_config(
-                        "salt://actual/path/config", template_vars=dict(temp_var_1=True)
+                        "salt://actual/path/config", template_vars=True
                     ),
                     ret,
                 )
-                mock_mkstemp.assert_called_with(dir="/tmp/argr5351afd")
+                mock_mkstemp.assert_called_with()
 
     def test_install_config_replace(self):
         with patch.dict(

--- a/tests/unit/modules/test_junos.py
+++ b/tests/unit/modules/test_junos.py
@@ -1261,6 +1261,49 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 self.assertEqual(junos.install_config("salt://actual/path/config"), ret)
                 mock_load.assert_called_with(path="test/path/config", format="text")
 
+    def test_install_config_cache_not_exists(self):
+        with patch.dict(
+            junos.__salt__,
+            {
+                "cp.is_cached": MagicMock(return_value=None),
+                "file.rmdir": MagicMock(return_value="True"),
+            },
+        ):
+            with patch("jnpr.junos.utils.config.Config.commit") as mock_commit, patch(
+                "jnpr.junos.utils.config.Config.commit_check"
+            ) as mock_commit_check, patch(
+                "jnpr.junos.utils.config.Config.diff"
+            ) as mock_diff, patch(
+                "jnpr.junos.utils.config.Config.load"
+            ) as mock_load, patch(
+                "salt.utils.files.safe_rm"
+            ) as mock_safe_rm, patch(
+                "salt.utils.files.mkstemp"
+            ) as mock_mkstemp, patch(
+                "tempfile.mkdtemp"
+            ) as mock_mkdtemp, patch(
+                "os.path.isfile"
+            ) as mock_isfile, patch(
+                "os.path.getsize"
+            ) as mock_getsize:
+                mock_isfile.return_value = True
+                mock_getsize.return_value = 10
+                mock_mkstemp.return_value = "test/path/config"
+                mock_diff.return_value = "diff"
+                mock_commit_check.return_value = True
+                mock_mkdtemp.return_value = "/tmp/argr5351afd"
+
+                ret = dict()
+                ret["message"] = "Successfully loaded and committed!"
+                ret["out"] = True
+                self.assertEqual(
+                    junos.install_config(
+                        "salt://actual/path/config", template_vars=dict(temp_var_1=True)
+                    ),
+                    ret,
+                )
+                mock_mkstemp.assert_called_with(dir="/tmp/argr5351afd")
+
     def test_install_config_replace(self):
         with patch.dict(
             junos.__salt__,


### PR DESCRIPTION
### What does this PR do?

When cache is not present, while copy we used cp_get_template, this return folder name and not the file path. Hence we got this error
```
[ERROR   ] {'out': False, 'message': 'Could not load configuration due to : "[Errno 21] Is a directory: \'/tmp/tmpgcohosan\'"', 'format': 'set'}
```
Hence first create tmp file in given dir, and use this file path as the location for the rendered config file.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/57667

### Previous Behavior
It used to work in older salt. With recent code changes in master/sodium, this got broken.

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ y ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
