### PR TITLE
Adding security-related links to Hardening Guide and Disclosure Policy

### DIFF
--- a/doc/security/index.rst
+++ b/doc/security/index.rst
@@ -114,8 +114,20 @@ quickly and safely as is possible.
     lists. The announcement contains a description of the issue and a link to
     the full release documentation and download locations.
 
+.. _saltstack_security_announcements:
+
 Receiving security announcements
 ================================
 
-The fastest place to receive security announcements is via the `salt-announce`_
-mailing list. This list is low-traffic.
+The following mailing lists, per the previous tasks identified in our response
+procedure, will receive security-relevant notifications:
+
+* `salt-packagers`_
+* `salt-users`_
+* `salt-announce`_
+
+In addition to the mailing lists, SaltStack also provides the following resources:
+
+* `SaltStack Security Announcements <https://www.saltstack.com/security-announcements/>`__ landing page
+* `SaltStack Security RSS Feed <http://www.saltstack.com/feed/?post_type=security>`__
+* `SaltStack Community Slack Workspace <http://saltstackcommunity.slack.com/>`__

--- a/doc/topics/hardening.rst
+++ b/doc/topics/hardening.rst
@@ -10,6 +10,11 @@ heavily on how you use Salt, where you use Salt, how your team is structured,
 where you get data from, and what kinds of access (internal and external) you
 require.
 
+.. important::
+
+    Refer to the :ref:`saltstack_security_announcements` documentation in order to stay updated
+    and secure.
+
 .. warning::
 
     For historical reasons, Salt requires PyCrypto as a "lowest common
@@ -43,7 +48,8 @@ Salt hardening tips
 ===================
 
 - Subscribe to `salt-users`_ or `salt-announce`_ so you know when new Salt
-  releases are available. Keep your systems up-to-date with the latest patches.
+  releases are available.
+- Keep your systems up-to-date with the latest patches.
 - Use Salt's Client :ref:`ACL system <acl>` to avoid having to give out root
   access in order to run Salt commands.
 - Use Salt's Client :ref:`ACL system <acl>` to restrict which users can run what commands.


### PR DESCRIPTION
### What does this PR do?

Adds additional information to the following pages:
- https://docs.saltstack.com/en/latest/security/index.html#receiving-security-announcements
  - Restating the mailing lists that get notifications, along with links to the following:
    - [SaltStack Security Announcements](https://www.saltstack.com/security-announcements/) landing page
    - [SaltStack Security RSS Feed](http://www.saltstack.com/feed/?post_type=security)
    - [SaltStack Community Slack Workspace](http://saltstackcommunity.slack.com/)
- https://docs.saltstack.com/en/latest/topics/hardening.html#hardening-salt
  - A new **Important** admonition toward the top about looking at the **Receiving Security Announcements** section to stay updated about security-related updates

### What issues does this PR fix or reference?

Relates to, but doesn't complete issue in #49636 (this adds the security RSS, but we don't have links in docs related to regular RSS info).

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
