### PR TITLE
Strip `comps` in order not to trigger state changes

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2322,7 +2322,7 @@ def mod_repo(repo, saltenv="base", **kwargs):
             "Error: repo '{}' not a well formatted definition".format(repo)
         )
 
-    full_comp_list = set(repo_comps)
+    full_comp_list = {comp.strip() for comp in repo_comps}
     no_proxy = __salt__["config.option"]("no_proxy")
 
     if "keyid" in kwargs:
@@ -2401,7 +2401,7 @@ def mod_repo(repo, saltenv="base", **kwargs):
             )
 
     if "comps" in kwargs:
-        kwargs["comps"] = kwargs["comps"].split(",")
+        kwargs["comps"] = [comp.strip() for comp in kwargs["comps"].split(",")]
         full_comp_list |= set(kwargs["comps"])
     else:
         kwargs["comps"] = list(full_comp_list)
@@ -2547,7 +2547,9 @@ def expand_repo_def(**kwargs):
     source_entry = sourceslist.SourceEntry(repo)
     for list_args in ("architectures", "comps"):
         if list_args in kwargs:
-            kwargs[list_args] = kwargs[list_args].split(",")
+            kwargs[list_args] = [
+                kwarg.strip() for kwarg in kwargs[list_args].split(",")
+            ]
     for kwarg in _MODIFY_OK:
         if kwarg in kwargs:
             setattr(source_entry, kwarg, kwargs[kwarg])

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -10,7 +10,7 @@ Support for APT (Advanced Packaging Tool)
     For repository management, the ``python-apt`` package must be installed.
 """
 
-# Import python libs
+
 import copy
 import datetime
 import fnmatch
@@ -18,8 +18,10 @@ import logging
 import os
 import re
 import time
+from urllib.error import HTTPError
+from urllib.request import Request as _Request
+from urllib.request import urlopen as _urlopen
 
-# Import salt libs
 import salt.config
 import salt.syspaths
 import salt.utils.args
@@ -37,17 +39,7 @@ import salt.utils.systemd
 import salt.utils.versions
 import salt.utils.yaml
 from salt.exceptions import CommandExecutionError, MinionError, SaltInvocationError
-
-# Import third party libs
-# pylint: disable=no-name-in-module,import-error,redefined-builtin
-from salt.ext import six
-from salt.ext.six.moves.urllib.error import HTTPError
-from salt.ext.six.moves.urllib.request import Request as _Request
-from salt.ext.six.moves.urllib.request import urlopen as _urlopen
 from salt.modules.cmdmod import _parse_env
-
-# pylint: enable=no-name-in-module,import-error,redefined-builtin
-
 
 log = logging.getLogger(__name__)
 
@@ -92,10 +84,6 @@ DPKG_ENV_VARS = {
     "DEBIAN_FRONTEND": "noninteractive",
     "UCF_FORCE_CONFFOLD": "1",
 }
-if six.PY2:
-    # Ensure no unicode in env vars on PY2, as it causes problems with
-    # subprocess.Popen()
-    DPKG_ENV_VARS = salt.utils.data.encode(DPKG_ENV_VARS)
 
 # Define the module's virtual name
 __virtualname__ = "pkg"

--- a/salt/states/aptpkg.py
+++ b/salt/states/aptpkg.py
@@ -1,14 +1,11 @@
-# -*- coding: utf-8 -*-
 """
 Package management operations specific to APT- and DEB-based systems
 ====================================================================
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
-# Import python libs
+
 import logging
 
-# Import salt libs
 import salt.utils.data
 
 log = logging.getLogger(__name__)
@@ -37,20 +34,18 @@ def held(name):
     ret = {"name": name, "changes": {}, "result": False, "comment": ""}
     state = __salt__["pkg.get_selections"](pattern=name,)
     if not state:
-        ret.update(comment="Package {0} does not have a state".format(name))
+        ret.update(comment="Package {} does not have a state".format(name))
     elif not salt.utils.data.is_true(state.get("hold", False)):
         if not __opts__["test"]:
             result = __salt__["pkg.set_selections"](selection={"hold": [name]})
             ret.update(
                 changes=result[name],
                 result=True,
-                comment="Package {0} is now being held".format(name),
+                comment="Package {} is now being held".format(name),
             )
         else:
-            ret.update(
-                result=None, comment="Package {0} is set to be held".format(name)
-            )
+            ret.update(result=None, comment="Package {} is set to be held".format(name))
     else:
-        ret.update(result=True, comment="Package {0} is already held".format(name))
+        ret.update(result=True, comment="Package {} is already held".format(name))
 
     return ret

--- a/tests/integration/modules/test_pkg.py
+++ b/tests/integration/modules/test_pkg.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import, print_function, unicode_literals
-
 import os
 import pprint
 
@@ -114,13 +110,13 @@ class PkgModuleTest(ModuleCase, SaltReturnAssertsMixin):
                 )
             elif grains["os_family"] == "RedHat":
                 repo = "saltstack"
-                name = "SaltStack repo for RHEL/CentOS {0}".format(
+                name = "SaltStack repo for RHEL/CentOS {}".format(
                     grains["osmajorrelease"]
                 )
-                baseurl = "http://repo.saltstack.com/yum/redhat/{0}/x86_64/latest/".format(
+                baseurl = "http://repo.saltstack.com/yum/redhat/{}/x86_64/latest/".format(
                     grains["osmajorrelease"]
                 )
-                gpgkey = "https://repo.saltstack.com/yum/rhel{0}/SALTSTACK-GPG-KEY.pub".format(
+                gpgkey = "https://repo.saltstack.com/yum/rhel{}/SALTSTACK-GPG-KEY.pub".format(
                     grains["osmajorrelease"]
                 )
                 gpgcheck = 1
@@ -419,8 +415,7 @@ class PkgModuleTest(ModuleCase, SaltReturnAssertsMixin):
             if not isinstance(ret, dict):
                 if ret.startswith("ERROR"):
                     self.skipTest(
-                        "Could not install older {0} to complete "
-                        "test.".format(target)
+                        "Could not install older {} to complete " "test.".format(target)
                     )
 
             # Run a system upgrade, which should catch the fact that the
@@ -463,19 +458,19 @@ class PkgModuleTest(ModuleCase, SaltReturnAssertsMixin):
 
         cmd_pkg = []
         if grains["os_family"] == "RedHat":
-            cmd_pkg = self.run_function("cmd.run", ["yum list {0}".format(self.pkg)])
+            cmd_pkg = self.run_function("cmd.run", ["yum list {}".format(self.pkg)])
         elif salt.utils.platform.is_windows():
             cmd_pkg = self.run_function("pkg.list_available", [self.pkg])
         elif grains["os_family"] == "Debian":
-            cmd_pkg = self.run_function("cmd.run", ["apt list {0}".format(self.pkg)])
+            cmd_pkg = self.run_function("cmd.run", ["apt list {}".format(self.pkg)])
         elif grains["os_family"] == "Arch":
-            cmd_pkg = self.run_function("cmd.run", ["pacman -Si {0}".format(self.pkg)])
+            cmd_pkg = self.run_function("cmd.run", ["pacman -Si {}".format(self.pkg)])
         elif grains["os_family"] == "FreeBSD":
             cmd_pkg = self.run_function(
-                "cmd.run", ["pkg search -S name -qQ version -e {0}".format(self.pkg)]
+                "cmd.run", ["pkg search -S name -qQ version -e {}".format(self.pkg)]
             )
         elif grains["os_family"] == "Suse":
-            cmd_pkg = self.run_function("cmd.run", ["zypper info {0}".format(self.pkg)])
+            cmd_pkg = self.run_function("cmd.run", ["zypper info {}".format(self.pkg)])
         elif grains["os_family"] == "MacOS":
             brew_bin = salt.utils.path.which("brew")
             mac_user = self.run_function("file.get_user", [brew_bin])
@@ -486,7 +481,7 @@ class PkgModuleTest(ModuleCase, SaltReturnAssertsMixin):
                     )
                 )
             cmd_pkg = self.run_function(
-                "cmd.run", ["brew info {0}".format(self.pkg)], run_as=mac_user
+                "cmd.run", ["brew info {}".format(self.pkg)], run_as=mac_user
             )
         else:
             self.skipTest(

--- a/tests/integration/states/test_pkgrepo.py
+++ b/tests/integration/states/test_pkgrepo.py
@@ -13,9 +13,11 @@ from tests.support.helpers import (
     requires_salt_modules,
     requires_salt_states,
     requires_system_grains,
+    runs_on,
     slowTest,
 )
 from tests.support.mixins import SaltReturnAssertsMixin
+from tests.support.pytest.helpers import temp_state_file
 from tests.support.unit import skipIf
 
 
@@ -314,3 +316,49 @@ class PkgrepoTest(ModuleCase, SaltReturnAssertsMixin):
         finally:
             # Clean up
             self.run_state("pkgrepo.absent", copr=kwargs["copr"])
+
+    @runs_on(kernel="linux", os="Ubuntu")
+    def test_managed_multiple_comps(self):
+        state_file = """
+        ubuntu-backports:
+          pkgrepo.managed:
+            - name: 'deb http://fi.archive.ubuntu.com/ubuntu focal-backports'
+            - comps: main, restricted, universe, multiverse
+            - refresh: false
+            - disabled: false
+            - clean_file: true
+            - file: /etc/apt/sources.list.d/99-salt-archive-ubuntu-focal-backports.list
+            - require_in:
+              - pkgrepo: canonical-ubuntu
+
+        canonical-ubuntu:
+          pkgrepo.managed:
+            - name: 'deb http://archive.canonical.com/ubuntu {{ salt['grains.get']('oscodename') }}'
+            - comps: partner
+            - refresh: false
+            - disabled: false
+            - clean_file: true
+            - file: /etc/apt/sources.list.d/99-salt-canonical-ubuntu.list
+        """
+
+        def remove_apt_list_file(path):
+            if os.path.exists(path):
+                os.unlink(path)
+
+        self.addCleanup(
+            remove_apt_list_file,
+            "/etc/apt/sources.list.d/99-salt-canonical-ubuntu.list",
+        )
+        self.addCleanup(
+            remove_apt_list_file,
+            "/etc/apt/sources.list.d/99-salt-archive-ubuntu-focal-backports.list",
+        )
+        with temp_state_file("multiple-comps-repos.sls", state_file):
+            ret = self.run_function("state.sls", ["multiple-comps-repos"])
+            for state_run in ret.values():
+                # On the first run, we must have changes
+                assert state_run["changes"]
+            ret = self.run_function("state.sls", ["multiple-comps-repos"])
+            for state_run in ret.values():
+                # On the second run though, we shouldn't have changes made
+                assert not state_run["changes"]

--- a/tests/integration/states/test_pkgrepo.py
+++ b/tests/integration/states/test_pkgrepo.py
@@ -2,16 +2,11 @@
 tests for pkgrepo states
 """
 
-# Import Python libs
 
 import os
 
 import salt.utils.files
-
-# Import Salt libs
 import salt.utils.platform
-
-# Import Salt Testing libs
 from tests.support.case import ModuleCase
 from tests.support.helpers import (
     destructiveTest,

--- a/tests/support/pytest/helpers.py
+++ b/tests/support/pytest/helpers.py
@@ -20,6 +20,18 @@ from tests.support.runtests import RUNTIME_VARS
 
 log = logging.getLogger(__name__)
 
+if not RUNTIME_VARS.PYTEST_SESSION:
+    # XXX: Remove this try/except once we fully switch to pytest
+
+    class FakePyTestHelpersNamespace:
+        __slots__ = ()
+
+        def register(self, func):
+            return func
+
+    # Patch pytest so it all works under runtests.py
+    pytest.helpers = FakePyTestHelpersNamespace()
+
 
 @pytest.helpers.register
 @contextmanager

--- a/tests/unit/modules/test_aptpkg.py
+++ b/tests/unit/modules/test_aptpkg.py
@@ -5,6 +5,7 @@
     versionadded:: 2017.7.0
 """
 
+
 import copy
 import logging
 import textwrap

--- a/tests/unit/states/test_aptpkg.py
+++ b/tests/unit/states/test_aptpkg.py
@@ -1,14 +1,9 @@
-# -*- coding: utf-8 -*-
 """
     :codeauthor: Jayesh Kariya <jayeshk@saltstack.com>
 """
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
-# Import Salt Libs
+
 import salt.states.aptpkg as aptpkg
-
-# Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase
@@ -34,7 +29,7 @@ class AptTestCase(TestCase, LoaderModuleMockMixin):
             "name": name,
             "result": False,
             "changes": {},
-            "comment": "Package {0} does not have a state".format(name),
+            "comment": "Package {} does not have a state".format(name),
         }
 
         mock = MagicMock(return_value=False)


### PR DESCRIPTION
### What does this PR do?
Strip `comps` in order not to trigger state changes.

### What issues does this PR fix or reference?
Fixes: #58781