### PR TITLE
Disable locale related test on FreeBSD

### DIFF
--- a/tests/integration/modules/test_localemod.py
+++ b/tests/integration/modules/test_localemod.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import, print_function, unicode_literals
-
 import pytest
 import salt.utils.platform
 from tests.support.case import ModuleCase
@@ -17,6 +13,10 @@ def _find_new_locale(current_locale):
 
 @skipIf(salt.utils.platform.is_windows(), "minion is windows")
 @skipIf(salt.utils.platform.is_darwin(), "locale method is not supported on mac")
+@skipIf(
+    salt.utils.platform.is_freebsd(),
+    "locale method is supported only within login classes or environment variables",
+)
 @requires_salt_modules("locale")
 @pytest.mark.windows_whitelisted
 class LocaleModuleTest(ModuleCase):
@@ -36,9 +36,7 @@ class LocaleModuleTest(ModuleCase):
 
         if char_maps["retcode"] and char_maps["stderr"]:
             self.skipTest(
-                "{0}. Cannot generate locale. Skipping test.".format(
-                    char_maps["stderr"]
-                )
+                "{}. Cannot generate locale. Skipping test.".format(char_maps["stderr"])
             )
 
         locale = self.run_function("locale.get_locale")


### PR DESCRIPTION
### What does this PR do?
Disable locale related test on FreeBSD. locale method is supported only within login classes or environment variables.