### PR TITLE
libvirt events engine: constant fixes

### DIFF
--- a/changelog/57746.fixed
+++ b/changelog/57746.fixed
@@ -1,0 +1,1 @@
+Fix the registration of libvirt pool and nodedev events

--- a/salt/engines/libvirt_events.py
+++ b/salt/engines/libvirt_events.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 An engine that listens for libvirt events and resends them to the salt event bus.
 
@@ -65,7 +63,6 @@ A polkit rule like the following one will allow `salt` user to connect to libvir
 .. versionadded:: 2019.2.0
 """
 
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
@@ -192,7 +189,7 @@ def _get_domain_event_detail(event, detail):
     if event_name == "unknown":
         return event_name, "unknown"
 
-    prefix = "VIR_DOMAIN_EVENT_{0}_".format(event_name.upper())
+    prefix = "VIR_DOMAIN_EVENT_{}_".format(event_name.upper())
     detail_name = _get_libvirt_enum_string(prefix, detail)
 
     return event_name, detail_name
@@ -337,7 +334,7 @@ def _domain_event_graphics_cb(
         """
         return {
             "family": _get_libvirt_enum_string(
-                "{0}_ADDRESS_".format(prefix), addr["family"]
+                "{}_ADDRESS_".format(prefix), addr["family"]
             ),
             "node": addr["node"],
             "service": addr["service"],
@@ -683,14 +680,14 @@ def _register_callback(cnx, tag_prefix, obj, event, real_id):
     """
     libvirt_name = real_id
     if real_id is None:
-        libvirt_name = "VIR_{0}_EVENT_ID_{1}".format(obj, event).upper()
+        libvirt_name = "VIR_{}_EVENT_ID_{}".format(obj, event).upper()
 
     if not hasattr(libvirt, libvirt_name):
         log.warning('Skipping "%s/%s" events: libvirt too old', obj, event)
         return None
 
     libvirt_id = getattr(libvirt, libvirt_name)
-    callback_name = "_{0}_event_{1}_cb".format(obj, event)
+    callback_name = "_{}_event_{}_cb".format(obj, event)
     callback = globals().get(callback_name, None)
     if callback is None:
         log.error("Missing function %s in engine", callback_name)

--- a/salt/engines/libvirt_events.py
+++ b/salt/engines/libvirt_events.py
@@ -33,7 +33,7 @@ CALLBACK_DEFS constant. If the filters list contains ``all``, all
 events will be relayed.
 
 Be aware that the list of events increases with libvirt versions, for example
-network events have been added in libvirt 1.2.1.
+network events have been added in libvirt 1.2.1 and storage events in 2.0.0.
 
 Running the engine on non-root
 ------------------------------
@@ -137,8 +137,14 @@ CALLBACK_DEFS = {
         ("block_threshold", None),
     ),
     "network": (("lifecycle", None),),
-    "pool": (("lifecycle", None), ("refresh", None)),
-    "nodedev": (("lifecycle", None), ("update", None)),
+    "pool": (
+        ("lifecycle", "VIR_STORAGE_POOL_EVENT_ID_LIFECYCLE"),
+        ("refresh", "VIR_STORAGE_POOL_EVENT_ID_REFRESH"),
+    ),
+    "nodedev": (
+        ("lifecycle", "VIR_NODE_DEVICE_EVENT_ID_LIFECYCLE"),
+        ("update", "VIR_NODE_DEVICE_EVENT_ID_UPDATE"),
+    ),
     "secret": (("lifecycle", None), ("value_changed", None)),
 }
 
@@ -753,7 +759,6 @@ def start(uri=None, tag_prefix="salt/engines/libvirt_events", filters=None):
         exit_loop = False
         while not exit_loop:
             exit_loop = libvirt.virEventRunDefaultImpl() < 0
-            log.debug("=== in the loop exit_loop %s ===", exit_loop)
 
     except Exception as err:  # pylint: disable=broad-except
         log.exception(err)

--- a/tests/unit/engines/test_libvirt_events.py
+++ b/tests/unit/engines/test_libvirt_events.py
@@ -28,6 +28,10 @@ class EngineLibvirtEventTestCase(TestCase, LoaderModuleMockMixin):
         )  # Don't loop for ever
         self.mock_libvirt.VIR_DOMAIN_EVENT_ID_LIFECYCLE = 0
         self.mock_libvirt.VIR_DOMAIN_EVENT_ID_REBOOT = 1
+        self.mock_libvirt.VIR_STORAGE_POOL_EVENT_ID_LIFECYCLE = 0
+        self.mock_libvirt.VIR_STORAGE_POOL_EVENT_ID_REFRESH = 1
+        self.mock_libvirt.VIR_NODE_DEVICE_EVENT_ID_LIFECYCLE = 0
+        self.mock_libvirt.VIR_NODE_DEVICE_EVENT_ID_UPDATE = 1
         self.addCleanup(patcher.stop)
         self.addCleanup(delattr, self, "mock_libvirt")
         return {libvirt_events: {}}
@@ -111,6 +115,30 @@ class EngineLibvirtEventTestCase(TestCase, LoaderModuleMockMixin):
             mock_libvirt.VIR_NETWORK_EVENT_ID_LIFECYCLE,
             libvirt_events._network_event_lifecycle_cb,
             {"prefix": "test/prefix", "object": "network", "event": "lifecycle"},
+        )
+        mock_cnx.storagePoolEventRegisterAny.assert_any_call(
+            None,
+            mock_libvirt.VIR_STORAGE_POOL_EVENT_ID_LIFECYCLE,
+            libvirt_events._pool_event_lifecycle_cb,
+            {"prefix": "test/prefix", "object": "pool", "event": "lifecycle"},
+        )
+        mock_cnx.storagePoolEventRegisterAny.assert_any_call(
+            None,
+            mock_libvirt.VIR_STORAGE_POOL_EVENT_ID_REFRESH,
+            libvirt_events._pool_event_refresh_cb,
+            {"prefix": "test/prefix", "object": "pool", "event": "refresh"},
+        )
+        mock_cnx.nodeDeviceEventRegisterAny.assert_any_call(
+            None,
+            mock_libvirt.VIR_NODE_DEVICE_EVENT_ID_LIFECYCLE,
+            libvirt_events._nodedev_event_lifecycle_cb,
+            {"prefix": "test/prefix", "object": "nodedev", "event": "lifecycle"},
+        )
+        mock_cnx.nodeDeviceEventRegisterAny.assert_any_call(
+            None,
+            mock_libvirt.VIR_NODE_DEVICE_EVENT_ID_UPDATE,
+            libvirt_events._nodedev_event_update_cb,
+            {"prefix": "test/prefix", "object": "nodedev", "event": "update"},
         )
 
         # Check that the deregister events are called with the result of register

--- a/tests/unit/engines/test_libvirt_events.py
+++ b/tests/unit/engines/test_libvirt_events.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
 """
 unit tests for the libvirt_events engine
 """
 # Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Libs
 import salt.engines.libvirt_events as libvirt_events


### PR DESCRIPTION
# What does this PR do?

The libvirt constants for pool and nodedev events need tweaking since
they don't match the rule used to autogenerate them.

### What issues does this PR fix or reference?
Fixes: #57746

### Previous Behavior
Storage pool and node device events were not reported as Salt events

### New Behavior
Storage pool and node device events are reported as Salt events

### Merge requirements satisfied?

- [X] Docs
- [X] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes