### PR TITLE
Fix some issues with the win_wua module

### DIFF
--- a/changelog/57762.fixed
+++ b/changelog/57762.fixed
@@ -1,0 +1,7 @@
+The 2004 release of Windows 10 introduced a bug in the InstallationBehavior COM
+object where you can no longer get properties from that object. Calls to this
+object are now wrapped in a try/except block with sane defaults when it fails to
+read attributes.
+
+Additionally, some pre-flight checks have been added to the win_wua module to
+make sure Windows Update can actually run.

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Windows Service module.
 
@@ -6,8 +5,6 @@ Windows Service module.
 """
 
 # Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
-
 import fnmatch
 import logging
 import re
@@ -118,7 +115,7 @@ def _cmd_quote(cmd):
         cmd = cmd.strip('"').strip("'")
     # Ensure the path to the binary is wrapped in double quotes to account for
     # spaces in the path
-    cmd = '"{0}"'.format(cmd)
+    cmd = '"{}"'.format(cmd)
     return cmd
 
 
@@ -346,9 +343,9 @@ def start(name, timeout=90):
     except pywintypes.error as exc:
         if exc.winerror != 1056:
             raise CommandExecutionError(
-                "Failed To Start {0}: {1}".format(name, exc.strerror)
+                "Failed To Start {}: {}".format(name, exc.strerror)
             )
-        log.debug('Service "{0}" is running'.format(name))
+        log.debug('Service "{}" is running'.format(name))
 
     srv_status = _status_wait(
         service_name=name,
@@ -387,9 +384,9 @@ def stop(name, timeout=90):
     except pywintypes.error as exc:
         if exc.winerror != 1062:
             raise CommandExecutionError(
-                "Failed To Stop {0}: {1}".format(name, exc.strerror)
+                "Failed To Stop {}: {}".format(name, exc.strerror)
             )
-        log.debug('Service "{0}" is not running'.format(name))
+        log.debug('Service "{}" is not running'.format(name))
 
     srv_status = _status_wait(
         service_name=name,
@@ -633,7 +630,7 @@ def modify(
             - NT Authority\\LocalService
             - NT Authority\\NetworkService
             - NT Authority\\LocalSystem
-            - .\LocalSystem
+            - .\\LocalSystem
 
         account_password (str):
             The password for the account name specified in ``account_name``. For
@@ -667,9 +664,7 @@ def modify(
             win32service.SERVICE_CHANGE_CONFIG | win32service.SERVICE_QUERY_CONFIG,
         )
     except pywintypes.error as exc:
-        raise CommandExecutionError(
-            "Failed To Open {0}: {1}".format(name, exc.strerror)
-        )
+        raise CommandExecutionError("Failed To Open {}: {}".format(name, exc.strerror))
 
     config_info = win32service.QueryServiceConfig(handle_svc)
 
@@ -680,7 +675,7 @@ def modify(
         # shlex.quote the path to the binary
         bin_path = _cmd_quote(bin_path)
         if exe_args is not None:
-            bin_path = "{0} {1}".format(bin_path, exe_args)
+            bin_path = "{} {}".format(bin_path, exe_args)
         changes["BinaryPath"] = bin_path
 
     if service_type is not None:
@@ -689,9 +684,7 @@ def modify(
             if run_interactive:
                 service_type = service_type | win32service.SERVICE_INTERACTIVE_PROCESS
         else:
-            raise CommandExecutionError(
-                "Invalid Service Type: {0}".format(service_type)
-            )
+            raise CommandExecutionError("Invalid Service Type: {}".format(service_type))
     else:
         if run_interactive is True:
             service_type = config_info[0] | win32service.SERVICE_INTERACTIVE_PROCESS
@@ -712,7 +705,7 @@ def modify(
         if start_type.lower() in SERVICE_START_TYPE:
             start_type = SERVICE_START_TYPE[start_type.lower()]
         else:
-            raise CommandExecutionError("Invalid Start Type: {0}".format(start_type))
+            raise CommandExecutionError("Invalid Start Type: {}".format(start_type))
         changes["StartType"] = SERVICE_START_TYPE[start_type]
     else:
         start_type = win32service.SERVICE_NO_CHANGE
@@ -722,7 +715,7 @@ def modify(
             error_control = SERVICE_ERROR_CONTROL[error_control.lower()]
         else:
             raise CommandExecutionError(
-                "Invalid Error Control: {0}".format(error_control)
+                "Invalid Error Control: {}".format(error_control)
             )
         changes["ErrorControl"] = SERVICE_ERROR_CONTROL[error_control]
     else:
@@ -1006,29 +999,29 @@ def create(
 
     # Test if the service already exists
     if name in get_all():
-        raise CommandExecutionError("Service Already Exists: {0}".format(name))
+        raise CommandExecutionError("Service Already Exists: {}".format(name))
 
     # shlex.quote the path to the binary
     bin_path = _cmd_quote(bin_path)
     if exe_args is not None:
-        bin_path = "{0} {1}".format(bin_path, exe_args)
+        bin_path = "{} {}".format(bin_path, exe_args)
 
     if service_type.lower() in SERVICE_TYPE:
         service_type = SERVICE_TYPE[service_type.lower()]
         if run_interactive:
             service_type = service_type | win32service.SERVICE_INTERACTIVE_PROCESS
     else:
-        raise CommandExecutionError("Invalid Service Type: {0}".format(service_type))
+        raise CommandExecutionError("Invalid Service Type: {}".format(service_type))
 
     if start_type.lower() in SERVICE_START_TYPE:
         start_type = SERVICE_START_TYPE[start_type.lower()]
     else:
-        raise CommandExecutionError("Invalid Start Type: {0}".format(start_type))
+        raise CommandExecutionError("Invalid Start Type: {}".format(start_type))
 
     if error_control.lower() in SERVICE_ERROR_CONTROL:
         error_control = SERVICE_ERROR_CONTROL[error_control.lower()]
     else:
-        raise CommandExecutionError("Invalid Error Control: {0}".format(error_control))
+        raise CommandExecutionError("Invalid Error Control: {}".format(error_control))
 
     if start_delayed:
         if start_type != 2:
@@ -1124,16 +1117,16 @@ def delete(name, timeout=90):
         win32service.CloseServiceHandle(handle_scm)
         if exc.winerror != 1060:
             raise CommandExecutionError(
-                "Failed to open {0}. {1}".format(name, exc.strerror)
+                "Failed to open {}. {}".format(name, exc.strerror)
             )
-        log.debug('Service "{0}" is not present'.format(name))
+        log.debug('Service "{}" is not present'.format(name))
         return True
 
     try:
         win32service.DeleteService(handle_svc)
     except pywintypes.error as exc:
         raise CommandExecutionError(
-            "Failed to delete {0}. {1}".format(name, exc.strerror)
+            "Failed to delete {}. {}".format(name, exc.strerror)
         )
     finally:
         log.debug("Cleaning up")

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -3,21 +3,16 @@ Windows Service module.
 
 .. versionchanged:: 2016.11.0 - Rewritten to use PyWin32
 """
-
-# Import Python libs
 import fnmatch
 import logging
 import re
 import time
 
 import salt.utils.path
-
-# Import Salt libs
 import salt.utils.platform
 import salt.utils.win_service
 from salt.exceptions import CommandExecutionError
 
-# Import 3rd party libs
 try:
     import win32service
     import win32serviceutil

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -22,7 +22,6 @@ from salt.exceptions import CommandExecutionError
 
 # Import 3rd party libs
 try:
-    import win32security
     import win32service
     import win32serviceutil
     import pywintypes

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -14,9 +14,9 @@ import salt.utils.win_service
 from salt.exceptions import CommandExecutionError
 
 try:
+    import pywintypes
     import win32service
     import win32serviceutil
-    import pywintypes
 
     HAS_WIN32_MODS = True
 except ImportError:

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -17,6 +17,7 @@ import salt.utils.path
 
 # Import Salt libs
 import salt.utils.platform
+import salt.utils.win_service
 from salt.exceptions import CommandExecutionError
 
 # Import 3rd party libs
@@ -35,71 +36,9 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = "service"
 
-SERVICE_TYPE = {
-    1: "Kernel Driver",
-    2: "File System Driver",
-    4: "Adapter Driver",
-    8: "Recognizer Driver",
-    16: "Win32 Own Process",
-    32: "Win32 Share Process",
-    256: "Interactive",
-    "kernel": 1,
-    "filesystem": 2,
-    "adapter": 4,
-    "recognizer": 8,
-    "own": 16,
-    "share": 32,
-}
-
-SERVICE_CONTROLS = {
-    1: "Stop",
-    2: "Pause/Continue",
-    4: "Shutdown",
-    8: "Change Parameters",
-    16: "Netbind Change",
-    32: "Hardware Profile Change",
-    64: "Power Event",
-    128: "Session Change",
-    256: "Pre-Shutdown",
-    512: "Time Change",
-    1024: "Trigger Event",
-}
-
-SERVICE_STATE = {
-    1: "Stopped",
-    2: "Start Pending",
-    3: "Stop Pending",
-    4: "Running",
-    5: "Continue Pending",
-    6: "Pause Pending",
-    7: "Paused",
-}
-
-SERVICE_ERRORS = {0: "No Error", 1066: "Service Specific Error"}
-
-SERVICE_START_TYPE = {
-    "boot": 0,
-    "system": 1,
-    "auto": 2,
-    "manual": 3,
-    "disabled": 4,
-    0: "Boot",
-    1: "System",
-    2: "Auto",
-    3: "Manual",
-    4: "Disabled",
-}
-
-SERVICE_ERROR_CONTROL = {
-    0: "Ignore",
-    1: "Normal",
-    2: "Severe",
-    3: "Critical",
-    "ignore": 0,
-    "normal": 1,
-    "severe": 2,
-    "critical": 3,
-}
+SERVICE_TYPE = salt.utils.win_service.SERVICE_TYPE
+SERVICE_START_TYPE = salt.utils.win_service.SERVICE_START_TYPE
+SERVICE_ERROR_CONTROL = salt.utils.win_service.SERVICE_ERROR_CONTROL
 
 
 def __virtual__():
@@ -369,102 +308,7 @@ def info(name):
 
         salt '*' service.info spooler
     """
-    try:
-        handle_scm = win32service.OpenSCManager(
-            None, None, win32service.SC_MANAGER_CONNECT
-        )
-    except pywintypes.error as exc:
-        raise CommandExecutionError(
-            "Failed to connect to the SCM: {0}".format(exc.strerror)
-        )
-
-    try:
-        handle_svc = win32service.OpenService(
-            handle_scm,
-            name,
-            win32service.SERVICE_ENUMERATE_DEPENDENTS
-            | win32service.SERVICE_INTERROGATE
-            | win32service.SERVICE_QUERY_CONFIG
-            | win32service.SERVICE_QUERY_STATUS,
-        )
-    except pywintypes.error as exc:
-        raise CommandExecutionError(
-            "Failed To Open {0}: {1}".format(name, exc.strerror)
-        )
-
-    try:
-        config_info = win32service.QueryServiceConfig(handle_svc)
-        status_info = win32service.QueryServiceStatusEx(handle_svc)
-
-        try:
-            description = win32service.QueryServiceConfig2(
-                handle_svc, win32service.SERVICE_CONFIG_DESCRIPTION
-            )
-        except pywintypes.error:
-            description = "Failed to get description"
-
-        delayed_start = win32service.QueryServiceConfig2(
-            handle_svc, win32service.SERVICE_CONFIG_DELAYED_AUTO_START_INFO
-        )
-    finally:
-        win32service.CloseServiceHandle(handle_scm)
-        win32service.CloseServiceHandle(handle_svc)
-
-    ret = dict()
-    try:
-        sid = win32security.LookupAccountName("", "NT Service\\{0}".format(name))[0]
-        ret["sid"] = win32security.ConvertSidToStringSid(sid)
-    except pywintypes.error:
-        ret["sid"] = "Failed to get SID"
-
-    ret["BinaryPath"] = config_info[3]
-    ret["LoadOrderGroup"] = config_info[4]
-    ret["TagID"] = config_info[5]
-    ret["Dependencies"] = config_info[6]
-    ret["ServiceAccount"] = config_info[7]
-    ret["DisplayName"] = config_info[8]
-    ret["Description"] = description
-    ret["Status_ServiceCode"] = status_info["ServiceSpecificExitCode"]
-    ret["Status_CheckPoint"] = status_info["CheckPoint"]
-    ret["Status_WaitHint"] = status_info["WaitHint"]
-    ret["StartTypeDelayed"] = delayed_start
-
-    flags = list()
-    for bit in SERVICE_TYPE:
-        if isinstance(bit, int):
-            if config_info[0] & bit:
-                flags.append(SERVICE_TYPE[bit])
-
-    ret["ServiceType"] = flags if flags else config_info[0]
-
-    flags = list()
-    for bit in SERVICE_CONTROLS:
-        if status_info["ControlsAccepted"] & bit:
-            flags.append(SERVICE_CONTROLS[bit])
-
-    ret["ControlsAccepted"] = flags if flags else status_info["ControlsAccepted"]
-
-    try:
-        ret["Status_ExitCode"] = SERVICE_ERRORS[status_info["Win32ExitCode"]]
-    except KeyError:
-        ret["Status_ExitCode"] = status_info["Win32ExitCode"]
-
-    try:
-        ret["StartType"] = SERVICE_START_TYPE[config_info[1]]
-    except KeyError:
-        ret["StartType"] = config_info[1]
-
-    try:
-        ret["ErrorControl"] = SERVICE_ERROR_CONTROL[config_info[2]]
-    except KeyError:
-        ret["ErrorControl"] = config_info[2]
-
-    try:
-        ret["Status"] = SERVICE_STATE[status_info["CurrentState"]]
-    except KeyError:
-        ret["Status"] = status_info["CurrentState"]
-
-    return ret
+    return salt.utils.win_service.info(name=name)
 
 
 def start(name, timeout=90):

--- a/salt/modules/win_wua.py
+++ b/salt/modules/win_wua.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Module for managing Windows Updates using the Windows Update Agent.
 
@@ -56,8 +55,6 @@ Group Policy using the ``lgpo`` module.
 :depends: salt.utils.win_update
 """
 # Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
-
 import logging
 
 # Import Salt libs
@@ -68,8 +65,6 @@ import salt.utils.winapi
 from salt.exceptions import CommandExecutionError
 
 # Import 3rd-party libs
-from salt.ext import six
-
 try:
     import win32com.client
 
@@ -664,11 +659,11 @@ def download(names):
         raise CommandExecutionError("No updates found")
 
     # Make sure it's a list so count comparison is correct
-    if isinstance(names, six.string_types):
+    if isinstance(names, str):
         names = [names]
 
-    if isinstance(names, six.integer_types):
-        names = [six.text_type(names)]
+    if isinstance(names, int):
+        names = [str(names)]
 
     if updates.count() > len(names):
         raise CommandExecutionError(
@@ -718,11 +713,11 @@ def install(names):
         raise CommandExecutionError("No updates found")
 
     # Make sure it's a list so count comparison is correct
-    if isinstance(names, six.string_types):
+    if isinstance(names, str):
         names = [names]
 
-    if isinstance(names, six.integer_types):
-        names = [six.text_type(names)]
+    if isinstance(names, int):
+        names = [str(names)]
 
     if updates.count() > len(names):
         raise CommandExecutionError(
@@ -954,17 +949,17 @@ def set_wu_settings(
     if time is not None:
         # Check for time as a string: if the time is not quoted, yaml will
         # treat it as an integer
-        if not isinstance(time, six.string_types):
+        if not isinstance(time, str):
             ret["Comment"] = (
                 "Time argument needs to be a string; it may need to "
-                "be quoted. Passed {0}. Time not set.".format(time)
+                "be quoted. Passed {}. Time not set.".format(time)
             )
             ret["Success"] = False
         # Check for colon in the time
         elif ":" not in time:
             ret["Comment"] = (
                 "Time argument needs to be in 00:00 format. "
-                "Passed {0}. Time not set.".format(time)
+                "Passed {}. Time not set.".format(time)
             )
             ret["Success"] = False
         else:
@@ -998,7 +993,7 @@ def set_wu_settings(
                     (hr, msg, exc, arg,) = error.args
                     # pylint: enable=unpacking-non-sequence,unbalanced-tuple-unpacking
                     # Consider checking for -2147024891 (0x80070005) Access Denied
-                    ret["Comment"] = "Failed with failure code: {0}".format(exc[5])
+                    ret["Comment"] = "Failed with failure code: {}".format(exc[5])
                     ret["Success"] = False
             else:
                 # msupdate is false, so remove it from the services
@@ -1017,7 +1012,7 @@ def set_wu_settings(
                         # -2147024891 (0x80070005) Access Denied
                         # -2145091564 (0x80248014) Service Not Found (shouldn't get
                         # this with the check for _get_msupdate_status above
-                        ret["Comment"] = "Failed with failure code: {0}".format(exc[5])
+                        ret["Comment"] = "Failed with failure code: {}".format(exc[5])
                         ret["Success"] = False
                 else:
                     ret["msupdate"] = msupdate
@@ -1121,11 +1116,11 @@ def get_wu_settings():
         # Scheduled Installation Time requires special handling to return the time
         # in the right format
         if obj_au_settings.ScheduledInstallationTime < 10:
-            ret["Scheduled Time"] = "0{0}:00".format(
+            ret["Scheduled Time"] = "0{}:00".format(
                 obj_au_settings.ScheduledInstallationTime
             )
         else:
-            ret["Scheduled Time"] = "{0}:00".format(
+            ret["Scheduled Time"] = "{}:00".format(
                 obj_au_settings.ScheduledInstallationTime
             )
 

--- a/salt/modules/win_wua.py
+++ b/salt/modules/win_wua.py
@@ -98,24 +98,37 @@ def __virtual__():
         return False, "WUA: Missing Libraries required by salt.utils.win_update"
 
     if salt.utils.win_service.info("wuauserv")["StartType"] == "Disabled":
-        return False, "WUA: The Windows Update service (wuauserv) must not " \
-                      "be disabled"
+        return (
+            False,
+            "WUA: The Windows Update service (wuauserv) must not be disabled",
+        )
 
     if salt.utils.win_service.info("msiserver")["StartType"] == "Disabled":
-        return False, "WUA: The Windows Installer service (msiserver) must " \
-                      "not be disabled"
+        return (
+            False,
+            "WUA: The Windows Installer service (msiserver) must not be disabled",
+        )
 
     if not salt.utils.win_service.info("BITS")["StartType"] == "Auto":
-        return False, "WUA: The Background Intelligent Transfer Service " \
-                      "(bits) must not be disabled"
+        return (
+            False,
+            "WUA: The Background Intelligent Transfer Service (bits) must not "
+            "be disabled",
+        )
 
     if not salt.utils.win_service.info("CryptSvc")["StartType"] == "Auto":
-        return False, "WUA: The Cryptographic Services service (CryptSvc) " \
-                      "must not be disabled"
+        return (
+            False,
+            "WUA: The Cryptographic Services service (CryptSvc) must not be "
+            "disabled",
+        )
 
     if salt.utils.win_service.info("TrustedInstaller")["StartType"] == "Disabled":
-        return False, "WUA: The Windows Module Installer service " \
-                      "(TrustedInstaller) must not be disabled"
+        return (
+            False,
+            "WUA: The Windows Module Installer service (TrustedInstaller) must "
+            "not be disabled",
+        )
 
     return True
 

--- a/salt/modules/win_wua.py
+++ b/salt/modules/win_wua.py
@@ -84,7 +84,7 @@ def __virtual__():
     Only works on Windows systems with PyWin32
     """
     if not salt.utils.platform.is_windows():
-        return False, "WUA: Only available on Window systems"
+        return False, "WUA: Only available on Windows systems"
 
     if not HAS_PYWIN32:
         return False, "WUA: Requires PyWin32 libraries"
@@ -107,7 +107,7 @@ def __virtual__():
     if not salt.utils.win_service.info("BITS")["StartType"] == "Auto":
         return (
             False,
-            "WUA: The Background Intelligent Transfer Service (bits) must not "
+            "WUA: The Background Intelligent Transfer service (bits) must not "
             "be disabled",
         )
 

--- a/salt/modules/win_wua.py
+++ b/salt/modules/win_wua.py
@@ -62,6 +62,7 @@ import logging
 
 # Import Salt libs
 import salt.utils.platform
+import salt.utils.win_service
 import salt.utils.win_update
 import salt.utils.winapi
 from salt.exceptions import CommandExecutionError
@@ -95,6 +96,26 @@ def __virtual__():
 
     if not salt.utils.win_update.HAS_PYWIN32:
         return False, "WUA: Missing Libraries required by salt.utils.win_update"
+
+    if salt.utils.win_service.info("wuauserv")["StartType"] == "Disabled":
+        return False, "WUA: The Windows Update service (wuauserv) must not " \
+                      "be disabled"
+
+    if salt.utils.win_service.info("msiserver")["StartType"] == "Disabled":
+        return False, "WUA: The Windows Installer service (msiserver) must " \
+                      "not be disabled"
+
+    if not salt.utils.win_service.info("BITS")["StartType"] == "Auto":
+        return False, "WUA: The Background Intelligent Transfer Service " \
+                      "(bits) must not be disabled"
+
+    if not salt.utils.win_service.info("CryptSvc")["StartType"] == "Auto":
+        return False, "WUA: The Cryptographic Services service (CryptSvc) " \
+                      "must not be disabled"
+
+    if salt.utils.win_service.info("TrustedInstaller")["StartType"] == "Disabled":
+        return False, "WUA: The Windows Module Installer service " \
+                      "(TrustedInstaller) must not be disabled"
 
     return True
 

--- a/salt/modules/win_wua.py
+++ b/salt/modules/win_wua.py
@@ -54,17 +54,14 @@ Group Policy using the ``lgpo`` module.
 
 :depends: salt.utils.win_update
 """
-# Import Python libs
 import logging
 
-# Import Salt libs
 import salt.utils.platform
 import salt.utils.win_service
 import salt.utils.win_update
 import salt.utils.winapi
 from salt.exceptions import CommandExecutionError
 
-# Import 3rd-party libs
 try:
     import win32com.client
 

--- a/salt/utils/win_service.py
+++ b/salt/utils/win_service.py
@@ -1,8 +1,6 @@
-# Import Salt libs
 import salt.utils.platform
 from salt.exceptions import CommandExecutionError
 
-# Import 3rd party libs
 try:
     import pywintypes
     import win32security

--- a/salt/utils/win_service.py
+++ b/salt/utils/win_service.py
@@ -1,0 +1,208 @@
+# Import Salt libs
+import salt.utils.platform
+from salt.exceptions import CommandExecutionError
+
+# Import 3rd party libs
+try:
+    import pywintypes
+    import win32security
+    import win32service
+    HAS_WIN32 = True
+except ImportError:
+    HAS_WIN32 = False
+
+SERVICE_TYPE = {
+    1: "Kernel Driver",
+    2: "File System Driver",
+    4: "Adapter Driver",
+    8: "Recognizer Driver",
+    16: "Win32 Own Process",
+    32: "Win32 Share Process",
+    256: "Interactive",
+    "kernel": 1,
+    "filesystem": 2,
+    "adapter": 4,
+    "recognizer": 8,
+    "own": 16,
+    "share": 32,
+}
+
+SERVICE_CONTROLS = {
+    1: "Stop",
+    2: "Pause/Continue",
+    4: "Shutdown",
+    8: "Change Parameters",
+    16: "Netbind Change",
+    32: "Hardware Profile Change",
+    64: "Power Event",
+    128: "Session Change",
+    256: "Pre-Shutdown",
+    512: "Time Change",
+    1024: "Trigger Event",
+}
+
+SERVICE_STATE = {
+    1: "Stopped",
+    2: "Start Pending",
+    3: "Stop Pending",
+    4: "Running",
+    5: "Continue Pending",
+    6: "Pause Pending",
+    7: "Paused",
+}
+
+SERVICE_ERRORS = {0: "No Error", 1066: "Service Specific Error"}
+
+SERVICE_START_TYPE = {
+    "boot": 0,
+    "system": 1,
+    "auto": 2,
+    "manual": 3,
+    "disabled": 4,
+    0: "Boot",
+    1: "System",
+    2: "Auto",
+    3: "Manual",
+    4: "Disabled",
+}
+
+SERVICE_ERROR_CONTROL = {
+    0: "Ignore",
+    1: "Normal",
+    2: "Severe",
+    3: "Critical",
+    "ignore": 0,
+    "normal": 1,
+    "severe": 2,
+    "critical": 3,
+}
+
+__virtualname__ = "win_service"
+
+
+def __virtual__():
+    """
+    Only load if Win32 Libraries are installed
+    """
+    if not salt.utils.platform.is_windows():
+        return False, "win_dacl: Requires Windows"
+
+    if not HAS_WIN32:
+        return False, "win_dacl: Requires pywin32"
+
+    return __virtualname__
+
+
+def info(name):
+    """
+    Get information about a service on the system
+
+    Args:
+        name (str): The name of the service. This is not the display name. Use
+            ``get_service_name`` to find the service name.
+
+    Returns:
+        dict: A dictionary containing information about the service.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.info spooler
+    """
+    try:
+        handle_scm = win32service.OpenSCManager(
+            None, None, win32service.SC_MANAGER_CONNECT
+        )
+    except pywintypes.error as exc:
+        raise CommandExecutionError(
+            "Failed to connect to the SCM: {0}".format(exc.strerror)
+        )
+
+    try:
+        handle_svc = win32service.OpenService(
+            handle_scm,
+            name,
+            win32service.SERVICE_ENUMERATE_DEPENDENTS
+            | win32service.SERVICE_INTERROGATE
+            | win32service.SERVICE_QUERY_CONFIG
+            | win32service.SERVICE_QUERY_STATUS,
+            )
+    except pywintypes.error as exc:
+        raise CommandExecutionError(
+            "Failed To Open {0}: {1}".format(name, exc.strerror)
+        )
+
+    try:
+        config_info = win32service.QueryServiceConfig(handle_svc)
+        status_info = win32service.QueryServiceStatusEx(handle_svc)
+
+        try:
+            description = win32service.QueryServiceConfig2(
+                handle_svc, win32service.SERVICE_CONFIG_DESCRIPTION
+            )
+        except pywintypes.error:
+            description = "Failed to get description"
+
+        delayed_start = win32service.QueryServiceConfig2(
+            handle_svc, win32service.SERVICE_CONFIG_DELAYED_AUTO_START_INFO
+        )
+    finally:
+        win32service.CloseServiceHandle(handle_scm)
+        win32service.CloseServiceHandle(handle_svc)
+
+    ret = dict()
+    try:
+        sid = win32security.LookupAccountName("", "NT Service\\{0}".format(name))[0]
+        ret["sid"] = win32security.ConvertSidToStringSid(sid)
+    except pywintypes.error:
+        ret["sid"] = "Failed to get SID"
+
+    ret["BinaryPath"] = config_info[3]
+    ret["LoadOrderGroup"] = config_info[4]
+    ret["TagID"] = config_info[5]
+    ret["Dependencies"] = config_info[6]
+    ret["ServiceAccount"] = config_info[7]
+    ret["DisplayName"] = config_info[8]
+    ret["Description"] = description
+    ret["Status_ServiceCode"] = status_info["ServiceSpecificExitCode"]
+    ret["Status_CheckPoint"] = status_info["CheckPoint"]
+    ret["Status_WaitHint"] = status_info["WaitHint"]
+    ret["StartTypeDelayed"] = delayed_start
+
+    flags = list()
+    for bit in SERVICE_TYPE:
+        if isinstance(bit, int):
+            if config_info[0] & bit:
+                flags.append(SERVICE_TYPE[bit])
+
+    ret["ServiceType"] = flags if flags else config_info[0]
+
+    flags = list()
+    for bit in SERVICE_CONTROLS:
+        if status_info["ControlsAccepted"] & bit:
+            flags.append(SERVICE_CONTROLS[bit])
+
+    ret["ControlsAccepted"] = flags if flags else status_info["ControlsAccepted"]
+
+    try:
+        ret["Status_ExitCode"] = SERVICE_ERRORS[status_info["Win32ExitCode"]]
+    except KeyError:
+        ret["Status_ExitCode"] = status_info["Win32ExitCode"]
+
+    try:
+        ret["StartType"] = SERVICE_START_TYPE[config_info[1]]
+    except KeyError:
+        ret["StartType"] = config_info[1]
+
+    try:
+        ret["ErrorControl"] = SERVICE_ERROR_CONTROL[config_info[2]]
+    except KeyError:
+        ret["ErrorControl"] = config_info[2]
+
+    try:
+        ret["Status"] = SERVICE_STATE[status_info["CurrentState"]]
+    except KeyError:
+        ret["Status"] = status_info["CurrentState"]
+
+    return ret

--- a/salt/utils/win_service.py
+++ b/salt/utils/win_service.py
@@ -117,7 +117,7 @@ def info(name):
         )
     except pywintypes.error as exc:
         raise CommandExecutionError(
-            "Failed to connect to the SCM: {0}".format(exc.strerror)
+            "Failed to connect to the SCM: {}".format(exc.strerror)
         )
 
     try:
@@ -131,7 +131,7 @@ def info(name):
         )
     except pywintypes.error as exc:
         raise CommandExecutionError(
-            "Failed To Open {0}: {1}".format(name, exc.strerror)
+            "Failed To Open {}: {}".format(name, exc.strerror)
         )
 
     try:
@@ -154,7 +154,7 @@ def info(name):
 
     ret = dict()
     try:
-        sid = win32security.LookupAccountName("", "NT Service\\{0}".format(name))[0]
+        sid = win32security.LookupAccountName("", "NT Service\\{}".format(name))[0]
         ret["sid"] = win32security.ConvertSidToStringSid(sid)
     except pywintypes.error:
         ret["sid"] = "Failed to get SID"

--- a/salt/utils/win_service.py
+++ b/salt/utils/win_service.py
@@ -7,6 +7,7 @@ try:
     import pywintypes
     import win32security
     import win32service
+
     HAS_WIN32 = True
 except ImportError:
     HAS_WIN32 = False
@@ -127,7 +128,7 @@ def info(name):
             | win32service.SERVICE_INTERROGATE
             | win32service.SERVICE_QUERY_CONFIG
             | win32service.SERVICE_QUERY_STATUS,
-            )
+        )
     except pywintypes.error as exc:
         raise CommandExecutionError(
             "Failed To Open {0}: {1}".format(name, exc.strerror)

--- a/salt/utils/win_service.py
+++ b/salt/utils/win_service.py
@@ -130,9 +130,7 @@ def info(name):
             | win32service.SERVICE_QUERY_STATUS,
         )
     except pywintypes.error as exc:
-        raise CommandExecutionError(
-            "Failed To Open {}: {}".format(name, exc.strerror)
-        )
+        raise CommandExecutionError("Failed To Open {}: {}".format(name, exc.strerror))
 
     try:
         config_info = win32service.QueryServiceConfig(handle_svc)

--- a/salt/utils/win_update.py
+++ b/salt/utils/win_update.py
@@ -1,7 +1,6 @@
 """
 Classes for working with Windows Update Agent
 """
-
 import logging
 import subprocess
 
@@ -172,7 +171,7 @@ class Updates:
                 "Mandatory": bool(update.IsMandatory),
                 "EULAAccepted": bool(update.EulaAccepted),
                 "NeedsReboot": bool(update.RebootRequired),
-                "Severity": six.text_type(update.MsrcSeverity),
+                "Severity": str(update.MsrcSeverity),
                 "UserInput": user_input,
                 "RebootBehavior": REBOOT_BEHAVIOR[requires_reboot],
                 "KBs": ["KB" + item for item in update.KBArticleIDs],

--- a/salt/utils/win_update.py
+++ b/salt/utils/win_update.py
@@ -161,6 +161,8 @@ class Updates:
                 )
                 requires_reboot = 2
 
+            # IUpdate Properties
+            # https://docs.microsoft.com/en-us/windows/win32/wua_sdk/iupdate-properties
             results[update.Identity.UpdateID] = {
                 "guid": update.Identity.UpdateID,
                 "Title": str(update.Title),

--- a/salt/utils/win_update.py
+++ b/salt/utils/win_update.py
@@ -149,13 +149,17 @@ class Updates:
             try:
                 user_input = bool(update.InstallationBehavior.CanRequestUserInput)
             except AttributeError:
-                log.debug("Windows Update: Error reading InstallationBehavior COM Object")
+                log.debug(
+                    "Windows Update: Error reading InstallationBehavior COM Object"
+                )
                 user_input = False
 
             try:
                 requires_reboot = update.InstallationBehavior.RebootBehavior
             except AttributeError:
-                log.debug("Windows Update: Error reading InstallationBehavior COM Object")
+                log.debug(
+                    "Windows Update: Error reading InstallationBehavior COM Object"
+                )
                 requires_reboot = 2
 
             results[update.Identity.UpdateID] = {
@@ -536,9 +540,13 @@ class WindowsUpdateAgent:
             # https://github.com/saltstack/salt/issues/57762 for more details.
             # The following try/except block will default to True
             try:
-                requires_reboot = salt.utils.data.is_true(update.InstallationBehavior.RebootBehavior)
+                requires_reboot = salt.utils.data.is_true(
+                    update.InstallationBehavior.RebootBehavior
+                )
             except AttributeError:
-                log.debug("Windows Update: Error reading InstallationBehavior COM Object")
+                log.debug(
+                    "Windows Update: Error reading InstallationBehavior COM Object"
+                )
                 requires_reboot = True
 
             if requires_reboot and skip_reboot:
@@ -855,9 +863,13 @@ class WindowsUpdateAgent:
                 # https://github.com/saltstack/salt/issues/57762 for more details.
                 # The following try/except block will default to 2
                 try:
-                    reboot_behavior = install_list.Item(i).InstallationBehavior.RebootBehavior
+                    reboot_behavior = install_list.Item(
+                        i
+                    ).InstallationBehavior.RebootBehavior
                 except AttributeError:
-                    log.debug("Windows Update: Error reading InstallationBehavior COM Object")
+                    log.debug(
+                        "Windows Update: Error reading InstallationBehavior COM Object"
+                    )
                     reboot_behavior = 2
                 ret["Updates"][uid]["RebootBehavior"] = REBOOT_BEHAVIOR[reboot_behavior]
 
@@ -1023,11 +1035,17 @@ class WindowsUpdateAgent:
                                 # https://github.com/saltstack/salt/issues/57762 for more details.
                                 # The following try/except block will default to 2
                                 try:
-                                    requires_reboot = update.InstallationBehavior.RebootBehavior
+                                    requires_reboot = (
+                                        update.InstallationBehavior.RebootBehavior
+                                    )
                                 except AttributeError:
-                                    log.debug("Windows Update: Error reading InstallationBehavior COM Object")
+                                    log.debug(
+                                        "Windows Update: Error reading InstallationBehavior COM Object"
+                                    )
                                     requires_reboot = 2
-                                ret["Updates"][uid]["RebootBehavior"] = REBOOT_BEHAVIOR[requires_reboot]
+                                ret["Updates"][uid]["RebootBehavior"] = REBOOT_BEHAVIOR[
+                                    requires_reboot
+                                ]
 
                     return ret
 
@@ -1067,9 +1085,13 @@ class WindowsUpdateAgent:
                 # https://github.com/saltstack/salt/issues/57762 for more details.
                 # The following try/except block will default to 2
                 try:
-                    reboot_behavior = uninstall_list.Item(i).InstallationBehavior.RebootBehavior
+                    reboot_behavior = uninstall_list.Item(
+                        i
+                    ).InstallationBehavior.RebootBehavior
                 except AttributeError:
-                    log.debug("Windows Update: Error reading InstallationBehavior COM Object")
+                    log.debug(
+                        "Windows Update: Error reading InstallationBehavior COM Object"
+                    )
                     reboot_behavior = 2
                 ret["Updates"][uid]["RebootBehavior"] = REBOOT_BEHAVIOR[reboot_behavior]
 

--- a/salt/utils/win_update.py
+++ b/salt/utils/win_update.py
@@ -176,6 +176,7 @@ class Updates:
                 "RebootBehavior": REBOOT_BEHAVIOR[requires_reboot],
                 "KBs": ["KB" + item for item in update.KBArticleIDs],
                 "Categories": [item.Name for item in update.Categories],
+                "SupportUrl": update.SupportUrl,
             }
 
         return results

--- a/salt/utils/win_update.py
+++ b/salt/utils/win_update.py
@@ -20,6 +20,12 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
+REBOOT_BEHAVIOR = {
+    0: "Never Requires Reboot",
+    1: "Always Requires Reboot",
+    2: "Can Require Reboot",
+}
+
 __virtualname__ = "win_update"
 
 
@@ -63,12 +69,6 @@ class Updates:
     """
 
     update_types = {1: "Software", 2: "Driver"}
-
-    reboot_behavior = {
-        0: "Never Requires Reboot",
-        1: "Always Requires Reboot",
-        2: "Can Require Reboot",
-    }
 
     def __init__(self):
         """
@@ -142,6 +142,22 @@ class Updates:
         results = {}
         for update in self.updates:
 
+            # Windows 10 build 2004 introduced some problems with the
+            # InstallationBehavior COM Object. See
+            # https://github.com/saltstack/salt/issues/57762 for more details.
+            # The following 2 try/except blocks will output sane defaults
+            try:
+                user_input = bool(update.InstallationBehavior.CanRequestUserInput)
+            except AttributeError:
+                log.debug("Windows Update: Error reading InstallationBehavior COM Object")
+                user_input = False
+
+            try:
+                requires_reboot = update.InstallationBehavior.RebootBehavior
+            except AttributeError:
+                log.debug("Windows Update: Error reading InstallationBehavior COM Object")
+                requires_reboot = 2
+
             results[update.Identity.UpdateID] = {
                 "guid": update.Identity.UpdateID,
                 "Title": str(update.Title),
@@ -152,11 +168,9 @@ class Updates:
                 "Mandatory": bool(update.IsMandatory),
                 "EULAAccepted": bool(update.EulaAccepted),
                 "NeedsReboot": bool(update.RebootRequired),
-                "Severity": str(update.MsrcSeverity),
-                "UserInput": bool(update.InstallationBehavior.CanRequestUserInput),
-                "RebootBehavior": self.reboot_behavior[
-                    update.InstallationBehavior.RebootBehavior
-                ],
+                "Severity": six.text_type(update.MsrcSeverity),
+                "UserInput": user_input,
+                "RebootBehavior": REBOOT_BEHAVIOR[requires_reboot],
                 "KBs": ["KB" + item for item in update.KBArticleIDs],
                 "Categories": [item.Name for item in update.Categories],
             }
@@ -517,10 +531,17 @@ class WindowsUpdateAgent:
             if salt.utils.data.is_true(update.IsMandatory) and skip_mandatory:
                 continue
 
-            if (
-                salt.utils.data.is_true(update.InstallationBehavior.RebootBehavior)
-                and skip_reboot
-            ):
+            # Windows 10 build 2004 introduced some problems with the
+            # InstallationBehavior COM Object. See
+            # https://github.com/saltstack/salt/issues/57762 for more details.
+            # The following try/except block will default to True
+            try:
+                requires_reboot = salt.utils.data.is_true(update.InstallationBehavior.RebootBehavior)
+            except AttributeError:
+                log.debug("Windows Update: Error reading InstallationBehavior COM Object")
+                requires_reboot = True
+
+            if requires_reboot and skip_reboot:
                 continue
 
             if not software and update.Type == 1:
@@ -824,15 +845,21 @@ class WindowsUpdateAgent:
                 log.debug("Install Failed")
                 ret["Success"] = False
 
-            reboot = {0: "Never Reboot", 1: "Always Reboot", 2: "Poss Reboot"}
             for i in range(install_list.Count):
                 uid = install_list.Item(i).Identity.UpdateID
                 ret["Updates"][uid]["Result"] = result_code[
                     result.GetUpdateResult(i).ResultCode
                 ]
-                ret["Updates"][uid]["RebootBehavior"] = reboot[
-                    install_list.Item(i).InstallationBehavior.RebootBehavior
-                ]
+                # Windows 10 build 2004 introduced some problems with the
+                # InstallationBehavior COM Object. See
+                # https://github.com/saltstack/salt/issues/57762 for more details.
+                # The following try/except block will default to 2
+                try:
+                    reboot_behavior = install_list.Item(i).InstallationBehavior.RebootBehavior
+                except AttributeError:
+                    log.debug("Windows Update: Error reading InstallationBehavior COM Object")
+                    reboot_behavior = 2
+                ret["Updates"][uid]["RebootBehavior"] = REBOOT_BEHAVIOR[reboot_behavior]
 
         return ret
 
@@ -978,8 +1005,6 @@ class WindowsUpdateAgent:
                     # Refresh the Updates Table
                     self.refresh(online=False)
 
-                    reboot = {0: "Never Reboot", 1: "Always Reboot", 2: "Poss Reboot"}
-
                     # Check the status of each update
                     for update in self._updates:
                         uid = update.Identity.UpdateID
@@ -993,9 +1018,16 @@ class WindowsUpdateAgent:
                                     ret["Updates"][uid][
                                         "Result"
                                     ] = "Uninstallation Failed"
-                                ret["Updates"][uid]["RebootBehavior"] = reboot[
-                                    update.InstallationBehavior.RebootBehavior
-                                ]
+                                # Windows 10 build 2004 introduced some problems with the
+                                # InstallationBehavior COM Object. See
+                                # https://github.com/saltstack/salt/issues/57762 for more details.
+                                # The following try/except block will default to 2
+                                try:
+                                    requires_reboot = update.InstallationBehavior.RebootBehavior
+                                except AttributeError:
+                                    log.debug("Windows Update: Error reading InstallationBehavior COM Object")
+                                    requires_reboot = 2
+                                ret["Updates"][uid]["RebootBehavior"] = REBOOT_BEHAVIOR[requires_reboot]
 
                     return ret
 
@@ -1025,15 +1057,21 @@ class WindowsUpdateAgent:
                 log.debug("Uninstall Failed")
                 ret["Success"] = False
 
-            reboot = {0: "Never Reboot", 1: "Always Reboot", 2: "Poss Reboot"}
             for i in range(uninstall_list.Count):
                 uid = uninstall_list.Item(i).Identity.UpdateID
                 ret["Updates"][uid]["Result"] = result_code[
                     result.GetUpdateResult(i).ResultCode
                 ]
-                ret["Updates"][uid]["RebootBehavior"] = reboot[
-                    uninstall_list.Item(i).InstallationBehavior.RebootBehavior
-                ]
+                # Windows 10 build 2004 introduced some problems with the
+                # InstallationBehavior COM Object. See
+                # https://github.com/saltstack/salt/issues/57762 for more details.
+                # The following try/except block will default to 2
+                try:
+                    reboot_behavior = uninstall_list.Item(i).InstallationBehavior.RebootBehavior
+                except AttributeError:
+                    log.debug("Windows Update: Error reading InstallationBehavior COM Object")
+                    reboot_behavior = 2
+                ret["Updates"][uid]["RebootBehavior"] = REBOOT_BEHAVIOR[reboot_behavior]
 
         return ret
 

--- a/tests/unit/modules/test_win_wua.py
+++ b/tests/unit/modules/test_win_wua.py
@@ -40,6 +40,7 @@ class WinWuaInstalledTestCase(TestCase):
     """
     Test the functions in the win_wua.installed function
     """
+
     service_auto = {"StartType": "Auto"}
     service_disabled = {"StartType": "Disabled"}
 

--- a/tests/unit/modules/test_win_wua.py
+++ b/tests/unit/modules/test_win_wua.py
@@ -1,12 +1,10 @@
 """
 Test the win_wua execution module
 """
-# Import Salt Libs
 import salt.modules.win_wua as win_wua
 import salt.utils.platform
 import salt.utils.win_update
 
-# Import Salt Testing Libs
 from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase, skipIf
 

--- a/tests/unit/modules/test_win_wua.py
+++ b/tests/unit/modules/test_win_wua.py
@@ -4,7 +4,6 @@ Test the win_wua execution module
 import salt.modules.win_wua as win_wua
 import salt.utils.platform
 import salt.utils.win_update
-
 from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase, skipIf
 

--- a/tests/unit/modules/test_win_wua.py
+++ b/tests/unit/modules/test_win_wua.py
@@ -1,17 +1,13 @@
-# -*- coding: utf-8 -*-
 """
 Test the win_wua execution module
 """
-# Import Python Libs
-from __future__ import absolute_import, print_function, unicode_literals
-
 # Import Salt Libs
 import salt.modules.win_wua as win_wua
 import salt.utils.platform
 import salt.utils.win_update
 
 # Import Salt Testing Libs
-from tests.support.mock import patch, MagicMock
+from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase, skipIf
 
 UPDATES_LIST = {
@@ -29,7 +25,7 @@ UPDATES_LIST = {
 UPDATES_SUMMARY = {"Installed": 10}
 
 
-class Updates(object):
+class Updates:
     @staticmethod
     def list():
         return UPDATES_LIST
@@ -69,15 +65,20 @@ class WinWuaInstalledTestCase(TestCase):
         """
         Test __virtual__ function when the wuauserv service is disabled
         """
-        disabled_wuauserv = MagicMock(side_effect=[
-            self.service_disabled,  # wuauserv
-            self.service_auto,  # msiserver
-            self.service_auto,  # BITS
-            self.service_auto,  # CryptSvc
-            self.service_auto,  # TrustedInstaller
-        ])
+        disabled_wuauserv = MagicMock(
+            side_effect=[
+                self.service_disabled,  # wuauserv
+                self.service_auto,  # msiserver
+                self.service_auto,  # BITS
+                self.service_auto,  # CryptSvc
+                self.service_auto,  # TrustedInstaller
+            ]
+        )
         with patch("salt.utils.win_service.info", disabled_wuauserv):
-            expected = (False, "WUA: The Windows Update service (wuauserv) must not be disabled")
+            expected = (
+                False,
+                "WUA: The Windows Update service (wuauserv) must not be disabled",
+            )
             result = win_wua.__virtual__()
             self.assertEqual(expected, result)
 
@@ -85,15 +86,20 @@ class WinWuaInstalledTestCase(TestCase):
         """
         Test __virtual__ function when the msiserver service is disabled
         """
-        disabled_wuauserv = MagicMock(side_effect=[
-            self.service_auto,  # wuauserv
-            self.service_disabled,  # msiserver
-            self.service_auto,  # BITS
-            self.service_auto,  # CryptSvc
-            self.service_auto,  # TrustedInstaller
-        ])
+        disabled_wuauserv = MagicMock(
+            side_effect=[
+                self.service_auto,  # wuauserv
+                self.service_disabled,  # msiserver
+                self.service_auto,  # BITS
+                self.service_auto,  # CryptSvc
+                self.service_auto,  # TrustedInstaller
+            ]
+        )
         with patch("salt.utils.win_service.info", disabled_wuauserv):
-            expected = (False, "WUA: The Windows Installer service (msiserver) must not be disabled")
+            expected = (
+                False,
+                "WUA: The Windows Installer service (msiserver) must not be disabled",
+            )
             result = win_wua.__virtual__()
             self.assertEqual(expected, result)
 
@@ -101,15 +107,20 @@ class WinWuaInstalledTestCase(TestCase):
         """
         Test __virtual__ function when the BITS service is disabled
         """
-        disabled_wuauserv = MagicMock(side_effect=[
-            self.service_auto,  # wuauserv
-            self.service_auto,  # msiserver
-            self.service_disabled,  # BITS
-            self.service_auto,  # CryptSvc
-            self.service_auto,  # TrustedInstaller
-        ])
+        disabled_wuauserv = MagicMock(
+            side_effect=[
+                self.service_auto,  # wuauserv
+                self.service_auto,  # msiserver
+                self.service_disabled,  # BITS
+                self.service_auto,  # CryptSvc
+                self.service_auto,  # TrustedInstaller
+            ]
+        )
         with patch("salt.utils.win_service.info", disabled_wuauserv):
-            expected = (False, "WUA: The Background Intelligent Transfer service (bits) must not be disabled")
+            expected = (
+                False,
+                "WUA: The Background Intelligent Transfer service (bits) must not be disabled",
+            )
             result = win_wua.__virtual__()
             self.assertEqual(expected, result)
 
@@ -117,15 +128,20 @@ class WinWuaInstalledTestCase(TestCase):
         """
         Test __virtual__ function when the CryptSvc service is disabled
         """
-        disabled_wuauserv = MagicMock(side_effect=[
-            self.service_auto,  # wuauserv
-            self.service_auto,  # msiserver
-            self.service_auto,  # BITS
-            self.service_disabled,  # CryptSvc
-            self.service_auto,  # TrustedInstaller
-        ])
+        disabled_wuauserv = MagicMock(
+            side_effect=[
+                self.service_auto,  # wuauserv
+                self.service_auto,  # msiserver
+                self.service_auto,  # BITS
+                self.service_disabled,  # CryptSvc
+                self.service_auto,  # TrustedInstaller
+            ]
+        )
         with patch("salt.utils.win_service.info", disabled_wuauserv):
-            expected = (False, "WUA: The Cryptographic Services service (CryptSvc) must not be disabled")
+            expected = (
+                False,
+                "WUA: The Cryptographic Services service (CryptSvc) must not be disabled",
+            )
             result = win_wua.__virtual__()
             self.assertEqual(expected, result)
 
@@ -133,15 +149,20 @@ class WinWuaInstalledTestCase(TestCase):
         """
         Test __virtual__ function when the TrustedInstaller service is disabled
         """
-        disabled_wuauserv = MagicMock(side_effect=[
-            self.service_auto,  # wuauserv
-            self.service_auto,  # msiserver
-            self.service_auto,  # BITS
-            self.service_auto,  # CryptSvc
-            self.service_disabled,  # TrustedInstaller
-        ])
+        disabled_wuauserv = MagicMock(
+            side_effect=[
+                self.service_auto,  # wuauserv
+                self.service_auto,  # msiserver
+                self.service_auto,  # BITS
+                self.service_auto,  # CryptSvc
+                self.service_disabled,  # TrustedInstaller
+            ]
+        )
         with patch("salt.utils.win_service.info", disabled_wuauserv):
-            expected = (False, "WUA: The Windows Module Installer service (TrustedInstaller) must not be disabled")
+            expected = (
+                False,
+                "WUA: The Windows Module Installer service (TrustedInstaller) must not be disabled",
+            )
             result = win_wua.__virtual__()
             self.assertEqual(expected, result)
 

--- a/tests/unit/modules/test_win_wua.py
+++ b/tests/unit/modules/test_win_wua.py
@@ -11,7 +11,7 @@ import salt.utils.platform
 import salt.utils.win_update
 
 # Import Salt Testing Libs
-from tests.support.mock import patch
+from tests.support.mock import patch, MagicMock
 from tests.support.unit import TestCase, skipIf
 
 UPDATES_LIST = {
@@ -44,6 +44,106 @@ class WinWuaInstalledTestCase(TestCase):
     """
     Test the functions in the win_wua.installed function
     """
+    service_auto = {"StartType": "Auto"}
+    service_disabled = {"StartType": "Disabled"}
+
+    def test__virtual__not_windows(self):
+        """
+        Test __virtual__ function on Non-Windows
+        """
+        with patch("salt.utils.platform.is_windows", autospec=True, return_value=False):
+            expected = (False, "WUA: Only available on Windows systems")
+            result = win_wua.__virtual__()
+            self.assertEqual(expected, result)
+
+    def test__virtual__missing_pywin32(self):
+        """
+        Test __virtual__ function when pywin32 is not installed
+        """
+        with patch("salt.modules.win_wua.HAS_PYWIN32", False):
+            expected = (False, "WUA: Requires PyWin32 libraries")
+            result = win_wua.__virtual__()
+            self.assertEqual(expected, result)
+
+    def test__virtual__wuauserv_disabled(self):
+        """
+        Test __virtual__ function when the wuauserv service is disabled
+        """
+        disabled_wuauserv = MagicMock(side_effect=[
+            self.service_disabled,  # wuauserv
+            self.service_auto,  # msiserver
+            self.service_auto,  # BITS
+            self.service_auto,  # CryptSvc
+            self.service_auto,  # TrustedInstaller
+        ])
+        with patch("salt.utils.win_service.info", disabled_wuauserv):
+            expected = (False, "WUA: The Windows Update service (wuauserv) must not be disabled")
+            result = win_wua.__virtual__()
+            self.assertEqual(expected, result)
+
+    def test__virtual__msiserver_disabled(self):
+        """
+        Test __virtual__ function when the msiserver service is disabled
+        """
+        disabled_wuauserv = MagicMock(side_effect=[
+            self.service_auto,  # wuauserv
+            self.service_disabled,  # msiserver
+            self.service_auto,  # BITS
+            self.service_auto,  # CryptSvc
+            self.service_auto,  # TrustedInstaller
+        ])
+        with patch("salt.utils.win_service.info", disabled_wuauserv):
+            expected = (False, "WUA: The Windows Installer service (msiserver) must not be disabled")
+            result = win_wua.__virtual__()
+            self.assertEqual(expected, result)
+
+    def test__virtual__BITS_disabled(self):
+        """
+        Test __virtual__ function when the BITS service is disabled
+        """
+        disabled_wuauserv = MagicMock(side_effect=[
+            self.service_auto,  # wuauserv
+            self.service_auto,  # msiserver
+            self.service_disabled,  # BITS
+            self.service_auto,  # CryptSvc
+            self.service_auto,  # TrustedInstaller
+        ])
+        with patch("salt.utils.win_service.info", disabled_wuauserv):
+            expected = (False, "WUA: The Background Intelligent Transfer service (bits) must not be disabled")
+            result = win_wua.__virtual__()
+            self.assertEqual(expected, result)
+
+    def test__virtual__CryptSvc_disabled(self):
+        """
+        Test __virtual__ function when the CryptSvc service is disabled
+        """
+        disabled_wuauserv = MagicMock(side_effect=[
+            self.service_auto,  # wuauserv
+            self.service_auto,  # msiserver
+            self.service_auto,  # BITS
+            self.service_disabled,  # CryptSvc
+            self.service_auto,  # TrustedInstaller
+        ])
+        with patch("salt.utils.win_service.info", disabled_wuauserv):
+            expected = (False, "WUA: The Cryptographic Services service (CryptSvc) must not be disabled")
+            result = win_wua.__virtual__()
+            self.assertEqual(expected, result)
+
+    def test__virtual__TrustedInstaller_disabled(self):
+        """
+        Test __virtual__ function when the TrustedInstaller service is disabled
+        """
+        disabled_wuauserv = MagicMock(side_effect=[
+            self.service_auto,  # wuauserv
+            self.service_auto,  # msiserver
+            self.service_auto,  # BITS
+            self.service_auto,  # CryptSvc
+            self.service_disabled,  # TrustedInstaller
+        ])
+        with patch("salt.utils.win_service.info", disabled_wuauserv):
+            expected = (False, "WUA: The Windows Module Installer service (TrustedInstaller) must not be disabled")
+            result = win_wua.__virtual__()
+            self.assertEqual(expected, result)
 
     def test_installed(self):
         """

--- a/tests/unit/states/test_win_wua.py
+++ b/tests/unit/states/test_win_wua.py
@@ -8,10 +8,15 @@ from __future__ import (  # Import Salt Libs
     print_function,
     unicode_literals,
 )
+from dataclasses import dataclass, field
+import sys
 
+# Import Salt Libs
 import salt.states.win_wua as win_wua
 import salt.utils.platform
 import salt.utils.win_update as win_update
+
+# Import Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase, skipIf
@@ -209,4 +214,280 @@ class WinWuaTestCase(TestCase, LoaderModuleMockMixin):
         with patch_winapi_com, patch_win32, patch_wua, patch_win_wua_update, patch_opts:
             wua = win_update.WindowsUpdateAgent(online=False)
             result = win_wua.uptodate(name="NA")
+            self.assertDictEqual(result, expected)
+
+    @skipIf(sys.version_info < (3, 7), "Test requires Python 3.7")
+    def test_installed(self):
+        """
+        Test installed function
+        """
+
+        @dataclass(unsafe_hash=True)
+        class UpdateRecord:
+            KBs: list = field(compare=False)
+            ID: str
+            IsDownloaded: bool
+            IsInstalled: bool
+            Title: str
+
+        update_search_obj = {
+            UpdateRecord(
+                KBs=["KB4052623"],
+                ID="eac02b09-d745-4891-b80f-400e0e5e4b6d",
+                IsDownloaded=False,
+                IsInstalled=False,
+                Title="Update 2"
+            ),
+        }
+        update_search_dict = {
+            "eac02b09-d745-4891-b80f-400e0e5e4b6d": {
+                "Downloaded": True,
+                "KBs": ["KB4052623"],
+                "Installed": True,
+                "NeedsReboot": True,
+                "Title": "Update 2",
+            },
+        }
+
+        updates_refresh = {
+            "a0f997b1-1abe-4a46-941f-b37f732f9fbd": {
+                "Downloaded": False,
+                "KBs": ["KB3193497"],
+                "Installed": False,
+                "NeedsReboot": False,
+                "Title": "Update 1",
+            },
+            "eac02b09-d745-4891-b80f-400e0e5e4b6d": {
+                "Downloaded": True,
+                "KBs": ["KB4052623"],
+                "Installed": True,
+                "NeedsReboot": True,
+                "Title": "Update 2",
+            },
+            "eac02c07-d744-4892-b80f-312d045e4ccc": {
+                "Downloaded": True,
+                "KBs": ["KB4052444"],
+                "Installed": True,
+                "NeedsReboot": False,
+                "Title": "Update 3",
+            },
+        }
+
+        # Mocks the connection to the Windows Update Agent
+        mock_wua = MagicMock()
+        # Mocks the initial search
+        mock_wua.search = MagicMock()
+        # Mocks the number of updates found.
+        mock_wua.search().count.return_value = 1
+        # Mocks the the updates collection object
+        mock_wua.search().updates = update_search_obj
+
+        # This mocks the updates collection in the install variable. This will
+        # get populated to as matches are found with the Add method
+        mock_updates = MagicMock()
+        # Needs to return the number of updates that need to be installed
+        # (IsInstalled = False)
+        mock_updates.count.return_value = 1
+        # Returns the updates that need to be installed as a dict
+        mock_updates.list.return_value = update_search_dict
+
+        # This gives us post_info
+        mock_wua.updates = MagicMock()
+        # Mock a refresh of the updates recognized by the machine. This would
+        # occur post install. This is compared with the updates on the machine
+        # to determine if the update was successful
+        mock_wua.updates().list.return_value = updates_refresh
+
+        patch_winapi_com = patch("salt.utils.winapi.Com", autospec=True)
+        patch_dispatch = patch("win32com.client.Dispatch", autospec=True)
+        patch_wua = patch(
+            "salt.utils.win_update.WindowsUpdateAgent",
+            autospec=True,
+            return_value=mock_wua,
+        )
+        patch_update_collection = patch(
+            "salt.utils.win_update.Updates", autospec=True, return_value=mock_updates
+        )
+        patch_opts = patch.dict(win_wua.__opts__, {"test": False})
+
+        with patch_winapi_com, patch_dispatch, patch_wua, patch_update_collection, patch_opts:
+            expected = {
+                'changes': {
+                    'installed': {
+                        'eac02b09-d745-4891-b80f-400e0e5e4b6d': {
+                            'KBs': ['KB4052623'],
+                            'NeedsReboot': True,
+                            'Title': 'Update 2...'}
+                    }
+                },
+                'comment': 'Updates installed successfully',
+                'name': 'KB4062623',
+                'result': True}
+            result = win_wua.installed(name="KB4062623")
+            self.assertDictEqual(result, expected)
+
+    def test_installed_no_updates(self):
+        """
+        Test installed function when no updates are found.
+        """
+        # Mocks the connection to the Windows Update Agent
+        mock_wua = MagicMock()
+        # Mocks the initial search
+        mock_wua.search = MagicMock()
+        # Mocks the number of updates found.
+        mock_wua.search().count.return_value = 0
+
+        patch_winapi_com = patch("salt.utils.winapi.Com", autospec=True)
+        patch_dispatch = patch("win32com.client.Dispatch", autospec=True)
+        patch_wua = patch(
+            "salt.utils.win_update.WindowsUpdateAgent",
+            autospec=True,
+            return_value=mock_wua,
+        )
+
+        with patch_winapi_com, patch_dispatch, patch_wua:
+            expected = {
+                "name": "KB4062623",
+                "changes": {},
+                "result": True,
+                "comment": "No updates found",
+            }
+            result = win_wua.installed(name="KB4062623")
+            self.assertDictEqual(result, expected)
+
+    @skipIf(sys.version_info < (3, 7), "Test requires Python 3.7")
+    def test_installed_test_mode(self):
+        """
+        Test installed function in test mode
+        """
+
+        @dataclass(unsafe_hash=True)
+        class UpdateRecordIdentity:
+            UpdateID: str
+
+        @dataclass(unsafe_hash=True)
+        class UpdateRecord:
+            KBArticleIDs: list = field(compare=False)
+            Identity: UpdateRecordIdentity
+            IsDownloaded: bool
+            IsInstalled: bool
+            Title: str
+
+        update_search_obj = {
+            UpdateRecord(
+                KBArticleIDs=["4052623"],
+                Identity=UpdateRecordIdentity(
+                    UpdateID="eac02b09-d745-4891-b80f-400e0e5e4b6d"
+                ),
+                IsDownloaded=False,
+                IsInstalled=False,
+                Title="Update 2"
+            ),
+        }
+
+        # Mocks the connection to the Windows Update Agent
+        mock_wua = MagicMock()
+        # Mocks the initial search
+        mock_wua.search = MagicMock()
+        # Mocks the number of updates found.
+        mock_wua.search().count.return_value = 1
+        # Mocks the the updates collection object
+        mock_wua.search().updates = update_search_obj
+
+        # This mocks the updates collection in the install variable. This will
+        # get populated to as matches are found with the Add method
+        mock_updates = MagicMock()
+        # Needs to return the number of updates that need to be installed
+        # (IsInstalled = False)
+        mock_updates.count.return_value = 1
+
+        patch_winapi_com = patch("salt.utils.winapi.Com", autospec=True)
+        patch_dispatch = patch("win32com.client.Dispatch", autospec=True)
+        patch_wua = patch(
+            "salt.utils.win_update.WindowsUpdateAgent",
+            autospec=True,
+            return_value=mock_wua,
+        )
+        patch_update_collection = patch(
+            "salt.utils.win_update.Updates", autospec=True, return_value=mock_updates
+        )
+        patch_opts = patch.dict(win_wua.__opts__, {"test": True})
+
+        with patch_winapi_com, patch_dispatch, patch_wua, patch_update_collection, patch_opts:
+            expected = {
+                'changes': {},
+                'comment': 'Updates will be installed:',
+                # I don't know how to mock this part so the list will show up.
+                # It's an update collection object populated using the Add
+                # method. But this works for now
+                'name': 'KB4062623',
+                'result': None}
+            result = win_wua.installed(name="KB4062623")
+            self.assertDictEqual(result, expected)
+
+    @skipIf(sys.version_info < (3, 7), "Test requires Python 3.7")
+    def test_installed_already_installed(self):
+        """
+        Test installed function when the update is already installed
+        """
+
+        @dataclass(unsafe_hash=True)
+        class UpdateRecordIdentity:
+            UpdateID: str
+
+        @dataclass(unsafe_hash=True)
+        class UpdateRecord:
+            KBArticleIDs: list = field(compare=False)
+            Identity: UpdateRecordIdentity
+            IsDownloaded: bool
+            IsInstalled: bool
+            Title: str
+
+        update_search_obj = {
+            UpdateRecord(
+                KBArticleIDs=["4052623"],
+                Identity=UpdateRecordIdentity(
+                    UpdateID="eac02b09-d745-4891-b80f-400e0e5e4b6d"
+                ),
+                IsDownloaded=True,
+                IsInstalled=True,
+                Title="Update 2"
+            ),
+        }
+
+        # Mocks the connection to the Windows Update Agent
+        mock_wua = MagicMock()
+        # Mocks the initial search
+        mock_wua.search = MagicMock()
+        # Mocks the number of updates found.
+        mock_wua.search().count.return_value = 1
+        # Mocks the the updates collection object
+        mock_wua.search().updates = update_search_obj
+
+        # This mocks the updates collection in the install variable. This will
+        # get populated to as matches are found with the Add method
+        mock_updates = MagicMock()
+        # Needs to return the number of updates that need to be installed
+        # (IsInstalled = False)
+        mock_updates.count.return_value = 0
+
+        patch_winapi_com = patch("salt.utils.winapi.Com", autospec=True)
+        patch_dispatch = patch("win32com.client.Dispatch", autospec=True)
+        patch_wua = patch(
+            "salt.utils.win_update.WindowsUpdateAgent",
+            autospec=True,
+            return_value=mock_wua,
+        )
+        patch_update_collection = patch(
+            "salt.utils.win_update.Updates", autospec=True, return_value=mock_updates
+        )
+        patch_opts = patch.dict(win_wua.__opts__, {"test": True})
+
+        with patch_winapi_com, patch_dispatch, patch_wua, patch_update_collection, patch_opts:
+            expected = {
+                'changes': {},
+                'comment': 'Updates already installed: KB4052623',
+                'name': 'KB4062623',
+                'result': True}
+            result = win_wua.installed(name="KB4062623")
             self.assertDictEqual(result, expected)

--- a/tests/unit/states/test_win_wua.py
+++ b/tests/unit/states/test_win_wua.py
@@ -2,6 +2,8 @@
 Test the win_wua state module
 """
 # Import Python Libs
+import sys
+
 try:
     from dataclasses import dataclass, field
 
@@ -214,7 +216,8 @@ class WinWuaTestCase(TestCase, LoaderModuleMockMixin):
             result = win_wua.uptodate(name="NA")
             self.assertDictEqual(result, expected)
 
-    @skipIf(not HAS_DATACLASSES, "Test requires dataclasses available in Python 3.7")
+    @skipIf(not HAS_DATACLASSES, "Test requires dataclasses")
+    @skipIf(sys.version_info < (3, 6), "Does not support variable annotation")
     def test_installed(self):
         """
         Test installed function
@@ -355,7 +358,8 @@ class WinWuaTestCase(TestCase, LoaderModuleMockMixin):
             result = win_wua.installed(name="KB4062623")
             self.assertDictEqual(result, expected)
 
-    @skipIf(not HAS_DATACLASSES, "Test requires dataclasses available in Python 3.7")
+    @skipIf(not HAS_DATACLASSES, "Test requires dataclasses")
+    @skipIf(sys.version_info < (3, 6), "Does not support variable annotation")
     def test_installed_test_mode(self):
         """
         Test installed function in test mode
@@ -426,7 +430,8 @@ class WinWuaTestCase(TestCase, LoaderModuleMockMixin):
             result = win_wua.installed(name="KB4062623")
             self.assertDictEqual(result, expected)
 
-    @skipIf(not HAS_DATACLASSES, "Test requires dataclasses available in Python 3.7")
+    @skipIf(not HAS_DATACLASSES, "Test requires dataclasses")
+    @skipIf(sys.version_info < (3, 6), "Does not support variable annotation")
     def test_installed_already_installed(self):
         """
         Test installed function when the update is already installed

--- a/tests/unit/states/test_win_wua.py
+++ b/tests/unit/states/test_win_wua.py
@@ -6,7 +6,6 @@ from collections import namedtuple
 import salt.states.win_wua as win_wua
 import salt.utils.platform
 import salt.utils.win_update as win_update
-
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase, skipIf

--- a/tests/unit/states/test_win_wua.py
+++ b/tests/unit/states/test_win_wua.py
@@ -2,8 +2,11 @@
 Test the win_wua state module
 """
 # Import Python Libs
-import sys
-from dataclasses import dataclass, field
+try:
+    from dataclasses import dataclass, field
+    HAS_DATACLASSES = True
+except ImportError:
+    HAS_DATACLASSES = False
 
 # Import Salt Libs
 import salt.states.win_wua as win_wua
@@ -210,7 +213,7 @@ class WinWuaTestCase(TestCase, LoaderModuleMockMixin):
             result = win_wua.uptodate(name="NA")
             self.assertDictEqual(result, expected)
 
-    @skipIf(sys.version_info < (3, 7), "Test requires Python 3.7")
+    @skipIf(not HAS_DATACLASSES, "Test requires dataclasses only available in Python 3.7")
     def test_installed(self):
         """
         Test installed function
@@ -351,7 +354,7 @@ class WinWuaTestCase(TestCase, LoaderModuleMockMixin):
             result = win_wua.installed(name="KB4062623")
             self.assertDictEqual(result, expected)
 
-    @skipIf(sys.version_info < (3, 7), "Test requires Python 3.7")
+    @skipIf(not HAS_DATACLASSES, "Test requires dataclasses only available in Python 3.7")
     def test_installed_test_mode(self):
         """
         Test installed function in test mode
@@ -422,7 +425,7 @@ class WinWuaTestCase(TestCase, LoaderModuleMockMixin):
             result = win_wua.installed(name="KB4062623")
             self.assertDictEqual(result, expected)
 
-    @skipIf(sys.version_info < (3, 7), "Test requires Python 3.7")
+    @skipIf(not HAS_DATACLASSES, "Test requires dataclasses only available in Python 3.7")
     def test_installed_already_installed(self):
         """
         Test installed function when the update is already installed

--- a/tests/unit/states/test_win_wua.py
+++ b/tests/unit/states/test_win_wua.py
@@ -128,7 +128,7 @@ class WinWuaTestCase(TestCase, LoaderModuleMockMixin):
             result = win_wua.uptodate(name="NA")
             self.assertDictEqual(result, expected)
 
-    def test_uptodate_testmode(self):
+    def test_uptodate_test_mode(self):
         """
         Test uptodate function in test=true mode.
         """

--- a/tests/unit/states/test_win_wua.py
+++ b/tests/unit/states/test_win_wua.py
@@ -213,7 +213,7 @@ class WinWuaTestCase(TestCase, LoaderModuleMockMixin):
             result = win_wua.uptodate(name="NA")
             self.assertDictEqual(result, expected)
 
-    @skipIf(not HAS_DATACLASSES, "Test requires dataclasses only available in Python 3.7")
+    @skipIf(not HAS_DATACLASSES, "Test requires dataclasses available in Python 3.7")
     def test_installed(self):
         """
         Test installed function
@@ -354,7 +354,7 @@ class WinWuaTestCase(TestCase, LoaderModuleMockMixin):
             result = win_wua.installed(name="KB4062623")
             self.assertDictEqual(result, expected)
 
-    @skipIf(not HAS_DATACLASSES, "Test requires dataclasses only available in Python 3.7")
+    @skipIf(not HAS_DATACLASSES, "Test requires dataclasses available in Python 3.7")
     def test_installed_test_mode(self):
         """
         Test installed function in test mode
@@ -425,7 +425,7 @@ class WinWuaTestCase(TestCase, LoaderModuleMockMixin):
             result = win_wua.installed(name="KB4062623")
             self.assertDictEqual(result, expected)
 
-    @skipIf(not HAS_DATACLASSES, "Test requires dataclasses only available in Python 3.7")
+    @skipIf(not HAS_DATACLASSES, "Test requires dataclasses available in Python 3.7")
     def test_installed_already_installed(self):
         """
         Test installed function when the update is already installed

--- a/tests/unit/states/test_win_wua.py
+++ b/tests/unit/states/test_win_wua.py
@@ -4,6 +4,7 @@ Test the win_wua state module
 # Import Python Libs
 try:
     from dataclasses import dataclass, field
+
     HAS_DATACLASSES = True
 except ImportError:
     HAS_DATACLASSES = False

--- a/tests/unit/states/test_win_wua.py
+++ b/tests/unit/states/test_win_wua.py
@@ -2,14 +2,7 @@
 Test the win_wua state module
 """
 # Import Python Libs
-import sys
-
-try:
-    from dataclasses import dataclass, field
-
-    HAS_DATACLASSES = True
-except ImportError:
-    HAS_DATACLASSES = False
+from collections import namedtuple
 
 # Import Salt Libs
 import salt.states.win_wua as win_wua
@@ -94,6 +87,14 @@ class WinWuaTestCase(TestCase, LoaderModuleMockMixin):
 
     def setup_loader_modules(self):
         return {win_wua: {"__opts__": {"test": False}, "__env__": "base"}}
+
+    def setUp(self):
+        # Use named tuples to mock the Update objects returned by the search
+        self.UpdateRecordIdentity = namedtuple("UpdateRecordIdentity", "UpdateID")
+        self.UpdateRecord = namedtuple(
+            "UpdateRecord",
+            ["KBArticleIDs", "Identity", "IsDownloaded", "IsInstalled", "Title"],
+        )
 
     def test_uptodate_no_updates(self):
         """
@@ -216,30 +217,23 @@ class WinWuaTestCase(TestCase, LoaderModuleMockMixin):
             result = win_wua.uptodate(name="NA")
             self.assertDictEqual(result, expected)
 
-    @skipIf(not HAS_DATACLASSES, "Test requires dataclasses")
-    @skipIf(sys.version_info < (3, 6), "Does not support variable annotation")
     def test_installed(self):
         """
         Test installed function
         """
 
-        @dataclass(unsafe_hash=True)
-        class UpdateRecord:
-            KBs: list = field(compare=False)
-            ID: str
-            IsDownloaded: bool
-            IsInstalled: bool
-            Title: str
-
         update_search_obj = {
-            UpdateRecord(
-                KBs=["KB4052623"],
-                ID="eac02b09-d745-4891-b80f-400e0e5e4b6d",
+            self.UpdateRecord(
+                KBArticleIDs=("4052623",),
+                Identity=self.UpdateRecordIdentity(
+                    UpdateID="eac02b09-d745-4891-b80f-400e0e5e4b6d"
+                ),
                 IsDownloaded=False,
                 IsInstalled=False,
                 Title="Update 2",
             ),
         }
+
         update_search_dict = {
             "eac02b09-d745-4891-b80f-400e0e5e4b6d": {
                 "Downloaded": True,
@@ -358,29 +352,15 @@ class WinWuaTestCase(TestCase, LoaderModuleMockMixin):
             result = win_wua.installed(name="KB4062623")
             self.assertDictEqual(result, expected)
 
-    @skipIf(not HAS_DATACLASSES, "Test requires dataclasses")
-    @skipIf(sys.version_info < (3, 6), "Does not support variable annotation")
     def test_installed_test_mode(self):
         """
         Test installed function in test mode
         """
 
-        @dataclass(unsafe_hash=True)
-        class UpdateRecordIdentity:
-            UpdateID: str
-
-        @dataclass(unsafe_hash=True)
-        class UpdateRecord:
-            KBArticleIDs: list = field(compare=False)
-            Identity: UpdateRecordIdentity
-            IsDownloaded: bool
-            IsInstalled: bool
-            Title: str
-
         update_search_obj = {
-            UpdateRecord(
-                KBArticleIDs=["4052623"],
-                Identity=UpdateRecordIdentity(
+            self.UpdateRecord(
+                KBArticleIDs=("4052623",),
+                Identity=self.UpdateRecordIdentity(
                     UpdateID="eac02b09-d745-4891-b80f-400e0e5e4b6d"
                 ),
                 IsDownloaded=False,
@@ -430,29 +410,15 @@ class WinWuaTestCase(TestCase, LoaderModuleMockMixin):
             result = win_wua.installed(name="KB4062623")
             self.assertDictEqual(result, expected)
 
-    @skipIf(not HAS_DATACLASSES, "Test requires dataclasses")
-    @skipIf(sys.version_info < (3, 6), "Does not support variable annotation")
     def test_installed_already_installed(self):
         """
         Test installed function when the update is already installed
         """
 
-        @dataclass(unsafe_hash=True)
-        class UpdateRecordIdentity:
-            UpdateID: str
-
-        @dataclass(unsafe_hash=True)
-        class UpdateRecord:
-            KBArticleIDs: list = field(compare=False)
-            Identity: UpdateRecordIdentity
-            IsDownloaded: bool
-            IsInstalled: bool
-            Title: str
-
         update_search_obj = {
-            UpdateRecord(
-                KBArticleIDs=["4052623"],
-                Identity=UpdateRecordIdentity(
+            self.UpdateRecord(
+                KBArticleIDs=("4052623",),
+                Identity=self.UpdateRecordIdentity(
                     UpdateID="eac02b09-d745-4891-b80f-400e0e5e4b6d"
                 ),
                 IsDownloaded=True,

--- a/tests/unit/states/test_win_wua.py
+++ b/tests/unit/states/test_win_wua.py
@@ -1,15 +1,12 @@
 """
 Test the win_wua state module
 """
-# Import Python Libs
 from collections import namedtuple
 
-# Import Salt Libs
 import salt.states.win_wua as win_wua
 import salt.utils.platform
 import salt.utils.win_update as win_update
 
-# Import Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase, skipIf

--- a/tests/unit/states/test_win_wua.py
+++ b/tests/unit/states/test_win_wua.py
@@ -1,15 +1,9 @@
-# -*- coding: utf-8 -*-
 """
 Test the win_wua state module
 """
 # Import Python Libs
-from __future__ import (  # Import Salt Libs
-    absolute_import,
-    print_function,
-    unicode_literals,
-)
-from dataclasses import dataclass, field
 import sys
+from dataclasses import dataclass, field
 
 # Import Salt Libs
 import salt.states.win_wua as win_wua
@@ -81,7 +75,7 @@ UPDATES_LIST_NONE = {}
 UPDATES_SUMMARY = {"Installed": 10}
 
 
-class Updates(object):
+class Updates:
     def __init__(self):
         self.updates = []
 
@@ -236,7 +230,7 @@ class WinWuaTestCase(TestCase, LoaderModuleMockMixin):
                 ID="eac02b09-d745-4891-b80f-400e0e5e4b6d",
                 IsDownloaded=False,
                 IsInstalled=False,
-                Title="Update 2"
+                Title="Update 2",
             ),
         }
         update_search_dict = {
@@ -312,17 +306,19 @@ class WinWuaTestCase(TestCase, LoaderModuleMockMixin):
 
         with patch_winapi_com, patch_dispatch, patch_wua, patch_update_collection, patch_opts:
             expected = {
-                'changes': {
-                    'installed': {
-                        'eac02b09-d745-4891-b80f-400e0e5e4b6d': {
-                            'KBs': ['KB4052623'],
-                            'NeedsReboot': True,
-                            'Title': 'Update 2...'}
+                "changes": {
+                    "installed": {
+                        "eac02b09-d745-4891-b80f-400e0e5e4b6d": {
+                            "KBs": ["KB4052623"],
+                            "NeedsReboot": True,
+                            "Title": "Update 2...",
+                        }
                     }
                 },
-                'comment': 'Updates installed successfully',
-                'name': 'KB4062623',
-                'result': True}
+                "comment": "Updates installed successfully",
+                "name": "KB4062623",
+                "result": True,
+            }
             result = win_wua.installed(name="KB4062623")
             self.assertDictEqual(result, expected)
 
@@ -381,7 +377,7 @@ class WinWuaTestCase(TestCase, LoaderModuleMockMixin):
                 ),
                 IsDownloaded=False,
                 IsInstalled=False,
-                Title="Update 2"
+                Title="Update 2",
             ),
         }
 
@@ -415,13 +411,14 @@ class WinWuaTestCase(TestCase, LoaderModuleMockMixin):
 
         with patch_winapi_com, patch_dispatch, patch_wua, patch_update_collection, patch_opts:
             expected = {
-                'changes': {},
-                'comment': 'Updates will be installed:',
+                "changes": {},
+                "comment": "Updates will be installed:",
                 # I don't know how to mock this part so the list will show up.
                 # It's an update collection object populated using the Add
                 # method. But this works for now
-                'name': 'KB4062623',
-                'result': None}
+                "name": "KB4062623",
+                "result": None,
+            }
             result = win_wua.installed(name="KB4062623")
             self.assertDictEqual(result, expected)
 
@@ -451,7 +448,7 @@ class WinWuaTestCase(TestCase, LoaderModuleMockMixin):
                 ),
                 IsDownloaded=True,
                 IsInstalled=True,
-                Title="Update 2"
+                Title="Update 2",
             ),
         }
 
@@ -485,9 +482,10 @@ class WinWuaTestCase(TestCase, LoaderModuleMockMixin):
 
         with patch_winapi_com, patch_dispatch, patch_wua, patch_update_collection, patch_opts:
             expected = {
-                'changes': {},
-                'comment': 'Updates already installed: KB4052623',
-                'name': 'KB4062623',
-                'result': True}
+                "changes": {},
+                "comment": "Updates already installed: KB4052623",
+                "name": "KB4062623",
+                "result": True,
+            }
             result = win_wua.installed(name="KB4062623")
             self.assertDictEqual(result, expected)

--- a/tests/unit/utils/test_win_service.py
+++ b/tests/unit/utils/test_win_service.py
@@ -1,26 +1,13 @@
-# Import Python Libs
-import os
-
 # Import Salt Libs
 import salt.utils.platform
 
 # Import Salt Testing Libs
-from tests.support.mock import patch, MagicMock
 from tests.support.unit import TestCase, skipIf
 
 try:
     import salt.utils.win_service as win_service
-    from salt.exceptions import CommandExecutionError
 except Exception as exc:  # pylint: disable=broad-except
     win_service = exc
-
-# Import 3rd Party Libs
-try:
-    import pywintypes
-    import win32service
-    WINAPI = True
-except ImportError:
-    WINAPI = False
 
 
 class WinServiceImportTestCase(TestCase):
@@ -36,7 +23,6 @@ class WinServiceImportTestCase(TestCase):
 
 
 @skipIf(not salt.utils.platform.is_windows(), "Only test on Windows systems")
-@skipIf(not WINAPI, "Missing PyWin32 libraries")
 class WinServiceTestCase(TestCase):
     """
     Test cases for salt.utils.win_service

--- a/tests/unit/utils/test_win_service.py
+++ b/tests/unit/utils/test_win_service.py
@@ -11,14 +11,13 @@ except Exception as exc:  # pylint: disable=broad-except
 
 
 class WinServiceImportTestCase(TestCase):
-
     def test_import(self):
         """
         Simply importing should not raise an error, especially on Linux
         """
         if isinstance(win_service, Exception):
             raise Exception(
-                "Importing win_system caused traceback: {0}".format(win_service)
+                "Importing win_system caused traceback: {}".format(win_service)
             )
 
 
@@ -54,7 +53,7 @@ class WinServiceTestCase(TestCase):
             "Status_ServiceCode",
             "Status_WaitHint",
             "TagID",
-            "sid"
+            "sid",
         ]
         for field_name in field_names:
             self.assertIn(field_name, info)

--- a/tests/unit/utils/test_win_service.py
+++ b/tests/unit/utils/test_win_service.py
@@ -1,7 +1,5 @@
-# Import Salt Libs
 import salt.utils.platform
 
-# Import Salt Testing Libs
 from tests.support.unit import TestCase, skipIf
 
 try:

--- a/tests/unit/utils/test_win_service.py
+++ b/tests/unit/utils/test_win_service.py
@@ -1,0 +1,77 @@
+# Import Python Libs
+import os
+
+# Import Salt Libs
+import salt.utils.platform
+
+# Import Salt Testing Libs
+from tests.support.mock import patch, MagicMock
+from tests.support.unit import TestCase, skipIf
+
+try:
+    import salt.utils.win_service as win_service
+    from salt.exceptions import CommandExecutionError
+except Exception as exc:  # pylint: disable=broad-except
+    win_service = exc
+
+# Import 3rd Party Libs
+try:
+    import pywintypes
+    import win32service
+    WINAPI = True
+except ImportError:
+    WINAPI = False
+
+
+class WinServiceImportTestCase(TestCase):
+
+    def test_import(self):
+        """
+        Simply importing should not raise an error, especially on Linux
+        """
+        if isinstance(win_service, Exception):
+            raise Exception(
+                "Importing win_system caused traceback: {0}".format(win_service)
+            )
+
+
+@skipIf(not salt.utils.platform.is_windows(), "Only test on Windows systems")
+@skipIf(not WINAPI, "Missing PyWin32 libraries")
+class WinServiceTestCase(TestCase):
+    """
+    Test cases for salt.utils.win_service
+    """
+
+    def test_info(self):
+        """
+        Test service.info
+        """
+        # Get info about the spooler service
+        info = win_service.info("spooler")
+
+        # Make sure it returns these fields
+        field_names = [
+            "BinaryPath",
+            "ControlsAccepted",
+            "Dependencies",
+            "Description",
+            "DisplayName",
+            "ErrorControl",
+            "LoadOrderGroup",
+            "ServiceAccount",
+            "ServiceType",
+            "StartType",
+            "StartTypeDelayed",
+            "Status",
+            "Status_CheckPoint",
+            "Status_ExitCode",
+            "Status_ServiceCode",
+            "Status_WaitHint",
+            "TagID",
+            "sid"
+        ]
+        for field_name in field_names:
+            self.assertIn(field_name, info)
+
+        # Make sure it returns a valid Display Name
+        self.assertEqual(info["DisplayName"], "Print Spooler")

--- a/tests/unit/utils/test_win_service.py
+++ b/tests/unit/utils/test_win_service.py
@@ -1,5 +1,4 @@
 import salt.utils.platform
-
 from tests.support.unit import TestCase, skipIf
 
 try:


### PR DESCRIPTION
### What does this PR do?
- Adds some pre-flight checks for the win_wua module to make sure Windows Update is in a running state
- Fixes an issue introduced by Windows 10 2004 release that breaks anything that calls attributes from the InstallationBehavior COM object

### What issues does this PR fix or reference?
Fixes: #57762, #58025, #58061, #58098

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes