### PR TITLE
LVM many small fixes

### DIFF
--- a/changelog/52363.fixed
+++ b/changelog/52363.fixed
@@ -1,0 +1,1 @@
+Cleaned up a trackback in lvm.pv_present when the disk doesn't exist.

--- a/changelog/55265.changed
+++ b/changelog/55265.changed
@@ -1,0 +1,2 @@
+Changed the lvm.lv_present state to accept a resizefs switch. So, when
+the logical volume is resized, the filesystem will be resized too.

--- a/changelog/56089.added
+++ b/changelog/56089.added
@@ -1,0 +1,1 @@
+Added pvresize and lvextend to linux_lvm

--- a/salt/modules/linux_lvm.py
+++ b/salt/modules/linux_lvm.py
@@ -370,9 +370,15 @@ def vgcreate(vgname, devices, force=False, **kwargs):
         if kwargs[var] and var in valid:
             cmd.append("--{}".format(var))
             cmd.append(kwargs[var])
-    out = __salt__["cmd.run"](cmd, python_shell=False).splitlines()
+
+    cmd_ret = __salt__["cmd.run_all"](cmd, python_shell=False)
+    if cmd_ret.get("retcode"):
+        out = cmd_ret.get("stderr").strip()
+    else:
+        out = 'Volume group "{}" successfully created'.format(vgname)
+
     vgdata = vgdisplay(vgname)
-    vgdata["Output from vgcreate"] = out[0].strip()
+    vgdata["Output from vgcreate"] = out
     return vgdata
 
 
@@ -401,8 +407,14 @@ def vgextend(vgname, devices, force=False):
 
     for device in devices:
         cmd.append(device)
-    out = __salt__["cmd.run"](cmd, python_shell=False).splitlines()
-    vgdata = {"Output from vgextend": out[0].strip()}
+
+    cmd_ret = __salt__["cmd.run_all"](cmd, python_shell=False)
+    if cmd_ret.get("retcode"):
+        out = cmd_ret.get("stderr").strip()
+    else:
+        out = 'Volume group "{}" successfully extended'.format(vgname)
+
+    vgdata = {"Output from vgextend": out}
     return vgdata
 
 
@@ -516,10 +528,15 @@ def lvcreate(
     else:
         cmd.append("-qq")
 
-    out = __salt__["cmd.run"](cmd, python_shell=False).splitlines()
+    cmd_ret = __salt__["cmd.run_all"](cmd, python_shell=False)
+    if cmd_ret.get("retcode"):
+        out = cmd_ret.get("stderr").strip()
+    else:
+        out = 'Logical volume "{}" created.'.format(lvname)
+
     lvdev = "/dev/{}/{}".format(vgname, lvname)
     lvdata = lvdisplay(lvdev)
-    lvdata["Output from lvcreate"] = out[0].strip()
+    lvdata["Output from lvcreate"] = out
     return lvdata
 
 
@@ -541,8 +558,12 @@ def vgremove(vgname, force=True):
     else:
         cmd.append("-qq")
 
-    out = __salt__["cmd.run"](cmd, python_shell=False)
-    return out.strip()
+    cmd_ret = __salt__["cmd.run_all"](cmd, python_shell=False)
+    if cmd_ret.get("retcode"):
+        out = cmd_ret.get("stderr").strip()
+    else:
+        out = 'Volume group "{}" successfully removed'.format(vgname)
+    return out
 
 
 def lvremove(lvname, vgname, force=True):
@@ -562,8 +583,13 @@ def lvremove(lvname, vgname, force=True):
     else:
         cmd.append("-qq")
 
-    out = __salt__["cmd.run"](cmd, python_shell=False)
-    return out.strip()
+    cmd_ret = __salt__["cmd.run_all"](cmd, python_shell=False)
+    if cmd_ret.get("retcode"):
+        out = cmd_ret.get("stderr").strip()
+    else:
+        out = 'Logical volume "{}" successfully removed'.format(lvname)
+
+    return out
 
 
 def lvresize(size=None, lvpath=None, extents=None, force=False, resizefs=False):
@@ -586,7 +612,7 @@ def lvresize(size=None, lvpath=None, extents=None, force=False, resizefs=False):
     cmd = ["lvresize"]
 
     if force:
-        cmd.append("--yes")
+        cmd.append("--force")
     else:
         cmd.append("-qq")
 
@@ -602,8 +628,14 @@ def lvresize(size=None, lvpath=None, extents=None, force=False, resizefs=False):
         return {}
 
     cmd.append(lvpath)
-    cmd_ret = __salt__["cmd.run"](cmd, python_shell=False).splitlines()
-    return {"Output from lvresize": cmd_ret[0].strip()}
+
+    cmd_ret = __salt__["cmd.run_all"](cmd, python_shell=False)
+    if cmd_ret.get("retcode"):
+        out = cmd_ret.get("stderr").strip()
+    else:
+        out = 'Logical volume "{}" successfully resized.'.format(lvpath)
+
+    return {"Output from lvresize": out}
 
 
 def lvextend(size=None, lvpath=None, extents=None, force=False, resizefs=False):
@@ -642,8 +674,14 @@ def lvextend(size=None, lvpath=None, extents=None, force=False, resizefs=False):
         return {}
 
     cmd.append(lvpath)
-    cmd_ret = __salt__["cmd.run"](cmd, python_shell=False).splitlines()
-    return {"Output from lvextend": cmd_ret[0].strip()}
+
+    cmd_ret = __salt__["cmd.run_all"](cmd, python_shell=False)
+    if cmd_ret.get("retcode"):
+        out = cmd_ret.get("stderr").strip()
+    else:
+        out = 'Logical volume "{}" successfully extended.'.format(lvpath)
+
+    return {"Output from lvextend": out}
 
 
 def pvresize(devices, override=True, force=True):

--- a/salt/modules/linux_lvm.py
+++ b/salt/modules/linux_lvm.py
@@ -10,7 +10,6 @@ import os.path
 
 # Import salt libs
 import salt.utils.path
-from salt.exceptions import CommandExecutionError
 from salt.ext import six
 
 # Set up logger
@@ -251,13 +250,11 @@ def pvcreate(devices, override=True, force=True, **kwargs):
 
     for device in devices:
         if not os.path.exists(device):
-            raise CommandExecutionError("{0} does not exist".format(device))
+            return "{0} does not exist".format(device)
         if not pvdisplay(device, quiet=True):
             cmd.append(device)
         elif not override:
-            raise CommandExecutionError(
-                'Device "{0}" is already an LVM physical volume.'.format(device)
-            )
+            return 'Device "{0}" is already an LVM physical volume.'.format(device)
 
     if not cmd[2:]:
         # All specified devices are already LVM volumes
@@ -275,7 +272,7 @@ def pvcreate(devices, override=True, force=True, **kwargs):
         "labelsector",
         "setphysicalvolumesize",
     )
