### PR TITLE
Automatically remove import comments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -738,10 +738,10 @@ repos:
         files: ^doc/.*\.rst
         additional_dependencies: [black==19.10b0]
 
-  - repo: https://github.com/saltstack/salt-nox-pre-commit
-    rev: master
+  - repo: https://github.com/saltstack/mirrors-nox
+    rev: v2020.8.22
     hooks:
-      - id: nox-py2
+      - id: nox
         alias: lint-salt
         name: Lint Salt
         files: ^((setup|noxfile)|(salt|tasks)/.*)\.py$
@@ -750,10 +750,10 @@ repos:
           - lint-salt-pre-commit
           - --
 
-  - repo: https://github.com/saltstack/salt-nox-pre-commit
-    rev: master
+  - repo: https://github.com/saltstack/mirrors-nox
+    rev: v2020.8.22
     hooks:
-      - id: nox-py2
+      - id: nox
         alias: lint-tests
         name: Lint Tests
         files: ^tests/.*\.py$
@@ -762,10 +762,10 @@ repos:
           - lint-tests-pre-commit
           - --
 
-  - repo: https://github.com/saltstack/salt-nox-pre-commit
-    rev: master
+  - repo: https://github.com/saltstack/mirrors-nox
+    rev: v2020.8.22
     hooks:
-      - id: nox-py2
+      - id: nox
         alias: check-docs
         name: Check Docs
         files: ^(salt/.*\.py|doc/ref/.*\.rst)$
@@ -775,10 +775,10 @@ repos:
           - --
           - docs.check
 
-  - repo: https://github.com/saltstack/salt-nox-pre-commit
-    rev: master
+  - repo: https://github.com/saltstack/mirrors-nox
+    rev: v2020.8.22
     hooks:
-      - id: nox-py2
+      - id: nox
         alias: check-filemap
         name: Check Filename Map Change Matching
         files: ^tests/filename_map\.yml$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -703,6 +703,19 @@ repos:
             salt/client/ssh/ssh_py_shim.py
           )$
 
+  - repo: https://github.com/saltstack/mirrors-nox
+    rev: v2020.8.22
+    hooks:
+      - id: nox
+        alias: remove-import-comments
+        name: Remove import comments
+        files: .*\.py$
+        args:
+          - -e
+          - invoke-pre-commit
+          - --
+          - imports.remove-comments
+
   - repo: https://github.com/timothycrosley/isort
     rev: "1e78a9acf3110e1f9721feb591f89a451fc9876a"
     hooks:

--- a/cicd/jenkins/pre-commit
+++ b/cicd/jenkins/pre-commit
@@ -5,7 +5,7 @@ if (env.CHANGE_ID) {
     pre_commit_skips = ''
 } else {
     // This is a branch build
-    pre_commit_skips = 'pyupgrade'
+    pre_commit_skips = 'pyupgrade,remove-import-comments'
 }
 
 runPreCommit(

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
-
 from invoke import Collection  # pylint: disable=3rd-party-module-not-gated
 
-from . import docs, filemap, loader
+from . import docs, filemap, imports, loader
 
 ns = Collection()
 ns.add_collection(Collection.from_module(docs, name="docs"), name="docs")
 ns.add_collection(Collection.from_module(loader, name="loader"), name="loader")
 ns.add_collection(Collection.from_module(filemap, name="filemap"), name="filemap")
+ns.add_collection(Collection.from_module(imports, name="imports"), name="imports")

--- a/tasks/imports.py
+++ b/tasks/imports.py
@@ -1,0 +1,54 @@
+"""
+    tasks.imports
+    ~~~~~~~~~~~~~
+
+    Imports related tasks
+"""
+
+import pathlib
+import re
+
+from invoke import task  # pylint: disable=3rd-party-module-not-gated
+from tasks import utils
+
+CODE_DIR = pathlib.Path(__file__).resolve().parent.parent
+SALT_CODE_DIR = CODE_DIR / "salt"
+
+
+@task(iterable=["files"], positional=["files"])
+def remove_comments(ctx, files):
+    """
+    Remove import comments, 'Import Python libs', 'Import salt libs', etc
+    """
+    # CD into Salt's repo root directory
+    ctx.cd(CODE_DIR)
+
+    # Unfortunately invoke does not support nargs.
+    # We migth have been passed --files="foo.py bar.py"
+    # Turn that into a list of paths
+    _files = []
+    for path in files:
+        if not path:
+            continue
+        _files.extend(path.split())
+    if not _files:
+        utils.exit_invoke(0)
+
+    _files = [
+        pathlib.Path(fname).resolve() for fname in _files if fname.endswith(".py")
+    ]
+
+    fixes = 0
+    exitcode = 0
+    comments_regex = re.compile(r"^# ([I|i])mports? .*(([L|l])ibs?)?\n", re.MULTILINE)
+    for path in _files:
+        contents = path.read_text()
+        fixed = comments_regex.sub("", contents)
+        if fixed == contents:
+            continue
+        fixes += 1
+        exitcode = 1
+        path.write_text(fixed)
+    if exitcode:
+        utils.error("Fixed {} files", fixes)
+    utils.exit_invoke(exitcode)


### PR DESCRIPTION
### What does this PR do?
Automatically remove import comments on files.
    
This is desired because now imports are automatically sorted and these header comments often get misplaced.

### What issues does this PR fix or reference?
Fixes: #57979
Fixes #58522

## NOTE
The master branch builds will actually skip this check until we get all comments removed, while on PR, the check will run.