### PR TITLE
Teach coverage a bit more about salt paths.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,7 @@ branch = True
 cover_pylib = False
 parallel = True
 concurrency = multiprocessing
+relative_files = True
 omit =
   setup.py
   .nox/*
@@ -27,3 +28,49 @@ exclude_lines =
 
 
 ignore_errors = True
+
+[paths]
+salt =
+  salt/
+  /tmp/kitchen/testing/salt/
+  /private/tmp/kitchen/testing/salt/
+  C:\Users\admini~1\AppData\Local\Temp\kitchen\testing\salt\
+  C:\Users\Administrator\AppData\Local\Temp\kitchen\testing\salt\
+tests =
+  tests/
+  /tmp/kitchen/testing/tests/
+  /private/tmp/kitchen/testing/tests/
+  C:\Users\admini~1\AppData\Local\Temp\kitchen\testing\tests\
+  C:\Users\Administrator\AppData\Local\Temp\kitchen\testing\tests\
+extension_modules =
+  tests/integration/files/extension_modules/
+  */extension_modules/
+  *\extension_modules\
+executors =
+  tests/integration/files/file/base/_executors/
+  */extmods/executors/
+  *\extmods\executors\
+grains =
+  tests/integration/files/file/base/_grains/
+  */extmods/grains/
+  *\extmods\grains\
+modules =
+  tests/integration/files/file/base/_modules/
+  */extmods/modules/
+  *\extmods\modules\
+renderers =
+  tests/integration/files/file/base/_renderers/
+  */extmods/renderers/
+  *\extmods\renderers\
+runners =
+  tests/integration/files/file/base/_runners/
+  */extmods/runners/
+  *\extmods\runners\
+states =
+  tests/integration/files/file/base/_states/
+  */extmods/states/
+  *\extmods\states\
+wheel =
+  tests/integration/files/file/base/_wheel/
+  */extmods/wheel/
+  *\extmods\wheel\

--- a/noxfile.py
+++ b/noxfile.py
@@ -293,7 +293,7 @@ def _install_requirements(session, transport, *extra_requirements):
 def _run_with_coverage(session, *test_cmd):
     if SKIP_REQUIREMENTS_INSTALL is False:
         session.install(
-            "--progress-bar=off", "coverage==5.0.1", silent=PIP_INSTALL_SILENT
+            "--progress-bar=off", "coverage==5.2", silent=PIP_INSTALL_SILENT
         )
     session.run("coverage", "erase")
     python_path_env_var = os.environ.get("PYTHONPATH") or None


### PR DESCRIPTION
### What does this PR do?
See title.

Additionally, store relative paths instead of absolute paths to ease
aggregating the coverage data across Linux, macOS and Windows.