### PR TITLE
[DOCS] Fix RST formatting for success_retcodes option in cmd states

### DIFF
--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -444,10 +444,11 @@ def wait(
         interactively to the console and the logs.
         This is experimental.
 
-    success_retcodes: This parameter will allow a list of
-        non-zero return codes that should be considered a success.  If the
-        return code returned from the run matches any in the provided list,
-        the return code will be overridden with zero.
+    success_retcodes
+        This parameter allows you to specify a list of non-zero return codes
+        that should be considered as successful. If the return code from the
+        command matches any in the list, the state will have a ``True`` result
+        instead of ``False``.
 
       .. versionadded:: 2019.2.0
 
@@ -594,10 +595,11 @@ def wait_script(
 
         .. versionadded:: 2018.3.0
 
-    success_retcodes: This parameter will allow a list of
-        non-zero return codes that should be considered a success.  If the
-        return code returned from the run matches any in the provided list,
-        the return code will be overridden with zero.
+    success_retcodes
+        This parameter allows you to specify a list of non-zero return codes
+        that should be considered as successful. If the return code from the
+        command matches any in the list, the state will have a ``True`` result
+        instead of ``False``.
 
       .. versionadded:: 2019.2.0
 
@@ -775,10 +777,11 @@ def run(
 
         .. versionadded:: 2016.3.6
 
-    success_retcodes: This parameter will allow a list of
-        non-zero return codes that should be considered a success.  If the
-        return code returned from the run matches any in the provided list,
-        the return code will be overridden with zero.
+    success_retcodes
+        This parameter allows you to specify a list of non-zero return codes
+        that should be considered as successful. If the return code from the
+        command matches any in the list, the state will have a ``True`` result
+        instead of ``False``.
 
       .. versionadded:: 2019.2.0
 
@@ -1074,10 +1077,11 @@ def script(
 
         .. versionadded:: 2018.3.0
 
-    success_retcodes: This parameter will allow a list of
-        non-zero return codes that should be considered a success.  If the
-        return code returned from the run matches any in the provided list,
-        the return code will be overridden with zero.
+    success_retcodes
+        This parameter allows you to specify a list of non-zero return codes
+        that should be considered as successful. If the return code from the
+        command matches any in the list, the state will have a ``True`` result
+        instead of ``False``.
 
       .. versionadded:: 2019.2.0
 


### PR DESCRIPTION
This fixes some bad RST formatting for this option's docs, and also rewords them slightly.