### PR TITLE
pillar: postgres: support DSN

### DIFF
--- a/salt/pillar/postgres.py
+++ b/salt/pillar/postgres.py
@@ -14,6 +14,11 @@ Complete Example
 .. code-block:: yaml
 
     postgres:
+      # the usage of dsn is optional and provides more flexibility. Other
+      # connection variables (user, pass, etc.) will then be ignored
+      # https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+      dsn: 'host=localhost dbname=salt'
+
       user: 'salt'
       pass: 'super_secret_password'
       db: 'salt_db'
@@ -92,13 +97,18 @@ class POSTGRESExtPillar(SqlBaseExtPillar):
         Yield a POSTGRES cursor
         """
         _options = self._get_options()
-        conn = psycopg2.connect(
-            host=_options["host"],
-            user=_options["user"],
-            password=_options["pass"],
-            dbname=_options["db"],
-            port=_options["port"],
-        )
+        if _options.get('dsn'):
+            conn = psycopg2.connect(
+                dsn=_options.get('dsn'),
+            )
+        else:
+            conn = psycopg2.connect(
+                host=_options["host"],
+                user=_options["user"],
+                password=_options["pass"],
+                dbname=_options["db"],
+                port=_options["port"],
+            )
         cursor = conn.cursor()
         try:
             yield cursor


### PR DESCRIPTION
### What does this PR do?

this commit adds support for providing a DNS when connecting to a
postgresql database. 

We extend this functionality by enabling a dsn to be defined in which
case it will take precedence and ignore former mentioned variables.

### What issues does this PR fix or reference?

Provide more flexibility (support all connection parameters) while connecting to a postgres database e.g. connecting via x509 certificates and verifying the tls connection.

### Previous Behavior

Previously only host, user, pass, dbname, port were supported.

### New Behavior

Additionally support a `postgres:dsn` key which will then be used as dsn for connecting to the database.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.
