### PR TITLE
Postgres privileges view

### DIFF
--- a/changelog/57690.fixed
+++ b/changelog/57690.fixed
@@ -1,0 +1,1 @@
+Fixes issue in postgresql privileges detection: privileges on views were never retrieved and always recreated.

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -2725,7 +2725,7 @@ def _make_privileges_list_query(name, object_type, prepend):
                     "ON n.oid = c.relnamespace",
                     "WHERE nspname = '{0}'",
                     "AND relname = '{1}'",
-                    "AND relkind = 'r'",
+                    "AND relkind in ('r', 'v')",
                     "ORDER BY relname",
                 ]
             )


### PR DESCRIPTION
### What does this PR do?

`postgres_privileges.present` says:

> View permissions should specify `object_type: table`.

But `_make_privileges_list_query` is unable to verify existing privileges on views because it filters on ordinary tables only.

### What issues does this PR fix or reference?
Fixes: #57690

### Previous Behavior

`postgres.privileges_list`, `state.high_state test=True` and similar functions are unable to verify existing privileges on views.

### New Behavior

Privileges on views are now detected correctly.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes
