### PR TITLE
[WIP] Add versionadded docs for new features

### DIFF
--- a/doc/topics/development/features.rst
+++ b/doc/topics/development/features.rst
@@ -1,0 +1,12 @@
+.. _writing_features:
+
+================
+Writing Features
+================
+
+Version Added
+-------------
+
+When adding new features in Salt, you need to add ``.. versionadded:: NEXT_RELEASE`` in
+the modules documentation. The release team will ensure ``NEXT_RELEASE`` is updated to
+the correct version.


### PR DESCRIPTION
### What does this PR do?
Adds a new "Writing Features" doc, that explains using the `versionadded` for new features.

Thanks to @nicholasmhughes for the inspiration here: https://github.com/saltstack/salt/pull/56259#discussion_r465781140 

I've included this to be WIP, to allow for any further discussion and opinions on this approach before merge. Each release we search/replace for the `<feature_name>` to `<release number>` for versionadded. If we just include one notation `NEXT_RELEASE` than a developer would not even need to know the name of the releases or have to update their PRs if it does not make it into said release.
