### PR TITLE
Support loading entrypoints by passing a module instead of a function

### DIFF
--- a/changelog/58938.added
+++ b/changelog/58938.added
@@ -1,0 +1,1 @@
+Salt's versions report `salt --versions-report` now includes all installed salt extensions into its versions report.

--- a/changelog/58939.added
+++ b/changelog/58939.added
@@ -1,0 +1,1 @@
+Support loading entrypoints by passing a module instead of a function.

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -139,7 +139,21 @@ def _module_dirs(
             ):
                 try:
                     loaded_entry_point = entry_point.load()
-                    for path in loaded_entry_point():
+                    if isinstance(loaded_entry_point, types.ModuleType):
+                        # New way of defining entrypoints
+                        #   [options.entry_points]
+                        #   salt.loader=
+                        #     runner_dirs = thirpartypackage.runners
+                        #     module_dirs = thirpartypackage.modules
+                        loaded_entry_point_paths = loaded_entry_point.__path__
+                    else:
+                        # Old way of defining loader entry points
+                        #   [options.entry_points]
+                        #   salt.loader=
+                        #     runner_dirs = thirpartypackage.loader:func_to_get_list_of_dirs
+                        #     module_dirs = thirpartypackage.loader:func_to_get_list_of_dirs
+                        loaded_entry_point_paths = loaded_entry_point()
+                    for path in loaded_entry_point_paths:
                         ext_type_types.append(path)
                 except Exception as exc:  # pylint: disable=broad-except
                     entry_point_details = entrypoints.name_and_version_from_entry_point(

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -7,6 +7,7 @@ plugin interfaces used by Salt.
 import contextvars
 import copy
 import functools
+import importlib
 import importlib.machinery  # pylint: disable=no-name-in-module,import-error
 import importlib.util  # pylint: disable=no-name-in-module,import-error
 import inspect
@@ -39,8 +40,6 @@ import salt.utils.platform
 import salt.utils.stringutils
 import salt.utils.versions
 from salt.exceptions import LoaderError
-from salt.ext import six
-from salt.ext.six.moves import reload_module
 from salt.template import check_render_pipe_str
 from salt.utils.decorators import Depends
 
@@ -1524,7 +1523,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                                 self.file_mapping[f_noext][0],
                             )
 
-                        if six.PY3 and ext == ".pyc" and curr_ext == ".pyc":
+                        if ext == ".pyc" and curr_ext == ".pyc":
                             # Check the optimization level
                             if opt_index >= curr_opt_index:
                                 # Module name match, but a higher-priority
@@ -1537,7 +1536,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                             # exists, so skip this.
                             continue
 
-                    if six.PY3 and not dirname and ext == ".pyc":
+                    if not dirname and ext == ".pyc":
                         # On Python 3, we should only load .pyc files from the
                         # __pycache__ subdirectory (i.e. when dirname is not an
                         # empty string).
@@ -1625,7 +1624,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         for submodule in submodules:
             # it is a submodule if the name is in a namespace under mod
             if submodule.__name__.startswith(mod.__name__ + "."):
-                reload_module(submodule)
+                importlib.reload(submodule)
                 self._reload_submodules(submodule)
 
     def __populate_sys_path(self):

--- a/salt/utils/entrypoints.py
+++ b/salt/utils/entrypoints.py
@@ -1,0 +1,81 @@
+import logging
+import sys
+import types
+
+USE_IMPORTLIB_METADATA_STDLIB = USE_IMPORTLIB_METADATA = USE_PKG_RESOURCES = False
+
+if sys.version_info >= (3, 10):
+    # Python 3.10 will include a fix in importlib.metadata which allows us to
+    # get the distribution of a loaded entry-point
+    import importlib.metadata  # pylint: disable=no-member,no-name-in-module
+
+    USE_IMPORTLIB_METADATA_STDLIB = True
+else:
+    if sys.version_info >= (3, 6):
+        # importlib_metadata available for python version lower than 3.6 do not
+        # include the functionality we need.
+        try:
+            import importlib_metadata
+
+            importlib_metadata_version = [
+                int(part)
+                for part in importlib_metadata.version("importlib_metadata").split(".")
+                if part.isdigit()
+            ]
+            if tuple(importlib_metadata_version) >= (3, 3, 0):
+                # Version 3.3.0 of importlib_metadata includes a fix which allows us to
+                # get the distribution of a loaded entry-point
+                USE_IMPORTLIB_METADATA = True
+        except ImportError:
+            # We don't have importlib_metadata but USE_IMPORTLIB_METADATA is set to false by default
+            pass
+
+if not USE_IMPORTLIB_METADATA_STDLIB and not USE_IMPORTLIB_METADATA:
+    # Try to use pkg_resources
+    try:
+        import pkg_resources
+
+        USE_PKG_RESOURCES = True
+    except ImportError:
+        # We don't have pkg_resources but USE_PKG_RESOURCES is set to false by default
+        pass
+
+
+log = logging.getLogger(__name__)
+
+
+def iter_entry_points(group, name=None):
+    entry_points_listing = []
+    if USE_IMPORTLIB_METADATA_STDLIB:
+        log.debug("Using importlib.metadata to load entry points")
+        entry_points = importlib.metadata.entry_points()
+    elif USE_IMPORTLIB_METADATA:
+        log.debug("Using importlib_metadata to load entry points")
+        entry_points = importlib_metadata.entry_points()
+    elif USE_PKG_RESOURCES:
+        log.debug("Using pkg_resources to load entry points")
+        entry_points_listing = list(pkg_resources.iter_entry_points(group, name=name))
+    else:
+        return entry_points_listing
+
+    if USE_IMPORTLIB_METADATA_STDLIB or USE_IMPORTLIB_METADATA:
+        for entry_point_group, entry_points_list in entry_points.items():
+            if entry_point_group != group:
+                continue
+            for entry_point in entry_points_list:
+                if name is not None and entry_point.name != name:
+                    continue
+                entry_points_listing.append(entry_point)
+
+    return entry_points_listing
+
+
+def name_and_version_from_entry_point(entry_point):
+    if USE_IMPORTLIB_METADATA_STDLIB or USE_IMPORTLIB_METADATA:
+        return types.SimpleNamespace(
+            name=entry_point.dist.metadata["name"], version=entry_point.dist.version,
+        )
+    elif USE_PKG_RESOURCES:
+        return types.SimpleNamespace(
+            name=entry_point.dist.key, version=entry_point.dist.version
+        )

--- a/salt/version.py
+++ b/salt/version.py
@@ -6,6 +6,8 @@ import platform
 import re
 import sys
 
+import salt.utils.entrypoints
+
 MAX_SIZE = sys.maxsize
 VERSION_LIMIT = MAX_SIZE - 200
 
@@ -757,7 +759,22 @@ def system_information():
         continue
 
 
-def versions_information(include_salt_cloud=False):
+def extensions_information():
+    """
+    Gather infomation about any installed salt extensions
+    """
+    extensions = {}
+    for entry_point in salt.utils.entrypoints.iter_entry_points("salt.loader"):
+        dist_nv = salt.utils.entrypoints.name_and_version_from_entry_point(entry_point)
+        if not dist_nv:
+            continue
+        if dist_nv.name in extensions:
+            continue
+        extensions[dist_nv.name] = dist_nv.version
+    return extensions
+
+
+def versions_information(include_salt_cloud=False, include_extensions=True):
     """
     Report the versions of dependent software.
     """
@@ -765,27 +782,46 @@ def versions_information(include_salt_cloud=False):
     lib_info = list(dependency_information(include_salt_cloud))
     sys_info = list(system_information())
 
