### PR TITLE
Raise SaltClientError in parse_host_port 

### DIFF
--- a/changelog/57789.fixed
+++ b/changelog/57789.fixed
@@ -1,0 +1,1 @@
+Raise SaltClientError in parse_host_port insted of ValueError so it is caught and handled properly when the minion is connecting to the master.

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -261,7 +261,10 @@ def prep_ip_port(opts):
     if opts["master_uri_format"] == "ip_only":
         ret["master"] = ipaddress.ip_address(opts["master"])
     else:
-        host, port = parse_host_port(opts["master"])
+        try:
+            host, port = parse_host_port(opts["master"])
+        except ValueError as exc:
+            raise SaltClientError(exc)
         ret = {"master": host}
         if port:
             ret.update({"master_port": port})

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -2145,7 +2145,7 @@ def parse_host_port(host_port):
                 port = int(_s_.lstrip(":"))
             else:
                 if len(_s_) > 1:
-                    raise SaltClientError(
+                    raise ValueError(
                         'found ambiguous "{}" port in "{}"'.format(_s_, host_port)
                     )
     else:
@@ -2154,7 +2154,7 @@ def parse_host_port(host_port):
             try:
                 port = int(port)
             except ValueError as _e_:
-                raise SaltClientError(
+                raise ValueError(
                     'host_port "{}" port value "{}" is not an integer.'.format(
                         host_port, port
                     )
@@ -2169,7 +2169,7 @@ def parse_host_port(host_port):
         log.debug('"%s" Not an IP address? Assuming it is a hostname.', host)
         if host != sanitize_host(host):
             log.error('bad hostname: "%s"', host)
-            raise SaltClientError('bad hostname: "{}"'.format(host))
+            raise ValueError('bad hostname: "{}"'.format(host))
 
     return host, port
 

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -2145,7 +2145,7 @@ def parse_host_port(host_port):
                 port = int(_s_.lstrip(":"))
             else:
                 if len(_s_) > 1:
-                    raise ValueError(
+                    raise SaltClientError(
                         'found ambiguous "{}" port in "{}"'.format(_s_, host_port)
                     )
     else:
@@ -2154,10 +2154,11 @@ def parse_host_port(host_port):
             try:
                 port = int(port)
             except ValueError as _e_:
-                log.error(
-                    'host_port "%s" port value "%s" is not an integer.', host_port, port
+                raise SaltClientError(
+                    'host_port "{}" port value "{}" is not an integer.'.format(
+                        host_port, port
+                    )
                 )
-                raise _e_
         else:
             host = _s_
     try:
@@ -2168,7 +2169,7 @@ def parse_host_port(host_port):
         log.debug('"%s" Not an IP address? Assuming it is a hostname.', host)
         if host != sanitize_host(host):
             log.error('bad hostname: "%s"', host)
-            raise ValueError('bad hostname: "{}"'.format(host))
+            raise SaltClientError('bad hostname: "{}"'.format(host))
 
     return host, port
 

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -2154,6 +2154,11 @@ def parse_host_port(host_port):
             try:
                 port = int(port)
             except ValueError as _e_:
+                log.error(
+                    'host_port "{}" port value "{}" is not an integer.'.format(
+                        host_port, port
+                    )
+                )
                 raise ValueError(
                     'host_port "{}" port value "{}" is not an integer.'.format(
                         host_port, port

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -7,6 +7,7 @@ import pytest
 import salt.exceptions
 import salt.utils.network as network
 from salt._compat import ipaddress
+from salt.exceptions import SaltClientError
 from tests.support.helpers import slowTest
 from tests.support.mock import MagicMock, create_autospec, mock_open, patch
 from tests.support.unit import TestCase
@@ -263,6 +264,8 @@ class NetworkTestCase(TestCase):
             "2001:0db8:0370:7334",
             "2001:0db8:0370::7334]:1234",
             "2001:0db8:0370:0:a:b:c:d:1234",
+            "host name",
+            "host name:1234",
         ]
         for host_port, assertion_value in good_host_ports.items():
             host = port = None
@@ -271,7 +274,7 @@ class NetworkTestCase(TestCase):
 
         for host_port in bad_host_ports:
             try:
-                self.assertRaises(ValueError, network.parse_host_port, host_port)
+                self.assertRaises(SaltClientError, network.parse_host_port, host_port)
             except AssertionError as _e_:
                 log.error(
                     'bad host_port value: "%s" failed to trigger ValueError exception',

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -7,7 +7,6 @@ import pytest
 import salt.exceptions
 import salt.utils.network as network
 from salt._compat import ipaddress
-from salt.exceptions import SaltClientError
 from tests.support.helpers import slowTest
 from tests.support.mock import MagicMock, create_autospec, mock_open, patch
 from tests.support.unit import TestCase
@@ -274,7 +273,7 @@ class NetworkTestCase(TestCase):
 
         for host_port in bad_host_ports:
             try:
-                self.assertRaises(SaltClientError, network.parse_host_port, host_port)
+                self.assertRaises(ValueError, network.parse_host_port, host_port)
             except AssertionError as _e_:
                 log.error(
                     'bad host_port value: "%s" failed to trigger ValueError exception',

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -265,6 +265,7 @@ class NetworkTestCase(TestCase):
             "2001:0db8:0370:0:a:b:c:d:1234",
             "host name",
             "host name:1234",
+            "10.10.0.3:abcd",
         ]
         for host_port, assertion_value in good_host_ports.items():
             host = port = None


### PR DESCRIPTION
### What does this PR do?
Raise SaltClientError in parse_host_port so it is caught and handled properly when the minion is connecting to the master.  Updating tests.

### What issues does this PR fix or reference?
Fixes: #57284

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
