### PR TITLE
Fix #57948 - KeyError: 'platform.is_windows'

### DIFF
--- a/changelog/57948.fixed
+++ b/changelog/57948.fixed
@@ -1,0 +1,2 @@
+Fix issue with `__utils__` usage in the `__virtual__` functions on a few of the
+execution modules.

--- a/salt/modules/boto_elbv2.py
+++ b/salt/modules/boto_elbv2.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Connection module for Amazon ALB
 
@@ -40,15 +39,12 @@ Connection module for Amazon ALB
 # keep lint from choking on _get_conn and _cache_id
 # pylint: disable=E0602
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 # Import Python libs
 import logging
 
-import salt.utils.versions
-
 # Import Salt libs
-from salt.ext import six
+import salt.utils.boto3mod
+import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
@@ -76,7 +72,7 @@ def __virtual__():
     """
     has_boto_reqs = salt.utils.versions.check_boto_reqs()
     if has_boto_reqs is True:
-        __utils__["boto3.assign_funcs"](__name__, "elbv2")
+        salt.utils.boto3mod.assign_funcs(__name__, "elbv2")
     return has_boto_reqs
 
 
@@ -296,7 +292,7 @@ def register_targets(name, targets, region=None, key=None, keyid=None, profile=N
         salt myminion boto_elbv2.register_targets myelb "[instance_id,instance_id]"
     """
     targetsdict = []
-    if isinstance(targets, six.string_types) or isinstance(targets, six.text_type):
+    if isinstance(targets, str):
         targetsdict.append({"Id": targets})
     else:
         for target in targets:
@@ -333,7 +329,7 @@ def deregister_targets(name, targets, region=None, key=None, keyid=None, profile
         salt myminion boto_elbv2.deregister_targets myelb "[instance_id,instance_id]"
     """
     targetsdict = []
-    if isinstance(targets, six.string_types) or isinstance(targets, six.text_type):
+    if isinstance(targets, str):
         targetsdict.append({"Id": targets})
     else:
         for target in targets:

--- a/salt/modules/boto_ssm.py
+++ b/salt/modules/boto_ssm.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Connection module for Amazon SSM
 
@@ -14,13 +13,11 @@ Connection module for Amazon SSM
 :depends: boto3
 """
 # Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
-
 import logging
 
-import salt.utils.json as json
-
 # Import Salt libs
+import salt.utils.boto3mod
+import salt.utils.json as json
 import salt.utils.versions
 
 log = logging.getLogger(__name__)
@@ -32,7 +29,7 @@ def __virtual__():
     """
     has_boto_reqs = salt.utils.versions.check_boto_reqs()
     if has_boto_reqs is True:
-        __utils__["boto3.assign_funcs"](__name__, "ssm")
+        salt.utils.boto3mod.assign_funcs(__name__, "ssm")
     return has_boto_reqs
 
 

--- a/tests/unit/modules/test_boto_elbv2.py
+++ b/tests/unit/modules/test_boto_elbv2.py
@@ -1,0 +1,26 @@
+# import Salt Libs
+import salt.modules.boto_elbv2 as boto_elbv2
+
+# Import Salt Testing Libs
+from tests.support.mock import patch
+from tests.support.unit import TestCase
+
+
+class BotoElbv2TestCase(TestCase):
+    """
+    TestCase for salt.modules.boto_elbv2 module
+    """
+
+    @patch("salt.utils.versions.check_boto_reqs")
+    @patch("salt.utils.boto3mod.assign_funcs")
+    def test___virtual__has_boto_reqs_true(self, mock_assign_funcs, mock_boto_reqs):
+        mock_boto_reqs.return_value = True
+        mock_assign_funcs.return_value = False
+        result = boto_elbv2.__virtual__()
+        self.assertEqual(result, True)
+
+    @patch("salt.utils.versions.check_boto_reqs")
+    def test___virtual__has_boto_reqs_false(self, mock_boto_reqs):
+        mock_boto_reqs.return_value = False
+        result = boto_elbv2.__virtual__()
+        self.assertEqual(result, False)

--- a/tests/unit/modules/test_boto_ssm.py
+++ b/tests/unit/modules/test_boto_ssm.py
@@ -1,0 +1,26 @@
+# import Salt Libs
+import salt.modules.boto_ssm as boto_ssm
+
+# Import Salt Testing Libs
+from tests.support.mock import patch
+from tests.support.unit import TestCase
+
+
+class BotoSsmTestCase(TestCase):
+    """
+    TestCase for salt.modules.boto_ssm module
+    """
+
+    @patch("salt.utils.versions.check_boto_reqs")
+    @patch("salt.utils.boto3mod.assign_funcs")
+    def test___virtual__has_boto_reqs_true(self, mock_assign_funcs, mock_boto_reqs):
+        mock_boto_reqs.return_value = True
+        mock_assign_funcs.return_value = False
+        result = boto_ssm.__virtual__()
+        self.assertEqual(result, True)
+
+    @patch("salt.utils.versions.check_boto_reqs")
+    def test___virtual__has_boto_reqs_false(self, mock_boto_reqs):
+        mock_boto_reqs.return_value = False
+        result = boto_ssm.__virtual__()
+        self.assertEqual(result, False)

--- a/tests/unit/modules/test_network.py
+++ b/tests/unit/modules/test_network.py
@@ -1,4 +1,3 @@
-
 # Import Python Libs
 import logging
 import os.path

--- a/tests/unit/modules/test_network.py
+++ b/tests/unit/modules/test_network.py
@@ -36,6 +36,22 @@ class NetworkTestCase(TestCase, LoaderModuleMockMixin):
             network: {"__utils__": utils},
         }
 
+    @patch("salt.utils.platform.is_windows")
+    def test___virtual__is_windows_true(self, mock_is_windows):
+        mock_is_windows.return_value = True
+        result = network.__virtual__()
+        expected = (
+            False,
+            "The network execution module cannot be loaded on Windows: use win_network instead."
+        )
+        self.assertEqual(result, expected)
+
+    @patch("salt.utils.platform.is_windows")
+    def test___virtual__is_windows_false(self, mock_is_windows):
+        mock_is_windows.return_value = False
+        result = network.__virtual__()
+        self.assertEqual(result, True)
+
     def test_wol_bad_mac(self):
         """
         tests network.wol with bad mac

--- a/tests/unit/modules/test_network.py
+++ b/tests/unit/modules/test_network.py
@@ -1,8 +1,5 @@
-# -*- coding: utf-8 -*-
 
 # Import Python Libs
-from __future__ import absolute_import, print_function, unicode_literals
-
 import logging
 import os.path
 import socket
@@ -42,7 +39,7 @@ class NetworkTestCase(TestCase, LoaderModuleMockMixin):
         result = network.__virtual__()
         expected = (
             False,
-            "The network execution module cannot be loaded on Windows: use win_network instead."
+            "The network execution module cannot be loaded on Windows: use win_network instead.",
         )
         self.assertEqual(result, expected)
 
@@ -66,7 +63,7 @@ class NetworkTestCase(TestCase, LoaderModuleMockMixin):
         mac = "080027136977"
         bcast = "255.255.255.255 7"
 
-        class MockSocket(object):
+        class MockSocket:
             def __init__(self, *args, **kwargs):
                 pass
 


### PR DESCRIPTION
### What does this PR do?
Uses `import salt.utils.platform` instead of relying on the function being present in `__utils__` in the `__virtual__` function for `modules/network.py`. Removes `__utils__` calls in other execution modules.

### What issues does this PR fix or reference?
Fixes: #57948 

### Previous Behavior
The minion was putting KeyError entries in the log file every time it ran anything.

### New Behavior
No more log file entries

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
