### PR TITLE
add User-Agent to linode salt-cloud module

### DIFF
--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -505,6 +505,7 @@ class LinodeAPIv4(LinodeAPI):
             headers = {}
         headers["Authorization"] = "Bearer {}".format(api_key)
         headers["Content-Type"] = "application/json"
+        headers["User-Agent"] = "salt-cloud-linode"
 
         url = "https://api.linode.com/{}{}".format(api_version, path)
 


### PR DESCRIPTION
Adds `User-Agent` header to all API requests for Linode's salt-cloud module.