### PR TITLE
57550 pip version user param

### DIFF
--- a/changelog/57550.fixed
+++ b/changelog/57550.fixed
@@ -1,0 +1,1 @@
+Fixed permissions issue with certain pip/virtualenv states/modules when configured for non-root user.

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -1326,6 +1326,7 @@ def version(bin_env=None, cwd=None):
     cmd = _get_pip_bin(bin_env)[:]
     cmd.append("--version")
 
+    # TODO: FIXME -W. Werner, 2020-06-23
     ret = __salt__["cmd.run_all"](cmd, cwd=cwd, python_shell=False)
     if ret["retcode"]:
         raise CommandNotFoundError("Could not find a `pip` binary")
@@ -1517,7 +1518,7 @@ def upgrade(bin_env=None, user=None, cwd=None, use_vt=False):
 
     old = list_(bin_env=bin_env, user=user, cwd=cwd)
 
-    cmd_kwargs = dict(cwd=cwd, use_vt=use_vt)
+    cmd_kwargs = dict(cwd=cwd, runas=user, use_vt=use_vt)
     if bin_env and os.path.isdir(bin_env):
         cmd_kwargs["env"] = {"VIRTUAL_ENV": bin_env}
     errors = False

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -698,7 +698,7 @@ def install(
     if error:
         return error
 
-    cur_version = version(bin_env, cwd)
+    cur_version = version(bin_env, cwd, user=user)
 
     if use_wheel:
         min_version = "1.4"
@@ -1359,7 +1359,7 @@ def list_upgrades(bin_env=None, user=None, cwd=None):
     cmd = _get_pip_bin(bin_env)
     cmd.extend(["list", "--outdated"])
 
-    pip_version = version(bin_env, cwd)
+    pip_version = version(bin_env, cwd, user=user)
     # Pip started supporting the ability to output json starting with 9.0.0
     min_version = "9.0"
     if salt.utils.versions.compare(ver1=pip_version, oper=">=", ver2=min_version):

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -1299,7 +1299,7 @@ def list_(prefix=None, bin_env=None, user=None, cwd=None, env_vars=None, **kwarg
     return packages
 
 
-def version(bin_env=None, cwd=None):
+def version(bin_env=None, cwd=None, user=None):
     """
     .. versionadded:: 0.17.0
 
@@ -1308,11 +1308,16 @@ def version(bin_env=None, cwd=None):
 
     If unable to detect the pip version, returns ``None``.
 
+    .. versionchanged:: 3001.1
+        The ``user`` parameter was added, to allow specifying the user who runs
+        the version command.
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' pip.version
+
     """
 
     cwd = _pip_bin_env(cwd, bin_env)
@@ -1326,8 +1331,7 @@ def version(bin_env=None, cwd=None):
     cmd = _get_pip_bin(bin_env)[:]
     cmd.append("--version")
 
-    # TODO: FIXME -W. Werner, 2020-06-23
-    ret = __salt__["cmd.run_all"](cmd, cwd=cwd, python_shell=False)
+    ret = __salt__["cmd.run_all"](cmd, cwd=cwd, runas=user, python_shell=False)
     if ret["retcode"]:
         raise CommandNotFoundError("Could not find a `pip` binary")
 

--- a/tests/unit/modules/test_pip.py
+++ b/tests/unit/modules/test_pip.py
@@ -1477,3 +1477,25 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
                 cwd=None,
                 use_vt=False,
             )
+
+    # TODO: When we switch to pytest, parameterize the user - None and fnord should be enough, maybe a 3rd user -W. Werner, 2020-07-07
+    def test_when_version_is_called_with_a_user_it_should_be_passed_to_undelying_runas(
+        self,
+    ):
+        fake_run_all = MagicMock(return_value={"retcode": 0, "stdout": ""})
+        expected_user = "fnord"
+        with patch.dict(pip.__salt__, {"cmd.run_all": fake_run_all}), patch(
+            "salt.modules.pip.list_upgrades", autospec=True, return_value=["fnord"]
+        ), patch(
+            "salt.modules.pip._get_pip_bin",
+            autospec=True,
+            return_value=["some-new-pip"],
+        ):
+            pip.version(user=expected_user)
+            print(fake_run_all.mock_calls)
+            fake_run_all.assert_called_with(
+                ["some-new-pip", "--version"],
+                runas=expected_user,
+                cwd=None,
+                python_shell=False,
+            )

--- a/tests/unit/modules/test_pip.py
+++ b/tests/unit/modules/test_pip.py
@@ -1455,3 +1455,25 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
                     use_vt=False,
                     python_shell=False,
                 )
+
+    # TODO: When we switch to pytest, mark parametrized with None for user as well -W. Werner, 2020-06-23
+    def test_when_upgrade_is_called_and_there_are_available_upgrades_it_should_call_correct_command(
+        self,
+    ):
+        fake_run_all = MagicMock(return_value={"retcode": 0, "stdout": ""})
+        expected_user = "fnord"
+        with patch.dict(pip.__salt__, {"cmd.run_all": fake_run_all}), patch(
+            "salt.modules.pip.list_upgrades", autospec=True, return_value=["fnord"]
+        ), patch(
+            "salt.modules.pip._get_pip_bin",
+            autospec=True,
+            return_value=["some-other-pip"],
+        ):
+            pip.upgrade(user=expected_user)
+
+            fake_run_all.assert_any_call(
+                ["some-other-pip", "install", "-U", "freeze", "--all", "fnord"],
+                runas=expected_user,
+                cwd=None,
+                use_vt=False,
+            )

--- a/tests/unit/modules/test_pip.py
+++ b/tests/unit/modules/test_pip.py
@@ -1478,6 +1478,62 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
                 use_vt=False,
             )
 
+    # TODO: Yeah, parametrize the user here -W. Werner, 2020-07-07
+    def test_when_list_upgrades_is_provided_a_user_it_should_be_passed_to_the_version_command(
+        self,
+    ):
+        fake_run_all = MagicMock(return_value={"retcode": 0, "stdout": "{}"})
+        expected_user = "fnord"
+
+        def all_new_commands(*args, **kwargs):
+            """
+            Without this, mutating the return value mutates the return value
+            for EVERYTHING.
+            """
+            return ["some-other-pip"]
+
+        with patch.dict(pip.__salt__, {"cmd.run_all": fake_run_all}), patch(
+            "salt.modules.pip._get_pip_bin",
+            autospec=True,
+            side_effect=all_new_commands,
+        ):
+            pip._clear_context()
+            pip.list_upgrades(user=expected_user)
+            fake_run_all.assert_any_call(
+                ["some-other-pip", "--version"],
+                runas=expected_user,
+                cwd=None,
+                python_shell=False,
+            )
+
+    # TODO: Yeah, parametrize the user here -W. Werner, 2020-07-07
+    def test_when_install_is_provided_a_user_it_should_be_passed_to_the_version_command(
+        self,
+    ):
+        fake_run_all = MagicMock(return_value={"retcode": 0, "stdout": "{}"})
+        expected_user = "fnord"
+
+        def all_new_commands(*args, **kwargs):
+            """
+            Without this, mutating the return value mutates the return value
+            for EVERYTHING.
+            """
+            return ["some-other-pip"]
+
+        with patch.dict(pip.__salt__, {"cmd.run_all": fake_run_all}), patch(
+            "salt.modules.pip._get_pip_bin",
+            autospec=True,
+            side_effect=all_new_commands,
+        ):
+            pip._clear_context()
+            pip.install(user=expected_user)
+            fake_run_all.assert_any_call(
+                ["some-other-pip", "--version"],
+                runas=expected_user,
+                cwd=None,
+                python_shell=False,
+            )
+
     # TODO: When we switch to pytest, parameterize the user - None and fnord should be enough, maybe a 3rd user -W. Werner, 2020-07-07
     def test_when_version_is_called_with_a_user_it_should_be_passed_to_undelying_runas(
         self,
@@ -1492,7 +1548,6 @@ class PipTestCase(TestCase, LoaderModuleMockMixin):
             return_value=["some-new-pip"],
         ):
             pip.version(user=expected_user)
-            print(fake_run_all.mock_calls)
             fake_run_all.assert_called_with(
                 ["some-new-pip", "--version"],
                 runas=expected_user,


### PR DESCRIPTION
### What does this PR do?

Adds a `user` parameter to `version`, as well as pass the runas parameter to `cmd.run_all` where missing in the pip module.

### What issues does this PR fix or reference?
Fixes: #57550 

### Previous Behavior

If you were not running virtualenvs as root, it would (sort of) fail because bad permissions. 

### New Behavior
Now we pass the runas parameter so every call is executed by the expected user.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
