### PR TITLE
Add pkg.services_need_restart

### DIFF
--- a/changelog/58261.added
+++ b/changelog/58261.added
@@ -1,0 +1,1 @@
+Added ``pkg.services_need_restart`` which lists system services that should be restarted after package management operations.

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -37,7 +37,12 @@ import salt.utils.stringutils
 import salt.utils.systemd
 import salt.utils.versions
 import salt.utils.yaml
-from salt.exceptions import CommandExecutionError, MinionError, SaltInvocationError
+from salt.exceptions import (
+    CommandExecutionError,
+    CommandNotFoundError,
+    MinionError,
+    SaltInvocationError,
+)
 from salt.modules.cmdmod import _parse_env
 
 log = logging.getLogger(__name__)
@@ -3009,3 +3014,38 @@ def list_downloaded(root=None, **kwargs):
                 ).isoformat(),
             }
     return ret
+
+
+def services_need_restart(**kwargs):
+    """
+    .. versionadded:: 3003
+
+    List services that use files which have been changed by the
+    package manager. It might be needed to restart them.
+
+    Requires checkrestart from the debian-goodies package.
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt '*' pkg.services_need_restart
+    """
+    if not salt.utils.path.which_bin(["checkrestart"]):
+        raise CommandNotFoundError(
+            "'checkrestart' is needed. It is part of the 'debian-goodies' "
+            "package which can be installed from official repositories."
+        )
+
+    cmd = ["checkrestart", "--machine", "--package"]
+    services = set()
+
+    cr_output = __salt__["cmd.run_stdout"](cmd, python_shell=False)
+    for line in cr_output.split("\n"):
+        if not line.startswith("SERVICE:"):
+            continue
+        end_of_name = line.find(",")
+        service = line[8:end_of_name]  # skip "SERVICE:"
+        services.add(service)
+
+    return list(services)

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -3399,13 +3399,10 @@ def services_need_restart(**kwargs):
 
     services = set()
     for line in dnf_output.split("\n"):
-        try:
-            pid, _ = line.split(":")
-        # Skip lines that can't be parsed
-        except ValueError:
-            continue
-        service = salt.utils.systemd.pid_to_service(pid.strip())
-        if service:
-            services.add(service)
+        pid, has_delim, _ = line.partition(":")
+        if has_delim:
+            service = salt.utils.systemd.pid_to_service(pid.strip())
+            if service:
+                services.add(service)
 
     return list(services)

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -3369,3 +3369,43 @@ def list_installed_patches(**kwargs):
         salt '*' pkg.list_installed_patches
     """
     return _get_patches(installed_only=True)
+
+
+def services_need_restart(**kwargs):
+    """
+    .. versionadded:: 3003
+
+    List services that use files which have been changed by the
+    package manager. It might be needed to restart them.
+
+    Requires systemd.
+
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt '*' pkg.services_need_restart
+    """
+    if _yum() != "dnf":
+        raise CommandExecutionError("dnf is required to list outdated services.")
+    if not salt.utils.systemd.booted(__context__):
+        raise CommandExecutionError("systemd is required to list outdated services.")
+
+    cmd = ["dnf", "--quiet", "needs-restarting"]
+    dnf_output = __salt__["cmd.run_stdout"](cmd, python_shell=False)
+    if not dnf_output:
+        return []
+
+    services = set()
+    for line in dnf_output.split("\n"):
+        try:
+            pid, _ = line.split(":")
+        # Skip lines that can't be parsed
+        except ValueError:
+            continue
+        service = salt.utils.systemd.pid_to_service(pid.strip())
+        if service:
+            services.add(service)
+
+    return list(services)

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -3014,3 +3014,27 @@ def resolve_capabilities(pkgs, refresh=False, root=None, **kwargs):
         else:
             ret.append(name)
     return ret
+
+
+def services_need_restart(root=None, **kwargs):
+    """
+    .. versionadded:: 3003
+
+    List services that use files which have been changed by the
+    package manager. It might be needed to restart them.
+
+    root
+        operate on a different root directory.
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt '*' pkg.services_need_restart
+    """
+    cmd = ["ps", "-sss"]
+
+    zypper_output = __zypper__(root=root).nolock.call(*cmd)
+    services = zypper_output.split()
+
+    return services

--- a/tests/pytests/unit/modules/test_aptpkg.py
+++ b/tests/pytests/unit/modules/test_aptpkg.py
@@ -14,7 +14,11 @@ import textwrap
 import pytest
 import salt.modules.aptpkg as aptpkg
 import salt.modules.pkg_resource as pkg_resource
-from salt.exceptions import CommandExecutionError, SaltInvocationError
+from salt.exceptions import (
+    CommandExecutionError,
+    CommandNotFoundError,
+    SaltInvocationError,
+)
 from tests.support.mock import MagicMock, Mock, call, patch
 
 try:
@@ -1071,3 +1075,31 @@ def test_call_apt_dpkg_lock():
             # We should attempt to call the cmd 5 times
             assert cmd_mock.call_count == 5
             cmd_mock.has_calls(expected_calls)
+
+
+def test_services_need_restart_checkrestart_missing():
+    """Test that the user is informed about the required dependency."""
+
+    with patch("salt.utils.path.which_bin", Mock(return_value=None)):
+        with pytest.raises(CommandNotFoundError):
+            aptpkg.services_need_restart()
+
+
+@patch("salt.utils.path.which_bin", Mock(return_value="/usr/sbin/checkrestart"))
+def test_services_need_restart():
+    """
+    Test that checkrestart output is parsed correctly
+    """
+    cr_output = """
+PROCESSES: 24
+PROGRAMS: 17
+PACKAGES: 8
+SERVICE:rsyslog,385,/usr/sbin/rsyslogd
+SERVICE:cups-daemon,390,/usr/sbin/cupsd
+    """
+
+    with patch.dict(aptpkg.__salt__, {"cmd.run_stdout": Mock(return_value=cr_output)}):
+        assert sorted(aptpkg.services_need_restart()) == [
+            "cups-daemon",
+            "rsyslog",
+        ]

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -2030,3 +2030,17 @@ pattern() = package-c"""
         with patch.dict(zypper.__context__, context):
             zypper._clean_cache()
             self.assertEqual(zypper.__context__, {"pkg.other_data": None})
+
+    def test_services_need_restart(self):
+        """
+        Test that zypper ps is used correctly to list services that need to
+        be restarted.
+        """
+        expected = ["salt-minion", "firewalld"]
+        zypper_output = "salt-minion\nfirewalld"
+        zypper_mock = Mock()
+        zypper_mock(root=None).nolock.call = Mock(return_value=zypper_output)
+
+        with patch("salt.modules.zypperpkg.__zypper__", zypper_mock):
+            assert zypper.services_need_restart() == expected
+            zypper_mock(root=None).nolock.call.assert_called_with("ps", "-sss")

--- a/tests/unit/utils/test_systemd.py
+++ b/tests/unit/utils/test_systemd.py
@@ -1,16 +1,9 @@
-# -*- coding: utf-8 -*-
-
-# Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
-
 import errno
+import subprocess
 
-# Import Salt libs
 import salt.utils.systemd as _systemd
 from salt.exceptions import SaltInvocationError
 from tests.support.mock import Mock, patch
-
-# Import Salt Testing libs
 from tests.support.unit import TestCase
 
 
@@ -85,7 +78,7 @@ class SystemdTestCase(TestCase):
         """
         with patch("subprocess.Popen") as popen_mock:
             _version = 231
-            output = "systemd {0}\n-SYSVINIT".format(_version)
+            output = "systemd {}\n-SYSVINIT".format(_version)
             popen_mock.return_value = Mock(
                 communicate=lambda *args, **kwargs: (output, None),
                 pid=lambda: 12345,
@@ -169,7 +162,7 @@ class SystemdTestCase(TestCase):
         with patch("subprocess.Popen") as popen_mock:
             _expected = False
             _version = 204
-            _output = "systemd {0}\n-SYSVINIT".format(_version)
+            _output = "systemd {}\n-SYSVINIT".format(_version)
             popen_mock.return_value = Mock(
                 communicate=lambda *args, **kwargs: (_output, None),
                 pid=lambda: 12345,
@@ -203,7 +196,7 @@ class SystemdTestCase(TestCase):
         with patch("subprocess.Popen") as popen_mock:
             _expected = True
             _version = 205
-            _output = "systemd {0}\n-SYSVINIT".format(_version)
+            _output = "systemd {}\n-SYSVINIT".format(_version)
             popen_mock.return_value = Mock(
                 communicate=lambda *args, **kwargs: (_output, None),
                 pid=lambda: 12345,
@@ -237,7 +230,7 @@ class SystemdTestCase(TestCase):
         with patch("subprocess.Popen") as popen_mock:
             _expected = True
             _version = 206
-            _output = "systemd {0}\n-SYSVINIT".format(_version)
+            _output = "systemd {}\n-SYSVINIT".format(_version)
             popen_mock.return_value = Mock(
                 communicate=lambda *args, **kwargs: (_output, None),
                 pid=lambda: 12345,
@@ -306,3 +299,62 @@ class SystemdTestCase(TestCase):
         # Test with invalid context data
         with self.assertRaises(SaltInvocationError):
             _systemd.has_scope(99999)
+
+    @patch("salt.utils.systemd.dbus", False)
+    def test_pid_to_service_systemctl_valid_pid(self):
+        """
+        Test parsing of systemctl status output for a valid PID.
+        """
+        systemctl_output = """
+        ● firewalld.service - firewalld - dynamic firewall daemon
+        Loaded: loaded (/usr/lib/systemd/system/firewalld.service; enabled; vendor preset: disabled)
+        {"_CAP_EFFECTIVE":"ffffffffff","_SYSTEMD_UNIT":"firewalld.service"}
+        """
+        subprocess_mock = Mock(return_value=Mock(stdout=systemctl_output))
+        with patch("salt.utils.systemd.subprocess.run", subprocess_mock):
+            assert _systemd.pid_to_service(1374) == "firewalld"
+
+    @patch("salt.utils.systemd.dbus", False)
+    def test_pid_to_service_systemctl_invalid_pid(self):
+        """
+        Test parsing of systemctl status output for an invalid PID.
+        """
+        subprocess_mock = Mock(
+            side_effect=subprocess.CalledProcessError(
+                returncode=1, cmd=["systemctl", "--output", "json", "status", "999999"]
+            )
+        )
+        with patch("salt.utils.systemd.subprocess.run", subprocess_mock):
+            # breakpoint()
+            assert _systemd.pid_to_service(999999) is None
+
+    def test_pid_to_service_dbus_valid_pid(self):
+        """
+        Test translating a valid PID to a service name via DBUS.
+        """
+        dbus_mock = Mock()
+        dbus_interface_get_mock = Mock(return_value="firewalld.service")
+        dbus_mock.Interface().Get = dbus_interface_get_mock
+        with patch("salt.utils.systemd.dbus", dbus_mock):
+            assert _systemd.pid_to_service(1374) == "firewalld"
+            dbus_interface_get_mock.assert_called_with(
+                "org.freedesktop.systemd1.Unit", "Id"
+            )
+
+    def test_pid_to_service_dbus_invalid_pid(self):
+        """
+        Test translating an invalid PID to a service name via DBUS.
+        """
+
+        class DBusException(Exception):
+            """
+            Raised by DBUS, e.g. when a PID does not belong to a service
+            """
+
+            ...
+
+        dbus_mock = Mock()
+        dbus_mock.DBusException = DBusException()
+        dbus_mock.GetUnitByPID = Mock(site_effect=dbus_mock.DBusException)
+        with patch("salt.utils.systemd.dbus", dbus_mock):
+            assert _systemd.pid_to_service(99999) is None


### PR DESCRIPTION
### What does this PR do?
Add `pkg.services_need_restarting` to Zypper, Yum(DNF) and Apt.

Current name proposal is `pkg.services_need_restarting`, but I don't mind changing the name to a better one if suggested.

### What issues does this PR fix or reference?
Fixes: #58261 

### New Behavior
```
server:~ # salt 192.168.100.194 pkg.services_need_restarting
192.168.100.194:
    - salt-minion
    - qemu-guest-agent
    - sssd
    - polkit
    - gssproxy
    - getty@tty1
    - firewalld
    - NetworkManager
    - ModemManager
```

### Merge requirements satisfied?
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes (always ;))


