### PR TITLE
[Fix] #57714 virtual grain should work on illumos

### DIFF
--- a/changelog/57714.fixed
+++ b/changelog/57714.fixed
@@ -1,0 +1,1 @@
+Due to some optimization the `virtual` grain was never updated on illumos. Move the fallback in prtdiag output parsing outside the loop that now gets skipped due to the command exiting non-zero.

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -919,16 +919,6 @@ def _virtual(osdata):
                 grains["virtual"] = "kvm"
             elif "joyent smartdc hvm" in model:
                 grains["virtual"] = "kvm"
-            else:
-                # Check if it's a "regular" zone
-                zonename = salt.utils.path.which("zonename")
-                if zonename:
-                    zone = __salt__["cmd.run"]("{0}".format(zonename))
-                    if zone != "global":
-                        grains["virtual"] = "zone"
-                # Check if it's a branded zone
-                elif os.path.isdir("/.SUNWnative"):
-                    grains["virtual"] = "zone"
             break
         elif command == "virtinfo":
             if output == "logical-domain":
@@ -1121,6 +1111,18 @@ def _virtual(osdata):
             ):
                 if os.path.isfile("/var/run/xenconsoled.pid"):
                     grains["virtual_subtype"] = "Xen Dom0"
+    elif osdata["kernel"] == "SunOS":
+        # we did not get any data from virtinfo or prtdiag
+        # check the zonename here as fallback
+        zonename = salt.utils.path.which("zonename")
+        if zonename:
+            zone = __salt__["cmd.run"]("{0}".format(zonename))
+            if zone != "global":
+                grains["virtual"] = "zone"
+
+        # last ditch efford to check the brand identifier
+        elif os.path.isdir("/.SUNWnative"):
+            grains["virtual"] = "zone"
 
     # If we have a virtual_subtype, we're virtual, but maybe we couldn't
     # figure out what specific virtual type we were?


### PR DESCRIPTION
### What does this PR do?
This fixes the `virtual` grain on illumos that got broken between 3000.1 and 3001, I didn't have time to hunt down the actually commit but after about an hour of analysis.

The loop over _cmds was slightly modified to abort differently if a command had a non-zero exit. On illumos/solaris `prtdiag` has a non-zero exit in the zones. Before we would avoid addning it to the failed_commands list but still continued. 

In the block dealing with prtdiag output we had a fallback that would do some other checks to figure out if we were a global zone(=physical) or zone (=zone).

This PR moves the fallback case outside of the loop, which is a better location for it. So we avoid the problem.

This also fixed resolved my other issues I saw when testing 3001 on SmartOS, which were because some modules depend on the virtual grain.

### What issues does this PR fix or reference?
Fixes:
- #57714 

### Previous Behavior
Fallback case was skipped.

### New Behavior
Fileback case gets executes, resulting in the correct (pre 3001) virtual grain.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No
