### PR TITLE
Upgrade to non vulnerable cryptography>=3.2

### DIFF
--- a/requirements/static/ci/py3.5/cloud.txt
+++ b/requirements/static/ci/py3.5/cloud.txt
@@ -4,11 +4,10 @@
 #
 #    pip-compile -o requirements/static/ci/py3.5/cloud.txt -v requirements/static/ci/cloud.in
 #
-asn1crypto==0.24.0        # via cryptography
 certifi==2019.3.9         # via requests
 cffi==1.12.2              # via cryptography
 chardet==3.0.4            # via requests
-cryptography==2.6.1       # via requests-ntlm, smbprotocol
+cryptography==3.2.1       # via requests-ntlm, smbprotocol
 idna==2.8                 # via requests
 netaddr==0.7.19
 ntlm-auth==1.3.0          # via requests-ntlm, smbprotocol

--- a/requirements/static/ci/py3.6/cloud.txt
+++ b/requirements/static/ci/py3.6/cloud.txt
@@ -4,11 +4,10 @@
 #
 #    pip-compile -o requirements/static/ci/py3.6/cloud.txt -v requirements/static/ci/cloud.in
 #
-asn1crypto==0.24.0        # via cryptography
 certifi==2019.3.9         # via requests
 cffi==1.12.2              # via cryptography
 chardet==3.0.4            # via requests
-cryptography==2.6.1       # via requests-ntlm, smbprotocol
+cryptography==3.2.1       # via requests-ntlm, smbprotocol
 idna==2.8                 # via requests
 netaddr==0.7.19
 ntlm-auth==1.3.0          # via requests-ntlm, smbprotocol

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -4,11 +4,10 @@
 #
 #    pip-compile -o requirements/static/ci/py3.7/cloud.txt -v requirements/static/ci/cloud.in
 #
-asn1crypto==0.24.0        # via cryptography
 certifi==2019.3.9         # via requests
 cffi==1.12.2              # via cryptography
 chardet==3.0.4            # via requests
-cryptography==2.6.1       # via requests-ntlm, smbprotocol
+cryptography==3.2.1       # via requests-ntlm, smbprotocol
 idna==2.8                 # via requests
 netaddr==0.7.19
 ntlm-auth==1.3.0          # via requests-ntlm, smbprotocol

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -4,11 +4,10 @@
 #
 #    pip-compile -o requirements/static/ci/py3.8/cloud.txt -v requirements/static/ci/cloud.in
 #
-asn1crypto==0.24.0        # via cryptography
 certifi==2019.3.9         # via requests
 cffi==1.12.2              # via cryptography
 chardet==3.0.4            # via requests
-cryptography==2.6.1       # via requests-ntlm, smbprotocol
+cryptography==3.2.1       # via requests-ntlm, smbprotocol
 idna==2.8                 # via requests
 netaddr==0.7.19
 ntlm-auth==1.3.0          # via requests-ntlm, smbprotocol

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -4,11 +4,10 @@
 #
 #    pip-compile -o requirements/static/ci/py3.9/cloud.txt -v requirements/static/ci/cloud.in
 #
-asn1crypto==0.24.0        # via cryptography
 certifi==2019.3.9         # via requests
 cffi==1.14.3              # via cryptography
 chardet==3.0.4            # via requests
-cryptography==2.6.1       # via requests-ntlm, smbprotocol
+cryptography==3.2.1       # via requests-ntlm, smbprotocol
 idna==2.8                 # via requests
 netaddr==0.7.19
 ntlm-auth==1.3.0          # via requests-ntlm, smbprotocol


### PR DESCRIPTION
Details:

```
GHSA-hggm-jpg3-v476
moderate severity
Vulnerable versions: < 3.2
Patched version: 3.2

Impact

RSA decryption was vulnerable to Bleichenbacher timing vulnerabilities, which would impact people using RSA decryption in online scenarios.
Patches

This is fixed in cryptography 3.2. pyca/cryptography@58494b4 is the resolving commit.
```

Closes #58827