### PR TITLE
Avoid decoding binary content types

### DIFF
--- a/changelog/58120.fixed
+++ b/changelog/58120.fixed
@@ -1,0 +1,1 @@
+Avoid decoding binary content types in metadata grains

--- a/salt/grains/metadata.py
+++ b/salt/grains/metadata.py
@@ -48,12 +48,12 @@ def _search(prefix="latest/"):
     linedata = http.query(os.path.join(HOST, prefix), headers=True)
     if "body" not in linedata:
         return ret
-    body = salt.utils.stringutils.to_unicode(linedata["body"])
     if (
         linedata["headers"].get("Content-Type", "text/plain")
         == "application/octet-stream"
     ):
-        return body
+        return linedata["body"]
+    body = salt.utils.stringutils.to_unicode(linedata["body"])
     for line in body.split("\n"):
         if line.endswith("/"):
             ret[line[:-1]] = _search(prefix=os.path.join(prefix, line))
@@ -80,7 +80,7 @@ def _search(prefix="latest/"):
                     ret[line] = salt.utils.stringutils.to_unicode(retdata)
             else:
                 ret[line] = retdata
-    return salt.utils.data.decode(ret)
+    return salt.utils.data.decode(ret, errors="ignore", keep=True)
 
 
 def metadata():


### PR DESCRIPTION
### What does this PR do?

Currently, using `meta-data` grains will cause errors if the `user-data` (`UserData`) attached to an instance (in eg AWS) contains **binary** data.  This may happen, for example, if the `UserData` is a gzipped blob for `cloudinit`.  The problem occurs here:
```
# salt/grains/metadata.py
#
def _search(prefix="latest/"):
    '''
    Recursively look up all grains in the metadata server
    '''
    ret = {}
    linedata = http.query(os.path.join(HOST, prefix), headers=True)
    if 'body' not in linedata:
        return ret

    # !!!! if its binary data (application/octet-stream) ... then we cannot decode it here!
    body = salt.utils.stringutils.to_unicode(linedata['body'])
    if linedata['headers'].get('Content-Type', 'text/plain') == 'application/octet-stream':
```

### Previous Behavior

Currently, any attempt to access the `meta-data` grain will cause an error as it attempts to decode the reponse from the aws metadata server:
```
$ salt-call grains.get meta-data
[CRITICAL] Failed to load grains defined in grain file metadata.metadata in function <function metadata at 0x7fdf2d08da28>, error:
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/loader.py", line 810, in grains
    ret = funcs[key](**kwargs)
  File "/usr/lib/python2.7/site-packages/salt/grains/metadata.py", line 89, in metadata
    return _search()
  File "/usr/lib/python2.7/site-packages/salt/grains/metadata.py", line 68, in _search
    ret[line] = _search(prefix=os.path.join(prefix, line + '/'))
  File "/usr/lib/python2.7/site-packages/salt/grains/metadata.py", line 58, in _search
    body = salt.utils.stringutils.to_unicode(linedata['body'])
  File "/usr/lib/python2.7/site-packages/salt/utils/stringutils.py", line 160, in to_unicode
    raise exc  # pylint: disable=raising-bad-type
UnicodeDecodeError: 'utf8' codec can't decode byte 0x8b in position 1: invalid start byte
```

### New Behavior
```
$ salt-call grains.get meta-data
local:
    ----------
    ami-id:
        ...
    ami-launch-index:
        ...

    ...
```
### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No