### PR TITLE
[BUGFIX] State 'pkg.installed' was not found fix for openEuler and Issabel PBX

### DIFF
--- a/changelog/57490.fixed
+++ b/changelog/57490.fixed
@@ -1,0 +1,1 @@
+Fixed bug 57490, which prevented package installation for Open Euler and Issabel PBX. Both Open Euler and Issabel PBX use Yum for package management, added them to yumpkg.py.

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -73,7 +73,11 @@ def __virtual__():
     except Exception:  # pylint: disable=broad-except
         return (False, "Module yumpkg: no yum based system detected")
 
-    enabled = ("amazon", "xcp", "xenserver", "virtuozzolinux", "virtuozzo")
+    enabled = (
+        "amazon", "xcp", "xenserver", "virtuozzolinux", "virtuozzo",
+        "issabel pbx", "openeuler"
+    )
+
     if os_family == "redhat" or os_grain in enabled:
         if _yum() is None:
             return (False, "DNF nor YUM found")

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -74,8 +74,13 @@ def __virtual__():
         return (False, "Module yumpkg: no yum based system detected")
 
     enabled = (
-        "amazon", "xcp", "xenserver", "virtuozzolinux", "virtuozzo",
-        "issabel pbx", "openeuler"
+        "amazon",
+        "xcp",
+        "xenserver",
+        "virtuozzolinux",
+        "virtuozzo",
+        "issabel pbx",
+        "openeuler"
     )
 
     if os_family == "redhat" or os_grain in enabled:

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -80,7 +80,7 @@ def __virtual__():
         "virtuozzolinux",
         "virtuozzo",
         "issabel pbx",
-        "openeuler"
+        "openeuler",
     )
 
     if os_family == "redhat" or os_grain in enabled:


### PR DESCRIPTION
### What does this PR do?
This PR adds support for package installation using Salt on openEuler and IssabelPBX.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/57490

### Previous Behavior
Installation would fail on both openEuler and Issabel PBX with the following error:
![image](https://user-images.githubusercontent.com/3043499/99529883-3cba8280-29a9-11eb-9cf8-1dc1c78b9dbc.png)


### New Behavior
Installation successful on both distributions. Tested manually using Virtualbox VMs

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
