### PR TITLE
Strip brackets from IPv6 addresses

### DIFF
--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -1161,7 +1161,7 @@ class SaltMessageClient(object):
                         )
                 with salt.utils.asynchronous.current_ioloop(self.io_loop):
                     self._stream = yield self._tcp_client.connect(
-                        self.host, self.port, ssl_options=self.opts.get("ssl"), **kwargs
+                        self.host.strip('[]'), self.port, ssl_options=self.opts.get("ssl"), **kwargs
                     )
                 self._connecting_future.set_result(True)
                 break


### PR DESCRIPTION
When connecting via tcp transport to an IPv6 address, salt uses `[a:b::c]` address format, when it should be using `a:b::c`. This silently makes salt client hang.
