### PR TITLE
Fix yumpkg.py incorrect arch parsing for yum

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -186,7 +186,7 @@ def _yum_pkginfo(output):
     cur = {}
     keys = itertools.cycle(("name", "version", "repoid"))
     values = salt.utils.itertools.split(_strip_headers(output))
-    osarch = __grains__["osarch"]
+    osarch = __grains__["cpuarch"]
     for (key, value) in zip(keys, values):
         if key == "name":
             try:
@@ -441,8 +441,8 @@ def normalize_name(name):
             return name
     except ValueError:
         return name
-    if arch in (__grains__["osarch"], "noarch") or salt.utils.pkg.rpm.check_32(
-        arch, osarch=__grains__["osarch"]
+    if arch in (__grains__["cpuarch"], "noarch") or salt.utils.pkg.rpm.check_32(
+        arch, osarch=__grains__["cpuarch"]
     ):
         return name[: -(len(arch) + 1)]
     return name
@@ -562,9 +562,9 @@ def latest_version(*names, **kwargs):
         try:
             arch = name.rsplit(".", 1)[-1]
             if arch not in salt.utils.pkg.rpm.ARCHES:
-                arch = __grains__["osarch"]
+                arch = __grains__["cpuarch"]
         except ValueError:
-            arch = __grains__["osarch"]
+            arch = __grains__["cpuarch"]
 
         # This loop will iterate over the updates derived by _yum_pkginfo()
         # above, which have been sorted descendingly by version number,
@@ -709,7 +709,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
         output = __salt__["cmd.run"](cmd, python_shell=False, output_loglevel="trace")
         for line in output.splitlines():
             pkginfo = salt.utils.pkg.rpm.parse_pkginfo(
-                line, osarch=__grains__["osarch"]
+                line, osarch=__grains__["cpuarch"]
             )
             if pkginfo is not None:
                 # see rpm version string rules available at https://goo.gl/UGKPNd


### PR DESCRIPTION
This uses the cpuarch grain as opposed to the osarch grain, which reports incorrectly on ppc64le as powerpc64le - causing pkg.installed and pkg.latest checks to fail.

cpuarch also seems to work fine on x86_64 - don't have an aarch64 system to test on but I suspect it will also be fine. 

This also works within kvm.

### What does this PR do?
Fixes RPM arch parsing for multi-arch

### What issues does this PR fix or reference?
Fixes: ??? There's a few issues this addresses, notably as an example people working around yumpkg.py elsewhere:

[https://wiki.nikhef.nl/grid/A_workaround_for_a_powerpc_saltstack_bug](https://wiki.nikhef.nl/grid/A_workaround_for_a_powerpc_saltstack_bug
)
### Previous Behavior
pkg installs on ppc64le do not work.

### New Behavior
pkg installs now work with no modifications for arch.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
