### PR TITLE
file.serialize state: fix corruption when using msgpack serializer

### DIFF
--- a/changelog/57858.changed
+++ b/changelog/57858.changed
@@ -1,0 +1,5 @@
+The ``serializer`` argument has been added to the :py:func:`file.serialize
+<salt.states.file.serialize>` state, as an alternative to ``formatter``. This
+brings it more in line with the ``serializer_opts`` and ``deserializer_opts``
+arguments. ``formatter`` is still supported, but using both ``serializer`` and
+``formatter`` will cause the state to fail.

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -7528,6 +7528,7 @@ def serialize(
     merge_if_exists=False,
     encoding=None,
     encoding_errors="strict",
+    serializer=None,
     serializer_opts=None,
     deserializer_opts=None,
     **kwargs
@@ -7552,9 +7553,13 @@ def serialize(
 
         .. versionadded:: 2015.8.0
 
-    formatter
+    serializer (or formatter)
         Write the data as this format. See the list of
         :ref:`all-salt.serializers` for supported output formats.
+
+        .. versionchanged:: 3002
+            ``serializer`` argument added as an alternative to ``formatter``.
+            Both are accepted, but using both will result in an error.
 
     encoding
         If specified, then the specified encoding will be used. Otherwise, the
@@ -7619,7 +7624,7 @@ def serialize(
 
            /etc/dummy/package.yaml
              file.serialize:
-               - formatter: yaml
+               - serializer: yaml
                - serializer_opts:
                  - explicit_start: True
                  - default_flow_style: True
@@ -7632,6 +7637,8 @@ def serialize(
         - For **yaml**: `yaml.dump()`_
         - For **json**: `json.dumps()`_
         - For **python**: `pprint.pformat()`_
+        - For **msgpack**: Run ``python -c 'import msgpack; help(msgpack.Packer)'``
+          to see the available options (``encoding``, ``unicode_errors``, etc.)
 
         .. _`yaml.dump()`: https://pyyaml.org/wiki/PyYAMLDocumentation
         .. _`json.dumps()`: https://docs.python.org/2/library/json.html#json.dumps
@@ -7649,7 +7656,7 @@ def serialize(
 
            /etc/dummy/package.yaml
              file.serialize:
-               - formatter: yaml
+               - serializer: yaml
                - serializer_opts:
                  - explicit_start: True
                  - default_flow_style: True
@@ -7688,7 +7695,7 @@ def serialize(
                   express: '>= 1.2.0'
                   optimist: '>= 0.1.0'
                 engine: node 0.4.1
-            - formatter: json
+            - serializer: json
 
     will manage the file ``/etc/dummy/package.json``:
 
@@ -7736,7 +7743,10 @@ def serialize(
             ).format(name)
             return ret
 
-    formatter = kwargs.pop("formatter", "yaml").lower()
+    formatter = kwargs.pop("formatter", None)
+    if serializer and formatter:
+        return _error(ret, "Only one of serializer and formatter are allowed")
+    serializer = str(serializer or formatter or "yaml").lower()
 
     if len([x for x in (dataset, dataset_pillar) if x]) > 1:
         return _error(ret, "Only one of 'dataset' and 'dataset_pillar' is permitted")
@@ -7756,13 +7766,16 @@ def serialize(
             )
         group = user
 
-    serializer_name = "{0}.serialize".format(formatter)
-    deserializer_name = "{0}.deserialize".format(formatter)
+    serializer_name = "{0}.serialize".format(serializer)
+    deserializer_name = "{0}.deserialize".format(serializer)
 
     if serializer_name not in __serializers__:
         return {
             "changes": {},
-            "comment": "{0} format is not supported".format(formatter.capitalize()),
+            "comment": (
+                "The {0} serializer could not be found. It either does "
+                "not exist or its prerequisites are not installed.".format(serializer)
+            ),
             "name": name,
             "result": False,
         }
@@ -7782,13 +7795,14 @@ def serialize(
             if deserializer_name not in __serializers__:
                 return {
                     "changes": {},
-                    "comment": "merge_if_exists is not supported for the {0} "
-                    "formatter".format(formatter),
+                    "comment": "merge_if_exists is not supported for the {0} serializer".format(
+                        serializer
+                    ),
                     "name": name,
                     "result": False,
                 }
             open_args = "r"
-            if formatter == "plist":
+            if serializer == "plist":
                 open_args += "b"
             with salt.utils.files.fopen(name, open_args) as fhr:
                 try:
@@ -7822,11 +7836,14 @@ def serialize(
         dataset, **serializer_options.get(serializer_name, {})
     )
 
-    if isinstance(contents, str):
+    # Insert a newline, but only if the serialized contents are not a
+    # bytestring. If it's a bytestring, it's almost certainly serialized into a
+    # binary format that does not take kindly to additional bytes being foisted
+    # upon it.
+    try:
         contents += "\n"
-    # adding a new line to a binary plist will invalidate it.
-    elif isinstance(contents, bytes) and formatter != "plist":
-        contents += b"\n"
+    except TypeError:
+        pass
 
     # Make sure that any leading zeros stripped by YAML loader are added back
     mode = salt.utils.files.normalize_mode(mode)


### PR DESCRIPTION
The `file.serialize` state adds a newline to the end of the serialized contents before writing them to disk. This works fine with some serializers, but not so well with others. MacOS plist files are invalid with a trailing newline, so a recent release added a check for that. But that still leaves msgpack, which is also corrupted by the addition of a trailing newline (resulting in a "received extra bytes" error when one attempts to unpack the file).

This changeset keeps the state from adding the newline to the end of the file when using the msgpack serializer. In doing so, it simplifies the logic that determines whether or not to add the newline. It makes the assumption that if the serialized contents are a bytestring (as in the plist and msgpack serializers), a newline should not be added, as the results are likely in a binary format that will not work well with unexpected bytes added.

Additionally, it introduces a new argument to the state: `serializer`. When the `file.serialize` state was added to Salt nearly 7 years ago, it for some reason was written to use `formatter` to specify which serializer to use. Which is fine, in its own quirky way, but later on the `serializer_opts` and `deserializer_opts` arguments were added to allow the user to pass through additional options to the serializer. And this leaves you with `serializer_opts`/`deserializer_opts`, and `formatter` instead of `serializer`. It's weird and asymmetric. So this changeset also adds `serializer` (updating docs to prefer this usage), while maintaining backwards compatibility with `formatter`.