### PR TITLE
Fixing an issue preventing using pillar.get against integer pillar keys

### DIFF
--- a/changelog/58714.fixed
+++ b/changelog/58714.fixed
@@ -1,0 +1,1 @@
+Fixing an issue preventing running pillar.get against pillar values with integers as pillar keys.

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -797,20 +797,34 @@ def traverse_dict_and_list(data, key, default=None, delimiter=DEFAULT_TARGET_DEL
             try:
                 idx = int(each)
             except ValueError:
-                idx = each
-
-            embed_match = False
-            # Index was not numeric, lets look at any embedded dicts
-            for embedded in (x for x in ptr if isinstance(x, dict)):
-                try:
-                    ptr = embedded[idx]
-                    embed_match = True
-                    break
-                except KeyError:
-                    pass
-            if not embed_match:
-                # No embedded dicts matched, return the default
-                return default
+                embed_match = False
+                # Index was not numeric, lets look at any embedded dicts
+                for embedded in (x for x in ptr if isinstance(x, dict)):
+                    try:
+                        ptr = embedded[each]
+                        embed_match = True
+                        break
+                    except KeyError:
+                        pass
+                if not embed_match:
+                    # No embedded dicts matched, return the default
+                    return default
+            else:
+                embed_match = False
+                # Index was numeric, lets look at any embedded dicts
+                # using the converted version of each.
+                for embedded in (x for x in ptr if isinstance(x, dict)):
+                    try:
+                        ptr = embedded[idx]
+                        embed_match = True
+                        break
+                    except KeyError:
+                        pass
+                if not embed_match:
+                    try:
+                        ptr = ptr[idx]
+                    except IndexError:
+                        return default
         else:
             try:
                 ptr = ptr[each]

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -789,28 +789,28 @@ def traverse_dict_and_list(data, key, default=None, delimiter=DEFAULT_TARGET_DEL
     if isinstance(key, str):
         key = key.split(delimiter)
 
+    if isinstance(key, int):
+        key = [key]
+
     for each in key:
         if isinstance(ptr, list):
             try:
                 idx = int(each)
             except ValueError:
-                embed_match = False
-                # Index was not numeric, lets look at any embedded dicts
-                for embedded in (x for x in ptr if isinstance(x, dict)):
-                    try:
-                        ptr = embedded[each]
-                        embed_match = True
-                        break
-                    except KeyError:
-                        pass
-                if not embed_match:
-                    # No embedded dicts matched, return the default
-                    return default
-            else:
+                idx = each
+
+            embed_match = False
+            # Index was not numeric, lets look at any embedded dicts
+            for embedded in (x for x in ptr if isinstance(x, dict)):
                 try:
-                    ptr = ptr[idx]
-                except IndexError:
-                    return default
+                    ptr = embedded[idx]
+                    embed_match = True
+                    break
+                except KeyError:
+                    pass
+            if not embed_match:
+                # No embedded dicts matched, return the default
+                return default
         else:
             try:
                 ptr = ptr[each]

--- a/tests/pytests/integration/modules/test_pillar.py
+++ b/tests/pytests/integration/modules/test_pillar.py
@@ -33,6 +33,10 @@ def pillar_tree(base_env_pillar_tree_root_dir, salt_minion, salt_call_cli):
       - Galahad
       - Bedevere
       - Robin
+
+    12345:
+      code:
+        - luggage
     """
     top_tempfile = pytest.helpers.temp_file(
         "top.sls", top_file, base_env_pillar_tree_root_dir
@@ -150,6 +154,26 @@ def test_pillar_command_line(salt_call_cli, pillar_tree):
     pillar_items = ret.json
     assert "new" in pillar_items
     assert pillar_items["new"] == "additional"
+
+
+def test_pillar_get_integer_key(salt_call_cli, pillar_tree):
+    """
+    Test to ensure we get expected output
+    from pillar.items
+    """
+    ret = salt_call_cli.run("pillar.items")
+    assert ret.exitcode == 0
+    assert ret.json
+    pillar_items = ret.json
+    assert "12345" in pillar_items
+    assert pillar_items["12345"] == {"code": ["luggage"]}
+
+    ret = salt_call_cli.run("pillar.get", key="12345")
+    assert ret.exitcode == 0
+    assert ret.json
+    pillar_get = ret.json
+    assert "code" in pillar_get
+    assert "luggage" in pillar_get["code"]
 
 
 @attr.s


### PR DESCRIPTION
### What does this PR do?
Fixing an issue preventing running `pillar.get` against pillar values with integers as pillar keys.  Adding tests.

### What issues does this PR fix or reference?
Fixes: #58714 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
