### PR TITLE
Loader Contexts

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,3 +4,4 @@ PyYAML
 MarkupSafe
 requests>=1.0.0
 distro>=1.5
+contextvars; python_version < '3.7'

--- a/requirements/static/ci/py3.5/darwin.txt
+++ b/requirements/static/ci/py3.5/darwin.txt
@@ -27,6 +27,7 @@ cherrypy==17.4.1
 click==7.0                # via geomet
 clustershell==1.8.1
 contextlib2==0.6.0.post1
+contextvars==2.4 ; python_version < "3.7"
 croniter==0.3.29
 cryptography==3.2
 distlib==0.3.0            # via virtualenv
@@ -44,6 +45,7 @@ gitdb2==2.0.6
 gitpython==2.1.15
 google-auth==1.6.3        # via kubernetes
 idna==2.8
+immutables==0.14
 importlib-metadata==0.23  # via importlib-resources, pluggy, pytest, virtualenv
 importlib-resources==1.3.1  # via virtualenv
 iniconfig==1.0.1          # via pytest

--- a/requirements/static/ci/py3.5/freebsd.txt
+++ b/requirements/static/ci/py3.5/freebsd.txt
@@ -26,6 +26,7 @@ cheetah3==3.1.0
 cheroot==6.5.4
 cherrypy==17.3.0
 contextlib2==0.5.5
+contextvars==2.4 ; python_version < "3.7"
 croniter==0.3.29
 cryptography==3.2
 distlib==0.3.0            # via virtualenv
@@ -43,6 +44,7 @@ gitpython==2.1.11
 google-auth==1.6.3        # via kubernetes
 hgtools==8.1.1
 idna==2.8
+immutables==0.14
 importlib-metadata==0.23  # via importlib-resources, pluggy, pytest, virtualenv
 importlib-resources==1.5.0  # via virtualenv
 iniconfig==1.0.1          # via pytest

--- a/requirements/static/ci/py3.5/linux.txt
+++ b/requirements/static/ci/py3.5/linux.txt
@@ -110,6 +110,7 @@ cheroot==6.5.4
 cherrypy==17.3.0
 click==7.1.1              # via geomet
 contextlib2==0.5.5
+contextvars==2.4 ; python_version < "3.7"
 croniter==0.3.29
 cryptography==3.2
 distlib==0.3.0            # via virtualenv
@@ -128,6 +129,7 @@ gitpython==2.1.11
 google-auth==1.6.3        # via kubernetes
 hgtools==8.1.1
 idna==2.8
+immutables==0.14
 importlib-metadata==0.23  # via importlib-resources, pluggy, pytest, virtualenv
 importlib-resources==1.5.0  # via virtualenv
 iniconfig==1.0.1          # via pytest

--- a/requirements/static/ci/py3.5/windows.txt
+++ b/requirements/static/ci/py3.5/windows.txt
@@ -23,6 +23,7 @@ cherrypy==17.4.1
 click==7.1.2              # via geomet
 colorama==0.4.1           # via pytest
 contextlib2==0.6.0.post1
+contextvars==2.4 ; python_version < "3.7"
 cryptography==3.2
 distlib==0.3.0            # via virtualenv
 distro==1.5.0
@@ -40,6 +41,7 @@ gitdb2==2.0.5
 gitpython==2.1.10
 google-auth==1.6.3        # via kubernetes
 idna==2.8
+immutables==0.14
 importlib-metadata==0.23  # via importlib-resources, pluggy, pytest, virtualenv
 importlib-resources==1.5.0  # via virtualenv
 iniconfig==1.0.1          # via pytest

--- a/requirements/static/ci/py3.6/darwin.txt
+++ b/requirements/static/ci/py3.6/darwin.txt
@@ -29,6 +29,7 @@ click==7.0                # via geomet
 clustershell==1.8.1
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.6.0.post1
+contextvars==2.4 ; python_version < "3.7"
 croniter==0.3.29
 cryptography==3.2
 distlib==0.3.0            # via virtualenv
@@ -46,6 +47,7 @@ gitdb2==2.0.6
 gitpython==2.1.15
 google-auth==1.6.3        # via kubernetes
 idna==2.8
+immutables==0.14
 importlib-metadata==0.23  # via importlib-resources, pluggy, pytest, virtualenv
 importlib-resources==1.3.1  # via virtualenv
 iniconfig==1.0.1          # via pytest

--- a/requirements/static/ci/py3.6/freebsd.txt
+++ b/requirements/static/ci/py3.6/freebsd.txt
@@ -28,6 +28,7 @@ cherrypy==17.3.0
 ciscoconfparse==1.5.19    # via napalm
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
+contextvars==2.4 ; python_version < "3.7"
 croniter==0.3.29
 cryptography==3.2
 distlib==0.3.0            # via virtualenv
@@ -45,6 +46,7 @@ gitpython==2.1.11
 google-auth==1.6.3        # via kubernetes
 hgtools==8.1.1
 idna==2.8
+immutables==0.14
 importlib-metadata==0.23  # via importlib-resources, pluggy, pytest, virtualenv
 importlib-resources==1.5.0  # via virtualenv
 iniconfig==1.0.1          # via pytest

--- a/requirements/static/ci/py3.6/linux.txt
+++ b/requirements/static/ci/py3.6/linux.txt
@@ -112,6 +112,7 @@ ciscoconfparse==1.5.19    # via napalm
 click==7.1.1              # via geomet
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
+contextvars==2.4 ; python_version < "3.7"
 croniter==0.3.29
 cryptography==3.2
 distlib==0.3.0            # via virtualenv
@@ -130,6 +131,7 @@ gitpython==2.1.11
 google-auth==1.6.3        # via kubernetes
 hgtools==8.1.1
 idna==2.8
+immutables==0.14
 importlib-metadata==0.23  # via importlib-resources, pluggy, pytest, virtualenv
 importlib-resources==1.5.0  # via virtualenv
 iniconfig==1.0.1          # via pytest

--- a/requirements/static/ci/py3.6/windows.txt
+++ b/requirements/static/ci/py3.6/windows.txt
@@ -23,6 +23,7 @@ cherrypy==17.4.1
 click==7.1.2              # via geomet
 colorama==0.4.1           # via pytest
 contextlib2==0.6.0.post1
+contextvars==2.4 ; python_version < "3.7"
 cryptography==3.2
 distlib==0.3.0            # via virtualenv
 distro==1.5.0
@@ -40,6 +41,7 @@ gitdb2==2.0.5
 gitpython==2.1.10
 google-auth==1.6.3        # via kubernetes
 idna==2.8
+immutables==0.14
 importlib-metadata==0.23  # via importlib-resources, pluggy, pytest, virtualenv
 importlib-resources==1.5.0  # via virtualenv
 iniconfig==1.0.1          # via pytest

--- a/requirements/static/pkg/py3.5/darwin.txt
+++ b/requirements/static/pkg/py3.5/darwin.txt
@@ -12,11 +12,13 @@ chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
+contextvars==2.4 ; python_version < "3.7"
 cryptography==3.2
 distro==1.5.0
 gitdb2==2.0.6             # via gitpython
 gitpython==2.1.15
 idna==2.8
+immutables==0.14          # via contextvars
 ipaddress==1.0.22
 jaraco.functools==2.0     # via cheroot, tempora
 jinja2==2.10.1

--- a/requirements/static/pkg/py3.5/freebsd.txt
+++ b/requirements/static/pkg/py3.5/freebsd.txt
@@ -12,9 +12,11 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.3.0
 contextlib2==0.5.5        # via cherrypy
+contextvars==2.4 ; python_version < "3.7"
 cryptography==3.2         # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
+immutables==0.14          # via contextvars
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
 markupsafe==1.1.1

--- a/requirements/static/pkg/py3.5/linux.txt
+++ b/requirements/static/pkg/py3.5/linux.txt
@@ -12,9 +12,11 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.3.0
 contextlib2==0.5.5        # via cherrypy
+contextvars==2.4 ; python_version < "3.7"
 cryptography==3.2         # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
+immutables==0.14          # via contextvars
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
 markupsafe==1.1.1

--- a/requirements/static/pkg/py3.5/windows.txt
+++ b/requirements/static/pkg/py3.5/windows.txt
@@ -11,11 +11,13 @@ chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
+contextvars==2.4 ; python_version < "3.7"
 cryptography==3.2
 distro==1.5.0
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.10
 idna==2.8
+immutables==0.14          # via contextvars
 ioloop==0.1a0
 ipaddress==1.0.22
 jaraco.functools==2.0     # via cheroot, tempora

--- a/requirements/static/pkg/py3.6/darwin.txt
+++ b/requirements/static/pkg/py3.6/darwin.txt
@@ -12,11 +12,13 @@ chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
+contextvars==2.4 ; python_version < "3.7"
 cryptography==3.2
 distro==1.5.0
 gitdb2==2.0.6             # via gitpython
 gitpython==2.1.15
 idna==2.8
+immutables==0.14          # via contextvars
 ipaddress==1.0.22
 jaraco.functools==2.0     # via cheroot, tempora
 jinja2==2.10.1

--- a/requirements/static/pkg/py3.6/freebsd.txt
+++ b/requirements/static/pkg/py3.6/freebsd.txt
@@ -12,9 +12,11 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.3.0
 contextlib2==0.5.5        # via cherrypy
+contextvars==2.4 ; python_version < "3.7"
 cryptography==3.2         # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
+immutables==0.14          # via contextvars
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
 markupsafe==1.1.1

--- a/requirements/static/pkg/py3.6/linux.txt
+++ b/requirements/static/pkg/py3.6/linux.txt
@@ -12,9 +12,11 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.3.0
 contextlib2==0.5.5        # via cherrypy
+contextvars==2.4 ; python_version < "3.7"
 cryptography==3.2         # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
+immutables==0.14          # via contextvars
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
 markupsafe==1.1.1

--- a/requirements/static/pkg/py3.6/windows.txt
+++ b/requirements/static/pkg/py3.6/windows.txt
@@ -11,11 +11,13 @@ chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
+contextvars==2.4 ; python_version < "3.7"
 cryptography==3.2
 distro==1.5.0
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.10
 idna==2.8
+immutables==0.14          # via contextvars
 ioloop==0.1a0
 ipaddress==1.0.22
 jaraco.functools==2.0     # via cheroot, tempora

--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -234,7 +234,7 @@ class BaseCaller:
                     sys.stderr.write(trace)
                 sys.exit(salt.defaults.exitcodes.EX_GENERIC)
             try:
-                retcode = sys.modules[func.__module__].__context__.get("retcode", 0)
+                retcode = self.minion.executors.pack["__context__"].get("retcode", 0)
             except AttributeError:
                 retcode = salt.defaults.exitcodes.EX_GENERIC
 

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -657,9 +657,8 @@ def render(opts, functions, states=None, proxy=None, context=None):
         pack["__states__"] = states
 
     if proxy is None:
-        pack["__proxy__"] = {}
-    else:
-        pack["proxy"] = proxy
+        proxy = {}
+    pack["__proxy__"] = proxy
 
     ret = LazyLoader(
         _module_dirs(opts, "renderers", "render", ext_type_dirs="render_dirs",),

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -305,7 +305,6 @@ def metaproxy(opts, loaded_base_name=None):
     """
     Return functions used in the meta proxy
     """
-
     return LazyLoader(
         _module_dirs(opts, "metaproxy"),
         opts,
@@ -567,7 +566,7 @@ def states(
     if context is None:
         context = {}
 
-    ret = LazyLoader(
+    return LazyLoader(
         _module_dirs(opts, "states"),
         opts,
         tag="states",
@@ -582,7 +581,6 @@ def states(
         extra_module_dirs=utils.module_dirs if utils else None,
         pack_self="__states__",
     )
-    return ret
 
 
 def beacons(opts, functions, context=None, proxy=None):
@@ -657,7 +655,12 @@ def render(opts, functions, states=None, proxy=None, context=None):
 
     if states:
         pack["__states__"] = states
-    pack["__proxy__"] = proxy or {}
+
+    if proxy is None:
+        pack["__proxy__"] = {}
+    else:
+        pack["proxy"] = proxy
+
     ret = LazyLoader(
         _module_dirs(opts, "renderers", "render", ext_type_dirs="render_dirs",),
         opts,
@@ -1080,7 +1083,7 @@ def executors(opts, functions=None, context=None, proxy=None):
     """
     Returns the executor modules
     """
-    executors = LazyLoader(
+    return LazyLoader(
         _module_dirs(opts, "executors", "executor"),
         opts,
         tag="executor",
@@ -1091,7 +1094,6 @@ def executors(opts, functions=None, context=None, proxy=None):
         },
         pack_self="__executors__",
     )
-    return executors
 
 
 def cache(opts, serial):

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -4,6 +4,8 @@ directories for python loadable code and organizes the code into the
 plugin interfaces used by Salt.
 """
 
+import contextvars
+import copy
 import functools
 import importlib.machinery  # pylint: disable=no-name-in-module,import-error
 import importlib.util  # pylint: disable=no-name-in-module,import-error
@@ -23,6 +25,7 @@ from zipimport import zipimporter
 import salt.config
 import salt.defaults.events
 import salt.defaults.exitcodes
+import salt.loader_context
 import salt.syspaths
 import salt.utils.args
 import salt.utils.context
@@ -240,9 +243,8 @@ def minion_mods(
         loaded_base_name=loaded_base_name,
         static_modules=static_modules,
         extra_module_dirs=utils.module_dirs if utils else None,
+        pack_self="__salt__",
     )
-
-    ret.pack["__salt__"] = ret
 
     # Load any provider overrides from the configuration file providers option
     #  Note: Providers can be pkg, service, user or group - not to be confused
@@ -339,12 +341,18 @@ def engines(opts, functions, runners, utils, proxy=None):
 
 
 def proxy(
-    opts, functions=None, returners=None, whitelist=None, utils=None, context=None
+    opts,
+    functions=None,
+    returners=None,
+    whitelist=None,
+    utils=None,
+    context=None,
+    pack_self="__proxy__",
 ):
     """
     Returns the proxy module for this salt-proxy-minion
     """
-    ret = LazyLoader(
+    return LazyLoader(
         _module_dirs(opts, "proxy"),
         opts,
         tag="proxy",
@@ -355,11 +363,8 @@ def proxy(
             "__context__": context,
         },
         extra_module_dirs=utils.module_dirs if utils else None,
+        pack_self=pack_self,
     )
-
-    ret.pack["__proxy__"] = ret
-
-    return ret
 
 
 def returners(opts, functions, whitelist=None, context=None, proxy=None):
@@ -375,7 +380,7 @@ def returners(opts, functions, whitelist=None, context=None, proxy=None):
     )
 
 
-def utils(opts, whitelist=None, context=None, proxy=proxy):
+def utils(opts, whitelist=None, context=None, proxy=proxy, pack_self=None):
     """
     Returns the utility modules
     """
@@ -385,6 +390,7 @@ def utils(opts, whitelist=None, context=None, proxy=proxy):
         tag="utils",
         whitelist=whitelist,
         pack={"__context__": context, "__proxy__": proxy or {}},
+        pack_self=pack_self,
     )
 
 
@@ -399,8 +405,8 @@ def pillars(opts, functions, context=None):
         tag="pillar",
         pack={"__salt__": functions, "__context__": context, "__utils__": _utils},
         extra_module_dirs=_utils.module_dirs,
+        pack_self="__ext_pillar__",
     )
-    ret.pack["__ext_pillar__"] = ret
     return FilterDictWrapper(ret, ".ext_pillar")
 
 
@@ -565,14 +571,17 @@ def states(
         _module_dirs(opts, "states"),
         opts,
         tag="states",
-        pack={"__salt__": functions, "__proxy__": proxy or {}},
+        pack={
+            "__salt__": functions,
+            "__proxy__": proxy or {},
+            "__utils__": utils,
+            "__serializers__": serializers,
+            "__context__": context,
+        },
         whitelist=whitelist,
         extra_module_dirs=utils.module_dirs if utils else None,
+        pack_self="__states__",
     )
-    ret.pack["__states__"] = ret
-    ret.pack["__utils__"] = utils
-    ret.pack["__serializers__"] = serializers
-    ret.pack["__context__"] = context
     return ret
 
 
@@ -683,7 +692,6 @@ def grain_funcs(opts, proxy=None, context=None):
     """
     _utils = utils(opts, proxy=proxy)
     pack = {"__utils__": utils(opts, proxy=proxy), "__context__": context}
-
     ret = LazyLoader(
         _module_dirs(opts, "grains", "grain", ext_type_dirs="grains_dirs",),
         opts,
@@ -960,17 +968,16 @@ def runner(opts, utils=None, context=None, whitelist=None):
         utils = {}
     if context is None:
         context = {}
-    ret = LazyLoader(
+    return LazyLoader(
         _module_dirs(opts, "runners", "runner", ext_type_dirs="runner_dirs"),
         opts,
         tag="runners",
         pack={"__utils__": utils, "__context__": context},
         whitelist=whitelist,
         extra_module_dirs=utils.module_dirs if utils else None,
+        # TODO: change from __salt__ to something else, we overload __salt__ too much
+        pack_self="__salt__",
     )
-    # TODO: change from __salt__ to something else, we overload __salt__ too much
-    ret.pack["__salt__"] = ret
-    return ret
 
 
 def queues(opts):
@@ -997,7 +1004,6 @@ def sdb(opts, functions=None, whitelist=None, utils=None):
         tag="sdb",
         pack={
             "__sdb__": functions,
-            "__opts__": opts,
             "__utils__": utils,
             "__salt__": minion_mods(opts, utils=utils),
         },
@@ -1083,8 +1089,8 @@ def executors(opts, functions=None, context=None, proxy=None):
             "__context__": context or {},
             "__proxy__": proxy or {},
         },
+        pack_self="__executors__",
     )
-    executors.pack["__executors__"] = executors
     return executors
 
 
@@ -1096,7 +1102,7 @@ def cache(opts, serial):
         _module_dirs(opts, "cache", "cache"),
         opts,
         tag="cache",
-        pack={"__opts__": opts, "__context__": {"serial": serial}},
+        pack={"__context__": {"serial": serial}},
     )
 
 
@@ -1147,6 +1153,54 @@ class FilterDictWrapper(MutableMapping):
                 yield key.replace(self.suffix, "")
 
 
+class LoadedFunc:
+    """
+    The functions loaded by LazyLoader instances using subscript notation
+    'a[k]' will be wrapped with LoadedFunc.
+
+      - Makes sure functions are called with the correct loader's context.
+      - Provides access to a wrapped func's __global__ attribute
+
+    :param func callable: The callable to wrap.
+    :param dict loader: The loader to use in the context when the wrapped callable is called.
+    """
+
+    def __init__(self, func, loader):
+        self.func = func
+        self.loader = loader
+        functools.update_wrapper(self, func)
+
+    def __getattr__(self, name):
+        if name == "__globals__":
+            return self.func.__globals__
+
+    def __call__(self, *args, **kwargs):
+        if self.loader.inject_globals:
+            run_func = global_injector_decorator(self.loader.inject_globals)(self.func)
+        else:
+            run_func = self.func
+        return self.loader.run(run_func, *args, **kwargs)
+
+
+class LoadedMod:
+    def __init__(self, mod, loader):
+        """
+        Return the wrapped func's globals via this object's __globals__
+        attribute.
+        """
+        self.mod = mod
+        self.loader = loader
+
+    def __getattr__(self, name):
+        """
+        Run the wrapped function in the loader's context.
+        """
+        attr = getattr(self.mod, name)
+        if inspect.isfunction(attr) or inspect.ismethod(attr):
+            return LoadedFunc(attr, self.loader)
+        return attr
+
+
 class LazyLoader(salt.utils.lazy.LazyDict):
     """
     A pseduo-dictionary which has a set of keys which are the
@@ -1168,6 +1222,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
     :param str virtual_funcs: The name of additional functions in the module to call to verify its functionality.
                                 If not true, the module will not load.
     :param list extra_module_dirs: A list of directories that will be able to import from
+    :param str pack_self: Pack this module into a variable by this name into modules loaded
     :returns: A LazyLoader object which functions as a dictionary. Keys are 'module.function' and values
     are function references themselves which are loaded on-demand.
     # TODO:
@@ -1191,19 +1246,25 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         proxy=None,
         virtual_funcs=None,
         extra_module_dirs=None,
+        pack_self=None,
     ):  # pylint: disable=W0231
         """
         In pack, if any of the values are None they will be replaced with an
         empty context-specific dict
         """
 
+        self.parent_loader = None
         self.inject_globals = {}
         self.pack = {} if pack is None else pack
+        for i in self.pack:
+            if isinstance(self.pack[i], salt.loader_context.NamedLoaderContext):
+                self.pack[i] = self.pack[i].value()
         if opts is None:
             opts = {}
         threadsafety = not opts.get("multiprocessing")
         self.context_dict = salt.utils.context.ContextDict(threadsafe=threadsafety)
         self.opts = self.__prep_mod_opts(opts)
+        self.pack_self = pack_self
 
         self.module_dirs = module_dirs
         self.tag = tag
@@ -1281,10 +1342,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         to last-minute inject globals
         """
         func = super().__getitem__(item)
-        if self.inject_globals:
-            return global_injector_decorator(self.inject_globals)(func)
-        else:
-            return func
+        return LoadedFunc(func, self)
 
     def __getattr__(self, mod_name):
         """
@@ -1309,7 +1367,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                 if self._load_module(name) and mod_name in self.loaded_modules:
                     break
         if mod_name in self.loaded_modules:
-            return self.loaded_modules[mod_name]
+            return LoadedMod(self.loaded_modules[mod_name], self)
         else:
             raise AttributeError(mod_name)
 
@@ -1704,7 +1762,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                     # loading using exec_module has been causing odd things
                     # with the magic dunders we pack into the loaded
                     # modules, most notably with salt-ssh's __opts__.
-                    mod = spec.loader.load_module()
+                    mod = self.run(spec.loader.load_module)
                     # mod = importlib.util.module_from_spec(spec)
                     # spec.loader.exec_module(mod)
                     # pylint: enable=no-member
@@ -1755,14 +1813,56 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             sys.path.remove(fpath_dirname)
             self.__clean_sys_path()
 
-        if hasattr(mod, "__opts__"):
-            mod.__opts__.update(self.opts)
+        loader_context = salt.loader_context.LoaderContext()
+        if hasattr(mod, "__salt_loader__"):
+            if not isinstance(mod.__salt_loader__, salt.loader_context.LoaderContext):
+                log.warning("Override  __salt_loader__: %s", mod)
+                mod.__salt_loader__ = loader_context
         else:
-            mod.__opts__ = self.opts
+            mod.__salt_loader__ = loader_context
+
+        if hasattr(mod, "__opts__"):
+            if not isinstance(mod.__opts__, salt.loader_context.NamedLoaderContext):
+                if not hasattr(mod, "__orig_opts__"):
+                    mod.__orig_opts__ = copy.deepcopy(mod.__opts__)
+                mod.__opts__ = copy.deepcopy(mod.__orig_opts__)
+                mod.__opts__.update(self.opts)
+        else:
+            if not hasattr(mod, "__orig_opts__"):
+                mod.__orig_opts__ = {}
+            mod.__opts__ = copy.deepcopy(mod.__orig_opts__)
+            mod.__opts__.update(self.opts)
 
         # pack whatever other globals we were asked to
         for p_name, p_value in self.pack.items():
-            setattr(mod, p_name, p_value)
+            mod_named_context = getattr(mod, p_name, None)
+            if hasattr(mod_named_context, "default"):
+                default = copy.deepcopy(mod_named_context.default)
+            else:
+                default = None
+            named_context = loader_context.named_context(p_name, default)
+            if mod_named_context is None:
+                setattr(mod, p_name, named_context)
+            elif named_context != mod_named_context:
+                log.debug("Override  %s: %s", p_name, mod)
+                setattr(mod, p_name, named_context)
+            else:
+                setattr(mod, p_name, named_context)
+
+        if self.pack_self is not None:
+            mod_named_context = getattr(mod, self.pack_self, None)
+            if hasattr(mod_named_context, "default"):
+                default = copy.deepcopy(mod_named_context.default)
+            else:
+                default = None
+            named_context = loader_context.named_context(self.pack_self, default)
+            if mod_named_context is None:
+                setattr(mod, self.pack_self, named_context)
+            elif named_context != mod_named_context:
+                log.debug("Override  %s: %s", self.pack_self, mod)
+                setattr(mod, self.pack_self, named_context)
+            else:
+                setattr(mod, self.pack_self, named_context)
 
         module_name = mod.__name__.rsplit(".", 1)[-1]
 
@@ -1770,7 +1870,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         module_init = getattr(mod, "__init__", None)
         if inspect.isfunction(module_init):
             try:
-                module_init(self.opts)
+                self.run(module_init, self.opts)
             except TypeError as e:
                 log.error(e)
             except Exception:  # pylint: disable=broad-except
@@ -1999,7 +2099,8 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             if hasattr(mod, "__virtual__") and inspect.isfunction(mod.__virtual__):
                 try:
                     start = time.time()
-                    virtual = getattr(mod, virtual_func)()
+                    virtual_attr = getattr(mod, virtual_func)
+                    virtual = self.run(virtual_attr)
                     if isinstance(virtual, tuple):
                         error_reason = virtual[1]
                         virtual = virtual[0]
@@ -2088,6 +2189,45 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             return (False, module_name, error_reason, virtual_aliases)
 
         return (True, module_name, None, virtual_aliases)
+
+    def run(self, method, *args, **kwargs):
+        """
+        Run the method in this loader's context
+        """
+        self._last_context = contextvars.copy_context()
+        return self._last_context.run(self._run_as, method, *args, **kwargs)
+
+    def _run_as(self, method, *args, **kwargs):
+        """
+        Handle setting up the context properly and call the method
+        """
+        self.parent_loader = None
+        try:
+            current_loader = salt.loader_context.loader_ctxvar.get()
+        except LookupError:
+            current_loader = None
+        if current_loader is not self:
+            self.parent_loader = current_loader
+        token = salt.loader_context.loader_ctxvar.set(self)
+        try:
+            return method(*args, **kwargs)
+        finally:
+            self.parent_loader = None
+            salt.loader_context.loader_ctxvar.reset(token)
+
+    def run_in_thread(self, method, *args, **kwargs):
+        """
+        Run the function in a new thread with the context of this loader
+        """
+        argslist = [self, method]
+        argslist.extend(args)
+        thread = threading.Thread(target=self.target, args=argslist, kwargs=kwargs)
+        thread.start()
+        return thread
+
+    @staticmethod
+    def target(loader, method, *args, **kwargs):
+        loader.run(method, *args, **kwargs)
 
 
 def global_injector_decorator(inject_globals):

--- a/salt/loader_context.py
+++ b/salt/loader_context.py
@@ -101,7 +101,7 @@ class NamedLoaderContext(collections.abc.MutableMapping):
         self.default = state["default"]
 
     def __getattr__(self, name):
-        return self.value().__getattr__(name)
+        return getattr(self.value(), name)
 
     def missing_fun_string(self, name):
         return self.loader().missing_fun_string(name)

--- a/salt/loader_context.py
+++ b/salt/loader_context.py
@@ -1,0 +1,141 @@
+"""
+Manage the context a module loaded by Salt's loader
+"""
+import collections.abc
+import contextlib
+import contextvars
+
+loader_ctxvar = contextvars.ContextVar("loader_ctxvar")
+
+
+@contextlib.contextmanager
+def loader_context(loader):
+    """
+    A context manager that sets and un-sets the loader context
+    """
+    tok = loader_ctxvar.set(loader)
+    try:
+        yield
+    finally:
+        loader_ctxvar.reset(tok)
+
+
+class NamedLoaderContext(collections.abc.MutableMapping):
+    """
+    A NamedLoaderContext object is injected by the loader providing access to
+    Salt's 'magic dunders' (__salt__, __utils__, ect).
+    """
+
+    def __init__(self, name, loader_context, default=None):
+        self.name = name
+        self.loader_context = loader_context
+        self.default = default
+
+    def loader(self):
+        try:
+            return self.loader_context.loader()
+        except AttributeError:
+            return None
+
+    def eldest_loader(self):
+        if self.loader() is None:
+            return None
+        loader = self.loader()
+        while loader.parent_loader is not None:
+            loader = loader.parent_loader
+        return loader
+
+    def value(self):
+        loader = self.loader()
+        if loader is None:
+            return self.default
+        if self.name == "__context__":
+            return loader.pack[self.name]
+        if self.name == loader.pack_self:
+            return loader
+        return loader.pack[self.name]
+
+    def get(self, key, default=None):
+        return self.value().get(key, default)
+
+    def __getitem__(self, item):
+        return self.value()[item]
+
+    def __contains__(self, item):
+        return item in self.value()
+
+    def __setitem__(self, item, value):
+        self.value()[item] = value
+
+    def __bool__(self):
+        try:
+            self.loader
+        except LookupError:
+            return False
+        return True
+
+    def __len__(self):
+        return self.value().__len__()
+
+    def __iter__(self):
+        return self.value().__iter__()
+
+    def __delitem__(self, item):
+        return self.value().__delitem__(item)
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+        return self.loader_context == other.loader_context and self.name == other.name
+
+    def __getstate__(self):
+        return {
+            "name": self.name,
+            "loader_context": self.loader_context,
+            "default": None,
+        }
+
+    def __setstate__(self, state):
+        self.name = state["name"]
+        self.loader_context = state["loader_context"]
+        self.default = state["default"]
+
+    def __getattr__(self, name):
+        return self.value().__getattr__(name)
+
+    def missing_fun_string(self, name):
+        return self.loader().missing_fun_string(name)
+
+
+class LoaderContext:
+    """
+    A loader context object, this object is injected at <loaded
+    module>.__salt_loader__ by the Salt loader. It is responsible for providing
+    access to the current context's loader
+    """
+
+    def __init__(self, loader_ctxvar=loader_ctxvar):
+        self.loader_ctxvar = loader_ctxvar
+
+    def __getitem__(self, item):
+        return self.loader[item]
+
+    def loader(self):
+        try:
+            return self.loader_ctxvar.get()
+        except LookupError:
+            raise AttributeError("No loader context")
+
+    def named_context(self, name, default=None, ctx_class=NamedLoaderContext):
+        return ctx_class(name, self, default)
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+        return self.loader_ctxvar == other.loader_ctxvar
+
+    def __getstate__(self):
+        return {"varname": self.loader_ctxvar.name}
+
+    def __setstate__(self, state):
+        self.loader_ctxvar = contextvars.ContextVar(state["varname"])

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Return/control aspects of the grains data
 
@@ -10,7 +9,6 @@ file on the minions. By default, this file is located at: ``/etc/salt/grains``
    This does **NOT** override any grains set in the minion config file.
 """
 
-from __future__ import absolute_import, print_function, unicode_literals
 
 import collections
 import logging
@@ -54,7 +52,7 @@ def _serial_sanitizer(instr):
     """Replaces the last 1/4 of a string with X's"""
     length = len(instr)
     index = int(math.floor(length * 0.75))
-    return "{0}{1}".format(instr[:index], "X" * (length - index))
+    return "{}{}".format(instr[:index], "X" * (length - index))
 
 
 _FQDN_SANITIZER = lambda x: "MINION.DOMAINNAME"
@@ -164,7 +162,7 @@ def items(sanitize=False):
                 out[key] = func(out[key])
         return out
     else:
-        return __grains__
+        return dict(__grains__)
 
 
 def item(*args, **kwargs):
@@ -258,7 +256,7 @@ def setvals(grains, destructive=False, refresh_pillar=True):
             try:
                 grains = salt.utils.yaml.safe_load(fp_)
             except salt.utils.yaml.YAMLError as exc:
-                return "Unable to read existing grains file: {0}".format(exc)
+                return "Unable to read existing grains file: {}".format(exc)
         if not isinstance(grains, dict):
             grains = {}
     for key, val in new_grains.items():
@@ -273,13 +271,13 @@ def setvals(grains, destructive=False, refresh_pillar=True):
     try:
         with salt.utils.files.fopen(gfn, "w+", encoding="utf-8") as fp_:
             salt.utils.yaml.safe_dump(grains, fp_, default_flow_style=False)
-    except (IOError, OSError):
+    except OSError:
         log.error("Unable to write to grains file at %s. Check permissions.", gfn)
     fn_ = os.path.join(__opts__["cachedir"], "module_refresh")
     try:
         with salt.utils.files.flopen(fn_, "w+"):
             pass
-    except (IOError, OSError):
+    except OSError:
         log.error("Unable to write to cache file %s. Check permissions.", fn_)
     if not __opts__.get("local", False):
         # Refresh the grains
@@ -354,9 +352,9 @@ def append(key, val, convert=False, delimiter=DEFAULT_TARGET_DELIM):
         if not isinstance(grains, list):
             grains = [] if grains is None else [grains]
     if not isinstance(grains, list):
-        return "The key {0} is not a valid list".format(key)
+        return "The key {} is not a valid list".format(key)
     if val in grains:
-        return "The val {0} was already in the list {1}".format(val, key)
+        return "The val {} was already in the list {}".format(val, key)
     if isinstance(val, list):
         for item in val:
             grains.append(item)
@@ -401,9 +399,9 @@ def remove(key, val, delimiter=DEFAULT_TARGET_DELIM):
     """
     grains = get(key, [], delimiter)
     if not isinstance(grains, list):
-        return "The key {0} is not a valid list".format(key)
+        return "The key {} is not a valid list".format(key)
     if val not in grains:
-        return "The val {0} was not in the list {1}".format(val, key)
+        return "The val {} was not in the list {}".format(val, key)
     grains.remove(val)
 
     while delimiter in key:
@@ -717,14 +715,14 @@ def set(key, val="", force=False, destructive=False, delimiter=DEFAULT_TARGET_DE
     if _existing_value is not None and not force:
         if _existing_value_type == "complex":
             ret["comment"] = (
-                "The key '{0}' exists but is a dict or a list. "
+                "The key '{}' exists but is a dict or a list. "
                 "Use 'force=True' to overwrite.".format(key)
             )
             ret["result"] = False
             return ret
         elif _new_value_type == "complex" and _existing_value_type is not None:
             ret["comment"] = (
-                "The key '{0}' exists and the given value is a dict or a "
+                "The key '{}' exists and the given value is a dict or a "
                 "list. Use 'force=True' to overwrite.".format(key)
             )
             ret["result"] = False
@@ -759,8 +757,8 @@ def set(key, val="", force=False, destructive=False, delimiter=DEFAULT_TARGET_DE
             _existing_value = {rest: _value}
         else:
             ret["comment"] = (
-                "The key '{0}' value is '{1}', which is different from "
-                "the provided key '{2}'. Use 'force=True' to overwrite.".format(
+                "The key '{}' value is '{}', which is different from "
+                "the provided key '{}'. Use 'force=True' to overwrite.".format(
                     key, _existing_value, rest
                 )
             )

--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
 """
 Extract the pillar data for this minion
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
 import copy
 import logging
@@ -184,7 +182,7 @@ def get(
 
     ret = salt.utils.data.traverse_dict_and_list(pillar_dict, key, default, delimiter)
     if ret is KeyError:
-        raise KeyError("Pillar key not found: {0}".format(key))
+        raise KeyError("Pillar key not found: {}".format(key))
 
     return ret
 
@@ -265,17 +263,16 @@ def items(*args, **kwargs):
             )
         except Exception as exc:  # pylint: disable=broad-except
             raise CommandExecutionError(
-                "Failed to decrypt pillar override: {0}".format(exc)
+                "Failed to decrypt pillar override: {}".format(exc)
             )
 
     pillar = salt.pillar.get_pillar(
         __opts__,
-        __grains__,
+        dict(__grains__),
         __opts__["id"],
         pillar_override=pillar_override,
         pillarenv=pillarenv,
     )
-
     return pillar.compile_pillar()
 
 
@@ -296,7 +293,7 @@ def _obfuscate_inner(var):
     elif isinstance(var, (list, set, tuple)):
         return type(var)(_obfuscate_inner(v) for v in var)
     else:
-        return "<{0}>".format(var.__class__.__name__)
+        return "<{}>".format(var.__class__.__name__)
 
 
 def obfuscate(*args):
@@ -445,7 +442,7 @@ def raw(key=None):
     if key:
         ret = __pillar__.get(key, {})
     else:
-        ret = __pillar__
+        ret = dict(__pillar__)
 
     return ret
 
@@ -539,10 +536,10 @@ def keys(key, delimiter=DEFAULT_TARGET_DELIM):
     ret = salt.utils.data.traverse_dict_and_list(__pillar__, key, KeyError, delimiter)
 
     if ret is KeyError:
-        raise KeyError("Pillar key not found: {0}".format(key))
+        raise KeyError("Pillar key not found: {}".format(key))
 
     if not isinstance(ret, dict):
-        raise ValueError("Pillar value in key {0} is not a dict".format(key))
+        raise ValueError("Pillar value in key {} is not a dict".format(key))
 
     return list(ret)
 

--- a/salt/renderers/jinja.py
+++ b/salt/renderers/jinja.py
@@ -1,23 +1,16 @@
-# -*- coding: utf-8 -*-
 """
 Jinja loading utils to enable a more powerful backend for jinja templates
 
 For Jinja usage information see :ref:`Understanding Jinja <understanding-jinja>`.
 """
 
-# Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
+from io import StringIO
 
 import salt.utils.templates
-
-# Import salt libs
 from salt.exceptions import SaltRenderError
-
-# Import 3rd-party libs
-from salt.ext import six
-from salt.ext.six.moves import StringIO  # pylint: disable=import-error
+from salt.loader_context import NamedLoaderContext
 
 log = logging.getLogger(__name__)
 
@@ -32,10 +25,13 @@ def _split_module_dicts():
 
         {{ salt.cmd.run('uptime') }}
     """
-    if not isinstance(__salt__, dict):
-        return __salt__
-    mod_dict = dict(__salt__)
-    for module_func_name, mod_fun in six.iteritems(mod_dict.copy()):
+    funcs = __salt__
+    if isinstance(__salt__, NamedLoaderContext) and isinstance(__salt__.value(), dict):
+        funcs = __salt__.value()
+    if not isinstance(funcs, dict):
+        return funcs
+    mod_dict = dict(funcs)
+    for module_func_name, mod_fun in mod_dict.copy().items():
         mod, fun = module_func_name.split(".", 1)
         if mod not in mod_dict:
             # create an empty object that we can add attributes to

--- a/salt/renderers/pyobjects.py
+++ b/salt/renderers/pyobjects.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Python renderer that includes a Pythonic Object based interface
 
@@ -298,8 +297,6 @@ file ``samba/map.sls``, you could do the following.
 """
 # TODO: Interface for working with reactor files
 
-# Import Python Libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 import os
@@ -307,9 +304,6 @@ import re
 
 import salt.loader
 import salt.utils.files
-
-# Import Salt Libs
-from salt.ext import six
 from salt.fileclient import get_file_client
 from salt.utils.pyobjects import Map, Registry, SaltObject, StateFactory
 
@@ -326,7 +320,7 @@ except NameError:
     __context__ = {}
 
 
-class PyobjectsModule(object):
+class PyobjectsModule:
     """This provides a wrapper for bare imports."""
 
     def __init__(self, name, attrs):
@@ -334,7 +328,7 @@ class PyobjectsModule(object):
         self.__dict__ = attrs
 
     def __repr__(self):
-        return "<module '{0!s}' (pyobjects)>".format(self.name)
+        return "<module '{!s}' (pyobjects)>".format(self.name)
 
 
 def load_states():
@@ -345,14 +339,14 @@ def load_states():
 
     # the loader expects to find pillar & grain data
     __opts__["grains"] = salt.loader.grains(__opts__)
-    __opts__["pillar"] = __pillar__
+    __opts__["pillar"] = __pillar__.value()
     lazy_utils = salt.loader.utils(__opts__)
     lazy_funcs = salt.loader.minion_mods(__opts__, utils=lazy_utils)
     lazy_serializers = salt.loader.serializers(__opts__)
     lazy_states = salt.loader.states(__opts__, lazy_funcs, lazy_utils, lazy_serializers)
 
     # TODO: some way to lazily do this? This requires loading *all* state modules
-    for key, func in six.iteritems(lazy_states):
+    for key, func in lazy_states.items():
         if "." not in key:
             continue
         mod_name, func_name = key.split(".", 1)
@@ -376,10 +370,10 @@ def render(template, saltenv="base", sls="", salt_data=True, **kwargs):
         mod_locals = {}
         mod_camel = "".join([part.capitalize() for part in mod.split("_")])
         valid_funcs = "','".join(__context__["pyobjects_states"][mod])
-        mod_cmd = "{0} = StateFactory('{1!s}', valid_funcs=['{2}'])".format(
+        mod_cmd = "{} = StateFactory('{!s}', valid_funcs=['{}'])".format(
             mod_camel, mod, valid_funcs
         )
-        six.exec_(mod_cmd, mod_globals, mod_locals)
+        exec(mod_cmd, mod_globals, mod_locals)
 
         _globals[mod_camel] = mod_locals[mod_camel]
 
@@ -450,12 +444,12 @@ def render(template, saltenv="base", sls="", salt_data=True, **kwargs):
                 state_file = client.cache_file(import_file, saltenv)
                 if not state_file:
                     raise ImportError(
-                        "Could not find the file '{0}'".format(import_file)
+                        "Could not find the file '{}'".format(import_file)
                     )
 
                 with salt.utils.files.fopen(state_file) as state_fh:
                     state_contents, state_globals = process_template(state_fh)
-                six.exec_(state_contents, state_globals)
+                exec(state_contents, state_globals)
 
                 # if no imports have been specified then we are being imported as: import salt://foo.sls
                 # so we want to stick all of the locals from our state file into the template globals
@@ -476,7 +470,7 @@ def render(template, saltenv="base", sls="", salt_data=True, **kwargs):
 
                         if name not in state_globals:
                             raise ImportError(
-                                "'{0}' was not found in '{1}'".format(name, import_file)
+                                "'{}' was not found in '{}'".format(name, import_file)
                             )
                         template_globals[alias] = state_globals[name]
 
@@ -496,6 +490,6 @@ def render(template, saltenv="base", sls="", salt_data=True, **kwargs):
     Registry.enabled = True
 
     # now exec our template using our created scopes
-    six.exec_(final_template, _globals)
+    exec(final_template, _globals)
 
     return Registry.salt_data()

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -6950,7 +6950,7 @@ def patch(
         try:
             orig_test = __opts__["test"]
             __opts__["test"] = False
-            sys.modules[__salt__["test.ping"].__module__].__opts__["test"] = False
+            sys.modules[__salt__["file.patch"].__module__].__opts__["test"] = False
             result = managed(
                 patch_file,
                 source=source_match,
@@ -6972,7 +6972,7 @@ def patch(
             log.debug("file.managed: %s", result)
         finally:
             __opts__["test"] = orig_test
-            sys.modules[__salt__["test.ping"].__module__].__opts__["test"] = orig_test
+            sys.modules[__salt__["file.patch"].__module__].__opts__["test"] = orig_test
 
         if not result["result"]:
             log.debug(

--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
 """
 Functions used for CLI argument handling
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
 import copy
 import fnmatch
@@ -70,9 +68,9 @@ def invalid_kwargs(invalid_kwargs, raise_exc=True):
     """
     if invalid_kwargs:
         if isinstance(invalid_kwargs, dict):
-            new_invalid = ["{0}={1}".format(x, y) for x, y in invalid_kwargs.items()]
+            new_invalid = ["{}={}".format(x, y) for x, y in invalid_kwargs.items()]
             invalid_kwargs = new_invalid
-    msg = "The following keyword arguments are not valid: {0}".format(
+    msg = "The following keyword arguments are not valid: {}".format(
         ", ".join(invalid_kwargs)
     )
     if raise_exc:
@@ -259,9 +257,9 @@ def get_function_argspec(func, is_class_method=None):
                             and this is not always wanted.
     """
     if not callable(func):
-        raise TypeError("{0} is not a callable".format(func))
+        raise TypeError("{} is not a callable".format(func))
 
-    if hasattr(func, "__wrapped__"):
+    while hasattr(func, "__wrapped__"):
         func = func.__wrapped__
 
     if is_class_method is True:
@@ -279,7 +277,7 @@ def get_function_argspec(func, is_class_method=None):
         try:
             sig = inspect.signature(func)
         except TypeError:
-            raise TypeError("Cannot inspect argument list for '{0}'".format(func))
+            raise TypeError("Cannot inspect argument list for '{}'".format(func))
         else:
             # argspec-related functions are deprecated in Python 3 in favor of
             # the new inspect.Signature class, and will be removed at some
@@ -470,7 +468,7 @@ def format_call(
         used_args_count = len(ret["args"]) + len(args)
         args_count = used_args_count + len(missing_args)
         raise SaltInvocationError(
-            "{0} takes at least {1} argument{2} ({3} given)".format(
+            "{} takes at least {} argument{} ({} given)".format(
                 fun.__name__, args_count, args_count > 1 and "s" or "", used_args_count
             )
         )
@@ -506,18 +504,18 @@ def format_call(
                     # In case this is being called for a state module
                     "full",
                     # Not a state module, build the name
-                    "{0}.{1}".format(fun.__module__, fun.__name__),
+                    "{}.{}".format(fun.__module__, fun.__name__),
                 ),
             )
         else:
-            msg = "{0} and '{1}' are invalid keyword arguments for '{2}'".format(
-                ", ".join(["'{0}'".format(e) for e in extra][:-1]),
+            msg = "{} and '{}' are invalid keyword arguments for '{}'".format(
+                ", ".join(["'{}'".format(e) for e in extra][:-1]),
                 list(extra.keys())[-1],
                 ret.get(
                     # In case this is being called for a state module
                     "full",
                     # Not a state module, build the name
-                    "{0}.{1}".format(fun.__module__, fun.__name__),
+                    "{}.{}".format(fun.__module__, fun.__name__),
                 ),
             )
 

--- a/salt/utils/boto3mod.py
+++ b/salt/utils/boto3mod.py
@@ -30,6 +30,7 @@ import logging
 import sys
 from functools import partial
 
+import salt.loader_context
 import salt.utils.stringutils
 import salt.utils.versions
 from salt.exceptions import SaltInvocationError
@@ -55,6 +56,8 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 __virtualname__ = "boto3"
+__salt_loader__ = salt.loader_context.LoaderContext()
+__context__ = __salt_loader__.named_context("__context__", {})
 
 
 def __virtual__():

--- a/salt/utils/botomod.py
+++ b/salt/utils/botomod.py
@@ -30,6 +30,7 @@ import logging
 import sys
 from functools import partial
 
+import salt.loader_context
 import salt.utils.stringutils
 import salt.utils.versions
 from salt.exceptions import SaltInvocationError
@@ -54,6 +55,8 @@ log = logging.getLogger(__name__)
 
 __salt__ = None
 __virtualname__ = "boto"
+__salt_loader__ = salt.loader_context.LoaderContext()
+__context__ = __salt_loader__.named_context("__context__", {})
 
 
 def __virtual__():

--- a/salt/utils/compat.py
+++ b/salt/utils/compat.py
@@ -1,17 +1,13 @@
-# -*- coding: utf-8 -*-
 """
 Compatibility functions for utils
 """
 
-# Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import copy
 import importlib
 import sys
 import types
 
-# Import salt libs
 import salt.loader
 
 
@@ -23,7 +19,9 @@ def pack_dunder(name):
 
     mod = sys.modules[name]
     if not hasattr(mod, "__utils__"):
-        setattr(mod, "__utils__", salt.loader.utils(mod.__opts__))
+        setattr(
+            mod, "__utils__", salt.loader.utils(mod.__opts__, pack_self="__utils__")
+        )
 
 
 def deepcopy_bound(name):

--- a/salt/utils/context.py
+++ b/salt/utils/context.py
@@ -21,7 +21,7 @@ def func_globals_inject(func, **overrides):
     Override specific variables within a function's global context.
     """
     # recognize methods
-    if hasattr(func, "im_func"):
+    if hasattr(func, "im_func") and func.im_func:
         func = func.__func__
 
     # Get a reference to the function globals dictionary

--- a/salt/utils/systemd.py
+++ b/salt/utils/systemd.py
@@ -1,18 +1,14 @@
-# -*- coding: utf-8 -*-
 """
 Contains systemd related help files
 """
-# import python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 import os
 import re
 import subprocess
 
+import salt.loader_context
 import salt.utils.stringutils
-
-# Import Salt libs
 from salt.exceptions import SaltInvocationError
 
 log = logging.getLogger(__name__)
@@ -26,7 +22,9 @@ def booted(context=None):
     keep the logic below from needing to be run again during the same salt run.
     """
     contextkey = "salt.utils.systemd.booted"
-    if isinstance(context, dict):
+    if isinstance(context, dict) or isinstance(
+        context, salt.loader_context.NamedLoaderContext
+    ):
         # Can't put this if block on the same line as the above if block,
         # because it willl break the elif below.
         if contextkey in context:
@@ -55,7 +53,9 @@ def version(context=None):
     version.
     """
     contextkey = "salt.utils.systemd.version"
-    if isinstance(context, dict):
+    if isinstance(context, dict) or isinstance(
+        context, salt.loader_context.NamedLoaderContext
+    ):
         # Can't put this if block on the same line as the above if block,
         # because it will break the elif below.
         if contextkey in context:

--- a/salt/utils/systemd.py
+++ b/salt/utils/systemd.py
@@ -22,9 +22,7 @@ def booted(context=None):
     keep the logic below from needing to be run again during the same salt run.
     """
     contextkey = "salt.utils.systemd.booted"
-    if isinstance(context, dict) or isinstance(
-        context, salt.loader_context.NamedLoaderContext
-    ):
+    if isinstance(context, (dict, salt.loader_context.NamedLoaderContext)):
         # Can't put this if block on the same line as the above if block,
         # because it willl break the elif below.
         if contextkey in context:
@@ -53,9 +51,7 @@ def version(context=None):
     version.
     """
     contextkey = "salt.utils.systemd.version"
-    if isinstance(context, dict) or isinstance(
-        context, salt.loader_context.NamedLoaderContext
-    ):
+    if isinstance(context, (dict, salt.loader_context.NamedLoaderContext)):
         # Can't put this if block on the same line as the above if block,
         # because it will break the elif below.
         if contextkey in context:

--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -2,6 +2,7 @@
 Generate the salt thin tarball from the installed python files
 """
 
+import contextvars
 import copy
 import logging
 import os
@@ -25,6 +26,16 @@ import salt.utils.path
 import salt.utils.stringutils
 import salt.version
 import yaml
+
+# This is needed until we drop support for python 3.6
+has_immutables = False
+try:
+    import immutables
+
+    has_immutables = True
+except ImportError:
+    pass
+
 
 try:
     import zlib
@@ -339,7 +350,7 @@ def get_tops(extra_mods="", so_mods=""):
     :return:
     """
     tops = []
-    for mod in [
+    mods = [
         salt,
         distro,
         jinja2,
@@ -353,7 +364,11 @@ def get_tops(extra_mods="", so_mods=""):
         ssl_match_hostname,
         markupsafe,
         backports_abc,
-    ]:
+        contextvars,
+    ]
+    if has_immutables:
+        mods.append(immutables)
+    for mod in mods:
         if mod:
             log.debug('Adding module to the tops: "%s"', mod.__name__)
             _add_dependency(tops, mod)

--- a/tests/pytests/unit/test_loader.py
+++ b/tests/pytests/unit/test_loader.py
@@ -30,6 +30,7 @@ def loader_dir(tmp_path):
         return __context__[key]
     """
     )
+    tmp_path = str(tmp_path)
     with salt.utils.files.fopen(os.path.join(tmp_path, "mod_a.py"), "w") as fp:
         fp.write(mod_content)
     with salt.utils.files.fopen(os.path.join(tmp_path, "mod_b.py"), "w") as fp:

--- a/tests/pytests/unit/test_loader.py
+++ b/tests/pytests/unit/test_loader.py
@@ -1,0 +1,93 @@
+"""
+Tests for salt.loader
+"""
+import os
+import shutil
+import sys
+
+import pytest
+import salt.loader
+import salt.loader_context
+import salt.utils.files
+from tests.support.helpers import dedent
+
+
+@pytest.fixture
+def loader_dir(tmp_path):
+    """
+    Create a simple directory with a couple modules to load and run tests
+    againt.
+    """
+    mod_content = dedent(
+        """
+    def __virtual__():
+        return True
+
+    def set_context(key, value):
+        __context__[key] = value
+
+    def get_context(key):
+        return __context__[key]
+    """
+    )
+    with salt.utils.files.fopen(os.path.join(tmp_path, "mod_a.py"), "w") as fp:
+        fp.write(mod_content)
+    with salt.utils.files.fopen(os.path.join(tmp_path, "mod_b.py"), "w") as fp:
+        fp.write(mod_content)
+    try:
+        yield tmp_path
+    finally:
+        shutil.rmtree(tmp_path)
+
+
+def test_loaders_have_uniq_context(loader_dir):
+    """
+    Loaded functions run in the LazyLoader's context.
+    """
+    opts = {"optimization_order": [0, 1, 2]}
+    loader_1 = salt.loader.LazyLoader([loader_dir], opts,)
+    loader_2 = salt.loader.LazyLoader([loader_dir], opts,)
+    loader_1._load_all()
+    assert loader_1.pack["__context__"] == {}
+    assert loader_2.pack["__context__"] == {}
+    loader_1["mod_a.set_context"]("foo", "bar")
+    assert loader_1.pack["__context__"] == {"foo": "bar"}
+    assert loader_1["mod_b.get_context"]("foo") == "bar"
+    with pytest.raises(KeyError):
+        loader_2["mod_a.get_context"]("foo")
+    assert loader_2.pack["__context__"] == {}
+
+
+def test_loaded_methods_are_loaded_func(loader_dir):
+    """
+    Functions loaded from LazyLoader's item lookups are LoadedFunc objects
+    """
+    opts = {"optimization_order": [0, 1, 2]}
+    loader_1 = salt.loader.LazyLoader([loader_dir], opts,)
+    fun = loader_1["mod_a.get_context"]
+    assert isinstance(fun, salt.loader.LoadedFunc)
+
+
+def test_loaded_modules_are_loaded_mods(loader_dir):
+    """
+    Modules looked up as attributes of LazyLoaders are LoadedMod objects.
+    """
+    opts = {"optimization_order": [0, 1, 2]}
+    loader_1 = salt.loader.LazyLoader([loader_dir], opts,)
+    mod = loader_1.mod_a
+    assert isinstance(mod, salt.loader.LoadedMod)
+
+
+def test_loaders_create_named_loader_contexts(loader_dir):
+    """
+    LazyLoader's create NamedLoaderContexts on the modules the load.
+    """
+    opts = {"optimization_order": [0, 1, 2]}
+    loader_1 = salt.loader.LazyLoader([loader_dir], opts,)
+    mod = loader_1.mod_a
+    assert isinstance(mod.mod, dict)
+    func = mod.set_context
+    assert isinstance(func, salt.loader.LoadedFunc)
+    module_name = func.func.__module__
+    module = sys.modules[module_name]
+    assert isinstance(module.__context__, salt.loader_context.NamedLoaderContext)

--- a/tests/pytests/unit/test_loader.py
+++ b/tests/pytests/unit/test_loader.py
@@ -16,7 +16,7 @@ from tests.support.helpers import dedent
 def loader_dir(tmp_path):
     """
     Create a simple directory with a couple modules to load and run tests
-    againt.
+    against.
     """
     mod_content = dedent(
         """

--- a/tests/pytests/unit/test_loader.py
+++ b/tests/pytests/unit/test_loader.py
@@ -48,6 +48,7 @@ def test_loaders_have_uniq_context(loader_dir):
     loader_1 = salt.loader.LazyLoader([loader_dir], opts,)
     loader_2 = salt.loader.LazyLoader([loader_dir], opts,)
     loader_1._load_all()
+    loader_2._load_all()
     assert loader_1.pack["__context__"] == {}
     assert loader_2.pack["__context__"] == {}
     loader_1["mod_a.set_context"]("foo", "bar")

--- a/tests/pytests/unit/test_loader_context.py
+++ b/tests/pytests/unit/test_loader_context.py
@@ -1,0 +1,33 @@
+"""
+Tests for salt.loader_context
+"""
+import salt.loader
+import salt.loader_context
+
+
+def test_named_loader_context():
+    loader_context = salt.loader_context.LoaderContext()
+    named_context = salt.loader_context.NamedLoaderContext("__test__", loader_context)
+    test_dunder = {"foo": "bar"}
+    lazy_loader = salt.loader.LazyLoader(["/foo"], pack={"__test__": test_dunder})
+    assert named_context.loader() is None
+    token = salt.loader_context.loader_ctxvar.set(lazy_loader)
+    try:
+        assert named_context.loader() == lazy_loader
+        # The loader's value is the same object as test_dunder
+        assert named_context.value() is test_dunder
+        assert named_context["foo"] == "bar"
+    finally:
+        salt.loader_context.loader_ctxvar.reset(token)
+
+
+def test_named_loader_default():
+    loader_context = salt.loader_context.LoaderContext()
+    default = {"foo": "bar"}
+    named_context = salt.loader_context.NamedLoaderContext(
+        "__test__", loader_context, default=default
+    )
+    assert named_context.loader() is None
+    # The loader's value is the same object as default
+    assert named_context.value() is default
+    assert named_context["foo"] == "bar"

--- a/tests/unit/modules/test_boto_apigateway.py
+++ b/tests/unit/modules/test_boto_apigateway.py
@@ -1,22 +1,16 @@
-# Import Python libs
-
 import datetime
 import logging
 import random
 import string
 
-# Import Salt libs
 import salt.loader
 import salt.loader_context
 import salt.modules.boto_apigateway as boto_apigateway
 from salt.utils.versions import LooseVersion
-
-# Import Salt Testing libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase, skipIf
 
-# Import 3rd-party libs
 # pylint: disable=import-error,no-name-in-module
 try:
     import boto3

--- a/tests/unit/modules/test_boto_apigateway.py
+++ b/tests/unit/modules/test_boto_apigateway.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
-
 # Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import datetime
 import logging
@@ -10,8 +7,8 @@ import string
 
 # Import Salt libs
 import salt.loader
+import salt.loader_context
 import salt.modules.boto_apigateway as boto_apigateway
-from salt.ext.six.moves import range, zip
 from salt.utils.versions import LooseVersion
 
 # Import Salt Testing libs
@@ -168,10 +165,10 @@ class BotoApiGatewayTestCaseBase(TestCase, LoaderModuleMockMixin):
 
     def setup_loader_modules(self):
         self.opts = opts = salt.config.DEFAULT_MINION_OPTS.copy()
-        utils = salt.loader.utils(
+        self.utils = salt.loader.utils(
             opts, whitelist=["boto3", "args", "systemd", "path", "platform"]
         )
-        return {boto_apigateway: {"__opts__": opts, "__utils__": utils}}
+        return {boto_apigateway: {"__opts__": opts, "__utils__": self.utils}}
 
     def setUp(self):
         TestCase.setUp(self)
@@ -196,9 +193,10 @@ class BotoApiGatewayTestCaseBase(TestCase, LoaderModuleMockMixin):
         self.conn = MagicMock()
         session_instance.client.return_value = self.conn
         self.addCleanup(delattr, self, "conn")
+        self.addCleanup(delattr, self, "utils")
 
 
-class BotoApiGatewayTestCaseMixin(object):
+class BotoApiGatewayTestCaseMixin:
     def _diff_list_dicts(self, listdict1, listdict2, sortkey):
         """
         Compares the two list of dictionaries to ensure they have same content.  Returns True
@@ -220,12 +218,12 @@ class BotoApiGatewayTestCaseMixin(object):
 @skipIf(
     _has_required_boto() is False,
     "The boto3 module must be greater than"
-    " or equal to version {0}".format(required_boto3_version),
+    " or equal to version {}".format(required_boto3_version),
 )
 @skipIf(
     _has_required_botocore() is False,
     "The botocore module must be greater than"
-    " or equal to version {0}".format(required_botocore_version),
+    " or equal to version {}".format(required_botocore_version),
 )
 class BotoApiGatewayTestCase(BotoApiGatewayTestCaseBase, BotoApiGatewayTestCaseMixin):
     """
@@ -485,7 +483,7 @@ class BotoApiGatewayTestCase(BotoApiGatewayTestCaseBase, BotoApiGatewayTestCaseM
         self.assertTrue(create_api_result.get("created"))
         self.assertTrue(api)
         self.assertEqual(api["id"], assigned_api_id)
-        self.assertEqual(api["createdDate"], "{0}".format(created_date))
+        self.assertEqual(api["createdDate"], "{}".format(created_date))
         self.assertEqual(api["name"], "unit-testing123")
         self.assertEqual(api["description"], "unit-testing1234")
 
@@ -707,7 +705,7 @@ class BotoApiGatewayTestCase(BotoApiGatewayTestCaseBase, BotoApiGatewayTestCaseM
             "test-salt-key", "test-lambda-api-key", **conn_parameters
         )
         api_key = create_api_key_result.get("apiKey")
-        now_str = "{0}".format(now)
+        now_str = "{}".format(now)
 
         self.assertTrue(create_api_key_result.get("created"))
         self.assertEqual(api_key.get("lastUpdatedDate"), now_str)
@@ -719,21 +717,21 @@ class BotoApiGatewayTestCase(BotoApiGatewayTestCaseBase, BotoApiGatewayTestCaseM
         """
         tests that we properly handle errors when create an api key fails.
         """
+        with salt.loader_context.loader_context(self.utils):
+            self.conn.create_api_key.side_effect = ClientError(
+                error_content, "create_api_key"
+            )
+            create_api_key_result = boto_apigateway.create_api_key(
+                "test-salt-key", "unit-testing1234"
+            )
+            api_key = create_api_key_result.get("apiKey")
 
-        self.conn.create_api_key.side_effect = ClientError(
-            error_content, "create_api_key"
-        )
-        create_api_key_result = boto_apigateway.create_api_key(
-            "test-salt-key", "unit-testing1234"
-        )
-        api_key = create_api_key_result.get("apiKey")
-
-        self.assertFalse(api_key)
-        self.assertIs(create_api_key_result.get("created"), False)
-        self.assertEqual(
-            create_api_key_result.get("error").get("message"),
-            error_message.format("create_api_key"),
-        )
+            self.assertFalse(api_key)
+            self.assertIs(create_api_key_result.get("created"), False)
+            self.assertEqual(
+                create_api_key_result.get("error").get("message"),
+                error_message.format("create_api_key"),
+            )
 
     def test_that_when_deleting_an_api_key_that_exists_the_delete_api_key_method_returns_true(
         self,
@@ -1057,7 +1055,7 @@ class BotoApiGatewayTestCase(BotoApiGatewayTestCaseBase, BotoApiGatewayTestCaseM
             restApiId="rm06h9oac4", stageName="test", **conn_parameters
         )
         deployment = result.get("deployment")
-        now_str = "{0}".format(now)
+        now_str = "{}".format(now)
 
         self.assertTrue(result.get("created"))
         self.assertEqual(deployment.get("createdDate"), now_str)
@@ -1320,7 +1318,7 @@ class BotoApiGatewayTestCase(BotoApiGatewayTestCaseBase, BotoApiGatewayTestCaseM
             **conn_parameters
         )
         stage = result.get("stage")
-        now_str = "{0}".format(now)
+        now_str = "{}".format(now)
         self.assertIs(result.get("created"), True)
         self.assertEqual(stage.get("createdDate"), now_str)
         self.assertEqual(stage.get("lastUpdatedDate"), now_str)

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -1299,10 +1299,16 @@ class LoaderMultipleGlobalTest(ModuleCase):
 
         self.loader2.pack["__foo__"] = "bar2"
         func2 = self.loader2["test.ping"]
-        salt.loader_context.loader_ctxvar.set(self.loader1)
-        assert func1.__globals__["__foo__"].value() == "bar1"
+        token = salt.loader_context.loader_ctxvar.set(self.loader1)
+        try:
+            assert func1.__globals__["__foo__"].value() == "bar1"
+        finally:
+            salt.loader_context.loader_ctxvar.reset(token)
         salt.loader_context.loader_ctxvar.set(self.loader2)
-        assert func2.__globals__["__foo__"].value() == "bar2"
+        try:
+            assert func2.__globals__["__foo__"].value() == "bar2"
+        finally:
+            salt.loader_context.loader_ctxvar.reset(token)
 
 
 class LoaderCleanupTest(ModuleCase):

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -1304,7 +1304,7 @@ class LoaderMultipleGlobalTest(ModuleCase):
             assert func1.__globals__["__foo__"].value() == "bar1"
         finally:
             salt.loader_context.loader_ctxvar.reset(token)
-        salt.loader_context.loader_ctxvar.set(self.loader2)
+        token = salt.loader_context.loader_ctxvar.set(self.loader2)
         try:
             assert func2.__globals__["__foo__"].value() == "bar2"
         finally:

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -19,6 +19,7 @@ import textwrap
 
 import salt.config
 import salt.loader
+import salt.loader_context
 import salt.utils.files
 import salt.utils.stringutils
 from tests.support.case import ModuleCase
@@ -120,7 +121,11 @@ class LazyLoaderTest(TestCase):
         """
         # Make sure depends correctly allowed a function to load. If this
         # results in a KeyError, the decorator is broken.
-        self.assertTrue(inspect.isfunction(self.loader[self.module_name + ".loaded"]))
+        self.assertTrue(
+            isinstance(
+                self.loader[self.module_name + ".loaded"], salt.loader.LoadedFunc,
+            )
+        )
         # Make sure depends correctly kept a function from loading
         self.assertTrue(self.module_name + ".not_loaded" not in self.loader)
 
@@ -202,7 +207,9 @@ class LazyLoaderUtilsTest(TestCase):
             tag="module",
             extra_module_dirs=[self.utils_dir],
         )
-        self.assertTrue(inspect.isfunction(loader[self.module_name + ".run"]))
+        self.assertTrue(
+            isinstance(loader[self.module_name + ".run"], salt.loader.LoadedFunc)
+        )
         self.assertTrue(loader[self.module_name + ".run"]())
 
     def test_utils_not_found(self):
@@ -259,7 +266,7 @@ class LazyLoaderVirtualEnabledTest(TestCase):
         # make sure it starts empty
         self.assertEqual(self.loader._dict, {})
         # get something, and make sure its a func
-        self.assertTrue(inspect.isfunction(self.loader["test.ping"]))
+        self.assertTrue(inspect.isfunction(self.loader["test.ping"].func))
 
         # make sure we only loaded "test" functions
         for key, val in self.loader._dict.items():
@@ -310,40 +317,47 @@ class LazyLoaderVirtualEnabledTest(TestCase):
         self.assertEqual(self.loader._dict, {})
         # get something, and make sure its a func
         func = self.loader["test.ping"]
-        with patch.dict(func.__globals__["__context__"], {"foo": "bar"}):
-            self.assertEqual(
-                self.loader["test.echo"].__globals__["__context__"]["foo"], "bar"
-            )
-            self.assertEqual(
-                self.loader["grains.get"].__globals__["__context__"]["foo"], "bar"
-            )
+        with salt.loader_context.loader_context(self.loader):
+            with patch.dict(func.__globals__["__context__"], {"foo": "bar"}):
+                self.assertEqual(
+                    self.loader["test.echo"].__globals__["__context__"]["foo"], "bar"
+                )
+                self.assertEqual(
+                    self.loader["grains.get"].__globals__["__context__"]["foo"], "bar"
+                )
 
     def test_globals(self):
-        func_globals = self.loader["test.ping"].__globals__
-        self.assertEqual(func_globals["__grains__"], self.opts.get("grains", {}))
-        self.assertEqual(func_globals["__pillar__"], self.opts.get("pillar", {}))
-        # the opts passed into modules is at least a subset of the whole opts
-        for key, val in func_globals["__opts__"].items():
-            if (
-                key in salt.config.DEFAULT_MASTER_OPTS
-                and key not in salt.config.DEFAULT_MINION_OPTS
-            ):
-                # We loaded the minion opts, but somewhere in the code, the master options got pulled in
-                # Let's just not check for equality since the option won't even exist in the loaded
-                # minion options
-                continue
-            if (
-                key not in salt.config.DEFAULT_MASTER_OPTS
-                and key not in salt.config.DEFAULT_MINION_OPTS
-            ):
-                # This isn't even a default configuration setting, lets carry on
-                continue
-            self.assertEqual(self.opts[key], val)
+        with salt.loader_context.loader_context(self.loader):
+            func_globals = self.loader["test.ping"].__globals__
+            self.assertEqual(
+                func_globals["__grains__"].value(), self.opts.get("grains", {})
+            )
+            self.assertEqual(
+                func_globals["__pillar__"].value(), self.opts.get("pillar", {})
+            )
+            # the opts passed into modules is at least a subset of the whole opts
+            for key, val in func_globals["__opts__"].items():
+                if (
+                    key in salt.config.DEFAULT_MASTER_OPTS
+                    and key not in salt.config.DEFAULT_MINION_OPTS
+                ):
+                    # We loaded the minion opts, but somewhere in the code, the master options got pulled in
+                    # Let's just not check for equality since the option won't even exist in the loaded
+                    # minion options
+                    continue
+                if (
+                    key not in salt.config.DEFAULT_MASTER_OPTS
+                    and key not in salt.config.DEFAULT_MINION_OPTS
+                ):
+                    # This isn't even a default configuration setting, lets carry on
+                    continue
+                self.assertEqual(self.opts[key], val)
 
     def test_pack(self):
-        self.loader.pack["__foo__"] = "bar"
-        func_globals = self.loader["test.ping"].__globals__
-        self.assertEqual(func_globals["__foo__"], "bar")
+        with salt.loader_context.loader_context(self.loader):
+            self.loader.pack["__foo__"] = "bar"
+            func_globals = self.loader["test.ping"].__globals__
+            self.assertEqual(func_globals["__foo__"].value(), "bar")
 
     @slowTest
     def test_virtual(self):
@@ -388,7 +402,9 @@ class LazyLoaderVirtualDisabledTest(TestCase):
 
     @slowTest
     def test_virtual(self):
-        self.assertTrue(inspect.isfunction(self.loader["test_virtual.ping"]))
+        self.assertTrue(
+            isinstance(self.loader["test_virtual.ping"], salt.loader.LoadedFunc,)
+        )
 
 
 class LazyLoaderWhitelistTest(TestCase):
@@ -429,8 +445,8 @@ class LazyLoaderWhitelistTest(TestCase):
 
     @slowTest
     def test_whitelist(self):
-        self.assertTrue(inspect.isfunction(self.loader["test.ping"]))
-        self.assertTrue(inspect.isfunction(self.loader["pillar.get"]))
+        self.assertTrue(inspect.isfunction(self.loader["test.ping"].func))
+        self.assertTrue(inspect.isfunction(self.loader["pillar.get"].func))
 
         self.assertNotIn("grains.get", self.loader)
 
@@ -614,17 +630,29 @@ class LazyLoaderReloadingTest(TestCase):
         self.update_module()
         self.assertNotIn("{}.test_alias".format(self.module_name), self.loader)
         self.assertTrue(
-            inspect.isfunction(self.loader["{}.working_alias".format(self.module_name)])
+            isinstance(
+                self.loader["{}.working_alias".format(self.module_name)],
+                salt.loader.LoadedFunc,
+            )
+        )
+        self.assertTrue(
+            inspect.isfunction(
+                self.loader["{}.working_alias".format(self.module_name)].func
+            )
         )
 
     @slowTest
     def test_clear(self):
-        self.assertTrue(inspect.isfunction(self.loader["test.ping"]))
+        self.assertTrue(isinstance(self.loader["test.ping"], salt.loader.LoadedFunc))
+        self.assertTrue(inspect.isfunction(self.loader["test.ping"].func))
         self.update_module()  # write out out custom module
         self.loader.clear()  # clear the loader dict
 
         # force a load of our module
-        self.assertTrue(inspect.isfunction(self.loader[self.module_key]))
+        self.assertTrue(
+            isinstance(self.loader[self.module_key], salt.loader.LoadedFunc)
+        )
+        self.assertTrue(inspect.isfunction(self.loader[self.module_key].func))
 
         # make sure we only loaded our custom module
         # which means that we did correctly refresh the file mapping
@@ -637,7 +665,10 @@ class LazyLoaderReloadingTest(TestCase):
         self.assertNotIn(self.module_key, self.loader)
 
         self.update_module()
-        self.assertTrue(inspect.isfunction(self.loader[self.module_key]))
+        self.assertTrue(
+            isinstance(self.loader[self.module_key], salt.loader.LoadedFunc)
+        )
+        self.assertTrue(inspect.isfunction(self.loader[self.module_key].func))
 
     @slowTest
     def test__load__(self):
@@ -1268,9 +1299,10 @@ class LoaderMultipleGlobalTest(ModuleCase):
 
         self.loader2.pack["__foo__"] = "bar2"
         func2 = self.loader2["test.ping"]
-
-        assert func1.__globals__["__foo__"] == "bar1"
-        assert func2.__globals__["__foo__"] == "bar2"
+        salt.loader_context.loader_ctxvar.set(self.loader1)
+        assert func1.__globals__["__foo__"].value() == "bar1"
+        salt.loader_context.loader_ctxvar.set(self.loader2)
+        assert func2.__globals__["__foo__"].value() == "bar2"
 
 
 class LoaderCleanupTest(ModuleCase):

--- a/tests/unit/utils/cache_mods/cache_mod.py
+++ b/tests/unit/utils/cache_mods/cache_mod.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
 """
 This is a module used in unit.utils.cache to test the context wrapper functions
 """
-from __future__ import absolute_import
 
 import salt.utils.cache
 
@@ -17,4 +15,4 @@ def test_context_module():
         __context__["called"] += 1
     else:
         __context__["called"] = 0
-    return __context__
+    return __context__.value()

--- a/tests/unit/utils/test_thin.py
+++ b/tests/unit/utils/test_thin.py
@@ -30,12 +30,18 @@ try:
 except ImportError:
     pytest = None
 
-if not salt.utils.thin.has_immutables:
 
-    class immutables:
-        __file__ = ""
+def patch_if(condition, *args, **kwargs):
+    """
+    Return a patch decorator if the provided condition is met
+    """
+    if condition:
+        return patch(*args, **kwargs)
 
-    salt.utils.thin.immutables = immutables
+    def inner(func):
+        return func
+
+    return inner
 
 
 @skipIf(pytest is None, "PyTest is missing")
@@ -431,7 +437,8 @@ class SSHThinTestCase(TestCase):
         "salt.utils.thin.contextvars",
         type("contextvars", (), {"__file__": "/site-packages/contextvars"}),
     )
-    @patch(
+    @patch_if(
+        salt.utils.thin.has_immutables,
         "salt.utils.thin.immutables",
         type("immutables", (), {"__file__": "/site-packages/immutables"}),
     )
@@ -517,7 +524,8 @@ class SSHThinTestCase(TestCase):
         "salt.utils.thin.contextvars",
         type("contextvars", (), {"__file__": "/site-packages/contextvars"}),
     )
-    @patch(
+    @patch_if(
+        salt.utils.thin.has_immutables,
         "salt.utils.thin.immutables",
         type("immutables", (), {"__file__": "/site-packages/immutables"}),
     )
@@ -612,7 +620,8 @@ class SSHThinTestCase(TestCase):
         "salt.utils.thin.contextvars",
         type("contextvars", (), {"__file__": "/site-packages/contextvars"}),
     )
-    @patch(
+    @patch_if(
+        salt.utils.thin.has_immutables,
         "salt.utils.thin.immutables",
         type("immutables", (), {"__file__": "/site-packages/immutables"}),
     )


### PR DESCRIPTION
### What does this PR do?

Adds loader contexts so that multiple loaders can't stomp on each other. 

### What issues does this PR fix or reference?

Prior to these changes salt's 'magic attributes' (`__utils__`, `__salt__`, `__opts__`, ect..). Would be added as global attributes to a s loaded module's namespace. This had the un-intended side effect of allowing a method call from one loader to change something in another loader. This can be particularly problematic for `__context__` and` __opts__`. This can also cause problems for loaders added with unique configs.
 
There is also an addition of a new `pack_self` attribute to Salt's `LazyLoader` class. This allows the loader to expose itself as a magic dunder without creating circular references on in the loader's pack dictionary. Those circular references are the cause of some memory leaks. The `pack_self` argument should be used to avoid memory leaks.

### Previous Behavior

Due to the global nature of Salt's dunder methods, calls from one loader could interfere with other loaders.

### New Behavior

Loaders use contextvars to provide a context that is specific the the loader that loads the function being called.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs - More needed
- [ ] Changelog - Still Needed
- [x] Tests written/updated - More needed
