### PR TITLE
Add ttp modules and tests

### DIFF
--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -483,6 +483,7 @@ execution modules
     trafficserver
     transactional_update
     travisci
+	ttp
     tuned
     twilio_notify
     udev

--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -483,7 +483,7 @@ execution modules
     trafficserver
     transactional_update
     travisci
-	ttp
+    ttp
     tuned
     twilio_notify
     udev

--- a/doc/ref/modules/all/salt.modules.ttp.rst
+++ b/doc/ref/modules/all/salt.modules.ttp.rst
@@ -1,0 +1,7 @@
+=======================
+salt.modules.ttp module
+=======================
+
+.. automodule:: salt.modules.ttp
+    :members:
+

--- a/doc/ref/runners/all/index.rst
+++ b/doc/ref/runners/all/index.rst
@@ -50,7 +50,7 @@ runner modules
     survey
     test
     thin
-	ttp
+    ttp
     vault
     venafiapi
     virt

--- a/doc/ref/runners/all/index.rst
+++ b/doc/ref/runners/all/index.rst
@@ -50,6 +50,7 @@ runner modules
     survey
     test
     thin
+	ttp
     vault
     venafiapi
     virt

--- a/doc/ref/runners/all/salt.runners.ttp.rst
+++ b/doc/ref/runners/all/salt.runners.ttp.rst
@@ -1,0 +1,6 @@
+================
+salt.runners.ttp
+================
+
+.. automodule:: salt.runners.ttp
+    :members:

--- a/requirements/static/ci/py3.6/linux.txt
+++ b/requirements/static/ci/py3.6/linux.txt
@@ -901,6 +901,7 @@ tornado==6.1
     # via python-telegram-bot
 transitions==0.8.1
     # via junos-eznc
+ttp==0.5.0
 twilio==7.9.2
     # via -r requirements/static/ci/linux.in
 typing-extensions==3.10.0.0

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -883,6 +883,7 @@ tomli==2.0.1
     # via pytest
 transitions==0.8.1
     # via junos-eznc
+ttp==0.5.0
 typing-extensions==3.10.0.0
     # via
     #   aiohttp

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -925,6 +925,7 @@ tornado==6.1
     # via python-telegram-bot
 transitions==0.8.1
     # via junos-eznc
+ttp==0.5.0
 twilio==7.9.2
     # via -r requirements/static/ci/linux.in
 typing-extensions==3.10.0.0

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -397,6 +397,7 @@ toml==0.10.2
     # via -r requirements/static/ci/common.in
 tomli==2.0.1
     # via pytest
+ttp==0.5.0
 typing-extensions==3.10.0.0
     # via
     #   aiohttp

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -873,6 +873,7 @@ tomli==2.0.1
     # via pytest
 transitions==0.8.1
     # via junos-eznc
+ttp==0.5.0
 typing-extensions==4.2.0
     # via
     #   pytest-shell-utilities

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -915,6 +915,7 @@ tornado==6.1
     # via python-telegram-bot
 transitions==0.8.1
     # via junos-eznc
+ttp==0.5.0
 twilio==7.9.2
     # via -r requirements/static/ci/linux.in
 typing-extensions==4.2.0

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -876,6 +876,7 @@ tomli==2.0.1
     # via pytest
 transitions==0.8.1
     # via junos-eznc
+ttp==0.5.0
 typing-extensions==4.2.0
     # via
     #   pytest-shell-utilities

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -920,6 +920,7 @@ tornado==6.1
     # via python-telegram-bot
 transitions==0.8.1
     # via junos-eznc
+ttp==0.5.0
 twilio==7.9.2
     # via -r requirements/static/ci/linux.in
 typing-extensions==4.2.0

--- a/salt/modules/ttp.py
+++ b/salt/modules/ttp.py
@@ -155,7 +155,8 @@ Sample template::
 """
 # Import python libs
 import logging
-import sys, traceback
+import sys
+import traceback
 from salt.exceptions import CommandExecutionError
 
 # Import third party modules
@@ -163,10 +164,11 @@ try:
     from ttp import ttp
 
     HAS_TTP = True
-except ImportError:
-    HAS_TTP = False
 except ModuleNotFoundError:
     HAS_TTP = False
+except ImportError:
+    HAS_TTP = False
+
 log = logging.getLogger(__name__)
 
 __virtualname__ = "ttp"
@@ -217,7 +219,7 @@ def _elasticsearch_return(data, **kwargs):
                         post_to_elk(salt.utils.json.dumps(i))
             # handle normal named groups case
             elif isinstance(input_res, dict):
-                post_to_elk(salt.utils.json.dumps(item))
+                post_to_elk(salt.utils.json.dumps(input_res))
     # handle per_template case
     elif isinstance(data, dict):
         post_to_elk(salt.utils.json.dumps(data))
@@ -372,10 +374,8 @@ def run(*args, **kwargs):
         output = __salt__[function](*arguments, **function_kwargs)
         default_input_data = _get_text_from_run_result(output, function_name=function)
         for template_name, template_inputs in input_load.items():
-            [
+            for i in default_input_data:
                 parser.add_input(data=i, template_name=template_name)
-                for i in default_input_data
-            ]
     # run inputs if any
     for template_name, template_inputs in input_load.items():
         for inpt_name, input_params in template_inputs.items():

--- a/salt/modules/ttp.py
+++ b/salt/modules/ttp.py
@@ -155,17 +155,19 @@ Sample template::
 """
 # Import python libs
 import logging
-import sys, traceback
+import sys
+import traceback
 
 # Import third party modules
 try:
     from ttp import ttp
 
     HAS_TTP = True
-except ImportError:
-    HAS_TTP = False
 except ModuleNotFoundError:
     HAS_TTP = False
+except ImportError:
+    HAS_TTP = False
+
 log = logging.getLogger(__name__)
 
 __virtualname__ = "ttp"
@@ -216,7 +218,7 @@ def _elasticsearch_return(data, **kwargs):
                         post_to_elk(salt.utils.json.dumps(i))
             # handle normal named groups case
             elif isinstance(input_res, dict):
-                post_to_elk(salt.utils.json.dumps(item))
+                post_to_elk(salt.utils.json.dumps(input_res))
     # handle per_template case
     elif isinstance(data, dict):
         post_to_elk(salt.utils.json.dumps(data))

--- a/salt/modules/ttp.py
+++ b/salt/modules/ttp.py
@@ -1,0 +1,402 @@
+"""
+Template Text Parser module
+===========================
+
+.. versionadded:: v3001
+
+:codeauthor: Denis Mulyalin <d.mulyalin@gmail.com>
+:maturity:   new
+:depends:    TTP
+:platform:   unix, windows
+
+Dependencies
+------------
+
+`TTP library <https://pypi.org/project/ttp/>`_ should be installed on minion
+
+Reference TTP `installation notes <https://ttp.readthedocs.io/en/latest/Installation.html>`_
+for additional dependencies
+
+Introduction
+------------
+
+Execution module to extract information from semi-structured text
+produced by minions using `TTP <https://pypi.org/project/ttp/>`_ templates.
+
+Supported SALT results structures
+---------------------------------
+
+This module uses TTP inputs system to run SALT commands to obtain text data
+from minions. SALT commands return results in a non-consistent format, for
+instance, for one module text output can be within
+``result["out"]["command"]["text_data"]`` path, for others it can be text data
+straightaway.
+
+To cope with above problem TTP execution module have support for this
+results structure:
+
+- if return result is a text it used as is
+- if return result is a list of text strings, items combined in single blob
+  of text for parsing
+- if return results produced by ``net.cli`` command, commands output combined
+  in a single blob of text reconstructing device's prompt by appending
+  ``minion_id#command`` in front of each command output item
+- if return results produced by ``nr.cli`` command, commands output combined
+  in a single blob of text reconstructing device's prompt by appending
+  ``host name#command`` in front of each output item
+- if return results produced by ``mine.get`` command and proxy minion type is
+  ``napalm``, commands output combined following ``net.cli`` command logic
+  in assumption that mine was collected using ``net.cli`` command as well
+- if return results produced by ``mine.get`` command and proxy minion type is
+  ``nornir``, commands output combined following ``nr.cli`` command logic
+  in assumption that mine was collected using ``nr.cli`` command as well
+
+For all other results, output passed to input as is and custom TTP input macro
+function should to be used within the template to pre-process results and extract
+text data for parsing.
+
+Sample TTP template::
+
+    <input name="run config">
+    fun = "net.cli"
+    arg = ['show run']
+    kwarg = {}
+    </input>
+
+    <input name="show arp">
+    fun = "net.cli"
+    arg = ['show ip arp']
+    kwarg = {}
+    </input>
+
+    <group name="interfaces" input="run config">
+    interface {{ interface | contains(".") }}
+     description {{ description | ORPHRASE }}
+    </group>
+
+    <group name="arp" input="show arp">
+    Internet  {{ ip }}  {{ age }}   {{ mac }}  ARPA   {{ intf }}
+    </group>
+
+Above template will run two SALT commands to collect output,
+output will be placed in respective inputs, each input parsed
+with specific groups.
+
+**Input Parameters**
+
+  * ``fun`` - mandatory, execution function to run and parse output for
+  * ``arg`` - list of arguments to pass to execution function
+  * ``kwarg`` - dictionary of key word arguments to pass to execution function
+
+TTP variables
+-------------
+
+`TTP variables <https://ttp.readthedocs.io/en/latest/Template%20Variables/index.html>`_
+can be referenced within TTP templates to validate results or can be consumed
+by various functions. These template variables are added to parser object automatically:
+
+  * ``_minion_id_`` - contains id of proxy minion from ``__opts__["id"]`` variable
+
+TTP Custom functions
+--------------------
+
+TTP supports capability to add custom function to parser object for the sake
+of extending functionality.
+
+.. note:: terms returner and formatter below given in the context of TTP
+  module and reference TTP functions that can be called within TTP templates.
+
+Returner - Elasticsearch
+++++++++++++++++++++++++
+
+TTP execution module can return parsing results to Elasticsearch database
+using ``document_create`` function of SALT Elasticsearch execution module
+following this logic
+
+  * if parsing result is a dictionary, it is posted to Elasticsearch as is
+  * if parsing result is a list of dictionaries, each list item posted
+    to Elasticsearch individually
+  * if parsing result is a lists of lists, where each list is a list of dictionaries,
+    each dictionary item posted to Elasticsearch individually
+
+**Prerequisites**
+
+Minion must be configured with necessary options as per
+`elasticsearch <https://docs.saltstack.com/en/master/ref/modules/all/salt.modules.elasticsearch.html>`_
+execution module documentation. For instance, elasticsearch cluster settings can
+be specified in minion's pillar.
+
+**TTP Elasticsearch Returner Parameters**
+
+* ``index`` Index name, default is "salt-ttp_mod-v1"
+* ``doc_type`` Type of the document, default is "default"
+
+Sample template::
+
+    <input>
+    fun="net.cli"
+    arg=["show interface"]
+    </input>
+
+    <vars>timestamp="get_timestamp_iso"</vars>
+
+    <group>
+    {{ interface }} is {{ admin | ORPHRASE }}, line protocol is {{ line | ORPHRASE }}
+         {{ in_packets | to_int }} packets input, {{ in_bytes | to_int }} bytes, 0 no buffer
+         {{ out_packets | to_int }} packets output, {{ out_bytes | to_int }} bytes, 0 underruns
+    {{ hostname | set(_minion_id_) }}
+    {{ @timestamp | set(timestamp) }}
+    </group>
+
+    <output>
+    returner = "elasticsearch"
+    index = "intf_counters_test"
+    </output>
+"""
+# Import python libs
+import logging
+import sys, traceback
+
+# Import third party modules
+try:
+    from ttp import ttp
+
+    HAS_TTP = True
+except ImportError:
+    HAS_TTP = False
+except ModuleNotFoundError:
+    HAS_TTP = False
+log = logging.getLogger(__name__)
+
+__virtualname__ = "ttp"
+__proxyenabled__ = ["*"]
+
+
+def __virtual__():
+    """
+    Only load this execution module if TTP is installed.
+    """
+    if HAS_TTP:
+        return __virtualname__
+    return (False, " TTP execution module failed to load: TTP library not found.")
+
+
+# -----------------------------------------------------------------------------
+# TTP custom functions
+# -----------------------------------------------------------------------------
+
+
+def _elasticsearch_return(data, **kwargs):
+    """
+    Custom TTP returner function to return results to elasticsearch
+    using SALT elasticsearch execution module.
+    """
+    import salt.utils.json
+
+    def post_to_elk(data):
+        elc_kwargs["body"] = data
+        post_result = __salt__["elasticsearch.document_create"](**elc_kwargs)
+        log.debug(
+            "TTP elasticsearch returner, server response: '{}'".format(post_result)
+        )
+
+    elc_kwargs = {
+        "doc_type": kwargs.get("doc_type", "default"),
+        "index": kwargs.get("index", "salt_ttp_mod"),
+    }
+    # handle per_input case
+    if isinstance(data, list):
+        # iterate over template's inputs results
+        for input_res in data:
+            # happens if _anonymous_ group in template
+            if isinstance(input_res, list):
+                # iterate over results within input
+                for i in input_res:
+                    if isinstance(i, dict):
+                        post_to_elk(salt.utils.json.dumps(i))
+            # handle normal named groups case
+            elif isinstance(input_res, dict):
+                post_to_elk(salt.utils.json.dumps(item))
+    # handle per_template case
+    elif isinstance(data, dict):
+        post_to_elk(salt.utils.json.dumps(data))
+
+
+# -----------------------------------------------------------------------------
+# Private functions
+# -----------------------------------------------------------------------------
+
+
+def _get_text_from_run_result(run_results, **kwargs):
+    """
+    Helper function to extract text from command run results.
+
+    Returns list of text items, one item per device
+    """
+    results_data = []
+    proxytype = __pillar__.get("proxy", {}).get("proxytype", None)
+    function_name = kwargs.get("function_name", None)
+    if function_name == "net.cli":
+        # run_results structure is:
+        # {"out": {command1: "result1", command2: "result2"}}
+        results_data.append("")
+        for command, output in run_results["out"].items():
+            results_data[-1] += "\n{}#{}\n{}".format(__opts__["id"], command, output)
+    elif function_name == "nr.cli":
+        # run_results structure is: {'hostname': {'command1': 'output1'}}
+        for hostname, commands in run_results.items():
+            results_data.append("")
+            for command, output in commands.items():
+                results_data[-1] += "\n{}#{}\n{}".format(hostname, command, output)
+    elif function_name == "mine.get":
+        if proxytype == "napalm":
+            fun_name = "net.cli"
+        elif proxytype == "nornir":
+            fun_name = "nr.cli"
+        for minion_id, output in run_results.items():
+            results_data += _get_text_from_run_result(output, function_name=fun_name)
+    elif isinstance(run_results, str):
+        results_data.append(run_results)
+    elif isinstance(run_results, list):
+        # concatenate list of string items if any
+        temp = "\n{}".join([i for i in run_results if isinstance(i, str)])
+        if temp:
+            results_data.append(temp)
+    if results_data:
+        return results_data
+    else:
+        return [run_results]
+
+
+# -----------------------------------------------------------------------------
+# callable module function
+# -----------------------------------------------------------------------------
+
+
+def run(*args, **kwargs):
+    """
+    .. versionadded:: v3001
+
+    Function to run TTP Templates retrieving data using SALT execution modules.
+
+    Commands specified either in template's inputs or inline.
+
+    Inline command execution results associated with default inputs only.
+
+    :param template: path to TTP template
+    :param saltenv: name of SALT environment
+    :param vars: dictionary of template variables to pass on to TTP parser
+    :param ttp_res_kwargs: arguments to use with 'TTP result method <https://ttp.readthedocs.io/en/latest/API%20reference.html#ttp.ttp.result>'_
+
+    Sample TTP template to use with inline command::
+
+        interface {{ interface }}
+         encapsulation dot1Q {{ dot1q }}
+         vrf forwarding {{ vrf }}
+         ip address {{ ip }} {{ mask }}
+         {{ hostname | set(hostname) }}
+
+    Sample TTP Template with inputs defined::
+
+        <input name="in_1">
+        fun = "net.cli"
+        arg = ['show run']
+        kwarg = {}
+        </input>
+
+        <vars>
+        hostname="gethostname"
+        </vars>
+
+        <group name="interfaces" input="in_1">
+        interface {{ interface }}
+         encapsulation dot1Q {{ dot1q }}
+         vrf forwarding {{ vrf }}
+         ip address {{ ip }} {{ mask }}
+         {{ hostname | set(hostname) }}
+        </group>
+
+    CLI Examples for template with inputs::
+
+        salt minion-2 ttp.run 'salt://ttp/subifs_and_arp.txt'
+        salt minion-2 ttp.run template='salt://ttp/subifs_and_arp.txt'
+        salt minion-2 ttp.run template='salt://ttp/subifs_and_arp.txt' vars='{"var1": "val1", "a": "b"}'
+
+    CLI Examples with inline command::
+
+        salt minion-2 ttp.run net.cli "show version" template='salt://ttp/version.txt'
+        salt minion-2 ttp.run net.cli "show version" template='salt://ttp/version.txt' vars='{"var1": "val1", "a": "b"}'
+    """
+    function = None
+    # get arguments
+    if "template" in kwargs:
+        template = kwargs.pop("template")
+        if args:
+            arguments = list(args)
+            function = arguments.pop(0)
+    else:
+        template = args[0]
+    vars_to_share = kwargs.pop("vars", {})
+    vars_to_share["_minion_id_"] = __opts__["id"]
+    ttp_res_kwargs = kwargs.pop("ttp_res_kwargs", {})
+    function_kwargs = {k: v for k, v in kwargs.items() if not k.startswith("_")}
+    # create TTP parser
+    parser = ttp(vars=vars_to_share)
+    # add custom functions
+    parser.add_function(_elasticsearch_return, scope="returners", name="elasticsearch")
+    # get ttp template
+    template_text = __salt__["cp.get_file_str"](
+        template, saltenv=kwargs.pop("saltenv", "base")
+    )
+    if not template_text:
+        return "Failed to get TTP template '{}'".format(template)
+    try:
+        parser.add_template(template_text)
+    except:
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+        return "Failed to load TTP template: {}\n{}".format(
+            template,
+            "".join(traceback.format_exception(exc_type, exc_value, exc_traceback)),
+        )
+    # get inputs load
+    input_load = parser.get_input_load()
+    input_load = (
+        input_load
+        if input_load.get("_root_template_")
+        else {"_root_template_": {"Default_Input": {}}}
+    )
+    # get command output from minion if any
+    if function:
+        output = __salt__[function](*arguments, **function_kwargs)
+        default_input_data = _get_text_from_run_result(output, function_name=function)
+        for template_name, template_inputs in input_load.items():
+            [
+                parser.add_input(data=i, template_name=template_name)
+                for i in default_input_data
+            ]
+    # run inputs if any
+    for template_name, template_inputs in input_load.items():
+        for inpt_name, input_params in template_inputs.items():
+            if not input_params.get("fun"):
+                continue
+            function = input_params["fun"]
+            fun_arg = input_params.get("arg", [])
+            fun_kwarg = input_params.get("kwarg", {})
+            # get output from minion
+            output = __salt__[function](*fun_arg, **fun_kwarg)
+            outputs_list = _get_text_from_run_result(output, function_name=function)
+            for item in outputs_list:
+                parser.add_input(
+                    data=item, template_name=template_name, input_name=inpt_name
+                )
+    # parse data
+    try:
+        parser.parse(one=True)
+        ret = parser.result(**ttp_res_kwargs)
+    except:
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+        return "Failed to parse output with TTP template '{}'\n\n{}".format(
+            template,
+            "".join(traceback.format_exception(exc_type, exc_value, exc_traceback)),
+        )
+    return ret

--- a/salt/modules/ttp.py
+++ b/salt/modules/ttp.py
@@ -166,8 +166,7 @@ try:
     HAS_TTP = True
 except ImportError:
     HAS_TTP = False
-except ModuleNotFoundError:
-    HAS_TTP = False
+
 log = logging.getLogger(__name__)
 
 __virtualname__ = "ttp"
@@ -198,9 +197,7 @@ def _elasticsearch_return(data, **kwargs):
     def post_to_elk(data):
         elc_kwargs["body"] = data
         post_result = __salt__["elasticsearch.document_create"](**elc_kwargs)
-        log.debug(
-            "TTP elasticsearch returner, server response: '{}'".format(post_result)
-        )
+        log.debug("TTP elasticsearch returner, server response: %s", post_result)
 
     elc_kwargs = {
         "doc_type": kwargs.get("doc_type", "default"),
@@ -218,7 +215,7 @@ def _elasticsearch_return(data, **kwargs):
                         post_to_elk(salt.utils.json.dumps(i))
             # handle normal named groups case
             elif isinstance(input_res, dict):
-                post_to_elk(salt.utils.json.dumps(item))
+                post_to_elk(salt.utils.json.dumps(input_res))
     # handle per_template case
     elif isinstance(data, dict):
         post_to_elk(salt.utils.json.dumps(data))

--- a/salt/modules/ttp.py
+++ b/salt/modules/ttp.py
@@ -166,7 +166,8 @@ try:
     HAS_TTP = True
 except ImportError:
     HAS_TTP = False
-
+except ModuleNotFoundError:
+    HAS_TTP = False
 log = logging.getLogger(__name__)
 
 __virtualname__ = "ttp"
@@ -217,7 +218,7 @@ def _elasticsearch_return(data, **kwargs):
                         post_to_elk(salt.utils.json.dumps(i))
             # handle normal named groups case
             elif isinstance(input_res, dict):
-                post_to_elk(salt.utils.json.dumps(input_res))
+                post_to_elk(salt.utils.json.dumps(item))
     # handle per_template case
     elif isinstance(data, dict):
         post_to_elk(salt.utils.json.dumps(data))

--- a/salt/modules/ttp.py
+++ b/salt/modules/ttp.py
@@ -155,31 +155,18 @@ Sample template::
 """
 # Import python libs
 import logging
-<<<<<<< HEAD
 import sys
 import traceback
 from salt.exceptions import CommandExecutionError
-=======
-import sys, traceback
->>>>>>> 1d9062141f (Added TTP execution and runner modules.)
 
 # Import third party modules
 try:
     from ttp import ttp
 
     HAS_TTP = True
-<<<<<<< HEAD
-except ModuleNotFoundError:
-    HAS_TTP = False
 except ImportError:
     HAS_TTP = False
 
-=======
-except ImportError:
-    HAS_TTP = False
-except ModuleNotFoundError:
-    HAS_TTP = False
->>>>>>> 1d9062141f (Added TTP execution and runner modules.)
 log = logging.getLogger(__name__)
 
 __virtualname__ = "ttp"
@@ -230,11 +217,7 @@ def _elasticsearch_return(data, **kwargs):
                         post_to_elk(salt.utils.json.dumps(i))
             # handle normal named groups case
             elif isinstance(input_res, dict):
-<<<<<<< HEAD
                 post_to_elk(salt.utils.json.dumps(input_res))
-=======
-                post_to_elk(salt.utils.json.dumps(item))
->>>>>>> 1d9062141f (Added TTP execution and runner modules.)
     # handle per_template case
     elif isinstance(data, dict):
         post_to_elk(salt.utils.json.dumps(data))
@@ -245,11 +228,7 @@ def _elasticsearch_return(data, **kwargs):
 # -----------------------------------------------------------------------------
 
 
-<<<<<<< HEAD
 def _get_text_from_run_result(run_results, function_name=None):
-=======
-def _get_text_from_run_result(run_results, **kwargs):
->>>>>>> 1d9062141f (Added TTP execution and runner modules.)
     """
     Helper function to extract text from command run results.
 
@@ -257,10 +236,6 @@ def _get_text_from_run_result(run_results, **kwargs):
     """
     results_data = []
     proxytype = __pillar__.get("proxy", {}).get("proxytype", None)
-<<<<<<< HEAD
-=======
-    function_name = kwargs.get("function_name", None)
->>>>>>> 1d9062141f (Added TTP execution and runner modules.)
     if function_name == "net.cli":
         # run_results structure is:
         # {"out": {command1: "result1", command2: "result2"}}
@@ -374,26 +349,16 @@ def run(*args, **kwargs):
         template, saltenv=kwargs.pop("saltenv", "base")
     )
     if not template_text:
-<<<<<<< HEAD
         raise CommandExecutionError("Failed to get TTP template '{}'".format(template))
-=======
-        return "Failed to get TTP template '{}'".format(template)
->>>>>>> 1d9062141f (Added TTP execution and runner modules.)
     try:
         parser.add_template(template_text)
     except:
         exc_type, exc_value, exc_traceback = sys.exc_info()
-<<<<<<< HEAD
         raise CommandExecutionError(
             "Failed to load TTP template: {}\n{}".format(
                 template,
                 "".join(traceback.format_exception(exc_type, exc_value, exc_traceback)),
             )
-=======
-        return "Failed to load TTP template: {}\n{}".format(
-            template,
-            "".join(traceback.format_exception(exc_type, exc_value, exc_traceback)),
->>>>>>> 1d9062141f (Added TTP execution and runner modules.)
         )
     # get inputs load
     input_load = parser.get_input_load()
@@ -407,15 +372,8 @@ def run(*args, **kwargs):
         output = __salt__[function](*arguments, **function_kwargs)
         default_input_data = _get_text_from_run_result(output, function_name=function)
         for template_name, template_inputs in input_load.items():
-<<<<<<< HEAD
             for i in default_input_data:
                 parser.add_input(data=i, template_name=template_name)
-=======
-            [
-                parser.add_input(data=i, template_name=template_name)
-                for i in default_input_data
-            ]
->>>>>>> 1d9062141f (Added TTP execution and runner modules.)
     # run inputs if any
     for template_name, template_inputs in input_load.items():
         for inpt_name, input_params in template_inputs.items():
@@ -437,16 +395,10 @@ def run(*args, **kwargs):
         ret = parser.result(**ttp_res_kwargs)
     except:
         exc_type, exc_value, exc_traceback = sys.exc_info()
-<<<<<<< HEAD
         raise CommandExecutionError(
             "Failed to parse output with TTP template '{}'\n\n{}".format(
                 template,
                 "".join(traceback.format_exception(exc_type, exc_value, exc_traceback)),
             )
-=======
-        return "Failed to parse output with TTP template '{}'\n\n{}".format(
-            template,
-            "".join(traceback.format_exception(exc_type, exc_value, exc_traceback)),
->>>>>>> 1d9062141f (Added TTP execution and runner modules.)
         )
     return ret

--- a/salt/modules/ttp.py
+++ b/salt/modules/ttp.py
@@ -155,20 +155,31 @@ Sample template::
 """
 # Import python libs
 import logging
+<<<<<<< HEAD
 import sys
 import traceback
 from salt.exceptions import CommandExecutionError
+=======
+import sys, traceback
+>>>>>>> 1d9062141f (Added TTP execution and runner modules.)
 
 # Import third party modules
 try:
     from ttp import ttp
 
     HAS_TTP = True
+<<<<<<< HEAD
 except ModuleNotFoundError:
     HAS_TTP = False
 except ImportError:
     HAS_TTP = False
 
+=======
+except ImportError:
+    HAS_TTP = False
+except ModuleNotFoundError:
+    HAS_TTP = False
+>>>>>>> 1d9062141f (Added TTP execution and runner modules.)
 log = logging.getLogger(__name__)
 
 __virtualname__ = "ttp"
@@ -219,7 +230,11 @@ def _elasticsearch_return(data, **kwargs):
                         post_to_elk(salt.utils.json.dumps(i))
             # handle normal named groups case
             elif isinstance(input_res, dict):
+<<<<<<< HEAD
                 post_to_elk(salt.utils.json.dumps(input_res))
+=======
+                post_to_elk(salt.utils.json.dumps(item))
+>>>>>>> 1d9062141f (Added TTP execution and runner modules.)
     # handle per_template case
     elif isinstance(data, dict):
         post_to_elk(salt.utils.json.dumps(data))
@@ -230,7 +245,11 @@ def _elasticsearch_return(data, **kwargs):
 # -----------------------------------------------------------------------------
 
 
+<<<<<<< HEAD
 def _get_text_from_run_result(run_results, function_name=None):
+=======
+def _get_text_from_run_result(run_results, **kwargs):
+>>>>>>> 1d9062141f (Added TTP execution and runner modules.)
     """
     Helper function to extract text from command run results.
 
@@ -238,6 +257,10 @@ def _get_text_from_run_result(run_results, function_name=None):
     """
     results_data = []
     proxytype = __pillar__.get("proxy", {}).get("proxytype", None)
+<<<<<<< HEAD
+=======
+    function_name = kwargs.get("function_name", None)
+>>>>>>> 1d9062141f (Added TTP execution and runner modules.)
     if function_name == "net.cli":
         # run_results structure is:
         # {"out": {command1: "result1", command2: "result2"}}
@@ -351,16 +374,26 @@ def run(*args, **kwargs):
         template, saltenv=kwargs.pop("saltenv", "base")
     )
     if not template_text:
