### PR TITLE
Added fepitre's Python 3.9 IPv6AddressScoped patch

### DIFF
--- a/salt/_compat.py
+++ b/salt/_compat.py
@@ -162,6 +162,9 @@ class IPv6AddressScoped(ipaddress.IPv6Address):
         else:
             self.__scope = None
 
+        # For compatibility with python3.9 ipaddress
+        self._scope_id = self.__scope
+
         if sys.version_info.major == 2:
             ipaddress._BaseAddress.__init__(self, address)
             ipaddress._BaseV6.__init__(self, address)


### PR DESCRIPTION
### What does this PR do?
A copy of the changes made by https://github.com/saltstack/salt/pull/58518 but with correct Git formatting. For all other fields in this PR please refer to https://github.com/saltstack/salt/pull/58518.

I would really like https://github.com/saltstack/salt/pull/58518 to be merged and for the original author to get Git credit for their great patch. But there hasn't been much movement on their PR and it looks like things are royally borked in Git. This patch makes it possible for Salt 3002 to be used with Python 3.9. Otherwise Salt 3002 on Python 3.9 is unusable. 

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
