### PR TITLE
[DOCS] Environment to saltenv and documenting color

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -530,11 +530,14 @@
 # enabled and can be disabled by changing this value to False.
 #clean_dynamic_modules: True
 #
-# Normally, the minion is not isolated to any single environment on the master
+# Renamed from ``environment`` to ``saltenv``. If ``environment`` is used,
+# ``saltenv`` will take its value. If both are used, ``environment`` will be
+# ignored and ``saltenv`` will be used.
+# Normally the minion is not isolated to any single environment on the master
 # when running states, but the environment can be isolated on the minion side
 # by statically setting it. Remember that the recommended way to manage
 # environments is to isolate via the top file.
-#environment: None
+#saltenv: None
 #
 # Isolates the pillar environment on the minion side. This functions the same
 # as the environment setting, but for pillar instead of states.

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -103,6 +103,16 @@ The option can also be set to a list of masters, enabling
           - address2
         master_type: failover
 
+.. conf_minion:: color
+
+``color``
+---------
+
+Default: ``True``
+
+By default output is colored. To disable colored output, set the color value to
+``False``.
+
 .. conf_minion:: ipv6
 
 ``ipv6``


### PR DESCRIPTION
### What does this PR do?

Updated `minion` configuration option documentation for `color` and `saltenv` (`environment`)

Needs engineering review/confirmation that this update reflects current usage/state of these configurations.

### What issues does this PR fix or reference?

Makes some progress against #58112

### Previous Behavior

- `environment` was listed as an option in the `minion` config
- `color` was undocumented as an option in the `.rst` doc of the `minion` config

### New Behavior

- `saltenv` is listed in the `minion` config instead of `environment`, with information about being superseded
- `color` was undocumented as an option in the `.rst` doc of the `minion` config

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
