### PR TITLE
yumpkg: report stdout when stderr is redirected to stdout

### DIFF
--- a/changelog/57862.fixed
+++ b/changelog/57862.fixed
@@ -1,0 +1,1 @@
+When using yumpkg, report stdout when stderr is redirected to stdout.

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1711,7 +1711,7 @@ def install(
             cmd.extend(targets)
             out = _call_yum(cmd, ignore_retcode=False, redirect_stderr=True)
             if out["retcode"] != 0:
-                errors.append(out["stderr"])
+                errors.append(out["stdout"])
 
     targets = []
     with _temporarily_unhold(to_downgrade, targets):
@@ -1720,9 +1720,9 @@ def install(
             _add_common_args(cmd)
             cmd.append("downgrade")
             cmd.extend(targets)
-            out = _call_yum(cmd)
+            out = _call_yum(cmd, redirect_stderr=True)
             if out["retcode"] != 0:
-                errors.append(out["stderr"])
+                errors.append(out["stdout"])
 
     targets = []
     with _temporarily_unhold(to_reinstall, targets):
@@ -1731,9 +1731,9 @@ def install(
             _add_common_args(cmd)
             cmd.append("reinstall")
             cmd.extend(targets)
-            out = _call_yum(cmd)
+            out = _call_yum(cmd, redirect_stderr=True)
             if out["retcode"] != 0:
-                errors.append(out["stderr"])
+                errors.append(out["stdout"])
 
     __context__.pop("pkg.list_pkgs", None)
     new = (

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2,15 +2,15 @@
 Support for YUM/DNF
 
 .. important::
-If you feel that Salt should be using this module to manage packages on a
-minion, and it is using a different module (or gives an error similar to
-*'pkg.install' is not available*), see :ref:`here
-<module-provider-override>`.
+    If you feel that Salt should be using this module to manage packages on a
+    minion, and it is using a different module (or gives an error similar to
+    *'pkg.install' is not available*), see :ref:`here
+    <module-provider-override>`.
 
 .. note::
-DNF is fully supported as of version 2015.5.10 and 2015.8.4 (partial
-support for DNF was initially added in 2015.8.0), and DNF is used
-automatically in place of YUM in Fedora 22 and newer.
+    DNF is fully supported as of version 2015.5.10 and 2015.8.4 (partial
+    support for DNF was initially added in 2015.8.0), and DNF is used
+    automatically in place of YUM in Fedora 22 and newer.
 """
 
 
@@ -2897,7 +2897,6 @@ def mod_repo(repo, basedir=None, **kwargs):
                 "The repo does not exist and needs to be created, but none "
                 "of the following basedir directories exist: {}".format(basedirs)
             )
-
         repofile = "{}/{}.repo".format(newdir, repo)
         if use_copr:
             # Is copr plugin installed?

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2,18 +2,19 @@
 Support for YUM/DNF
 
 .. important::
-    If you feel that Salt should be using this module to manage packages on a
-    minion, and it is using a different module (or gives an error similar to
-    *'pkg.install' is not available*), see :ref:`here
-    <module-provider-override>`.
+If you feel that Salt should be using this module to manage packages on a
+minion, and it is using a different module (or gives an error similar to
+*'pkg.install' is not available*), see :ref:`here
+<module-provider-override>`.
 
 .. note::
-    DNF is fully supported as of version 2015.5.10 and 2015.8.4 (partial
-    support for DNF was initially added in 2015.8.0), and DNF is used
-    automatically in place of YUM in Fedora 22 and newer.
+DNF is fully supported as of version 2015.5.10 and 2015.8.4 (partial
+support for DNF was initially added in 2015.8.0), and DNF is used
+automatically in place of YUM in Fedora 22 and newer.
 """
 
 
+import configparser
 import contextlib
 import datetime
 import fnmatch
@@ -2897,6 +2898,7 @@ def mod_repo(repo, basedir=None, **kwargs):
                 "of the following basedir directories exist: {}".format(basedirs)
             )
 
+        repofile = "{}/{}.repo".format(newdir, repo)
         if use_copr:
             # Is copr plugin installed?
             copr_plugin_name = ""

--- a/tests/unit/modules/test_yumpkg.py
+++ b/tests/unit/modules/test_yumpkg.py
@@ -4,8 +4,8 @@ import salt.modules.cmdmod as cmdmod
 import salt.modules.pkg_resource as pkg_resource
 import salt.modules.rpm_lowpkg as rpm
 import salt.modules.yumpkg as yumpkg
-from salt.exceptions import CommandExecutionError
 import salt.utils.platform
+from salt.exceptions import CommandExecutionError
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, Mock, patch
 from tests.support.unit import TestCase, skipIf

--- a/tests/unit/modules/test_yumpkg.py
+++ b/tests/unit/modules/test_yumpkg.py
@@ -1,11 +1,11 @@
 import os
 
-import salt.utils.platform
 import salt.modules.cmdmod as cmdmod
 import salt.modules.pkg_resource as pkg_resource
 import salt.modules.rpm_lowpkg as rpm
 import salt.modules.yumpkg as yumpkg
 from salt.exceptions import CommandExecutionError
+import salt.utils.platform
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, Mock, patch
 from tests.support.unit import TestCase, skipIf


### PR DESCRIPTION
### What does this PR do?

When 'redirect_stderr=True' is set, stderr is empty and both
stdout+stderr are logged into stdout. Include the right one in the
output.

### What issues does this PR fix or reference?
Fixes: 57862

### Previous Behavior
Empty `errors` field on errors.

### New Behavior
`errors` field populated.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes


