### PR TITLE
Add timeout kwarg docs for service.running and service.dead

### DIFF
--- a/58311.fixed
+++ b/58311.fixed
@@ -1,0 +1,1 @@
+Add timeout kwarg docs for service.running and service.dead

--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -388,6 +388,15 @@ def running(name, enable=None, sig=None, init_delay=None, **kwargs):
 
         .. versionadded:: 2017.7.0
 
+    timeout
+        **For Windows minions only.**
+
+        The time in seconds to wait for the service to start before returning.
+        Default is the default for :py:func:`win_service.start
+        <salt.modules.win_service.start>`.
+
+        .. versionadded:: 2017.7.9,2018.3.4
+
     unmask : False
         **For systemd minions only.** Set to ``True`` to remove an indefinite
         mask before attempting to start the service.
@@ -601,6 +610,16 @@ def dead(name, enable=None, sig=None, init_delay=None, **kwargs):
         **For systemd minions only.** Stops the service using ``--no-block``.
 
         .. versionadded:: 2017.7.0
+
+    timeout
+        **For Windows minions only.**
+
+        The time in seconds to wait for the service to stop before returning.
+        Default is the default for :py:func:`win_service.stop
+        <salt.modules.win_service.stop>`.
+
+        .. versionadded:: 2017.7.9,2018.3.4
+
     """
     ret = {"name": name, "changes": {}, "result": True, "comment": ""}
 


### PR DESCRIPTION
### What does this PR do?

Adds `timeout` kwarg docs for `service.running` and `service.dead`.

### What issues does this PR fix or reference?

Fixes #58311.

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- (n/a) Tests written/updated

### Commits signed with GPG?

No