### PR TITLE
fix formatting for terse output mode

### DIFF
--- a/changelog/58953.fixed
+++ b/changelog/58953.fixed
@@ -1,0 +1,1 @@
+Fixed formatting for terse output mode

--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -810,7 +810,7 @@ def _format_terse(tcolor, comps, ret, colors, tabular):
             )
         fmt_string += " {0} Name: {1} - Function: {2}.{3} - Result: {4}"
         if __opts__.get("state_output_profile") and "start_time" in ret:
-            fmt_string += " Started: - {6[start_time]!s} Duration: {6[duration]!s} ms"
+            fmt_string += " - Started: {6[start_time]!s} - Duration: {6[duration]!s} ms"
         fmt_string += "{5}"
 
     msg = fmt_string.format(

--- a/tests/pytests/unit/output/test_highstate_terse.py
+++ b/tests/pytests/unit/output/test_highstate_terse.py
@@ -1,0 +1,87 @@
+import logging
+import re
+
+import pytest
+
+import salt.config
+import salt.output.highstate as highstate
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def configure_loader_modules():
+    minion_opts = salt.config.DEFAULT_MINION_OPTS.copy()
+    overrides = {
+        "extension_modules": "",
+        "optimization_order": [0, 1, 2],
+        "color": False,
+        "state_output_pct": True,
+        "state_output": "terse",
+    }
+    minion_opts.update(overrides)
+    return {highstate: {"__opts__": minion_opts}}
+
+
+def test_terse_output():
+    nested_data = {
+        "outputter": "highstate",
+        "state_output": "terse",
+        "data": {
+            "local_master": {
+                "salt_|-nested_|-state.orchestrate_|-runner": {
+                    "comment": "Runner function 'state.orchestrate' executed.",
+                    "name": "state.orchestrate",
+                    "__orchestration__": True,
+                    "start_time": "09:22:53.158742",
+                    "result": True,
+                    "duration": 980.694,
+                    "__run_num__": 0,
+                    "__jid__": "20180326092253538853",
+                    "__sls__": "orch.test.nested",
+                    "changes": {
+                        "return": {
+                            "outputter": "highstate",
+                            "data": {
+                                "local_master": {
+                                    "test_|-always-passes-with-changes_|-oinaosf_|-succeed_with_changes": {
+                                        "comment": "Success!",
+                                        "name": "oinaosf",
+                                        "start_time": "09:22:54.128415",
+                                        "result": True,
+                                        "duration": 0.437,
+                                        "__run_num__": 0,
+                                        "__sls__": "orch.test.changes",
+                                        "changes": {
+                                            "testing": {
+                                                "new": (
+                                                    "Something pretended to change"
+                                                ),
+                                                "old": "Unchanged",
+                                            }
+                                        },
+                                        "__id__": "always-passes-with-changes",
+                                    }
+                                }
+                            },
+                            "retcode": 0,
+                        }
+                    },
+                    "__id__": "nested",
+                }
+            }
+        },
+        "retcode": 0,
+    }
+
+    ret = highstate.output(nested_data)
+    # test whether we have at least the normal output
+    assert "Succeeded: 1 (changed=1)" in ret
+    # test whether the TERSE output is correct
+    assert (
+        re.search(
+            "Name: state[.]orchestrate - Function: salt[.]runner - Result: Changed - Started: [0-2][0-9]:[0-5][0-9]:[0-5][0-9]([.][0-9][0-9]*)? - Duration: [1-9][0-9]*([.][0-9][0-9]*)? ms",
+            ret,
+        )
+        is not None
+    )


### PR DESCRIPTION
### What does this PR do?
This PR fixes a small layout defect in the TERSE output mode for state information.

### What issues does this PR fix or reference?
None, a separate issue was not raised.

### Previous Behavior
Output was like:
`Name: apache2 - Function: pkg.installed - Result: Clean Started: - 06:03:52.163350 Duration: 20.209 ms`

### New Behavior
Output now like:
`Name: apache2 - Function: pkg.installed - Result: Clean - Started: 06:03:52.163350 - Duration: 20.209 ms`
"`-`" was used to separate name-value pairs. The start of the line was fine. But the end of the line needed a few small corrections.

### Merge requirements satisfied?
- [ ] Docs
no docs to update; previous situation is not described in that detail
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written ~~/updated~~
~~no unit test need updates; previous situation was not tested~~

### Commits signed with GPG?
No