### PR TITLE
Fixed Custom Python Scripts example.

### DIFF
--- a/doc/topics/event/events.rst
+++ b/doc/topics/event/events.rst
@@ -248,7 +248,7 @@ done at the CLI:
     caller = salt.client.Caller()
 
     ret = caller.cmd('event.send',
-                     'myco/event/success'
+                     'myco/event/success',
                      { 'success': True,
                        'message': "It works!" })
 


### PR DESCRIPTION
Added missing comma in caller cmd.

### What does this PR do?

### What issues does this PR fix or reference?
Fixes: Custom Python script example in events documentation

### Previous Behavior
Custom python script example does not work.

SyntaxError: invalid syntax

### New Behavior
A working Python script example for custom events

### Merge requirements satisfied?
- [x] Docs
