### PR TITLE
Upgrade to non vulnerable cryptography==3.2

### DIFF
--- a/requirements/static/ci/py3.5/darwin.txt
+++ b/requirements/static/ci/py3.5/darwin.txt
@@ -7,7 +7,7 @@
 apache-libcloud==2.4.0
 appdirs==1.4.3            # via virtualenv
 argh==0.26.2              # via watchdog
-asn1crypto==1.3.0
+asn1crypto==1.3.0         # via certvalidator, oscrypto
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
 backports.ssl-match-hostname==3.7.0.1 ; python_version < "3.7"
@@ -28,7 +28,7 @@ click==7.0                # via geomet
 clustershell==1.8.1
 contextlib2==0.6.0.post1
 croniter==0.3.29
-cryptography==2.6.1
+cryptography==3.2
 distlib==0.3.0            # via virtualenv
 distro==1.5.0
 dnspython==1.16.0

--- a/requirements/static/ci/py3.5/freebsd.txt
+++ b/requirements/static/ci/py3.5/freebsd.txt
@@ -27,7 +27,7 @@ cheroot==6.5.4
 cherrypy==17.3.0
 contextlib2==0.5.5
 croniter==0.3.29
-cryptography==3.1.1
+cryptography==3.2
 distlib==0.3.0            # via virtualenv
 distro==1.5.0
 dnspython==1.16.0

--- a/requirements/static/ci/py3.5/linux.txt
+++ b/requirements/static/ci/py3.5/linux.txt
@@ -111,7 +111,7 @@ cherrypy==17.3.0
 click==7.1.1              # via geomet
 contextlib2==0.5.5
 croniter==0.3.29
-cryptography==3.1.1
+cryptography==3.2
 distlib==0.3.0            # via virtualenv
 distro==1.5.0
 dnspython==1.16.0

--- a/requirements/static/ci/py3.5/windows.txt
+++ b/requirements/static/ci/py3.5/windows.txt
@@ -5,7 +5,6 @@
 #    pip-compile -o requirements/static/ci/py3.5/windows.txt -v requirements/static/pkg/py3.5/windows.txt requirements/pytest.txt requirements/static/ci/windows.in
 #
 appdirs==1.4.4            # via virtualenv
-asn1crypto==1.3.0
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
@@ -24,7 +23,7 @@ cherrypy==17.4.1
 click==7.1.2              # via geomet
 colorama==0.4.1           # via pytest
 contextlib2==0.6.0.post1
-cryptography==2.6.1
+cryptography==3.2
 distlib==0.3.0            # via virtualenv
 distro==1.5.0
 dmidecode==0.9.0

--- a/requirements/static/ci/py3.6/darwin.txt
+++ b/requirements/static/ci/py3.6/darwin.txt
@@ -7,7 +7,7 @@
 apache-libcloud==2.4.0
 appdirs==1.4.3            # via virtualenv
 argh==0.26.2              # via watchdog
-asn1crypto==1.3.0
+asn1crypto==1.3.0         # via certvalidator, oscrypto
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
 backports.ssl-match-hostname==3.7.0.1 ; python_version < "3.7"
@@ -30,7 +30,7 @@ clustershell==1.8.1
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.6.0.post1
 croniter==0.3.29
-cryptography==2.6.1
+cryptography==3.2
 distlib==0.3.0            # via virtualenv
 distro==1.5.0
 dnspython==1.16.0

--- a/requirements/static/ci/py3.6/freebsd.txt
+++ b/requirements/static/ci/py3.6/freebsd.txt
@@ -29,7 +29,7 @@ ciscoconfparse==1.5.19    # via napalm
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
 croniter==0.3.29
-cryptography==3.1.1
+cryptography==3.2
 distlib==0.3.0            # via virtualenv
 distro==1.5.0
 dnspython==1.16.0

--- a/requirements/static/ci/py3.6/linux.txt
+++ b/requirements/static/ci/py3.6/linux.txt
@@ -113,7 +113,7 @@ click==7.1.1              # via geomet
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
 croniter==0.3.29
-cryptography==3.1.1
+cryptography==3.2
 distlib==0.3.0            # via virtualenv
 distro==1.5.0
 dnspython==1.16.0

--- a/requirements/static/ci/py3.6/windows.txt
+++ b/requirements/static/ci/py3.6/windows.txt
@@ -5,7 +5,6 @@
 #    pip-compile -o requirements/static/ci/py3.6/windows.txt -v requirements/static/pkg/py3.6/windows.txt requirements/pytest.txt requirements/static/ci/windows.in
 #
 appdirs==1.4.4            # via virtualenv
-asn1crypto==1.3.0
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
@@ -24,7 +23,7 @@ cherrypy==17.4.1
 click==7.1.2              # via geomet
 colorama==0.4.1           # via pytest
 contextlib2==0.6.0.post1
-cryptography==2.6.1
+cryptography==3.2
 distlib==0.3.0            # via virtualenv
 distro==1.5.0
 dmidecode==0.9.0

--- a/requirements/static/ci/py3.7/darwin.txt
+++ b/requirements/static/ci/py3.7/darwin.txt
@@ -7,7 +7,7 @@
 apache-libcloud==2.4.0
 appdirs==1.4.3            # via virtualenv
 argh==0.26.2              # via watchdog
-asn1crypto==1.3.0
+asn1crypto==1.3.0         # via certvalidator, oscrypto
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
 bcrypt==3.1.6             # via paramiko
@@ -29,7 +29,7 @@ clustershell==1.8.1
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.6.0.post1
 croniter==0.3.29
-cryptography==2.6.1
+cryptography==3.2
 distlib==0.3.0            # via virtualenv
 distro==1.5.0
 dnspython==1.16.0

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -28,7 +28,7 @@ ciscoconfparse==1.5.19    # via napalm
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
 croniter==0.3.29
-cryptography==3.1.1
+cryptography==3.2
 distlib==0.3.0            # via virtualenv
 distro==1.5.0
 dnspython==1.16.0

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -112,7 +112,7 @@ click==7.1.1              # via geomet
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
 croniter==0.3.29
-cryptography==3.1.1
+cryptography==3.2
 distlib==0.3.0            # via virtualenv
 distro==1.5.0
 dnspython==1.16.0

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -5,7 +5,6 @@
 #    pip-compile -o requirements/static/ci/py3.7/windows.txt -v requirements/static/pkg/py3.7/windows.txt requirements/pytest.txt requirements/static/ci/windows.in
 #
 appdirs==1.4.4            # via virtualenv
-asn1crypto==1.3.0
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
@@ -23,7 +22,7 @@ cherrypy==17.4.1
 click==7.1.2              # via geomet
 colorama==0.4.1           # via pytest
 contextlib2==0.6.0.post1
-cryptography==2.6.1
+cryptography==3.2
 distlib==0.3.0            # via virtualenv
 distro==1.5.0
 dmidecode==0.9.0

--- a/requirements/static/ci/py3.8/darwin.txt
+++ b/requirements/static/ci/py3.8/darwin.txt
@@ -7,7 +7,7 @@
 apache-libcloud==2.4.0
 appdirs==1.4.3            # via virtualenv
 argh==0.26.2              # via watchdog
-asn1crypto==1.3.0
+asn1crypto==1.3.0         # via certvalidator, oscrypto
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
 bcrypt==3.1.6             # via paramiko
@@ -29,7 +29,7 @@ clustershell==1.8.1
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.6.0.post1
 croniter==0.3.29
-cryptography==2.6.1
+cryptography==3.2
 distlib==0.3.0            # via virtualenv
 distro==1.5.0
 dnspython==1.16.0

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -28,7 +28,7 @@ ciscoconfparse==1.5.19    # via napalm
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
 croniter==0.3.29
-cryptography==3.1.1
+cryptography==3.2
 distlib==0.3.0            # via virtualenv
 distro==1.5.0
 dnspython==1.16.0

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -113,7 +113,7 @@ click==7.1.1              # via geomet
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
 croniter==0.3.29
-cryptography==3.1.1
+cryptography==3.2
 distlib==0.3.0            # via virtualenv
 distro==1.5.0
 dnspython==1.16.0

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -7,7 +7,7 @@
 apache-libcloud==2.4.0
 appdirs==1.4.3            # via virtualenv
 argh==0.26.2              # via watchdog
-asn1crypto==1.3.0
+asn1crypto==1.3.0         # via certvalidator, oscrypto
 attrs==19.1.0             # via pytest
 aws-xray-sdk==0.95        # via moto
 bcrypt==3.1.6             # via paramiko
@@ -29,7 +29,7 @@ clustershell==1.8.1
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.6.0.post1
 croniter==0.3.29
-cryptography==2.6.1
+cryptography==3.2
 distlib==0.3.0            # via virtualenv
 distro==1.5.0
 dnspython==1.16.0

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -28,7 +28,7 @@ ciscoconfparse==1.5.19    # via napalm
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
 croniter==0.3.29
-cryptography==3.1.1
+cryptography==3.2
 distlib==0.3.0            # via virtualenv
 distro==1.5.0
 dnspython==1.16.0

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -113,7 +113,7 @@ click==7.1.1              # via geomet
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
 croniter==0.3.29
-cryptography==3.1.1
+cryptography==3.2
 distlib==0.3.0            # via virtualenv
 distro==1.5.0
 dnspython==1.16.0

--- a/requirements/static/pkg/py3.5/darwin.txt
+++ b/requirements/static/pkg/py3.5/darwin.txt
@@ -5,7 +5,6 @@
 #    pip-compile -o requirements/static/pkg/py3.5/darwin.txt -v pkg/osx/req_pyobjc.txt requirements/darwin.txt requirements/static/pkg/darwin.in
 #
 apache-libcloud==2.4.0
-asn1crypto==1.3.0         # via cryptography
 backports.ssl-match-hostname==3.7.0.1 ; python_version < "3.7"
 certifi==2020.6.20        # via requests
 cffi==1.12.2              # via cryptography
@@ -13,7 +12,7 @@ chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
-cryptography==2.6.1
+cryptography==3.2
 distro==1.5.0
 gitdb2==2.0.6             # via gitpython
 gitpython==2.1.15

--- a/requirements/static/pkg/py3.5/freebsd.txt
+++ b/requirements/static/pkg/py3.5/freebsd.txt
@@ -12,7 +12,7 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.3.0
 contextlib2==0.5.5        # via cherrypy
-cryptography==3.1.1       # via pyopenssl
+cryptography==3.2         # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
 jaraco.functools==2.0     # via tempora

--- a/requirements/static/pkg/py3.5/linux.txt
+++ b/requirements/static/pkg/py3.5/linux.txt
@@ -12,7 +12,7 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.3.0
 contextlib2==0.5.5        # via cherrypy
-cryptography==3.1.1       # via pyopenssl
+cryptography==3.2         # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
 jaraco.functools==2.0     # via tempora

--- a/requirements/static/pkg/py3.5/windows.txt
+++ b/requirements/static/pkg/py3.5/windows.txt
@@ -4,7 +4,6 @@
 #
 #    pip-compile -o requirements/static/pkg/py3.5/windows.txt -v requirements/windows.txt requirements/static/pkg/windows.in
 #
-asn1crypto==1.3.0         # via cryptography
 backports.ssl-match-hostname==3.7.0.1 ; python_version < "3.7"
 certifi==2020.6.20
 cffi==1.12.2
@@ -12,7 +11,7 @@ chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
-cryptography==2.6.1
+cryptography==3.2
 distro==1.5.0
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.10

--- a/requirements/static/pkg/py3.6/darwin.txt
+++ b/requirements/static/pkg/py3.6/darwin.txt
@@ -5,7 +5,6 @@
 #    pip-compile -o requirements/static/pkg/py3.6/darwin.txt -v pkg/osx/req_pyobjc.txt requirements/darwin.txt requirements/static/pkg/darwin.in
 #
 apache-libcloud==2.4.0
-asn1crypto==1.3.0         # via cryptography
 backports.ssl-match-hostname==3.7.0.1 ; python_version < "3.7"
 certifi==2020.6.20        # via requests
 cffi==1.12.2              # via cryptography
@@ -13,7 +12,7 @@ chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
-cryptography==2.6.1
+cryptography==3.2
 distro==1.5.0
 gitdb2==2.0.6             # via gitpython
 gitpython==2.1.15

--- a/requirements/static/pkg/py3.6/freebsd.txt
+++ b/requirements/static/pkg/py3.6/freebsd.txt
@@ -12,7 +12,7 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.3.0
 contextlib2==0.5.5        # via cherrypy
-cryptography==3.1.1       # via pyopenssl
+cryptography==3.2         # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
 jaraco.functools==2.0     # via tempora

--- a/requirements/static/pkg/py3.6/linux.txt
+++ b/requirements/static/pkg/py3.6/linux.txt
@@ -12,7 +12,7 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.3.0
 contextlib2==0.5.5        # via cherrypy
-cryptography==3.1.1       # via pyopenssl
+cryptography==3.2         # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
 jaraco.functools==2.0     # via tempora

--- a/requirements/static/pkg/py3.6/windows.txt
+++ b/requirements/static/pkg/py3.6/windows.txt
@@ -4,7 +4,6 @@
 #
 #    pip-compile -o requirements/static/pkg/py3.6/windows.txt -v requirements/windows.txt requirements/static/pkg/windows.in
 #
-asn1crypto==1.3.0         # via cryptography
 backports.ssl-match-hostname==3.7.0.1 ; python_version < "3.7"
 certifi==2020.6.20
 cffi==1.12.2
@@ -12,7 +11,7 @@ chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
-cryptography==2.6.1
+cryptography==3.2
 distro==1.5.0
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.10

--- a/requirements/static/pkg/py3.7/darwin.txt
+++ b/requirements/static/pkg/py3.7/darwin.txt
@@ -5,14 +5,13 @@
 #    pip-compile -o requirements/static/pkg/py3.7/darwin.txt -v pkg/osx/req_pyobjc.txt requirements/darwin.txt requirements/static/pkg/darwin.in
 #
 apache-libcloud==2.4.0
-asn1crypto==1.3.0         # via cryptography
 certifi==2020.6.20        # via requests
 cffi==1.12.2              # via cryptography
 chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
-cryptography==2.6.1
+cryptography==3.2
 distro==1.5.0
 gitdb2==2.0.6             # via gitpython
 gitpython==2.1.15

--- a/requirements/static/pkg/py3.7/freebsd.txt
+++ b/requirements/static/pkg/py3.7/freebsd.txt
@@ -11,7 +11,7 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.3.0
 contextlib2==0.5.5        # via cherrypy
-cryptography==3.1.1       # via pyopenssl
+cryptography==3.2         # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
 jaraco.functools==2.0     # via tempora

--- a/requirements/static/pkg/py3.7/linux.txt
+++ b/requirements/static/pkg/py3.7/linux.txt
@@ -11,7 +11,7 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.3.0
 contextlib2==0.5.5        # via cherrypy
-cryptography==3.1.1       # via pyopenssl
+cryptography==3.2         # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
 jaraco.functools==2.0     # via tempora

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -4,14 +4,13 @@
 #
 #    pip-compile -o requirements/static/pkg/py3.7/windows.txt -v requirements/windows.txt requirements/static/pkg/windows.in
 #
-asn1crypto==1.3.0         # via cryptography
 certifi==2020.6.20
 cffi==1.12.2
 chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
-cryptography==2.6.1
+cryptography==3.2
 distro==1.5.0
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.10

--- a/requirements/static/pkg/py3.8/darwin.txt
+++ b/requirements/static/pkg/py3.8/darwin.txt
@@ -5,14 +5,13 @@
 #    pip-compile -o requirements/static/pkg/py3.8/darwin.txt -v pkg/osx/req_pyobjc.txt requirements/darwin.txt requirements/static/pkg/darwin.in
 #
 apache-libcloud==2.4.0
-asn1crypto==1.3.0         # via cryptography
 certifi==2020.6.20        # via requests
 cffi==1.12.2              # via cryptography
 chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
-cryptography==2.6.1
+cryptography==3.2
 distro==1.5.0
 gitdb2==2.0.6             # via gitpython
 gitpython==2.1.15

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -11,7 +11,7 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.3.0
 contextlib2==0.5.5        # via cherrypy
-cryptography==3.1.1       # via pyopenssl
+cryptography==3.2         # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
 jaraco.functools==2.0     # via tempora

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -11,7 +11,7 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.3.0
 contextlib2==0.5.5        # via cherrypy
-cryptography==3.1.1       # via pyopenssl
+cryptography==3.2         # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
 jaraco.functools==2.0     # via tempora

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -13,7 +13,7 @@ chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
-cryptography==2.6.1
+cryptography==3.2
 distro==1.5.0
 gitdb2==2.0.5
 gitpython==2.1.10

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -5,14 +5,13 @@
 #    pip-compile -o requirements/static/pkg/py3.9/darwin.txt -v pkg/osx/req_pyobjc.txt requirements/darwin.txt requirements/static/pkg/darwin.in
 #
 apache-libcloud==2.4.0
-asn1crypto==1.3.0         # via cryptography
 certifi==2020.6.20        # via requests
 cffi==1.12.2              # via cryptography
 chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
-cryptography==2.6.1
+cryptography==3.2
 distro==1.5.0
 gitdb2==2.0.6             # via gitpython
 gitpython==2.1.15

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -11,7 +11,7 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.3.0
 contextlib2==0.5.5        # via cherrypy
-cryptography==3.1.1       # via pyopenssl
+cryptography==3.2         # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
 jaraco.functools==2.0     # via tempora

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -11,7 +11,7 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.3.0
 contextlib2==0.5.5        # via cherrypy
-cryptography==3.1.1       # via pyopenssl
+cryptography==3.2         # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
 jaraco.functools==2.0     # via tempora

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -13,7 +13,7 @@ chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
-cryptography==2.6.1
+cryptography==3.2
 distro==1.5.0
 gitdb2==2.0.5
 gitpython==2.1.10


### PR DESCRIPTION
### What does this PR do?

Upgrade to non vulnerable cryptography==3.2

Details:

```
GHSA-hggm-jpg3-v476
moderate severity
Vulnerable versions: < 3.2
Patched version: 3.2

Impact

RSA decryption was vulnerable to Bleichenbacher timing vulnerabilities, which would impact people using RSA decryption in online scenarios.
Patches

This is fixed in cryptography 3.2. pyca/cryptography@58494b4 is the resolving commit.
```

### What issues does this PR fix or reference?
Closes #58827
Closes https://github.com/saltstack/salt/pull/58899