### PR TITLE
Update arch.rst

### DIFF
--- a/doc/topics/installation/arch.rst
+++ b/doc/topics/installation/arch.rst
@@ -26,7 +26,7 @@ use the -git package. Installing the -git package as follows:
 
 .. code-block:: bash
 
-    wget https://aur.archlinux.org/packages/sa/salt-git/salt-git.tar.gz
+    wget https://aur.archlinux.org/cgit/aur.git/snapshot/salt-git.tar.gz 
     tar xf salt-git.tar.gz
     cd salt-git/
     makepkg -is


### PR DESCRIPTION
Fixed typo in Arch Installation documenation that led to an invalid URL.

### What does this PR do?
Fixes a typo in the Arch Installation documenation.

### What issues does this PR fix or reference?
Fixes: None

### Previous Behavior
Remove this section if not relevant


### Merge requirements satisfied?

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
