### PR TITLE
Change get_repo in yumpkg.py to expect repo param

### DIFF
--- a/changelog/57778.fixed
+++ b/changelog/57778.fixed
@@ -1,0 +1,4 @@
+Changed get_repo in yumpkg.py to use "repo" as first parameter.
+This fixes #57778, a bug were every run of pkgrepo.managed state were
+marked as changed because the get_repo did fail to detect a previously
+applied run.

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -13,7 +13,6 @@ Support for YUM/DNF
     automatically in place of YUM in Fedora 22 and newer.
 """
 
-# Import python libs
 
 import contextlib
 import datetime
@@ -24,7 +23,6 @@ import os
 import re
 import string
 
-# Import Salt libs
 import salt.utils.args
 import salt.utils.data
 import salt.utils.decorators.path
@@ -40,9 +38,7 @@ import salt.utils.systemd
 import salt.utils.versions
 from salt.exceptions import CommandExecutionError, MinionError, SaltInvocationError
 
-# Import 3rd-party libs
 # pylint: disable=import-error,redefined-builtin
-# Import 3rd-party libs
 from salt.ext.six.moves import configparser, zip
 from salt.utils.versions import LooseVersion as _LooseVersion
 

--- a/tests/unit/modules/test_yumpkg.py
+++ b/tests/unit/modules/test_yumpkg.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
-
 # Import Python Libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 
@@ -11,7 +8,6 @@ import salt.modules.yumpkg as yumpkg
 
 # Import Salt libs
 from salt.exceptions import CommandExecutionError
-from salt.ext import six
 
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
@@ -332,10 +328,7 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
                 ],
             }
             for pkgname, pkginfo in pkgs.items():
-                if six.PY3:
-                    self.assertCountEqual(pkginfo, expected_pkg_list[pkgname])
-                else:
-                    self.assertItemsEqual(pkginfo, expected_pkg_list[pkgname])
+                self.assertCountEqual(pkginfo, expected_pkg_list[pkgname])
 
     def test_list_patches(self):
         """
@@ -632,7 +625,7 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
                             except AssertionError:
                                 continue
                         else:
-                            self.fail("repo '{0}' not checked".format(repo))
+                            self.fail("repo '{}' not checked".format(repo))
 
     def test_list_upgrades_dnf(self):
         """

--- a/tests/unit/modules/test_yumpkg.py
+++ b/tests/unit/modules/test_yumpkg.py
@@ -1,15 +1,9 @@
-# Import Python Libs
-
 import os
 
 import salt.modules.pkg_resource as pkg_resource
 import salt.modules.rpm_lowpkg as rpm
 import salt.modules.yumpkg as yumpkg
-
-# Import Salt libs
 from salt.exceptions import CommandExecutionError
-
-# Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, Mock, patch
 from tests.support.unit import TestCase, skipIf


### PR DESCRIPTION
### What does this PR do?
Changes the first parameter of yumpkg.get_repo  from "name" to "repo" as the state repopkg.managed changed the call from:

`pkg.get_repo(repo, ppa_auth=kwargs.get('ppa_auth', None)`

to:

`pkg.get_repo(repo=repo, **kwargs)`

And kwargs have another "name" parameter mapped, that makes the get_repo from yumpkg never returns an already existing repository. get_repo at aptpkg, zypperpkg and opkg already uses "repo" as the first parameter.

### What issues does this PR fix or reference?
Fixes: #57778 

### Previous Behavior
Everytime that a pkgrepo.managed state was applied it was "changed" regardless the repository already exists or not.

### New Behavior
If the repository already exists with the same configuration, it is leaved unchanged. The expected behaviour for an already applied state.

### Merge requirements satisfied?
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No