### PR TITLE
Correct TypeError in _openbsd_remotes_on()

### DIFF
--- a/changelog/58158.fixed
+++ b/changelog/58158.fixed
@@ -1,0 +1,1 @@
+Fix occasional crash on OpenBSD due to buglet in network._openbsd_remotes_on.

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1817,7 +1817,7 @@ def _openbsd_remotes_on(port, which_end):
         log.error("Failed netstat")
         raise
 
-    lines = data.split("\n")
+    lines = salt.utils.stringutils.to_str(data).split("\n")
     for line in lines:
         if "ESTABLISHED" not in line:
             continue

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 # pylint: disable=invalid-name
 """
 Define some generic socket functions for network modules
 """
 
-from __future__ import absolute_import, print_function, unicode_literals
 
 import fnmatch
 import itertools
@@ -139,7 +137,7 @@ def _generate_minion_id():
 
         def append(self, p_object):
             if p_object and p_object not in self and not self.filter(p_object):
-                super(DistinctList, self).append(p_object)
+                super().append(p_object)
             return self
 
         def extend(self, iterable):
@@ -201,7 +199,7 @@ def _generate_minion_id():
                     if hst:
                         if hst[0][:4] in ("127.", "::1") or len(hst) == 1:
                             hosts.extend(hst)
-        except IOError:
+        except OSError:
             pass
 
     # include public and private ipaddresses
@@ -655,7 +653,7 @@ def cidr_to_ipv4_netmask(cidr_bits):
             netmask += "255"
             cidr_bits -= 8
         else:
-            netmask += "{0:d}".format(256 - (2 ** (8 - cidr_bits)))
+            netmask += "{:d}".format(256 - (2 ** (8 - cidr_bits)))
             cidr_bits = 0
     return netmask
 
@@ -819,9 +817,9 @@ def _interfaces_ifconfig(out):
                     expand_mac = []
                     for chunk in data["hwaddr"].split(":"):
                         expand_mac.append(
-                            "0{0}".format(chunk)
+                            "0{}".format(chunk)
                             if len(chunk) < 2
-                            else "{0}".format(chunk)
+                            else "{}".format(chunk)
                         )
                     data["hwaddr"] = ":".join(expand_mac)
             if mip:
@@ -897,27 +895,27 @@ def linux_interfaces():
     ifconfig_path = None if ip_path else salt.utils.path.which("ifconfig")
     if ip_path:
         cmd1 = subprocess.Popen(
-            "{0} link show".format(ip_path),
+            "{} link show".format(ip_path),
             shell=True,
             close_fds=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         ).communicate()[0]
         cmd2 = subprocess.Popen(
-            "{0} addr show".format(ip_path),
+            "{} addr show".format(ip_path),
             shell=True,
             close_fds=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         ).communicate()[0]
         ifaces = _interfaces_ip(
-            "{0}\n{1}".format(
+            "{}\n{}".format(
                 salt.utils.stringutils.to_str(cmd1), salt.utils.stringutils.to_str(cmd2)
             )
         )
     elif ifconfig_path:
         cmd = subprocess.Popen(
-            "{0} -a".format(ifconfig_path),
+            "{} -a".format(ifconfig_path),
             shell=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -998,7 +996,7 @@ def netbsd_interfaces():
 
     ifconfig_path = salt.utils.path.which("ifconfig")
     cmd = subprocess.Popen(
-        "{0} -a".format(ifconfig_path),
+        "{} -a".format(ifconfig_path),
         shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -1083,7 +1081,7 @@ def get_net_start(ipaddr, netmask):
     """
     Return the address of the network
     """
-    net = ipaddress.ip_network("{0}/{1}".format(ipaddr, netmask), strict=False)
+    net = ipaddress.ip_network("{}/{}".format(ipaddr, netmask), strict=False)
     return str(net.network_address)
 
 
@@ -1105,7 +1103,7 @@ def calc_net(ipaddr, netmask=None):
     (The IP can be any IP inside the subnet)
     """
     if netmask is not None:
-        ipaddr = "{0}/{1}".format(ipaddr, netmask)
+        ipaddr = "{}/{}".format(ipaddr, netmask)
 
     return str(ipaddress.ip_network(ipaddr, strict=False))
 
@@ -1128,7 +1126,7 @@ def _get_iface_info(iface):
     if iface in iface_info.keys():
         return iface_info, False
     else:
-        error_msg = 'Interface "{0}" not in available interfaces: "{1}"' "".format(
+        error_msg = 'Interface "{}" not in available interfaces: "{}"' "".format(
             iface, '", "'.join(iface_info.keys())
         )
         log.error(error_msg)
@@ -1141,7 +1139,7 @@ def _hw_addr_aix(iface):
     MAC address not available in through interfaces
     """
     cmd = subprocess.Popen(
-        "entstat -d {0} | grep 'Hardware Address'".format(iface),
+        "entstat -d {} | grep 'Hardware Address'".format(iface),
         shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -1153,7 +1151,7 @@ def _hw_addr_aix(iface):
             mac_addr = comps[2].strip("'").strip()
             return mac_addr
 
-    error_msg = 'Interface "{0}" either not available or does not contain a hardware address'.format(
+    error_msg = 'Interface "{}" either not available or does not contain a hardware address'.format(
         iface
     )
     log.error(error_msg)
@@ -1239,11 +1237,11 @@ def _subnets(proto="inet", interfaces_=None):
         for intf in addrs:
             if subnet in intf:
                 intf = ipaddress.ip_interface(
-                    "{0}/{1}".format(intf["address"], intf[subnet])
+                    "{}/{}".format(intf["address"], intf[subnet])
                 )
             else:
                 intf = ipaddress.ip_interface(
-                    "{0}/{1}".format(intf["address"], dflt_cidr)
+                    "{}/{}".format(intf["address"], dflt_cidr)
                 )
             if not intf.is_loopback:
                 ret.add(intf.network)
@@ -1310,7 +1308,7 @@ def _filter_interfaces(interface=None, interface_data=None):
         ret = {
             k: v
             for k, v in ifaces.items()
-            if any((fnmatch.fnmatch(k, pat) for pat in interface))
+            if any(fnmatch.fnmatch(k, pat) for pat in interface)
         }
         # pylint: enable=not-an-iterable
     return ret
@@ -1372,7 +1370,7 @@ def _ip_networks(
         _net = addr.get("netmask" if proto == "inet" else "prefixlen")
         if _ip and _net:
             try:
-                ip_net = ipaddress.ip_network("{0}/{1}".format(_ip, _net), strict=False)
+                ip_net = ipaddress.ip_network("{}/{}".format(_ip, _net), strict=False)
             except Exception:  # pylint: disable=broad-except
                 continue
             if not ip_net.is_loopback or include_loopback:
@@ -1461,7 +1459,7 @@ def hex2ip(hex_ip, invert=False):
         return "{3}.{2}.{1}.{0}".format(
             hip >> 24 & 255, hip >> 16 & 255, hip >> 8 & 255, hip & 255
         )
-    return "{0}.{1}.{2}.{3}".format(
+    return "{}.{}.{}.{}".format(
         hip >> 24 & 255, hip >> 16 & 255, hip >> 8 & 255, hip & 255
     )
 
@@ -1481,8 +1479,8 @@ def mac2eui64(mac, prefix=None):
     else:
         try:
             net = ipaddress.ip_network(prefix, strict=False)
-            euil = int("0x{0}".format(eui64), 16)
-            return "{0}/{1}".format(net[euil], net.prefixlen)
+            euil = int("0x{}".format(eui64), 16)
+            return "{}/{}".format(net[euil], net.prefixlen)
         except Exception:  # pylint: disable=broad-except
             return
 
@@ -1608,7 +1606,7 @@ def _netlink_tool_remote_on(port, which_end):
     tcp_end = "dst" if which_end == "remote_port" else "src"
     try:
         data = subprocess.check_output(
-            ["ss", "-ant", tcp_end, ":{0}".format(port)]
+            ["ss", "-ant", tcp_end, ":{}".format(port)]
         )  # pylint: disable=minimum-python-version
     except subprocess.CalledProcessError:
         log.error("Failed ss")
@@ -1697,7 +1695,7 @@ def _freebsd_remotes_on(port, which_end):
     remotes = set()
 
     try:
-        cmd = salt.utils.args.shlex_split("sockstat -4 -c -p {0}".format(port))
+        cmd = salt.utils.args.shlex_split("sockstat -4 -c -p {}".format(port))
         data = subprocess.check_output(cmd)  # pylint: disable=minimum-python-version
     except subprocess.CalledProcessError as ex:
         log.error('Failed "sockstat" with returncode = %s', ex.returncode)
@@ -1759,7 +1757,7 @@ def _netbsd_remotes_on(port, which_end):
     remotes = set()
 
     try:
-        cmd = salt.utils.args.shlex_split("sockstat -4 -c -n -p {0}".format(port))
+        cmd = salt.utils.args.shlex_split("sockstat -4 -c -n -p {}".format(port))
         data = subprocess.check_output(cmd)  # pylint: disable=minimum-python-version
     except subprocess.CalledProcessError as ex:
         log.error('Failed "sockstat" with returncode = %s', ex.returncode)
@@ -1898,7 +1896,7 @@ def _linux_remotes_on(port, which_end):
         data = subprocess.check_output(
             [
                 "lsof",
-                "-iTCP:{0:d}".format(port),
+                "-iTCP:{:d}".format(port),
                 "-n",
                 "-P",
             ]  # pylint: disable=minimum-python-version
@@ -2008,7 +2006,7 @@ def gen_mac(prefix="AC:DE:48"):
      - https://www.wireshark.org/tools/oui-lookup.html
      - https://en.wikipedia.org/wiki/MAC_address
     """
-    return "{0}:{1:02X}:{2:02X}:{3:02X}".format(
+    return "{}:{:02X}:{:02X}:{:02X}".format(
         prefix,
         random.randint(0, 0xFF),
         random.randint(0, 0xFF),
@@ -2071,14 +2069,14 @@ def dns_check(addr, port, safe=False, ipv6=None):
         ip_addrs = _test_addrs(addrinfo, port)
     except TypeError:
         err = (
-            "Attempt to resolve address '{0}' failed. Invalid or unresolveable address"
+            "Attempt to resolve address '{}' failed. Invalid or unresolveable address"
         ).format(addr)
         raise SaltSystemExit(code=42, msg=err)
-    except socket.error:
+    except OSError:
         pass
 
     if not ip_addrs:
-        err = ("DNS lookup or connection check of '{0}' failed.").format(addr)
+        err = ("DNS lookup or connection check of '{}' failed.").format(addr)
         if safe:
             if salt.log.is_console_configured():
                 # If logging is not configured it also means that either
@@ -2113,7 +2111,7 @@ def _test_addrs(addrinfo, port):
 
             ip_addrs = [ip_addr]
             break
-        except socket.error:
+        except OSError:
             pass
     return ip_addrs
 

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, print_function, unicode_literals
-
 import logging
 import socket
 import textwrap
@@ -609,7 +606,7 @@ class NetworkTestCase(TestCase):
             with patch("salt.utils.platform.is_freebsd", lambda: True):
                 with patch("subprocess.check_output", return_value=FREEBSD_SOCKSTAT):
                     remotes = network._freebsd_remotes_on("4506", "remote")
-                    self.assertEqual(remotes, set(["127.0.0.1"]))
+                    self.assertEqual(remotes, {"127.0.0.1"})
 
     def test_freebsd_remotes_on_with_fat_pid(self):
         with patch("salt.utils.platform.is_sunos", lambda: False):
@@ -619,7 +616,7 @@ class NetworkTestCase(TestCase):
                     return_value=FREEBSD_SOCKSTAT_WITH_FAT_PID,
                 ):
                     remotes = network._freebsd_remotes_on("4506", "remote")
-                    self.assertEqual(remotes, set(["127.0.0.1"]))
+                    self.assertEqual(remotes, {"127.0.0.1"})
 
     def test_netlink_tool_remote_on_a(self):
         with patch("salt.utils.platform.is_sunos", lambda: False):
@@ -628,14 +625,12 @@ class NetworkTestCase(TestCase):
                     "subprocess.check_output", return_value=LINUX_NETLINK_SS_OUTPUT
                 ):
                     remotes = network._netlink_tool_remote_on("4506", "local")
-                    self.assertEqual(
-                        remotes, set(["192.168.122.177", "::ffff:127.0.0.1"])
-                    )
+                    self.assertEqual(remotes, {"192.168.122.177", "::ffff:127.0.0.1"})
 
     def test_netlink_tool_remote_on_b(self):
         with patch("subprocess.check_output", return_value=NETLINK_SS):
             remotes = network._netlink_tool_remote_on("4505", "remote_port")
-            self.assertEqual(remotes, set(["127.0.0.1", "::ffff:1.2.3.4"]))
+            self.assertEqual(remotes, {"127.0.0.1", "::ffff:1.2.3.4"})
 
     def test_generate_minion_id_distinct(self):
         """

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -117,6 +117,12 @@ ESTAB      0      0                    127.0.0.1:56726                    127.0.
 ESTAB      0      0                    ::ffff:1.2.3.4:5678                ::ffff:1.2.3.4:4505
 """
 
+OPENBSD_NETSTAT = """\
+Active Internet connections
+Proto   Recv-Q Send-Q  Local Address          Foreign Address        (state)
+tcp          0      0  127.0.0.1.4506         127.0.0.1.45329         ESTABLISHED
+"""
+
 LINUX_NETLINK_SS_OUTPUT = """\
 State       Recv-Q Send-Q                                                            Local Address:Port                                                                           Peer Address:Port
 TIME-WAIT   0      0                                                                         [::1]:8009                                                                                  [::1]:40368
@@ -616,6 +622,13 @@ class NetworkTestCase(TestCase):
                     return_value=FREEBSD_SOCKSTAT_WITH_FAT_PID,
                 ):
                     remotes = network._freebsd_remotes_on("4506", "remote")
+                    self.assertEqual(remotes, {"127.0.0.1"})
+
+    def test_openbsd_remotes_on(self):
+        with patch("salt.utils.platform.is_sunos", lambda: False):
+            with patch("salt.utils.platform.is_openbsd", lambda: True):
+                with patch("subprocess.check_output", return_value=OPENBSD_NETSTAT):
+                    remotes = network._openbsd_remotes_on("4506", "remote")
                     self.assertEqual(remotes, {"127.0.0.1"})
 
     def test_netlink_tool_remote_on_a(self):


### PR DESCRIPTION
### What does this PR do?

This function could fail with a `TypeError: a bytes-like object is expected, not 'str'`

This was the only `_remotes_on()` function which wasn't using the `salt.utils.stringutils.to_str()` helper yet.

### What issues does this PR fix or reference?


### Previous Behavior

Minion would crash.

### New Behavior

It doesn't :)

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes