### PR TITLE
ubuntu-20.04 arm requirements

### DIFF
--- a/requirements/static/ci/linux.in
+++ b/requirements/static/ci/linux.in
@@ -25,7 +25,8 @@ passlib
 paramiko>=2.1.6
 pycurl
 pygit2<=0.28.2; python_version < '3.8'
-pygit2>=1.2.0; python_version >= '3.8'
+pygit2<1.1.0; python_version == '3.8'
+pygit2>=1.2.0; python_version >= '3.9'
 pyiface
 pyinotify
 python-etcd>0.4.2

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -98,7 +98,6 @@ bcrypt==3.1.6             # via paramiko
 boto3==1.13.5
 boto==2.49.0
 botocore==1.16.26         # via boto3, moto, s3transfer
-cached-property==1.5.1    # via pygit2
 cachetools==3.1.0         # via google-auth
 cassandra-driver==3.23.0
 certifi==2020.6.20
@@ -177,7 +176,7 @@ pycryptodome==3.8.1       # via python-jose
 pycryptodomex==3.9.8
 pycurl==7.43.0.6
 pyeapi==0.8.3             # via napalm
-pygit2==1.2.0 ; python_version >= "3.8"
+pygit2==1.0.3 ; python_version == "3.8"
 pyiface==0.0.11
 pyinotify==0.9.6
 pyjwt==1.7.1              # via adal

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -177,7 +177,7 @@ pycryptodome==3.8.1       # via python-jose
 pycryptodomex==3.9.8
 pycurl==7.43.0.6
 pyeapi==0.8.3             # via napalm
-pygit2==1.2.0 ; python_version >= "3.8"
+pygit2==1.2.0 ; python_version >= "3.9"
 pyiface==0.0.11
 pyinotify==0.9.6
 pyjwt==1.7.1              # via adal


### PR DESCRIPTION
update requirements to be able to be installed on arm64 version of ubuntu 20.04
see: https://github.com/saltstack/salt-jenkins/pull/1659

This is necessary because pygit2>=1.1.0 requires a newer version of libgit2-dev than ubuntu20.0 has in the repos.