### PR TITLE
NetBSD: Fix grains over salt-ssh when binaries are not in PATH

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -292,7 +292,9 @@ def _netbsd_gpu_data():
     gpus = []
     try:
         pcictl = salt.utils.path.which("pcictl")
-        pcictl_out = __salt__["cmd.run"]("{0} pci0 list".format(pcictl)) if pcictl else ""
+        pcictl_out = (
+            __salt__["cmd.run"]("{0} pci0 list".format(pcictl)) if pcictl else ""
+        )
 
         for line in pcictl_out.splitlines():
             for vendor in known_vendors:

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -293,7 +293,7 @@ def _netbsd_gpu_data():
     try:
         pcictl = salt.utils.path.which("pcictl")
         pcictl_out = (
-            __salt__["cmd.run"]("{0} pci0 list".format(pcictl)) if pcictl else ""
+            __salt__["cmd.run"]("{} pci0 list".format(pcictl)) if pcictl else ""
         )
 
         for line in pcictl_out.splitlines():
@@ -382,7 +382,7 @@ def _bsd_cpudata(osdata):
     if osdata["kernel"] == "NetBSD":
         grains["cpu_flags"] = []
         cmd = salt.utils.path.which("cpuctl")
-        cpuctl_out = __salt__["cmd.run"]("{0} identify 0".format(cmd)) if cmd else ""
+        cpuctl_out = __salt__["cmd.run"]("{} identify 0".format(cmd)) if cmd else ""
         for line in cpuctl_out.splitlines():
             cpu_match = re.match(r"cpu[0-9]:\ features[0-9]?\ .+<(.+)>", line)
             if cpu_match:

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -291,7 +291,8 @@ def _netbsd_gpu_data():
 
     gpus = []
     try:
-        pcictl_out = __salt__["cmd.run"]("pcictl pci0 list")
+        pcictl = salt.utils.path.which("pcictl")
+        pcictl_out = __salt__["cmd.run"]("{0} pci0 list".format(pcictl)) if pcictl else ""
 
         for line in pcictl_out.splitlines():
             for vendor in known_vendors:
@@ -378,7 +379,9 @@ def _bsd_cpudata(osdata):
 
     if osdata["kernel"] == "NetBSD":
         grains["cpu_flags"] = []
-        for line in __salt__["cmd.run"]("cpuctl identify 0").splitlines():
+        cmd = salt.utils.path.which("cpuctl")
+        cpuctl_out = __salt__["cmd.run"]("{0} identify 0".format(cmd)) if cmd else ""
+        for line in cpuctl_out.splitlines():
             cpu_match = re.match(r"cpu[0-9]:\ features[0-9]?\ .+<(.+)>", line)
             if cpu_match:
                 flag = cpu_match.group(1).split(",")


### PR DESCRIPTION
### What does this PR do?

Running salt-ssh on Tumbleweed, Salt 3000 against NetBSD 9 crashes out of the box because some external commands used by core grains are not found.

Currently, grains code has inconsistencies on how external commands are executed:

- by using full path (eg. psrinfo on Solaris)
- checking with salt.utils.which (eg. prtconf on AIX)
- just hoping they are on PATH

cpuctl and pcictl are called directly, and `/usr/sbin` ends out of _PATH_ when using salt-ssh on my system.
The `set_path` roster setting is only available on >= 3001, and requires to be explicitly set.

Long term, all the calls should be fixed to be done in a consistent way. The current code needs love. You can find stuff like in `_osx_gpudata()` where clearly code was copy pasted. ie. `system_profiler` is called, but the variable is called `pcictl_out`

```python
        pcictl_out = __salt__["cmd.run"]("system_profiler SPDisplaysDataType")

        for line in pcictl_out.splitlines():
```

### Previous Behavior

Crash

```
            grains.update(_bsd_cpudata(grains))
          File "/var/tmp/.root_a4e8a0_salt/pyall/salt/grains/core.py", line 385, in _bsd_cpudata
            for line in __salt__['cmd.run']('cpuctl identify 0').splitlines():
          File "/var/tmp/.root_a4e8a0_salt/pyall/salt/modules/cmdmod.py", line 886, in _run_quiet
            success_retcodes=success_retcodes)['stdout']
          File "/var/tmp/.root_a4e8a0_salt/pyall/salt/modules/cmdmod.py", line 681, in _run
            raise CommandExecutionError(msg)
        salt.exceptions.CommandExecutionError: Unable to run command 'REDACTED' with the context '{'cwd': '/root', 'shell': False, 'env': {'PWD': '/root', 'MAIL': '/var/mail/root', 'HOME': '/root', 'PATH': '/usr/bin:/bin:/usr/pkg/bin:/usr/local/bin', 'SSH_CONNECTION': '192.168.xx.xx 44086 192.168.xx.xx 22', 'USER': 'root', 'SSH_AUTH_INFO_0': 'publickey ssh-rsa xxxx\n', 'SSH_CLIENT': '192.168.xx.xx 44086 22', 'LOGNAME': 'root', 'SHELL': '/bin/sh', 'LC_CTYPE': 'C', 'LC_NUMERIC': 'C', 'LC_TIME': 'C', 'LC_COLLATE': 'C', 'LC_MONETARY': 'C', 'LC_MESSAGES': 'C', 'LC_PAPER': 'C', 'LC_NAME': 'C', 'LC_ADDRESS': 'C', 'LC_TELEPHONE': 'C', 'LC_MEASUREMENT': 'C', 'LC_IDENTIFICATION': 'C', 'LANGUAGE': 'C'}, 'stdin': None, 'stdout': -1, 'stderr': -2, 'with_communicate': True, 'timeout': None, 'bg': False, 'close_fds': True}', reason: [Errno 2] No such file or directory: 'cpuctl': 'cpuctl'
    stdout:
```

You can workaround this by adding `  set_path: '$PATH:/usr/sbin'` in the roster entry. This only works in Salt >= 3001

### New Behavior

_salt-ssh_ `test.ping` and `grains.items` works out of the box on NetBSD 9.

### Merge requirements satisfied?

I ran the core grains unit test.

### Commits signed with GPG?

No

*Edit* 25.10: Add workaround information.