### PR TITLE
Properly fix memory setting regression in virt.update

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -2755,6 +2755,8 @@ def update(
         value = node.get("memory") or node.text
         return _handle_unit("{}{}".format(value, unit)) if value else None
 
+    old_mem = int(_get_with_unit(desc.find("memory")) / 1024)
+
     # Update the kernel boot parameters
     params_mapping = [
         {"path": "boot:kernel", "xpath": "os/kernel"},
@@ -2918,16 +2920,23 @@ def update(
                 )
             if mem:
                 if isinstance(mem, dict):
-                    mem = str(_handle_unit(mem.get("current", 0)))
+                    # setMemoryFlags takes memory amount in KiB
+                    new_mem = (
+                        int(_handle_unit(mem.get("current")) / 1024)
+                        if "current" in mem
+                        else None
+                    )
                 elif isinstance(mem, int):
-                    mem = str(mem * 1024)
-                commands.append(
-                    {
-                        "device": "mem",
-                        "cmd": "setMemoryFlags",
-                        "args": [mem, libvirt.VIR_DOMAIN_AFFECT_LIVE],
-                    }
-                )
+                    new_mem = int(mem * 1024)
+
+                if old_mem != new_mem and new_mem is not None:
+                    commands.append(
+                        {
+                            "device": "mem",
+                            "cmd": "setMemoryFlags",
+                            "args": [new_mem, libvirt.VIR_DOMAIN_AFFECT_LIVE],
+                        }
+                    )
 
             # Look for removable device source changes
             new_disks = []

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -1872,6 +1872,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         setxml = ET.fromstring(define_mock.call_args[0][0])
         self.assertEqual("2", setxml.find("vcpu").text)
         self.assertEqual("2147483648", setxml.find("memory").text)
+        self.assertEqual(2048 * 1024, domain_mock.setMemoryFlags.call_args[0][0])
 
         # Same parameters passed than in default virt.defined state case
         self.assertEqual(
@@ -2031,7 +2032,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 "definition": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
-                "mem": True,
             },
             virt.update("my_vm", mem=memtune),
         )
@@ -2079,7 +2079,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         setxml = ET.fromstring(define_mock.call_args[0][0])
         self.assertEqual(setxml.find("memory").text, str(2048 * 1024 ** 2))
         self.assertEqual(setxml.find("memory").get("unit"), "bytes")
-        self.assertEqual(setmem_mock.call_args[0][0], str(2048 * 1024))
+        self.assertEqual(setmem_mock.call_args[0][0], 2048 * 1024)
 
         mem_dict = {"boot": "0.5g", "current": "2g", "max": "1g", "slots": 12}
         self.assertEqual(
@@ -2107,7 +2107,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 "definition": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
-                "mem": True,
             },
             virt.update("my_vm", mem=max_slot_reverse),
         )
@@ -2825,14 +2824,18 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             "min_guarantee": "1 g",
         }
 
+        domain_mock.setMemoryFlags.return_value = 0
         self.assertEqual(
             {
                 "definition": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
-                "mem": False,
+                "mem": True,
             },
             virt.update("vm_with_memtune_param", mem=memtune_new_val),
+        )
+        self.assertEqual(
+            domain_mock.setMemoryFlags.call_args[0][0], int(2.5 * 1024 ** 2)
         )
 
         setxml = ET.fromstring(define_mock.call_args[0][0])
@@ -2869,7 +2872,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 "definition": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
-                "mem": False,
             },
             virt.update("vm_with_memtune_param", mem=max_slot_reverse),
         )
@@ -2889,14 +2891,18 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             "min_guarantee": "1 g",
         }
 
+        domain_mock.setMemoryFlags.reset_mock()
         self.assertEqual(
             {
                 "definition": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
-                "mem": False,
+                "mem": True,
             },
             virt.update("vm_with_memtune_param", mem=max_swap_none),
+        )
+        self.assertEqual(
+            domain_mock.setMemoryFlags.call_args[0][0], int(2.5 * 1024 ** 2)
         )
 
         setxml = ET.fromstring(define_mock.call_args[0][0])
@@ -2929,7 +2935,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 "definition": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
-                "mem": False,
             },
             virt.update("vm_with_memtune_param", mem=memtune_none),
         )
@@ -2949,7 +2954,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 "definition": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
-                "mem": False,
             },
             virt.update("vm_with_memtune_param", mem=max_none),
         )


### PR DESCRIPTION
# What does this PR do?

The `mem` property in the `virt.update()` return value should indicate the result
of a live memory setting. The value should be an int in KiB. Fixing the
code and tests for this.

### What issues does this PR fix or reference?

Fixes regression introduced in PR #57636 and fix a wrong fix in PR #58565

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Tests written/updated

### Commits signed with GPG?
Yes