### PR TITLE
datadog_api: Include information about required 3rd-party module

### DIFF
--- a/salt/modules/datadog_api.py
+++ b/salt/modules/datadog_api.py
@@ -1,13 +1,18 @@
 """
 An execution module that interacts with the Datadog API
 
-The following parameters are required for all functions.
+:depends: datadog_ Python module
 
-api_key
-    The datadog API key
+.. _datadog: https://pypi.python.org/pypi/datadog
 
-app_key
-    The datadog application key
+.. note::
+    The following parameters are required for all functions:
+
+    api_key
+        The datadog API key
+
+    app_key
+        The datadog application key
 
 Full argument reference is available on the Datadog API reference page
 https://docs.datadoghq.com/api/

--- a/salt/modules/datadog_api.py
+++ b/salt/modules/datadog_api.py
@@ -18,7 +18,6 @@ Full argument reference is available on the Datadog API reference page
 https://docs.datadoghq.com/api/
 """
 
-
 import requests
 
 from salt.exceptions import SaltInvocationError


### PR DESCRIPTION
The required 3rd-party module was not included in the docstring for this module. This properly documents the required module, to help reduce confusion.