### PR TITLE
states.postgres_initdb: docfix "checksums" parameter

### DIFF
--- a/salt/states/postgres_initdb.py
+++ b/salt/states/postgres_initdb.py
@@ -20,7 +20,7 @@ data directory.
         - locale: C
         - runas: postgres
         - allow_group_access: True
-        - data_checksums: True
+        - checksums: True
         - wal_segsize: 32
 
 """


### PR DESCRIPTION
The example lists the "checksums" parameter (correct name, used
throughout the code) erroneously as "data_checksums", this has
confused people (private report).

### What does this PR do?
documentation fix (example was wrong)
