### PR TITLE
Fix docstring examples that had been erroneously changed

### DIFF
--- a/salt/modules/salt_version.py
+++ b/salt/modules/salt_version.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Access Salt's elemental release code-names.
 
@@ -32,15 +31,11 @@ A simple example might be something like the following:
 """
 
 # Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
 import salt.utils.versions
 import salt.version
-
-# Import Salt libs
-from salt.ext import six
 
 log = logging.getLogger(__name__)
 
@@ -170,9 +165,7 @@ def _check_release_cmp(name):
         log.info("Release code name {} was not found.".format(name))
         return None
 
-    current_version = six.text_type(
-        salt.version.SaltStackVersion(*salt.version.__version_info__)
-    )
+    current_version = str(salt.version.SaltStackVersion(*salt.version.__version_info__))
     current_version = current_version.rsplit(".", 1)[0]
     version_cmp = salt.utils.versions.version_cmp(current_version, map_version)
     return version_cmp

--- a/salt/modules/salt_version.py
+++ b/salt/modules/salt_version.py
@@ -126,7 +126,7 @@ def greater_than(name):
 
     .. code-block:: bash
 
-        salt '*' salt_version.greater_than '3001'
+        salt '*' salt_version.greater_than 'Oxygen'
     """
     if _check_release_cmp(name) == 1:
         log.info("The minion's version code name is greater than '{}'.".format(name))
@@ -147,7 +147,7 @@ def less_than(name):
 
     .. code-block:: bash
 
-        salt '*' salt_version.less_than '3001'
+        salt '*' salt_version.less_than 'Oxygen'
     """
     if _check_release_cmp(name) == -1:
         log.info("The minion's version code name is less than '{}'.".format(name))


### PR DESCRIPTION

### What does this PR do?

Fixes docstring examples that had been erroneously changed
by replacing `3001` with example release name`Oxygen`.

### What issues does this PR fix or reference?

None

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

Is changelog needed for docs-only PR?

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
