### PR TITLE
Port pkgrepo and pkg support for Photon OS

### DIFF
--- a/changelog/51912.added
+++ b/changelog/51912.added
@@ -1,1 +1,1 @@
-The yumpkg module has been updated to support VMWare's Photon OS, which uses tdnf (a C implementation of dnf).
+The yumpkg module has been updated to support VMWare's Photon OS, which uses tdnf (a C implementation of dnf).  "VMware Photon OS" has been added to the "RedHat" `os_family` map as part of this change.

--- a/changelog/51912.added
+++ b/changelog/51912.added
@@ -1,0 +1,1 @@
+The yumpkg module has been updated to support VMWare's Photon OS, which uses tdnf (a C implementation of dnf).

--- a/changelog/52550.added
+++ b/changelog/52550.added
@@ -1,1 +1,1 @@
-The pkgrepo state now supports VMware Photon.
+The pkgrepo state now supports VMware Photon OS.

--- a/changelog/52550.added
+++ b/changelog/52550.added
@@ -1,0 +1,1 @@
+The pkgrepo state now supports VMware Photon.

--- a/doc/topics/releases/3003.rst
+++ b/doc/topics/releases/3003.rst
@@ -6,3 +6,14 @@ Salt 3003 Release Notes - Codename Aluminium
 
 Salt 3003 is an *unreleased* upcoming feature release.
 
+Execution Module Changes
+========================
+
+Changed
+-------
+
+- The :py:mod:`pkg <salt.modules.yumpkg>` module now supports ``tdnf`` used by
+  VMWare Photon OS.  As part of this change, ``VMWare Photon OS``'s
+  ``os_family`` grain will now resolve as ``RedHat``.  This may require changes
+  to existing uses of :py:func:`grains.filter_by
+  <salt.modules.grains.filter_by>`

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1582,6 +1582,7 @@ _OS_FAMILY_MAP = {
     "XenServer": "RedHat",
     "RES": "RedHat",
     "Sangoma": "RedHat",
+    "VMware Photon OS": "RedHat",
     "Mandrake": "Mandriva",
     "ESXi": "VMware",
     "Mint": "Debian",

--- a/salt/modules/rpm_lowpkg.py
+++ b/salt/modules/rpm_lowpkg.py
@@ -55,7 +55,7 @@ def __virtual__():
             "The rpm execution module failed to load: failed to detect os or os_family grains.",
         )
 
-    enabled = ("amazon", "xcp", "xenserver", "VirtuozzoLinux")
+    enabled = ("amazon", "xcp", "xenserver", "virtuozzolinux", "vmware photon os")
 
     if os_family in ["redhat", "suse"] or os_grain in enabled:
         return __virtualname__

--- a/salt/modules/rpm_lowpkg.py
+++ b/salt/modules/rpm_lowpkg.py
@@ -55,7 +55,7 @@ def __virtual__():
             "The rpm execution module failed to load: failed to detect os or os_family grains.",
         )
 
-    enabled = ("amazon", "xcp", "xenserver", "virtuozzolinux", "vmware photon os")
+    enabled = ("amazon", "xcp", "xenserver", "virtuozzolinux")
 
     if os_family in ["redhat", "suse"] or os_grain in enabled:
         return __virtualname__

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -11,6 +11,9 @@ Support for YUM/DNF
     DNF is fully supported as of version 2015.5.10 and 2015.8.4 (partial
     support for DNF was initially added in 2015.8.0), and DNF is used
     automatically in place of YUM in Fedora 22 and newer.
+
+.. versionadded:: 3003
+    Support for ``tdnf`` on Photon OS.
 """
 
 
@@ -70,7 +73,14 @@ def __virtual__():
     except Exception:  # pylint: disable=broad-except
         return (False, "Module yumpkg: no yum based system detected")
 
-    enabled = ("amazon", "xcp", "xenserver", "virtuozzolinux", "virtuozzo")
+    enabled = (
+        "amazon",
+        "xcp",
+        "xenserver",
+        "virtuozzolinux",
+        "virtuozzo",
+        "vmware photon",
+    )
 
     if os_family == "redhat" or os_grain in enabled:
         if _yum() is None:
@@ -163,6 +173,9 @@ def _yum():
                 break
             elif _check(os.path.join(dir, "yum")):
                 context[contextkey] = "yum"
+                break
+            elif _check(os.path.join(dir, "tdnf")):
+                context[contextkey] = "tdnf"
                 break
     return context.get(contextkey)
 
@@ -366,7 +379,12 @@ def _get_yum_config():
         # fall back to parsing the config ourselves
         # Look for the config the same order yum does
         fn = None
-        paths = ("/etc/yum/yum.conf", "/etc/yum.conf", "/etc/dnf/dnf.conf")
+        paths = (
+            "/etc/yum/yum.conf",
+            "/etc/yum.conf",
+            "/etc/dnf/dnf.conf",
+            "/etc/tdnf/tdnf.conf",
+        )
         for path in paths:
             if os.path.exists(path):
                 fn = path

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -73,15 +73,7 @@ def __virtual__():
     except Exception:  # pylint: disable=broad-except
         return (False, "Module yumpkg: no yum based system detected")
 
-    enabled = (
-        "amazon",
-        "xcp",
-        "xenserver",
-        "virtuozzolinux",
-        "virtuozzo",
-        "vmware photon os",
-    )
-
+    enabled = ("amazon", "xcp", "xenserver", "virtuozzolinux", "virtuozzo")
     if os_family == "redhat" or os_grain in enabled:
         if _yum() is None:
             return (False, "DNF nor YUM found")

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -255,6 +255,8 @@ def _versionlock_pkg(grains=None):
         if int(grains.get("osmajorrelease")) >= 8:
             return "python3-dnf-plugin-versionlock"
         return "python2-dnf-plugin-versionlock"
+    elif _yum() == "tdnf":
+        raise SaltInvocationError("Cannot proceed, no versionlock for tdnf")
     else:
         return (
             "yum-versionlock"

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -79,7 +79,7 @@ def __virtual__():
         "xenserver",
         "virtuozzolinux",
         "virtuozzo",
-        "vmware photon",
+        "vmware photon os",
     )
 
     if os_family == "redhat" or os_grain in enabled:

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -374,7 +374,7 @@ def managed(name, ppa=None, copr=None, **kwargs):
             else salt.utils.data.is_true(disabled)
         )
 
-    elif __grains__["os_family"] in ("RedHat", "Suse", "VMware Photon"):
+    elif __grains__["os_family"] in ("RedHat", "Suse", "VMware Photon OS",):
         if __grains__["os_family"] in "RedHat":
             if copr is not None:
                 repo = ":".join(("copr", copr))
@@ -433,7 +433,7 @@ def managed(name, ppa=None, copr=None, **kwargs):
                     # not explicitly set, so we don't need to update the repo
                     # if it's desired to be enabled and the 'enabled' key is
                     # missing from the repo definition
-                    if __grains__["os_family"] in ("RedHat", "VMware Photon"):
+                    if __grains__["os_family"] in ("RedHat", "VMware Photon OS",):
                         if not salt.utils.data.is_true(sanitizedkwargs[kwarg]):
                             break
                     else:
@@ -462,7 +462,7 @@ def managed(name, ppa=None, copr=None, **kwargs):
                         break
             elif kwarg == "comments" and __grains__["os_family"] in (
                 "RedHat",
-                "VMware Photon",
+                "VMware Photon OS",
             ):
                 precomments = salt.utils.pkg.rpm.combine_comments(pre[kwarg])
                 kwargcomments = salt.utils.pkg.rpm.combine_comments(
@@ -477,7 +477,7 @@ def managed(name, ppa=None, copr=None, **kwargs):
                 if __grains__["os_family"] in (
                     "RedHat",
                     "Suse",
-                    "VMware Photon",
+                    "VMware Photon OS",
                 ) and any(
                     isinstance(x, bool) for x in (sanitizedkwargs[kwarg], pre[kwarg])
                 ):

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -374,7 +374,7 @@ def managed(name, ppa=None, copr=None, **kwargs):
             else salt.utils.data.is_true(disabled)
         )
 
-    elif __grains__["os_family"] in ("RedHat", "Suse", "VMware Photon OS",):
+    elif __grains__["os_family"] in ("RedHat", "Suse"):
         if __grains__["os_family"] in "RedHat":
             if copr is not None:
                 repo = ":".join(("copr", copr))
@@ -433,7 +433,7 @@ def managed(name, ppa=None, copr=None, **kwargs):
                     # not explicitly set, so we don't need to update the repo
                     # if it's desired to be enabled and the 'enabled' key is
                     # missing from the repo definition
-                    if __grains__["os_family"] in ("RedHat", "VMware Photon OS",):
+                    if __grains__["os_family"] == "RedHat":
                         if not salt.utils.data.is_true(sanitizedkwargs[kwarg]):
                             break
                     else:
@@ -460,10 +460,7 @@ def managed(name, ppa=None, copr=None, **kwargs):
                     )
                     if pre_comments != post_comments:
                         break
-            elif kwarg == "comments" and __grains__["os_family"] in (
-                "RedHat",
-                "VMware Photon OS",
-            ):
+            elif kwarg == "comments" and __grains__["os_family"] == "RedHat":
                 precomments = salt.utils.pkg.rpm.combine_comments(pre[kwarg])
                 kwargcomments = salt.utils.pkg.rpm.combine_comments(
                     sanitizedkwargs[kwarg]
@@ -474,11 +471,7 @@ def managed(name, ppa=None, copr=None, **kwargs):
                 if set(sanitizedkwargs[kwarg]) != set(pre[kwarg]):
                     break
             else:
-                if __grains__["os_family"] in (
-                    "RedHat",
-                    "Suse",
-                    "VMware Photon OS",
-                ) and any(
+                if __grains__["os_family"] in ("RedHat", "Suse") and any(
                     isinstance(x, bool) for x in (sanitizedkwargs[kwarg], pre[kwarg])
                 ):
                     # This check disambiguates 1/0 from True/False

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -92,7 +92,6 @@ package managers are APT, DNF, YUM and Zypper. Here is some example SLS:
 
 """
 
