### PR TITLE
kitchen-ec2 >=3.8 is fixed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :windows do
 end
 
 group :ec2 do
-  gem 'kitchen-ec2', '3.6'
+  gem 'kitchen-ec2', '>=3.8'
 end
 
 group :vagrant do


### PR DESCRIPTION
### What does this PR do?
They fixed spot instance creation in kitchen-ec2 starting with 3.8
