### PR TITLE
clarifying the pillar_opts is configured on both master and minion.

### DIFF
--- a/doc/topics/tutorials/pillar.rst
+++ b/doc/topics/tutorials/pillar.rst
@@ -67,8 +67,9 @@ The contents of the master configuration file can be made available to minion
 pillar files. This makes global configuration of services and systems very easy,
 but note that this may not be desired or appropriate if sensitive data is stored
 in the master's configuration file. To enable the master configuration file to be
-available to a minion's pillar files, set ``pillar_opts`` to ``True`` in the
-minion configuration file.
+available to minion as pillar, set ``pillar_opts: True`` in the master
+confugration file, and then for appropriate minions also set ``pillar_opts: True``
+in the minion(s) configuration file.
 
 Similar to the state tree, the pillar is comprised of sls files and has a top file.
 The default location for the pillar is in /srv/pillar.


### PR DESCRIPTION
rebase of #56656 onto master so we can get this in.  I would have updated the original pr but it didn't allow edits by maintainers.