### PR TITLE
Issue 57718 - Add force option to grains module delkey and delval

### DIFF
--- a/changelog/57718.fixed
+++ b/changelog/57718.fixed
@@ -1,0 +1,2 @@
+Grains module delkey and delval methods now support the force option. This is
+needed for deleting grains with complex (nested) values.

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -426,6 +426,10 @@ def delkey(key, force=False):
     key
         The grain key from which to delete the value.
 
+    force
+        Force remove the grain even when it is a mapped value.
+        Defaults to False
+
     CLI Example:
 
     .. code-block:: bash
@@ -448,6 +452,10 @@ def delval(key, destructive=False, force=False):
 
     destructive
         Delete the key, too. Defaults to False.
+
+    force
+        Force remove the grain even when it is a mapped value.
+        Defaults to False
 
     CLI Example:
 

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -416,7 +416,7 @@ def remove(key, val, delimiter=DEFAULT_TARGET_DELIM):
     return setval(key, grains)
 
 
-def delkey(key):
+def delkey(key, force=False):
     """
     .. versionadded:: 2017.7.0
 
@@ -432,10 +432,10 @@ def delkey(key):
 
         salt '*' grains.delkey key
     """
-    return delval(key, destructive=True)
+    return delval(key, destructive=True, force=force)
 
 
-def delval(key, destructive=False):
+def delval(key, destructive=False, force=False):
     """
     .. versionadded:: 0.17.0
 
@@ -455,7 +455,7 @@ def delval(key, destructive=False):
 
         salt '*' grains.delval key
     """
-    return set(key, None, destructive=destructive)
+    return set(key, None, destructive=destructive, force=force)
 
 
 def ls():  # pylint: disable=C0103

--- a/tests/unit/modules/test_grains.py
+++ b/tests/unit/modules/test_grains.py
@@ -785,7 +785,7 @@ class GrainsModuleTestCase(TestCase, LoaderModuleMockMixin):
             grainsmod.__grains__, {"a": "aval", "b": {"nested": "val"}, "c": 8}
         ):
             res = grainsmod.delkey("b", force=True)
-            assert res['comment'].find("Use 'force=True' to overwrite.") == -1
+            assert res["comment"].find("Use 'force=True' to overwrite.") == -1
             self.assertTrue(res["result"])
             self.assertEqual(res["changes"], {"b": None})
             self.assertEqual(grainsmod.__grains__, {"a": "aval", "c": 8})

--- a/tests/unit/modules/test_grains.py
+++ b/tests/unit/modules/test_grains.py
@@ -779,3 +779,13 @@ class GrainsModuleTestCase(TestCase, LoaderModuleMockMixin):
             self.assertTrue(res["result"])
             self.assertEqual(res["changes"], {"b": {}})
             self.assertEqual(grainsmod.__grains__, {"a": "aval", "b": {}, "c": 8})
+
+    def test_delkey_nested_key_force_needed(self):
+        with patch.dict(
+            grainsmod.__grains__, {"a": "aval", "b": {"nested": "val"}, "c": 8}
+        ):
+            res = grainsmod.delkey("b", force=True)
+            assert res['comment'].find("Use 'force=True' to overwrite.") == -1
+            self.assertTrue(res["result"])
+            self.assertEqual(res["changes"], {"b": None})
+            self.assertEqual(grainsmod.__grains__, {"a": "aval", "c": 8})


### PR DESCRIPTION
### What does this PR do?

Add force option to grains module delkey and delval

### What issues does this PR fix or reference?

Closes #57718

### Previous Behavior

Trying to remove grains with complex values resulted in an error like: 
`"The key 'b' exists but is a dict or a list. Use 'force=True' to overwrite."`
But no `force=True` option existed

### New Behavior

`force=True` option exists

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->

- [x] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes
