### PR TITLE
modules/opkg: create restartcheck state if it's dir doesn't exist

### DIFF
--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Support for Opkg
 
@@ -17,7 +16,6 @@ Support for Opkg
 
 """
 # Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import copy
 import errno
@@ -37,7 +35,6 @@ import salt.utils.versions
 from salt.exceptions import CommandExecutionError, MinionError, SaltInvocationError
 
 # Import 3rd-party libs
-from salt.ext import six
 from salt.ext.six.moves import shlex_quote as _cmd_quote  # pylint: disable=import-error
 
 REPO_REGEXP = r'^#?\s*(src|src/gz)\s+([^\s<>]+|"[^<>]+")\s+[^\s<>]+'
@@ -71,12 +68,12 @@ def _update_nilrt_restart_state():
 
     """
     __salt__["cmd.shell"](
-        "stat -c %Y /lib/modules/$(uname -r)/modules.dep >{0}/modules.dep.timestamp".format(
+        "stat -c %Y /lib/modules/$(uname -r)/modules.dep >{}/modules.dep.timestamp".format(
             NILRT_RESTARTCHECK_STATE_PATH
         )
     )
     __salt__["cmd.shell"](
-        "md5sum /lib/modules/$(uname -r)/modules.dep >{0}/modules.dep.md5sum".format(
+        "md5sum /lib/modules/$(uname -r)/modules.dep >{}/modules.dep.md5sum".format(
             NILRT_RESTARTCHECK_STATE_PATH
         )
     )
@@ -85,12 +82,12 @@ def _update_nilrt_restart_state():
     nisysapi_path = "/usr/local/natinst/share/nisysapi.ini"
     if os.path.exists(nisysapi_path):
         __salt__["cmd.shell"](
-            "stat -c %Y {0} >{1}/nisysapi.ini.timestamp".format(
+            "stat -c %Y {} >{}/nisysapi.ini.timestamp".format(
                 nisysapi_path, NILRT_RESTARTCHECK_STATE_PATH
             )
         )
         __salt__["cmd.shell"](
-            "md5sum {0} >{1}/nisysapi.ini.md5sum".format(
+            "md5sum {} >{}/nisysapi.ini.md5sum".format(
                 nisysapi_path, NILRT_RESTARTCHECK_STATE_PATH
             )
         )
@@ -134,19 +131,12 @@ def __virtual__():
             if exc.errno != errno.EEXIST:
                 return (
                     False,
-                    "Error creating {0} (-{1}): {2}".format(
+                    "Error creating {} (-{}): {}".format(
                         NILRT_RESTARTCHECK_STATE_PATH, exc.errno, exc.strerror
                     ),
                 )
-        # modules.dep always exists, make sure its restart state files also exist
-        if not (
-            os.path.exists(
-                os.path.join(NILRT_RESTARTCHECK_STATE_PATH, "modules.dep.timestamp")
-            )
-            and os.path.exists(
-                os.path.join(NILRT_RESTARTCHECK_STATE_PATH, "modules.dep.md5sum")
-            )
-        ):
+        # populate state dir if empty
+        if not os.listdir(NILRT_RESTARTCHECK_STATE_PATH):
             _update_nilrt_restart_state()
         return __virtualname__
 
@@ -278,7 +268,7 @@ def refresh_db(failhard=False, **kwargs):  # pylint: disable=unused-argument
 
     if failhard and error_repos:
         raise CommandExecutionError(
-            "Error getting repos: {0}".format(", ".join(error_repos))
+            "Error getting repos: {}".format(", ".join(error_repos))
         )
 
     # On a non-zero exit code where no failed repos were found, raise an
@@ -480,7 +470,7 @@ def install(
     elif pkg_type == "repository":
         if not kwargs.get("install_recommends", True):
             cmd_prefix.append("--no-install-recommends")
-        for pkgname, pkgversion in six.iteritems(pkg_params):
+        for pkgname, pkgversion in pkg_params.items():
             if name and pkgs is None and kwargs.get("version") and len(pkg_params) == 1:
                 # Only use the 'version' param if 'name' was not specified as a
                 # comma-separated list
@@ -496,7 +486,7 @@ def install(
                 else:
                     to_install.append(pkgname)
             else:
-                pkgstr = "{0}={1}".format(pkgname, version_num)
+                pkgstr = "{}={}".format(pkgname, version_num)
                 cver = old.get(pkgname, "")
                 if (
                     reinstall
@@ -804,18 +794,18 @@ def hold(name=None, pkgs=None, sources=None, **kwargs):  # pylint: disable=W0613
 
         state = _get_state(target)
         if not state:
-            ret[target]["comment"] = "Package {0} not currently held.".format(target)
+            ret[target]["comment"] = "Package {} not currently held.".format(target)
         elif state != "hold":
             if "test" in __opts__ and __opts__["test"]:
                 ret[target].update(result=None)
-                ret[target]["comment"] = "Package {0} is set to be held.".format(target)
+                ret[target]["comment"] = "Package {} is set to be held.".format(target)
             else:
                 result = _set_state(target, "hold")
                 ret[target].update(changes=result[target], result=True)
-                ret[target]["comment"] = "Package {0} is now being held.".format(target)
+                ret[target]["comment"] = "Package {} is now being held.".format(target)
         else:
             ret[target].update(result=True)
-            ret[target]["comment"] = "Package {0} is already set to be held.".format(
+            ret[target]["comment"] = "Package {} is already set to be held.".format(
                 target
             )
     return ret
@@ -867,22 +857,22 @@ def unhold(name=None, pkgs=None, sources=None, **kwargs):  # pylint: disable=W06
 
         state = _get_state(target)
         if not state:
-            ret[target]["comment"] = "Package {0} does not have a state.".format(target)
+            ret[target]["comment"] = "Package {} does not have a state.".format(target)
         elif state == "hold":
             if "test" in __opts__ and __opts__["test"]:
                 ret[target].update(result=None)
-                ret["comment"] = "Package {0} is set not to be held.".format(target)
+                ret["comment"] = "Package {} is set not to be held.".format(target)
             else:
                 result = _set_state(target, "ok")
                 ret[target].update(changes=result[target], result=True)
                 ret[target][
                     "comment"
-                ] = "Package {0} is no longer being " "held.".format(target)
+                ] = "Package {} is no longer being " "held.".format(target)
         else:
             ret[target].update(result=True)
             ret[target][
                 "comment"
-            ] = "Package {0} is already set not to be " "held.".format(target)
+            ] = "Package {} is already set not to be " "held.".format(target)
     return ret
 
 
@@ -925,7 +915,7 @@ def _set_state(pkg, state):
     ret = {}
     valid_states = ("hold", "noprune", "user", "ok", "installed", "unpacked")
     if state not in valid_states:
-        raise SaltInvocationError("Invalid state: {0}".format(state))
+        raise SaltInvocationError("Invalid state: {}".format(state))
     oldstate = _get_state(pkg)
     cmd = ["opkg", "flag"]
     cmd.append(state)
@@ -1109,7 +1099,7 @@ def info_installed(*names, **kwargs):
     attr = kwargs.pop("attr", None)
     if attr is None:
         filter_attrs = None
-    elif isinstance(attr, six.string_types):
+    elif isinstance(attr, str):
         filter_attrs = set(attr.split(","))
     else:
         filter_attrs = set(attr)
@@ -1180,11 +1170,7 @@ def version_cmp(
 
         salt '*' pkg.version_cmp '0.2.4-0' '0.2.4.1-0'
     """
-    normalize = (
-        lambda x: six.text_type(x).split(":", 1)[-1]
-        if ignore_epoch
-        else six.text_type(x)
-    )
+    normalize = lambda x: str(x).split(":", 1)[-1] if ignore_epoch else str(x)
     pkg1 = normalize(pkg1)
     pkg2 = normalize(pkg2)
 
@@ -1271,7 +1257,7 @@ def get_repo(repo, **kwargs):  # pylint: disable=unused-argument
     repos = list_repos()
 
     if repos:
-        for source in six.itervalues(repos):
+        for source in repos.values():
             for sub in source:
                 if sub["name"] == repo:
                     return sub
@@ -1361,7 +1347,7 @@ def del_repo(repo, **kwargs):  # pylint: disable=unused-argument
                 source = repos[repository][0]
                 if source["file"] in deleted_from:
                     deleted_from[source["file"]] += 1
-            for repo_file, count in six.iteritems(deleted_from):
+            for repo_file, count in deleted_from.items():
                 msg = "Repo '{0}' has been removed from {1}.\n"
                 if count == 1 and os.path.isfile(repo_file):
                     msg = "File {1} containing repo '{0}' has been " "removed.\n"
@@ -1374,7 +1360,7 @@ def del_repo(repo, **kwargs):  # pylint: disable=unused-argument
                 refresh_db()
             return ret
 
-    return "Repo {0} doesn't exist in the opkg repo lists".format(repo)
+    return "Repo {} doesn't exist in the opkg repo lists".format(repo)
 
 
 def mod_repo(repo, **kwargs):
@@ -1422,23 +1408,21 @@ def mod_repo(repo, **kwargs):
                 repostr += "src/gz" if source["compressed"] else "src"
             repo_alias = kwargs["alias"] if "alias" in kwargs else repo
             if " " in repo_alias:
-                repostr += ' "{0}"'.format(repo_alias)
+                repostr += ' "{}"'.format(repo_alias)
             else:
-                repostr += " {0}".format(repo_alias)
-            repostr += " {0}".format(
-                kwargs["uri"] if "uri" in kwargs else source["uri"]
-            )
+                repostr += " {}".format(repo_alias)
+            repostr += " {}".format(kwargs["uri"] if "uri" in kwargs else source["uri"])
             _mod_repo_in_file(repo, repostr, source["file"])
         elif uri and source["uri"] == uri:
             raise CommandExecutionError(
-                "Repository '{0}' already exists as '{1}'.".format(uri, source["name"])
+                "Repository '{}' already exists as '{}'.".format(uri, source["name"])
             )
 
     if not found:
         # Need to add a new repo
         if "uri" not in kwargs:
             raise CommandExecutionError(
-                "Repository '{0}' not found and no URI passed to create one.".format(
+                "Repository '{}' not found and no URI passed to create one.".format(
                     repo
                 )
             )
@@ -1543,7 +1527,7 @@ def owner(*paths, **kwargs):  # pylint: disable=unused-argument
         else:
             ret[path] = ""
     if len(ret) == 1:
-        return next(six.itervalues(ret))
+        return next(iter(ret.values()))
     return ret
 
 


### PR DESCRIPTION
This is a code cleanup change as the directory contains more than
the module.dep.{timestamp,md5sum} files, so the test was misleading.

The old file test was a remnant from when the only reboot sources were
kernel module changes (the files still get created unconditionally).

This is a change done by Ioan-Adrian Ratiu in NI salt repo: commit 505206

Signed-off-by: Cristian <cristian.hotea@ni.com>

### What does this PR do?
See above.

### What issues does this PR fix or reference?
No reported issue.

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No
