### PR TITLE
Add option to disable clients in netapi

### DIFF
--- a/changelog/58872.added
+++ b/changelog/58872.added
@@ -1,0 +1,1 @@
+netapi_disable_clients option to allow disabling of clients in salt-api

--- a/conf/master
+++ b/conf/master
@@ -1331,3 +1331,6 @@
 ############################################
 # Allow the raw_shell parameter to be used when calling Salt SSH client via API
 #netapi_allow_raw_shell: True
+
+# Set a list of clients to disable in in the API
+#netapi_disable_clients: []

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -942,6 +942,8 @@ VALID_OPTS = immutabletypes.freeze(
         # Allow raw_shell option when using the ssh
         # client via the Salt API
         "netapi_allow_raw_shell": bool,
+        # Disable clients in the Salt API
+        "netapi_disable_clients": list,
         "disabled_requisites": (str, list),
         # Feature flag config
         "features": dict,
@@ -1578,6 +1580,7 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze(
         "minion_data_cache_events": True,
         "enable_ssh_minions": False,
         "netapi_allow_raw_shell": False,
+        "netapi_disable_clients": [],
     }
 )
 

--- a/salt/netapi/__init__.py
+++ b/salt/netapi/__init__.py
@@ -1,10 +1,7 @@
-# encoding: utf-8
 """
 Make api awesomeness
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
-# Import Python libs
 import inspect
 import os
 
@@ -12,19 +9,15 @@ import salt.client
 import salt.client.ssh.client
 import salt.config
 import salt.exceptions
-
-# Import Salt libs
 import salt.log  # pylint: disable=W0611
 import salt.runner
 import salt.syspaths
 import salt.utils.args
 import salt.wheel
-
-# Import third party libs
 from salt.ext import six
 
 
-class NetapiClient(object):
+class NetapiClient:
     """
     Provide a uniform method of accessing the various client interfaces in Salt
     in the form of low-data data structures. For example:
@@ -68,7 +61,12 @@ class NetapiClient(object):
 
         if low.get("client") not in CLIENTS:
             raise salt.exceptions.SaltInvocationError(
-                "Invalid client specified: '{0}'".format(low.get("client"))
+                "Invalid client specified: '{}'".format(low.get("client"))
+            )
+
+        if low.get("client") in self.opts.get("netapi_disable_clients"):
+            raise salt.exceptions.SaltInvocationError(
+                "Client disabled: '{}'".format(low.get("client"))
             )
 
         if not ("token" in low or "eauth" in low):

--- a/tests/integration/netapi/test_client.py
+++ b/tests/integration/netapi/test_client.py
@@ -5,7 +5,7 @@ import time
 import pytest
 import salt.config
 import salt.netapi
