### PR TITLE
Fix virt update when cpu and memory are changed

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -75,7 +75,6 @@ The calls not using the libvirt connection setup are:
 # Special Thanks to Michael Dehann, many of the concepts, and a few structures
 # of his in the virt func module have been used
 
-# Import python libs
 
 import base64
 import copy
@@ -91,10 +90,7 @@ import time
 from xml.etree import ElementTree
 from xml.sax import saxutils
 
-# Import third party libs
 import jinja2.exceptions
-
-# Import salt libs
 import salt.utils.data
 import salt.utils.files
 import salt.utils.json
@@ -2616,8 +2612,8 @@ def update(
     data = {k: v for k, v in locals().items() if bool(v)}
     if boot_dev:
         data["boot_dev"] = {i + 1: dev for i, dev in enumerate(boot_dev.split())}
-    need_update = need_update or salt.utils.xmlutil.change_xml(
-        desc, data, params_mapping
+    need_update = (
+        salt.utils.xmlutil.change_xml(desc, data, params_mapping) or need_update
     )
 
     # Update the XML definition with the new disks and diff changes

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -4,7 +4,6 @@ virt execution module unit tests
 
 # pylint: disable=3rd-party-module-not-gated
 
-# Import python libs
 
 import datetime
 import os
@@ -15,16 +14,12 @@ import salt.config
 import salt.modules.config as config
 import salt.modules.virt as virt
 import salt.syspaths
-
-# Import salt libs
 import salt.utils.yaml
 from salt._compat import ElementTree as ET
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 
 # pylint: disable=import-error
 from salt.ext.six.moves import range  # pylint: disable=redefined-builtin
-
-# Import Salt Testing libs
 from tests.support.helpers import dedent
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch
@@ -1857,6 +1852,24 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             },
             virt.update("my_vm"),
         )
+
+        # mem + cpu case
+        define_mock.reset_mock()
+        domain_mock.setMemoryFlags.return_value = 0
+        domain_mock.setVcpusFlags.return_value = 0
+        self.assertEqual(
+            {
+                "definition": True,
+                "disk": {"attached": [], "detached": [], "updated": []},
+                "interface": {"attached": [], "detached": []},
+                "mem": True,
+                "cpu": True,
+            },
+            virt.update("my_vm", mem=2048, cpu=2),
+        )
+        setxml = ET.fromstring(define_mock.call_args[0][0])
+        self.assertEqual("2", setxml.find("vcpu").text)
+        self.assertEqual("2048", setxml.find("memory").text)
 
         # Same parameters passed than in default virt.defined state case
         self.assertEqual(


### PR DESCRIPTION
# What does this PR do?

If both CPU and memory are changed, the memory change would be short circuited since the `need_update` would be set to `True` before due to the CPU value change. 

### What issues does this PR fix or reference?

Fixes a regression introduced by PR #58332

### Merge requirements satisfied?
- [X] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes