### PR TITLE
Ensuring that the version check is run a second time in case password changed

### DIFF
--- a/changelog/58773.fixed
+++ b/changelog/58773.fixed
@@ -1,0 +1,1 @@
+Ensuring that the version check function is run a second time in all the user related functions incase the user being managed is the connection user and the password has been updated.

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Module to provide MySQL compatibility to salt.
 
@@ -33,8 +32,6 @@ Module to provide MySQL compatibility to salt.
     Additionally, it is now possible to setup a user with no password.
 """
 
-# Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import copy
 import hashlib
@@ -45,13 +42,9 @@ import shlex
 import sys
 import time
 
-# Import salt libs
 import salt.utils.data
 import salt.utils.files
 import salt.utils.stringutils
-
-# Import third party libs
-from salt.ext import six
 
 # pylint: disable=import-error
 from salt.ext.six.moves import range, zip
@@ -261,7 +254,7 @@ def __virtual__():
 
 def __mysql_hash_password(password):
     _password = hashlib.sha1(password.encode()).digest()
-    _password = "*{0}".format(hashlib.sha1(_password).hexdigest().upper())
+    _password = "*{}".format(hashlib.sha1(_password).hexdigest().upper())
     return _password
 
 
@@ -273,7 +266,7 @@ def __check_table(name, table, **connection_args):
     s_name = quote_identifier(name)
     s_table = quote_identifier(table)
     # identifiers cannot be used as values
-    qry = "CHECK TABLE {0}.{1}".format(s_name, s_table)
+    qry = "CHECK TABLE {}.{}".format(s_name, s_table)
     _execute(cur, qry)
     results = cur.fetchall()
     log.debug(results)
@@ -288,7 +281,7 @@ def __repair_table(name, table, **connection_args):
     s_name = quote_identifier(name)
     s_table = quote_identifier(table)
     # identifiers cannot be used as values
-    qry = "REPAIR TABLE {0}.{1}".format(s_name, s_table)
+    qry = "REPAIR TABLE {}.{}".format(s_name, s_table)
     _execute(cur, qry)
     results = cur.fetchall()
     log.debug(results)
@@ -303,7 +296,7 @@ def __optimize_table(name, table, **connection_args):
     s_name = quote_identifier(name)
     s_table = quote_identifier(table)
     # identifiers cannot be used as values
-    qry = "OPTIMIZE TABLE {0}.{1}".format(s_name, s_table)
+    qry = "OPTIMIZE TABLE {}.{}".format(s_name, s_table)
     _execute(cur, qry)
     results = cur.fetchall()
     log.debug(results)
@@ -343,7 +336,7 @@ def __get_auth_plugin(user, host, **connection_args):
         args = {"user": user, "host": host}
         _execute(cur, qry, args)
     except MySQLdb.OperationalError as exc:
-        err = "MySQL Error {0}: {1}".format(*exc.args)
+        err = "MySQL Error {}: {}".format(*exc.args)
         __context__["mysql.error"] = err
         log.error(err)
         return "mysql_native_password"
@@ -384,7 +377,7 @@ def _connect(**kwargs):
                     name = name[len(prefix) :]
                 except IndexError:
                     return
-            val = __salt__["config.option"]("mysql.{0}".format(name), None)
+            val = __salt__["config.option"]("mysql.{}".format(name), None)
             if val is not None:
                 connargs[key] = val
 
@@ -427,12 +420,12 @@ def _connect(**kwargs):
     try:
         dbc = MySQLdb.connect(**connargs)
     except OperationalError as exc:
-        err = "MySQL Error {0}: {1}".format(*exc.args)
+        err = "MySQL Error {}: {}".format(*exc.args)
         __context__["mysql.error"] = err
         log.error(err)
         return None
     except MySQLdb.err.InternalError as exc:
-        err = "MySQL Error {0}: {1}".format(*exc.args)
+        err = "MySQL Error {}: {}".format(*exc.args)
         __context__["mysql.error"] = err
         log.error(err)
         return None
@@ -566,7 +559,7 @@ def _grant_to_tokens(grant):
                     if not column:
                         current_grant = token
                     else:
-                        token = "{0}.{1}".format(current_grant, token)
+                        token = "{}.{}".format(current_grant, token)
                     grant_tokens.append(token)
             else:  # This is a multi-word, ala LOCK TABLES
                 multiword_statement.append(token)
@@ -786,7 +779,7 @@ def query(database, query, **connection_args):
     try:
         affected = _execute(cur, query)
     except OperationalError as exc:
-        err = "MySQL Error {0}: {1}".format(*exc.args)
+        err = "MySQL Error {}: {}".format(*exc.args)
         __context__["mysql.error"] = err
         log.error(err)
         return False
@@ -896,13 +889,11 @@ def file_query(database, file_name, **connection_args):
             if "rows affected" in query_result:
                 ret["rows affected"] += query_result["rows affected"]
 
-    ret["query time"]["human"] = (
-        six.text_type(round(float(ret["query time"]["raw"]), 2)) + "s"
-    )
+    ret["query time"]["human"] = str(round(float(ret["query time"]["raw"]), 2)) + "s"
     ret["query time"]["raw"] = round(float(ret["query time"]["raw"]), 5)
 
     # Remove empty keys in ret
-    ret = {k: v for k, v in six.iteritems(ret) if v}
+    ret = {k: v for k, v in ret.items() if v}
 
     return ret
 
@@ -926,7 +917,7 @@ def status(**connection_args):
     try:
         _execute(cur, qry)
     except OperationalError as exc:
-        err = "MySQL Error {0}: {1}".format(*exc.args)
+        err = "MySQL Error {}: {}".format(*exc.args)
         __context__["mysql.error"] = err
         log.error(err)
         return {}
@@ -960,7 +951,7 @@ def version(**connection_args):
     try:
         _execute(cur, qry)
     except MySQLdb.OperationalError as exc:
-        err = "MySQL Error {0}: {1}".format(*exc.args)
+        err = "MySQL Error {}: {}".format(*exc.args)
         __context__["mysql.error"] = err
         log.error(err)
         return ""
@@ -994,7 +985,7 @@ def slave_lag(**connection_args):
     try:
         _execute(cur, qry)
     except MySQLdb.OperationalError as exc:
-        err = "MySQL Error {0}: {1}".format(*exc.args)
+        err = "MySQL Error {}: {}".format(*exc.args)
         __context__["mysql.error"] = err
         log.error(err)
         return -3
@@ -1079,7 +1070,7 @@ def db_list(**connection_args):
     try:
         _execute(cur, qry)
     except MySQLdb.OperationalError as exc:
-        err = "MySQL Error {0}: {1}".format(*exc.args)
+        err = "MySQL Error {}: {}".format(*exc.args)
         __context__["mysql.error"] = err
         log.error(err)
         return []
@@ -1109,7 +1100,7 @@ def alter_db(name, character_set=None, collate=None, **connection_args):
         return []
     cur = dbc.cursor()
     existing = db_get(name, **connection_args)
-    qry = "ALTER DATABASE `{0}` CHARACTER SET {1} COLLATE {2};".format(
+    qry = "ALTER DATABASE `{}` CHARACTER SET {} COLLATE {};".format(
         name.replace("%", r"\%").replace("_", r"\_"),
         character_set or existing.get("character_set"),
         collate or existing.get("collate"),
@@ -1166,11 +1157,11 @@ def db_tables(name, **connection_args):
     cur = dbc.cursor()
     s_name = quote_identifier(name)
     # identifiers cannot be used as values
-    qry = "SHOW TABLES IN {0}".format(s_name)
+    qry = "SHOW TABLES IN {}".format(s_name)
     try:
         _execute(cur, qry)
     except MySQLdb.OperationalError as exc:
-        err = "MySQL Error {0}: {1}".format(*exc.args)
+        err = "MySQL Error {}: {}".format(*exc.args)
         __context__["mysql.error"] = err
         log.error(err)
         return []
@@ -1205,7 +1196,7 @@ def db_exists(name, **connection_args):
     try:
         _execute(cur, qry, args)
     except MySQLdb.OperationalError as exc:
-        err = "MySQL Error {0}: {1}".format(*exc.args)
+        err = "MySQL Error {}: {}".format(*exc.args)
         __context__["mysql.error"] = err
         log.error(err)
         return False
@@ -1245,7 +1236,7 @@ def db_create(name, character_set=None, collate=None, **connection_args):
     cur = dbc.cursor()
     s_name = quote_identifier(name)
     # identifiers cannot be used as values
-    qry = "CREATE DATABASE IF NOT EXISTS {0}".format(s_name)
+    qry = "CREATE DATABASE IF NOT EXISTS {}".format(s_name)
     args = {}
     if character_set is not None:
         qry += " CHARACTER SET %(character_set)s"
@@ -1260,7 +1251,7 @@ def db_create(name, character_set=None, collate=None, **connection_args):
             log.info("DB '%s' created", name)
             return True
     except MySQLdb.OperationalError as exc:
-        err = "MySQL Error {0}: {1}".format(*exc.args)
+        err = "MySQL Error {}: {}".format(*exc.args)
         __context__["mysql.error"] = err
         log.error(err)
     return False
@@ -1292,11 +1283,11 @@ def db_remove(name, **connection_args):
     cur = dbc.cursor()
     s_name = quote_identifier(name)
     # identifiers cannot be used as values
-    qry = "DROP DATABASE {0};".format(s_name)
+    qry = "DROP DATABASE {};".format(s_name)
     try:
         _execute(cur, qry)
     except MySQLdb.OperationalError as exc:
-        err = "MySQL Error {0}: {1}".format(*exc.args)
+        err = "MySQL Error {}: {}".format(*exc.args)
         __context__["mysql.error"] = err
         log.error(err)
         return False
@@ -1328,7 +1319,7 @@ def user_list(**connection_args):
         qry = "SELECT User,Host FROM mysql.user"
         _execute(cur, qry)
     except MySQLdb.OperationalError as exc:
-        err = "MySQL Error {0}: {1}".format(*exc.args)
+        err = "MySQL Error {}: {}".format(*exc.args)
         __context__["mysql.error"] = err
         log.error(err)
         return []
@@ -1367,16 +1358,16 @@ def _mysql_user_exists(
     elif password:
         if salt.utils.versions.version_cmp(server_version, compare_version) >= 0:
             if auth_plugin == "mysql_native_password":
-                _password = __mysql_hash_password(six.text_type(password))
+                _password = __mysql_hash_password(str(password))
                 qry += " AND " + password_column + " = %(password)s"
-                args["password"] = six.text_type(_password)
+                args["password"] = str(_password)
             else:
                 err = "Unable to verify password."
                 log.error(err)
                 __context__["mysql.error"] = err
         else:
             qry += " AND " + password_column + " = PASSWORD(%(password)s)"
-            args["password"] = six.text_type(password)
+            args["password"] = str(password)
     elif password_hash:
         qry += " AND " + password_column + " = %(password)s"
         args["password"] = password_hash
@@ -1411,7 +1402,7 @@ def _mariadb_user_exists(
             qry += " AND " + password_column + " = ''"
     elif password:
         qry += " AND " + password_column + " = PASSWORD(%(password)s)"
-        args["password"] = six.text_type(password)
+        args["password"] = str(password)
     elif password_hash:
         qry += " AND " + password_column + " = %(password)s"
         args["password"] = password_hash
@@ -1448,20 +1439,30 @@ def user_exists(
     """
     run_verify = False
     server_version = salt.utils.data.decode(version(**connection_args))
-    if not server_version:
-        last_err = __context__["mysql.error"]
-        err = 'MySQL Error: Unable to fetch current server version. Last error was: "{}"'.format(
-            last_err
-        )
-        log.error(err)
-        return False
+    if not server_version and password:
+        # Did we fail to connect with the user we are checking
+        # Its password might have previously change with the same command/state
+
+        # Clear the previous error
+        __context__["mysql.error"] = None
+        connection_args["connection_pass"] = password
+
+        server_version = salt.utils.data.decode(version(**connection_args))
+        if not server_version:
+            last_err = __context__["mysql.error"]
+            err = 'MySQL Error: Unable to fetch current server version. Last error was: "{}"'.format(
+                last_err
+            )
+            log.error(err)
+            return False
+
     dbc = _connect(**connection_args)
     # Did we fail to connect with the user we are checking
     # Its password might have previously change with the same command/state
     if (
         dbc is None
         and __context__["mysql.error"].startswith(
-            "MySQL Error 1045: Access denied for user '{0}'@".format(user)
+            "MySQL Error 1045: Access denied for user '{}'@".format(user)
         )
         and password
     ):
@@ -1506,7 +1507,7 @@ def user_exists(
     try:
         _execute(cur, qry, args)
     except MySQLdb.OperationalError as exc:
-        err = "MySQL Error {0}: {1}".format(*exc.args)
+        err = "MySQL Error {}: {}".format(*exc.args)
         __context__["mysql.error"] = err
         log.error(err)
         return False
@@ -1537,7 +1538,7 @@ def user_info(user, host="localhost", **connection_args):
     try:
         _execute(cur, qry, args)
     except MySQLdb.OperationalError as exc:
-        err = "MySQL Error {0}: {1}".format(*exc.args)
+        err = "MySQL Error {}: {}".format(*exc.args)
         __context__["mysql.error"] = err
         log.error(err)
         return False
@@ -1571,7 +1572,7 @@ def _mysql_user_create(
             qry += " IDENTIFIED WITH %(auth_plugin)s BY %(password)s"
         else:
             qry += " IDENTIFIED BY %(password)s"
-        args["password"] = six.text_type(password)
+        args["password"] = str(password)
     elif password_hash is not None:
         if salt.utils.versions.version_cmp(server_version, compare_version) >= 0:
             qry += " IDENTIFIED BY %(password)s"
@@ -1618,7 +1619,7 @@ def _mariadb_user_create(
     args["host"] = host
     if password is not None:
         qry += " IDENTIFIED BY %(password)s"
-        args["password"] = six.text_type(password)
+        args["password"] = str(password)
     elif password_hash is not None:
         qry += " IDENTIFIED BY PASSWORD %(password)s"
         args["password"] = password_hash
@@ -1703,13 +1704,22 @@ def user_create(
         salt '*' mysql.user_create 'username' 'hostname' allow_passwordless=True
     """
     server_version = salt.utils.data.decode(version(**connection_args))
-    if not server_version:
-        last_err = __context__["mysql.error"]
-        err = 'MySQL Error: Unable to fetch current server version. Last error was: "{}"'.format(
-            last_err
-        )
-        log.error(err)
-        return False
+    if not server_version and password:
+        # Did we fail to connect with the user we are checking
+        # Its password might have previously change with the same command/state
+
+        # Clear the previous error
+        __context__["mysql.error"] = None
+        connection_args["connection_pass"] = password
+
+        server_version = salt.utils.data.decode(version(**connection_args))
+        if not server_version:
+            last_err = __context__["mysql.error"]
+            err = 'MySQL Error: Unable to fetch current server version. Last error was: "{}"'.format(
+                last_err
+            )
+            log.error(err)
+            return False
 
     if user_exists(user, host, **connection_args):
         log.info("User '%s'@'%s' already exists", user, host)
@@ -1754,7 +1764,7 @@ def user_create(
     try:
         _execute(cur, qry, args)
     except MySQLdb.OperationalError as exc:
-        err = "MySQL Error {0}: {1}".format(*exc.args)
+        err = "MySQL Error {}: {}".format(*exc.args)
         __context__["mysql.error"] = err
         log.error(err)
         return False
@@ -1767,7 +1777,7 @@ def user_create(
         password_column=password_column,
         **connection_args
     ):
-        msg = "User '{0}'@'{1}' has been created".format(user, host)
+        msg = "User '{}'@'{}' has been created".format(user, host)
         if not any((password, password_hash)):
             msg += " with passwordless login"
         log.info(msg)
@@ -1974,13 +1984,22 @@ def user_chpass(
         salt '*' mysql.user_chpass frank localhost allow_passwordless=True
     """
     server_version = salt.utils.data.decode(version(**connection_args))
-    if not server_version:
-        last_err = __context__["mysql.error"]
-        err = 'MySQL Error: Unable to fetch current server version. Last error was: "{}"'.format(
-            last_err
-        )
-        log.error(err)
-        return False
+    if not server_version and password:
+        # Did we fail to connect with the user we are checking
+        # Its password might have previously change with the same command/state
+
+        # Clear the previous error
+        __context__["mysql.error"] = None
+        connection_args["connection_pass"] = password
+
+        server_version = salt.utils.data.decode(version(**connection_args))
+        if not server_version:
+            last_err = __context__["mysql.error"]
+            err = 'MySQL Error: Unable to fetch current server version. Last error was: "{}"'.format(
+                last_err
+            )
+            log.error(err)
+            return False
 
     if not user_exists(user, host, **connection_args):
         log.info("User '%s'@'%s' does not exists", user, host)
@@ -2026,7 +2045,7 @@ def user_chpass(
     try:
         result = _execute(cur, qry, args)
     except MySQLdb.OperationalError as exc:
-        err = "MySQL Error {0}: {1}".format(*exc.args)
+        err = "MySQL Error {}: {}".format(*exc.args)
         __context__["mysql.error"] = err
         log.error(err)
         return False
@@ -2087,7 +2106,7 @@ def user_remove(user, host="localhost", **connection_args):
     try:
         _execute(cur, qry, args)
     except MySQLdb.OperationalError as exc:
-        err = "MySQL Error {0}: {1}".format(*exc.args)
+        err = "MySQL Error {}: {}".format(*exc.args)
         __context__["mysql.error"] = err
         log.error(err)
         return False
@@ -2198,7 +2217,7 @@ def __grant_normalize(grant):
     exploded_grants = __grant_split(grant)
     for chkgrant, _ in exploded_grants:
         if chkgrant.strip().upper() not in __grants__:
-            raise Exception("Invalid grant : '{0}'".format(chkgrant))
+            raise Exception("Invalid grant : '{}'".format(chkgrant))
 
     return grant
 
@@ -2213,18 +2232,18 @@ def __ssl_option_sanitize(ssl_option):
 
     # Like most other "salt dsl" YAML structures, ssl_option is a list of single-element dicts
     for opt in ssl_option:
-        key = next(six.iterkeys(opt))
+        key = next(iter(opt.keys()))
 
         normal_key = key.strip().upper()
 
         if normal_key not in __ssl_options__:
-            raise Exception("Invalid SSL option : '{0}'".format(key))
+            raise Exception("Invalid SSL option : '{}'".format(key))
 
         if normal_key in __ssl_options_parameterized__:
             # SSL option parameters (cipher, issuer, subject) are pasted directly to SQL so
             # we need to sanitize for single quotes...
             new_ssl_option.append(
-                "{0} '{1}'".format(normal_key, opt[key].replace("'", ""))
+                "{} '{}'".format(normal_key, opt[key].replace("'", ""))
             )
         # omit if falsey
         elif opt[key]:
@@ -2266,7 +2285,7 @@ def __grant_generate(
         if table != "*":
             table = quote_identifier(table)
     # identifiers cannot be used as values, and same thing for grants
-    qry = "GRANT {0} ON {1}.{2} TO %(user)s@%(host)s".format(grant, dbc, table)
+    qry = "GRANT {} ON {}.{} TO %(user)s@%(host)s".format(grant, dbc, table)
     args = {}
     args["user"] = user
     args["host"] = host
@@ -2303,7 +2322,7 @@ def user_grants(user, host="localhost", **connection_args):
     try:
         _execute(cur, qry, args)
     except MySQLdb.OperationalError as exc:
-        err = "MySQL Error {0}: {1}".format(*exc.args)
+        err = "MySQL Error {}: {}".format(*exc.args)
         __context__["mysql.error"] = err
         log.error(err)
         return False
@@ -2313,7 +2332,7 @@ def user_grants(user, host="localhost", **connection_args):
     for grant in results:
         tmp = grant[0].split(" IDENTIFIED BY")[0]
         if "WITH GRANT OPTION" in grant[0] and "WITH GRANT OPTION" not in tmp:
-            tmp = "{0} WITH GRANT OPTION".format(tmp)
+            tmp = "{} WITH GRANT OPTION".format(tmp)
         ret.append(tmp)
     log.debug(ret)
     return ret
@@ -2470,7 +2489,7 @@ def grant_add(
     try:
         _execute(cur, qry["qry"], qry["args"])
     except (MySQLdb.OperationalError, MySQLdb.ProgrammingError) as exc:
-        err = "MySQL Error {0}: {1}".format(*exc.args)
+        err = "MySQL Error {}: {}".format(*exc.args)
         __context__["mysql.error"] = err
         log.error(err)
         return False
@@ -2532,9 +2551,7 @@ def grant_revoke(
     if table != "*":
         table = quote_identifier(table)
     # identifiers cannot be used as values, same thing for grants
-    qry = "REVOKE {0} ON {1}.{2} FROM %(user)s@%(host)s;".format(
-        grant, s_database, table
-    )
+    qry = "REVOKE {} ON {}.{} FROM %(user)s@%(host)s;".format(grant, s_database, table)
     args = {}
     args["user"] = user
     args["host"] = host
@@ -2542,7 +2559,7 @@ def grant_revoke(
     try:
         _execute(cur, qry, args)
     except MySQLdb.OperationalError as exc:
-        err = "MySQL Error {0}: {1}".format(*exc.args)
+        err = "MySQL Error {}: {}".format(*exc.args)
         __context__["mysql.error"] = err
         log.error(err)
         return False
@@ -2863,7 +2880,7 @@ def plugins_list(**connection_args):
     try:
         _execute(cur, qry)
     except MySQLdb.OperationalError as exc:
-        err = "MySQL Error {0}: {1}".format(*exc.args)
+        err = "MySQL Error {}: {}".format(*exc.args)
         __context__["mysql.error"] = err
         log.error(err)
         return []
@@ -2899,17 +2916,17 @@ def plugin_add(name, soname=None, **connection_args):
     if dbc is None:
         return False
     cur = dbc.cursor()
-    qry = "INSTALL PLUGIN {0}".format(name)
+    qry = "INSTALL PLUGIN {}".format(name)
 
     if soname:
-        qry += ' SONAME "{0}"'.format(soname)
+        qry += ' SONAME "{}"'.format(soname)
     else:
-        qry += ' SONAME "{0}.so"'.format(name)
+        qry += ' SONAME "{}.so"'.format(name)
 
     try:
         _execute(cur, qry)
     except MySQLdb.OperationalError as exc:
-        err = "MySQL Error {0}: {1}".format(*exc.args)
+        err = "MySQL Error {}: {}".format(*exc.args)
         __context__["mysql.error"] = err
         log.error(err)
         return False
@@ -2939,14 +2956,14 @@ def plugin_remove(name, **connection_args):
     if dbc is None:
         return False
     cur = dbc.cursor()
-    qry = "UNINSTALL PLUGIN {0}".format(name)
+    qry = "UNINSTALL PLUGIN {}".format(name)
     args = {}
     args["name"] = name
 
     try:
         _execute(cur, qry)
     except MySQLdb.OperationalError as exc:
-        err = "MySQL Error {0}: {1}".format(*exc.args)
+        err = "MySQL Error {}: {}".format(*exc.args)
         __context__["mysql.error"] = err
         log.error(err)
         return False
@@ -2979,7 +2996,7 @@ def plugin_status(name, **connection_args):
     try:
         _execute(cur, qry, args)
     except MySQLdb.OperationalError as exc:
-        err = "MySQL Error {0}: {1}".format(*exc.args)
+        err = "MySQL Error {}: {}".format(*exc.args)
         __context__["mysql.error"] = err
         log.error(err)
         return ""

--- a/tests/unit/modules/test_mysql.py
+++ b/tests/unit/modules/test_mysql.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
     :codeauthor: Mike Place (mp@saltstack.com)
 
@@ -7,15 +6,10 @@
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 """
 
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
-# Import salt libs
 import salt.modules.mysql as mysql
-
-# Import Salt Testing libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, call, patch
 from tests.support.unit import TestCase, skipIf
@@ -81,7 +75,7 @@ __all_privileges__ = [
 ]
 
 
-class MockMySQLConnect(object):
+class MockMySQLConnect:
     def __init__(self, *args, **kwargs):
         self.args = args
         self.kwargs = kwargs
@@ -201,6 +195,30 @@ class MySQLTestCase(TestCase, LoaderModuleMockMixin):
                 password="BLUECOW",
             )
 
+        with patch.object(
+            mysql, "version", side_effect=["", "10.2.21-MariaDB", "10.2.21-MariaDB"]
+        ):
+            self._test_call(
+                mysql.user_exists,
+                {
+                    "sql": (
+                        "SELECT User,Host FROM mysql.user WHERE "
+                        "User = %(user)s AND Host = %(host)s AND "
+                        "Password = PASSWORD(%(password)s)"
+                    ),
+                    "sql_args": {
+                        "host": "localhost",
+                        "password": "new_pass",
+                        "user": "root",
+                    },
+                },
+                user="root",
+                host="localhost",
+                password="new_pass",
+                connection_user="root",
+                connection_pass="old_pass",
+            )
+
         # test_user_create_when_user_exists(self):
         # ensure we don't try to create a user when one already exists
         # mock the version of MySQL
@@ -292,6 +310,30 @@ class MySQLTestCase(TestCase, LoaderModuleMockMixin):
                     unix_socket=True,
                 )
 
+        with patch.object(mysql, "version", side_effect=["", "8.0.10", "8.0.10"]):
+            with patch.object(
+                mysql, "user_exists", MagicMock(return_value=False)
+            ), patch.object(
+                mysql,
+                "__get_auth_plugin",
+                MagicMock(return_value="mysql_native_password"),
+            ):
+                self._test_call(
+                    mysql.user_create,
+                    {
+                        "sql": "CREATE USER %(user)s@%(host)s IDENTIFIED BY %(password)s",
+                        "sql_args": {
+                            "password": "new_pass",
+                            "user": "root",
+                            "host": "localhost",
+                        },
+                    },
+                    "root",
+                    password="new_pass",
+                    connection_user="root",
+                    connection_pass="old_pass",
+                )
+
     def test_user_chpass(self):
         """
         Test changing a MySQL user password in mysql exec module
@@ -331,6 +373,32 @@ class MySQLTestCase(TestCase, LoaderModuleMockMixin):
                                 {
                                     "password": "BLUECOW",
                                     "user": "testuser",
+                                    "host": "localhost",
+                                },
+                            ),
+                            call().cursor().execute("FLUSH PRIVILEGES;"),
+                        )
+                        connect_mock.assert_has_calls(calls, any_order=True)
+
+        connect_mock = MagicMock()
+        with patch.object(mysql, "_connect", connect_mock):
+            with patch.object(mysql, "version", side_effect=["", "8.0.11", "8.0.11"]):
+                with patch.object(mysql, "user_exists", MagicMock(return_value=True)):
+                    with patch.dict(mysql.__salt__, {"config.option": MagicMock()}):
+                        mysql.user_chpass(
+                            "root",
+                            password="new_pass",
+                            connection_user="root",
+                            connection_pass="old_pass",
+                        )
+                        calls = (
+                            call()
+                            .cursor()
+                            .execute(
+                                "ALTER USER %(user)s@%(host)s IDENTIFIED BY %(password)s;",
+                                {
+                                    "password": "new_pass",
+                                    "user": "root",
                                     "host": "localhost",
                                 },
                             ),
@@ -679,11 +747,11 @@ insert into test_update values ("crazy -- not comment");
                         call()
                         .cursor()
                         .execute(
-                            "{0}".format(expected_sql["sql"]), expected_sql["sql_args"]
+                            "{}".format(expected_sql["sql"]), expected_sql["sql_args"]
                         )
                     )
                 else:
-                    calls = call().cursor().execute("{0}".format(expected_sql))
+                    calls = call().cursor().execute("{}".format(expected_sql))
                 connect_mock.assert_has_calls((calls,), True)
 
     @skipIf(


### PR DESCRIPTION
### What does this PR do?
Ensuring that the version check function is run a second time in all the user related functions incase the user being managed is the connection user and the password has been updated.

### What issues does this PR fix or reference?
Fixes: #58765 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
