### PR TITLE
Fix to exsi grains

### DIFF
--- a/changelog/57743.fixed
+++ b/changelog/57743.fixed
@@ -1,4 +1,4 @@
-Moving import salt.modules.vsphere into virtual so we have access to test proxytype in opts,
-previously this was causing a traceback when run on proxy minion as __opts__ does not exist
+Moving import salt.modules.vsphere into `__virtual__` so we have access to test proxytype in opts,
+previously this was causing a traceback when run on proxy minion as `__opts__` does not exist
 outside of any functions. Introducing a new utils function, is_proxytype, to check that the
 device is a proxy minion and also that the proxy type matches.

--- a/changelog/57743.fixed
+++ b/changelog/57743.fixed
@@ -1,0 +1,4 @@
+Moving import salt.modules.vsphere into virtual so we have access to test proxytype in opts,
+previously this was causing a traceback when run on proxy minion as __opts__ does not exist
+outside of any functions. Introducing a new utils function, is_proxytype, to check that the
+device is a proxy minion and also that the proxy type matches.

--- a/salt/grains/esxi.py
+++ b/salt/grains/esxi.py
@@ -12,12 +12,8 @@ from __future__ import absolute_import, print_function, unicode_literals
 import logging
 
 # Import Salt Libs
-import salt.utils.platform
+import salt.utils.proxy
 from salt.exceptions import SaltSystemExit
-
-if salt.utils.platform.is_proxy() and __opts__["proxy"]["proxytype"] == "esxi":
-    import salt.modules.vsphere
-
 
 __proxyenabled__ = ["esxi"]
 __virtualname__ = "esxi"
@@ -29,8 +25,14 @@ GRAINS_CACHE = {}
 
 def __virtual__():
 
+    # import salt.utils.proxy again
+    # so it is available for tests.
+    import salt.utils.proxy
+
     try:
-        if salt.utils.platform.is_proxy() and __opts__["proxy"]["proxytype"] == "esxi":
+        if salt.utils.proxy.is_proxytype(__opts__, "esxi"):
+            import salt.modules.vsphere
+
             return __virtualname__
     except KeyError:
         pass
@@ -104,7 +106,7 @@ def _grains():
                 port=port,
             )
             GRAINS_CACHE.update(ret)
-    except KeyError:
+    except KeyError as e:
         pass
 
     return GRAINS_CACHE

--- a/salt/grains/esxi.py
+++ b/salt/grains/esxi.py
@@ -11,7 +11,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
-# Import Salt Libs
 import salt.utils.proxy
 from salt.exceptions import SaltSystemExit
 
@@ -106,7 +105,7 @@ def _grains():
                 port=port,
             )
             GRAINS_CACHE.update(ret)
-    except KeyError as e:
+    except KeyError:
         pass
 
     return GRAINS_CACHE

--- a/salt/utils/proxy.py
+++ b/salt/utils/proxy.py
@@ -3,7 +3,6 @@
 Utils for proxy.
 """
 
-# Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
 
 import logging

--- a/salt/utils/proxy.py
+++ b/salt/utils/proxy.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""
+Utils for proxy.
+"""
+
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+import logging
+
+import salt.utils.platform
+
+log = logging.getLogger(__file__)
+
+
+def is_proxytype(opts, proxytype):
+    """
+    Is this a proxy minion of type proxytype
+    """
+    return (
+        salt.utils.platform.is_proxy()
+        and opts.get("proxy", None).get("proxytype", None) == proxytype
+    )

--- a/salt/utils/proxy.py
+++ b/salt/utils/proxy.py
@@ -18,5 +18,5 @@ def is_proxytype(opts, proxytype):
     """
     return (
         salt.utils.platform.is_proxy()
-        and opts.get("proxy", None).get("proxytype", None) == proxytype
+        and opts.get("proxy", {}).get("proxytype", None) == proxytype
     )

--- a/tests/unit/grains/test_esxi.py
+++ b/tests/unit/grains/test_esxi.py
@@ -5,14 +5,11 @@
     :codeauthor: :email:`Gareth J. Greenaway <gareth@saltstack.com>`
 """
 
-# Import Python Libs
 from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
 import salt.grains.esxi as esxi_grains
-
-# Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import patch
 from tests.support.unit import TestCase

