### PR TITLE
#58412 dont overwrite kwargs

### DIFF
--- a/salt/modules/netmiko_mod.py
+++ b/salt/modules/netmiko_mod.py
@@ -581,7 +581,7 @@ def send_config(
         else:
             conn, kwargs = _prepare_connection(**__proxy__["netmiko.args"]())
     else:
-        conn, kwargs = _prepare_connection(**kwargs)
+        conn, _ = _prepare_connection(**kwargs)
     if commit:
         kwargs["exit_config_mode"] = False  # don't exit config mode after
         # loading the commands, wait for explicit commit

--- a/salt/modules/netmiko_mod.py
+++ b/salt/modules/netmiko_mod.py
@@ -579,9 +579,9 @@ def send_config(
         if __proxy__["netmiko.conn"]().is_alive():
             conn = __proxy__["netmiko.conn"]()
         else:
-            conn, kwargs = _prepare_connection(**__proxy__["netmiko.args"]())
+            conn, _ = _prepare_connection(**__proxy__["netmiko.args"]())
     else:
-        conn, _ = _prepare_connection(**kwargs)
+        conn, kwargs = _prepare_connection(**kwargs)
     if commit:
         kwargs["exit_config_mode"] = False  # don't exit config mode after
         # loading the commands, wait for explicit commit

--- a/tests/unit/modules/test_netmiko_mod.py
+++ b/tests/unit/modules/test_netmiko_mod.py
@@ -1,6 +1,8 @@
+# pylint: disable=W0223,W0231,W0221
 import logging
 
 import salt.modules.netmiko_mod as netmiko_mod
+from salt.utils.args import get_function_argspec
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import patch
 from tests.support.unit import TestCase
@@ -9,6 +11,10 @@ log = logging.getLogger(__name__)
 
 
 class MockNetmikoConnection:
+    def __init__(self, *args, **kwargs):
+        self.user = kwargs["username"]
+        self.password = kwargs["password"]
+
     def is_alive(self):
         return False
 
@@ -17,15 +23,19 @@ class MockNetmikoConnection:
 
 
 def mock_netmiko_args():
-    return {"user": "salt", "password": "password"}
+    return {"username": "salt", "password": "password"}
 
 
-def mock_prepare_connection(**kwargs):
-    return MockNetmikoConnection(), kwargs
+def mock_netmiko_conn():
+    return MockNetmikoConnection(**mock_netmiko_args())
 
 
 def mock_file_apply_template_on_contents(*args):
     return args[0]
+
+
+def mock_config_get(key, default):
+    return default
 
 
 class NetmikoTestCase(TestCase, LoaderModuleMockMixin):
@@ -33,13 +43,15 @@ class NetmikoTestCase(TestCase, LoaderModuleMockMixin):
         return {
             netmiko_mod: {
                 "__salt__": {
-                    "file.apply_template_on_contents": mock_file_apply_template_on_contents
+                    "file.apply_template_on_contents": mock_file_apply_template_on_contents,
+                    "config.get": mock_config_get,
                 },
                 "__proxy__": {
-                    "netmiko.conn": MockNetmikoConnection,
+                    "netmiko.conn": mock_netmiko_conn,
                     "netmiko.args": mock_netmiko_args,
                 },
-                "_prepare_connection": mock_prepare_connection,
+                "__utils__": {"args.get_function_argspec": get_function_argspec},
+                "ConnectHandler": MockNetmikoConnection,
             }
         }
 
@@ -47,10 +59,12 @@ class NetmikoTestCase(TestCase, LoaderModuleMockMixin):
         """
         Test netmiko.send_config function
         """
-        _, ret = netmiko_mod.send_config(config_commands=["ls", "echo hello world"])
+        _, ret = netmiko_mod.send_config(
+            config_commands=["ls", "echo hello world"],
+            config_mode_command="config config-sess",
+        )
         self.assertEqual(ret.get("config_commands"), ["ls", "echo hello world"])
-        self.assertEqual(ret.get("user"), "salt")
-        self.assertEqual(ret.get("password"), "password")
+        self.assertEqual(ret.get("config_mode_command"), "config config-sess")
 
     def test_virtual(self):
         with patch("salt.utils.platform.is_proxy", return_value=True, autospec=True):

--- a/tests/unit/modules/test_netmiko_mod.py
+++ b/tests/unit/modules/test_netmiko_mod.py
@@ -2,7 +2,6 @@
 import logging
 
 import salt.modules.netmiko_mod as netmiko_mod
-from salt.utils.args import get_function_argspec
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import patch
 from tests.support.unit import TestCase
@@ -34,8 +33,8 @@ def mock_file_apply_template_on_contents(*args):
     return args[0]
 
 
-def mock_config_get(key, default):
-    return default
+def mock_prepare_connection(**kwargs):
+    return MockNetmikoConnection(**kwargs), {}
 
 
 class NetmikoTestCase(TestCase, LoaderModuleMockMixin):
@@ -44,14 +43,12 @@ class NetmikoTestCase(TestCase, LoaderModuleMockMixin):
             netmiko_mod: {
                 "__salt__": {
                     "file.apply_template_on_contents": mock_file_apply_template_on_contents,
-                    "config.get": mock_config_get,
                 },
                 "__proxy__": {
                     "netmiko.conn": mock_netmiko_conn,
                     "netmiko.args": mock_netmiko_args,
                 },
-                "__utils__": {"args.get_function_argspec": get_function_argspec},
-                "ConnectHandler": MockNetmikoConnection,
+                "_prepare_connection": mock_prepare_connection,
             }
         }
 


### PR DESCRIPTION
### What does this PR do?
Hotfix related to https://github.com/saltstack/salt/issues/58412 and recent PR https://github.com/saltstack/salt/pull/58425. When passing extra kwargs at the cli, for example config_mode_command, `_prepare_connection` overwrites the kwargs passed at the cli. This can be a critical functional error when configuring devices with netmiko.

### Previous Behavior
kwargs were overwritten

### New Behavior
kwargs not overwritten

### Commits signed with GPG?
No