### PR TITLE
add newer versions of google custom search engines

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -290,7 +290,13 @@ elif build_type == "next":
     search_cx = "011515552685726825874:ht0p8miksrm"  # latest
 elif build_type == "previous":
     release = previous_release
-    if release.startswith("3000"):
+    if release.startswith("3003"):
+        search_cx = "a70a1a73eef62aecd"  # 3003
+    elif release.startswith("3002"):
+        search_cx = "5026f4f2af0bdbe2d"  # 3002
+    elif release.startswith("3001"):
+        search_cx = "f0e4f298fa32b8a5e"  # 3001
+    elif release.startswith("3000"):
         search_cx = "011515552685726825874:3skhaozjtyn"  # 3000
     elif release.startswith("2019.2"):
         search_cx = "011515552685726825874:huvjhlpptnm"  # 2019.2


### PR DESCRIPTION
### What does this PR do?
Updates the google custom search engines used for future releases.

We missed it for 3001, but it should be fine as long it makes it into some future point release if there are any or we add this to a _docs tag once 3002 is released.  This only really matters once a particular major release is no longer `latest`.