### PR TITLE
Skip tests depending on the `ssl_webserver` fixture if on Py < 3.5.3

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1330,6 +1330,8 @@ def ssl_webserver(integration_files_dir, scope="module"):
     """
     spins up an https webserver.
     """
+    if sys.version_info < (3, 5, 3):
+        pytest.skip("Python versions older than 3.5.3 do not define `ssl.PROTOCOL_TLS`")
     context = ssl.SSLContext(ssl.PROTOCOL_TLS)
     context.load_cert_chain(
         str(integration_files_dir / "https" / "cert.pem"),


### PR DESCRIPTION
### What does this PR do?
See title

Fixes:
```
integration_files_dir = PosixPath('/tmp/salt-tests-tmpdir/integration-files')
scope = 'module'

    @pytest.fixture
    def ssl_webserver(integration_files_dir, scope="module"):
        """
        spins up an https webserver.
        """
>       context = ssl.SSLContext(ssl.PROTOCOL_TLS)
E       AttributeError: module 'ssl' has no attribute 'PROTOCOL_TLS'

integration_files_dir = PosixPath('/tmp/salt-tests-tmpdir/integration-files')
scope      = 'module'

tests/conftest.py:1333: AttributeError
```