### PR TITLE
Add minion_id_lowercase details to minion conf

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -118,6 +118,13 @@
 # set this config to ``False``.
 #minion_id_caching: True
 
+# Convert minion id to lowercase when it is being generated. Helpful when some
+# hosts get the minion id in uppercase. Cached ids will remain the same and
+# not converted. For example, Windows minions often have uppercase minion
+# names when they are set up but not always. To turn on, set this config to
+# ``True``.
+#minion_id_lowercase: False
+
 # Append a domain to a hostname in the event that it does not exist.  This is
 # useful for systems where socket.getfqdn() does not actually result in a
 # FQDN (for instance, Solaris).


### PR DESCRIPTION
### What does this PR do?
Adds `minion_id_lowercase` details to the `conf/minion` configuration file.

### What issues does this PR fix or reference?
Fixes: #57931

Another issue has been made related to `minion` configuration options, in general, here, for additional follow-up: #58112 

### Previous Behavior
Details were missing, so people could only find out about this option via:

- https://docs.saltstack.com/en/latest/ref/configuration/minion.html#minion-id-lowercase

### New Behavior
Details are now included.

### Merge requirements satisfied?
This is only adding comments to the configuration file, so this shouldn't have additional requirements.

### Commits signed with GPG?
Yes