### PR TITLE
test_git_pillar: passphrase-protected actually works on current Debian

### DIFF
--- a/tests/integration/pillar/test_git_pillar.py
+++ b/tests/integration/pillar/test_git_pillar.py
@@ -91,12 +91,7 @@ from tests.support.gitfs import (
     GitPillarHTTPTestBase,
     GitPillarSSHTestBase,
 )
-from tests.support.helpers import (
-    destructiveTest,
-    requires_system_grains,
-    skip_if_not_root,
-    slowTest,
-)
+from tests.support.helpers import destructiveTest, skip_if_not_root, slowTest
 from tests.support.unit import skipIf
 
 # Check for requisite components
@@ -715,9 +710,8 @@ class TestPygit2SSH(GitPillarSSHTestBase):
     username = USERNAME
     passphrase = PASSWORD
 
-    @requires_system_grains
     @slowTest
-    def test_single_source(self, grains):
+    def test_single_source(self):
         """
         Test using a single ext_pillar repo
         """
@@ -765,10 +759,6 @@ class TestPygit2SSH(GitPillarSSHTestBase):
         )
         self.assertEqual(ret, expected)
 
-        if grains["os_family"] == "Debian":
-            # passphrase-protected currently does not work here
-            return
-
         # Test with passphrase-protected key and global credential options
         ret = self.get_pillar(
             """\
@@ -805,9 +795,8 @@ class TestPygit2SSH(GitPillarSSHTestBase):
         )
         self.assertEqual(ret, expected)
 
-    @requires_system_grains
     @slowTest
-    def test_multiple_sources_master_dev_no_merge_lists(self, grains):
+    def test_multiple_sources_master_dev_no_merge_lists(self):
         """
         Test using two ext_pillar dirs. Since all git_pillar repos are merged
         into a single dictionary, ordering matters.
@@ -866,10 +855,6 @@ class TestPygit2SSH(GitPillarSSHTestBase):
         )
         self.assertEqual(ret, expected)
 
-        if grains["os_family"] == "Debian":
-            # passphrase-protected currently does not work here
-            return
-
         # Test with passphrase-protected key and global credential options
         ret = self.get_pillar(
             """\
@@ -913,9 +898,8 @@ class TestPygit2SSH(GitPillarSSHTestBase):
         )
         self.assertEqual(ret, expected)
 
-    @requires_system_grains
     @slowTest
-    def test_multiple_sources_dev_master_no_merge_lists(self, grains):
+    def test_multiple_sources_dev_master_no_merge_lists(self):
         """
         Test using two ext_pillar dirs. Since all git_pillar repos are merged
         into a single dictionary, ordering matters.
@@ -974,10 +958,6 @@ class TestPygit2SSH(GitPillarSSHTestBase):
         )
         self.assertEqual(ret, expected)
 
-        if grains["os_family"] == "Debian":
-            # passphrase-protected currently does not work here
-            return
-
         # Test with passphrase-protected key and global credential options
         ret = self.get_pillar(
             """\
@@ -1021,9 +1001,8 @@ class TestPygit2SSH(GitPillarSSHTestBase):
         )
         self.assertEqual(ret, expected)
 
-    @requires_system_grains
     @slowTest
-    def test_multiple_sources_master_dev_merge_lists(self, grains):
+    def test_multiple_sources_master_dev_merge_lists(self):
         """
         Test using two ext_pillar dirs. Since all git_pillar repos are merged
         into a single dictionary, ordering matters.
@@ -1082,10 +1061,6 @@ class TestPygit2SSH(GitPillarSSHTestBase):
         )
         self.assertEqual(ret, expected)
 
-        if grains["os_family"] == "Debian":
-            # passphrase-protected currently does not work here
-            return
-
         # Test with passphrase-protected key and global credential options
         ret = self.get_pillar(
             """\
@@ -1129,9 +1104,8 @@ class TestPygit2SSH(GitPillarSSHTestBase):
         )
         self.assertEqual(ret, expected)
 
-    @requires_system_grains
     @slowTest
-    def test_multiple_sources_dev_master_merge_lists(self, grains):
+    def test_multiple_sources_dev_master_merge_lists(self):
         """
         Test using two ext_pillar dirs. Since all git_pillar repos are merged
         into a single dictionary, ordering matters.
@@ -1190,10 +1164,6 @@ class TestPygit2SSH(GitPillarSSHTestBase):
         )
         self.assertEqual(ret, expected)
 
-        if grains["os_family"] == "Debian":
-            # passphrase-protected currently does not work here
-            return
-
         # Test with passphrase-protected key and global credential options
         ret = self.get_pillar(
             """\
@@ -1237,9 +1207,8 @@ class TestPygit2SSH(GitPillarSSHTestBase):
         )
         self.assertEqual(ret, expected)
 
-    @requires_system_grains
     @slowTest
-    def test_multiple_sources_with_pillarenv(self, grains):
+    def test_multiple_sources_with_pillarenv(self):
         """
         Test using pillarenv to restrict results to those from a single branch
         """
@@ -1293,10 +1262,6 @@ class TestPygit2SSH(GitPillarSSHTestBase):
         )
         self.assertEqual(ret, expected)
 
-        if grains["os_family"] == "Debian":
-            # passphrase-protected currently does not work here
-            return
-
         # Test with passphrase-protected key and global credential options
         ret = self.get_pillar(
             """\
@@ -1340,9 +1305,8 @@ class TestPygit2SSH(GitPillarSSHTestBase):
         )
         self.assertEqual(ret, expected)
 
-    @requires_system_grains
     @slowTest
-    def test_includes_enabled(self, grains):
+    def test_includes_enabled(self):
         """
         Test with git_pillar_includes enabled. The top_only branch references
         an SLS file from the master branch, so we should see the
@@ -1399,10 +1363,6 @@ class TestPygit2SSH(GitPillarSSHTestBase):
         )
         self.assertEqual(ret, expected)
 
-        if grains["os_family"] == "Debian":
-            # passphrase-protected currently does not work here
-            return
-
         # Test with passphrase-protected key and global credential options
         ret = self.get_pillar(
             """\
@@ -1446,9 +1406,8 @@ class TestPygit2SSH(GitPillarSSHTestBase):
         )
         self.assertEqual(ret, expected)
 
-    @requires_system_grains
     @slowTest
-    def test_includes_disabled(self, grains):
+    def test_includes_disabled(self):
         """
         Test with git_pillar_includes enabled. The top_only branch references
         an SLS file from the master branch, but since includes are disabled it
@@ -1511,10 +1470,6 @@ class TestPygit2SSH(GitPillarSSHTestBase):
             """
         )
         self.assertEqual(ret, expected)
-
-        if grains["os_family"] == "Debian":
-            # passphrase-protected currently does not work here
-            return
 
         # Test with passphrase-protected key and global credential options
         ret = self.get_pillar(
@@ -1602,9 +1557,8 @@ class TestPygit2SSH(GitPillarSSHTestBase):
             },
         )
 
-    @requires_system_grains
     @slowTest
-    def test_root_parameter(self, grains):
+    def test_root_parameter(self):
         """
         Test root parameter
         """
@@ -1652,10 +1606,6 @@ class TestPygit2SSH(GitPillarSSHTestBase):
         )
         self.assertEqual(ret, expected)
 
-        if grains["os_family"] == "Debian":
-            # passphrase-protected currently does not work here
-            return
-
         # Test with passphrase-protected key and global credential options
         ret = self.get_pillar(
             """\
@@ -1701,9 +1651,8 @@ class TestPygit2SSH(GitPillarSSHTestBase):
         )
         self.assertEqual(ret, expected)
 
-    @requires_system_grains
     @slowTest
-    def test_mountpoint_parameter(self, grains):
+    def test_mountpoint_parameter(self):
         """
         Test mountpoint parameter
         """
@@ -1751,10 +1700,6 @@ class TestPygit2SSH(GitPillarSSHTestBase):
         )
         self.assertEqual(ret, expected)
 
-        if grains["os_family"] == "Debian":
-            # passphrase-protected currently does not work here
-            return
-
         # Test with passphrase-protected key and global credential options
         ret = self.get_pillar(
             """\
@@ -1800,9 +1745,8 @@ class TestPygit2SSH(GitPillarSSHTestBase):
         )
         self.assertEqual(ret, expected)
 
-    @requires_system_grains
     @slowTest
-    def test_root_and_mountpoint_parameters(self, grains):
+    def test_root_and_mountpoint_parameters(self):
         """
         Test root and mountpoint parameters
         """
@@ -1852,10 +1796,6 @@ class TestPygit2SSH(GitPillarSSHTestBase):
         )
         self.assertEqual(ret, expected)
 
-        if grains["os_family"] == "Debian":
-            # passphrase-protected currently does not work here
-            return
-
         # Test with passphrase-protected key and global credential options
         ret = self.get_pillar(
             """\
@@ -1903,9 +1843,8 @@ class TestPygit2SSH(GitPillarSSHTestBase):
         )
         self.assertEqual(ret, expected)
 
-    @requires_system_grains
     @slowTest
-    def test_all_saltenvs(self, grains):
+    def test_all_saltenvs(self):
         """
         Test all_saltenvs parameter.
         """
@@ -1964,10 +1903,6 @@ class TestPygit2SSH(GitPillarSSHTestBase):
         )
         self.assertEqual(ret, expected)
 
-        if grains["os_family"] == "Debian":
-            # passphrase-protected currently does not work here
-            return
-
         # Test with passphrase-protected key and global credential options
         ret = self.get_pillar(
             """\
@@ -2015,9 +1950,8 @@ class TestPygit2SSH(GitPillarSSHTestBase):
         )
         self.assertEqual(ret, expected)
 
-    @requires_system_grains
     @slowTest
-    def test_all_saltenvs_base(self, grains):
+    def test_all_saltenvs_base(self):
         """
         Test all_saltenvs parameter.
         """
@@ -2074,10 +2008,6 @@ class TestPygit2SSH(GitPillarSSHTestBase):
         )
         self.assertEqual(ret, expected)
 
-        if grains["os_family"] == "Debian":
-            # passphrase-protected currently does not work here
-            return
-
         # Test with passphrase-protected key and global credential options
         ret = self.get_pillar(
             """\
@@ -2123,8 +2053,7 @@ class TestPygit2SSH(GitPillarSSHTestBase):
         )
         self.assertEqual(ret, expected)
 
-    @requires_system_grains
-    def test_fallback(self, grains):
+    def test_fallback(self):
         """
         Test fallback parameter.
         """
@@ -2184,10 +2113,6 @@ class TestPygit2SSH(GitPillarSSHTestBase):
             """
         )
         self.assertEqual(ret, expected)
-
-        if grains["os_family"] == "Debian":
-            # passphrase-protected currently does not work here
-            return
 
         # Test with passphrase-protected key and global credential options
         ret = self.get_pillar(


### PR DESCRIPTION
# What does this PR do?
Improve test coverage
