### PR TITLE
Fix missing minion returns in batch mode

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -951,7 +951,7 @@ class LocalClient(object):
 
                 self._clean_up_subscriptions(pub_data["jid"])
         finally:
-            if not was_listening:
+            if not was_listening and not self.event.pending_events:
                 self.event.close_pub()
 
     def cmd_full_return(


### PR DESCRIPTION
Don't close pub if there are pending events, otherwise events will be lost
resulting in empty minion returns.

### What does this PR do?
It fixes a bug in the batch client that randomly looses minion returns

### What issues does this PR fix or reference?
Fixes: #58502
