### PR TITLE
Invalidate file list cache when cache file has a future last modified time

### DIFF
--- a/changelog/58529.fixed
+++ b/changelog/58529.fixed
@@ -1,0 +1,1 @@
+Invalidate file list cache when cache file has a future last modified time

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -132,7 +132,7 @@ def check_file_list_cache(opts, form, list_cache, w_lock):
                             current_time,
                             file_mtime,
                         )
-                        age = 0
+                        age = -1
                     else:
                         age = current_time - file_mtime
                 else:

--- a/tests/unit/test_fileserver.py
+++ b/tests/unit/test_fileserver.py
@@ -3,7 +3,14 @@
 """
 
 
+import datetime
+import os
+import time
+
+import salt.utils.files
 from salt import fileserver
+
+from tests.support.helpers import with_tempdir
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import TestCase
 
@@ -39,3 +46,35 @@ class VCSBackendWhitelistCase(TestCase, LoaderModuleMockMixin):
         assert sorted(fs.servers.whitelist) == sorted(
             ["git", "gitfs", "hg", "hgfs", "svn", "svnfs", "roots", "s3fs"]
         ), fs.servers.whitelist
+
+    @with_tempdir()
+    def test_future_file_list_cache_file_ignored(self, cachedir):
+        opts = {
+            "fileserver_backend": ["roots"],
+            "cachedir": cachedir,
+            "extension_modules": "",
+        }
+
+        back_cachedir = os.path.join(cachedir, "file_lists/roots")
+        os.makedirs(os.path.join(back_cachedir))
+
+        # Touch a couple files
+        for filename in ("base.p", "foo.txt"):
+            with salt.utils.files.fopen(
+                os.path.join(back_cachedir, filename), "wb"
+            ) as _f:
+                if filename == "base.p":
+                    _f.write(b"\x80")
+
+        # Set modification time to file list cache file to 1 year in the future
+        now = datetime.datetime.utcnow()
+        future = now + datetime.timedelta(days=365)
+        mod_time = time.mktime(future.timetuple())
+        os.utime(os.path.join(back_cachedir, "base.p"), (mod_time, mod_time))
+
+        list_cache = os.path.join(back_cachedir, "base.p")
+        w_lock = os.path.join(back_cachedir, ".base.w")
+        ret = fileserver.check_file_list_cache(opts, "files", list_cache, w_lock)
+        assert (
+            ret[1] is True
+        ), "Cache file list cache file is not refreshed when future modification time"

--- a/tests/unit/test_fileserver.py
+++ b/tests/unit/test_fileserver.py
@@ -9,7 +9,6 @@ import time
 
 import salt.utils.files
 from salt import fileserver
-
 from tests.support.helpers import with_tempdir
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import TestCase


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue in `fileserver.check_file_list_cache` which happens if the last modification time for the file list cache file is set to a future time.

When this situation happens, the cache file is always taken and *never** refreshed. Therefore, new files placed on the "file_roots" are not visible for the minions.

### Previous Behavior

We see these logs and cache file is **NOT** refreshed:

```console
2020-09-22 13:36:48,228 [salt.fileserver  :143 ][DEBUG   ][11349] Cache file modified time is in the future, ignoring. file=/var/cache/salt/master
/file_lists/roots/base.p mtime=1600774608 current_time=1923304320
2020-09-22 13:36:48,229 [salt.fileserver  :159 ][DEBUG   ][11349] Returning file list from cache: age=0 cache_time=20 /var/cache/salt/master/file_
lists/roots/base.p
```

### New Behavior

We see these logs and cache file is refreshed:

```console
2020-09-22 13:37:42,475 [salt.fileserver  :143 ][DEBUG   ][12474] Cache file modified time is in the future, ignoring. file=/var/cache/salt/master
/file_lists/roots/base.p mtime=1600774662 current_time=1923304320
2020-09-22 13:37:42,475 [salt.fileserver  :153 ][WARNING ][12474] The file list_cache was created in the future!
```

### Merge requirements satisfied?
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes