### PR TITLE
Fix build scripts for OSX

### DIFF
--- a/pkg/osx/build_env.sh
+++ b/pkg/osx/build_env.sh
@@ -50,6 +50,9 @@ quit_on_error() {
 ############################################################################
 echo -n -e "\033]0;Build_Env: Variables\007"
 
+MACOSX_DEPLOYMENT_TARGET=10.13
+export MACOSX_DEPLOYMENT_TARGET
+
 # This is needed to allow the some test suites (zmq) to pass
 # taken from https://github.com/zeromq/libzmq/issues/1878
 SET_ULIMIT=200000

--- a/pkg/osx/req_pyobjc.in
+++ b/pkg/osx/req_pyobjc.in
@@ -11,6 +11,7 @@ pyobjc-framework-adsupport==6.2.2  # 10.14, 10.15
 pyobjc-framework-authenticationservices==6.2.2  # 10.15
 pyobjc-framework-automaticassessmentconfiguration==6.2.2  # 10.15
 pyobjc-framework-businesschat==6.2.2  # 10.14, 10.15
+pyobjc-framework-corehaptics==6.2.2  # 10.15
 pyobjc-framework-coremotion==6.2.2  # 10.15
 pyobjc-framework-devicecheck==6.2.2  # 10.15
 pyobjc-framework-executionpolicy==6.2.2  # 10.15

--- a/pkg/osx/req_pyobjc.in
+++ b/pkg/osx/req_pyobjc.in
@@ -4,3 +4,28 @@
 #
 # Should only be necessary when changing the pyobjc version bellow
 pyobjc==6.2.2
+
+# There is some discrepancy between versions of OSX
+# All discrepancies are listed here to ensure they are present when needed
+pyobjc-framework-adsupport==6.2.2  # 10.14, 10.15
+pyobjc-framework-authenticationservices==6.2.2  # 10.15
+pyobjc-framework-automaticassessmentconfiguration==6.2.2  # 10.15
+pyobjc-framework-businesschat==6.2.2  # 10.14, 10.15
+pyobjc-framework-coremotion==6.2.2  # 10.15
+pyobjc-framework-devicecheck==6.2.2  # 10.15
+pyobjc-framework-executionpolicy==6.2.2  # 10.15
+pyobjc-framework-fileprovider==6.2.2  # 10.15
+pyobjc-framework-fileproviderui==6.2.2  # 10.15
+pyobjc-framework-linkpresentation==6.2.2  # 10.15
+pyobjc-framework-naturallanguage==6.2.2  # 10.14, 10.15
+pyobjc-framework-network==6.2.2  # 10.14, 10.15
+pyobjc-framework-oslog==6.2.2  # 10.15
+pyobjc-framework-pencilkit==6.2.2  # 10.15
+pyobjc-framework-pubsub==6.2.2  # 10.13
+pyobjc-framework-pushkit==6.2.2  # 10.15
+pyobjc-framework-qtkit==6.2.2  # 10.13, 10.14
+pyobjc-framework-quicklookthumbnailing==6.2.2  # 10.15
+pyobjc-framework-soundanalysis==6.2.2  # 10.15
+pyobjc-framework-speech==6.2.2  # 10.15
+pyobjc-framework-systemextensions==6.2.2  # 10.15
+pyobjc-framework-videosubscriberaccount==6.2.2  # 10.14, 10.15

--- a/pkg/osx/req_pyobjc.txt
+++ b/pkg/osx/req_pyobjc.txt
@@ -4,23 +4,23 @@
 #
 #    pip-compile --output-file=pkg/osx/req_pyobjc.txt pkg/osx/req_pyobjc.in
 #
-pyobjc-core==6.2.2        # via pyobjc, pyobjc-framework-accounts, pyobjc-framework-addressbook, pyobjc-framework-adsupport, pyobjc-framework-applescriptkit, pyobjc-framework-applescriptobjc, pyobjc-framework-applicationservices, pyobjc-framework-authenticationservices, pyobjc-framework-automaticassessmentconfiguration, pyobjc-framework-automator, pyobjc-framework-avfoundation, pyobjc-framework-avkit, pyobjc-framework-businesschat, pyobjc-framework-calendarstore, pyobjc-framework-cfnetwork, pyobjc-framework-cloudkit, pyobjc-framework-cocoa, pyobjc-framework-collaboration, pyobjc-framework-colorsync, pyobjc-framework-contacts, pyobjc-framework-contactsui, pyobjc-framework-coreaudio, pyobjc-framework-coreaudiokit, pyobjc-framework-corebluetooth, pyobjc-framework-coredata, pyobjc-framework-corehaptics, pyobjc-framework-corelocation, pyobjc-framework-coremedia, pyobjc-framework-coremediaio, pyobjc-framework-coreml, pyobjc-framework-coremotion, pyobjc-framework-coreservices, pyobjc-framework-corespotlight, pyobjc-framework-coretext, pyobjc-framework-corewlan, pyobjc-framework-cryptotokenkit, pyobjc-framework-devicecheck, pyobjc-framework-dictionaryservices, pyobjc-framework-discrecording, pyobjc-framework-discrecordingui, pyobjc-framework-diskarbitration, pyobjc-framework-dvdplayback, pyobjc-framework-eventkit, pyobjc-framework-exceptionhandling, pyobjc-framework-executionpolicy, pyobjc-framework-externalaccessory, pyobjc-framework-fileprovider, pyobjc-framework-fileproviderui, pyobjc-framework-findersync, pyobjc-framework-fsevents, pyobjc-framework-gamecenter, pyobjc-framework-gamecontroller, pyobjc-framework-gamekit, pyobjc-framework-gameplaykit, pyobjc-framework-imagecapturecore, pyobjc-framework-imserviceplugin, pyobjc-framework-inputmethodkit, pyobjc-framework-installerplugins, pyobjc-framework-instantmessage, pyobjc-framework-intents, pyobjc-framework-iosurface, pyobjc-framework-ituneslibrary, pyobjc-framework-latentsemanticmapping, pyobjc-framework-launchservices, pyobjc-framework-libdispatch, pyobjc-framework-linkpresentation, pyobjc-framework-localauthentication, pyobjc-framework-mapkit, pyobjc-framework-mediaaccessibility, pyobjc-framework-medialibrary, pyobjc-framework-mediaplayer, pyobjc-framework-mediatoolbox, pyobjc-framework-metal, pyobjc-framework-metalkit, pyobjc-framework-modelio, pyobjc-framework-multipeerconnectivity, pyobjc-framework-naturallanguage, pyobjc-framework-netfs, pyobjc-framework-network, pyobjc-framework-networkextension, pyobjc-framework-notificationcenter, pyobjc-framework-opendirectory, pyobjc-framework-osakit, pyobjc-framework-oslog, pyobjc-framework-pencilkit, pyobjc-framework-photos, pyobjc-framework-photosui, pyobjc-framework-preferencepanes, pyobjc-framework-pushkit, pyobjc-framework-quartz, pyobjc-framework-quicklookthumbnailing, pyobjc-framework-safariservices, pyobjc-framework-scenekit, pyobjc-framework-screensaver, pyobjc-framework-scriptingbridge, pyobjc-framework-searchkit, pyobjc-framework-security, pyobjc-framework-securityfoundation, pyobjc-framework-securityinterface, pyobjc-framework-servicemanagement, pyobjc-framework-social, pyobjc-framework-soundanalysis, pyobjc-framework-speech, pyobjc-framework-spritekit, pyobjc-framework-storekit, pyobjc-framework-syncservices, pyobjc-framework-systemconfiguration, pyobjc-framework-systemextensions, pyobjc-framework-usernotifications, pyobjc-framework-videosubscriberaccount, pyobjc-framework-videotoolbox, pyobjc-framework-vision, pyobjc-framework-webkit
+pyobjc-core==6.2.2        # via pyobjc, pyobjc-framework-accounts, pyobjc-framework-addressbook, pyobjc-framework-adsupport, pyobjc-framework-applescriptkit, pyobjc-framework-applescriptobjc, pyobjc-framework-applicationservices, pyobjc-framework-authenticationservices, pyobjc-framework-automaticassessmentconfiguration, pyobjc-framework-automator, pyobjc-framework-avfoundation, pyobjc-framework-avkit, pyobjc-framework-businesschat, pyobjc-framework-calendarstore, pyobjc-framework-cfnetwork, pyobjc-framework-cloudkit, pyobjc-framework-cocoa, pyobjc-framework-collaboration, pyobjc-framework-colorsync, pyobjc-framework-contacts, pyobjc-framework-contactsui, pyobjc-framework-coreaudio, pyobjc-framework-coreaudiokit, pyobjc-framework-corebluetooth, pyobjc-framework-coredata, pyobjc-framework-corelocation, pyobjc-framework-coremedia, pyobjc-framework-coremediaio, pyobjc-framework-coreml, pyobjc-framework-coremotion, pyobjc-framework-coreservices, pyobjc-framework-corespotlight, pyobjc-framework-coretext, pyobjc-framework-corewlan, pyobjc-framework-cryptotokenkit, pyobjc-framework-devicecheck, pyobjc-framework-dictionaryservices, pyobjc-framework-discrecording, pyobjc-framework-discrecordingui, pyobjc-framework-diskarbitration, pyobjc-framework-dvdplayback, pyobjc-framework-eventkit, pyobjc-framework-exceptionhandling, pyobjc-framework-executionpolicy, pyobjc-framework-externalaccessory, pyobjc-framework-fileprovider, pyobjc-framework-fileproviderui, pyobjc-framework-findersync, pyobjc-framework-fsevents, pyobjc-framework-gamecenter, pyobjc-framework-gamecontroller, pyobjc-framework-gamekit, pyobjc-framework-gameplaykit, pyobjc-framework-imagecapturecore, pyobjc-framework-imserviceplugin, pyobjc-framework-inputmethodkit, pyobjc-framework-installerplugins, pyobjc-framework-instantmessage, pyobjc-framework-intents, pyobjc-framework-iosurface, pyobjc-framework-ituneslibrary, pyobjc-framework-latentsemanticmapping, pyobjc-framework-launchservices, pyobjc-framework-libdispatch, pyobjc-framework-linkpresentation, pyobjc-framework-localauthentication, pyobjc-framework-mapkit, pyobjc-framework-mediaaccessibility, pyobjc-framework-medialibrary, pyobjc-framework-mediaplayer, pyobjc-framework-mediatoolbox, pyobjc-framework-metal, pyobjc-framework-metalkit, pyobjc-framework-modelio, pyobjc-framework-multipeerconnectivity, pyobjc-framework-naturallanguage, pyobjc-framework-netfs, pyobjc-framework-network, pyobjc-framework-networkextension, pyobjc-framework-notificationcenter, pyobjc-framework-opendirectory, pyobjc-framework-osakit, pyobjc-framework-oslog, pyobjc-framework-pencilkit, pyobjc-framework-photos, pyobjc-framework-photosui, pyobjc-framework-preferencepanes, pyobjc-framework-pubsub, pyobjc-framework-pushkit, pyobjc-framework-qtkit, pyobjc-framework-quartz, pyobjc-framework-quicklookthumbnailing, pyobjc-framework-safariservices, pyobjc-framework-scenekit, pyobjc-framework-screensaver, pyobjc-framework-scriptingbridge, pyobjc-framework-searchkit, pyobjc-framework-security, pyobjc-framework-securityfoundation, pyobjc-framework-securityinterface, pyobjc-framework-servicemanagement, pyobjc-framework-social, pyobjc-framework-soundanalysis, pyobjc-framework-speech, pyobjc-framework-spritekit, pyobjc-framework-storekit, pyobjc-framework-syncservices, pyobjc-framework-systemconfiguration, pyobjc-framework-systemextensions, pyobjc-framework-usernotifications, pyobjc-framework-videosubscriberaccount, pyobjc-framework-videotoolbox, pyobjc-framework-vision, pyobjc-framework-webkit
 pyobjc-framework-accounts==6.2.2  # via pyobjc, pyobjc-framework-cloudkit
 pyobjc-framework-addressbook==6.2.2  # via pyobjc
-pyobjc-framework-adsupport==6.2.2  # via pyobjc
+pyobjc-framework-adsupport==6.2.2  # via -r ./req_pyobjc.in, pyobjc
 pyobjc-framework-applescriptkit==6.2.2  # via pyobjc
 pyobjc-framework-applescriptobjc==6.2.2  # via pyobjc
 pyobjc-framework-applicationservices==6.2.2  # via pyobjc
-pyobjc-framework-authenticationservices==6.2.2  # via pyobjc
-pyobjc-framework-automaticassessmentconfiguration==6.2.2  # via pyobjc
+pyobjc-framework-authenticationservices==6.2.2  # via -r ./req_pyobjc.in
+pyobjc-framework-automaticassessmentconfiguration==6.2.2  # via -r ./req_pyobjc.in
 pyobjc-framework-automator==6.2.2  # via pyobjc
 pyobjc-framework-avfoundation==6.2.2  # via pyobjc, pyobjc-framework-mediaplayer
 pyobjc-framework-avkit==6.2.2  # via pyobjc
-pyobjc-framework-businesschat==6.2.2  # via pyobjc
+pyobjc-framework-businesschat==6.2.2  # via -r ./req_pyobjc.in, pyobjc
 pyobjc-framework-calendarstore==6.2.2  # via pyobjc
 pyobjc-framework-cfnetwork==6.2.2  # via pyobjc
 pyobjc-framework-cloudkit==6.2.2  # via pyobjc
-pyobjc-framework-cocoa==6.2.2  # via pyobjc, pyobjc-framework-accounts, pyobjc-framework-addressbook, pyobjc-framework-adsupport, pyobjc-framework-applescriptkit, pyobjc-framework-applescriptobjc, pyobjc-framework-applicationservices, pyobjc-framework-authenticationservices, pyobjc-framework-automaticassessmentconfiguration, pyobjc-framework-automator, pyobjc-framework-avfoundation, pyobjc-framework-avkit, pyobjc-framework-businesschat, pyobjc-framework-calendarstore, pyobjc-framework-cfnetwork, pyobjc-framework-cloudkit, pyobjc-framework-collaboration, pyobjc-framework-colorsync, pyobjc-framework-contacts, pyobjc-framework-contactsui, pyobjc-framework-coreaudio, pyobjc-framework-coreaudiokit, pyobjc-framework-corebluetooth, pyobjc-framework-coredata, pyobjc-framework-corehaptics, pyobjc-framework-corelocation, pyobjc-framework-coremedia, pyobjc-framework-coremediaio, pyobjc-framework-coreml, pyobjc-framework-coremotion, pyobjc-framework-corespotlight, pyobjc-framework-coretext, pyobjc-framework-corewlan, pyobjc-framework-cryptotokenkit, pyobjc-framework-devicecheck, pyobjc-framework-discrecording, pyobjc-framework-discrecordingui, pyobjc-framework-diskarbitration, pyobjc-framework-dvdplayback, pyobjc-framework-eventkit, pyobjc-framework-exceptionhandling, pyobjc-framework-executionpolicy, pyobjc-framework-externalaccessory, pyobjc-framework-fileprovider, pyobjc-framework-findersync, pyobjc-framework-fsevents, pyobjc-framework-gamecenter, pyobjc-framework-gamecontroller, pyobjc-framework-gamekit, pyobjc-framework-gameplaykit, pyobjc-framework-imagecapturecore, pyobjc-framework-imserviceplugin, pyobjc-framework-inputmethodkit, pyobjc-framework-installerplugins, pyobjc-framework-instantmessage, pyobjc-framework-intents, pyobjc-framework-iosurface, pyobjc-framework-ituneslibrary, pyobjc-framework-latentsemanticmapping, pyobjc-framework-linkpresentation, pyobjc-framework-localauthentication, pyobjc-framework-mapkit, pyobjc-framework-mediaaccessibility, pyobjc-framework-medialibrary, pyobjc-framework-mediatoolbox, pyobjc-framework-metal, pyobjc-framework-metalkit, pyobjc-framework-modelio, pyobjc-framework-multipeerconnectivity, pyobjc-framework-naturallanguage, pyobjc-framework-netfs, pyobjc-framework-network, pyobjc-framework-networkextension, pyobjc-framework-notificationcenter, pyobjc-framework-opendirectory, pyobjc-framework-osakit, pyobjc-framework-oslog, pyobjc-framework-pencilkit, pyobjc-framework-photos, pyobjc-framework-photosui, pyobjc-framework-preferencepanes, pyobjc-framework-pushkit, pyobjc-framework-quartz, pyobjc-framework-quicklookthumbnailing, pyobjc-framework-safariservices, pyobjc-framework-scenekit, pyobjc-framework-screensaver, pyobjc-framework-scriptingbridge, pyobjc-framework-security, pyobjc-framework-securityfoundation, pyobjc-framework-securityinterface, pyobjc-framework-servicemanagement, pyobjc-framework-social, pyobjc-framework-soundanalysis, pyobjc-framework-speech, pyobjc-framework-spritekit, pyobjc-framework-storekit, pyobjc-framework-syncservices, pyobjc-framework-systemconfiguration, pyobjc-framework-systemextensions, pyobjc-framework-usernotifications, pyobjc-framework-videosubscriberaccount, pyobjc-framework-videotoolbox, pyobjc-framework-vision, pyobjc-framework-webkit
+pyobjc-framework-cocoa==6.2.2  # via pyobjc, pyobjc-framework-accounts, pyobjc-framework-addressbook, pyobjc-framework-adsupport, pyobjc-framework-applescriptkit, pyobjc-framework-applescriptobjc, pyobjc-framework-applicationservices, pyobjc-framework-authenticationservices, pyobjc-framework-automaticassessmentconfiguration, pyobjc-framework-automator, pyobjc-framework-avfoundation, pyobjc-framework-avkit, pyobjc-framework-businesschat, pyobjc-framework-calendarstore, pyobjc-framework-cfnetwork, pyobjc-framework-cloudkit, pyobjc-framework-collaboration, pyobjc-framework-colorsync, pyobjc-framework-contacts, pyobjc-framework-contactsui, pyobjc-framework-coreaudio, pyobjc-framework-coreaudiokit, pyobjc-framework-corebluetooth, pyobjc-framework-coredata, pyobjc-framework-corelocation, pyobjc-framework-coremedia, pyobjc-framework-coremediaio, pyobjc-framework-coreml, pyobjc-framework-coremotion, pyobjc-framework-corespotlight, pyobjc-framework-coretext, pyobjc-framework-corewlan, pyobjc-framework-cryptotokenkit, pyobjc-framework-devicecheck, pyobjc-framework-discrecording, pyobjc-framework-discrecordingui, pyobjc-framework-diskarbitration, pyobjc-framework-dvdplayback, pyobjc-framework-eventkit, pyobjc-framework-exceptionhandling, pyobjc-framework-executionpolicy, pyobjc-framework-externalaccessory, pyobjc-framework-fileprovider, pyobjc-framework-findersync, pyobjc-framework-fsevents, pyobjc-framework-gamecenter, pyobjc-framework-gamecontroller, pyobjc-framework-gamekit, pyobjc-framework-gameplaykit, pyobjc-framework-imagecapturecore, pyobjc-framework-imserviceplugin, pyobjc-framework-inputmethodkit, pyobjc-framework-installerplugins, pyobjc-framework-instantmessage, pyobjc-framework-intents, pyobjc-framework-iosurface, pyobjc-framework-ituneslibrary, pyobjc-framework-latentsemanticmapping, pyobjc-framework-linkpresentation, pyobjc-framework-localauthentication, pyobjc-framework-mapkit, pyobjc-framework-mediaaccessibility, pyobjc-framework-medialibrary, pyobjc-framework-mediatoolbox, pyobjc-framework-metal, pyobjc-framework-metalkit, pyobjc-framework-modelio, pyobjc-framework-multipeerconnectivity, pyobjc-framework-naturallanguage, pyobjc-framework-netfs, pyobjc-framework-network, pyobjc-framework-networkextension, pyobjc-framework-notificationcenter, pyobjc-framework-opendirectory, pyobjc-framework-osakit, pyobjc-framework-oslog, pyobjc-framework-pencilkit, pyobjc-framework-photos, pyobjc-framework-photosui, pyobjc-framework-preferencepanes, pyobjc-framework-pubsub, pyobjc-framework-pushkit, pyobjc-framework-qtkit, pyobjc-framework-quartz, pyobjc-framework-quicklookthumbnailing, pyobjc-framework-safariservices, pyobjc-framework-scenekit, pyobjc-framework-screensaver, pyobjc-framework-scriptingbridge, pyobjc-framework-security, pyobjc-framework-securityfoundation, pyobjc-framework-securityinterface, pyobjc-framework-servicemanagement, pyobjc-framework-social, pyobjc-framework-soundanalysis, pyobjc-framework-speech, pyobjc-framework-spritekit, pyobjc-framework-storekit, pyobjc-framework-syncservices, pyobjc-framework-systemconfiguration, pyobjc-framework-systemextensions, pyobjc-framework-usernotifications, pyobjc-framework-videosubscriberaccount, pyobjc-framework-videotoolbox, pyobjc-framework-vision, pyobjc-framework-webkit
 pyobjc-framework-collaboration==6.2.2  # via pyobjc
 pyobjc-framework-colorsync==6.2.2  # via pyobjc
 pyobjc-framework-contacts==6.2.2  # via pyobjc, pyobjc-framework-contactsui
@@ -29,18 +29,17 @@ pyobjc-framework-coreaudio==6.2.2  # via pyobjc, pyobjc-framework-coreaudiokit
 pyobjc-framework-coreaudiokit==6.2.2  # via pyobjc
 pyobjc-framework-corebluetooth==6.2.2  # via pyobjc
 pyobjc-framework-coredata==6.2.2  # via pyobjc, pyobjc-framework-cloudkit, pyobjc-framework-syncservices
-pyobjc-framework-corehaptics==6.2.2  # via pyobjc
 pyobjc-framework-corelocation==6.2.2  # via pyobjc, pyobjc-framework-cloudkit, pyobjc-framework-mapkit
 pyobjc-framework-coremedia==6.2.2  # via pyobjc, pyobjc-framework-avfoundation, pyobjc-framework-oslog, pyobjc-framework-videotoolbox
 pyobjc-framework-coremediaio==6.2.2  # via pyobjc
 pyobjc-framework-coreml==6.2.2  # via pyobjc, pyobjc-framework-vision
-pyobjc-framework-coremotion==6.2.2  # via pyobjc
+pyobjc-framework-coremotion==6.2.2  # via -r ./req_pyobjc.in
 pyobjc-framework-coreservices==6.2.2  # via pyobjc, pyobjc-framework-dictionaryservices, pyobjc-framework-launchservices, pyobjc-framework-searchkit
 pyobjc-framework-corespotlight==6.2.2  # via pyobjc
 pyobjc-framework-coretext==6.2.2  # via pyobjc
 pyobjc-framework-corewlan==6.2.2  # via pyobjc
 pyobjc-framework-cryptotokenkit==6.2.2  # via pyobjc
-pyobjc-framework-devicecheck==6.2.2  # via pyobjc
+pyobjc-framework-devicecheck==6.2.2  # via -r ./req_pyobjc.in
 pyobjc-framework-dictionaryservices==6.2.2  # via pyobjc
 pyobjc-framework-discrecording==6.2.2  # via pyobjc, pyobjc-framework-discrecordingui
 pyobjc-framework-discrecordingui==6.2.2  # via pyobjc
@@ -48,10 +47,10 @@ pyobjc-framework-diskarbitration==6.2.2  # via pyobjc
 pyobjc-framework-dvdplayback==6.2.2  # via pyobjc
 pyobjc-framework-eventkit==6.2.2  # via pyobjc
 pyobjc-framework-exceptionhandling==6.2.2  # via pyobjc
-pyobjc-framework-executionpolicy==6.2.2  # via pyobjc
+pyobjc-framework-executionpolicy==6.2.2  # via -r ./req_pyobjc.in
 pyobjc-framework-externalaccessory==6.2.2  # via pyobjc
-pyobjc-framework-fileprovider==6.2.2  # via pyobjc, pyobjc-framework-fileproviderui
-pyobjc-framework-fileproviderui==6.2.2  # via pyobjc
+pyobjc-framework-fileprovider==6.2.2  # via -r ./req_pyobjc.in, pyobjc-framework-fileproviderui
+pyobjc-framework-fileproviderui==6.2.2  # via -r ./req_pyobjc.in
 pyobjc-framework-findersync==6.2.2  # via pyobjc
 pyobjc-framework-fsevents==6.2.2  # via pyobjc, pyobjc-framework-coreservices
 pyobjc-framework-gamecenter==6.2.2  # via pyobjc
@@ -69,7 +68,7 @@ pyobjc-framework-ituneslibrary==6.2.2  # via pyobjc
 pyobjc-framework-latentsemanticmapping==6.2.2  # via pyobjc
 pyobjc-framework-launchservices==6.2.2  # via pyobjc
 pyobjc-framework-libdispatch==6.2.2  # via pyobjc
-pyobjc-framework-linkpresentation==6.2.2  # via pyobjc
+pyobjc-framework-linkpresentation==6.2.2  # via -r ./req_pyobjc.in
 pyobjc-framework-localauthentication==6.2.2  # via pyobjc
 pyobjc-framework-mapkit==6.2.2  # via pyobjc
 pyobjc-framework-mediaaccessibility==6.2.2  # via pyobjc
@@ -80,21 +79,23 @@ pyobjc-framework-metal==6.2.2  # via pyobjc, pyobjc-framework-metalkit
 pyobjc-framework-metalkit==6.2.2  # via pyobjc
 pyobjc-framework-modelio==6.2.2  # via pyobjc
 pyobjc-framework-multipeerconnectivity==6.2.2  # via pyobjc
-pyobjc-framework-naturallanguage==6.2.2  # via pyobjc
+pyobjc-framework-naturallanguage==6.2.2  # via -r ./req_pyobjc.in, pyobjc
 pyobjc-framework-netfs==6.2.2  # via pyobjc
-pyobjc-framework-network==6.2.2  # via pyobjc
+pyobjc-framework-network==6.2.2  # via -r ./req_pyobjc.in, pyobjc
 pyobjc-framework-networkextension==6.2.2  # via pyobjc
 pyobjc-framework-notificationcenter==6.2.2  # via pyobjc
 pyobjc-framework-opendirectory==6.2.2  # via pyobjc
 pyobjc-framework-osakit==6.2.2  # via pyobjc
-pyobjc-framework-oslog==6.2.2  # via pyobjc
-pyobjc-framework-pencilkit==6.2.2  # via pyobjc
+pyobjc-framework-oslog==6.2.2  # via -r ./req_pyobjc.in
+pyobjc-framework-pencilkit==6.2.2  # via -r ./req_pyobjc.in
 pyobjc-framework-photos==6.2.2  # via pyobjc
 pyobjc-framework-photosui==6.2.2  # via pyobjc
 pyobjc-framework-preferencepanes==6.2.2  # via pyobjc
-pyobjc-framework-pushkit==6.2.2  # via pyobjc
-pyobjc-framework-quartz==6.2.2  # via pyobjc, pyobjc-framework-applicationservices, pyobjc-framework-avfoundation, pyobjc-framework-avkit, pyobjc-framework-coretext, pyobjc-framework-gamekit, pyobjc-framework-instantmessage, pyobjc-framework-linkpresentation, pyobjc-framework-mapkit, pyobjc-framework-medialibrary, pyobjc-framework-modelio, pyobjc-framework-oslog, pyobjc-framework-quicklookthumbnailing, pyobjc-framework-scenekit, pyobjc-framework-spritekit, pyobjc-framework-videotoolbox, pyobjc-framework-vision
-pyobjc-framework-quicklookthumbnailing==6.2.2  # via pyobjc
+pyobjc-framework-pubsub==6.2.2  # via -r ./req_pyobjc.in
+pyobjc-framework-pushkit==6.2.2  # via -r ./req_pyobjc.in
+pyobjc-framework-qtkit==6.2.2  # via -r ./req_pyobjc.in, pyobjc
+pyobjc-framework-quartz==6.2.2  # via pyobjc, pyobjc-framework-applicationservices, pyobjc-framework-avfoundation, pyobjc-framework-avkit, pyobjc-framework-coretext, pyobjc-framework-gamekit, pyobjc-framework-instantmessage, pyobjc-framework-linkpresentation, pyobjc-framework-mapkit, pyobjc-framework-medialibrary, pyobjc-framework-modelio, pyobjc-framework-oslog, pyobjc-framework-qtkit, pyobjc-framework-quicklookthumbnailing, pyobjc-framework-scenekit, pyobjc-framework-spritekit, pyobjc-framework-videotoolbox, pyobjc-framework-vision
+pyobjc-framework-quicklookthumbnailing==6.2.2  # via -r ./req_pyobjc.in
 pyobjc-framework-safariservices==6.2.2  # via pyobjc
 pyobjc-framework-scenekit==6.2.2  # via pyobjc
 pyobjc-framework-screensaver==6.2.2  # via pyobjc
@@ -105,16 +106,16 @@ pyobjc-framework-securityfoundation==6.2.2  # via pyobjc
 pyobjc-framework-securityinterface==6.2.2  # via pyobjc
 pyobjc-framework-servicemanagement==6.2.2  # via pyobjc
 pyobjc-framework-social==6.2.2  # via pyobjc
-pyobjc-framework-soundanalysis==6.2.2  # via pyobjc
-pyobjc-framework-speech==6.2.2  # via pyobjc
+pyobjc-framework-soundanalysis==6.2.2  # via -r ./req_pyobjc.in
+pyobjc-framework-speech==6.2.2  # via -r ./req_pyobjc.in
 pyobjc-framework-spritekit==6.2.2  # via pyobjc, pyobjc-framework-gameplaykit
 pyobjc-framework-storekit==6.2.2  # via pyobjc
 pyobjc-framework-syncservices==6.2.2  # via pyobjc
 pyobjc-framework-systemconfiguration==6.2.2  # via pyobjc
-pyobjc-framework-systemextensions==6.2.2  # via pyobjc
+pyobjc-framework-systemextensions==6.2.2  # via -r ./req_pyobjc.in
 pyobjc-framework-usernotifications==6.2.2  # via pyobjc
-pyobjc-framework-videosubscriberaccount==6.2.2  # via pyobjc
+pyobjc-framework-videosubscriberaccount==6.2.2  # via -r ./req_pyobjc.in, pyobjc
 pyobjc-framework-videotoolbox==6.2.2  # via pyobjc
 pyobjc-framework-vision==6.2.2  # via pyobjc
 pyobjc-framework-webkit==6.2.2  # via pyobjc
-pyobjc==6.2.2             # via -r pkg/osx/req_pyobjc.in
+pyobjc==6.2.2             # via -r ./req_pyobjc.in

--- a/pkg/osx/req_pyobjc.txt
+++ b/pkg/osx/req_pyobjc.txt
@@ -29,6 +29,7 @@ pyobjc-framework-coreaudio==6.2.2  # via pyobjc, pyobjc-framework-coreaudiokit
 pyobjc-framework-coreaudiokit==6.2.2  # via pyobjc
 pyobjc-framework-corebluetooth==6.2.2  # via pyobjc
 pyobjc-framework-coredata==6.2.2  # via pyobjc, pyobjc-framework-cloudkit, pyobjc-framework-syncservices
+pyobjc-framework-corehaptics==6.2.2  # via pyobjc
 pyobjc-framework-corelocation==6.2.2  # via pyobjc, pyobjc-framework-cloudkit, pyobjc-framework-mapkit
 pyobjc-framework-coremedia==6.2.2  # via pyobjc, pyobjc-framework-avfoundation, pyobjc-framework-oslog, pyobjc-framework-videotoolbox
 pyobjc-framework-coremediaio==6.2.2  # via pyobjc


### PR DESCRIPTION
# What does this PR do?
There are discrepancies in the output of pip-compile between versions of OSX. This adds all the discrepancies to the `req_pyobjc.in` file so they are present across all versions.

Also added `MACOS_DEPLOYMENT_TARGET=10.13` to the `build_env.sh` script so that python is built with the minimum supported version of OSX as the target. Thanks @weswhet 

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/57973

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes