### PR TITLE
Fix __virtual__ function in win_wua

### DIFF
--- a/changelog/58848.fixed
+++ b/changelog/58848.fixed
@@ -1,0 +1,1 @@
+Fix issue where win_wua module fails to load when BITS is set to Manual

--- a/salt/modules/win_wua.py
+++ b/salt/modules/win_wua.py
@@ -101,7 +101,7 @@ def __virtual__():
             "WUA: The Windows Installer service (msiserver) must not be disabled",
         )
 
-    if not salt.utils.win_service.info("BITS")["StartType"] == "Auto":
+    if salt.utils.win_service.info("BITS")["StartType"] == "Disabled":
         return (
             False,
             "WUA: The Background Intelligent Transfer service (bits) must not "

--- a/tests/unit/modules/test_win_wua.py
+++ b/tests/unit/modules/test_win_wua.py
@@ -40,6 +40,7 @@ class WinWuaInstalledTestCase(TestCase):
 
     service_auto = {"StartType": "Auto"}
     service_disabled = {"StartType": "Disabled"}
+    service_manual = {"StartType": "Manual"}
 
     def test__virtual__not_windows(self):
         """
@@ -63,7 +64,7 @@ class WinWuaInstalledTestCase(TestCase):
         """
         Test __virtual__ function when the wuauserv service is disabled
         """
-        disabled_wuauserv = MagicMock(
+        mock_service_info = MagicMock(
             side_effect=[
                 self.service_disabled,  # wuauserv
                 self.service_auto,  # msiserver
@@ -72,7 +73,7 @@ class WinWuaInstalledTestCase(TestCase):
                 self.service_auto,  # TrustedInstaller
             ]
         )
-        with patch("salt.utils.win_service.info", disabled_wuauserv):
+        with patch("salt.utils.win_service.info", mock_service_info):
             expected = (
                 False,
                 "WUA: The Windows Update service (wuauserv) must not be disabled",
@@ -84,7 +85,7 @@ class WinWuaInstalledTestCase(TestCase):
         """
         Test __virtual__ function when the msiserver service is disabled
         """
-        disabled_wuauserv = MagicMock(
+        mock_service_info = MagicMock(
             side_effect=[
                 self.service_auto,  # wuauserv
                 self.service_disabled,  # msiserver
@@ -93,7 +94,7 @@ class WinWuaInstalledTestCase(TestCase):
                 self.service_auto,  # TrustedInstaller
             ]
         )
-        with patch("salt.utils.win_service.info", disabled_wuauserv):
+        with patch("salt.utils.win_service.info", mock_service_info):
             expected = (
                 False,
                 "WUA: The Windows Installer service (msiserver) must not be disabled",
@@ -105,7 +106,7 @@ class WinWuaInstalledTestCase(TestCase):
         """
         Test __virtual__ function when the BITS service is disabled
         """
-        disabled_wuauserv = MagicMock(
+        mock_service_info = MagicMock(
             side_effect=[
                 self.service_auto,  # wuauserv
                 self.service_auto,  # msiserver
@@ -114,7 +115,7 @@ class WinWuaInstalledTestCase(TestCase):
                 self.service_auto,  # TrustedInstaller
             ]
         )
-        with patch("salt.utils.win_service.info", disabled_wuauserv):
+        with patch("salt.utils.win_service.info", mock_service_info):
             expected = (
                 False,
                 "WUA: The Background Intelligent Transfer service (bits) must not be disabled",
@@ -122,11 +123,30 @@ class WinWuaInstalledTestCase(TestCase):
             result = win_wua.__virtual__()
             self.assertEqual(expected, result)
 
+    def test__virtual__BITS_manual(self):
+        """
+        Test __virtual__ function when the BITS service is set to manual
+        Should not disable the module (__virtual__ should return True)
+        """
+        mock_service_info = MagicMock(
+            side_effect=[
+                self.service_auto,  # wuauserv
+                self.service_auto,  # msiserver
+                self.service_manual,  # BITS
+                self.service_auto,  # CryptSvc
+                self.service_auto,  # TrustedInstaller
+            ]
+        )
+        with patch("salt.utils.win_service.info", mock_service_info):
+            expected = True
+            result = win_wua.__virtual__()
+            self.assertEqual(expected, result)
+
     def test__virtual__CryptSvc_disabled(self):
         """
         Test __virtual__ function when the CryptSvc service is disabled
         """
-        disabled_wuauserv = MagicMock(
+        mock_service_info = MagicMock(
             side_effect=[
                 self.service_auto,  # wuauserv
                 self.service_auto,  # msiserver
@@ -135,7 +155,7 @@ class WinWuaInstalledTestCase(TestCase):
                 self.service_auto,  # TrustedInstaller
             ]
         )
-        with patch("salt.utils.win_service.info", disabled_wuauserv):
+        with patch("salt.utils.win_service.info", mock_service_info):
             expected = (
                 False,
                 "WUA: The Cryptographic Services service (CryptSvc) must not be disabled",
@@ -147,7 +167,7 @@ class WinWuaInstalledTestCase(TestCase):
         """
         Test __virtual__ function when the TrustedInstaller service is disabled
         """
-        disabled_wuauserv = MagicMock(
+        mock_service_info = MagicMock(
             side_effect=[
                 self.service_auto,  # wuauserv
                 self.service_auto,  # msiserver
@@ -156,7 +176,7 @@ class WinWuaInstalledTestCase(TestCase):
                 self.service_disabled,  # TrustedInstaller
             ]
         )
-        with patch("salt.utils.win_service.info", disabled_wuauserv):
+        with patch("salt.utils.win_service.info", mock_service_info):
             expected = (
                 False,
                 "WUA: The Windows Module Installer service (TrustedInstaller) must not be disabled",


### PR DESCRIPTION
### What does this PR do?
The test for the BITS service was too strict. On some systems "manual" is a valid setting. It just can't be disabled.

### What issues does this PR fix or reference?
Fixes: #58848

### Previous Behavior
win_wua module would fail to start if BITS service was set to Manual start

### New Behavior
win_wua module now loads when the BITS service is set to Manual start

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes