### PR TITLE
Force version type to string in deb_postgres module

### DIFF
--- a/changelog/50899.fixed
+++ b/changelog/50899.fixed
@@ -1,0 +1,5 @@
+permit the use of int/float type for the version in:
+ - the state postgres_cluster.present
+ - the state postgres_cluster.absent
+ - the module postgres.cluster_create
+ - the module postgres.cluster_remove

--- a/salt/modules/deb_postgres.py
+++ b/salt/modules/deb_postgres.py
@@ -73,7 +73,7 @@ def cluster_create(
         cmd += ["--encoding", encoding]
     if datadir:
         cmd += ["--datadir", datadir]
-    cmd += [version, name]
+    cmd += [six.text_type(version), name]
     # initdb-specific options are passed after '--'
     if allow_group_access or data_checksums or wal_segsize:
         cmd += ["--"]
@@ -147,7 +147,7 @@ def cluster_remove(version, name="main", stop=False):
     cmd = [salt.utils.path.which("pg_dropcluster")]
     if stop:
         cmd += ["--stop"]
-    cmd += [version, name]
+    cmd += [six.text_type(version), name]
     cmdstr = " ".join([pipes.quote(c) for c in cmd])
     ret = __salt__["cmd.run_all"](cmdstr, python_shell=False)
     # FIXME - return Boolean ?

--- a/salt/modules/deb_postgres.py
+++ b/salt/modules/deb_postgres.py
@@ -1,18 +1,15 @@
-# -*- coding: utf-8 -*-
 """
 Module to provide Postgres compatibility to salt for debian family specific tools.
 
 """
 
 # Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 import pipes
 
 # Import salt libs
 import salt.utils.path
-from salt.ext import six
 
 # Import 3rd-party libs
 
@@ -66,14 +63,14 @@ def cluster_create(
 
     cmd = [salt.utils.path.which("pg_createcluster")]
     if port:
-        cmd += ["--port", six.text_type(port)]
+        cmd += ["--port", str(port)]
     if locale:
         cmd += ["--locale", locale]
     if encoding:
         cmd += ["--encoding", encoding]
     if datadir:
         cmd += ["--datadir", datadir]
-    cmd += [six.text_type(version), name]
+    cmd += [str(version), name]
     # initdb-specific options are passed after '--'
     if allow_group_access or data_checksums or wal_segsize:
         cmd += ["--"]
@@ -125,7 +122,7 @@ def cluster_exists(version, name="main"):
 
         salt '*' postgres.cluster_exists '9.3' 'main'
     """
-    return "{0}/{1}".format(version, name) in cluster_list()
+    return "{}/{}".format(version, name) in cluster_list()
 
 
 def cluster_remove(version, name="main", stop=False):
@@ -147,16 +144,14 @@ def cluster_remove(version, name="main", stop=False):
     cmd = [salt.utils.path.which("pg_dropcluster")]
     if stop:
         cmd += ["--stop"]
-    cmd += [six.text_type(version), name]
+    cmd += [str(version), name]
     cmdstr = " ".join([pipes.quote(c) for c in cmd])
     ret = __salt__["cmd.run_all"](cmdstr, python_shell=False)
     # FIXME - return Boolean ?
     if ret.get("retcode", 0) != 0:
         log.error("Error removing a Postgresql cluster %s/%s", version, name)
     else:
-        ret["changes"] = ("Successfully removed" " cluster {0}/{1}").format(
-            version, name
-        )
+        ret["changes"] = ("Successfully removed" " cluster {}/{}").format(version, name)
     return ret
 
 
@@ -167,7 +162,7 @@ def _parse_pg_lscluster(output):
     cluster_dict = {}
     for line in output.splitlines():
         version, name, port, status, user, datadir, log = line.split()
-        cluster_dict["{0}/{1}".format(version, name)] = {
+        cluster_dict["{}/{}".format(version, name)] = {
             "port": int(port),
             "status": status,
             "user": user,

--- a/tests/unit/modules/test_deb_postgres.py
+++ b/tests/unit/modules/test_deb_postgres.py
@@ -82,14 +82,22 @@ class PostgresClusterTestCase(TestCase, LoaderModuleMockMixin):
         )
         self.assertEqual(cmdstr, self.cmd_run_all_mock.call_args[0][0])
 
-    # XXX version should be a string but from cmdline you get a float
-    # def test_cluster_create_with_float(self):
-    #     self.assertRaises(AssertionError, deb_postgres.cluster_create,
-    #                       (9.3,'main',),
-    #                       dict(port='5432',
-    #                            locale='fr_FR',
-    #                            encoding='UTF-8',
-    #                            datadir='/opt/postgresql'))
+    def test_cluster_create_with_float(self):
+        deb_postgres.cluster_create(
+            9.3,
+            "main",
+            port="5432",
+            locale="fr_FR",
+            encoding="UTF-8",
+            datadir="/opt/postgresql",
+        )
+        cmdstr = (
+            "/usr/bin/pg_createcluster "
+            "--port 5432 --locale fr_FR --encoding UTF-8 "
+            "--datadir /opt/postgresql "
+            "9.3 main"
+        )
+        self.assertEqual(cmdstr, self.cmd_run_all_mock.call_args[0][0])
 
 
 class PostgresLsClusterTestCase(TestCase, LoaderModuleMockMixin):
@@ -180,6 +188,11 @@ class PostgresDeleteClusterTestCase(TestCase, LoaderModuleMockMixin):
             "/usr/bin/pg_dropcluster 9.3 main", self.cmd_run_all_mock.call_args[0][0]
         )
         deb_postgres.cluster_remove("9.3", "main", stop=True)
+        self.assertEqual(
+            "/usr/bin/pg_dropcluster --stop 9.3 main",
+            self.cmd_run_all_mock.call_args[0][0],
+        )
+        deb_postgres.cluster_remove(9.3, "main", stop=True)
         self.assertEqual(
             "/usr/bin/pg_dropcluster --stop 9.3 main",
             self.cmd_run_all_mock.call_args[0][0],


### PR DESCRIPTION
### What does this PR do?
It ensure every-time we use 'version' in the deb_postgress module, it will be converted as a string.
Either by str or by format.

### What issues does this PR fix or reference?
Fixes: #50899 

### Previous Behavior
`salt-call postgres.cluster_create '9.6' 'pgtest' port=5433 -l debug` would not work because the `'` would be eaten by bash, requiring
`salt-call postgres.cluster_create "'9.6'" 'pgtest' port=5433 -l debug`

```
postgresql_9.6_cluser_pgtest_present:
  postgres_cluster.present:
    - name: pgtest
    - version: 9.6
    - port: 5433
```
would not work because Yaml see version as a float, requiring
```
postgresql_9.6_cluser_pgtest_present:
  postgres_cluster.present:
    - name: pgtest
    - version: '9.6'
    - port: 5433
```

### New Behavior
What's above now work.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
