### PR TITLE
hacking: Switch OpenComparison to Django Packages

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -23,14 +23,14 @@ The goal here is to make contributions clear, make sure there is a trail for
 where the code has come from, but most importantly, to give credit where credit
 is due!
 
-The `Open Comparison Contributing Docs`__ explains the workflow for forking,
+The `Django Packages Contributing Docs`__ explains the workflow for forking,
 cloning, branching, committing, and sending a pull request for the git
 repository.
 
 ``git pull upstream develop`` is a shorter way to update your local repository
 to the latest version.
 
-.. __: http://opencomparison.readthedocs.org/en/latest/contributing.html
+.. __: https://djangopackages.readthedocs.io/en/latest/contributing.html
 
 Editing and Previewing the Docs
 -------------------------------


### PR DESCRIPTION
# What does this PR do?

The OpenComparison project has been renamed to Django Packages (https://github.com/djangopackages/djangopackages/commit/7f33346). This PR updates the `HACKING` documentation.