### PR TITLE
Fix/enable boto tests

### DIFF
--- a/tests/unit/modules/test_boto_cognitoidentity.py
+++ b/tests/unit/modules/test_boto_cognitoidentity.py
@@ -167,7 +167,7 @@ class BotoCognitoIdentityTestCaseMixin(object):
     pass
 
 
-@skipIf(True, "Skip these tests while investigating failures")
+#@skipIf(True, "Skip these tests while investigating failures")
 @skipIf(HAS_BOTO is False, "The boto module must be installed.")
 @skipIf(
     _has_required_boto() is False,

--- a/tests/unit/modules/test_boto_cognitoidentity.py
+++ b/tests/unit/modules/test_boto_cognitoidentity.py
@@ -1,25 +1,15 @@
-# -*- coding: utf-8 -*-
-
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
-
 import logging
 import random
 import string
 
-# Import Salt libs
 import salt.config
 import salt.loader
 import salt.modules.boto_cognitoidentity as boto_cognitoidentity
 from salt.ext.six.moves import range  # pylint: disable=import-error
 from salt.utils.versions import LooseVersion
-
-# Import Salt Testing libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase, skipIf
-
-# Import 3rd-party libs
 
 # pylint: disable=import-error,no-name-in-module
 try:
@@ -140,7 +130,7 @@ class BotoCognitoIdentityTestCaseBase(TestCase, LoaderModuleMockMixin):
         return {boto_cognitoidentity: {"__utils__": utils}}
 
     def setUp(self):
-        super(BotoCognitoIdentityTestCaseBase, self).setUp()
+        super().setUp()
         boto_cognitoidentity.__init__(self.opts)
         del self.opts
 
@@ -163,16 +153,16 @@ class BotoCognitoIdentityTestCaseBase(TestCase, LoaderModuleMockMixin):
         session_instance.client.return_value = self.conn
 
 
-class BotoCognitoIdentityTestCaseMixin(object):
+class BotoCognitoIdentityTestCaseMixin:
     pass
 
 
-#@skipIf(True, "Skip these tests while investigating failures")
+# @skipIf(True, "Skip these tests while investigating failures")
 @skipIf(HAS_BOTO is False, "The boto module must be installed.")
 @skipIf(
     _has_required_boto() is False,
     "The boto3 module must be greater than"
-    " or equal to version {0}".format(required_boto3_version),
+    " or equal to version {}".format(required_boto3_version),
 )
 class BotoCognitoIdentityTestCase(
     BotoCognitoIdentityTestCaseBase, BotoCognitoIdentityTestCaseMixin

--- a/tests/unit/modules/test_boto_elasticsearch_domain.py
+++ b/tests/unit/modules/test_boto_elasticsearch_domain.py
@@ -1,8 +1,3 @@
-# -*- coding: utf-8 -*-
-
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
-
 import copy
 import logging
 import random
@@ -10,18 +5,11 @@ import string
 
 import salt.loader
 import salt.modules.boto_elasticsearch_domain as boto_elasticsearch_domain
-
-# Import Salt libs
-from salt.ext import six
 from salt.ext.six.moves import range
 from salt.utils.versions import LooseVersion
-
-# Import Salt Testing libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase, skipIf
-
-# Import 3rd-party libs
 
 # pylint: disable=import-error,no-name-in-module
 try:
@@ -102,7 +90,7 @@ class BotoElasticsearchDomainTestCaseBase(TestCase, LoaderModuleMockMixin):
         return {boto_elasticsearch_domain: {"__utils__": utils}}
 
     def setUp(self):
-        super(BotoElasticsearchDomainTestCaseBase, self).setUp()
+        super().setUp()
         boto_elasticsearch_domain.__init__(self.opts)
         del self.opts
 
@@ -125,16 +113,16 @@ class BotoElasticsearchDomainTestCaseBase(TestCase, LoaderModuleMockMixin):
         session_instance.client.return_value = self.conn
 
 
-class BotoElasticsearchDomainTestCaseMixin(object):
+class BotoElasticsearchDomainTestCaseMixin:
     pass
 
 
-#@skipIf(True, "Skip these tests while investigating failures")
+# @skipIf(True, "Skip these tests while investigating failures")
 @skipIf(HAS_BOTO is False, "The boto module must be installed.")
 @skipIf(
     _has_required_boto() is False,
     "The boto3 module must be greater than"
-    " or equal to version {0}".format(required_boto3_version),
+    " or equal to version {}".format(required_boto3_version),
 )
 class BotoElasticsearchDomainTestCase(
     BotoElasticsearchDomainTestCaseBase, BotoElasticsearchDomainTestCaseMixin
@@ -224,7 +212,7 @@ class BotoElasticsearchDomainTestCase(
         Tests describing parameters if domain exists
         """
         domainconfig = {}
-        for k, v in six.iteritems(domain_ret):
+        for k, v in domain_ret.items():
             if k == "DomainName":
                 continue
             domainconfig[k] = {"Options": v}

--- a/tests/unit/modules/test_boto_elasticsearch_domain.py
+++ b/tests/unit/modules/test_boto_elasticsearch_domain.py
@@ -129,7 +129,7 @@ class BotoElasticsearchDomainTestCaseMixin(object):
     pass
 
 
-@skipIf(True, "Skip these tests while investigating failures")
+#@skipIf(True, "Skip these tests while investigating failures")
 @skipIf(HAS_BOTO is False, "The boto module must be installed.")
 @skipIf(
     _has_required_boto() is False,

--- a/tests/unit/modules/test_boto_elb.py
+++ b/tests/unit/modules/test_boto_elb.py
@@ -143,10 +143,6 @@ class BotoElbTestCase(TestCase, LoaderModuleMockMixin):
 
     @mock_ec2_deprecated
     @mock_elb_deprecated
-    @skipIf(
-        sys.version_info > (3, 6),
-        "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
-    )
     def test_register_instances_valid_id_result_true(self):
         """
         tests that given a valid instance id and valid ELB that
@@ -165,10 +161,6 @@ class BotoElbTestCase(TestCase, LoaderModuleMockMixin):
 
     @mock_ec2_deprecated
     @mock_elb_deprecated
-    @skipIf(
-        sys.version_info > (3, 6),
-        "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
-    )
     def test_register_instances_valid_id_string(self):
         """
         tests that given a string containing a instance id and valid ELB that
@@ -193,10 +185,6 @@ class BotoElbTestCase(TestCase, LoaderModuleMockMixin):
 
     @mock_ec2_deprecated
     @mock_elb_deprecated
-    @skipIf(
-        sys.version_info > (3, 6),
-        "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
-    )
     def test_deregister_instances_valid_id_result_true(self):
         """
         tests that given an valid id the boto_elb deregister_instances method
@@ -218,10 +206,6 @@ class BotoElbTestCase(TestCase, LoaderModuleMockMixin):
 
     @mock_ec2_deprecated
     @mock_elb_deprecated
-    @skipIf(
-        sys.version_info > (3, 6),
-        "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
-    )
     def test_deregister_instances_valid_id_string(self):
         """
         tests that given an valid id the boto_elb deregister_instances method
@@ -250,10 +234,6 @@ class BotoElbTestCase(TestCase, LoaderModuleMockMixin):
 
     @mock_ec2_deprecated
     @mock_elb_deprecated
-    @skipIf(
-        sys.version_info > (3, 6),
-        "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
-    )
     def test_deregister_instances_valid_id_list(self):
         """
         tests that given an valid ids in the form of a list that the boto_elb

--- a/tests/unit/modules/test_boto_elb.py
+++ b/tests/unit/modules/test_boto_elb.py
@@ -1,30 +1,18 @@
-# -*- coding: utf-8 -*-
-
-# import Python Libs
-from __future__ import absolute_import, print_function, unicode_literals
-
 import logging
 import os.path
-import sys
 from copy import deepcopy
 
 import pkg_resources
 
-# Import Salt Libs
 import salt.config
 import salt.loader
 import salt.modules.boto_elb as boto_elb
 import salt.utils.versions
 from salt.ext import six
-
-# Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
-
-# Import test support libs
 from tests.support.runtests import RUNTIME_VARS
 from tests.support.unit import TestCase, skipIf
 
-# import Python Third Party Libs
 # pylint: disable=import-error
 try:
     import boto
@@ -120,8 +108,8 @@ def _has_required_moto():
 @skipIf(HAS_MOTO is False, "The moto module must be installed.")
 @skipIf(
     _has_required_moto() is False,
-    "The moto module must be >= to {0} for "
-    "PY2 or {1} for PY3.".format(required_moto, required_moto_py3),
+    "The moto module must be >= to {} for "
+    "PY2 or {} for PY3.".format(required_moto, required_moto_py3),
 )
 class BotoElbTestCase(TestCase, LoaderModuleMockMixin):
     """

--- a/tests/unit/modules/test_boto_secgroup.py
+++ b/tests/unit/modules/test_boto_secgroup.py
@@ -168,10 +168,6 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         ]
         self.assertEqual(boto_secgroup._split_rules(rules), split_rules)
 
-    @skipIf(
-        sys.version_info > (3, 6),
-        "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
-    )
     @mock_ec2_deprecated
     def test_create_ec2_classic(self):
         """
@@ -192,10 +188,6 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         ]
         self.assertEqual(expected_create_result, secgroup_create_result)
 
-    @skipIf(
-        sys.version_info > (3, 6),
-        "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
-    )
     @mock_ec2_deprecated
     def test_create_ec2_vpc(self):
         """
@@ -220,10 +212,6 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         ]
         self.assertEqual(expected_create_result, secgroup_create_result)
 
-    @skipIf(
-        sys.version_info > (3, 6),
-        "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
-    )
     @mock_ec2_deprecated
     def test_get_group_id_ec2_classic(self):
         """
@@ -271,10 +259,6 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         )
         self.assertEqual(group_vpc.id, retrieved_group_id)
 
-    @skipIf(
-        sys.version_info > (3, 6),
-        "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
-    )
     @mock_ec2_deprecated
     def test_get_config_single_rule_group_name(self):
         """
@@ -329,10 +313,6 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         )
         self.assertEqual(expected_get_config_result, secgroup_get_config_result)
 
-    @skipIf(
-        sys.version_info > (3, 6),
-        "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
-    )
     @mock_ec2_deprecated
     def test_exists_true_name_classic(self):
         """
@@ -348,18 +328,10 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         salt_exists_result = boto_secgroup.exists(name=group_name, **conn_parameters)
         self.assertTrue(salt_exists_result)
 
-    @skipIf(
-        sys.version_info > (3, 6),
-        "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
-    )
     @mock_ec2_deprecated
     def test_exists_false_name_classic(self):
         pass
 
-    @skipIf(
-        sys.version_info > (3, 6),
-        "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
-    )
     @mock_ec2_deprecated
     def test_exists_true_name_vpc(self):
         """
@@ -374,10 +346,6 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         )
         self.assertTrue(salt_exists_result)
 
-    @skipIf(
-        sys.version_info > (3, 6),
-        "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
-    )
     @mock_ec2_deprecated
     def test_exists_false_name_vpc(self):
         """
@@ -389,10 +357,6 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         )
         self.assertFalse(salt_exists_result)
 
-    @skipIf(
-        sys.version_info > (3, 6),
-        "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
-    )
     @mock_ec2_deprecated
     def test_exists_true_group_id(self):
         """
@@ -405,10 +369,6 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         salt_exists_result = boto_secgroup.exists(group_id=group.id, **conn_parameters)
         self.assertTrue(salt_exists_result)
 
-    @skipIf(
-        sys.version_info > (3, 6),
-        "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
-    )
     @mock_ec2_deprecated
     def test_exists_false_group_id(self):
         """
@@ -418,10 +378,6 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         salt_exists_result = boto_secgroup.exists(group_id=group_id, **conn_parameters)
         self.assertFalse(salt_exists_result)
 
-    @skipIf(
-        sys.version_info > (3, 6),
-        "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
-    )
     @mock_ec2_deprecated
     def test_delete_group_ec2_classic(self):
         """
@@ -452,18 +408,10 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         actual_groups = [group.id for group in conn.get_all_security_groups()]
         self.assertEqual(expected_groups, actual_groups)
 
-    @skipIf(
-        sys.version_info > (3, 6),
-        "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
-    )
     @mock_ec2_deprecated
     def test_delete_group_name_ec2_vpc(self):
         pass
 
-    @skipIf(
-        sys.version_info > (3, 6),
-        "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
-    )
     @mock_ec2_deprecated
     def test__get_conn_true(self):
         """

--- a/tests/unit/modules/test_boto_secgroup.py
+++ b/tests/unit/modules/test_boto_secgroup.py
@@ -1,26 +1,16 @@
-# -*- coding: utf-8 -*-
-
-# import Python Libs
-from __future__ import absolute_import, print_function, unicode_literals
-
 import os.path
 import random
 import string
-import sys
 from copy import deepcopy
 
-# Import Salt libs
 import salt.config
 import salt.loader
 import salt.modules.boto_secgroup as boto_secgroup
 
-# Import Third Party Libs
 # pylint: disable=import-error
 from salt.ext.six.moves import range  # pylint: disable=redefined-builtin
 from salt.utils.odict import OrderedDict
 from salt.utils.versions import LooseVersion
-
-# Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.runtests import RUNTIME_VARS
 from tests.support.unit import TestCase, skipIf
@@ -79,12 +69,12 @@ boto_conn_parameters = {
 
 
 def _random_group_id():
-    group_id = "sg-{0:x}".format(random.randrange(2 ** 32))
+    group_id = "sg-{:x}".format(random.randrange(2 ** 32))
     return group_id
 
 
 def _random_group_name():
-    group_name = "boto_secgroup-{0}".format(
+    group_name = "boto_secgroup-{}".format(
         "".join((random.choice(string.ascii_lowercase)) for char in range(12))
     )
     return group_name
@@ -108,7 +98,7 @@ def _has_required_boto():
 @skipIf(
     _has_required_boto() is False,
     "The boto module must be greater than"
-    " or equal to version {0}".format(required_boto_version),
+    " or equal to version {}".format(required_boto_version),
 )
 class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
     """
@@ -126,7 +116,7 @@ class BotoSecgroupTestCase(TestCase, LoaderModuleMockMixin):
         }
 
     def setUp(self):
-        super(BotoSecgroupTestCase, self).setUp()
+        super().setUp()
         # __virtual__ must be caller in order for _get_conn to be injected
         boto_secgroup.__virtual__()
 

--- a/tests/unit/modules/test_boto_vpc.py
+++ b/tests/unit/modules/test_boto_vpc.py
@@ -713,10 +713,6 @@ class BotoVpcTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
     _has_required_moto() is False,
     "The moto version must be >= to version {}".format(required_moto_version),
 )
-@skipIf(
-    sys.version_info > (3, 6),
-    "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
-)
 class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
     @mock_ec2_deprecated
     def test_get_subnet_association_single_subnet(self):
@@ -985,7 +981,6 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         )
         self.assertEqual(describe_subnet_results["subnet"], None)
 
-    @skipIf(True, "Skip these tests while investigating failures")
     @mock_ec2_deprecated
     def test_that_describe_subnet_by_name_for_existing_subnet_returns_correct_data(
         self,
@@ -1016,7 +1011,6 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         )
         self.assertEqual(describe_subnet_results["subnet"], None)
 
-    @skipIf(True, "Skip these tests while investigating failures")
     @mock_ec2_deprecated
     def test_that_describe_subnets_by_id_for_existing_subnet_returns_correct_data(self):
         """
@@ -1038,7 +1032,6 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
             {"id", "cidr_block", "availability_zone", "tags"},
         )
 
-    @skipIf(True, "Skip these tests while investigating failures")
     @mock_ec2_deprecated
     def test_that_describe_subnets_by_name_for_existing_subnets_returns_correct_data(
         self,
@@ -1085,10 +1078,6 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
     " or equal to version {}. Installed: {}".format(
         required_boto_version, _get_boto_version()
     ),
-)
-@skipIf(
-    sys.version_info > (3, 6),
-    "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
 )
 class BotoVpcInternetGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
     @mock_ec2_deprecated
@@ -1158,10 +1147,6 @@ class BotoVpcInternetGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
     " or equal to version {}. Installed: {}".format(
         required_boto_version, _get_boto_version()
     ),
-)
-@skipIf(
-    sys.version_info > (3, 6),
-    "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
 )
 class BotoVpcNatGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
     @mock_ec2_deprecated
@@ -1281,10 +1266,6 @@ class BotoVpcCustomerGatewayTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 @skipIf(
     _has_required_moto() is False,
     "The moto version must be >= to version {}".format(required_moto_version),
-)
-@skipIf(
-    sys.version_info > (3, 6),
-    "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
 )
 class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
     @mock_ec2_deprecated
@@ -1502,10 +1483,6 @@ class BotoVpcDHCPOptionsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
     " or equal to version {}. Installed: {}".format(
         required_boto_version, _get_boto_version()
     ),
-)
-@skipIf(
-    sys.version_info > (3, 6),
-    "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
 )
 class BotoVpcNetworkACLTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
     @mock_ec2_deprecated
@@ -2233,10 +2210,6 @@ class BotoVpcRouteTablesTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
 @skipIf(
     _has_required_moto() is False,
     "The moto version must be >= to version {}".format(required_moto_version),
-)
-@skipIf(
-    sys.version_info > (3, 6),
-    "Disabled for 3.7+ pending https://github.com/spulec/moto/issues/1706.",
 )
 class BotoVpcPeeringConnectionsTest(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
     @mock_ec2_deprecated

--- a/tests/unit/modules/test_boto_vpc.py
+++ b/tests/unit/modules/test_boto_vpc.py
@@ -5,7 +5,6 @@
 import os.path
 import random
 import string
-import sys
 
 # pylint: disable=3rd-party-module-not-gated
 import pkg_resources

--- a/tests/unit/modules/test_boto_vpc.py
+++ b/tests/unit/modules/test_boto_vpc.py
@@ -996,7 +996,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         )
         self.assertEqual(
             set(describe_subnet_results["subnet"].keys()),
-            {"id", "cidr_block", "availability_zone", "tags"},
+            {"id", "vpc_id", "cidr_block", "availability_zone", "tags"},
         )
 
     @mock_ec2_deprecated
@@ -1029,7 +1029,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         self.assertEqual(len(describe_subnet_results["subnets"]), 2)
         self.assertEqual(
             set(describe_subnet_results["subnets"][0].keys()),
-            {"id", "cidr_block", "availability_zone", "tags"},
+            {"id", "vpc_id", "cidr_block", "availability_zone", "tags"},
         )
 
     @mock_ec2_deprecated
@@ -1052,7 +1052,7 @@ class BotoVpcSubnetsTestCase(BotoVpcTestCaseBase, BotoVpcTestCaseMixin):
         self.assertEqual(len(describe_subnet_results["subnets"]), 2)
         self.assertEqual(
             set(describe_subnet_results["subnets"][0].keys()),
-            {"id", "cidr_block", "availability_zone", "tags"},
+            {"id", "vpc_id", "cidr_block", "availability_zone", "tags"},
         )
 
     @mock_ec2_deprecated


### PR DESCRIPTION
### What does this PR do?

Re-enables close to 1/3rd of the boto unit tests that were previously disabled.

### Previous Behavior

Unit tests where previously disabled due to: https://github.com/spulec/moto/issues/1706

### New Behavior

Unit tests are re-enabled and 3 tests in `test_boto_vpc` have been fixed.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
