### PR TITLE
fix regression tests failure

### DIFF
--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -1871,7 +1871,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         )
         setxml = ET.fromstring(define_mock.call_args[0][0])
         self.assertEqual("2", setxml.find("vcpu").text)
-        self.assertEqual("2048", setxml.find("memory").text)
+        self.assertEqual("2147483648", setxml.find("memory").text)
 
         # Same parameters passed than in default virt.defined state case
         self.assertEqual(
@@ -2031,7 +2031,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 "definition": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
-                "mem": False,
+                "mem": True,
             },
             virt.update("my_vm", mem=memtune),
         )


### PR DESCRIPTION
### What does this PR do?
This PR fix the regression test failure on memory size assertion. The memory size unit  is standardized with `bytes` after memory tuning feature is added.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
