### PR TITLE
[PyTest Migration] Upgrade to `pytest-salt-factories >= 0.92.1`

### DIFF
--- a/requirements/pytest.txt
+++ b/requirements/pytest.txt
@@ -2,6 +2,6 @@ mock >= 3.0.0
 # PyTest
 pytest >= 6.0.1
 pytest-salt
-pytest-salt-factories >= 0.92.0
+pytest-salt-factories >= 0.92.1
 pytest-tempdir >= 2019.10.12
 pytest-helpers-namespace >= 2019.1.8

--- a/requirements/static/py3.5/darwin.txt
+++ b/requirements/static/py3.5/darwin.txt
@@ -90,7 +90,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.92.1
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.0.2

--- a/requirements/static/py3.5/freebsd.txt
+++ b/requirements/static/py3.5/freebsd.txt
@@ -90,7 +90,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.92.1
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.0.2

--- a/requirements/static/py3.5/linux.txt
+++ b/requirements/static/py3.5/linux.txt
@@ -181,7 +181,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.92.1
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.0.2

--- a/requirements/static/py3.5/windows.txt
+++ b/requirements/static/py3.5/windows.txt
@@ -83,7 +83,7 @@ pymysql==0.9.3
 pyopenssl==19.0.0
 pyparsing==2.4.5          # via packaging
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.92.1
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.0.2

--- a/requirements/static/py3.6/darwin.txt
+++ b/requirements/static/py3.6/darwin.txt
@@ -95,7 +95,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.92.1
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.0.2

--- a/requirements/static/py3.6/freebsd.txt
+++ b/requirements/static/py3.6/freebsd.txt
@@ -95,7 +95,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.92.1
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.0.2

--- a/requirements/static/py3.6/linux.txt
+++ b/requirements/static/py3.6/linux.txt
@@ -185,7 +185,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.92.1
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.0.2

--- a/requirements/static/py3.6/windows.txt
+++ b/requirements/static/py3.6/windows.txt
@@ -82,7 +82,7 @@ pymysql==0.9.3
 pyopenssl==19.0.0
 pyparsing==2.4.5          # via packaging
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.92.1
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.0.2

--- a/requirements/static/py3.7/darwin.txt
+++ b/requirements/static/py3.7/darwin.txt
@@ -93,7 +93,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.92.1
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.0.2

--- a/requirements/static/py3.7/freebsd.txt
+++ b/requirements/static/py3.7/freebsd.txt
@@ -94,7 +94,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.92.1
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.0.2

--- a/requirements/static/py3.7/linux.txt
+++ b/requirements/static/py3.7/linux.txt
@@ -184,7 +184,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.92.1
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.0.2

--- a/requirements/static/py3.7/windows.txt
+++ b/requirements/static/py3.7/windows.txt
@@ -80,7 +80,7 @@ pymysql==0.9.3
 pyopenssl==19.0.0
 pyparsing==2.4.5          # via packaging
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.92.1
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.0.2

--- a/requirements/static/py3.8/darwin.txt
+++ b/requirements/static/py3.8/darwin.txt
@@ -92,7 +92,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.92.1
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.0.2

--- a/requirements/static/py3.8/freebsd.txt
+++ b/requirements/static/py3.8/freebsd.txt
@@ -93,7 +93,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.92.1
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.0.2

--- a/requirements/static/py3.8/linux.txt
+++ b/requirements/static/py3.8/linux.txt
@@ -184,7 +184,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.92.1
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.0.2

--- a/requirements/static/py3.9/darwin.txt
+++ b/requirements/static/py3.9/darwin.txt
@@ -92,7 +92,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.92.1
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.0.2

--- a/requirements/static/py3.9/freebsd.txt
+++ b/requirements/static/py3.9/freebsd.txt
@@ -93,7 +93,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.92.1
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.0.2

--- a/requirements/static/py3.9/linux.txt
+++ b/requirements/static/py3.9/linux.txt
@@ -184,7 +184,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.92.1
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.0.2


### PR DESCRIPTION
### What does this PR do?
See title