### PR TITLE
[port jam] 49227 - add ability to pass exclude kwarg to salt.state within orchestrate

### DIFF
--- a/changelog/49130.added
+++ b/changelog/49130.added
@@ -1,0 +1,1 @@
+Added ability to pass exclude kwarg to salt.state inside orchestrate.

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -113,6 +113,7 @@ def state(
     pillar=None,
     pillarenv=None,
     expect_minions=True,
+    exclude=None,
     fail_minions=None,
     allow_fail=0,
     concurrent=False,
@@ -196,6 +197,9 @@ def state(
         Pass in the number of minions to allow for failure before setting
         the result of the execution to False
 
+    exclude
+        Pass exclude kwarg to state
+
     concurrent
         Allow multiple state runs to occur at once.
 
@@ -235,6 +239,18 @@ def state(
               - apache
               - django
               - core
+            - saltenv: prod
+
+    Run sls file via :py:func:`state.sls <salt.state.sls>` on target
+    minions with exclude:
+
+    .. code-block:: yaml
+
+        docker:
+          salt.state:
+            - tgt: 'docker*'
+            - sls: docker
+            - exclude: docker.swarm
             - saltenv: prod
 
     Run a full :py:func:`state.highstate <salt.state.highstate>` on target
@@ -296,6 +312,9 @@ def state(
 
     if saltenv is not None:
         cmd_kw["kwarg"]["saltenv"] = saltenv
+
+    if exclude is not None:
+        cmd_kw["kwarg"]["exclude"] = exclude
 
     cmd_kw["kwarg"]["queue"] = queue
 

--- a/tests/pytests/unit/states/test_saltmod.py
+++ b/tests/pytests/unit/states/test_saltmod.py
@@ -1,0 +1,56 @@
+import pytest
+import salt.modules.saltutil as saltutil
+import salt.states.saltmod as saltmod
+from tests.support.mock import create_autospec, patch
+
+
+@pytest.fixture(autouse=True)
+def setup_loader(request):
+    setup_loader_modules = {saltmod: {"__opts__": {"__role": "testsuite"}}}
+    with pytest.helpers.loader_mock(request, setup_loader_modules) as loader_mock:
+        yield loader_mock
+
+
+@pytest.fixture
+def fake_cmd():
+    fake_cmd = create_autospec(saltutil.cmd)
+    with patch.dict(saltmod.__salt__, {"saltutil.cmd": fake_cmd}):
+        yield fake_cmd
+
+
+@pytest.mark.parametrize(
+    "exclude",
+    [True, False],
+)
+def test_exclude_parameter_gets_passed(exclude, fake_cmd):
+    """
+    Smoke test for for salt.states.statemod.state().  Ensures that we
+    don't take an exception if optional parameters are not specified in
+    __opts__ or __env__.
+    """
+    args = ("webserver_setup", "webserver2")
+    expected_exclude = exclude
+    kwargs = {
+        "tgt_type": "glob",
+        "exclude": expected_exclude,
+        "highstate": True,
+    }
+
+    saltmod.state(*args, **kwargs)
+
+    call = fake_cmd.call_args[1]
+    assert call["kwarg"]["exclude"] == expected_exclude
+
+
+def test_exclude_parameter_is_not_passed_if_not_provided(fake_cmd):
+    # Make sure we don't barf on existing behavior
+    args = ("webserver_setup", "webserver2")
+    kwargs_without_exclude = {
+        "tgt_type": "glob",
+        "highstate": True,
+    }
+
+    saltmod.state(*args, **kwargs_without_exclude)
+
+    call = fake_cmd.call_args[1]
+    assert "exclude" not in call["kwarg"]


### PR DESCRIPTION
### What does this PR do?

Port #49227
and
Closes https://github.com/saltstack/salt/pull/58547
### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes