### PR TITLE
Remove py2 support from the winrepo runner

### DIFF
--- a/58596.fixed
+++ b/58596.fixed
@@ -1,1 +1,0 @@
-Add missing import back to winrepo.

--- a/58596.fixed
+++ b/58596.fixed
@@ -1,0 +1,1 @@
+Add missing import back to winrepo.

--- a/changelog/58596.fixed
+++ b/changelog/58596.fixed
@@ -1,0 +1,1 @@
+Remove py2 support from winrepo execution module and runner

--- a/salt/modules/winrepo.py
+++ b/salt/modules/winrepo.py
@@ -30,6 +30,7 @@ from salt.exceptions import CommandExecutionError, SaltRenderError
 from salt.runners.winrepo import GLOBAL_ONLY, PER_REMOTE_ONLY, PER_REMOTE_OVERRIDES
 from salt.runners.winrepo import genrepo as _genrepo
 from salt.runners.winrepo import update_git_repos as _update_git_repos
+from salt.ext import six
 
 # pylint: enable=unused-import
 

--- a/salt/modules/winrepo.py
+++ b/salt/modules/winrepo.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 r"""
 Module to manage Windows software repo on a Standalone Minion
 
@@ -8,15 +7,11 @@ For documentation on Salt's Windows Repo feature, see :ref:`here
 <windows-package-manager>`.
 """
 
-# Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 import os
 
 import salt.loader
-
-# Import salt libs
 import salt.output
 import salt.template
 import salt.utils.functools
@@ -30,7 +25,6 @@ from salt.exceptions import CommandExecutionError, SaltRenderError
 from salt.runners.winrepo import GLOBAL_ONLY, PER_REMOTE_ONLY, PER_REMOTE_OVERRIDES
 from salt.runners.winrepo import genrepo as _genrepo
 from salt.runners.winrepo import update_git_repos as _update_git_repos
-from salt.ext import six
 
 # pylint: enable=unused-import
 
@@ -176,15 +170,15 @@ def show_sls(name, saltenv="base"):
         repo.extend(definition)
 
         # Check for the sls file by name
-        sls_file = "{0}.sls".format(os.sep.join(repo))
+        sls_file = "{}.sls".format(os.sep.join(repo))
         if not os.path.exists(sls_file):
 
             # Maybe it's a directory with an init.sls
-            sls_file = "{0}\\init.sls".format(os.sep.join(repo))
+            sls_file = "{}\\init.sls".format(os.sep.join(repo))
             if not os.path.exists(sls_file):
 
                 # It's neither, return
-                return "Software definition {0} not found".format(name)
+                return "Software definition {} not found".format(name)
 
     # Load the renderer
     renderers = salt.loader.render(__opts__, __salt__)
@@ -204,7 +198,7 @@ def show_sls(name, saltenv="base"):
     except SaltRenderError as exc:
         log.debug("Failed to compile %s.", sls_file)
         log.debug("Error: %s.", exc)
-        config["Message"] = "Failed to compile {0}".format(sls_file)
-        config["Error"] = "{0}".format(exc)
+        config["Message"] = "Failed to compile {}".format(sls_file)
+        config["Error"] = "{}".format(exc)
 
     return config

--- a/salt/runners/winrepo.py
+++ b/salt/runners/winrepo.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Runner to manage Windows software repo
 """
@@ -6,8 +5,6 @@ Runner to manage Windows software repo
 # WARNING: Any modules imported here must also be added to
 # salt/modules/win_repo.py
 
-# Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 import os
@@ -19,12 +16,7 @@ import salt.utils.files
 import salt.utils.gitfs
 import salt.utils.msgpack
 import salt.utils.path
-
-# Import salt libs
 from salt.exceptions import CommandExecutionError, SaltRenderError
-
-# Import third party libs
-from salt.ext import six
 
 log = logging.getLogger(__name__)
 
@@ -83,20 +75,20 @@ def genrepo(opts=None, fire_event=True):
                     continue
                 if config:
                     revmap = {}
-                    for pkgname, versions in six.iteritems(config):
+                    for pkgname, versions in config.items():
                         log.debug("Compiling winrepo data for package '%s'", pkgname)
-                        for version, repodata in six.iteritems(versions):
+                        for version, repodata in versions.items():
                             log.debug(
                                 "Compiling winrepo data for %s version %s",
                                 pkgname,
                                 version,
                             )
-                            if not isinstance(version, six.string_types):
-                                config[pkgname][six.text_type(version)] = config[
-                                    pkgname
-                                ].pop(version)
+                            if not isinstance(version, str):
+                                config[pkgname][str(version)] = config[pkgname].pop(
+                                    version
+                                )
                             if not isinstance(repodata, dict):
-                                msg = "Failed to compile {0}.".format(
+                                msg = "Failed to compile {}.".format(
                                     os.path.join(root, name)
                                 )
                                 log.debug(msg)
@@ -192,7 +184,7 @@ def update_git_repos(opts=None, clean=False, masterless=False):
                     if isinstance(result, list):
                         # Errors were detected
                         raise CommandExecutionError(
-                            "Failed up update winrepo remotes: {0}".format(
+                            "Failed up update winrepo remotes: {}".format(
                                 "\n".join(result)
                             )
                         )
@@ -232,7 +224,7 @@ def update_git_repos(opts=None, clean=False, masterless=False):
                     winrepo.clear_old_remotes()
                 winrepo.checkout()
             except Exception as exc:  # pylint: disable=broad-except
-                msg = "Failed to update winrepo_remotes: {0}".format(exc)
+                msg = "Failed to update winrepo_remotes: {}".format(exc)
                 log.error(msg, exc_info_on_loglevel=logging.DEBUG)
                 return msg
             ret.update(winrepo.winrepo_dirs)


### PR DESCRIPTION
### What does this PR do?
This PR removes py2 support from the winrepo runner. Py2 support was removed from the execution module which imports functions from the runner. The runner code had py2 code which was failing because py2 support had been removed from the execution module.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/58596

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
