### PR TITLE
update format_ret not to throw an exception

### DIFF
--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -425,7 +425,7 @@ class SaltCMD(salt.utils.parsers.SaltCMDOptionParser):
             if "out" in data:
                 out = data["out"]
             ret_retcode = self._get_retcode(data)
-            if ret_retcode > retcode:
+            if ret_retcode and ret_retcode > retcode:
                 retcode = ret_retcode
         return ret, out, retcode
 


### PR DESCRIPTION
_format_ret will throw an exception when ret_code is None. This happens on older version of the minions in my test when running cmd.run_bg.
Checking the variable before fixes the issue
```
Traceback (most recent call last):

  File "/bin/salt", line 11, in <module>

    load_entry_point('salt==3000.5', 'console_scripts', 'salt')()

  File "/usr/lib/python3.6/site-packages/salt/scripts.py", line 530, in salt_main

    client.run()

  File "/usr/lib/python3.6/site-packages/salt/cli/salt.py", line 196, in run

    ret_, out, retcode = self._format_ret(full_ret)

  File "/usr/lib/python3.6/site-packages/salt/cli/salt.py", line 394, in _format_ret

    if ret_retcode > retcode:

TypeError: '>' not supported between instances of 'NoneType' and 'int'

 ```
### What does this PR do?

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
