### PR TITLE
ssh_pre_flight: fail on retcode not stderr

### DIFF
--- a/changelog/58439.fixed
+++ b/changelog/58439.fixed
@@ -1,0 +1,1 @@
+When using ssh_pre_flight if there is a failure, fail on retcode not stderr.

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1058,7 +1058,7 @@ class Single:
                 )
             else:
                 stdout, stderr, retcode = self.run_ssh_pre_flight()
-                if stderr:
+                if retcode != 0:
                     log.error(
                         "Error running ssh_pre_flight script {}".format(
                             self.ssh_pre_file

--- a/tests/integration/ssh/test_pre_flight.py
+++ b/tests/integration/ssh/test_pre_flight.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
 """
 Test for ssh_pre_flight roster option
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 
@@ -18,7 +16,7 @@ class SSHPreFlightTest(SSHCase):
     """
 
     def setUp(self):
-        super(SSHPreFlightTest, self).setUp()
+        super().setUp()
         self.roster = os.path.join(RUNTIME_VARS.TMP, "pre_flight_roster")
         self.data = {
             "ssh_pre_flight": os.path.join(RUNTIME_VARS.TMP, "ssh_pre_flight.sh")
@@ -31,7 +29,7 @@ class SSHPreFlightTest(SSHCase):
         self.custom_roster(self.roster, self.data)
 
         with salt.utils.files.fopen(self.data["ssh_pre_flight"], "w") as fp_:
-            fp_.write("touch {0}".format(self.test_script))
+            fp_.write("touch {}".format(self.test_script))
 
     @slowTest
     def test_ssh_pre_flight(self):
@@ -40,7 +38,7 @@ class SSHPreFlightTest(SSHCase):
         ensure the script runs successfully
         """
         self._create_roster()
-        ret = self.run_function("test.ping", roster_file=self.roster)
+        assert self.run_function("test.ping", roster_file=self.roster)
 
         assert os.path.exists(self.test_script)
 
@@ -55,10 +53,25 @@ class SSHPreFlightTest(SSHCase):
         self.run_function("test.ping", wipe=False)
         assert not os.path.exists(self.test_script)
 
-        ret = self.run_function(
+        assert self.run_function(
             "test.ping", ssh_opts="--pre-flight", roster_file=self.roster, wipe=False
         )
         assert os.path.exists(self.test_script)
+
+    @slowTest
+    def test_ssh_run_pre_flight_failure(self):
+        """
+        test ssh_pre_flight when there is a failure
+        in the script.
+        """
+        self._create_roster()
+        with salt.utils.files.fopen(self.data["ssh_pre_flight"], "w") as fp_:
+            fp_.write("exit 2")
+
+        ret = self.run_function(
+            "test.ping", ssh_opts="--pre-flight", roster_file=self.roster, wipe=False
+        )
+        assert ret["retcode"] == 2
 
     def tearDown(self):
         """


### PR DESCRIPTION
### What does this PR do?
Fails on retcode not stderr when there is a failure in the ssh_pre_flight script.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/58439

