### PR TITLE
Added serial console options to `virt.running`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,37 +8,17 @@ Versions are `MAJOR.PATCH`.
 
 ### 3000.3
 
-### Removed
-
-### Deprecated
-
-### Changed
-
 ### Fixed
 - [#57100](https://github.com/saltstack/salt/pull/57100) - Address Issues in CVE Release
-### Added
 
 
 ### 3000.2
 
-### Removed
-
-### Deprecated
-
-### Changed
-
 ### Fixed
 - [#56987](https://github.com/saltstack/salt/pull/56987) - CVE fix
-### Added
 
 
 ### 3000.1
-
-### Removed
-
-### Deprecated
-
-### Changed
 
 ### Fixed
 - [#56082](https://github.com/saltstack/salt/pull/56082) - Fix saltversioninfo grain for new version
@@ -71,9 +51,8 @@ Versions are `MAJOR.PATCH`.
 - [#56418](https://github.com/saltstack/salt/pull/56418) - Ensure version.py included before we install
 - [#56435](https://github.com/saltstack/salt/pull/56435) - Update mac build scripts
 
-### Added
 
-## 3000 - Neon [2020-02-10]
+### 3000 - Neon [2020-02-10]
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ This changelog follows [keepachangelog](https://keepachangelog.com/en/1.0.0/) fo
 This project versioning is _similar_ to [Semantic Versioning](https://semver.org), and is documented in [SEP 14](https://github.com/saltstack/salt-enhancement-proposals/pull/20/files).
 Versions are `MAJOR.PATCH`.
 
+### 3000.3
+
+### Removed
+
+### Deprecated
+
+### Changed
+
+### Fixed
+- [#57100](https://github.com/saltstack/salt/pull/57100) - Address Issues in CVE Release
+### Added
+
+
+### 3000.2
+
+### Removed
+
+### Deprecated
+
+### Changed
+
+### Fixed
+- [#56987](https://github.com/saltstack/salt/pull/56987) - CVE fix
+### Added
+
+
 ### 3000.1
 
 ### Removed

--- a/doc/man/salt-api.1
+++ b/doc/man/salt-api.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-API" "1" "Apr 14, 2020" "3000.2" "Salt"
+.TH "SALT-API" "1" "May 05, 2020" "3000.3" "Salt"
 .SH NAME
 salt-api \- salt-api Command
 .

--- a/doc/man/salt-api.1
+++ b/doc/man/salt-api.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-API" "1" "Mar 10, 2020" "3000.1" "Salt"
+.TH "SALT-API" "1" "Apr 14, 2020" "3000.2" "Salt"
 .SH NAME
 salt-api \- salt-api Command
 .

--- a/doc/man/salt-call.1
+++ b/doc/man/salt-call.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-CALL" "1" "Apr 14, 2020" "3000.2" "Salt"
+.TH "SALT-CALL" "1" "May 05, 2020" "3000.3" "Salt"
 .SH NAME
 salt-call \- salt-call Documentation
 .

--- a/doc/man/salt-call.1
+++ b/doc/man/salt-call.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-CALL" "1" "Mar 10, 2020" "3000.1" "Salt"
+.TH "SALT-CALL" "1" "Apr 14, 2020" "3000.2" "Salt"
 .SH NAME
 salt-call \- salt-call Documentation
 .

--- a/doc/man/salt-cloud.1
+++ b/doc/man/salt-cloud.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-CLOUD" "1" "Mar 10, 2020" "3000.1" "Salt"
+.TH "SALT-CLOUD" "1" "Apr 14, 2020" "3000.2" "Salt"
 .SH NAME
 salt-cloud \- Salt Cloud Command
 .

--- a/doc/man/salt-cloud.1
+++ b/doc/man/salt-cloud.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-CLOUD" "1" "Apr 14, 2020" "3000.2" "Salt"
+.TH "SALT-CLOUD" "1" "May 05, 2020" "3000.3" "Salt"
 .SH NAME
 salt-cloud \- Salt Cloud Command
 .

--- a/doc/man/salt-cp.1
+++ b/doc/man/salt-cp.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-CP" "1" "Mar 10, 2020" "3000.1" "Salt"
+.TH "SALT-CP" "1" "Apr 14, 2020" "3000.2" "Salt"
 .SH NAME
 salt-cp \- salt-cp Documentation
 .

--- a/doc/man/salt-cp.1
+++ b/doc/man/salt-cp.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-CP" "1" "Apr 14, 2020" "3000.2" "Salt"
+.TH "SALT-CP" "1" "May 05, 2020" "3000.3" "Salt"
 .SH NAME
 salt-cp \- salt-cp Documentation
 .

--- a/doc/man/salt-key.1
+++ b/doc/man/salt-key.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-KEY" "1" "Mar 10, 2020" "3000.1" "Salt"
+.TH "SALT-KEY" "1" "Apr 14, 2020" "3000.2" "Salt"
 .SH NAME
 salt-key \- salt-key Documentation
 .

--- a/doc/man/salt-key.1
+++ b/doc/man/salt-key.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-KEY" "1" "Apr 14, 2020" "3000.2" "Salt"
+.TH "SALT-KEY" "1" "May 05, 2020" "3000.3" "Salt"
 .SH NAME
 salt-key \- salt-key Documentation
 .

--- a/doc/man/salt-master.1
+++ b/doc/man/salt-master.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-MASTER" "1" "Apr 14, 2020" "3000.2" "Salt"
+.TH "SALT-MASTER" "1" "May 05, 2020" "3000.3" "Salt"
 .SH NAME
 salt-master \- salt-master Documentation
 .

--- a/doc/man/salt-master.1
+++ b/doc/man/salt-master.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-MASTER" "1" "Mar 10, 2020" "3000.1" "Salt"
+.TH "SALT-MASTER" "1" "Apr 14, 2020" "3000.2" "Salt"
 .SH NAME
 salt-master \- salt-master Documentation
 .

--- a/doc/man/salt-minion.1
+++ b/doc/man/salt-minion.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-MINION" "1" "Mar 10, 2020" "3000.1" "Salt"
+.TH "SALT-MINION" "1" "Apr 14, 2020" "3000.2" "Salt"
 .SH NAME
 salt-minion \- salt-minion Documentation
 .

--- a/doc/man/salt-minion.1
+++ b/doc/man/salt-minion.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-MINION" "1" "Apr 14, 2020" "3000.2" "Salt"
+.TH "SALT-MINION" "1" "May 05, 2020" "3000.3" "Salt"
 .SH NAME
 salt-minion \- salt-minion Documentation
 .

--- a/doc/man/salt-proxy.1
+++ b/doc/man/salt-proxy.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-PROXY" "1" "Apr 14, 2020" "3000.2" "Salt"
+.TH "SALT-PROXY" "1" "May 05, 2020" "3000.3" "Salt"
 .SH NAME
 salt-proxy \- salt-proxy Documentation
 .

--- a/doc/man/salt-proxy.1
+++ b/doc/man/salt-proxy.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-PROXY" "1" "Mar 10, 2020" "3000.1" "Salt"
+.TH "SALT-PROXY" "1" "Apr 14, 2020" "3000.2" "Salt"
 .SH NAME
 salt-proxy \- salt-proxy Documentation
 .

--- a/doc/man/salt-run.1
+++ b/doc/man/salt-run.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-RUN" "1" "Apr 14, 2020" "3000.2" "Salt"
+.TH "SALT-RUN" "1" "May 05, 2020" "3000.3" "Salt"
 .SH NAME
 salt-run \- salt-run Documentation
 .

--- a/doc/man/salt-run.1
+++ b/doc/man/salt-run.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-RUN" "1" "Mar 10, 2020" "3000.1" "Salt"
+.TH "SALT-RUN" "1" "Apr 14, 2020" "3000.2" "Salt"
 .SH NAME
 salt-run \- salt-run Documentation
 .

--- a/doc/man/salt-ssh.1
+++ b/doc/man/salt-ssh.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-SSH" "1" "Mar 10, 2020" "3000.1" "Salt"
+.TH "SALT-SSH" "1" "Apr 14, 2020" "3000.2" "Salt"
 .SH NAME
 salt-ssh \- salt-ssh Documentation
 .

--- a/doc/man/salt-ssh.1
+++ b/doc/man/salt-ssh.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-SSH" "1" "Apr 14, 2020" "3000.2" "Salt"
+.TH "SALT-SSH" "1" "May 05, 2020" "3000.3" "Salt"
 .SH NAME
 salt-ssh \- salt-ssh Documentation
 .

--- a/doc/man/salt-syndic.1
+++ b/doc/man/salt-syndic.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-SYNDIC" "1" "Apr 14, 2020" "3000.2" "Salt"
+.TH "SALT-SYNDIC" "1" "May 05, 2020" "3000.3" "Salt"
 .SH NAME
 salt-syndic \- salt-syndic Documentation
 .

--- a/doc/man/salt-syndic.1
+++ b/doc/man/salt-syndic.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-SYNDIC" "1" "Mar 10, 2020" "3000.1" "Salt"
+.TH "SALT-SYNDIC" "1" "Apr 14, 2020" "3000.2" "Salt"
 .SH NAME
 salt-syndic \- salt-syndic Documentation
 .

--- a/doc/man/salt-unity.1
+++ b/doc/man/salt-unity.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-UNITY" "1" "Apr 14, 2020" "3000.2" "Salt"
+.TH "SALT-UNITY" "1" "May 05, 2020" "3000.3" "Salt"
 .SH NAME
 salt-unity \- salt-unity Command
 .

--- a/doc/man/salt-unity.1
+++ b/doc/man/salt-unity.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-UNITY" "1" "Mar 10, 2020" "3000.1" "Salt"
+.TH "SALT-UNITY" "1" "Apr 14, 2020" "3000.2" "Salt"
 .SH NAME
 salt-unity \- salt-unity Command
 .

--- a/doc/man/salt.1
+++ b/doc/man/salt.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT" "1" "Mar 10, 2020" "3000.1" "Salt"
+.TH "SALT" "1" "Apr 14, 2020" "3000.2" "Salt"
 .SH NAME
 salt \- salt
 .

--- a/doc/man/salt.1
+++ b/doc/man/salt.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT" "1" "Apr 14, 2020" "3000.2" "Salt"
+.TH "SALT" "1" "May 05, 2020" "3000.3" "Salt"
 .SH NAME
 salt \- salt
 .

--- a/doc/man/spm.1
+++ b/doc/man/spm.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SPM" "1" "Mar 10, 2020" "3000.1" "Salt"
+.TH "SPM" "1" "Apr 14, 2020" "3000.2" "Salt"
 .SH NAME
 spm \- Salt Package Manager Command
 .

--- a/doc/man/spm.1
+++ b/doc/man/spm.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SPM" "1" "Apr 14, 2020" "3000.2" "Salt"
+.TH "SPM" "1" "May 05, 2020" "3000.3" "Salt"
 .SH NAME
 spm \- Salt Package Manager Command
 .

--- a/doc/topics/hardening.rst
+++ b/doc/topics/hardening.rst
@@ -71,6 +71,10 @@ Salt hardening tips
   particularly sensitive minions. There is also :ref:`salt-ssh` or the
   :mod:`modules.sudo <salt.modules.sudo>` if you need to further restrict
   a minion.
+- Monitor specific security releated log messages. Salt ``salt-master`` logs
+  attempts to access methods which are not exposed to network clients. These log
+  messages are logged at the ``error`` log level and start with ``Requested
+  method not exposed``.
 
 .. _salt-users: https://groups.google.com/forum/#!forum/salt-users
 .. _salt-announce: https://groups.google.com/forum/#!forum/salt-announce

--- a/doc/topics/hardening.rst
+++ b/doc/topics/hardening.rst
@@ -36,7 +36,8 @@ General hardening tips
 - Don't expose the Salt master any more than what is required.
 - Harden the system as you would with any high-priority target.
 - Keep the system patched and up-to-date.
-- Use tight firewall rules.
+- Use tight firewall rules. Pay particular attention to TCP/4505 and TCP/4506
+  on the salt master and avoid exposing these ports unnecessarily.
 
 Salt hardening tips
 ===================

--- a/doc/topics/index.rst
+++ b/doc/topics/index.rst
@@ -110,6 +110,12 @@ is hosted by Google Groups. It is open to new members.
 
 .. _`salt-users mailing list`: https://groups.google.com/forum/#!forum/salt-users
 
+Additionally, all users of Salt should be subscribed to the Announcements mailing
+list which contains important updates about Salt, such as new releaes and
+security-related announcements. This list is low-traffic.
+
+.. _`salt-announce mailing list`: https://groups.google.com/forum/#!forum/salt-announce
+
 
 IRC
 ===

--- a/doc/topics/index.rst
+++ b/doc/topics/index.rst
@@ -141,6 +141,11 @@ is happening in Salt development:
 
 |saltrepo|
 
+Long-term planning and strategic decisions are handled via Salt Enhancement Proposals
+and can be found on GitHub.
+
+.. _`Salt Enhancement Proposals`: https://github.com/saltstack/salt-enhancement-proposals
+
 
 Blogs
 =====

--- a/doc/topics/releases/2019.2.4.rst
+++ b/doc/topics/releases/2019.2.4.rst
@@ -22,3 +22,22 @@ An issue was discovered in SaltStack Salt before 2019.2.4 and 3000 before 3000.2
 The salt-master process ClearFuncs class allows access to some methods
 that improperly sanitize paths. These methods allow arbitrary
 directory access to authenticated users.
+
+
+Known Issue
+===========
+
+Part of the fix for CVE-2020-11651 added better validation of the methods allowed to be called by remote clients.
+Both AESFuncs and ClearFuncs now have an explicit list of methods that can be called.
+The name of one of these whitlisted methods on AESFuncs had a typo.
+The _minion_runner method should be minion_runner (without the underscore prefix).
+This typo breaks the publish module’s runner method.
+Calling runners, for example:
+
+.. code-block:: bash
+
+    salt minion publish.runner manage.down
+
+Will not work, and you will receive and empty reply from the salt master.
+
+This will be addressed in the Sodium release of Salt set for mid-June 2020.

--- a/doc/topics/releases/2019.2.4.rst
+++ b/doc/topics/releases/2019.2.4.rst
@@ -1,0 +1,24 @@
+===========================
+Salt 2019.2.4 Release Notes
+===========================
+
+Version 2019.2.4 is a CVE-fix release for :ref:`2019.2.0 <release-2019-2-0>`.
+
+Security Fix
+============
+
+**CVE-2020-11651** 
+
+An issue was discovered in SaltStack Salt before 2019.2.4 and 3000 before 3000.2.
+The salt-master process ClearFuncs class does not properly validate
+method calls. This allows a remote user to access some methods without
+authentication. These methods can be used to retrieve user tokens from
+the salt master and/or run arbitrary commands on salt minions.
+
+
+**CVE-2020-11652** 
+
+An issue was discovered in SaltStack Salt before 2019.2.4 and 3000 before 3000.2.
+The salt-master process ClearFuncs class allows access to some methods
+that improperly sanitize paths. These methods allow arbitrary
+directory access to authenticated users.

--- a/doc/topics/releases/2019.2.5.rst
+++ b/doc/topics/releases/2019.2.5.rst
@@ -1,0 +1,5 @@
+===========================
+Salt 2019.2.5 Release Notes
+===========================
+
+Version 2019.2.5 is a bug-fix release for :ref:`2019.2.0 <release-2019-2-0>`.

--- a/doc/topics/releases/2019.2.5.rst
+++ b/doc/topics/releases/2019.2.5.rst
@@ -3,3 +3,50 @@ Salt 2019.2.5 Release Notes
 ===========================
 
 Version 2019.2.5 is a bug-fix release for :ref:`2019.2.0 <release-2019-2-0>`.
+
+Statistics
+==========
+
+- Total Merges: **2**
+- Total Issue References: **2**
+- Total PR References: **2**
+
+- Contributors: **2** (`dwoz`_, `frogunder`_)
+
+Changelog for v2019.2.4..v2019.2.5
+==================================
+
+*Generated at: 2020-05-05 22:43:12 UTC*
+
+* **PR** `#57096`_: (`frogunder`_) Update man_pages 2019.2.5
+  @ *2020-05-05 22:10:46 UTC*
+
+  * 6877b7259a Merge pull request `#57096`_ from frogunder/man_pages_2019.2.5
+
+  * 58ea351a59 Update man_pages 2019.2.5
+
+* **ISSUE** `#57027`_: (`ecarson`_) [BUG] Master running 2019.2.4 or 3000.2 unable to synchronize files using saltutil.sync_all to 2017.7.1 minion due to CVE fix (refs: `#57090`_)
+
+* **ISSUE** `#57016`_: (`idontwanttosignin`_) [BUG] Requested method not exposed: minion_runner (refs: `#57090`_)
+
+* **PR** `#57090`_: (`dwoz`_) Address Issues in CVE Release
+  @ *2020-05-05 22:09:25 UTC*
+
+  * 8fe0f66f94 Merge pull request `#57090`_ from dwoz/bugs_n_stuff
+
+  * f3e8590bac Describe SEPs
+
+  * aa1a9d340d Update hardening doc to mention 4505/4506
+
+  * ca303f7c0c Add link to salt-announce to documentation
+
+  * c63253ef9c Address issues in cve release
+
+.. _`#57016`: https://github.com/saltstack/salt/issues/57016
+.. _`#57027`: https://github.com/saltstack/salt/issues/57027
+.. _`#57090`: https://github.com/saltstack/salt/pull/57090
+.. _`#57096`: https://github.com/saltstack/salt/pull/57096
+.. _`dwoz`: https://github.com/dwoz
+.. _`ecarson`: https://github.com/ecarson
+.. _`frogunder`: https://github.com/frogunder
+.. _`idontwanttosignin`: https://github.com/idontwanttosignin

--- a/doc/topics/releases/3000.1.rst
+++ b/doc/topics/releases/3000.1.rst
@@ -9,16 +9,32 @@ Version 3000.1 is a bugfix release for :ref:`3000 <release-3000>`.
 Statistics
 ==========
 
-- Total Merges: **51**
+- Total Merges: **53**
 - Total Issue References: **15**
-- Total PR References: **52**
+- Total PR References: **54**
 
 - Contributors: **16** (`Ch3LL`_, `UtahDave`_, `bryceml`_, `cmcmarrow`_, `dwoz`_, `frogunder`_, `garethgreenaway`_, `lorengordon`_, `mchugh19`_, `oeuftete`_, `raddessi`_, `s0undt3ch`_, `sjorge`_, `terminalmage`_, `twangboy`_, `waynew`_)
 
 Changelog for v3000..v3000.1
 ============================
 
-*Generated at: 2020-03-24 19:52:52 UTC*
+*Generated at: 2020-03-27 16:48:41 UTC*
+
+* **PR** `#56455`_: (`s0undt3ch`_) Fix gitpython windows requirement
+  @ *2020-03-27 16:31:57 UTC*
+
+  * c5a700e01e Merge pull request `#56455`_ from s0undt3ch/hotfix/gitpython
+
+  * d9791c393f Revert and fix windows requirements
+
+  * 4b573c1c94 Revert "Fix win deps"
+
+* **PR** `#56446`_: (`frogunder`_) 3000.1 releasenotes updates
+  @ *2020-03-24 20:28:23 UTC*
+
+  * 7ba36325d9 Merge pull request `#56446`_ from frogunder/releasenotes_3000.1_updates
+
+  * 6b47f474af 3000.1 releasenotes updates
 
 * **PR** `#56435`_: (`twangboy`_) Update mac build scripts
   @ *2020-03-24 19:47:40 UTC*
@@ -122,7 +138,7 @@ Changelog for v3000..v3000.1
 
   * 6c83beeb9e Fix win deps
 
-* **PR** `#56378`_: (`Ch3LL`_)  Include _version.py if building wheel
+* **PR** `#56378`_: (`Ch3LL`_)  Include _version.py if building wheel 
   @ *2020-03-17 17:01:33 UTC*
 
   * e72a8d2cbc Merge pull request `#56378`_ from Ch3LL/wheel_version
@@ -564,7 +580,7 @@ Changelog for v3000..v3000.1
 
 * **ISSUE** `#56121`_: (`githubcdr`_) salt-minion broken after upgrade to 3000 (refs: `#56143`_)
 
-* **ISSUE** `#51854`_: (`Oloremo`_) Fluorine: minion_pillar_cache: True leads to exception (refs: `#52195`_, `#56143`_)
+* **ISSUE** `#51854`_: (`Oloremo`_) Fluorine: minion_pillar_cache: True leads to exception (refs: `#56143`_, `#52195`_)
 
 * **PR** `#56143`_: (`waynew`_) Use encoding when caching pillar data
   @ *2020-03-10 01:33:37 UTC*
@@ -700,6 +716,8 @@ Changelog for v3000..v3000.1
 .. _`#56433`: https://github.com/saltstack/salt/issues/56433
 .. _`#56435`: https://github.com/saltstack/salt/pull/56435
 .. _`#56436`: https://github.com/saltstack/salt/pull/56436
+.. _`#56446`: https://github.com/saltstack/salt/pull/56446
+.. _`#56455`: https://github.com/saltstack/salt/pull/56455
 .. _`Ch3LL`: https://github.com/Ch3LL
 .. _`Oloremo`: https://github.com/Oloremo
 .. _`UtahDave`: https://github.com/UtahDave

--- a/doc/topics/releases/3000.2.rst
+++ b/doc/topics/releases/3000.2.rst
@@ -1,0 +1,24 @@
+===========================
+Salt 3000.2 Release Notes
+===========================
+
+Version 3000.2 is a CVE-fix release for :ref:`3000 <release-3000>`.
+
+Security Fix
+============
+
+**CVE-2020-11651** 
+
+An issue was discovered in SaltStack Salt before 2019.2.4 and 3000 before 3000.2.
+The salt-master process ClearFuncs class does not properly validate
+method calls. This allows a remote user to access some methods without
+authentication. These methods can be used to retrieve user tokens from
+the salt master and/or run arbitrary commands on salt minions.
+
+
+**CVE-2020-11652** 
+
+An issue was discovered in SaltStack Salt before 2019.2.4 and 3000 before 3000.2.
+The salt-master process ClearFuncs class allows access to some methods
+that improperly sanitize paths. These methods allow arbitrary
+directory access to authenticated users.

--- a/doc/topics/releases/3000.2.rst
+++ b/doc/topics/releases/3000.2.rst
@@ -22,3 +22,20 @@ An issue was discovered in SaltStack Salt before 2019.2.4 and 3000 before 3000.2
 The salt-master process ClearFuncs class allows access to some methods
 that improperly sanitize paths. These methods allow arbitrary
 directory access to authenticated users.
+
+
+Known Issue
+===========
+
+Part of the fix for CVE-2020-11651 added better validation of the methods allowed to be called by remote clients.
+Both AESFuncs and ClearFuncs now have an explicit list of methods that can be called.
+The name of one of these whitlisted methods on AESFuncs had a typo.
+The _minion_runner method should be minion_runner (without the underscore prefix).
+This typo breaks the publish module’s runner method.
+Calling runners, for example:
+
+.. code-block:: bash
+
+    salt minion publish.runner manage.down
+
+Will not work, and you will receive and empty reply from the salt master.

--- a/doc/topics/releases/3000.2.rst
+++ b/doc/topics/releases/3000.2.rst
@@ -39,3 +39,5 @@ Calling runners, for example:
     salt minion publish.runner manage.down
 
 Will not work, and you will receive and empty reply from the salt master.
+
+This will be addressed in the Sodium release of Salt set for mid-June 2020.

--- a/doc/topics/releases/3000.3.rst
+++ b/doc/topics/releases/3000.3.rst
@@ -1,0 +1,39 @@
+===========================
+Salt 3000.3 Release Notes
+===========================
+
+Version 3000.3 is a bug-fix release for :ref:`3000 <release-3000>`.
+
+Statistics
+==========
+
+- Total Merges: **2**
+- Total Issue References: **2**
+- Total PR References: **2**
+
+- Contributors: **2** (`dwoz`_, `frogunder`_)
+
+
+Changelog for v3000.2..v3000.3
+==============================
+
+*Generated at: 2020-05-06 02:53:12 UTC*
+
+* **PR** `#57097`_: (`frogunder`_) Update man_pages 3000.3
+  @ *2020-05-05 22:13:09 UTC*
+
+* **ISSUE** `#57027`_: (`ecarson`_) [BUG] Master running 2019.2.4 or 3000.2 unable to synchronize files using saltutil.sync_all to 2017.7.1 minion due to CVE fix (refs: `#57100`_)
+
+* **ISSUE** `#57016`_: (`idontwanttosignin`_) [BUG] Requested method not exposed: minion_runner (refs: `#57100`_)
+
+* **PR** `#57100`_: (`dwoz`_) Address Issues in CVE Release
+  @ *2020-05-05 22:09:25 UTC*
+
+.. _`#57016`: https://github.com/saltstack/salt/issues/57016
+.. _`#57027`: https://github.com/saltstack/salt/issues/57027
+.. _`#57097`: https://github.com/saltstack/salt/pull/57097
+.. _`#57100`: https://github.com/saltstack/salt/pull/57100
+.. _`dwoz`: https://github.com/dwoz
+.. _`ecarson`: https://github.com/ecarson
+.. _`frogunder`: https://github.com/frogunder
+.. _`idontwanttosignin`: https://github.com/idontwanttosignin

--- a/salt/master.py
+++ b/salt/master.py
@@ -1177,9 +1177,9 @@ class AESFuncs(TransportMethods):
         'verify_minion', '_master_tops', '_ext_nodes', '_master_opts',
         '_mine_get', '_mine', '_mine_delete', '_mine_flush', '_file_recv',
         '_pillar', '_minion_event', '_handle_minion_event', '_return',
-        '_syndic_return', '_minion_runner', 'pub_ret', 'minion_pub',
-        'minion_publish', 'revoke_auth', 'run_func', '_serve_file',
-        '_file_find', '_file_hash', '_file_find_and_stat', '_file_list',
+        '_syndic_return', 'minion_runner', 'pub_ret', 'minion_pub',
+        'minion_publish', 'revoke_auth', '_serve_file', '_file_find',
+        '_file_hash', '_file_hash_and_stat', '_file_list',
         '_file_list_emptydirs', '_dir_list', '_symlink_list', '_file_envs',
     )
 

--- a/salt/master.py
+++ b/salt/master.py
@@ -1162,7 +1162,7 @@ class TransportMethods(object):
             try:
                 return getattr(self, name)
             except AttributeError:
-                log.error("Expose method not found: %s", name)
+                log.error("Requested method not exposed: %s", name)
         else:
             log.error("Requested method not exposed: %s", name)
 

--- a/salt/master.py
+++ b/salt/master.py
@@ -1088,12 +1088,13 @@ class MWorker(salt.utils.process.SignalHandlingProcess):
         '''
         log.trace('Clear payload received with command %s', load['cmd'])
         cmd = load['cmd']
-        if cmd.startswith('__'):
-            return False
+        method = self.clear_funcs.get_method(cmd)
+        if not method:
+            return {}, {'fun': 'send_clear'}
         if self.opts['master_stats']:
             start = time.time()
             self.stats[cmd]['runs'] += 1
-        ret = getattr(self.clear_funcs, cmd)(load), {'fun': 'send_clear'}
+        ret = method(load), {'fun': 'send_clear'}
         if self.opts['master_stats']:
             self._post_stats(start, cmd)
         return ret
@@ -1111,8 +1112,9 @@ class MWorker(salt.utils.process.SignalHandlingProcess):
             return {}
         cmd = data['cmd']
         log.trace('AES payload received with command %s', data['cmd'])
-        if cmd.startswith('__'):
-            return False
+        method = self.aes_funcs.get_method(cmd)
+        if not method:
+            return {}, {'fun': 'send'}
         if self.opts['master_stats']:
             start = time.time()
             self.stats[cmd]['runs'] += 1
@@ -1143,13 +1145,44 @@ class MWorker(salt.utils.process.SignalHandlingProcess):
         self.__bind()
 
 
+class TransportMethods(object):
+    '''
+    Expose methods to the transport layer, methods with their names found in
+    the class attribute 'expose_methods' will be exposed to the transport layer
+    via 'get_method'.
+    '''
+
+    expose_methods = ()
+
+    def get_method(self, name):
+        '''
+        Get a method which should be exposed to the transport layer
+        '''
+        if name in self.expose_methods:
+            try:
+                return getattr(self, name)
+            except AttributeError:
+                log.error("Expose method not found: %s", name)
+        else:
+            log.error("Requested method not exposed: %s", name)
+
+
 # TODO: rename? No longer tied to "AES", just "encrypted" or "private" requests
-class AESFuncs(object):
+class AESFuncs(TransportMethods):
     '''
     Set up functions that are available when the load is encrypted with AES
     '''
-    # The AES Functions:
-    #
+
+    expose_methods = (
+        'verify_minion', '_master_tops', '_ext_nodes', '_master_opts',
+        '_mine_get', '_mine', '_mine_delete', '_mine_flush', '_file_recv',
+        '_pillar', '_minion_event', '_handle_minion_event', '_return',
+        '_syndic_return', '_minion_runner', 'pub_ret', 'minion_pub',
+        'minion_publish', 'revoke_auth', 'run_func', '_serve_file',
+        '_file_find', '_file_hash', '_file_find_and_stat', '_file_list',
+        '_file_list_emptydirs', '_dir_list', '_symlink_list', '_file_envs',
+    )
+
     def __init__(self, opts):
         '''
         Create a new AESFuncs
@@ -1863,11 +1896,18 @@ class AESFuncs(object):
         return ret, {'fun': 'send'}
 
 
-class ClearFuncs(object):
+class ClearFuncs(TransportMethods):
     '''
     Set up functions that are safe to execute when commands sent to the master
     without encryption and authentication
     '''
+
+    # These methods will be exposed to the transport layer by
+    # MWorker._handle_clear
+    expose_methods = (
+        'ping', 'publish', 'get_token', 'mk_token', 'wheel', 'runner',
+    )
+
     # The ClearFuncs object encapsulates the functions that can be executed in
     # the clear:
     # publish (The publish from the LocalClient)

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -92,7 +92,12 @@ import jinja2
 import jinja2.exceptions
 try:
     import libvirt  # pylint: disable=import-error
+
+    # pylint: disable=no-name-in-module
     from libvirt import libvirtError
+
+    # pylint: enable=no-name-in-module
+
     HAS_LIBVIRT = True
 except ImportError:
     HAS_LIBVIRT = False

--- a/salt/states/virt.py
+++ b/salt/states/virt.py
@@ -265,7 +265,10 @@ def running(name,
             password=None,
             os_type=None,
             arch=None,
-            boot=None):
+            boot=None,
+            serial_type=None,
+            console=True,
+            telnet_port=None):
     '''
     Starts an existing guest, or defines and starts a new VM with specified arguments.
 
@@ -367,6 +370,25 @@ def running(name,
 
         .. versionadded:: 3000
 
+
+    :param serial_type: 
+        Serial device type. One of 'pty', 'tcp' (Default: None)
+        Only used when creating a new virtual machine.
+    
+        .. versionadded:: 3000.4
+
+    :param console: 
+        True to add a console device along with serial one (Default: True)      
+        Only used when creating a new virtual machine.
+
+        .. versionadded:: 3000.4
+
+    :param telnet_port: 
+        Telnet port to use for serial device of type tcp (Default: None)
+        Only used when creating a new virtual machine.
+
+        .. versionadded:: 3000.4
+        
     .. rubric:: Example States
 
     Make sure an already-defined virtual machine called ``domain_name`` is running:
@@ -487,7 +509,10 @@ def running(name,
                                   connection=connection,
                                   username=username,
                                   password=password,
-                                  boot=boot)
+                                  boot=boot,
+                                  serial_type=serial_type,
+                                  console=console,
+                                  telnet_port=telnet_port)
             ret['changes'][name] = 'Domain defined and started'
             ret['comment'] = 'Domain {0} defined and started'.format(name)
     except libvirt.libvirtError as err:

--- a/salt/tokens/localfs.py
+++ b/salt/tokens/localfs.py
@@ -12,6 +12,7 @@ import logging
 
 import salt.utils.files
 import salt.utils.path
+import salt.utils.verify
 import salt.payload
 
 from salt.ext import six
@@ -61,6 +62,8 @@ def get_token(opts, tok):
     :returns: Token data if successful. Empty dict if failed.
     '''
     t_path = os.path.join(opts['token_dir'], tok)
+    if not salt.utils.verify.clean_path(opts['token_dir'], t_path):
+        return {}
     if not os.path.isfile(t_path):
         return {}
     serial = salt.payload.Serial(opts)

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -31,6 +31,7 @@ import salt.utils.files
 import salt.utils.path
 import salt.utils.platform
 import salt.utils.user
+import salt.ext.six
 
 log = logging.getLogger(__name__)
 
@@ -495,23 +496,69 @@ def check_max_open_files(opts):
     log.log(level=level, msg=msg)
 
 
+def _realpath_darwin(path):
+    base = ''
+    for part in path.split(os.path.sep)[1:]:
+        if base != '':
+            if os.path.islink(os.path.sep.join([base, part])):
+                base = os.readlink(os.path.sep.join([base, part]))
+            else:
+                base = os.path.abspath(os.path.sep.join([base, part]))
+        else:
+            base = os.path.abspath(os.path.sep.join([base, part]))
+    return base
+
+
+def _realpath_windows(path):
+    base = ''
+    for part in path.split(os.path.sep):
+        if base != '':
+            try:
+                part = os.readlink(os.path.sep.join([base, part]))
+                base = os.path.abspath(part)
+            except OSError:
+                base = os.path.abspath(os.path.sep.join([base, part]))
+        else:
+            base = part
+    return base
+
+
+def _realpath(path):
+    '''
+    Cross platform realpath method. On Windows when python 3, this method
+    uses the os.readlink method to resolve any filesystem links. On Windows
+    when python 2, this method is a no-op. All other platforms and version use
+    os.path.realpath
+    '''
+    if salt.utils.platform.is_darwin():
+        return _realpath_darwin(path)
+    elif salt.utils.platform.is_windows():
+        if salt.ext.six.PY3:
+            return _realpath_windows(path)
+        else:
+            return path
+    return os.path.realpath(path)
+
+
 def clean_path(root, path, subdir=False):
     '''
     Accepts the root the path needs to be under and verifies that the path is
     under said root. Pass in subdir=True if the path can result in a
     subdirectory of the root instead of having to reside directly in the root
     '''
-    if not os.path.isabs(root):
+    real_root = _realpath(root)
+    if not os.path.isabs(real_root):
         return ''
     if not os.path.isabs(path):
         path = os.path.join(root, path)
     path = os.path.normpath(path)
+    real_path = _realpath(path)
     if subdir:
-        if path.startswith(root):
-            return path
+        if real_path.startswith(real_root):
+            return real_path
     else:
-        if os.path.dirname(path) == os.path.normpath(root):
-            return path
+        if os.path.dirname(real_path) == os.path.normpath(real_root):
+            return real_path
     return ''
 
 

--- a/salt/wheel/config.py
+++ b/salt/wheel/config.py
@@ -12,6 +12,7 @@ import os
 import salt.config
 import salt.utils.files
 import salt.utils.yaml
+import salt.utils.verify
 
 # Import 3rd-party libs
 from salt.ext import six

--- a/salt/wheel/config.py
+++ b/salt/wheel/config.py
@@ -75,13 +75,19 @@ def update_config(file_name, yaml_contents):
     dir_path = os.path.join(__opts__['config_dir'],
                             os.path.dirname(__opts__['default_include']))
     try:
-        yaml_out = salt.utils.yaml.safe_dump(yaml_contents, default_flow_style=False)
+        yaml_out = salt.utils.yaml.safe_dump(
+            yaml_contents,
+            default_flow_style=False,
+        )
 
         if not os.path.exists(dir_path):
             log.debug('Creating directory %s', dir_path)
             os.makedirs(dir_path, 0o755)
 
         file_path = os.path.join(dir_path, file_name)
+        if not salt.utils.verify.clean_path(dir_path, file_path):
+            return 'Invalid path'
+
         with salt.utils.files.fopen(file_path, 'w') as fp_:
             fp_.write(yaml_out)
 

--- a/salt/wheel/file_roots.py
+++ b/salt/wheel/file_roots.py
@@ -25,6 +25,8 @@ def find(path, saltenv='base'):
         return ret
     for root in __opts__['file_roots'][saltenv]:
         full = os.path.join(root, path)
+        if not salt.utils.verify.clean_path(root, full):
+            continue
         if os.path.isfile(full):
             # Add it to the dict
             with salt.utils.files.fopen(full, 'rb') as fp_:
@@ -107,7 +109,10 @@ def write(data, path, saltenv='base', index=0):
     if os.path.isabs(path):
         return ('The path passed in {0} is not relative to the environment '
                 '{1}').format(path, saltenv)
-    dest = os.path.join(__opts__['file_roots'][saltenv][index], path)
+    root = __opts__['file_roots'][saltenv][index]
+    dest = os.path.join(root, path)
+    if not salt.utils.verify.clean_path(root, dest, subdir=True):
+        return 'Invalid path: {}'.format(path)
     dest_dir = os.path.dirname(dest)
     if not os.path.isdir(dest_dir):
         os.makedirs(dest_dir)

--- a/tests/integration/master/test_clear_funcs.py
+++ b/tests/integration/master/test_clear_funcs.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, unicode_literals
+import getpass
+import os
+import tempfile
+import time
+
+import salt.master
+import salt.transport.client
+import salt.utils.platform
+import salt.utils.files
+import salt.utils.user
+
+from tests.support.case import TestCase
+from tests.support.mixins import AdaptedConfigurationTestCaseMixin
+from tests.support.runtests import RUNTIME_VARS
+
+
+def keyuser():
+    user = salt.utils.user.get_specific_user()
+    if user.startswith('sudo_'):
+        user = user[5:].replace('\\', '_')
+    return user
+
+
+class ClearFuncsAuthTestCase(TestCase):
+
+    def test_auth_info_not_allowed(self):
+        assert hasattr(salt.master.ClearFuncs, '_prep_auth_info')
+        master = '127.0.0.1'
+        ret_port = 64506
+        user = getpass.getuser()
+        keyfile = '.{}_key'.format(user)
+
+        keypath = os.path.join(RUNTIME_VARS.TMP, 'rootdir', 'cache', keyfile)
+
+        with salt.utils.files.fopen(keypath) as keyfd:
+            key = keyfd.read()
+
+        minion_config = {
+            'transport': 'zeromq',
+            'pki_dir': '/tmp',
+            'id': 'root',
+            'master_ip': master,
+            'master_port': ret_port,
+            'auth_timeout': 5,
+            'auth_tries': 1,
+            'master_uri': 'tcp://{0}:{1}'.format(master, ret_port)
+        }
+
+        clear_channel = salt.transport.client.ReqChannel.factory(
+            minion_config, crypt='clear')
+
+        msg = {'cmd': '_prep_auth_info'}
+        rets = clear_channel.send(msg, timeout=15)
+        ret_key = None
+        for ret in rets:
+            try:
+                ret_key = ret[user]
+                break
+            except (TypeError, KeyError):
+                pass
+        assert ret_key != key, 'Able to retrieve user key'
+
+
+class ClearFuncsPubTestCase(TestCase):
+
+    def setUp(self):
+        self.master = '127.0.0.1'
+        self.ret_port = 64506
+        self.tmpfile = os.path.join(tempfile.mkdtemp(), 'evil_file')
+        self.master_opts = AdaptedConfigurationTestCaseMixin.get_config('master')
+
+    def tearDown(self):
+        try:
+            os.remove(self.tmpfile + 'x')
+        except OSError:
+            pass
+        delattr(self, 'master')
+        delattr(self, 'ret_port')
+        delattr(self, 'tmpfile')
+
+    def test_pub_not_allowed(self):
+        assert hasattr(salt.master.ClearFuncs, '_send_pub')
+        assert not os.path.exists(self.tmpfile)
+        minion_config = {
+            'transport': 'zeromq',
+            'pki_dir': '/tmp',
+            'id': 'root',
+            'master_ip': self.master,
+            'master_port': self.ret_port,
+            'auth_timeout': 5,
+            'auth_tries': 1,
+            'master_uri': 'tcp://{0}:{1}'.format(self.master, self.ret_port),
+        }
+        clear_channel = salt.transport.client.ReqChannel.factory(
+            minion_config, crypt='clear')
+        jid = '202003100000000001'
+        msg = {
+            'cmd': '_send_pub',
+            'fun': 'file.write',
+            'jid': jid,
+            'arg': [self.tmpfile, 'evil contents'],
+            'kwargs': {'show_jid': False, 'show_timeout': False},
+            'ret': '',
+            'tgt': 'minion',
+            'tgt_type': 'glob',
+            'user': 'root'
+        }
+        eventbus = salt.utils.event.get_event(
+            'master',
+            sock_dir=self.master_opts['sock_dir'],
+            transport=self.master_opts['transport'],
+            opts=self.master_opts)
+        ret = clear_channel.send(msg, timeout=15)
+        if salt.utils.platform.is_windows():
+            time.sleep(30)
+            timeout = 30
+        else:
+            timeout = 5
+        ret_evt = None
+        start = time.time()
+        while time.time() - start <= timeout:
+            raw = eventbus.get_event(timeout, auto_reconnect=True)
+            if raw and 'jid' in raw and raw['jid'] == jid:
+                ret_evt = raw
+                break
+        assert not os.path.exists(self.tmpfile), 'Evil file created'

--- a/tests/integration/master/test_clear_funcs.py
+++ b/tests/integration/master/test_clear_funcs.py
@@ -126,3 +126,185 @@ class ClearFuncsPubTestCase(TestCase):
                 ret_evt = raw
                 break
         assert not os.path.exists(self.tmpfile), 'Evil file created'
+
+
+class ClearFuncsConfigTest(TestCase):
+
+    def setUp(self):
+        master_opts = AdaptedConfigurationTestCaseMixin.get_config('master')
+        self.conf_dir = os.path.dirname(master_opts['conf_file'])
+        master = '127.0.0.1'
+        ret_port = 64506
+        user = keyuser()
+        keyfile = '.{}_key'.format(user)
+        keypath = os.path.join(RUNTIME_VARS.TMP, 'rootdir', 'cache', keyfile)
+
+        with salt.utils.files.fopen(keypath) as keyfd:
+            self.key = keyfd.read()
+
+        self.minion_config = {
+            'transport': 'zeromq',
+            'pki_dir': '/tmp',
+            'id': 'root',
+            'master_ip': master,
+            'master_port': ret_port,
+            'auth_timeout': 5,
+            'auth_tries': 1,
+            'master_uri': 'tcp://{0}:{1}'.format(master, ret_port)
+        }
+
+    def tearDown(self):
+        try:
+            os.remove(os.path.join(self.conf_dir, 'evil.conf'))
+        except OSError:
+            pass
+        delattr(self, 'conf_dir')
+        delattr(self, 'key')
+        delattr(self, 'minion_config')
+
+    def test_clearfuncs_config(self):
+        clear_channel = salt.transport.client.ReqChannel.factory(
+            self.minion_config, crypt='clear')
+
+        msg = {
+           'key': self.key,
+           'cmd': 'wheel',
+           'fun': 'config.update_config',
+           'file_name': '../evil',
+           'yaml_contents': 'win',
+        }
+        ret = clear_channel.send(msg, timeout=5)
+        assert not os.path.exists(os.path.join(self.conf_dir, 'evil.conf')), \
+            'Wrote file via directory traversal'
+
+
+class ClearFuncsFileRoots(TestCase):
+
+    def setUp(self):
+        self.master_opts = AdaptedConfigurationTestCaseMixin.get_config('master')
+        self.target_dir = os.path.dirname(
+            self.master_opts['file_roots']['base'][0]
+        )
+        master = '127.0.0.1'
+        ret_port = 64506
+        user = keyuser()
+        self.keyfile = '.{}_key'.format(user)
+        keypath = os.path.join(RUNTIME_VARS.TMP, 'rootdir', 'cache', self.keyfile)
+
+        with salt.utils.files.fopen(keypath) as keyfd:
+            self.key = keyfd.read()
+
+        self.minion_config = {
+            'transport': 'zeromq',
+            'pki_dir': '/tmp',
+            'id': 'root',
+            'master_ip': master,
+            'master_port': ret_port,
+            'auth_timeout': 5,
+            'auth_tries': 1,
+            'master_uri': 'tcp://{0}:{1}'.format(master, ret_port)
+        }
+
+    def tearDown(self):
+        try:
+            os.remove(os.path.join(self.target_dir, 'pwn.txt'))
+        except OSError:
+            pass
+        delattr(self, 'master_opts')
+        delattr(self, 'target_dir')
+        delattr(self, 'keyfile')
+        delattr(self, 'key')
+        delattr(self, 'minion_config')
+
+    def test_fileroots_write(self):
+        clear_channel = salt.transport.client.ReqChannel.factory(
+            self.minion_config, crypt='clear')
+
+        msg = {
+            'key': self.key,
+            'cmd': 'wheel',
+            'fun': 'file_roots.write',
+            'data': 'win',
+            'path': os.path.join('..', 'pwn.txt'),
+            'saltenv': 'base',
+        }
+        ret = clear_channel.send(msg, timeout=5)
+        assert not os.path.exists(os.path.join(self.target_dir, 'pwn.txt')), \
+            'Wrote file via directory traversal'
+
+    def test_fileroots_read(self):
+        rootdir = self.master_opts['root_dir']
+        fileroot = self.master_opts['file_roots']['base'][0]
+        # If this asserion fails the test may need to be re-written
+        assert os.path.dirname(os.path.dirname(rootdir)) == os.path.dirname(fileroot)
+        clear_channel = salt.transport.client.ReqChannel.factory(
+            self.minion_config, crypt='clear')
+        readpath = os.path.join(
+            '..',
+            'salt-tests-tmpdir',
+            'rootdir',
+            'cache',
+            self.keyfile,
+        )
+        msg = {
+            'key': self.key,
+            'cmd': 'wheel',
+            'fun': 'file_roots.read',
+            'path': os.path.join(
+                '..',
+                'salt-tests-tmpdir',
+                'rootdir',
+                'cache',
+                self.keyfile,
+            ),
+            'saltenv': 'base',
+        }
+
+        ret = clear_channel.send(msg, timeout=5)
+        try:
+            # When vulnerable this assertion will fail.
+            assert list(ret['data']['return'][0].items())[0][1] != self.key, \
+                'Read file via directory traversal'
+        except IndexError:
+            pass
+        # If the vulnerability is fixed, no data will be returned.
+        assert ret['data']['return'] == []
+
+
+class ClearFuncsTokenTest(TestCase):
+
+    def setUp(self):
+        self.master_opts = AdaptedConfigurationTestCaseMixin.get_config('master')
+        master = '127.0.0.1'
+        ret_port = 64506
+        self.minion_config = {
+            'transport': 'zeromq',
+            'pki_dir': '/tmp',
+            'id': 'root',
+            'master_ip': master,
+            'master_port': ret_port,
+            'auth_timeout': 5,
+            'auth_tries': 1,
+            'master_uri': 'tcp://{0}:{1}'.format(master, ret_port)
+        }
+
+    def tearDown(self):
+        delattr(self, 'master_opts')
+        delattr(self, 'minion_config')
+
+    def test_token(self):
+        tokensdir = os.path.join(
+            self.master_opts['root_dir'],
+            self.master_opts['cachedir'],
+            'tokens'
+        )
+        assert os.path.exists(tokensdir), tokensdir
+        clear_channel = salt.transport.client.ReqChannel.factory(
+            self.minion_config, crypt='clear')
+        msg = {
+            'arg': [],
+            'cmd': 'get_token',
+            'token': os.path.join('..', 'minions', 'minion', 'data.p'),
+        }
+        ret = clear_channel.send(msg, timeout=5)
+        assert 'pillar' not in ret, 'Read minion data via directory traversal'

--- a/tests/integration/master/test_clear_funcs.py
+++ b/tests/integration/master/test_clear_funcs.py
@@ -176,6 +176,7 @@ class ClearFuncsConfigTest(TestCase):
         ret = clear_channel.send(msg, timeout=5)
         assert not os.path.exists(os.path.join(self.conf_dir, 'evil.conf')), \
             'Wrote file via directory traversal'
+        assert ret['data']['return'] == 'Invalid path'
 
 
 class ClearFuncsFileRoots(TestCase):

--- a/tests/unit/test_master.py
+++ b/tests/unit/test_master.py
@@ -32,6 +32,115 @@ class TransportMethodsTest(TestCase):
         assert foo.get_method('bar') is not None
         assert foo.get_method('bang') is None
 
+    def test_aes_funcs_white(self):
+        '''
+        Validate methods exposed on AESFuncs exist and are callable
+        '''
+        opts = salt.config.master_config(None)
+        aes_funcs = salt.master.AESFuncs(opts)
+        for name in aes_funcs.expose_methods:
+            func = getattr(aes_funcs, name, None)
+            assert callable(func)
+
+    def test_aes_funcs_black(self):
+        '''
+        Validate methods on AESFuncs that should not be called remotely
+        '''
+        opts = salt.config.master_config(None)
+        aes_funcs = salt.master.AESFuncs(opts)
+        # Any callable that should not explicitly be allowed should be added
+        # here.
+        blacklist_methods = [
+            '_AESFuncs__setup_fileserver',
+            '_AESFuncs__verify_load',
+            '_AESFuncs__verify_minion',
+            '_AESFuncs__verify_minion_publish',
+            '__class__',
+            '__delattr__',
+            '__dir__',
+            '__eq__',
+            '__format__',
+            '__ge__',
+            '__getattribute__',
+            '__gt__',
+            '__hash__',
+            '__init__',
+            '__init_subclass__',
+            '__le__',
+            '__lt__',
+            '__ne__',
+            '__new__',
+            '__reduce__',
+            '__reduce_ex__',
+            '__repr__',
+            '__setattr__',
+            '__sizeof__',
+            '__str__',
+            '__subclasshook__',
+            'get_method',
+            'run_func',
+
+        ]
+        for name in dir(aes_funcs):
+            if name in aes_funcs.expose_methods:
+                continue
+            if not callable(getattr(aes_funcs, name)):
+                continue
+            assert name in blacklist_methods, name
+
+    def test_clear_funcs_white(self):
+        '''
+        Validate methods exposed on ClearFuncs exist and are callable
+        '''
+        opts = salt.config.master_config(None)
+        clear_funcs = salt.master.ClearFuncs(opts, {})
+        for name in clear_funcs.expose_methods:
+            func = getattr(clear_funcs, name, None)
+            assert callable(func)
+
+    def test_clear_funcs_black(self):
+        '''
+        Validate methods on ClearFuncs that should not be called remotely
+        '''
+        opts = salt.config.master_config(None)
+        clear_funcs = salt.master.ClearFuncs(opts, {})
+        blacklist_methods = [
+            '__class__',
+            '__delattr__',
+            '__dir__',
+            '__eq__',
+            '__format__',
+            '__ge__',
+            '__getattribute__',
+            '__gt__',
+            '__hash__',
+            '__init__',
+            '__init_subclass__',
+            '__le__',
+            '__lt__',
+            '__ne__',
+            '__new__',
+            '__reduce__',
+            '__reduce_ex__',
+            '__repr__',
+            '__setattr__',
+            '__sizeof__',
+            '__str__',
+            '__subclasshook__',
+            '_prep_auth_info',
+            '_prep_jid',
+            '_prep_pub',
+            '_send_pub',
+            '_send_ssh_pub',
+            'get_method',
+        ]
+        for name in dir(clear_funcs):
+            if name in clear_funcs.expose_methods:
+                continue
+            if not callable(getattr(clear_funcs, name)):
+                continue
+            assert name in blacklist_methods, name
+
 
 class ClearFuncsTestCase(TestCase):
     '''

--- a/tests/unit/test_master.py
+++ b/tests/unit/test_master.py
@@ -15,6 +15,24 @@ from tests.support.mock import (
 )
 
 
+class TransportMethodsTest(TestCase):
+
+    def test_transport_methods(self):
+
+        class Foo(salt.master.TransportMethods):
+            expose_methods = ['bar']
+
+            def bar(self):
+                pass
+
+            def bang(self):
+                pass
+
+        foo = Foo()
+        assert foo.get_method('bar') is not None
+        assert foo.get_method('bang') is None
+
+
 class ClearFuncsTestCase(TestCase):
     '''
     TestCase for salt.master.ClearFuncs class
@@ -23,6 +41,13 @@ class ClearFuncsTestCase(TestCase):
     def setUp(self):
         opts = salt.config.master_config(None)
         self.clear_funcs = salt.master.ClearFuncs(opts, {})
+
+    def tearDown(self):
+        del self.clear_funcs
+
+    def test_get_method(self):
+        assert getattr(self.clear_funcs, '_send_pub', None) is not None
+        assert self.clear_funcs.get_method('_send_pub') is None
 
     # runner tests
 

--- a/tests/unit/test_module_names.py
+++ b/tests/unit/test_module_names.py
@@ -133,6 +133,7 @@ class BadTestModuleNamesTestCase(TestCase):
             'integration.logging.test_jid_logging',
             'integration.logging.handlers.test_logstash_mod',
             'integration.master.test_event_return',
+            'integration.master.test_clear_funcs',
             'integration.minion.test_blackout',
             'integration.minion.test_executor',
             'integration.minion.test_minion_cache',

--- a/tests/unit/utils/test_verify.py
+++ b/tests/unit/utils/test_verify.py
@@ -12,6 +12,7 @@ import stat
 import shutil
 import tempfile
 import socket
+import ctypes
 
 # Import third party libs
 if sys.platform.startswith('win'):
@@ -45,6 +46,7 @@ from salt.utils.verify import (
     verify_log,
     verify_logs_filter,
     verify_log_files,
+    clean_path
 )
 
 # Import 3rd-party libs
@@ -320,3 +322,80 @@ class TestVerifyLog(TestCase):
         self.assertFalse(os.path.exists(path))
         verify_log_files([path], getpass.getuser())
         self.assertTrue(os.path.exists(path))
+
+
+class TestCleanPath(TestCase):
+    '''
+    salt.utils.clean_path works as expected
+    '''
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def test_clean_path_valid(self):
+        path_a = os.path.join(self.tmpdir, 'foo')
+        path_b = os.path.join(self.tmpdir, 'foo', 'bar')
+        assert clean_path(path_a, path_b) == path_b
+
+    def test_clean_path_invalid(self):
+        path_a = os.path.join(self.tmpdir, 'foo')
+        path_b = os.path.join(self.tmpdir, 'baz', 'bar')
+        assert clean_path(path_a, path_b) == ''
+
+
+__CSL = None
+
+
+def symlink(source, link_name):
+    '''
+    symlink(source, link_name) Creates a symbolic link pointing to source named
+    link_name
+    '''
+    global __CSL
+    if __CSL is None:
+        csl = ctypes.windll.kernel32.CreateSymbolicLinkW
+        csl.argtypes = (ctypes.c_wchar_p, ctypes.c_wchar_p, ctypes.c_uint32)
+        csl.restype = ctypes.c_ubyte
+        __CSL = csl
+    flags = 0
+    if source is not None and os.path.isdir(source):
+        flags = 1
+    if __CSL(link_name, source, flags) == 0:
+        raise ctypes.WinError()
+
+
+@skipIf(six.PY2 and salt.utils.platform.is_windows(), 'Skipped on windows py2')
+class TestCleanPathLink(TestCase):
+    '''
+    Ensure salt.utils.clean_path works with symlinked directories and files
+    '''
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.to_path = os.path.join(self.tmpdir, 'linkto')
+        self.from_path = os.path.join(self.tmpdir, 'linkfrom')
+        if six.PY2 or salt.utils.platform.is_windows():
+            kwargs = {}
+        else:
+            kwargs = {'target_is_directory': True}
+        if salt.utils.platform.is_windows():
+            symlink(self.to_path, self.from_path, **kwargs)
+        else:
+            os.symlink(self.to_path, self.from_path, **kwargs)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def test_clean_path_symlinked_src(self):
+        test_path = os.path.join(self.from_path, 'test')
+        expect_path = os.path.join(self.to_path, 'test')
+        ret = clean_path(self.from_path, test_path)
+        assert ret == expect_path, "{} is not {}".format(ret, expect_path)
+
+    def test_clean_path_symlinked_tgt(self):
+        test_path = os.path.join(self.to_path, 'test')
+        expect_path = os.path.join(self.to_path, 'test')
+        ret = clean_path(self.from_path, test_path)
+        assert ret == expect_path, "{} is not {}".format(ret, expect_path)

--- a/tests/whitelist.txt
+++ b/tests/whitelist.txt
@@ -10,6 +10,7 @@ integration.grains.test_core
 integration.grains.test_custom
 integration.loader.test_ext_grains
 integration.loader.test_ext_modules
+integration.master.test_clear_funcs
 integration.minion.test_blackout
 integration.minion.test_pillar
 integration.minion.test_timeout


### PR DESCRIPTION
This will allow setting up a serial console on a new VM.

### What does this PR do?
This PR extends the options that `virt.running` will forward to the `virt.init` execution module to allow for creation of a serial console during VM creation.

### What issues does this PR fix or reference?
Fixes:
https://github.com/saltstack/salt/issues/53081

### Previous Behavior
VM would always be created without a serial console.

### New Behavior
User can add relevant options to allow creation of serial console on a new VM.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