--- a/tests/unit/grains/test_esxi.py
+++ b/tests/unit/grains/test_esxi.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+"""
+    Unit tests for salt.utils.proxy
+
+    :codeauthor: :email:`Gareth J. Greenaway <gareth@saltstack.com>`
+"""
+
+# Import Python Libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+import logging
+
+import salt.grains.esxi as esxi_grains
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.mock import patch
+from tests.support.unit import TestCase
+
+log = logging.getLogger(__name__)
+
+
+class EsxiGrainsTestCase(TestCase, LoaderModuleMockMixin):
+    def setup_loader_modules(self):
+        module_globals = {
+            "__salt__": {},
+            "__opts__": {
+                "proxy": {
+                    "proxytype": "esxi",
+                    "host": "esxi.domain.com",
+                    "username": "username",
+                    "passwords": ["password1"],
+                }
+            },
+            "__pillar__": {
+                "proxy": {
+                    "proxytype": "esxi",
+                    "host": "esxi.domain.com",
+                    "username": "username",
+                    "passwords": ["password1"],
+                }
+            },
+        }
+
+        return {esxi_grains: module_globals}
+
+    def test_virtual(self):
+        with patch("salt.utils.proxy.is_proxytype", return_value=True, autospec=True):
+            ret = esxi_grains.__virtual__()
+            self.assertEqual(ret, "esxi")
+
+    def test_kernel(self):
+        with patch("salt.utils.proxy.is_proxytype", return_value=True, autospec=True):
+            ret = esxi_grains.kernel()
+            self.assertEqual(ret, {"kernel": "proxy"})
+
+    def test_osfamily(self):
+        with patch("salt.utils.proxy.is_proxytype", return_value=True, autospec=True):
+            ret = esxi_grains.os_family()
+            self.assertEqual(ret, {"os_family": "proxy"})
+
+    def test_os(self):
+        grain_cache_return = {
+            "name": "VMware vCenter Server",
+            "fullName": "VMware vCenter Server 6.7.0 build-15679289",
+            "vendor": "VMware, Inc.",
+            "version": "6.7.0",
+            "build": "15679289",
+            "localeVersion": "INTL",
+            "localeBuild": "000",
+            "osType": "linux-x64",
+            "productLineId": "vpx",
+            "apiType": "VirtualCenter",
+            "apiVersion": "6.7.3",
+            "instanceUuid": "058ed113-1820-41dc-a8a9-8a5dd48632a4",
+            "licenseProductName": "VMware VirtualCenter Server",
+            "licenseProductVersion": "6.0",
+        }
+
+        expected = {"os": "VMware vCenter Server 6.7.0 build-15679289"}
+        with patch("salt.utils.proxy.is_proxytype", return_value=True, autospec=True):
+            with patch(
+                "salt.modules.vsphere.system_info", return_value=grain_cache_return
+            ):
+                ret = esxi_grains.os()
+                self.assertEqual(ret, expected)
+
+    def test_esxi(self):
+        grain_cache_return = {
+            "name": "VMware vCenter Server",
+            "fullName": "VMware vCenter Server 6.7.0 build-15679289",
+            "vendor": "VMware, Inc.",
+            "version": "6.7.0",
+            "build": "15679289",
+            "localeVersion": "INTL",
+            "localeBuild": "000",
+            "osType": "linux-x64",
+            "productLineId": "vpx",
+            "apiType": "VirtualCenter",
+            "apiVersion": "6.7.3",
+            "instanceUuid": "058ed113-1820-41dc-a8a9-8a5dd48632a4",
+            "licenseProductName": "VMware VirtualCenter Server",
+            "licenseProductVersion": "6.0",
+        }
+
+        with patch("salt.utils.proxy.is_proxytype", return_value=True, autospec=True):
+            with patch(
+                "salt.modules.vsphere.system_info", return_value=grain_cache_return
+            ):
+                ret = esxi_grains.esxi()
+                self.assertEqual(ret, grain_cache_return)

--- a/tests/unit/utils/test_proxy.py
+++ b/tests/unit/utils/test_proxy.py
@@ -4,19 +4,15 @@
     :codeauthor: :email:`Gareth J. Greenaway <gareth@saltstack.com>`
 """
 
-# Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
 
-# Import Salt libs
 import salt.utils.proxy
 from tests.support.mock import patch
-
-# Import Salt Testing libs
 from tests.support.unit import TestCase
 
 
 class ProxyUtilsTestCase(TestCase):
-    def test_is_proxytype(self):
+    def test_is_proxytype_true(self):
         opts = {
             "proxy": {
                 "proxytype": "esxi",
@@ -29,3 +25,17 @@ class ProxyUtilsTestCase(TestCase):
         with patch("salt.utils.platform.is_proxy", return_value=True, autospec=True):
             ret = salt.utils.proxy.is_proxytype(opts, "esxi")
             self.assertTrue(ret)
+
+    def test_is_proxytype_false(self):
+        opts = {
+            "proxy": {
+                "proxytype": "esxi",
+                "host": "esxi.domain.com",
+                "username": "username",
+                "passwords": ["password1"],
+            }
+        }
+
+        with patch("salt.utils.platform.is_proxy", return_value=True, autospec=True):
+            ret = salt.utils.proxy.is_proxytype(opts, "docker")
+            self.assertFalse(ret)

--- a/tests/unit/utils/test_proxy.py
+++ b/tests/unit/utils/test_proxy.py
@@ -39,3 +39,10 @@ class ProxyUtilsTestCase(TestCase):
         with patch("salt.utils.platform.is_proxy", return_value=True, autospec=True):
             ret = salt.utils.proxy.is_proxytype(opts, "docker")
             self.assertFalse(ret)
+
+    def test_is_proxytype_not_proxy(self):
+        opts = {}
+
+        with patch("salt.utils.platform.is_proxy", return_value=False, autospec=True):
+            ret = salt.utils.proxy.is_proxytype(opts, "docker")
+            self.assertFalse(ret)

--- a/tests/unit/utils/test_proxy.py
+++ b/tests/unit/utils/test_proxy.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""
+    Unit tests for salt.utils.proxy
+    :codeauthor: :email:`Gareth J. Greenaway <gareth@saltstack.com>`
+"""
+
+# Import python libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+# Import Salt libs
+import salt.utils.proxy
+from tests.support.mock import patch
+
+# Import Salt Testing libs
+from tests.support.unit import TestCase
+
+
+class ProxyUtilsTestCase(TestCase):
+    def test_is_proxytype(self):
+        opts = {
+            "proxy": {
+                "proxytype": "esxi",
+                "host": "esxi.domain.com",
+                "username": "username",
+                "passwords": ["password1"],
+            }
+        }
+
+        with patch("salt.utils.platform.is_proxy", return_value=True, autospec=True):
+            ret = salt.utils.proxy.is_proxytype(opts, "esxi")
+            self.assertTrue(ret)


### PR DESCRIPTION
### What does this PR do?
Moving import salt.modules.vsphere into virtual so we have access to test proxytype in opts.  Gating the check with salt.utils.proxy.is_proxytype.  Adding tests.

### What issues does this PR fix or reference?
Fixes: #57811

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