-    return {
+    info = {
         "Salt Version": dict(salt_info),
         "Dependency Versions": dict(lib_info),
         "System Versions": dict(sys_info),
     }
+    if include_extensions:
+        extensions_info = extensions_information()
+        if extensions_info:
+            info["Salt Extensions"] = extensions_info
+    return info
 
 
-def versions_report(include_salt_cloud=False):
+def versions_report(include_salt_cloud=False, include_extensions=True):
     """
     Yield each version properly formatted for console output.
     """
-    ver_info = versions_information(include_salt_cloud)
+    ver_info = versions_information(
+        include_salt_cloud=include_salt_cloud, include_extensions=include_extensions
+    )
     not_installed = "Not Installed"
     ns_pad = len(not_installed)
     lib_pad = max(len(name) for name in ver_info["Dependency Versions"])
     sys_pad = max(len(name) for name in ver_info["System Versions"])
-    padding = max(lib_pad, sys_pad, ns_pad) + 1
+    if include_extensions and "Salt Extensions" in ver_info:
+        ext_pad = max(len(name) for name in ver_info["Salt Extensions"])
+    else:
+        ext_pad = 1
+    padding = max(lib_pad, sys_pad, ns_pad, ext_pad) + 1
 
     fmt = "{0:>{pad}}: {1}"
     info = []
-    for ver_type in ("Salt Version", "Dependency Versions", "System Versions"):
+    for ver_type in (
+        "Salt Version",
+        "Dependency Versions",
+        "Salt Extensions",
+        "System Versions",
+    ):
+        if ver_type == "Salt Extensions" and ver_type not in ver_info:
+            # No salt Extensions to report
+            continue
         info.append("{}:".format(ver_type))
         # List dependencies in alphabetical, case insensitive order
         for name in sorted(ver_info[ver_type], key=lambda x: x.lower()):

--- a/tests/pytests/functional/test_loader.py
+++ b/tests/pytests/functional/test_loader.py
@@ -1,0 +1,113 @@
+import json
+
+import pytest
+from tests.support.helpers import SaltVirtualEnv
+from tests.support.pytest.helpers import FakeSaltExtension
+
+pytestmark = [
+    # These are slow because they create a virtualenv and install salt in it
+    pytest.mark.slow_test,
+]
+
+
+@pytest.fixture(scope="module")
+def salt_extension(tmp_path_factory):
+    with FakeSaltExtension(
+        tmp_path_factory=tmp_path_factory, name="salt-ext-loader-test"
+    ) as extension:
+        yield extension
+
+
+def test_new_entry_points_passing_module(tmp_path, salt_extension, salt_minion_factory):
+    with SaltVirtualEnv(venv_dir=tmp_path / ".venv") as venv:
+        # Install our extension into the virtualenv
+        venv.install(str(salt_extension.srcdir))
+        installed_packages = venv.get_installed_packages()
+        assert salt_extension.name in installed_packages
+        code = """
+        import sys
+        import json
+
+        # If the test fails, for debugging purposes, comment out the following 2 lines
+        #import salt.log.setup
+        #salt.log.setup.setup_console_logger(log_level="debug")
+
+        import salt.loader
+
+        minion_config = json.loads(sys.stdin.read())
+        loader = salt.loader.minion_mods(minion_config)
+        print(json.dumps(list(loader)))
+        """
+        ret = venv.run_code(code, input=json.dumps(salt_minion_factory.config.copy()))
+        loader_functions = json.loads(ret.stdout)
+
+        # A non existing module should not appear in the loader
+        assert "monty.python" not in loader_functions
+
+        # But our extension's modules should appear on the loader
+        assert "foobar.echo1" in loader_functions
+        assert "foobar.echo2" in loader_functions
+
+
+def test_new_entry_points_passing_func_returning_a_dict(
+    tmp_path, salt_extension, salt_minion_factory
+):
+    with SaltVirtualEnv(venv_dir=tmp_path / ".venv") as venv:
+        # Install our extension into the virtualenv
+        venv.install(str(salt_extension.srcdir))
+        installed_packages = venv.get_installed_packages()
+        assert salt_extension.name in installed_packages
+        code = """
+        import sys
+        import json
+
+        # If the test fails, for debugging purposes, comment out the following 2 lines
+        #import salt.log.setup
+        #salt.log.setup.setup_console_logger(log_level="debug")
+
+        import salt.loader
+
+        minion_config = json.loads(sys.stdin.read())
+        loader = salt.loader.wheels(minion_config)
+        print(json.dumps(list(loader)))
+        """
+        ret = venv.run_code(code, input=json.dumps(salt_minion_factory.config.copy()))
+        loader_functions = json.loads(ret.stdout)
+
+        # A non existing module should not appear in the loader
+        assert "monty.python" not in loader_functions
+
+        # But our extension's modules should appear on the loader
+        assert "foobar.echo1" in loader_functions
+        assert "foobar.echo2" in loader_functions
+
+
+def test_old_entry_points(tmp_path, salt_extension, salt_minion_factory):
+    with SaltVirtualEnv(venv_dir=tmp_path / ".venv") as venv:
+        # Install our extension into the virtualenv
+        venv.install(str(salt_extension.srcdir))
+        installed_packages = venv.get_installed_packages()
+        assert salt_extension.name in installed_packages
+        code = """
+        import sys
+        import json
+
+        # If the test fails, for debugging purposes, comment out the following 2 lines
+        #import salt.log.setup
+        #salt.log.setup.setup_console_logger(log_level="debug")
+
+        import salt.loader
+
+        minion_config = json.loads(sys.stdin.read())
+        loader = salt.loader.runner(minion_config)
+        print(json.dumps(list(loader)))
+        """
+        ret = venv.run_code(code, input=json.dumps(salt_minion_factory.config.copy()))
+        loader_functions = json.loads(ret.stdout)
+
+        # A non existing module should not appear in the loader
+        assert "monty.python" not in loader_functions
+
+        # But our extension's modules should appear on the loader
+        assert "foobar.echo1" in loader_functions
+        assert "foobar.echo2" in loader_functions

--- a/tests/pytests/functional/test_version.py
+++ b/tests/pytests/functional/test_version.py
@@ -1,0 +1,59 @@
+import json
+import logging
+
+import pytest
+from tests.support.helpers import SaltVirtualEnv
+from tests.support.pytest.helpers import FakeSaltExtension
+
+pytestmark = [
+    # These are slow because they create a virtualenv and install salt in it
+    pytest.mark.slow_test,
+]
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def salt_extension(tmp_path_factory):
+    with FakeSaltExtension(
+        tmp_path_factory=tmp_path_factory, name="salt-ext-version-test"
+    ) as extension:
+        yield extension
+
+
+def test_salt_extensions_in_versions_report(tmp_path, salt_extension):
+    with SaltVirtualEnv(venv_dir=tmp_path / ".venv") as venv:
+        # Install our extension into the virtualenv
+        venv.install(str(salt_extension.srcdir))
+        installed_packages = venv.get_installed_packages()
+        assert salt_extension.name in installed_packages
+        ret = venv.run_code(
+            """
+            import json
+            import salt.version
+
+            print(json.dumps(salt.version.versions_information()))
+            """
+        )
+    versions_information = json.loads(ret.stdout)
+    assert "Salt Extensions" in versions_information
+    assert salt_extension.name in versions_information["Salt Extensions"]
+
+
+def test_salt_extensions_absent_in_versions_report(tmp_path, salt_extension):
+    """
+    Ensure that the 'Salt Extensions' header does not show up when no extension is installed
+    """
+    with SaltVirtualEnv(venv_dir=tmp_path / ".venv") as venv:
+        installed_packages = venv.get_installed_packages()
+        assert salt_extension.name not in installed_packages
+        ret = venv.run_code(
+            """
+            import json
+            import salt.version
+
+            print(json.dumps(salt.version.versions_information()))
+            """
+        )
+    versions_information = json.loads(ret.stdout)
+    assert "Salt Extensions" not in versions_information

--- a/tests/pytests/unit/test_version.py
+++ b/tests/pytests/unit/test_version.py
@@ -1,6 +1,6 @@
 """
-tests.unit.version_test
-~~~~~~~~~~~~~~~~~~~~~~~
+tests.pytests.unit.test_version
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Test salt's regex git describe version parsing
 """
@@ -463,3 +463,19 @@ def test_system_version_windows():
         versions = [item for item in system_information()]
         version = ("version", "2016Server 10.0.14393 SP0 Multiprocessor Free")
         assert version in versions
+
+
+def test_versions_report_includes_salt_extensions():
+    with patch(
+        "salt.version.extensions_information", return_value={"foo-bar-ext": "1.0"}
+    ):
+        versions_information = salt.version.versions_information()
+        assert "Salt Extensions" in versions_information
+        assert "foo-bar-ext" in versions_information["Salt Extensions"]
+        assert versions_information["Salt Extensions"]["foo-bar-ext"] == "1.0"
+
+
+def test_versions_report_no_extensions_available():
+    with patch("salt.utils.entrypoints.iter_entry_points", return_value=()):
+        versions_information = salt.version.versions_information()
+        assert "Salt Extensions" not in versions_information

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -8,15 +8,16 @@
 
     Test support helpers
 """
-
 import base64
 import builtins
 import errno
 import fnmatch
 import functools
 import inspect
+import json
 import logging
 import os
+import pathlib
 import random
 import shutil
 import socket
@@ -30,6 +31,7 @@ import time
 import types
 from contextlib import contextmanager
 
+import attr
 import pytest
 import salt.ext.tornado.ioloop
 import salt.ext.tornado.web
@@ -294,9 +296,6 @@ class RedirectStdStreams:
     """
 
     def __init__(self, stdout=None, stderr=None):
-        # Late import
-        import salt.utils.files
-
         if stdout is None:
             # pylint: disable=resource-leakage
             stdout = salt.utils.files.fopen(os.devnull, "w")
@@ -1646,18 +1645,35 @@ class PatchedEnviron:
 patched_environ = PatchedEnviron
 
 
+@attr.s(frozen=True, slots=True)
 class VirtualEnv:
-    def __init__(self, venv_dir=None, env=None):
-        self.venv_dir = venv_dir or tempfile.mkdtemp(dir=RUNTIME_VARS.TMP)
+    venv_dir = attr.ib()
+    env = attr.ib(default=None)
+    system_site_packages = attr.ib(default=False)
+    environ = attr.ib(init=False, repr=False)
+    venv_python = attr.ib(init=False, repr=False)
+    venv_bin_dir = attr.ib(init=False, repr=False)
+
+    @venv_dir.default
+    def _default_venv_dir(self):
+        return pathlib.Path(tempfile.mkdtemp(dir=RUNTIME_VARS.TMP))
+
+    @environ.default
+    def _default_environ(self):
         environ = os.environ.copy()
-        if env:
-            environ.update(env)
-        self.environ = environ
+        if self.env:
+            environ.update(self.env)
+        return environ
+
+    @venv_python.default
+    def _default_venv_python(self):
         if salt.utils.platform.is_windows():
-            self.venv_python = os.path.join(self.venv_dir, "Scripts", "python.exe")
-        else:
-            self.venv_python = os.path.join(self.venv_dir, "bin", "python")
-        self.venv_bin_dir = os.path.dirname(self.venv_python)
+            return self.venv_dir / "Scripts" / "python.exe"
+        return self.venv_dir / "bin" / "python"
+
+    @venv_bin_dir.default
+    def _default_venv_bin_dir(self):
+        return self.venv_python.parent
 
     def __enter__(self):
         try:
@@ -1667,14 +1683,14 @@ class VirtualEnv:
         return self
 
     def __exit__(self, *args):
-        salt.utils.files.rm_rf(self.venv_dir)
+        shutil.rmtree(str(self.venv_dir), ignore_errors=True)
 
     def install(self, *args, **kwargs):
-        return self.run(self.venv_python, "-m", "pip", "install", *args, **kwargs)
+        return self.run(str(self.venv_python), "-m", "pip", "install", *args, **kwargs)
 
     def run(self, *args, **kwargs):
         check = kwargs.pop("check", True)
-        kwargs.setdefault("cwd", self.venv_dir)
+        kwargs.setdefault("cwd", str(self.venv_dir))
         kwargs.setdefault("stdout", subprocess.PIPE)
         kwargs.setdefault("stderr", subprocess.PIPE)
         kwargs.setdefault("universal_newlines", True)
@@ -1700,7 +1716,8 @@ class VirtualEnv:
                 )
         return ret
 