-    no_parameter = ("force", "norestorefile")
+    no_parameter = "norestorefile"
     for var in kwargs:
         if kwargs[var] and var in valid:
             cmd.extend(["--{0}".format(var), kwargs[var]])
@@ -284,12 +281,12 @@ def pvcreate(devices, override=True, force=True, **kwargs):
 
     out = __salt__["cmd.run_all"](cmd, python_shell=False)
     if out.get("retcode"):
-        raise CommandExecutionError(out.get("stderr"))
+        return out.get("stderr")
 
     # Verify pvcreate was successful
     for device in devices:
         if not pvdisplay(device):
-            raise CommandExecutionError('Device "{0}" was not affected.'.format(device))
+            return 'Device "{0}" was not affected.'.format(device)
 
     return True
 
@@ -321,7 +318,7 @@ def pvremove(devices, override=True, force=True):
         if pvdisplay(device):
             cmd.append(device)
         elif not override:
-            raise CommandExecutionError("{0} is not a physical volume".format(device))
+            return "{0} is not a physical volume".format(device)
 
     if not cmd[2:]:
         # Nothing to do
@@ -329,12 +326,12 @@ def pvremove(devices, override=True, force=True):
 
     out = __salt__["cmd.run_all"](cmd, python_shell=False)
     if out.get("retcode"):
-        raise CommandExecutionError(out.get("stderr"))
+        return out.get("stderr")
 
     # Verify pvremove was successful
     for device in devices:
         if pvdisplay(device, quiet=True):
-            raise CommandExecutionError('Device "{0}" was not affected.'.format(device))
+            return 'Device "{0}" was not affected.'.format(device)
 
     return True
 

--- a/salt/states/lvm.py
+++ b/salt/states/lvm.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Management of Linux logical volumes
 ===================================
@@ -21,14 +20,12 @@ A state module to manage LVMs
         - stripes: 5
         - stripesize: 8K
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
 import os
 
 # Import salt libs
 import salt.utils.path
-from salt.ext import six
 
 
 def __virtual__():
@@ -61,7 +58,7 @@ def _convert_to_mb(size):
     elif unit == "p":
         target_size = size * 1024 * 1024 * 1024
     else:
-        raise salt.exceptions.ArgumentValueError("Unit {0} is invalid.".format(unit))
+        raise salt.exceptions.ArgumentValueError("Unit {} is invalid.".format(unit))
     return target_size
 
 
@@ -79,19 +76,19 @@ def pv_present(name, **kwargs):
     ret = {"changes": {}, "comment": "", "name": name, "result": True}
 
     if __salt__["lvm.pvdisplay"](name, quiet=True):
-        ret["comment"] = "Physical Volume {0} already present".format(name)
+        ret["comment"] = "Physical Volume {} already present".format(name)
     elif __opts__["test"]:
-        ret["comment"] = "Physical Volume {0} is set to be created".format(name)
+        ret["comment"] = "Physical Volume {} is set to be created".format(name)
         ret["result"] = None
         return ret
     else:
         changes = __salt__["lvm.pvcreate"](name, **kwargs)
 
         if __salt__["lvm.pvdisplay"](name):
-            ret["comment"] = "Created Physical Volume {0}".format(name)
+            ret["comment"] = "Created Physical Volume {}".format(name)
             ret["changes"]["created"] = changes
         else:
-            ret["comment"] = "Failed to create Physical Volume {0}".format(name)
+            ret["comment"] = "Failed to create Physical Volume {}".format(name)
             ret["result"] = False
     return ret
 
@@ -106,19 +103,19 @@ def pv_absent(name):
     ret = {"changes": {}, "comment": "", "name": name, "result": True}
 
     if not __salt__["lvm.pvdisplay"](name, quiet=True):
-        ret["comment"] = "Physical Volume {0} does not exist".format(name)
+        ret["comment"] = "Physical Volume {} does not exist".format(name)
     elif __opts__["test"]:
-        ret["comment"] = "Physical Volume {0} is set to be removed".format(name)
+        ret["comment"] = "Physical Volume {} is set to be removed".format(name)
         ret["result"] = None
         return ret
     else:
         changes = __salt__["lvm.pvremove"](name)
 
         if __salt__["lvm.pvdisplay"](name, quiet=True):
-            ret["comment"] = "Failed to remove Physical Volume {0}".format(name)
+            ret["comment"] = "Failed to remove Physical Volume {}".format(name)
             ret["result"] = False
         else:
-            ret["comment"] = "Removed Physical Volume {0}".format(name)
+            ret["comment"] = "Removed Physical Volume {}".format(name)
             ret["changes"]["removed"] = changes
     return ret
 
@@ -138,54 +135,54 @@ def vg_present(name, devices=None, **kwargs):
         :mod:`linux_lvm <salt.modules.linux_lvm>` for more details.
     """
     ret = {"changes": {}, "comment": "", "name": name, "result": True}
-    if isinstance(devices, six.string_types):
+    if isinstance(devices, str):
         devices = devices.split(",")
 
     if __salt__["lvm.vgdisplay"](name, quiet=True):
-        ret["comment"] = "Volume Group {0} already present".format(name)
+        ret["comment"] = "Volume Group {} already present".format(name)
         for device in devices:
             realdev = os.path.realpath(device)
             pvs = __salt__["lvm.pvdisplay"](realdev, real=True)
             if pvs and pvs.get(realdev, None):
                 if pvs[realdev]["Volume Group Name"] == name:
-                    ret["comment"] = "{0}\n{1}".format(
-                        ret["comment"], "{0} is part of Volume Group".format(device)
+                    ret["comment"] = "{}\n{}".format(
+                        ret["comment"], "{} is part of Volume Group".format(device)
                     )
                 elif pvs[realdev]["Volume Group Name"] in ["", "#orphans_lvm2"]:
                     __salt__["lvm.vgextend"](name, device)
                     pvs = __salt__["lvm.pvdisplay"](realdev, real=True)
                     if pvs[realdev]["Volume Group Name"] == name:
-                        ret["changes"].update({device: "added to {0}".format(name)})
+                        ret["changes"].update({device: "added to {}".format(name)})
                     else:
-                        ret["comment"] = "{0}\n{1}".format(
-                            ret["comment"], "{0} could not be added".format(device)
+                        ret["comment"] = "{}\n{}".format(
+                            ret["comment"], "{} could not be added".format(device)
                         )
                         ret["result"] = False
                 else:
-                    ret["comment"] = "{0}\n{1}".format(
+                    ret["comment"] = "{}\n{}".format(
                         ret["comment"],
-                        "{0} is part of {1}".format(
+                        "{} is part of {}".format(
                             device, pvs[realdev]["Volume Group Name"]
                         ),
                     )
                     ret["result"] = False
             else:
-                ret["comment"] = "{0}\n{1}".format(
-                    ret["comment"], "pv {0} is not present".format(device)
+                ret["comment"] = "{}\n{}".format(
+                    ret["comment"], "pv {} is not present".format(device)
                 )
                 ret["result"] = False
     elif __opts__["test"]:
-        ret["comment"] = "Volume Group {0} is set to be created".format(name)
+        ret["comment"] = "Volume Group {} is set to be created".format(name)
         ret["result"] = None
         return ret
     else:
         changes = __salt__["lvm.vgcreate"](name, devices, **kwargs)
 
         if __salt__["lvm.vgdisplay"](name):
-            ret["comment"] = "Created Volume Group {0}".format(name)
+            ret["comment"] = "Created Volume Group {}".format(name)
             ret["changes"]["created"] = changes
         else:
-            ret["comment"] = "Failed to create Volume Group {0}".format(name)
+            ret["comment"] = "Failed to create Volume Group {}".format(name)
             ret["result"] = False
     return ret
 
@@ -200,19 +197,19 @@ def vg_absent(name):
     ret = {"changes": {}, "comment": "", "name": name, "result": True}
 
     if not __salt__["lvm.vgdisplay"](name, quiet=True):
-        ret["comment"] = "Volume Group {0} already absent".format(name)
+        ret["comment"] = "Volume Group {} already absent".format(name)
     elif __opts__["test"]:
-        ret["comment"] = "Volume Group {0} is set to be removed".format(name)
+        ret["comment"] = "Volume Group {} is set to be removed".format(name)
         ret["result"] = None
         return ret
     else:
         changes = __salt__["lvm.vgremove"](name)
 
         if not __salt__["lvm.vgdisplay"](name, quiet=True):
-            ret["comment"] = "Removed Volume Group {0}".format(name)
+            ret["comment"] = "Removed Volume Group {}".format(name)
             ret["changes"]["removed"] = changes
         else:
-            ret["comment"] = "Failed to remove Volume Group {0}".format(name)
+            ret["comment"] = "Failed to remove Volume Group {}".format(name)
             ret["result"] = False
     return ret
 
@@ -227,6 +224,7 @@ def lv_present(
     thinvolume=False,
     thinpool=False,
     force=False,
+    resizefs=False,
     **kwargs
 ):
     """
@@ -267,6 +265,11 @@ def lv_present(
     force
         Assume yes to all prompts
 
+    .. versionadded:: to_complete
+
+    resizefs
+        Use fsadm to resize the logical volume filesystem if needed
+
     """
     ret = {"changes": {}, "comment": "", "name": name, "result": True}
 
@@ -282,16 +285,16 @@ def lv_present(
         name = snapshot
 
     if thinvolume:
-        lvpath = "/dev/{0}/{1}".format(vgname.split("/")[0], name)
+        lvpath = "/dev/{}/{}".format(vgname.split("/")[0], name)
     else:
-        lvpath = "/dev/{0}/{1}".format(vgname, name)
+        lvpath = "/dev/{}/{}".format(vgname, name)
 
     lv_info = __salt__["lvm.lvdisplay"](lvpath, quiet=True)
     lv_info = lv_info.get(lvpath)
 
     if not lv_info:
         if __opts__["test"]:
-            ret["comment"] = "Logical Volume {0} is set to be created".format(name)
+            ret["comment"] = "Logical Volume {} is set to be created".format(name)
             ret["result"] = None
             return ret
         else:
@@ -309,17 +312,15 @@ def lv_present(
             )
 
             if __salt__["lvm.lvdisplay"](lvpath):
-                ret["comment"] = "Created Logical Volume {0}".format(name)
+                ret["comment"] = "Created Logical Volume {}".format(name)
                 ret["changes"]["created"] = changes
             else:
-                ret[
-                    "comment"
-                ] = "Failed to create Logical Volume {0}. Error: {1}".format(
-                    name, changes
+                ret["comment"] = "Failed to create Logical Volume {}. Error: {}".format(
+                    name, changes["Output from lvcreate"]
                 )
                 ret["result"] = False
     else:
-        ret["comment"] = "Logical Volume {0} already present".format(name)
+        ret["comment"] = "Logical Volume {} already present".format(name)
         if size or extents:
             old_extents = int(lv_info["Current Logical Extents Associated"])
             old_size_mb = _convert_to_mb(lv_info["Logical Volume Size"] + "s")
@@ -330,24 +331,31 @@ def lv_present(
                 size_mb = old_size_mb
 
             # This is here waiting a change in lvm.lvresize backend
-            if size_mb < old_size_mb or extents < old_extents:
-                ret["comment"] = "Reducing a LV is not supported by now"
+            if force is False and (size_mb < old_size_mb or extents < old_extents):
+                ret[
+                    "comment"
+                ] = "To reduce a Logical Volume option 'force' must be True."
                 ret["result"] = False
                 return ret
 
             if size_mb != old_size_mb or extents != old_extents:
                 if __opts__["test"]:
-                    ret["comment"] = "Logical Volume {0} is set to be resized".format(
+                    ret["comment"] = "Logical Volume {} is set to be resized".format(
                         name
                     )
                     ret["result"] = None
                     return ret
                 else:
                     if size:
-                        changes = __salt__["lvm.lvresize"](lvpath=lvpath, size=size,)
+                        changes = __salt__["lvm.lvresize"](
+                            lvpath=lvpath, size=size, resizefs=resizefs, force=force
+                        )
                     else:
                         changes = __salt__["lvm.lvresize"](
-                            lvpath=lvpath, extents=extents,
+                            lvpath=lvpath,
+                            extents=extents,
+                            resizefs=resizefs,
+                            force=force,
                         )
 
                     if not changes:
@@ -359,13 +367,13 @@ def lv_present(
                     lv_info = __salt__["lvm.lvdisplay"](lvpath, quiet=True)[lvpath]
                     new_size_mb = _convert_to_mb(lv_info["Logical Volume Size"] + "s")
                     if new_size_mb != old_size_mb:
-                        ret["comment"] = "Resized Logical Volume {0}".format(name)
+                        ret["comment"] = "Resized Logical Volume {}".format(name)
                         ret["changes"]["resized"] = changes
                     else:
                         ret[
                             "comment"
-                        ] = "Failed to resize Logical Volume {0}. Error: {1}".format(
-                            name, changes
+                        ] = "Failed to resize Logical Volume {}.\nError: {}".format(
+                            name, changes["Output from lvresize"]
                         )
                         ret["result"] = False
     return ret
@@ -383,20 +391,20 @@ def lv_absent(name, vgname=None):
     """
     ret = {"changes": {}, "comment": "", "name": name, "result": True}
 
-    lvpath = "/dev/{0}/{1}".format(vgname, name)
+    lvpath = "/dev/{}/{}".format(vgname, name)
     if not __salt__["lvm.lvdisplay"](lvpath, quiet=True):
-        ret["comment"] = "Logical Volume {0} already absent".format(name)
+        ret["comment"] = "Logical Volume {} already absent".format(name)
     elif __opts__["test"]:
-        ret["comment"] = "Logical Volume {0} is set to be removed".format(name)
+        ret["comment"] = "Logical Volume {} is set to be removed".format(name)
         ret["result"] = None
         return ret
     else:
         changes = __salt__["lvm.lvremove"](name, vgname)
 
         if not __salt__["lvm.lvdisplay"](lvpath, quiet=True):
-            ret["comment"] = "Removed Logical Volume {0}".format(name)
+            ret["comment"] = "Removed Logical Volume {}".format(name)
             ret["changes"]["removed"] = changes
         else:
-            ret["comment"] = "Failed to remove Logical Volume {0}".format(name)
+            ret["comment"] = "Failed to remove Logical Volume {}".format(name)
             ret["result"] = False
     return ret

--- a/tests/unit/modules/test_linux_lvm.py
+++ b/tests/unit/modules/test_linux_lvm.py
@@ -265,6 +265,38 @@ class LinuxLVMTestCase(TestCase, LoaderModuleMockMixin):
                 with patch.dict(linux_lvm.__salt__, {"cmd.run_all": mock}):
                     self.assertEqual(linux_lvm.pvremove("A"), True)
 
+    def test_pvresize_not_pv(self):
+        """
+        Tests for resize a physical device not being used as an LVM physical volume
+        """
+        pvdisplay = MagicMock(return_value=False)
+        with patch("salt.modules.linux_lvm.pvdisplay", pvdisplay):
+            self.assertEqual(
+                linux_lvm.pvresize("A", override=False), "A is not a physical volume"
+            )
+
+        pvdisplay = MagicMock(return_value=False)
+        with patch("salt.modules.linux_lvm.pvdisplay", pvdisplay):
+            self.assertEqual(linux_lvm.pvresize("A"), True)
+
+    def test_pvresize(self):
+        """
+        Tests for resize a physical device being used as an LVM physical volume
+        """
+        pvdisplay = MagicMock(return_value=False)
+        with patch("salt.modules.linux_lvm.pvdisplay", pvdisplay):
+            mock = MagicMock(return_value=True)
+            with patch.dict(linux_lvm.__salt__, {"lvm.pvdisplay": mock}):
+                ret = {
+                    "stdout": "saltines",
+                    "stderr": "cheese",
+                    "retcode": 0,
+                    "pid": "1337",
+                }
+                mock = MagicMock(return_value=ret)
+                with patch.dict(linux_lvm.__salt__, {"cmd.run_all": mock}):
+                    self.assertEqual(linux_lvm.pvresize("A"), True)
+
     def test_vgcreate(self):
         """
         Tests create an LVM volume group
@@ -273,11 +305,14 @@ class LinuxLVMTestCase(TestCase, LoaderModuleMockMixin):
             linux_lvm.vgcreate("", ""), "Error: vgname and device(s) are both required"
         )
 
-        mock = MagicMock(return_value="A\nB")
-        with patch.dict(linux_lvm.__salt__, {"cmd.run": mock}):
+        mock = MagicMock(return_value={"retcode": 0, "stderr": ""})
+        with patch.dict(linux_lvm.__salt__, {"cmd.run_all": mock}):
             with patch.object(linux_lvm, "vgdisplay", return_value={}):
                 self.assertDictEqual(
-                    linux_lvm.vgcreate("A", "B"), {"Output from vgcreate": "A"}
+                    linux_lvm.vgcreate("fakevg", "B"),
+                    {
+                        "Output from vgcreate": 'Volume group "fakevg" successfully created'
+                    },
                 )
 
     def test_vgextend(self):
@@ -288,11 +323,14 @@ class LinuxLVMTestCase(TestCase, LoaderModuleMockMixin):
             linux_lvm.vgextend("", ""), "Error: vgname and device(s) are both required"
         )
 
-        mock = MagicMock(return_value="A\nB")
-        with patch.dict(linux_lvm.__salt__, {"cmd.run": mock}):
+        mock = MagicMock(return_value={"retcode": 0, "stderr": ""})
+        with patch.dict(linux_lvm.__salt__, {"cmd.run_all": mock}):
             with patch.object(linux_lvm, "vgdisplay", return_value={}):
                 self.assertDictEqual(
-                    linux_lvm.vgextend("A", "B"), {"Output from vgextend": "A"}
+                    linux_lvm.vgextend("fakevg", "B"),
+                    {
+                        "Output from vgextend": 'Volume group "fakevg" successfully extended'
+                    },
                 )
 
     def test_lvcreate(self):
@@ -320,12 +358,12 @@ class LinuxLVMTestCase(TestCase, LoaderModuleMockMixin):
             "Error: Thin volume size cannot be specified as extents",
         )
 
-        mock = MagicMock(return_value="A\nB")
-        with patch.dict(linux_lvm.__salt__, {"cmd.run": mock}):
+        mock = MagicMock(return_value={"retcode": 0, "stderr": ""})
+        with patch.dict(linux_lvm.__salt__, {"cmd.run_all": mock}):
             with patch.object(linux_lvm, "lvdisplay", return_value={}):
                 self.assertDictEqual(
                     linux_lvm.lvcreate(None, None, None, 1),
-                    {"Output from lvcreate": "A"},
+                    {"Output from lvcreate": 'Logical volume "None" created.'},
                 )
 
     def test_lvcreate_with_force(self):
@@ -333,41 +371,77 @@ class LinuxLVMTestCase(TestCase, LoaderModuleMockMixin):
         Test create a new logical volume, with option
         for which physical volume to be used
         """
-        mock = MagicMock(return_value="A\nB")
-        with patch.dict(linux_lvm.__salt__, {"cmd.run": mock}):
+        mock = MagicMock(return_value={"retcode": 0, "stderr": ""})
+        with patch.dict(linux_lvm.__salt__, {"cmd.run_all": mock}):
             with patch.object(linux_lvm, "lvdisplay", return_value={}):
                 self.assertDictEqual(
                     linux_lvm.lvcreate(None, None, None, 1, force=True),
-                    {"Output from lvcreate": "A"},
+                    {"Output from lvcreate": 'Logical volume "None" created.'},
                 )
 
     def test_vgremove(self):
         """
         Tests to remove an LVM volume group
         """
-        mock = MagicMock(return_value="A")
-        with patch.dict(linux_lvm.__salt__, {"cmd.run": mock}):
-            self.assertEqual(linux_lvm.vgremove("A"), "A")
+        mock = MagicMock(
+            return_value={
+                "retcode": 0,
+                "stdout": '  Volume group "fakevg" successfully removed',
+            }
+        )
+        with patch.dict(linux_lvm.__salt__, {"cmd.run_all": mock}):
+            self.assertEqual(
+                linux_lvm.vgremove("fakevg"),
+                'Volume group "fakevg" successfully removed',
+            )
 
     def test_lvremove(self):
         """
         Test to remove a given existing logical volume
         from a named existing volume group
         """
-        mock = MagicMock(return_value="A")
-        with patch.dict(linux_lvm.__salt__, {"cmd.run": mock}):
-            self.assertEqual(linux_lvm.lvremove("", ""), "A")
+        mock = MagicMock(
+            return_value={
+                "retcode": 0,
+                "stdout": '  Logical volume "lvtest" successfully removed',
+            }
+        )
+        with patch.dict(linux_lvm.__salt__, {"cmd.run_all": mock}):
+            self.assertEqual(
+                linux_lvm.lvremove("fakelv", "fakevg"),
+                'Logical volume "fakelv" successfully removed',
+            )
 
     def test_lvresize(self):
         """
-        Test to return information about the logical volume(s)
+        Tests to resize an LVM logical volume
         """
         self.assertEqual(linux_lvm.lvresize(1, None, 1), {})
 
         self.assertEqual(linux_lvm.lvresize(None, None, None), {})
 
-        mock = MagicMock(return_value="A")
-        with patch.dict(linux_lvm.__salt__, {"cmd.run": mock}):
+        mock = MagicMock(return_value={"retcode": 0, "stderr": ""})
+        with patch.dict(linux_lvm.__salt__, {"cmd.run_all": mock}):
             self.assertDictEqual(
-                linux_lvm.lvresize("A", 1), {"Output from lvresize": "A"}
+                linux_lvm.lvresize(12, "/dev/fakevg/fakelv"),
+                {
+                    "Output from lvresize": 'Logical volume "/dev/fakevg/fakelv" successfully resized.'
+                },
+            )
+
+    def test_lvextend(self):
+        """
+        Tests to extend an LVM logical volume
+        """
+        self.assertEqual(linux_lvm.lvextend(1, None, 1), {})
+
+        self.assertEqual(linux_lvm.lvextend(None, None, None), {})
+
+        mock = MagicMock(return_value={"retcode": 0, "stderr": ""})
+        with patch.dict(linux_lvm.__salt__, {"cmd.run_all": mock}):
+            self.assertDictEqual(
+                linux_lvm.lvextend(12, "/dev/fakevg/fakelv"),
+                {
+                    "Output from lvextend": 'Logical volume "/dev/fakevg/fakelv" successfully extended.'
+                },
             )

--- a/tests/unit/states/test_lvm.py
+++ b/tests/unit/states/test_lvm.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
 """
     :codeauthor: Jayesh Kariya <jayeshk@saltstack.com>
 """
 # Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Libs
 import salt.states.lvm as lvm
@@ -66,7 +64,7 @@ class LvmTestCase(TestCase, LoaderModuleMockMixin):
         """
         name = "/dev/sda5"
 
-        comt = "Physical Volume {0} already present".format(name)
+        comt = "Physical Volume {} already present".format(name)
 
         ret = {"name": name, "changes": {}, "result": True, "comment": comt}
 
@@ -74,7 +72,7 @@ class LvmTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(lvm.__salt__, {"lvm.pvdisplay": mock}):
             self.assertDictEqual(lvm.pv_present(name), ret)
 
-            comt = "Physical Volume {0} is set to be created".format(name)
+            comt = "Physical Volume {} is set to be created".format(name)
             ret.update({"comment": comt, "result": None})
             with patch.dict(lvm.__opts__, {"test": True}):
                 self.assertDictEqual(lvm.pv_present(name), ret)
@@ -87,7 +85,7 @@ class LvmTestCase(TestCase, LoaderModuleMockMixin):
         """
         name = "/dev/sda5"
 
-        comt = "Physical Volume {0} does not exist".format(name)
+        comt = "Physical Volume {} does not exist".format(name)
 
         ret = {"name": name, "changes": {}, "result": True, "comment": comt}
 
@@ -95,7 +93,7 @@ class LvmTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(lvm.__salt__, {"lvm.pvdisplay": mock}):
             self.assertDictEqual(lvm.pv_absent(name), ret)
 
-            comt = "Physical Volume {0} is set to be removed".format(name)
+            comt = "Physical Volume {} is set to be removed".format(name)
             ret.update({"comment": comt, "result": None})
             with patch.dict(lvm.__opts__, {"test": True}):
                 self.assertDictEqual(lvm.pv_absent(name), ret)
@@ -108,7 +106,7 @@ class LvmTestCase(TestCase, LoaderModuleMockMixin):
         """
         name = "testvg00"
 
-        comt = "Failed to create Volume Group {0}".format(name)
+        comt = "Failed to create Volume Group {}".format(name)
 
         ret = {"name": name, "changes": {}, "result": False, "comment": comt}
 
@@ -117,7 +115,7 @@ class LvmTestCase(TestCase, LoaderModuleMockMixin):
             with patch.dict(lvm.__opts__, {"test": False}):
                 self.assertDictEqual(lvm.vg_present(name), ret)
 
-            comt = "Volume Group {0} is set to be created".format(name)
+            comt = "Volume Group {} is set to be created".format(name)
             ret.update({"comment": comt, "result": None})
             with patch.dict(lvm.__opts__, {"test": True}):
                 self.assertDictEqual(lvm.vg_present(name), ret)
@@ -130,7 +128,7 @@ class LvmTestCase(TestCase, LoaderModuleMockMixin):
         """
         name = "testvg00"
 
-        comt = "Volume Group {0} already absent".format(name)
+        comt = "Volume Group {} already absent".format(name)
 
         ret = {"name": name, "changes": {}, "result": True, "comment": comt}
 
@@ -138,12 +136,12 @@ class LvmTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(lvm.__salt__, {"lvm.vgdisplay": mock}):
             self.assertDictEqual(lvm.vg_absent(name), ret)
 
-            comt = "Volume Group {0} is set to be removed".format(name)
+            comt = "Volume Group {} is set to be removed".format(name)
             ret.update({"comment": comt, "result": None})
             with patch.dict(lvm.__opts__, {"test": True}):
                 self.assertDictEqual(lvm.vg_absent(name), ret)
 
-    # 'lv_present' function tests: 5
+    # 'lv_present' function tests: 6
 
     def test_lv_present(self):
         """
@@ -151,7 +149,7 @@ class LvmTestCase(TestCase, LoaderModuleMockMixin):
         """
         name = "testlv01"
         vgname = "testvg01"
-        comt = "Logical Volume {0} already present".format(name)
+        comt = "Logical Volume {} already present".format(name)
         ret = {"name": name, "changes": {}, "result": True, "comment": comt}
 
         mock = MagicMock(return_value=STUB_LVDISPLAY_LV01)
@@ -160,7 +158,7 @@ class LvmTestCase(TestCase, LoaderModuleMockMixin):
 
         mock = MagicMock(return_value=STUB_LVDISPLAY_LV02)
         with patch.dict(lvm.__salt__, {"lvm.lvdisplay": mock}):
-            comt = "Logical Volume {0} is set to be created".format(name)
+            comt = "Logical Volume {} is set to be created".format(name)
             ret.update({"comment": comt, "result": None})
             with patch.dict(lvm.__opts__, {"test": True}):
                 self.assertDictEqual(lvm.lv_present(name, vgname=vgname), ret)
@@ -171,7 +169,7 @@ class LvmTestCase(TestCase, LoaderModuleMockMixin):
         """
         name = "testlv01"
         vgname = "testvg01"
-        comt = "Logical Volume {0} already present".format(name)
+        comt = "Logical Volume {} already present".format(name)
         ret = {"name": name, "changes": {}, "result": True, "comment": comt}
 
         mock = MagicMock(return_value=STUB_LVDISPLAY_LV01)
@@ -180,7 +178,7 @@ class LvmTestCase(TestCase, LoaderModuleMockMixin):
 
         mock = MagicMock(return_value=STUB_LVDISPLAY_LV02)
         with patch.dict(lvm.__salt__, {"lvm.lvdisplay": mock}):
-            comt = "Logical Volume {0} is set to be created".format(name)
+            comt = "Logical Volume {} is set to be created".format(name)
             ret.update({"comment": comt, "result": None})
             with patch.dict(lvm.__opts__, {"test": True}):
                 self.assertDictEqual(
@@ -193,7 +191,7 @@ class LvmTestCase(TestCase, LoaderModuleMockMixin):
         """
         name = "testlv01"
         vgname = "testvg01"
-        comt = "Logical Volume {0} already present".format(name)
+        comt = "Logical Volume {} already present".format(name)
         ret = {"name": name, "changes": {}, "result": True, "comment": comt}
 
         mock = MagicMock(return_value=STUB_LVDISPLAY_LV01)
@@ -206,7 +204,7 @@ class LvmTestCase(TestCase, LoaderModuleMockMixin):
         """
         name = "testlv01"
         vgname = "testvg01"
-        comt = "Logical Volume {0} is set to be resized".format(name)
+        comt = "Logical Volume {} is set to be resized".format(name)
         ret = {"name": name, "changes": {}, "result": None, "comment": comt}
 
         mock = MagicMock(return_value=STUB_LVDISPLAY_LV01)
@@ -216,18 +214,34 @@ class LvmTestCase(TestCase, LoaderModuleMockMixin):
                     lvm.lv_present(name, vgname=vgname, size="10G"), ret
                 )
 
-    def test_lv_present_with_reduce(self):
+    def test_lv_present_with_reduce_without_force(self):
         """
         Test to reduce a logical volume
         """
         name = "testlv01"
         vgname = "testvg01"
-        comt = "Reducing a LV is not supported by now"
+        comt = "To reduce a Logical Volume option 'force' must be True."
         ret = {"name": name, "changes": {}, "result": False, "comment": comt}
 
         mock = MagicMock(return_value=STUB_LVDISPLAY_LV01)
         with patch.dict(lvm.__salt__, {"lvm.lvdisplay": mock}):
             self.assertDictEqual(lvm.lv_present(name, vgname=vgname, size="1G"), ret)
+
+    def test_lv_present_with_reduce_with_force(self):
+        """
+        Test to reduce a logical volume
+        """
+        name = "testlv01"
+        vgname = "testvg01"
+        comt = "Logical Volume {} is set to be resized".format(name)
+        ret = {"name": name, "changes": {}, "result": None, "comment": comt}
+
+        mock = MagicMock(return_value=STUB_LVDISPLAY_LV01)
+        with patch.dict(lvm.__salt__, {"lvm.lvdisplay": mock}):
+            with patch.dict(lvm.__opts__, {"test": True}):
+                self.assertDictEqual(
+                    lvm.lv_present(name, vgname=vgname, size="1G", force=True), ret
+                )
 
     # 'lv_absent' function tests: 1
 
@@ -238,7 +252,7 @@ class LvmTestCase(TestCase, LoaderModuleMockMixin):
         """
         name = "testlv00"
 
-        comt = "Logical Volume {0} already absent".format(name)
+        comt = "Logical Volume {} already absent".format(name)
 
         ret = {"name": name, "changes": {}, "result": True, "comment": comt}
 
@@ -246,7 +260,7 @@ class LvmTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(lvm.__salt__, {"lvm.lvdisplay": mock}):
             self.assertDictEqual(lvm.lv_absent(name), ret)
 
-            comt = "Logical Volume {0} is set to be removed".format(name)
+            comt = "Logical Volume {} is set to be removed".format(name)
             ret.update({"comment": comt, "result": None})
             with patch.dict(lvm.__opts__, {"test": True}):
                 self.assertDictEqual(lvm.lv_absent(name), ret)


### PR DESCRIPTION
### What does this PR do?
This PR does a few visible changes:

- Added the pvresize and lvextend support (#56089)
- Fixes some trackbacks when some LVM commands returns errors (#52363)
- Added the resizefs option to lv_present state so it can resize not only the logical volume, but the filesystem inside it too. (suggested in the already closed #55265)

This PR does also an invisible change to the user, default answers.

Some LVM commands asks questions to the user, but the user isn't there to answer any of them. To avoid this situation, we used the "force" paramenter to set the default answers. It's invisible because the current behaviour is preserved. The functions that already had the "yes" or "force" hardcoded are now with the "force" defaulted to True. The functions that didn't have it, now have the "force" defaulted to False.

### What issues does this PR fix or reference?
Fixes: #52363 #56089

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No