### PR TITLE
Use default timezone offset in scheduler when correct timezone cannot be determined

### DIFF
--- a/changelog/58379.fixed
+++ b/changelog/58379.fixed
@@ -1,2 +1,3 @@
 Fixed issue with win_timezone when dst is turned off. This was causing the
 minion not to start
+Use default timezone offset in scheduler when correct timezone cannot be determined

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -160,7 +160,18 @@ class Schedule:
                 self.returners = returners
             else:
                 self.returners = returners.loader.gen_functions()
-        self.time_offset = self.functions.get("timezone.get_offset", lambda: "0000")()
+        try:
+            self.time_offset = self.functions.get(
+                "timezone.get_offset", lambda: "0000"
+            )()
+        except Exception:  # pylint: disable=W0703
+            # get_offset can fail, if that happens, default to 0000
+            log.warning(
+                "Unable to obtain correct timezone offset, defaulting to 0000",
+                exc_info_on_loglevel=logging.DEBUG,
+            )
+            self.time_offset = "0000"
+
         self.schedule_returner = self.option("schedule_returner")
         # Keep track of the lowest loop interval needed in this variable
         self.loop_interval = six.MAXSIZE

--- a/tests/pytests/unit/utils/test_schedule.py
+++ b/tests/pytests/unit/utils/test_schedule.py
@@ -1,0 +1,57 @@
+import pytest
+import salt.utils.schedule
+from tests.support.mock import MagicMock
+
+try:
+    import pytz.exceptions
+
+    HAS_LIBS = True
+except ImportError:
+    HAS_LIBS = False
+
+
+def test_correct_tz_offset():
+    kwargs = {
+        "opts": {},
+        "functions": {"timezone.get_offset": lambda: "0200"},
+        "cleanup": False,
+        "standalone": True,
+        "new_instance": True,
+        "utils": {"k": "v"},
+    }
+
+    s = salt.utils.schedule.Schedule(**kwargs)
+    assert s.time_offset == "0200"
+
+
+def test_default_tz_offset():
+    kwargs = {
+        "opts": {},
+        "functions": {},
+        "cleanup": False,
+        "standalone": True,
+        "new_instance": True,
+        "utils": {"k": "v"},
+    }
+
+    s = salt.utils.schedule.Schedule(**kwargs)
+    assert s.time_offset == "0000"
+
+
+@pytest.mark.skipif(not HAS_LIBS, reason="pytz is not installed")
+def test_default_tz_offset_exc():
+    kwargs = {
+        "opts": {},
+        "functions": {
+            "timezone.get_offset": MagicMock(
+                side_effect=pytz.exceptions.UnknownTimeZoneError("Unknown")
+            )
+        },
+        "cleanup": False,
+        "standalone": True,
+        "new_instance": True,
+        "utils": {"k": "v"},
+    }
+
+    s = salt.utils.schedule.Schedule(**kwargs)
+    assert s.time_offset == "0000"


### PR DESCRIPTION
### What does this PR do?
Defaults timezone offset to `0000` if `timezone.get_offset` raises and exception when scheduler is instantiated.

There can be also destructive integration tests written, to test this scenario fully (which will mess with Win registries), but from grepping the Salt codebase, it seems `timezone` module is only used in `salt.util.schedule` and `salt.states.timezone` 

### What issues does this PR fix or reference?
Fixes: #58379

### Previous Behavior
Minion fails hard with `[salt.minion      :1050][CRITICAL][972] Unexpected error while connecting to <master>` if timezone cannot be determined.

### New Behavior
Minions starts up and connects to master, although using default offset. Note that `win_timezone.*` modules can still fail with `pytz.exceptions.UnknownTimeZoneError` error and `win_timezone.get_timezone` still returns `Unknown`.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

