### PR TITLE
Add teamed network interface support to rh_ip.py

### DIFF
--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -711,7 +711,7 @@ def _parse_settings_eth(opts, iface_type, enabled, iface):
             if iface_type != "slave":
                 ifaces = __salt__["network.interfaces"]()
                 if iface in ifaces and "hwaddr" in ifaces[iface]:
-                    result["addr"] = ifaces[iface]["hwaddr"]
+                    result["hwaddr"] = ifaces[iface]["hwaddr"]
     if iface_type == "eth":
         result["devtype"] = "Ethernet"
     if iface_type == "bridge":

--- a/salt/states/network.py
+++ b/salt/states/network.py
@@ -283,6 +283,47 @@ all interfaces are ignored unless specified.
           - 8.8.8.8
           - 8.8.4.4
 
+    # Teamed network using libteam
+    eth9:
+      network.managed:
+        - enabled: True
+        - type: teamport
+        - team_master: team0
+        - team_port_config:
+            prio: -10
+            sticky: true
+
+    eth10:
+      network.managed:
+        - enabled: True
+        - type: teamport
+        - team_master: team0
+        - team_port_config:
+            prio: 100
+
+    team0:
+      network.managed:
+        - enabled: True
+        - type: team
+        - ipaddr: 192.168.23.11
+        - prefix: 24
+        - team_config:
+            runner:
+              name: activebackup
+            link_watch:
+              name: arp_ping
+              interval: 100
+              missed_max: 30
+              source_host: 192.168.23.2
+              target_host: 192.168.23.1
+
+    .. note::
+        When using teamd, the port/team configuration is a dictionary which
+        means the indentation is very important. Just indenting 2 spaces is
+        not enough and would result in team_config being None, 4 however works.
+
+    .. versionadded:: master
+
     system:
       network.system:
         - enabled: True

--- a/salt/templates/rh_ip/rh7_eth.jinja
+++ b/salt/templates/rh_ip/rh7_eth.jinja
@@ -11,6 +11,7 @@ DEVICE="{{name}}"
 {%endif%}{% if vlan_id %}VID="{{vlan_id}}"
 {%endif%}{% if phys_dev %}PHYSDEV="{{phys_dev}}"
 {%endif%}{%endif%}{% if devtype %}TYPE="{{devtype}}"
+{%endif%}{% if devicetype %}DEVICETYPE="{{devicetype}}"
 {%endif%}{% if proto %}BOOTPROTO="{{proto}}"
 {%endif%}{% if onboot %}ONBOOT="{{onboot}}"
 {%endif%}{% if onparent %}ONPARENT={{onparent}}
@@ -48,6 +49,9 @@ PREFIX{{loop.index}}="{{i['prefix']}}"
 {%endif%}{% if zone %}ZONE="{{zone}}"
 {%endif%}{% if my_inner_ipaddr %}MY_INNER_IPADDR={{my_inner_ipaddr}}
 {%endif%}{% if my_outer_ipaddr %}MY_OUTER_IPADDR={{my_outer_ipaddr}}
+{%endif%}{% if team_master %}TEAM_MASTER="{{team_master}}"
+{%endif%}{% if team_config %}TEAM_CONFIG='{{team_config|tojson}}'
+{%endif%}{% if team_port_config %}TEAM_PORT_CONFIG='{{team_port_config|tojson}}'
 {%endif%}{% if bonding %}BONDING_OPTS="{%for item in bonding %}{{item}}={{bonding[item]}} {%endfor%}"
 {%endif%}{% if ethtool %}ETHTOOL_OPTS="{%for item in ethtool %}{{item}} {{ethtool[item]}} {%endfor%}"
 {%endif%}{% if domain %}DOMAIN="{{ domain|join(' ') }}"


### PR DESCRIPTION
### What does this PR do?
Salt currently allows to configure bonded network interfaces for
redundancy.

With RHEL7 RedHat has added an alterantive approach called teamd.
The website for this project is at <http://libteam.org>.
Teamd is a userspace daemon that controls the trunked interfaces
via the netlink layer allowing for more flexibility than the
bonding module.

Add support for teamd configuration to salt rh_ip.