### PR TITLE
Use atomic open to write cache

### DIFF
--- a/changelog/57798.fixed
+++ b/changelog/57798.fixed
@@ -1,0 +1,1 @@
+Fixes UnpackValueError when using GPG cache by using atomic open.

--- a/salt/utils/cache.py
+++ b/salt/utils/cache.py
@@ -13,6 +13,7 @@ import time
 # Import salt libs
 import salt.config
 import salt.payload
+import salt.utils.atomicfile
 import salt.utils.data
 import salt.utils.dictupdate
 import salt.utils.files
@@ -161,7 +162,7 @@ class CacheDisk(CacheDict):
             return
         # TODO Add check into preflight to ensure dir exists
         # TODO Dir hashing?
-        with salt.utils.files.fopen(self._path, "wb+") as fp_:
+        with salt.utils.atomicfile.atomic_open(self._path, "wb+") as fp_:
             cache = {
                 "CacheDisk_data": self._dict,
                 "CacheDisk_cachetime": self._key_cache_time,

--- a/tests/unit/renderers/test_gpg.py
+++ b/tests/unit/renderers/test_gpg.py
@@ -3,6 +3,7 @@
 # Import Python Libs
 from __future__ import absolute_import, print_function, unicode_literals
 
+from subprocess import PIPE
 from textwrap import dedent
 
 # Import Salt libs
@@ -10,12 +11,15 @@ import salt.renderers.gpg as gpg
 from salt.exceptions import SaltRenderError
 
 # Import Salt Testing libs
-from tests.support.mixins import LoaderModuleMockMixin
-from tests.support.mock import MagicMock, patch
+from tests.support.mixins import (
+    AdaptedConfigurationTestCaseMixin,
+    LoaderModuleMockMixin,
+)
+from tests.support.mock import MagicMock, Mock, call, patch
 from tests.support.unit import TestCase
 
 
-class GPGTestCase(TestCase, LoaderModuleMockMixin):
+class GPGTestCase(TestCase, LoaderModuleMockMixin, AdaptedConfigurationTestCaseMixin):
     """
     unit test GPG renderer
     """
@@ -193,3 +197,100 @@ class GPGTestCase(TestCase, LoaderModuleMockMixin):
                         gpg.render(crypted, translate_newlines=True, encoding="utf-8"),
                         expected,
                     )
+
+    def test_render_without_cache(self):
+        key_dir = "/etc/salt/gpgkeys"
+        secret = "Use more salt."
+        expected = "\n".join([secret] * 3)
+        crypted = dedent(
+            """\
+            -----BEGIN PGP MESSAGE-----
+            !@#$%^&*()_+
+            -----END PGP MESSAGE-----
+            -----BEGIN PGP MESSAGE-----
+            !@#$%^&*()_+
+            -----END PGP MESSAGE-----
+            -----BEGIN PGP MESSAGE-----
+            !@#$%^&*()_+
+            -----END PGP MESSAGE-----
+        """
+        )
+
+        with patch("salt.renderers.gpg.Popen") as popen_mock:
+            popen_mock.return_value = Mock(
+                communicate=lambda *args, **kwargs: (secret, None),
+            )
+            with patch(
+                "salt.renderers.gpg._get_gpg_exec",
+                MagicMock(return_value="/usr/bin/gpg"),
+            ):
+                with patch(
+                    "salt.renderers.gpg._get_key_dir", MagicMock(return_value=key_dir)
+                ):
+                    self.assertEqual(gpg.render(crypted), expected)
+                    gpg_call = call(
+                        [
+                            "/usr/bin/gpg",
+                            "--homedir",
+                            "/etc/salt/gpgkeys",
+                            "--status-fd",
+                            "2",
+                            "--no-tty",
+                            "-d",
+                        ],
+                        shell=False,
+                        stderr=PIPE,
+                        stdin=PIPE,
+                        stdout=PIPE,
+                    )
+                    popen_mock.assert_has_calls([gpg_call] * 3)
+
+    def test_render_with_cache(self):
+        key_dir = "/etc/salt/gpgkeys"
+        secret = "Use more salt."
+        expected = "\n".join([secret] * 3)
+        crypted = dedent(
+            """\
+            -----BEGIN PGP MESSAGE-----
+            !@#$%^&*()_+
+            -----END PGP MESSAGE-----
+            -----BEGIN PGP MESSAGE-----
+            !@#$%^&*()_+
+            -----END PGP MESSAGE-----
+            -----BEGIN PGP MESSAGE-----
+            !@#$%^&*()_+
+            -----END PGP MESSAGE-----
+        """
+        )
+
+        minion_opts = self.get_temp_config("minion", gpg_cache=True)
+        with patch.dict(gpg.__opts__, minion_opts):
+            with patch("salt.renderers.gpg.Popen") as popen_mock:
+                popen_mock.return_value = Mock(
+                    communicate=lambda *args, **kwargs: (secret, None),
+                )
+                with patch(
+                    "salt.renderers.gpg._get_gpg_exec",
+                    MagicMock(return_value="/usr/bin/gpg"),
+                ):
+                    with patch(
+                        "salt.renderers.gpg._get_key_dir",
+                        MagicMock(return_value=key_dir),
+                    ):
+                        self.assertEqual(gpg.render(crypted), expected)
+                        gpg_call = call(
+                            [
+                                "/usr/bin/gpg",
+                                "--homedir",
+                                "/etc/salt/gpgkeys",
+                                "--status-fd",
+                                "2",
+                                "--no-tty",
+                                "-d",
+                            ],
+                            shell=False,
+                            stderr=PIPE,
+                            stdin=PIPE,
+                            stdout=PIPE,
+                        )
+                        popen_mock.assert_has_calls([gpg_call] * 1)


