### PR TITLE
The right msgpack is now `msgpack` and not `msgpack-python`. It got renamed.

### DIFF
--- a/doc/topics/development/hacking.rst
+++ b/doc/topics/development/hacking.rst
@@ -66,7 +66,7 @@ Install Salt (and dependencies) into the virtualenv:
 
 .. code-block:: bash
 
-    pip install pyzmq PyYAML pycrypto msgpack-python jinja2 psutil futures tornado
+    pip install pyzmq PyYAML pycrypto msgpack jinja2 psutil futures tornado
     pip install -e ./salt   # the path to the salt git clone from above
 
 .. note:: Installing psutil

--- a/doc/topics/installation/index.rst
+++ b/doc/topics/installation/index.rst
@@ -90,7 +90,7 @@ Dependencies
 Salt should run on any Unix-like platform so long as the dependencies are met.
 
 * `Python`_ - Python2 >= 2.7, Python3 >= 3.4
-* `msgpack-python`_ - High-performance message interchange format
+* `msgpack`_ - High-performance message interchange format
 * `YAML`_ - Python YAML bindings
 * `Jinja2`_ - parsing Salt States (configurable in the master settings)
 * `MarkupSafe`_ - Implements a XML/HTML/XHTML Markup safe string for Python
@@ -156,7 +156,7 @@ Optional Dependencies
 .. _`Python`: https://www.python.org/downloads/
 .. _`ZeroMQ`: https://zeromq.org/
 .. _`pyzmq`: https://github.com/zeromq/pyzmq
-.. _`msgpack-python`:  https://pypi.org/project/msgpack-python/
+.. _`msgpack`:  https://pypi.python.org/project/msgpack/
 .. _`M2Crypto`: https://gitlab.com/m2crypto/m2crypto
 .. _`PyCrypto`: https://www.dlitz.net/software/pycrypto/
 .. _`YAML`: https://pyyaml.org/

--- a/pkg/windows/readme.md
+++ b/pkg/windows/readme.md
@@ -19,7 +19,7 @@ salt for Windows with their corresponding licenses:
 | lxml | BSD |
 | Mako | MIT |
 | MarkupSafe | BSD |
-| msgpack-python | Apache 2.0 |
+| msgpack | Apache 2.0 |
 | pip | MIT |
 | psutil | BSD |
 | pyasn1 | BSD |

--- a/salt/version.py
+++ b/salt/version.py
@@ -617,7 +617,7 @@ def dependency_information(include_salt_cloud=False):
         ("Python", None, sys.version.rsplit("\n")[0].strip()),
         ("Jinja2", "jinja2", "__version__"),
         ("M2Crypto", "M2Crypto", "version"),
-        ("msgpack-python", "msgpack", "version"),
+        ("msgpack", "msgpack", "version"),
         ("msgpack-pure", "msgpack_pure", "version"),
         ("pycrypto", "Crypto", "__version__"),
         ("pycryptodome", "Cryptodome", "version_info"),


### PR DESCRIPTION
### What does this PR do?
See title