### PR TITLE
Stop using deprecated cgi.escape

### DIFF
--- a/changelog/57983.fixed
+++ b/changelog/57983.fixed
@@ -1,0 +1,1 @@
+Replace deprecated `cgi.escape()` with `html.escape()` after it was removed from Python 3.8.

--- a/salt/returners/highstate_return.py
+++ b/salt/returners/highstate_return.py
@@ -79,7 +79,7 @@ the time of execution.
 """
 from __future__ import absolute_import, print_function, unicode_literals
 
-import cgi
+import html
 import logging
 import smtplib
 from email.mime.text import MIMEText
@@ -226,7 +226,7 @@ def _generate_html_table(data, out, level=0, extra_style=""):
                                 "td",
                                 [cell_style, second_style, "value", new_extra_style],
                             ),
-                            cgi.escape(six.text_type(value)),
+                            html.escape(six.text_type(value)),
                         ),
                         file=out,
                     )
@@ -251,7 +251,7 @@ def _generate_html_table(data, out, level=0, extra_style=""):
                     _lookup_style(
                         "td", [cell_style, first_style, "value", extra_style]
                     ),
-                    cgi.escape(six.text_type(subdata)),
+                    html.escape(six.text_type(subdata)),
                 ),
                 file=out,
             )

--- a/salt/returners/highstate_return.py
+++ b/salt/returners/highstate_return.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Return the results of a highstate (or any other state function that returns
 data in a compatible format) via an HTML email or HTML file.
@@ -77,9 +76,9 @@ values at the time of pillar generation, these will contain minion values at
 the time of execution.
 
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
 import html
+import io
 import logging
 import smtplib
 from email.mime.text import MIMEText
@@ -89,8 +88,6 @@ import salt.utils.files
 import salt.utils.json
 import salt.utils.stringutils
 import salt.utils.yaml
-from salt.ext import six
-from salt.ext.six.moves import StringIO, range
 
 log = logging.getLogger(__name__)
 
@@ -166,16 +163,14 @@ def _generate_html_table(data, out, level=0, extra_style=""):
     Generate a single table of data
     """
     print(
-        '<table style="{0}">'.format(
-            _lookup_style("table", ["table" + six.text_type(level)])
-        ),
+        '<table style="{}">'.format(_lookup_style("table", ["table" + str(level)])),
         file=out,
     )
 
     firstone = True
 
-    row_style = "row" + six.text_type(level)
-    cell_style = "cell" + six.text_type(level)
+    row_style = "row" + str(level)
+    cell_style = "cell" + str(level)
 
     for subdata in data:
         first_style = "first_first" if firstone else "notfirst_first"
@@ -188,13 +183,13 @@ def _generate_html_table(data, out, level=0, extra_style=""):
             else:
                 new_extra_style = extra_style
             if len(subdata) == 1:
-                name, value = next(six.iteritems(subdata))
+                name, value = next(iter(subdata.items()))
                 print(
-                    '<tr style="{0}">'.format(_lookup_style("tr", [row_style])),
+                    '<tr style="{}">'.format(_lookup_style("tr", [row_style])),
                     file=out,
                 )
                 print(
-                    '<td style="{0}">{1}</td>'.format(
+                    '<td style="{}">{}</td>'.format(
                         _lookup_style(
                             "td", [cell_style, first_style, "name", new_extra_style]
                         ),
@@ -204,7 +199,7 @@ def _generate_html_table(data, out, level=0, extra_style=""):
                 )
                 if isinstance(value, list):
                     print(
-                        '<td style="{0}">'.format(
+                        '<td style="{}">'.format(
                             _lookup_style(
                                 "td",
                                 [
@@ -221,20 +216,20 @@ def _generate_html_table(data, out, level=0, extra_style=""):
                     print("</td>", file=out)
                 else:
                     print(
-                        '<td style="{0}">{1}</td>'.format(
+                        '<td style="{}">{}</td>'.format(
                             _lookup_style(
                                 "td",
                                 [cell_style, second_style, "value", new_extra_style],
                             ),
-                            html.escape(six.text_type(value)),
+                            html.escape(str(value)),
                         ),
                         file=out,
                     )
                 print("</tr>", file=out)
         elif isinstance(subdata, list):
-            print('<tr style="{0}">'.format(_lookup_style("tr", [row_style])), file=out)
+            print('<tr style="{}">'.format(_lookup_style("tr", [row_style])), file=out)
             print(
-                '<td style="{0}">'.format(
+                '<td style="{}">'.format(
                     _lookup_style(
                         "td", [cell_style, first_style, "container", extra_style]
                     )
@@ -245,13 +240,13 @@ def _generate_html_table(data, out, level=0, extra_style=""):
             print("</td>", file=out)
             print("</tr>", file=out)
         else:
-            print('<tr style="{0}">'.format(_lookup_style("tr", [row_style])), file=out)
+            print('<tr style="{}">'.format(_lookup_style("tr", [row_style])), file=out)
             print(
-                '<td style="{0}">{1}</td>'.format(
+                '<td style="{}">{}</td>'.format(
                     _lookup_style(
                         "td", [cell_style, first_style, "value", extra_style]
                     ),
-                    html.escape(six.text_type(subdata)),
+                    html.escape(str(subdata)),
                 ),
                 file=out,
             )
@@ -409,7 +404,7 @@ def _sprinkle(config_str):
     """
     parts = [x for sub in config_str.split("{") for x in sub.split("}")]
     for i in range(1, len(parts), 2):
-        parts[i] = six.text_type(__grains__.get(parts[i], ""))
+        parts[i] = str(__grains__.get(parts[i], ""))
     return "".join(parts)
 
 
@@ -424,12 +419,12 @@ def _produce_output(report, failed, setup):
     if report_format == "json":
         report_text = salt.utils.json.dumps(report)
     elif report_format == "yaml":
-        string_file = StringIO()
+        string_file = io.StringIO()
         salt.utils.yaml.safe_dump(report, string_file, default_flow_style=False)
         string_file.seek(0)
         report_text = string_file.read()
     else:
-        string_file = StringIO()
+        string_file = io.StringIO()
         _generate_html(report, string_file)
         string_file.seek(0)
         report_text = string_file.read()
@@ -494,7 +489,7 @@ def __test_html():
         data_text = salt.utils.stringutils.to_unicode(input_file.read())
     data = salt.utils.yaml.safe_load(data_text)
 
-    string_file = StringIO()
+    string_file = io.StringIO()
     _generate_html(data, string_file)
     string_file.seek(0)
     result = string_file.read()

--- a/salt/returners/nagios_nrdp_return.py
+++ b/salt/returners/nagios_nrdp_return.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Return salt data to Nagios
 
@@ -48,19 +47,13 @@ To override individual configuration items, append --return_kwargs '{"key:": "va
     salt '*' test.ping --return nagios --return_kwargs '{"service": "service-name"}'
 
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
 import html
+import http.client
 import logging
 
-import salt.ext.six.moves.http_client
 import salt.returners
-
-# pylint: disable=import-error,no-name-in-module,redefined-builtin
-from salt.ext import six
-
-# pylint: enable=import-error,no-name-in-module,redefined-builtin
 
 log = logging.getLogger(__name__)
 
@@ -101,7 +94,7 @@ def _get_options(ret=None):
         _options["checktype"] = "1"
 
     # checktype should be a string
-    _options["checktype"] = six.text_type(_options["checktype"])
+    _options["checktype"] = str(_options["checktype"])
 
     return _options
 
@@ -121,18 +114,12 @@ def _prepare_xml(options=None, state=None):
     # No service defined then we set the status of the hostname
     if "service" in options and options["service"] != "":
         xml += (
-            "<checkresult type='service' checktype='"
-            + six.text_type(options["checktype"])
-            + "'>"
+            "<checkresult type='service' checktype='" + str(options["checktype"]) + "'>"
         )
         xml += "<hostname>" + html.escape(options["hostname"]) + "</hostname>"
         xml += "<servicename>" + html.escape(options["service"]) + "</servicename>"
     else:
-        xml += (
-            "<checkresult type='host' checktype='"
-            + six.text_type(options["checktype"])
-            + "'>"
-        )
+        xml += "<checkresult type='host' checktype='" + str(options["checktype"]) + "'>"
         xml += "<hostname>" + html.escape(options["hostname"]) + "</hostname>"
 
     xml += "<state>" + _state + "</state>"
@@ -175,7 +162,7 @@ def _post_data(options=None, xml=None):
         opts=__opts__,
     )
 
-    if res.get("status", None) == salt.ext.six.moves.http_client.OK:
+    if res.get("status", None) == http.client.OK:
         if res.get("dict", None) and isinstance(res["dict"], list):
             _content = res["dict"][0]
             if _content.get("status", None):

--- a/salt/returners/nagios_nrdp_return.py
+++ b/salt/returners/nagios_nrdp_return.py
@@ -51,7 +51,7 @@ To override individual configuration items, append --return_kwargs '{"key:": "va
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
-import cgi
+import html
 import logging
 
 import salt.ext.six.moves.http_client
@@ -125,20 +125,20 @@ def _prepare_xml(options=None, state=None):
             + six.text_type(options["checktype"])
             + "'>"
         )
-        xml += "<hostname>" + cgi.escape(options["hostname"], True) + "</hostname>"
-        xml += "<servicename>" + cgi.escape(options["service"], True) + "</servicename>"
+        xml += "<hostname>" + html.escape(options["hostname"]) + "</hostname>"
+        xml += "<servicename>" + html.escape(options["service"]) + "</servicename>"
     else:
         xml += (
             "<checkresult type='host' checktype='"
             + six.text_type(options["checktype"])
             + "'>"
         )
-        xml += "<hostname>" + cgi.escape(options["hostname"], True) + "</hostname>"
+        xml += "<hostname>" + html.escape(options["hostname"]) + "</hostname>"
 
     xml += "<state>" + _state + "</state>"
 
     if "output" in options:
-        xml += "<output>" + cgi.escape(options["output"], True) + "</output>"
+        xml += "<output>" + html.escape(options["output"]) + "</output>"
 
     xml += "</checkresult>"
 

--- a/salt/returners/nagios_nrdp_return.py
+++ b/salt/returners/nagios_nrdp_return.py
@@ -112,7 +112,7 @@ def _prepare_xml(options=None, state=None):
     xml = "<?xml version='1.0'?>\n<checkresults>\n"
 
     # No service defined then we set the status of the hostname
-    if "service" in options and options["service"] != "":
+    if options.get("service"):
         xml += (
             "<checkresult type='service' checktype='" + str(options["checktype"]) + "'>"
         )
@@ -124,7 +124,7 @@ def _prepare_xml(options=None, state=None):
 
     xml += "<state>" + _state + "</state>"
 
-    if "output" in options:
+    if options.get("output"):
         xml += "<output>" + html.escape(options["output"]) + "</output>"
 
     xml += "</checkresult>"

--- a/tests/pytests/unit/returners/test_highstate_return.py
+++ b/tests/pytests/unit/returners/test_highstate_return.py
@@ -1,0 +1,20 @@
+import io
+
+# import pytest
+import salt.returners.highstate_return as highstate_return
+
+
+def test_generate_table_should_correctly_escape_html_characters_when_data_contains_both_list_and_dict():
+    unescaped_fnord = "&fnord&"
+    unescaped_dronf = "<dronf>"
+    expected_escaped_fnord = "&amp;fnord&amp;"
+    expected_escaped_dronf = "&lt;dronf&gt;"
+    data = [["something", "or", "another", unescaped_fnord, {"cool": unescaped_dronf}]]
+
+    out = io.StringIO()
+    highstate_return._generate_html_table(data=data, out=out)
+    out.seek(0)
+    actual_table = out.read()
+
+    assert expected_escaped_fnord in actual_table
+    assert expected_escaped_dronf in actual_table

--- a/tests/pytests/unit/returners/test_nagios_nrdp_return.py
+++ b/tests/pytests/unit/returners/test_nagios_nrdp_return.py
@@ -1,0 +1,23 @@
+# import pytest
+import salt.returners.nagios_nrdp_return as nagios_nrdp_return
+from salt._compat import ElementTree as ET
+
+
+def test_prepare_xml():
+    hostname = "salt"
+    service = "salt-minion"
+
+    opts = {
+        "service": service,
+        "hostname": hostname,
+        "checktype": "active",
+    }
+    prepared_xml = nagios_nrdp_return._prepare_xml(options=opts)
+    root = ET.fromstring(prepared_xml)
+
+    checkresult = root.find("checkresult")
+    hostname_res = checkresult.find("hostname").text
+    servicename_res = checkresult.find("servicename").text
+
+    assert servicename_res == service
+    assert hostname_res == hostname

--- a/tests/pytests/unit/returners/test_nagios_nrdp_return.py
+++ b/tests/pytests/unit/returners/test_nagios_nrdp_return.py
@@ -8,16 +8,33 @@ def test_prepare_xml():
     service = "salt-minion"
 
     opts = {
-        "service": service,
         "hostname": hostname,
+        "service": service,
         "checktype": "active",
     }
-    prepared_xml = nagios_nrdp_return._prepare_xml(options=opts)
-    root = ET.fromstring(prepared_xml)
+
+    xml_ret = nagios_nrdp_return._prepare_xml(options=opts)
+    root = ET.fromstring(xml_ret)
 
     checkresult = root.find("checkresult")
     hostname_res = checkresult.find("hostname").text
     servicename_res = checkresult.find("servicename").text
 
+    # Verify the regular XML format.
     assert servicename_res == service
     assert hostname_res == hostname
+
+
+def test_escaped_xml():
+    opts = {
+        "hostname": "s&lt",
+        "output": 'output"',
+        "service": "salt-<minion>",
+        "checktype": "active",
+    }
+
+    xml_ret = nagios_nrdp_return._prepare_xml(options=opts)
+
+    assert "s&amp;lt" in xml_ret
+    assert "salt-&lt;minion&gt;" in xml_ret
+    assert "output&quot;" in xml_ret


### PR DESCRIPTION
## What does this PR do?

[cgi.escape has been deprecated](https://docs.python.org/3.2/library/cgi.html#cgi.escape) since python 3.2 and removed in 3.8. Its usage should be replaced with `html.escape`.

This issue was originally discovered and fixed in OpenBSD ports by @fobser .

### Previous Behavior

Salt would crash:

```
2020-07-09 08:38:44,604 [salt.utils.schedule                                                   :853 ][ERROR   ][26771] Unhandled exception running stat
e.highstate
Traceback (most recent call last):
 File "/usr/local/lib/python3.8/site-packages/salt/utils/schedule.py", line 844, in handle_func
   self.returners[ret_str](ret)
 File "/usr/local/lib/python3.8/site-packages/salt/returners/highstate_return.py", line 480, in returner
   _produce_output(report, failed, setup)
 File "/usr/local/lib/python3.8/site-packages/salt/returners/highstate_return.py", line 433, in _produce_output
   _generate_html(report, string_file)
 File "/usr/local/lib/python3.8/site-packages/salt/returners/highstate_return.py", line 269, in _generate_html
   _generate_html_table(data, out, 0)
 File "/usr/local/lib/python3.8/site-packages/salt/returners/highstate_return.py", line 220, in _generate_html_table
   _generate_html_table(value, out, level + 1, new_extra_style)
 File "/usr/local/lib/python3.8/site-packages/salt/returners/highstate_return.py", line 229, in _generate_html_table
   cgi.escape(six.text_type(value)),
AttributeError: module 'cgi' has no attribute 'escape'
```

### New Behavior

It no longer crashes.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html

### Commits signed with GPG?
Yes