### PR TITLE
Added ability to filter docs for specific runner

### DIFF
--- a/salt/runners/doc.py
+++ b/salt/runners/doc.py
@@ -25,7 +25,7 @@ def __virtual__():
     return True
 
 
-def runner():
+def runner(mod_name="*"):
     """
     Return all inline documentation for runner modules
 
@@ -36,7 +36,10 @@ def runner():
         salt-run doc.runner
     """
     client = salt.runner.RunnerClient(__opts__)
-    ret = client.get_docs()
+    if mod_name == "*":
+        ret = client.get_docs()
+    else:
+        ret = client.get_docs(mod_name)
     return ret
 
 

--- a/tests/pytests/unit/runners/test_doc.py
+++ b/tests/pytests/unit/runners/test_doc.py
@@ -1,0 +1,72 @@
+import pytest
+import salt.runner
+import salt.runners.doc as doc
+from tests.support.mock import PropertyMock, patch
+
+
+@pytest.fixture(autouse=True)
+def setup_loader(request):
+    setup_loader_modules = {doc: {}}
+    with pytest.helpers.loader_mock(request, setup_loader_modules) as loader_mock:
+        yield loader_mock
+
+
+@pytest.fixture()
+def runner_client():
+    client = salt.runner.RunnerClient({})
+
+    def fnord():
+        """
+        This is some docstring, OK?
+        """
+
+    def baz():
+        """
+        This is another docstring, OK?
+        """
+
+    functions = {
+        "fnord": fnord,
+        "baz": baz,
+    }
+    patch_rc = patch("salt.runner.RunnerClient", return_value=client)
+    patch_functions = patch.object(
+        type(client), "functions", PropertyMock(return_value=functions)
+    )
+    with patch_rc, patch_functions:
+        yield
+
+
+def test_when_no_mod_name_is_provided_then_default_results_should_be_returned(
+    runner_client,
+):
+    expected_docs = {
+        "fnord": "\n        This is some docstring, OK?\n        ",
+        "baz": "\n        This is another docstring, OK?\n        ",
+    }
+
+    actual_docs = doc.runner()
+
+    assert actual_docs == expected_docs
+
+
+def test_when_mod_name_is_provided_then_docs_for_that_mod_should_be_returned(
+    runner_client,
+):
+    module_name = "fnord"
+    expected_docs = {module_name: "\n        This is some docstring, OK?\n        "}
+
+    actual_docs = doc.runner(module_name)
+
+    assert actual_docs == expected_docs
+
+
+def test_when_mod_name_is_provided_and_mod_name_does_not_exist_then_empty_data_should_be_returned(
+    runner_client,
+):
+    expected_docs = {}
+    module_name = "not-da-module"
+
+    actual_docs = doc.runner(module_name)
+
+    assert actual_docs == expected_docs


### PR DESCRIPTION
### What does this PR do?
Updates `doc.runner` to make use of the already underlying functionality to supply an argument to look at docs for a specific runner.

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
Calling `salt-run doc.runner` would dump all runner docs

### New Behavior
You can now call `salt-run doc.runner winrepo` or `salt-run doc.runner manage.down` to get docs specific to that module, or method.

