### PR TITLE
use spot instance for windows2019

### DIFF
--- a/cicd/jenkins/kitchen-windows2019-py3
+++ b/cicd/jenkins/kitchen-windows2019-py3
@@ -12,6 +12,6 @@ runTestSuite(
     nox_passthrough_opts: '--unit',
     python_version: 'py3',
     testrun_timeout: 10,
-    use_spot_instances: false)
+    use_spot_instances: true)
 
 // vim: ft=groovy

--- a/cicd/jenkins/kitchen-windows2019-py3-pytest
+++ b/cicd/jenkins/kitchen-windows2019-py3-pytest
@@ -13,7 +13,7 @@ runTestSuite(
     python_version: 'py3',
     //splits: ['unit', 'integration'],
     testrun_timeout: 10,
-    use_spot_instances: false,
+    use_spot_instances: true,
     //fast_slow_staged_testrun: true
 )
 


### PR DESCRIPTION
### What does this PR do?
Switches to spot instances for windows2019 since they are available for c4.xlarges now.
