### PR TITLE
use yaml highlight for version report in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -36,7 +36,7 @@ If applicable, add screenshots to help explain your problem.
 <details><summary>salt --versions-report</summary>
 (Provided by running salt --versions-report. Please also mention any differences in master/minion versions.) 
 
-```
+```yaml
 PASTE HERE
 ```
 </details>


### PR DESCRIPTION
### What does this PR do?
Updates the github template for bugs, and set highlighting in the spot where users paste version reports

### Previous Behavior
No syntax highlighting

```
Salt Version:
           Salt: 3001

Dependency Versions:
           cffi: 1.14.1
       cherrypy: Not Installed
       dateutil: Not Installed

System Versions:
           dist: centos 7 Core
         locale: UTF-8
        machine: x86_64
        release: 3.10.0-1127.el7.x86_64
         system: Linux
        version: CentOS Linux 7 Core
```

### New Behavior
YAML syntax highlighting

```yaml
Salt Version:
           Salt: 3001

Dependency Versions:
           cffi: 1.14.1
       cherrypy: Not Installed
       dateutil: Not Installed

System Versions:
           dist: centos 7 Core
         locale: UTF-8
        machine: x86_64
        release: 3.10.0-1127.el7.x86_64
         system: Linux
        version: CentOS Linux 7 Core
```

### Merge requirements satisfied?
n/a

### Commits signed with GPG?
No

