### PR TITLE
Tweak regex in salt-minion is_running to be more specific

### DIFF
--- a/pkg/rpm/salt-minion
+++ b/pkg/rpm/salt-minion
@@ -72,7 +72,7 @@ _get_pid() {
 
 
 _is_running() {
-    [ -n "$(_get_pid)" ] && ps wwwaxu | grep '[s]alt-minion' | awk '{print $2}' | grep -qi "\b$(_get_pid)\b"
+    [ -n "$(_get_pid)" ] && ps wwwaxu | grep '\/[s]alt-minion ' | awk '{print $2}' | grep -qi "\b$(_get_pid)\b"
 }
 
 


### PR DESCRIPTION
We run SaltStack on our customer's servers, and occasionally have customers that themselves wish to run SaltStack. So our implementation involved renaming our salt-minion binaries and startup script to `cd-salt-minion` to avoid confusion. The check in `is_running` falsely matches any other process containing `salt-minion`, causing the customer's service to fail to start (because it sees ours running in `ps` and exits out).

It's a super ticky-tack change, but didn't know if this might be helpful since it'll continue to match `salt-minion` as intended, and not (on the extreme off-chance) match something else unintentionally.

### What does this PR do?

Updates the grep called in `is_running` to match a leading slash and space after `salt-minion`. Intent is to match `/salt-minion` without. matching other process names containing `salt-minion` (e.g. `ab-salt-minion` or `salt-minion-xy`).

### What issues does this PR fix or reference?

Fixes: N/A

### Merge requirements satisfied?

**[NOTICE] Bug fixes or features added to Salt require tests.**

((Should not change any known functionality, so marked these done. But open to changes, if needed.))

- [x] Docs
- [x] Changelog
- [x] Tests written/updated

### Commits signed with GPG?
No
