### PR TITLE
Removing reference to minion key length

### DIFF
--- a/doc/topics/tutorials/intro_scale.rst
+++ b/doc/topics/tutorials/intro_scale.rst
@@ -200,23 +200,6 @@ run in.  But here are some general tuning tips for different situations:
 The Master is CPU bound
 -----------------------
 
-Salt uses RSA-Key-Pairs on the masters and minions end. Both generate 4096
-bit key-pairs on first start. While the key-size for the Master is currently
-not configurable, the minions keysize can be configured with different
-key-sizes. For example with a 2048 bit key:
-
-.. code-block:: yaml
-
-    keysize: 2048
-
-With thousands of decryptions, the amount of time that can be saved on the
-masters end should not be neglected. See here for reference:
-`Pull Request 9235 <https://github.com/saltstack/salt/pull/9235>`_ how much
-influence the key-size can have.
-
-Downsizing the Salt Master's key is not that important, because the minions
-do not encrypt as many messages as the Master does.
-
 In installations with large or with complex pillar files, it is possible
 for the master to exhibit poor performance as a result of having to render
 many pillar files at once. This exhibit itself in a number of ways, both


### PR DESCRIPTION
This tutorial currently states that both master/minion both generate 4096 bit keys and that the key size for the master is not configurable. According to the latest configuration documentation, this is false. Both are configurable using `keysize`, with defaults of 2048 bits. Reducing this key size to 1024 would reduce burden on the master as described, but doing so would be inadvisable with NIST considering 1024 bit keys "legacy" (https://www.keylength.com/en/4/).

### What does this PR do?
Removes inaccurate reference to key size in "Using Salt at Scale"

### What issues does this PR fix or reference?
None

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
