### PR TITLE
Fix cascading KeyError in rh_ip

### DIFF
--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -752,7 +752,7 @@ def _parse_settings_eth(opts, iface_type, enabled, iface):
         result["devtype"] = "IPIP"
         for opt in ["my_inner_ipaddr", "my_outer_ipaddr"]:
             if opt not in opts:
-                _raise_error_iface(iface, opts[opt], ["1.2.3.4"])
+                _raise_error_iface(iface, opt, ["1.2.3.4"])
             else:
                 result[opt] = opts[opt]
     if iface_type == "ib":


### PR DESCRIPTION
### What does this PR do?
Fix a cascading KeyError exception

### Intended behavior
If configuring an IPIP interface, two options are mandatory.
If one option is missing, the _raise_error_iface() function is called.

This function should raise an AttributeError: Invalid option.

### Previous behavior
With the current code, what will happen though is that the error is
raised, the opts dictionary is searched for the missing key which in
turn raises another KeyError during the handling of the first exception.

The intention was to print the key (opt) and not the value (opts['opt']).

### New behavior
Fix this, new error will correctly print the AttributeError
