### PR TITLE
Fix name returned by list_vdirs

### DIFF
--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -1719,7 +1719,7 @@ def list_vdirs(site, app=_DEFAULT_APP):
         r"'{0}'".format(app),
         "|",
         "Select-Object PhysicalPath, @{ Name = 'name';",
-        r"Expression = { $_.path.Split('/')[-1] } }",
+        r"Expression = { $_.path.Trim('/') } }",
     ]
 
     cmd_ret = _srvmgr(cmd=ps_cmd, return_json=True)

--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -8,17 +8,14 @@ Microsoft IIS site management via WebAdministration powershell module
 
 .. versionadded:: 2016.3.0
 """
-# Import python libs
-
 import decimal
 import logging
 import os
 import re
+import yaml
 
-# Import salt libs
 import salt.utils.json
 import salt.utils.platform
-import yaml
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 from salt.ext.six.moves import map, range
 

--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Microsoft IIS site management via WebAdministration powershell module
 
@@ -10,7 +9,6 @@ Microsoft IIS site management via WebAdministration powershell module
 .. versionadded:: 2016.3.0
 """
 # Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import decimal
 import logging
@@ -22,7 +20,6 @@ import salt.utils.json
 import salt.utils.platform
 import yaml
 from salt.exceptions import CommandExecutionError, SaltInvocationError
-from salt.ext import six
 from salt.ext.six.moves import map, range
 
 log = logging.getLogger(__name__)
@@ -69,7 +66,7 @@ def _get_binding_info(host_header="", ip_address="*", port=80):
         str: A properly formatted bindingInformation string (IP:port:hostheader)
             eg: 192.168.0.12:80:www.contoso.com
     """
-    return ":".join([ip_address, six.text_type(port), host_header.replace(" ", "")])
+    return ":".join([ip_address, str(port), host_header.replace(" ", "")])
 
 
 def _list_certs(certificate_store="My"):
@@ -90,7 +87,7 @@ def _list_certs(certificate_store="My"):
     ps_cmd = [
         "Get-ChildItem",
         "-Path",
-        r"'Cert:\LocalMachine\{0}'".format(certificate_store),
+        r"'Cert:\LocalMachine\{}'".format(certificate_store),
         "|",
         "Select-Object DnsNameList, SerialNumber, Subject, Thumbprint, Version",
     ]
@@ -132,7 +129,7 @@ def _iisVersion():
         return -1
 
     return decimal.Decimal(
-        "{0}.{1}".format(items[0]["MajorVersion"], items[0]["MinorVersion"])
+        "{}.{}".format(items[0]["MajorVersion"], items[0]["MinorVersion"])
     )
 
 
@@ -152,14 +149,14 @@ def _srvmgr(cmd, return_json=False):
         cmd = " ".join(cmd)
 
     if return_json:
-        cmd = "ConvertTo-Json -Compress -Depth 4 -InputObject @({0})" "".format(cmd)
+        cmd = "ConvertTo-Json -Compress -Depth 4 -InputObject @({})" "".format(cmd)
 
-    cmd = "Import-Module WebAdministration; {0}".format(cmd)
+    cmd = "Import-Module WebAdministration; {}".format(cmd)
 
     ret = __salt__["cmd.run_all"](cmd, shell="powershell", python_shell=True)
 
     if ret["retcode"] != 0:
-        msg = "Unable to execute command: {0}\nError: {1}" "".format(cmd, ret["stderr"])
+        msg = "Unable to execute command: {}\nError: {}" "".format(cmd, ret["stderr"])
         log.error(msg)
 
     return ret
@@ -312,8 +309,8 @@ def create_site(
 
         salt '*' win_iis.create_site name='My Test Site' sourcepath='c:\\stage' apppool='TestPool'
     """
-    protocol = six.text_type(protocol).lower()
-    site_path = r"IIS:\Sites\{0}".format(name)
+    protocol = str(protocol).lower()
+    site_path = r"IIS:\Sites\{}".format(name)
     binding_info = _get_binding_info(hostheader, ipaddress, port)
     current_sites = list_sites()
 
@@ -322,7 +319,7 @@ def create_site(
         return True
 
     if protocol not in _VALID_PROTOCOLS:
-        message = ("Invalid protocol '{0}' specified. Valid formats:" " {1}").format(
+        message = ("Invalid protocol '{}' specified. Valid formats:" " {}").format(
             protocol, _VALID_PROTOCOLS
         )
         raise SaltInvocationError(message)
@@ -330,9 +327,9 @@ def create_site(
     ps_cmd = [
         "New-Item",
         "-Path",
-        r"'{0}'".format(site_path),
+        r"'{}'".format(site_path),
         "-PhysicalPath",
-        r"'{0}'".format(sourcepath),
+        r"'{}'".format(sourcepath),
         "-Bindings",
         "@{{ protocol='{0}'; bindingInformation='{1}' }};"
         "".format(protocol, binding_info),
@@ -349,20 +346,18 @@ def create_site(
             [
                 "Set-ItemProperty",
                 "-Path",
-                "'{0}'".format(site_path),
+                "'{}'".format(site_path),
                 "-Name",
                 "ApplicationPool",
                 "-Value",
-                "'{0}'".format(apppool),
+                "'{}'".format(apppool),
             ]
         )
 
     cmd_ret = _srvmgr(ps_cmd)
 
     if cmd_ret["retcode"] != 0:
-        msg = "Unable to create site: {0}\nError: {1}" "".format(
-            name, cmd_ret["stderr"]
-        )
+        msg = "Unable to create site: {}\nError: {}" "".format(name, cmd_ret["stderr"])
         raise CommandExecutionError(msg)
 
     log.debug("Site created successfully: %s", name)
@@ -394,11 +389,11 @@ def modify_site(name, sourcepath=None, apppool=None):
 
         salt '*' win_iis.modify_site name='My Test Site' sourcepath='c:\\new_path' apppool='NewTestPool'
     """
-    site_path = r"IIS:\Sites\{0}".format(name)
+    site_path = r"IIS:\Sites\{}".format(name)
     current_sites = list_sites()
 
     if name not in current_sites:
-        log.debug("Site '{0}' not defined.".format(name))
+        log.debug("Site '{}' not defined.".format(name))
         return False
 
     ps_cmd = list()
@@ -408,20 +403,20 @@ def modify_site(name, sourcepath=None, apppool=None):
             [
                 "Set-ItemProperty",
                 "-Path",
-                r"'{0}'".format(site_path),
+                r"'{}'".format(site_path),
                 "-Name",
                 "PhysicalPath",
                 "-Value",
-                r"'{0}'".format(sourcepath),
+                r"'{}'".format(sourcepath),
             ]
         )
 
     if apppool:
 
         if apppool in list_apppools():
-            log.debug("Utilizing pre-existing application pool: {0}" "".format(apppool))
+            log.debug("Utilizing pre-existing application pool: {}" "".format(apppool))
         else:
-            log.debug("Application pool will be created: {0}".format(apppool))
+            log.debug("Application pool will be created: {}".format(apppool))
             create_apppool(apppool)
 
         # If ps_cmd isn't empty, we need to add a semi-colon to run two commands
@@ -432,20 +427,18 @@ def modify_site(name, sourcepath=None, apppool=None):
             [
                 "Set-ItemProperty",
                 "-Path",
-                r"'{0}'".format(site_path),
+                r"'{}'".format(site_path),
                 "-Name",
                 "ApplicationPool",
                 "-Value",
-                r"'{0}'".format(apppool),
+                r"'{}'".format(apppool),
             ]
         )
 
     cmd_ret = _srvmgr(ps_cmd)
 
     if cmd_ret["retcode"] != 0:
-        msg = "Unable to modify site: {0}\nError: {1}" "".format(
-            name, cmd_ret["stderr"]
-        )
+        msg = "Unable to modify site: {}\nError: {}" "".format(name, cmd_ret["stderr"])
         raise CommandExecutionError(msg)
 
     log.debug("Site modified successfully: %s", name)
@@ -479,14 +472,12 @@ def remove_site(name):
         log.debug("Site already absent: %s", name)
         return True
 
-    ps_cmd = ["Remove-WebSite", "-Name", r"'{0}'".format(name)]
+    ps_cmd = ["Remove-WebSite", "-Name", r"'{}'".format(name)]
 
     cmd_ret = _srvmgr(ps_cmd)
 
     if cmd_ret["retcode"] != 0:
-        msg = "Unable to remove site: {0}\nError: {1}" "".format(
-            name, cmd_ret["stderr"]
-        )
+        msg = "Unable to remove site: {}\nError: {}" "".format(name, cmd_ret["stderr"])
         raise CommandExecutionError(msg)
 
     log.debug("Site removed successfully: %s", name)
@@ -511,7 +502,7 @@ def stop_site(name):
 
         salt '*' win_iis.stop_site name='My Test Site'
     """
-    ps_cmd = ["Stop-WebSite", r"'{0}'".format(name)]
+    ps_cmd = ["Stop-WebSite", r"'{}'".format(name)]
 
     cmd_ret = _srvmgr(ps_cmd)
 
@@ -536,7 +527,7 @@ def start_site(name):
 
         salt '*' win_iis.start_site name='My Test Site'
     """
-    ps_cmd = ["Start-WebSite", r"'{0}'".format(name)]
+    ps_cmd = ["Start-WebSite", r"'{}'".format(name)]
 
     cmd_ret = _srvmgr(ps_cmd)
 
@@ -626,11 +617,11 @@ def create_binding(
 
         salt '*' win_iis.create_binding site='site0' hostheader='example.com' ipaddress='*' port='80'
     """
-    protocol = six.text_type(protocol).lower()
+    protocol = str(protocol).lower()
     name = _get_binding_info(hostheader, ipaddress, port)
 
     if protocol not in _VALID_PROTOCOLS:
-        message = ("Invalid protocol '{0}' specified. Valid formats:" " {1}").format(
+        message = ("Invalid protocol '{}' specified. Valid formats:" " {}").format(
             protocol, _VALID_PROTOCOLS
         )
         raise SaltInvocationError(message)
@@ -639,7 +630,7 @@ def create_binding(
         sslflags = int(sslflags)
         if sslflags not in _VALID_SSL_FLAGS:
             message = (
-                "Invalid sslflags '{0}' specified. Valid sslflags range:" " {1}..{2}"
+                "Invalid sslflags '{}' specified. Valid sslflags range:" " {}..{}"
             ).format(sslflags, _VALID_SSL_FLAGS[0], _VALID_SSL_FLAGS[-1])
             raise SaltInvocationError(message)
 
@@ -653,37 +644,37 @@ def create_binding(
         ps_cmd = [
             "New-WebBinding",
             "-Name",
-            "'{0}'".format(site),
+            "'{}'".format(site),
             "-HostHeader",
-            "'{0}'".format(hostheader),
+            "'{}'".format(hostheader),
             "-IpAddress",
-            "'{0}'".format(ipaddress),
+            "'{}'".format(ipaddress),
             "-Port",
-            "'{0}'".format(port),
+            "'{}'".format(port),
             "-Protocol",
-            "'{0}'".format(protocol),
+            "'{}'".format(protocol),
             "-SslFlags",
-            "{0}".format(sslflags),
+            "{}".format(sslflags),
         ]
     else:
         ps_cmd = [
             "New-WebBinding",
             "-Name",
-            "'{0}'".format(site),
+            "'{}'".format(site),
             "-HostHeader",
-            "'{0}'".format(hostheader),
+            "'{}'".format(hostheader),
             "-IpAddress",
-            "'{0}'".format(ipaddress),
+            "'{}'".format(ipaddress),
             "-Port",
-            "'{0}'".format(port),
+            "'{}'".format(port),
             "-Protocol",
-            "'{0}'".format(protocol),
+            "'{}'".format(protocol),
         ]
 
     cmd_ret = _srvmgr(ps_cmd)
 
     if cmd_ret["retcode"] != 0:
-        msg = "Unable to create binding: {0}\nError: {1}" "".format(
+        msg = "Unable to create binding: {}\nError: {}" "".format(
             site, cmd_ret["stderr"]
         )
         raise CommandExecutionError(msg)
@@ -731,7 +722,7 @@ def modify_binding(
     """
     if sslflags is not None and sslflags not in _VALID_SSL_FLAGS:
         message = (
-            "Invalid sslflags '{0}' specified. Valid sslflags range:" " {1}..{2}"
+            "Invalid sslflags '{}' specified. Valid sslflags range:" " {}..{}"
         ).format(sslflags, _VALID_SSL_FLAGS[0], _VALID_SSL_FLAGS[-1])
         raise SaltInvocationError(message)
 
@@ -753,7 +744,7 @@ def modify_binding(
     new_binding = ":".join(
         [
             ipaddress if ipaddress is not None else i,
-            six.text_type(port) if port is not None else six.text_type(p),
+            str(port) if port is not None else str(p),
             hostheader if hostheader is not None else h,
         ]
     )
@@ -762,19 +753,19 @@ def modify_binding(
         ps_cmd = [
             "Set-WebBinding",
             "-Name",
-            "'{0}'".format(site),
+            "'{}'".format(site),
             "-BindingInformation",
-            "'{0}'".format(binding),
+            "'{}'".format(binding),
             "-PropertyName",
             "BindingInformation",
             "-Value",
-            "'{0}'".format(new_binding),
+            "'{}'".format(new_binding),
         ]
 
         cmd_ret = _srvmgr(ps_cmd)
 
         if cmd_ret["retcode"] != 0:
-            msg = "Unable to modify binding: {0}\nError: {1}" "".format(
+            msg = "Unable to modify binding: {}\nError: {}" "".format(
                 binding, cmd_ret["stderr"]
             )
             raise CommandExecutionError(msg)
@@ -786,19 +777,19 @@ def modify_binding(
         ps_cmd = [
             "Set-WebBinding",
             "-Name",
-            "'{0}'".format(site),
+            "'{}'".format(site),
             "-BindingInformation",
-            "'{0}'".format(new_binding),
+            "'{}'".format(new_binding),
             "-PropertyName",
             "sslflags",
             "-Value",
-            "'{0}'".format(sslflags),
+            "'{}'".format(sslflags),
         ]
 
         cmd_ret = _srvmgr(ps_cmd)
 
         if cmd_ret["retcode"] != 0:
-            msg = "Unable to modify binding SSL Flags: {0}\nError: {1}" "".format(
+            msg = "Unable to modify binding SSL Flags: {}\nError: {}" "".format(
                 sslflags, cmd_ret["stderr"]
             )
             raise CommandExecutionError(msg)
@@ -835,17 +826,17 @@ def remove_binding(site, hostheader="", ipaddress="*", port=80):
     ps_cmd = [
         "Remove-WebBinding",
         "-HostHeader",
-        "'{0}'".format(hostheader),
+        "'{}'".format(hostheader),
         "-IpAddress",
-        "'{0}'".format(ipaddress),
+        "'{}'".format(ipaddress),
         "-Port",
-        "'{0}'".format(port),
+        "'{}'".format(port),
     ]
 
     cmd_ret = _srvmgr(ps_cmd)
 
     if cmd_ret["retcode"] != 0:
-        msg = "Unable to remove binding: {0}\nError: {1}" "".format(
+        msg = "Unable to remove binding: {}\nError: {}" "".format(
             site, cmd_ret["stderr"]
         )
         raise CommandExecutionError(msg)
@@ -921,18 +912,18 @@ def create_cert_binding(name, site, hostheader="", ipaddress="*", port=443, sslf
 
         salt '*' win_iis.create_cert_binding name='AAA000' site='site0' hostheader='example.com' ipaddress='*' port='443'
     """
-    name = six.text_type(name).upper()
+    name = str(name).upper()
     binding_info = _get_binding_info(hostheader, ipaddress, port)
 
     if _iisVersion() < 8:
         # IIS 7.5 and earlier don't support SNI for HTTPS, therefore cert bindings don't contain the host header
         binding_info = binding_info.rpartition(":")[0] + ":"
 
-    binding_path = r"IIS:\SslBindings\{0}".format(binding_info.replace(":", "!"))
+    binding_path = r"IIS:\SslBindings\{}".format(binding_info.replace(":", "!"))
 
     if sslflags not in _VALID_SSL_FLAGS:
         message = (
-            "Invalid sslflags '{0}' specified. Valid sslflags range: " "{1}..{2}"
+            "Invalid sslflags '{}' specified. Valid sslflags range: " "{}..{}"
         ).format(sslflags, _VALID_SSL_FLAGS[0], _VALID_SSL_FLAGS[-1])
         raise SaltInvocationError(message)
 
@@ -975,25 +966,25 @@ def create_cert_binding(name, site, hostheader="", ipaddress="*", port=443, sslf
         ps_cmd = [
             "New-Item",
             "-Path",
-            "'{0}'".format(iis7path),
+            "'{}'".format(iis7path),
             "-Thumbprint",
-            "'{0}'".format(name),
+            "'{}'".format(name),
         ]
     else:
         ps_cmd = [
             "New-Item",
             "-Path",
-            "'{0}'".format(binding_path),
+            "'{}'".format(binding_path),
             "-Thumbprint",
-            "'{0}'".format(name),
+            "'{}'".format(name),
             "-SSLFlags",
-            "{0}".format(sslflags),
+            "{}".format(sslflags),
         ]
 
     cmd_ret = _srvmgr(ps_cmd)
 
     if cmd_ret["retcode"] != 0:
-        msg = "Unable to create certificate binding: {0}\nError: {1}" "".format(
+        msg = "Unable to create certificate binding: {}\nError: {}" "".format(
             name, cmd_ret["stderr"]
         )
         raise CommandExecutionError(msg)
@@ -1040,7 +1031,7 @@ def remove_cert_binding(name, site, hostheader="", ipaddress="*", port=443):
 
         salt '*' win_iis.remove_cert_binding name='AAA000' site='site0' hostheader='example.com' ipaddress='*' port='443'
     """
-    name = six.text_type(name).upper()
+    name = str(name).upper()
     binding_info = _get_binding_info(hostheader, ipaddress, port)
 
     # Child items of IIS:\SslBindings do not return populated host header info
@@ -1073,7 +1064,7 @@ def remove_cert_binding(name, site, hostheader="", ipaddress="*", port=443):
     cmd_ret = _srvmgr(ps_cmd)
 
     if cmd_ret["retcode"] != 0:
-        msg = "Unable to remove certificate binding: {0}\nError: {1}" "".format(
+        msg = "Unable to remove certificate binding: {}\nError: {}" "".format(
             name, cmd_ret["stderr"]
         )
         raise CommandExecutionError(msg)
@@ -1180,18 +1171,18 @@ def create_apppool(name):
         salt '*' win_iis.create_apppool name='MyTestPool'
     """
     current_apppools = list_apppools()
-    apppool_path = r"IIS:\AppPools\{0}".format(name)
+    apppool_path = r"IIS:\AppPools\{}".format(name)
 
     if name in current_apppools:
         log.debug("Application pool '%s' already present.", name)
         return True
 
-    ps_cmd = ["New-Item", "-Path", r"'{0}'".format(apppool_path)]
+    ps_cmd = ["New-Item", "-Path", r"'{}'".format(apppool_path)]
 
     cmd_ret = _srvmgr(ps_cmd)
 
     if cmd_ret["retcode"] != 0:
-        msg = "Unable to create application pool: {0}\nError: {1}" "".format(
+        msg = "Unable to create application pool: {}\nError: {}" "".format(
             name, cmd_ret["stderr"]
         )
         raise CommandExecutionError(msg)
@@ -1217,18 +1208,18 @@ def remove_apppool(name):
         salt '*' win_iis.remove_apppool name='MyTestPool'
     """
     current_apppools = list_apppools()
-    apppool_path = r"IIS:\AppPools\{0}".format(name)
+    apppool_path = r"IIS:\AppPools\{}".format(name)
 
     if name not in current_apppools:
         log.debug("Application pool already absent: %s", name)
         return True
 
-    ps_cmd = ["Remove-Item", "-Path", r"'{0}'".format(apppool_path), "-Recurse"]
+    ps_cmd = ["Remove-Item", "-Path", r"'{}'".format(apppool_path), "-Recurse"]
 
     cmd_ret = _srvmgr(ps_cmd)
 
     if cmd_ret["retcode"] != 0:
-        msg = "Unable to remove application pool: {0}\nError: {1}" "".format(
+        msg = "Unable to remove application pool: {}\nError: {}" "".format(
             name, cmd_ret["stderr"]
         )
         raise CommandExecutionError(msg)
@@ -1255,7 +1246,7 @@ def stop_apppool(name):
 
         salt '*' win_iis.stop_apppool name='MyTestPool'
     """
-    ps_cmd = ["Stop-WebAppPool", r"'{0}'".format(name)]
+    ps_cmd = ["Stop-WebAppPool", r"'{}'".format(name)]
 
     cmd_ret = _srvmgr(ps_cmd)
 
@@ -1280,7 +1271,7 @@ def start_apppool(name):
 
         salt '*' win_iis.start_apppool name='MyTestPool'
     """
-    ps_cmd = ["Start-WebAppPool", r"'{0}'".format(name)]
+    ps_cmd = ["Start-WebAppPool", r"'{}'".format(name)]
 
     cmd_ret = _srvmgr(ps_cmd)
 
@@ -1305,7 +1296,7 @@ def restart_apppool(name):
 
         salt '*' win_iis.restart_apppool name='MyTestPool'
     """
-    ps_cmd = ["Restart-WebAppPool", r"'{0}'".format(name)]
+    ps_cmd = ["Restart-WebAppPool", r"'{}'".format(name)]
 
     cmd_ret = _srvmgr(ps_cmd)
 
@@ -1337,7 +1328,7 @@ def get_container_setting(name, container, settings):
     ret = dict()
     ps_cmd = list()
     ps_cmd_validate = list()
-    container_path = r"IIS:\{0}\{1}".format(container, name)
+    container_path = r"IIS:\{}\{}".format(container, name)
 
     if not settings:
         log.warning("No settings provided")
@@ -1351,9 +1342,9 @@ def get_container_setting(name, container, settings):
             [
                 "Get-ItemProperty",
                 "-Path",
-                "'{0}'".format(container_path),
+                "'{}'".format(container_path),
                 "-Name",
-                "'{0}'".format(setting),
+                "'{}'".format(setting),
                 "-ErrorAction",
                 "Stop",
                 "|",
@@ -1364,13 +1355,13 @@ def get_container_setting(name, container, settings):
         # Some ItemProperties are Strings and others are ConfigurationAttributes.
         # Since the former doesn't have a Value property, we need to account
         # for this.
-        ps_cmd.append("$Property = Get-ItemProperty -Path '{0}'".format(container_path))
-        ps_cmd.append("-Name '{0}' -ErrorAction Stop;".format(setting))
+        ps_cmd.append("$Property = Get-ItemProperty -Path '{}'".format(container_path))
+        ps_cmd.append("-Name '{}' -ErrorAction Stop;".format(setting))
         ps_cmd.append(r"if (([String]::IsNullOrEmpty($Property) -eq $False) -and")
         ps_cmd.append(r"($Property.GetType()).Name -eq 'ConfigurationAttribute') {")
         ps_cmd.append(r"$Property = $Property | Select-Object")
         ps_cmd.append(r"-ExpandProperty Value };")
-        ps_cmd.append("$Settings['{0}'] = [String] $Property;".format(setting))
+        ps_cmd.append("$Settings['{}'] = [String] $Property;".format(setting))
         ps_cmd.append(r"$Property = $Null;")
 
     # Validate the setting names that were passed in.
@@ -1435,7 +1426,7 @@ def set_container_setting(name, container, settings):
         "ApplicationPoolIdentity": "4",
     }
     ps_cmd = list()
-    container_path = r"IIS:\{0}\{1}".format(container, name)
+    container_path = r"IIS:\{}\{}".format(container, name)
 
     if not settings:
         log.warning("No settings provided")
@@ -1443,7 +1434,7 @@ def set_container_setting(name, container, settings):
 
     # Treat all values as strings for the purpose of comparing them to existing values.
     for setting in settings:
-        settings[setting] = six.text_type(settings[setting])
+        settings[setting] = str(settings[setting])
 
     current_settings = get_container_setting(
         name=name, container=container, settings=settings.keys()
@@ -1459,7 +1450,7 @@ def set_container_setting(name, container, settings):
             complex(settings[setting])
             value = settings[setting]
         except ValueError:
-            value = "'{0}'".format(settings[setting])
+            value = "'{}'".format(settings[setting])
 
         # Map to numeric to support server 2008
         if (
@@ -1472,18 +1463,18 @@ def set_container_setting(name, container, settings):
             [
                 "Set-ItemProperty",
                 "-Path",
-                "'{0}'".format(container_path),
+                "'{}'".format(container_path),
                 "-Name",
-                "'{0}'".format(setting),
+                "'{}'".format(setting),
                 "-Value",
-                "{0};".format(value),
+                "{};".format(value),
             ]
         )
 
     cmd_ret = _srvmgr(ps_cmd)
 
     if cmd_ret["retcode"] != 0:
-        msg = "Unable to set settings for {0}: {1}".format(container, name)
+        msg = "Unable to set settings for {}: {}".format(container, name)
         raise CommandExecutionError(msg)
 
     # Get the fields post-change so that we can verify tht all values
@@ -1502,7 +1493,7 @@ def set_container_setting(name, container, settings):
         ):
             settings[setting] = identityType_map2string[settings[setting]]
 
-        if six.text_type(settings[setting]) != six.text_type(new_settings[setting]):
+        if str(settings[setting]) != str(new_settings[setting]):
             failed_settings[setting] = settings[setting]
 
     if failed_settings:
@@ -1530,7 +1521,7 @@ def list_apps(site):
     """
     ret = dict()
     ps_cmd = list()
-    ps_cmd.append("Get-WebApplication -Site '{0}'".format(site))
+    ps_cmd.append("Get-WebApplication -Site '{}'".format(site))
     ps_cmd.append(
         r"| Select-Object applicationPool, path, PhysicalPath, preloadEnabled,"
     )
@@ -1614,20 +1605,20 @@ def create_app(name, site, sourcepath, apppool=None):
     ps_cmd = [
         "New-WebApplication",
         "-Name",
-        "'{0}'".format(name),
+        "'{}'".format(name),
         "-Site",
-        "'{0}'".format(site),
+        "'{}'".format(site),
         "-PhysicalPath",
-        "'{0}'".format(sourcepath),
+        "'{}'".format(sourcepath),
     ]
 
     if apppool:
-        ps_cmd.extend(["-ApplicationPool", "'{0}'".format(apppool)])
+        ps_cmd.extend(["-ApplicationPool", "'{}'".format(apppool)])
 
     cmd_ret = _srvmgr(ps_cmd)
 
     if cmd_ret["retcode"] != 0:
-        msg = "Unable to create application: {0}\nError: {1}" "".format(
+        msg = "Unable to create application: {}\nError: {}" "".format(
             name, cmd_ret["stderr"]
         )
         raise CommandExecutionError(msg)
@@ -1668,15 +1659,15 @@ def remove_app(name, site):
     ps_cmd = [
         "Remove-WebApplication",
         "-Name",
-        "'{0}'".format(name),
+        "'{}'".format(name),
         "-Site",
-        "'{0}'".format(site),
+        "'{}'".format(site),
     ]
 
     cmd_ret = _srvmgr(ps_cmd)
 
     if cmd_ret["retcode"] != 0:
-        msg = "Unable to remove application: {0}\nError: {1}" "".format(
+        msg = "Unable to remove application: {}\nError: {}" "".format(
             name, cmd_ret["stderr"]
         )
         raise CommandExecutionError(msg)
@@ -1714,9 +1705,9 @@ def list_vdirs(site, app=_DEFAULT_APP):
     ps_cmd = [
         "Get-WebVirtualDirectory",
         "-Site",
-        r"'{0}'".format(site),
+        r"'{}'".format(site),
         "-Application",
-        r"'{0}'".format(app),
+        r"'{}'".format(app),
         "|",
         "Select-Object PhysicalPath, @{ Name = 'name';",
         r"Expression = { $_.path.Trim('/') } }",
@@ -1778,20 +1769,20 @@ def create_vdir(name, site, sourcepath, app=_DEFAULT_APP):
     ps_cmd = [
         "New-WebVirtualDirectory",
         "-Name",
-        r"'{0}'".format(name),
+        r"'{}'".format(name),
         "-Site",
-        r"'{0}'".format(site),
+        r"'{}'".format(site),
         "-PhysicalPath",
-        r"'{0}'".format(sourcepath),
+        r"'{}'".format(sourcepath),
     ]
 
     if app != _DEFAULT_APP:
-        ps_cmd.extend(["-Application", r"'{0}'".format(app)])
+        ps_cmd.extend(["-Application", r"'{}'".format(app)])
 
     cmd_ret = _srvmgr(ps_cmd)
 
     if cmd_ret["retcode"] != 0:
-        msg = "Unable to create virtual directory: {0}\nError: {1}" "".format(
+        msg = "Unable to create virtual directory: {}\nError: {}" "".format(
             name, cmd_ret["stderr"]
         )
         raise CommandExecutionError(msg)
@@ -1828,8 +1819,8 @@ def remove_vdir(name, site, app=_DEFAULT_APP):
     app_path = os.path.join(*app.rstrip("/").split("/"))
 
     if app_path:
-        app_path = "{0}\\".format(app_path)
-    vdir_path = r"IIS:\Sites\{0}\{1}{2}".format(site, app_path, name)
+        app_path = "{}\\".format(app_path)
+    vdir_path = r"IIS:\Sites\{}\{}{}".format(site, app_path, name)
 
     if name not in current_vdirs:
         log.debug("Virtual directory already absent: %s", name)
@@ -1838,12 +1829,12 @@ def remove_vdir(name, site, app=_DEFAULT_APP):
     # We use Remove-Item here instead of Remove-WebVirtualDirectory, since the
     # latter has a bug that causes it to always prompt for user input.
 
-    ps_cmd = ["Remove-Item", "-Path", r"'{0}'".format(vdir_path), "-Recurse"]
+    ps_cmd = ["Remove-Item", "-Path", r"'{}'".format(vdir_path), "-Recurse"]
 
     cmd_ret = _srvmgr(ps_cmd)
 
     if cmd_ret["retcode"] != 0:
-        msg = "Unable to remove virtual directory: {0}\nError: {1}" "".format(
+        msg = "Unable to remove virtual directory: {}\nError: {}" "".format(
             name, cmd_ret["stderr"]
         )
         raise CommandExecutionError(msg)
@@ -1928,14 +1919,14 @@ def create_backup(name):
         salt '*' win_iis.create_backup good_config_20170209
     """
     if name in list_backups():
-        raise CommandExecutionError("Backup already present: {0}".format(name))
+        raise CommandExecutionError("Backup already present: {}".format(name))
 
-    ps_cmd = ["Backup-WebConfiguration", "-Name", "'{0}'".format(name)]
+    ps_cmd = ["Backup-WebConfiguration", "-Name", "'{}'".format(name)]
 
     cmd_ret = _srvmgr(ps_cmd)
 
     if cmd_ret["retcode"] != 0:
-        msg = "Unable to backup web configuration: {0}\nError: {1}" "".format(
+        msg = "Unable to backup web configuration: {}\nError: {}" "".format(
             name, cmd_ret["stderr"]
         )
         raise CommandExecutionError(msg)
@@ -1965,12 +1956,12 @@ def remove_backup(name):
         log.debug("Backup already removed: %s", name)
         return True
 
-    ps_cmd = ["Remove-WebConfigurationBackup", "-Name", "'{0}'".format(name)]
+    ps_cmd = ["Remove-WebConfigurationBackup", "-Name", "'{}'".format(name)]
 
     cmd_ret = _srvmgr(ps_cmd)
 
     if cmd_ret["retcode"] != 0:
-        msg = "Unable to remove web configuration: {0}\nError: {1}" "".format(
+        msg = "Unable to remove web configuration: {}\nError: {}" "".format(
             name, cmd_ret["stderr"]
         )
         raise CommandExecutionError(msg)
@@ -1997,7 +1988,7 @@ def list_worker_processes(apppool):
 
         salt '*' win_iis.list_worker_processes 'My App Pool'
     """
-    ps_cmd = ["Get-ChildItem", r"'IIS:\AppPools\{0}\WorkerProcesses'".format(apppool)]
+    ps_cmd = ["Get-ChildItem", r"'IIS:\AppPools\{}\WorkerProcesses'".format(apppool)]
 
     cmd_ret = _srvmgr(cmd=ps_cmd, return_json=True)
 
@@ -2055,24 +2046,24 @@ def get_webapp_settings(name, site, settings):
         if setting in availableSettings:
             if setting == "userName" or setting == "password":
                 pscmd.append(
-                    " $Property = Get-WebConfigurationProperty -Filter \"system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']/virtualDirectory[@path='/']\"".format(
+                    " $Property = Get-WebConfigurationProperty -Filter \"system.applicationHost/sites/site[@name='{}']/application[@path='/{}']/virtualDirectory[@path='/']\"".format(
                         site, name
                     )
                 )
                 pscmd.append(
-                    r' -Name "{0}" -ErrorAction Stop | select Value;'.format(setting)
+                    r' -Name "{}" -ErrorAction Stop | select Value;'.format(setting)
                 )
                 pscmd.append(
                     r" $Property = $Property | Select-Object -ExpandProperty Value;"
                 )
-                pscmd.append(r" $Settings['{0}'] = [String] $Property;".format(setting))
+                pscmd.append(r" $Settings['{}'] = [String] $Property;".format(setting))
                 pscmd.append(r" $Property = $Null;")
 
             if setting == "physicalPath" or setting == "applicationPool":
                 pscmd.append(
-                    r" $Property = (get-webapplication {0}).{1};".format(name, setting)
+                    r" $Property = (get-webapplication {}).{};".format(name, setting)
                 )
-                pscmd.append(r" $Settings['{0}'] = [String] $Property;".format(setting))
+                pscmd.append(r" $Settings['{}'] = [String] $Property;".format(setting))
                 pscmd.append(r" $Property = $Null;")
 
         else:
@@ -2087,7 +2078,7 @@ def get_webapp_settings(name, site, settings):
 
     pscmd.append(" $Settings")
     # Run commands and return data as json
-    cmd_ret = _srvmgr(cmd=six.text_type().join(pscmd), return_json=True)
+    cmd_ret = _srvmgr(cmd="".join(pscmd), return_json=True)
 
     # Update dict var to return data
     try:
@@ -2100,7 +2091,7 @@ def get_webapp_settings(name, site, settings):
     except ValueError:
         log.error("Unable to parse return data as Json.")
 
-    if None in six.viewvalues(ret):
+    if None in ret.values():
         message = "Some values are empty - please validate site and web application names. Some commands are case sensitive"
         raise SaltInvocationError(message)
 
@@ -2154,7 +2145,7 @@ def set_webapp_settings(name, site, settings):
     # Treat all values as strings for the purpose of comparing them to existing values & validate settings exists in predefined settings list
     for setting in settings.keys():
         if setting in availableSettings:
-            settings[setting] = six.text_type(settings[setting])
+            settings[setting] = str(settings[setting])
         else:
             availSetStr = ", ".join(availableSettings)
             log.error("Unexpected setting: %s ", setting)
@@ -2177,20 +2168,20 @@ def set_webapp_settings(name, site, settings):
             complex(settings[setting])
             value = settings[setting]
         except ValueError:
-            value = "'{0}'".format(settings[setting])
+            value = "'{}'".format(settings[setting])
 
         # Append relevant update command per setting key
         if setting == "userName" or setting == "password":
             pscmd.append(
-                " Set-WebConfigurationProperty -Filter \"system.applicationHost/sites/site[@name='{0}']/application[@path='/{1}']/virtualDirectory[@path='/']\"".format(
+                " Set-WebConfigurationProperty -Filter \"system.applicationHost/sites/site[@name='{}']/application[@path='/{}']/virtualDirectory[@path='/']\"".format(
                     site, name
                 )
             )
-            pscmd.append(' -Name "{0}" -Value {1};'.format(setting, value))
+            pscmd.append(' -Name "{}" -Value {};'.format(setting, value))
 
         if setting == "physicalPath" or setting == "applicationPool":
             pscmd.append(
-                r' Set-ItemProperty "IIS:\Sites\{0}\{1}" -Name {2} -Value {3};'.format(
+                r' Set-ItemProperty "IIS:\Sites\{}\{}" -Name {} -Value {};'.format(
                     site, name, setting, value
                 )
             )
@@ -2204,7 +2195,7 @@ def set_webapp_settings(name, site, settings):
 
     # Verify commands completed successfully
     if cmd_ret["retcode"] != 0:
-        msg = "Unable to set settings for web application {0}".format(name)
+        msg = "Unable to set settings for web application {}".format(name)
         raise SaltInvocationError(msg)
 
     # verify changes
@@ -2212,14 +2203,14 @@ def set_webapp_settings(name, site, settings):
     failed_settings = dict()
 
     for setting in settings:
-        if six.text_type(settings[setting]) != six.text_type(new_settings[setting]):
+        if str(settings[setting]) != str(new_settings[setting]):
             failed_settings[setting] = settings[setting]
 
     if failed_settings:
         log.error("Failed to change settings: %s", failed_settings)
         return False
 
-    log.debug("Settings configured successfully: {0}".format(settings.keys()))
+    log.debug("Settings configured successfully: {}".format(settings.keys()))
     return True
 
 
@@ -2257,11 +2248,11 @@ def get_webconfiguration_settings(name, settings):
             [
                 "Get-WebConfigurationProperty",
                 "-PSPath",
-                "'{0}'".format(name),
+                "'{}'".format(name),
                 "-Filter",
-                "'{0}'".format(setting["filter"]),
+                "'{}'".format(setting["filter"]),
                 "-Name",
-                "'{0}'".format(setting["name"]),
+                "'{}'".format(setting["name"]),
                 "-ErrorAction",
                 "Stop",
                 "|",
@@ -2273,17 +2264,17 @@ def get_webconfiguration_settings(name, settings):
         # Since the former doesn't have a Value property, we need to account
         # for this.
         ps_cmd.append(
-            "$Property = Get-WebConfigurationProperty -PSPath '{0}'".format(name)
+            "$Property = Get-WebConfigurationProperty -PSPath '{}'".format(name)
         )
         ps_cmd.append(
-            "-Name '{0}' -Filter '{1}' -ErrorAction Stop;".format(
+            "-Name '{}' -Filter '{}' -ErrorAction Stop;".format(
                 setting["name"], setting["filter"]
             )
         )
         if setting["name"].split(".")[-1] == "Collection":
             if "value" in setting:
                 ps_cmd.append(
-                    "$Property = $Property | select -Property {0} ;".format(
+                    "$Property = $Property | select -Property {} ;".format(
                         ",".join(list(setting["value"][0].keys()))
                     )
                 )
@@ -2350,7 +2341,7 @@ def set_webconfiguration_settings(name, settings):
     # Treat all values as strings for the purpose of comparing them to existing values.
     for idx, setting in enumerate(settings):
         if setting["name"].split(".")[-1] != "Collection":
-            settings[idx]["value"] = six.text_type(setting["value"])
+            settings[idx]["value"] = str(setting["value"])
 
     current_settings = get_webconfiguration_settings(name=name, settings=settings)
 
@@ -2365,13 +2356,13 @@ def set_webconfiguration_settings(name, settings):
                 complex(setting["value"])
                 value = setting["value"]
             except ValueError:
-                value = "'{0}'".format(setting["value"])
+                value = "'{}'".format(setting["value"])
         else:
             configelement_list = []
             for value_item in setting["value"]:
                 configelement_construct = []
                 for key, value in value_item.items():
-                    configelement_construct.append("{0}='{1}'".format(key, value))
+                    configelement_construct.append("{}='{}'".format(key, value))
                 configelement_list.append(
                     "@{" + ";".join(configelement_construct) + "}"
                 )
@@ -2381,20 +2372,20 @@ def set_webconfiguration_settings(name, settings):
             [
                 "Set-WebConfigurationProperty",
                 "-PSPath",
-                "'{0}'".format(name),
+                "'{}'".format(name),
                 "-Filter",
-                "'{0}'".format(setting["filter"]),
+                "'{}'".format(setting["filter"]),
                 "-Name",
-                "'{0}'".format(setting["name"]),
+                "'{}'".format(setting["name"]),
                 "-Value",
-                "{0};".format(value),
+                "{};".format(value),
             ]
         )
 
     cmd_ret = _srvmgr(ps_cmd)
 
     if cmd_ret["retcode"] != 0:
-        msg = "Unable to set settings for {0}".format(name)
+        msg = "Unable to set settings for {}".format(name)
         raise CommandExecutionError(msg)
 
     # Get the fields post-change so that we can verify tht all values
@@ -2409,8 +2400,7 @@ def set_webconfiguration_settings(name, settings):
 
         if (
             not is_collection
-            and six.text_type(setting["value"])
-            != six.text_type(new_settings[idx]["value"])
+            and str(setting["value"]) != str(new_settings[idx]["value"])
         ) or (
             is_collection
             and list(map(dict, setting["value"]))

--- a/salt/modules/win_iis.py
+++ b/salt/modules/win_iis.py
@@ -12,10 +12,10 @@ import decimal
 import logging
 import os
 import re
-import yaml
 
 import salt.utils.json
 import salt.utils.platform
+import yaml
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 from salt.ext.six.moves import map, range
 

--- a/tests/unit/modules/test_win_iis.py
+++ b/tests/unit/modules/test_win_iis.py
@@ -4,16 +4,9 @@
     :maturity: develop
     versionadded:: 2016.11.0
 """
-
-# Import Python Libs
-
 import salt.modules.win_iis as win_iis
 import salt.utils.json
-
-# Import Salt Libs
 from salt.exceptions import SaltInvocationError
-
-# Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, call, patch
 from tests.support.unit import TestCase

--- a/tests/unit/modules/test_win_iis.py
+++ b/tests/unit/modules/test_win_iis.py
@@ -62,6 +62,10 @@ SITE_LIST = {
 }
 
 VDIR_LIST = {"TestVdir": {"sourcepath": r"C:\inetpub\vdirs\TestVdir"}}
+NESTED_VDIR_LIST = {
+    "Test/Nested/Vdir": {"sourcepath": r"C:\inetpub\vdirs\NestedTestVdir"}
+}
+
 
 LIST_APPS_SRVMGR = {
     "retcode": 0,
@@ -96,6 +100,19 @@ LIST_VDIRS_SRVMGR = {
     "retcode": 0,
     "stdout": salt.utils.json.dumps(
         [{"name": "TestVdir", "physicalPath": r"C:\inetpub\vdirs\TestVdir"}]
+    ),
+}
+
+LIST_MORE_VDIRS_SRVMGR = {
+    "retcode": 0,
+    "stdout": salt.utils.json.dumps(
+        [
+            {"name": "TestVdir", "physicalPath": r"C:\inetpub\vdirs\TestVdir"},
+            {
+                "name": "Test/Nested/Vdir",
+                "physicalPath": r"C:\inetpub\vdirs\NestedTestVdir",
+            },
+        ]
     ),
 }
 
@@ -354,6 +371,38 @@ class WinIisTestCase(TestCase, LoaderModuleMockMixin):
             "salt.modules.win_iis._srvmgr", MagicMock(return_value={"retcode": 0})
         ), patch("salt.modules.win_iis.list_vdirs", MagicMock(return_value=VDIR_LIST)):
             self.assertTrue(win_iis.remove_vdir(**kwargs))
+
+    def test_create_nested_vdir(self):
+        """
+        Test - Create a nested IIS virtual directory.
+        """
+        kwargs = {
+            "name": "Test/Nested/Vdir",
+            "site": "MyTestSite",
+            "sourcepath": r"C:\inetpub\vdirs\NestedTestVdir",
+        }
+        with patch.dict(win_iis.__salt__), patch(
+            "os.path.isdir", MagicMock(return_value=True)
+        ), patch(
+            "salt.modules.win_iis._srvmgr", MagicMock(return_value={"retcode": 0})
+        ), patch(
+            "salt.modules.win_iis.list_vdirs", MagicMock(return_value=NESTED_VDIR_LIST)
+        ):
+            self.assertTrue(win_iis.create_vdir(**kwargs))
+
+    def test_list_nested_vdirs(self):
+        """
+        Test - Get configured IIS virtual directories.
+        """
+        vdirs = {
+            "TestVdir": {"sourcepath": r"C:\inetpub\vdirs\TestVdir"},
+            "Test/Nested/Vdir": {"sourcepath": r"C:\inetpub\vdirs\NestedTestVdir"},
+        }
+        with patch.dict(win_iis.__salt__), patch(
+            "salt.modules.win_iis._srvmgr",
+            MagicMock(return_value=LIST_MORE_VDIRS_SRVMGR),
+        ):
+            self.assertEqual(win_iis.list_vdirs("MyTestSite"), vdirs)
 
     def test_create_cert_binding(self):
         """


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes: #58404

### Previous Behavior
list_vdirs returned the last part of the path in the vdir name.

### New Behavior
list_vdirs returns the entire path, minus the initial forward-slash.
This shouldn't affect people using it since there's no way it ever worked for nested paths. If there is some hidden reason for this trim command removing nested paths, then it needs documentation or something, or an IIS expert needs to step in and tell me what up.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No
