### PR TITLE
[PyTest Migration] Use `pathlib` to fix the thin unit tests under windows

### DIFF
--- a/tests/unit/utils/test_thin.py
+++ b/tests/unit/utils/test_thin.py
@@ -1,11 +1,10 @@
-# -*- coding: utf-8 -*-
 """
     :codeauthor: :email:`Bo Maryniuk <bo@suse.de>`
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
 import copy
 import os
+import pathlib
 import shutil
 import sys
 import tarfile
@@ -65,18 +64,15 @@ class SSHThinTestCase(TestCase):
             "msgpack": os.path.join(lib_root, "msgpack"),
         }
 
+        code_dir = pathlib.Path(RUNTIME_VARS.CODE_DIR).resolve()
         self.exp_ret = {
-            "distro": os.path.normpath(
-                os.path.join(RUNTIME_VARS.CODE_DIR, "distro.py")
-            ),
-            "jinja2": os.path.normpath(os.path.join(RUNTIME_VARS.CODE_DIR, "jinja2")),
-            "yaml": os.path.normpath(os.path.join(RUNTIME_VARS.CODE_DIR, "yaml")),
-            "tornado": os.path.normpath(os.path.join(RUNTIME_VARS.CODE_DIR, "tornado")),
-            "msgpack": os.path.normpath(os.path.join(RUNTIME_VARS.CODE_DIR, "msgpack")),
-            "certifi": os.path.normpath(os.path.join(RUNTIME_VARS.CODE_DIR, "certifi")),
-            "singledispatch": os.path.normpath(
-                os.path.join(RUNTIME_VARS.CODE_DIR, "singledispatch.py")
-            ),
+            "distro": str(code_dir / "distro.py"),
+            "jinja2": str(code_dir / "jinja2"),
+            "yaml": str(code_dir / "yaml"),
+            "tornado": str(code_dir / "tornado"),
+            "msgpack": str(code_dir / "msgpack"),
+            "certifi": str(code_dir / "certifi"),
+            "singledispatch": str(code_dir / "singledispatch.py"),
         }
         self.exc_libs = ["jinja2", "yaml"]
 
@@ -319,7 +315,7 @@ class SSHThinTestCase(TestCase):
         """
         container = []
         for pth in ["/foo/bar.py", "/something/else/__init__.py"]:
-            thin._add_dependency(container, type(str("obj"), (), {"__file__": pth})())
+            thin._add_dependency(container, type("obj", (), {"__file__": pth})())
         assert "__init__" not in container[1]
         assert container == ["/foo/bar.py", "/something/else"]
 
@@ -381,52 +377,50 @@ class SSHThinTestCase(TestCase):
         type("distro", (), {"__file__": "/site-packages/distro"}),
     )
     @patch(
-        "salt.utils.thin.salt",
-        type(str("salt"), (), {"__file__": "/site-packages/salt"}),
+        "salt.utils.thin.salt", type("salt", (), {"__file__": "/site-packages/salt"}),
     )
     @patch(
         "salt.utils.thin.jinja2",
-        type(str("jinja2"), (), {"__file__": "/site-packages/jinja2"}),
+        type("jinja2", (), {"__file__": "/site-packages/jinja2"}),
     )
     @patch(
-        "salt.utils.thin.yaml",
-        type(str("yaml"), (), {"__file__": "/site-packages/yaml"}),
+        "salt.utils.thin.yaml", type("yaml", (), {"__file__": "/site-packages/yaml"}),
     )
     @patch(
         "salt.utils.thin.tornado",
-        type(str("tornado"), (), {"__file__": "/site-packages/tornado"}),
+        type("tornado", (), {"__file__": "/site-packages/tornado"}),
     )
     @patch(
         "salt.utils.thin.msgpack",
-        type(str("msgpack"), (), {"__file__": "/site-packages/msgpack"}),
+        type("msgpack", (), {"__file__": "/site-packages/msgpack"}),
     )
     @patch(
         "salt.utils.thin.certifi",
-        type(str("certifi"), (), {"__file__": "/site-packages/certifi"}),
+        type("certifi", (), {"__file__": "/site-packages/certifi"}),
     )
     @patch(
         "salt.utils.thin.singledispatch",
-        type(str("singledispatch"), (), {"__file__": "/site-packages/sdp"}),
+        type("singledispatch", (), {"__file__": "/site-packages/sdp"}),
     )
     @patch(
         "salt.utils.thin.singledispatch_helpers",
-        type(str("singledispatch_helpers"), (), {"__file__": "/site-packages/sdp_hlp"}),
+        type("singledispatch_helpers", (), {"__file__": "/site-packages/sdp_hlp"}),
     )
     @patch(
         "salt.utils.thin.ssl_match_hostname",
-        type(str("ssl_match_hostname"), (), {"__file__": "/site-packages/ssl_mh"}),
+        type("ssl_match_hostname", (), {"__file__": "/site-packages/ssl_mh"}),
     )
     @patch(
         "salt.utils.thin.markupsafe",
-        type(str("markupsafe"), (), {"__file__": "/site-packages/markupsafe"}),
+        type("markupsafe", (), {"__file__": "/site-packages/markupsafe"}),
     )
     @patch(
         "salt.utils.thin.backports_abc",
-        type(str("backports_abc"), (), {"__file__": "/site-packages/backports_abc"}),
+        type("backports_abc", (), {"__file__": "/site-packages/backports_abc"}),
     )
     @patch(
         "salt.utils.thin.concurrent",
-        type(str("concurrent"), (), {"__file__": "/site-packages/concurrent"}),
+        type("concurrent", (), {"__file__": "/site-packages/concurrent"}),
     )
     @patch("salt.utils.thin.log", MagicMock())
     def test_get_tops(self):
@@ -459,52 +453,50 @@ class SSHThinTestCase(TestCase):
         type("distro", (), {"__file__": "/site-packages/distro"}),
     )
     @patch(
-        "salt.utils.thin.salt",
-        type(str("salt"), (), {"__file__": "/site-packages/salt"}),
+        "salt.utils.thin.salt", type("salt", (), {"__file__": "/site-packages/salt"}),
     )
     @patch(
         "salt.utils.thin.jinja2",
-        type(str("jinja2"), (), {"__file__": "/site-packages/jinja2"}),
+        type("jinja2", (), {"__file__": "/site-packages/jinja2"}),
     )
     @patch(
-        "salt.utils.thin.yaml",
-        type(str("yaml"), (), {"__file__": "/site-packages/yaml"}),
+        "salt.utils.thin.yaml", type("yaml", (), {"__file__": "/site-packages/yaml"}),
     )
     @patch(
         "salt.utils.thin.tornado",
-        type(str("tornado"), (), {"__file__": "/site-packages/tornado"}),
+        type("tornado", (), {"__file__": "/site-packages/tornado"}),
     )
     @patch(
         "salt.utils.thin.msgpack",
-        type(str("msgpack"), (), {"__file__": "/site-packages/msgpack"}),
+        type("msgpack", (), {"__file__": "/site-packages/msgpack"}),
     )
     @patch(
         "salt.utils.thin.certifi",
-        type(str("certifi"), (), {"__file__": "/site-packages/certifi"}),
+        type("certifi", (), {"__file__": "/site-packages/certifi"}),
     )
     @patch(
         "salt.utils.thin.singledispatch",
-        type(str("singledispatch"), (), {"__file__": "/site-packages/sdp"}),
+        type("singledispatch", (), {"__file__": "/site-packages/sdp"}),
     )
     @patch(
         "salt.utils.thin.singledispatch_helpers",
-        type(str("singledispatch_helpers"), (), {"__file__": "/site-packages/sdp_hlp"}),
+        type("singledispatch_helpers", (), {"__file__": "/site-packages/sdp_hlp"}),
     )
     @patch(
         "salt.utils.thin.ssl_match_hostname",
-        type(str("ssl_match_hostname"), (), {"__file__": "/site-packages/ssl_mh"}),
+        type("ssl_match_hostname", (), {"__file__": "/site-packages/ssl_mh"}),
     )
     @patch(
         "salt.utils.thin.markupsafe",
-        type(str("markupsafe"), (), {"__file__": "/site-packages/markupsafe"}),
+        type("markupsafe", (), {"__file__": "/site-packages/markupsafe"}),
     )
     @patch(
         "salt.utils.thin.backports_abc",
-        type(str("backports_abc"), (), {"__file__": "/site-packages/backports_abc"}),
+        type("backports_abc", (), {"__file__": "/site-packages/backports_abc"}),
     )
     @patch(
         "salt.utils.thin.concurrent",
-        type(str("concurrent"), (), {"__file__": "/site-packages/concurrent"}),
+        type("concurrent", (), {"__file__": "/site-packages/concurrent"}),
     )
     @patch("salt.utils.thin.log", MagicMock())
     def test_get_tops_extra_mods(self):
@@ -534,9 +526,7 @@ class SSHThinTestCase(TestCase):
         bar = {"__file__": os.sep + os.path.join("custom", "bar")}
         with patch(
             "{}.__import__".format(builtins),
-            MagicMock(
-                side_effect=[type(str("foo"), (), foo), type(str("bar"), (), bar)]
-            ),
+            MagicMock(side_effect=[type("foo", (), foo), type("bar", (), bar)]),
         ):
             tops = thin.get_tops(extra_mods="foo,bar")
         self.assertEqual(len(tops), len(base_tops))
@@ -547,52 +537,50 @@ class SSHThinTestCase(TestCase):
         type("distro", (), {"__file__": "/site-packages/distro"}),
     )
     @patch(
-        "salt.utils.thin.salt",
-        type(str("salt"), (), {"__file__": "/site-packages/salt"}),
+        "salt.utils.thin.salt", type("salt", (), {"__file__": "/site-packages/salt"}),
     )
     @patch(
         "salt.utils.thin.jinja2",
-        type(str("jinja2"), (), {"__file__": "/site-packages/jinja2"}),
+        type("jinja2", (), {"__file__": "/site-packages/jinja2"}),
     )
     @patch(
-        "salt.utils.thin.yaml",
-        type(str("yaml"), (), {"__file__": "/site-packages/yaml"}),
+        "salt.utils.thin.yaml", type("yaml", (), {"__file__": "/site-packages/yaml"}),
     )
     @patch(
         "salt.utils.thin.tornado",
-        type(str("tornado"), (), {"__file__": "/site-packages/tornado"}),
+        type("tornado", (), {"__file__": "/site-packages/tornado"}),
     )
     @patch(
         "salt.utils.thin.msgpack",
-        type(str("msgpack"), (), {"__file__": "/site-packages/msgpack"}),
+        type("msgpack", (), {"__file__": "/site-packages/msgpack"}),
     )
     @patch(
         "salt.utils.thin.certifi",
-        type(str("certifi"), (), {"__file__": "/site-packages/certifi"}),
+        type("certifi", (), {"__file__": "/site-packages/certifi"}),
     )
     @patch(
         "salt.utils.thin.singledispatch",
-        type(str("singledispatch"), (), {"__file__": "/site-packages/sdp"}),
+        type("singledispatch", (), {"__file__": "/site-packages/sdp"}),
     )
     @patch(
         "salt.utils.thin.singledispatch_helpers",
-        type(str("singledispatch_helpers"), (), {"__file__": "/site-packages/sdp_hlp"}),
+        type("singledispatch_helpers", (), {"__file__": "/site-packages/sdp_hlp"}),
     )
     @patch(
         "salt.utils.thin.ssl_match_hostname",
-        type(str("ssl_match_hostname"), (), {"__file__": "/site-packages/ssl_mh"}),
+        type("ssl_match_hostname", (), {"__file__": "/site-packages/ssl_mh"}),
     )
     @patch(
         "salt.utils.thin.markupsafe",
-        type(str("markupsafe"), (), {"__file__": "/site-packages/markupsafe"}),
+        type("markupsafe", (), {"__file__": "/site-packages/markupsafe"}),
     )
     @patch(
         "salt.utils.thin.backports_abc",
-        type(str("backports_abc"), (), {"__file__": "/site-packages/backports_abc"}),
+        type("backports_abc", (), {"__file__": "/site-packages/backports_abc"}),
     )
     @patch(
         "salt.utils.thin.concurrent",
-        type(str("concurrent"), (), {"__file__": "/site-packages/concurrent"}),
+        type("concurrent", (), {"__file__": "/site-packages/concurrent"}),
     )
     @patch("salt.utils.thin.log", MagicMock())
     def test_get_tops_so_mods(self):
@@ -622,8 +610,8 @@ class SSHThinTestCase(TestCase):
             "{}.__import__".format(builtins),
             MagicMock(
                 side_effect=[
-                    type(str("salt"), (), {"__file__": "/custom/foo.so"}),
-                    type(str("salt"), (), {"__file__": "/custom/bar.so"}),
+                    type("salt", (), {"__file__": "/custom/foo.so"}),
+                    type("salt", (), {"__file__": "/custom/bar.so"}),
                 ]
             ),
         ):
@@ -910,9 +898,9 @@ class SSHThinTestCase(TestCase):
         files = []
         for py in ("py2", "py2", "py3", "pyall"):
             for i in range(1, 4):
-                files.append(os.path.join(py, "root", "r{0}".format(i)))
+                files.append(os.path.join(py, "root", "r{}".format(i)))
             for i in range(4, 7):
-                files.append(os.path.join(py, "root2", "r{0}".format(i)))
+                files.append(os.path.join(py, "root2", "r{}".format(i)))
         for cl in thin.tarfile.open().method_calls[:-6]:
             arcname = cl[2].get("arcname")
             self.assertIn(arcname, files)
@@ -999,9 +987,9 @@ class SSHThinTestCase(TestCase):
         files = []
         for py in ("pyall", "pyall", "py2"):
             for i in range(1, 4):
-                files.append(os.path.join("namespace", py, "root", "r{0}".format(i)))
+                files.append(os.path.join("namespace", py, "root", "r{}".format(i)))
             for i in range(4, 7):
-                files.append(os.path.join("namespace", py, "root2", "r{0}".format(i)))
+                files.append(os.path.join("namespace", py, "root2", "r{}".format(i)))
 
         for idx, cl in enumerate(thin.tarfile.open().method_calls[12:-6]):
             arcname = cl[2].get("arcname")
@@ -1143,8 +1131,14 @@ class SSHThinTestCase(TestCase):
         patch_which = patch("salt.utils.path.which", return_value=True)
         with patch_proc, patch_os, patch_which:
             with TstSuiteLoggingHandler() as log_handler:
+                exp_ret = copy.deepcopy(self.exp_ret)
                 ret = thin.get_tops_python("python2.7")
-                assert ret == self.exp_ret
+                if salt.utils.platform.is_windows():
+                    for key, value in ret.items():
+                        ret[key] = str(pathlib.Path(value).resolve(strict=False))
+                    for key, value in exp_ret.items():
+                        exp_ret[key] = str(pathlib.Path(value).resolve(strict=False))
+                assert ret == exp_ret
                 assert (
                     "ERROR:Could not auto detect file location for module concurrent for python version python2.7"
                     in log_handler.messages
@@ -1180,6 +1174,11 @@ class SSHThinTestCase(TestCase):
         patch_which = patch("salt.utils.path.which", return_value=True)
         with patch_proc, patch_os, patch_which:
             ret = thin.get_tops_python("python2.7", exclude=self.exc_libs)
+            if salt.utils.platform.is_windows():
+                for key, value in ret.items():
+                    ret[key] = str(pathlib.Path(value).resolve(strict=False))
+                for key, value in exp_ret.items():
+                    exp_ret[key] = str(pathlib.Path(value).resolve(strict=False))
             assert ret == exp_ret
 
     def test_pack_alternatives_exclude(self):


### PR DESCRIPTION
### What does this PR do?
See title