### PR TITLE
Fixing unhold in yumpkg

### DIFF
--- a/changelog/58883.fixed
+++ b/changelog/58883.fixed
@@ -1,0 +1,1 @@
+Fixing unhold in yumpkg. Removing unnecessary code and relying on the code that handles dicts later. Adding tests when pkg.installed is called with hold=False.

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2256,8 +2256,7 @@ def unhold(name=None, pkgs=None, sources=None, **kwargs):  # pylint: disable=W06
 
     targets = []
     if pkgs:
-        for pkg in salt.utils.data.repack_dictlist(pkgs):
-            targets.append(pkg)
+        targets.extend(pkgs)
     elif sources:
         for source in sources:
             targets.append(next(iter(source)))

--- a/tests/integration/states/test_pkg.py
+++ b/tests/integration/states/test_pkg.py
@@ -527,7 +527,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
             pkgs = {
                 p
                 for p in self.run_function("pkg.list_repo_pkgs")
-                if "-versionlock" in p
+                if "yum-plugin-versionlock" in p
             }
             if not pkgs:
                 self.skipTest("No versionlock package found in repositories")

--- a/tests/integration/states/test_pkg.py
+++ b/tests/integration/states/test_pkg.py
@@ -525,7 +525,9 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         versionlock_pkg = None
         if grains["os_family"] == "RedHat":
             pkgs = {
-                p for p in self.run_function("pkg.list_pkgs") if "-versionlock" in p
+                p
+                for p in self.run_function("pkg.list_repo_pkgs")
+                if "-versionlock" in p
             }
             if not pkgs:
                 self.skipTest("No versionlock package found in repositories")
@@ -622,6 +624,63 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertSaltTrueReturn(ret)
         ret = self.run_state("pkg.removed", name=target)
         self.assertSaltTrueReturn(ret)
+
+    @requires_salt_modules("pkg.hold", "pkg.unhold", "pkg.version", "pkg.list_pkgs")
+    @requires_salt_states("pkg.installed", "pkg.removed")
+    @requires_system_grains
+    @slowTest
+    def test_pkg_017_installed_held_equals_false(self, grains=None):
+        """
+        Tests that a package installed with held set to False
+        """
+        versionlock_pkg = None
+        if grains["os_family"] == "RedHat":
+            pkgs = {
+                p
+                for p in self.run_function("pkg.list_repo_pkgs")
+                if "-versionlock" in p
+            }
+            if not pkgs:
+                self.skipTest("No versionlock package found in repositories")
+            for versionlock_pkg in pkgs:
+                ret = self.run_state(
+                    "pkg.installed", name=versionlock_pkg, refresh=False
+                )
+                # Exit loop if a versionlock package installed correctly
+                try:
+                    self.assertSaltTrueReturn(ret)
+                    log.debug(
+                        "Installed versionlock package: {}".format(versionlock_pkg)
+                    )
+                    break
+                except AssertionError as e:
+                    log.debug("Versionlock package not found:\n{}".format(e))
+            else:
+                self.fail("Could not install versionlock package from {}".format(pkgs))
+
+        target = self._PKG_TARGETS[0]
+
+        # First we ensure that the package is installed
+        ret = self.run_state("pkg.installed", name=target, hold=False, refresh=False,)
+        self.assertSaltTrueReturn(ret)
+
+        if versionlock_pkg and "-versionlock is not installed" in str(ret):
+            self.skipTest("{}  `{}` is installed".format(ret, versionlock_pkg))
+
+        try:
+            tag = "pkg_|-{0}_|-{0}_|-installed".format(target)
+            self.assertSaltTrueReturn(ret)
+            self.assertIn(tag, ret)
+            self.assertIn("changes", ret[tag])
+            self.assertIn(target, ret[tag]["changes"])
+            self.assertIn("Package units is not being held.", ret[tag]["comment"])
+        finally:
+            # Clean up, unhold package and remove
+            ret = self.run_state("pkg.removed", name=target)
+            self.assertSaltTrueReturn(ret)
+            if versionlock_pkg:
+                ret = self.run_state("pkg.removed", name=versionlock_pkg)
+                self.assertSaltTrueReturn(ret)
 
     @requires_salt_modules("pkg.version")
     @requires_salt_states("pkg.installed", "pkg.removed")

--- a/tests/integration/states/test_pkg.py
+++ b/tests/integration/states/test_pkg.py
@@ -673,7 +673,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
             self.assertIn(tag, ret)
             self.assertIn("changes", ret[tag])
             self.assertIn(target, ret[tag]["changes"])
-            self.assertIn("Package units is not being held.", ret[tag]["comment"])
+            self.assertIn("held", ret[tag]["comment"])
         finally:
             # Clean up, unhold package and remove
             ret = self.run_state("pkg.removed", name=target)

--- a/tests/integration/states/test_pkg.py
+++ b/tests/integration/states/test_pkg.py
@@ -638,7 +638,7 @@ class PkgTest(ModuleCase, SaltReturnAssertsMixin):
             pkgs = {
                 p
                 for p in self.run_function("pkg.list_repo_pkgs")
-                if "-versionlock" in p
+                if "yum-plugin-versionlock" in p
             }
             if not pkgs:
                 self.skipTest("No versionlock package found in repositories")


### PR DESCRIPTION
### What does this PR do?
Fixing unhold in yumpkg.  Removing unnecessary code and relying on the code that handles dicts later.  Adding tests when pkg.installed is called with `hold=False`.

### What issues does this PR fix or reference?
Fixes: #58801 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
