### PR TITLE
 Ensure reactor system available when running reactor runner

### DIFF
--- a/changelog/58384.fixed
+++ b/changelog/58384.fixed
@@ -1,0 +1,1 @@
+Reactor runner functions will now ensure reactor system is available before attempting to run and error out if it is not available.

--- a/salt/runners/reactor.py
+++ b/salt/runners/reactor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 A convenience system to manage reactors
 
@@ -14,7 +13,6 @@ engine configuration for the Salt master.
 
 """
 # Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
@@ -25,6 +23,7 @@ import salt.utils.event
 import salt.utils.master
 import salt.utils.process
 import salt.utils.reactor
+from salt.exceptions import CommandExecutionError
 from salt.ext.six import string_types
 
 log = logging.getLogger(__name__)
@@ -32,6 +31,18 @@ log = logging.getLogger(__name__)
 __func_alias__ = {
     "list_": "list",
 }
+
+
+def _reactor_system_available():
+    """
+    Helper to see if the reactor system is available
+    """
+    if __opts__.get("engines", {}):
+        if any([True for engine in __opts__["engines"] if "reactor" in engine]):
+            return True
+    elif __opts__.get("reactor", {}) and __opts__["reactor"]:
+        return True
+    return False
 
 
 def list_(saltenv="base", test=None):
@@ -44,6 +55,9 @@ def list_(saltenv="base", test=None):
 
         salt-run reactor.list
     """
+    if not _reactor_system_available():
+        raise CommandExecutionError("Reactor system is not running.")
+
     sevent = salt.utils.event.get_event(
         "master",
         __opts__["sock_dir"],
@@ -71,6 +85,9 @@ def add(event, reactors, saltenv="base", test=None):
 
         salt-run reactor.add 'salt/cloud/*/destroyed' reactors='/srv/reactor/destroy/*.sls'
     """
+    if not _reactor_system_available():
+        raise CommandExecutionError("Reactor system is not running.")
+
     if isinstance(reactors, string_types):
         reactors = [reactors]
 
@@ -103,6 +120,9 @@ def delete(event, saltenv="base", test=None):
 
         salt-run reactor.delete 'salt/cloud/*/destroyed'
     """
+    if not _reactor_system_available():
+        raise CommandExecutionError("Reactor system is not running.")
+
     sevent = salt.utils.event.get_event(
         "master",
         __opts__["sock_dir"],
@@ -131,6 +151,9 @@ def is_leader():
 
         salt-run reactor.is_leader
     """
+    if not _reactor_system_available():
+        raise CommandExecutionError("Reactor system is not running.")
+
     sevent = salt.utils.event.get_event(
         "master",
         __opts__["sock_dir"],
@@ -157,6 +180,9 @@ def set_leader(value=True):
 
         salt-run reactor.set_leader True
     """
+    if not _reactor_system_available():
+        raise CommandExecutionError("Reactor system is not running.")
+
     sevent = salt.utils.event.get_event(
         "master",
         __opts__["sock_dir"],

--- a/tests/support/case.py
+++ b/tests/support/case.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
     :codeauthor: Pedro Algarvio (pedro@algarvio.me)
 
@@ -165,6 +164,7 @@ class ShellCase(TestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixin):
         Execute the runner function and return the return data and output in a dict
         """
         output = kwargs.pop("_output", None)
+        opts_overrides = kwargs.pop("opts_overrides", None)
         ret = {"fun": fun}
 
         # Late import
@@ -173,6 +173,8 @@ class ShellCase(TestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixin):
         import salt.runner
 
         opts = salt.config.client_config(self.get_config_file_path("master"))
+        if opts_overrides:
+            opts.update(opts_overrides)
 
         opts_arg = list(arg)
         if kwargs:


### PR DESCRIPTION
### What does this PR do?
Need to check that the reactor system is available before attempting to run any of the reactor runner functions.  Adding tests.

### What issues does this PR fix or reference?
Fixes: #57791 

### Previous Behavior
Reactor runner would hand if the reactor system was not available.

### New Behavior
Reactor runner functions will now ensure reactor system is available before attempting to run and error out if it is not available.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
