### PR TITLE
Fix __mount_device wrapper

### DIFF
--- a/changelog/58012.fixed
+++ b/changelog/58012.fixed
@@ -1,0 +1,1 @@
+Fix btrfs state decorator, that produces exceptions when creating subvolumes.

--- a/salt/states/btrfs.py
+++ b/salt/states/btrfs.py
@@ -1,12 +1,9 @@
-# -*- coding: utf-8 -*-
-
 """
 :maintainer:    Alberto Planas <aplanas@suse.com>
 :maturity:      new
 :depends:       None
 :platform:      Linux
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
 import functools
 import logging
@@ -85,8 +82,8 @@ def __mount_device(action):
 
     @functools.wraps(action)
     def wrapper(*args, **kwargs):
-        name = kwargs["name"]
-        device = kwargs["device"]
+        name = kwargs.get("name", args[0] if args else None)
+        device = kwargs.get("device", args[1] if len(args) > 1 else None)
         use_default = kwargs.get("use_default", False)
 
         ret = {

--- a/tests/unit/states/test_btrfs.py
+++ b/tests/unit/states/test_btrfs.py
@@ -1,11 +1,7 @@
-# -*- coding: utf-8 -*-
-
 """
 :maintainer:    Alberto Planas <aplanas@suse.com>
 :platform:      Linux
 """
-# Import Python Libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import pytest
 import salt.states.btrfs as btrfs
@@ -210,6 +206,33 @@ class BtrfsTestCase(TestCase, LoaderModuleMockMixin):
             btrfs.__opts__, opts_mock
         ):
             assert btrfs.subvolume_created(name="@/var", device="/dev/sda1") == {
+                "name": "@/var",
+                "result": True,
+                "changes": {},
+                "comment": ["Subvolume @/var already present"],
+            }
+            salt_mock["btrfs.subvolume_exists"].assert_called_with("/tmp/xxx/@/var")
+            mount.assert_called_once()
+            umount.assert_called_once()
+
+    @skipIf(salt.utils.platform.is_windows(), "Skip on Windows")
+    @patch("salt.states.btrfs._umount")
+    @patch("salt.states.btrfs._mount")
+    def test_subvolume_created_exists_decorator(self, mount, umount):
+        """
+        Test creating a subvolume using a non-kwargs call
+        """
+        mount.return_value = "/tmp/xxx"
+        salt_mock = {
+            "btrfs.subvolume_exists": MagicMock(return_value=True),
+        }
+        opts_mock = {
+            "test": False,
+        }
+        with patch.dict(btrfs.__salt__, salt_mock), patch.dict(
+            btrfs.__opts__, opts_mock
+        ):
+            assert btrfs.subvolume_created("@/var", "/dev/sda1") == {
                 "name": "@/var",
                 "result": True,
                 "changes": {},


### PR DESCRIPTION
### What does this PR do?

Some recent change in Salt is now doing the right thing, and calling the
different states with separated args and kwargs.  This change trigger a
hidden bug in the __mount_device decorator, that expect those parameter
to be in kwargs, as is happening during the test.

This patch change the way that the wrapper inside the decorator search
for the name and device parameters, first looking into kwargs and later
in args if possible.  A new test is introduced to exercise both cases.

Fix #58012

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
No
