### PR TITLE
%PATH% manipulation with EnVar Plugin for NSIS

### DIFF
--- a/pkg/windows/build_env.ps1
+++ b/pkg/windows/build_env.ps1
@@ -202,7 +202,7 @@ If (Test-Path "$( $ini[$bitPaths]['NSISPluginsDirU'] )\nsisunz.dll") {
 # Check for installation of EnVar Plugin for NSIS
 #------------------------------------------------------------------------------
 Write-Output " - Checking for EnVar Plugin of NSIS installation  . . ."
-If (Test-Path "$($ini[$bitPaths]['NSISPluginsDirA'])\EnVar.dll" -and TestPath "$($ini[$bitPaths]['NSISPluginsDirU'])\EnVar.dll") {
+If ( (Test-Path "$($ini[$bitPaths]['NSISPluginsDirA'])\EnVar.dll") -and (Test-Path "$($ini[$bitPaths]['NSISPluginsDirU'])\EnVar.dll") ) {
     # Found EnVar Plugin for NSIS, do nothing
     Write-Output " - EnVar Plugin for NSIS Found . . ."
 } Else {
@@ -216,7 +216,7 @@ If (Test-Path "$($ini[$bitPaths]['NSISPluginsDirA'])\EnVar.dll" -and TestPath "$
 
     # Extract Zip File
     Write-Output " - Extracting . . ."
-    Expand-ZipFile $file "$ini['Settings']['DownloadDir']\nsisenvar"
+    Expand-ZipFile $file "$($ini['Settings']['DownloadDir'])\nsisenvar"
 
     # Copy dlls to plugins directory (both ANSI and Unicode)
     Write-Output " - Copying dlls to plugins directory . . ."

--- a/pkg/windows/build_env.ps1
+++ b/pkg/windows/build_env.ps1
@@ -196,6 +196,7 @@ If (Test-Path "$( $ini[$bitPaths]['NSISPluginsDirU'] )\nsisunz.dll") {
     # Remove temp files
     Remove-Item "$( $ini['Settings']['DownloadDir'] )\NSISunzU" -Force -Recurse
     Remove-Item "$file" -Force
+}
 
 #------------------------------------------------------------------------------
 # Check for installation of EnVar Plugin for NSIS

--- a/pkg/windows/build_env.ps1
+++ b/pkg/windows/build_env.ps1
@@ -255,7 +255,7 @@ If (Test-Path "$($ini[$bitPaths]['VCppBuildToolsDir'])\vcbuildtools.bat") {
 #------------------------------------------------------------------------------
 Write-Output " - Checking for Python 3 installation . . ."
 If (Test-Path "$($ini['Settings']['Python3Dir'])\python.exe") {
-    # Found Python 3.5, do nothing
+    # Found Python 3, do nothing
     Write-Output " - Python 3 Found . . ."
 } Else {
     Write-Output " - Downloading $($ini[$bitPrograms]['Python3']) . . ."

--- a/pkg/windows/build_env.ps1
+++ b/pkg/windows/build_env.ps1
@@ -196,6 +196,36 @@ If (Test-Path "$( $ini[$bitPaths]['NSISPluginsDirU'] )\nsisunz.dll") {
     # Remove temp files
     Remove-Item "$( $ini['Settings']['DownloadDir'] )\NSISunzU" -Force -Recurse
     Remove-Item "$file" -Force
+
+#------------------------------------------------------------------------------
+# Check for installation of EnVar Plugin for NSIS
+#------------------------------------------------------------------------------
+Write-Output " - Checking for EnVar Plugin of NSIS installation  . . ."
+If (Test-Path "$($ini[$bitPaths]['NSISPluginsDirA'])\EnVar.dll" -and TestPath "$($ini[$bitPaths]['NSISPluginsDirU'])\EnVar.dll") {
+    # Found EnVar Plugin for NSIS, do nothing
+    Write-Output " - EnVar Plugin for NSIS Found . . ."
+} Else {
+    # EnVar Plugin for NSIS not found, install
+    Write-Output " - EnVar Plugin for NSIS Not Found . . ."
+    Write-Output " - Downloading $($ini['Prerequisites']['NSISPluginEnVar']) . . ."
+    $file = "$($ini['Prerequisites']['NSISPluginEnVar'])"
+    $url  = "$($ini['Settings']['SaltRepo'])/$file"
+    $file = "$($ini['Settings']['DownloadDir'])\$file"
+    DownloadFileWithProgress $url $file
+
+    # Extract Zip File
+    Write-Output " - Extracting . . ."
+    Expand-ZipFile $file "$ini['Settings']['DownloadDir']\nsisenvar"
+
+    # Copy dlls to plugins directory (both ANSI and Unicode)
+    Write-Output " - Copying dlls to plugins directory . . ."
+    Move-Item "$( $ini['Settings']['DownloadDir'] )\nsisenvar\Plugins\x86-ansi\EnVar.dll" "$( $ini[$bitPaths]['NSISPluginsDirA'] )\EnVar.dll" -Force
+    Move-Item "$( $ini['Settings']['DownloadDir'] )\nsisenvar\Plugins\x86-unicode\EnVar.dll" "$( $ini[$bitPaths]['NSISPluginsDirU'] )\EnVar.dll" -Force
+
+    # Remove temp files
+    Remove-Item "$( $ini['Settings']['DownloadDir'] )\nsisenvar" -Force -Recurse
+    Remove-Item "$file" -Force
+
 }
 
 #------------------------------------------------------------------------------

--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -743,8 +743,9 @@ Section -Post
         Call updateMinionConfig
     ${EndIf}
 
-    Push "C:\salt"
-    Call AddToPath
+    # Add $INSTDIR in the Path
+    EnVar::SetHKLM
+    EnVar::AddValue Path "$INSTDIR"
 
 SectionEnd
 
@@ -788,9 +789,9 @@ Section Uninstall
 
     Call un.uninstallSalt
 
-    # Remove C:\salt from the Path
-    Push "C:\salt"
-    Call un.RemoveFromPath
+    # Remove $INSTDIR from the Path
+    EnVar::SetHKLM
+    EnVar::DeleteValue Path "$INSTDIR"
 
 SectionEnd
 
@@ -1057,191 +1058,6 @@ FunctionEnd
 !insertmacro StrStr ""
 !insertmacro StrStr "un."
 
-
-#------------------------------------------------------------------------------
-# AddToPath Function
-# - Adds item to Path for All Users
-# - Overcomes NSIS ReadRegStr limitation of 1024 characters by using Native
-#   Windows Commands
-#
-# Usage:
-#   Push "C:\path\to\add"
-#   Call AddToPath
-#------------------------------------------------------------------------------
-!define Environ 'HKLM "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"'
-Function AddToPath
-
-    Exch $0 # Path to add
-    Push $1 # Current Path
-    Push $2 # Results of StrStr / Length of Path + Path to Add
-    Push $3 # Handle to Reg / Length of Path
-    Push $4 # Result of Registry Call
-
-    # Open a handle to the key in the registry, handle in $3, Error in $4
-    System::Call "advapi32::RegOpenKey(i 0x80000002, t'SYSTEM\CurrentControlSet\Control\Session Manager\Environment', *i.r3) i.r4"
-    # Make sure registry handle opened successfully (returned 0)
-    IntCmp $4 0 0 done done
-
-    # Load the contents of path into $1, Error Code into $4, Path length into $2
-    System::Call "advapi32::RegQueryValueEx(i $3, t'PATH', i 0, i 0, t.r1, *i ${NSIS_MAX_STRLEN} r2) i.r4"
-
-    # Close the handle to the registry ($3)
-    System::Call "advapi32::RegCloseKey(i $3)"
-
-    # Check for Error Code 234, Path too long for the variable
-    IntCmp $4 234 0 +4 +4 # $4 == ERROR_MORE_DATA
-        DetailPrint "AddToPath Failed: original length $2 > ${NSIS_MAX_STRLEN}"
-        MessageBox MB_OK \
-            "You may add C:\salt to the %PATH% for convenience when issuing local salt commands from the command line." \
-            /SD IDOK
-        Goto done
-
-    # If no error, continue
-    IntCmp $4 0 +5 # $4 != NO_ERROR
-        # Error 2 means the Key was not found
-        IntCmp $4 2 +3 # $4 != ERROR_FILE_NOT_FOUND
-            DetailPrint "AddToPath: unexpected error code $4"
-            Goto done
-        StrCpy $1 ""
-
-    # Check if already in PATH
-    Push "$1;"          # The string to search
-    Push "$0;"          # The string to find
-    Call StrStr
-    Pop $2              # The result of the search
-    StrCmp $2 "" 0 done # String not found, try again with ';' at the end
-                        # Otherwise, it's already in the path
-    Push "$1;"          # The string to search
-    Push "$0\;"         # The string to find
-    Call StrStr
-    Pop $2              # The result
-    StrCmp $2 "" 0 done # String not found, continue (add)
-                        # Otherwise, it's already in the path
-
-    # Prevent NSIS string overflow
-    StrLen $2 $0        # Length of path to add ($2)
-    StrLen $3 $1        # Length of current path ($3)
-    IntOp $2 $2 + $3    # Length of current path + path to add ($2)
-    IntOp $2 $2 + 2     # Account for the additional ';'
-                        # $2 = strlen(dir) + strlen(PATH) + sizeof(";")
-
-    # Make sure the new length isn't over the NSIS_MAX_STRLEN
-    IntCmp $2 ${NSIS_MAX_STRLEN} +4 +4 0
-        DetailPrint "AddToPath Failed: new length $2 > ${NSIS_MAX_STRLEN}"
-        MessageBox MB_OK \
-            "You may add C:\salt to the %PATH% for convenience when issuing local salt commands from the command line." \
-            /SD IDOK
-        Goto done
-
-    # Append dir to PATH
-    DetailPrint "Add to PATH: $0"
-    StrCpy $2 $1 1 -1       # Copy the last character of the existing path
-    StrCmp $2 ";" 0 +2      # Check for trailing ';'
-        StrCpy $1 $1 -1     # remove trailing ';'
-    StrCmp $1 "" +2         # Make sure Path is not empty
-        StrCpy $0 "$1;$0"   # Append new path at the end ($0)
-
-    # We can use the NSIS command here. Only 'ReadRegStr' is affected
-    WriteRegExpandStr ${Environ} "PATH" $0
-
-    # Broadcast registry change to open programs
-    SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
-
-    done:
-        Pop $4
-        Pop $3
-        Pop $2
-        Pop $1
-        Pop $0
-
-FunctionEnd
-
-
-#------------------------------------------------------------------------------
-# RemoveFromPath Function
-# - Removes item from Path for All Users
-# - Overcomes NSIS ReadRegStr limitation of 1024 characters by using Native
-#   Windows Commands
-#
-# Usage:
-#   Push "C:\path\to\add"
-#   Call un.RemoveFromPath
-#------------------------------------------------------------------------------
-Function un.RemoveFromPath
-
-    Exch $0
-    Push $1
-    Push $2
-    Push $3
-    Push $4
-    Push $5
-    Push $6
-
-    # Open a handle to the key in the registry, handle in $3, Error in $4
-    System::Call "advapi32::RegOpenKey(i 0x80000002, t'SYSTEM\CurrentControlSet\Control\Session Manager\Environment', *i.r3) i.r4"
-    # Make sure registry handle opened successfully (returned 0)
-    IntCmp $4 0 0 done done
-
-    # Load the contents of path into $1, Error Code into $4, Path length into $2
-    System::Call "advapi32::RegQueryValueEx(i $3, t'PATH', i 0, i 0, t.r1, *i ${NSIS_MAX_STRLEN} r2) i.r4"
-
-    # Close the handle to the registry ($3)
-    System::Call "advapi32::RegCloseKey(i $3)"
-
-    # Check for Error Code 234, Path too long for the variable
-    IntCmp $4 234 0 +4 +4 # $4 == ERROR_MORE_DATA
-        DetailPrint "AddToPath: original length $2 > ${NSIS_MAX_STRLEN}"
-        Goto done
-
-    # If no error, continue
-    IntCmp $4 0 +5 # $4 != NO_ERROR
-        # Error 2 means the Key was not found
-        IntCmp $4 2 +3 # $4 != ERROR_FILE_NOT_FOUND
-            DetailPrint "AddToPath: unexpected error code $4"
-            Goto done
-        StrCpy $1 ""
-
-    # Ensure there's a trailing ';'
-    StrCpy $5 $1 1 -1   # Copy the last character of the path
-    StrCmp $5 ";" +2    # Check for trailing ';', if found continue
-        StrCpy $1 "$1;" # ensure trailing ';'
-
-    # Check for our directory inside the path
-    Push $1             # String to Search
-    Push "$0;"          # Dir to Find
-    Call un.StrStr
-    Pop $2              # The results of the search
-    StrCmp $2 "" done   # If results are empty, we're done, otherwise continue
-
-    # Remove our Directory from the Path
-    DetailPrint "Remove from PATH: $0"
-    StrLen $3 "$0;"       # Get the length of our dir ($3)
-    StrLen $4 $2          # Get the length of the return from StrStr ($4)
-    StrCpy $5 $1 -$4      # $5 is now the part before the path to remove
-    StrCpy $6 $2 "" $3    # $6 is now the part after the path to remove
-    StrCpy $3 "$5$6"      # Combine $5 and $6
-
-    # Check for Trailing ';'
-    StrCpy $5 $3 1 -1     # Load the last character of the string
-    StrCmp $5 ";" 0 +2    # Check for ';'
-        StrCpy $3 $3 -1   # remove trailing ';'
-
-    # Write the new path to the registry
-    WriteRegExpandStr ${Environ} "PATH" $3
-
-    # Broadcast the change to all open applications
-    SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
-
-    done:
-        Pop $6
-        Pop $5
-        Pop $4
-        Pop $3
-        Pop $2
-        Pop $1
-        Pop $0
-
-FunctionEnd
 
 #------------------------------------------------------------------------------
 # UninstallMSI Function

--- a/pkg/windows/modules/get-settings.psm1
+++ b/pkg/windows/modules/get-settings.psm1
@@ -28,6 +28,7 @@ Function Get-Settings {
         # Prerequisite software
         $Prerequisites = @{
             "NSIS"             = "nsis-3.03-setup.exe"
+            "NSISPluginEnVar"  = "nsis-plugin-envar.zip"
             "NSISPluginUnzipA" = "nsis-plugin-nsisunz.zip"
             "NSISPluginUnzipU" = "nsis-plugin-nsisunzu.zip"
             "VCppBuildTools"   = "visualcppbuildtools_full.exe"


### PR DESCRIPTION
This plugin is recommended for updating %PATH%. It overcomes the limit of 1024 characters in the %PATH% environment variable.

### What does this PR do?
Fixes %PATH% update errors when installing and uninstalling SaltStack.

### What issues does this PR fix or reference?
Fixes: #57673

### Previous Behavior
When %PATH% exceeds 1024 characters and the %PATH% does not update as expected.
When uninstalling SaltStack, %PATH% is also not updated regardless of its length.

### New Behavior
%PATH% is updated as intended.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
