### PR TITLE
fix linode cloudtest

### DIFF
--- a/tests/integration/files/conf/cloud.profiles.d/linode.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/linode.conf
@@ -1,5 +1,5 @@
 linode-test:
   provider: linode-config
   size: Linode 2GB
-  image: Ubuntu 14.04 LTS
+  image: Ubuntu 18.04 LTS
   script_args: '-P'


### PR DESCRIPTION
### What does this PR do?
ubuntu 14.04 is no longer supported by salt, this upgrades the cloud tests to use ubuntu 18.04 on linode
### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/57962
