### PR TITLE
fix: remove boto version checks from boto3 modules

### DIFF
--- a/salt/modules/boto3_elasticache.py
+++ b/salt/modules/boto3_elasticache.py
@@ -78,7 +78,7 @@ def __virtual__():
     Only load if boto libraries exist and if boto libraries are greater than
     a given version.
     """
-    return salt.utils.versions.check_boto_reqs()
+    return salt.utils.versions.check_boto_reqs(check_boto=False)
 
 
 def __init__(opts):

--- a/salt/modules/boto3_elasticache.py
+++ b/salt/modules/boto3_elasticache.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Execution module for Amazon Elasticache using boto3
 ===================================================
@@ -46,21 +45,16 @@ Execution module for Amazon Elasticache using boto3
 # keep lint from choking on _get_conn and _cache_id
 # pylint: disable=E0602
 
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 import time
 
 import salt.utils.compat
 import salt.utils.versions
-
-# Import Salt libs
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 
 log = logging.getLogger(__name__)
 
-# Import third party libs
 try:
     # pylint: disable=unused-import
     import botocore
@@ -123,11 +117,11 @@ def _describe_resource(
         f = getattr(conn, func)
     except (AttributeError, KeyError) as e:
         raise SaltInvocationError(
-            "No function '{0}()' found: {1}".format(func, e.message)
+            "No function '{}()' found: {}".format(func, e.message)
         )
     # Undocumented, but you can't pass 'Marker' if searching for a specific resource...
     args.update({name_param: name} if name else {"Marker": ""})
-    args = dict([(k, v) for k, v in args.items() if not k.startswith("_")])
+    args = {k: v for k, v in args.items() if not k.startswith("_")}
     try:
         return _collect_results(f, info_node, args)
     except botocore.exceptions.ClientError as e:
@@ -156,7 +150,7 @@ def _delete_resource(
         wait = int(wait)
     except Exception:  # pylint: disable=broad-except
         raise SaltInvocationError(
-            "Bad value ('{0}') passed for 'wait' param - must be an "
+            "Bad value ('{}') passed for 'wait' param - must be an "
             "int or boolean.".format(wait)
         )
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
@@ -170,7 +164,7 @@ def _delete_resource(
         name = args[name_param]
     else:
         args[name_param] = name
-    args = dict([(k, v) for k, v in args.items() if not k.startswith("_")])
+    args = {k: v for k, v in args.items() if not k.startswith("_")}
     try:
         func = "delete_" + res_type
         f = getattr(conn, func)
@@ -179,7 +173,7 @@ def _delete_resource(
             s = globals()[func]
     except (AttributeError, KeyError) as e:
         raise SaltInvocationError(
-            "No function '{0}()' found: {1}".format(func, e.message)
+            "No function '{}()' found: {}".format(func, e.message)
         )
     try:
 
@@ -224,7 +218,7 @@ def _create_resource(
         wait = int(wait)
     except Exception:  # pylint: disable=broad-except
         raise SaltInvocationError(
-            "Bad value ('{0}') passed for 'wait' param - must be an "
+            "Bad value ('{}') passed for 'wait' param - must be an "
             "int or boolean.".format(wait)
         )
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
@@ -238,7 +232,7 @@ def _create_resource(
         name = args[name_param]
     else:
         args[name_param] = name
-    args = dict([(k, v) for k, v in args.items() if not k.startswith("_")])
+    args = {k: v for k, v in args.items() if not k.startswith("_")}
     try:
         func = "create_" + res_type
         f = getattr(conn, func)
@@ -247,7 +241,7 @@ def _create_resource(
             s = globals()[func]
     except (AttributeError, KeyError) as e:
         raise SaltInvocationError(
-            "No function '{0}()' found: {1}".format(func, e.message)
+            "No function '{}()' found: {}".format(func, e.message)
         )
     try:
         f(**args)
@@ -277,7 +271,7 @@ def _create_resource(
         )
         return False
     except botocore.exceptions.ClientError as e:
-        msg = "Failed to create {0} {1}: {2}".format(desc, name, e)
+        msg = "Failed to create {} {}: {}".format(desc, name, e)
         log.error(msg)
         return False
 
@@ -300,7 +294,7 @@ def _modify_resource(
         wait = int(wait)
     except Exception:  # pylint: disable=broad-except
         raise SaltInvocationError(
-            "Bad value ('{0}') passed for 'wait' param - must be an "
+            "Bad value ('{}') passed for 'wait' param - must be an "
             "int or boolean.".format(wait)
         )
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
@@ -314,7 +308,7 @@ def _modify_resource(
         name = args[name_param]
     else:
         args[name_param] = name
-    args = dict([(k, v) for k, v in args.items() if not k.startswith("_")])
+    args = {k: v for k, v in args.items() if not k.startswith("_")}
     try:
         func = "modify_" + res_type
         f = getattr(conn, func)
@@ -323,7 +317,7 @@ def _modify_resource(
             s = globals()[func]
     except (AttributeError, KeyError) as e:
         raise SaltInvocationError(
-            "No function '{0}()' found: {1}".format(func, e.message)
+            "No function '{}()' found: {}".format(func, e.message)
         )
     try:
         f(**args)
@@ -353,7 +347,7 @@ def _modify_resource(
         )
         return False
     except botocore.exceptions.ClientError as e:
-        msg = "Failed to modify {0} {1}: {2}".format(desc, name, e)
+        msg = "Failed to modify {} {}: {}".format(desc, name, e)
         log.error(msg)
         return False
 
@@ -437,7 +431,7 @@ def create_cache_cluster(
         if "SecurityGroupIds" not in args:
             args["SecurityGroupIds"] = []
         args["SecurityGroupIds"] += sgs
-    args = dict([(k, v) for k, v in args.items() if not k.startswith("_")])
+    args = {k: v for k, v in args.items() if not k.startswith("_")}
     return _create_resource(
         name,
         name_param="CacheClusterId",
@@ -491,7 +485,7 @@ def modify_cache_cluster(
         if "SecurityGroupIds" not in args:
             args["SecurityGroupIds"] = []
         args["SecurityGroupIds"] += sgs
-    args = dict([(k, v) for k, v in args.items() if not k.startswith("_")])
+    args = {k: v for k, v in args.items() if not k.startswith("_")}
     return _modify_resource(
         name,
         name_param="CacheClusterId",
@@ -610,7 +604,7 @@ def create_replication_group(
         if "SecurityGroupIds" not in args:
             args["SecurityGroupIds"] = []
         args["SecurityGroupIds"] += sgs
-    args = dict([(k, v) for k, v in args.items() if not k.startswith("_")])
+    args = {k: v for k, v in args.items() if not k.startswith("_")}
     return _create_resource(
         name,
         name_param="ReplicationGroupId",
@@ -656,7 +650,7 @@ def modify_replication_group(
         if "SecurityGroupIds" not in args:
             args["SecurityGroupIds"] = []
         args["SecurityGroupIds"] += sgs
-    args = dict([(k, v) for k, v in args.items() if not k.startswith("_")])
+    args = {k: v for k, v in args.items() if not k.startswith("_")}
     return _modify_resource(
         name,
         name_param="ReplicationGroupId",
@@ -790,15 +784,15 @@ def create_cache_subnet_group(
             ).get("subnets")
             if not sn:
                 raise SaltInvocationError(
-                    "Could not resolve Subnet Name {0} to an ID.".format(subnet)
+                    "Could not resolve Subnet Name {} to an ID.".format(subnet)
                 )
             if len(sn) == 1:
                 args["SubnetIds"] += [sn[0]["id"]]
             elif len(sn) > 1:
                 raise CommandExecutionError(
-                    "Subnet Name {0} returned more than one ID.".format(subnet)
+                    "Subnet Name {} returned more than one ID.".format(subnet)
                 )
-    args = dict([(k, v) for k, v in args.items() if not k.startswith("_")])
+    args = {k: v for k, v in args.items() if not k.startswith("_")}
     return _create_resource(
         name,
         name_param="CacheSubnetGroupName",
@@ -843,16 +837,16 @@ def modify_cache_subnet_group(
                 args["SubnetIds"] += [sn[0]["id"]]
             elif len(sn) > 1:
                 raise CommandExecutionError(
-                    "Subnet Name {0} returned more than one ID.".format(subnet)
+                    "Subnet Name {} returned more than one ID.".format(subnet)
                 )
             elif subnet.startswith("subnet-"):
                 # Moderately safe assumption... :)  Will be caught later if incorrect.
                 args["SubnetIds"] += [subnet]
             else:
                 raise SaltInvocationError(
-                    "Could not resolve Subnet Name {0} to an ID.".format(subnet)
+                    "Could not resolve Subnet Name {} to an ID.".format(subnet)
                 )
-    args = dict([(k, v) for k, v in args.items() if not k.startswith("_")])
+    args = {k: v for k, v in args.items() if not k.startswith("_")}
     return _modify_resource(
         name,
         name_param="CacheSubnetGroupName",
@@ -1010,7 +1004,7 @@ def authorize_cache_security_group_ingress(
         name = args["CacheSecurityGroupName"]
     else:
         args["CacheSubnetGroupName"] = name
-    args = dict([(k, v) for k, v in args.items() if not k.startswith("_")])
+    args = {k: v for k, v in args.items() if not k.startswith("_")}
     try:
         conn.authorize_cache_security_group_ingress(**args)
         log.info(
@@ -1051,7 +1045,7 @@ def revoke_cache_security_group_ingress(
         name = args["CacheSecurityGroupName"]
     else:
         args["CacheSubnetGroupName"] = name
-    args = dict([(k, v) for k, v in args.items() if not k.startswith("_")])
+    args = {k: v for k, v in args.items() if not k.startswith("_")}
     try:
         conn.revoke_cache_security_group_ingress(**args)
         log.info(
@@ -1096,7 +1090,7 @@ def list_tags_for_resource(
         name = args["ResourceName"]
     else:
         args["ResourceName"] = name
-    args = dict([(k, v) for k, v in args.items() if not k.startswith("_")])
+    args = {k: v for k, v in args.items() if not k.startswith("_")}
     try:
         r = conn.list_tags_for_resource(**args)
         if r and "Taglist" in r:
@@ -1137,7 +1131,7 @@ def add_tags_to_resource(name, region=None, key=None, keyid=None, profile=None, 
         name = args["ResourceName"]
     else:
         args["ResourceName"] = name
-    args = dict([(k, v) for k, v in args.items() if not k.startswith("_")])
+    args = {k: v for k, v in args.items() if not k.startswith("_")}
     try:
         conn.add_tags_to_resource(**args)
         log.info("Added tags %s to %s.", args["Tags"], name)
@@ -1179,7 +1173,7 @@ def remove_tags_from_resource(
         name = args["ResourceName"]
     else:
         args["ResourceName"] = name
-    args = dict([(k, v) for k, v in args.items() if not k.startswith("_")])
+    args = {k: v for k, v in args.items() if not k.startswith("_")}
     try:
         conn.remove_tags_from_resource(**args)
         log.info("Added tags %s to %s.", args["Tags"], name)
@@ -1211,7 +1205,7 @@ def copy_snapshot(name, region=None, key=None, keyid=None, profile=None, **args)
         name = args["SourceSnapshotName"]
     else:
         args["SourceSnapshotName"] = name
-    args = dict([(k, v) for k, v in args.items() if not k.startswith("_")])
+    args = {k: v for k, v in args.items() if not k.startswith("_")}
     try:
         conn.copy_snapshot(**args)
         log.info("Snapshot %s copied to %s.", name, args["TargetSnapshotName"])

--- a/salt/modules/boto3_elasticsearch.py
+++ b/salt/modules/boto3_elasticsearch.py
@@ -87,7 +87,7 @@ def __virtual__():
     Only load if boto libraries exist and if boto libraries are greater than
     a given version.
     """
-    return salt.utils.versions.check_boto_reqs(boto3_ver="1.2.7")
+    return salt.utils.versions.check_boto_reqs(boto3_ver="1.2.7", check_boto=False)
 
 
 def __init__(opts):

--- a/salt/modules/boto3_elasticsearch.py
+++ b/salt/modules/boto3_elasticsearch.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Connection module for Amazon Elasticsearch Service
 
@@ -50,8 +49,6 @@ Connection module for Amazon Elasticsearch Service
 # keep lint from choking on _get_conn and _cache_id
 # pylint: disable=E0602
 
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
@@ -59,12 +56,7 @@ import salt.utils.compat
 import salt.utils.json
 import salt.utils.versions
 from salt.exceptions import SaltInvocationError
-
-# Import Salt libs
-from salt.ext import six
 from salt.utils.decorators import depends
-
-# Import third party libs
 
 try:
     # Disable unused import-errors as these are only used for dependency checking
@@ -155,9 +147,7 @@ def add_tags(
     if arn:
         boto_params = {
             "ARN": arn,
-            "TagList": [
-                {"Key": k, "Value": value} for k, value in six.iteritems(tags or {})
-            ],
+            "TagList": [{"Key": k, "Value": tags[k]} for k in tags or {}.items],
         }
         try:
             conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
@@ -349,7 +339,7 @@ def create_elasticsearch_domain(
     boto_kwargs = salt.utils.data.filter_falsey(
         {
             "DomainName": domain_name,
-            "ElasticsearchVersion": six.text_type(elasticsearch_version or ""),
+            "ElasticsearchVersion": str(elasticsearch_version or ""),
             "ElasticsearchClusterConfig": elasticsearch_cluster_config,
             "EBSOptions": ebs_options,
             "AccessPolicies": (
@@ -574,7 +564,7 @@ def describe_elasticsearch_instance_type_limits(
         {
             "DomainName": domain_name,
             "InstanceType": instance_type,
-            "ElasticsearchVersion": six.text_type(elasticsearch_version),
+            "ElasticsearchVersion": str(elasticsearch_version),
         }
     )
     try:
@@ -828,7 +818,7 @@ def list_elasticsearch_instance_types(
         conn = _get_conn(region=region, keyid=keyid, key=key, profile=profile)
         boto_params = salt.utils.data.filter_falsey(
             {
-                "ElasticsearchVersion": six.text_type(elasticsearch_version),
+                "ElasticsearchVersion": str(elasticsearch_version),
                 "DomainName": domain_name,
             }
         )
@@ -1269,7 +1259,7 @@ def upgrade_elasticsearch_domain(
     boto_params = salt.utils.data.filter_falsey(
         {
             "DomainName": domain_name,
-            "TargetVersion": six.text_type(target_version),
+            "TargetVersion": str(target_version),
             "PerformCheckOnly": perform_check_only,
         }
     )
@@ -1385,7 +1375,7 @@ def check_upgrade_eligibility(
     if "error" in res:
         return res
     compatible_versions = res["response"][0]["TargetVersions"]
-    if six.text_type(elasticsearch_version) not in compatible_versions:
+    if str(elasticsearch_version) not in compatible_versions:
         ret["result"] = True
         ret["response"] = False
         ret["error"] = 'Desired version "{}" not in compatible versions: {}.' "".format(

--- a/salt/modules/boto3_route53.py
+++ b/salt/modules/boto3_route53.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Execution module for Amazon Route53 written against Boto 3
 
@@ -48,23 +47,18 @@ Execution module for Amazon Route53 written against Boto 3
 # keep lint from choking on _get_conn and _cache_id
 # pylint: disable=E0602,W0106
 
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 import re
 import time
 
-# Import Salt libs
 import salt.utils.compat
 import salt.utils.versions
 from salt.exceptions import CommandExecutionError, SaltInvocationError
-from salt.ext import six
 from salt.ext.six.moves import range
 
 log = logging.getLogger(__name__)  # pylint: disable=W1699
 
-# Import third party libs
 try:
     # pylint: disable=unused-import
     import boto3
@@ -126,7 +120,7 @@ def _wait_for_sync(change, conn, tries=10, sleep=20):
             if e.response.get("Error", {}).get("Code") == "Throttling":
                 log.debug("Throttled by AWS API.")
             else:
-                six.reraise(*sys.exc_info())
+                raise
         if status == "INSYNC":
             return True
         time.sleep(sleep)
@@ -1066,7 +1060,7 @@ def get_resource_records(
                 log.debug("Throttled by AWS API.")
                 time.sleep(3)
                 continue
-            six.reraise(*sys.exc_info())
+            raise
 
 
 def change_resource_record_sets(
@@ -1186,7 +1180,7 @@ def change_resource_record_sets(
             log.error(
                 "Failed to apply requested changes to the hosted zone %s: %s",
                 (Name or HostedZoneId),
-                six.text_type(e),
+                str(e),
             )
             raise e
     return False

--- a/salt/modules/boto3_route53.py
+++ b/salt/modules/boto3_route53.py
@@ -83,7 +83,7 @@ def __virtual__():
     Only load if boto libraries exist and if boto libraries are greater than
     a given version.
     """
-    return salt.utils.versions.check_boto_reqs()
+    return salt.utils.versions.check_boto_reqs(check_boto=False)
 
 
 def __init__(opts):

--- a/salt/modules/boto3_sns.py
+++ b/salt/modules/boto3_sns.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Connection module for Amazon SNS
 
@@ -42,17 +41,13 @@ Connection module for Amazon SNS
 # keep lint from choking on _get_conn and _cache_id
 # pylint: disable=E0602
 
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
-# Import Salt libs
 import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
-# Import third party libs
 # pylint: disable=unused-import
 try:
     import botocore

--- a/salt/modules/boto3_sns.py
+++ b/salt/modules/boto3_sns.py
@@ -70,7 +70,7 @@ def __virtual__():
     """
     Only load if boto libraries exist.
     """
-    has_boto_reqs = salt.utils.versions.check_boto_reqs()
+    has_boto_reqs = salt.utils.versions.check_boto_reqs(check_boto=False)
     if has_boto_reqs is True:
         __utils__["boto3.assign_funcs"](__name__, "sns")
     return has_boto_reqs

--- a/salt/modules/boto_apigateway.py
+++ b/salt/modules/boto_apigateway.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Connection module for Amazon APIGateway
 
@@ -77,8 +76,6 @@ Connection module for Amazon APIGateway
 # keep lint from choking on _get_conn and _cache_id
 # pylint: disable=E0602
 
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import datetime
 import logging
@@ -87,12 +84,8 @@ import salt.utils.compat
 import salt.utils.json
 import salt.utils.versions
 
-# Import Salt libs
-from salt.ext import six
-
 log = logging.getLogger(__name__)
 
-# Import third party libs
 
 # pylint: disable=import-error
 try:
@@ -136,8 +129,8 @@ def _convert_datetime_str(response):
     if response:
         return dict(
             [
-                (k, "{0}".format(v)) if isinstance(v, datetime.date) else (k, v)
-                for k, v in six.iteritems(response)
+                (k, "{}".format(v)) if isinstance(v, datetime.date) else (k, v)
+                for k, v in response.items()
             ]
         )
     return None
@@ -383,9 +376,9 @@ def create_api_resources(
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         for path_part in path_parts:
             if current_path == "/":
-                current_path = "{0}{1}".format(current_path, path_part)
+                current_path = "{}{}".format(current_path, path_part)
             else:
-                current_path = "{0}/{1}".format(current_path, path_part)
+                current_path = "{}/{}".format(current_path, path_part)
             r = describe_api_resource(
                 restApiId,
                 current_path,
@@ -436,7 +429,7 @@ def delete_api_resources(
             conn.delete_resource(restApiId=restApiId, resourceId=resource["id"])
             return {"deleted": True}
         else:
-            return {"deleted": False, "error": "no resource found by {0}".format(path)}
+            return {"deleted": False, "error": "no resource found by {}".format(path)}
     except ClientError as e:
         return {"created": False, "error": __utils__["boto3.get_error"](e)}
 
@@ -900,12 +893,12 @@ def overwrite_api_stage_variables(
         for old_var in old_vars:
             if old_var not in variables:
                 patch_ops.append(
-                    dict(op="remove", path="/variables/{0}".format(old_var), value="")
+                    dict(op="remove", path="/variables/{}".format(old_var), value="")
                 )
-        for var, val in six.iteritems(variables):
+        for var, val in variables.items():
             if var not in old_vars or old_vars[var] != val:
                 patch_ops.append(
-                    dict(op="replace", path="/variables/{0}".format(var), value=val)
+                    dict(op="replace", path="/variables/{}".format(var), value=val)
                 )
 
         if patch_ops:
@@ -1627,7 +1620,7 @@ def _get_role_arn(name, region=None, key=None, keyid=None, profile=None):
         region=region, key=key, keyid=keyid, profile=profile
     )
 
-    return "arn:aws:iam::{0}:role/{1}".format(account_id, name)
+    return "arn:aws:iam::{}:role/{}".format(account_id, name)
 
 
 def create_api_integration(
@@ -1804,7 +1797,7 @@ def _validate_throttle(throttle):
     if throttle is not None:
         if not isinstance(throttle, dict):
             raise TypeError(
-                "throttle must be a dictionary, provided value: {0}".format(throttle)
+                "throttle must be a dictionary, provided value: {}".format(throttle)
             )
 
 
@@ -1815,12 +1808,12 @@ def _validate_quota(quota):
     if quota is not None:
         if not isinstance(quota, dict):
             raise TypeError(
-                "quota must be a dictionary, provided value: {0}".format(quota)
+                "quota must be a dictionary, provided value: {}".format(quota)
             )
         periods = ["DAY", "WEEK", "MONTH"]
         if "period" not in quota or quota["period"] not in periods:
             raise ValueError(
-                "quota must have a valid period specified, valid values are {0}".format(
+                "quota must have a valid period specified, valid values are {}".format(
                     ",".join(periods)
                 )
             )
@@ -1892,7 +1885,7 @@ def create_usage_plan(
     except ClientError as e:
         return {"error": __utils__["boto3.get_error"](e)}
     except (TypeError, ValueError) as e:
-        return {"error": six.text_type(e)}
+        return {"error": str(e)}
 
 
 def update_usage_plan(
@@ -1995,7 +1988,7 @@ def update_usage_plan(
     except ClientError as e:
         return {"error": __utils__["boto3.get_error"](e)}
     except (TypeError, ValueError) as e:
-        return {"error": six.text_type(e)}
+        return {"error": str(e)}
 
 
 def delete_usage_plan(plan_id, region=None, key=None, keyid=None, profile=None):
@@ -2052,7 +2045,7 @@ def _update_usage_plan_apis(
                 {
                     "op": op,
                     "path": "/apiStages",
-                    "value": "{0}:{1}".format(api["apiId"], api["stage"]),
+                    "value": "{}:{}".format(api["apiId"], api["stage"]),
                 }
             )
         res = None

--- a/salt/modules/boto_apigateway.py
+++ b/salt/modules/boto_apigateway.py
@@ -5,7 +5,6 @@ Connection module for Amazon APIGateway
 .. versionadded:: 2016.11.0
 
 :depends:
-  - boto >= 2.8.0
   - boto3 >= 1.2.1
   - botocore >= 1.4.49
 
@@ -98,14 +97,12 @@ log = logging.getLogger(__name__)
 # pylint: disable=import-error
 try:
     # pylint: disable=unused-import
-    import boto
     import boto3
 
     # pylint: enable=unused-import
     from botocore.exceptions import ClientError
     from botocore import __version__ as found_botocore_version
 
-    logging.getLogger("boto").setLevel(logging.CRITICAL)
     logging.getLogger("boto3").setLevel(logging.CRITICAL)
     HAS_BOTO = True
 except ImportError:
@@ -122,7 +119,7 @@ def __virtual__():
     # which was added in boto 2.8.0
     # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
     return salt.utils.versions.check_boto_reqs(
-        boto_ver="2.8.0", boto3_ver="1.2.1", botocore_ver="1.4.49"
+        check_boto=False, boto3_ver="1.2.1", botocore_ver="1.4.49"
     )
 
 

--- a/salt/modules/boto_cloudfront.py
+++ b/salt/modules/boto_cloudfront.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Connection module for Amazon CloudFront
 
@@ -50,17 +49,12 @@ Connection module for Amazon CloudFront
 # keep lint from choking on _get_conn and _cache_id
 # pylint: disable=E0602
 
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
-# Import Salt libs
-import salt.ext.six as six
 import salt.utils.versions
 from salt.utils.odict import OrderedDict
 
-# Import third party libs
 try:
     # pylint: disable=unused-import
     import boto3
@@ -102,7 +96,7 @@ def _list_distributions(
             continue
         for partial_dist in distribution_list["Items"]:
             tags = conn.list_tags_for_resource(Resource=partial_dist["ARN"])
-            tags = dict((kv["Key"], kv["Value"]) for kv in tags["Tags"]["Items"])
+            tags = {kv["Key"]: kv["Value"] for kv in tags["Tags"]["Items"]}
 
             id_ = partial_dist["Id"]
             if "Name" not in tags:
@@ -235,25 +229,22 @@ def export_distributions(region=None, key=None, keyid=None, profile=None):
     """
     results = OrderedDict()
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-    try:
-        for name, distribution in _list_distributions(
-            conn, region=region, key=key, keyid=keyid, profile=profile,
-        ):
-            config = distribution["distribution"]["DistributionConfig"]
-            tags = distribution["tags"]
+    # Do not catch the exception as this is meant to be user-invoked at the CLI
+    # as opposed to being called from execution or state modules
+    for name, distribution in _list_distributions(
+        conn, region=region, key=key, keyid=keyid, profile=profile,
+    ):
+        config = distribution["distribution"]["DistributionConfig"]
+        tags = distribution["tags"]
 
-            distribution_sls_data = [
-                {"name": name},
-                {"config": config},
-                {"tags": tags},
-            ]
-            results["Manage CloudFront distribution {0}".format(name)] = {
-                "boto_cloudfront.present": distribution_sls_data,
-            }
-    except botocore.exceptions.ClientError as err:
-        # Raise an exception, as this is meant to be user-invoked at the CLI
-        # as opposed to being called from execution or state modules
-        six.reraise(*sys.exc_info())
+        distribution_sls_data = [
+            {"name": name},
+            {"config": config},
+            {"tags": tags},
+        ]
+        results["Manage CloudFront distribution {}".format(name)] = {
+            "boto_cloudfront.present": distribution_sls_data,
+        }
 
     dumper = __utils__["yaml.get_dumper"]("IndentedSafeOrderedDumper")
     return __utils__["yaml.dump"](results, default_flow_style=False, Dumper=dumper,)
@@ -301,7 +292,7 @@ def create_distribution(
         if tags["Name"] != name:
             return {"error": "Must not pass `Name` in `tags` but as `name`"}
     tags["Name"] = name
-    tags = {"Items": [{"Key": k, "Value": v} for k, v in six.iteritems(tags)]}
+    tags = {"Items": [{"Key": k, "Value": v} for k, v in tags.items()]}
 
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     try:
@@ -385,8 +376,7 @@ def update_distribution(
             if "new" in tags_diff:
                 tags_to_add = {
                     "Items": [
-                        {"Key": k, "Value": v}
-                        for k, v in six.iteritems(tags_diff["new"])
+                        {"Key": k, "Value": v} for k, v in tags_diff["new"].items()
                     ],
                 }
                 conn.tag_resource(

--- a/salt/modules/boto_cloudfront.py
+++ b/salt/modules/boto_cloudfront.py
@@ -79,7 +79,7 @@ def __virtual__():
     """
     Only load if boto3 libraries exist.
     """
-    has_boto_reqs = salt.utils.versions.check_boto_reqs()
+    has_boto_reqs = salt.utils.versions.check_boto_reqs(check_boto=False)
     if has_boto_reqs is True:
         __utils__["boto3.assign_funcs"](__name__, "cloudfront")
     return has_boto_reqs

--- a/salt/modules/boto_cloudtrail.py
+++ b/salt/modules/boto_cloudtrail.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Connection module for Amazon CloudTrail
 
@@ -48,20 +47,14 @@ The dependencies listed above can be installed via package or pip.
 # keep lint from choking on _get_conn and _cache_id
 # pylint: disable=E0602
 
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
 import salt.utils.compat
 import salt.utils.versions
 
-# Import Salt libs
-from salt.ext import six
-
 log = logging.getLogger(__name__)
 
-# Import third party libs
 
 # pylint: disable=import-error
 try:
@@ -234,7 +227,7 @@ def describe(Name, region=None, key=None, keyid=None, profile=None):
                 "KmsKeyId",
             )
             trail = trails["trailList"].pop()
-            return {"trail": dict([(k, trail.get(k)) for k in keys])}
+            return {"trail": {k: trail.get(k) for k in keys}}
         else:
             return {"trail": None}
     except ClientError as e:
@@ -281,7 +274,7 @@ def status(Name, region=None, key=None, keyid=None, profile=None):
                 "TimeLoggingStarted",
                 "TimeLoggingStopped",
             )
-            return {"trail": dict([(k, trail.get(k)) for k in keys])}
+            return {"trail": {k: trail.get(k) for k in keys}}
         else:
             return {"trail": None}
     except ClientError as e:
@@ -430,7 +423,7 @@ def _get_trail_arn(name, region=None, key=None, keyid=None, profile=None):
         region = profile["region"]
     if region is None:
         region = "us-east-1"
-    return "arn:aws:cloudtrail:{0}:{1}:trail/{2}".format(region, account_id, name)
+    return "arn:aws:cloudtrail:{}:{}:trail/{}".format(region, account_id, name)
 
 
 def add_tags(Name, region=None, key=None, keyid=None, profile=None, **kwargs):
@@ -451,10 +444,10 @@ def add_tags(Name, region=None, key=None, keyid=None, profile=None, **kwargs):
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         tagslist = []
-        for k, v in six.iteritems(kwargs):
-            if six.text_type(k).startswith("__"):
+        for k, v in kwargs.items():
+            if str(k).startswith("__"):
                 continue
-            tagslist.append({"Key": six.text_type(k), "Value": six.text_type(v)})
+            tagslist.append({"Key": str(k), "Value": str(v)})
         conn.add_tags(
             ResourceId=_get_trail_arn(
                 Name, region=region, key=key, keyid=keyid, profile=profile
@@ -484,10 +477,10 @@ def remove_tags(Name, region=None, key=None, keyid=None, profile=None, **kwargs)
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         tagslist = []
-        for k, v in six.iteritems(kwargs):
-            if six.text_type(k).startswith("__"):
+        for k, v in kwargs.items():
+            if str(k).startswith("__"):
                 continue
-            tagslist.append({"Key": six.text_type(k), "Value": six.text_type(v)})
+            tagslist.append({"Key": str(k), "Value": str(v)})
         conn.remove_tags(
             ResourceId=_get_trail_arn(
                 Name, region=region, key=key, keyid=keyid, profile=profile

--- a/salt/modules/boto_cloudtrail.py
+++ b/salt/modules/boto_cloudtrail.py
@@ -5,7 +5,6 @@ Connection module for Amazon CloudTrail
 .. versionadded:: 2016.3.0
 
 :depends:
-    - boto
     - boto3
 
 The dependencies listed above can be installed via package or pip.
@@ -67,7 +66,6 @@ log = logging.getLogger(__name__)
 # pylint: disable=import-error
 try:
     # pylint: disable=unused-import
-    import boto
     import boto3
 
     # pylint: enable=unused-import
@@ -88,7 +86,7 @@ def __virtual__():
     # the boto_lambda execution module relies on the connect_to_region() method
     # which was added in boto 2.8.0
     # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
-    return salt.utils.versions.check_boto_reqs(boto3_ver="1.2.5")
+    return salt.utils.versions.check_boto_reqs(boto3_ver="1.2.5", check_boto=False)
 
 
 def __init__(opts):

--- a/salt/modules/boto_cloudwatch_event.py
+++ b/salt/modules/boto_cloudwatch_event.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Connection module for Amazon CloudWatch Events
 
@@ -44,20 +43,15 @@ Connection module for Amazon CloudWatch Events
 # keep lint from choking on _get_conn and _cache_id
 # pylint: disable=E0602
 
-from __future__ import absolute_import, print_function, unicode_literals
 
-# Import Python libs
 import logging
 
-# Import Salt libs
 import salt.utils.compat
 import salt.utils.json
 import salt.utils.versions
-from salt.ext import six
 
 log = logging.getLogger(__name__)
 
-# Import third party libs
 # pylint: disable=import-error
 try:
     # pylint: disable=unused-import
@@ -212,13 +206,13 @@ def describe(Name, region=None, key=None, keyid=None, profile=None):
                 "Description",
                 "RoleArn",
             )
-            return {"rule": dict([(k, rule.get(k)) for k in keys])}
+            return {"rule": {k: rule.get(k) for k in keys}}
         else:
             return {"rule": None}
     except ClientError as e:
         err = __utils__["boto3.get_error"](e)
         if e.response.get("Error", {}).get("Code") == "RuleNotFoundException":
-            return {"error": "Rule {0} not found".format(Rule)}
+            return {"error": "Rule {} not found".format(Rule)}
         return {"error": __utils__["boto3.get_error"](e)}
 
 
@@ -265,14 +259,14 @@ def list_targets(Rule, region=None, key=None, keyid=None, profile=None):
         if targets and "Targets" in targets:
             keys = ("Id", "Arn", "Input", "InputPath")
             for target in targets.get("Targets"):
-                ret.append(dict([(k, target.get(k)) for k in keys if k in target]))
+                ret.append({k: target.get(k) for k in keys if k in target})
             return {"targets": ret}
         else:
             return {"targets": None}
     except ClientError as e:
         err = __utils__["boto3.get_error"](e)
         if e.response.get("Error", {}).get("Code") == "RuleNotFoundException":
-            return {"error": "Rule {0} not found".format(Rule)}
+            return {"error": "Rule {} not found".format(Rule)}
         return {"error": __utils__["boto3.get_error"](e)}
 
 
@@ -291,7 +285,7 @@ def put_targets(Rule, Targets, region=None, key=None, keyid=None, profile=None):
     """
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-        if isinstance(Targets, six.string_types):
+        if isinstance(Targets, str):
             Targets = salt.utils.json.loads(Targets)
         failures = conn.put_targets(Rule=Rule, Targets=Targets)
         if failures and failures.get("FailedEntryCount", 0) > 0:
@@ -301,7 +295,7 @@ def put_targets(Rule, Targets, region=None, key=None, keyid=None, profile=None):
     except ClientError as e:
         err = __utils__["boto3.get_error"](e)
         if e.response.get("Error", {}).get("Code") == "RuleNotFoundException":
-            return {"error": "Rule {0} not found".format(Rule)}
+            return {"error": "Rule {} not found".format(Rule)}
         return {"error": __utils__["boto3.get_error"](e)}
 
 
@@ -320,7 +314,7 @@ def remove_targets(Rule, Ids, region=None, key=None, keyid=None, profile=None):
     """
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-        if isinstance(Ids, six.string_types):
+        if isinstance(Ids, str):
             Ids = salt.utils.json.loads(Ids)
         failures = conn.remove_targets(Rule=Rule, Ids=Ids)
         if failures and failures.get("FailedEntryCount", 0) > 0:
@@ -330,5 +324,5 @@ def remove_targets(Rule, Ids, region=None, key=None, keyid=None, profile=None):
     except ClientError as e:
         err = __utils__["boto3.get_error"](e)
         if e.response.get("Error", {}).get("Code") == "RuleNotFoundException":
-            return {"error": "Rule {0} not found".format(Rule)}
+            return {"error": "Rule {} not found".format(Rule)}
         return {"error": __utils__["boto3.get_error"](e)}

--- a/salt/modules/boto_cloudwatch_event.py
+++ b/salt/modules/boto_cloudwatch_event.py
@@ -61,7 +61,6 @@ log = logging.getLogger(__name__)
 # pylint: disable=import-error
 try:
     # pylint: disable=unused-import
-    import boto
     import boto3
 
     # pylint: enable=unused-import
@@ -78,7 +77,7 @@ def __virtual__():
     """
     Only load if boto libraries exist.
     """
-    return salt.utils.versions.check_boto_reqs()
+    return salt.utils.versions.check_boto_reqs(check_boto=False)
 
 
 def __init__(opts):

--- a/salt/modules/boto_cognitoidentity.py
+++ b/salt/modules/boto_cognitoidentity.py
@@ -92,13 +92,11 @@ log = logging.getLogger(__name__)
 # pylint: disable=import-error
 try:
     # pylint: disable=unused-import
-    import boto
     import boto3
 
     # pylint: enable=unused-import
     from botocore.exceptions import ClientError
 
-    logging.getLogger("boto").setLevel(logging.CRITICAL)
     logging.getLogger("boto3").setLevel(logging.CRITICAL)
     HAS_BOTO = True
 except ImportError:
@@ -114,7 +112,7 @@ def __virtual__():
     # the boto_cognitoidentity execution module relies on the connect_to_region() method
     # which was added in boto 2.8.0
     # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
-    return salt.utils.versions.check_boto_reqs(boto_ver="2.8.0", boto3_ver="1.2.1")
+    return salt.utils.versions.check_boto_reqs(check_boto=False, boto3_ver="1.2.1")
 
 
 def __init__(opts):

--- a/salt/modules/boto_cognitoidentity.py
+++ b/salt/modules/boto_cognitoidentity.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Connection module for Amazon CognitoIdentity
 
@@ -76,18 +75,14 @@ Connection module for Amazon CognitoIdentity
 # keep lint from choking on _get_conn and _cache_id
 # pylint: disable=E0602
 
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
-# Import Salt libs
 import salt.utils.compat
 import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
-# Import third party libs
 
 # pylint: disable=import-error
 try:
@@ -369,7 +364,7 @@ def set_identity_pool_roles(
             if role_arn is None:
                 return {
                     "set": False,
-                    "error": "invalid AuthenticatedRole {0}".format(AuthenticatedRole),
+                    "error": "invalid AuthenticatedRole {}".format(AuthenticatedRole),
                 }
             AuthenticatedRole = role_arn
 
@@ -378,7 +373,7 @@ def set_identity_pool_roles(
             if role_arn is None:
                 return {
                     "set": False,
-                    "error": "invalid UnauthenticatedRole {0}".format(
+                    "error": "invalid UnauthenticatedRole {}".format(
                         UnauthenticatedRole
                     ),
                 }

--- a/salt/modules/boto_elasticsearch_domain.py
+++ b/salt/modules/boto_elasticsearch_domain.py
@@ -94,13 +94,11 @@ log = logging.getLogger(__name__)
 # pylint: disable=import-error
 try:
     # pylint: disable=unused-import
-    import boto
     import boto3
 
     # pylint: enable=unused-import
     from botocore.exceptions import ClientError
 
-    logging.getLogger("boto").setLevel(logging.CRITICAL)
     logging.getLogger("boto3").setLevel(logging.CRITICAL)
     HAS_BOTO = True
 except ImportError:
@@ -116,7 +114,7 @@ def __virtual__():
     # the boto_lambda execution module relies on the connect_to_region() method
     # which was added in boto 2.8.0
     # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
-    return salt.utils.versions.check_boto_reqs(boto_ver="2.8.0", boto3_ver="1.4.0")
+    return salt.utils.versions.check_boto_reqs(check_boto=False, boto3_ver="1.4.0")
 
 
 def __init__(opts):

--- a/salt/modules/boto_elasticsearch_domain.py
+++ b/salt/modules/boto_elasticsearch_domain.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Connection module for Amazon Elasticsearch Service
 
@@ -74,8 +73,6 @@ Connection module for Amazon Elasticsearch Service
 # keep lint from choking on _get_conn and _cache_id
 # pylint: disable=E0602
 
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
@@ -84,12 +81,8 @@ import salt.utils.json
 import salt.utils.versions
 from salt.exceptions import SaltInvocationError
 
-# Import Salt libs
-from salt.ext import six
-
 log = logging.getLogger(__name__)
 
-# Import third party libs
 
 # pylint: disable=import-error
 try:
@@ -181,7 +174,7 @@ def status(DomainName, region=None, key=None, keyid=None, profile=None):
                 "ARN",
                 "ElasticsearchVersion",
             )
-            return {"domain": dict([(k, domain.get(k)) for k in keys if k in domain])}
+            return {"domain": {k: domain.get(k) for k in keys if k in domain}}
         else:
             return {"domain": None}
     except ClientError as e:
@@ -215,9 +208,9 @@ def describe(DomainName, region=None, key=None, keyid=None, profile=None):
                 "AdvancedOptions",
             )
             return {
-                "domain": dict(
-                    [(k, domain.get(k, {}).get("Options")) for k in keys if k in domain]
-                )
+                "domain": {
+                    k: domain.get(k, {}).get("Options") for k in keys if k in domain
+                }
             }
         else:
             return {"domain": None}
@@ -273,21 +266,19 @@ def create(
         ):
             if locals()[k] is not None:
                 val = locals()[k]
-                if isinstance(val, six.string_types):
+                if isinstance(val, str):
                     try:
                         val = salt.utils.json.loads(val)
                     except ValueError as e:
                         return {
                             "updated": False,
-                            "error": "Error parsing {0}: {1}".format(k, e.message),
+                            "error": "Error parsing {}: {}".format(k, e.message),
                         }
                 kwargs[k] = val
         if "AccessPolicies" in kwargs:
             kwargs["AccessPolicies"] = salt.utils.json.dumps(kwargs["AccessPolicies"])
         if "ElasticsearchVersion" in kwargs:
-            kwargs["ElasticsearchVersion"] = six.text_type(
-                kwargs["ElasticsearchVersion"]
-            )
+            kwargs["ElasticsearchVersion"] = str(kwargs["ElasticsearchVersion"])
         domain = conn.create_elasticsearch_domain(DomainName=DomainName, **kwargs)
         if domain and "DomainStatus" in domain:
             return {"created": True}
@@ -366,13 +357,13 @@ def update(
     ):
         if locals()[k] is not None:
             val = locals()[k]
-            if isinstance(val, six.string_types):
+            if isinstance(val, str):
                 try:
                     val = salt.utils.json.loads(val)
                 except ValueError as e:
                     return {
                         "updated": False,
-                        "error": "Error parsing {0}: {1}".format(k, e.message),
+                        "error": "Error parsing {}: {}".format(k, e.message),
                     }
             call_args[k] = val
     if "AccessPolicies" in call_args:
@@ -410,10 +401,10 @@ def add_tags(
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         tagslist = []
-        for k, v in six.iteritems(kwargs):
-            if six.text_type(k).startswith("__"):
+        for k, v in kwargs.items():
+            if str(k).startswith("__"):
                 continue
-            tagslist.append({"Key": six.text_type(k), "Value": six.text_type(v)})
+            tagslist.append({"Key": str(k), "Value": str(v)})
         if ARN is None:
             if DomainName is None:
                 raise SaltInvocationError(

--- a/salt/modules/boto_elbv2.py
+++ b/salt/modules/boto_elbv2.py
@@ -39,17 +39,14 @@ Connection module for Amazon ALB
 # keep lint from choking on _get_conn and _cache_id
 # pylint: disable=E0602
 
-# Import Python libs
 import logging
 
-# Import Salt libs
 import salt.utils.boto3mod
 import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
 
-# Import third-party libs
 try:
     # pylint: disable=unused-import
     import boto3

--- a/salt/modules/boto_elbv2.py
+++ b/salt/modules/boto_elbv2.py
@@ -70,7 +70,7 @@ def __virtual__():
     """
     Only load if boto3 libraries exist.
     """
-    has_boto_reqs = salt.utils.versions.check_boto_reqs()
+    has_boto_reqs = salt.utils.versions.check_boto_reqs(check_boto=False)
     if has_boto_reqs is True:
         salt.utils.boto3mod.assign_funcs(__name__, "elbv2")
     return has_boto_reqs

--- a/salt/modules/boto_iot.py
+++ b/salt/modules/boto_iot.py
@@ -5,7 +5,6 @@ Connection module for Amazon IoT
 .. versionadded:: 2016.3.0
 
 :depends:
-    - boto
     - boto3
 
 The dependencies listed above can be installed via package or pip.
@@ -69,7 +68,6 @@ log = logging.getLogger(__name__)
 # pylint: disable=import-error
 try:
     # pylint: disable=unused-import
-    import boto
     import boto3
 
     # pylint: enable=unused-import
@@ -91,7 +89,7 @@ def __virtual__():
     # the boto_lambda execution module relies on the connect_to_region() method
     # which was added in boto 2.8.0
     # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
-    return salt.utils.versions.check_boto_reqs(boto3_ver="1.2.1", botocore_ver="1.4.41")
+    return salt.utils.versions.check_boto_reqs(check_boto=False, boto3_ver="1.2.1", botocore_ver="1.4.41")
 
 
 def __init__(opts):

--- a/salt/modules/boto_iot.py
+++ b/salt/modules/boto_iot.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Connection module for Amazon IoT
 
@@ -48,18 +47,13 @@ The dependencies listed above can be installed via package or pip.
 # keep lint from choking on _get_conn and _cache_id
 # pylint: disable=E0602
 
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import datetime
 import logging
 
-# Import Salt libs
 import salt.utils.compat
 import salt.utils.json
 import salt.utils.versions
-
-# Import third party libs
 from salt.ext.six import string_types
 
 log = logging.getLogger(__name__)
@@ -89,7 +83,9 @@ def __virtual__():
     # the boto_lambda execution module relies on the connect_to_region() method
     # which was added in boto 2.8.0
     # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
-    return salt.utils.versions.check_boto_reqs(check_boto=False, boto3_ver="1.2.1", botocore_ver="1.4.41")
+    return salt.utils.versions.check_boto_reqs(
+        check_boto=False, boto3_ver="1.2.1", botocore_ver="1.4.41"
+    )
 
 
 def __init__(opts):
@@ -154,7 +150,7 @@ def describe_thing_type(thingTypeName, region=None, key=None, keyid=None, profil
                 for dtype in ("creationDate", "deprecationDate"):
                     dval = thingTypeMetadata.get(dtype)
                     if dval and isinstance(dval, datetime.date):
-                        thingTypeMetadata[dtype] = "{0}".format(dval)
+                        thingTypeMetadata[dtype] = "{}".format(dval)
             return {"thing_type": res}
         else:
             return {"thing_type": None}
@@ -382,7 +378,7 @@ def describe_policy(policyName, region=None, key=None, keyid=None, profile=None)
         policy = conn.get_policy(policyName=policyName)
         if policy:
             keys = ("policyName", "policyArn", "policyDocument", "defaultVersionId")
-            return {"policy": dict([(k, policy.get(k)) for k in keys])}
+            return {"policy": {k: policy.get(k) for k in keys}}
         else:
             return {"policy": None}
     except ClientError as e:
@@ -524,7 +520,7 @@ def describe_policy_version(
                 "policyVersionId",
                 "isDefaultVersion",
             )
-            return {"policy": dict([(k, policy.get(k)) for k in keys])}
+            return {"policy": {k: policy.get(k) for k in keys}}
         else:
             return {"policy": None}
     except ClientError as e:
@@ -881,7 +877,7 @@ def describe_topic_rule(ruleName, region=None, key=None, keyid=None, profile=Non
         if rule and "rule" in rule:
             rule = rule["rule"]
             keys = ("ruleName", "sql", "description", "actions", "ruleDisabled")
-            return {"rule": dict([(k, rule.get(k)) for k in keys])}
+            return {"rule": {k: rule.get(k) for k in keys}}
         else:
             return {"rule": None}
     except ClientError as e:

--- a/salt/modules/boto_kinesis.py
+++ b/salt/modules/boto_kinesis.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Connection module for Amazon Kinesis
 
@@ -45,20 +44,14 @@ Connection module for Amazon Kinesis
 # keep lint from choking on _get_conn
 # pylint: disable=E0602
 
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 import random
-import sys
 import time
 
 import salt.utils.versions
-
-# Import Salt libs
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 
-# Import third party libs
 # pylint: disable=unused-import
 try:
     import boto3
@@ -355,10 +348,7 @@ def long_int(hash_key):
 
     :return: long object if python 2.X, int object if python 3.X
     """
-    if sys.version_info < (3,):
-        return long(hash_key)  # pylint: disable=incompatible-py3-code
-    else:
-        return int(hash_key)
+    return int(hash_key)
 
 
 def reshard(
@@ -476,7 +466,7 @@ def reshard(
             # merge
             next_shard_id = _get_next_open_shard(stream_details, shard_id)
             if not next_shard_id:
-                r["error"] = "failed to find next shard after {0}".format(shard_id)
+                r["error"] = "failed to find next shard after {}".format(shard_id)
                 return r
             if force:
                 log.debug(
@@ -607,7 +597,7 @@ def _execute_with_retries(conn, function, **kwargs):
                 r["result"] = None
                 return r
 
-    r["error"] = "Tried to execute function {0} {1} times, but was unable".format(
+    r["error"] = "Tried to execute function {} {} times, but was unable".format(
         function, max_attempts
     )
     log.error(r["error"])

--- a/salt/modules/boto_kinesis.py
+++ b/salt/modules/boto_kinesis.py
@@ -79,7 +79,7 @@ def __virtual__():
     """
     Only load if boto3 libraries exist.
     """
-    has_boto_reqs = salt.utils.versions.check_boto_reqs()
+    has_boto_reqs = salt.utils.versions.check_boto_reqs(check_boto=False)
     if has_boto_reqs is True:
         __utils__["boto3.assign_funcs"](__name__, "kinesis")
         return __virtualname__

--- a/salt/modules/boto_lambda.py
+++ b/salt/modules/boto_lambda.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Connection module for Amazon Lambda
 
@@ -77,8 +76,6 @@ as a passed in dict, or as a string to pull from pillars or minion config:
 # keep lint from choking on _get_conn and _cache_id
 # pylint: disable=E0602
 
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 import random
@@ -89,14 +86,10 @@ import salt.utils.files
 import salt.utils.json
 import salt.utils.versions
 from salt.exceptions import SaltInvocationError
-
-# Import Salt libs
-from salt.ext import six
 from salt.ext.six.moves import range  # pylint: disable=import-error
 
 log = logging.getLogger(__name__)
 
-# Import third party libs
 
 # pylint: disable=import-error
 try:
@@ -182,7 +175,7 @@ def _get_role_arn(name, region=None, key=None, keyid=None, profile=None):
         region = profile["region"]
     if region is None:
         region = "us-east-1"
-    return "arn:aws:iam::{0}:role/{1}".format(account_id, name)
+    return "arn:aws:iam::{}:role/{}".format(account_id, name)
 
 
 def _filedata(infile):
@@ -191,7 +184,7 @@ def _filedata(infile):
 
 
 def _resolve_vpcconfig(conf, region=None, key=None, keyid=None, profile=None):
-    if isinstance(conf, six.string_types):
+    if isinstance(conf, str):
         conf = salt.utils.json.loads(conf)
     if not conf:
         return None
@@ -278,7 +271,7 @@ def create_function(
                 dlZipFile = __salt__["cp.cache_file"](path=ZipFile)
                 if dlZipFile is False:
                     ret["result"] = False
-                    ret["comment"] = "Failed to cache ZipFile `{0}`.".format(ZipFile)
+                    ret["comment"] = "Failed to cache ZipFile `{}`.".format(ZipFile)
                     return ret
                 ZipFile = dlZipFile
             code = {
@@ -412,7 +405,7 @@ def describe_function(FunctionName, region=None, key=None, keyid=None, profile=N
                 "VpcConfig",
                 "Environment",
             )
-            return {"function": dict([(k, func.get(k)) for k in keys])}
+            return {"function": {k: func.get(k) for k in keys}}
         else:
             return {"function": None}
     except ClientError as e:
@@ -474,7 +467,7 @@ def update_function_config(
     }
 
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-    for val, var in six.iteritems(options):
+    for val, var in options.items():
         if var:
             args[val] = var
     if Role:
@@ -525,7 +518,7 @@ def update_function_config(
                 "VpcConfig",
                 "Environment",
             )
-            return {"updated": True, "function": dict([(k, r.get(k)) for k in keys])}
+            return {"updated": True, "function": {k: r.get(k) for k in keys}}
         else:
             log.warning("Function was not updated")
             return {"updated": False}
@@ -601,7 +594,7 @@ def update_function_code(
                 "VpcConfig",
                 "Environment",
             )
-            return {"updated": True, "function": dict([(k, r.get(k)) for k in keys])}
+            return {"updated": True, "function": {k: r.get(k) for k in keys}}
         else:
             log.warning("Function was not updated")
             return {"updated": False}
@@ -720,7 +713,7 @@ def get_permissions(
         # massage it until it is, for better ease of use.
         policy = conn.get_policy(FunctionName=FunctionName, **kwargs)
         policy = policy.get("Policy", {})
-        if isinstance(policy, six.string_types):
+        if isinstance(policy, str):
             policy = salt.utils.json.loads(policy)
         if policy is None:
             policy = {}
@@ -935,7 +928,7 @@ def describe_alias(FunctionName, Name, region=None, key=None, keyid=None, profil
         )
         if alias:
             keys = ("AliasArn", "Name", "FunctionVersion", "Description")
-            return {"alias": dict([(k, alias.get(k)) for k in keys])}
+            return {"alias": {k: alias.get(k) for k in keys}}
         else:
             return {"alias": None}
     except ClientError as e:
@@ -976,7 +969,7 @@ def update_alias(
         r = conn.update_alias(FunctionName=FunctionName, Name=Name, **args)
         if r:
             keys = ("Name", "FunctionVersion", "Description")
-            return {"updated": True, "alias": dict([(k, r.get(k)) for k in keys])}
+            return {"updated": True, "alias": {k: r.get(k) for k in keys}}
         else:
             log.warning("Alias was not updated")
             return {"updated": False}
@@ -1204,7 +1197,7 @@ def describe_event_source_mapping(
                 "State",
                 "StateTransitionReason",
             )
-            return {"event_source_mapping": dict([(k, desc.get(k)) for k in keys])}
+            return {"event_source_mapping": {k: desc.get(k) for k in keys}}
         else:
             return {"event_source_mapping": None}
     except ClientError as e:
@@ -1258,7 +1251,7 @@ def update_event_source_mapping(
             )
             return {
                 "updated": True,
-                "event_source_mapping": dict([(k, r.get(k)) for k in keys]),
+                "event_source_mapping": {k: r.get(k) for k in keys},
             }
         else:
             log.warning("Mapping was not updated")

--- a/salt/modules/boto_lambda.py
+++ b/salt/modules/boto_lambda.py
@@ -6,7 +6,6 @@ Connection module for Amazon Lambda
 
 :depends:
 
-- boto
 - boto3
 
 The dependencies listed above can be installed via package or pip.
@@ -102,14 +101,12 @@ log = logging.getLogger(__name__)
 # pylint: disable=import-error
 try:
     # pylint: disable=unused-import
-    import boto
     import boto3
 
     # pylint: enable=unused-import
     from botocore.exceptions import ClientError
     from botocore import __version__ as found_botocore_version
 
-    logging.getLogger("boto").setLevel(logging.CRITICAL)
     logging.getLogger("boto3").setLevel(logging.CRITICAL)
     HAS_BOTO = True
 except ImportError:
@@ -127,7 +124,7 @@ def __virtual__():
     # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
     # botocore version >= 1.5.2 is required due to lambda environment variables
     return salt.utils.versions.check_boto_reqs(
-        boto_ver="2.8.0", boto3_ver="1.2.5", botocore_ver="1.5.2"
+        check_boto=False, boto3_ver="1.2.5", botocore_ver="1.5.2"
     )
 
 

--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Connection module for Amazon RDS
 
@@ -47,20 +46,13 @@ Connection module for Amazon RDS
 # pylint: disable=W0106
 
 
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
-
 import logging
 import time
 
-# Import Salt libs
 import salt.utils.compat
 import salt.utils.odict as odict
 import salt.utils.versions
 from salt.exceptions import SaltInvocationError
-
-# Import third party libs
-from salt.ext import six
 
 log = logging.getLogger(__name__)
 
@@ -294,7 +286,7 @@ def create(
         wait_stati = ["available", "modifying", "backing-up"]
         if wait_status not in wait_stati:
             raise SaltInvocationError(
-                "wait_status can be one of: {0}".format(wait_stati)
+                "wait_status can be one of: {}".format(wait_stati)
             )
     if vpc_security_groups:
         v_tmp = __salt__["boto_secgroup.convert_to_group_ids"](
@@ -326,7 +318,7 @@ def create(
 
         # Validation doesn't want parameters that are None
         # https://github.com/boto/boto3/issues/400
-        kwargs = dict((k, v) for k, v in six.iteritems(kwargs) if v is not None)
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
 
         rds = conn.create_db_instance(**kwargs)
 
@@ -335,7 +327,7 @@ def create(
         if not wait_status:
             return {
                 "created": True,
-                "message": "RDS instance {0} created.".format(name),
+                "message": "RDS instance {} created.".format(name),
             }
 
         while True:
@@ -354,14 +346,14 @@ def create(
                 # Whoops, something is horribly wrong...
                 return {
                     "created": False,
-                    "error": "RDS instance {0} should have been created but"
+                    "error": "RDS instance {} should have been created but"
                     " now I can't find it.".format(name),
                 }
             if stat == wait_status:
                 return {
                     "created": True,
-                    "message": "RDS instance {0} created (current status "
-                    "{1})".format(name, stat),
+                    "message": "RDS instance {} created (current status "
+                    "{})".format(name, stat),
                 }
             time.sleep(10)
             log.info("Instance status after 10 seconds is: %s", stat)
@@ -404,14 +396,14 @@ def create_read_replica(
     if not res.get("exists"):
         return {
             "exists": bool(res),
-            "message": "RDS instance source {0} does not exists.".format(source_name),
+            "message": "RDS instance source {} does not exists.".format(source_name),
         }
 
     res = __salt__["boto_rds.exists"](name, tags, region, key, keyid, profile)
     if res.get("exists"):
         return {
             "exists": bool(res),
-            "message": "RDS replica instance {0} already exists.".format(name),
+            "message": "RDS replica instance {} already exists.".format(name),
         }
 
     try:
@@ -533,12 +525,12 @@ def create_parameter_group(
         if not rds:
             return {
                 "created": False,
-                "message": "Failed to create RDS parameter group {0}".format(name),
+                "message": "Failed to create RDS parameter group {}".format(name),
             }
 
         return {
             "exists": bool(rds),
-            "message": "Created RDS parameter group {0}".format(name),
+            "message": "Created RDS parameter group {}".format(name),
         }
     except ClientError as e:
         return {"error": __utils__["boto3.get_error"](e)}
@@ -613,11 +605,11 @@ def update_parameter_group(
     if not res.get("exists"):
         return {
             "exists": bool(res),
-            "message": "RDS parameter group {0} does not exist.".format(name),
+            "message": "RDS parameter group {} does not exist.".format(name),
         }
 
     param_list = []
-    for key, value in six.iteritems(parameters):
+    for key, value in parameters.items():
         item = odict.OrderedDict()
         item.update({"ParameterName": key})
         item.update({"ApplyMethod": apply_method})
@@ -658,7 +650,7 @@ def describe(name, tags=None, region=None, key=None, keyid=None, profile=None):
     if not res.get("exists"):
         return {
             "exists": bool(res),
-            "message": "RDS instance {0} does not exist.".format(name),
+            "message": "RDS instance {} does not exist.".format(name),
         }
 
     try:
@@ -706,7 +698,7 @@ def describe(name, tags=None, region=None, key=None, keyid=None, profile=None):
                 "PromotionTier",
                 "DomainMemberships",
             )
-            return {"rds": dict([(k, rds.get(k)) for k in keys])}
+            return {"rds": {k: rds.get(k) for k in keys}}
         else:
             return {"rds": None}
     except ClientError as e:
@@ -855,7 +847,7 @@ def delete(
         if not wait_for_deletion:
             return {
                 "deleted": bool(res),
-                "message": "Deleted RDS instance {0}.".format(name),
+                "message": "Deleted RDS instance {}.".format(name),
             }
 
         start_time = time.time()
@@ -871,13 +863,13 @@ def delete(
             if not res.get("exists"):
                 return {
                     "deleted": bool(res),
-                    "message": "Deleted RDS instance {0} completely.".format(name),
+                    "message": "Deleted RDS instance {} completely.".format(name),
                 }
 
             if time.time() - start_time > timeout:
                 raise SaltInvocationError(
-                    "RDS instance {0} has not been "
-                    "deleted completely after {1} "
+                    "RDS instance {} has not been "
+                    "deleted completely after {} "
                     "seconds".format(name, timeout)
                 )
             log.info(
@@ -908,12 +900,12 @@ def delete_option_group(name, region=None, key=None, keyid=None, profile=None):
         if not res:
             return {
                 "deleted": bool(res),
-                "message": "Failed to delete RDS option group {0}.".format(name),
+                "message": "Failed to delete RDS option group {}.".format(name),
             }
 
         return {
             "deleted": bool(res),
-            "message": "Deleted RDS option group {0}.".format(name),
+            "message": "Deleted RDS option group {}.".format(name),
         }
     except ClientError as e:
         return {"error": __utils__["boto3.get_error"](e)}
@@ -936,7 +928,7 @@ def delete_parameter_group(name, region=None, key=None, keyid=None, profile=None
         r = conn.delete_db_parameter_group(DBParameterGroupName=name)
         return {
             "deleted": bool(r),
-            "message": "Deleted RDS parameter group {0}.".format(name),
+            "message": "Deleted RDS parameter group {}.".format(name),
         }
     except ClientError as e:
         return {"error": __utils__["boto3.get_error"](e)}
@@ -959,7 +951,7 @@ def delete_subnet_group(name, region=None, key=None, keyid=None, profile=None):
         r = conn.delete_db_subnet_group(DBSubnetGroupName=name)
         return {
             "deleted": bool(r),
-            "message": "Deleted RDS subnet group {0}.".format(name),
+            "message": "Deleted RDS subnet group {}.".format(name),
         }
     except ClientError as e:
         return {"error": __utils__["boto3.get_error"](e)}
@@ -1008,12 +1000,12 @@ def describe_parameter_group(
         if not info:
             return {
                 "results": bool(info),
-                "message": "Failed to get RDS description for group {0}.".format(name),
+                "message": "Failed to get RDS description for group {}.".format(name),
             }
 
         return {
             "results": bool(info),
-            "message": "Got RDS descrition for group {0}.".format(name),
+            "message": "Got RDS descrition for group {}.".format(name),
         }
     except ClientError as e:
         return {"error": __utils__["boto3.get_error"](e)}
@@ -1042,7 +1034,7 @@ def describe_parameters(
     if not res.get("exists"):
         return {
             "result": False,
-            "message": "Parameter group {0} does not exist".format(name),
+            "message": "Parameter group {} does not exist".format(name),
         }
 
     try:
@@ -1152,7 +1144,7 @@ def modify_db_instance(
     if not res.get("exists"):
         return {
             "modified": False,
-            "message": "RDS db instance {0} does not exist.".format(name),
+            "message": "RDS db instance {} does not exist.".format(name),
         }
 
     try:
@@ -1161,7 +1153,7 @@ def modify_db_instance(
             return {"modified": False}
 
         kwargs = {}
-        excluded = set(("name",))
+        excluded = {"name"}
         boto_params = set(boto3_param_map.keys())
         keys = set(locals().keys())
         for key in keys.intersection(boto_params).difference(excluded):
@@ -1175,12 +1167,12 @@ def modify_db_instance(
         if not info:
             return {
                 "modified": bool(info),
-                "message": "Failed to modify RDS db instance {0}.".format(name),
+                "message": "Failed to modify RDS db instance {}.".format(name),
             }
 
         return {
             "modified": bool(info),
-            "message": "Modified RDS db instance {0}.".format(name),
+            "message": "Modified RDS db instance {}.".format(name),
             "results": dict(info),
         }
     except ClientError as e:
@@ -1190,8 +1182,8 @@ def modify_db_instance(
 def _tag_doc(tags):
     taglist = []
     if tags is not None:
-        for k, v in six.iteritems(tags):
-            if six.text_type(k).startswith("__"):
+        for k, v in tags.items():
+            if str(k).startswith("__"):
                 continue
-            taglist.append({"Key": six.text_type(k), "Value": six.text_type(v)})
+            taglist.append({"Key": str(k), "Value": str(v)})
     return taglist

--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -68,13 +68,11 @@ log = logging.getLogger(__name__)
 # pylint: disable=import-error
 try:
     # pylint: disable=unused-import
-    import boto
     import boto3
 
     # pylint: enable=unused-import
     from botocore.exceptions import ClientError
 
-    logging.getLogger("boto").setLevel(logging.CRITICAL)
     logging.getLogger("boto3").setLevel(logging.CRITICAL)
     HAS_BOTO = True
 except ImportError:
@@ -132,7 +130,7 @@ def __virtual__():
     Only load if boto libraries exist and if boto libraries are greater than
     a given version.
     """
-    return salt.utils.versions.check_boto_reqs(boto3_ver="1.3.1")
+    return salt.utils.versions.check_boto_reqs(check_boto=False, boto3_ver="1.3.1")
 
 
 def __init__(opts):

--- a/salt/modules/boto_s3.py
+++ b/salt/modules/boto_s3.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Connection module for Amazon S3 using boto3
 
@@ -50,12 +49,9 @@ Connection module for Amazon S3 using boto3
 # keep lint from choking on _get_conn and _cache_id
 # pylint: disable=E0602
 
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
-# Import Salt libs
 import salt.utils.versions
 
 log = logging.getLogger(__name__)

--- a/salt/modules/boto_s3.py
+++ b/salt/modules/boto_s3.py
@@ -80,7 +80,7 @@ def __virtual__():
     Only load if boto libraries exist and if boto libraries are greater than
     a given version.
     """
-    return salt.utils.versions.check_boto_reqs(boto3_ver="1.2.1")
+    return salt.utils.versions.check_boto_reqs(check_boto=False, boto3_ver="1.2.1")
 
 
 def __init__(opts):  # pylint: disable=unused-argument

--- a/salt/modules/boto_s3_bucket.py
+++ b/salt/modules/boto_s3_bucket.py
@@ -5,7 +5,6 @@ Connection module for Amazon S3 Buckets
 .. versionadded:: 2016.3.0
 
 :depends:
-    - boto
     - boto3
 
 The dependencies listed above can be installed via package or pip.
@@ -72,7 +71,6 @@ log = logging.getLogger(__name__)
 # pylint: disable=import-error
 try:
     # pylint: disable=unused-import
-    import boto
     import boto3
 
     # pylint: enable=unused-import
@@ -93,7 +91,7 @@ def __virtual__():
     # the boto_lambda execution module relies on the connect_to_region() method
     # which was added in boto 2.8.0
     # https://github.com/boto/boto/commit/33ac26b416fbb48a60602542b4ce15dcc7029f12
-    return salt.utils.versions.check_boto_reqs(boto3_ver="1.2.1")
+    return salt.utils.versions.check_boto_reqs(check_boto=False, boto3_ver="1.2.1")
 
 
 def __init__(opts):

--- a/salt/modules/boto_s3_bucket.py
+++ b/salt/modules/boto_s3_bucket.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Connection module for Amazon S3 Buckets
 
@@ -50,8 +49,6 @@ The dependencies listed above can be installed via package or pip.
 #  disable complaints about perfectly valid non-assignment code
 # pylint: disable=W0106
 
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
@@ -59,14 +56,10 @@ import salt.utils.compat
 import salt.utils.json
 import salt.utils.versions
 from salt.exceptions import SaltInvocationError
-
-# Import Salt libs
-from salt.ext import six
 from salt.ext.six.moves import range  # pylint: disable=import-error
 
 log = logging.getLogger(__name__)
 
-# Import third party libs
 
 # pylint: disable=import-error
 try:
@@ -258,7 +251,7 @@ def delete_objects(
 
     """
 
-    if isinstance(Delete, six.string_types):
+    if isinstance(Delete, str):
         Delete = salt.utils.json.loads(Delete)
     if not isinstance(Delete, dict):
         raise SaltInvocationError("Malformed Delete request.")
@@ -318,7 +311,7 @@ def describe(Bucket, region=None, key=None, keyid=None, profile=None):
             "Website": conn.get_bucket_website,
         }
 
-        for key, query in six.iteritems(conn_dict):
+        for key, query in conn_dict.items():
             try:
                 data = query(Bucket=Bucket)
             except ClientError as e:
@@ -553,7 +546,7 @@ def put_acl(
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         kwargs = {}
         if AccessControlPolicy is not None:
-            if isinstance(AccessControlPolicy, six.string_types):
+            if isinstance(AccessControlPolicy, str):
                 AccessControlPolicy = salt.utils.json.loads(AccessControlPolicy)
             kwargs["AccessControlPolicy"] = AccessControlPolicy
         for arg in (
@@ -597,7 +590,7 @@ def put_cors(Bucket, CORSRules, region=None, key=None, keyid=None, profile=None)
 
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-        if CORSRules is not None and isinstance(CORSRules, six.string_types):
+        if CORSRules is not None and isinstance(CORSRules, str):
             CORSRules = salt.utils.json.loads(CORSRules)
         conn.put_bucket_cors(Bucket=Bucket, CORSConfiguration={"CORSRules": CORSRules})
         return {"updated": True, "name": Bucket}
@@ -632,7 +625,7 @@ def put_lifecycle_configuration(
 
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
-        if Rules is not None and isinstance(Rules, six.string_types):
+        if Rules is not None and isinstance(Rules, str):
             Rules = salt.utils.json.loads(Rules)
         conn.put_bucket_lifecycle_configuration(
             Bucket=Bucket, LifecycleConfiguration={"Rules": Rules}
@@ -674,14 +667,14 @@ def put_logging(
             "TargetGrants": TargetGrants,
             "TargetPrefix": TargetPrefix,
         }
-        for key, val in six.iteritems(targets):
+        for key, val in targets.items():
             if val is not None:
                 logstate[key] = val
         if logstate:
             logstatus = {"LoggingEnabled": logstate}
         else:
             logstatus = {}
-        if TargetGrants is not None and isinstance(TargetGrants, six.string_types):
+        if TargetGrants is not None and isinstance(TargetGrants, str):
             TargetGrants = salt.utils.json.loads(TargetGrants)
         conn.put_bucket_logging(Bucket=Bucket, BucketLoggingStatus=logstatus)
         return {"updated": True, "name": Bucket}
@@ -720,15 +713,15 @@ def put_notification_configuration(
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         if TopicConfigurations is None:
             TopicConfigurations = []
-        elif isinstance(TopicConfigurations, six.string_types):
+        elif isinstance(TopicConfigurations, str):
             TopicConfigurations = salt.utils.json.loads(TopicConfigurations)
         if QueueConfigurations is None:
             QueueConfigurations = []
-        elif isinstance(QueueConfigurations, six.string_types):
+        elif isinstance(QueueConfigurations, str):
             QueueConfigurations = salt.utils.json.loads(QueueConfigurations)
         if LambdaFunctionConfigurations is None:
             LambdaFunctionConfigurations = []
-        elif isinstance(LambdaFunctionConfigurations, six.string_types):
+        elif isinstance(LambdaFunctionConfigurations, str):
             LambdaFunctionConfigurations = salt.utils.json.loads(
                 LambdaFunctionConfigurations
             )
@@ -765,7 +758,7 @@ def put_policy(Bucket, Policy, region=None, key=None, keyid=None, profile=None):
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         if Policy is None:
             Policy = "{}"
-        elif not isinstance(Policy, six.string_types):
+        elif not isinstance(Policy, str):
             Policy = salt.utils.json.dumps(Policy)
         conn.put_bucket_policy(Bucket=Bucket, Policy=Policy)
         return {"updated": True, "name": Bucket}
@@ -784,7 +777,7 @@ def _get_role_arn(name, region=None, key=None, keyid=None, profile=None):
         region = profile["region"]
     if region is None:
         region = "us-east-1"
-    return "arn:aws:iam::{0}:role/{1}".format(account_id, name)
+    return "arn:aws:iam::{}:role/{}".format(account_id, name)
 
 
 def put_replication(
@@ -811,7 +804,7 @@ def put_replication(
         )
         if Rules is None:
             Rules = []
-        elif isinstance(Rules, six.string_types):
+        elif isinstance(Rules, str):
             Rules = salt.utils.json.loads(Rules)
         conn.put_bucket_replication(
             Bucket=Bucket, ReplicationConfiguration={"Role": Role, "Rules": Rules}
@@ -864,10 +857,10 @@ def put_tagging(Bucket, region=None, key=None, keyid=None, profile=None, **kwarg
     try:
         conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
         tagslist = []
-        for k, v in six.iteritems(kwargs):
-            if six.text_type(k).startswith("__"):
+        for k, v in kwargs.items():
+            if str(k).startswith("__"):
                 continue
-            tagslist.append({"Key": six.text_type(k), "Value": six.text_type(v)})
+            tagslist.append({"Key": str(k), "Value": str(v)})
         conn.put_bucket_tagging(Bucket=Bucket, Tagging={"TagSet": tagslist})
         return {"updated": True, "name": Bucket}
     except ClientError as e:
@@ -950,7 +943,7 @@ def put_website(
         ):
             val = locals()[key]
             if val is not None:
-                if isinstance(val, six.string_types):
+                if isinstance(val, str):
                     WebsiteConfiguration[key] = salt.utils.json.loads(val)
                 else:
                     WebsiteConfiguration[key] = val

--- a/salt/modules/boto_sqs.py
+++ b/salt/modules/boto_sqs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Connection module for Amazon SQS
 
@@ -44,17 +43,11 @@ Connection module for Amazon SQS
 # keep lint from choking on _get_conn and _cache_id
 # pylint: disable=E0602
 
-from __future__ import absolute_import, print_function, unicode_literals
 
-# Import Python libs
 import logging
 
-# Import Salt libs
 import salt.utils.json
 import salt.utils.versions
-
-# Import 3rd-party libs
-from salt.ext import six
 from salt.ext.six.moves.urllib.parse import urlparse as _urlparse
 
 log = logging.getLogger(__name__)
@@ -63,7 +56,6 @@ __func_alias__ = {
     "list_": "list",
 }
 
-# Import third party libs
 try:
     # pylint: disable=unused-import
     import boto3
@@ -90,7 +82,7 @@ def _preprocess_attributes(attributes):
     """
     Pre-process incoming queue attributes before setting them
     """
-    if isinstance(attributes, six.string_types):
+    if isinstance(attributes, str):
         attributes = salt.utils.json.loads(attributes)
 
     def stringified(val):
@@ -100,7 +92,7 @@ def _preprocess_attributes(attributes):
             return salt.utils.json.dumps(val)
         return val
 
-    return dict((attr, stringified(val)) for attr, val in six.iteritems(attributes))
+    return {attr: stringified(val) for attr, val in attributes.items()}
 
 
 def exists(name, region=None, key=None, keyid=None, profile=None):

--- a/salt/modules/boto_sqs.py
+++ b/salt/modules/boto_sqs.py
@@ -80,7 +80,7 @@ def __virtual__():
     """
     Only load if boto3 libraries exist.
     """
-    has_boto_reqs = salt.utils.versions.check_boto_reqs()
+    has_boto_reqs = salt.utils.versions.check_boto_reqs(check_boto=False)
     if has_boto_reqs is True:
         __utils__["boto3.assign_funcs"](__name__, "sqs")
     return has_boto_reqs

--- a/salt/modules/boto_ssm.py
+++ b/salt/modules/boto_ssm.py
@@ -12,10 +12,8 @@ Connection module for Amazon SSM
 
 :depends: boto3
 """
-# Import Python libs
 import logging
 
-# Import Salt libs
 import salt.utils.boto3mod
 import salt.utils.json as json
 import salt.utils.versions

--- a/salt/modules/boto_ssm.py
+++ b/salt/modules/boto_ssm.py
@@ -27,7 +27,7 @@ def __virtual__():
     """
     Only load if boto libraries exist.
     """
-    has_boto_reqs = salt.utils.versions.check_boto_reqs()
+    has_boto_reqs = salt.utils.versions.check_boto_reqs(check_boto=False)
     if has_boto_reqs is True:
         salt.utils.boto3mod.assign_funcs(__name__, "ssm")
     return has_boto_reqs

--- a/salt/utils/versions.py
+++ b/salt/utils/versions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
     :copyright: Copyright 2017 by the SaltStack Team, see AUTHORS for more details.
     :license: Apache 2.0, see LICENSE for more details.
@@ -11,8 +10,6 @@
     because on python 3 you can no longer compare strings against integers.
 """
 
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import contextlib
 import datetime
@@ -26,12 +23,8 @@ import warnings
 from distutils.version import LooseVersion as _LooseVersion
 from distutils.version import StrictVersion as _StrictVersion
 
-# Import Salt libs
 import salt.version
 from salt.exceptions import SaltException
-
-# Import 3rd-party libs
-from salt.ext import six
 
 # pylint: enable=blacklisted-module,no-name-in-module
 
@@ -44,7 +37,7 @@ class StrictVersion(_StrictVersion):
         _StrictVersion.parse(self, vstring)
 
     def _cmp(self, other):
-        if isinstance(other, six.string_types):
+        if isinstance(other, str):
             other = StrictVersion(other)
         return _StrictVersion._cmp(self, other)
 
@@ -53,36 +46,32 @@ class LooseVersion(_LooseVersion):
     def parse(self, vstring):
         _LooseVersion.parse(self, vstring)
 
-        if six.PY3:
-            # Convert every part of the version to string in order to be able to compare
-            self._str_version = [
-                six.text_type(vp).zfill(8) if isinstance(vp, int) else vp
-                for vp in self.version
-            ]
+        # Convert every part of the version to string in order to be able to compare
+        self._str_version = [
+            str(vp).zfill(8) if isinstance(vp, int) else vp for vp in self.version
+        ]
 
-    if six.PY3:
+    def _cmp(self, other):
+        if isinstance(other, str):
+            other = LooseVersion(other)
 
-        def _cmp(self, other):
-            if isinstance(other, six.string_types):
-                other = LooseVersion(other)
+        string_in_version = False
+        for part in self.version + other.version:
+            if not isinstance(part, int):
+                string_in_version = True
+                break
 
-            string_in_version = False
-            for part in self.version + other.version:
-                if not isinstance(part, int):
-                    string_in_version = True
-                    break
+        if string_in_version is False:
+            return _LooseVersion._cmp(self, other)
 
-            if string_in_version is False:
-                return _LooseVersion._cmp(self, other)
-
-            # If we reached this far, it means at least a part of the version contains a string
-            # In python 3, strings and integers are not comparable
-            if self._str_version == other._str_version:
-                return 0
-            if self._str_version < other._str_version:
-                return -1
-            if self._str_version > other._str_version:
-                return 1
+        # If we reached this far, it means at least a part of the version contains a string
+        # In python 3, strings and integers are not comparable
+        if self._str_version == other._str_version:
+            return 0
+        if self._str_version < other._str_version:
+            return -1
+        if self._str_version > other._str_version:
+            return 1
 
 
 def _format_warning(message, category, filename, lineno, line=None):
@@ -95,14 +84,8 @@ def _format_warning(message, category, filename, lineno, line=None):
 
 @contextlib.contextmanager
 def _patched_format_warning():
-    if six.PY2:
-        saved = warnings.formatwarning
-        warnings.formatwarning = _format_warning
-        yield
-        warnings.formatwarning = saved
-    else:
-        # Under Py3 we no longer have to patch warnings.formatwarning
-        yield
+    # Under Py3 we no longer have to patch warnings.formatwarning
+    yield
 
 
 def warn_until(
@@ -135,16 +118,14 @@ def warn_until(
                                 issued. When we're only after the salt version
                                 checks to raise a ``RuntimeError``.
     """
-    if not isinstance(
-        version, (tuple, six.string_types, salt.version.SaltStackVersion)
-    ):
+    if not isinstance(version, (tuple, (str,), salt.version.SaltStackVersion)):
         raise RuntimeError(
             "The 'version' argument should be passed as a tuple, string or "
             "an instance of 'salt.version.SaltStackVersion'."
         )
     elif isinstance(version, tuple):
         version = salt.version.SaltStackVersion(*version)
-    elif isinstance(version, six.string_types):
+    elif isinstance(version, str):
         version = salt.version.SaltStackVersion.from_name(version)
 
     if stacklevel is None:
@@ -205,7 +186,7 @@ def warn_until_date(
                                 checks to raise a ``RuntimeError``.
     """
     _strptime_fmt = "%Y%m%d"
-    if not isinstance(date, (six.string_types, datetime.date, datetime.datetime)):
+    if not isinstance(date, ((str,), datetime.date, datetime.datetime)):
         raise RuntimeError(
             "The 'date' argument should be passed as a 'datetime.date()' or "
             "'datetime.datetime()' objects or as string parserable by "
@@ -213,7 +194,7 @@ def warn_until_date(
                 _strptime_fmt
             )
         )
-    elif isinstance(date, six.text_type):
+    elif isinstance(date, str):
         date = datetime.datetime.strptime(date, _strptime_fmt)
 
     # We're really not interested in the time
@@ -285,16 +266,14 @@ def kwargs_warn_until(
                                 issued. When we're only after the salt version
                                 checks to raise a ``RuntimeError``.
     """
-    if not isinstance(
-        version, (tuple, six.string_types, salt.version.SaltStackVersion)
-    ):
+    if not isinstance(version, (tuple, (str,), salt.version.SaltStackVersion)):
         raise RuntimeError(
             "The 'version' argument should be passed as a tuple, string or "
             "an instance of 'salt.version.SaltStackVersion'."
         )
     elif isinstance(version, tuple):
         version = salt.version.SaltStackVersion(*version)
-    elif isinstance(version, six.string_types):
+    elif isinstance(version, str):
         version = salt.version.SaltStackVersion.from_name(version)
 
     if stacklevel is None:
@@ -308,11 +287,11 @@ def kwargs_warn_until(
     _version_ = salt.version.SaltStackVersion(*_version_info_)
 
     if kwargs or _version_.info >= version.info:
-        arg_names = ", ".join("'{0}'".format(key) for key in kwargs)
+        arg_names = ", ".join("'{}'".format(key) for key in kwargs)
         warn_until(
             version,
             message="The following parameter(s) have been deprecated and "
-            "will be removed in '{0}': {1}.".format(version.string, arg_names),
+            "will be removed in '{}': {}.".format(version.string, arg_names),
             category=category,
             stacklevel=stacklevel,
             _version_info_=_version_.info,
@@ -328,11 +307,7 @@ def version_cmp(pkg1, pkg2, ignore_epoch=False):
     version2, and 1 if version1 > version2. Return None if there was a problem
     making the comparison.
     """
-    normalize = (
-        lambda x: six.text_type(x).split(":", 1)[-1]
-        if ignore_epoch
-        else six.text_type(x)
-    )
+    normalize = lambda x: str(x).split(":", 1)[-1] if ignore_epoch else str(x)
     pkg1 = normalize(pkg1)
     pkg2 = normalize(pkg2)
 
@@ -384,7 +359,11 @@ def compare(ver1="", oper="==", ver2="", cmp_func=None, ignore_epoch=False):
 
 
 def check_boto_reqs(
-    boto_ver=None, boto3_ver=None, botocore_ver=None, check_boto=False, check_boto3=False
+    boto_ver=None,
+    boto3_ver=None,
+    botocore_ver=None,
+    check_boto=False,
+    check_boto3=False,
 ):
     """
     Checks for the version of various required boto libs in one central location. Most
@@ -430,7 +409,7 @@ def check_boto_reqs(
             boto_ver = "2.0.0"
 
         if not has_boto or version_cmp(boto.__version__, boto_ver) == -1:
-            return False, "A minimum version of boto {0} is required.".format(boto_ver)
+            return False, "A minimum version of boto {} is required.".format(boto_ver)
 
     if check_boto3 is True:
         try:
@@ -452,12 +431,12 @@ def check_boto_reqs(
         if not has_boto3 or version_cmp(boto3.__version__, boto3_ver) == -1:
             return (
                 False,
-                "A minimum version of boto3 {0} is required.".format(boto3_ver),
+                "A minimum version of boto3 {} is required.".format(boto3_ver),
             )
         elif version_cmp(botocore.__version__, botocore_ver) == -1:
             return (
                 False,
-                "A minimum version of botocore {0} is required".format(botocore_ver),
+                "A minimum version of botocore {} is required".format(botocore_ver),
             )
 
     return True

--- a/salt/utils/versions.py
+++ b/salt/utils/versions.py
@@ -28,6 +28,7 @@ from distutils.version import StrictVersion as _StrictVersion
 
 # Import Salt libs
 import salt.version
+from salt.exceptions import SaltException
 
 # Import 3rd-party libs
 from salt.ext import six
@@ -383,7 +384,7 @@ def compare(ver1="", oper="==", ver2="", cmp_func=None, ignore_epoch=False):
 
 
 def check_boto_reqs(
-    boto_ver=None, boto3_ver=None, botocore_ver=None, check_boto=True, check_boto3=True
+    boto_ver=None, boto3_ver=None, botocore_ver=None, check_boto=False, check_boto3=False
 ):
     """
     Checks for the version of various required boto libs in one central location. Most
@@ -412,6 +413,10 @@ def check_boto_reqs(
         This defaults to ``True`` as most boto modules/states rely on boto3/botocore, but
         some do not.
     """
+
+    if check_boto is True and check_boto3 is True:
+        raise SaltException("Simultaneous use of boto and boto3 is prohibited.")
+
     if check_boto is True:
         try:
             # Late import so we can only load these for this function


### PR DESCRIPTION
A number of boto3 modules contain boto checks and imports, but do not actually make any boto calls via the boto libraries.

### What does this PR do?
1. Remove check_boto/check_boto3 parameters from `salt.utils.version.check_boto_reqs()` and require passing versions.
2. Disallow passing versions for both boto and boto3 at the same time.
3. Update various boto/boto3 mods to explicitly declare which version of boto they are checking for
4. Remove unused boto imports from boto3 modules
5. Changes introduced by pre-commit scripts.

### Previous Behavior
Previously calls to `salt.utils.version.check_boto_reqs()` assumed all modules used both boto and boto3 libraries. This allowed modules to import both libraries and mix commands across boto and boto3 sessions.

### New Behavior
`salt.utils.version.check_boto_reqs()` now requires a module to specify which version of boto or boto3 the module uses, and only allows checking for boto _or_ boto3.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.