-    def _get_real_python(self):
+    @staticmethod
+    def get_real_python():
         """
         The reason why the virtualenv creation is proxied by this function is mostly
         because under windows, we can't seem to properly create a virtualenv off of
@@ -1733,12 +1750,41 @@ class VirtualEnv:
         except AttributeError:
             return sys.executable
 
+    def run_code(self, code_string, **kwargs):
+        if code_string.startswith("\n"):
+            code_string = code_string[1:]
+        code_string = textwrap.dedent(code_string)
+        return self.run(str(self.venv_python), "-c", code_string, **kwargs)
+
+    def get_installed_packages(self):
+        data = {}
+        ret = self.run(str(self.venv_python), "-m", "pip", "list", "--format", "json")
+        for pkginfo in json.loads(ret.stdout):
+            data[pkginfo["name"]] = pkginfo["version"]
+        return data
+
     def _create_virtualenv(self):
         sminion = create_sminion()
         sminion.functions.virtualenv.create(
-            self.venv_dir, python=self._get_real_python()
+            str(self.venv_dir),
+            python=self.get_real_python(),
+            system_site_packages=self.system_site_packages,
         )
         self.install("-U", "pip", "setuptools!=50.*,!=51.*,!=52.*")
+        log.debug("Created virtualenv in %s", self.venv_dir)
+
+
+@attr.s(frozen=True, slots=True)
+class SaltVirtualEnv(VirtualEnv):
+    """
+    This is a VirtualEnv implementation which has this salt checkout installed in it
+    """
+
+    system_site_packages = attr.ib(init=False, default=True)
+
+    def _create_virtualenv(self):
+        super()._create_virtualenv()
+        self.install("--no-use-pep517", RUNTIME_VARS.CODE_DIR)
 
 
 @contextmanager

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -1753,7 +1753,10 @@ class VirtualEnv:
     def run_code(self, code_string, **kwargs):
         if code_string.startswith("\n"):
             code_string = code_string[1:]
-        code_string = textwrap.dedent(code_string)
+        code_string = textwrap.dedent(code_string).rstrip()
+        log.debug(
+            "Code to run passed to python:\n>>>>>>>>>>\n%s\n<<<<<<<<<<", code_string
+        )
         return self.run(str(self.venv_python), "-c", code_string, **kwargs)
 
     def get_installed_packages(self):

--- a/tests/support/pytest/helpers.py
+++ b/tests/support/pytest/helpers.py
@@ -533,6 +533,178 @@ def shell_test_false():
     return "/bin/false"
 
 
+@attr.s(kw_only=True, frozen=True)
+class FakeSaltExtension:
+    tmp_path_factory = attr.ib(repr=False)
+    name = attr.ib()
+    pkgname = attr.ib(init=False)
+    srcdir = attr.ib(init=False)
+
+    @srcdir.default
+    def _srcdir(self):
+        return self.tmp_path_factory.mktemp("src", numbered=True)
+
+    @pkgname.default
+    def _pkgname(self):
+        replace_chars = ("-", " ")
+        name = self.name
+        for char in replace_chars:
+            name = name.replace(char, "_")
+        return name
+
+    def __attrs_post_init__(self):
+        self._laydown_files()
+
+    def _laydown_files(self):
+        if not self.srcdir.exists():
+            self.srcdir.mkdir()
+        setup_py = self.srcdir.joinpath("setup.py")
+        if not setup_py.exists():
+            setup_py.write_text(
+                textwrap.dedent(
+                    """\
+            import setuptools
+
+            if __name__ == "__main__":
+                setuptools.setup()
+            """
+                )
+            )
+        setup_cfg = self.srcdir.joinpath("setup.cfg")
+        if not setup_cfg.exists():
+            setup_cfg.write_text(
+                textwrap.dedent(
+                    """\
+            [metadata]
+            name = {0}
+            version = 1.0
+            description = Salt Extension Test
+            author = Pedro
+            author_email = pedro@algarvio.me
+            keywords = salt-extension
+            url = http://saltstack.com
+            license = Apache Software License 2.0
+            classifiers =
+                Programming Language :: Python
+                Programming Language :: Cython
+                Programming Language :: Python :: 3
+                Programming Language :: Python :: 3 :: Only
+                Development Status :: 4 - Beta
+                Intended Audience :: Developers
+                License :: OSI Approved :: Apache Software License
+            platforms = any
+
+            [options]
+            zip_safe = False
+            include_package_data = True
+            packages = find:
+            python_requires = >= 3.5
+            setup_requires =
+              wheel
+              setuptools>=50.3.2
+
+            [options.entry_points]
+            salt.loader=
+              module_dirs = {1}.loader:get_module_dirs
+              runner_dirs = {1}.loader:get_runner_dirs
+            """.format(
+                        self.name, self.pkgname
+                    )
+                )
+            )
+
+        extension_package_dir = self.srcdir / self.pkgname
+        if not extension_package_dir.exists():
+            extension_package_dir.mkdir()
+            extension_package_dir.joinpath("__init__.py").write_text("")
+            extension_package_dir.joinpath("loader.py").write_text(
+                textwrap.dedent(
+                    """\
+            import pathlib
+
+            PKG_ROOT = pathlib.Path(__file__).resolve().parent
+
+            def get_module_dirs():
+                return [str(PKG_ROOT / "modules")]
+
+            def get_runner_dirs():
+                return [str(PKG_ROOT / "runners1"), str(PKG_ROOT / "runners2")]
+            """
+                )
+            )
+
+            runners1_dir = extension_package_dir / "runners1"
+            runners1_dir.mkdir()
+            runners1_dir.joinpath("__init__.py").write_text("")
+            runners1_dir.joinpath("foobar1.py").write_text(
+                textwrap.dedent(
+                    """\
+            __virtualname__ = "foobar"
+
+            def __virtual__():
+                return True
+
+            def echo1(string):
+                return string
+            """
+                )
+            )
+
+            runners2_dir = extension_package_dir / "runners2"
+            runners2_dir.mkdir()
+            runners2_dir.joinpath("__init__.py").write_text("")
+            runners2_dir.joinpath("foobar2.py").write_text(
+                textwrap.dedent(
+                    """\
+            __virtualname__ = "foobar"
+
+            def __virtual__():
+                return True
+
+            def echo2(string):
+                return string
+            """
+                )
+            )
+
+            modules_dir = extension_package_dir / "modules"
+            modules_dir.mkdir()
+            modules_dir.joinpath("__init__.py").write_text("")
+            modules_dir.joinpath("foobar1.py").write_text(
+                textwrap.dedent(
+                    """\
+            __virtualname__ = "foobar"
+
+            def __virtual__():
+                return True
+
+            def echo1(string):
+                return string
+            """
+                )
+            )
+            modules_dir.joinpath("foobar2.py").write_text(
+                textwrap.dedent(
+                    """\
+            __virtualname__ = "foobar"
+
+            def __virtual__():
+                return True
+
+            def echo2(string):
+                return string
+            """
+                )
+            )
+
+    def __enter__(self):
+        self._laydown_files()
+        return self
+
+    def __exit__(self, *_):
+        shutil.rmtree(str(self.srcdir), ignore_errors=True)
+
+
 # Only allow star importing the functions defined in this module
 __all__ = [
     name

--- a/tests/support/pytest/helpers.py
+++ b/tests/support/pytest/helpers.py
@@ -605,8 +605,9 @@ class FakeSaltExtension:
 
             [options.entry_points]
             salt.loader=
-              module_dirs = {1}.loader:get_module_dirs
+              module_dirs = {1}
               runner_dirs = {1}.loader:get_runner_dirs
+              wheel_dirs = {1}.loader:get_new_style_entry_points
             """.format(
                         self.name, self.pkgname
                     )
@@ -629,6 +630,9 @@ class FakeSaltExtension:
 
             def get_runner_dirs():
                 return [str(PKG_ROOT / "runners1"), str(PKG_ROOT / "runners2")]
+
+            def get_new_style_entry_points():
+                return {"wheel": [str(PKG_ROOT / "the_wheel_modules")]}
             """
                 )
             )
@@ -684,6 +688,36 @@ class FakeSaltExtension:
                 )
             )
             modules_dir.joinpath("foobar2.py").write_text(
+                textwrap.dedent(
+                    """\
+            __virtualname__ = "foobar"
+
+            def __virtual__():
+                return True
+
+            def echo2(string):
+                return string
+            """
+                )
+            )
+
+            wheel_dir = extension_package_dir / "the_wheel_modules"
+            wheel_dir.mkdir()
+            wheel_dir.joinpath("__init__.py").write_text("")
+            wheel_dir.joinpath("foobar1.py").write_text(
+                textwrap.dedent(
+                    """\
+            __virtualname__ = "foobar"
+
+            def __virtual__():
+                return True
+
+            def echo1(string):
+                return string
+            """
+                )
+            )
+            wheel_dir.joinpath("foobar2.py").write_text(
                 textwrap.dedent(
                     """\
             __virtualname__ = "foobar"

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -1,6 +1,6 @@
 """
-    unit.loader
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    tests.unit.test_loader
+    ~~~~~~~~~~~~~~~~~~~~~~
 
     Test Salt's loader
 """


