### PR TITLE
Fixes to fail_with_changes in test state 

### DIFF
--- a/changelog/57766.fixed
+++ b/changelog/57766.fixed
@@ -1,0 +1,1 @@
+Fixed fail_with_changes in the test state to use the comment argument when passed.

--- a/salt/states/test.py
+++ b/salt/states/test.py
@@ -163,7 +163,7 @@ def fail_with_changes(name, **kwargs):  # pylint: disable=unused-argument
     """
     comment = kwargs.get("comment", "Failure!")
 
-    ret = {"name": name, "changes": {}, "result": False, "comment": "Failure!"}
+    ret = {"name": name, "changes": {}, "result": False, "comment": comment}
 
     # Following the docs as written here
     # http://docs.saltstack.com/ref/states/writing.html#return-data
@@ -173,7 +173,7 @@ def fail_with_changes(name, **kwargs):  # pylint: disable=unused-argument
 
     if __opts__["test"]:
         ret["result"] = None
-        ret["comment"] = "If we weren't testing, this would be failed with " "changes"
+        ret["comment"] = "If we weren't testing, this would be failed with changes"
 
     return ret
 

--- a/tests/unit/states/test_test.py
+++ b/tests/unit/states/test_test.py
@@ -57,6 +57,10 @@ class TestTestCase(TestCase, LoaderModuleMockMixin):
                 test.fail_without_changes("salt", comment="A failure comment!"), ret
             )
 
+        with patch.dict(test.__opts__, {"test": True}):
+            ret.update({"comment": "If we weren't testing, this would be a failure!"})
+            self.assertDictEqual(test.fail_without_changes("salt"), ret)
+
     def test_succeed_with_changes(self):
         """
             Test to returns successful and changes is not empty
@@ -67,7 +71,7 @@ class TestTestCase(TestCase, LoaderModuleMockMixin):
                 {
                     "changes": {
                         "testing": {
-                            "new": "Something pretended" " to change",
+                            "new": "Something pretended to change",
                             "old": "Unchanged",
                         }
                     },
@@ -82,12 +86,29 @@ class TestTestCase(TestCase, LoaderModuleMockMixin):
                 {
                     "changes": {
                         "testing": {
-                            "new": "Something pretended" " to change",
+                            "new": "Something pretended to change",
                             "old": "Unchanged",
                         }
                     },
                     "comment": "A success comment!",
                     "result": True,
+                }
+            )
+            self.assertDictEqual(
+                test.succeed_with_changes("salt", comment="A success comment!"), ret
+            )
+
+        with patch.dict(test.__opts__, {"test": True}):
+            ret.update(
+                {
+                    "changes": {
+                        "testing": {
+                            "new": "Something pretended to change",
+                            "old": "Unchanged",
+                        }
+                    },
+                    "comment": "If we weren't testing, this would be successful with changes",
+                    "result": None,
                 }
             )
             self.assertDictEqual(
@@ -104,31 +125,48 @@ class TestTestCase(TestCase, LoaderModuleMockMixin):
                 {
                     "changes": {
                         "testing": {
-                            "new": "Something pretended" " to change",
+                            "new": "Something pretended to change",
                             "old": "Unchanged",
                         }
                     },
-                    "comment": "Success!",
-                    "result": True,
+                    "comment": "Failure!",
+                    "result": False,
                 }
             )
-            self.assertDictEqual(test.succeed_with_changes("salt"), ret)
+            self.assertDictEqual(test.fail_with_changes("salt"), ret)
 
         with patch.dict(test.__opts__, {"test": False}):
             ret.update(
                 {
                     "changes": {
                         "testing": {
-                            "new": "Something pretended" " to change",
+                            "new": "Something pretended to change",
                             "old": "Unchanged",
                         }
                     },
                     "comment": "A failure comment!",
-                    "result": True,
+                    "result": False,
                 }
             )
             self.assertDictEqual(
-                test.succeed_with_changes("salt", comment="A failure comment!"), ret
+                test.fail_with_changes("salt", comment="A failure comment!"), ret
+            )
+
+        with patch.dict(test.__opts__, {"test": True}):
+            ret.update(
+                {
+                    "changes": {
+                        "testing": {
+                            "new": "Something pretended to change",
+                            "old": "Unchanged",
+                        }
+                    },
+                    "comment": "If we weren't testing, this would be failed with changes",
+                    "result": None,
+                }
+            )
+            self.assertDictEqual(
+                test.fail_with_changes("salt", comment="A failure comment!"), ret
             )
 
     def test_configurable_test_state(self):


### PR DESCRIPTION
### What does this PR do?
The fail_with_changes state should use the comment argument when passed.  Additional tests.

### What issues does this PR fix or reference?
Fixes: #51821

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
