### PR TITLE
Death to globals!

### DIFF
--- a/salt/utils/immutabletypes.py
+++ b/salt/utils/immutabletypes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
     :codeauthor: Pedro Algarvio (pedro@algarvio.me)
 
@@ -8,7 +7,6 @@
 
     Immutable types
 """
-from __future__ import absolute_import, unicode_literals
 
 import copy
 from collections.abc import Mapping, Sequence, Set
@@ -32,7 +30,7 @@ class ImmutableDict(Mapping):
         return freeze(self.__obj[key])
 
     def __repr__(self):
-        return "<{0} {1}>".format(self.__class__.__name__, repr(self.__obj))
+        return "<{} {}>".format(self.__class__.__name__, repr(self.__obj))
 
     def __deepcopy__(self, memo):
         return copy.deepcopy(self.__obj)
@@ -68,9 +66,15 @@ class ImmutableList(Sequence):
         return freeze(self.__obj[key])
 
     def __repr__(self):
-        return "<{0} {1}>".format(self.__class__.__name__, repr(self.__obj))
+        return "<{} {}>".format(self.__class__.__name__, repr(self.__obj))
 
     def __deepcopy__(self, memo):
+        return copy.deepcopy(self.__obj)
+
+    def copy(self):
+        """
+        Return an un-frozen copy of self
+        """
         return copy.deepcopy(self.__obj)
 
 
@@ -92,9 +96,15 @@ class ImmutableSet(Set):
         return key in self.__obj
 
     def __repr__(self):
-        return "<{0} {1}>".format(self.__class__.__name__, repr(self.__obj))
+        return "<{} {}>".format(self.__class__.__name__, repr(self.__obj))
 
     def __deepcopy__(self, memo):
+        return copy.deepcopy(self.__obj)
+
+    def copy(self):
+        """
+        Return an un-frozen copy of self
+        """
         return copy.deepcopy(self.__obj)
 
 

--- a/tests/unit/modules/test_win_lgpo.py
+++ b/tests/unit/modules/test_win_lgpo.py
@@ -1,9 +1,8 @@
-# -*- coding: utf-8 -*-
 """
 :codeauthor: Shane Lee <slee@saltstack.com>
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
+import copy
 import glob
 import os
 
@@ -19,13 +18,6 @@ from tests.support.helpers import destructiveTest, slowTest
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, Mock, patch
 from tests.support.unit import TestCase, skipIf
-
-# We're going to actually use the loader, without grains (slow)
-opts = salt.config.DEFAULT_MINION_OPTS.copy()
-utils = salt.loader.utils(opts)
-modules = salt.loader.minion_mods(opts, utils=utils)
-
-LOADER_DICTS = {win_lgpo: {"__opts__": opts, "__salt__": modules, "__utils__": utils}}
 
 
 class WinLGPOTestCase(TestCase):
@@ -253,8 +245,24 @@ class WinLGPOGetPolicyADMXTestCase(TestCase, LoaderModuleMockMixin):
     (admx/adml)
     """
 
+    @classmethod
+    def setUpClass(cls):
+        cls.opts = salt.config.DEFAULT_MINION_OPTS.copy()
+        cls.utils = salt.loader.utils(cls.opts)
+        cls.modules = salt.loader.minion_mods(cls.opts, utils=cls.utils)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.opts = cls.utils = cls.modules = None
+
     def setup_loader_modules(self):
-        return LOADER_DICTS
+        return {
+            win_lgpo: {
+                "__opts__": copy.deepcopy(self.opts),
+                "__salt__": self.modules,
+                "__utils__": self.utils,
+            }
+        }
 
     def test_get_policy_name(self):
         result = win_lgpo.get_policy(
@@ -394,7 +402,7 @@ class WinLGPOGetPolicyADMXTestCase(TestCase, LoaderModuleMockMixin):
             # Remove source file
             os.remove(bogus_fle)
             # Remove cached file
-            search_string = "{0}\\_bogus*.adml".format(cache_dir)
+            search_string = "{}\\_bogus*.adml".format(cache_dir)
             for file_name in glob.glob(search_string):
                 os.remove(file_name)
 
@@ -406,8 +414,24 @@ class WinLGPOGetPolicyFromPolicyInfoTestCase(TestCase, LoaderModuleMockMixin):
     object
     """
 
