### PR TITLE
WIP/boto3 refactor boto_cfn to use boto3

### DIFF
--- a/changelog/58772.changed
+++ b/changelog/58772.changed
@@ -1,0 +1,1 @@
+Refactor boto_cfn to use boto3

--- a/salt/modules/boto_cfn.py
+++ b/salt/modules/boto_cfn.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Connection module for Amazon Cloud Formation
 
@@ -32,19 +31,13 @@ Connection module for Amazon Cloud Formation
 # keep lint from choking on _get_conn and _cache_id
 # pylint: disable=E0602
 
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
 import salt.utils.versions
 
-# Import Salt libs
-from salt.ext import six
-
 log = logging.getLogger(__name__)
 
-# Import third party libs
 # pylint: disable=import-error
 try:
     # pylint: disable=unused-import
@@ -124,7 +117,7 @@ def describe(name, region=None, key=None, keyid=None, profile=None):
                 "tags",
             )
 
-            ret = dict([(k, getattr(stack, k)) for k in keys if hasattr(stack, k)])
+            ret = {k: getattr(stack, k) for k in keys if hasattr(stack, k)}
             o = getattr(stack, "outputs")
             p = getattr(stack, "parameters")
             outputs = {}
@@ -191,7 +184,7 @@ def create(
             stack_policy_url,
         )
     except BotoServerError as e:
-        msg = "Failed to create stack {0}.\n{1}".format(name, e)
+        msg = "Failed to create stack {}.\n{}".format(name, e)
         log.error(msg)
         log.debug(e)
         return False
