### PR TITLE
modules/opkg+restartcheck: test nisysapi conf.d dir for changes

### DIFF
--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -92,6 +92,32 @@ def _update_nilrt_restart_state():
             )
         )
 
+    # Expert plugin files get added to a conf.d dir, so keep track of the total
+    # no. of files, their timestamps and content hashes
+    nisysapi_conf_d_path = "/usr/lib/{}/nisysapi/conf.d/experts/".format(
+        "arm-linux-gnueabi"
+        if "arm" in __grains__.get("cpuarch")
+        else "x86_64-linux-gnu"
+    )
+
+    if os.path.exists(nisysapi_conf_d_path):
+        with salt.utils.files.fopen(
+            "{}/sysapi.conf.d.count".format(NILRT_RESTARTCHECK_STATE_PATH), "w"
+        ) as fcount:
+            fcount.write(str(len(os.listdir(nisysapi_conf_d_path))))
+
+        for fexpert in os.listdir(nisysapi_conf_d_path):
+            __salt__["cmd.shell"](
+                "stat -c %Y {0}/{1} >{2}/{1}.timestamp".format(
+                    nisysapi_conf_d_path, fexpert, NILRT_RESTARTCHECK_STATE_PATH
+                )
+            )
+            __salt__["cmd.shell"](
+                "md5sum {0}/{1} >{2}/{1}.md5sum".format(
+                    nisysapi_conf_d_path, fexpert, NILRT_RESTARTCHECK_STATE_PATH
+                )
+            )
+
 
 def _get_restartcheck_result(errors):
     """

--- a/salt/modules/restartcheck.py
+++ b/salt/modules/restartcheck.py
@@ -398,7 +398,7 @@ def _file_changed_nilrt(full_filepath):
     md5sum_file = os.path.join(rs_state_dir, "{0}.md5sum".format(base_filename))
 
     if not os.path.exists(timestamp_file) or not os.path.exists(md5sum_file):
-        return False
+        return True
 
     prev_timestamp = __salt__["file.read"](timestamp_file).rstrip()
     # Need timestamp in seconds so floor it using int()

--- a/salt/modules/restartcheck.py
+++ b/salt/modules/restartcheck.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 checkrestart functionality for Debian and Red Hat Based systems
 
@@ -10,7 +9,6 @@ https://packages.debian.org/debian-goodies) and psdel by Sam Morris.
 
 :codeauthor: Jiri Kotlin <jiri.kotlin@ultimum.io>
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
 import os
@@ -24,9 +22,6 @@ import salt.exceptions
 import salt.utils.args
 import salt.utils.files
 import salt.utils.path
-
-# Import 3rd partylibs
-from salt.ext import six
 
 NILRT_FAMILY_NAME = "NILinuxRT"
 
@@ -131,12 +126,12 @@ def _deleted_files():
             pinfo = proc.as_dict(attrs=["pid", "name"])
             try:
                 with salt.utils.files.fopen(
-                    "/proc/{0}/maps".format(pinfo["pid"])
+                    "/proc/{}/maps".format(pinfo["pid"])
                 ) as maps:  # pylint: disable=resource-leakage
-                    dirpath = "/proc/" + six.text_type(pinfo["pid"]) + "/fd/"
+                    dirpath = "/proc/" + str(pinfo["pid"]) + "/fd/"
                     listdir = os.listdir(dirpath)
                     maplines = maps.readlines()
-            except (OSError, IOError):
+            except OSError:
                 yield False
 
             # /proc/PID/maps
@@ -228,14 +223,14 @@ def _format_output(
             ret = "System restart required.\n\n"
 
         if packages:
-            ret += "Found {0} processes using old versions of upgraded files.\n".format(
+            ret += "Found {} processes using old versions of upgraded files.\n".format(
                 len(packages)
             )
             ret += "These are the packages:\n"
 
         if restartable:
             ret += (
-                "Of these, {0} seem to contain systemd service definitions or init scripts "
+                "Of these, {} seem to contain systemd service definitions or init scripts "
                 "which can be used to restart them:\n".format(len(restartable))
             )
             for package in restartable:
@@ -253,7 +248,7 @@ def _format_output(
 
         if nonrestartable:
             ret += (
-                "\n\nThese processes {0} do not seem to have an associated init script "
+                "\n\nThese processes {} do not seem to have an associated init script "
                 "to restart them:\n".format(len(nonrestartable))
             )
             for package in nonrestartable:
@@ -337,7 +332,7 @@ def _kernel_versions_nilrt():
         Get kernel version from a binary image or None if detection fails
         """
         kvregex = r"[0-9]+\.[0-9]+\.[0-9]+-rt\S+"
