### PR TITLE
Support for groups in publisher_acl access control list.

### DIFF
--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -486,6 +486,16 @@ class LoadAuth(object):
                 auth_list = salt.utils.master.get_values_of_matching_keys(
                     self.opts["publisher_acl"], auth_ret
                 )
+
+                # Extend the auth_list with all acl items ending with % and the user is a member of it
+                groups = salt.utils.user.get_group_dict(auth_ret).keys()
+                for expr in [
+                    expr
+                    for expr in self.opts["publisher_acl"]
+                    if expr.endswith("%") and expr[:-1] in groups
+                ]:
+                    auth_list.extend(self.opts["publisher_acl"][expr])
+
                 if not auth_list:
                     ret["error"] = {"name": "UserAuthenticationError", "message": msg}
                     return ret

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -221,6 +221,16 @@ def access_keys(opts):
     if opts.get("user"):
         acl_users.add(opts["user"])
     acl_users.add(salt.utils.user.get_user())
+
+    # Loop all entries which ends with % and add group members to acl_users
+    for group in [group for group in acl_users if group.endswith("%")]:
+        members = salt.utils.user.get_group_members(group[:-1])
+        if members is not None:
+            for member in members:
+                if member not in acl_users:
+                    acl_users.add(member)
+            acl_users.discard(group)
+
     for user in acl_users:
         log.info("Preparing the %s key for local communication", user)
         key = mk_key(opts, user)

--- a/salt/utils/user.py
+++ b/salt/utils/user.py
@@ -363,6 +363,20 @@ def get_group_dict(user=None, include_default=True):
     return group_dict
 
 
+def get_group_members(group):
+    """
+    Returns a list of users for a given group name. If the group does not
+    exist, None will be returned. On systems which do not support grp it will
+    return None.
+    """
+    if HAS_GRP is False:
+        return None
+    try:
+        return grp.getgrnam(group).gr_mem
+    except KeyError:
+        return None
+
+
 def get_gid_list(user, include_default=True):
     """
     Returns a list of all of the system group IDs of which the user


### PR DESCRIPTION
- Feature Name: Publisher_acl group support
- Start Date: 2020-07-06
- RFC PR: 
- Salt Issue: 

# Summary
[summary]: #summary

Support for groups in publisher_acl access control list.

# Motivation
[motivation]: #motivation

Groups are currently not supported in the Master' config publisher_acl entries. Salt master will treat all items ending with % as a group and extracts its members from it. Function get_group_members is added to get members from a group.

Fixes #42060

## Alternatives
[alternatives]: #alternatives

As a workaround a Salt engineer can template a /etc/salt/master.d/acl.conf file like:
```
{%- set salt_group = salt['pillar.get']('salt_developers_group') %}
publisher_acl:
  {{ '\|'.join(salt['group.info'](salt_group)['members']) }}:
    - .*
```

## Unresolved questions
[unresolved]: #unresolved-questions

When a group member is added or removed from a group, the Salt master won't notice this. The keys in masterapi.py are written once (at startup). Key maintenance is not implemented.

# Drawbacks
[drawbacks]: #drawbacks

- Maybe it will affects acl with users ending with %
- Not able to combine a regex with a group name % entry. For example: user1|group1%.

If there is any need to fix one of these drawbacks I'm happy to change this proposal / PR!