+<<<<<<< HEAD
         raise CommandExecutionError("Failed to get TTP template '{}'".format(template))
+=======
+        return "Failed to get TTP template '{}'".format(template)
+>>>>>>> 1d9062141f (Added TTP execution and runner modules.)
     try:
         parser.add_template(template_text)
     except:
         exc_type, exc_value, exc_traceback = sys.exc_info()
+<<<<<<< HEAD
         raise CommandExecutionError(
             "Failed to load TTP template: {}\n{}".format(
                 template,
                 "".join(traceback.format_exception(exc_type, exc_value, exc_traceback)),
             )
+=======
+        return "Failed to load TTP template: {}\n{}".format(
+            template,
+            "".join(traceback.format_exception(exc_type, exc_value, exc_traceback)),
+>>>>>>> 1d9062141f (Added TTP execution and runner modules.)
         )
     # get inputs load
     input_load = parser.get_input_load()
@@ -374,8 +407,15 @@ def run(*args, **kwargs):
         output = __salt__[function](*arguments, **function_kwargs)
         default_input_data = _get_text_from_run_result(output, function_name=function)
         for template_name, template_inputs in input_load.items():
+<<<<<<< HEAD
             for i in default_input_data:
                 parser.add_input(data=i, template_name=template_name)
+=======
+            [
+                parser.add_input(data=i, template_name=template_name)
+                for i in default_input_data
+            ]
+>>>>>>> 1d9062141f (Added TTP execution and runner modules.)
     # run inputs if any
     for template_name, template_inputs in input_load.items():
         for inpt_name, input_params in template_inputs.items():
@@ -397,10 +437,16 @@ def run(*args, **kwargs):
         ret = parser.result(**ttp_res_kwargs)
     except:
         exc_type, exc_value, exc_traceback = sys.exc_info()
+<<<<<<< HEAD
         raise CommandExecutionError(
             "Failed to parse output with TTP template '{}'\n\n{}".format(
                 template,
                 "".join(traceback.format_exception(exc_type, exc_value, exc_traceback)),
             )
+=======
+        return "Failed to parse output with TTP template '{}'\n\n{}".format(
+            template,
+            "".join(traceback.format_exception(exc_type, exc_value, exc_traceback)),
+>>>>>>> 1d9062141f (Added TTP execution and runner modules.)
         )
     return ret

--- a/salt/modules/ttp.py
+++ b/salt/modules/ttp.py
@@ -2,7 +2,7 @@
 Template Text Parser module
 ===========================
 
-.. versionadded:: v3001
+.. versionadded:: 3006
 
 :codeauthor: Denis Mulyalin <d.mulyalin@gmail.com>
 :maturity:   new
@@ -153,10 +153,10 @@ Sample template::
     index = "intf_counters_test"
     </output>
 """
-# Import python libs
 import logging
 import sys
 import traceback
+
 from salt.exceptions import CommandExecutionError
 
 # Import third party modules
@@ -276,7 +276,7 @@ def _get_text_from_run_result(run_results, function_name=None):
 
 def run(*args, **kwargs):
     """
-    .. versionadded:: v3001
+    .. versionadded:: 3006
 
     Function to run TTP Templates retrieving data using SALT execution modules.
 

--- a/salt/runners/ttp.py
+++ b/salt/runners/ttp.py
@@ -163,11 +163,8 @@ import logging
 import sys
 import traceback
 
-log = logging.getLogger(__name__)
 # Import salt modules
 from salt.client import LocalClient
-
-client = LocalClient()
 
 # Import third party modules
 try:
@@ -180,7 +177,8 @@ except ImportError:
     HAS_TTP = False
 
 __virtualname__ = "ttp"
-
+log = logging.getLogger(__name__)
+client = LocalClient()
 
 def __virtual__():
     """

--- a/salt/runners/ttp.py
+++ b/salt/runners/ttp.py
@@ -1,0 +1,432 @@
+"""
+Template Text Parser runner
+===========================
+
+.. versionadded:: v3001
+
+:codeauthor: Denis Mulyalin <d.mulyalin@gmail.com>
+:maturity:   new
+:depends:    TTP
+:platform:   unix, windows
+
+Dependencies
+------------
+
+`TTP library <https://pypi.org/project/ttp/>`_ should be installed on master
+
+Reference TTP `installation notes <https://ttp.readthedocs.io/en/latest/Installation.html>`_
+for additional dependencies
+
+Introduction
+------------
+
+Runner module to extract information from semi-structured text
+produced by minions using `TTP <https://pypi.org/project/ttp/>`_ templates.
+
+While :mod:`TTP execution module <salt.modules.ttp_mod>` can extract data from
+output produced by single minion, TTP runner can work with output produced by
+several minions, joining result in a combined structure. For instance, combined
+report can be generated across all minions that satisfy certain criteria or network
+wide data extraction can be performed.
+
+Supported SALT results structures
+---------------------------------
+
+This module uses TTP inputs system to run SALT commands to obtain text data
+from minions. SALT commands return results in a non-consistent format, for
+instance, for one module text output can be within
+``result["out"]["command"]["text_data"]`` path, for others it can be text data
+straightaway.
+
+To cope with above problem TTP runner module have support for this
+results structure:
+
+- if return result is a text it used as is
+- if return result is a list of text strings, items combined in single blob
+  of text for parsing
+- if return results produced by ``net.cli`` command, commands output combined
+  in a single blob of text reconstructing device's prompt by appending
+  ``minion_id#command`` in front of each command output item
+- if return results produced by ``nr.cli`` command, commands output combined
+  in a single blob of text reconstructing device's prompt by appending
+  ``host name#command`` in front of each output item
+- if return results produced by ``mine.get`` command and proxy minion type is
+  ``napalm``, commands output combined following ``net.cli`` command logic
+  in assumption that mine was collected using ``net.cli`` command as well
+- if return results produced by ``mine.get`` command and proxy minion type is
+  ``nornir``, commands output combined following ``nr.cli`` command logic
+  in assumption that mine was collected using ``nr.cli`` command as well
+
+For all other results, output passed to input as is and custom TTP input macro
+function should to be used within the template to pre-process results and extract
+text data for parsing.
+
+Sample TTP template::
+
+    <input name="run config">
+    tgt = "*"
+    fun = "net.cli"
+    arg = ['show run']
+    kwarg = {}
+    tgt_type = "glob"
+    </input>
+
+    <input name="show arp">
+    fun = "net.cli"
+    arg = ['show ip arp']
+    kwarg = {}
+    </input>
+
+    <group name="interfaces" input="run config">
+    interface {{ interface | contains(".") }}
+     description {{ description | ORPHRASE }}
+    </group>
+
+    <group name="arp" input="show arp">
+    Internet  {{ ip }}  {{ age }}   {{ mac }}  ARPA   {{ intf }}
+    </group>
+
+Above template will run two SALT commands to collect output,
+output will be placed in respective inputs, each input parsed
+with specific groups.
+
+**Input Parameters**
+
+  * ``tgt`` - mandatory, target to run function for
+  * ``tgt_type`` - targeting type to use, default is ``glob``
+  * ``fun`` - mandatory, execution function to run and parse output for
+  * ``arg`` - list of arguments to pass to execution function
+  * ``kwarg`` - dictionary of key word arguments to pass to execution function
+
+Input Parameters unpacked to ``client.cmd_iter(**input_params)`` function, hence
+any arguments supported by that method can be defined within input tag load.
+
+TTP Custom functions
+--------------------
+
+TTP supports capability to add custom function to parser object for the sake
+of extending functionality.
+
+.. note:: terms returner and formatter below given in the context of TTP
+  module and reference TTP functions that can be called within TTP templates.
+
+Returner - Elasticsearch
+++++++++++++++++++++++++
+
+TTP execution module can return parsing results to Elasticsearch database
+using ``document_create`` function of SALT Elasticsearch execution module
+following this logic
+
+  * if parsing result is a dictionary, it is posted to Elasticsearch as is
+  * if parsing result is a list of dictionaries, each list item posted
+    to Elasticsearch individually
+  * if parsing result is a lists of lists, where each list is a list of dictionaries,
+    each dictionary item posted to Elasticsearch individually
+
+**Prerequisites**
+
+Minion must be configured with necessary options as per
+`elasticsearch <https://docs.saltstack.com/en/master/ref/modules/all/salt.modules.elasticsearch.html>`_
+execution module documentation. For instance, elasticsearch cluster settings can
+be specified in minion's pillar.
+
+**TTP Elasticsearch Returner Parameters**
+
+* ``index`` Index name, default is "salt-ttp_mod-v1"
+* ``doc_type`` Type of the document, default is "default"
+
+Sample template::
+
+    <input>
+    tgt = "*"
+    fun="net.cli"
+    arg=["show interface"]
+    </input>
+
+    <vars>timestamp="get_timestamp_iso"</vars>
+
+    <group>
+    {{ interface }} is {{ admin | ORPHRASE }}, line protocol is {{ line | ORPHRASE }}
+         {{ in_packets | to_int }} packets input, {{ in_bytes | to_int }} bytes, 0 no buffer
+         {{ out_packets | to_int }} packets output, {{ out_bytes | to_int }} bytes, 0 underruns
+    {{ hostname | set(_minion_id_) }}
+    {{ @timestamp | set(timestamp) }}
+    </group>
+
+    <output>
+    returner = "elasticsearch"
+    index = "intf_counters_test"
+    </output>
+"""
+# Import python libs
+import logging
+import sys, traceback
+
+log = logging.getLogger(__name__)
+# Import salt modules
+from salt.client import LocalClient
+
+client = LocalClient()
+
+# Import third party modules
+try:
+    from ttp import ttp
+
+    HAS_TTP = True
+except ImportError:
+    HAS_TTP = False
+__virtualname__ = "ttp"
+
+
+def __virtual__():
+    """
+    TTP must be installed
+    """
+    if HAS_TTP:
+        return __virtualname__
+    else:
+        log.error("Not TTP Module found")
+        return False
+
+
+# -----------------------------------------------------------------------------
+# TTP custom functions
+# -----------------------------------------------------------------------------
+
+
+def _elasticsearch_return(data, **kwargs):
+    """
+    Custom TTP returner function to return results to elasticsearch
+    using SALT elasticsearch execution module.
+    """
+    import salt.utils.json
+
+    def post_to_elk(data):
+        elc_kwargs["body"] = data
+        post_result = __salt__["elasticsearch.document_create"](**elc_kwargs)
+        log.debug(
+            "TTP elasticsearch returner, server response: '{}'".format(post_result)
+        )
+
+    elc_kwargs = {
+        "doc_type": kwargs.get("doc_type", "default"),
+        "index": kwargs.get("index", "salt_ttp_mod"),
+    }
+    # handle per_input case
+    if isinstance(data, list):
+        # iterate over template's inputs results
+        for input_res in data:
+            # happens if _anonymous_ group in template
+            if isinstance(input_res, list):
+                # iterate over results within input
+                for i in input_res:
+                    if isinstance(i, dict):
+                        post_to_elk(salt.utils.json.dumps(i))
+            # handle normal named groups case
+            elif isinstance(input_res, dict):
+                post_to_elk(salt.utils.json.dumps(item))
+    # handle per_template case
+    elif isinstance(data, dict):
+        post_to_elk(salt.utils.json.dumps(data))
+
+
+# -----------------------------------------------------------------------------
+# Private functions
+# -----------------------------------------------------------------------------
+
+
+def _get_text_from_run_result(run_results, minion_name, **kwargs):
+    results_data = []
+    function_name = kwargs.get("function_name", None)
+    if function_name == "net.cli":
+        # run_results structure is:
+        # {"out": {command: "result1", command: "result2"}}
+        for k, value in run_results["out"].items():
+            results_data += "\n{}#{}\n{}".format(minion_name, k, value)
+    elif function_name == "nr.cli":
+        results_data = []
+        # run_results structure is: {'hostname': {'command1': 'output1'}}
+        for hostname, commands in run_results.items():
+            results_data.append("")
+            for command, output in commands.items():
+                results_data[-1] += "\n{}#{}\n{}".format(hostname, command, output)
+    elif function_name == "mine.get":
+        # get proxytype from minion pillar
+        proxy_config = client.cmd(minion_name, "pillar.item", arg=["proxy"])
+        proxytype = proxy_config[minion_name].get("proxy", {}).get("proxytype", "")
+        if proxytype == "nornir":
+            function_name = "nr.cli"
+        elif proxytype == "napalm":
+            function_name = "net.cli"
+        for minion_id, output in run_results.items():
+            results_data += _get_text_from_run_result(
+                output, minion_name, function_name=function_name
+            )
+    elif isinstance(run_results, str):
+        results_data.append(run_results)
+    elif isinstance(run_results, list):
+        # concatenate list of string items if any
+        temp = "\n{}".join([i for i in run_results if isinstance(i, str)])
+        if temp:
+            results_data.append(temp)
+    if results_data:
+        return results_data
+    else:
+        return [run_results]
+
+
+# -----------------------------------------------------------------------------
+# callable module function
+# -----------------------------------------------------------------------------
+
+
+def run(*args, **kwargs):
+    """
+    Function to run TTP template retrieving data using SALT execution modules.
+
+    Inline command's execution results associated with default inputs only.
+
+    :param template: path to TTP template
+    :param saltenv: name of SALT environment
+    :param vars: dictionary of template variables to pass on to TTP parser
+    :param ttp_res_kwargs: kwargs to pass to TTP result method
+    :param tgt_type: targeting type to use with "client.cmd_iter" for inline command
+
+    Sample TTP template to use with inline command::
+
+        interface {{ interface }}
+         encapsulation dot1Q {{ dot1q }}
+         vrf forwarding {{ vrf }}
+         ip address {{ ip }} {{ mask }}
+         {{ hostname | set(hostname) }}
+
+    Sample TTP Template with inputs defined::
+
+        <input name="in_1">
+        tgt = "LAB_R[1|2]"
+        fun = "net.cli"
+        arg = ['show run']
+        kwarg = {}
+        tgt_type = "glob"
+        </input>
+
+        <vars>
+        hostname="gethostname"
+        </vars>
+
+        <group name="interfaces" input="in_1">
+        interface {{ interface }}
+         encapsulation dot1Q {{ dot1q }}
+         vrf forwarding {{ vrf }}
+         ip address {{ ip }} {{ mask }}
+         {{ hostname | set(hostname) }}
+        </group>
+
+    CLI Examples with inline command::
+
+        salt-run ttp.parse "LAB-R*"" net.cli "show run" template="salt://ttp/intf.txt"
+        salt-run ttp.parse "net:lab" net.cli "show run" template="salt://ttp/intf.txt" tgt_type=pillar
+
+    CLI Examples for template with inputs::
+
+        salt-run ttp.run salt://ttp/interfaces_summary.txt
+        salt-run ttp.run template=salt://ttp/interfaces_summary.txt
+    """
+    # get arguments
+    if "template" in kwargs:
+        template = kwargs.pop("template")
+    else:
+        template = list(args).pop(0)
+        args = None
+    vars_to_share = kwargs.pop("vars", {})
+    ttp_res_kwargs = kwargs.pop("ttp_res_kwargs", {})
+    tgt_type = kwargs.pop("tgt_type", "glob")
+    function_kwargs = {k: v for k, v in kwargs.items() if not k.startswith("_")}
+    # create TTP parser object
+    parser = ttp(vars=vars_to_share)
+    parser.add_function(_elasticsearch_return, scope="returners", name="elasticsearch")
+    # get TTP template
+    template_text = __salt__["salt.cmd"](
+        "cp.get_file_str",
+        template,
+        saltenv=kwargs.pop("saltenv", "base"),
+    )
+    if not template_text:
+        return "Failed to get TTP template '{}'".format(template)
+    try:
+        parser.add_template(template_text)
+    except:
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+        return "Failed to load TTP template: {}\n{}".format(
+            template,
+            "".join(traceback.format_exception(exc_type, exc_value, exc_traceback)),
+        )
+    # get template inputs load
+    input_load = parser.get_input_load()
+    input_load = (
+        input_load
+        if input_load.get("_root_template_")
+        else {"_root_template_": {"Default_Input": {}}}
+    )
+    # run inline commands if any
+    if args:
+        inline_cmd_results = client.cmd_iter(
+            tgt=args[0],
+            fun=args[1],
+            arg=args[2:] if len(args) > 2 else [],
+            kwarg=function_kwargs,
+            tgt_type=tgt_type,
+            timeout=__opts__["timeout"],
+        )
+        # sort obtained results across inputs
+        for item in inline_cmd_results:
+            for minion_name, run_results in item.items():
+                # get results data text
+                default_input_data = _get_text_from_run_result(
+                    run_results["ret"], minion_name, function_name=args[1]
+                )
+                if not default_input_data:
+                    continue
+                for template_name, template_inputs in input_load.items():
+                    [
+                        parser.add_input(data=i, template_name=template_name)
+                        for i in default_input_data
+                    ]
+    # run inputs
+    for template_name, template_inputs in input_load.items():
+        for input_name, input_params in template_inputs.items():
+            if not input_params.get("fun"):
+                continue
+            input_params.setdefault("timeout", __opts__["timeout"])
+            result = client.cmd_iter(**input_params)
+            # map results data text to TTP inputs
+            for item in result:
+                for minion_name, run_results in item.items():
+                    # get results data text
+                    results_data = _get_text_from_run_result(
+                        run_results["ret"],
+                        minion_name,
+                        function_name=input_params["fun"],
+                    )
+                    if not results_data:
+                        continue
+                    # add data to parser:
+                    [
+                        parser.add_input(
+                            data=item,
+                            template_name=template_name,
+                            input_name=input_name,
+                        )
+                        for item in results_data
+                    ]
+    # run ttp parsing
+    try:
+        parser.parse(one=True)
+        ret = parser.result(**ttp_res_kwargs)
+    except:
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+        return "Failed to parse output with TTP template '{}'\n\n{}".format(
+            template,
+            "".join(traceback.format_exception(exc_type, exc_value, exc_traceback)),
+        )
+    return ret

--- a/salt/runners/ttp.py
+++ b/salt/runners/ttp.py
@@ -160,7 +160,8 @@ Sample template::
 """
 # Import python libs
 import logging
-import sys, traceback
+import sys
+import traceback
 
 log = logging.getLogger(__name__)
 # Import salt modules
@@ -173,8 +174,11 @@ try:
     from ttp import ttp
 
     HAS_TTP = True
+except ModuleNotFoundError:
+    HAS_TTP = False
 except ImportError:
     HAS_TTP = False
+
 __virtualname__ = "ttp"
 
 
@@ -224,7 +228,7 @@ def _elasticsearch_return(data, **kwargs):
                         post_to_elk(salt.utils.json.dumps(i))
             # handle normal named groups case
             elif isinstance(input_res, dict):
-                post_to_elk(salt.utils.json.dumps(item))
+                post_to_elk(salt.utils.json.dumps(input_res))
     # handle per_template case
     elif isinstance(data, dict):
         post_to_elk(salt.utils.json.dumps(data))

--- a/salt/runners/ttp.py
+++ b/salt/runners/ttp.py
@@ -167,8 +167,6 @@ import traceback
 from salt.client import LocalClient
 from salt.exceptions import CommandExecutionError
 
-client = LocalClient()
-
 # Import third party modules
 try:
     from ttp import ttp
@@ -180,7 +178,8 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 __virtualname__ = "ttp"
-
+log = logging.getLogger(__name__)
+client = LocalClient()
 
 def __virtual__():
     """

--- a/salt/runners/ttp.py
+++ b/salt/runners/ttp.py
@@ -2,7 +2,7 @@
 Template Text Parser runner
 ===========================
 
-.. versionadded:: v3001
+.. versionadded:: 3006
 
 :codeauthor: Denis Mulyalin <d.mulyalin@gmail.com>
 :maturity:   new
@@ -158,7 +158,6 @@ Sample template::
     index = "intf_counters_test"
     </output>
 """
-# Import python libs
 import logging
 import sys
 import traceback
@@ -180,6 +179,7 @@ log = logging.getLogger(__name__)
 __virtualname__ = "ttp"
 log = logging.getLogger(__name__)
 client = LocalClient()
+
 
 def __virtual__():
     """

--- a/salt/runners/ttp.py
+++ b/salt/runners/ttp.py
@@ -205,9 +205,7 @@ def _elasticsearch_return(data, **kwargs):
     def post_to_elk(data):
         elc_kwargs["body"] = data
         post_result = __salt__["elasticsearch.document_create"](**elc_kwargs)
-        log.debug(
-            "TTP elasticsearch returner, server response: '{}'".format(post_result)
-        )
+        log.debug("TTP elasticsearch returner, server response: '%s'", post_result)
 
     elc_kwargs = {
         "doc_type": kwargs.get("doc_type", "default"),

--- a/salt/runners/ttp.py
+++ b/salt/runners/ttp.py
@@ -160,20 +160,12 @@ Sample template::
 """
 # Import python libs
 import logging
-<<<<<<< HEAD
 import sys
 import traceback
 
 # Import salt modules
 from salt.client import LocalClient
 from salt.exceptions import CommandExecutionError
-=======
-import sys, traceback
-
-log = logging.getLogger(__name__)
-# Import salt modules
-from salt.client import LocalClient
->>>>>>> 1d9062141f (Added TTP execution and runner modules.)
 
 client = LocalClient()
 
@@ -182,37 +174,21 @@ try:
     from ttp import ttp
 
     HAS_TTP = True
-<<<<<<< HEAD
-except ModuleNotFoundError:
-    HAS_TTP = False
 except ImportError:
     HAS_TTP = False
+
 log = logging.getLogger(__name__)
 
-=======
-except ImportError:
-    HAS_TTP = False
->>>>>>> 1d9062141f (Added TTP execution and runner modules.)
 __virtualname__ = "ttp"
 
 
 def __virtual__():
     """
-<<<<<<< HEAD
     Only load this execution module if TTP is installed.
     """
     if HAS_TTP:
         return __virtualname__
     return (False, " TTP execution module failed to load: TTP library not found.")
-=======
-    TTP must be installed
-    """
-    if HAS_TTP:
-        return __virtualname__
-    else:
-        log.error("Not TTP Module found")
-        return False
->>>>>>> 1d9062141f (Added TTP execution and runner modules.)
 
 
 # -----------------------------------------------------------------------------
@@ -250,11 +226,7 @@ def _elasticsearch_return(data, **kwargs):
                         post_to_elk(salt.utils.json.dumps(i))
             # handle normal named groups case
             elif isinstance(input_res, dict):
-<<<<<<< HEAD
                 post_to_elk(salt.utils.json.dumps(input_res))
-=======
-                post_to_elk(salt.utils.json.dumps(item))
->>>>>>> 1d9062141f (Added TTP execution and runner modules.)
     # handle per_template case
     elif isinstance(data, dict):
         post_to_elk(salt.utils.json.dumps(data))
@@ -265,7 +237,6 @@ def _elasticsearch_return(data, **kwargs):
 # -----------------------------------------------------------------------------
 
 
-<<<<<<< HEAD
 def _get_text_from_run_result(run_results, minion_name, function_name=None):
     results_data = []
     if function_name == "net.cli":
@@ -274,16 +245,6 @@ def _get_text_from_run_result(run_results, minion_name, function_name=None):
         results_data.append("")
         for command, output in run_results["out"].items():
             results_data[-1] += "\n{}#{}\n{}".format(minion_name, command, output)
-=======
-def _get_text_from_run_result(run_results, minion_name, **kwargs):
-    results_data = []
-    function_name = kwargs.get("function_name", None)
-    if function_name == "net.cli":
-        # run_results structure is:
-        # {"out": {command: "result1", command: "result2"}}
-        for k, value in run_results["out"].items():
-            results_data += "\n{}#{}\n{}".format(minion_name, k, value)
->>>>>>> 1d9062141f (Added TTP execution and runner modules.)
     elif function_name == "nr.cli":
         results_data = []
         # run_results structure is: {'hostname': {'command1': 'output1'}}
@@ -365,13 +326,8 @@ def run(*args, **kwargs):
 
     CLI Examples with inline command::
 
-<<<<<<< HEAD
         salt-run ttp.run "LAB-R*"" net.cli "show run" template="salt://ttp/intf.txt"
         salt-run ttp.run "net:lab" net.cli "show run" template="salt://ttp/intf.txt" tgt_type=pillar
-=======
-        salt-run ttp.parse "LAB-R*"" net.cli "show run" template="salt://ttp/intf.txt"
-        salt-run ttp.parse "net:lab" net.cli "show run" template="salt://ttp/intf.txt" tgt_type=pillar
->>>>>>> 1d9062141f (Added TTP execution and runner modules.)
 
     CLI Examples for template with inputs::
 
@@ -398,26 +354,16 @@ def run(*args, **kwargs):
         saltenv=kwargs.pop("saltenv", "base"),
     )
     if not template_text:
-<<<<<<< HEAD
         raise CommandExecutionError("Failed to get TTP template '{}'".format(template))
-=======
-        return "Failed to get TTP template '{}'".format(template)
->>>>>>> 1d9062141f (Added TTP execution and runner modules.)
     try:
         parser.add_template(template_text)
     except:
         exc_type, exc_value, exc_traceback = sys.exc_info()
-<<<<<<< HEAD
         raise CommandExecutionError(
             "Failed to load TTP template: {}\n{}".format(
                 template,
                 "".join(traceback.format_exception(exc_type, exc_value, exc_traceback)),
             )
-=======
-        return "Failed to load TTP template: {}\n{}".format(
-            template,
-            "".join(traceback.format_exception(exc_type, exc_value, exc_traceback)),
->>>>>>> 1d9062141f (Added TTP execution and runner modules.)
         )
     # get template inputs load
     input_load = parser.get_input_load()
@@ -446,15 +392,8 @@ def run(*args, **kwargs):
                 if not default_input_data:
                     continue
                 for template_name, template_inputs in input_load.items():
-<<<<<<< HEAD
                     for i in default_input_data:
                         parser.add_input(data=i, template_name=template_name)
-=======
-                    [
-                        parser.add_input(data=i, template_name=template_name)
-                        for i in default_input_data
-                    ]
->>>>>>> 1d9062141f (Added TTP execution and runner modules.)
     # run inputs
     for template_name, template_inputs in input_load.items():
         for input_name, input_params in template_inputs.items():
@@ -474,37 +413,22 @@ def run(*args, **kwargs):
                     if not results_data:
                         continue
                     # add data to parser:
-<<<<<<< HEAD
                     for item in results_data:
-=======
-                    [
->>>>>>> 1d9062141f (Added TTP execution and runner modules.)
                         parser.add_input(
                             data=item,
                             template_name=template_name,
                             input_name=input_name,
                         )
-<<<<<<< HEAD
-=======
-                        for item in results_data
-                    ]
->>>>>>> 1d9062141f (Added TTP execution and runner modules.)
     # run ttp parsing
     try:
         parser.parse(one=True)
         ret = parser.result(**ttp_res_kwargs)
     except:
         exc_type, exc_value, exc_traceback = sys.exc_info()
-<<<<<<< HEAD
         raise CommandExecutionError(
             "Failed to parse output with TTP template '{}'\n\n{}".format(
                 template,
                 "".join(traceback.format_exception(exc_type, exc_value, exc_traceback)),
             )
-=======
-        return "Failed to parse output with TTP template '{}'\n\n{}".format(
-            template,
-            "".join(traceback.format_exception(exc_type, exc_value, exc_traceback)),
->>>>>>> 1d9062141f (Added TTP execution and runner modules.)
         )
     return ret

--- a/salt/runners/ttp.py
+++ b/salt/runners/ttp.py
@@ -160,12 +160,20 @@ Sample template::
 """
 # Import python libs
 import logging
+<<<<<<< HEAD
 import sys
 import traceback
 
 # Import salt modules
 from salt.client import LocalClient
 from salt.exceptions import CommandExecutionError
+=======
+import sys, traceback
+
+log = logging.getLogger(__name__)
+# Import salt modules
+from salt.client import LocalClient
+>>>>>>> 1d9062141f (Added TTP execution and runner modules.)
 
 client = LocalClient()
 
@@ -174,22 +182,37 @@ try:
     from ttp import ttp
 
     HAS_TTP = True
+<<<<<<< HEAD
 except ModuleNotFoundError:
     HAS_TTP = False
 except ImportError:
     HAS_TTP = False
 log = logging.getLogger(__name__)
 
+=======
+except ImportError:
+    HAS_TTP = False
+>>>>>>> 1d9062141f (Added TTP execution and runner modules.)
 __virtualname__ = "ttp"
 
 
 def __virtual__():
     """
+<<<<<<< HEAD
     Only load this execution module if TTP is installed.
     """
     if HAS_TTP:
         return __virtualname__
     return (False, " TTP execution module failed to load: TTP library not found.")
+=======
+    TTP must be installed
+    """
+    if HAS_TTP:
+        return __virtualname__
+    else:
+        log.error("Not TTP Module found")
+        return False
+>>>>>>> 1d9062141f (Added TTP execution and runner modules.)
 
 
 # -----------------------------------------------------------------------------
@@ -227,7 +250,11 @@ def _elasticsearch_return(data, **kwargs):
                         post_to_elk(salt.utils.json.dumps(i))
             # handle normal named groups case
             elif isinstance(input_res, dict):
+<<<<<<< HEAD
                 post_to_elk(salt.utils.json.dumps(input_res))
+=======
+                post_to_elk(salt.utils.json.dumps(item))
+>>>>>>> 1d9062141f (Added TTP execution and runner modules.)
     # handle per_template case
     elif isinstance(data, dict):
         post_to_elk(salt.utils.json.dumps(data))
@@ -238,6 +265,7 @@ def _elasticsearch_return(data, **kwargs):
 # -----------------------------------------------------------------------------
 
 
+<<<<<<< HEAD
 def _get_text_from_run_result(run_results, minion_name, function_name=None):
     results_data = []
     if function_name == "net.cli":
@@ -246,6 +274,16 @@ def _get_text_from_run_result(run_results, minion_name, function_name=None):
         results_data.append("")
         for command, output in run_results["out"].items():
             results_data[-1] += "\n{}#{}\n{}".format(minion_name, command, output)
+=======
+def _get_text_from_run_result(run_results, minion_name, **kwargs):
+    results_data = []
+    function_name = kwargs.get("function_name", None)
+    if function_name == "net.cli":
+        # run_results structure is:
+        # {"out": {command: "result1", command: "result2"}}
+        for k, value in run_results["out"].items():
+            results_data += "\n{}#{}\n{}".format(minion_name, k, value)
+>>>>>>> 1d9062141f (Added TTP execution and runner modules.)
     elif function_name == "nr.cli":
         results_data = []
         # run_results structure is: {'hostname': {'command1': 'output1'}}
@@ -327,8 +365,13 @@ def run(*args, **kwargs):
 
     CLI Examples with inline command::
 
+<<<<<<< HEAD
         salt-run ttp.run "LAB-R*"" net.cli "show run" template="salt://ttp/intf.txt"
         salt-run ttp.run "net:lab" net.cli "show run" template="salt://ttp/intf.txt" tgt_type=pillar
+=======
+        salt-run ttp.parse "LAB-R*"" net.cli "show run" template="salt://ttp/intf.txt"
+        salt-run ttp.parse "net:lab" net.cli "show run" template="salt://ttp/intf.txt" tgt_type=pillar
+>>>>>>> 1d9062141f (Added TTP execution and runner modules.)
 
     CLI Examples for template with inputs::
 
@@ -355,16 +398,26 @@ def run(*args, **kwargs):
         saltenv=kwargs.pop("saltenv", "base"),
     )
     if not template_text:
+<<<<<<< HEAD
         raise CommandExecutionError("Failed to get TTP template '{}'".format(template))
+=======
+        return "Failed to get TTP template '{}'".format(template)
+>>>>>>> 1d9062141f (Added TTP execution and runner modules.)
     try:
         parser.add_template(template_text)
     except:
         exc_type, exc_value, exc_traceback = sys.exc_info()
+<<<<<<< HEAD
         raise CommandExecutionError(
             "Failed to load TTP template: {}\n{}".format(
                 template,
                 "".join(traceback.format_exception(exc_type, exc_value, exc_traceback)),
             )
+=======
+        return "Failed to load TTP template: {}\n{}".format(
+            template,
+            "".join(traceback.format_exception(exc_type, exc_value, exc_traceback)),
+>>>>>>> 1d9062141f (Added TTP execution and runner modules.)
         )
     # get template inputs load
     input_load = parser.get_input_load()
@@ -393,8 +446,15 @@ def run(*args, **kwargs):
                 if not default_input_data:
                     continue
                 for template_name, template_inputs in input_load.items():
+<<<<<<< HEAD
                     for i in default_input_data:
                         parser.add_input(data=i, template_name=template_name)
+=======
+                    [
+                        parser.add_input(data=i, template_name=template_name)
+                        for i in default_input_data
+                    ]
+>>>>>>> 1d9062141f (Added TTP execution and runner modules.)
     # run inputs
     for template_name, template_inputs in input_load.items():
         for input_name, input_params in template_inputs.items():
@@ -414,22 +474,37 @@ def run(*args, **kwargs):
                     if not results_data:
                         continue
                     # add data to parser:
+<<<<<<< HEAD
                     for item in results_data:
+=======
+                    [
+>>>>>>> 1d9062141f (Added TTP execution and runner modules.)
                         parser.add_input(
                             data=item,
                             template_name=template_name,
                             input_name=input_name,
                         )
+<<<<<<< HEAD
+=======
+                        for item in results_data
+                    ]
+>>>>>>> 1d9062141f (Added TTP execution and runner modules.)
     # run ttp parsing
     try:
         parser.parse(one=True)
         ret = parser.result(**ttp_res_kwargs)
     except:
         exc_type, exc_value, exc_traceback = sys.exc_info()
+<<<<<<< HEAD
         raise CommandExecutionError(
             "Failed to parse output with TTP template '{}'\n\n{}".format(
                 template,
                 "".join(traceback.format_exception(exc_type, exc_value, exc_traceback)),
             )
+=======
+        return "Failed to parse output with TTP template '{}'\n\n{}".format(
+            template,
+            "".join(traceback.format_exception(exc_type, exc_value, exc_traceback)),
+>>>>>>> 1d9062141f (Added TTP execution and runner modules.)
         )
     return ret

--- a/tests/unit/modules/test_ttp.py
+++ b/tests/unit/modules/test_ttp.py
@@ -1,0 +1,585 @@
+"""
+    :codeauthor: Denis Mulyalin <d.mulyalin@gmail.com>
+"""
+import salt.modules.ttp as ttp_module
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.mock import MagicMock, patch
+from tests.support.unit import TestCase
+from salt.exceptions import CommandExecutionError
+
+
+class TTPModuleTestCase(TestCase, LoaderModuleMockMixin):
+    def setup_loader_modules(self):
+        module_globals = {"__salt__": {}, "__opts__": {"id": "test_minion_id"}}
+
+        return {ttp_module: module_globals}
+
+    def test_ttp_run_minion_inline_command(self):
+        ttp_template = """
+ Static hostname: {{ hostname }}
+         Chassis: {{ chassis }}
+      Machine ID: {{ machine_id }}
+Operating System: {{ os | ORPHRASE }}
+        """
+        data_to_parse = """
+ Static hostname: localhost.localdomain
+         Chassis: vm
+      Machine ID: 2a26648f68764152a772fc20c9a3ddb3
+Operating System: CentOS Linux 7 (Core)
+        """
+        mock_cp_get_file_str = MagicMock(return_value=ttp_template)
+        mock_cmd_run = MagicMock(return_value=data_to_parse)
+        with patch.dict(
+            ttp_module.__salt__,
+            {"cmd.run": mock_cmd_run, "cp.get_file_str": mock_cp_get_file_str},
+        ):
+            # Simulate TTP run command
+            res = ttp_module.run(
+                "cmd.run", "hostnamectl", template="salt://ttp/test_template_1.txt"
+            )
+            assert res == [
+                [
+                    {
+                        "os": "CentOS Linux 7 (Core)",
+                        "machine_id": "2a26648f68764152a772fc20c9a3ddb3",
+                        "chassis": "vm",
+                        "hostname": "localhost.localdomain",
+                    }
+                ]
+            ]
+
+    def test_ttp_run_minion_inline_command_flat_list(self):
+        ttp_template = """
+ Static hostname: {{ hostname }}
+         Chassis: {{ chassis }}
+      Machine ID: {{ machine_id }}
+Operating System: {{ os | ORPHRASE }}
+        """
+        data_to_parse = """
+ Static hostname: localhost.localdomain
+         Chassis: vm
+      Machine ID: 2a26648f68764152a772fc20c9a3ddb3
+Operating System: CentOS Linux 7 (Core)
+        """
+        mock_cp_get_file_str = MagicMock(return_value=ttp_template)
+        mock_cmd_run = MagicMock(return_value=data_to_parse)
+        with patch.dict(
+            ttp_module.__salt__,
+            {"cmd.run": mock_cmd_run, "cp.get_file_str": mock_cp_get_file_str},
+        ):
+            # Simulate TTP run command
+            res = ttp_module.run(
+                "cmd.run",
+                "hostnamectl",
+                template="salt://ttp/test_template_1.txt",
+                ttp_res_kwargs={"structure": "flat_list"},
+            )
+            assert res == [
+                {
+                    "os": "CentOS Linux 7 (Core)",
+                    "machine_id": "2a26648f68764152a772fc20c9a3ddb3",
+                    "chassis": "vm",
+                    "hostname": "localhost.localdomain",
+                }
+            ]
+
+    def test_ttp_run_fail_template_file_load(self):
+        """
+        This test returns None for "cp.get_file_str" simulating
+        wrong path to or non existing template raising CommandExecutionError
+        dues to "template_text" is None
+        """
+        mock_cp_get_file_str = MagicMock(return_value=None)
+        with patch.dict(
+            ttp_module.__salt__,
+            {"cp.get_file_str": mock_cp_get_file_str},
+        ):
+            self.assertRaises(
+                CommandExecutionError,
+                ttp_module.run,
+                "cmd.run",
+                "hostnamectl",
+                template="salt://ttp/test_template_1.txt",
+            )
+
+    def test_ttp_run_template_fail_to_load(self):
+        """
+        This test loads badly formatted template, causing
+        CommandExecutionError for "parser.add_template(template_text)"
+        call
+        """
+        broken_template = """
+<group name="bla">
+ Static hostname: {{ hostname }}
+<
+        """
+        mock_cp_get_file_str = MagicMock(return_value=broken_template)
+        with patch.dict(
+            ttp_module.__salt__,
+            {"cp.get_file_str": mock_cp_get_file_str},
+        ):
+            self.assertRaises(
+                CommandExecutionError,
+                ttp_module.run,
+                "cmd.run",
+                "hostnamectl",
+                template="salt://ttp/test_template.txt",
+            )
+
+    def test_ttp_run_fail_to_parse(self):
+        """
+        This template raises exception withoint template macro trigerring
+        causing CommandExecutionError fpr "parser.parse(one=True)" call
+        """
+        ttp_template = """
+<macro>
+def raise_error(data):
+    raise NameError('HiThere, testing exception')
+</macro>
+
+<group macro="raise_error">
+ Static hostname: {{ hostname }}
+         Chassis: {{ chassis }}
+      Machine ID: {{ machine_id }}
+Operating System: {{ os | ORPHRASE }}
+</group>
+        """
+        data_to_parse = """
+ Static hostname: localhost.localdomain
+         Chassis: vm
+      Machine ID: 2a26648f68764152a772fc20c9a3ddb3
+Operating System: CentOS Linux 7 (Core)
+        """
+        mock_cp_get_file_str = MagicMock(return_value=ttp_template)
+        mock_cmd_run = MagicMock(return_value=data_to_parse)
+        with patch.dict(
+            ttp_module.__salt__,
+            {"cmd.run": mock_cmd_run, "cp.get_file_str": mock_cp_get_file_str},
+        ):
+            # Simulate TTP run command
+            self.assertRaises(
+                CommandExecutionError,
+                ttp_module.run,
+                "cmd.run",
+                "hostnamectl",
+                template="salt://ttp/test_template.txt",
+            )
+
+    def test_ttp_run_template_with_imputs(self):
+        ttp_template = """
+<input>
+fun = "cmd.run"
+arg = ['hostnamectl']
+kwarg = {}
+</input>
+
+<group name="system">
+ Static hostname: {{ hostname }}
+         Chassis: {{ chassis }}
+      Machine ID: {{ machine_id }}
+Operating System: {{ os | ORPHRASE }}
+</group>
+        """
+        data_to_parse = """
+ Static hostname: localhost.localdomain
+         Chassis: vm
+      Machine ID: 2a26648f68764152a772fc20c9a3ddb3
+Operating System: CentOS Linux 7 (Core)
+        """
+        mock_cp_get_file_str = MagicMock(return_value=ttp_template)
+        mock_cmd_run = MagicMock(return_value=data_to_parse)
+        with patch.dict(
+            ttp_module.__salt__,
+            {"cmd.run": mock_cmd_run, "cp.get_file_str": mock_cp_get_file_str},
+        ):
+            # Simulate TTP run command
+            res = ttp_module.run(template="salt://ttp/test_template_1.txt")
+            assert res == [
+                [
+                    {
+                        "system": {
+                            "chassis": "vm",
+                            "hostname": "localhost.localdomain",
+                            "machine_id": "2a26648f68764152a772fc20c9a3ddb3",
+                            "os": "CentOS Linux 7 (Core)",
+                        }
+                    }
+                ]
+            ]
+
+    def test_ttp_run_net_cli_output(self):
+        ttp_template = """
+<group name="system">
+hostname {{ hostname }}
+</group>
+
+<group name="interfaces">
+interface {{ interface }}
+ description {{ description }}
+</group>
+        """
+        data_to_parse = {
+            "out": {
+                "show run | inc hostname": """
+hostname RT-CORE-1 
+                """,
+                "show run | sec interrface": """
+interface Eth1/1
+ description core381:Eth1/32
+interface Eth1/2
+ description chas012-sw1
+                """,
+            }
+        }
+        mock_cp_get_file_str = MagicMock(return_value=ttp_template)
+        mock_cmd_run = MagicMock(return_value=data_to_parse)
+        with patch.dict(
+            ttp_module.__salt__,
+            {"net.cli": mock_cmd_run, "cp.get_file_str": mock_cp_get_file_str},
+        ):
+            # Simulate TTP run command
+            res = ttp_module.run(
+                "net.cli",
+                "show run | inc hostname",
+                "show run | sec interrface",
+                template="salt://ttp/test_template_1.txt",
+            )
+            assert res == [
+                [
+                    {
+                        "interfaces": [
+                            {"description": "core381:Eth1/32", "interface": "Eth1/1"},
+                            {"description": "chas012-sw1", "interface": "Eth1/2"},
+                        ],
+                        "system": {"hostname": "RT-CORE-1"},
+                    }
+                ]
+            ]
+
+    def test_ttp_run_nr_cli_output(self):
+        ttp_template = """
+<group name="system">
+hostname {{ hostname }}
+</group>
+
+<group name="interfaces">
+interface {{ interface }}
+ description {{ description }}
+</group>
+        """
+        data_to_parse = {
+            "RT-CORE-1": {
+                "show run | inc hostname": """
+hostname RT-CORE-1 
+                """,
+                "show run | sec interrface": """
+interface Eth1/1
+ description core381:Eth1/32
+interface Eth1/2
+ description chas012-sw1
+                """,
+            },
+            "RT-CORE-2": {
+                "show run | inc hostname": """
+hostname RT-CORE-2
+                """,
+                "show run | sec interrface": """
+interface Eth1/11
+ description core382:Eth1/34
+interface Eth1/22
+ description chas011-sw2
+                """,
+            },
+        }
+        mock_cp_get_file_str = MagicMock(return_value=ttp_template)
+        mock_cmd_run = MagicMock(return_value=data_to_parse)
+        with patch.dict(
+            ttp_module.__salt__,
+            {"nr.cli": mock_cmd_run, "cp.get_file_str": mock_cp_get_file_str},
+        ):
+            # Simulate TTP run command
+            res = ttp_module.run(
+                "nr.cli",
+                "show run | inc hostname",
+                "show run | sec interrface",
+                template="salt://ttp/test_template_1.txt",
+            )
+            assert res == [
+                [
+                    {
+                        "interfaces": [
+                            {"description": "core381:Eth1/32", "interface": "Eth1/1"},
+                            {"description": "chas012-sw1", "interface": "Eth1/2"},
+                        ],
+                        "system": {"hostname": "RT-CORE-1"},
+                    },
+                    {
+                        "interfaces": [
+                            {"description": "core382:Eth1/34", "interface": "Eth1/11"},
+                            {"description": "chas011-sw2", "interface": "Eth1/22"},
+                        ],
+                        "system": {"hostname": "RT-CORE-2"},
+                    },
+                ]
+            ]
+
+    def test_ttp_run_mine_get_napalm_proxy_net_cli(self):
+        ttp_template = """
+<group name="system">
+hostname {{ hostname }}
+</group>
+
+<group name="interfaces">
+interface {{ interface }}
+ description {{ description }}
+</group>
+        """
+        data_to_parse = {
+            "proxy_minion_1": {
+                "out": {
+                    "show run | inc hostname": """
+hostname RT-CORE-1 
+                """,
+                    "show run | sec interrface": """
+interface Eth1/1
+ description core381:Eth1/32
+interface Eth1/2
+ description chas012-sw1
+                """,
+                }
+            }
+        }
+        mock_cp_get_file_str = MagicMock(return_value=ttp_template)
+        mock_cmd_run = MagicMock(return_value=data_to_parse)
+        with patch.dict(
+            ttp_module.__salt__,
+            {"mine.get": mock_cmd_run, "cp.get_file_str": mock_cp_get_file_str},
+        ):
+            with patch.dict(
+                ttp_module.__pillar__,
+                {"proxy": {"proxytype": "napalm"}},
+            ):
+                # Simulate TTP run command
+                res = ttp_module.run(
+                    "mine.get",
+                    "proxy_minion_1",
+                    "net.cli",
+                    template="salt://ttp/test_template_1.txt",
+                )
+                assert res == [
+                    [
+                        {
+                            "interfaces": [
+                                {
+                                    "description": "core381:Eth1/32",
+                                    "interface": "Eth1/1",
+                                },
+                                {"description": "chas012-sw1", "interface": "Eth1/2"},
+                            ],
+                            "system": {"hostname": "RT-CORE-1"},
+                        }
+                    ]
+                ]
+
+    def test_ttp_run_mine_get_nornir_proxy_nr_cli(self):
+        ttp_template = """
+<group name="system">
+hostname {{ hostname }}
+</group>
+
+<group name="interfaces">
+interface {{ interface }}
+ description {{ description }}
+</group>
+        """
+        data_to_parse = {
+            "proxy_minion_1": {
+                "RT-CORE-1": {
+                    "show run | inc hostname": """
+hostname RT-CORE-1 
+                """,
+                    "show run | sec interrface": """
+interface Eth1/1
+ description core381:Eth1/32
+interface Eth1/2
+ description chas012-sw1
+                """,
+                },
+                "RT-CORE-2": {
+                    "show run | inc hostname": """
+hostname RT-CORE-2
+                """,
+                    "show run | sec interrface": """
+interface Eth1/11
+ description core382:Eth1/34
+interface Eth1/22
+ description chas011-sw2
+                """,
+                },
+            }
+        }
+        mock_cp_get_file_str = MagicMock(return_value=ttp_template)
+        mock_cmd_run = MagicMock(return_value=data_to_parse)
+        with patch.dict(
+            ttp_module.__salt__,
+            {"mine.get": mock_cmd_run, "cp.get_file_str": mock_cp_get_file_str},
+        ):
+            with patch.dict(
+                ttp_module.__pillar__,
+                {"proxy": {"proxytype": "nornir"}},
+            ):
+                # Simulate TTP run command
+                res = ttp_module.run(
+                    "mine.get",
+                    "proxy_minion_1",
+                    "nr.cli",
+                    template="salt://ttp/test_template_1.txt",
+                )
+                assert res == [
+                    [
+                        {
+                            "interfaces": [
+                                {
+                                    "description": "core381:Eth1/32",
+                                    "interface": "Eth1/1",
+                                },
+                                {"description": "chas012-sw1", "interface": "Eth1/2"},
+                            ],
+                            "system": {"hostname": "RT-CORE-1"},
+                        },
+                        {
+                            "interfaces": [
+                                {
+                                    "description": "core382:Eth1/34",
+                                    "interface": "Eth1/11",
+                                },
+                                {"description": "chas011-sw2", "interface": "Eth1/22"},
+                            ],
+                            "system": {"hostname": "RT-CORE-2"},
+                        },
+                    ]
+                ]
+
+    def test_ttp_run_elc_ttp_custom_returner(self):
+        ttp_template = """
+<group>
+ Static hostname: {{ hostname }}
+         Chassis: {{ chassis }}
+      Machine ID: {{ machine_id }}
+Operating System: {{ os | ORPHRASE }}
+</group>
+
+<output>
+returner = "elasticsearch"
+index = "intf_counters_test"
+</output>
+        """
+        data_to_parse = """
+ Static hostname: localhost.localdomain
+         Chassis: vm
+      Machine ID: 2a26648f68764152a772fc20c9a3ddb3
+Operating System: CentOS Linux 7 (Core)
+        """
+        mock_cp_get_file_str = MagicMock(return_value=ttp_template)
+        mock_cmd_run = MagicMock(return_value=data_to_parse)
+        with patch.dict(
+            ttp_module.__salt__,
+            {
+                "cmd.run": mock_cmd_run,
+                "cp.get_file_str": mock_cp_get_file_str,
+                "elasticsearch.document_create": MagicMock(return_value=True),
+            },
+        ):
+            # Simulate TTP run command
+            res = ttp_module.run(
+                "cmd.run", "hostnamectl", template="salt://ttp/test_template_1.txt"
+            )
+            assert res == [
+                [
+                    [
+                        {
+                            "chassis": "vm",
+                            "hostname": "localhost.localdomain",
+                            "machine_id": "2a26648f68764152a772fc20c9a3ddb3",
+                            "os": "CentOS Linux 7 (Core)",
+                        }
+                    ]
+                ]
+            ]
+
+    def test_ttp_run_minion_id_injection_in_ttp_vars(self):
+        ttp_template = """
+ Static hostname: {{ hostname }}
+         Chassis: {{ chassis }}
+      Machine ID: {{ machine_id }}
+Operating System: {{ os | ORPHRASE }}
+{{ minon_id | set("_minion_id_") }}
+        """
+        data_to_parse = """
+ Static hostname: localhost.localdomain
+         Chassis: vm
+      Machine ID: 2a26648f68764152a772fc20c9a3ddb3
+Operating System: CentOS Linux 7 (Core)
+        """
+        mock_cp_get_file_str = MagicMock(return_value=ttp_template)
+        mock_cmd_run = MagicMock(return_value=data_to_parse)
+        with patch.dict(
+            ttp_module.__salt__,
+            {"cmd.run": mock_cmd_run, "cp.get_file_str": mock_cp_get_file_str},
+        ):
+            # Simulate TTP run command
+            res = ttp_module.run(
+                "cmd.run", "hostnamectl", template="salt://ttp/test_template_1.txt"
+            )
+            assert res == [
+                [
+                    {
+                        "chassis": "vm",
+                        "hostname": "localhost.localdomain",
+                        "machine_id": "2a26648f68764152a772fc20c9a3ddb3",
+                        "minon_id": "test_minion_id",
+                        "os": "CentOS Linux 7 (Core)",
+                    }
+                ]
+            ]
+
+    def test_ttp_run_custom_vars_injection_in_ttp_vars(self):
+        ttp_template = """
+ Static hostname: {{ hostname }}
+         Chassis: {{ chassis }}
+      Machine ID: {{ machine_id }}
+Operating System: {{ os | ORPHRASE }}
+{{ cust_var_1 | set("var1") }}
+        """
+        data_to_parse = """
+ Static hostname: localhost.localdomain
+         Chassis: vm
+      Machine ID: 2a26648f68764152a772fc20c9a3ddb3
+Operating System: CentOS Linux 7 (Core)
+        """
+        mock_cp_get_file_str = MagicMock(return_value=ttp_template)
+        mock_cmd_run = MagicMock(return_value=data_to_parse)
+        with patch.dict(
+            ttp_module.__salt__,
+            {"cmd.run": mock_cmd_run, "cp.get_file_str": mock_cp_get_file_str},
+        ):
+            # Simulate TTP run command
+            res = ttp_module.run(
+                "cmd.run",
+                "hostnamectl",
+                template="salt://ttp/test_template_1.txt",
+                vars={"var1": "val1", "a": "b"},
+            )
+            assert res == [
+                [
+                    {
+                        "chassis": "vm",
+                        "cust_var_1": "val1",
+                        "hostname": "localhost.localdomain",
+                        "machine_id": "2a26648f68764152a772fc20c9a3ddb3",
+                        "os": "CentOS Linux 7 (Core)",
+                    }
+                ]
+            ]

--- a/tests/unit/modules/test_ttp.py
+++ b/tests/unit/modules/test_ttp.py
@@ -89,7 +89,7 @@ Operating System: CentOS Linux 7 (Core)
         """
         This test returns None for "cp.get_file_str" simulating
         wrong path to or non existing template raising CommandExecutionError
-        dues to "template_text" is None
+        due to "template_text" is None
         """
         mock_cp_get_file_str = MagicMock(return_value=None)
         with patch.dict(
@@ -130,8 +130,8 @@ Operating System: CentOS Linux 7 (Core)
 
     def test_ttp_run_fail_to_parse(self):
         """
-        This template raises exception withoint template macro trigerring
-        causing CommandExecutionError fpr "parser.parse(one=True)" call
+        This template raises exception within template macro triggering
+        CommandExecutionError for "parser.parse(one=True)" call
         """
         ttp_template = """
 <macro>

--- a/tests/unit/modules/test_ttp.py
+++ b/tests/unit/modules/test_ttp.py
@@ -6,10 +6,11 @@ import salt.modules.ttp as ttp_module
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch
-from tests.support.unit import TestCase
+from tests.support.unit import TestCase, skipIf
 from salt.exceptions import CommandExecutionError
 
 
+@skipIf(not ttp_module.HAS_TTP, "TTP module required for this test")
 class TTPModuleTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         module_globals = {"__salt__": {}, "__opts__": {"id": "test_minion_id"}}

--- a/tests/unit/modules/test_ttp.py
+++ b/tests/unit/modules/test_ttp.py
@@ -3,11 +3,10 @@
 """
 import salt.modules.ttp as ttp_module
 
-# Import Salt Testing Libs
+from salt.exceptions import CommandExecutionError
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase, skipIf
-from salt.exceptions import CommandExecutionError
 
 
 @skipIf(not ttp_module.HAS_TTP, "TTP module required for this test")
@@ -90,11 +89,7 @@ Operating System: CentOS Linux 7 (Core)
         """
         This test returns None for "cp.get_file_str" simulating
         wrong path to or non existing template raising CommandExecutionError
-<<<<<<< HEAD
         due to "template_text" is None
-=======
-        dues to "template_text" is None
->>>>>>> 2a368deaa7 (Added test for ttp execution module.)
         """
         mock_cp_get_file_str = MagicMock(return_value=None)
         with patch.dict(
@@ -135,13 +130,8 @@ Operating System: CentOS Linux 7 (Core)
 
     def test_ttp_run_fail_to_parse(self):
         """
-<<<<<<< HEAD
         This template raises exception within template macro triggering
         CommandExecutionError for "parser.parse(one=True)" call
-=======
-        This template raises exception withoint template macro trigerring
-        causing CommandExecutionError fpr "parser.parse(one=True)" call
->>>>>>> 2a368deaa7 (Added test for ttp execution module.)
         """
         ttp_template = """
 <macro>

--- a/tests/unit/modules/test_ttp.py
+++ b/tests/unit/modules/test_ttp.py
@@ -2,7 +2,6 @@
     :codeauthor: Denis Mulyalin <d.mulyalin@gmail.com>
 """
 import salt.modules.ttp as ttp_module
-
 from salt.exceptions import CommandExecutionError
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch

--- a/tests/unit/modules/test_ttp.py
+++ b/tests/unit/modules/test_ttp.py
@@ -89,7 +89,11 @@ Operating System: CentOS Linux 7 (Core)
         """
         This test returns None for "cp.get_file_str" simulating
         wrong path to or non existing template raising CommandExecutionError
+<<<<<<< HEAD
         due to "template_text" is None
+=======
+        dues to "template_text" is None
+>>>>>>> 2a368deaa7 (Added test for ttp execution module.)
         """
         mock_cp_get_file_str = MagicMock(return_value=None)
         with patch.dict(
@@ -130,8 +134,13 @@ Operating System: CentOS Linux 7 (Core)
 
     def test_ttp_run_fail_to_parse(self):
         """
+<<<<<<< HEAD
         This template raises exception within template macro triggering
         CommandExecutionError for "parser.parse(one=True)" call
+=======
+        This template raises exception withoint template macro trigerring
+        causing CommandExecutionError fpr "parser.parse(one=True)" call
+>>>>>>> 2a368deaa7 (Added test for ttp execution module.)
         """
         ttp_template = """
 <macro>

--- a/tests/unit/runners/test_ttp.py
+++ b/tests/unit/runners/test_ttp.py
@@ -1,0 +1,774 @@
+"""
+    :codeauthor: Denis Mulyalin <d.mulyalin@gmail.com>
+"""
+import salt.runners.ttp as ttp_module
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.mock import MagicMock, patch
+from tests.support.unit import TestCase
+from salt.exceptions import CommandExecutionError
+
+
+class TTPRunnerModuleTestCase(TestCase, LoaderModuleMockMixin):
+    def setup_loader_modules(self):
+        module_globals = {
+            "__salt__": {},
+            "__opts__": {"id": "master", "timeout": 100},
+        }
+
+        return {ttp_module: module_globals}
+
+    def test_ttp_run_minion_inline_command(self):
+        ttp_template = """
+ Static hostname: {{ hostname }}
+         Chassis: {{ chassis }}
+      Machine ID: {{ machine_id }}
+Operating System: {{ os | ORPHRASE }}
+        """
+        data_to_parse = [
+            {
+                "minion_1": {
+                    "ret": """
+ Static hostname: localhost.localdomain
+         Chassis: vm
+      Machine ID: 2a26648f68764152a772fc20c9a3ddb3
+Operating System: CentOS Linux 7 (Core)
+        """
+                }
+            }
+        ]
+        mock_cp_get_file_str = MagicMock(return_value=ttp_template)
+        with patch.dict(
+            ttp_module.__salt__,
+            {"salt.cmd": mock_cp_get_file_str},
+        ):
+            with patch.object(ttp_module, "client", MagicMock()) as MockClient:
+
+                def mock(*args, **kwargs):
+                    return data_to_parse
+
+                # ttp getting results by calling:
+                # inline_cmd_results = client.cmd_iter(*args, **kwargs)
+                # below we creating dummy "cmd_iter" method for MockClient
+                MockClient.cmd_iter = mock
+
+                # Simulate TTP run command
+                res = ttp_module.run(
+                    "minion_1",
+                    "cmd.run",
+                    "hostnamectl",
+                    template="salt://ttp/test_template_1.txt",
+                )
+                assert res == [
+                    [
+                        {
+                            "chassis": "vm",
+                            "hostname": "localhost.localdomain",
+                            "machine_id": "2a26648f68764152a772fc20c9a3ddb3",
+                            "os": "CentOS Linux 7 (Core)",
+                        }
+                    ]
+                ]
+
+    def test_ttp_run_minion_inline_command_flat_list(self):
+        ttp_template = """
+ Static hostname: {{ hostname }}
+         Chassis: {{ chassis }}
+      Machine ID: {{ machine_id }}
+Operating System: {{ os | ORPHRASE }}
+        """
+        data_to_parse = [
+            {
+                "minion_1": {
+                    "ret": """
+ Static hostname: localhost.localdomain
+         Chassis: vm
+      Machine ID: 2a26648f68764152a772fc20c9a3ddb3
+Operating System: CentOS Linux 7 (Core)
+        """
+                }
+            }
+        ]
+        mock_cp_get_file_str = MagicMock(return_value=ttp_template)
+        with patch.dict(
+            ttp_module.__salt__,
+            {"salt.cmd": mock_cp_get_file_str},
+        ):
+            with patch.object(ttp_module, "client", MagicMock()) as MockClient:
+
+                def mock(*args, **kwargs):
+                    return data_to_parse
+
+                # ttp getting results by calling:
+                # inline_cmd_results = client.cmd_iter(*args, **kwargs)
+                # below we creating dummy "cmd_iter" method for MockClient
+                MockClient.cmd_iter = mock
+
+                # Simulate TTP run command
+                res = ttp_module.run(
+                    "minion_1",
+                    "cmd.run",
+                    "hostnamectl",
+                    template="salt://ttp/test_template_1.txt",
+                    ttp_res_kwargs={"structure": "flat_list"},
+                )
+                assert res == [
+                    {
+                        "chassis": "vm",
+                        "hostname": "localhost.localdomain",
+                        "machine_id": "2a26648f68764152a772fc20c9a3ddb3",
+                        "os": "CentOS Linux 7 (Core)",
+                    }
+                ]
+
+    def test_ttp_run_fail_template_file_load(self):
+        """
+        This test returns None for "cp.get_file_str" simulating
+        wrong path to or non existing template raising CommandExecutionError
+        dues to "template_text" is None
+        """
+        mock_cp_get_file_str = MagicMock(return_value=None)
+        with patch.dict(
+            ttp_module.__salt__,
+            {"salt.cmd": mock_cp_get_file_str},
+        ):
+            self.assertRaises(
+                CommandExecutionError,
+                ttp_module.run,
+                "minion_1",
+                "cmd.run",
+                "hostnamectl",
+                template="salt://ttp/test_template_1.txt",
+            )
+
+    def test_ttp_run_template_fail_to_load(self):
+        """
+        This test loads badly formatted template, causing
+        CommandExecutionError for "parser.add_template(template_text)"
+        call
+        """
+        broken_template = """
+<group name="bla">
+ Static hostname: {{ hostname }}
+<
+        """
+        mock_cp_get_file_str = MagicMock(return_value=broken_template)
+        with patch.dict(
+            ttp_module.__salt__,
+            {"salt.cmd": mock_cp_get_file_str},
+        ):
+            # Simulate TTP run command
+            self.assertRaises(
+                CommandExecutionError,
+                ttp_module.run,
+                "minion_1",
+                "cmd.run",
+                "hostnamectl",
+                template="salt://ttp/test_template_1.txt",
+            )
+
+    def test_ttp_run_fail_to_parse(self):
+        """
+        This template raises exception within template macro trigerring
+        CommandExecutionError for "parser.parse(one=True)" call
+        """
+        ttp_template = """
+<macro>
+def raise_error(data):
+    raise NameError('HiThere, testing exception')
+</macro>
+
+<group macro="raise_error">
+ Static hostname: {{ hostname }}
+         Chassis: {{ chassis }}
+      Machine ID: {{ machine_id }}
+Operating System: {{ os | ORPHRASE }}
+</group>
+        """
+        data_to_parse = [
+            {
+                "minion_1": {
+                    "ret": """
+ Static hostname: localhost.localdomain
+         Chassis: vm
+      Machine ID: 2a26648f68764152a772fc20c9a3ddb3
+Operating System: CentOS Linux 7 (Core)
+        """
+                }
+            }
+        ]
+        mock_cp_get_file_str = MagicMock(return_value=ttp_template)
+        with patch.dict(
+            ttp_module.__salt__,
+            {"salt.cmd": mock_cp_get_file_str},
+        ):
+            with patch.object(ttp_module, "client", MagicMock()) as MockClient:
+
+                def mock(*args, **kwargs):
+                    return data_to_parse
+
+                # ttp getting results by calling:
+                # inline_cmd_results = client.cmd_iter(*args, **kwargs)
+                # below we creating dummy "cmd_iter" method for MockClient
+                MockClient.cmd_iter = mock
+
+                # Simulate TTP run command
+                self.assertRaises(
+                    CommandExecutionError,
+                    ttp_module.run,
+                    "minion_1",
+                    "cmd.run",
+                    "hostnamectl",
+                    template="salt://ttp/test_template_1.txt",
+                )
+
+    def test_ttp_run_net_cli_output(self):
+        ttp_template = """
+<group name="system">
+hostname {{ hostname }}
+</group>
+
+<vars>sysname="gethostname"</vars>
+
+<group name="interfaces">
+interface {{ interface }}
+ description {{ description }}
+{{ system_name | set("sysname") }}
+</group>
+        """
+        data_to_parse = [
+            {
+                "minion_1": {
+                    "ret": {
+                        "out": {
+                            "show run | inc hostname": """
+hostname RT-CORE-1 
+                            """,
+                            "show run | sec interface": """
+interface Eth1/1
+ description core381:Eth1/32
+interface Eth1/2
+ description chas012-sw1
+                            """,
+                        }
+                    }
+                }
+            }
+        ]
+        mock_cp_get_file_str = MagicMock(return_value=ttp_template)
+        with patch.dict(
+            ttp_module.__salt__,
+            {"salt.cmd": mock_cp_get_file_str},
+        ):
+            with patch.object(ttp_module, "client", MagicMock()) as MockClient:
+
+                def mock(*args, **kwargs):
+                    return data_to_parse
+
+                # ttp getting results by calling:
+                # inline_cmd_results = client.cmd_iter(*args, **kwargs)
+                # below we creating dummy "cmd_iter" method for MockClient
+                MockClient.cmd_iter = mock
+
+                # Simulate TTP run command
+                res = ttp_module.run(
+                    "minion_1",
+                    "net.cli",
+                    "show run | inc hostname",
+                    "show run | sec interface",
+                    template="salt://ttp/test_template_1.txt",
+                )
+                assert res == [
+                    [
+                        {
+                            "interfaces": [
+                                {
+                                    "description": "core381:Eth1/32",
+                                    "interface": "Eth1/1",
+                                    "system_name": "minion_1",
+                                },
+                                {
+                                    "description": "chas012-sw1",
+                                    "interface": "Eth1/2",
+                                    "system_name": "minion_1",
+                                },
+                            ],
+                            "system": {"hostname": "RT-CORE-1"},
+                        }
+                    ]
+                ]
+
+    def test_ttp_run_nr_cli_output(self):
+        ttp_template = """
+<group name="system">
+hostname {{ hostname }}
+</group>
+
+<vars>sysname="gethostname"</vars>
+
+<group name="interfaces">
+interface {{ interface }}
+ description {{ description }}
+{{ system_name | set("sysname") }}
+</group>
+        """
+        data_to_parse = [
+            {
+                "minion_1": {
+                    "ret": {
+                        "minion_111": {
+                            "show run | inc hostname": """
+hostname RT-CORE-1 
+                            """,
+                            "show run | sec interface": """
+interface Eth1/1
+ description core381:Eth1/32
+interface Eth1/2
+ description chas012-sw1
+                            """,
+                        },
+                        "minion_222": {
+                            "show run | inc hostname": """
+hostname RT-CORE-341
+                            """,
+                            "show run | sec interface": """
+interface Eth1/35
+ description core389:Eth1/36
+interface Eth1/22
+ description chas0121-sw11
+                            """,
+                        },
+                    }
+                }
+            }
+        ]
+        mock_cp_get_file_str = MagicMock(return_value=ttp_template)
+        with patch.dict(
+            ttp_module.__salt__,
+            {"salt.cmd": mock_cp_get_file_str},
+        ):
+            with patch.object(ttp_module, "client", MagicMock()) as MockClient:
+
+                def mock(*args, **kwargs):
+                    return data_to_parse
+
+                # ttp getting results by calling:
+                # inline_cmd_results = client.cmd_iter(*args, **kwargs)
+                # below we creating dummy "cmd_iter" method for MockClient
+                MockClient.cmd_iter = mock
+
+                # Simulate TTP run command
+                res = ttp_module.run(
+                    "nornir_minion",
+                    "nr.cli",
+                    "show run | inc hostname",
+                    "show run | sec interface",
+                    template="salt://ttp/test_template_1.txt",
+                )
+                assert res == [
+                    [
+                        {
+                            "interfaces": [
+                                {
+                                    "description": "core381:Eth1/32",
+                                    "interface": "Eth1/1",
+                                    "system_name": "minion_111",
+                                },
+                                {
+                                    "description": "chas012-sw1",
+                                    "interface": "Eth1/2",
+                                    "system_name": "minion_111",
+                                },
+                            ],
+                            "system": {"hostname": "RT-CORE-1"},
+                        },
+                        {
+                            "interfaces": [
+                                {
+                                    "description": "core389:Eth1/36",
+                                    "interface": "Eth1/35",
+                                    "system_name": "minion_222",
+                                },
+                                {
+                                    "description": "chas0121-sw11",
+                                    "interface": "Eth1/22",
+                                    "system_name": "minion_222",
+                                },
+                            ],
+                            "system": {"hostname": "RT-CORE-341"},
+                        },
+                    ]
+                ]
+
+    def test_ttp_run_mine_get_napalm_proxy_net_cli(self):
+        """
+        To test that TTP can parse mine.get output for net.cli
+        function
+        """
+        ttp_template = """
+<group name="system">
+hostname {{ hostname }}
+</group>
+
+<vars>sysname="gethostname"</vars>
+
+<group name="interfaces">
+interface {{ interface }}
+ description {{ description }}
+{{ system_name | set("sysname") }}
+</group>
+        """
+        data_to_parse = [
+            {
+                "minion_1": {
+                    "ret": {
+                        "minion_1": {
+                            "out": {
+                                "show run | inc hostname": """
+hostname RT-CORE-1 
+                                """,
+                                "show run | sec interface": """
+interface Eth1/1
+ description core381:Eth1/32
+interface Eth1/2
+ description chas012-sw1
+                                """,
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+        mock_cp_get_file_str = MagicMock(return_value=ttp_template)
+        with patch.dict(
+            ttp_module.__salt__,
+            {"salt.cmd": mock_cp_get_file_str},
+        ):
+            with patch.object(ttp_module, "client", MagicMock()) as MockClient:
+
+                def mock_cmd_iter(*args, **kwargs):
+                    return data_to_parse
+
+                def mock_cmd(*args, **kwargs):
+                    return {"minion_1": {"proxy": {"proxytype": "napalm"}}}
+
+                # ttp getting results by calling:
+                # inline_cmd_results = client.cmd_iter(*args, **kwargs)
+                # below we creating dummy "cmd_iter" method for MockClient
+                MockClient.cmd_iter = mock_cmd_iter
+                MockClient.cmd = mock_cmd
+
+                # Simulate TTP run command
+                res = ttp_module.run(
+                    "minion_1",
+                    "mine.get",
+                    "minion_1",
+                    "net.cli",
+                    template="salt://ttp/test_template_1.txt",
+                )
+                assert res == [
+                    [
+                        {
+                            "interfaces": [
+                                {
+                                    "description": "core381:Eth1/32",
+                                    "interface": "Eth1/1",
+                                    "system_name": "minion_1",
+                                },
+                                {
+                                    "description": "chas012-sw1",
+                                    "interface": "Eth1/2",
+                                    "system_name": "minion_1",
+                                },
+                            ],
+                            "system": {"hostname": "RT-CORE-1"},
+                        }
+                    ]
+                ]
+
+    def test_ttp_run_mine_get_nornir_proxy_nr_cli(self):
+        ttp_template = """
+<group name="system">
+hostname {{ hostname }}
+</group>
+
+<vars>sysname="gethostname"</vars>
+
+<group name="interfaces">
+interface {{ interface }}
+ description {{ description }}
+{{ system_name | set("sysname") }}
+</group>
+        """
+        data_to_parse = [
+            {
+                "nornir_minion": {
+                    "ret": {
+                        "nornir_minion": {
+                            "minion_111": {
+                                "show run | inc hostname": """
+hostname RT-CORE-1 
+                            """,
+                                "show run | sec interface": """
+interface Eth1/1
+ description core381:Eth1/32
+interface Eth1/2
+ description chas012-sw1
+                            """,
+                            },
+                            "minion_222": {
+                                "show run | inc hostname": """
+hostname RT-CORE-341
+                            """,
+                                "show run | sec interface": """
+interface Eth1/35
+ description core389:Eth1/36
+interface Eth1/22
+ description chas0121-sw11
+                            """,
+                            },
+                        }
+                    }
+                }
+            }
+        ]
+        mock_cp_get_file_str = MagicMock(return_value=ttp_template)
+        with patch.dict(
+            ttp_module.__salt__,
+            {"salt.cmd": mock_cp_get_file_str},
+        ):
+            with patch.object(ttp_module, "client", MagicMock()) as MockClient:
+
+                def mock_cmd_iter(*args, **kwargs):
+                    return data_to_parse
+
+                def mock_cmd(*args, **kwargs):
+                    return {"nornir_minion": {"proxy": {"proxytype": "nornir"}}}
+
+                # ttp getting results by calling:
+                # inline_cmd_results = client.cmd_iter(*args, **kwargs)
+                # below we creating dummy "cmd_iter" method for MockClient
+                MockClient.cmd_iter = mock_cmd_iter
+                MockClient.cmd = mock_cmd
+
+                # Simulate TTP run command
+                res = ttp_module.run(
+                    "nornir_minion",
+                    "mine.get",
+                    "nornir_minion",
+                    template="salt://ttp/test_template_1.txt",
+                )
+                assert res == [
+                    [
+                        {
+                            "interfaces": [
+                                {
+                                    "description": "core381:Eth1/32",
+                                    "interface": "Eth1/1",
+                                    "system_name": "minion_111",
+                                },
+                                {
+                                    "description": "chas012-sw1",
+                                    "interface": "Eth1/2",
+                                    "system_name": "minion_111",
+                                },
+                            ],
+                            "system": {"hostname": "RT-CORE-1"},
+                        },
+                        {
+                            "interfaces": [
+                                {
+                                    "description": "core389:Eth1/36",
+                                    "interface": "Eth1/35",
+                                    "system_name": "minion_222",
+                                },
+                                {
+                                    "description": "chas0121-sw11",
+                                    "interface": "Eth1/22",
+                                    "system_name": "minion_222",
+                                },
+                            ],
+                            "system": {"hostname": "RT-CORE-341"},
+                        },
+                    ]
+                ]
+
+    def test_ttp_run_elc_ttp_custom_returner(self):
+        ttp_template = """
+<group>
+ Static hostname: {{ hostname }}
+         Chassis: {{ chassis }}
+      Machine ID: {{ machine_id }}
+Operating System: {{ os | ORPHRASE }}
+</group>
+
+<output>
+returner = "elasticsearch"
+index = "intf_counters_test"
+</output>
+        """
+        data_to_parse = [
+            {
+                "minion_1": {
+                    "ret": """
+ Static hostname: localhost.localdomain
+         Chassis: vm
+      Machine ID: 2a26648f68764152a772fc20c9a3ddb3
+Operating System: CentOS Linux 7 (Core)
+        """
+                }
+            }
+        ]
+        mock_cp_get_file_str = MagicMock(return_value=ttp_template)
+        with patch.dict(
+            ttp_module.__salt__,
+            {
+                "salt.cmd": mock_cp_get_file_str,
+                "elasticsearch.document_create": MagicMock(return_value=True),
+            },
+        ):
+            with patch.object(ttp_module, "client", MagicMock()) as MockClient:
+
+                def mock(*args, **kwargs):
+                    return data_to_parse
+
+                # ttp getting results by calling:
+                # inline_cmd_results = client.cmd_iter(*args, **kwargs)
+                # below we creating dummy "cmd_iter" method for MockClient
+                MockClient.cmd_iter = mock
+
+                # Simulate TTP run command
+                res = ttp_module.run(
+                    "minion_1",
+                    "cmd.run",
+                    "hostnamectl",
+                    template="salt://ttp/test_template_1.txt",
+                )
+                assert res == [
+                    [
+                        [
+                            {
+                                "chassis": "vm",
+                                "hostname": "localhost.localdomain",
+                                "machine_id": "2a26648f68764152a772fc20c9a3ddb3",
+                                "os": "CentOS Linux 7 (Core)",
+                            }
+                        ]
+                    ]
+                ]
+
+    def test_ttp_run_custom_vars_injection_in_ttp_vars(self):
+        ttp_template = """
+ Static hostname: {{ hostname }}
+         Chassis: {{ chassis }}
+      Machine ID: {{ machine_id }}
+Operating System: {{ os | ORPHRASE }}
+{{ custom_var1 | set("var1") }}
+        """
+        data_to_parse = [
+            {
+                "minion_1": {
+                    "ret": """
+ Static hostname: localhost.localdomain
+         Chassis: vm
+      Machine ID: 2a26648f68764152a772fc20c9a3ddb3
+Operating System: CentOS Linux 7 (Core)
+        """
+                }
+            }
+        ]
+        mock_cp_get_file_str = MagicMock(return_value=ttp_template)
+        with patch.dict(
+            ttp_module.__salt__,
+            {"salt.cmd": mock_cp_get_file_str},
+        ):
+            with patch.object(ttp_module, "client", MagicMock()) as MockClient:
+
+                def mock(*args, **kwargs):
+                    return data_to_parse
+
+                # ttp getting results by calling:
+                # inline_cmd_results = client.cmd_iter(*args, **kwargs)
+                # below we creating dummy "cmd_iter" method for MockClient
+                MockClient.cmd_iter = mock
+
+                # Simulate TTP run command
+                res = ttp_module.run(
+                    "minion_1",
+                    "cmd.run",
+                    "hostnamectl",
+                    template="salt://ttp/test_template_1.txt",
+                    vars={"var1": "val1"},
+                )
+                assert res == [
+                    [
+                        {
+                            "chassis": "vm",
+                            "hostname": "localhost.localdomain",
+                            "machine_id": "2a26648f68764152a772fc20c9a3ddb3",
+                            "os": "CentOS Linux 7 (Core)",
+                            "custom_var1": "val1",
+                        }
+                    ]
+                ]
+
+    def test_ttp_run_minion_template_with_inputs(self):
+        ttp_template = """
+<input name="sys_host">
+tgt = "minion_1"
+fun = "cmd.run"
+arg = ['hostnamectl']
+kwarg = {}
+tgt_type = "glob"
+</input>
+    
+<group name="system" input="sys_host">
+ Static hostname: {{ hostname }}
+         Chassis: {{ chassis }}
+      Machine ID: {{ machine_id }}
+Operating System: {{ os | ORPHRASE }}
+</group>
+        """
+        data_to_parse = [
+            {
+                "minion_1": {
+                    "ret": """
+ Static hostname: localhost.localdomain
+         Chassis: vm
+      Machine ID: 2a26648f68764152a772fc20c9a3ddb3
+Operating System: CentOS Linux 7 (Core)
+        """
+                }
+            }
+        ]
+        mock_cp_get_file_str = MagicMock(return_value=ttp_template)
+        with patch.dict(
+            ttp_module.__salt__,
+            {"salt.cmd": mock_cp_get_file_str},
+        ):
+            with patch.object(ttp_module, "client", MagicMock()) as MockClient:
+
+                def mock(*args, **kwargs):
+                    return data_to_parse
+
+                # ttp getting results by calling:
+                # inline_cmd_results = client.cmd_iter(*args, **kwargs)
+                # below we creating dummy "cmd_iter" method for MockClient
+                MockClient.cmd_iter = mock
+
+                # Simulate TTP run command
+                res = ttp_module.run("salt://ttp/test_template_1.txt")
+
+                assert res == [
+                    [
+                        {
+                            "system": {
+                                "chassis": "vm",
+                                "hostname": "localhost.localdomain",
+                                "machine_id": "2a26648f68764152a772fc20c9a3ddb3",
+                                "os": "CentOS Linux 7 (Core)",
+                            }
+                        }
+                    ]
+                ]

--- a/tests/unit/runners/test_ttp.py
+++ b/tests/unit/runners/test_ttp.py
@@ -6,10 +6,11 @@ import salt.runners.ttp as ttp_module
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch
-from tests.support.unit import TestCase
+from tests.support.unit import TestCase, skipIf
 from salt.exceptions import CommandExecutionError
 
 
+@skipIf(not ttp_module.HAS_TTP, "TTP module required for this test")
 class TTPRunnerModuleTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         module_globals = {

--- a/tests/unit/runners/test_ttp.py
+++ b/tests/unit/runners/test_ttp.py
@@ -2,7 +2,6 @@
     :codeauthor: Denis Mulyalin <d.mulyalin@gmail.com>
 """
 import salt.runners.ttp as ttp_module
-
 from salt.exceptions import CommandExecutionError
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch

--- a/tests/unit/runners/test_ttp.py
+++ b/tests/unit/runners/test_ttp.py
@@ -3,11 +3,10 @@
 """
 import salt.runners.ttp as ttp_module
 
-# Import Salt Testing Libs
+from salt.exceptions import CommandExecutionError
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase, skipIf
-from salt.exceptions import CommandExecutionError
 
 
 @skipIf(not ttp_module.HAS_TTP, "TTP module required for this test")


### PR DESCRIPTION
### What does this PR do?

Added two new modules:
 - TTP execution module
 - TTP runner module

TTP is a library for parsing semi structured text using templates. New execution and runner modules allow to run commands against minions to obtain output in a text format for the sake of parsing and processing using TTP templates to transform it in structured data such as lists or dictionaries.

Sample use cases that TTP can help to address
- reporting across several minions by parsing text output and returning text tables
- transforming text data in structured format for storing in mine
- time series data can be produced using TTP templates and pushed to databases using returners
- compliance testing by parsing text into structured data with further processing and analysis to detect deviations

Given that text data can be transformed into structured data of arbitrary hierarchy, this modules can significantly expand functionality in the area of minions state analysis and processing.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
