### PR TITLE
Fix pending reboot

### DIFF
--- a/salt/grains/pending_reboot.py
+++ b/salt/grains/pending_reboot.py
@@ -26,6 +26,6 @@ def __virtual__():
 
 def pending_reboot():
     """
-    A grain that indicates that the system is pending a reboot.
+    A grain that indicates that a Windows system is pending a reboot.
     """
     return {"pending_reboot": salt.utils.win_system.get_pending_reboot()}

--- a/salt/grains/pending_reboot.py
+++ b/salt/grains/pending_reboot.py
@@ -1,11 +1,8 @@
-# -*- coding: utf-8 -*-
 """
 Grain that indicates the system is pending a reboot
 See functions in salt.utils.win_system to see what conditions would indicate
 a reboot is pending
 """
-from __future__ import absolute_import, print_function, unicode_literals
-
 # Import python libs
 import logging
 

--- a/salt/utils/win_system.py
+++ b/salt/utils/win_system.py
@@ -111,7 +111,7 @@ def get_pending_computer_name():
         # and should always be present
         return None
     if pending:
-        return pending if pending != current else None
+        return pending if pending.lower() != current.lower() else None
 
 
 def get_pending_component_servicing():

--- a/salt/utils/win_system.py
+++ b/salt/utils/win_system.py
@@ -318,7 +318,9 @@ def get_pending_update():
         salt.utils.win_system.get_pending_update()
     """
     # So long as any of the registry keys exists, a reboot is pending.
-    base_key = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\WindowsUpdate\\Auto Update"
+    base_key = (
+        "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\WindowsUpdate\\Auto Update"
+    )
     sub_keys = ("RebootRequired", "PostRebootReporting")
     for sub_key in sub_keys:
         key = "\\".join((base_key, sub_key))

--- a/salt/utils/win_system.py
+++ b/salt/utils/win_system.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Win System Utils
 
@@ -8,9 +7,6 @@ Functions shared with salt.modules.win_system and salt.grains.pending_reboot
 """
 # NOTE: DO NOT USE RAW STRINGS IN THIS MODULE! UNICODE_LITERALS DOES NOT PLAY
 # NICELY WITH RAW STRINGS CONTAINING \u or \U.
-
-# When production windows installer is using Python 3, Python 2 code can be removed
-from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
 import logging

--- a/tests/unit/utils/test_win_system.py
+++ b/tests/unit/utils/test_win_system.py
@@ -212,15 +212,6 @@ class WinSystemTestCase(TestCase):
         with patch("salt.utils.win_reg.key_exists", side_effect=[False, True]):
             self.assertTrue(win_system.get_pending_update())
 
-    def test_get_pending_update_true_3(self):
-        """
-        If the Pending key contains subkeys, should return True
-        """
-        with patch("salt.utils.win_reg.key_exists", side_effect=[False, False]), patch(
-            "salt.utils.win_reg.list_keys", return_value=["subkey"]
-        ):
-            self.assertTrue(win_system.get_pending_update())
-
     def test_get_reboot_required_witnessed_false_1(self):
         """
         The ``Reboot Required`` value name does not exist, should return False

--- a/tests/unit/utils/test_win_system.py
+++ b/tests/unit/utils/test_win_system.py
@@ -1,8 +1,4 @@
-# -*- coding: utf-8 -*-
-
 # Import Python Libs
-from __future__ import absolute_import, print_function, unicode_literals
-
 import os
 
 # Import Salt Libs
@@ -26,7 +22,7 @@ class WinSystemImportTestCase(TestCase):
     def test_import(self):
         if isinstance(win_system, Exception):
             raise Exception(
-                "Importing win_system caused traceback: {0}".format(win_system)
+                "Importing win_system caused traceback: {}".format(win_system)
             )
 
 


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with the `pending_reboot` grains where it was returning a false positive.

### Previous Behavior
The `pending_reboot` grain was returning ``True`` when the system did not require a reboot.

### New Behavior
The  `pending_reboot` grain is less strict in determining `pending_reboot` status.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes