### PR TITLE
Support inter-region peering in boto_vpc.

### DIFF
--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -3713,6 +3713,7 @@ def request_vpc_peering_connection(
     peer_vpc_name=None,
     name=None,
     peer_owner_id=None,
+    peer_region=None,
     region=None,
     key=None,
     keyid=None,
@@ -3746,8 +3747,11 @@ def request_vpc_peering_connection(
         ID of the owner of the peer VPC. Defaults to your account ID, so a value
         is required if peering with a VPC in a different account.
 
+    peer_region
+        Region to issue the request to. Defaults to region if none specified.
+
     region
-        Region to connect to.
+        Region to issue the request from.
 
     key
         Secret key to be used.
@@ -3775,6 +3779,8 @@ def request_vpc_peering_connection(
 
     """
     conn = _get_conn3(region=region, key=key, keyid=keyid, profile=profile)
+
+    if peer_region is None: peer_region = region
 
     if name and _vpc_peering_conn_id_for_name(name, conn):
         raise SaltInvocationError(
@@ -3818,13 +3824,17 @@ def request_vpc_peering_connection(
         log.debug("Trying to request vpc peering connection")
         if not peer_owner_id:
             vpc_peering = conn.create_vpc_peering_connection(
-                VpcId=requester_vpc_id, PeerVpcId=peer_vpc_id, DryRun=dry_run
+                VpcId=requester_vpc_id,
+                PeerVpcId=peer_vpc_id,
+                PeerRegion=peer_region,
+                DryRun=dry_run
             )
         else:
             vpc_peering = conn.create_vpc_peering_connection(
                 VpcId=requester_vpc_id,
                 PeerVpcId=peer_vpc_id,
                 PeerOwnerId=peer_owner_id,
+                PeerRegion=peer_region,
                 DryRun=dry_run,
             )
         peering = vpc_peering.get("VpcPeeringConnection", {})

--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -3836,7 +3836,7 @@ def request_vpc_peering_connection(
                 PeerVpcId=peer_vpc_id,
                 PeerOwnerId=peer_owner_id,
                 PeerRegion=peer_region,
-                DryRun=dry_run,
+                DryRun=dry_run
             )
         peering = vpc_peering.get("VpcPeeringConnection", {})
         peering_conn_id = peering.get("VpcPeeringConnectionId", "ERROR")

--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -3780,7 +3780,8 @@ def request_vpc_peering_connection(
     """
     conn = _get_conn3(region=region, key=key, keyid=keyid, profile=profile)
 
-    if peer_region is None: peer_region = region
+    if peer_region is None:
+        peer_region = region
 
     if name and _vpc_peering_conn_id_for_name(name, conn):
         raise SaltInvocationError(

--- a/salt/states/boto_vpc.py
+++ b/salt/states/boto_vpc.py
@@ -1869,6 +1869,7 @@ def request_vpc_peering_connection(
     peer_vpc_name=None,
     conn_name=None,
     peer_owner_id=None,
+    peer_region=None,
     region=None,
     key=None,
     keyid=None,
@@ -1896,8 +1897,11 @@ def request_vpc_peering_connection(
     peer_owner_id
         ID of the owner of the peer VPC. String type. If this isn't supplied AWS uses your account ID.  Required if peering to a different account.
 
+    peer_region
+        Region to issue the request to. Defaults to region if none specified.
+
     region
-        Region to connect to.
+        Region to issue the request from.
 
     key
         Secret key to be used.
@@ -1954,6 +1958,7 @@ def request_vpc_peering_connection(
         peer_vpc_name,
         name=conn_name,
         peer_owner_id=peer_owner_id,
+        peer_region=peer_region,
         region=region,
         key=key,
         keyid=keyid,


### PR DESCRIPTION
### What does this PR do?
Existing boto_vpc.request_vpc_peering_connection doesn't handle
inter-region VPC peering. This enables inter-region peering but
assumes intra-region peering unless peer_region is specified.

### What issues does this PR fix or reference?
Fixes: n/a

### Previous Behavior
Attempting to issue a peering request would succeed as a salt state, but fail at AWS due to the peer vpc_id not existing in the region the peering request is issued from.

### New Behavior
Inter-region VPC peering requests work now. Yay!