### PR TITLE
 Documentation: Update incorrect example code in x509.py

### DIFF
--- a/salt/states/x509.py
+++ b/salt/states/x509.py
@@ -24,7 +24,7 @@ For remote signing, peers must be permitted to remotely call the
 
     peer:
       .*:
-        - sign_remote_certificate
+        - x509.sign_remote_certificate
 
 
 /srv/salt/top.sls


### PR DESCRIPTION
If you use the provided "peer" example, it doesn't work.  It seems that the whole function name "x509.sign_remote_certificate" is required.

### What does this PR do?
Fix documentation error on this page: https://docs.saltstack.com/en/master/ref/states/all/salt.states.x509.html that incorrectly advises the following "peer.conf" content:
```
peer:
  .*:
    - sign_remote_certificate
```
This configuration is missing the "x509" prefix.  The module documentation shows the correct content: https://docs.saltstack.com/en/master/ref/modules/all/salt.modules.x509.html

```
peer:
  .*:
    - x509.sign_remote_certificate
```

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
The process fails.  You get the following error:
```
salt.exceptions.SaltInvocationError: ca_server did not respond salt master must permit peers to call the sign_remote_certificate function
```
Crying.  Gnashing of teeth.

### New Behavior
You can successfully setup your PKI.  Happiness.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/[No]

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
