### PR TITLE
Add ~user expansion for various git states

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -643,6 +643,7 @@ def latest(
     if target is not None:
         if not isinstance(target, six.string_types):
             target = six.text_type(target)
+        target = os.path.expanduser(target)
         if not os.path.isabs(target):
             return _fail(ret, "target '{0}' is not an absolute path".format(target))
     if branch is not None and not isinstance(branch, six.string_types):
@@ -2095,6 +2096,7 @@ def present(
     ret = {"name": name, "result": True, "comment": "", "changes": {}}
 
     # If the named directory is a git repo return True
+    name = os.path.expanduser(name)
     if os.path.isdir(name):
         if bare and os.path.isfile(os.path.join(name, "HEAD")):
             return ret
@@ -2299,6 +2301,7 @@ def detached(
     if target is not None:
         if not isinstance(target, six.string_types):
             target = six.text_type(target)
+        target = os.path.expanduser(target)
         if not os.path.isabs(target):
             return _fail(ret, "Target '{0}' is not an absolute path".format(target))
     if user is not None and not isinstance(user, six.string_types):
@@ -2721,6 +2724,7 @@ def cloned(
     elif not isinstance(target, six.string_types):
         target = six.text_type(target)
 
+    target = os.path.expanduser(target)
     if not os.path.isabs(target):
         ret["comment"] = "'target' path must be absolute"
         return ret

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -2096,7 +2096,6 @@ def present(
     ret = {"name": name, "result": True, "comment": "", "changes": {}}
 
     # If the named directory is a git repo return True
-    name = os.path.expanduser(name)
     if os.path.isdir(name):
         if bare and os.path.isfile(os.path.join(name, "HEAD")):
             return ret


### PR DESCRIPTION
### What does this PR do?

Add ~user expansion for the target parameter in git.{cloned,detached,latest} states.

Note that ~user expansion already works for `git.present`, so there's no need to add it.

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior

Test file:

```
latest:
  git.latest:
    - name: https://github.com/saltstack/salt-bootstrap.git
    - target: ~dave/salt-bootstrap
    - branch: master
    - user: dave
    
cloned:
  git.cloned:
    - name: https://github.com/saltstack/salt-bootstrap.git
    - target: ~dave/salt-bootstrap
    - branch: master
    - user: dave
    
detached:
  git.detached:
    - name: https://github.com/saltstack/salt-bootstrap.git
    - target: ~dave/detached-bootstrap
    - rev: develop
    - user: dave
```
Running it gives this:
```
----------
          ID: latest
    Function: git.latest
        Name: https://github.com/saltstack/salt-bootstrap.git
      Result: False
     Comment: target '~dave/salt-bootstrap' is not an absolute path
     Started: 11:04:55.859000
    Duration: 5.994 ms
     Changes:   
----------
          ID: cloned
    Function: git.cloned
        Name: https://github.com/saltstack/salt-bootstrap.git
      Result: False
     Comment: 'target' path must be absolute
     Started: 11:04:55.865580
    Duration: 4.093 ms
     Changes:   
----------
          ID: detached
    Function: git.detached
        Name: https://github.com/saltstack/salt-bootstrap.git
      Result: False
     Comment: Target '~dave/detached-bootstrap' is not an absolute path
     Started: 11:04:55.870181
    Duration: 4.346 ms
     Changes:   
```

### New Behavior
Now it works.

```
----------
          ID: latest
    Function: git.latest
        Name: https://github.com/saltstack/salt-bootstrap.git
      Result: True
     Comment: https://github.com/saltstack/salt-bootstrap.git cloned to /home/dave/salt-bootstrap. Branch 'master' checked out, with remote HEAD (69bfde2) as a starting point.
     Started: 11:08:53.001141
    Duration: 3929.469 ms
     Changes:   
              ----------
              new:
                  https://github.com/saltstack/salt-bootstrap.git => /home/dave/salt-bootstrap
              revision:
                  ----------
                  new:
                      69bfde2d63e155d8c98b1bc85568b297cc8418df
                  old:
                      None
----------
          ID: cloned
    Function: git.cloned
        Name: https://github.com/saltstack/salt-bootstrap.git
      Result: True
     Comment: Repository already exists at /home/dave/salt-bootstrap and is checked out to branch 'master'
     Started: 11:08:56.931151
    Duration: 148.563 ms
     Changes:   
----------
          ID: detached
    Function: git.detached
        Name: https://github.com/saltstack/salt-bootstrap.git
      Result: True
     Comment: https://github.com/saltstack/salt-bootstrap.git cloned to /home/dave/detached-bootstrap. Commit ID 69bfde2d63e155d8c98b1bc85568b297cc8418df was checked out at /home/dave/detached-bootstrap.
     Started: 11:08:57.080597
    Duration: 3999.005 ms
     Changes:   
              ----------
              HEAD:
                  ----------
                  new:
                      69bfde2d63e155d8c98b1bc85568b297cc8418df
                  old:
                      None

```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
