### PR TITLE
Make extmod not found error message mean more

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -1201,7 +1201,9 @@ class Pillar:
             for key, val in run.items():
                 if key not in self.ext_pillars:
                     log.critical(
-                        "ext_pillar interface named %s is unavailable. Make sure it is placed in the correct directory/location. Check https://docs.saltstack.com/en/latest/ref/configuration/master.html#extension-modules for details.", key
+                        "ext_pillar interface named %s is unavailable. Make sure it is placed in the correct "
+                        "directory/location. Check https://docs.saltstack.com/en/latest/ref/configuration/master.html#extension-modules for details.",
+                        key,
                     )
                     continue
                 try:

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -1201,7 +1201,7 @@ class Pillar:
             for key, val in run.items():
                 if key not in self.ext_pillars:
                     log.critical(
-                        "Specified ext_pillar interface %s is unavailable", key
+                        "ext_pillar interface named %s is unavailable. Make sure it is placed in the correct directory/location. Check https://docs.saltstack.com/en/latest/ref/configuration/master.html#extension-modules for details.", key
                     )
                     continue
                 try:


### PR DESCRIPTION
When module is placed in the incorrect directory, the loading of the module will fail. Give more meaningful error message and a possible solution to the problem.
I've hit this problem personally and debugging it took more than 3 hours.

### What does this PR do?

### What issues does this PR fix or reference?
Fixes: Confusing error message when extmod is placed in wrong directory/location

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
