### PR TITLE
dont log errors in virtuals.

### DIFF
--- a/salt/returners/appoptics_return.py
+++ b/salt/returners/appoptics_return.py
@@ -96,10 +96,6 @@ log = logging.getLogger(__name__)
 
 def __virtual__():
     if not HAS_APPOPTICS:
-        log.debug(
-            "The appoptics_return module couldn't load the appoptics_metrics module."
-        )
-        log.debug("please make sure it is installed and is in the PYTHON_PATH.")
         return (
             False,
             "Could not import appoptics_metrics module; "

--- a/salt/returners/appoptics_return.py
+++ b/salt/returners/appoptics_return.py
@@ -96,10 +96,10 @@ log = logging.getLogger(__name__)
 
 def __virtual__():
     if not HAS_APPOPTICS:
-        log.error(
+        log.debug(
             "The appoptics_return module couldn't load the appoptics_metrics module."
         )
-        log.error("please make sure it is installed and is in the PYTHON_PATH.")
+        log.debug("please make sure it is installed and is in the PYTHON_PATH.")
         return (
             False,
             "Could not import appoptics_metrics module; "

--- a/salt/returners/appoptics_return.py
+++ b/salt/returners/appoptics_return.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Salt returner to return highstate stats to AppOptics Metrics
 
 To enable this returner the minion will need the AppOptics Metrics
@@ -70,17 +69,12 @@ the name of the state that was invoked, e.g. ``role_salt_master.netapi``.
 
 """
 
-# Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
 import salt.returners
-
-# Import Salt libs
 import salt.utils.jid
 
-# Import third party libs
 try:
     import appoptics_metrics
 
@@ -183,7 +177,7 @@ def _state_metrics(ret, options, tags):
 
     log.debug(
         "Batching with  Metric total states {}".format(
-            (stats["num_failed_states"] + stats["num_passed_states"])
+            stats["num_failed_states"] + stats["num_passed_states"]
         )
     )
     q.add(

--- a/salt/returners/appoptics_return.py
+++ b/salt/returners/appoptics_return.py
@@ -119,7 +119,7 @@ def _get_options(ret=None):
         "tags", {"host_hostname_alias": __salt__["grains.get"]("id")}
     )
 
-    log.debug("Retrieved appoptics options: {}".format(_options))
+    log.debug("Retrieved appoptics options: %s", _options)
     return _options
 
 
@@ -150,35 +150,30 @@ def _calculate_runtimes(states):
             # Count durations
             results["runtime"] += resultset["duration"]
 
-    log.debug("Parsed state metrics: {}".format(results))
+    log.debug("Parsed state metrics: %s", results)
     return results
 
 
 def _state_metrics(ret, options, tags):
     # Calculate the runtimes and number of failed states.
     stats = _calculate_runtimes(ret["return"])
-    log.debug("Batching Metric retcode with {}".format(ret["retcode"]))
+    log.debug("Batching Metric retcode with %s", ret["retcode"])
     appoptics_conn = _get_appoptics(options)
     q = appoptics_conn.new_queue(tags=tags)
 
     q.add("saltstack.retcode", ret["retcode"])
-    log.debug(
-        "Batching Metric num_failed_jobs with {}".format(stats["num_failed_states"])
-    )
+    log.debug("Batching Metric num_failed_jobs with %s", stats["num_failed_states"])
     q.add("saltstack.failed", stats["num_failed_states"])
 
-    log.debug(
-        "Batching Metric num_passed_states with {}".format(stats["num_passed_states"])
-    )
+    log.debug("Batching Metric num_passed_states with %s", stats["num_passed_states"])
     q.add("saltstack.passed", stats["num_passed_states"])
 
-    log.debug("Batching Metric runtime with {}".format(stats["runtime"]))
+    log.debug("Batching Metric runtime with %s".stats["runtime"])
     q.add("saltstack.runtime", stats["runtime"])
 
     log.debug(
-        "Batching with  Metric total states {}".format(
-            stats["num_failed_states"] + stats["num_passed_states"]
-        )
+        "Batching with Metric total states %s",
+        stats["num_failed_states"] + stats["num_passed_states"],
     )
     q.add(
         "saltstack.highstate.total_states",
@@ -203,7 +198,7 @@ def returner(ret):
     if ret["fun"] in states_to_report:
         tags = options.get("tags", {}).copy()
         tags["state_type"] = ret["fun"]
-        log.info("Tags for this run are {}".format(str(tags)))
+        log.info("Tags for this run are %s", str(tags))
         matched_states = set(ret["fun_args"]).intersection(
             set(options.get("sls_states", []))
         )
@@ -211,5 +206,5 @@ def returner(ret):
         # In the mean time, find one matching state name and use it.
         if matched_states:
             tags["state_name"] = sorted(matched_states)[0]
-            log.debug("Found returned data from {}.".format(tags["state_name"]))
+            log.debug("Found returned data from %s.", tags["state_name"])
         _state_metrics(ret, options, tags)


### PR DESCRIPTION
### What does this PR do?
changes two log.errors into log.debug in a virtual function. as longing errors can get noisy here. 

### Previous Behavior
Noisy log from errors being logged for an unused returner. 

### New Behavior
The log will only be noisy in debug mode.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated - no, only changed two log lines.

Does this change require tests? It is literally only changing log.error to log.debug for two items. 

### Commits signed with GPG?
No