-        kernel_strings = __salt__["cmd.run"]("strings {0}".format(kbin))
+        kernel_strings = __salt__["cmd.run"]("strings {}".format(kbin))
         re_result = re.search(kvregex, kernel_strings)
         return None if re_result is None else re_result.group(0)
 
@@ -350,11 +345,11 @@ def _kernel_versions_nilrt():
             compressed_kernel = "/var/volatile/tmp/uImage.gz"
             uncompressed_kernel = "/var/volatile/tmp/uImage"
             __salt__["cmd.run"](
-                "dumpimage -i {0} -T flat_dt -p0 kernel -o {1}".format(
+                "dumpimage -i {} -T flat_dt -p0 kernel -o {}".format(
                     itb_path, compressed_kernel
                 )
             )
-            __salt__["cmd.run"]("gunzip -f {0}".format(compressed_kernel))
+            __salt__["cmd.run"]("gunzip -f {}".format(compressed_kernel))
             kver = _get_kver_from_bin(uncompressed_kernel)
         else:
             # the kernel bzImage is copied to rootfs without package management or
@@ -394,8 +389,8 @@ def _file_changed_nilrt(full_filepath):
     """
     rs_state_dir = "/var/lib/salt/restartcheck_state"
     base_filename = os.path.basename(full_filepath)
-    timestamp_file = os.path.join(rs_state_dir, "{0}.timestamp".format(base_filename))
-    md5sum_file = os.path.join(rs_state_dir, "{0}.md5sum".format(base_filename))
+    timestamp_file = os.path.join(rs_state_dir, "{}.timestamp".format(base_filename))
+    md5sum_file = os.path.join(rs_state_dir, "{}.md5sum".format(base_filename))
 
     if not os.path.exists(timestamp_file) or not os.path.exists(md5sum_file):
         return True
@@ -409,7 +404,7 @@ def _file_changed_nilrt(full_filepath):
 
     return bool(
         __salt__["cmd.retcode"](
-            "md5sum -cs {0}".format(md5sum_file), output_loglevel="quiet"
+            "md5sum -cs {}".format(md5sum_file), output_loglevel="quiet"
         )
     )
 
@@ -425,7 +420,7 @@ def _kernel_modules_changed_nilrt(kernelversion):
              - True/False depending if modules.dep got modified/touched
     """
     if kernelversion is not None:
-        return _file_changed_nilrt("/lib/modules/{0}/modules.dep".format(kernelversion))
+        return _file_changed_nilrt("/lib/modules/{}/modules.dep".format(kernelversion))
     return False
 
 
@@ -438,12 +433,35 @@ def _sysapi_changed_nilrt():
     daemons restarted, etc.
 
     Returns:
-             - True/False depending on if nisysapi.ini got modified/touched
-             - False if nisysapi.ini does not exist to avoid triggering unnecessary reboots
+             - True/False depending if nisysapi .ini files got modified/touched
+             - False if no nisysapi .ini files exist
     """
     nisysapi_path = "/usr/local/natinst/share/nisysapi.ini"
-    if os.path.exists(nisysapi_path):
-        return _file_changed_nilrt(nisysapi_path)
+    if os.path.exists(nisysapi_path) and _file_changed_nilrt(nisysapi_path):
+        return True
+
+    restartcheck_state_dir = "/var/lib/salt/restartcheck_state"
+    nisysapi_conf_d_path = "/usr/lib/{}/nisysapi/conf.d/experts/".format(
+        "arm-linux-gnueabi"
+        if "arm" in __grains__.get("cpuarch")
+        else "x86_64-linux-gnu"
+    )
+
+    if os.path.exists(nisysapi_conf_d_path):
+        rs_count_file = "{}/sysapi.conf.d.count".format(restartcheck_state_dir)
+        if not os.path.exists(rs_count_file):
+            return True
+
+        with salt.utils.files.fopen(rs_count_file, "r") as fcount:
+            current_nb_files = len(os.listdir(nisysapi_conf_d_path))
+            rs_stored_nb_files = int(fcount.read())
+            if current_nb_files != rs_stored_nb_files:
+                return True
+
+        for fexpert in os.listdir(nisysapi_conf_d_path):
+            if _file_changed_nilrt("{}/{}".format(nisysapi_conf_d_path, fexpert)):
+                return True
+
     return False
 
 
@@ -555,7 +573,7 @@ def restartcheck(ignorelist=None, blacklist=None, excludepid=None, **kwargs):
         if path in blacklist or pid in excludepid:
             continue
         try:
-            readlink = os.readlink("/proc/{0}/exe".format(pid))
+            readlink = os.readlink("/proc/{}/exe".format(pid))
         except OSError:
             excludepid.append(pid)
             continue
@@ -576,15 +594,7 @@ def restartcheck(ignorelist=None, blacklist=None, excludepid=None, **kwargs):
                     restart_services.append(running_service)
                     name = running_service
         if packagename and packagename not in ignorelist:
-            program = (
-                "\t"
-                + six.text_type(pid)
-                + " "
-                + readlink
-                + " (file: "
-                + six.text_type(path)
-                + ")"
-            )
+            program = "\t" + str(pid) + " " + readlink + " (file: " + str(path) + ")"
             if packagename not in packages:
                 packages[packagename] = {
                     "initscripts": [],
@@ -624,7 +634,7 @@ def restartcheck(ignorelist=None, blacklist=None, excludepid=None, **kwargs):
                     # pylint: disable=resource-leakage
                     servicefile = salt.utils.files.fopen(pth)
                     # pylint: enable=resource-leakage
-                except IOError:
+                except OSError:
                     continue
                 sysfold_len = len(systemd_folder)
 

--- a/salt/modules/restartcheck.py
+++ b/salt/modules/restartcheck.py
@@ -521,9 +521,11 @@ def restartcheck(ignorelist=None, blacklist=None, excludepid=None, **kwargs):
         if kernel in kernel_current:
             if __grains__.get("os_family") == "NILinuxRT":
                 # Check kernel modules and hardware API's for version changes
+                # If a restartcheck=True event was previously witnessed, propagate it
                 if (
                     not _kernel_modules_changed_nilrt(kernel)
                     and not _sysapi_changed_nilrt()
+                    and not __salt__["system.get_reboot_required_witnessed"]()
                 ):
                     kernel_restart = False
                     break


### PR DESCRIPTION
Upstream 3 commits in opgk/restartcheck modules from ni salt branch + added tests.

----------------------------------

 modules/restartcheck: return True if NILRT file state doesn't exist

This fixes a bug on NILinuxRT where first-time installation of sysapi
files did not trigger a reboot.

If _file_changed_nilrt is called on a file without timestamp/checksum
info it means the file was newly created/first-time installed and a
reboot is required even though the timestamp/checksum info is missing.

The timestamp/checksum info will be generated for the new file by
_update_nilrt_restart_state() in the opkg module as a result of
returning True here.

Signed-off-by: Ioan-Adrian Ratiu <adrian.ratiu@ni.com>

------------------------------------------

 modules/opkg/restartcheck: test nisysapi conf.d dir for changes

NISysAPI expert .ini conf files can also be installed separately in a
conf.d directory as opposed to all expert configuration living in the
global .ini config file.

This change makes restartcheck and opkg aware of changes to the sysapi
conf.d by tracking the total number of files and each file's timestamp
and checksum.

Signed-off-by: Ioan-Adrian Ratiu <adrian.ratiu@ni.com>

----------------------------------------

 modules/restartcheck: propagate previous NILRT restartcheck=True

If a reboot required event was previously witnessed on NILinuxRT as a
result of running restartcheck, propagate that restartcheck = True
result forward in subsequent restartcheck.restartcheck runs.

In other words, if once restartcheck returns True on NILinuxRT, it
will always return True until the next reboot.

This enables other software on the system which already uses salt to
check for reboots via the salt interface by calling restartcheck
directly instead searching the OS filesystem for a 'reboot_witnessed'
file.

Signed-off-by: Ioan-Adrian Ratiu <adrian.ratiu@ni.com>
