### PR TITLE
dep_async_from_mandrill

### DIFF
--- a/salt/modules/.58640.removed
+++ b/salt/modules/.58640.removed
@@ -1,0 +1,1 @@
+removed kwargs from mandrill.send if you use "async" please use "asynchronous"

--- a/salt/modules/mandrill.py
+++ b/salt/modules/mandrill.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Mandrill
 ========
@@ -18,16 +17,12 @@ In the minion configuration file, the following block is required:
 .. versionadded:: 2018.3.0
 """
 
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
-# Import Salt libs
 import salt.utils.json
 import salt.utils.versions
 
-# import third party
 try:
     import requests
 
@@ -132,7 +127,6 @@ def send(
     api_url=None,
     api_version=None,
     api_key=None,
-    **kwargs
 ):
     """
     Send out the email using the details from the ``message`` argument.
@@ -220,14 +214,6 @@ def send(
             result:
                 True
     """
-    if "async" in kwargs:  # Remove this in 3001
-        salt.utils.versions.warn_until(
-            "Sodium",
-            'Parameter "async" is renamed to "asynchronous" '
-            "and will be removed in version {version}.",
-        )
-        asynchronous = bool(kwargs["async"])
-
     params = _get_api_params(api_url=api_url, api_version=api_version, api_key=api_key)
     url = _get_url(
         "messages/send", api_url=params["api_url"], api_version=params["api_version"]

--- a/tests/unit/modules/test_mandrill.py
+++ b/tests/unit/modules/test_mandrill.py
@@ -1,15 +1,9 @@
-# -*- coding: utf-8 -*-
 """
 Tests for the Mandrill execution module.
 """
 
-# Import Python Libs
-from __future__ import absolute_import, print_function, unicode_literals
 
-# Import Salt Libs
 import salt.modules.mandrill as mandrill
-
-# Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase
@@ -63,4 +57,25 @@ class MandrillModuleTest(TestCase, LoaderModuleMockMixin):
                     }
                 ),
                 TEST_SEND,
+            )
+
+    def test_deprecation_58640(self):
+        # check that type error will be raised
+        message = {
+            "subject": "Hi",
+            "from_email": "test@example.com",
+            "to": [{"email": "recv@example.com", "type": "to"}],
+        }
+        self.assertRaises(
+            TypeError, mandrill.send, **{"message": message, "async": True}
+        )
+
+        # check that async will raise an error
+        try:
+            mandrill.send(  # pylint: disable=unexpected-keyword-arg
+                **{"message": message, "async": True}
+            )
+        except TypeError as no_async:
+            self.assertEqual(
+                str(no_async), "send() got an unexpected keyword argument 'async'",
             )


### PR DESCRIPTION
### What does this PR do?
deprecates async and kwargs

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/58221

### Merge requirements satisfied?
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes
