### PR TITLE
Fixes to pillar cache when backend is memory

### DIFF
--- a/changelog/58861.fixed
+++ b/changelog/58861.fixed
@@ -1,0 +1,1 @@
+Log a different obeject when debugging if we're using disk cache vs memory cache. The disk cache pillar class has the dict object but the cache pillar object which is used with the memory cache does not include a _dict obeject because it is a dict already.

--- a/changelog/58861.fixed
+++ b/changelog/58861.fixed
@@ -1,1 +1,1 @@
-Log a different obeject when debugging if we're using disk cache vs memory cache. The disk cache pillar class has the dict object but the cache pillar object which is used with the memory cache does not include a _dict obeject because it is a dict already.
+Log a different object when debugging if we're using disk cache vs memory cache. The disk cache pillar class has the dict object but the cache pillar object which is used with the memory cache does not include a _dict obeject because it is a dict already.

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -2,7 +2,6 @@
 Render the pillar data
 """
 
-# Import python libs
 
 import collections
 import copy
@@ -15,8 +14,6 @@ import traceback
 
 import salt.ext.tornado.gen
 import salt.fileclient
-
-# Import salt libs
 import salt.loader
 import salt.minion
 import salt.transport.client
@@ -27,8 +24,6 @@ import salt.utils.data
 import salt.utils.dictupdate
 import salt.utils.url
 from salt.exceptions import SaltClientError
-
-# Import 3rd-party libs
 from salt.ext import six
 from salt.template import compile_template
 
@@ -442,7 +437,12 @@ class PillarCache:
             self.minion_id,
             self.pillarenv,
         )
-        log.debug("Scanning cache: %s", self.cache._dict)
+        if self.opts["pillar_cache_backend"] == "memory":
+            cache_dict = self.cache
+        else:
+            cache_dict = self.cache._dict
+
+        log.debug("Scanning cache: %s", cache_dict)
         # Check the cache!
         if self.minion_id in self.cache:  # Keyed by minion_id
             # TODO Compare grains, etc?
@@ -473,7 +473,7 @@ class PillarCache:
             fresh_pillar = self.fetch_pillar()
             self.cache[self.minion_id] = {self.pillarenv: fresh_pillar}
             log.debug("Pillar cache miss for minion %s", self.minion_id)
-            log.debug("Current pillar cache: %s", self.cache._dict)  # FIXME hack!
+            log.debug("Current pillar cache: %s", cache_dict)  # FIXME hack!
             return fresh_pillar
 
 


### PR DESCRIPTION
### What does this PR do?
Log a different obeject when debugging if we're using disk cache vs memory cache.  The disk cache pillar class has the _dict_ object but the cache pillar object which is used with the memory cache does not include a _dict obeject because it is a dict already.  Adding a test when pillar_cache_backend is memory.

### What issues does this PR fix or reference?
Fixes: #58838 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
