### PR TITLE
Reconfigure syndic publication to publish to all upstream masters

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -14,8 +14,8 @@ of the Salt system each have a respective configuration file. The
     :ref:`Example master configuration file <configuration-examples-master>`.
 
 The configuration file for the salt-master is located at ``/etc/salt/master``
-by default. Atomic included configuration files can be placed in 
-``/etc/salt/master.d/*.conf``. Warning: files with other suffixes than .conf will 
+by default. Atomic included configuration files can be placed in
+``/etc/salt/master.d/*.conf``. Warning: files with other suffixes than .conf will
 not be included. A notable exception is FreeBSD, where the configuration file is
 located at ``/usr/local/etc/salt``. The available options are as follows:
 
@@ -5079,22 +5079,6 @@ check in with their lists of expected minions before giving up.
 .. code-block:: yaml
 
     syndic_wait: 5
-
-.. conf_master:: syndic_forward_all_events
-
-``syndic_forward_all_events``
------------------------------
-
-.. versionadded:: 2017.7.0
-
-Default: ``False``
-
-Option on multi-syndic or single when connected to multiple masters to be able to
-send events to all connected masters.
-
-.. code-block:: yaml
-
-    syndic_forward_all_events: False
 
 
 .. _peer-publish-settings:

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -627,7 +627,6 @@ VALID_OPTS = immutabletypes.freeze(
         # specify 'random' (default) or 'ordered'. If set to 'random' masters will be iterated in random
         # order if 'ordered' the configured order will be used.
         "syndic_failover": six.string_types,
-        "syndic_forward_all_events": bool,
         "runner_dirs": list,
         "client_acl_verify": bool,
         "publisher_acl": dict,
@@ -1382,7 +1381,6 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze(
         "preserve_minion_cache": False,
         "syndic_master": "masterofmasters",
         "syndic_failover": "random",
-        "syndic_forward_all_events": False,
         "syndic_log_file": os.path.join(salt.syspaths.LOGS_DIR, "syndic"),
         "syndic_pidfile": os.path.join(salt.syspaths.PIDFILE_DIR, "salt-syndic.pid"),
         "outputter_dirs": [],

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -3434,8 +3434,13 @@ class SyndicManager(MinionBase):
             future, data = self.pub_futures.get(master, (None, None))
             if future is not None:
                 if not future.done():
-                    continue
-                if future.exception():
+                    if master == master_id:
+                        # Targeted master previous send not done yet, call again later
+                        return False
+                    else:
+                        # Fallback master is busy, try the next one
+                        continue
+                elif future.exception():
                     # Previous execution on this master returned an error
                     log.error(
                         "Unable to call %s on %s, trying another...", func, master


### PR DESCRIPTION
### What does this PR do?
Solves an issue with events being forwarded to only one master by syndic nodes.

### What issues does this PR fix or reference?
Fixes: #58193 

### Previous Behavior
Would return on first successful master pub

### New Behavior
Publishes to all masters possible and returns a failure if none are successful

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
