### PR TITLE
[PyTest Migration] Issue a warning when `loader_mock` get's passed `request` as an argument

### DIFF
--- a/tests/pytests/unit/states/test_ini_manage.py
+++ b/tests/pytests/unit/states/test_ini_manage.py
@@ -14,7 +14,7 @@ def sections():
 
 
 @pytest.fixture(autouse=True)
-def setup_loader(request):
+def setup_loader():
     setup_loader_modules = {
         ini_manage: {
             "__salt__": {
@@ -25,7 +25,7 @@ def setup_loader(request):
         },
         mod_ini_manage: {"__opts__": {"test": False}},
     }
-    with pytest.helpers.loader_mock(request, setup_loader_modules) as loader_mock:
+    with pytest.helpers.loader_mock(setup_loader_modules) as loader_mock:
         yield loader_mock
 
 

--- a/tests/support/pytest/helpers.py
+++ b/tests/support/pytest/helpers.py
@@ -10,6 +10,7 @@ import shutil
 import tempfile
 import textwrap
 import types
+import warnings
 from contextlib import contextmanager
 
 import pytest
@@ -221,7 +222,15 @@ def temp_pillar_file(name, contents, saltenv="base", strip_first_newline=True):
 
 
 @pytest.helpers.register
-def loader_mock(loader_modules, **kwargs):
+def loader_mock(*args, **kwargs):
+    if len(args) > 1:
+        loader_modules = args[1]
+        warnings.warn(
+            "'request' is not longer an accepted argument to 'loader_mock()'. Please stop passing it.",
+            category=DeprecationWarning,
+        )
+    else:
+        loader_modules = args[0]
     return LoaderModuleMock(loader_modules, **kwargs)
 
 


### PR DESCRIPTION
### What does this PR do?
Issue a warning when `loader_mock` get's passed `request` as an argument

This prevents open PRs from either breaking the test suite or the need
to update them before the merge.