-from salt.exceptions import EauthAuthenticationError
+from salt.exceptions import EauthAuthenticationError, SaltInvocationError
 from tests.support.case import SSHCase
 from tests.support.helpers import (
     SKIP_IF_NOT_RUNNING_PYTEST,
@@ -64,6 +64,17 @@ class NetapiClientTest(TestCase):
         self.assertIn({"sub_minion": True}, rets)
         self.assertIn({"minion": True}, rets)
 
+    def test_local_batch_disabled(self):
+        low = {"client": "local_batch", "tgt": "*", "fun": "test.ping", "timeout": 300}
+        low.update(self.eauth_creds)
+
+        ret = None
+        with patch.dict(self.netapi.opts, {"netapi_disable_clients": ["local_batch"]}):
+            with self.assertRaises(SaltInvocationError) as excinfo:
+                ret = self.netapi.run(low)
+
+        self.assertEqual(ret, None)
+
     def test_local_async(self):
         low = {"client": "local_async", "tgt": "*", "fun": "test.ping"}
         low.update(self.eauth_creds)
@@ -89,6 +100,28 @@ class NetapiClientTest(TestCase):
 
         with self.assertRaises(EauthAuthenticationError) as excinfo:
             ret = self.netapi.run(low)
+
+    def test_local_disabled(self):
+        low = {"client": "local", "tgt": "*", "fun": "test.ping"}
+        low.update(self.eauth_creds)
+
+        ret = None
+        with patch.dict(self.netapi.opts, {"netapi_disable_clients": ["local"]}):
+            with self.assertRaises(SaltInvocationError) as excinfo:
+                ret = self.netapi.run(low)
+
+        self.assertEqual(ret, None)
+
+    def test_local_subset_disabled(self):
+        low = {"client": "local_subset", "tgt": "*", "fun": "test.ping", "subset": 1}
+        low.update(self.eauth_creds)
+
+        ret = None
+        with patch.dict(self.netapi.opts, {"netapi_disable_clients": ["local_subset"]}):
+            with self.assertRaises(SaltInvocationError) as excinfo:
+                ret = self.netapi.run(low)
+
+        self.assertEqual(ret, None)
 
     @slowTest
     def test_wheel(self):
@@ -133,6 +166,28 @@ class NetapiClientTest(TestCase):
         with self.assertRaises(EauthAuthenticationError) as excinfo:
             ret = self.netapi.run(low)
 
+    def test_wheel_disabled(self):
+        low = {"client": "wheel", "tgt": "*", "fun": "test.ping"}
+        low.update(self.eauth_creds)
+
+        ret = None
+        with patch.dict(self.netapi.opts, {"netapi_disable_clients": ["wheel"]}):
+            with self.assertRaises(SaltInvocationError) as excinfo:
+                ret = self.netapi.run(low)
+
+        self.assertEqual(ret, None)
+
+    def test_wheel_async_disabled(self):
+        low = {"client": "wheel_async", "tgt": "*", "fun": "test.ping"}
+        low.update(self.eauth_creds)
+
+        ret = None
+        with patch.dict(self.netapi.opts, {"netapi_disable_clients": ["wheel_async"]}):
+            with self.assertRaises(SaltInvocationError) as excinfo:
+                ret = self.netapi.run(low)
+
+        self.assertEqual(ret, None)
+
     @skipIf(True, "This is not testing anything. Skipping for now.")
     def test_runner(self):
         # TODO: fix race condition in init of event-- right now the event class
@@ -157,6 +212,17 @@ class NetapiClientTest(TestCase):
 
         with self.assertRaises(EauthAuthenticationError) as excinfo:
             ret = self.netapi.run(low)
+
+    def test_runner_disabled(self):
+        low = {"client": "runner", "tgt": "*", "fun": "test.ping"}
+        low.update(self.eauth_creds)
+
+        ret = None
+        with patch.dict(self.netapi.opts, {"netapi_disable_clients": ["runner"]}):
+            with self.assertRaises(SaltInvocationError) as excinfo:
+                ret = self.netapi.run(low)
+
+        self.assertEqual(ret, None)
 
 
 @SKIP_IF_NOT_RUNNING_PYTEST
@@ -268,3 +334,14 @@ class NetapiSSHClientTest(SSHCase):
 
         self.assertEqual(ret, None)
         self.assertFalse(os.path.exists("badfile.txt"))
+
+    def test_ssh_disabled(self):
+        low = {"client": "ssh", "tgt": "localhost", "fun": "test.ping"}
+        low.update(self.eauth_creds)
+
+        ret = None
+        with patch.dict(self.netapi.opts, {"netapi_disable_clients": ["ssh"]}):
+            with self.assertRaises(SaltInvocationError) as excinfo:
+                ret = self.netapi.run(low)
+
+        self.assertEqual(ret, None)


### PR DESCRIPTION
### What does this PR do?

Adds a new config option "netapi_disable_clients" that takes a list of clients to disable in the netapi.

Checks the list early in handling the the request before authentication occurs. Should be useful where certain clients (eg ssh or wheel) aren't required and should be disabled to reduce attack surface in the salt-api.

### What issues does this PR fix or reference?

### New Behavior

Adds "netapi_disable_clients" list option to the config which is checked when a request is passed to NetApiClient.run() and an exception raised if the requested client is in the list.

### Merge requirements satisfied?
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
No
