### PR TITLE
user.present: Restore "gid_from_name" and put on a deprecation path

### DIFF
--- a/changelog/57843.fixed
+++ b/changelog/57843.fixed
@@ -1,0 +1,3 @@
+The ``gid_from_name`` argument was removed from the ``user.present`` state in
+version 3001, with no deprecation path. It has been restored and put on a
+proper deprecation path.


### PR DESCRIPTION
This argument was removed in 3001 with no deprecation path. This restores it and puts it on a proper deprecation path.

Fixes #57843 