### PR TITLE
wip: use exactly_n and exactly_one from salt.utils.data

### DIFF
--- a/changelog/58708.md
+++ b/changelog/58708.md
@@ -1,0 +1,3 @@
+**fixed:**
+
+Code maintenance replacing usage of `botomod._exactly_one` with `salt.utils.data.exactly_one`.

--- a/salt/modules/boto3_elasticache.py
+++ b/salt/modules/boto3_elasticache.py
@@ -81,7 +81,7 @@ def __init__(opts):
             __name__,
             "elasticache",
             get_conn_funcname="_get_conn",
-            cache_id_funcname="_cache_id"
+            cache_id_funcname="_cache_id",
         )
 
 

--- a/salt/modules/boto3_elasticache.py
+++ b/salt/modules/boto3_elasticache.py
@@ -81,8 +81,7 @@ def __init__(opts):
             __name__,
             "elasticache",
             get_conn_funcname="_get_conn",
-            cache_id_funcname="_cache_id",
-            exactly_one_funcname=None,
+            cache_id_funcname="_cache_id"
         )
 
 

--- a/salt/modules/boto3_route53.py
+++ b/salt/modules/boto3_route53.py
@@ -54,6 +54,7 @@ import time
 
 import salt.utils.compat
 import salt.utils.versions
+from salt.utils.data import exactly_one
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 from salt.ext.six.moves import range
 
@@ -170,7 +171,7 @@ def find_hosted_zone(
         salt myminion boto3_route53.find_hosted_zone Name=salt.org. \
                 profile='{"region": "us-east-1", "keyid": "A12345678AB", "key": "xblahblahblah"}'
     """
-    if not _exactly_one((Id, Name)):
+    if not exactly_one((Id, Name)):
         raise SaltInvocationError("Exactly one of either Id or Name is required.")
     if PrivateZone is not None and not isinstance(PrivateZone, bool):
         raise SaltInvocationError(
@@ -402,7 +403,7 @@ def create_hosted_zone(
     }
     args.update({"DelegationSetId": DelegationSetId}) if DelegationSetId else None
     if PrivateZone:
-        if not _exactly_one((VPCName, VPCId)):
+        if not exactly_one((VPCName, VPCId)):
             raise SaltInvocationError(
                 "Either VPCName or VPCId is required when creating a " "private zone."
             )
@@ -489,7 +490,7 @@ def update_hosted_zone_comment(
         salt myminion boto3_route53.update_hosted_zone_comment Name=example.org. \
                 Comment="This is an example comment for an example zone"
     """
-    if not _exactly_one((Id, Name)):
+    if not exactly_one((Id, Name)):
         raise SaltInvocationError("Exactly one of either Id or Name is required.")
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     if Name:
@@ -580,11 +581,11 @@ def associate_vpc_with_hosted_zone(
                     VPCRegion=us-east-1 Comment="Whoo-hoo!  I added another VPC."
 
     """
-    if not _exactly_one((HostedZoneId, Name)):
+    if not exactly_one((HostedZoneId, Name)):
         raise SaltInvocationError(
             "Exactly one of either HostedZoneId or Name is required."
         )
-    if not _exactly_one((VPCId, VPCName)):
+    if not exactly_one((VPCId, VPCName)):
         raise SaltInvocationError("Exactly one of either VPCId or VPCName is required.")
     if Name:
         # {'PrivateZone': True} because you can only associate VPCs with private hosted zones.
@@ -704,11 +705,11 @@ def disassociate_vpc_from_hosted_zone(
                     VPCRegion=us-east-1 Comment="Whoops!  Don't wanna talk to this-here zone no more."
 
     """
-    if not _exactly_one((HostedZoneId, Name)):
+    if not exactly_one((HostedZoneId, Name)):
         raise SaltInvocationError(
             "Exactly one of either HostedZoneId or Name is required."
         )
-    if not _exactly_one((VPCId, VPCName)):
+    if not exactly_one((VPCId, VPCName)):
         raise SaltInvocationError("Exactly one of either VPCId or VPCName is required.")
     if Name:
         # {'PrivateZone': True} because you can only associate VPCs with private hosted zones.
@@ -980,7 +981,7 @@ def get_resource_records(
 
         salt myminion boto3_route53.get_records test.example.org example.org A
     """
-    if not _exactly_one((HostedZoneId, Name)):
+    if not exactly_one((HostedZoneId, Name)):
         raise SaltInvocationError(
             "Exactly one of either HostedZoneId or Name must " "be provided."
         )
@@ -1138,7 +1139,7 @@ def change_resource_record_sets(
                 keyid=A1234567890ABCDEF123 key=xblahblahblah \
                 ChangeBatch="{'Changes': [{'Action': 'UPSERT', 'ResourceRecordSet': $foo}]}"
     """
-    if not _exactly_one((HostedZoneId, Name)):
+    if not exactly_one((HostedZoneId, Name)):
         raise SaltInvocationError(
             "Exactly one of either HostZoneId or Name must be provided."
         )

--- a/salt/modules/boto3_route53.py
+++ b/salt/modules/boto3_route53.py
@@ -54,9 +54,9 @@ import time
 
 import salt.utils.compat
 import salt.utils.versions
-from salt.utils.data import exactly_one
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 from salt.ext.six.moves import range
+from salt.utils.data import exactly_one
 
 log = logging.getLogger(__name__)  # pylint: disable=W1699
 

--- a/salt/modules/boto_elasticache.py
+++ b/salt/modules/boto_elasticache.py
@@ -52,6 +52,7 @@ import time
 
 import salt.utils.odict as odict
 import salt.utils.versions
+from salt.utils.data import exactly_one
 from salt.exceptions import SaltInvocationError
 
 # Import Salt libs
@@ -478,7 +479,7 @@ def create_subnet_group(
             "group description" subnet_ids='[subnet-12345678, subnet-87654321]' \
             region=us-east-1
     """
-    if not _exactly_one((subnet_ids, subnet_names)):
+    if not exactly_one((subnet_ids, subnet_names)):
         raise SaltInvocationError(
             "Exactly one of either 'subnet_ids' or " "'subnet_names' must be provided."
         )

--- a/salt/modules/boto_elasticache.py
+++ b/salt/modules/boto_elasticache.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Connection module for Amazon Elasticache
 
@@ -44,23 +43,17 @@ Connection module for Amazon Elasticache
 # keep lint from choking on _get_conn and _cache_id
 # pylint: disable=E0602
 
-from __future__ import absolute_import, print_function, unicode_literals
 
-# Import Python libs
 import logging
 import time
 
 import salt.utils.odict as odict
 import salt.utils.versions
-from salt.utils.data import exactly_one
 from salt.exceptions import SaltInvocationError
-
-# Import Salt libs
-from salt.ext import six
+from salt.utils.data import exactly_one
 
 log = logging.getLogger(__name__)
 
-# Import third party libs
 try:
     # pylint: disable=unused-import
     import boto
@@ -158,7 +151,7 @@ def create_replication_group(
             if config["status"] == "available":
                 return True
     except boto.exception.BotoServerError as e:
-        msg = "Failed to create replication group {0}.".format(name)
+        msg = "Failed to create replication group {}.".format(name)
         log.error(msg)
         log.debug(e)
         return {}
@@ -178,12 +171,12 @@ def delete_replication_group(name, region=None, key=None, keyid=None, profile=No
         return False
     try:
         conn.delete_replication_group(name)
-        msg = "Deleted ElastiCache replication group {0}.".format(name)
+        msg = "Deleted ElastiCache replication group {}.".format(name)
         log.info(msg)
         return True
     except boto.exception.BotoServerError as e:
         log.debug(e)
-        msg = "Failed to delete ElastiCache replication group {0}".format(name)
+        msg = "Failed to delete ElastiCache replication group {}".format(name)
         log.error(msg)
         return False
 
@@ -205,7 +198,7 @@ def describe_replication_group(
     try:
         cc = conn.describe_replication_groups(name)
     except boto.exception.BotoServerError as e:
-        msg = "Failed to get config for cache cluster {0}.".format(name)
+        msg = "Failed to get config for cache cluster {}.".format(name)
         log.error(msg)
         log.debug(e)
         return {}
@@ -223,7 +216,7 @@ def describe_replication_group(
         "primary_cluster_id",
         "node_groups",
     ]
-    for key, val in six.iteritems(cc):
+    for key, val in cc.items():
         _key = boto.utils.pythonize_name(key)
         if _key == "status":
             if val:
@@ -273,7 +266,7 @@ def get_config(name, region=None, key=None, keyid=None, profile=None):
     try:
         cc = conn.describe_cache_clusters(name, show_cache_node_info=True)
     except boto.exception.BotoServerError as e:
-        msg = "Failed to get config for cache cluster {0}.".format(name)
+        msg = "Failed to get config for cache cluster {}.".format(name)
         log.error(msg)
         log.debug(e)
         return {}
@@ -299,7 +292,7 @@ def get_config(name, region=None, key=None, keyid=None, profile=None):
         "cache_cluster_status",
         "cache_nodes",
     ]
-    for key, val in six.iteritems(cc):
+    for key, val in cc.items():
         _key = boto.utils.pythonize_name(key)
         if _key not in attrs:
             continue
@@ -350,7 +343,7 @@ def get_node_host(name, region=None, key=None, keyid=None, profile=None):
     try:
         cc = conn.describe_cache_clusters(name, show_cache_node_info=True)
     except boto.exception.BotoServerError as e:
-        msg = "Failed to get config for cache cluster {0}.".format(name)
+        msg = "Failed to get config for cache cluster {}.".format(name)
         log.error(msg)
         log.debug(e)
         return {}
@@ -375,7 +368,7 @@ def get_group_host(name, region=None, key=None, keyid=None, profile=None):
     try:
         cc = conn.describe_replication_groups(name)
     except boto.exception.BotoServerError as e:
-        msg = "Failed to get config for cache cluster {0}.".format(name)
+        msg = "Failed to get config for cache cluster {}.".format(name)
         log.error(msg)
         log.debug(e)
         return {}
@@ -450,7 +443,7 @@ def subnet_group_exists(
     try:
         ec = conn.describe_cache_subnet_groups(cache_subnet_group_name=name)
         if not ec:
-            msg = "ElastiCache subnet group does not exist in region {0}".format(region)
+            msg = "ElastiCache subnet group does not exist in region {}".format(region)
             log.debug(msg)
             return False
         return True
@@ -501,14 +494,14 @@ def create_subnet_group(
     try:
         ec = conn.create_cache_subnet_group(name, description, subnet_ids)
         if not ec:
-            msg = "Failed to create ElastiCache subnet group {0}".format(name)
+            msg = "Failed to create ElastiCache subnet group {}".format(name)
             log.error(msg)
             return False
         log.info("Created ElastiCache subnet group %s", name)
         return True
     except boto.exception.BotoServerError as e:
         log.debug(e)
-        msg = "Failed to create ElastiCache subnet group {0}".format(name)
+        msg = "Failed to create ElastiCache subnet group {}".format(name)
         log.error(msg)
         return False
 
@@ -528,16 +521,16 @@ def get_cache_subnet_group(name, region=None, key=None, keyid=None, profile=None
         csg = csg["DescribeCacheSubnetGroupsResponse"]
         csg = csg["DescribeCacheSubnetGroupsResult"]["CacheSubnetGroups"][0]
     except boto.exception.BotoServerError as e:
-        msg = "Failed to get cache subnet group {0}.".format(name)
+        msg = "Failed to get cache subnet group {}.".format(name)
         log.error(msg)
         log.debug(e)
         return False
     except (IndexError, TypeError, KeyError):
-        msg = "Failed to get cache subnet group {0} (2).".format(name)
+        msg = "Failed to get cache subnet group {} (2).".format(name)
         log.error(msg)
         return False
     ret = {}
-    for key, val in six.iteritems(csg):
+    for key, val in csg.items():
         if key == "CacheSubnetGroupName":
             ret["cache_subnet_group_name"] = val
         elif key == "CacheSubnetGroupDescription":
@@ -571,12 +564,12 @@ def delete_subnet_group(name, region=None, key=None, keyid=None, profile=None):
         return False
     try:
         conn.delete_cache_subnet_group(name)
-        msg = "Deleted ElastiCache subnet group {0}.".format(name)
+        msg = "Deleted ElastiCache subnet group {}.".format(name)
         log.info(msg)
         return True
     except boto.exception.BotoServerError as e:
         log.debug(e)
-        msg = "Failed to delete ElastiCache subnet group {0}".format(name)
+        msg = "Failed to delete ElastiCache subnet group {}".format(name)
         log.error(msg)
         return False
 
@@ -645,7 +638,7 @@ def create(
                 return True
         log.info("Created cache cluster %s.", name)
     except boto.exception.BotoServerError as e:
-        msg = "Failed to create cache cluster {0}.".format(name)
+        msg = "Failed to create cache cluster {}.".format(name)
         log.error(msg)
         log.debug(e)
         return False
@@ -676,7 +669,7 @@ def delete(name, wait=False, region=None, key=None, keyid=None, profile=None):
         log.info("Deleted cache cluster %s.", name)
         return True
     except boto.exception.BotoServerError as e:
-        msg = "Failed to delete cache cluster {0}.".format(name)
+        msg = "Failed to delete cache cluster {}.".format(name)
         log.error(msg)
         log.debug(e)
         return False
@@ -699,7 +692,7 @@ def create_cache_security_group(
         log.info("Created cache security group %s.", name)
         return True
     else:
-        msg = "Failed to create cache security group {0}.".format(name)
+        msg = "Failed to create cache security group {}.".format(name)
         log.error(msg)
         return False
 
@@ -719,7 +712,7 @@ def delete_cache_security_group(name, region=None, key=None, keyid=None, profile
         log.info("Deleted cache security group %s.", name)
         return True
     else:
-        msg = "Failed to delete cache security group {0}.".format(name)
+        msg = "Failed to delete cache security group {}.".format(name)
         log.error(msg)
         return False
 

--- a/salt/modules/boto_route53.py
+++ b/salt/modules/boto_route53.py
@@ -51,8 +51,8 @@ import time
 import salt.utils.compat
 import salt.utils.odict as odict
 import salt.utils.versions
-from salt.utils.data import exactly_one
 from salt.exceptions import SaltInvocationError
+from salt.utils.data import exactly_one
 
 log = logging.getLogger(__name__)
 

--- a/salt/modules/boto_route53.py
+++ b/salt/modules/boto_route53.py
@@ -51,6 +51,7 @@ import time
 import salt.utils.compat
 import salt.utils.odict as odict
 import salt.utils.versions
+from salt.utils.data import exactly_one
 from salt.exceptions import SaltInvocationError
 
 log = logging.getLogger(__name__)
@@ -1046,7 +1047,7 @@ def create_hosted_zone(
     }
 
     if private_zone:
-        if not _exactly_one((vpc_name, vpc_id)):
+        if not exactly_one((vpc_name, vpc_id)):
             raise SaltInvocationError(
                 "Either vpc_name or vpc_id is required " "when creating a private zone."
             )

--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -131,8 +131,8 @@ import time
 
 import salt.utils.compat
 import salt.utils.versions
-from salt.utils.data import exactly_one
 from salt.exceptions import CommandExecutionError, SaltInvocationError
+from salt.utils.data import exactly_one
 
 PROVISIONING = "provisioning"
 PENDING_ACCEPTANCE = "pending-acceptance"

--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -131,11 +131,9 @@ import time
 
 import salt.utils.compat
 import salt.utils.versions
+from salt.utils.data import exactly_one
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 
-# from salt.utils import exactly_one
-# TODO: Uncomment this and s/_exactly_one/exactly_one/
-# See note in utils.boto
 PROVISIONING = "provisioning"
 PENDING_ACCEPTANCE = "pending-acceptance"
 ACTIVE = "active"
@@ -191,7 +189,6 @@ def __init__(opts):
             "ec2",
             get_conn_funcname="_get_conn3",
             cache_id_funcname="_cache_id3",
-            exactly_one_funcname=None,
         )
 
 
@@ -213,7 +210,7 @@ def check_vpc(
         salt myminion boto_vpc.check_vpc vpc_name=myvpc profile=awsprofile
     """
 
-    if not _exactly_one((vpc_name, vpc_id)):
+    if not exactly_one((vpc_name, vpc_id)):
         raise SaltInvocationError(
             "One (but not both) of vpc_id or vpc_name " "must be provided."
         )
@@ -310,7 +307,7 @@ def _delete_resource(
     Delete a VPC resource. Returns True if successful, otherwise False.
     """
 
-    if not _exactly_one((name, resource_id)):
+    if not exactly_one((name, resource_id)):
         raise SaltInvocationError(
             "One (but not both) of name or id must be " "provided."
         )
@@ -373,7 +370,7 @@ def _get_resource(
     Cache the id if name was provided.
     """
 
-    if not _exactly_one((name, resource_id)):
+    if not exactly_one((name, resource_id)):
         raise SaltInvocationError(
             "One (but not both) of name or id must be " "provided."
         )
@@ -841,7 +838,7 @@ def delete(
         )
         vpc_name = name
 
-    if not _exactly_one((vpc_name, vpc_id)):
+    if not exactly_one((vpc_name, vpc_id)):
         raise SaltInvocationError(
             "One (but not both) of vpc_name or vpc_id must be " "provided."
         )
@@ -2513,7 +2510,7 @@ def disassociate_network_acl(
 
     """
 
-    if not _exactly_one((subnet_name, subnet_id)):
+    if not exactly_one((subnet_name, subnet_id)):
         raise SaltInvocationError(
             "One (but not both) of subnet_id or subnet_name " "must be provided."
         )
@@ -2571,7 +2568,7 @@ def _create_network_acl_entry(
     else:
         rkey = "created"
 
-    if not _exactly_one((network_acl_name, network_acl_id)):
+    if not exactly_one((network_acl_name, network_acl_id)):
         raise SaltInvocationError(
             "One (but not both) of network_acl_id or "
             "network_acl_name must be provided."
@@ -2722,7 +2719,7 @@ def delete_network_acl_entry(
         salt myminion boto_vpc.delete_network_acl_entry 'acl-5fb85d36' '32767'
 
     """
-    if not _exactly_one((network_acl_name, network_acl_id)):
+    if not exactly_one((network_acl_name, network_acl_id)):
         raise SaltInvocationError(
             "One (but not both) of network_acl_id or "
             "network_acl_name must be provided."
@@ -3130,13 +3127,13 @@ def create_route(
 
     """
 
-    if not _exactly_one((route_table_name, route_table_id)):
+    if not exactly_one((route_table_name, route_table_id)):
         raise SaltInvocationError(
             "One (but not both) of route_table_id or route_table_name "
             "must be provided."
         )
 
-    if not _exactly_one(
+    if not exactly_one(
         (
             gateway_id,
             internet_gateway_name,
@@ -3304,7 +3301,7 @@ def delete_route(
 
     """
 
-    if not _exactly_one((route_table_name, route_table_id)):
+    if not exactly_one((route_table_name, route_table_id)):
         raise SaltInvocationError(
             "One (but not both) of route_table_id or route_table_name "
             "must be provided."
@@ -3370,7 +3367,7 @@ def replace_route(
 
     """
 
-    if not _exactly_one((route_table_name, route_table_id)):
+    if not exactly_one((route_table_name, route_table_id)):
         raise SaltInvocationError(
             "One (but not both) of route_table_id or route_table_name "
             "must be provided."
@@ -3710,11 +3707,11 @@ def request_vpc_peering_connection(
             "exists! Please specify a different name."
         )
 
-    if not _exactly_one((requester_vpc_id, requester_vpc_name)):
+    if not exactly_one((requester_vpc_id, requester_vpc_name)):
         raise SaltInvocationError(
             "Exactly one of requester_vpc_id or " "requester_vpc_name is required"
         )
-    if not _exactly_one((peer_vpc_id, peer_vpc_name)):
+    if not exactly_one((peer_vpc_id, peer_vpc_name)):
         raise SaltInvocationError(
             "Exactly one of peer_vpc_id or " "peer_vpc_name is required."
         )
@@ -3859,7 +3856,7 @@ def accept_vpc_peering_connection(  # pylint: disable=too-many-arguments
         salt myminion boto_vpc.accept_vpc_peering_connection conn_id=pcx-8a8939e3
 
     """
-    if not _exactly_one((conn_id, name)):
+    if not exactly_one((conn_id, name)):
         raise SaltInvocationError(
             "One (but not both) of "
             "vpc_peering_connection_id or name "
@@ -3960,7 +3957,7 @@ def delete_vpc_peering_connection(
         salt myminion boto_vpc.delete_vpc_peering_connection conn_id=pcx-8a8939e3
 
     """
-    if not _exactly_one((conn_id, conn_name)):
+    if not exactly_one((conn_id, conn_name)):
         raise SaltInvocationError(
             "Exactly one of conn_id or " "conn_name must be provided."
         )
@@ -4023,7 +4020,7 @@ def is_peering_connection_pending(
         salt myminion boto_vpc.is_peering_connection_pending conn_id=pcx-8a8939e3
 
     """
-    if not _exactly_one((conn_id, conn_name)):
+    if not exactly_one((conn_id, conn_name)):
         raise SaltInvocationError(
             "Exactly one of conn_id or conn_name must be provided."
         )
@@ -4107,12 +4104,12 @@ def peering_connection_pending_from_vpc(
         salt myminion boto_vpc.is_peering_connection_pending name=salt-vpc
 
     """
-    if not _exactly_one((conn_id, conn_name)):
+    if not exactly_one((conn_id, conn_name)):
         raise SaltInvocationError(
             "Exactly one of conn_id or conn_name must be provided."
         )
 
-    if not _exactly_one((vpc_id, vpc_name)):
+    if not exactly_one((vpc_id, vpc_name)):
         raise SaltInvocationError("Exactly one of vpc_id or vpc_name must be provided.")
 
     if vpc_name:

--- a/salt/utils/boto3mod.py
+++ b/salt/utils/boto3mod.py
@@ -33,7 +33,6 @@ from functools import partial
 import salt.utils.stringutils
 import salt.utils.versions
 from salt.exceptions import SaltInvocationError
-from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 
 # pylint: disable=import-error
 try:
@@ -250,7 +249,7 @@ def assign_funcs(
     service,
     module=None,
     get_conn_funcname="_get_conn",
-    cache_id_funcname="_cache_id"
+    cache_id_funcname="_cache_id",
 ):
     """
     Assign _get_conn and _cache_id functions to the named module.
@@ -262,6 +261,7 @@ def assign_funcs(
     mod = sys.modules[modname]
     setattr(mod, get_conn_funcname, get_connection_func(service, module=module))
     setattr(mod, cache_id_funcname, cache_id_func(service))
+
 
 def paged_call(function, *args, **kwargs):
     """Retrieve full set of values from a boto3 API call that may truncate

--- a/salt/utils/boto3mod.py
+++ b/salt/utils/boto3mod.py
@@ -245,26 +245,12 @@ def get_error(e):
     return r
 
 
-def exactly_n(l, n=1):
-    """
-    Tests that exactly N items in an iterable are "truthy" (neither None,
-    False, nor 0).
-    """
-    i = iter(l)
-    return all(any(i) for j in range(n)) and not any(i)
-
-
-def exactly_one(l):
-    return exactly_n(l)
-
-
 def assign_funcs(
     modname,
     service,
     module=None,
     get_conn_funcname="_get_conn",
-    cache_id_funcname="_cache_id",
-    exactly_one_funcname="_exactly_one",
+    cache_id_funcname="_cache_id"
 ):
     """
     Assign _get_conn and _cache_id functions to the named module.
@@ -276,12 +262,6 @@ def assign_funcs(
     mod = sys.modules[modname]
     setattr(mod, get_conn_funcname, get_connection_func(service, module=module))
     setattr(mod, cache_id_funcname, cache_id_func(service))
-
-    # TODO: Remove this and import salt.utils.data.exactly_one into boto_* modules instead
-    # Leaving this way for now so boto modules can be back ported
-    if exactly_one_funcname is not None:
-        setattr(mod, exactly_one_funcname, exactly_one)
-
 
 def paged_call(function, *args, **kwargs):
     """Retrieve full set of values from a boto3 API call that may truncate

--- a/salt/utils/botomod.py
+++ b/salt/utils/botomod.py
@@ -237,19 +237,6 @@ def get_error(e):
     return r
 
 
-def exactly_n(l, n=1):
-    """
-    Tests that exactly N items in an iterable are "truthy" (neither None,
-    False, nor 0).
-    """
-    i = iter(l)
-    return all(any(i) for j in range(n)) and not any(i)
-
-
-def exactly_one(l):
-    return exactly_n(l)
-
-
 def assign_funcs(modname, service, module=None, pack=None):
     """
     Assign _get_conn and _cache_id functions to the named module.
@@ -264,10 +251,6 @@ def assign_funcs(modname, service, module=None, pack=None):
     mod = sys.modules[modname]
     setattr(mod, "_get_conn", get_connection_func(service, module=module))
     setattr(mod, "_cache_id", cache_id_func(service))
-
-    # TODO: Remove this and import salt.utils.data.exactly_one into boto_* modules instead
-    # Leaving this way for now so boto modules can be back ported
-    setattr(mod, "_exactly_one", exactly_one)
 
 
 def paged_call(function, *args, **kwargs):

--- a/salt/utils/botomod.py
+++ b/salt/utils/botomod.py
@@ -33,7 +33,6 @@ from functools import partial
 import salt.utils.stringutils
 import salt.utils.versions
 from salt.exceptions import SaltInvocationError
-from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 from salt.loader import minion_mods
 
 # pylint: disable=import-error


### PR DESCRIPTION
### What does this PR do?

Code maintenance replacing old usage of `botomod._exactly_one` with `salt.utils.data.exactly_one`

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- N/A Docs
- [X] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- N/A Tests written/updated

### Commits signed with GPG?
Yes