### PR TITLE
Fix Pop!_OS 20.04 not using aptpkg

### DIFF
--- a/changelog/58395.fixed
+++ b/changelog/58395.fixed
@@ -1,0 +1,1 @@
+Pop!_OS 20.04 and 20.10 now support using pkg.* / aptpkg.*

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1556,6 +1556,7 @@ _OS_NAME_MAP = {
     "slesexpand": "RES",
     "linuxmint": "Mint",
     "neon": "KDE neon",
+    "pop": "Pop",
 }
 
 # Map the 'os' grain to the 'os_family' grain
@@ -1628,6 +1629,7 @@ _OS_FAMILY_MAP = {
     "Funtoo": "Gentoo",
     "AIX": "AIX",
     "TurnKey": "Debian",
+    "Pop": "Debian",
 }
 
 # Matches any possible format:

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -726,6 +726,46 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         }
         self._run_os_grains_tests("ubuntu-17.10", _os_release_map, expectation)
 
+    @skipIf(not salt.utils.platform.is_linux(), "System is not Linux")
+    def test_pop_focal_os_grains(self):
+        """
+        Test if OS grains are parsed correctly in Pop!_OS 20.04 "Focal Fossa"
+        """
+        _os_release_map = {
+            "_linux_distribution": ("Pop", "20.04", "focal"),
+        }
+        expectation = {
+            "os": "Pop",
+            "os_family": "Debian",
+            "oscodename": "focal",
+            "osfullname": "Pop",
+            "osrelease": "20.04",
+            "osrelease_info": (20, 4),
+            "osmajorrelease": 20,
+            "osfinger": "Pop-20",
+        }
+        self._run_os_grains_tests("pop-20.04", _os_release_map, expectation)
+
+    @skipIf(not salt.utils.platform.is_linux(), "System is not Linux")
+    def test_pop_groovy_os_grains(self):
+        """
+        Test if OS grains are parsed correctly in Pop!_OS 20.10 "Groovy Gorilla"
+        """
+        _os_release_map = {
+            "_linux_distribution": ("Pop", "20.10", "groovy"),
+        }
+        expectation = {
+            "os": "Pop",
+            "os_family": "Debian",
+            "oscodename": "groovy",
+            "osfullname": "Pop",
+            "osrelease": "20.10",
+            "osrelease_info": (20, 10),
+            "osmajorrelease": 20,
+            "osfinger": "Pop-20",
+        }
+        self._run_os_grains_tests("pop-20.10", _os_release_map, expectation)
+
     @skipIf(not salt.utils.platform.is_windows(), "System is not Windows")
     def test_windows_platform_data(self):
         """


### PR DESCRIPTION
### What does this PR do?

Pop!_OS 20.04 not recognized as aptpkg for pkg states

### What issues does this PR fix or reference?
Fixes: #58395

### Previous Behavior
aptpkg is not selected for pkg states

### New Behavior
aptpkg is selected for pkg states

### Merge requirements satisfied?
- [X] Docs
- [X] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

NOTE: I'm far from a Salt developer, and just trying to get the ball rolling here.

It's unclear if a test is necessary, it didn't look like most other stuff in the ```_OS_FAMILY_MAP``` had one.

By a quick test, this patch now reports the correct os and os_family:

```
[:~] $ salt-call grains.get os_family
local:
    Debian
[:~] $ salt-call grains.get os
local:
    Pop
```

And pkg.installed also works.