### PR TITLE
[Pytest Migration] Bump PyTest requirement to 6.0.2

### DIFF
--- a/requirements/static/py3.5/darwin.txt
+++ b/requirements/static/py3.5/darwin.txt
@@ -93,7 +93,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.1
+pytest==6.0.2
 python-dateutil==2.8.0
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.5/freebsd.txt
+++ b/requirements/static/py3.5/freebsd.txt
@@ -93,7 +93,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.1
+pytest==6.0.2
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, vcert
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.5/linux.txt
+++ b/requirements/static/py3.5/linux.txt
@@ -184,7 +184,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.1
+pytest==6.0.2
 python-dateutil==2.8.0    # via adal, azure-cosmosdb-table, azure-storage-common, botocore, croniter, kubernetes, moto, vcert
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.5/windows.txt
+++ b/requirements/static/py3.5/windows.txt
@@ -86,7 +86,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.1
+pytest==6.0.2
 python-dateutil==2.8.0
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.6/darwin.txt
+++ b/requirements/static/py3.6/darwin.txt
@@ -98,7 +98,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.1
+pytest==6.0.2
 python-dateutil==2.8.0
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.6/freebsd.txt
+++ b/requirements/static/py3.6/freebsd.txt
@@ -98,7 +98,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.1
+pytest==6.0.2
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, vcert
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.6/linux.txt
+++ b/requirements/static/py3.6/linux.txt
@@ -188,7 +188,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.1
+pytest==6.0.2
 python-dateutil==2.8.0    # via adal, azure-cosmosdb-table, azure-storage-common, botocore, croniter, kubernetes, moto, vcert
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.6/windows.txt
+++ b/requirements/static/py3.6/windows.txt
@@ -85,7 +85,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.1
+pytest==6.0.2
 python-dateutil==2.8.0
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.7/darwin.txt
+++ b/requirements/static/py3.7/darwin.txt
@@ -96,7 +96,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.1
+pytest==6.0.2
 python-dateutil==2.8.0
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.7/freebsd.txt
+++ b/requirements/static/py3.7/freebsd.txt
@@ -97,7 +97,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.1
+pytest==6.0.2
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, vcert
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.7/linux.txt
+++ b/requirements/static/py3.7/linux.txt
@@ -187,7 +187,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.1
+pytest==6.0.2
 python-dateutil==2.8.0    # via adal, azure-cosmosdb-table, azure-storage-common, botocore, croniter, kubernetes, moto, vcert
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.7/windows.txt
+++ b/requirements/static/py3.7/windows.txt
@@ -83,7 +83,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.1
+pytest==6.0.2
 python-dateutil==2.8.0
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.8/darwin.txt
+++ b/requirements/static/py3.8/darwin.txt
@@ -95,7 +95,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.1
+pytest==6.0.2
 python-dateutil==2.8.0
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.8/freebsd.txt
+++ b/requirements/static/py3.8/freebsd.txt
@@ -96,7 +96,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.1
+pytest==6.0.2
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, vcert
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.8/linux.txt
+++ b/requirements/static/py3.8/linux.txt
@@ -187,7 +187,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.1
+pytest==6.0.2
 python-dateutil==2.8.0    # via adal, azure-cosmosdb-table, azure-storage-common, botocore, croniter, kubernetes, moto, vcert
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.9/darwin.txt
+++ b/requirements/static/py3.9/darwin.txt
@@ -95,7 +95,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.1
+pytest==6.0.2
 python-dateutil==2.8.0
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.9/freebsd.txt
+++ b/requirements/static/py3.9/freebsd.txt
@@ -96,7 +96,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.1
+pytest==6.0.2
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, vcert
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.9/linux.txt
+++ b/requirements/static/py3.9/linux.txt
@@ -187,7 +187,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.1
+pytest==6.0.2
 python-dateutil==2.8.0    # via adal, azure-cosmosdb-table, azure-storage-common, botocore, croniter, kubernetes, moto, vcert
 python-etcd==0.4.5
 python-gnupg==0.4.4


### PR DESCRIPTION
### What does this PR do?
See title