### PR TITLE
Fix tuned module on RHEL/CentOS 7.8

### DIFF
--- a/salt/modules/tuned.py
+++ b/salt/modules/tuned.py
@@ -51,6 +51,11 @@ def list_():
     result = __salt__["cmd.run"]("tuned-adm list").splitlines()
     # Remove "Available profiles:"
     result.pop(0)
+    # Cut off any warnings
+    try:
+        result = result[: result.index("** COLLECTED WARNINGS **") - 1]
+    except ValueError:
+        pass
     # Remove "Current active profile:.*"
     result.pop()
     # Output can be : " - <profile name> - <description>" (v2.7.1)

--- a/tests/unit/modules/test_tuned.py
+++ b/tests/unit/modules/test_tuned.py
@@ -88,6 +88,44 @@ Current active profile: virtual-guest
                 ],
             )
 
+    def test_v_2110_with_warnings(self):
+        """
+        Test the list_ function for newer tuned-adm (v2.11.0)
+        as shipped with CentOS-7.8 when warnings are emitted
+        """
+        tuned_list = """Available profiles:
+- balanced                    - General non-specialized tuned profile
+- desktop                     - Optmize for the desktop use-case
+- latency-performance         - Optimize for deterministic performance
+- network-latency             - Optimize for deterministic performance
+- network-throughput          - Optimize for streaming network throughput.
+- powersave                   - Optimize for low power-consumption
+- throughput-performance      - Broadly applicable tuning that provides--
+- virtual-guest               - Optimize for running inside a virtual-guest.
+- virtual-host                - Optimize for running KVM guests
+Current active profile: virtual-guest
+
+** COLLECTED WARNINGS **
+No SMBIOS nor DMI entry point found, sorry.
+** END OF WARNINGS **
+"""
+        mock_cmd = MagicMock(return_value=tuned_list)
+        with patch.dict(tuned.__salt__, {"cmd.run": mock_cmd}):
+            self.assertEqual(
+                tuned.list_(),
+                [
+                    "balanced",
+                    "desktop",
+                    "latency-performance",
+                    "network-latency",
+                    "network-throughput",
+                    "powersave",
+                    "throughput-performance",
+                    "virtual-guest",
+                    "virtual-host",
+                ],
+            )
+
     def test_none(self):
         """
         """


### PR DESCRIPTION
Tuneadm will - under certain circumstances - append a list of errors
found:

```
Available profiles:
- balanced                    - General non-specialized tuned profile
- desktop                     - Optimize for the desktop use-case
- hpc-compute                 - Optimize for HPC compute workloads
- latency-performance         - Optimize for deterministic performance at the cost of increased power consumption
- network-latency             - Optimize for deterministic performance at the cost of increased power consumption, focused on low latency network performance
- network-throughput          - Optimize for streaming network throughput, generally only necessary on older CPUs or 40G+ networks
- powersave                   - Optimize for low power consumption
- throughput-performance      - Broadly applicable tuning that provides excellent performance across a variety of common server workloads
- virtual-guest               - Optimize for running inside a virtual guest
- virtual-host                - Optimize for running KVM guests
Current active profile: virtual-guest

** COLLECTED WARNINGS **
No SMBIOS nor DMI entry point found, sorry.
** END OF WARNINGS **
```

This will confuse the cheap parser and result in the following error:

```
          ID: set_tuned_profile
    Function: tuned.profile
        Name: virtual-guest
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python3.6/site-packages/salt/state.py", line 2154, in call
                  *cdata["args"], **cdata["kwargs"]
                File "/usr/lib/python3.6/site-packages/salt/loader.py", line 2087, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python3.6/site-packages/salt/states/tuned.py", line 45, in profile
                  valid_profiles = __salt__["tuned.list"]()
                File "/usr/lib/python3.6/site-packages/salt/modules/tuned.py", line 64, in list_
                  result = [i.split("- ")[1].strip() for i in result]
                File "/usr/lib/python3.6/site-packages/salt/modules/tuned.py", line 64, in <listcomp>
                  result = [i.split("- ")[1].strip() for i in result]
              IndexError: list index out of range
```

This commit fixes the problem by cutting off any warnings.
A test was added for the specific situation as well.