### PR TITLE
Fail when func_ret is False new module.run syntax

### DIFF
--- a/changelog/57768.fixed
+++ b/changelog/57768.fixed
@@ -1,0 +1,1 @@
+Fail when func_ret is False when using the new module.run syntax.

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -432,6 +432,12 @@ def run(**kwargs):
                                 func, func_ret.get("comment", "(error message N/A)")
                             )
                         )
+                    if func_ret is False:
+                        failures.append(
+                            "'{}': {}".format(
+                                func, func_ret
+                            )
+                        )
                 else:
                     success.append(
                         "{0}: {1}".format(

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 r"""
 Execution of Salt modules from within states
 ============================================
@@ -300,15 +299,12 @@ Windows system:
 
 .. _file_roots: https://docs.saltstack.com/en/latest/ref/configuration/master.html#file-roots
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
-# Import salt libs
 import salt.loader
 import salt.utils.args
 import salt.utils.functools
 import salt.utils.jid
 from salt.exceptions import SaltInvocationError
-from salt.ext import six
 from salt.ext.six.moves import range
 from salt.utils.decorators import with_deprecated
 
@@ -428,19 +424,15 @@ def run(**kwargs):
                 if not _get_result(func_ret, ret["changes"].get("ret", {})):
                     if isinstance(func_ret, dict):
                         failures.append(
-                            "'{0}' failed: {1}".format(
+                            "'{}' failed: {}".format(
                                 func, func_ret.get("comment", "(error message N/A)")
                             )
                         )
                     if func_ret is False:
-                        failures.append(
-                            "'{}': {}".format(
-                                func, func_ret
-                            )
-                        )
+                        failures.append("'{}': {}".format(func, func_ret))
                 else:
                     success.append(
-                        "{0}: {1}".format(
+                        "{}: {}".format(
                             func,
                             func_ret.get("comment", "Success")
                             if isinstance(func_ret, dict)
@@ -449,7 +441,7 @@ def run(**kwargs):
                     )
                     ret["changes"][func] = func_ret
             except (SaltInvocationError, TypeError) as ex:
-                failures.append("'{0}' failed: {1}".format(func, ex))
+                failures.append("'{}' failed: {}".format(func, ex))
         ret["comment"] = ", ".join(failures + success)
         ret["result"] = not bool(failures)
 
@@ -505,12 +497,12 @@ def _run(name, **kwargs):
     """
     ret = {"name": name, "changes": {}, "comment": "", "result": None}
     if name not in __salt__:
-        ret["comment"] = "Module function {0} is not available".format(name)
+        ret["comment"] = "Module function {} is not available".format(name)
         ret["result"] = False
         return ret
 
     if __opts__["test"]:
-        ret["comment"] = "Module function {0} is set to execute".format(name)
+        ret["comment"] = "Module function {} is set to execute".format(name)
         return ret
 
     aspec = salt.utils.args.get_function_argspec(__salt__[name])
@@ -568,7 +560,7 @@ def _run(name, **kwargs):
     if missing:
         comment = "The following arguments are missing:"
         for arg in missing:
-            comment += " {0}".format(arg)
+            comment += " {}".format(arg)
         ret["comment"] = comment
         ret["result"] = False
         return ret
@@ -613,9 +605,9 @@ def _run(name, **kwargs):
         else:
             mret = __salt__[name](*args)
     except Exception as e:  # pylint: disable=broad-except
-        ret[
-            "comment"
-        ] = "Module function {0} threw an exception. Exception: {1}".format(name, e)
+        ret["comment"] = "Module function {} threw an exception. Exception: {}".format(
+            name, e
+        )
         ret["result"] = False
         return ret
     else:
@@ -632,7 +624,7 @@ def _run(name, **kwargs):
         returners = salt.loader.returners(__opts__, __salt__)
         if kwargs["returner"] in returners:
             returners[kwargs["returner"]](ret_ret)
-    ret["comment"] = "Module function {0} executed".format(name)
+    ret["comment"] = "Module function {} executed".format(name)
     ret["result"] = _get_result(mret, ret["changes"])
 
     return ret
@@ -664,7 +656,7 @@ def _get_result(func_ret, changes):
 
 def _get_dict_result(node):
     ret = True
-    for key, val in six.iteritems(node):
+    for key, val in node.items():
         if key == "result" and val is False:
             ret = False
             break

--- a/tests/unit/states/test_module.py
+++ b/tests/unit/states/test_module.py
@@ -1,18 +1,12 @@
-# -*- coding: utf-8 -*-
 """
     :codeauthor: Nicole Thomas (nicole@saltstack.com)
 """
 
-# Import Python Libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 from inspect import ArgSpec
 
-# Import Salt Libs
 import salt.states.module as module
-
-# Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase
@@ -131,8 +125,8 @@ class ModuleStateTest(TestCase, LoaderModuleMockMixin):
             module.__opts__, {"use_superseded": ["module.run"]}
         ):
             ret = module.run(**{CMD: None})
-        if ret["comment"] != "Unavailable function: {0}.".format(CMD) or ret["result"]:
-            self.fail("module.run did not fail as expected: {0}".format(ret))
+        if ret["comment"] != "Unavailable function: {}.".format(CMD) or ret["result"]:
+            self.fail("module.run did not fail as expected: {}".format(ret))
 
     def test_module_run_hidden_varargs(self):
         """
@@ -155,10 +149,10 @@ class ModuleStateTest(TestCase, LoaderModuleMockMixin):
         ):
             ret = module.run(**{CMD: None})
         if (
-            ret["comment"] != "Function {0} to be executed.".format(CMD)
+            ret["comment"] != "Function {} to be executed.".format(CMD)
             or not ret["result"]
         ):
-            self.fail("module.run failed: {0}".format(ret))
+            self.fail("module.run failed: {}".format(ret))
 
     def test_run_missing_arg(self):
         """
@@ -182,8 +176,8 @@ class ModuleStateTest(TestCase, LoaderModuleMockMixin):
             module.__opts__, {"use_superseded": ["module.run"]}
         ):
             ret = module.run(**{CMD: ["Fred"]})
-        if ret["comment"] != "{0}: Success".format(CMD) or not ret["result"]:
-            self.fail("module.run failed: {0}".format(ret))
+        if ret["comment"] != "{}: Success".format(CMD) or not ret["result"]:
+            self.fail("module.run failed: {}".format(ret))
 
     def test_run_state_apply_result_false(self):
         """
@@ -205,8 +199,21 @@ class ModuleStateTest(TestCase, LoaderModuleMockMixin):
         with patch.dict(
             module.__salt__, {func: MagicMock(return_value=False)}
         ), patch.dict(module.__opts__, {"use_superseded": ["module.run"]}):
-            ret = module.run(**{"name": "test_service_state", "service.status": {"name": "doesnotexist"}})
-            self.assertEqual(ret, {'name': ['service.status'], 'changes': {}, 'comment': "'service.status': False", 'result': False})
+            ret = module.run(
+                **{
+                    "name": "test_service_state",
+                    "service.status": {"name": "doesnotexist"},
+                }
+            )
+            self.assertEqual(
+                ret,
+                {
+                    "name": ["service.status"],
+                    "changes": {},
+                    "comment": "'service.status': False",
+                    "result": False,
+                },
+            )
 
     def test_run_unexpected_keywords(self):
         with patch.dict(module.__salt__, {CMD: _mocked_func_args}), patch.dict(
@@ -217,7 +224,7 @@ class ModuleStateTest(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             ret["comment"],
             (
-                "'{0}' failed: {1}() got an unexpected keyword argument "
+                "'{}' failed: {}() got an unexpected keyword argument "
                 "'foo'".format(CMD, module_function)
             ),
         )
@@ -342,7 +349,7 @@ class ModuleStateTest(TestCase, LoaderModuleMockMixin):
             ret = module._run(CMD)
         self.assertFalse(ret["result"])
         self.assertEqual(
-            ret["comment"], "Module function {0} is not available".format(CMD)
+            ret["comment"], "Module function {} is not available".format(CMD)
         )
 
     def test_module_run_test_true(self):
@@ -352,7 +359,7 @@ class ModuleStateTest(TestCase, LoaderModuleMockMixin):
         with patch.dict(module.__opts__, {"test": True}):
             ret = module._run(CMD)
         self.assertEqual(
-            ret["comment"], "Module function {0} is set to execute".format(CMD)
+            ret["comment"], "Module function {} is set to execute".format(CMD)
         )
 
     def test_module_run_missing_arg(self):


### PR DESCRIPTION
### What does this PR do?
If a function run returns false we are not returning a False result when using the new module.run syntax, this PR ensures we fail on a False return.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/57768

### Previous Behavior

For the given state:

```
new-bad-module:
  module.run:
    - service.status:
      - name: salt-api
```

and salt-api is not running

```
----------
          ID: new-bad-module
    Function: module.run
      Result: True
     Comment: 
     Started: 15:30:24.716271
    Duration: 29.127 ms
     Changes:   

```

### New Behavior

```
----------
          ID: new-bad-module
    Function: module.run
      Result: False
     Comment: 'service.status': False
     Started: 15:29:58.551748
    Duration: 26.74 ms
     Changes:   
----------
```

### Merge requirements satisfied?

- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes