### PR TITLE
Partially revert "Port #53452 to master"

### DIFF
--- a/salt/states/zpool.py
+++ b/salt/states/zpool.py
@@ -89,10 +89,9 @@ def __virtual__():
     """
     Provides zpool state
     """
-    if __grains__["zfs_support"]:
-        return __virtualname__
-    else:
+    if not __grains__.get("zfs_support"):
         return False, "The zpool state cannot be loaded: zfs not supported"
+    return __virtualname__
 
 
 def _layout_to_vdev(layout, device_dir=None):
@@ -399,7 +398,7 @@ def absent(name, export=False, force=False):
     name : string
         name of storage pool
     export : boolean
-        export instread of destroy the zpool if present
+        export instead of destroy the zpool if present
     force : boolean
         force destroy or export
 


### PR DESCRIPTION
### What does this PR do?
This reverts a wrong part of commit 60b820c7b6a3f08dd3f9577f1c5c11c1f7954126.
By some reason the same PR was ported twice. The first port is #55386 that was good. The second one is #56813 that had wrongly resolved conflicts that produced the error described in #51810: exception on system having no zfs support (Windows).

This don't need any test, this fixes wrong conflict resolution during merge.

### What issues does this PR fix or reference?
Fixes: #57810 

### Merge requirements satisfied?
- [ ] Docs **N/A**
- [ ] Changelog **N/A** - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated **N/A**

### Commits signed with GPG?
Yes