### PR DESCRIPTION
### What does this PR do?

Following #55772, the `gpg_cache` can be read by a `salt-master` process while another process is writing. This can lead to unpack errors:

    Traceback (most recent call last):
      File "/usr/lib/python3/dist-packages/salt/pillar/__init__.py", line 745, in render_pstate
        **defaults)
      File "/usr/lib/python3/dist-packages/salt/template.py", line 101, in compile_template
        ret = render(input_data, saltenv, sls, **render_kwargs)
      File "/usr/lib/python3/dist-packages/salt/renderers/gpg.py", line 378, in render
        return _decrypt_object(gpg_data, translate_newlines=translate_newlines, encoding=kwargs.get('encoding', None))
      File "/usr/lib/python3/dist-packages/salt/renderers/gpg.py", line 357, in _decrypt_object
       translate_newlines=translate_newlines)
      File "/usr/lib/python3/dist-packages/salt/renderers/gpg.py", line 353, in _decrypt_object
        return _decrypt_ciphertexts(obj, translate_newlines=translate_newlines, encoding=encoding)
      File "/usr/lib/python3/dist-packages/salt/renderers/gpg.py", line 328, in _decrypt_ciphertexts
        ret, num = GPG_CIPHERTEXT.subn(replace, to_bytes(cipher))
      File "/usr/lib/python3/dist-packages/salt/renderers/gpg.py", line 325, in replace
        result = to_bytes(_decrypt_ciphertext(match.group()))
      File "/usr/lib/python3/dist-packages/salt/renderers/gpg.py", line 298, in _decrypt_ciphertext
        cache = _get_cache()
      File "/usr/lib/python3/dist-packages/salt/renderers/gpg.py", line 280, in _get_cache
        minion_cache_path=os.path.join(cachedir, 'gpg_cache')
      File "/usr/lib/python3/dist-packages/salt/utils/cache.py", line 37, in factory
        return CacheDisk(ttl, kwargs['minion_cache_path'], *args, **kwargs)
      File "/usr/lib/python3/dist-packages/salt/utils/cache.py", line 90, in __init__
        self._read()
      File "/usr/lib/python3/dist-packages/salt/utils/cache.py", line 138, in _read
        cache = salt.utils.data.decode(salt.utils.msgpack.load(fp_, encoding=__salt_system_encoding__))
      File "/usr/lib/python3/dist-packages/salt/utils/msgpack.py", line 116, in unpack
        return msgpack.unpack(stream, **_sanitize_msgpack_kwargs(kwargs))
      File "/usr/lib/python3/dist-packages/msgpack/__init__.py", line 58, in unpack
        return unpackb(data, **kwargs)
      File "msgpack/_unpacker.pyx", line 211, in msgpack._unpacker.unpackb
    msgpack.exceptions.UnpackValueError: Unpack failed: error = 0


### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
The above exception may be raised, and the pillar is not rendered.

### New Behavior
The race condition is avoided.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No