### PR TITLE
Fix auto_addr logic in rh_ip

### DIFF
--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -711,7 +711,7 @@ def _parse_settings_eth(opts, iface_type, enabled, iface):
             if iface_type != "slave":
                 ifaces = __salt__["network.interfaces"]()
                 if iface in ifaces and "hwaddr" in ifaces[iface]:
-                    result["addr"] = ifaces[iface]["hwaddr"]
+                    result["hwaddr"] = ifaces[iface]["hwaddr"]
     if iface_type == "eth":
         result["devtype"] = "Ethernet"
     if iface_type == "bridge":


### PR DESCRIPTION
### What does this PR do?

RedHat interface configuration files expect the MAC address of the
interface to be set in the file using the HWADDR key to ensure that
the right interface is being controlled, even if a name/index
should have changed.

This key can be set using the hwaddr key for the network.managed
state module.

If the hwaddr key is omitted, salt has a bit of code that will
call network.interfaces to figure out the mac address by itself.

This logic is called auto_addr and has a small problem as the just
detected address is written to the addr key instead of the
hwaddr key.
The addr key is never used...

Fix this.

The original bug was introduced in dd7a1cb9558 when addr was changed
to hwaddr and this spot was missed.