### PR TITLE
[merge jam] 48812 - Use Adler32 algorithm to compute server id

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 """
 All salt configuration loading and defaults should be in this module
 """
 
 # Import python libs
-from __future__ import absolute_import, generators, print_function, unicode_literals
 
 import codecs
 import glob
@@ -110,30 +108,30 @@ _DFLT_IPC_RBUFFER = _gather_buffer_space() * 0.5
 VALID_OPTS = immutabletypes.freeze(
     {
         # The address of the salt master. May be specified as IP address or hostname
-        "master": (six.string_types, list),
+        "master": ((str,), list),
         # The TCP/UDP port of the master to connect to in order to listen to publications
-        "master_port": (six.string_types, int),
+        "master_port": ((str,), int),
         # The behaviour of the minion when connecting to a master. Can specify 'failover',
         # 'disable', 'distributed', or 'func'. If 'func' is specified, the 'master' option should be
         # set to an exec module function to run to determine the master hostname. If 'disable' is
         # specified the minion will run, but will not try to connect to a master. If 'distributed'
         # is specified the minion will try to deterministically pick a master based on its' id.
-        "master_type": six.string_types,
+        "master_type": (str,),
         # Specify the format in which the master address will be specified. Can
         # specify 'default' or 'ip_only'. If 'ip_only' is specified, then the
         # master address will not be split into IP and PORT.
-        "master_uri_format": six.string_types,
+        "master_uri_format": (str,),
         # The following optiosn refer to the Minion only, and they specify
         # the details of the source address / port to be used when connecting to
         # the Master. This is useful when dealing withmachines where due to firewall
         # rules you are restricted to use a certain IP/port combination only.
-        "source_interface_name": six.string_types,
-        "source_address": six.string_types,
-        "source_ret_port": (six.string_types, int),
-        "source_publish_port": (six.string_types, int),
+        "source_interface_name": (str,),
+        "source_address": (str,),
+        "source_ret_port": ((str,), int),
+        "source_publish_port": ((str,), int),
         # The fingerprint of the master key may be specified to increase security. Generate
         # a master fingerprint with `salt-key -F master`
-        "master_finger": six.string_types,
+        "master_finger": (str,),
         # Deprecated in 2019.2.0. Use 'random_master' instead.
         # Do not remove! Keep as an alias for usability.
         "master_shuffle": bool,
@@ -147,7 +145,7 @@ VALID_OPTS = immutabletypes.freeze(
         # interval.
         "master_failback_interval": int,
         # The name of the signing key-pair
-        "master_sign_key_name": six.string_types,
+        "master_sign_key_name": (str,),
         # Sign the master auth-replies with a cryptographic signature of the masters public key.
         "master_sign_pubkey": bool,
         # Enables verification of the master-public-signature returned by the master in auth-replies.
@@ -158,7 +156,7 @@ VALID_OPTS = immutabletypes.freeze(
         "always_verify_signature": bool,
         # The name of the file in the masters pki-directory that holds the pre-calculated signature of
         # the masters public-key
-        "master_pubkey_signature": six.string_types,
+        "master_pubkey_signature": (str,),
         # Instead of computing the signature for each auth-reply, use a pre-calculated signature.
         # The master_pubkey_signature must also be set for this.
         "master_use_pubkey_signature": bool,
@@ -168,22 +166,22 @@ VALID_OPTS = immutabletypes.freeze(
         "master_stats_event_iter": int,
         # The key fingerprint of the higher-level master for the syndic to verify it is talking to the
         # intended master
-        "syndic_finger": six.string_types,
+        "syndic_finger": (str,),
         # The caching mechanism to use for the PKI key store. Can substantially decrease master publish
         # times. Available types:
         # 'maint': Runs on a schedule as a part of the maintanence process.
         # '': Disable the key cache [default]
-        "key_cache": six.string_types,
+        "key_cache": (str,),
         # The user under which the daemon should run
-        "user": six.string_types,
+        "user": (str,),
         # The root directory prepended to these options: pki_dir, cachedir,
         # sock_dir, log_file, autosign_file, autoreject_file, extension_modules,
         # key_logfile, pidfile:
-        "root_dir": six.string_types,
+        "root_dir": (str,),
         # The directory used to store public key data
-        "pki_dir": six.string_types,
+        "pki_dir": (str,),
         # A unique identifier for this daemon
-        "id": six.string_types,
+        "id": (str,),
         # Use a module function to determine the unique identifier. If this is
         # set and 'id' is not set, it will allow invocation of a module function
         # to determine the value of 'id'. For simple invocations without function
@@ -192,9 +190,9 @@ VALID_OPTS = immutabletypes.freeze(
         # key being the function name, and the value being an embedded dictionary
         # where each key is a function argument name and each value is the
         # corresponding argument value.
-        "id_function": (dict, six.string_types),
+        "id_function": (dict, (str,)),
         # The directory to store all cache files.
-        "cachedir": six.string_types,
+        "cachedir": (str,),
         # Append minion_id to these directories.  Helps with
         # multiple proxies and minions running on the same machine.
         # Allowed elements in the list: pki_dir, cachedir, extension_modules, pidfile
@@ -202,16 +200,16 @@ VALID_OPTS = immutabletypes.freeze(
         # Flag to cache jobs locally.
         "cache_jobs": bool,
         # The path to the salt configuration file
-        "conf_file": six.string_types,
+        "conf_file": (str,),
         # The directory containing unix sockets for things like the event bus
-        "sock_dir": six.string_types,
+        "sock_dir": (str,),
         # The pool size of unix sockets, it is necessary to avoid blocking waiting for zeromq and tcp communications.
         "sock_pool_size": int,
         # Specifies how the file server should backup files, if enabled. The backups
         # live in the cache dir.
-        "backup_mode": six.string_types,
+        "backup_mode": (str,),
         # A default renderer for all operations on this host
-        "renderer": six.string_types,
+        "renderer": (str,),
         # Renderer whitelist. The only renderers from this list are allowed.
         "renderer_whitelist": list,
         # Rendrerer blacklist. Renderers from this list are disalloed even if specified in whitelist.
@@ -221,27 +219,27 @@ VALID_OPTS = immutabletypes.freeze(
         # A flag to indicate that highstate runs should force refresh the modules prior to execution
         "autoload_dynamic_modules": bool,
         # Force the minion into a single environment when it fetches files from the master
-        "saltenv": (type(None), six.string_types),
+        "saltenv": (type(None), (str,)),
         # Prevent saltenv from being overridden on the command line
         "lock_saltenv": bool,
         # Force the minion into a single pillar root when it fetches pillar data from the master
-        "pillarenv": (type(None), six.string_types),
+        "pillarenv": (type(None), (str,)),
         # Make the pillarenv always match the effective saltenv
         "pillarenv_from_saltenv": bool,
         # Allows a user to provide an alternate name for top.sls
-        "state_top": six.string_types,
-        "state_top_saltenv": (type(None), six.string_types),
+        "state_top": (str,),
+        "state_top_saltenv": (type(None), (str,)),
         # States to run when a minion starts up
-        "startup_states": six.string_types,
+        "startup_states": (str,),
         # List of startup states
         "sls_list": list,
         # Configuration for snapper in the state system
         "snapper_states": bool,
-        "snapper_states_config": six.string_types,
+        "snapper_states_config": (str,),
         # A top file to execute if startup_states == 'top'
-        "top_file": six.string_types,
+        "top_file": (str,),
         # Location of the files a minion should look for. Set to 'local' to never ask the master.
-        "file_client": six.string_types,
+        "file_client": (str,),
         "local": bool,
         # When using a local file_client, this parameter is used to allow the client to connect to
         # a master for remote execution.
@@ -255,13 +253,13 @@ VALID_OPTS = immutabletypes.freeze(
         # A map of glob paths to be used
         "decrypt_pillar": list,
         # Delimiter to use in path expressions for decrypt_pillar
-        "decrypt_pillar_delimiter": six.string_types,
+        "decrypt_pillar_delimiter": (str,),
         # Default renderer for decrypt_pillar
-        "decrypt_pillar_default": six.string_types,
+        "decrypt_pillar_default": (str,),
         # List of renderers available for decrypt_pillar
         "decrypt_pillar_renderers": list,
         # The type of hashing algorithm to use when doing file comparisons
-        "hash_type": six.string_types,
+        "hash_type": (str,),
         # Order of preference for optimized .pyc files (PY3 only)
         "optimization_order": list,
         # Refuse to load these modules
@@ -302,7 +300,7 @@ VALID_OPTS = immutabletypes.freeze(
         # The number of minutes between mine updates.
         "mine_interval": int,
         # The ipc strategy. (i.e., sockets versus tcp, etc)
-        "ipc_mode": six.string_types,
+        "ipc_mode": (str,),
         # Enable ipv6 support for daemons
         "ipv6": (type(None), bool),
         # The chunk size to use when streaming files with the file server
@@ -321,19 +319,19 @@ VALID_OPTS = immutabletypes.freeze(
         # The TCP port for mworkers to connect to on the master
         "tcp_master_workers": int,
         # The file to send logging data to
-        "log_file": six.string_types,
+        "log_file": (str,),
         # The level of verbosity at which to log
-        "log_level": six.string_types,
+        "log_level": (str,),
         # The log level to log to a given file
-        "log_level_logfile": (type(None), six.string_types),
+        "log_level_logfile": (type(None), (str,)),
         # The format to construct dates in log files
-        "log_datefmt": six.string_types,
+        "log_datefmt": (str,),
         # The dateformat for a given logfile
-        "log_datefmt_logfile": six.string_types,
+        "log_datefmt_logfile": (str,),
         # The format for console logs
-        "log_fmt_console": six.string_types,
+        "log_fmt_console": (str,),
         # The format for a given log file
-        "log_fmt_logfile": (tuple, six.string_types),
+        "log_fmt_logfile": (tuple, (str,)),
         # A dictionary of logging levels
         "log_granular_levels": dict,
         # The maximum number of bytes a single log file may contain before
@@ -372,7 +370,7 @@ VALID_OPTS = immutabletypes.freeze(
         # Tells the highstate outputter to show successful states. False will omit successes.
         "state_verbose": bool,
         # Specify the format for state outputs. See highstate outputter for additional details.
-        "state_output": six.string_types,
+        "state_output": (str,),
         # Tells the highstate outputter to only report diffs of states that changed
         "state_output_diff": bool,
         # When true, states run in the order defined in an SLS file, unless requisites re-order them
@@ -396,14 +394,14 @@ VALID_OPTS = immutabletypes.freeze(
         # Allow a daemon to function even if the key directories are not secured
         "permissive_pki_access": bool,
         # The passphrase of the master's private key
-        "key_pass": (type(None), six.string_types),
+        "key_pass": (type(None), (str,)),
         # The passphrase of the master's private signing key
-        "signing_key_pass": (type(None), six.string_types),
+        "signing_key_pass": (type(None), (str,)),
         # The path to a directory to pull in configuration file includes
-        "default_include": six.string_types,
+        "default_include": (str,),
         # If a minion is running an esky build of salt, upgrades can be performed using the url
         # defined here. See saltutil.update() for additional information
-        "update_url": (bool, six.string_types),
+        "update_url": (bool, (str,)),
         # If using update_url with saltutil.update(), provide a list of services to be restarted
         # post-install
         "update_restart_services": list,
@@ -425,7 +423,7 @@ VALID_OPTS = immutabletypes.freeze(
         "return_retry_timer_max": int,
         # Specify one or more returners in which all events will be sent to. Requires that the returners
         # in question have an event_return(event) function!
-        "event_return": (list, six.string_types),
+        "event_return": (list, (str,)),
         # The number of events to queue up in memory before pushing them down the pipe to an event
         # returner specified by 'event_return'
         "event_return_queue": int,
@@ -438,11 +436,11 @@ VALID_OPTS = immutabletypes.freeze(
         # Events matching a tag in this list should never be sent to an event returner.
         "event_return_blacklist": list,
         # default match type for filtering events tags: startswith, endswith, find, regex, fnmatch
-        "event_match_type": six.string_types,
+        "event_match_type": (str,),
         # This pidfile to write out to when a daemon starts
-        "pidfile": six.string_types,
+        "pidfile": (str,),
         # Used with the SECO range master tops system
-        "range_server": six.string_types,
+        "range_server": (str,),
         # The tcp keepalive interval to set on TCP ports. This setting can be used to tune Salt
         # connectivity issues in messy network environments with misbehaving firewalls
         "tcp_keepalive": bool,
@@ -453,7 +451,7 @@ VALID_OPTS = immutabletypes.freeze(
         # Sets zeromq TCP keepalive interval. May be used to tune issues with minion disconnects.
         "tcp_keepalive_intvl": float,
         # The network interface for a daemon to bind to
-        "interface": six.string_types,
+        "interface": (str,),
         # The port for a salt master to broadcast publications on. This will also be the port minions
         # connect to to listen for publications.
         "publish_port": int,
@@ -504,7 +502,7 @@ VALID_OPTS = immutabletypes.freeze(
         "proxy_deep_merge_pillar_in_opts": bool,
         # The strategy used when merging pillar into opts.
         # Considered only when `proxy_merge_pillar_in_opts` is True.
-        "proxy_merge_pillar_in_opts_strategy": six.string_types,
+        "proxy_merge_pillar_in_opts_strategy": (str,),
         # Allow enabling mine details using pillar data.
         "proxy_mines_pillar": bool,
         # In some particular cases, always alive proxies are not beneficial.
@@ -534,12 +532,12 @@ VALID_OPTS = immutabletypes.freeze(
         # possible types they could be, we'll just skip type-checking.
         "git_pillar_ssl_verify": bool,
         "git_pillar_global_lock": bool,
-        "git_pillar_user": six.string_types,
-        "git_pillar_password": six.string_types,
+        "git_pillar_user": (str,),
+        "git_pillar_password": (str,),
         "git_pillar_insecure_auth": bool,
-        "git_pillar_privkey": six.string_types,
-        "git_pillar_pubkey": six.string_types,
-        "git_pillar_passphrase": six.string_types,
+        "git_pillar_privkey": (str,),
+        "git_pillar_pubkey": (str,),
+        "git_pillar_passphrase": (str,),
         "git_pillar_refspecs": list,
         "git_pillar_includes": bool,
         "git_pillar_verify_config": bool,
@@ -549,9 +547,9 @@ VALID_OPTS = immutabletypes.freeze(
         # include all the possible types they could be, we'll just skip type-checking.
         "gitfs_remotes": list,
         "gitfs_insecure_auth": bool,
-        "gitfs_privkey": six.string_types,
-        "gitfs_pubkey": six.string_types,
-        "gitfs_passphrase": six.string_types,
+        "gitfs_privkey": (str,),
+        "gitfs_pubkey": (str,),
+        "gitfs_passphrase": (str,),
         "gitfs_saltenv_whitelist": list,
         "gitfs_saltenv_blacklist": list,
         "gitfs_ssl_verify": bool,
@@ -561,22 +559,22 @@ VALID_OPTS = immutabletypes.freeze(
         "gitfs_refspecs": list,
         "gitfs_disable_saltenv_mapping": bool,
         "hgfs_remotes": list,
-        "hgfs_mountpoint": six.string_types,
-        "hgfs_root": six.string_types,
-        "hgfs_base": six.string_types,
-        "hgfs_branch_method": six.string_types,
+        "hgfs_mountpoint": (str,),
+        "hgfs_root": (str,),
+        "hgfs_base": (str,),
+        "hgfs_branch_method": (str,),
         "hgfs_saltenv_whitelist": list,
         "hgfs_saltenv_blacklist": list,
         "svnfs_remotes": list,
-        "svnfs_mountpoint": six.string_types,
-        "svnfs_root": six.string_types,
-        "svnfs_trunk": six.string_types,
-        "svnfs_branches": six.string_types,
-        "svnfs_tags": six.string_types,
+        "svnfs_mountpoint": (str,),
+        "svnfs_root": (str,),
+        "svnfs_trunk": (str,),
+        "svnfs_branches": (str,),
+        "svnfs_tags": (str,),
         "svnfs_saltenv_whitelist": list,
         "svnfs_saltenv_blacklist": list,
-        "minionfs_env": six.string_types,
-        "minionfs_mountpoint": six.string_types,
+        "minionfs_env": (str,),
+        "minionfs_mountpoint": (str,),
         "minionfs_whitelist": list,
         "minionfs_blacklist": list,
         # Specify a list of external pillar systems to use
@@ -590,38 +588,38 @@ VALID_OPTS = immutabletypes.freeze(
         # Pillar cache TTL, in seconds. Has no effect unless `pillar_cache` is True
         "pillar_cache_ttl": int,
         # Pillar cache backend. Defaults to `disk` which stores caches in the master cache
-        "pillar_cache_backend": six.string_types,
+        "pillar_cache_backend": (str,),
         # Cache the GPG data to avoid having to pass through the gpg renderer
         "gpg_cache": bool,
         # GPG data cache TTL, in seconds. Has no effect unless `gpg_cache` is True
         "gpg_cache_ttl": int,
         # GPG data cache backend. Defaults to `disk` which stores caches in the master cache
-        "gpg_cache_backend": six.string_types,
+        "gpg_cache_backend": (str,),
         "pillar_safe_render_error": bool,
         # When creating a pillar, there are several strategies to choose from when
         # encountering duplicate values
-        "pillar_source_merging_strategy": six.string_types,
+        "pillar_source_merging_strategy": (str,),
         # Recursively merge lists by aggregating them instead of replacing them.
         "pillar_merge_lists": bool,
         # If True, values from included pillar SLS targets will override
         "pillar_includes_override_sls": bool,
         # How to merge multiple top files from multiple salt environments
         # (saltenvs); can be 'merge' or 'same'
-        "top_file_merging_strategy": six.string_types,
+        "top_file_merging_strategy": (str,),
         # The ordering for salt environment merging, when top_file_merging_strategy
         # is set to 'same'
         "env_order": list,
         # The salt environment which provides the default top file when
         # top_file_merging_strategy is set to 'same'; defaults to 'base'
-        "default_top": six.string_types,
+        "default_top": (str,),
         "ping_on_rotate": bool,
         "peer": dict,
         "preserve_minion_cache": bool,
-        "syndic_master": (six.string_types, list),
+        "syndic_master": ((str,), list),
         # The behaviour of the multimaster syndic when connection to a master of masters failed. Can
         # specify 'random' (default) or 'ordered'. If set to 'random' masters will be iterated in random
         # order if 'ordered' the configured order will be used.
-        "syndic_failover": six.string_types,
+        "syndic_failover": (str,),
         "syndic_forward_all_events": bool,
         "runner_dirs": list,
         "client_acl_verify": bool,
@@ -633,8 +631,8 @@ VALID_OPTS = immutabletypes.freeze(
         "token_expire_user_override": (bool, dict),
         "file_recv": bool,
         "file_recv_max_size": int,
-        "file_ignore_regex": (list, six.string_types),
-        "file_ignore_glob": (list, six.string_types),
+        "file_ignore_regex": (list, (str,)),
+        "file_ignore_glob": (list, (str,)),
         "fileserver_backend": list,
         "fileserver_followsymlinks": bool,
         "fileserver_ignoresymlinks": bool,
@@ -647,10 +645,10 @@ VALID_OPTS = immutabletypes.freeze(
         "keep_acl_in_token": bool,
         # Auth subsystem module to use to get authorized access list for a user. By default it's the
         # same module used for external authentication.
-        "eauth_acl_module": six.string_types,
+        "eauth_acl_module": (str,),
         # Subsystem to use to maintain eauth tokens. By default, tokens are stored on the local
         # filesystem
-        "eauth_tokens": six.string_types,
+        "eauth_tokens": (str,),
         # The number of open files a daemon is allowed to have open. Frequently needs to be increased
         # higher than the system default in order to account for the way zeromq consumes file handles.
         "max_open_files": int,
@@ -670,10 +668,10 @@ VALID_OPTS = immutabletypes.freeze(
         # Whether or not to cache jobs so that they can be examined later on
         "job_cache": bool,
         # Define a returner to be used as an external job caching storage backend
-        "ext_job_cache": six.string_types,
+        "ext_job_cache": (str,),
         # Specify a returner for the master to use as a backend storage system to cache jobs returns
         # that it receives
-        "master_job_cache": six.string_types,
+        "master_job_cache": (str,),
         # Specify whether the master should store end times for jobs as returns come in
         "job_cache_store_endtime": bool,
         # The minion data cache is a cache of information about the minions stored on the master.
@@ -695,8 +693,8 @@ VALID_OPTS = immutabletypes.freeze(
         "engines": list,
         # Whether or not to store runner returns in the job cache
         "runner_returns": bool,
-        "serial": six.string_types,
-        "search": six.string_types,
+        "serial": (str,),
+        "search": (str,),
         # A compound target definition.
         # See: http://docs.saltstack.com/en/latest/topics/targeting/nodegroups.html
         "nodegroups": (dict, list),
@@ -709,7 +707,7 @@ VALID_OPTS = immutabletypes.freeze(
         # generated RSA key if that file doesn't exist.
         "ssh_use_home_key": bool,
         # The logfile location for salt-key
-        "key_logfile": six.string_types,
+        "key_logfile": (str,),
         # The upper bound for the random number of seconds that a minion should
         # delay when starting in up before it connects to a master. This can be
         # used to mitigate a thundering-herd scenario when many minions start up
@@ -717,10 +715,10 @@ VALID_OPTS = immutabletypes.freeze(
         "random_startup_delay": int,
         # The source location for the winrepo sls files
         # (used by win_pkg.py, minion only)
-        "winrepo_source_dir": six.string_types,
-        "winrepo_dir": six.string_types,
-        "winrepo_dir_ng": six.string_types,
-        "winrepo_cachefile": six.string_types,
+        "winrepo_source_dir": (str,),
+        "winrepo_dir": (str,),
+        "winrepo_dir_ng": (str,),
+        "winrepo_cachefile": (str,),
         # NOTE: winrepo_branch omitted here because its value could conceivably be
         # loaded as a non-string type, which is OK because winrepo will normalize
         # them to strings. But rather than include all the possible types it could
@@ -730,12 +728,12 @@ VALID_OPTS = immutabletypes.freeze(
         "winrepo_remotes": list,
         "winrepo_remotes_ng": list,
         "winrepo_ssl_verify": bool,
-        "winrepo_user": six.string_types,
-        "winrepo_password": six.string_types,
+        "winrepo_user": (str,),
+        "winrepo_password": (str,),
         "winrepo_insecure_auth": bool,
-        "winrepo_privkey": six.string_types,
-        "winrepo_pubkey": six.string_types,
-        "winrepo_passphrase": six.string_types,
+        "winrepo_privkey": (str,),
+        "winrepo_pubkey": (str,),
+        "winrepo_passphrase": (str,),
         "winrepo_refspecs": list,
         # Set a hard limit for the amount of memory modules can consume on a minion.
         "modules_max_memory": int,
@@ -762,13 +760,13 @@ VALID_OPTS = immutabletypes.freeze(
         # Always generate minion id in lowercase.
         "minion_id_lowercase": bool,
         # Remove either a single domain (foo.org), or all (True) from a generated minion id.
-        "minion_id_remove_domain": (six.string_types, bool),
+        "minion_id_remove_domain": ((str,), bool),
         # If set, the master will sign all publications before they are sent out
         "sign_pub_messages": bool,
         # The size of key that should be generated when creating new keys
         "keysize": int,
         # The transport system for this daemon. (i.e. zeromq, tcp, detect, etc)
-        "transport": six.string_types,
+        "transport": (str,),
         # The number of seconds to wait when the client is requesting information about running jobs
         "gather_job_timeout": int,
         # The number of seconds to wait before timing out an authentication request
@@ -794,21 +792,21 @@ VALID_OPTS = immutabletypes.freeze(
         # The length that the syndic event queue must hit before events are popped off and forwarded
         "syndic_jid_forward_cache_hwm": int,
         # Salt SSH configuration
-        "ssh_passwd": six.string_types,
-        "ssh_port": six.string_types,
+        "ssh_passwd": (str,),
+        "ssh_port": (str,),
         "ssh_sudo": bool,
-        "ssh_sudo_user": six.string_types,
+        "ssh_sudo_user": (str,),
         "ssh_timeout": float,
-        "ssh_user": six.string_types,
-        "ssh_scan_ports": six.string_types,
+        "ssh_user": (str,),
+        "ssh_scan_ports": (str,),
         "ssh_scan_timeout": float,
         "ssh_identities_only": bool,
-        "ssh_log_file": six.string_types,
-        "ssh_config_file": six.string_types,
+        "ssh_log_file": (str,),
+        "ssh_config_file": (str,),
         "ssh_merge_pillar": bool,
         "ssh_run_pre_flight": bool,
         "cluster_mode": bool,
-        "sqlite_queue_dir": six.string_types,
+        "sqlite_queue_dir": (str,),
         "queue_dirs": list,
         # Instructs the minion to ping its master(s) every n number of minutes. Used
         # primarily as a mitigation technique against minion disconnects.
@@ -818,8 +816,8 @@ VALID_OPTS = immutabletypes.freeze(
         # The maximum number of minion connections allowed by the master. Can have performance
         # implications in large setups.
         "max_minions": int,
-        "username": (type(None), six.string_types),
-        "password": (type(None), six.string_types),
+        "username": (type(None), (str,)),
+        "password": (type(None), (str,)),
         # Use zmq.SUSCRIBE to limit listening sockets to only process messages bound for them
         "zmq_filtering": bool,
         # Connection caching. Can greatly speed up salt performance.
@@ -832,7 +830,7 @@ VALID_OPTS = immutabletypes.freeze(
         # Used by salt-api for master requests timeout
         "rest_timeout": int,
         # If set, all minion exec module actions will be rerouted through sudo as this user
-        "sudo_user": six.string_types,
+        "sudo_user": (str,),
         # HTTP connection timeout in seconds. Applied for tornado http fetch functions like cp.get_url
         # should be greater than overall download time
         "http_connect_timeout": float,
@@ -856,16 +854,16 @@ VALID_OPTS = immutabletypes.freeze(
         # Useful when a returner is the source of truth for a job result
         "pub_ret": bool,
         # HTTP proxy settings. Used in tornado fetch functions, apt-key etc
-        "proxy_host": six.string_types,
-        "proxy_username": six.string_types,
-        "proxy_password": six.string_types,
+        "proxy_host": (str,),
+        "proxy_username": (str,),
+        "proxy_password": (str,),
         "proxy_port": int,
         # Exclude list of hostnames from proxy
         "no_proxy": list,
         # Minion de-dup jid cache max size
         "minion_jid_queue_hwm": int,
         # Minion data cache driver (one of satl.cache.* modules)
-        "cache": six.string_types,
+        "cache": (str,),
         # Enables a fast in-memory cache booster and sets the expiration time.
         "memcache_expire_seconds": int,
         # Set a memcache limit in items (bank + key) per cache storage (driver + driver_opts).
@@ -875,10 +873,10 @@ VALID_OPTS = immutabletypes.freeze(
         # Enable collecting the memcache stats and log it on `debug` log level.
         "memcache_debug": bool,
         # Thin and minimal Salt extra modules
-        "thin_extra_mods": six.string_types,
-        "min_extra_mods": six.string_types,
+        "thin_extra_mods": (str,),
+        "min_extra_mods": (str,),
         # Default returners minion should use. List or comma-delimited string
-        "return": (six.string_types, list),
+        "return": ((str,), list),
         # TLS/SSL connection options. This could be set to a dictionary containing arguments
         # corresponding to python ssl.wrap_socket method. For details see:
         # http://www.tornadoweb.org/en/stable/tcpserver.html#tornado.tcpserver.TCPServer
@@ -903,8 +901,8 @@ VALID_OPTS = immutabletypes.freeze(
         "extmod_whitelist": dict,
         "extmod_blacklist": dict,
         # django auth
-        "django_auth_path": six.string_types,
-        "django_auth_settings": six.string_types,
+        "django_auth_path": (str,),
+        "django_auth_settings": (str,),
         # Number of times to try to auth with the master on a reconnect with the
         # tcp transport
         "tcp_authentication_retries": int,
@@ -925,7 +923,7 @@ VALID_OPTS = immutabletypes.freeze(
         # The list of config entries to be passed to external pillar function as
         # part of the extra_minion_data param
         # Subconfig entries can be specified by using the ':' notation (e.g. key:subkey)
-        "pass_to_ext_pillars": (six.string_types, list),
+        "pass_to_ext_pillars": ((str,), list),
         # SSDP discovery publisher description.
         # Contains publisher configuration and minion mapping.
         # Setting it to False disables discovery
@@ -939,13 +937,16 @@ VALID_OPTS = immutabletypes.freeze(
         # Enable calling ssh minions from the salt master
         "enable_ssh_minions": bool,
         # Thorium saltenv
-        "thoriumenv": (type(None), six.string_types),
+        "thoriumenv": (type(None), (str,)),
         # Thorium top file location
-        "thorium_top": six.string_types,
+        "thorium_top": (str,),
         # Allow raw_shell option when using the ssh
         # client via the Salt API
         "netapi_allow_raw_shell": bool,
-        "disabled_requisites": (six.string_types, list),
+        "disabled_requisites": ((str,), list),
+        # Use Adler32 hashing algorithm for server_id (default False until Sodium, "adler32" after)
+        # Possible values are: False, adler32, crc32
+        "server_id_use_crc": (bool, (str,)),
     }
 )
 
@@ -1244,6 +1245,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze(
         "schedule": {},
         "ssh_merge_pillar": True,
         "disabled_requisites": [],
+        "server_id_use_crc": False,
     }
 )
 
@@ -1698,8 +1700,8 @@ def _normalize_roots(file_roots):
     """
     Normalize file or pillar roots.
     """
-    for saltenv, dirs in six.iteritems(file_roots):
-        normalized_saltenv = six.text_type(saltenv)
+    for saltenv, dirs in file_roots.items():
+        normalized_saltenv = str(saltenv)
         if normalized_saltenv != saltenv:
             file_roots[normalized_saltenv] = file_roots.pop(saltenv)
         if not isinstance(dirs, (list, tuple)):
@@ -1795,7 +1797,7 @@ def _validate_opts(opts):
         "Config option '{0}' with value {1} has an invalid type of {2}, a "
         "{3} is required for this option"
     )
-    for key, val in six.iteritems(opts):
+    for key, val in opts.items():
         if key in VALID_OPTS:
             if val is None:
                 if VALID_OPTS[key] is None:
@@ -1813,7 +1815,7 @@ def _validate_opts(opts):
 
             # We don't know what data type sdb will return at run-time so we
             # simply cannot check it for correctness here at start-time.
-            if isinstance(val, six.string_types) and val.startswith("sdb://"):
+            if isinstance(val, str) and val.startswith("sdb://"):
                 continue
 
             if hasattr(VALID_OPTS[key], "__call__"):
@@ -1901,7 +1903,7 @@ def _read_conf_file(path):
         try:
             conf_opts = salt.utils.yaml.safe_load(conf_file) or {}
         except salt.utils.yaml.YAMLError as err:
-            message = "Error parsing configuration file: {0} - {1}".format(path, err)
+            message = "Error parsing configuration file: {} - {}".format(path, err)
             log.error(message)
             raise salt.exceptions.SaltConfigurationError(message)
 
@@ -1909,16 +1911,16 @@ def _read_conf_file(path):
         # which might have been caused by invalid yaml syntax
         if not isinstance(conf_opts, dict):
             message = (
-                "Error parsing configuration file: {0} - conf "
-                "should be a document, not {1}.".format(path, type(conf_opts))
+                "Error parsing configuration file: {} - conf "
+                "should be a document, not {}.".format(path, type(conf_opts))
             )
             log.error(message)
             raise salt.exceptions.SaltConfigurationError(message)
 
         # allow using numeric ids: convert int to string
         if "id" in conf_opts:
-            if not isinstance(conf_opts["id"], six.string_types):
-                conf_opts["id"] = six.text_type(conf_opts["id"])
+            if not isinstance(conf_opts["id"], str):
+                conf_opts["id"] = str(conf_opts["id"])
             else:
                 conf_opts["id"] = salt.utils.data.decode(conf_opts["id"])
         return conf_opts
@@ -1987,7 +1989,7 @@ def load_config(path, env_var, default_path=None, exit_on_config_errors=True):
     # If the configuration file is missing, attempt to copy the template,
     # after removing the first header line.
     if not os.path.isfile(path):
-        template = "{0}.template".format(path)
+        template = "{}.template".format(path)
         if os.path.isfile(template):
             log.debug("Writing %s based on %s", path, template)
             with salt.utils.files.fopen(path, "w") as out:
@@ -2025,7 +2027,7 @@ def include_config(include, orig_path, verbose, exit_on_config_errors=False):
         # defaults, not actually loading the whole configuration.
         return {}
 
-    if isinstance(include, six.string_types):
+    if isinstance(include, str):
         include = [include]
 
     configuration = {}
@@ -2121,7 +2123,7 @@ def insert_system_path(opts, paths):
     """
     Inserts path into python path taking into consideration 'root_dir' option.
     """
-    if isinstance(paths, six.string_types):
+    if isinstance(paths, str):
         paths = [paths]
     for path in paths:
         path_options = {"path": path, "root_dir": opts["root_dir"]}
@@ -2340,10 +2342,10 @@ def apply_sdb(opts, sdb_opts=None):
 
     if sdb_opts is None:
         sdb_opts = opts
-    if isinstance(sdb_opts, six.string_types) and sdb_opts.startswith("sdb://"):
+    if isinstance(sdb_opts, str) and sdb_opts.startswith("sdb://"):
         return salt.utils.sdb.sdb_get(sdb_opts, opts)
     elif isinstance(sdb_opts, dict):
-        for key, value in six.iteritems(sdb_opts):
+        for key, value in sdb_opts.items():
             if value is None:
                 continue
             sdb_opts[key] = apply_sdb(opts, value)
@@ -2445,7 +2447,7 @@ def cloud_config(
         "deploy_scripts_search_path",
         defaults.get("deploy_scripts_search_path", "cloud.deploy.d"),
     )
-    if isinstance(deploy_scripts_search_path, six.string_types):
+    if isinstance(deploy_scripts_search_path, str):
         deploy_scripts_search_path = [deploy_scripts_search_path]
 
     # Check the provided deploy scripts search path removing any non existing
@@ -2603,12 +2605,12 @@ def apply_cloud_config(overrides, defaults=None):
         # Reset the providers dictionary
         config["providers"] = {}
         # Populate the providers dictionary
-        for alias, details in six.iteritems(providers):
+        for alias, details in providers.items():
             if isinstance(details, list):
                 for detail in details:
                     if "driver" not in detail:
                         raise salt.exceptions.SaltCloudConfigError(
-                            "The cloud provider alias '{0}' has an entry "
+                            "The cloud provider alias '{}' has an entry "
                             "missing the required setting of 'driver'.".format(alias)
                         )
 
@@ -2621,12 +2623,12 @@ def apply_cloud_config(overrides, defaults=None):
                     if alias not in config["providers"]:
                         config["providers"][alias] = {}
 
-                    detail["provider"] = "{0}:{1}".format(alias, driver)
+                    detail["provider"] = "{}:{}".format(alias, driver)
                     config["providers"][alias][driver] = detail
             elif isinstance(details, dict):
                 if "driver" not in details:
                     raise salt.exceptions.SaltCloudConfigError(
-                        "The cloud provider alias '{0}' has an entry "
+                        "The cloud provider alias '{}' has an entry "
                         "missing the required setting of 'driver'".format(alias)
                     )
 
@@ -2638,7 +2640,7 @@ def apply_cloud_config(overrides, defaults=None):
                 if alias not in config["providers"]:
                     config["providers"][alias] = {}
 
-                details["provider"] = "{0}:{1}".format(alias, driver)
+                details["provider"] = "{}:{}".format(alias, driver)
                 config["providers"][alias][driver] = details
 
     # Migrate old configuration
@@ -2712,7 +2714,7 @@ def apply_vm_profiles_config(providers, overrides, defaults=None):
 
     vms = {}
 
-    for key, val in six.iteritems(config):
+    for key, val in config.items():
         if key in ("conf_file", "include", "default_include", "user"):
             continue
         if not isinstance(val, dict):
@@ -2724,7 +2726,7 @@ def apply_vm_profiles_config(providers, overrides, defaults=None):
         vms[key] = val
 
     # Is any VM profile extending data!?
-    for profile, details in six.iteritems(vms.copy()):
+    for profile, details in vms.copy().items():
         if "extends" not in details:
             if ":" in details["provider"]:
                 alias, driver = details["provider"].split(":")
@@ -2857,7 +2859,7 @@ def apply_cloud_providers_config(overrides, defaults=None):
         config.update(overrides)
 
     # Is the user still using the old format in the new configuration file?!
-    for name, settings in six.iteritems(config.copy()):
+    for name, settings in config.copy().items():
         if "." in name:
             log.warning("Please switch to the new providers configuration syntax")
 
@@ -2866,13 +2868,13 @@ def apply_cloud_providers_config(overrides, defaults=None):
 
             # old_to_new will migrate the old data into the 'providers' key of
             # the config dictionary. Let's map it correctly
-            for prov_name, prov_settings in six.iteritems(config.pop("providers")):
+            for prov_name, prov_settings in config.pop("providers").items():
                 config[prov_name] = prov_settings
             break
 
     providers = {}
     ext_count = 0
-    for key, val in six.iteritems(config):
+    for key, val in config.items():
         if key in ("conf_file", "include", "default_include", "user"):
             continue
 
@@ -2909,7 +2911,7 @@ def apply_cloud_providers_config(overrides, defaults=None):
         for entry in val:
 
             if "driver" not in entry:
-                entry["driver"] = "-only-extendable-{0}".format(ext_count)
+                entry["driver"] = "-only-extendable-{}".format(ext_count)
                 ext_count += 1
 
             if key not in providers:
@@ -2922,8 +2924,8 @@ def apply_cloud_providers_config(overrides, defaults=None):
     # Is any provider extending data!?
     while True:
         keep_looping = False
-        for provider_alias, entries in six.iteritems(providers.copy()):
-            for driver, details in six.iteritems(entries):
+        for provider_alias, entries in providers.copy().items():
+            for driver, details in entries.items():
                 # Set a holder for the defined profiles
                 providers[provider_alias][driver]["profiles"] = {}
 
@@ -2952,14 +2954,14 @@ def apply_cloud_providers_config(overrides, defaults=None):
                                 details["driver"], provider_alias, alias, provider
                             )
                         )
-                    details["extends"] = "{0}:{1}".format(alias, provider)
+                    details["extends"] = "{}:{}".format(alias, provider)
                     # change provider details '-only-extendable-' to extended
                     # provider name
                     details["driver"] = provider
                 elif providers.get(extends):
                     raise salt.exceptions.SaltCloudConfigError(
-                        "The '{0}' cloud provider entry in '{1}' is "
-                        "trying to extend from '{2}' and no provider was "
+                        "The '{}' cloud provider entry in '{}' is "
+                        "trying to extend from '{}' and no provider was "
                         "specified. Not extending!".format(
                             details["driver"], provider_alias, extends
                         )
@@ -2973,10 +2975,10 @@ def apply_cloud_providers_config(overrides, defaults=None):
                     )
                 else:
                     if driver in providers.get(extends):
-                        details["extends"] = "{0}:{1}".format(extends, driver)
+                        details["extends"] = "{}:{}".format(extends, driver)
                     elif "-only-extendable-" in providers.get(extends):
-                        details["extends"] = "{0}:{1}".format(
-                            extends, "-only-extendable-{0}".format(ext_count)
+                        details["extends"] = "{}:{}".format(
+                            extends, "-only-extendable-{}".format(ext_count)
                         )
                     else:
                         # We're still not aware of what we're trying to extend
@@ -2989,8 +2991,8 @@ def apply_cloud_providers_config(overrides, defaults=None):
     while True:
         # Merge provided extends
         keep_looping = False
-        for alias, entries in six.iteritems(providers.copy()):
-            for driver in list(six.iterkeys(entries)):
+        for alias, entries in providers.copy().items():
+            for driver in list(entries.keys()):
                 # Don't use iteritems, because the values of the dictionary will be changed
                 details = entries[driver]
 
@@ -3025,8 +3027,8 @@ def apply_cloud_providers_config(overrides, defaults=None):
 
     # Now clean up any providers entry that was just used to be a data tree to
     # extend from
-    for provider_alias, entries in six.iteritems(providers.copy()):
-        for driver, details in six.iteritems(entries.copy()):
+    for provider_alias, entries in providers.copy().items():
+        for driver, details in entries.copy().items():
             if not driver.startswith("-only-extendable-"):
                 continue
 
@@ -3153,8 +3155,8 @@ def is_provider_configured(
         # Return it!
         return opts["providers"][alias][driver]
 
-    for alias, drivers in six.iteritems(opts["providers"]):
-        for driver, provider_details in six.iteritems(drivers):
+    for alias, drivers in opts["providers"].items():
+        for driver, provider_details in drivers.items():
             if driver != provider and driver not in aliases:
                 continue
 
@@ -3235,9 +3237,7 @@ def is_profile_configured(opts, provider, profile_name, vm_=None):
     if driver == "linode" and profile_key.get("clonefrom", False):
         non_image_drivers.append("linode")
         non_size_drivers.append("linode")
-    elif driver == "gce" and "sourceImage" in six.text_type(
-        vm_.get("ex_disks_gce_struct")
-    ):
+    elif driver == "gce" and "sourceImage" in str(vm_.get("ex_disks_gce_struct")):
         non_image_drivers.append("gce")
 
     # If cloning on VMware, specifying image is not necessary.
@@ -3307,7 +3307,7 @@ def check_driver_dependencies(driver, dependencies):
         The dictionary of dependencies to check.
     """
     ret = True
-    for key, value in six.iteritems(dependencies):
+    for key, value in dependencies.items():
         if value is False:
             log.warning(
                 "Missing dependency: '%s'. The %s driver requires "
@@ -3342,7 +3342,7 @@ def _cache_id(minion_id, cache_file):
     try:
         with salt.utils.files.fopen(cache_file, "w") as idf:
             idf.write(minion_id)
-    except (IOError, OSError) as exc:
+    except OSError as exc:
         log.error("Could not cache minion ID: %s", exc)
 
 
@@ -3357,11 +3357,11 @@ def call_id_function(opts):
     # Import 'salt.loader' here to avoid a circular dependency
     import salt.loader as loader
 
-    if isinstance(opts["id_function"], six.string_types):
+    if isinstance(opts["id_function"], str):
         mod_fun = opts["id_function"]
         fun_kwargs = {}
     elif isinstance(opts["id_function"], dict):
-        mod_fun, fun_kwargs = six.next(six.iteritems(opts["id_function"]))
+        mod_fun, fun_kwargs = next(opts["id_function"].items())
         if fun_kwargs is None:
             fun_kwargs = {}
     else:
@@ -3380,7 +3380,7 @@ def call_id_function(opts):
             raise KeyError
         # we take whatever the module returns as the minion ID
         newid = id_mod[mod_fun](**fun_kwargs)
-        if not isinstance(newid, six.string_types) or not newid:
+        if not isinstance(newid, str) or not newid:
             log.error(
                 'Function %s returned value "%s" of type %s instead of string',
                 mod_fun,
@@ -3455,7 +3455,7 @@ def get_id(opts, cache_minion_id=False):
             if name and name != "localhost":
                 log.debug("Using cached minion ID from %s: %s", id_cache, name)
                 return name, False
-        except (IOError, OSError):
+        except OSError:
             pass
     if "__role" in opts and opts.get("__role") == "minion":
         log.debug(
@@ -3508,11 +3508,11 @@ def _update_ssl_config(opts):
         if val is None:
             continue
         if (
-            not isinstance(val, six.string_types)
+            not isinstance(val, str)
             or not val.startswith(prefix)
             or not hasattr(ssl, val)
         ):
-            message = "SSL option '{0}' must be set to one of the following values: '{1}'.".format(
+            message = "SSL option '{}' must be set to one of the following values: '{}'.".format(
                 key, "', '".join([val for val in dir(ssl) if val.startswith(prefix)])
             )
             log.error(message)
@@ -3691,7 +3691,7 @@ def _update_discovery_config(opts):
         for key in opts["discovery"]:
             if key not in discovery_config:
                 raise salt.exceptions.SaltConfigurationError(
-                    "Unknown discovery option: {0}".format(key)
+                    "Unknown discovery option: {}".format(key)
                 )
         if opts.get("__role") != "minion":
             for key in ["attempts", "pause", "match"]:
@@ -3874,7 +3874,7 @@ def apply_master_config(overrides=None, defaults=None):
     if opts["file_ignore_regex"]:
         # If file_ignore_regex was given, make sure it's wrapped in a list.
         # Only keep valid regex entries for improved performance later on.
-        if isinstance(opts["file_ignore_regex"], six.string_types):
+        if isinstance(opts["file_ignore_regex"], str):
             ignore_regex = [opts["file_ignore_regex"]]
         elif isinstance(opts["file_ignore_regex"], list):
             ignore_regex = opts["file_ignore_regex"]
@@ -3891,7 +3891,7 @@ def apply_master_config(overrides=None, defaults=None):
 
     if opts["file_ignore_glob"]:
         # If file_ignore_glob was given, make sure it's wrapped in a list.
-        if isinstance(opts["file_ignore_glob"], six.string_types):
+        if isinstance(opts["file_ignore_glob"], str):
             opts["file_ignore_glob"] = [opts["file_ignore_glob"]]
 
     # Let's make sure `worker_threads` does not drop below 3 which has proven

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 The static grains, these are the core, or built in grains.
 
@@ -9,10 +8,8 @@ will always be executed first, so that any grains loaded here in the core
 module can be overwritten just by returning dict keys with the same value
 as those returned here
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
 import datetime
-import hashlib
 import locale
 import logging
 import os
@@ -22,6 +19,7 @@ import socket
 import sys
 import time
 import uuid
+import zlib
 from errno import EACCES, EPERM
 
 import distro
@@ -41,7 +39,6 @@ import salt.utils.path
 import salt.utils.pkg.rpm
 import salt.utils.platform
 import salt.utils.stringutils
-from salt.ext import six
 from salt.ext.six.moves import range
 from salt.utils.network import _get_interfaces
 
@@ -222,7 +219,7 @@ def _linux_gpu_data():
 
     devs = []
     try:
-        lspci_out = __salt__["cmd.run"]("{0} -vmm".format(lspci))
+        lspci_out = __salt__["cmd.run"]("{} -vmm".format(lspci))
 
         cur_dev = {}
         error = False
@@ -296,7 +293,7 @@ def _netbsd_gpu_data():
         for line in pcictl_out.splitlines():
             for vendor in known_vendors:
                 vendor_match = re.match(
-                    r"[0-9:]+ ({0}) (.+) \(VGA .+\)".format(vendor), line, re.IGNORECASE
+                    r"[0-9:]+ ({}) (.+) \(VGA .+\)".format(vendor), line, re.IGNORECASE
                 )
                 if vendor_match:
                     gpus.append(
@@ -358,22 +355,22 @@ def _bsd_cpudata(osdata):
     if sysctl:
         cmds.update(
             {
-                "num_cpus": "{0} -n hw.ncpu".format(sysctl),
-                "cpuarch": "{0} -n hw.machine".format(sysctl),
-                "cpu_model": "{0} -n hw.model".format(sysctl),
+                "num_cpus": "{} -n hw.ncpu".format(sysctl),
+                "cpuarch": "{} -n hw.machine".format(sysctl),
+                "cpu_model": "{} -n hw.model".format(sysctl),
             }
         )
 
     if arch and osdata["kernel"] == "OpenBSD":
-        cmds["cpuarch"] = "{0} -s".format(arch)
+        cmds["cpuarch"] = "{} -s".format(arch)
 
     if osdata["kernel"] == "Darwin":
-        cmds["cpu_model"] = "{0} -n machdep.cpu.brand_string".format(sysctl)
-        cmds["cpu_flags"] = "{0} -n machdep.cpu.features".format(sysctl)
+        cmds["cpu_model"] = "{} -n machdep.cpu.brand_string".format(sysctl)
+        cmds["cpu_flags"] = "{} -n machdep.cpu.features".format(sysctl)
 
-    grains = dict([(k, __salt__["cmd.run"](v)) for k, v in six.iteritems(cmds)])
+    grains = {k: __salt__["cmd.run"](v) for k, v in cmds.items()}
 
-    if "cpu_flags" in grains and isinstance(grains["cpu_flags"], six.string_types):
+    if "cpu_flags" in grains and isinstance(grains["cpu_flags"], str):
         grains["cpu_flags"] = grains["cpu_flags"].split(" ")
 
     if osdata["kernel"] == "NetBSD":
@@ -454,7 +451,7 @@ def _aix_cpudata():
     grains = {}
     cmd = salt.utils.path.which("prtconf")
     if cmd:
-        data = __salt__["cmd.run"]("{0}".format(cmd)) + os.linesep
+        data = __salt__["cmd.run"]("{}".format(cmd)) + os.linesep
         for dest, regstring in (
             ("cpuarch", r"(?im)^\s*Processor\s+Type:\s+(\S+)"),
             ("cpu_flags", r"(?im)^\s*Processor\s+Version:\s+(\S+)"),
@@ -500,9 +497,9 @@ def _osx_memdata():
 
     sysctl = salt.utils.path.which("sysctl")
     if sysctl:
-        mem = __salt__["cmd.run"]("{0} -n hw.memsize".format(sysctl))
+        mem = __salt__["cmd.run"]("{} -n hw.memsize".format(sysctl))
         swap_total = (
-            __salt__["cmd.run"]("{0} -n vm.swapusage".format(sysctl))
+            __salt__["cmd.run"]("{} -n vm.swapusage".format(sysctl))
             .split()[2]
             .replace(",", ".")
         )
@@ -527,20 +524,20 @@ def _bsd_memdata(osdata):
 
     sysctl = salt.utils.path.which("sysctl")
     if sysctl:
-        mem = __salt__["cmd.run"]("{0} -n hw.physmem".format(sysctl))
+        mem = __salt__["cmd.run"]("{} -n hw.physmem".format(sysctl))
         if osdata["kernel"] == "NetBSD" and mem.startswith("-"):
-            mem = __salt__["cmd.run"]("{0} -n hw.physmem64".format(sysctl))
+            mem = __salt__["cmd.run"]("{} -n hw.physmem64".format(sysctl))
         grains["mem_total"] = int(mem) // 1024 // 1024
 
         if osdata["kernel"] in ["OpenBSD", "NetBSD"]:
             swapctl = salt.utils.path.which("swapctl")
-            swap_data = __salt__["cmd.run"]("{0} -sk".format(swapctl))
+            swap_data = __salt__["cmd.run"]("{} -sk".format(swapctl))
             if swap_data == "no swap devices configured":
                 swap_total = 0
             else:
                 swap_total = swap_data.split(" ")[1]
         else:
-            swap_total = __salt__["cmd.run"]("{0} -n vm.swap_total".format(sysctl))
+            swap_total = __salt__["cmd.run"]("{} -n vm.swap_total".format(sysctl))
         grains["swap_total"] = int(swap_total) // 1024 // 1024
     return grains
 
@@ -558,7 +555,7 @@ def _sunos_memdata():
             grains["mem_total"] = int(comps[2].strip())
 
     swap_cmd = salt.utils.path.which("swap")
-    swap_data = __salt__["cmd.run"]("{0} -s".format(swap_cmd)).split()
+    swap_data = __salt__["cmd.run"]("{} -s".format(swap_cmd)).split()
     try:
         swap_avail = int(swap_data[-2][:-1])
         swap_used = int(swap_data[-4][:-1])
@@ -586,7 +583,7 @@ def _aix_memdata():
 
     swap_cmd = salt.utils.path.which("swap")
     if swap_cmd:
-        swap_data = __salt__["cmd.run"]("{0} -s".format(swap_cmd)).split()
+        swap_data = __salt__["cmd.run"]("{} -s".format(swap_cmd)).split()
         try:
             swap_total = (int(swap_data[-2]) + int(swap_data[-6])) * 4
         except ValueError:
@@ -639,7 +636,7 @@ def _aix_get_machine_id():
     grains = {}
     cmd = salt.utils.path.which("lsattr")
     if cmd:
-        data = __salt__["cmd.run"]("{0} -El sys0".format(cmd)) + os.linesep
+        data = __salt__["cmd.run"]("{} -El sys0".format(cmd)) + os.linesep
         uuid_regexes = [re.compile(r"(?im)^\s*os_uuid\s+(\S+)\s+(.*)")]
         for regex in uuid_regexes:
             res = regex.search(data)
@@ -780,7 +777,7 @@ def _virtual(osdata):
         if not cmd:
             continue
 
-        cmd = "{0} {1}".format(cmd, " ".join(args))
+        cmd = "{} {}".format(cmd, " ".join(args))
 
         try:
             ret = __salt__["cmd.run_all"](cmd)
@@ -935,10 +932,10 @@ def _virtual(osdata):
                 grains["virtual"] = "LDOM"
                 roles = []
                 for role in ("control", "io", "root", "service"):
-                    subtype_cmd = "{0} -c current get -H -o value {1}-role".format(
+                    subtype_cmd = "{} -c current get -H -o value {}-role".format(
                         command, role
                     )
-                    ret = __salt__["cmd.run"]("{0}".format(subtype_cmd))
+                    ret = __salt__["cmd.run"]("{}".format(subtype_cmd))
                     if ret == "true":
                         roles.append(role)
                 if roles:
@@ -963,7 +960,7 @@ def _virtual(osdata):
                 init_root = os.stat("/proc/1/root/.")
                 if self_root != init_root:
                     grains["virtual_subtype"] = "chroot"
-            except (IOError, OSError):
+            except OSError:
                 pass
         if isdir("/proc/vz"):
             if os.path.isfile("/proc/vz/version"):
@@ -1032,7 +1029,7 @@ def _virtual(osdata):
                     ):
                         grains["virtual"] = "container"
                         grains["virtual_subtype"] = "Docker"
-            except IOError:
+            except OSError:
                 pass
         if os.path.isfile("/proc/cpuinfo"):
             with salt.utils.files.fopen("/proc/cpuinfo", "r") as fhr:
@@ -1064,19 +1061,19 @@ def _virtual(osdata):
                 log.debug(
                     "The content in /sys/devices/virtual/dmi/id/product_name is not valid"
                 )
-            except IOError:
+            except OSError:
                 pass
     elif osdata["kernel"] == "FreeBSD":
         kenv = salt.utils.path.which("kenv")
         if kenv:
-            product = __salt__["cmd.run"]("{0} smbios.system.product".format(kenv))
-            maker = __salt__["cmd.run"]("{0} smbios.system.maker".format(kenv))
+            product = __salt__["cmd.run"]("{} smbios.system.product".format(kenv))
+            maker = __salt__["cmd.run"]("{} smbios.system.maker".format(kenv))
             if product.startswith("VMware"):
                 grains["virtual"] = "VMware"
             if product.startswith("VirtualBox"):
                 grains["virtual"] = "VirtualBox"
             if maker.startswith("Xen"):
-                grains["virtual_subtype"] = "{0} {1}".format(maker, product)
+                grains["virtual_subtype"] = "{} {}".format(maker, product)
                 grains["virtual"] = "xen"
             if maker.startswith("Microsoft") and product.startswith("Virtual"):
                 grains["virtual"] = "VirtualPC"
@@ -1085,9 +1082,9 @@ def _virtual(osdata):
             if maker.startswith("Bochs"):
                 grains["virtual"] = "kvm"
         if sysctl:
-            hv_vendor = __salt__["cmd.run"]("{0} -n hw.hv_vendor".format(sysctl))
-            model = __salt__["cmd.run"]("{0} -n hw.model".format(sysctl))
-            jail = __salt__["cmd.run"]("{0} -n security.jail.jailed".format(sysctl))
+            hv_vendor = __salt__["cmd.run"]("{} -n hw.hv_vendor".format(sysctl))
+            model = __salt__["cmd.run"]("{} -n hw.model".format(sysctl))
+            jail = __salt__["cmd.run"]("{} -n security.jail.jailed".format(sysctl))
             if "bhyve" in hv_vendor:
                 grains["virtual"] = "bhyve"
             elif "QEMU Virtual CPU" in model:
@@ -1103,20 +1100,20 @@ def _virtual(osdata):
     elif osdata["kernel"] == "NetBSD":
         if sysctl:
             if "QEMU Virtual CPU" in __salt__["cmd.run"](
-                "{0} -n machdep.cpu_brand".format(sysctl)
+                "{} -n machdep.cpu_brand".format(sysctl)
             ):
                 grains["virtual"] = "kvm"
             elif "invalid" not in __salt__["cmd.run"](
-                "{0} -n machdep.xen.suspend".format(sysctl)
+                "{} -n machdep.xen.suspend".format(sysctl)
             ):
                 grains["virtual"] = "Xen PV DomU"
             elif "VMware" in __salt__["cmd.run"](
-                "{0} -n machdep.dmi.system-vendor".format(sysctl)
+                "{} -n machdep.dmi.system-vendor".format(sysctl)
             ):
                 grains["virtual"] = "VMware"
             # NetBSD has Xen dom0 support
             elif (
-                __salt__["cmd.run"]("{0} -n machdep.idle-mechanism".format(sysctl))
+                __salt__["cmd.run"]("{} -n machdep.idle-mechanism".format(sysctl))
                 == "xen"
             ):
                 if os.path.isfile("/var/run/xenconsoled.pid"):
@@ -1126,7 +1123,7 @@ def _virtual(osdata):
         # check the zonename here as fallback
         zonename = salt.utils.path.which("zonename")
         if zonename:
-            zone = __salt__["cmd.run"]("{0}".format(zonename))
+            zone = __salt__["cmd.run"]("{}".format(zonename))
             if zone != "global":
                 grains["virtual"] = "zone"
 
@@ -1179,7 +1176,7 @@ def _virtual_hv(osdata):
             version["minor"],
             version["extra"],
         ]
-    except (IOError, OSError, KeyError):
+    except (OSError, KeyError):
         pass
 
     # Try to read and decode the supported feature set of the hypervisor
@@ -1205,12 +1202,12 @@ def _virtual_hv(osdata):
         with salt.utils.files.fopen("/sys/hypervisor/properties/features", "r") as fhr:
             features = salt.utils.stringutils.to_unicode(fhr.read().strip())
         enabled_features = []
-        for bit, feat in six.iteritems(xen_feature_table):
+        for bit, feat in xen_feature_table.items():
             if int(features, 16) & (1 << bit):
                 enabled_features.append(feat)
         grains["virtual_hv_features"] = features
         grains["virtual_hv_features_list"] = enabled_features
-    except (IOError, OSError, KeyError):
+    except (OSError, KeyError):
         pass
 
     return grains
@@ -1322,7 +1319,7 @@ def _windows_os_release_grain(caption, product_type):
                 # ie: R2
                 if re.match(r"^R\d+$", item):
                     release = item
-        os_release = "{0}Server{1}".format(version, release)
+        os_release = "{}Server{}".format(version, release)
     else:
         for item in caption.split(" "):
             # If it's a number, decimal number, Thin or Vista, then it's the
@@ -1408,7 +1405,7 @@ def _windows_platform_data():
 
         service_pack = None
         if info["ServicePackMajor"] > 0:
-            service_pack = "".join(["SP", six.text_type(info["ServicePackMajor"])])
+            service_pack = "".join(["SP", str(info["ServicePackMajor"])])
 
         os_release = _windows_os_release_grain(
             caption=osinfo.Caption, product_type=osinfo.ProductType
@@ -1621,10 +1618,8 @@ _OS_FAMILY_MAP = {
 #     DISTRIB_CODENAME='squeeze'
 #     DISTRIB_DESCRIPTION='Ubuntu 10.10'
 _LSB_REGEX = re.compile(
-    (
-        "^(DISTRIB_(?:ID|RELEASE|CODENAME|DESCRIPTION))=(?:'|\")?"
-        "([\\w\\s\\.\\-_]+)(?:'|\")?"
-    )
+    "^(DISTRIB_(?:ID|RELEASE|CODENAME|DESCRIPTION))=(?:'|\")?"
+    "([\\w\\s\\.\\-_]+)(?:'|\")?"
 )
 
 
@@ -1634,14 +1629,14 @@ def _linux_bin_exists(binary):
     """
     for search_cmd in ("which", "type -ap"):
         try:
-            return __salt__["cmd.retcode"]("{0} {1}".format(search_cmd, binary)) == 0
+            return __salt__["cmd.retcode"]("{} {}".format(search_cmd, binary)) == 0
         except salt.exceptions.CommandExecutionError:
             pass
 
     try:
         return (
             len(
-                __salt__["cmd.run_all"]("whereis -b {0}".format(binary))[
+                __salt__["cmd.run_all"]("whereis -b {}".format(binary))[
                     "stdout"
                 ].split()
             )
@@ -1663,8 +1658,8 @@ def _parse_lsb_release():
                     pass
                 else:
                     # Adds lsb_distrib_{id,release,codename,description}
-                    ret["lsb_{0}".format(key.lower())] = value.rstrip()
-    except (IOError, OSError) as exc:
+                    ret["lsb_{}".format(key.lower())] = value.rstrip()
+    except OSError as exc:
         log.trace("Failed to parse /etc/lsb-release: %s", exc)
     return ret
 
@@ -1690,7 +1685,7 @@ def _parse_os_release(*os_release_files):
                             r'\\([$"\'\\`])', r"\1", match.group(2)
                         )
             break
-        except (IOError, OSError):
+        except OSError:
             pass
 
     return ret
@@ -1826,11 +1821,11 @@ def os_data():
         try:
             os.stat("/run/systemd/system")
             grains["init"] = "systemd"
-        except (OSError, IOError):
+        except OSError:
             try:
                 with salt.utils.files.fopen("/proc/1/cmdline") as fhr:
                     init_cmdline = fhr.read().replace("\x00", " ").split()
-            except (IOError, OSError):
+            except OSError:
                 pass
             else:
                 try:
@@ -1855,14 +1850,13 @@ def os_data():
                                 buf = edge + buf
                                 for item in supported_inits:
                                     if item in buf:
-                                        if six.PY3:
-                                            item = item.decode("utf-8")
+                                        item = item.decode("utf-8")
                                         grains["init"] = item
                                         buf = b""
                                         break
                                 edge = buf[-edge_len:]
                                 buf = fp_.read(buf_size).lower()
-                    except (IOError, OSError) as exc:
+                    except OSError as exc:
                         log.error(
                             "Unable to read from init_bin (%s): %s", init_bin, exc
                         )
@@ -1895,9 +1889,9 @@ def os_data():
             import lsb_release  # pylint: disable=import-error
 
             release = lsb_release.get_distro_information()
-            for key, value in six.iteritems(release):
+            for key, value in release.items():
                 key = key.lower()
-                lsb_param = "lsb_{0}{1}".format(
+                lsb_param = "lsb_{}{}".format(
                     "" if key.startswith("distrib_") else "distrib_", key
                 )
                 grains[lsb_param] = value
@@ -2157,7 +2151,7 @@ def os_data():
         osbuild = __salt__["cmd.run"]("sw_vers -buildVersion")
         grains["os"] = "MacOS"
         grains["os_family"] = "MacOS"
-        grains["osfullname"] = "{0} {1}".format(osname, osrelease)
+        grains["osfullname"] = "{} {}".format(osname, osrelease)
         grains["osrelease"] = osrelease
         grains["osbuild"] = osbuild
         grains["init"] = "launchd"
@@ -2192,7 +2186,7 @@ def os_data():
         if grains["kernel"] == "NetBSD":
             grains.update(_netbsd_gpu_data())
     if not grains["os"]:
-        grains["os"] = "Unknown {0}".format(grains["kernel"])
+        grains["os"] = "Unknown {}".format(grains["kernel"])
         grains["os_family"] = "Unknown"
     else:
         # this assigns family names based on the os name
@@ -2250,7 +2244,7 @@ def os_data():
             in ("Debian", "FreeBSD", "OpenBSD", "NetBSD", "Mac", "Raspbian")
             else "osfullname"
         ]
-        grains["osfinger"] = "{0}-{1}".format(
+        grains["osfinger"] = "{}-{}".format(
             os_name,
             grains["osrelease"]
             if os_name in ("Ubuntu",)
@@ -2392,8 +2386,8 @@ def ip_fqdn():
             try:
                 start_time = datetime.datetime.utcnow()
                 info = socket.getaddrinfo(_fqdn, None, socket_type)
-                ret[key] = list(set(item[4][0] for item in info))
-            except (socket.error, UnicodeError):
+                ret[key] = list({item[4][0] for item in info})
+            except (OSError, UnicodeError):
                 timediff = datetime.datetime.utcnow() - start_time
                 if timediff.seconds > 5 and __opts__["__role"] == "master":
                     log.warning(
@@ -2517,7 +2511,7 @@ def dns():
     resolv = salt.utils.dns.parse_resolv()
     for key in ("nameservers", "ip4_nameservers", "ip6_nameservers", "sortlist"):
         if key in resolv:
-            resolv[key] = [six.text_type(i) for i in resolv[key]]
+            resolv[key] = [str(i) for i in resolv[key]]
 
     return {"dns": resolv} if resolv else {}
 
@@ -2682,7 +2676,7 @@ def _hw_data(osdata):
                     log.debug(
                         "The content in /sys/devices/virtual/dmi/id/product_name is not valid"
                     )
-                except (IOError, OSError) as err:
+                except OSError as err:
                     # PermissionError is new to Python 3, but corresponds to the EACESS and
                     # EPERM error numbers. Use those instead here for PY2 compatibility.
                     if err.errno == EACCES or err.errno == EPERM:
@@ -2703,7 +2697,7 @@ def _hw_data(osdata):
             "biosreleasedate": __salt__["smbios.get"]("bios-release-date"),
             "uuid": __salt__["smbios.get"]("system-uuid"),
         }
-        grains = dict([(key, val) for key, val in grains.items() if val is not None])
+        grains = {key: val for key, val in grains.items() if val is not None}
         uuid = __salt__["smbios.get"]("system-uuid")
         if uuid is not None:
             grains["uuid"] = uuid.lower()
@@ -2723,8 +2717,8 @@ def _hw_data(osdata):
             "serialnumber": "serial#",
             "productname": "DeviceDesc",
         }
-        for grain_name, cmd_key in six.iteritems(hwdata):
-            result = __salt__["cmd.run_all"]("fw_printenv {0}".format(cmd_key))
+        for grain_name, cmd_key in hwdata.items():
+            result = __salt__["cmd.run_all"]("fw_printenv {}".format(cmd_key))
             if result["retcode"] == 0:
                 uboot_keyval = result["stdout"].split("=")
                 grains[grain_name] = _clean_value(grain_name, uboot_keyval[1])
@@ -2742,8 +2736,8 @@ def _hw_data(osdata):
                 "biosreleasedate": "smbios.bios.reldate",
                 "uuid": "smbios.system.uuid",
             }
-            for key, val in six.iteritems(fbsd_hwdata):
-                value = __salt__["cmd.run"]("{0} {1}".format(kenv, val))
+            for key, val in fbsd_hwdata.items():
+                value = __salt__["cmd.run"]("{} {}".format(kenv, val))
                 grains[key] = _clean_value(key, value)
     elif osdata["kernel"] == "OpenBSD":
         sysctl = salt.utils.path.which("sysctl")
@@ -2754,8 +2748,8 @@ def _hw_data(osdata):
             "serialnumber": "hw.serialno",
             "uuid": "hw.uuid",
         }
-        for key, oid in six.iteritems(hwdata):
-            value = __salt__["cmd.run"]("{0} -n {1}".format(sysctl, oid))
+        for key, oid in hwdata.items():
+            value = __salt__["cmd.run"]("{} -n {}".format(sysctl, oid))
             if not value.endswith(" value is not available"):
                 grains[key] = _clean_value(key, value)
     elif osdata["kernel"] == "NetBSD":
@@ -2768,8 +2762,8 @@ def _hw_data(osdata):
             "biosreleasedate": "machdep.dmi.bios-date",
             "uuid": "machdep.dmi.system-uuid",
         }
-        for key, oid in six.iteritems(nbsd_hwdata):
-            result = __salt__["cmd.run_all"]("{0} -n {1}".format(sysctl, oid))
+        for key, oid in nbsd_hwdata.items():
+            result = __salt__["cmd.run_all"]("{} -n {}".format(sysctl, oid))
             if result["retcode"] == 0:
                 grains[key] = _clean_value(key, result["stdout"])
     elif osdata["kernel"] == "Darwin":
@@ -2777,7 +2771,7 @@ def _hw_data(osdata):
         sysctl = salt.utils.path.which("sysctl")
         hwdata = {"productname": "hw.model"}
         for key, oid in hwdata.items():
-            value = __salt__["cmd.run"]("{0} -b {1}".format(sysctl, oid))
+            value = __salt__["cmd.run"]("{} -b {}".format(sysctl, oid))
             if not value.endswith(" is invalid"):
                 grains[key] = _clean_value(key, value)
     elif osdata["kernel"] == "SunOS" and osdata["cpuarch"].startswith("sparc"):
@@ -2791,7 +2785,7 @@ def _hw_data(osdata):
             ("/usr/sbin/virtinfo", "-a"),
         ):
             if salt.utils.path.which(cmd):  # Also verifies that cmd is executable
-                data += __salt__["cmd.run"]("{0} {1}".format(cmd, args))
+                data += __salt__["cmd.run"]("{} {}".format(cmd, args))
                 data += "\n"
 
         sn_regexes = [
@@ -2906,7 +2900,7 @@ def _hw_data(osdata):
     elif osdata["kernel"] == "AIX":
         cmd = salt.utils.path.which("prtconf")
         if cmd:
-            data = __salt__["cmd.run"]("{0}".format(cmd)) + os.linesep
+            data = __salt__["cmd.run"]("{}".format(cmd)) + os.linesep
             for dest, regstring in (
                 ("serialnumber", r"(?im)^\s*Machine\s+Serial\s+Number:\s+(\S+)"),
                 ("systemfirmware", r"(?im)^\s*Firmware\s+Version:\s+(.*)"),
@@ -2930,6 +2924,36 @@ def _hw_data(osdata):
     return grains
 
 
+def _get_hash_by_shell():
+    """
+    Shell-out Python 3 for compute reliable hash
+    :return:
+    """
+    id_ = __opts__.get("id", "")
+    id_hash = None
+    py_ver = sys.version_info[:2]
+    if py_ver >= (3, 3):
+        # Python 3.3 enabled hash randomization, so we need to shell out to get
+        # a reliable hash.
+        id_hash = __salt__["cmd.run"](
+            [sys.executable, "-c", 'print(hash("{}"))'.format(id_)],
+            env={"PYTHONHASHSEED": "0"},
+        )
+        try:
+            id_hash = int(id_hash)
+        except (TypeError, ValueError):
+            log.debug(
+                "Failed to hash the ID to get the server_id grain. Result of hash command: %s",
+                id_hash,
+            )
+            id_hash = None
+    if id_hash is None:
+        # Python < 3.3 or error encountered above
+        id_hash = hash(id_)
+
+    return abs(id_hash % (2 ** 31))
+
+
 def get_server_id():
     """
     Provides an integer based on the FQDN of a machine.
@@ -2940,10 +2964,26 @@ def get_server_id():
     #   server_id
 
     if salt.utils.platform.is_proxy():
-        return {}
-    id_ = __opts__.get("id", "")
-    hash_ = int(hashlib.sha256(id_.encode()).hexdigest(), 16)
-    return {"server_id": abs(hash_ % (2 ** 31))}
+        server_id = {}
+    else:
+        use_crc = __opts__.get("server_id_use_crc")
+        if bool(use_crc):
+            id_hash = (
+                getattr(zlib, use_crc, zlib.adler32)(__opts__.get("id", "").encode())
+                & 0xFFFFFFFF
+            )
+        else:
+            salt.utils.versions.warn_until(
+                "Sodium",
+                "This server_id is computed nor by Adler32 neither by CRC32. "
+                'Please use "server_id_use_crc" option and define algorithm you'
+                'prefer (default "Adler32"). The server_id will be computed with'
+                "Adler32 by default.",
+            )
+            id_hash = _get_hash_by_shell()
+        server_id = {"server_id": id_hash}
+
+    return server_id
 
 
 def get_master():
@@ -2988,14 +3028,14 @@ def default_gateway():
             for line in out.splitlines():
                 if line.startswith("default"):
                     grains["ip_gw"] = True
-                    grains["ip{0}_gw".format(ip_version)] = True
+                    grains["ip{}_gw".format(ip_version)] = True
                     try:
                         via, gw_ip = line.split()[1:3]
                     except ValueError:
                         pass
                     else:
                         if via == "via":
-                            grains["ip{0}_gw".format(ip_version)] = gw_ip
+                            grains["ip{}_gw".format(ip_version)] = gw_ip
                     break
         except Exception:  # pylint: disable=broad-except
             continue
@@ -3018,7 +3058,7 @@ def kernelparams():
                     value = data[1].strip('"')
 
                 grains["kernelparams"] += [(data[0], value)]
-    except IOError as exc:
+    except OSError as exc:
         grains = {}
         log.debug("Failed to read /proc/cmdline: %s", exc)
 


### PR DESCRIPTION
# What does this PR do?

Ports #48812

In Python3 the generated server_id has changed due to the way that Salt
seeds the hash function. Using the Adler32 instead of PYTHONHASHSEED=0
allows us to avoid a shell call.

This is an alternative to #46649

### Previous Behavior

Had to shell out with PYTHONHASHSEED to get the correct server ID hash

### New Behavior

Uses Adler32 instead of CRC32 to generate the server hash

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

TODO: add docs/changelog/tests, if we really do want this functionality.

### Commits signed with GPG?
Yes