### PR TITLE
fix msgpack max_buffer_size being to low in ver >= 0.6 and < 1.0

### DIFF
--- a/salt/utils/msgpack.py
+++ b/salt/utils/msgpack.py
@@ -92,7 +92,7 @@ def _add_msgpack_unpack_kwargs(kwargs):
     """
     Add any msgpack unpack kwargs here.
 
-    max_buffer_size: will make sure the buffer is set to a minimum 
+    max_buffer_size: will make sure the buffer is set to a minimum
     of 100MiB in versions >=6 and <1.0
     """
     assert isinstance(kwargs, dict)

--- a/salt/utils/msgpack.py
+++ b/salt/utils/msgpack.py
@@ -87,17 +87,19 @@ def _sanitize_msgpack_unpack_kwargs(kwargs):
         kwargs.setdefault("strict_map_key", False)
     return _sanitize_msgpack_kwargs(kwargs)
 
+
 def _add_msgpack_unpack_kwargs(kwargs):
-    '''
+    """
     Add any msgpack unpack kwargs here.
 
     max_buffer_size: will make sure the buffer is set to a minimum 
     of 100MiB in versions >=6 and <1.0
-    '''
+    """
     assert isinstance(kwargs, dict)
     if version >= (0, 6, 0) and version < (1, 0, 0):
         kwargs["max_buffer_size"] = 100 * 1024 * 1024
     return _sanitize_msgpack_unpack_kwargs(kwargs)
+
 
 class Unpacker(msgpack.Unpacker):
     """
@@ -105,9 +107,8 @@ class Unpacker(msgpack.Unpacker):
     """
 
     def __init__(self, *args, **kwargs):
-        msgpack.Unpacker.__init__(
-            self, *args, **_add_msgpack_unpack_kwargs(kwargs)
-        )
+        msgpack.Unpacker.__init__(self, *args, **_add_msgpack_unpack_kwargs(kwargs))
+
 
 def pack(o, stream, **kwargs):
     """

--- a/salt/utils/msgpack.py
+++ b/salt/utils/msgpack.py
@@ -87,6 +87,17 @@ def _sanitize_msgpack_unpack_kwargs(kwargs):
         kwargs.setdefault("strict_map_key", False)
     return _sanitize_msgpack_kwargs(kwargs)
 
+def _add_msgpack_unpack_kwargs(kwargs):
+    '''
+    Add any msgpack unpack kwargs here.
+
+    max_buffer_size: will make sure the buffer is set to a minimum 
+    of 100MiB in versions >=6 and <1.0
+    '''
+    assert isinstance(kwargs, dict)
+    if version >= (0, 6, 0) and version < (1, 0, 0):
+        kwargs["max_buffer_size"] = 100 * 1024 * 1024
+    return _sanitize_msgpack_unpack_kwargs(kwargs)
 
 class Unpacker(msgpack.Unpacker):
     """
@@ -95,9 +106,8 @@ class Unpacker(msgpack.Unpacker):
 
     def __init__(self, *args, **kwargs):
         msgpack.Unpacker.__init__(
-            self, *args, **_sanitize_msgpack_unpack_kwargs(kwargs)
+            self, *args, **_add_msgpack_unpack_kwargs(kwargs)
         )
-
 
 def pack(o, stream, **kwargs):
     """

--- a/salt/utils/msgpack.py
+++ b/salt/utils/msgpack.py
@@ -87,6 +87,17 @@ def _sanitize_msgpack_unpack_kwargs(kwargs):
         kwargs.setdefault("strict_map_key", False)
     return _sanitize_msgpack_kwargs(kwargs)
 
+def _add_msgpack_unpack_kwargs(kwargs):
+    '''
+    Add any msgpack unpack kwargs here.
+
+    max_buffer_size: will make sure the buffer is set to a minimum 
+    of 100MiB in versions >=6 and <1.0
+    '''
+    assert isinstance(kwargs, dict)
+    if version >= (0, 6, 0) and version < (1, 0, 0):
+        kwargs["max_buffer_size"] = 100 * 1024 * 1024
+    return _sanitize_msgpack_unpack_kwargs(kwargs)
 
 def _add_msgpack_unpack_kwargs(kwargs):
     """
@@ -107,8 +118,9 @@ class Unpacker(msgpack.Unpacker):
     """
 
     def __init__(self, *args, **kwargs):
-        msgpack.Unpacker.__init__(self, *args, **_add_msgpack_unpack_kwargs(kwargs))
-
+        msgpack.Unpacker.__init__(
+            self, *args, **_add_msgpack_unpack_kwargs(kwargs)
+        )
 
 def pack(o, stream, **kwargs):
     """

--- a/salt/utils/msgpack.py
+++ b/salt/utils/msgpack.py
@@ -1,14 +1,10 @@
 """
 Functions to work with MessagePack
 """
-
-# Import Python libs
-
 import logging
 
 log = logging.getLogger(__name__)
 
-# Import 3rd party libs
 HAS_MSGPACK = False
 try:
     import msgpack

--- a/salt/utils/msgpack.py
+++ b/salt/utils/msgpack.py
@@ -87,23 +87,12 @@ def _sanitize_msgpack_unpack_kwargs(kwargs):
         kwargs.setdefault("strict_map_key", False)
     return _sanitize_msgpack_kwargs(kwargs)
 
-def _add_msgpack_unpack_kwargs(kwargs):
-    '''
-    Add any msgpack unpack kwargs here.
-
-    max_buffer_size: will make sure the buffer is set to a minimum 
-    of 100MiB in versions >=6 and <1.0
-    '''
-    assert isinstance(kwargs, dict)
-    if version >= (0, 6, 0) and version < (1, 0, 0):
-        kwargs["max_buffer_size"] = 100 * 1024 * 1024
-    return _sanitize_msgpack_unpack_kwargs(kwargs)
 
 def _add_msgpack_unpack_kwargs(kwargs):
     """
     Add any msgpack unpack kwargs here.
 
-    max_buffer_size: will make sure the buffer is set to a minimum
+    max_buffer_size: will make sure the buffer is set to a minimum 
     of 100MiB in versions >=6 and <1.0
     """
     assert isinstance(kwargs, dict)
@@ -118,9 +107,8 @@ class Unpacker(msgpack.Unpacker):
     """
 
     def __init__(self, *args, **kwargs):
-        msgpack.Unpacker.__init__(
-            self, *args, **_add_msgpack_unpack_kwargs(kwargs)
-        )
+        msgpack.Unpacker.__init__(self, *args, **_add_msgpack_unpack_kwargs(kwargs))
+
 
 def pack(o, stream, **kwargs):
     """

--- a/tests/unit/utils/test_msgpack.py
+++ b/tests/unit/utils/test_msgpack.py
@@ -164,6 +164,21 @@ class TestMsgpack(TestCase):
         for size in sizes:
             self.assertEqual(unpacker.unpack(), {i: i * 2 for i in range(size)})
 
+    def test_max_buffer_size(self):
+        '''
+        Test if max buffer size allows at least 100MiB
+        '''
+        bio = BytesIO()
+        bio.write(salt.utils.msgpack.packb('0' * (100 * 1024 * 1024)))
+        bio.seek(0)
+        unpacker = salt.utils.msgpack.Unpacker(bio)
+        raised = False
+        try:
+            unpacker.unpack()
+        except ValueError:
+            raised = True
+        self.assertFalse(raised)
+
     def test_exceptions(self):
         # Verify that this exception exists
         self.assertTrue(salt.utils.msgpack.exceptions.PackValueError)

--- a/tests/unit/utils/test_msgpack.py
+++ b/tests/unit/utils/test_msgpack.py
@@ -165,11 +165,11 @@ class TestMsgpack(TestCase):
             self.assertEqual(unpacker.unpack(), {i: i * 2 for i in range(size)})
 
     def test_max_buffer_size(self):
-        '''
+        """
         Test if max buffer size allows at least 100MiB
