### PR TITLE
lvm.lv_present accept percentage as valid extents - Fix issue 58759

### DIFF
--- a/changelog/58759.fixed
+++ b/changelog/58759.fixed
@@ -1,0 +1,2 @@
+Restored the ability to specify the amount of extents for a Logical
+Volume as a percentage.

--- a/salt/states/lvm.py
+++ b/salt/states/lvm.py
@@ -21,10 +21,8 @@ A state module to manage LVMs
         - stripesize: 8K
 """
 
-# Import python libs
 import os
 
-# Import salt libs
 import salt.utils.path
 
 
@@ -228,7 +226,7 @@ def lv_present(
     **kwargs
 ):
     """
-    Create a new Logical Volume
+    Ensure that a Logical Volume is present, creating it if absent.
 
     name
         The name of the Logical Volume
@@ -240,7 +238,9 @@ def lv_present(
         The size of the Logical Volume
 
     extents
-        The number of logical extents to allocate
+        The number of extents the Logical Volume
+        It can be a percentage allowed by lvcreate's syntax, in this case
+        it will set the Logical Volume initial size and won't be resized.
 
     snapshot
         The name of the snapshot
@@ -265,7 +265,7 @@ def lv_present(
     force
         Assume yes to all prompts
 
-    .. versionadded:: to_complete
+    .. versionadded:: 3002.0
 
     resizefs
         Use fsadm to resize the logical volume filesystem if needed
@@ -321,6 +321,7 @@ def lv_present(
                 ret["result"] = False
     else:
         ret["comment"] = "Logical Volume {} already present".format(name)
+
         if size or extents:
             old_extents = int(lv_info["Current Logical Extents Associated"])
             old_size_mb = _convert_to_mb(lv_info["Logical Volume Size"] + "s")
@@ -328,9 +329,11 @@ def lv_present(
                 size_mb = _convert_to_mb(size)
                 extents = old_extents
             else:
+                # ignore percentage "extents" if the logical volume already exists
+                if "%" in str(extents):
+                    extents = old_extents
                 size_mb = old_size_mb
 
-            # This is here waiting a change in lvm.lvresize backend
             if force is False and (size_mb < old_size_mb or extents < old_extents):
                 ret[
                     "comment"

--- a/salt/states/lvm.py
+++ b/salt/states/lvm.py
@@ -238,7 +238,7 @@ def lv_present(
         The size of the Logical Volume
 
     extents
-        The number of extents the Logical Volume
+        The number of logical extents allocated to the Logical Volume
         It can be a percentage allowed by lvcreate's syntax, in this case
         it will set the Logical Volume initial size and won't be resized.
 

--- a/salt/states/lvm.py
+++ b/salt/states/lvm.py
@@ -331,6 +331,11 @@ def lv_present(
             else:
                 # ignore percentage "extents" if the logical volume already exists
                 if "%" in str(extents):
+                    ret[
+                        "comment"
+                    ] = "Logical Volume {} already present, {} won't be resized.".format(
+                        name, extents
+                    )
                     extents = old_extents
                 size_mb = old_size_mb
 

--- a/tests/unit/states/test_lvm.py
+++ b/tests/unit/states/test_lvm.py
@@ -1,12 +1,8 @@
 """
     :codeauthor: Jayesh Kariya <jayeshk@saltstack.com>
 """
-# Import Python libs
 
-# Import Salt Libs
 import salt.states.lvm as lvm
-
-# Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase
@@ -162,6 +158,34 @@ class LvmTestCase(TestCase, LoaderModuleMockMixin):
             ret.update({"comment": comt, "result": None})
             with patch.dict(lvm.__opts__, {"test": True}):
                 self.assertDictEqual(lvm.lv_present(name, vgname=vgname), ret)
+
+    def test_lv_present_with_percentage_extents(self):
+        """
+        Test do create a new logical volume specifying extents as a percentage
+        """
+        name = "testlv01"
+        vgname = "testvg01"
+        extents = "42%FREE"
+        comt = "Logical Volume {} already present, {} won't be resized.".format(
+            name, extents
+        )
+        ret = {"name": name, "changes": {}, "result": True, "comment": comt}
+
+        mock = MagicMock(return_value=STUB_LVDISPLAY_LV01)
+        with patch.dict(lvm.__salt__, {"lvm.lvdisplay": mock}):
+            self.assertDictEqual(
+                lvm.lv_present(name, vgname=vgname, extents=extents), ret
+            )
+
+        extents = "42%VG"
+        mock = MagicMock(return_value=STUB_LVDISPLAY_LV02)
+        with patch.dict(lvm.__salt__, {"lvm.lvdisplay": mock}):
+            comt = "Logical Volume {} is set to be created".format(name)
+            ret.update({"comment": comt, "result": None})
+            with patch.dict(lvm.__opts__, {"test": True}):
+                self.assertDictEqual(
+                    lvm.lv_present(name, vgname=vgname, extents=extents), ret
+                )
 
     def test_lv_present_with_force(self):
         """


### PR DESCRIPTION
### What does this PR do?
Restore the ability to specify the amount of extents for a Logical Volume as a percentage.

### What issues does this PR fix or reference?
Fixes: #58759 

### Previous Behavior
When the amount of extents for a Logical Volume was passed as a percentage, the logical volume was created in the first run, but brokes the state at subsequent runs when comparing the "PP%SOMETHING" string with the actual Logical Volume size.

### New Behavior
If the amount of extents is passed as a percentage, it still creates the Logical Volume in the first run. But in subsequents runs, now the parameter "extents" will be ignored and no resize operation will happen, restoring the behaviour of 3001.x version.

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No
