### PR TITLE
[PyTest Migration] Bump to PyTest >= 6.1.0 &  Fix PyTest's tests integration files copy 

### DIFF
--- a/requirements/pytest.txt
+++ b/requirements/pytest.txt
@@ -2,6 +2,6 @@ mock >= 3.0.0
 # PyTest
 pytest >= 6.1.0
 pytest-salt
-pytest-salt-factories >= 0.92.0
+pytest-salt-factories >= 0.93.0
 pytest-tempdir >= 2019.10.12
 pytest-helpers-namespace >= 2019.1.8

--- a/requirements/pytest.txt
+++ b/requirements/pytest.txt
@@ -1,6 +1,6 @@
 mock >= 3.0.0
 # PyTest
-pytest >= 6.0.1
+pytest >= 6.1.0
 pytest-salt
 pytest-salt-factories >= 0.92.0
 pytest-tempdir >= 2019.10.12

--- a/requirements/static/lint.in
+++ b/requirements/static/lint.in
@@ -1,4 +1,4 @@
 # Lint requirements
 pylint==2.4.4
-SaltPyLint>=v2020.5.22
+SaltPyLint>=v2020.9.28
 toml

--- a/requirements/static/py3.5/darwin.txt
+++ b/requirements/static/py3.5/darwin.txt
@@ -90,7 +90,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.93.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.1.0

--- a/requirements/static/py3.5/darwin.txt
+++ b/requirements/static/py3.5/darwin.txt
@@ -93,7 +93,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.2
+pytest==6.1.0
 python-dateutil==2.8.0
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.5/darwin.txt
+++ b/requirements/static/py3.5/darwin.txt
@@ -35,7 +35,7 @@ distro==1.5.0
 dnspython==1.16.0
 docker-pycreds==0.4.0     # via docker
 docker==3.7.2
-docutils==0.15.2            # via botocore
+docutils==0.15.2          # via botocore
 ecdsa==0.13.3             # via python-jose
 filelock==3.0.12          # via virtualenv
 future==0.17.1            # via python-jose, textfsm

--- a/requirements/static/py3.5/docs.txt
+++ b/requirements/static/py3.5/docs.txt
@@ -8,7 +8,7 @@ alabaster==0.7.12         # via sphinx
 babel==2.8.0              # via sphinx
 certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
-docutils==0.15.2            # via sphinx
+docutils==0.15.2          # via sphinx
 idna==2.9                 # via requests
 imagesize==1.2.0          # via sphinx
 jinja2==2.11.2            # via sphinx

--- a/requirements/static/py3.5/freebsd.txt
+++ b/requirements/static/py3.5/freebsd.txt
@@ -90,7 +90,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.93.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.1.0

--- a/requirements/static/py3.5/freebsd.txt
+++ b/requirements/static/py3.5/freebsd.txt
@@ -32,7 +32,7 @@ distro==1.5.0
 dnspython==1.16.0
 docker-pycreds==0.4.0     # via docker
 docker==3.7.2
-docutils==0.15.2            # via botocore
+docutils==0.15.2          # via botocore
 ecdsa==0.13.3             # via python-jose
 filelock==3.0.12          # via virtualenv
 future==0.17.1            # via python-jose, textfsm

--- a/requirements/static/py3.5/freebsd.txt
+++ b/requirements/static/py3.5/freebsd.txt
@@ -93,7 +93,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.2
+pytest==6.1.0
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, vcert
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.5/lint.txt
+++ b/requirements/static/py3.5/lint.txt
@@ -11,7 +11,7 @@ mccabe==0.6.1             # via pylint
 modernize==0.5            # via saltpylint
 pycodestyle==2.5.0        # via saltpylint
 pylint==2.4.4
-saltpylint==2020.5.22
+saltpylint==2020.9.28
 six==1.15.0               # via astroid
 toml==0.10.0
 typed-ast==1.4.1          # via astroid

--- a/requirements/static/py3.5/linux.txt
+++ b/requirements/static/py3.5/linux.txt
@@ -181,7 +181,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.93.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.1.0

--- a/requirements/static/py3.5/linux.txt
+++ b/requirements/static/py3.5/linux.txt
@@ -184,7 +184,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.2
+pytest==6.1.0
 python-dateutil==2.8.0    # via adal, azure-cosmosdb-table, azure-storage-common, botocore, croniter, kubernetes, moto, vcert
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.5/linux.txt
+++ b/requirements/static/py3.5/linux.txt
@@ -116,7 +116,7 @@ distro==1.5.0
 dnspython==1.16.0
 docker-pycreds==0.4.0     # via docker
 docker==3.7.2
-docutils==0.15.2            # via botocore
+docutils==0.15.2          # via botocore
 ecdsa==0.13.3             # via python-jose
 filelock==3.0.12          # via virtualenv
 future==0.17.1            # via python-jose, textfsm

--- a/requirements/static/py3.5/windows.txt
+++ b/requirements/static/py3.5/windows.txt
@@ -86,7 +86,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.2
+pytest==6.1.0
 python-dateutil==2.8.0
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.5/windows.txt
+++ b/requirements/static/py3.5/windows.txt
@@ -32,7 +32,7 @@ dmidecode==0.9.0
 dnspython==1.16.0
 docker-pycreds==0.4.0     # via docker
 docker==2.7.0
-docutils==0.15.2            # via botocore
+docutils==0.15.2          # via botocore
 ecdsa==0.13.3             # via python-jose
 filelock==3.0.12          # via virtualenv
 future==0.17.1            # via python-jose

--- a/requirements/static/py3.5/windows.txt
+++ b/requirements/static/py3.5/windows.txt
@@ -83,7 +83,7 @@ pymysql==0.9.3
 pyopenssl==19.0.0
 pyparsing==2.4.5          # via packaging
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.93.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.1.0

--- a/requirements/static/py3.6/darwin.txt
+++ b/requirements/static/py3.6/darwin.txt
@@ -98,7 +98,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.2
+pytest==6.1.0
 python-dateutil==2.8.0
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.6/darwin.txt
+++ b/requirements/static/py3.6/darwin.txt
@@ -37,7 +37,7 @@ distro==1.5.0
 dnspython==1.16.0
 docker-pycreds==0.4.0     # via docker
 docker==3.7.2
-docutils==0.15.2            # via botocore
+docutils==0.15.2          # via botocore
 ecdsa==0.13.3             # via python-jose
 filelock==3.0.12          # via virtualenv
 future==0.17.1            # via napalm, python-jose, textfsm

--- a/requirements/static/py3.6/darwin.txt
+++ b/requirements/static/py3.6/darwin.txt
@@ -95,7 +95,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.93.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.1.0

--- a/requirements/static/py3.6/docs.txt
+++ b/requirements/static/py3.6/docs.txt
@@ -8,7 +8,7 @@ alabaster==0.7.12         # via sphinx
 babel==2.8.0              # via sphinx
 certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
-docutils==0.15.2            # via sphinx
+docutils==0.15.2          # via sphinx
 idna==2.9                 # via requests
 imagesize==1.2.0          # via sphinx
 jinja2==2.11.2            # via sphinx

--- a/requirements/static/py3.6/freebsd.txt
+++ b/requirements/static/py3.6/freebsd.txt
@@ -98,7 +98,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.2
+pytest==6.1.0
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, vcert
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.6/freebsd.txt
+++ b/requirements/static/py3.6/freebsd.txt
@@ -95,7 +95,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.93.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.1.0

--- a/requirements/static/py3.6/freebsd.txt
+++ b/requirements/static/py3.6/freebsd.txt
@@ -34,7 +34,7 @@ distro==1.5.0
 dnspython==1.16.0
 docker-pycreds==0.4.0     # via docker
 docker==3.7.2
-docutils==0.15.2            # via botocore
+docutils==0.15.2          # via botocore
 ecdsa==0.13.3             # via python-jose
 filelock==3.0.12          # via virtualenv
 future==0.17.1            # via napalm, python-jose, textfsm

--- a/requirements/static/py3.6/lint.txt
+++ b/requirements/static/py3.6/lint.txt
@@ -11,7 +11,7 @@ mccabe==0.6.1             # via pylint
 modernize==0.5            # via saltpylint
 pycodestyle==2.5.0        # via saltpylint
 pylint==2.4.4
-saltpylint==2020.5.22
+saltpylint==2020.9.28
 six==1.15.0               # via astroid
 toml==0.10.0
 typed-ast==1.4.1          # via astroid

--- a/requirements/static/py3.6/linux.txt
+++ b/requirements/static/py3.6/linux.txt
@@ -188,7 +188,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.2
+pytest==6.1.0
 python-dateutil==2.8.0    # via adal, azure-cosmosdb-table, azure-storage-common, botocore, croniter, kubernetes, moto, vcert
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.6/linux.txt
+++ b/requirements/static/py3.6/linux.txt
@@ -185,7 +185,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.93.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.1.0

--- a/requirements/static/py3.6/linux.txt
+++ b/requirements/static/py3.6/linux.txt
@@ -118,7 +118,7 @@ distro==1.5.0
 dnspython==1.16.0
 docker-pycreds==0.4.0     # via docker
 docker==3.7.2
-docutils==0.15.2            # via botocore
+docutils==0.15.2          # via botocore
 ecdsa==0.13.3             # via python-jose
 filelock==3.0.12          # via virtualenv
 future==0.17.1            # via napalm, python-jose, textfsm

--- a/requirements/static/py3.6/windows.txt
+++ b/requirements/static/py3.6/windows.txt
@@ -82,7 +82,7 @@ pymysql==0.9.3
 pyopenssl==19.0.0
 pyparsing==2.4.5          # via packaging
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.93.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.1.0

--- a/requirements/static/py3.6/windows.txt
+++ b/requirements/static/py3.6/windows.txt
@@ -32,7 +32,7 @@ dmidecode==0.9.0
 dnspython==1.16.0
 docker-pycreds==0.4.0     # via docker
 docker==2.7.0
-docutils==0.15.2            # via botocore
+docutils==0.15.2          # via botocore
 ecdsa==0.13.3             # via python-jose
 filelock==3.0.12          # via virtualenv
 future==0.17.1            # via python-jose

--- a/requirements/static/py3.6/windows.txt
+++ b/requirements/static/py3.6/windows.txt
@@ -85,7 +85,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.2
+pytest==6.1.0
 python-dateutil==2.8.0
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.7/darwin.txt
+++ b/requirements/static/py3.7/darwin.txt
@@ -96,7 +96,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.2
+pytest==6.1.0
 python-dateutil==2.8.0
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.7/darwin.txt
+++ b/requirements/static/py3.7/darwin.txt
@@ -36,7 +36,7 @@ distro==1.5.0
 dnspython==1.16.0
 docker-pycreds==0.4.0     # via docker
 docker==3.7.2
-docutils==0.15.2            # via botocore
+docutils==0.15.2          # via botocore
 ecdsa==0.13.3             # via python-jose
 filelock==3.0.12          # via virtualenv
 future==0.17.1            # via napalm, python-jose, textfsm

--- a/requirements/static/py3.7/darwin.txt
+++ b/requirements/static/py3.7/darwin.txt
@@ -93,7 +93,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.93.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.1.0

--- a/requirements/static/py3.7/docs.txt
+++ b/requirements/static/py3.7/docs.txt
@@ -8,7 +8,7 @@ alabaster==0.7.12         # via sphinx
 babel==2.8.0              # via sphinx
 certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
-docutils==0.15.2            # via sphinx
+docutils==0.15.2          # via sphinx
 idna==2.9                 # via requests
 imagesize==1.2.0          # via sphinx
 jinja2==2.11.2            # via sphinx

--- a/requirements/static/py3.7/freebsd.txt
+++ b/requirements/static/py3.7/freebsd.txt
@@ -97,7 +97,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.2
+pytest==6.1.0
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, vcert
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.7/freebsd.txt
+++ b/requirements/static/py3.7/freebsd.txt
@@ -34,7 +34,7 @@ distro==1.5.0
 dnspython==1.16.0
 docker-pycreds==0.4.0     # via docker
 docker==3.7.2
-docutils==0.15.2            # via botocore
+docutils==0.15.2          # via botocore
 ecdsa==0.13.3             # via python-jose
 filelock==3.0.12          # via virtualenv
 future==0.17.1            # via napalm, python-jose, textfsm

--- a/requirements/static/py3.7/freebsd.txt
+++ b/requirements/static/py3.7/freebsd.txt
@@ -94,7 +94,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.93.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.1.0

--- a/requirements/static/py3.7/lint.txt
+++ b/requirements/static/py3.7/lint.txt
@@ -11,7 +11,7 @@ mccabe==0.6.1             # via pylint
 modernize==0.5            # via saltpylint
 pycodestyle==2.5.0        # via saltpylint
 pylint==2.4.4
-saltpylint==2020.5.22
+saltpylint==2020.9.28
 six==1.15.0               # via astroid
 toml==0.10.0
 typed-ast==1.4.1          # via astroid

--- a/requirements/static/py3.7/linux.txt
+++ b/requirements/static/py3.7/linux.txt
@@ -118,7 +118,7 @@ distro==1.5.0
 dnspython==1.16.0
 docker-pycreds==0.4.0     # via docker
 docker==3.7.2
-docutils==0.15.2            # via botocore
+docutils==0.15.2          # via botocore
 ecdsa==0.13.3             # via python-jose
 filelock==3.0.12          # via virtualenv
 future==0.17.1            # via napalm, python-jose, textfsm

--- a/requirements/static/py3.7/linux.txt
+++ b/requirements/static/py3.7/linux.txt
@@ -187,7 +187,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.2
+pytest==6.1.0
 python-dateutil==2.8.0    # via adal, azure-cosmosdb-table, azure-storage-common, botocore, croniter, kubernetes, moto, vcert
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.7/linux.txt
+++ b/requirements/static/py3.7/linux.txt
@@ -184,7 +184,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.93.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.1.0

--- a/requirements/static/py3.7/windows.txt
+++ b/requirements/static/py3.7/windows.txt
@@ -80,7 +80,7 @@ pymysql==0.9.3
 pyopenssl==19.0.0
 pyparsing==2.4.5          # via packaging
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.93.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.1.0

--- a/requirements/static/py3.7/windows.txt
+++ b/requirements/static/py3.7/windows.txt
@@ -31,7 +31,7 @@ dmidecode==0.9.0
 dnspython==1.16.0
 docker-pycreds==0.4.0     # via docker
 docker==2.7.0
-docutils==0.15.2            # via botocore
+docutils==0.15.2          # via botocore
 ecdsa==0.13.3             # via python-jose
 filelock==3.0.12          # via virtualenv
 future==0.17.1            # via python-jose

--- a/requirements/static/py3.7/windows.txt
+++ b/requirements/static/py3.7/windows.txt
@@ -83,7 +83,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.2
+pytest==6.1.0
 python-dateutil==2.8.0
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.8/darwin.txt
+++ b/requirements/static/py3.8/darwin.txt
@@ -95,7 +95,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.2
+pytest==6.1.0
 python-dateutil==2.8.0
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.8/darwin.txt
+++ b/requirements/static/py3.8/darwin.txt
@@ -92,7 +92,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.93.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.1.0

--- a/requirements/static/py3.8/darwin.txt
+++ b/requirements/static/py3.8/darwin.txt
@@ -36,7 +36,7 @@ distro==1.5.0
 dnspython==1.16.0
 docker-pycreds==0.4.0     # via docker
 docker==3.7.2
-docutils==0.15.2            # via botocore
+docutils==0.15.2          # via botocore
 ecdsa==0.13.3             # via python-jose
 filelock==3.0.12          # via virtualenv
 future==0.17.1            # via napalm, python-jose, textfsm

--- a/requirements/static/py3.8/docs.txt
+++ b/requirements/static/py3.8/docs.txt
@@ -8,7 +8,7 @@ alabaster==0.7.12         # via sphinx
 babel==2.7.0              # via sphinx
 certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
-docutils==0.15.2            # via sphinx
+docutils==0.15.2          # via sphinx
 idna==2.8                 # via requests
 imagesize==1.1.0          # via sphinx
 jinja2==2.10.1            # via sphinx

--- a/requirements/static/py3.8/freebsd.txt
+++ b/requirements/static/py3.8/freebsd.txt
@@ -93,7 +93,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.93.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.1.0

--- a/requirements/static/py3.8/freebsd.txt
+++ b/requirements/static/py3.8/freebsd.txt
@@ -96,7 +96,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.2
+pytest==6.1.0
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, vcert
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.8/freebsd.txt
+++ b/requirements/static/py3.8/freebsd.txt
@@ -34,7 +34,7 @@ distro==1.5.0
 dnspython==1.16.0
 docker-pycreds==0.4.0     # via docker
 docker==3.7.2
-docutils==0.15.2            # via botocore
+docutils==0.15.2          # via botocore
 ecdsa==0.13.3             # via python-jose
 filelock==3.0.12          # via virtualenv
 future==0.17.1            # via napalm, python-jose, textfsm

--- a/requirements/static/py3.8/lint.txt
+++ b/requirements/static/py3.8/lint.txt
@@ -11,7 +11,7 @@ mccabe==0.6.1             # via pylint
 modernize==0.5            # via saltpylint
 pycodestyle==2.5.0        # via saltpylint
 pylint==2.4.4
-saltpylint==2020.5.22
+saltpylint==2020.9.28
 six==1.15.0               # via astroid
 toml==0.10.0
 wrapt==1.11.1             # via astroid

--- a/requirements/static/py3.8/linux.txt
+++ b/requirements/static/py3.8/linux.txt
@@ -187,7 +187,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.2
+pytest==6.1.0
 python-dateutil==2.8.0    # via adal, azure-cosmosdb-table, azure-storage-common, botocore, croniter, kubernetes, moto, vcert
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.8/linux.txt
+++ b/requirements/static/py3.8/linux.txt
@@ -119,7 +119,7 @@ distro==1.5.0
 dnspython==1.16.0
 docker-pycreds==0.4.0     # via docker
 docker==3.7.2
-docutils==0.15.2            # via botocore
+docutils==0.15.2          # via botocore
 ecdsa==0.13.3             # via python-jose
 filelock==3.0.12          # via virtualenv
 future==0.17.1            # via napalm, python-jose, textfsm

--- a/requirements/static/py3.8/linux.txt
+++ b/requirements/static/py3.8/linux.txt
@@ -184,7 +184,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.93.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.1.0

--- a/requirements/static/py3.9/darwin.txt
+++ b/requirements/static/py3.9/darwin.txt
@@ -95,7 +95,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.2
+pytest==6.1.0
 python-dateutil==2.8.0
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.9/darwin.txt
+++ b/requirements/static/py3.9/darwin.txt
@@ -92,7 +92,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.93.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.1.0

--- a/requirements/static/py3.9/darwin.txt
+++ b/requirements/static/py3.9/darwin.txt
@@ -36,7 +36,7 @@ distro==1.5.0
 dnspython==1.16.0
 docker-pycreds==0.4.0     # via docker
 docker==3.7.2
-docutils==0.15.2            # via botocore
+docutils==0.15.2          # via botocore
 ecdsa==0.13.3             # via python-jose
 filelock==3.0.12          # via virtualenv
 future==0.17.1            # via napalm, python-jose, textfsm

--- a/requirements/static/py3.9/docs.txt
+++ b/requirements/static/py3.9/docs.txt
@@ -8,7 +8,7 @@ alabaster==0.7.12         # via sphinx
 babel==2.7.0              # via sphinx
 certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
-docutils==0.15.2            # via sphinx
+docutils==0.15.2          # via sphinx
 idna==2.8                 # via requests
 imagesize==1.1.0          # via sphinx
 jinja2==2.10.1            # via sphinx

--- a/requirements/static/py3.9/freebsd.txt
+++ b/requirements/static/py3.9/freebsd.txt
@@ -93,7 +93,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.93.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.1.0

--- a/requirements/static/py3.9/freebsd.txt
+++ b/requirements/static/py3.9/freebsd.txt
@@ -96,7 +96,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.2
+pytest==6.1.0
 python-dateutil==2.8.0    # via botocore, croniter, kubernetes, moto, vcert
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.9/freebsd.txt
+++ b/requirements/static/py3.9/freebsd.txt
@@ -34,7 +34,7 @@ distro==1.5.0
 dnspython==1.16.0
 docker-pycreds==0.4.0     # via docker
 docker==3.7.2
-docutils==0.15.2            # via botocore
+docutils==0.15.2          # via botocore
 ecdsa==0.13.3             # via python-jose
 filelock==3.0.12          # via virtualenv
 future==0.17.1            # via napalm, python-jose, textfsm

--- a/requirements/static/py3.9/lint.txt
+++ b/requirements/static/py3.9/lint.txt
@@ -11,7 +11,7 @@ mccabe==0.6.1             # via pylint
 modernize==0.5            # via saltpylint
 pycodestyle==2.5.0        # via saltpylint
 pylint==2.4.4
-saltpylint==2020.5.22
+saltpylint==2020.9.28
 six==1.15.0               # via astroid
 toml==0.10.0
 wrapt==1.11.1             # via astroid

--- a/requirements/static/py3.9/linux.txt
+++ b/requirements/static/py3.9/linux.txt
@@ -187,7 +187,7 @@ pytest-helpers-namespace==2019.1.8
 pytest-salt-factories==0.92.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.0.2
+pytest==6.1.0
 python-dateutil==2.8.0    # via adal, azure-cosmosdb-table, azure-storage-common, botocore, croniter, kubernetes, moto, vcert
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/py3.9/linux.txt
+++ b/requirements/static/py3.9/linux.txt
@@ -119,7 +119,7 @@ distro==1.5.0
 dnspython==1.16.0
 docker-pycreds==0.4.0     # via docker
 docker==3.7.2
-docutils==0.15.2            # via botocore
+docutils==0.15.2          # via botocore
 ecdsa==0.13.3             # via python-jose
 filelock==3.0.12          # via virtualenv
 future==0.17.1            # via napalm, python-jose, textfsm

--- a/requirements/static/py3.9/linux.txt
+++ b/requirements/static/py3.9/linux.txt
@@ -184,7 +184,7 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.92.0
+pytest-salt-factories==0.93.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
 pytest==6.1.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -624,12 +624,12 @@ def integration_files_dir(salt_factories):
     Creates the directory if it does not yet exist.
     """
     dirname = salt_factories.root_dir / "integration-files"
-    int_files = os.path.join(
-        salt_factories.code_dir, "tests", "pytests", "integration", "files"
-    )
-    if not os.path.exists(dirname):
-        shutil.copytree(int_files, dirname)
     dirname.mkdir(exist_ok=True)
+    for child in (PYTESTS_DIR / "integration" / "files").iterdir():
+        if child.is_dir():
+            shutil.copytree(str(child), str(dirname / child.name))
+        else:
+            shutil.copyfile(str(child), str(dirname / child.name))
     return dirname
 
 
@@ -1331,12 +1331,12 @@ def ssl_webserver(integration_files_dir, scope="module"):
     spins up an https webserver.
     """
     context = ssl.SSLContext()
-    root_dir = os.path.join(integration_files_dir, "https")
     context.load_cert_chain(
-        os.path.join(root_dir, "cert.pem"), os.path.join(root_dir, "key.pem")
+        str(integration_files_dir / "https" / "cert.pem"),
+        str(integration_files_dir / "https" / "key.pem"),
     )
 
-    webserver = Webserver(root=integration_files_dir, ssl_opts=context)
+    webserver = Webserver(root=str(integration_files_dir), ssl_opts=context)
     webserver.start()
     yield webserver
     webserver.stop()

--- a/tests/pytests/unit/modules/test_ini_manage.py
+++ b/tests/pytests/unit/modules/test_ini_manage.py
@@ -1,3 +1,5 @@
+import os
+
 import salt.modules.ini_manage
 
 
@@ -5,4 +7,5 @@ def test_section_req():
     """
     Test the __repr__ in the _Section class
     """
-    assert repr(salt.modules.ini_manage._Section("test")) == "_Section()\n{}"
+    expected = "_Section(){}{{}}".format(os.linesep)
+    assert repr(salt.modules.ini_manage._Section("test")) == expected

--- a/tests/pytests/unit/states/test_ini_manage.py
+++ b/tests/pytests/unit/states/test_ini_manage.py
@@ -4,12 +4,16 @@ import os
 import pytest
 import salt.modules.ini_manage as mod_ini_manage
 import salt.states.ini_manage as ini_manage
+from salt.utils.odict import OrderedDict
 from tests.support.mock import patch
 
 
-@pytest.fixture()
+@pytest.fixture
 def sections():
-    sections = {"general": {"hostname": "myserver.com", "port": "1234"}}
+    sections = OrderedDict()
+    sections["general"] = OrderedDict()
+    sections["general"]["hostname"] = "myserver.com"
+    sections["general"]["port"] = "1234"
     return sections
 
 

--- a/tests/unit/utils/test_jid.py
+++ b/tests/unit/utils/test_jid.py
@@ -1,15 +1,11 @@
-# -*- coding: utf-8 -*-
 """
 Tests for salt.utils.jid
 """
 
-# Import Python libs
-from __future__ import absolute_import, unicode_literals
 
 import datetime
 import os
 
-# Import Salt libs
 import salt.utils.jid
 from tests.support.mock import patch
 from tests.support.unit import TestCase
@@ -37,23 +33,8 @@ class JidTestCase(TestCase):
         with patch("salt.utils.jid._utc_now", return_value=now):
             ret = salt.utils.jid.gen_jid({})
             self.assertEqual(ret, "20021225120000000000")
-            salt.utils.jid.LAST_JID_DATETIME = None
-            ret = salt.utils.jid.gen_jid({"unique_jid": True})
-            self.assertEqual(ret, "20021225120000000000_{0}".format(os.getpid()))
-            ret = salt.utils.jid.gen_jid({"unique_jid": True})
-            self.assertEqual(ret, "20021225120000000001_{0}".format(os.getpid()))
-
-    def test_gen_jid_utc(self):
-        utcnow = datetime.datetime(2002, 12, 25, 12, 7, 0, 0)
-        with patch("salt.utils.jid._utc_now", return_value=utcnow):
-            ret = salt.utils.jid.gen_jid({"utc_jid": True})
-            self.assertEqual(ret, "20021225120700000000")
-
-    def test_gen_jid_utc_unique(self):
-        utcnow = datetime.datetime(2002, 12, 25, 12, 7, 0, 0)
-        with patch("salt.utils.jid._utc_now", return_value=utcnow):
-            salt.utils.jid.LAST_JID_DATETIME = None
-            ret = salt.utils.jid.gen_jid({"utc_jid": True, "unique_jid": True})
-            self.assertEqual(ret, "20021225120700000000_{0}".format(os.getpid()))
-            ret = salt.utils.jid.gen_jid({"utc_jid": True, "unique_jid": True})
-            self.assertEqual(ret, "20021225120700000001_{0}".format(os.getpid()))
+            with patch("salt.utils.jid.LAST_JID_DATETIME", None):
+                ret = salt.utils.jid.gen_jid({"unique_jid": True})
+                self.assertEqual(ret, "20021225120000000000_{}".format(os.getpid()))
+                ret = salt.utils.jid.gen_jid({"unique_jid": True})
+                self.assertEqual(ret, "20021225120000000001_{}".format(os.getpid()))


### PR DESCRIPTION
### What does this PR do?
See title