### PR TITLE
dpkg_lowpkg: Do not access dpkg internals directly

### DIFF
--- a/changelog/52605.fixed.md
+++ b/changelog/52605.fixed.md
@@ -1,0 +1,1 @@
+``dpkg_lowpkg`` no longer reads ``/var/lib/dpkg/available`` or ``/var/lib/dpkg/info/<package>.list`` directly. It now uses ``dpkg-query`` exclusively, addressing the lintian ``uses-dpkg-database-directly`` warning reported in #52605. ``lowpkg.info`` derives the package install time from dpkg's ``${db-fsys:Last-Modified}`` field instead of the ``.list`` file mtime.

--- a/salt/modules/dpkg_lowpkg.py
+++ b/salt/modules/dpkg_lowpkg.py
@@ -254,8 +254,10 @@ def _get_pkg_info(*packages, **kwargs):
         bin_var = "${Package}"
 
     ret = []
-    cmd = (
-        "dpkg-query -W -f='package:" + bin_var + "\\n"
+    cmd = [
+        "dpkg-query",
+        "-W",
+        "-f=package:" + bin_var + "\\n"
         "revision:${binary:Revision}\\n"
         "architecture:${Architecture}\\n"
         "maintainer:${Maintainer}\\n"
@@ -271,11 +273,10 @@ def _get_pkg_info(*packages, **kwargs):
         "origin:${Origin}\\n"
         "homepage:${Homepage}\\n"
         "status:${db:Status-Abbrev}\\n"
+        "install_date:${db-fsys:Last-Modified}\\n"
         "description:${Description}\\n"
-        "\\n*/~^\\\\*\\n'"
-    )
-    cmd += " {}".format(" ".join(packages))
-    cmd = cmd.strip()
+        "\\n*/~^\\\\*\\n",
+    ] + list(packages)
 
     call = __salt__["cmd.run_all"](cmd, python_shell=False)
     if call["retcode"]:
@@ -297,11 +298,22 @@ def _get_pkg_info(*packages, **kwargs):
             el.strip() for el in pkg_info.split(os.linesep) if el.strip()
         ]:
             key, value = pkg_info_line.split(":", 1)
+            if key == "install_date":
+                # ${db-fsys:Last-Modified} is a Unix timestamp; convert to ISO
+                # format in UTC. Empty/non-integer values (older dpkg, packages
+                # without that field) are skipped.
+                try:
+                    value = (
+                        datetime.datetime.fromtimestamp(
+                            int(value), tz=datetime.timezone.utc
+                        )
+                        .isoformat()
+                        .replace("+00:00", "Z")
+                    )
+                except ValueError:
+                    value = None
             if value:
                 pkg_data[key] = value
-            install_date = _get_pkg_install_time(pkg_data.get("package"))
-            if install_date:
-                pkg_data["install_date"] = install_date
         pkg_data["description"] = pkg_descr
         ret.append(pkg_data)
 
@@ -327,53 +339,42 @@ def _get_pkg_license(pkg):
     return ", ".join(sorted(licenses))
 
 
-def _get_pkg_install_time(pkg):
-    """
-    Return package install time, based on the /var/lib/dpkg/info/<package>.list
-
-    :return:
-    """
-    iso_time = None
-    if pkg is not None:
-        location = f"/var/lib/dpkg/info/{pkg}.list"
-        if os.path.exists(location):
-            iso_time = (
-                datetime.datetime.utcfromtimestamp(
-                    int(os.path.getmtime(location))
-                ).isoformat()
-                + "Z"
-            )
-
-    return iso_time
-
-
 def _get_pkg_ds_avail():
     """
-    Get the package information of the available packages, maintained by dselect.
-    Note, this will be not very useful, if dselect isn't installed.
+    Get the package information of the available packages via
+    ``dpkg-query --print-avail``. Returns an empty dict when ``dselect`` is
+    not installed (the legacy ``/var/lib/dpkg/available`` file is only
+    maintained by dselect).
+
+    Previously this read ``/var/lib/dpkg/available`` directly, which is a
+    dpkg internal file. Now uses the public ``dpkg-query`` interface to get
+    the same data; see https://lintian.debian.org/tags/uses-dpkg-database-directly.
 
     :return:
     """
-    avail = "/var/lib/dpkg/available"
-    if not salt.utils.path.which("dselect") or not os.path.exists(avail):
-        return dict()
+    if not salt.utils.path.which("dselect"):
+        return {}
 
-    # Do not update with dselect, just read what is.
-    ret = dict()
+    call = __salt__["cmd.run_all"](
+        ["dpkg-query", "--print-avail"], python_shell=False, ignore_retcode=True
+    )
+    if call["retcode"]:
+        return {}
+
+    ret = {}
     pkg_mrk = "Package:"
     pkg_name = "package"
-    with salt.utils.files.fopen(avail) as fp_:
-        for pkg_info in salt.utils.stringutils.to_unicode(fp_.read()).split(pkg_mrk):
-            nfo = dict()
-            for line in (pkg_mrk + pkg_info).split(os.linesep):
-                line = line.split(": ", 1)
-                if len(line) != 2:
-                    continue
-                key, value = line
-                if value.strip():
-                    nfo[key.lower()] = value
-            if nfo.get(pkg_name):
-                ret[nfo[pkg_name]] = nfo
+    for pkg_info in call["stdout"].split(pkg_mrk):
+        nfo = {}
+        for line in (pkg_mrk + pkg_info).split(os.linesep):
+            line = line.split(": ", 1)
+            if len(line) != 2:
+                continue
+            key, value = line
+            if value.strip():
+                nfo[key.lower()] = value
+        if nfo.get(pkg_name):
+            ret[nfo[pkg_name]] = nfo
 
     return ret
 
@@ -402,8 +403,9 @@ def info(*packages, **kwargs):
         salt '*' lowpkg.info apache2 bash
         salt '*' lowpkg.info 'php5*' failhard=false
     """
-    # Get the missing information from the /var/lib/dpkg/available, if it is there.
-    # However, this file is operated by dselect which has to be installed.
+    # Get the missing information via `dpkg-query --print-avail`, if dselect is
+    # installed. This data is only kept up-to-date by dselect, so it is only
+    # queried when dselect is present.
     dselect_pkg_avail = _get_pkg_ds_avail()
 
     kwargs = salt.utils.args.clean_kwargs(**kwargs)

--- a/tests/pytests/unit/modules/test_dpkg_lowpkg.py
+++ b/tests/pytests/unit/modules/test_dpkg_lowpkg.py
@@ -297,6 +297,7 @@ def test_info():
                     "origin:",
                     "homepage:http://tiswww.case.edu/php/chet/bash/bashtop.html",
                     "status:ii ",
+                    "install_date:1560199259",
                     "description:GNU Bourne Again SHell",
                     " Bash is an sh-compatible command language interpreter that"
                     " executes",
@@ -324,8 +325,6 @@ def test_info():
         dpkg.__grains__, {"os": "Ubuntu", "osrelease_info": (18, 4)}
     ), patch("salt.utils.path.which", MagicMock(return_value=False)), patch(
         "os.path.exists", MagicMock(return_value=False)
-    ), patch(
-        "os.path.getmtime", MagicMock(return_value=1560199259.0)
     ):
         assert dpkg.info("bash") == {
             "bash": {
@@ -351,6 +350,7 @@ def test_info():
                     ]
                 ),
                 "homepage": "http://tiswww.case.edu/php/chet/bash/bashtop.html",
+                "install_date": "2019-06-10T20:40:59Z",
                 "maintainer": (
                     "Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>"
                 ),
@@ -361,6 +361,165 @@ def test_info():
                 "version": "4.4.18-2ubuntu1",
             }
         }
+
+
+def test_info_uses_dpkg_query_only(tmp_path):
+    """
+    Regression test for https://github.com/saltstack/salt/issues/52605:
+    dpkg_lowpkg must not read /var/lib/dpkg/{available,info/*.list} directly.
+    It must only invoke dpkg-query. Lintian flags direct dpkg-database access
+    via the ``uses-dpkg-database-directly`` tag.
+    """
+    seen_cmds = []
+
+    def fake_run_all(cmd, **kwargs):
+        seen_cmds.append(cmd)
+        return {
+            "retcode": 0,
+            "stderr": "",
+            "stdout": os.linesep.join(
+                [
+                    "package:bash",
+                    "revision:",
+                    "architecture:amd64",
+                    "maintainer:",
+                    "summary:",
+                    "source:bash",
+                    "version:4.4.18",
+                    "section:shells",
+                    "installed_size:1588",
+                    "size:",
+                    "MD5:",
+                    "SHA1:",
+                    "SHA256:",
+                    "origin:",
+                    "homepage:",
+                    "status:ii ",
+                    "install_date:1560199259",
+                    "description:GNU Bourne Again SHell",
+                    "",
+                    "*/~^\\*",  # pylint: disable=W1401
+                ]
+            ),
+        }
+
+    # The dpkg-query call must be passed as a list (no shell), and dselect
+    # is mocked absent so dpkg-query --print-avail is not invoked.
+    with patch.dict(
+        dpkg.__salt__, {"cmd.run_all": MagicMock(side_effect=fake_run_all)}
+    ), patch.dict(dpkg.__grains__, {"os": "Ubuntu", "osrelease_info": (18, 4)}), patch(
+        "salt.utils.path.which", MagicMock(return_value=False)
+    ), patch(
+        "os.path.exists", MagicMock(return_value=False)
+    ):
+        dpkg.info("bash")
+
+    # First (and only) cmd.run_all call must be `dpkg-query -W ...` as a list,
+    # not a shell string. This pins the "pass cmd as list" half of the fix.
+    assert seen_cmds, "cmd.run_all was never called"
+    cmd = seen_cmds[0]
+    assert isinstance(cmd, list), f"cmd must be a list, got {type(cmd).__name__}"
+    assert cmd[0] == "dpkg-query"
+    assert cmd[1] == "-W"
+    # The format string must request install_date from dpkg's public field,
+    # not from /var/lib/dpkg/info/<pkg>.list mtime.
+    assert "${db-fsys:Last-Modified}" in cmd[2]
+    # No call to dpkg-query should reference /var/lib/dpkg internals.
+    for seen in seen_cmds:
+        assert "/var/lib/dpkg/info" not in " ".join(seen)
+        assert "/var/lib/dpkg/available" not in " ".join(seen)
+
+
+def test_info_handles_missing_install_date():
+    """
+    Older dpkg (< 1.19.3) does not expose ``${db-fsys:Last-Modified}`` and
+    substitutes an empty value. Salt must not crash and must omit
+    ``install_date`` from the result rather than raising.
+    """
+    mock = MagicMock(
+        return_value={
+            "retcode": 0,
+            "stderr": "",
+            "stdout": os.linesep.join(
+                [
+                    "package:bash",
+                    "revision:",
+                    "architecture:amd64",
+                    "maintainer:",
+                    "summary:",
+                    "source:bash",
+                    "version:4.4.18",
+                    "section:shells",
+                    "installed_size:1588",
+                    "size:",
+                    "MD5:",
+                    "SHA1:",
+                    "SHA256:",
+                    "origin:",
+                    "homepage:",
+                    "status:ii ",
+                    "install_date:",
+                    "description:GNU Bourne Again SHell",
+                    "",
+                    "*/~^\\*",  # pylint: disable=W1401
+                ]
+            ),
+        }
+    )
+    with patch.dict(dpkg.__salt__, {"cmd.run_all": mock}), patch.dict(
+        dpkg.__grains__, {"os": "Ubuntu", "osrelease_info": (18, 4)}
+    ), patch("salt.utils.path.which", MagicMock(return_value=False)), patch(
+        "os.path.exists", MagicMock(return_value=False)
+    ):
+        result = dpkg.info("bash")
+
+    assert "install_date" not in result["bash"]
+    assert result["bash"]["package"] == "bash"
+
+
+def test_get_pkg_ds_avail_uses_dpkg_query():
+    """
+    ``_get_pkg_ds_avail`` must call ``dpkg-query --print-avail`` instead of
+    reading ``/var/lib/dpkg/available`` directly. When dselect is not
+    installed it returns an empty dict without invoking dpkg-query.
+    """
+    # dselect absent: must not call dpkg-query, returns empty dict.
+    run_all_mock = MagicMock()
+    with patch("salt.utils.path.which", MagicMock(return_value=None)), patch.dict(
+        dpkg.__salt__, {"cmd.run_all": run_all_mock}
+    ):
+        assert dpkg._get_pkg_ds_avail() == {}
+    assert run_all_mock.call_count == 0
+
+    # dselect present: must call `dpkg-query --print-avail` as a list, parse output.
+    run_all_mock = MagicMock(
+        return_value={
+            "retcode": 0,
+            "stderr": "",
+            "stdout": (
+                "Package: bash\n"
+                "Architecture: amd64\n"
+                "Version: 4.4.18-2ubuntu1\n"
+                "\n"
+                "Package: hostname\n"
+                "Architecture: amd64\n"
+                "Version: 3.20\n"
+            ),
+        }
+    )
+    with patch(
+        "salt.utils.path.which", MagicMock(return_value="/usr/bin/dselect")
+    ), patch.dict(dpkg.__salt__, {"cmd.run_all": run_all_mock}):
+        result = dpkg._get_pkg_ds_avail()
+
+    assert run_all_mock.call_count == 1
+    called_cmd = run_all_mock.call_args[0][0]
+    assert isinstance(called_cmd, list)
+    assert called_cmd == ["dpkg-query", "--print-avail"]
+    # parsed entries must contain both packages with lowercased keys
+    assert "bash" in result
+    assert result["bash"]["package"] == "bash"
+    assert "hostname" in result
 
 
 def test_get_pkg_license():


### PR DESCRIPTION
salt contains modules, which directly access the dpkg internal database, instead of using one of the public interfaces provided by dpkg. This is a problem for several reasons, because even though the layout and format of the dpkg database is administrator friendly, and it is expected that those might need to mess with it, in case of emergency, this “interface” does not extend to other programs besides the dpkg suite of tools. The admindir can also be configured differently at dpkg build or run-time. And finally, the contents and its format, will be changing in the near future.

So use something like:

```
dpkg-query --showformat '${db-fsys:Last-Modified}\n' --show $pkg
```

to get the mtime from /var/lib/dpkg/info/<package>.list files.

`/var/lib/dpkg/available` should not be read directly. Instead `dpkg-query --print-avail` should be used. The `/var/lib/dpkg/available` file is only kept up-to-date when using dselect, but nowadays `apt` is used, and therefore this file does not provide much more information than `dpkg-query -W`. Users of APT-based frontends should use `apt show` or in our case the `pkg.show` salt module.

This merge request addresses the issues in `dpkg_lowpkg`. A separate merge request for `alternatives` will follow. Please have a look at the individual commits for more details of the changes.

Bug: https://github.com/saltstack/salt/issues/52605 and drive by fix for #58735
Bug-Debian: https://bugs.debian.org/944970