### PR DESCRIPTION
### What does this PR do?
Support loading entrypoints by passing a module instead of a function.

The old way of defining salt loader entrypoints was, for example, on `setup.cfg`:
```ini
[options.entry_points]
salt.loader=
  runner_dirs = thirpartypackage.loader:func_to_get_list_of_dirs
  module_dirs = thirpartypackage.loader:func_to_get_list_of_dirs
```
This old way is still supported in the rare ocasion where you actually
want to pass multiple paths to the loader and to not break backwards
compatibility.
    
The new way of defining the salt loader entrypoints is, for example, on `setup.cfg`:
```ini
[options.entry_points]
salt.loader=
  <this-name-does-not-matter = thirpartypackage
  <this-name-does-not-matter = thirpartypackage:callable
```
    
With this new approach, when the target is a package, Salt looks for the
`ext_type` being loaded as submodule of the package and if it exists, it
loads from there.
If the target is a callable, then, that callable should return a
dictionary where the keys are the several salt loader names. For
salt execution modules it would be `modules`, for salt state modules it would
be `states`, etc. The same directory layout you see in salt.
The values for those keys needs to be an iterable(not a string which is
also an iterable), ie, a list, a generator, etc, whose values are the
paths from where to load the salt loader modules.

### What issues does this PR fix or reference?

Fixes #58939