### PR TITLE
Ensure file_tree pillar returns unicode

### DIFF
--- a/changelog/58794.fixed
+++ b/changelog/58794.fixed
@@ -1,0 +1,1 @@
+Ensure file_tree pillar returns unicode.

--- a/salt/pillar/file_tree.py
+++ b/salt/pillar/file_tree.py
@@ -259,9 +259,9 @@ def _construct_pillar(
                         whitelist=renderer_whitelist,
                     )
                 if salt.utils.stringio.is_readable(data):
-                    pillar_node[file_name] = data.getvalue()
+                    pillar_node[file_name] = salt.utils.stringutils.to_unicode(data.getvalue())
                 else:
-                    pillar_node[file_name] = data
+                    pillar_node[file_name] = salt.utils.stringutils.to_unicode(data)
 
     return pillar
 

--- a/salt/pillar/file_tree.py
+++ b/salt/pillar/file_tree.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 The ``file_tree`` external pillar allows values from all files in a directory
 tree to be imported as Pillar data.
@@ -142,14 +141,11 @@ will result in the following pillar tree for minion with ID ``test-host``:
 
     The leaf data in the example shown is the contents of the pillar files.
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
-# Import python libs
 import fnmatch
 import logging
 import os
 
-# Import salt libs
 import salt.loader
 import salt.template
 import salt.utils.dictupdate
@@ -158,7 +154,6 @@ import salt.utils.minions
 import salt.utils.path
 import salt.utils.stringio
 import salt.utils.stringutils
-from salt.ext import six
 
 # Set up logging
 log = logging.getLogger(__name__)
@@ -187,7 +182,7 @@ def _check_newline(prefix, file_name, keep_newline):
             if fnmatch.fnmatch(full_path, pattern):
                 return False
         except TypeError:
-            if fnmatch.fnmatch(full_path, six.text_type(pattern)):
+            if fnmatch.fnmatch(full_path, str(pattern)):
                 return False
     return True
 
@@ -246,7 +241,7 @@ def _construct_pillar(
                         prefix, file_name, keep_newline
                     ):
                         contents = contents[:-1]
-            except (IOError, OSError) as exc:
+            except OSError as exc:
                 log.error("file_tree: Error reading %s: %s", file_path, exc.strerror)
             else:
                 data = contents
@@ -259,7 +254,9 @@ def _construct_pillar(
                         whitelist=renderer_whitelist,
                     )
                 if salt.utils.stringio.is_readable(data):
-                    pillar_node[file_name] = salt.utils.stringutils.to_unicode(data.getvalue())
+                    pillar_node[file_name] = salt.utils.stringutils.to_unicode(
+                        data.getvalue()
+                    )
                 else:
                     pillar_node[file_name] = salt.utils.stringutils.to_unicode(data)
 
@@ -500,9 +497,7 @@ def _ext_pillar(
                     )
                     match = _res["minions"]
                     if minion_id in match:
