### PR TITLE
Fix import of Crypto in salt.cloud.clouds.ec2

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -138,7 +138,9 @@ except ImportError:
     HAS_M2 = False
 
 try:
-    import Crypto
+    import Crypto.Hash.SHA
+    import Crypto.PublicKey.RSA
+    import Crypto.Random
 
     # PKCS1_v1_5 was added in PyCrypto 2.5
     from Crypto.Cipher import PKCS1_v1_5  # pylint: disable=E0611


### PR DESCRIPTION
When running the salt tests against the installed salt module (with `Crypto`
available, but not `M2Crypto`), `test_get_password_data` failed:

```
======================================================================
ERROR: test_get_password_data (unit.cloud.clouds.test_ec2.EC2TestCase)
[CPU:0.0%|MEM:29.4%]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.8/unittest/mock.py", line 1325, in patched
    return func(*newargs, **newkeywargs)
  File "tests/unit/cloud/clouds/test_ec2.py", line 90, in test_get_password_data
    ret = ec2.get_password_data(
  File "/usr/lib/python3/dist-packages/salt/cloud/clouds/ec2.py", line 4970, in get_password_data
    key_obj = Crypto.PublicKey.RSA.importKey(rsa_key)
AttributeError: module 'Crypto.PublicKey' has no attribute 'RSA'
```

When importing `Crypto`, only `Crypto.version_info` was available. Therefore
import the needed submodules of `Crypto` explicitly. Split
`test_get_password_data` into two tests: One to test the code path for
`M2Crypto` and one for `Crypto`.
