### PR TITLE
states.saltmod: Handle `roster` in `salt.function` state

### DIFF
--- a/changelog/58662.fixed
+++ b/changelog/58662.fixed
@@ -1,0 +1,1 @@
+Allowe use of `roster` in salt.function state when using the SSH client.

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -497,6 +497,8 @@ def function(
     roster
         In the event of using salt-ssh, a roster system can be set
 
+        .. versionadded:: 3005
+
     batch
         Execute the command :ref:`in batches <targeting-batch>`. E.g.: ``10%``.
 

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -494,6 +494,9 @@ def function(
     ssh
         Set to `True` to use the ssh client instead of the standard salt client
 
+    roster
+        In the event of using salt-ssh, a roster system can be set
+
     batch
         Execute the command :ref:`in batches <targeting-batch>`. E.g.: ``10%``.
 
@@ -524,6 +527,8 @@ def function(
 
     cmd_kw["tgt_type"] = tgt_type
     cmd_kw["ssh"] = ssh
+    if "roster" in kwargs:
+        cmd_kw["roster"] = kwargs["roster"]
     cmd_kw["expect_minions"] = expect_minions
     cmd_kw["_cmd_meta"] = True
 

--- a/tests/unit/states/test_saltmod.py
+++ b/tests/unit/states/test_saltmod.py
@@ -352,7 +352,7 @@ class SaltmodTestCase(TestCase, LoaderModuleMockMixin):
     @pytest.mark.slow_test
     def test_state_ssh(self):
         """
-        Test saltmod passes roster to saltutil.cmd
+        Test saltmod state passes roster to saltutil.cmd
         """
         origcmd = saltmod.__salt__["saltutil.cmd"]
         cmd_kwargs = {}
@@ -367,6 +367,27 @@ class SaltmodTestCase(TestCase, LoaderModuleMockMixin):
             ret = saltmod.state(
                 "state.sls", tgt="*", ssh=True, highstate=True, roster="my_roster"
             )
+        assert "roster" in cmd_kwargs
+        assert cmd_kwargs["roster"] == "my_roster"
+
+    @pytest.mark.slow_test
+    def test_function_ssh(self):
+        """
+        Test saltmod function passes roster to saltutil.cmd
+        """
+        origcmd = saltmod.__salt__["saltutil.cmd"]
+        cmd_kwargs = {}
+        cmd_args = []
+
+        def cmd_mock(*args, **kwargs):
+            cmd_args.extend(args)
+            cmd_kwargs.update(kwargs)
+            return origcmd(*args, **kwargs)
+
+        with patch.dict(saltmod.__opts__, {"test": False}), patch.dict(
+            saltmod.__salt__, {"saltutil.cmd": cmd_mock}
+        ):
+            saltmod.function("state", tgt="*", ssh=True, roster="my_roster")
         assert "roster" in cmd_kwargs
         assert cmd_kwargs["roster"] == "my_roster"
 


### PR DESCRIPTION
### What does this PR do?

The salt states `salt.function` handle `roster` as the `salt.states`
states does

### What issues does this PR fix or reference?
Fixes: #58662

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
