### PR TITLE
saltstack/salt#58412 check if conn is alive

### DIFF
--- a/salt/modules/netmiko_mod.py
+++ b/salt/modules/netmiko_mod.py
@@ -576,7 +576,10 @@ def send_config(
     config_commands = [line for line in file_str.splitlines() if line.strip()]
     kwargs = clean_kwargs(**kwargs)
     if "netmiko.conn" in __proxy__:
-        conn = __proxy__["netmiko.conn"]()
+        if __proxy__["netmiko.conn"]().is_alive():
+            conn = __proxy__["netmiko.conn"]()
+        else:
+            conn, kwargs = _prepare_connection(**__proxy__["netmiko.args"]())
     else:
         conn, kwargs = _prepare_connection(**kwargs)
     if commit:

--- a/salt/modules/netmiko_mod.py
+++ b/salt/modules/netmiko_mod.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Netmiko Execution Module
 ========================
@@ -182,7 +181,6 @@ outside a ``netmiko`` Proxy, e.g.:
     Minion. If you want to use the :mod:`<salt.proxy.netmiko_px>`, please follow
     the documentation notes for a proper setup.
 """
-from __future__ import absolute_import
 
 # Import python stdlib
 import logging
@@ -190,7 +188,6 @@ import logging
 from salt.exceptions import CommandExecutionError
 
 # Import Salt libs
-from salt.ext import six
 from salt.utils.args import clean_kwargs
 
 # Import third party libs
@@ -253,7 +250,7 @@ def _prepare_connection(**kwargs):
         BaseConnection.__init__
     )
     check_self = netmiko_init_args.pop(0)
-    for karg, warg in six.iteritems(netmiko_kwargs):
+    for karg, warg in netmiko_kwargs.items():
         if karg not in netmiko_init_args:
             if warg is not None:
                 fun_kwargs[karg] = warg
@@ -564,7 +561,7 @@ def send_config(
         if file_str is False:
             raise CommandExecutionError("Source file {} not found".format(config_file))
     elif config_commands:
-        if isinstance(config_commands, (six.string_types, six.text_type)):
+        if isinstance(config_commands, ((str,), str)):
             config_commands = [config_commands]
         file_str = "\n".join(config_commands)
         # unify all the commands in a single file, to render them in a go

--- a/tests/unit/modules/test_netmiko_mod.py
+++ b/tests/unit/modules/test_netmiko_mod.py
@@ -1,0 +1,48 @@
+import salt.modules.netmiko_mod as netmiko_mod
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase
+
+
+class MockNetmikoConnection:
+    def is_alive(self):
+        return False
+
+    def send_config_set(self, *args, **kwargs):
+        return args, kwargs
+
+
+def mock_netmiko_args():
+    return {"user": "salt", "password": "password"}
+
+
+def mock_prepare_connection(**kwargs):
+    return MockNetmikoConnection(), kwargs
+
+
+def mock_file_apply_template_on_contents(*args):
+    return args[0]
+
+
+class NetmikoTestCase(TestCase, LoaderModuleMockMixin):
+    def setup_loader_modules(self):
+        return {
+            netmiko_mod: {
+                "__salt__": {
+                    "file.apply_template_on_contents": mock_file_apply_template_on_contents
+                },
+                "__proxy__": {
+                    "netmiko.conn": MockNetmikoConnection,
+                    "netmiko.args": mock_netmiko_args,
+                },
+                "_prepare_connection": mock_prepare_connection,
+            }
+        }
+
+    def test_send_config(self):
+        """
+        Test netmiko.send_config function
+        """
+        _, ret = netmiko_mod.send_config(config_commands=["ls", "echo hello world"])
+        self.assertEqual(ret.get("config_commands"), ["ls", "echo hello world"])
+        self.assertEqual(ret.get("user"), "salt")
+        self.assertEqual(ret.get("password"), "password")


### PR DESCRIPTION
### What does this PR do?
Fixes bug related to `netmiko.send_config` failing when `always_alive` is `False` in the proxy config. These code changes will have the function check is the connection is alive, and if so, re-use the connection, or if not, prepare a new connection

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/58412

### Previous Behavior
When the proxy minion `always_alive` is set to `False`, the connection is not refreshed and `netmiko.send_config` results in a failure traceback.

### New Behavior
Check if connection is alive using built in netmiko connection attr. If the connection is not "alive", prepare a new connection.