-        '''
+        """
         bio = BytesIO()
-        bio.write(salt.utils.msgpack.packb('0' * (100 * 1024 * 1024)))
+        bio.write(salt.utils.msgpack.packb("0" * (100 * 1024 * 1024)))
         bio.seek(0)
         unpacker = salt.utils.msgpack.Unpacker(bio)
         raised = False

--- a/tests/unit/utils/test_msgpack.py
+++ b/tests/unit/utils/test_msgpack.py
@@ -1,9 +1,6 @@
 """
 Test the MessagePack utility
 """
-
-# Import Python Libs
-
 import inspect
 import os
 import pprint
@@ -13,11 +10,7 @@ from io import BytesIO
 
 import salt.utils.msgpack
 from salt.ext.six.moves import range
-
-# Import Salt Libs
 from salt.utils.odict import OrderedDict
-
-# Import Salt Testing Libs
 from tests.support.unit import TestCase, skipIf
 
 try:

--- a/tests/unit/utils/test_msgpack.py
+++ b/tests/unit/utils/test_msgpack.py
@@ -179,21 +179,6 @@ class TestMsgpack(TestCase):
             raised = True
         self.assertFalse(raised)
 
-    def test_max_buffer_size(self):
-        """
-        Test if max buffer size allows at least 100MiB
-        """
-        bio = BytesIO()
-        bio.write(salt.utils.msgpack.packb("0" * (100 * 1024 * 1024)))
-        bio.seek(0)
-        unpacker = salt.utils.msgpack.Unpacker(bio)
-        raised = False
-        try:
-            unpacker.unpack()
-        except ValueError:
-            raised = True
-        self.assertFalse(raised)
-
     def test_exceptions(self):
         # Verify that this exception exists
         self.assertTrue(salt.utils.msgpack.exceptions.PackValueError)

--- a/tests/unit/utils/test_msgpack.py
+++ b/tests/unit/utils/test_msgpack.py
@@ -179,6 +179,21 @@ class TestMsgpack(TestCase):
             raised = True
         self.assertFalse(raised)
 
+    def test_max_buffer_size(self):
+        '''
+        Test if max buffer size allows at least 100MiB
+        '''
+        bio = BytesIO()
+        bio.write(salt.utils.msgpack.packb('0' * (100 * 1024 * 1024)))
+        bio.seek(0)
+        unpacker = salt.utils.msgpack.Unpacker(bio)
+        raised = False
+        try:
+            unpacker.unpack()
+        except ValueError:
+            raised = True
+        self.assertFalse(raised)
+
     def test_exceptions(self):
         # Verify that this exception exists
         self.assertTrue(salt.utils.msgpack.exceptions.PackValueError)

--- a/tests/unit/utils/test_msgpack.py
+++ b/tests/unit/utils/test_msgpack.py
@@ -180,11 +180,11 @@ class TestMsgpack(TestCase):
         self.assertFalse(raised)
 
     def test_max_buffer_size(self):
-        '''
+        """
         Test if max buffer size allows at least 100MiB
-        '''
+        """
         bio = BytesIO()
-        bio.write(salt.utils.msgpack.packb('0' * (100 * 1024 * 1024)))
+        bio.write(salt.utils.msgpack.packb("0" * (100 * 1024 * 1024)))
         bio.seek(0)
         unpacker = salt.utils.msgpack.Unpacker(bio)
         raised = False


### PR DESCRIPTION
salt 3000 introduced a dependency on Python msgpack >= 0.6. In msgpack 0.6 their
developers changed the max length of a string that could be unpacked from 2GiB
to 1MiB. They then proceeded to change it to 100MiB in msgpack 1.0. Now when
using msgpack >=0.6 and < 1.0, any message that is unpacked larger than 1MiB
will throw an error. For example a file state which tries to send a file larger
than 1MiB will get the following error:

Unable to manage file: 1048688 exceeds max_str_len(1048576)

This error could send the master into a tailspin where subsequent file
operations take a long time or just time out.

This patch sets the keyword argument max_buffer_size for the Unpacker to 100MiB
which is the msgpack 1.0 default now. It will allow people to use msgpack
versions >.6 and < 1.0 without this crazy low limit. It should be discussed if
we go back to the 2GiB size from < 0.6 days (my vote), or just anything larger
than 100MB. This code does a version check, and will only set the keyword on
msgpack > = 0.6 and < 1.0.

The test checks that we have a buffer size of at least 100MiB in case the Python
msgpack devs decide to lower this value again, and break things. We want enforce
a decent minimum.

fixes saltstack/salt#53230, fixes saltstack/salt#54884,
fixes saltstack/salt#55180, fixes saltstack/salt#55184,
fixes saltstack/salt#57026, fixes saltstack/salt#57921

### What does this PR do?
Fixes error "...exceeds max_str_len(1048576)" when using msgpack ver >= 0.6 and < 1.0.

### What issues does this PR fix or reference?
fixes saltstack/salt#53230, fixes saltstack/salt#54884,
fixes saltstack/salt#55180, fixes saltstack/salt#55184,
fixes saltstack/salt#57026, fixes saltstack/salt#57921

### Previous Behavior
When trying to unpack a message larger than 1MiB from the salt bus using msgpack, you will get the error mentioned in "What does this PR do?". Then the master will usually hang for long periods or just die. 

### New Behavior
After patch, the limit will be bumped to 100MiB and allow much larger files and not throw errors.

### Merge requirements satisfied?
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No
