### PR TITLE
Print jinja line numbers & error context on UndefinedError

### DIFF
--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -400,11 +400,10 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
         output = template.render(**decoded_context)
     except jinja2.exceptions.UndefinedError as exc:
         trace = traceback.extract_tb(sys.exc_info()[2])
-        out = _get_jinja_error(trace, context=decoded_context)[1]
-        tmplstr = ""
-        # Don't include the line number, since it is misreported
-        # https://github.com/mitsuhiko/jinja2/issues/276
-        raise SaltRenderError("Jinja variable {0}{1}".format(exc, out), buf=tmplstr)
+        line, out = _get_jinja_error(trace, context=decoded_context)
+        if not line:
+            tmplstr = ""
+        raise SaltRenderError("Jinja variable {0}{1}".format(exc, out), line, tmplstr)
     except (
         jinja2.exceptions.TemplateRuntimeError,
         jinja2.exceptions.TemplateSyntaxError,


### PR DESCRIPTION
This provides both the line number on which the error occurred in the
Jinja template, and also several lines of context around the error in
the Jinja template source.

The one caveat to this change is that if paired with jinja2<2.11 it
could possibly report incorrect line numbers for some errors. This was
fixed in https://github.com/pallets/jinja/pull/1109

Traces/errors before were vague and ambiguous:

    File "/usr/lib/python2.7/dist-packages/salt/utils/templates.py", line 387, in render_jinja_tmpl
      buf=tmplstr)
    SaltRenderError: Jinja variable 'str object' has no attribute 'items'

This gives a line number and multiple lines of context:

```jinja
File "/usr/lib/python2.7/dist-packages/salt/utils/templates.py", line 387, in render_jinja_tmpl
  tmplstr)
SaltRenderError: Jinja variable 'str object' has no attribute 'items'; line 5

---
# {{ salt.pillar.get('managed_by_salt_message', '') }}
# salt template: {{ source }}

{%- for section in sections %}
  {%- for name, config in section.items() %}    <======================
[{{ name }}]
    {%- for line in config %}
{{ line }}
    {%- endfor %}
  {%- endfor %}
[...]
---
```

Signed-off-by: Joe Groocock <jgroocock@cloudflare.com>

### What does this PR do?
Makes Jinja undefined error messages more helpful

### What issues does this PR fix or reference?
Fixes: #21298

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
