### PR TITLE
Load system grains when custom grains are set

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1071,6 +1071,10 @@ class MinionManager(MinionBase):
         """
         Helper function to return the correct type of object
         """
+        load_grains = False
+        if opts.get("grains", {}):
+            # we have custom grains in config, we need to also load default grains
+            load_grains = True
         return Minion(
             opts,
             timeout,
@@ -1078,6 +1082,7 @@ class MinionManager(MinionBase):
             io_loop=io_loop,
             loaded_base_name=loaded_base_name,
             jid_queue=jid_queue,
+            load_grains=load_grains,
         )
 
     def _check_minions(self):
@@ -1212,6 +1217,7 @@ class Minion(MinionBase):
         loaded_base_name=None,
         io_loop=None,
         jid_queue=None,
+        load_grains=False,
     ):  # pylint: disable=W0231
         """
         Pass in the options dict
@@ -1253,7 +1259,7 @@ class Minion(MinionBase):
         # before we can get the grains.  We do this for proxies in the
         # post_master_init
         if not salt.utils.platform.is_proxy():
-            if not self.opts.get("grains", {}):
+            if not self.opts.get("grains", {}) or load_grains:
                 self.opts["grains"] = salt.loader.grains(opts)
         else:
             if self.opts.get("beacons_before_connect", False):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1066,15 +1066,18 @@ class MinionManager(MinionBase):
             minion.handle_event(package)
 
     def _create_minion_object(
-        self, opts, timeout, safe, io_loop=None, loaded_base_name=None, jid_queue=None
+        self,
+        opts,
+        timeout,
+        safe,
+        io_loop=None,
+        loaded_base_name=None,
+        jid_queue=None,
+        load_grains=True,
     ):
         """
         Helper function to return the correct type of object
         """
-        load_grains = False
-        if opts.get("grains"):
-            # we have custom grains in config, we need to also load default grains
-            load_grains = True
         return Minion(
             opts,
             timeout,
@@ -1217,7 +1220,7 @@ class Minion(MinionBase):
         loaded_base_name=None,
         io_loop=None,
         jid_queue=None,
-        load_grains=False,
+        load_grains=True,
     ):  # pylint: disable=W0231
         """
         Pass in the options dict
@@ -1259,7 +1262,7 @@ class Minion(MinionBase):
         # before we can get the grains.  We do this for proxies in the
         # post_master_init
         if not salt.utils.platform.is_proxy():
-            if not self.opts.get("grains", {}) or load_grains:
+            if load_grains:
                 self.opts["grains"] = salt.loader.grains(opts)
         else:
             if self.opts.get("beacons_before_connect", False):
@@ -1762,7 +1765,7 @@ class Minion(MinionBase):
     @classmethod
     def _target(cls, minion_instance, opts, data, connected):
         if not minion_instance:
-            minion_instance = cls(opts)
+            minion_instance = cls(opts, load_grains=False)
             minion_instance.connected = connected
             if not hasattr(minion_instance, "functions"):
                 (
@@ -3614,7 +3617,14 @@ class ProxyMinionManager(MinionManager):
     """
 
     def _create_minion_object(
-        self, opts, timeout, safe, io_loop=None, loaded_base_name=None, jid_queue=None
+        self,
+        opts,
+        timeout,
+        safe,
+        io_loop=None,
+        loaded_base_name=None,
+        jid_queue=None,
+        load_grains=True,
     ):
         """
         Helper function to return the correct type of object
@@ -3626,6 +3636,7 @@ class ProxyMinionManager(MinionManager):
             io_loop=io_loop,
             loaded_base_name=loaded_base_name,
             jid_queue=jid_queue,
+            load_grains=True,
         )
 
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1072,7 +1072,7 @@ class MinionManager(MinionBase):
         Helper function to return the correct type of object
         """
         load_grains = False
-        if opts.get("grains", {}):
+        if opts.get("grains"):
             # we have custom grains in config, we need to also load default grains
             load_grains = True
         return Minion(

--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -2,20 +2,31 @@ import salt.minion
 from tests.support.mock import patch
 
 
-def test_minion_grains_in_opts():
+def test_minion_load_grains_false():
     """
-    Minion does not generate grains when they are already in opts
+    Minion does not generate grains when load_grains is False
     """
     opts = {"random_startup_delay": 0, "grains": {"foo": "bar"}}
     with patch("salt.loader.grains") as grainsfunc:
-        minion = salt.minion.Minion(opts)
+        minion = salt.minion.Minion(opts, load_grains=False)
         assert minion.opts["grains"] == opts["grains"]
         grainsfunc.assert_not_called()
 
 
-def test_minion_grains_not_in_opts():
+def test_minion_load_grains_true():
     """
-    Minion generates grains when they are not already in opts
+    Minion generates grains when load_grains is True
+    """
+    opts = {"random_startup_delay": 0, "grains": {}}
+    with patch("salt.loader.grains") as grainsfunc:
+        minion = salt.minion.Minion(opts, load_grains=True)
+        assert minion.opts["grains"] != {}
+        grainsfunc.assert_called()
+
+
+def test_minion_load_grains_default():
+    """
+    Minion load_grains defaults to True
     """
     opts = {"random_startup_delay": 0, "grains": {}}
     with patch("salt.loader.grains") as grainsfunc:


### PR DESCRIPTION
### What does this PR do?
After this PR was merged in https://github.com/saltstack/salt/pull/58903 if you have custom grains set in your config file the grains will not be loaded when we initialize the salt.minion.Minion object. This results in the grains being loaded at a much later time. This will fix this test failure: `tests.integration.modules.test_state.StateModuleTest.test_get_file_from_env_in_top_match`  This test is failing only on pytest because during this test we startup the `sub_minion`. When this test tries to render the `general.sls` pillar file it fails because `os` is not in the grains dict yet. If I delay the startup of the `sub_minion` the test passes, but we should ensure we are loading the grains sooner when custom grains are set in the config file.

I am still working on writing tests for this right now.