@@ -251,10 +244,10 @@ def update_stack(
         log.debug("Updated result is : %s.", update)
         return update
     except BotoServerError as e:
-        msg = "Failed to update stack {0}.".format(name)
+        msg = "Failed to update stack {}.".format(name)
         log.debug(e)
         log.error(msg)
-        return six.text_type(e)
+        return str(e)
 
 
 def delete(name, region=None, key=None, keyid=None, profile=None):
@@ -272,10 +265,10 @@ def delete(name, region=None, key=None, keyid=None, profile=None):
     try:
         return conn.delete_stack(name)
     except BotoServerError as e:
-        msg = "Failed to create stack {0}.".format(name)
+        msg = "Failed to create stack {}.".format(name)
         log.error(msg)
         log.debug(e)
-        return six.text_type(e)
+        return str(e)
 
 
 def get_template(name, region=None, key=None, keyid=None, profile=None):
@@ -296,9 +289,9 @@ def get_template(name, region=None, key=None, keyid=None, profile=None):
         return template
     except BotoServerError as e:
         log.debug(e)
-        msg = "Template {0} does not exist".format(name)
+        msg = "Template {} does not exist".format(name)
         log.error(msg)
-        return six.text_type(e)
+        return str(e)
 
 
 def validate_template(
@@ -327,6 +320,6 @@ def validate_template(
         return conn.validate_template(template_body, template_url)
     except BotoServerError as e:
         log.debug(e)
-        msg = "Error while trying to validate template {0}.".format(template_body)
+        msg = "Error while trying to validate template {}.".format(template_body)
         log.error(msg)
-        return six.text_type(e)
+        return str(e)

--- a/tests/unit/modules/test_boto_cfn.py
+++ b/tests/unit/modules/test_boto_cfn.py
@@ -1,0 +1,145 @@
+import random
+import string
+
+import salt.config
+import salt.modules.boto_cfn as boto_cfn
+from salt.exceptions import SaltInvocationError
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.unit import TestCase, skipIf
+
+try:
+    import boto3
+    import botocore
+
+    HAS_BOTO3 = True
+except ImportError:
+    HAS_BOTO3 = False
+
+try:
+    from moto import mock_cloudformation
+
+    HAS_MOTO = True
+except ImportError:
+    HAS_MOTO = False
+
+
+def _random_stack_name():
+    return "boto3_stack-{}".format(
+        "".join((random.choice(string.ascii_lowercase)) for char in range(12))
+    )
+
+
+@skipIf(HAS_BOTO3 is False, "The boto3 module must be installed.")
+@skipIf(HAS_MOTO is False, "The moto module must be installed.")
+class BotoSnsTestCase(TestCase, LoaderModuleMockMixin):
+    """
+    TestCase for salt.modules.boto_cfn module
+    """
+
+    region = "us-east-1"
+    access_key = "GKTADJGHEIQSXMKKRBJ08H"
+    secret_key = "askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs"
+    conn_parameters = {}
+    template_body = """
+        {
+          "Description" : "CloudFormation template for testing boto_cfn",
+          "Resources" : {
+            "CFNTestPolicy" : {
+              "Type" : "AWS::IAM::Policy",
+              "Properties" : {
+                "PolicyName" : "TestPolicy",
+                "PolicyDocument" : {
+                  "Statement": [{
+                    "Effect"   : "Allow",
+                    "Action"   : [
+                      "cloudformation:Describe*",
+                      "cloudformation:List*",
+                      "cloudformation:Get*"
+                      ],
+                    "Resource" : "*"
+                  }]
+                }
+              }
+            }
+          }
+        }
+    """
+    conn = None
+
+    def setup_loader_modules(self):
+        self.opts = salt.config.DEFAULT_MINION_OPTS.copy()
+        utils = salt.loader.utils(
+            self.opts,
+            whitelist=["boto3", "args", "systemd", "path", "platform"],
+            context={},
+        )
+        return {boto_cfn: {"__utils__": utils}}
+
+    def setUp(self):
+        super().setUp()
+        boto_cfn.__init__(self.opts)
+        del self.opts
+
+        self.conn_parameters = {
+            "region": self.region,
+            "key": self.access_key,
+            "keyid": self.secret_key,
+            "profile": {},
+        }
+
+        self.mock = mock_cloudformation()
+        self.mock.start()
+        self.session = boto3.session.Session(
+            aws_access_key_id=self.access_key,
+            aws_secret_access_key=self.secret_key,
+            region_name=self.region,
+        )
+        self.conn = self.session.client("cloudformation")
+
+    def tearDown(self):
+        self.mock.stop()
+
+    def test_stack_exists_that_does_not_exist(self):
+        name = _random_stack_name()
+        self.assertFalse(boto_cfn.exists(name, **self.conn_parameters))
+
+    def test_stack_exists_that_does_exist(self):
+        name = _random_stack_name()
+        resp = self.conn.create_stack(StackName=name, TemplateBody=self.template_body)
+        self.assertTrue(boto_cfn.exists(name, **self.conn_parameters))
+
+    def test_stack_describe_returns_correct_json(self):
+        name = _random_stack_name()
+        self.conn.create_stack(StackName=name, TemplateBody=self.template_body)
+        resp = self.conn.describe_stacks(StackName=name)
+        stack = {"stack": resp["Stacks"][0]}
+        self.assertEqual(boto_cfn.describe(name, **self.conn_parameters), stack)
+
+    def test_passing_templatebody_and_template_url_raises_exception(self):
+        name = _random_stack_name()
+        with self.assertRaises(SaltInvocationError):
+            boto_cfn.create(
+                name, self.template_body, "s3://anywhere", **self.conn_parameters
+            )
+
+    def test_stack_create_new_stack_returns_true(self):
+        name = _random_stack_name()
+        self.assertTrue(
+            boto_cfn.create(name, self.template_body, **self.conn_parameters)
+        )
+
+    def test_stack_create_existing_stack_returns_true(self):
+        name = _random_stack_name()
+        resp = self.conn.create_stack(StackName=name, TemplateBody=self.template_body)
+        self.assertTrue(
+            boto_cfn.create(name, self.template_body, **self.conn_parameters)
+        )
+
+    def test_delete_none_existant_stack_returns_success(self):
+        name = _random_stack_name()
+        self.assertTrue(boto_cfn.delete(name, **self.conn_parameters))
+
+    def test_delete_none_existant_stack_returns_success(self):
+        name = _random_stack_name()
+        self.conn.create_stack(StackName=name, TemplateBody=self.template_body)
+        self.assertTrue(boto_cfn.delete(name, **self.conn_parameters))


### PR DESCRIPTION
### What does this PR do?
Port `salt.modules.boto_cfn` from boto2 to boto3.

Boto3 was released 5 years ago and boto2 is deprecated and has not received any updates in 2 years. This PR makes the necessary changes such that boto_cfn uses boto3.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- N/A Docs
- [X] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes