### PR TITLE
virt: use the pool path in case the volume doesn't exist

### DIFF
--- a/tests/pytests/unit/modules/virt/conftest.py
+++ b/tests/pytests/unit/modules/virt/conftest.py
@@ -130,14 +130,18 @@ def make_mock_storage_pool():
         source = ""
         if type == "disk":
             source = "<device path='/dev/{}'/>".format(name)
+        pool_path = "/path/to/{}".format(name)
         mocked_pool.XMLDesc.return_value = """
             <pool type='{}'>
                 <source>
                 {}
                 </source>
+                <target>
+                    <path>{}</path>
+                </target>
             </pool>
             """.format(
-            type, source
+            type, source, pool_path
         )
         mocked_pool.name.return_value = name
         mocked_pool.info.return_value = [
@@ -160,7 +164,7 @@ def make_mock_storage_pool():
         for volume in volumes:
             mocked_pool.storageVolLookupByName.add(volume)
             mocked_vol = mocked_pool.storageVolLookupByName(volume)
-            vol_path = "/path/to/{}/{}".format(name, volume)
+            vol_path = "{}/{}".format(pool_path, volume)
             mocked_vol.XMLDesc.return_value = """
             <volume>
                 <target>

--- a/tests/pytests/unit/modules/virt/test_domain.py
+++ b/tests/pytests/unit/modules/virt/test_domain.py
@@ -19,7 +19,7 @@ def test_update_xen_disk_volumes(make_mock_vm, make_mock_storage_pool):
           <devices>
             <disk type='file' device='disk'>
               <driver name='qemu' type='qcow2' cache='none' io='native'/>
-              <source file='/path/to/default/vm03_system'/>
+              <source file='/path/to/default/my_vm_system'/>
               <target dev='xvda' bus='xen'/>
             </disk>
             <disk type='block' device='disk'>
@@ -41,6 +41,7 @@ def test_update_xen_disk_volumes(make_mock_vm, make_mock_storage_pool):
             {"name": "system", "pool": "default"},
             {"name": "iscsi-data", "pool": "my-iscsi", "source_file": "unit:0:0:1"},
             {"name": "vdb-data", "pool": "vdb", "source_file": "vdb1"},
+            {"name": "file-data", "pool": "default", "size": "10240"},
         ],
     )
 
@@ -49,6 +50,12 @@ def test_update_xen_disk_volumes(make_mock_vm, make_mock_storage_pool):
     setxml = ET.fromstring(define_mock.call_args[0][0])
     assert "block" == setxml.find(".//disk[3]").get("type")
     assert "/path/to/vdb/vdb1" == setxml.find(".//disk[3]/source").get("dev")
+
+    # Note that my_vm-file-data was not an existing volume before the update
+    assert "file" == setxml.find(".//disk[4]").get("type")
+    assert "/path/to/default/my_vm_file-data" == setxml.find(".//disk[4]/source").get(
+        "file"
+    )
 
 
 def test_get_disks(make_mock_vm, make_mock_storage_pool):

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -4,7 +4,6 @@ virt execution module unit tests
 
 # pylint: disable=3rd-party-module-not-gated
 
-# Import python libs
 
 import datetime
 import os
@@ -15,16 +14,12 @@ import salt.config
 import salt.modules.config as config
 import salt.modules.virt as virt
 import salt.syspaths
-
-# Import salt libs
 import salt.utils.yaml
 from salt._compat import ElementTree as ET
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 
 # pylint: disable=import-error
 from salt.ext.six.moves import range  # pylint: disable=redefined-builtin
-
-# Import Salt Testing libs
 from tests.support.helpers import dedent
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch
@@ -1148,7 +1143,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         """
         self.mock_conn.listStoragePools.return_value = ["default"]
         pool_mock = MagicMock()
-        pool_mock.XMLDesc.return_value = "<pool type='dir'/>"
+        pool_mock.XMLDesc.return_value = (
+            "<pool type='dir'><target><path>/path/to/images</path></target></pool>"
+        )
         volume_xml = "<volume><target><path>/path/to/images/hello_system</path></target></volume>"
         pool_mock.storageVolLookupByName.return_value.XMLDesc.return_value = volume_xml
         self.mock_conn.storagePoolLookupByName.return_value = pool_mock


### PR DESCRIPTION
# What does this PR do?

When computing the volume path to generate the XML of a domain, the
volume may not exist yet. This happens typically during a virt.update
when generating the new XML to compare.

In such cases, use the pool target path to compute the volume path.

### What issues does this PR fix or reference?

Fixes a regression from PR #58400

### Merge requirements satisfied?
- [X] Tests written/updated

### Commits signed with GPG?
Yes