### PR TITLE
Fix typo by adding device_write_iops in documentation.

### DIFF
--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -2811,15 +2811,15 @@ def create(
         - ``device_write_bps="/dev/sda:100mb,/dev/sdb:50mb"``
         - ``device_write_bps="['/dev/sda:100mb', '/dev/sdb:50mb']"``
 
-    device_read_iops
+    device_write_iops
         Limit write rate (I/O per second) from a device, specified as a list
         of expressions in the format ``PATH:RATE``, where ``RATE`` is a number
         of I/O operations.
 
         Examples:
 
-        - ``device_read_iops="/dev/sda:1000,/dev/sdb:500"``
-        - ``device_read_iops="['/dev/sda:1000', '/dev/sdb:500']"``
+        - ``device_write_iops="/dev/sda:1000,/dev/sdb:500"``
+        - ``device_write_iops="['/dev/sda:1000', '/dev/sdb:500']"``
 
     dns
         List of DNS nameservers. Can be passed as a comma-separated list or a

--- a/salt/states/docker_container.py
+++ b/salt/states/docker_container.py
@@ -752,7 +752,7 @@ def running(
                   - /dev/sdb:5mb
 
 
-    device_read_iops
+    device_write_iops
         Limit write rate (I/O per second) from a device, specified as a list
         of expressions in the format ``PATH:RATE``, where ``RATE`` is a number
         of I/O operations. Can be expressed as a comma-separated list or a
@@ -763,14 +763,14 @@ def running(
             foo:
               docker_container.running:
                 - image: bar/baz:latest
-                - devices_read_iops: /dev/sda:1000,/dev/sdb:500
+                - devices_write_iops: /dev/sda:1000,/dev/sdb:500
 
         .. code-block:: yaml
 
             foo:
               docker_container.running:
                 - image: bar/baz:latest
-                - devices_read_iops:
+                - devices_write_iops:
                   - /dev/sda:1000
                   - /dev/sdb:500
 


### PR DESCRIPTION
Reported in: https://github.com/saltstack/salt/issues/57677
No test cases required as it handles comments and documentation

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/57677
