### PR TITLE
Fix behaviour of mount module on solaris where this incorrectly reporting nfs mount options have changed and then forcing a umount/mount of the filesystem.

### DIFF
--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -194,6 +194,20 @@ def _active_mounts_solaris(ret):
             "fstype": comps[4],
             "opts": _resolve_user_group_names(comps[5].split("/")),
         }
+
+        if ret[comps[2]].get('fstype') == 'nfs':
+            if 'write' in ret[comps[2]].get('opts') and 'read' in ret[comps[2]].get('opts'):
+                opts = ret[comps[2]].get('opts')
+                opts.remove('read')
+                opts.remove('write')
+                opts.append('rw')
+                ret[comps[2]].update({'opts': opts})
+            elif 'read-only' in ret[comps[2]].get('opts'):
+                opts = ret[comps[2]].get('opts')
+                opts.remove('read-only')
+                opts.append('ro')
+                ret[comps[2]].update({'opts': opts})
+
     return ret
 
 


### PR DESCRIPTION
thinks mount options have changed for existing nfs mounts and
then forces a umount/mount of the filesystem.

Forced unmount and mount because options (rw) changed.

### What does this PR do?

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
