### PR TITLE
Fix use of unauthd cached vmware service instance

### DIFF
--- a/changelog/58691.fixed
+++ b/changelog/58691.fixed
@@ -1,0 +1,1 @@
+Fix use of unauthd cached vmware service instance

--- a/salt/utils/vmware.py
+++ b/salt/utils/vmware.py
@@ -435,8 +435,6 @@ def get_service_instance(
             # and reconnect
             Disconnect(service_instance)
             service_instance = None
-        else:
-            return service_instance
 
     if not service_instance:
         service_instance = _get_service_instance(

--- a/tests/unit/utils/test_vmware.py
+++ b/tests/unit/utils/test_vmware.py
@@ -2006,7 +2006,6 @@ class GetServiceInstanceTestCase(TestCase):
 
     def test_cached_service_instance_different_host(self):
         mock_si = MagicMock()
-        mock_si_stub = MagicMock()
         mock_disconnect = MagicMock()
         mock_get_si = MagicMock(return_value=mock_si)
         mock_getstub = MagicMock()
@@ -2073,6 +2072,30 @@ class GetServiceInstanceTestCase(TestCase):
                 self.assertEqual(mock_si_current_time.call_count, 1)
                 self.assertEqual(mock_disconnect.call_count, 1)
                 self.assertEqual(mock_get_si.call_count, 2)
+
+    def test_cached_unauthenticated_service_instance(self):
+        mock_si_current_time = MagicMock(side_effect=vim.fault.NotAuthenticated)
+        mock_si = MagicMock()
+        mock_get_si = MagicMock(return_value=mock_si)
+        mock_getsi = MagicMock(return_value=mock_si)
+        mock_si.CurrentTime = mock_si_current_time
+        mock_disconnect = MagicMock()
+        with patch("salt.utils.vmware.GetSi", mock_getsi):
+            with patch("salt.utils.vmware._get_service_instance", mock_get_si):
+                with patch("salt.utils.vmware.Disconnect", mock_disconnect):
+                    salt.utils.vmware.get_service_instance(
+                        host="fake_host",
+                        username="fake_username",
+                        password="fake_password",
+                        protocol="fake_protocol",
+                        port=1,
+                        mechanism="fake_mechanism",
+                        principal="fake_principal",
+                        domain="fake_domain",
+                    )
+                    self.assertEqual(mock_si_current_time.call_count, 1)
+                    self.assertEqual(mock_disconnect.call_count, 1)
+                    self.assertEqual(mock_get_si.call_count, 1)
 
     def test_current_time_raise_no_permission(self):
         exc = vim.fault.NoPermission()


### PR DESCRIPTION
### What does this PR do?

Fixes the use of unauthenticated cached vmware service instances.  Before, any cached instance (that wasn't a proxy or using a different host) would just be used without checking to see if its authentication had expired.

### What issues does this PR fix or reference?

Fixes: #58691 

### Merge requirements satisfied?

- n/a Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?

Nope
