### PR TITLE
[PyTest Migration] Skip tests which randomly fail under Py3.5

### DIFF
--- a/tests/pytests/unit/utils/test_data.py
+++ b/tests/pytests/unit/utils/test_data.py
@@ -1,3 +1,6 @@
+import sys
+
+import pytest
 import salt.utils.data
 
 
@@ -6,6 +9,10 @@ def test_get_value_simple_path():
     assert [{"value": "foo"}] == salt.utils.data.get_value(data, "a:b:c")
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 6),
+    reason="Test will randomly fail since Python3.5 does not have ordered dictionaries",
+)
 def test_get_value_placeholder_dict():
     data = {"a": {"b": {"name": "foo"}, "c": {"name": "bar"}}}
     assert [
@@ -14,6 +21,10 @@ def test_get_value_placeholder_dict():
     ] == salt.utils.data.get_value(data, "a:{id}:name")
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 6),
+    reason="Test will randomly fail since Python3.5 does not have ordered dictionaries",
+)
 def test_get_value_placeholder_list():
     data = {"a": [{"name": "foo"}, {"name": "bar"}]}
     assert [
@@ -22,6 +33,10 @@ def test_get_value_placeholder_list():
     ] == salt.utils.data.get_value(data, "a:{id}:name")
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 6),
+    reason="Test will randomly fail since Python3.5 does not have ordered dictionaries",
+)
 def test_get_value_nested_placeholder():
     data = {
         "a": {


### PR DESCRIPTION
### What does this PR do?
Skip tests which randomly fail under Py3.5
There's no point in fixing this since Py3.5 is EOL and support will be dropped soon.