### PR TITLE
Fix incorrect hostname quoting on Red Hat family OS

### DIFF
--- a/changelog/58956.fixed
+++ b/changelog/58956.fixed
@@ -1,0 +1,1 @@
+Fix incorrect hostname quoting in /etc/sysconfig/networking on Red Hat family OS.

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -1456,10 +1456,8 @@ def mod_hostname(hostname):
                     # fmt: off
                     fh_.write(
                         __utils__["stringutils.to_str"](
-                            "HOSTNAME={}{}{}\n".format(
-                                __utils__["stringutils.dequote"](hostname),
-                                quote_type,
-                                __utils__["stringutils.dequote"](hostname),
+                            "HOSTNAME={1}{0}{1}\n".format(
+                                __utils__["stringutils.dequote"](hostname), quote_type
                             )
                         )
                     )


### PR DESCRIPTION
network.mod_hostname() will incorrectly set a duplicate
hostname string in the configuration file. Fix that.

Fixes #58956