-                        ngroup_dir = os.path.join(
-                            nodegroups_dir, six.text_type(nodegroup)
-                        )
+                        ngroup_dir = os.path.join(nodegroups_dir, str(nodegroup))
                         ngroup_pillar = salt.utils.dictupdate.merge(
                             ngroup_pillar,
                             _construct_pillar(

--- a/tests/unit/pillar/test_file_tree.py
+++ b/tests/unit/pillar/test_file_tree.py
@@ -27,18 +27,18 @@ MINION_ID = "test-host"
 NODEGROUP_PATH = os.path.join("nodegroups", "test-group", "files")
 HOST_PATH = os.path.join("hosts", MINION_ID, "files")
 
-BASE_PILLAR_CONTENT = {"files": {"hostfile": b"base", "groupfile": b"base"}}
+BASE_PILLAR_CONTENT = {"files": {"hostfile": "base", "groupfile": "base"}}
 DEV_PILLAR_CONTENT = {
     "files": {
-        "hostfile": b"base",
-        "groupfile": b"dev2",
-        "hostfile1": b"dev1",
-        "groupfile1": b"dev1",
-        "hostfile2": b"dev2",
+        "hostfile": "base",
+        "groupfile": "dev2",
+        "hostfile1": "dev1",
+        "groupfile1": "dev1",
+        "hostfile2": "dev2",
     }
 }
 PARENT_PILLAR_CONTENT = {
-    "files": {"hostfile": b"base", "groupfile": b"base", "hostfile2": b"dev2"}
+    "files": {"hostfile": "base", "groupfile": "base", "hostfile2": "dev2"}
 }
 
 FILE_DATA = {
@@ -159,3 +159,26 @@ class FileTreePillarTestCase(TestCase, LoaderModuleMockMixin):
                             break
                     else:
                         raise AssertionError("Did not find error message")
+
+    def test_file_tree_no_bytes(self):
+        """
+        test file_tree pillar does not return bytes
+        """
+        absolute_path = os.path.join(self.pillar_path, "base")
+        with patch(
+            "salt.utils.minions.CkMinions.check_minions",
+            MagicMock(return_value=_CHECK_MINIONS_RETURN),
+        ):
+            mypillar = file_tree.ext_pillar(MINION_ID, None, absolute_path)
+            self.assertEqual(BASE_PILLAR_CONTENT, mypillar)
+
+            with patch.dict(file_tree.__opts__, {"pillarenv": "dev"}):
+                mypillar = file_tree.ext_pillar(MINION_ID, None, absolute_path)
+                for key,value in mypillar.items():
+                    if isinstance(value, dict):
+                        for ikey,ivalue in value.items():
+                            self.assertTrue(isinstance(ikey, str))
+                            self.assertTrue(isinstance(ivalue, str))
+                    else:
+                        self.assertTrue(isinstance(value, str))
+                    self.assertTrue(isinstance(key, str))

--- a/tests/unit/pillar/test_file_tree.py
+++ b/tests/unit/pillar/test_file_tree.py
@@ -1,25 +1,18 @@
-# -*- coding: utf-8 -*-
 """
 test for pillar file_tree.py
 """
 
-# Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 import shutil
 import tempfile
 
 import salt.pillar.file_tree as file_tree
-
-# Import Salt Libs
 import salt.utils.files
 import salt.utils.stringutils
 from tests.support.helpers import TstSuiteLoggingHandler
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch
-
-# Import Salt Testing libs
 from tests.support.runtests import RUNTIME_VARS
 from tests.support.unit import TestCase
 
@@ -174,9 +167,9 @@ class FileTreePillarTestCase(TestCase, LoaderModuleMockMixin):
 
             with patch.dict(file_tree.__opts__, {"pillarenv": "dev"}):
                 mypillar = file_tree.ext_pillar(MINION_ID, None, absolute_path)
-                for key,value in mypillar.items():
+                for key, value in mypillar.items():
                     if isinstance(value, dict):
-                        for ikey,ivalue in value.items():
+                        for ikey, ivalue in value.items():
                             self.assertTrue(isinstance(ikey, str))
                             self.assertTrue(isinstance(ivalue, str))
                     else:


### PR DESCRIPTION
### What does this PR do?
Checks for both string and bytes types. This started occurring after this change: https://github.com/saltstack/salt/pull/57563/files#diff-47cbc339d9c1deba6eb99276ecca993b8a07eb211a58d7d597a10c33ec2907d1L19

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/58794

### Previous Behavior
```
[root@b5472ae2c75a salt-dev]# salt-run pillar.show_pillar test_minion
one.sls:
    secret: |
      -----BEGIN PGP MESSAGE-----
    
      sjdalfk...
      -----END PGP MESSAGE-----
```

### New Behavior

```
[root@b5472ae2c75a salt-dev]# salt-run pillar.show_pillar test_minion
one.sls:
    secret: |
      supersecret
```

### Merge requirements satisfied?
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes