### PR TITLE
no __opts__ outside function for VSPHERE ESXI

### DIFF
--- a/salt/grains/esxi.py
+++ b/salt/grains/esxi.py
@@ -15,7 +15,7 @@ import logging
 import salt.utils.platform
 from salt.exceptions import SaltSystemExit
 
-if salt.utils.platform.is_proxy() and __opts__["proxy"]["proxytype"] == "esxi":
+if salt.utils.platform.is_proxy():
     import salt.modules.vsphere
 
 


### PR DESCRIPTION
### What does this PR do?
Removes a misplaced `__opts__`

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/57811

Originates from: https://github.com/saltstack/salt/pull/57579

### Previous Behavior
A proxy client throws the exception `name '__opts__' is not defined`.

### New Behavior
A proxy client imports the vsphere module.

