### PR TITLE
Fix Docs: Salt 3000 onlyif targeting with grains cannot have a space in function query

### DIFF
--- a/doc/ref/states/requisites.rst
+++ b/doc/ref/states/requisites.rst
@@ -972,14 +972,14 @@ if the gluster commands return a 0 ret value.
             - name: httpd
             - onlyif:
               - fun: match.grain
-                tgt: 'os_family: RedHat'
+                tgt: 'os_family:RedHat'
 
         install apache on debian based distros:
           pkg.latest:
             - name: apache2
             - onlyif:
               - fun: match.grain
-                tgt: 'os_family: Debian'
+                tgt: 'os_family:Debian'
 
     .. code-block:: yaml
 


### PR DESCRIPTION
# What does this PR do?

This PR updates documentation on `onlyif` and grain targeting. The example when copy-pasted does not work and the requisite ends up being `False` because of the space in the grain target.

### What issues does this PR fix or reference?
Have not filed an Issue for this.

### Previous Behavior
Salt State:
```
common_packages_xenial:
  <custom_package_module>.latest:
    - pkgs:
      - libprocps4
      - libjson-c2
    - require:
      - cmd: run an apt-get update
    - onlyif:
      - fun: match.grain
        tgt: 'os_family: Debian'
```
Output:
```
----------
          ID: common_packages_xenial
    Function: <custom_package_module>.latest
      Result: True
     Comment: onlyif condition is false
     Started: 18:41:38.048329
    Duration: 920.968 ms
     Changes:
```

### New Behavior
Salt State:
```
common_packages_xenial:
  <custom_package_module>.latest:
    - pkgs:
      - libprocps4
      - libjson-c2
    - require:
      - cmd: run an apt-get update
    - onlyif:
      - fun: match.grain
        tgt: 'os_family:Debian'
```
Output:
```
----------
          ID: common_packages_xenial
    Function: <custom_package_module>.latest
      Result: True
     Comment: All packages are up-to-date (libjson-c2, libprocps4).
     Started: 18:49:18.433027
    Duration: 1152.311 ms
     Changes:
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