+    @classmethod
+    def setUpClass(cls):
+        cls.opts = salt.config.DEFAULT_MINION_OPTS.copy()
+        cls.utils = salt.loader.utils(cls.opts)
+        cls.modules = salt.loader.minion_mods(cls.opts, utils=cls.utils)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.opts = cls.utils = cls.modules = None
+
     def setup_loader_modules(self):
-        return LOADER_DICTS
+        return {
+            win_lgpo: {
+                "__opts__": copy.deepcopy(self.opts),
+                "__salt__": self.modules,
+                "__utils__": self.utils,
+            }
+        }
 
     def test_get_policy_name(self):
         result = win_lgpo.get_policy(
@@ -538,12 +562,25 @@ class WinLGPOPolicyInfoMechanismsTestCase(TestCase, LoaderModuleMockMixin):
     Go through each mechanism
     """
 
-    def setup_loader_modules(self):
-        return LOADER_DICTS
-
     @classmethod
     def setUpClass(cls):
+        cls.opts = salt.config.DEFAULT_MINION_OPTS.copy()
+        cls.utils = salt.loader.utils(cls.opts)
+        cls.modules = salt.loader.minion_mods(cls.opts, utils=cls.utils)
         cls.policy_data = salt.modules.win_lgpo._policy_info()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.opts = cls.utils = cls.modules = cls.policy_data = None
+
+    def setup_loader_modules(self):
+        return {
+            win_lgpo: {
+                "__opts__": copy.deepcopy(self.opts),
+                "__salt__": self.modules,
+                "__utils__": self.utils,
+            }
+        }
 
     def _test_policy(self, policy_name):
         """
@@ -666,8 +703,24 @@ class WinLGPOGetPointAndPrintNCTestCase(TestCase, LoaderModuleMockMixin):
 
     not_configured = False
 
+    @classmethod
+    def setUpClass(cls):
+        cls.opts = salt.config.DEFAULT_MINION_OPTS.copy()
+        cls.utils = salt.loader.utils(cls.opts)
+        cls.modules = salt.loader.minion_mods(cls.opts, utils=cls.utils)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.opts = cls.utils = cls.modules = None
+
     def setup_loader_modules(self):
-        return LOADER_DICTS
+        return {
+            win_lgpo: {
+                "__opts__": copy.deepcopy(self.opts),
+                "__salt__": self.modules,
+                "__utils__": self.utils,
+            }
+        }
 
     def setUp(self):
         if not self.not_configured:
@@ -757,8 +810,24 @@ class WinLGPOGetPointAndPrintENTestCase(TestCase, LoaderModuleMockMixin):
 
     configured = False
 
+    @classmethod
+    def setUpClass(cls):
+        cls.opts = salt.config.DEFAULT_MINION_OPTS.copy()
+        cls.utils = salt.loader.utils(cls.opts)
+        cls.modules = salt.loader.minion_mods(cls.opts, utils=cls.utils)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.opts = cls.utils = cls.modules = None
+
     def setup_loader_modules(self):
-        return LOADER_DICTS
+        return {
+            win_lgpo: {
+                "__opts__": copy.deepcopy(self.opts),
+                "__salt__": self.modules,
+                "__utils__": self.utils,
+            }
+        }
 
     def setUp(self):
         if not self.configured:
@@ -896,8 +965,24 @@ class WinLGPOGetPolicyFromPolicyResources(TestCase, LoaderModuleMockMixin):
 
     adml_data = None
 
+    @classmethod
+    def setUpClass(cls):
+        cls.opts = salt.config.DEFAULT_MINION_OPTS.copy()
+        cls.utils = salt.loader.utils(cls.opts)
+        cls.modules = salt.loader.minion_mods(cls.opts, utils=cls.utils)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.opts = cls.utils = cls.modules = None
+
     def setup_loader_modules(self):
-        return LOADER_DICTS
+        return {
+            win_lgpo: {
+                "__opts__": copy.deepcopy(self.opts),
+                "__salt__": self.modules,
+                "__utils__": self.utils,
+            }
+        }
 
     def setUp(self):
         if self.adml_data is None:

--- a/tests/unit/states/test_win_lgpo.py
+++ b/tests/unit/states/test_win_lgpo.py
@@ -1,32 +1,18 @@
-# -*- coding: utf-8 -*-
 """
 :codeauthor: Shane Lee <slee@saltstack.com>
 """
-# Import Python Libs
-from __future__ import absolute_import, print_function, unicode_literals
+import copy
 
-# Import Salt Libs
 import salt.config
-
-# Import 3rd Party Libs
 import salt.ext.six as six
 import salt.loader
 import salt.states.win_lgpo as win_lgpo
 import salt.utils.platform
 import salt.utils.stringutils
-
-# Import Salt Testing Libs
 from tests.support.helpers import destructiveTest, slowTest
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import patch
 from tests.support.unit import TestCase, skipIf
-
-# We're going to actually use the loader, without grains (slow)
-opts = salt.config.DEFAULT_MINION_OPTS.copy()
-utils = salt.loader.utils(opts)
-modules = salt.loader.minion_mods(opts, utils=utils)
-
-LOADER_DICTS = {win_lgpo: {"__opts__": opts, "__salt__": modules, "__utils__": utils}}
 
 
 class WinLGPOComparePoliciesTestCase(TestCase):
@@ -115,8 +101,24 @@ class WinLGPOPolicyElementNames(TestCase, LoaderModuleMockMixin):
     Configured (NC)
     """
 
+    @classmethod
+    def setUpClass(cls):
+        cls.opts = salt.config.DEFAULT_MINION_OPTS.copy()
+        cls.utils = salt.loader.utils(cls.opts)
+        cls.modules = salt.loader.minion_mods(cls.opts, utils=cls.utils)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.opts = cls.utils = cls.modules = None
+
     def setup_loader_modules(self):
-        return LOADER_DICTS
+        return {
+            win_lgpo: {
+                "__opts__": copy.deepcopy(self.opts),
+                "__salt__": self.modules,
+                "__utils__": self.utils,
+            }
+        }
 
     def setUp(self):
         computer_policy = {"Point and Print Restrictions": "Not Configured"}
@@ -226,8 +228,24 @@ class WinLGPOPolicyElementNamesTestTrue(TestCase, LoaderModuleMockMixin):
 
     configured = False
 
+    @classmethod
+    def setUpClass(cls):
+        cls.opts = salt.config.DEFAULT_MINION_OPTS.copy()
+        cls.utils = salt.loader.utils(cls.opts)
+        cls.modules = salt.loader.minion_mods(cls.opts, utils=cls.utils)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.opts = cls.utils = cls.modules = None
+
     def setup_loader_modules(self):
-        return LOADER_DICTS
+        return {
+            win_lgpo: {
+                "__opts__": copy.deepcopy(self.opts),
+                "__salt__": self.modules,
+                "__utils__": self.utils,
+            }
+        }
 
     def setUp(self):
         if not self.configured:


### PR DESCRIPTION
### What does this PR do?
This, at the very minimum, slows down test collection under PyTest.
We should never do computation intensive tasks at the global module scope.
On top of that, using a mutable objects opens up for strange behaviour across
tests since it's not guaranteed that each test will get the exact same,
untouched, object.