-# Import Python libs
 
 import sys
 
@@ -101,11 +100,7 @@ import salt.utils.files
 import salt.utils.pkg.deb
 import salt.utils.pkg.rpm
 import salt.utils.versions
-
-# Import salt libs
 from salt.exceptions import CommandExecutionError, SaltInvocationError
-
-# Import 3rd-party libs
 from salt.state import STATE_INTERNAL_KEYWORDS as _STATE_INTERNAL_KEYWORDS
 
 
@@ -379,7 +374,7 @@ def managed(name, ppa=None, copr=None, **kwargs):
             else salt.utils.data.is_true(disabled)
         )
 
-    elif __grains__["os_family"] in ("RedHat", "Suse"):
+    elif __grains__["os_family"] in ("RedHat", "Suse", "VMware Photon"):
         if __grains__["os_family"] in "RedHat":
             if copr is not None:
                 repo = ":".join(("copr", copr))
@@ -438,7 +433,7 @@ def managed(name, ppa=None, copr=None, **kwargs):
                     # not explicitly set, so we don't need to update the repo
                     # if it's desired to be enabled and the 'enabled' key is
                     # missing from the repo definition
-                    if __grains__["os_family"] == "RedHat":
+                    if __grains__["os_family"] in ("RedHat", "VMware Photon"):
                         if not salt.utils.data.is_true(sanitizedkwargs[kwarg]):
                             break
                     else:
@@ -465,7 +460,10 @@ def managed(name, ppa=None, copr=None, **kwargs):
                     )
                     if pre_comments != post_comments:
                         break
-            elif kwarg == "comments" and __grains__["os_family"] == "RedHat":
+            elif kwarg == "comments" and __grains__["os_family"] in (
+                "RedHat",
+                "VMware Photon",
+            ):
                 precomments = salt.utils.pkg.rpm.combine_comments(pre[kwarg])
                 kwargcomments = salt.utils.pkg.rpm.combine_comments(
                     sanitizedkwargs[kwarg]
@@ -476,7 +474,11 @@ def managed(name, ppa=None, copr=None, **kwargs):
                 if set(sanitizedkwargs[kwarg]) != set(pre[kwarg]):
                     break
             else:
-                if __grains__["os_family"] in ("RedHat", "Suse") and any(
+                if __grains__["os_family"] in (
+                    "RedHat",
+                    "Suse",
+                    "VMware Photon",
+                ) and any(
                     isinstance(x, bool) for x in (sanitizedkwargs[kwarg], pre[kwarg])
                 ):
                     # This check disambiguates 1/0 from True/False

--- a/tests/integration/modules/test_pkg.py
+++ b/tests/integration/modules/test_pkg.py
@@ -25,9 +25,10 @@ class PkgModuleTest(ModuleCase, SaltReturnAssertsMixin):
         if salt.utils.platform.is_windows():
             cls.pkg = "putty"
         elif grains["os_family"] == "RedHat":
-            cls.pkg = "units"
-        elif grains["os_family"] == "VMware Photon OS":
-            cls.pkg = "snoopy"
+            if grains["os"] == "VMware Photon OS":
+                cls.pkg = "snoopy"
+            else:
+                cls.pkg = "units"
 
     @pytest.mark.skip_if_not_root
     @pytest.mark.requires_salt_modules("pkg.refresh_db")
@@ -102,7 +103,7 @@ class PkgModuleTest(ModuleCase, SaltReturnAssertsMixin):
                         pprint.pformat(ret)
                     ),
                 )
-            elif grains["os_family"] in ("RedHat", "VMware Photon OS"):
+            elif grains["os_family"] == "RedHat":
                 repo = "saltstack"
                 name = "SaltStack repo for RHEL/CentOS {}".format(
                     grains["osmajorrelease"]
@@ -315,7 +316,7 @@ class PkgModuleTest(ModuleCase, SaltReturnAssertsMixin):
                 "Upstream repo did not return coherent results: {}".format(ret)
             )
 
-        if grains["os_family"] in ("RedHat", "VMWare Photon OS"):
+        if grains["os_family"] == "RedHat":
             self.assertIn(ret, (True, None))
         elif grains["os_family"] == "Suse":
             if not isinstance(ret, dict):

--- a/tests/unit/modules/test_yumpkg.py
+++ b/tests/unit/modules/test_yumpkg.py
@@ -5,7 +5,7 @@ import salt.modules.pkg_resource as pkg_resource
 import salt.modules.rpm_lowpkg as rpm
 import salt.modules.yumpkg as yumpkg
 import salt.utils.platform
-from salt.exceptions import CommandExecutionError
+from salt.exceptions import CommandExecutionError, SaltInvocationError
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, Mock, patch
 from tests.support.unit import TestCase, skipIf
@@ -1246,6 +1246,14 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
                 output_loglevel="trace",
                 python_shell=False,
             )
+
+    def test_pkg_hold_tdnf(self):
+        """
+        Tests that we raise a SaltInvocationError if we try to use
+        hold-related functions on Photon OS.
+        """
+        with patch.dict(yumpkg.__context__, {"yum_bin": "tdnf"}):
+            self.assertRaises(SaltInvocationError, yumpkg.hold, "foo")
 
     def test_pkg_hold_dnf(self):
         """


### PR DESCRIPTION
### What does this PR do?

Ports @lomeroe's #51912 and #52550, which added `pkg` and `pkgrepo` support, respectively, for VMWare's Photon OS.

### Merge requirements satisfied?

- [x] Docs
  - needs reference somewhere along with annotation of the added version
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Other todos

* [x] grain to match is `VMware Photon OS` for 3.0 at least
* [x] need to handle/disable `hold`/`unhold`
* ? maybe pull in #58918 locally to help testing

### Commits signed with GPG?

No