### PR TITLE
CPU model, topology and NUMA node tuning  GSoC

### DIFF
--- a/changelog/57880.added
+++ b/changelog/57880.added
@@ -1,0 +1,1 @@
+CPU model, topology and NUMA node tuning

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -943,6 +943,7 @@ def _gen_xml(
     graphics=None,
     boot=None,
     boot_dev=None,
+    numatune=None,
     **kwargs
 ):
     """
@@ -968,6 +969,7 @@ def _gen_xml(
                     context["mem"][tag] = str(int(_handle_unit(val) / 1024))
 
     if hypervisor in ["qemu", "kvm"]:
+        context["numatune"] = numatune if numatune else {}
         context["controller_model"] = False
     elif hypervisor == "vmware":
         # TODO: make bus and model parameterized, this works for 64-bit Linux
@@ -1886,6 +1888,7 @@ def init(
     arch=None,
     boot=None,
     boot_dev=None,
+    numatune=None,
     **kwargs
 ):
     """
@@ -1996,6 +1999,21 @@ def init(
         Values can be ``hd``, ``fd``, ``cdrom`` or ``network``.
 
         By default, the value will ``"hd"``.
+
+    :param numatune:
+        The optional numatune element provides details of how to tune the performance of a NUMA host via controlling NUMA
+        policy for domain process. The optional ``memory`` element specifies how to allocate memory for the domain process
+        on a NUMA host. ``memnode`` elements can specify memory allocation policies per each guest NUMA node. The definition
+        used in the dictionary can be found at :ref:`init-cpu-def`.
+
+        .. versionadded:: Aluminium
+
+        .. code-block:: python
+
+            {
+                'memory': {'mode': 'strict', 'nodeset': '0-11'},
+                'memnodes': {0: {'mode': 'strict', 'nodeset': 1}, 1: {'mode': 'preferred', 'nodeset': 2}}
+            }
 
     .. _init-boot-def:
 
@@ -2351,6 +2369,7 @@ def init(
             graphics,
             boot,
             boot_dev,
+            numatune,
             **kwargs
         )
         log.debug("New virtual machine definition: %s", vm_xml)
@@ -2578,6 +2597,7 @@ def update(
     graphics=None,
     live=True,
     boot=None,
+    numatune=None,
     test=False,
     boot_dev=None,
     **kwargs
@@ -2660,6 +2680,18 @@ def update(
         By default, the value will ``"hd"``.
 
         .. versionadded:: 3002
+
+    :param numatune:
+        The optional numatune element provides details of how to tune the performance of a NUMA host via controlling NUMA
+        policy for domain process. The optional ``memory`` element specifies how to allocate memory for the domain process
+        on a NUMA host. ``memnode`` elements can specify memory allocation policies per each guest NUMA node. The definition
+        used in the dictionary can be found at :ref:`init-cpu-def`.
+
+        To update any numatune parameters, specify the new value. To remove any ``numatune`` parameters, pass a None object,
+        for instance: 'numatune': ``None``. Please note that ``None`` is mapped to ``null`` in sls file, pass ``null`` in
+        sls file instead.
+
+        .. versionadded:: Aluminium
 
     :param test: run in dry-run mode if set to True
 
@@ -2843,6 +2875,39 @@ def update(
             "del": salt.utils.xmlutil.del_attribute("dev"),
         },
     ]
+
+    # update NUMA host policy
+    if hypervisor in ["qemu", "kvm"]:
+        params_mapping += [
+            {
+                "path": "numatune:memory:mode",
+                "xpath": "numatune/memory",
+                "get": lambda n: n.get("mode"),
+                "set": lambda n, v: n.set("mode", str(v)),
+                "del": salt.utils.xmlutil.del_attribute("mode"),
+            },
+            {
+                "path": "numatune:memory:nodeset",
+                "xpath": "numatune/memory",
+                "get": lambda n: n.get("nodeset"),
+                "set": lambda n, v: n.set("nodeset", str(v)),
+                "del": salt.utils.xmlutil.del_attribute("nodeset"),
+            },
+            {
+                "path": "numatune:memnodes:{id}:mode",
+                "xpath": "numatune/memnode[@cellid='$id']",
+                "get": lambda n: n.get("mode") if n.get("mode") else None,
+                "set": lambda n, v: n.set("mode", str(v)),
+                "del": salt.utils.xmlutil.del_attribute("mode", ["cellid"]),
+            },
+            {
+                "path": "numatune:memnodes:{id}:nodeset",
+                "xpath": "numatune/memnode[@cellid='$id']",
+                "get": lambda n: str(n.get("nodeset")) if n.get("nodeset") else None,
+                "set": lambda n, v: n.set("nodeset", str(v)),
+                "del": salt.utils.xmlutil.del_attribute("nodeset", ["cellid"]),
+            },
+        ]
 
     data = {k: v for k, v in locals().items() if bool(v)}
     if boot_dev:

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -923,11 +923,11 @@ def _handle_unit(s, def_unit="m"):
     return int(value)
 
 
-def nesthash():
+def nesthash(value=None):
     """
     create default dict that allows arbitrary level of nesting
     """
-    return collections.defaultdict(nesthash)
+    return collections.defaultdict(nesthash, value or {})
 
 
 def _gen_xml(
@@ -954,6 +954,9 @@ def _gen_xml(
         "name": name,
     }
 
+    context["to_kib"] = lambda v: int(_handle_unit(v) / 1024)
+    context["yesno"] = lambda v: "yes" if v else "no"
+
     context["mem"] = nesthash()
     if isinstance(mem, int):
         mem = int(mem) * 1024  # MB
@@ -971,73 +974,7 @@ def _gen_xml(
     if isinstance(cpu, int):
         context["cpu"]["maximum"] = str(cpu)
     elif isinstance(cpu, dict):
-        # preprocess the cpu context, make attributes directly usable in jinja template.
-        if cpu:
-            context["cpu"]["maximum"] = cpu.get("maximum")
-            for tag in cpu:
-                if cpu.get(tag):
-                    if tag in [
-                        "placement",
-                        "cpuset",
-                        "current",
-                        "match",
-                        "mode",
-                        "check",
-                    ]:
-                        context["cpu"][tag] = "{}='{}'".format(tag, cpu.get(tag))
-                    elif tag == "vcpus":
-                        vcpus_param = cpu.get(tag)
-                        for vcpu_id in vcpus_param:
-                            if vcpus_param.get(vcpu_id):
-                                for k, v in vcpus_param.get(vcpu_id).items():
-                                    if v is not None:
-                                        if k in ["hotpluggable", "enabled"]:
-                                            context["cpu"]["vcpus"][vcpu_id][
-                                                k
-                                            ] = "{}='{}'".format(
-                                                k, "yes" if v else "no"
-                                            )
-                                        else:
-                                            context["cpu"]["vcpus"][vcpu_id][
-                                                k
-                                            ] = "{}='{}'".format(k, v)
-                    elif tag in ["model", "topology", "cache"]:
-                        for k, v in cpu.get(tag).items():
-                            if not (tag == "model" and k == "name"):
-                                if v:
-                                    context["cpu"][tag][k] = "{}='{}'".format(k, v)
-                            else:
-                                if v:
-                                    context["cpu"][tag][k] = v
-                    elif tag == "numa":
-                        numa_param = cpu.get(tag)
-                        for cell_id in numa_param:
-                            if numa_param.get(cell_id):
-                                for k, v in numa_param[cell_id].items():
-                                    if k == "memory":
-                                        if v:
-                                            context["cpu"]["numa"][cell_id][
-                                                k
-                                            ] = "{}='{}'".format(
-                                                k, int(_handle_unit(v) / 1024)
-                                            )
-                                    elif k == "distances":
-                                        if v:
-                                            context["cpu"]["numa"][cell_id][k] = v
-                                    else:
-                                        if v is not None:
-                                            if k == "discard":
-                                                context["cpu"]["numa"][cell_id][
-                                                    k
-                                                ] = "{}='{}'".format(
-                                                    k, "yes" if v else "no"
-                                                )
-                                            else:
-                                                context["cpu"]["numa"][cell_id][
-                                                    k
-                                                ] = "{}='{}'".format(k, v)
-                    else:
-                        context["cpu"][tag] = cpu.get(tag)
+        context["cpu"] = nesthash(cpu)
 
     if hypervisor in ["qemu", "kvm"]:
         context["numatune"] = numatune if numatune else {}

--- a/salt/states/virt.py
+++ b/salt/states/virt.py
@@ -294,7 +294,8 @@ def defined(
     .. versionadded:: 3001
 
     :param name: name of the virtual machine to run
-    :param cpu: number of CPUs for the virtual machine to create
+    :param cpu: Number of virtual CPUs to assign to the virtual machine or a dictionary with detailed information to configure
+        cpu model and topology. The structure of the dictionary is documented in :ref:`init-cpu-def`.
     :param mem: Amount of memory to allocate to the virtual machine in MiB. Since 3002, a dictionary can be used to
         contain detailed configuration which support memory allocation or tuning. Supported parameters are ``boot``,
         ``current``, ``max``, ``slots``, ``hard_limit``, ``soft_limit``, ``swap_hard_limit`` and ``min_guarantee``. The
@@ -533,7 +534,12 @@ def running(
     .. versionadded:: 2016.3.0
 
     :param name: name of the virtual machine to run
-    :param cpu: number of CPUs for the virtual machine to create
+    :param cpu: Number of virtual CPUs to assign to the virtual machine or a dictionary with detailed information to
+        configure cpu model and topology. The structure of the dictionary is documented in :ref:`init-cpu-def`.
+
+        To update any cpu/vcpu element specify the new values to the corresponding tag. To remove any element or
+        attribute,specify ``None`` object. Please note that ``None`` object is mapped to ``null`` in yaml, use ``null``
+        in sls file instead.
     :param mem: Amount of memory to allocate to the virtual machine in MiB. Since 3002, a dictionary can be used to
         contain detailed configuration which support memory allocation or tuning. Supported parameters are ``boot``,
         ``current``, ``max``, ``slots``, ``hard_limit``, ``soft_limit``, ``swap_hard_limit`` and ``min_guarantee``. The

--- a/salt/states/virt.py
+++ b/salt/states/virt.py
@@ -284,6 +284,7 @@ def defined(
     os_type=None,
     arch=None,
     boot=None,
+    numatune=None,
     update=True,
     boot_dev=None,
 ):
@@ -375,6 +376,21 @@ def defined(
 
         .. versionadded:: 3002
 
+    :param numatune:
+        The optional numatune element provides details of how to tune the performance of a NUMA host via controlling NUMA
+        policy for domain process. The optional ``memory`` element specifies how to allocate memory for the domain process
+        on a NUMA host. ``memnode`` elements can specify memory allocation policies per each guest NUMA node. The definition
+        used in the dictionary can be found at :ref:`init-cpu-def`.
+
+        .. versionadded:: Aluminium
+
+        .. code-block:: python
+
+            {
+                'memory': {'mode': 'strict', 'nodeset': '0-11'},
+                'memnodes': {0: {'mode': 'strict', 'nodeset': 1}, 1: {'mode': 'preferred', 'nodeset': 2}}
+            }
+
     .. rubric:: Example States
 
     Make sure a virtual machine called ``domain_name`` is defined:
@@ -437,6 +453,7 @@ def defined(
                     username=username,
                     password=password,
                     boot=boot,
+                    numatune=numatune,
                     test=__opts__["test"],
                     boot_dev=boot_dev,
                 )
@@ -472,6 +489,7 @@ def defined(
                     username=username,
                     password=password,
                     boot=boot,
+                    numatune=numatune,
                     start=False,
                     boot_dev=boot_dev,
                 )
@@ -507,6 +525,7 @@ def running(
     arch=None,
     boot=None,
     boot_dev=None,
+    numatune=None,
 ):
     """
     Starts an existing guest, or defines and starts a new VM with specified arguments.
@@ -625,6 +644,18 @@ def running(
 
         .. versionadded:: 3002
 
+    :param numatune:
+        The optional numatune element provides details of how to tune the performance of a NUMA host via controlling NUMA
+        policy for domain process. The optional ``memory`` element specifies how to allocate memory for the domain process
+        on a NUMA host. ``memnode`` elements can specify memory allocation policies per each guest NUMA node. The definition
+        used in the dictionary can be found at :ref:`init-cpu-def`.
+
+        To update any numatune parameters, specify the new value. To remove any ``numatune`` parameters, pass a None object,
+        for instance: 'numatune': ``None``. Please note that ``None`` is mapped to ``null`` in sls file, pass ``null`` in
+        sls file instead.
+
+        .. versionadded:: Aluminium
+
     .. rubric:: Example States
 
     Make sure an already-defined virtual machine called ``domain_name`` is running:
@@ -693,6 +724,7 @@ def running(
         boot=boot,
         update=update,
         boot_dev=boot_dev,
+        numatune=numatune,
         connection=connection,
         username=username,
         password=password,

--- a/salt/templates/virt/libvirt_domain.jinja
+++ b/salt/templates/virt/libvirt_domain.jinja
@@ -1,7 +1,54 @@
 {%- import 'libvirt_disks.jinja' as libvirt_disks -%}
 <domain type='{{ hypervisor }}'>
         <name>{{ name }}</name>
-        <vcpu>{{ cpu }}</vcpu>
+        {%- if cpu %}
+            <vcpu {{ cpu.get('placement', '') }} {{ cpu.get('cpuset', '') }} {{ cpu.get('current', '') }}>{{ cpu.get('maximum', '') }}</vcpu>
+        {%- endif %}
+        {%- if cpu.get('vcpus') %}
+            <vcpus>
+            {%- for vcpu_id in cpu["vcpus"].keys() %}
+            <vcpu id='{{ vcpu_id }}' {{ cpu.vcpus[vcpu_id].get('enabled', '') }} {{ cpu.vcpus[vcpu_id].get('hotpluggable', '') }} {{ cpu.vcpus[vcpu_id].get('order', '') }}/>
+            {%- endfor %}
+            </vcpus>
+        {%- endif %}
+         {%- if cpu %}
+          <cpu {{cpu.get('match', '') }} {{ cpu.get('mode', '') }} {{ cpu.get('check', '') }} >
+            {%- if cpu.model %}
+            <model {{ cpu.model.get('fallback', '') }} {{ cpu.model.get('vendor_id', '') }}>{{ cpu.model.get('name', '') }}</model>
+            {%- endif %}
+            {%- if cpu.vendor %}
+            <vendor>{{ cpu.get('vendor', '') }}</vendor>
+            {%- endif %}
+            {%- if cpu.topology %}
+            <topology {{ cpu.topology.get('sockets', '') }} {{ cpu.topology.get('dies', '') }} {{ cpu.topology.get('cores', '') }} {{ cpu.topology.get('threads', '') }}/>
+            {%- endif %}
+            {%- if cpu.cache %}
+            <cache {{ cpu.cache.get('level', '') }} {{ cpu.cache.get('mode', '') }}/>
+            {%- endif %}
+            {%- if cpu.features %}
+            {%- for k, v in cpu.features.items() %}
+            <feature policy='{{ v }}' name='{{ k }}'/>
+            {%- endfor %}
+            {%- endif %}
+            {%- if cpu.numa %}
+            <numa>
+            {%- for numa_id in cpu.numa.keys() %}
+            {%- if cpu.numa.get(numa_id) %}
+            <cell id='{{ numa_id }}' {{ cpu.numa[numa_id].get('cpus','') }} {{ cpu.numa[numa_id].get('memory', '') }} {{ cpu.numa[numa_id].get('discard', '') }} {{ cpu.numa[numa_id].get('memAccess', '') }}>
+                {%- if cpu.numa[numa_id].distances %}
+                    <distances>
+                    {%- for sibling_id in cpu.numa[numa_id].distances %}
+                    <sibling id='{{ sibling_id }}' value='{{ cpu.numa[numa_id].distances[sibling_id] }}'/>
+                    {%- endfor %}
+                    </distances>
+                {%- endif %}
+            </cell>
+            {%- endif %}
+            {%- endfor %}
+            </numa>
+            {%- endif %}
+          </cpu>
+        {%- endif %}
         {%- if mem.max %}
         <maxMemory {{ mem.get('slots', '') }} unit='KiB'>{{ mem.max }}</maxMemory>
         {%- endif %}

--- a/salt/templates/virt/libvirt_domain.jinja
+++ b/salt/templates/virt/libvirt_domain.jinja
@@ -3,7 +3,7 @@
         <name>{{ name }}</name>
         <vcpu>{{ cpu }}</vcpu>
         {%- if mem.max %}
-        <maxMemory {{ mem.slots }} unit='KiB'> {{ mem.max }}</maxMemory>
+        <maxMemory {{ mem.get('slots', '') }} unit='KiB'>{{ mem.max }}</maxMemory>
         {%- endif %}
         {%- if mem.boot %}
         <memory unit='KiB'>{{ mem.boot }}</memory>

--- a/salt/templates/virt/libvirt_domain.jinja
+++ b/salt/templates/virt/libvirt_domain.jinja
@@ -1,29 +1,32 @@
 {%- import 'libvirt_disks.jinja' as libvirt_disks -%}
+{%- macro opt_attribute(obj, name, conv=none) %}
+{%- if obj.get(name) is not none %}{{ name }}='{{ obj[name] if conv is none else conv(obj[name]) }}'{% endif -%}
+{%- endmacro %}
 <domain type='{{ hypervisor }}'>
         <name>{{ name }}</name>
         {%- if cpu %}
-            <vcpu {{ cpu.get('placement', '') }} {{ cpu.get('cpuset', '') }} {{ cpu.get('current', '') }}>{{ cpu.get('maximum', '') }}</vcpu>
+            <vcpu {{ opt_attribute(cpu, 'placement') }} {{ opt_attribute(cpu, 'cpuset') }} {{ opt_attribute(cpu, 'current') }}>{{ cpu.get('maximum', '') }}</vcpu>
         {%- endif %}
         {%- if cpu.get('vcpus') %}
             <vcpus>
             {%- for vcpu_id in cpu["vcpus"].keys() %}
-            <vcpu id='{{ vcpu_id }}' {{ cpu.vcpus[vcpu_id].get('enabled', '') }} {{ cpu.vcpus[vcpu_id].get('hotpluggable', '') }} {{ cpu.vcpus[vcpu_id].get('order', '') }}/>
+            <vcpu id='{{ vcpu_id }}' {{ opt_attribute(cpu.vcpus[vcpu_id], 'enabled', yesno) }} {{ opt_attribute(cpu.vcpus[vcpu_id], 'hotpluggable', yesno) }} {{ opt_attribute(cpu.vcpus[vcpu_id], 'order') }}/>
             {%- endfor %}
             </vcpus>
         {%- endif %}
          {%- if cpu %}
-          <cpu {{cpu.get('match', '') }} {{ cpu.get('mode', '') }} {{ cpu.get('check', '') }} >
+          <cpu {{ opt_attribute(cpu, 'match') }} {{ opt_attribute(cpu, 'mode') }} {{ opt_attribute(cpu, 'check') }} >
             {%- if cpu.model %}
-            <model {{ cpu.model.get('fallback', '') }} {{ cpu.model.get('vendor_id', '') }}>{{ cpu.model.get('name', '') }}</model>
+            <model {{ opt_attribute(cpu.model, 'fallback') }} {{ opt_attribute(cpu.model, 'vendor_id') }}>{{ cpu.model.get('name', '') }}</model>
             {%- endif %}
             {%- if cpu.vendor %}
             <vendor>{{ cpu.get('vendor', '') }}</vendor>
             {%- endif %}
             {%- if cpu.topology %}
-            <topology {{ cpu.topology.get('sockets', '') }} {{ cpu.topology.get('dies', '') }} {{ cpu.topology.get('cores', '') }} {{ cpu.topology.get('threads', '') }}/>
+            <topology {{ opt_attribute(cpu.topology, 'sockets') }} {{ opt_attribute(cpu.topology, 'dies') }} {{ opt_attribute(cpu.topology, 'cores') }} {{ opt_attribute(cpu.topology, 'threads') }}/>
             {%- endif %}
             {%- if cpu.cache %}
-            <cache {{ cpu.cache.get('level', '') }} {{ cpu.cache.get('mode', '') }}/>
+            <cache {{ opt_attribute(cpu.cache, 'level') }} {{ opt_attribute(cpu.cache, 'mode') }}/>
             {%- endif %}
             {%- if cpu.features %}
             {%- for k, v in cpu.features.items() %}
@@ -34,7 +37,7 @@
             <numa>
             {%- for numa_id in cpu.numa.keys() %}
             {%- if cpu.numa.get(numa_id) %}
-            <cell id='{{ numa_id }}' {{ cpu.numa[numa_id].get('cpus','') }} {{ cpu.numa[numa_id].get('memory', '') }} {{ cpu.numa[numa_id].get('discard', '') }} {{ cpu.numa[numa_id].get('memAccess', '') }}>
+            <cell id='{{ numa_id }}' {{ opt_attribute(cpu.numa[numa_id], 'cpus') }} {{ opt_attribute(cpu.numa[numa_id], 'memory', to_kib) }} {{ opt_attribute(cpu.numa[numa_id], 'discard', yesno) }} {{ opt_attribute(cpu.numa[numa_id], 'memAccess') }}>
                 {%- if cpu.numa[numa_id].distances %}
                     <distances>
                     {%- for sibling_id in cpu.numa[numa_id].distances %}

--- a/salt/templates/virt/libvirt_domain.jinja
+++ b/salt/templates/virt/libvirt_domain.jinja
@@ -27,6 +27,20 @@
             {%- endif %}
         </memtune>
         {%- endif %}
+        {%- if numatune %}
+        <numatune>
+            {%- if 'memory' in numatune and numatune.memory %}
+                <memory mode='{{ numatune.memory.mode }}'
+                    {%- if numatune.memory.nodeset %}nodeset='{{ numatune.memory.nodeset }}'{%- endif %}
+                />
+            {%- endif %}
+            {%- if 'memnodes' in numatune and numatune.memnodes %}
+                {%- for cell_id in numatune['memnodes'] %}
+                <memnode cellid='{{ cell_id }}' mode='{{ numatune.memnodes[cell_id].mode }}' nodeset='{{ numatune.memnodes[cell_id].nodeset }}'/>
+                {%- endfor %}
+            {%- endif %}
+        </numatune>
+        {%- endif %}
         <os {{ boot.os_attrib }}>
                 <type arch='{{ arch }}'>{{ os_type }}</type>
                 {% if boot %}

--- a/tests/unit/states/test_virt.py
+++ b/tests/unit/states/test_virt.py
@@ -1,21 +1,15 @@
 """
     :codeauthor: Jayesh Kariya <jayeshk@saltstack.com>
 """
-# Import Python libs
 
 import shutil
 import tempfile
 
-# Import Salt Libs
 import salt.states.virt as virt
 import salt.utils.files
 from salt.exceptions import CommandExecutionError, SaltInvocationError
-
-# Import 3rd-party libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, mock_open, patch
-
-# Import Salt Testing Libs
 from tests.support.runtests import RUNTIME_VARS
 from tests.support.unit import TestCase
 

--- a/tests/unit/states/test_virt.py
+++ b/tests/unit/states/test_virt.py
@@ -372,6 +372,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     hypervisor="qemu",
                     seed=False,
                     boot=None,
+                    numatune=None,
                     install=False,
                     start=False,
                     pub_key="/path/to/key.pub",
@@ -488,6 +489,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     username=None,
                     password=None,
                     boot=None,
+                    numatune=None,
                     test=False,
                 )
 
@@ -599,6 +601,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     username=None,
                     password=None,
                     boot=None,
+                    numatune=None,
                     test=True,
                     boot_dev=None,
                 )
@@ -634,6 +637,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     username=None,
                     password=None,
                     boot=None,
+                    numatune=None,
                     test=True,
                     boot_dev=None,
                 )
@@ -701,6 +705,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     os_type=None,
                     arch=None,
                     boot=None,
+                    numatune=None,
                     disk=None,
                     disks=[{"name": "system", "image": "/path/to/img.qcow2"}],
                     nic=None,
@@ -795,6 +800,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     hypervisor="qemu",
                     seed=False,
                     boot=None,
+                    numatune=None,
                     install=False,
                     start=False,
                     pub_key="/path/to/key.pub",
@@ -943,6 +949,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     username=None,
                     password=None,
                     boot=None,
+                    numatune=None,
                     test=False,
                     boot_dev=None,
                 )
@@ -1062,6 +1069,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     username=None,
                     password=None,
                     boot=None,
+                    numatune=None,
                     test=True,
                     boot_dev=None,
                 )
@@ -1099,6 +1107,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     username=None,
                     password=None,
                     boot=None,
+                    numatune=None,
                     test=True,
                     boot_dev=None,
                 )


### PR DESCRIPTION
### What does this PR do?
In response to feature request #57880 

This PR add the feature to support CPU model and topology. configurable parameters are:
- `mode`
- `match`
- `check`
- `model`
- `vendor`
- `topology`
- `cache` 
- `feature` 

`numa` which is used to specify the attributes and sub-elements of numa `guest`. configurable parameters are:
- `cpus`
- `memory`
- `memAccess`
- `distance`
- `sibling` id and values

To configure numa `guest`,  numa `host ` must be configured beforehand, `numatune` can be used to specify `memory` which tells how to allocate memory for the domain process on a NUMA host and `memnode` which specify memory allocation policies per each guest NUMA node.

See [Libvirt domain XML](https://libvirt.org/formatdomain.html#elementsCPU) for more details.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
