### PR TITLE
This PR implements waiting for actual vm stop for proxmox cloud driver, which as marked as TBD.

### DIFF
--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -1302,7 +1302,14 @@ def stop(name, vmid=None, call=None):
         log.error('Unable to bring VM %s (%s) down..', name, vmid)
         raise SaltCloudExecutionFailure
 
-    # xxx: TBD: Check here whether the status was actually changed to 'stopped'
+    if vmid is None:
+        vmobj = _get_vm_by_name(name)
+        vmid = vmobj['vmid']
+
+    # Wait until the VM has fully started
+    log.debug('Waiting for state "stopped" for vm %s on %s', vmid, name)
+    if not wait_for_state(vmid, 'stopped'):
+        return {'Error': 'Unable to start {0}, command timed out'.format(name)}
 
     return {'Stopped': '{0} was stopped.'.format(name)}
 
@@ -1326,6 +1333,13 @@ def shutdown(name=None, vmid=None, call=None):
         log.error('Unable to shut VM %s (%s) down..', name, vmid)
         raise SaltCloudExecutionFailure
 
-    # xxx: TBD: Check here whether the status was actually changed to 'stopped'
+    if vmid is None:
+        vmobj = _get_vm_by_name(name)
+        vmid = vmobj['vmid']
+
+    # Wait until the VM has fully started
+    log.debug('Waiting for state "stopped" for vm %s on %s', vmid, name)
+    if not wait_for_state(vmid, 'stopped'):
+        return {'Error': 'Unable to start {0}, command timed out'.format(name)}
 
     return {'Shutdown': '{0} was shutdown.'.format(name)}


### PR DESCRIPTION
### What does this PR do?

Implements waiting for actual vm stop for proxmox cloud driver, so we can avoid race conditions when stopping/starting a VM in sequence during deployment orchestration.

This feature was missing from existing driver and marked with a TBD comment.

### What issues does this PR fix or reference?

N/A

### Previous Behavior

When invoking 'stop' action on proxmox cloud driver, salt-cloud did not wait until the VM was actually stopped.

### New Behavior

Now the code waits until the VM is reported as stopped, or times out.

### Merge requirements satisfied?

- No docs updated as there is no specific mention to stop (or other proxmox actions) on existing documentation.
- I've found no tests regarding proxmox cloud driver.

### Commits signed with GPG?

No

