### PR TITLE
keystore: fix TypeError for non-empty keystore

### DIFF
--- a/salt/modules/keystore.py
+++ b/salt/modules/keystore.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 """
 Module to interact with keystores
 """
 
 # Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 import os
@@ -32,7 +30,7 @@ def __virtual__():
     Check dependencies
     """
     if has_depends is False:
-        msg = "jks unavailable: {0} execution module cant be loaded ".format(
+        msg = "jks unavailable: {} execution module cant be loaded ".format(
             __virtualname__
         )
         return False, msg
@@ -160,7 +158,7 @@ def add(name, keystore, passphrase, certificate, private_key=None):
         cert_string = __salt__["x509.get_pem_entry"](certificate)
     except SaltInvocationError:
         raise SaltInvocationError(
-            "Invalid certificate file or string: {0}".format(certificate)
+            "Invalid certificate file or string: {}".format(certificate)
         )
 
     if private_key:

--- a/salt/modules/keystore.py
+++ b/salt/modules/keystore.py
@@ -43,14 +43,14 @@ def _parse_cert(alias, public_cert, return_cert=False):
     ASN1 = OpenSSL.crypto.FILETYPE_ASN1
     PEM = OpenSSL.crypto.FILETYPE_PEM
     cert_data = {}
-    sha1 = public_cert.digest(b"sha1")
+    sha1 = public_cert.digest("sha1")
 
     cert_pem = OpenSSL.crypto.dump_certificate(PEM, public_cert)
-    raw_until = public_cert.get_notAfter()
+    raw_until = public_cert.get_notAfter().decode(__salt_system_encoding__)
     date_until = datetime.strptime(raw_until, "%Y%m%d%H%M%SZ")
     string_until = date_until.strftime("%B %d %Y")
 
-    raw_start = public_cert.get_notBefore()
+    raw_start = public_cert.get_notBefore().decode(__salt_system_encoding__)
     date_start = datetime.strptime(raw_start, "%Y%m%d%H%M%SZ")
     string_start = date_start.strftime("%B %d %Y")
 
@@ -117,7 +117,8 @@ def list(keystore, passphrase, alias=None, return_cert=False):
                 )
 
             # Detect if ASN1 binary, otherwise assume PEM
-            if "\x30" in cert_result[0]:
+            # ASN1 sequence is 30 in hexadecimal (48 in decimal)
+            if cert_result[0] == 48:
                 public_cert = OpenSSL.crypto.load_certificate(ASN1, cert_result)
             else:
                 public_cert = OpenSSL.crypto.load_certificate(PEM, cert_result)


### PR DESCRIPTION
Signed-off-by: Jean-Philippe Menil <jpmenil@gmail.com>

### What does this PR do?
Fix keystore state

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
```
╭─ubuntu@ubuntu /srv/salt
╰─➤sudo salt-call --local state.apply
[ERROR   ] An exception occurred in this state: Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/salt/state.py", line 2153, in call
    ret = self.states[cdata["full"]](
  File "/usr/lib/python3/dist-packages/salt/loader.py", line 2087, in wrapper
    return f(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/salt/states/keystore.py", line 90, in managed
    existing_entries = __salt__["keystore.list"](name, passphrase)
  File "/usr/lib/python3/dist-packages/salt/modules/keystore.py", line 120, in list
    if '\x30' in cert_result[0]:
TypeError: argument of type 'int' is not iterable

local:
----------
          ID: define_keystore
    Function: keystore.managed
        Name: /tmp/keystore
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python3/dist-packages/salt/state.py", line 2153, in call
                  ret = self.states[cdata["full"]](
                File "/usr/lib/python3/dist-packages/salt/loader.py", line 2087, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python3/dist-packages/salt/states/keystore.py", line 90, in managed
                  existing_entries = __salt__["keystore.list"](name, passphrase)
                File "/usr/lib/python3/dist-packages/salt/modules/keystore.py", line 120, in list
                  if '\x30' in cert_result[0]:
              TypeError: argument of type 'int' is not iterable
     Started: 22:07:30.166563
    Duration: 4.348 ms
     Changes:

Summary for local
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time:   4.348 ms
```

### New Behavior
```
╭─ubuntu@ubuntu /srv/salt
╰─➤sudo salt-call --local state.apply                                                                                                                                 1 ↵
local:
----------
          ID: define_keystore
    Function: keystore.managed
        Name: /tmp/keystore
      Result: True
     Comment: Alias hostname1 added.
              Alias test added.
              Alias client removed.
     Started: 22:04:56.307769
    Duration: 17.93 ms
     Changes:
              ----------
              client:
                  Removed
              hostname1:
                  Added
              test:
                  Added

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time:  17.930 ms
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
