### PR TITLE
[PyTest Migration] PyTest now uses argparse.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,7 +155,7 @@ def pytest_addoption(parser):
         default="zeromq",
         choices=("zeromq", "tcp"),
         help=(
-            "Select which transport to run the integration tests with, zeromq or tcp. Default: %default"
+            "Select which transport to run the integration tests with, zeromq or tcp. Default: %(default)s"
         ),
     )
     test_selection_group.addoption(


### PR DESCRIPTION
### What does this PR do?
See title