### PR TITLE
Do not regenerate grains for every job on windows

### DIFF
--- a/changelog/58904.fixed
+++ b/changelog/58904.fixed
@@ -1,0 +1,2 @@
+Do not generate grains for every job run on Windows minions. This makes Windows
+conform more to the way posix OSes work today.

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1253,7 +1253,8 @@ class Minion(MinionBase):
         # before we can get the grains.  We do this for proxies in the
         # post_master_init
         if not salt.utils.platform.is_proxy():
-            self.opts["grains"] = salt.loader.grains(opts)
+            if not self.opts.get("grains", {}):
+                self.opts["grains"] = salt.loader.grains(opts)
         else:
             if self.opts.get("beacons_before_connect", False):
                 log.warning(

--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -1,0 +1,24 @@
+import salt.minion
+from tests.support.mock import patch
+
+
+def test_minion_grains_in_opts():
+    """
+    Minion does not generate grains when they are already in opts
+    """
+    opts = {"random_startup_delay": 0, "grains": {"foo": "bar"}}
+    with patch("salt.loader.grains") as grainsfunc:
+        minion = salt.minion.Minion(opts)
+        assert minion.opts["grains"] == opts["grains"]
+        grainsfunc.assert_not_called()
+
+
+def test_minoin_grains_not_in_opts():
+    """
+    Minion generates grains when they are not already in opts
+    """
+    opts = {"random_startup_delay": 0, "grains": {}}
+    with patch("salt.loader.grains") as grainsfunc:
+        minion = salt.minion.Minion(opts)
+        assert minion.opts["grains"] != {}
+        grainsfunc.assert_called()

--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -13,7 +13,7 @@ def test_minion_grains_in_opts():
         grainsfunc.assert_not_called()
 
 
-def test_minoin_grains_not_in_opts():
+def test_minion_grains_not_in_opts():
     """
     Minion generates grains when they are not already in opts
     """

--- a/tests/unit/test_minion.py
+++ b/tests/unit/test_minion.py
@@ -427,6 +427,8 @@ class MinionTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
     @slowTest
     def test_when_passed_start_event_grains(self):
         mock_opts = self.get_config("minion", from_scratch=True)
+        # provide mock opts an os grain since we'll look for it later.
+        mock_opts["grains"]["os"] = "linux"
         mock_opts["start_event_grains"] = ["os"]
         io_loop = salt.ext.tornado.ioloop.IOLoop()
         io_loop.make_current()


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?

Fixes: #58904

Running a test.ping with a single minion

before: 5.379
after: 3.663

Running the PR tests on windows 2019

before: Kitchen is finished. (60m12.00s)
after: Kitchen is finished. (48m52.20s)

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
