### PR TITLE
Fixed issue with a missing key being returned from the win_system.workgroup state.

### DIFF
--- a/changelog/57790.fixed
+++ b/changelog/57790.fixed
@@ -1,0 +1,3 @@
+Fixed issue with the return dictionary from the workgroup() function in the
+salt.states.win_system module. This resulted in a windows-based minion logging
+an error and could also interfere with a highstate being applied.

--- a/salt/states/win_system.py
+++ b/salt/states/win_system.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Management of Windows system information
 ========================================
@@ -16,7 +15,6 @@ description.
     This is Erik's computer, don't touch!:
       system.computer_desc: []
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Python libs
 import logging
@@ -24,7 +22,6 @@ import logging
 # Import Salt libs
 import salt.utils.functools
 import salt.utils.platform
-from salt.ext import six
 
 log = logging.getLogger(__name__)
 
@@ -51,13 +48,13 @@ def computer_desc(name):
         The desired computer description
     """
     # Just in case someone decides to enter a numeric description
-    name = six.text_type(name)
+    name = str(name)
 
     ret = {
         "name": name,
         "changes": {},
         "result": True,
-        "comment": "Computer description already set to '{0}'".format(name),
+        "comment": "Computer description already set to '{}'".format(name),
     }
 
     before_desc = __salt__["system.get_computer_desc"]()
@@ -67,18 +64,18 @@ def computer_desc(name):
 
     if __opts__["test"]:
         ret["result"] = None
-        ret["comment"] = "Computer description will be changed to '{0}'".format(name)
+        ret["comment"] = "Computer description will be changed to '{}'".format(name)
         return ret
 
     result = __salt__["system.set_computer_desc"](name)
     if result["Computer Description"] == name:
-        ret["comment"] = "Computer description successfully changed to '{0}'".format(
+        ret["comment"] = "Computer description successfully changed to '{}'".format(
             name
         )
         ret["changes"] = {"old": before_desc, "new": name}
     else:
         ret["result"] = False
-        ret["comment"] = "Unable to set computer description to " "'{0}'".format(name)
+        ret["comment"] = "Unable to set computer description to " "'{}'".format(name)
     return ret
 
 
@@ -95,13 +92,13 @@ def computer_name(name):
         The desired computer name
     """
     # Just in case someone decides to enter a numeric description
-    name = six.text_type(name)
+    name = str(name)
 
     ret = {
         "name": name,
         "changes": {},
         "result": True,
-        "comment": "Computer name already set to '{0}'".format(name),
+        "comment": "Computer name already set to '{}'".format(name),
     }
 
     before_name = __salt__["system.get_computer_name"]()
@@ -111,14 +108,14 @@ def computer_name(name):
         return ret
     elif pending_name == name.upper():
         ret["comment"] = (
-            "The current computer name is '{0}', but will be "
-            "changed to '{1}' on the next reboot".format(before_name, name)
+            "The current computer name is '{}', but will be "
+            "changed to '{}' on the next reboot".format(before_name, name)
         )
         return ret
 
     if __opts__["test"]:
         ret["result"] = None
-        ret["comment"] = "Computer name will be changed to '{0}'".format(name)
+        ret["comment"] = "Computer name will be changed to '{}'".format(name)
         return ret
 
     result = __salt__["system.set_computer_name"](name)
@@ -128,13 +125,13 @@ def computer_name(name):
         if (after_pending is not None and after_pending == name) or (
             after_pending is None and after_name == name
         ):
-            ret["comment"] = "Computer name successfully set to '{0}'".format(name)
+            ret["comment"] = "Computer name successfully set to '{}'".format(name)
             if after_pending is not None:
                 ret["comment"] += " (reboot required for change to take effect)"
         ret["changes"] = {"old": before_name, "new": name}
     else:
         ret["result"] = False
-        ret["comment"] = "Unable to set computer name to '{0}'".format(name)
+        ret["comment"] = "Unable to set computer name to '{}'".format(name)
     return ret
 
 
@@ -152,15 +149,15 @@ def hostname(name):
     current_hostname = __salt__["system.get_hostname"]()
 
     if current_hostname.upper() == name.upper():
-        ret["comment"] = "Hostname is already set to '{0}'".format(name)
+        ret["comment"] = "Hostname is already set to '{}'".format(name)
         return ret
 
     out = __salt__["system.set_hostname"](name)
 
     if out:
         ret["comment"] = (
-            "The current hostname is '{0}', "
-            "but will be changed to '{1}' on the next reboot".format(
+            "The current hostname is '{}', "
+            "but will be changed to '{}' on the next reboot".format(
                 current_hostname, name
             )
         )
@@ -204,14 +201,14 @@ def workgroup(name):
     # Notify the user if the requested workgroup is the same
     if current_workgroup.upper() == name.upper():
         ret["result"] = True
-        ret["comment"] = "Workgroup is already set to '{0}'".format(name.upper())
+        ret["comment"] = "Workgroup is already set to '{}'".format(name.upper())
         return ret
 
     # If being run in test-mode, inform the user what is supposed to happen
     if __opts__["test"]:
         ret["result"] = None
         ret["changes"] = {}
-        ret["comment"] = "Computer will be joined to workgroup '{0}'".format(name)
+        ret["comment"] = "Computer will be joined to workgroup '{}'".format(name)
         return ret
 
     # Set our new workgroup, and then immediately ask the machine what it
@@ -229,12 +226,12 @@ def workgroup(name):
     # Return our results based on the changes
     if res and current_workgroup.upper() == new_workgroup.upper():
         ret["result"] = True
-        ret["comment"] = "The new workgroup '{0}' is the same as '{1}'".format(
+        ret["comment"] = "The new workgroup '{}' is the same as '{}'".format(
             current_workgroup.upper(), new_workgroup.upper()
         )
     elif res:
         ret["result"] = True
-        ret["comment"] = "The workgroup has been changed from '{0}' to '{1}'".format(
+        ret["comment"] = "The workgroup has been changed from '{}' to '{}'".format(
             current_workgroup.upper(), new_workgroup.upper()
         )
         ret["changes"] = {
@@ -243,7 +240,7 @@ def workgroup(name):
         }
     else:
         ret["result"] = False
-        ret["comment"] = "Unable to join the requested workgroup '{0}'".format(
+        ret["comment"] = "Unable to join the requested workgroup '{}'".format(
             new_workgroup.upper()
         )
 
@@ -304,7 +301,7 @@ def join_domain(
         "name": name,
         "changes": {},
         "result": True,
-        "comment": "Computer already added to '{0}'".format(name),
+        "comment": "Computer already added to '{}'".format(name),
     }
 
     current_domain_dic = __salt__["system.get_domain_workgroup"]()
@@ -316,12 +313,12 @@ def join_domain(
         current_domain = None
 
     if name.lower() == current_domain.lower():
-        ret["comment"] = "Computer already added to '{0}'".format(name)
+        ret["comment"] = "Computer already added to '{}'".format(name)
         return ret
 
     if __opts__["test"]:
         ret["result"] = None
-        ret["comment"] = "Computer will be added to '{0}'".format(name)
+        ret["comment"] = "Computer will be added to '{}'".format(name)
         return ret
 
     result = __salt__["system.join_domain"](
@@ -333,14 +330,14 @@ def join_domain(
         restart=restart,
     )
     if result is not False:
-        ret["comment"] = "Computer added to '{0}'".format(name)
+        ret["comment"] = "Computer added to '{}'".format(name)
         if restart:
             ret["comment"] += "\nSystem will restart"
         else:
             ret["comment"] += "\nSystem needs to be restarted"
         ret["changes"] = {"old": current_domain, "new": name}
     else:
-        ret["comment"] = "Computer failed to join '{0}'".format(name)
+        ret["comment"] = "Computer failed to join '{}'".format(name)
         ret["result"] = False
     return ret
 
@@ -467,17 +464,17 @@ def shutdown(
     if only_on_pending_reboot and not __salt__["system.get_pending_reboot"]():
         if __opts__["test"]:
             ret["comment"] = (
-                "System {0} will be skipped because " "no reboot is pending"
+                "System {} will be skipped because " "no reboot is pending"
             ).format(action)
         else:
             ret["comment"] = (
-                "System {0} has been skipped because " "no reboot was pending"
+                "System {} has been skipped because " "no reboot was pending"
             ).format(action)
         return ret
 
     if __opts__["test"]:
         ret["result"] = None
-        ret["comment"] = "Will attempt to schedule a {0}".format(action)
+        ret["comment"] = "Will attempt to schedule a {}".format(action)
         return ret
 
     ret["result"] = __salt__["system.shutdown"](
@@ -492,9 +489,9 @@ def shutdown(
     if ret["result"]:
         ret["changes"] = {
             "old": "No reboot or shutdown was scheduled",
-            "new": "A {0} has been scheduled".format(action),
+            "new": "A {} has been scheduled".format(action),
         }
-        ret["comment"] = "Request to {0} was successful".format(action)
+        ret["comment"] = "Request to {} was successful".format(action)
     else:
-        ret["comment"] = "Request to {0} failed".format(action)
+        ret["comment"] = "Request to {} failed".format(action)
     return ret

--- a/salt/states/win_system.py
+++ b/salt/states/win_system.py
@@ -16,10 +16,8 @@ description.
       system.computer_desc: []
 """
 
-# Import Python libs
 import logging
 
-# Import Salt libs
 import salt.utils.functools
 import salt.utils.platform
 

--- a/salt/states/win_system.py
+++ b/salt/states/win_system.py
@@ -227,7 +227,6 @@ def workgroup(name):
     )
 
     # Return our results based on the changes
-    ret = {}
     if res and current_workgroup.upper() == new_workgroup.upper():
         ret["result"] = True
         ret["comment"] = "The new workgroup '{0}' is the same as '{1}'".format(

--- a/tests/unit/states/test_win_system.py
+++ b/tests/unit/states/test_win_system.py
@@ -2,12 +2,8 @@
     :codeauthor: Rahul Handay <rahulha@saltstack.com>
 """
 
-# Import Python Libs
 
-# Import Salt Libs
 import salt.states.win_system as win_system
-
-# Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase

--- a/tests/unit/states/test_win_system.py
+++ b/tests/unit/states/test_win_system.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 """
     :codeauthor: Rahul Handay <rahulha@saltstack.com>
 """
 
 # Import Python Libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Libs
 import salt.states.win_system as win_system

--- a/tests/unit/states/test_win_system.py
+++ b/tests/unit/states/test_win_system.py
@@ -152,3 +152,51 @@ class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
             )
 
             self.assertDictEqual(win_system.hostname("SALT"), ret)
+
+    def test_workgroup(self):
+        ret = {"name": "salt", "changes": {}, "result": True, "comment": ""}
+
+        mock = MagicMock(return_value={"Workgroup": "WORKGROUP"})
+        with patch.dict(win_system.__salt__, {"system.get_domain_workgroup": mock}):
+            mock = MagicMock(return_value=True)
+            with patch.dict(win_system.__salt__, {"system.set_domain_workgroup": mock}):
+                with patch.dict(win_system.__opts__, {"test": True}):
+                    ret.update(
+                        {
+                            "comment": "Computer will be joined to workgroup 'WERKGROUP'",
+                            "name": "WERKGROUP",
+                            "result": None,
+                        }
+                    )
+                    self.assertDictEqual(win_system.workgroup("WERKGROUP"), ret)
+
+        mock = MagicMock(return_value={"Workgroup": "WORKGROUP"})
+        with patch.dict(win_system.__salt__, {"system.get_domain_workgroup": mock}):
+            mock = MagicMock(return_value=True)
+            with patch.dict(win_system.__salt__, {"system.set_domain_workgroup": mock}):
+                with patch.dict(win_system.__opts__, {"test": False}):
+                    ret.update(
+                        {
+                            "comment": "Workgroup is already set to 'WORKGROUP'",
+                            "name": "WORKGROUP",
+                            "result": True,
+                        }
+                    )
+                    self.assertDictEqual(win_system.workgroup("WORKGROUP"), ret)
+
+        mock = MagicMock(
+            side_effect=[{"Workgroup": "WORKGROUP"}, {"Workgroup": "WERKGROUP"}]
+        )
+        with patch.dict(win_system.__salt__, {"system.get_domain_workgroup": mock}):
+            mock = MagicMock(return_value=True)
+            with patch.dict(win_system.__salt__, {"system.set_domain_workgroup": mock}):
+                with patch.dict(win_system.__opts__, {"test": False}):
+                    ret.update(
+                        {
+                            "comment": "The workgroup has been changed from 'WORKGROUP' to 'WERKGROUP'",
+                            "name": "WERKGROUP",
+                            "changes": {"new": "WERKGROUP", "old": "WORKGROUP"},
+                            "result": True,
+                        }
+                    )
+                    self.assertDictEqual(win_system.workgroup("WERKGROUP"), ret)


### PR DESCRIPTION
# What does this PR do?
The `win_system.workgroup` state was returning a dictionary that did not include the "name" key which resulted in a windows-minion logging an error during the application of a state. This is due to the function re-initializing its return dictionary with an empty one thus clearing out the necessary dictionary item. In some cases this could interfere with a high-state being applied.

### What issues does this PR fix or reference?
fixes #57790 

### Previous Behavior
Previously when calling the `win_system.workgroup` state the dictionary that it would return would be missing the "name" key that was passed as its parameters. During the validation of the return dictionary, an error would be logged and interrupt the state that is currently being applied.

### New Behavior
The line that reassigns the return dictionary has been removed which allows the previous assignment of the "name" key to be returned passing the checks imposed by the content checker decorator.

### Merge requirements satisfied?
- [ ] Docs
- [X] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No