### PR TITLE
File state: skip symlink file permissions on linux

### DIFF
--- a/changelog/55878.fixed
+++ b/changelog/55878.fixed
@@ -1,0 +1,1 @@
+Fixed file.directory state always showing mode change for symlinks.

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3520,6 +3520,11 @@ def directory(
 
         .. versionadded:: 2014.1.4
 
+        .. versionchanged:: 3001.1
+        If set to False symlinks permissions are ignored on Linux systems
+        because it does not support permissions modification. Symlinks
+        permissions are always 0o777 on Linux.
+
     force
         If the name of the directory exists and is not a directory and
         force is set to False, the state will fail. If force is set to

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3532,9 +3532,9 @@ def directory(
         .. versionadded:: 2014.1.4
 
         .. versionchanged:: 3001.1
-        If set to False symlinks permissions are ignored on Linux systems
-        because it does not support permissions modification. Symlinks
-        permissions are always 0o777 on Linux.
+            If set to False symlinks permissions are ignored on Linux systems
+            because it does not support permissions modification. Symlinks
+            permissions are always 0o777 on Linux.
 
     force
         If the name of the directory exists and is not a directory and

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -754,9 +754,18 @@ def _check_directory(
                         fchange["user"] = user
                     if group is not None and group != stats.get("group"):
                         fchange["group"] = group
-                    if file_mode is not None and salt.utils.files.normalize_mode(
-                        file_mode
-                    ) != salt.utils.files.normalize_mode(stats.get("mode")):
+                    if (
+                        file_mode is not None
+                        and salt.utils.files.normalize_mode(file_mode)
+                        != salt.utils.files.normalize_mode(stats.get("mode"))
+                        and (
+                            # Ignore mode for symlinks on linux based systems where we can not
+                            # change symlink file permissions
+                            follow_symlinks
+                            or stats.get("type") != "link"
+                            or not salt.utils.platform.is_linux()
+                        )
+                    ):
                         fchange["mode"] = file_mode
                     if fchange:
                         changes[path] = fchange

--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -2892,23 +2892,23 @@ class TestFilePrivateFunctions(TestCase, LoaderModuleMockMixin):
                     create_files(sub_dir_name)
             # Symlinks on linux systems always have 0o777 permissions.
             # Ensure we are not treating them as modified files.
-            path = os.path.join(root_tmp_dir, "symlink_target_dir")
-            os.mkdir(path)
-            os.chmod(path, expected_mode)
-            file_path = os.path.join(path, "symlink_file")
-            with salt.utils.files.fopen(file_path, "w+"):
+            target_dir = os.path.join(root_tmp_dir, "link_target_dir")
+            target_file = os.path.join(target_dir, "link_target_file")
+            link_dir = os.path.join(root_tmp_dir, "link_dir")
+            link_to_dir = os.path.join(link_dir, "link_to_dir")
+            link_to_file = os.path.join(link_dir, "link_to_file")
+
+            os.mkdir(target_dir)
+            os.mkdir(link_dir)
+            with salt.utils.files.fopen(target_file, "w+"):
                 pass
-            os.chmod(file_path, expected_mode)
-            path = os.path.join(root_tmp_dir, "symlink_dir")
-            os.mkdir(path)
-            os.chmod(path, expected_mode)
-            link_path = os.path.join(path, "symlink")
-            os.symlink(file_path, link_path)
-            try:
-                # For non-linux platforms
-                os.chmod(link_path, expected_mode, follow_symlinks=False)
-            except NotImplementedError:
-                pass
+            os.symlink(target_dir, link_to_dir)
+            os.symlink(target_file, link_to_file)
+            for path in (target_dir, target_file, link_dir, link_to_dir, link_to_file):
+                try:
+                    os.chmod(path, expected_mode, follow_symlinks=False)
+                except NotImplementedError:
+                    os.chmod(path, expected_mode)
 
             # Set some bad permissions
             changed_files = {

--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -2907,7 +2907,7 @@ class TestFilePrivateFunctions(TestCase, LoaderModuleMockMixin):
             for path in (target_dir, target_file, link_dir, link_to_dir, link_to_file):
                 try:
                     os.chmod(path, expected_mode, follow_symlinks=False)
-                except NotImplementedError:
+                except (NotImplementedError, SystemError):
                     os.chmod(path, expected_mode)
 
             # Set some bad permissions


### PR DESCRIPTION
### What does this PR do?
Ignore file permissions for symlinks on linux if `follow_symlinks` is `False` since it does not allow permission change.

### What issues does this PR fix or reference?
Fixes: #55878

### Previous Behavior
`file.directory` state always reports permission changes on symlinks when `follow_symlinks = True` and it is targeted to a symlink or recursively targeted to a directory containing a symlink if `dir_mode` is different from `0o777`. See #55878 for details.

### New Behavior
`file.directory` reports no change when it's not expected.

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes