### PR TITLE
remove escaping of dbname in mysql.alter_db function.

### DIFF
--- a/changelog/51559.fixed
+++ b/changelog/51559.fixed
@@ -1,0 +1,1 @@
+remove escaping of dbname in mysql.alter_db function.

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -676,6 +676,12 @@ def _execute(cur, qry, args=None):
 def _sanitize_comments(content):
     # Remove comments which might affect line by line parsing
     # Regex should remove any text beginning with # (or --) not inside of ' or "
+    if not HAS_SQLPARSE:
+        log.error(
+            "_sanitize_comments unavailable, no python sqlparse library installed."
+        )
+        return content
+
     return sqlparse.format(content, strip_comments=True)
 
 
@@ -1104,8 +1110,9 @@ def alter_db(name, character_set=None, collate=None, **connection_args):
         return []
     cur = dbc.cursor()
     existing = db_get(name, **connection_args)
+    # escaping database name is not required because of backticks in query expression
     qry = "ALTER DATABASE `{}` CHARACTER SET {} COLLATE {};".format(
-        name.replace("%", r"\%").replace("_", r"\_"),
+        name,
         character_set or existing.get("character_set"),
         collate or existing.get("collate"),
     )

--- a/tests/pytests/unit/modules/test_mysql.py
+++ b/tests/pytests/unit/modules/test_mysql.py
@@ -515,6 +515,26 @@ def test_db_create():
     )
 
 
+def test_alter_db():
+    """
+    Test MySQL alter_db function in mysql exec module
+    """
+    mock_get_db = {
+        "character_set": "utf8",
+        "collate": "utf8_unicode_ci",
+        "name": "my_test",
+    }
+    mock = MagicMock(return_value=mock_get_db)
+    with patch.object(mysql, "db_get", return_value=mock) as mock_db_get:
+        _test_call(
+            mysql.alter_db,
+            "ALTER DATABASE `my_test` CHARACTER SET utf8 COLLATE utf8_unicode_ci;",
+            "my_test",
+            "utf8",
+            "utf8_unicode_ci",
+        )
+
+
 def test_user_list():
     """
     Test MySQL user_list function in mysql exec module


### PR DESCRIPTION
### What does this PR do?
Fixes issue #51559

### What issues does this PR fix or reference?
Fixes:
#51559

### Previous Behavior
In case we run mysql_database state with different (charset or collation) than setup in database, and the database has underscore ("_") on the name, the mysql.alter_db module function is unable to update the database.

### New Behavior
Databases with "_" (underscore) in the name will get updated by mysql_database.present if collation or charset differ of current values.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
