### PR TITLE
Feat/boto describe default vpc

### DIFF
--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -197,7 +197,7 @@ def __init__(opts):
 
 
 def check_vpc(
-    vpc_id=None, vpc_name=None, region=None, key=None, keyid=None, profile=None
+    vpc_id=None, vpc_name=None, region=None, key=None, keyid=None, profile=None,
 ):
     """
     Check whether a VPC with the given name or id exists.
@@ -607,7 +607,7 @@ def _find_vpcs(
     )
 
     if vpcs:
-        if not any ((vpc_id, vpc_name, cidr, tags)):
+        if not any((vpc_id, vpc_name, cidr, tags)):
             return [vpc.id for vpc in vpcs if vpc.is_default]
         else:
             return [vpc.id for vpc in vpcs]
@@ -616,7 +616,13 @@ def _find_vpcs(
 
 
 def _get_id(
-    vpc_name=None, cidr=None, tags=None, region=None, key=None, keyid=None, profile=None
+    vpc_name=None,
+    cidr=None,
+    tags=None,
+    region=None,
+    key=None,
+    keyid=None,
+    profile=None,
 ):
     """
     Given VPC properties, return the VPC id if a match is found.
@@ -624,8 +630,7 @@ def _get_id(
 
     if not any((vpc_name, tags, cidr)):
         raise SaltInvocationError(
-            "At least one of the following must be "
-            "provided: vpc_name, cidr or tags."
+            "At least one of the following must be provided: vpc_name, cidr or tags."
         )
 
     if vpc_name and not any((cidr, tags)):
@@ -668,7 +673,7 @@ def _get_id(
 
 
 def get_id(
-    name=None, cidr=None, tags=None, region=None, key=None, keyid=None, profile=None
+    name=None, cidr=None, tags=None, region=None, key=None, keyid=None, profile=None,
 ):
     """
     Given VPC properties, return the VPC id if a match is found.
@@ -879,7 +884,7 @@ def delete(
 
 
 def describe(
-    vpc_id=None, vpc_name=None, region=None, key=None, keyid=None, profile=None
+    vpc_id=None, vpc_name=None, region=None, key=None, keyid=None, profile=None,
 ):
     """
     Describe a VPC's properties. If no VPC ID/Name is spcified then describe the default VPC.
@@ -906,7 +911,8 @@ def describe(
             region=region,
             key=key,
             keyid=keyid,
-            profile=profile)
+            profile=profile,
+        )
     except BotoServerError as err:
         boto_err = __utils__["boto.get_error"](err)
         if boto_err.get("aws", {}).get("code") == "InvalidVpcID.NotFound":

--- a/tests/unit/modules/test_boto_vpc.py
+++ b/tests/unit/modules/test_boto_vpc.py
@@ -332,10 +332,6 @@ class BotoVpcTestCaseMixin:
         return rtbl
 
 
-@skipIf(
-    sys.version_info > (3, 6),
-    "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
-)
 class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
     """
     TestCase for salt.modules.boto_vpc module
@@ -541,7 +537,7 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         """
         with self.assertRaisesRegex(
             SaltInvocationError,
-            "At least one of the following must be provided: vpc_id, vpc_name, cidr or tags.",
+            "At least one of the following must be provided: vpc_name, cidr or tags.",
         ):
             boto_vpc.get_id(**conn_parameters)
 
@@ -693,16 +689,15 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
             self.assertTrue("error" in describe_result)
 
     @mock_ec2_deprecated
-    def test_that_when_describing_vpc_but_providing_no_vpc_id_the_describe_method_raises_a_salt_invocation_error(
+    def test_that_when_describing_vpc_but_providing_no_vpc_id_the_describe_method_returns_the_default_vpc(
         self,
     ):
         """
         Tests describing vpc without vpc id
         """
-        with self.assertRaisesRegex(
-            SaltInvocationError, "A valid vpc id or name needs to be specified."
-        ):
-            boto_vpc.describe(vpc_id=None, **conn_parameters)
+        describe_vpc = boto_vpc.describe(vpc_id=None, **conn_parameters)
+
+        self.assertTrue(describe_vpc["vpc"]["is_default"])
 
 
 @skipIf(HAS_BOTO is False, "The boto module must be installed.")


### PR DESCRIPTION
### What does this PR do?
Allow looking up the default AWS VPC which is automatically created at account creation time.

### Previous Behavior
Previously the `boto_vpc` module only allowed looking up a VPC via the `vpc_id` or the `vpc_name`. The default VPC does not have a `vpc_name` and as such it is not possible to look it up.

### New Behavior
If neither the `vpc_id` nor the `vpc_name` are supplied to `boto_vpc.describe()` then it will describe the default VPC.

The following functions were modified to make this possible:
- `_find_vpcs()`
- `describe()`

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.