### PR TITLE
Mount.mounted uses ordered options Fix 57520

### DIFF
--- a/changelog/57520.fixed
+++ b/changelog/57520.fixed
@@ -1,0 +1,2 @@
+Fixes an issue with filesystems options ordering which kept already
+applied NFS fstab entries being updated.

--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -344,6 +344,8 @@ def mounted(
                 device_list.append(uuid_device)
             if label_device and label_device not in device_list:
                 device_list.append(label_device)
+            if opts:
+                opts.sort()
 
                 mount_invisible_options = [
                     "_netdev",

--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -222,6 +222,8 @@ def mounted(
     # string
     if isinstance(opts, str):
         opts = opts.split(",")
+    if opts:
+        opts.sort()
 
     if isinstance(hidden_opts, str):
         hidden_opts = hidden_opts.split(",")
@@ -342,8 +344,6 @@ def mounted(
                 device_list.append(uuid_device)
             if label_device and label_device not in device_list:
                 device_list.append(label_device)
-            if opts:
-                opts.sort()
 
                 mount_invisible_options = [
                     "_netdev",

--- a/tests/unit/states/test_mount.py
+++ b/tests/unit/states/test_mount.py
@@ -43,15 +43,7 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
         ret = {"name": name, "result": False, "comment": "", "changes": {}}
 
         mock = MagicMock(
-            side_effect=[
-                "new",
-                "present",
-                "new",
-                "change",
-                "bad config",
-                "salt",
-                "present",
-            ]
+            side_effect=["new", "present", "new", "change", "bad config", "salt"]
         )
         mock_t = MagicMock(return_value=True)
         mock_f = MagicMock(return_value=False)
@@ -231,6 +223,7 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
 
         # Test no change for uid provided as a name #25293
         with patch.dict(mount.__grains__, {"os": "CentOS"}):
+            set_fstab_mock = MagicMock(autospec=True, return_value="present")
             with patch.dict(
                 mount.__salt__,
                 {
@@ -239,7 +232,7 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                     "mount.umount": mock_f,
                     "mount.read_mount_cache": mock_read_cache,
                     "mount.write_mount_cache": mock_write_cache,
-                    "mount.set_fstab": mock,
+                    "mount.set_fstab": set_fstab_mock,
                     "user.info": mock_user,
                     "group.info": mock_group,
                 },
@@ -257,6 +250,18 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                                 opts=["uid=user1", "gid=group1"],
                             ),
                             ret,
+                        )
+                        # Test to check the options order #57520
+                        set_fstab_mock.assert_called_with(
+                            "/mnt/cifs",
+                            "//SERVER/SHARE/",
+                            "cifs",
+                            ["gid=group1", "uid=user1"],
+                            0,
+                            0,
+                            "/etc/fstab",
+                            test=True,
+                            match_on="auto",
                         )
 
         with patch.dict(mount.__grains__, {"os": "AIX"}):

--- a/tests/unit/states/test_mount.py
+++ b/tests/unit/states/test_mount.py
@@ -253,7 +253,7 @@ class MountTestCase(TestCase, LoaderModuleMockMixin):
                         )
                         # Test to check the options order #57520
                         set_fstab_mock.assert_called_with(
-                            "/mnt/cifs",
+                            name2,
                             "//SERVER/SHARE/",
                             "cifs",
                             ["gid=group1", "uid=user1"],


### PR DESCRIPTION
### What does this PR do?
When using the mount.mounted "persist", the mount options were given to fstab in different order when the filesystem is mounted and when its unmounted. That kepts  an already created fstab entry being updated by the state, depending on the filesystem being or not mounted when the state is applied.

This PR fixes this behaviour ordering the options regardless the filesystem is or not mounted.

### What issues does this PR fix or reference?
Fixes: #57520 

### Previous Behavior
When the filesystem isn't mounted, the fstab entry obeys the options order given by user.
When the filesystem is mounted, the fstab entry options were ordered by sort().

### New Behavior
fstab entry options were ordered by sort() regardless the filesystem is or not mounted.

### Merge requirements satisfied?
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No