### PR TITLE
Adding Juniper native minion changes for Salt 3002 to master branch

### DIFF
--- a/doc/ref/beacons/all/index.rst
+++ b/doc/ref/beacons/all/index.rst
@@ -21,6 +21,7 @@ beacon modules
     haproxy
     inotify
     journald
+    junos_rre_keys
     load
     log_beacon
     memusage

--- a/doc/ref/beacons/all/salt.beacons.junos_rre_keys.rst
+++ b/doc/ref/beacons/all/salt.beacons.junos_rre_keys.rst
@@ -1,0 +1,5 @@
+salt.beacons.junos_rre_keys module
+====================================
+
+.. automodule:: salt.beacons.junos_rre_keys
+    :members:

--- a/salt/beacons/junos_rre_keys.py
+++ b/salt/beacons/junos_rre_keys.py
@@ -1,0 +1,32 @@
+#
+# Junos redundant routing engine beacon
+#
+# NOTE this beacon only works on the Juniper native minion
+#
+# Copies salt-minion keys to the backup RE when present
+#
+# Configure with
+#
+# beacon:
+#   beacons:
+#     junos_rre_keys:
+#       - interval: 43200
+#
+# `interval` above is in seconds, 43200 is recommended (every 12 hours)
+
+__virtualname__ = "junos_rre_keys"
+
+
+def beacon(config):
+    ret = []
+
+    engine_status = __salt__["junos.routing_engine"]()
+
+    if not engine_status["success"]:
+        return []
+
+    for e in engine_status["backup"]:
+        result = __salt__["junos.dir_copy"]("/var/local/salt/etc", e)
+        ret.append({"result": result, "success": True})
+
+    return ret

--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -1,15 +1,11 @@
-# coding: utf-8 -*-
 """
 Make me some salt!
 """
 
-# Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 import warnings
 
-# Import salt libs
 # We import log ASAP because we NEED to make sure that any logger instance salt
 # instantiates is using salt.log.setup.SaltLoggingClass
 import salt.log.setup
@@ -49,9 +45,9 @@ warnings.filterwarnings(
 
 
 try:
-    from salt.utils.zeromq import ip_bracket
     import salt.utils.parsers
     from salt.utils.verify import check_user, verify_env, verify_socket
+    from salt.utils.zeromq import ip_bracket
 except ImportError as exc:
     if exc.args[0] != "No module named _msgpack":
         raise
@@ -62,7 +58,7 @@ except ImportError as exc:
 log = salt.log.setup.logging.getLogger(__name__)
 
 
-class DaemonsMixin(object):  # pylint: disable=no-init
+class DaemonsMixin:  # pylint: disable=no-init
     """
     Uses the same functions for all daemons
     """
@@ -135,7 +131,7 @@ class Master(
             self.master.process_manager.send_signal_to_processes(signum)
             # kill any remaining processes
             self.master.process_manager.kill_children()
-        super(Master, self)._handle_signals(signum, sigframe)
+        super()._handle_signals(signum, sigframe)
 
     def prepare(self):
         """
@@ -145,7 +141,7 @@ class Master(
 
             super(YourSubClass, self).prepare()
         """
-        super(Master, self).prepare()
+        super().prepare()
 
         try:
             if self.config["verify_env"]:
@@ -210,7 +206,7 @@ class Master(
 
         NOTE: Run any required code before calling `super()`.
         """
-        super(Master, self).start()
+        super().start()
         if check_user(self.config["user"]):
             self.action_log_info("Starting up")
             self.verify_hash_type()
@@ -226,7 +222,7 @@ class Master(
             exitmsg = msg + exitmsg
         else:
             exitmsg = msg.strip()
-        super(Master, self).shutdown(exitcode, exitmsg)
+        super().shutdown(exitcode, exitmsg)
 
 
 class Minion(
@@ -240,7 +236,7 @@ class Minion(
         # escalate signal to the process manager processes
         if hasattr(self.minion, "stop"):
             self.minion.stop(signum)
-        super(Minion, self)._handle_signals(signum, sigframe)
+        super()._handle_signals(signum, sigframe)
 
     # pylint: disable=no-member
     def prepare(self):
@@ -251,7 +247,7 @@ class Minion(
 
             super(YourSubClass, self).prepare()
         """
-        super(Minion, self).prepare()
+        super().prepare()
 
         try:
             if self.config["verify_env"]:
@@ -337,7 +333,7 @@ class Minion(
 
         NOTE: Run any required code before calling `super()`.
         """
-        super(Minion, self).start()
+        super().start()
         while True:
             try:
                 self._real_start()
@@ -403,10 +399,10 @@ class Minion(
         self.action_log_info("Shutting down")
         if hasattr(self, "minion") and hasattr(self.minion, "destroy"):
             self.minion.destroy()
-        super(Minion, self).shutdown(
+        super().shutdown(
             exitcode,
             (
-                "The Salt {0} is shutdown. {1}".format(
+                "The Salt {} is shutdown. {}".format(
                     self.__class__.__name__, (exitmsg or "")
                 ).strip()
             ),
@@ -425,7 +421,7 @@ class ProxyMinion(
     def _handle_signals(self, signum, sigframe):  # pylint: disable=unused-argument
         # escalate signal to the process manager processes
         self.minion.stop(signum)
-        super(ProxyMinion, self)._handle_signals(signum, sigframe)
+        super()._handle_signals(signum, sigframe)
 
     # pylint: disable=no-member
     def prepare(self):
@@ -436,10 +432,11 @@ class ProxyMinion(
 
             super(YourSubClass, self).prepare()
         """
-        super(ProxyMinion, self).prepare()
+        super().prepare()
 
-        if not self.values.proxyid:
-            self.error("salt-proxy requires --proxyid")
+        ## allow for native minion
+        ## if not self.values.proxyid:
+        ##     self.error("salt-proxy requires --proxyid")
 
         # Proxies get their ID from the command line.  This may need to change in
         # the future.
@@ -487,7 +484,7 @@ class ProxyMinion(
 
         self.setup_logfile_logger()
         verify_log(self.config)
-        self.action_log_info('Setting up "{0}"'.format(self.config["id"]))
+        self.action_log_info('Setting up "{}"'.format(self.config["id"]))
 
         migrations.migrate_paths(self.config)
 
@@ -520,7 +517,7 @@ class ProxyMinion(
 
         NOTE: Run any required code before calling `super()`.
         """
-        super(ProxyMinion, self).start()
+        super().start()
         try:
             if check_user(self.config["user"]):
                 self.action_log_info("The Proxy Minion is starting up")
@@ -548,10 +545,10 @@ class ProxyMinion(
             proxy_fn = self.minion.opts["proxymodule"].loaded_base_name + ".shutdown"
             self.minion.opts["proxymodule"][proxy_fn](self.minion.opts)
         self.action_log_info("Shutting down")
-        super(ProxyMinion, self).shutdown(
+        super().shutdown(
             exitcode,
             (
-                "The Salt {0} is shutdown. {1}".format(
+                "The Salt {} is shutdown. {}".format(
                     self.__class__.__name__, (exitmsg or "")
                 ).strip()
             ),
@@ -575,7 +572,7 @@ class Syndic(
 
             super(YourSubClass, self).prepare()
         """
-        super(Syndic, self).prepare()
+        super().prepare()
         try:
             if self.config["verify_env"]:
                 verify_env(
@@ -595,7 +592,7 @@ class Syndic(
 
         self.setup_logfile_logger()
         verify_log(self.config)
-        self.action_log_info('Setting up "{0}"'.format(self.config["id"]))
+        self.action_log_info('Setting up "{}"'.format(self.config["id"]))
 
         # Late import so logging works correctly
         import salt.minion
@@ -614,7 +611,7 @@ class Syndic(
 
         NOTE: Run any required code before calling `super()`.
         """
-        super(Syndic, self).start()
+        super().start()
         if check_user(self.config["user"]):
             self.action_log_info("Starting up")
             self.verify_hash_type()
@@ -632,10 +629,10 @@ class Syndic(
         :param exitmsg
         """
         self.action_log_info("Shutting down")
-        super(Syndic, self).shutdown(
+        super().shutdown(
             exitcode,
             (
-                "The Salt {0} is shutdown. {1}".format(
+                "The Salt {} is shutdown. {}".format(
                     self.__class__.__name__, (exitmsg or "")
                 ).strip()
             ),

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -46,7 +46,7 @@ import salt.utils.verify
 from salt.ext import six
 from salt.ext.six.moves import input  # pylint: disable=import-error,redefined-builtin
 from salt.template import compile_template
-from salt.utils.platform import is_windows
+from salt.utils.platform import is_junos, is_windows
 from salt.utils.process import Process
 from salt.utils.zeromq import zmq
 
@@ -190,13 +190,15 @@ EOF'''.format(
     ]
 )
 
-if not is_windows():
+if not is_windows() and not is_junos():
     shim_file = os.path.join(os.path.dirname(__file__), "ssh_py_shim.py")
     if not os.path.exists(shim_file):
         # On esky builds we only have the .pyc file
         shim_file += "c"
     with salt.utils.files.fopen(shim_file) as ssh_py_shim:
         SSH_PY_SHIM = ssh_py_shim.read()
+else:
+    SSH_PY_SHIM = None
 
 log = logging.getLogger(__name__)
 

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -17,6 +17,7 @@ import os
 import platform
 import re
 import socket
+import subprocess
 import sys
 import time
 import uuid
@@ -68,10 +69,11 @@ if salt.utils.platform.is_windows():
     # attempt to import the python wmi module
     # the Windows minion uses WMI for some of its grains
     try:
-        import wmi  # pylint: disable=import-error
-        import salt.utils.winapi
         import win32api
+        import wmi  # pylint: disable=import-error
+
         import salt.utils.win_reg
+        import salt.utils.winapi
 
         HAS_WMI = True
     except ImportError:
@@ -98,6 +100,24 @@ HAS_UNAME = hasattr(os, "uname")
 # Possible value for h_errno defined in netdb.h
 HOST_NOT_FOUND = 1
 NO_DATA = 4
+
+
+def _parse_junos_showver(txt):
+    showver = {}
+    for l in txt.splitlines():
+        decoded_line = l.decode("utf-8")
+        if decoded_line.startswith("Model"):
+            showver["model"] = decoded_line.split(" ")[1]
+        if decoded_line.startswith("Junos"):
+            showver["osrelease"] = decoded_line.split(" ")[1]
+            showver["osmajorrelease"] = decoded_line.split(".")[0]
+            showver["osrelease_info"] = decoded_line.split(".")
+        if decoded_line.startswith("JUNOS OS Kernel"):
+            showver["kernelversion"] = decoded_line
+            relno = re.search(r"\[(.*)\]", decoded_line)
+            if relno:
+                showver["kernelrelease"] = relno.group(1)
+    return showver
 
 
 def _windows_cpudata():
@@ -1511,6 +1531,7 @@ _OS_NAME_MAP = {
     "archarm": "Arch ARM",
     "arch": "Arch",
     "debian": "Debian",
+    "Junos": "Junos",
     "raspbian": "Raspbian",
     "fedoraremi": "Fedora",
     "chapeau": "Chapeau",
@@ -1757,7 +1778,18 @@ def os_data():
     ) = platform.uname()
     # pylint: enable=unpacking-non-sequence
 
-    if salt.utils.platform.is_proxy():
+    if salt.utils.platform.is_junos():
+        grains["kernel"] = "Junos"
+        grains["osfullname"] = "Junos"
+        grains["os"] = "Junos"
+        grains["os_family"] = "FreeBSD"
+        showver = _parse_junos_showver(
+            subprocess.run(
+                ["/usr/sbin/cli", "show", "version"], stdout=subprocess.PIPE, check=True
+            ).stdout
+        )
+        grains.update(showver)
+    elif salt.utils.platform.is_proxy():
         grains["kernel"] = "proxy"
         grains["kernelrelease"] = "proxy"
         grains["kernelversion"] = "proxy"

--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -918,7 +918,7 @@ def _iostat_aix(interval, count, disks):
     """
     AIX support to gather and return (averaged) IO stats.
     """
-    log.debug("DGM disk iostat entry")
+    log.debug("AIX disk iostat entry")
 
     if disks is None:
         iostat_cmd = "iostat -dD {} {} ".format(interval, count)

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -278,7 +278,7 @@ def facts_refresh():
     try:
         conn.facts_refresh()
     except Exception as exception:  # pylint: disable=broad-except
-        ret["message"] = "Execution failed due to '{}'".format(exception)
+        ret["message"] = 'Execution failed due to "{}"'.format(exception)
         ret["out"] = False
         _restart_connection()
         return ret
@@ -309,7 +309,7 @@ def facts():
         ret["facts"] = __proxy__["junos.get_serialized_facts"]()
         ret["out"] = True
     except Exception as exception:  # pylint: disable=broad-except
-        ret["message"] = "Could not display facts due to '{}'".format(exception)
+        ret["message"] = 'Could not display facts due to "{}"'.format(exception)
         ret["out"] = False
         _restart_connection()
 
@@ -395,7 +395,7 @@ def rpc(cmd=None, dest=None, **kwargs):
         try:
             reply = getattr(conn.rpc, cmd.replace("-", "_"))(filter_reply, options=op)
         except Exception as exception:  # pylint: disable=broad-except
-            ret["message"] = "RPC execution failed due to '{}'".format(exception)
+            ret["message"] = 'RPC execution failed due to "{}"'.format(exception)
             ret["out"] = False
             _restart_connection()
             return ret
@@ -409,7 +409,7 @@ def rpc(cmd=None, dest=None, **kwargs):
         try:
             reply = getattr(conn.rpc, cmd.replace("-", "_"))({"format": format_}, **op)
         except Exception as exception:  # pylint: disable=broad-except
-            ret["message"] = "RPC execution failed due to '{}'".format(exception)
+            ret["message"] = 'RPC execution failed due to "{}"'.format(exception)
             ret["out"] = False
             _restart_connection()
             return ret
@@ -480,7 +480,7 @@ def set_hostname(hostname=None, **kwargs):
     try:
         conn.cu.load(set_string, format="set")
     except Exception as exception:  # pylint: disable=broad-except
-        ret["message"] = "Could not load configuration due to error '{}'".format(
+        ret["message"] = 'Could not load configuration due to error "{}"'.format(
             exception
         )
         ret["out"] = False
@@ -490,7 +490,7 @@ def set_hostname(hostname=None, **kwargs):
     try:
         commit_ok = conn.cu.commit_check()
     except Exception as exception:  # pylint: disable=broad-except
-        ret["message"] = "Could not commit check due to error '{}'".format(exception)
+        ret["message"] = 'Could not commit check due to error "{}"'.format(exception)
         ret["out"] = False
         _restart_connection()
         return ret
@@ -504,7 +504,7 @@ def set_hostname(hostname=None, **kwargs):
             ret["out"] = False
             ret[
                 "message"
-            ] = "Successfully loaded host-name but commit failed with '{}'".format(
+            ] = 'Successfully loaded host-name but commit failed with "{}"'.format(
                 exception
             )
             _restart_connection()
@@ -518,7 +518,7 @@ def set_hostname(hostname=None, **kwargs):
             ret["out"] = False
             ret[
                 "message"
-            ] = "Successfully loaded host-name but rollback before exit failed '{}'".format(
+            ] = 'Successfully loaded host-name but rollback before exit failed "{}"'.format(
                 exception
             )
             _restart_connection()
@@ -583,7 +583,7 @@ def commit(**kwargs):
     try:
         commit_ok = conn.cu.commit_check()
     except Exception as exception:  # pylint: disable=broad-except
-        ret["message"] = "Could not perform commit check due to '{}'".format(exception)
+        ret["message"] = 'Could not perform commit check due to "{}"'.format(exception)
         ret["out"] = False
         _restart_connection()
         return ret
@@ -604,7 +604,7 @@ def commit(**kwargs):
             ret["out"] = False
             ret[
                 "message"
-            ] = "Commit check succeeded but actual commit failed with '{}'".format(
+            ] = 'Commit check succeeded but actual commit failed with "{}"'.format(
                 exception
             )
             _restart_connection()
@@ -617,7 +617,7 @@ def commit(**kwargs):
             ret["out"] = False
             ret[
                 "message"
-            ] = "Pre-commit check failed, and exception during rollback '{}'".format(
+            ] = 'Pre-commit check failed, and exception during rollback "{}"'.format(
                 exception
             )
             _restart_connection()
@@ -693,7 +693,7 @@ def rollback(**kwargs):
     try:
         ret["out"] = conn.cu.rollback(id_)
     except Exception as exception:  # pylint: disable=broad-except
-        ret["message"] = "Rollback failed due to '{}'".format(exception)
+        ret["message"] = 'Rollback failed due to "{}"'.format(exception)
         ret["out"] = False
         _restart_connection()
         return ret
@@ -718,7 +718,7 @@ def rollback(**kwargs):
     try:
         commit_ok = conn.cu.commit_check()
     except Exception as exception:  # pylint: disable=broad-except
-        ret["message"] = "Could not commit check due to '{}'".format(exception)
+        ret["message"] = 'Could not commit check due to "{}"'.format(exception)
         ret["out"] = False
         _restart_connection()
         return ret
@@ -731,7 +731,7 @@ def rollback(**kwargs):
             ret["out"] = False
             ret[
                 "message"
-            ] = "Rollback successful but commit failed with error '{}'".format(
+            ] = 'Rollback successful but commit failed with error "{}"'.format(
                 exception
             )
             _restart_connection()
@@ -789,7 +789,7 @@ def diff(**kwargs):
     try:
         ret["message"] = conn.cu.diff(rb_id=id_)
     except Exception as exception:  # pylint: disable=broad-except
-        ret["message"] = "Could not get diff with error '{}'".format(exception)
+        ret["message"] = 'Could not get diff with error "{}"'.format(exception)
         ret["out"] = False
         _restart_connection()
 
@@ -854,7 +854,7 @@ def ping(dest_ip=None, **kwargs):
     try:
         ret["message"] = jxmlease.parse(etree.tostring(conn.rpc.ping(**op)))
     except Exception as exception:  # pylint: disable=broad-except
-        ret["message"] = "Execution failed due to '{}'".format(exception)
+        ret["message"] = 'Execution failed due to "{}"'.format(exception)
         ret["out"] = False
         _restart_connection()
 
@@ -911,7 +911,7 @@ def cli(command=None, **kwargs):
     try:
         result = conn.cli(command, format_, warning=False)
     except Exception as exception:  # pylint: disable=broad-except
-        ret["message"] = "Execution failed due to '{}'".format(exception)
+        ret["message"] = 'Execution failed due to "{}"'.format(exception)
         ret["out"] = False
         _restart_connection()
         return ret
@@ -1004,7 +1004,7 @@ def shutdown(**kwargs):
         ret["message"] = "Successfully powered off/rebooted."
         ret["out"] = True
     except Exception as exception:  # pylint: disable=broad-except
-        ret["message"] = "Could not poweroff/reboot because '{}'".format(exception)
+        ret["message"] = 'Could not poweroff/reboot because "{}"'.format(exception)
         ret["out"] = False
         _restart_connection()
 
@@ -1174,7 +1174,7 @@ def install_config(path=None, **kwargs):
                 except Exception as exception:  # pylint: disable=broad-except
                     ret[
                         "message"
-                    ] = "Could not load configuration due to : '{}'".format(exception)
+                    ] = 'Could not load configuration due to : "{}"'.format(exception)
                     ret["format"] = op["format"]
                     ret["out"] = False
                     _restart_connection()
@@ -1206,7 +1206,7 @@ def install_config(path=None, **kwargs):
                     except Exception as exception:  # pylint: disable=broad-except
                         ret[
                             "message"
-                        ] = "Commit check threw the following exception: '{}'".format(
+                        ] = 'Commit check threw the following exception: "{}"'.format(
                             exception
                         )
                         ret["out"] = False
@@ -1220,7 +1220,7 @@ def install_config(path=None, **kwargs):
                     except Exception as exception:  # pylint: disable=broad-except
                         ret[
                             "message"
-                        ] = "Commit check successful but commit failed with '{}'".format(
+                        ] = 'Commit check successful but commit failed with "{}"'.format(
                             exception
                         )
                         ret["out"] = False
@@ -1236,7 +1236,7 @@ def install_config(path=None, **kwargs):
                     except Exception as exception:  # pylint: disable=broad-except
                         ret[
                             "message"
-                        ] = "Loaded configuration but commit check failed, and exception occurred during rolling back configuration '{}'".format(
+                        ] = 'Loaded configuration but commit check failed, and exception occurred during rolling back configuration "{}"'.format(
                             exception
                         )
                         _restart_connection()
@@ -1252,7 +1252,7 @@ def install_config(path=None, **kwargs):
                     except Exception as exception:  # pylint: disable=broad-except
                         ret[
                             "message"
-                        ] = "Commit check passed, but skipping commit for dry-run andi while rolling back configuration exception occurred '{}'".format(
+                        ] = 'Commit check passed, but skipping commit for dry-run andi while rolling back configuration exception occurred "{}"'.format(
                             exception
                         )
                         ret["out"] = False
@@ -1265,7 +1265,7 @@ def install_config(path=None, **kwargs):
                 except Exception as exception:  # pylint: disable=broad-except
                     ret[
                         "message"
-                    ] = "Could not write into diffs_file due to: '{}'".format(exception)
+                    ] = 'Could not write into diffs_file due to: "{}"'.format(exception)
                     ret["out"] = False
 
         except ValueError as ex:
@@ -1312,7 +1312,7 @@ def zeroize():
         conn.cli("request system zeroize")
         ret["message"] = "Completed zeroize and rebooted"
     except Exception as exception:  # pylint: disable=broad-except
-        ret["message"] = "Could not zeroize due to : '{}'".format(exception)
+        ret["message"] = 'Could not zeroize due to : "{}"'.format(exception)
         ret["out"] = False
         _restart_connection()
 
@@ -1429,7 +1429,7 @@ def install_os(path=None, **kwargs):
                 ret["out"] = False
                 __proxy__["junos.reboot_clear"]()
                 return ret
-            if not salt.utils.platform.is_proxy():
+            if salt.utils.platform.is_junos():
                 # If its native minion running on Junos, pyez dont need to SCP file
                 # hence setting no_copy as True, HandleFileCopy already copied file
                 # from master to Junos
@@ -1442,7 +1442,7 @@ def install_os(path=None, **kwargs):
                     image_path, progress=True, timeout=timeout, **op
                 )
             except Exception as exception:  # pylint: disable=broad-except
-                ret["message"] = "Installation failed due to: '{}'".format(exception)
+                ret["message"] = 'Installation failed due to: "{}"'.format(exception)
                 ret["out"] = False
                 __proxy__["junos.reboot_clear"]()
                 _restart_connection()
@@ -1453,7 +1453,7 @@ def install_os(path=None, **kwargs):
                 path, progress=True, timeout=timeout, **op
             )
         except Exception as exception:  # pylint: disable=broad-except
-            ret["message"] = "Installation failed due to: '{}'".format(exception)
+            ret["message"] = 'Installation failed due to: "{}"'.format(exception)
             ret["out"] = False
             __proxy__["junos.reboot_clear"]()
             _restart_connection()
@@ -1481,7 +1481,7 @@ def install_os(path=None, **kwargs):
             __proxy__["junos.reboot_clear"]()
             ret[
                 "message"
-            ] = "Installation successful but reboot failed due to : '{}'".format(
+            ] = 'Installation successful but reboot failed due to : "{}"'.format(
                 exception
             )
             ret["out"] = False
@@ -1516,7 +1516,7 @@ def file_copy(src=None, dest=None):
 
         salt 'device_name' junos.file_copy /home/m2/info.txt info_copy.txt
     """
-    if not salt.utils.platform.is_proxy():
+    if salt.utils.platform.is_junos():
         return {
             "success": False,
             "message": "This method is unsupported on the current operating system!",
@@ -1537,7 +1537,7 @@ def file_copy(src=None, dest=None):
                 scp.put(fp, dest)
             ret["message"] = "Successfully copied file from {} to {}".format(src, dest)
         except Exception as exception:  # pylint: disable=broad-except
-            ret["message"] = "Could not copy file : '{}'".format(exception)
+            ret["message"] = 'Could not copy file : "{}"'.format(exception)
             ret["out"] = False
 
         return ret
@@ -1569,12 +1569,12 @@ def lock():
         conn.cu.lock()
         ret["message"] = "Successfully locked the configuration."
     except RpcTimeoutError as exception:
-        ret["message"] = "Could not gain lock due to : '{}'".format(exception)
+        ret["message"] = 'Could not gain lock due to : "{}"'.format(exception)
         ret["out"] = False
         _restart_connection()
 
     except LockError as exception:
-        ret["message"] = "Could not gain lock due to : '{}'".format(exception)
+        ret["message"] = "Could not gain lock due to : \"{}'".format(exception)
         ret["out"] = False
 
     return ret
@@ -1599,14 +1599,14 @@ def unlock():
         conn.cu.unlock()
         ret["message"] = "Successfully unlocked the configuration."
     except RpcTimeoutError as exception:
-        ret["message"] = "Could not unlock configuration due to : '{}'".format(
+        ret["message"] = 'Could not unlock configuration due to : "{}"'.format(
             exception
         )
         ret["out"] = False
         _restart_connection()
 
     except UnlockError as exception:
-        ret["message"] = "Could not unlock configuration due to : '{}'".format(
+        ret["message"] = 'Could not unlock configuration due to : "{}"'.format(
             exception
         )
         ret["out"] = False
@@ -1751,7 +1751,7 @@ def load(path=None, **kwargs):
             conn.cu.load(**op)
             ret["message"] = "Successfully loaded the configuration."
         except Exception as exception:  # pylint: disable=broad-except
-            ret["message"] = "Could not load configuration due to : '{}'".format(
+            ret["message"] = 'Could not load configuration due to : "{}"'.format(
                 exception
             )
             ret["format"] = op["format"]
@@ -2103,7 +2103,7 @@ def file_compare(file1, file2, **kwargs):
         success:
             True
     """
-    if salt.utils.platform.is_proxy():
+    if not salt.utils.platform.is_junos():
         return {
             "success": False,
             "message": "This method is unsupported on the current operating system!",
@@ -2158,7 +2158,7 @@ def fsentry_exists(dir, **kwargs):
         exists:
             True
     """
-    if salt.utils.platform.is_proxy():
+    if not salt.utils.platform.is_junos():
         return {
             "success": False,
             "message": "This method is unsupported on the current operating system!",
@@ -2303,7 +2303,7 @@ def dir_copy(source, dest, force=False, **kwargs):
     contents to routing engine 1 root directory. The result will be
     `re1:/etc/salt/pki/<files and dirs in /etc/salt/pki`.
     """
-    if salt.utils.platform.is_proxy():
+    if not salt.utils.platform.is_junos():
         return {
             "success": False,
             "message": "This method is unsupported on the current operating system!",

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -699,7 +699,7 @@ def rollback(**kwargs):
         return ret
 
     if ret["out"]:
-        ret["message"] = "Rollback successful"
+        ret["message"] = "Rollback successfull"
     else:
         ret["message"] = "Rollback failed"
         return ret
@@ -1574,7 +1574,7 @@ def lock():
         _restart_connection()
 
     except LockError as exception:
-        ret["message"] = "Could not gain lock due to : \"{}'".format(exception)
+        ret["message"] = 'Could not gain lock due to : "{}"'.format(exception)
         ret["out"] = False
 
     return ret

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -14,18 +14,20 @@ Refer to :mod:`junos <salt.proxy.junos>` for information on connecting to junos 
 """
 
 # Import Python libraries
+
 import copy
 import json
 import logging
 import os
+import re
 import tempfile
-import traceback
 from functools import wraps
 
-# Import Salt libs
 import salt.utils.args
 import salt.utils.files
 import salt.utils.json
+import salt.utils.path
+import salt.utils.platform
 import salt.utils.stringutils
 import yaml
 
@@ -39,19 +41,24 @@ except ImportError:
 # https://github.com/Juniper/py-junos-eznc
 try:
     # pylint: disable=W0611
-    from jnpr.junos import Device
-    from jnpr.junos.utils.config import Config
-    from jnpr.junos.utils.sw import SW
-    from jnpr.junos.utils.scp import SCP
-    import jnpr.junos.utils
     import jnpr.junos.cfg
-    import jxmlease
-    from jnpr.junos.factory.optable import OpTable
-    from jnpr.junos.factory.cfgtable import CfgTable
     import jnpr.junos.op as tables_dir
-    from jnpr.junos.factory.factory_loader import FactoryLoader
+    import jnpr.junos.utils
+    import jxmlease
     import yamlordereddictloader
-    from jnpr.junos.exception import ConnectClosedError, LockError
+    from jnpr.junos import Device
+    from jnpr.junos.exception import (
+        ConnectClosedError,
+        LockError,
+        RpcTimeoutError,
+        UnlockError,
+    )
+    from jnpr.junos.factory.cfgtable import CfgTable
+    from jnpr.junos.factory.factory_loader import FactoryLoader
+    from jnpr.junos.factory.optable import OpTable
+    from jnpr.junos.utils.config import Config
+    from jnpr.junos.utils.scp import SCP
+    from jnpr.junos.utils.sw import SW
 
     # pylint: enable=W0611
     HAS_JUNOS = True
@@ -89,7 +96,6 @@ class HandleFileCopy:
     To figure out proper path either from proxy local file system
     or proxy cache or on master. If required, then only copy from
     master to proxy
-
     """
 
     def __init__(self, path, **kwargs):
@@ -138,7 +144,7 @@ class HandleFileCopy:
             if self._cached_file != "":
                 return self._cached_file
         else:
-            # check for local location of the file
+            # check for local location of file
             if __salt__["file.file_exists"](self._file_path):
                 if self._kwargs:
                     self._cached_file = salt.utils.files.mkstemp()
@@ -165,10 +171,12 @@ class HandleFileCopy:
 def timeoutDecorator(function):
     @wraps(function)
     def wrapper(*args, **kwargs):
-        if "dev_timeout" in kwargs:
+        if "dev_timeout" in kwargs or "timeout" in kwargs:
+            dev_timeout = max(kwargs.pop("dev_timeout", 0), kwargs.pop("timeout", 0))
             conn = __proxy__["junos.conn"]()
             restore_timeout = conn.timeout
-            conn.timeout = kwargs.pop("dev_timeout", None)
+            kwargs["dev_timeout"] = dev_timeout
+            conn.timeout = dev_timeout
             try:
                 result = function(*args, **kwargs)
                 conn.timeout = restore_timeout
@@ -182,6 +190,76 @@ def timeoutDecorator(function):
     return wrapper
 
 
+def timeoutDecorator_cleankwargs(function):
+    @wraps(function)
+    def wrapper(*args, **kwargs):
+        if "dev_timeout" in kwargs or "timeout" in kwargs:
+            dev_timeout = max(kwargs.pop("dev_timeout", 0), kwargs.pop("timeout", 0))
+            conn = __proxy__["junos.conn"]()
+            restore_timeout = conn.timeout
+            kwargs["dev_timeout"] = dev_timeout
+            conn.timeout = dev_timeout
+            try:
+                restore_kwargs = False
+                del_list = []
+                op = {}
+                op.update(kwargs)
+                for keychk in kwargs:
+                    if keychk.startswith("__pub"):
+                        del_list.append(keychk)
+                if del_list:
+                    restore_kwargs = True
+                    for delkey in del_list:
+                        kwargs.pop(delkey)
+
+                result = function(*args, **kwargs)
+                if restore_kwargs:
+                    kwargs.update(op)
+
+                conn.timeout = restore_timeout
+                return result
+            except Exception:  # pylint: disable=broad-except
+                conn.timeout = restore_timeout
+                raise
+        else:
+            restore_kwargs = False
+            del_list = []
+            op = {}
+            op.update(kwargs)
+            for keychk in kwargs:
+                if keychk.startswith("__pub"):
+                    del_list.append(keychk)
+            if del_list:
+                restore_kwargs = True
+                for delkey in del_list:
+                    kwargs.pop(delkey)
+
+            ret = function(*args, **kwargs)
+            if restore_kwargs:
+                kwargs.update(op)
+
+            return ret
+
+    return wrapper
+
+
+def _restart_connection():
+    minion_id = __opts__.get("proxyid", "") or __opts__.get("id", "")
+    log.info(
+        "Junos exception occurred {} (junos proxy) is down. Restarting.".format(
+            minion_id
+        )
+    )
+    __salt__["event.fire_master"](
+        {}, "junos/proxy/{}/stop".format(__opts__["proxy"]["host"])
+    )
+    __proxy__["junos.shutdown"](__opts__)  # safely close connection
+    __proxy__["junos.init"](__opts__)  # reopen connection
+    log.debug("Junos exception occurred, restarted {} (junos proxy)!".format(minion_id))
+
+
+## @timeoutDecorator
+@timeoutDecorator_cleankwargs
 def facts_refresh():
     """
     Reload the facts dictionary from the device. Usually only needed if,
@@ -200,8 +278,9 @@ def facts_refresh():
     try:
         conn.facts_refresh()
     except Exception as exception:  # pylint: disable=broad-except
-        ret["message"] = 'Execution failed due to "{}"'.format(exception)
+        ret["message"] = "Execution failed due to '{}'".format(exception)
         ret["out"] = False
+        _restart_connection()
         return ret
 
     ret["facts"] = __proxy__["junos.get_serialized_facts"]()
@@ -210,6 +289,7 @@ def facts_refresh():
         __salt__["saltutil.sync_grains"]()
     except Exception as exception:  # pylint: disable=broad-except
         log.error('Grains could not be updated due to "%s"', exception)
+
     return ret
 
 
@@ -229,8 +309,10 @@ def facts():
         ret["facts"] = __proxy__["junos.get_serialized_facts"]()
         ret["out"] = True
     except Exception as exception:  # pylint: disable=broad-except
-        ret["message"] = 'Could not display facts due to "{}"'.format(exception)
+        ret["message"] = "Could not display facts due to '{}'".format(exception)
         ret["out"] = False
+        _restart_connection()
+
     return ret
 
 
@@ -313,17 +395,23 @@ def rpc(cmd=None, dest=None, **kwargs):
         try:
             reply = getattr(conn.rpc, cmd.replace("-", "_"))(filter_reply, options=op)
         except Exception as exception:  # pylint: disable=broad-except
-            ret["message"] = 'RPC execution failed due to "{}"'.format(exception)
+            ret["message"] = "RPC execution failed due to '{}'".format(exception)
             ret["out"] = False
+            _restart_connection()
             return ret
     else:
         if "filter" in op:
             log.warning('Filter ignored as it is only used with "get-config" rpc')
+
+        if "dest" in op:
+            log.warning("dest in op, rpc may reject this for cmd {}".format(cmd))
+
         try:
             reply = getattr(conn.rpc, cmd.replace("-", "_"))({"format": format_}, **op)
         except Exception as exception:  # pylint: disable=broad-except
-            ret["message"] = 'RPC execution failed due to "{}"'.format(exception)
+            ret["message"] = "RPC execution failed due to '{}'".format(exception)
             ret["out"] = False
+            _restart_connection()
             return ret
 
     if format_ == "text":
@@ -342,6 +430,7 @@ def rpc(cmd=None, dest=None, **kwargs):
             write_response = etree.tostring(reply)
         with salt.utils.files.fopen(dest, "w") as fp:
             fp.write(salt.utils.stringutils.to_str(write_response))
+
     return ret
 
 
@@ -391,17 +480,19 @@ def set_hostname(hostname=None, **kwargs):
     try:
         conn.cu.load(set_string, format="set")
     except Exception as exception:  # pylint: disable=broad-except
-        ret["message"] = 'Could not load configuration due to error "{}"'.format(
+        ret["message"] = "Could not load configuration due to error '{}'".format(
             exception
         )
         ret["out"] = False
+        _restart_connection()
         return ret
 
     try:
         commit_ok = conn.cu.commit_check()
     except Exception as exception:  # pylint: disable=broad-except
-        ret["message"] = 'Could not commit check due to error "{}"'.format(exception)
+        ret["message"] = "Could not commit check due to error '{}'".format(exception)
         ret["out"] = False
+        _restart_connection()
         return ret
 
     if commit_ok:
@@ -413,14 +504,24 @@ def set_hostname(hostname=None, **kwargs):
             ret["out"] = False
             ret[
                 "message"
-            ] = 'Successfully loaded host-name but commit failed with "{}"'.format(
+            ] = "Successfully loaded host-name but commit failed with '{}'".format(
                 exception
             )
+            _restart_connection()
             return ret
     else:
         ret["out"] = False
         ret["message"] = "Successfully loaded host-name but pre-commit check failed."
-        conn.cu.rollback()
+        try:
+            conn.cu.rollback()
+        except Exception as exception:  # pylint: disable=broad-except
+            ret["out"] = False
+            ret[
+                "message"
+            ] = "Successfully loaded host-name but rollback before exit failed '{}'".format(
+                exception
+            )
+            _restart_connection()
 
     return ret
 
@@ -482,8 +583,9 @@ def commit(**kwargs):
     try:
         commit_ok = conn.cu.commit_check()
     except Exception as exception:  # pylint: disable=broad-except
-        ret["message"] = 'Could not perform commit check due to "{}"'.format(exception)
+        ret["message"] = "Could not perform commit check due to '{}'".format(exception)
         ret["out"] = False
+        _restart_connection()
         return ret
 
     if commit_ok:
@@ -502,13 +604,23 @@ def commit(**kwargs):
             ret["out"] = False
             ret[
                 "message"
-            ] = 'Commit check succeeded but actual commit failed with "{}"'.format(
+            ] = "Commit check succeeded but actual commit failed with '{}'".format(
                 exception
             )
+            _restart_connection()
     else:
         ret["out"] = False
         ret["message"] = "Pre-commit check failed."
-        conn.cu.rollback()
+        try:
+            conn.cu.rollback()
+        except Exception as exception:  # pylint: disable=broad-except
+            ret["out"] = False
+            ret[
+                "message"
+            ] = "Pre-commit check failed, and exception during rollback '{}'".format(
+                exception
+            )
+            _restart_connection()
 
     return ret
 
@@ -519,6 +631,9 @@ def rollback(**kwargs):
     Roll back the last committed configuration changes and commit
 
     id : 0
+        The rollback ID value (0-49)
+
+    d_id : 0
         The rollback ID value (0-49)
 
     dev_timeout : 30
@@ -542,9 +657,27 @@ def rollback(**kwargs):
 
     .. code-block:: bash
 
-        salt 'device_name' junos.rollback id=10
+        salt 'device_name' junos.rollback 10
+
+    NOTE: Because of historical reasons and the internals of the Salt state
+    compiler, there are three possible sources of the rollback ID--the
+    positional argument, and the `id` and `d_id` kwargs.  The precedence of
+    the arguments are `id` (positional), `id` (kwarg), `d_id` (kwarg).  In
+    other words, if all three are passed, only the positional argument
+    will be used.  A warning is logged if more than one is passed.
     """
-    id_ = kwargs.pop("id", 0)
+    ids_passed = 0
+    id_ = 0
+    if "d_id" in kwargs:
+        id_ = kwargs.pop("d_id")
+        ids_passed = ids_passed + 1
+    if "id" in kwargs:
+        id_ = kwargs.pop("id", 0)
+        ids_passed = ids_passed + 1
+
+    if ids_passed > 1:
+        log.warning("junos.rollback called with more than one possible ID.")
+        log.warning("Use only one of the positional argument, `id`, or `d_id` kwargs")
 
     ret = {}
     conn = __proxy__["junos.conn"]()
@@ -560,8 +693,9 @@ def rollback(**kwargs):
     try:
         ret["out"] = conn.cu.rollback(id_)
     except Exception as exception:  # pylint: disable=broad-except
-        ret["message"] = 'Rollback failed due to "{}"'.format(exception)
+        ret["message"] = "Rollback failed due to '{}'".format(exception)
         ret["out"] = False
+        _restart_connection()
         return ret
 
     if ret["out"]:
@@ -584,8 +718,9 @@ def rollback(**kwargs):
     try:
         commit_ok = conn.cu.commit_check()
     except Exception as exception:  # pylint: disable=broad-except
-        ret["message"] = 'Could not commit check due to "{}"'.format(exception)
+        ret["message"] = "Could not commit check due to '{}'".format(exception)
         ret["out"] = False
+        _restart_connection()
         return ret
 
     if commit_ok:
@@ -596,16 +731,19 @@ def rollback(**kwargs):
             ret["out"] = False
             ret[
                 "message"
-            ] = 'Rollback successful but commit failed with error "{}"'.format(
+            ] = "Rollback successful but commit failed with error '{}'".format(
                 exception
             )
+            _restart_connection()
             return ret
     else:
-        ret["message"] = "Rollback successful but pre-commit check failed."
+        ret["message"] = "Rollback succesfull but pre-commit check failed."
         ret["out"] = False
+
     return ret
 
 
+@timeoutDecorator
 def diff(**kwargs):
     """
     Returns the difference between the candidate and the current configuration
@@ -613,14 +751,35 @@ def diff(**kwargs):
     id : 0
         The rollback ID value (0-49)
 
+    d_id : 0
+        The rollback ID value (0-49)
+
     CLI Example:
 
     .. code-block:: bash
 
-        salt 'device_name' junos.diff id=3
+        salt 'device_name' junos.diff d_id=3
+
+    NOTE: Because of historical reasons and the internals of the Salt state
+    compiler, there are three possible sources of the rollback ID--the
+    positional argument, and the `id` and `d_id` kwargs.  The precedence of
+    the arguments are `id` (positional), `id` (kwarg), `d_id` (kwarg).  In
+    other words, if all three are passed, only the positional argument
+    will be used.  A warning is logged if more than one is passed.
     """
     kwargs = salt.utils.args.clean_kwargs(**kwargs)
-    id_ = kwargs.pop("id", 0)
+    ids_passed = 0
+    id_ = 0
+    if "d_id" in kwargs:
+        id_ = kwargs.pop("d_id")
+        ids_passed = ids_passed + 1
+    if "id" in kwargs:
+        id_ = kwargs.pop("id", 0)
+        ids_passed = ids_passed + 1
+    if ids_passed > 1:
+        log.warning("junos.rollback called with more than one possible ID.")
+        log.warning("Use only one of the positional argument, `id`, or `d_id` kwargs")
+
     if kwargs:
         salt.utils.args.invalid_kwargs(kwargs)
 
@@ -630,8 +789,9 @@ def diff(**kwargs):
     try:
         ret["message"] = conn.cu.diff(rb_id=id_)
     except Exception as exception:  # pylint: disable=broad-except
-        ret["message"] = 'Could not get diff with error "{}"'.format(exception)
+        ret["message"] = "Could not get diff with error '{}'".format(exception)
         ret["out"] = False
+        _restart_connection()
 
     return ret
 
@@ -694,8 +854,10 @@ def ping(dest_ip=None, **kwargs):
     try:
         ret["message"] = jxmlease.parse(etree.tostring(conn.rpc.ping(**op)))
     except Exception as exception:  # pylint: disable=broad-except
-        ret["message"] = 'Execution failed due to "{}"'.format(exception)
+        ret["message"] = "Execution failed due to '{}'".format(exception)
         ret["out"] = False
+        _restart_connection()
+
     return ret
 
 
@@ -749,8 +911,9 @@ def cli(command=None, **kwargs):
     try:
         result = conn.cli(command, format_, warning=False)
     except Exception as exception:  # pylint: disable=broad-except
-        ret["message"] = 'Execution failed due to "{}"'.format(exception)
+        ret["message"] = "Execution failed due to '{}'".format(exception)
         ret["out"] = False
+        _restart_connection()
         return ret
 
     if format_ == "text":
@@ -772,6 +935,7 @@ def cli(command=None, **kwargs):
     return ret
 
 
+@timeoutDecorator
 def shutdown(**kwargs):
     """
     Shut down (power off) or reboot a device running Junos OS. This includes
@@ -840,8 +1004,10 @@ def shutdown(**kwargs):
         ret["message"] = "Successfully powered off/rebooted."
         ret["out"] = True
     except Exception as exception:  # pylint: disable=broad-except
-        ret["message"] = 'Could not poweroff/reboot beacause "{}"'.format(exception)
+        ret["message"] = "Could not poweroff/reboot because '{}'".format(exception)
         ret["out"] = False
+        _restart_connection()
+
     return ret
 
 
@@ -872,6 +1038,11 @@ def install_config(path=None, **kwargs):
 
         .. note:: This option cannot be used if **format** is "set".
 
+    replace : False
+        Specify whether the configuration file uses ``replace:`` statements. If
+        ``True``, only those statements under the ``replace`` tag will be
+        changed.
+
     merge : False
         If set to ``True`` will set the load-config action to merge.
         the default load-config action is 'replace' for xml/json/text config
@@ -899,10 +1070,9 @@ def install_config(path=None, **kwargs):
     diffs_file
       Path to the file where the diff (difference in old configuration and the
       committed configuration) will be stored. Note that the file will be
-      stored on the proxy minion. To push the files to the master
+      stored on the proxy minion. To push the files to the master use:
 
-      use
-      :py:func:`cp.push <salt.modules.cp.push>`.
+        py:func:`cp.push <salt.modules.cp.push>`.
 
     template_vars
       Variables to be passed into the template processing engine in addition to
@@ -1004,9 +1174,10 @@ def install_config(path=None, **kwargs):
                 except Exception as exception:  # pylint: disable=broad-except
                     ret[
                         "message"
-                    ] = 'Could not load configuration due to : "{}"'.format(exception)
+                    ] = "Could not load configuration due to : '{}'".format(exception)
                     ret["format"] = op["format"]
                     ret["out"] = False
+                    _restart_connection()
                     return ret
 
                 config_diff = None
@@ -1035,10 +1206,11 @@ def install_config(path=None, **kwargs):
                     except Exception as exception:  # pylint: disable=broad-except
                         ret[
                             "message"
-                        ] = 'Commit check threw the following exception: "{}"'.format(
+                        ] = "Commit check threw the following exception: '{}'".format(
                             exception
                         )
                         ret["out"] = False
+                        _restart_connection()
                         return ret
 
                 if check and not test:
@@ -1048,23 +1220,44 @@ def install_config(path=None, **kwargs):
                     except Exception as exception:  # pylint: disable=broad-except
                         ret[
                             "message"
-                        ] = 'Commit check successful but commit failed with "{}"'.format(
+                        ] = "Commit check successful but commit failed with '{}'".format(
                             exception
                         )
                         ret["out"] = False
+                        _restart_connection()
                         return ret
+
                 elif not check:
-                    cu.rollback()
-                    ret[
-                        "message"
-                    ] = "Loaded configuration but commit check failed, hence rolling back configuration."
+                    try:
+                        cu.rollback()
+                        ret[
+                            "message"
+                        ] = "Loaded configuration but commit check failed, hence rolling back configuration."
+                    except Exception as exception:  # pylint: disable=broad-except
+                        ret[
+                            "message"
+                        ] = "Loaded configuration but commit check failed, and exception occurred during rolling back configuration '{}'".format(
+                            exception
+                        )
+                        _restart_connection()
+
                     ret["out"] = False
                 else:
-                    cu.rollback()
-                    ret[
-                        "message"
-                    ] = "Commit check passed, but skipping commit for dry-run and rolling back configuration."
-                    ret["out"] = True
+                    try:
+                        cu.rollback()
+                        ret[
+                            "message"
+                        ] = "Commit check passed, but skipping commit for dry-run and rolling back configuration."
+                        ret["out"] = True
+                    except Exception as exception:  # pylint: disable=broad-except
+                        ret[
+                            "message"
+                        ] = "Commit check passed, but skipping commit for dry-run andi while rolling back configuration exception occurred '{}'".format(
+                            exception
+                        )
+                        ret["out"] = False
+                        _restart_connection()
+
                 try:
                     if write_diff and config_diff is not None:
                         with salt.utils.files.fopen(write_diff, "w") as fp:
@@ -1072,8 +1265,9 @@ def install_config(path=None, **kwargs):
                 except Exception as exception:  # pylint: disable=broad-except
                     ret[
                         "message"
-                    ] = 'Could not write into diffs_file due to: "{}"'.format(exception)
+                    ] = "Could not write into diffs_file due to: '{}'".format(exception)
                     ret["out"] = False
+
         except ValueError as ex:
             message = "install_config failed due to: {}".format(str(ex))
             log.error(message)
@@ -1083,10 +1277,17 @@ def install_config(path=None, **kwargs):
             log.error("Configuration database is locked")
             ret["message"] = ex.message
             ret["out"] = False
+        except RpcTimeoutError as ex:
+            message = "install_config failed due to timeout error : {}".format(str(ex))
+            log.error(message)
+            ret["message"] = message
+            ret["out"] = False
 
         return ret
 
 
+## @timeoutDecorator
+@timeoutDecorator_cleankwargs
 def zeroize():
     """
     Resets the device to default factory settings
@@ -1111,8 +1312,9 @@ def zeroize():
         conn.cli("request system zeroize")
         ret["message"] = "Completed zeroize and rebooted"
     except Exception as exception:  # pylint: disable=broad-except
-        ret["message"] = 'Could not zeroize due to : "{}"'.format(exception)
+        ret["message"] = "Could not zeroize due to : '{}'".format(exception)
         ret["out"] = False
+        _restart_connection()
 
     return ret
 
@@ -1169,11 +1371,11 @@ def install_os(path=None, **kwargs):
         When True (default), executes the software install on all Routing Engines of the Junos
         device. When False, execute the software install only on the current Routing Engine.
 
-        .. versionadded:: 3001
+        .. versionadded:: Sodium
 
     .. note::
         Any additional keyword arguments specified are passed down to PyEZ sw.install() as is.
-        Please refer to below URl for PyEZ sw.install() documentation:
+        Please refer to below URl for PyEZ sw.install() documentaion:
         https://pyez.readthedocs.io/en/latest/jnpr.junos.utils.html#jnpr.junos.utils.sw.SW.install
 
     CLI Examples:
@@ -1200,6 +1402,7 @@ def install_os(path=None, **kwargs):
     # For info: https://github.com/Juniper/salt/issues/116
     dev_timeout = max(op.pop("dev_timeout", 0), op.pop("timeout", 0))
     timeout = max(1800, conn.timeout, dev_timeout)
+
     # Reboot should not be passed as a keyword argument to install(),
     # Please refer to https://github.com/Juniper/salt/issues/115 for more details
     reboot = op.pop("reboot", False)
@@ -1212,34 +1415,56 @@ def install_os(path=None, **kwargs):
         ret["out"] = False
         return ret
 
+    if reboot:
+        #  flag reboot active, disables proxy_reconnect since it's probing
+        # of connection interferes with the reboot, especially with a
+        # package install (time taken to xfer package and install)
+        __proxy__["junos.reboot_active"]()
+
     install_status = False
     if not no_copy_:
         with HandleFileCopy(path) as image_path:
             if image_path is None:
                 ret["message"] = "Invalid path. Please provide a valid image path"
                 ret["out"] = False
+                __proxy__["junos.reboot_clear"]()
                 return ret
+            if not salt.utils.platform.is_proxy():
+                # If its native minion running on Junos, pyez dont need to SCP file
+                # hence setting no_copy as True, HandleFileCopy already copied file
+                # from master to Junos
+                tmp_absfile = image_path
+                op["no_copy"] = True
+                op["remote_path"] = os.path.dirname(tmp_absfile)
+                image_path = os.path.basename(tmp_absfile)
             try:
-                install_status = conn.sw.install(
+                install_status, install_message = conn.sw.install(
                     image_path, progress=True, timeout=timeout, **op
                 )
             except Exception as exception:  # pylint: disable=broad-except
-                ret["message"] = 'Installation failed due to: "{}"'.format(exception)
+                ret["message"] = "Installation failed due to: '{}'".format(exception)
                 ret["out"] = False
+                __proxy__["junos.reboot_clear"]()
+                _restart_connection()
                 return ret
     else:
         try:
-            install_status = conn.sw.install(path, progress=True, timeout=timeout, **op)
+            install_status, install_message = conn.sw.install(
+                path, progress=True, timeout=timeout, **op
+            )
         except Exception as exception:  # pylint: disable=broad-except
-            ret["message"] = 'Installation failed due to: "{}"'.format(exception)
+            ret["message"] = "Installation failed due to: '{}'".format(exception)
             ret["out"] = False
+            __proxy__["junos.reboot_clear"]()
+            _restart_connection()
             return ret
 
     if install_status is True:
         ret["message"] = "Installed the os."
     else:
-        ret["message"] = "Installation failed."
+        ret["message"] = "Installation failed. Reason: {}".format(install_message)
         ret["out"] = False
+        __proxy__["junos.reboot_clear"]()
         return ret
 
     # Handle reboot, after the install has finished
@@ -1250,21 +1475,31 @@ def install_os(path=None, **kwargs):
         if "all_re" in op:
             reboot_kwargs["all_re"] = op.get("all_re")
         try:
+            __proxy__["junos.reboot_active"]()
             conn.sw.reboot(**reboot_kwargs)
         except Exception as exception:  # pylint: disable=broad-except
+            __proxy__["junos.reboot_clear"]()
             ret[
                 "message"
-            ] = 'Installation successful but reboot failed due to : "{}"'.format(
+            ] = "Installation successful but reboot failed due to : '{}'".format(
                 exception
             )
             ret["out"] = False
+            _restart_connection()
             return ret
+
+        __proxy__["junos.reboot_clear"]()
         ret["message"] = "Successfully installed and rebooted!"
+
     return ret
 
 
-def file_copy(src, dest):
+## @timeoutDecorator
+@timeoutDecorator_cleankwargs
+def file_copy(src=None, dest=None):
     """
+    NOTE This function does not work on Juniper native minions
+
     Copies the file from the local device to the junos device
 
     src
@@ -1279,6 +1514,12 @@ def file_copy(src, dest):
 
         salt 'device_name' junos.file_copy /home/m2/info.txt info_copy.txt
     """
+    if not salt.utils.platform.is_proxy():
+        return {
+            "success": False,
+            "message": "This method is unsupported on the current operating system!",
+        }
+
     conn = __proxy__["junos.conn"]()
     ret = {}
     ret["out"] = True
@@ -1294,11 +1535,14 @@ def file_copy(src, dest):
                 scp.put(fp, dest)
             ret["message"] = "Successfully copied file from {} to {}".format(src, dest)
         except Exception as exception:  # pylint: disable=broad-except
-            ret["message"] = 'Could not copy file : "{}"'.format(exception)
+            ret["message"] = "Could not copy file : '{}'".format(exception)
             ret["out"] = False
+
         return ret
 
 
+## @timeoutDecorator
+@timeoutDecorator_cleankwargs
 def lock():
     """
     Attempts an exclusive lock on the candidate configuration. This
@@ -1322,13 +1566,20 @@ def lock():
     try:
         conn.cu.lock()
         ret["message"] = "Successfully locked the configuration."
-    except jnpr.junos.exception.LockError as exception:
-        ret["message"] = 'Could not gain lock due to : "{}"'.format(exception)
+    except RpcTimeoutError as exception:
+        ret["message"] = "Could not gain lock due to : '{}'".format(exception)
+        ret["out"] = False
+        _restart_connection()
+
+    except LockError as exception:
+        ret["message"] = "Could not gain lock due to : '{}'".format(exception)
         ret["out"] = False
 
     return ret
 
 
+## @timeoutDecorator
+@timeoutDecorator_cleankwargs
 def unlock():
     """
     Unlocks the candidate configuration.
@@ -1345,8 +1596,15 @@ def unlock():
     try:
         conn.cu.unlock()
         ret["message"] = "Successfully unlocked the configuration."
-    except jnpr.junos.exception.UnlockError as exception:
-        ret["message"] = 'Could not unlock configuration due to : "{}"'.format(
+    except RpcTimeoutError as exception:
+        ret["message"] = "Could not unlock configuration due to : '{}'".format(
+            exception
+        )
+        ret["out"] = False
+        _restart_connection()
+
+    except UnlockError as exception:
+        ret["message"] = "Could not unlock configuration due to : '{}'".format(
             exception
         )
         ret["out"] = False
@@ -1354,6 +1612,7 @@ def unlock():
     return ret
 
 
+@timeoutDecorator
 def load(path=None, **kwargs):
     """
     Loads the configuration from the file provided onto the device.
@@ -1370,6 +1629,11 @@ def load(path=None, **kwargs):
         configuration file. Sets action to override
 
         .. note:: This option cannot be used if **format** is "set".
+
+    replace : False
+        Specify whether the configuration file uses ``replace:`` statements. If
+        ``True``, only those statements under the ``replace`` tag will be
+        changed.
 
     merge : False
         If set to ``True`` will set the load-config action to merge.
@@ -1485,16 +1749,19 @@ def load(path=None, **kwargs):
             conn.cu.load(**op)
             ret["message"] = "Successfully loaded the configuration."
         except Exception as exception:  # pylint: disable=broad-except
-            ret["message"] = 'Could not load configuration due to : "{}"'.format(
+            ret["message"] = "Could not load configuration due to : '{}'".format(
                 exception
             )
             ret["format"] = op["format"]
             ret["out"] = False
+            _restart_connection()
             return ret
 
         return ret
 
 
+## @timeoutDecorator
+@timeoutDecorator_cleankwargs
 def commit_check():
     """
     Perform a commit check on the configuration
@@ -1514,10 +1781,13 @@ def commit_check():
     except Exception as exception:  # pylint: disable=broad-except
         ret["message"] = "Commit check failed with {}".format(exception)
         ret["out"] = False
+        _restart_connection()
 
     return ret
 
 
+## @timeoutDecorator
+@timeoutDecorator_cleankwargs
 def get_table(
     table,
     table_file,
@@ -1529,7 +1799,7 @@ def get_table(
     table_args=None,
 ):
     """
-    .. versionadded:: 3001
+    .. versionadded:: Sodium
 
     Retrieve data from a Junos device using Tables/Views
 
@@ -1630,6 +1900,7 @@ def get_table(
                     conn
                 )
                 ret["out"] = False
+                _restart_connection()
                 return ret
             ret["reply"] = json.loads(data.to_json())
             if data.__class__.__bases__[0] in [OpTable, CfgTable]:
@@ -1661,10 +1932,435 @@ def get_table(
             "with {}".format(str(conn))
         )
         ret["out"] = False
+        _restart_connection()
         return ret
     except Exception as err:  # pylint: disable=broad-except
         ret["message"] = "Uncaught exception - please report: {}".format(str(err))
-        traceback.print_exc()
+        ##        traceback.print_exc()
         ret["out"] = False
+        _restart_connection()
         return ret
     return ret
+
+
+def _recursive_dict(node):
+    """
+    Convert an lxml.etree node tree into a dict.
+    """
+    result = {}
+
+    for element in node.iterchildren():
+        # Remove namespace prefix
+        key = element.tag.split("}")[1] if "}" in element.tag else element.tag
+
+        # Process element as tree element if the inner XML contains non-whitespace content
+        if element.text and element.text.strip():
+            value = element.text
+        else:
+            value = _recursive_dict(element)
+        if key in result:
+
+            if type(result[key]) is list:
+                result[key].append(value)
+            else:
+                tempvalue = result[key].copy()
+                result[key] = [tempvalue, value]
+        else:
+            result[key] = value
+    return result
+
+
+@timeoutDecorator
+def rpc_file_list(path, **kwargs):
+    """
+    Use the Junos RPC interface to get a list of files and return
+    them as a structure dictionary.
+
+    CLI Example :
+
+        salt junos-router junos.rpc_file_list /var/local/salt/etc
+
+        junos-router:
+        ----------
+        files:
+            ----------
+            directory:
+                ----------
+                directory-name:
+
+                    /var/local/salt/etc
+                file-information:
+                    |_
+                      ----------
+                      file-directory:
+                          ----------
+                      file-name:
+
+                          pki
+                    |_
+                      ----------
+                      file-name:
+
+                          proxy
+                    |_
+                      ----------
+                      file-directory:
+                          ----------
+                      file-name:
+
+                          proxy.d
+                total-file-blocks:
+
+                    10
+                total-files:
+
+                    1
+        success:
+            True
+    """
+    kwargs = salt.utils.args.clean_kwargs(**kwargs)
+    conn = __proxy__["junos.conn"]()
+    if conn._conn is None:
+        return False
+
+    results = conn.rpc.file_list(path=path)
+
+    ret = {}
+    ret["files"] = _recursive_dict(results)
+    ret["success"] = True
+
+    return ret
+
+
+def _strip_newlines(str):
+    stripped = str.replace("\n", "")
+    return stripped
+
+
+def _make_source_list(dir):
+
+    dir_list = []
+    if not dir:
+        return
+    base = rpc_file_list(dir)["files"]["directory"]
+
+    # No files in this directory
+    if "file-information" not in base:
+        if "directory_name" not in base:
+            return None
+        return [os.path.join(_strip_newlines(base.get("directory-name", None))) + "/"]
+
+    if isinstance(base["file-information"], dict):
+        dirname = os.path.join(
+            dir, _strip_newlines(base["file-information"]["file-name"])
+        )
+        if "file-directory" in base["file-information"]:
+            new_list = _make_source_list(os.path.join(dir, dirname))
+            return new_list
+        else:
+            return [dirname]
+    for entry in base["file-information"]:
+        if "file-directory" in entry:
+            new_list = _make_source_list(
+                os.path.join(dir, _strip_newlines(entry["file-name"]))
+            )
+            if new_list:
+                dir_list.extend(new_list)
+        else:
+            dir_list.append(os.path.join(dir, _strip_newlines(entry["file-name"])))
+
+    return dir_list
+
+
+@timeoutDecorator
+def file_compare(file1, file2, **kwargs):
+    """
+    NOTE This function only works on Juniper native minions
+
+    Compare two files and return a dictionary indicating if they
+    are different.
+
+    Dictionary includes `success` key.  If False, one or more files do not
+    exist or some other error occurred.
+
+    Under the hood, this uses the junos CLI command `file compare files ...`
+
+    CLI Example :
+
+        salt junos-router junos.file_compare /var/tmp/backup1/cmt.script /var/tmp/backup2/cmt.script
+
+        junos-router:
+        -------------
+        identical:
+            False
+        success:
+            True
+    """
+    if salt.utils.platform.is_proxy():
+        return {
+            "success": False,
+            "message": "This method is unsupported on the current operating system!",
+        }
+
+    ret = {"message": "", "identical": False, "success": True}
+
+    junos_cli = salt.utils.path.which("cli")
+    if not junos_cli:
+        return {"success": False, "message": "Cannot find Junos cli command"}
+
+    cliret = __salt__["cmd.run"](
+        "{} file compare files {} {} ".format(junos_cli, file1, file2)
+    )
+    clilines = cliret.splitlines()
+
+    for r in clilines:
+        if r.strip() != "":
+            if "No such file" in r:
+                ret["identical"] = False
+                ret["success"] = False
+                return ret
+
+            ret["identical"] = False
+            ret["success"] = True
+            return ret
+
+    ret["identical"] = True
+    ret["success"] = True
+    return ret
+
+
+@timeoutDecorator
+def fsentry_exists(dir, **kwargs):
+    """
+    NOTE This function only works on Juniper native minions
+
+    Returns a dictionary indicating if `dir` refers to a file
+    or a non-file (generally a directory) in the file system,
+    or if there is no file by that name.
+
+    CLI Example :
+
+        salt junos-router junos.fsentry_exists /var/log
+
+        junos-router:
+        -------------
+        is_dir:
+            True
+        exists:
+            True
+
+    """
+    if salt.utils.platform.is_proxy():
+        return {
+            "success": False,
+            "message": "This method is unsupported on the current operating system!",
+        }
+
+    junos_cli = salt.utils.path.which("cli")
+    if not junos_cli:
+        return {"success": False, "message": "Cannot find Junos cli command"}
+
+    ret = __salt__["cmd.run"]("{} file show {}".format(junos_cli, dir))
+    retlines = ret.splitlines()
+    exists = True
+    is_dir = False
+    status = {"is_dir": False, "exists": True}
+    for r in retlines:
+        if "could not resolve" in r or "error: Could not connect" in r:
+            status["is_dir"] = False
+            status["exists"] = False
+        if "is not a regular file" in r:
+            status["is_dir"] = True
+            status["exists"] = True
+
+    return status
+
+
+def _find_routing_engines():
+    junos_cli = salt.utils.path.which("cli")
+    if not junos_cli:
+        return {"success": False, "message": "Cannot find Junos cli command"}
+
+    re_check = __salt__["cmd.run"]("{} show chassis routing-engine".format(junos_cli))
+    engine_present = True
+    engine = {}
+
+    # for l in re_check.splitlines():
+    #     if 'error: Unrecognized command' in l:
+    #         engine_present = False
+
+    # if not engine_present:
+    #     return {'success': False,
+    #             'message': 'Device does not have multiple routing engines'}
+
+    current_engine = None
+    status = None
+    for l in re_check.splitlines():
+        if "Slot" in l:
+            mat = re.search(".*(\\d+):.*", l)
+            if mat:
+                current_engine = "re" + str(mat.group(1)) + ":"
+        if "Current state" in l:
+            if "Master" in l:
+                status = "Master"
+            if "Disabled" in l:
+                status = "Disabled"
+            if "Backup" in l:
+                status = "Backup"
+
+        if current_engine and status:
+            engine[current_engine] = status
+            current_engine = None
+            status = None
+
+    if not engine:
+        return {
+            "success": False,
+            "message": "Junos cli command returned no information",
+        }
+
+    engine["success"] = True
+    return engine
+
+
+@timeoutDecorator
+def routing_engine(**kwargs):
+    """
+    Returns a dictionary containing the routing engines on the device and
+    their status (Master, Disabled, Backup).
+
+    Under the hood parses the result of `show chassis routing-engine`
+
+    CLI Example :
+
+        salt junos-router junos.routing_engine
+
+        junos-router:
+        ----------
+        backup:
+          - re1:
+        master:
+          re0:
+        success:
+          True
+
+    Returns `success: False` if the device does not appear to have multiple routing engines.
+    """
+    engine_status = _find_routing_engines()
+    if not engine_status["success"]:
+        return {"success": False}
+
+    master = None
+    backup = []
+    for k, v in engine_status.items():
+        if v == "Master":
+            master = k
+        if v == "Backup" or v == "Disabled":
+            backup.append(k)
+
+    if master:
+        ret = {"master": master, "backup": backup, "success": True}
+    else:
+        ret = {"master": master, "backup": backup, "success": False}
+    log.debug(ret)
+    return ret
+
+
+@timeoutDecorator
+def dir_copy(source, dest, force=False, **kwargs):
+    """
+    Copy a directory and recursively its contents from source to dest.
+
+    NOTE this function only works on the Juniper native minion
+
+    Parameters:
+
+    source : Directory to use as the source
+
+    dest : Directory in which to place the source and its contents.
+
+    force : This function will not copy identical files unless `force` is `True`
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'device_name' junos.dir_copy /etc/salt/pki re1:/
+
+    This will take the `pki` directory, its absolute path and copy it and its
+    contents to routing engine 1 root directory. The result will be
+    `re1:/etc/salt/pki/<files and dirs in /etc/salt/pki`.
+
+    """
+    if salt.utils.platform.is_proxy():
+        return {
+            "success": False,
+            "message": "This method is unsupported on the current operating system!",
+        }
+
+    junos_cli = salt.utils.path.which("cli")
+    if not junos_cli:
+        return {"success": False, "message": "Cannot find Junos cli command"}
+
+    ret = {}
+    ret_messages = ""
+    if not source.startswith("/"):
+        ret["message"] = "Source directory must be a fully qualified path."
+        ret["success"] = False
+        return ret
+
+    if not (dest.endswith(":") or dest.startswith("/")):
+        ret[
+            "message"
+        ] = "Destination must be a routing engine reference (e.g. re1:) or a fully qualified path."
+        ret["success"] = False
+        return ret
+
+    check_source = fsentry_exists(source)
+    if not check_source["exists"]:
+        ret["message"] = "Source does not exist"
+        ret["success"] = False
+        return ret
+
+    if not check_source["is_dir"]:
+        ret["message"] = "Source is not a directory."
+        ret["success"] = False
+        return ret
+
+    filelist = _make_source_list(source)
+    dirops = []
+    for f in filelist:
+        splitpath = os.path.split(f)[0]
+        fullpath = "/"
+        for component in splitpath.split("/"):
+            fullpath = os.path.join(fullpath, component)
+            if fullpath not in dirops:
+                dirops.append(fullpath)
+
+    for d in dirops:
+        target = dest + d
+        status = fsentry_exists(target)
+        if not status["exists"]:
+            ret = __salt__["cmd.run"](
+                "{} file make-directory {}".format(junos_cli, target)
+            )
+            ret = ret_messages + ret
+        else:
+            ret_messages = ret_messages + "Directory " + target + " already exists.\n"
+    for f in filelist:
+        if not f.endswith("/"):
+            target = dest + f
+            comp_result = file_compare(f, target)
+
+            if not comp_result["identical"] or force:
+                ret = __salt__["cmd.run"](
+                    "{} file copy {} {}".format(junos_cli, f, target)
+                )
+                ret = ret_messages + ret
+            else:
+                ret_messages = (
+                    ret_messages
+                    + "Files {} and {} are identical, not copying.\n".format(f, target)
+                )
+
+    return ret_messages

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -173,11 +173,11 @@ def timeoutDecorator(function):
     @wraps(function)
     def wrapper(*args, **kwargs):
         if "dev_timeout" in kwargs or "timeout" in kwargs:
-            dev_timeout = max(kwargs.pop("dev_timeout", 0), kwargs.pop("timeout", 0))
+            ldev_timeout = max(kwargs.pop("dev_timeout", 0), kwargs.pop("timeout", 0))
             conn = __proxy__["junos.conn"]()
             restore_timeout = conn.timeout
-            kwargs["dev_timeout"] = dev_timeout
-            conn.timeout = dev_timeout
+            kwargs["dev_timeout"] = ldev_timeout
+            conn.timeout = ldev_timeout
             try:
                 result = function(*args, **kwargs)
                 conn.timeout = restore_timeout
@@ -195,11 +195,11 @@ def timeoutDecorator_cleankwargs(function):
     @wraps(function)
     def wrapper(*args, **kwargs):
         if "dev_timeout" in kwargs or "timeout" in kwargs:
-            dev_timeout = max(kwargs.pop("dev_timeout", 0), kwargs.pop("timeout", 0))
+            ldev_timeout = max(kwargs.pop("dev_timeout", 0), kwargs.pop("timeout", 0))
             conn = __proxy__["junos.conn"]()
             restore_timeout = conn.timeout
-            kwargs["dev_timeout"] = dev_timeout
-            conn.timeout = dev_timeout
+            kwargs["dev_timeout"] = ldev_timeout
+            conn.timeout = ldev_timeout
             try:
                 restore_kwargs = False
                 del_list = []
@@ -738,7 +738,7 @@ def rollback(**kwargs):
             _restart_connection()
             return ret
     else:
-        ret["message"] = "Rollback succesful but pre-commit check failed."
+        ret["message"] = "Rollback successful but pre-commit check failed."
         ret["out"] = False
 
     return ret

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -1371,7 +1371,7 @@ def install_os(path=None, **kwargs):
         When True (default), executes the software install on all Routing Engines of the Junos
         device. When False, execute the software install only on the current Routing Engine.
 
-        .. versionadded:: Sodium
+        .. versionadded:: 3001
 
     .. note::
         Any additional keyword arguments specified are passed down to PyEZ sw.install() as is.
@@ -1507,6 +1507,8 @@ def file_copy(src=None, dest=None):
 
     dest
         The destination path on the where the file will be copied
+
+    .. versionadded:: 3001
 
     CLI Example:
 
@@ -1799,7 +1801,7 @@ def get_table(
     table_args=None,
 ):
     """
-    .. versionadded:: Sodium
+    .. versionadded:: 3001
 
     Retrieve data from a Junos device using Tables/Views
 
@@ -1976,6 +1978,8 @@ def rpc_file_list(path, **kwargs):
     Use the Junos RPC interface to get a list of files and return
     them as a structure dictionary.
 
+    .. versionadded:: Aluminum
+
     CLI Example :
 
         salt junos-router junos.rpc_file_list /var/local/salt/etc
@@ -2017,6 +2021,7 @@ def rpc_file_list(path, **kwargs):
                     1
         success:
             True
+
     """
     kwargs = salt.utils.args.clean_kwargs(**kwargs)
     conn = __proxy__["junos.conn"]()
@@ -2085,6 +2090,8 @@ def file_compare(file1, file2, **kwargs):
 
     Under the hood, this uses the junos CLI command `file compare files ...`
 
+    .. versionadded:: Aluminum
+
     CLI Example :
 
         salt junos-router junos.file_compare /var/tmp/backup1/cmt.script /var/tmp/backup2/cmt.script
@@ -2138,6 +2145,8 @@ def fsentry_exists(dir, **kwargs):
     or a non-file (generally a directory) in the file system,
     or if there is no file by that name.
 
+    .. versionadded:: Aluminum
+
     CLI Example :
 
         salt junos-router junos.fsentry_exists /var/log
@@ -2148,7 +2157,6 @@ def fsentry_exists(dir, **kwargs):
             True
         exists:
             True
-
     """
     if salt.utils.platform.is_proxy():
         return {
@@ -2231,6 +2239,8 @@ def routing_engine(**kwargs):
 
     Under the hood parses the result of `show chassis routing-engine`
 
+    .. versionadded:: Aluminum
+
     CLI Example :
 
         salt junos-router junos.routing_engine
@@ -2281,6 +2291,8 @@ def dir_copy(source, dest, force=False, **kwargs):
 
     force : This function will not copy identical files unless `force` is `True`
 
+    .. versionadded:: Aluminum
+
     CLI Example:
 
     .. code-block:: bash
@@ -2290,7 +2302,6 @@ def dir_copy(source, dest, force=False, **kwargs):
     This will take the `pki` directory, its absolute path and copy it and its
     contents to routing engine 1 root directory. The result will be
     `re1:/etc/salt/pki/<files and dirs in /etc/salt/pki`.
-
     """
     if salt.utils.platform.is_proxy():
         return {

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -96,6 +96,7 @@ class HandleFileCopy:
     To figure out proper path either from proxy local file system
     or proxy cache or on master. If required, then only copy from
     master to proxy
+
     """
 
     def __init__(self, path, **kwargs):
@@ -699,7 +700,7 @@ def rollback(**kwargs):
         return ret
 
     if ret["out"]:
-        ret["message"] = "Rollback successfull"
+        ret["message"] = "Rollback successful"
     else:
         ret["message"] = "Rollback failed"
         return ret
@@ -737,7 +738,7 @@ def rollback(**kwargs):
             _restart_connection()
             return ret
     else:
-        ret["message"] = "Rollback succesfull but pre-commit check failed."
+        ret["message"] = "Rollback succesful but pre-commit check failed."
         ret["out"] = False
 
     return ret
@@ -1496,7 +1497,7 @@ def install_os(path=None, **kwargs):
 
 ## @timeoutDecorator
 @timeoutDecorator_cleankwargs
-def file_copy(src=None, dest=None):
+def file_copy(src, dest):
     """
     NOTE This function does not work on Juniper native minions
 

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -176,7 +176,6 @@ def timeoutDecorator(function):
             ldev_timeout = max(kwargs.pop("dev_timeout", 0), kwargs.pop("timeout", 0))
             conn = __proxy__["junos.conn"]()
             restore_timeout = conn.timeout
-            kwargs["dev_timeout"] = ldev_timeout
             conn.timeout = ldev_timeout
             try:
                 result = function(*args, **kwargs)
@@ -198,7 +197,6 @@ def timeoutDecorator_cleankwargs(function):
             ldev_timeout = max(kwargs.pop("dev_timeout", 0), kwargs.pop("timeout", 0))
             conn = __proxy__["junos.conn"]()
             restore_timeout = conn.timeout
-            kwargs["dev_timeout"] = ldev_timeout
             conn.timeout = ldev_timeout
             try:
                 restore_kwargs = False
@@ -1461,6 +1459,7 @@ def install_os(path=None, **kwargs):
             return ret
 
     if install_status is True:
+        ret["out"] = True
         ret["message"] = "Installed the os."
     else:
         ret["message"] = "Installation failed. Reason: {}".format(install_message)
@@ -1490,6 +1489,7 @@ def install_os(path=None, **kwargs):
             return ret
 
         __proxy__["junos.reboot_clear"]()
+        ret["out"] = True
         ret["message"] = "Successfully installed and rebooted!"
 
     return ret

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -1499,9 +1499,10 @@ def install_os(path=None, **kwargs):
 @timeoutDecorator_cleankwargs
 def file_copy(src, dest):
     """
-    NOTE This function does not work on Juniper native minions
-
     Copies the file from the local device to the junos device
+
+    .. note::
+        This function does not work on Juniper native minions
 
     src
         The source path where the file is kept.
@@ -2081,8 +2082,6 @@ def _make_source_list(dir):
 @timeoutDecorator
 def file_compare(file1, file2, **kwargs):
     """
-    NOTE This function only works on Juniper native minions
-
     Compare two files and return a dictionary indicating if they
     are different.
 
@@ -2090,6 +2089,9 @@ def file_compare(file1, file2, **kwargs):
     exist or some other error occurred.
 
     Under the hood, this uses the junos CLI command `file compare files ...`
+
+    .. note::
+        This function only works on Juniper native minions
 
     .. versionadded:: Aluminum
 
@@ -2103,6 +2105,7 @@ def file_compare(file1, file2, **kwargs):
             False
         success:
             True
+
     """
     if not salt.utils.platform.is_junos():
         return {
@@ -2140,11 +2143,12 @@ def file_compare(file1, file2, **kwargs):
 @timeoutDecorator
 def fsentry_exists(dir, **kwargs):
     """
-    NOTE This function only works on Juniper native minions
-
     Returns a dictionary indicating if `dir` refers to a file
     or a non-file (generally a directory) in the file system,
     or if there is no file by that name.
+
+    .. note::
+        This function only works on Juniper native minions
 
     .. versionadded:: Aluminum
 
@@ -2158,6 +2162,7 @@ def fsentry_exists(dir, **kwargs):
             True
         exists:
             True
+
     """
     if not salt.utils.platform.is_junos():
         return {
@@ -2256,6 +2261,7 @@ def routing_engine(**kwargs):
           True
 
     Returns `success: False` if the device does not appear to have multiple routing engines.
+
     """
     engine_status = _find_routing_engines()
     if not engine_status["success"]:
@@ -2282,7 +2288,8 @@ def dir_copy(source, dest, force=False, **kwargs):
     """
     Copy a directory and recursively its contents from source to dest.
 
-    NOTE this function only works on the Juniper native minion
+    .. note::
+        This function only works on the Juniper native minion
 
     Parameters:
 
@@ -2303,6 +2310,7 @@ def dir_copy(source, dest, force=False, **kwargs):
     This will take the `pki` directory, its absolute path and copy it and its
     contents to routing engine 1 root directory. The result will be
     `re1:/etc/salt/pki/<files and dirs in /etc/salt/pki`.
+
     """
     if not salt.utils.platform.is_junos():
         return {

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -1940,7 +1940,6 @@ def get_table(
         return ret
     except Exception as err:  # pylint: disable=broad-except
         ret["message"] = "Uncaught exception - please report: {}".format(str(err))
-        ##        traceback.print_exc()
         ret["out"] = False
         _restart_connection()
         return ret

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -1984,42 +1984,30 @@ def rpc_file_list(path, **kwargs):
 
     CLI Example :
 
+    .. code-block:: bash
+
         salt junos-router junos.rpc_file_list /var/local/salt/etc
 
         junos-router:
-        ----------
-        files:
-            ----------
-            directory:
-                ----------
-                directory-name:
-
-                    /var/local/salt/etc
-                file-information:
-                    |_
-                      ----------
-                      file-directory:
-                          ----------
-                      file-name:
-
-                          pki
-                    |_
-                      ----------
-                      file-name:
-
-                          proxy
-                    |_
-                      ----------
-                      file-directory:
-                          ----------
-                      file-name:
-
-                          proxy.d
+            files:
+                directory:
+                    directory-name:
+                        /var/local/salt/etc
+                    file-information:
+                        |_
+                          file-directory:
+                              file-name:
+                                  pki
+                        |_
+                          file-name:
+                              proxy
+                        |_
+                          file-directory:
+                              file-name:
+                                  proxy.d
                 total-file-blocks:
-
                     10
                 total-files:
-
                     1
         success:
             True
@@ -2097,14 +2085,15 @@ def file_compare(file1, file2, **kwargs):
 
     CLI Example :
 
+    .. code-block:: bash
+
         salt junos-router junos.file_compare /var/tmp/backup1/cmt.script /var/tmp/backup2/cmt.script
 
         junos-router:
-        -------------
-        identical:
-            False
-        success:
-            True
+            identical:
+                False
+            success:
+                True
 
     """
     if not salt.utils.platform.is_junos():
@@ -2154,14 +2143,15 @@ def fsentry_exists(dir, **kwargs):
 
     CLI Example :
 
+    .. code-block:: bash
+
         salt junos-router junos.fsentry_exists /var/log
 
         junos-router:
-        -------------
-        is_dir:
-            True
-        exists:
-            True
+            is_dir:
+                True
+            exists:
+                True
 
     """
     if not salt.utils.platform.is_junos():
@@ -2249,16 +2239,17 @@ def routing_engine(**kwargs):
 
     CLI Example :
 
+    .. code-block:: bash
+
         salt junos-router junos.routing_engine
 
         junos-router:
-        ----------
-        backup:
-          - re1:
-        master:
-          re0:
-        success:
-          True
+            backup:
+              - re1:
+            master:
+              re0:
+            success:
+              True
 
     Returns `success: False` if the device does not appear to have multiple routing engines.
 

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -1,11 +1,8 @@
-# -*- coding: utf-8 -*-
 """
 Module for returning various status data about a minion.
 These data can be useful for compiling into stats later.
 """
 
-# Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import collections
 import copy
@@ -16,7 +13,6 @@ import os
 import re
 import time
 
-# Import salt libs
 import salt.config
 import salt.minion
 import salt.utils.event
@@ -26,9 +22,6 @@ import salt.utils.path
 import salt.utils.platform
 import salt.utils.stringutils
 from salt.exceptions import CommandExecutionError
-
-# Import 3rd-party libs
-from salt.ext import six
 from salt.ext.six.moves import range, zip
 
 log = logging.getLogger(__file__)
@@ -184,8 +177,8 @@ def custom():
     """
     ret = {}
     conf = __salt__["config.dot_vals"]("status")
-    for key, val in six.iteritems(conf):
-        func = "{0}()".format(key.split(".")[1])
+    for key, val in conf.items():
+        func = "{}()".format(key.split(".")[1])
         vals = eval(func)  # pylint: disable=W0123
 
         for item in val:
@@ -244,9 +237,9 @@ def uptime():
         if not bt_data:
             raise CommandExecutionError("Cannot find kern.boottime system parameter")
         data = bt_data.split("{")[-1].split("}")[0].strip().replace(" ", "")
-        uptime = dict(
-            [(k, int(v,)) for k, v in [p.strip().split("=") for p in data.split(",")]]
-        )
+        uptime = {
+            k: int(v,) for k, v in [p.strip().split("=") for p in data.split(",")]
+        }
         seconds = int(curr_seconds - uptime["sec"])
     elif salt.utils.platform.is_aix():
         seconds = _get_boot_time_aix()
@@ -264,7 +257,7 @@ def uptime():
         "since_iso": boot_time.isoformat(),
         "since_t": int(curr_seconds - seconds),
         "days": up_time.days,
-        "time": "{0}:{1}".format(up_time.seconds // 3600, up_time.seconds % 3600 // 60),
+        "time": "{}:{}".format(up_time.seconds // 3600, up_time.seconds % 3600 // 60),
     }
 
     if salt.utils.path.which("who"):
@@ -329,7 +322,7 @@ def cpustats():
         try:
             with salt.utils.files.fopen("/proc/stat", "r") as fp_:
                 stats = salt.utils.stringutils.to_unicode(fp_.read())
-        except IOError:
+        except OSError:
             pass
         else:
             for line in stats.splitlines():
@@ -452,6 +445,7 @@ def cpustats():
     get_version = {
         "Linux": linux_cpustats,
         "FreeBSD": freebsd_cpustats,
+        "Junos": freebsd_cpustats,
         "OpenBSD": openbsd_cpustats,
         "SunOS": sunos_cpustats,
         "AIX": aix_cpustats,
@@ -486,7 +480,7 @@ def meminfo():
         try:
             with salt.utils.files.fopen("/proc/meminfo", "r") as fp_:
                 stats = salt.utils.stringutils.to_unicode(fp_.read())
-        except IOError:
+        except OSError:
             pass
         else:
             for line in stats.splitlines():
@@ -565,7 +559,7 @@ def meminfo():
                 procn = len(ret["svmon"])
                 ret["svmon"].append({})
                 comps = line.split()
-                pg_space = "{0} {1}".format(comps[0], comps[1])
+                pg_space = "{} {}".format(comps[0], comps[1])
                 ret["svmon"][procn][pg_space] = {}
                 for i in range(0, len(fields)):
                     if len(comps) > i + 2:
@@ -624,6 +618,7 @@ def meminfo():
     get_version = {
         "Linux": linux_meminfo,
         "FreeBSD": freebsd_meminfo,
+        "Junos": freebsd_meminfo,
         "OpenBSD": openbsd_meminfo,
         "AIX": aix_meminfo,
     }
@@ -658,7 +653,7 @@ def cpuinfo():
         try:
             with salt.utils.files.fopen("/proc/cpuinfo", "r") as fp_:
                 stats = salt.utils.stringutils.to_unicode(fp_.read())
-        except IOError:
+        except OSError:
             pass
         else:
             for line in stats.splitlines():
@@ -755,9 +750,7 @@ def cpuinfo():
                 ret["psrinfo"][procn]["family"] = _number(line[4])
                 ret["psrinfo"][procn]["model"] = _number(line[6])
                 ret["psrinfo"][procn]["step"] = _number(line[8])
-                ret["psrinfo"][procn]["clock"] = "{0} {1}".format(
-                    line[10], line[11][:-1]
-                )
+                ret["psrinfo"][procn]["clock"] = "{} {}".format(line[10], line[11][:-1])
         return ret
 
     def aix_cpuinfo():
@@ -839,6 +832,7 @@ def cpuinfo():
     get_version = {
         "Linux": linux_cpuinfo,
         "FreeBSD": bsd_cpuinfo,
+        "Junos": bsd_cpuinfo,
         "NetBSD": bsd_cpuinfo,
         "OpenBSD": bsd_cpuinfo,
         "SunOS": sunos_cpuinfo,
@@ -872,7 +866,7 @@ def diskstats():
         try:
             with salt.utils.files.fopen("/proc/diskstats", "r") as fp_:
                 stats = salt.utils.stringutils.to_unicode(fp_.read())
-        except IOError:
+        except OSError:
             pass
         else:
             for line in stats.splitlines():
@@ -971,6 +965,7 @@ def diskstats():
     get_version = {
         "Linux": linux_diskstats,
         "FreeBSD": generic_diskstats,
+        "Junos": generic_diskstats,
         "SunOS": generic_diskstats,
         "AIX": aix_diskstats,
     }
@@ -1078,7 +1073,7 @@ def vmstats():
         try:
             with salt.utils.files.fopen("/proc/vmstat", "r") as fp_:
                 stats = salt.utils.stringutils.to_unicode(fp_.read())
-        except IOError:
+        except OSError:
             pass
         else:
             for line in stats.splitlines():
@@ -1104,6 +1099,7 @@ def vmstats():
     get_version = {
         "Linux": linux_vmstats,
         "FreeBSD": generic_vmstats,
+        "Junos": generic_vmstats,
         "OpenBSD": generic_vmstats,
         "SunOS": generic_vmstats,
         "AIX": generic_vmstats,
@@ -1155,6 +1151,7 @@ def nproc():
         "Linux": linux_nproc,
         "Darwin": generic_nproc,
         "FreeBSD": generic_nproc,
+        "Junos": generic_nproc,
         "OpenBSD": generic_nproc,
         "AIX": _aix_nproc,
     }
@@ -1188,7 +1185,7 @@ def netstats():
         try:
             with salt.utils.files.fopen("/proc/net/netstat", "r") as fp_:
                 stats = salt.utils.stringutils.to_unicode(fp_.read())
-        except IOError:
+        except OSError:
             pass
         else:
             headers = [""]
@@ -1283,6 +1280,7 @@ def netstats():
     get_version = {
         "Linux": linux_netstats,
         "FreeBSD": bsd_netstats,
+        "Junos": bsd_netstats,
         "OpenBSD": bsd_netstats,
         "SunOS": sunos_netstats,
         "AIX": aix_netstats,
@@ -1315,7 +1313,7 @@ def netdev():
         try:
             with salt.utils.files.fopen("/proc/net/dev", "r") as fp_:
                 stats = salt.utils.stringutils.to_unicode(fp_.read())
-        except IOError:
+        except OSError:
             pass
         else:
             for line in stats.splitlines():
@@ -1445,7 +1443,7 @@ def netdev():
                 comps = line.split()
                 if len(comps) < 3:
                     raise CommandExecutionError(
-                        "Insufficent data returned by command to process '{0}'".format(
+                        "Insufficent data returned by command to process '{}'".format(
                             line
                         )
                     )
@@ -1468,7 +1466,7 @@ def netdev():
                 comps = line.split()
                 if len(comps) < 3:
                     raise CommandExecutionError(
-                        "Insufficent data returned by command to process '{0}'".format(
+                        "Insufficent data returned by command to process '{}'".format(
                             line
                         )
                     )
@@ -1489,6 +1487,7 @@ def netdev():
     get_version = {
         "Linux": linux_netdev,
         "FreeBSD": freebsd_netdev,
+        "Junos": freebsd_netdev,
         "SunOS": sunos_netdev,
         "AIX": aix_netdev,
     }
@@ -1555,6 +1554,7 @@ def w():  # pylint: disable=C0103
     get_version = {
         "Darwin": bsd_w,
         "FreeBSD": bsd_w,
+        "Junos": bsd_w,
         "Linux": linux_w,
         "OpenBSD": bsd_w,
     }
@@ -1645,7 +1645,7 @@ def version():
         try:
             with salt.utils.files.fopen("/proc/version", "r") as fp_:
                 return salt.utils.stringutils.to_unicode(fp_.read()).strip()
-        except IOError:
+        except OSError:
             return {}
 
     def bsd_version():
@@ -1658,6 +1658,7 @@ def version():
     get_version = {
         "Linux": linux_version,
         "FreeBSD": bsd_version,
+        "Junos": bsd_version,
         "OpenBSD": bsd_version,
         "AIX": lambda: __salt__["cmd.run"]("oslevel -s"),
     }
@@ -1789,6 +1790,18 @@ def proxy_reconnect(proxy_name, opts=None):
     proxy_keepalive_fn = proxy_name + ".alive"
     if proxy_keepalive_fn not in __proxy__:
         return False  # fail
+
+    if __proxy__[proxy_name + ".get_reboot_active"]():
+        # if rebooting or shutting down, don't run proxy_reconnect
+        # it interferes with the connection and disrupts the shutdown/reboot
+        # especially
+        minion_id = opts.get("proxyid", "") or opts.get("id", "")
+        log.info(
+            "{} ({} proxy) is rebooting or shutting down. Don't probe connection.".format(
+                minion_id, proxy_name
+            )
+        )
+        return True
 
     is_alive = __proxy__[proxy_keepalive_fn](opts)
     if not is_alive:

--- a/salt/proxy/junos.py
+++ b/salt/proxy/junos.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Interface with a Junos device via proxy-minion. To connect to a junos device \
 via junos proxy, specify the host information in the pillar in '/srv/pillar/details.sls'
@@ -35,11 +34,9 @@ Run the salt proxy via the following command:
 
 
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
-# Import 3rd-party libs
 try:
     HAS_JUNOS = True
     import jnpr.junos
@@ -47,14 +44,14 @@ try:
     import jnpr.junos.utils.config
     import jnpr.junos.utils.sw
     from jnpr.junos.exception import (
-        RpcTimeoutError,
-        ConnectClosedError,
-        RpcError,
-        ConnectError,
-        ProbeError,
         ConnectAuthError,
+        ConnectClosedError,
+        ConnectError,
         ConnectRefusedError,
         ConnectTimeoutError,
+        ProbeError,
+        RpcError,
+        RpcTimeoutError,
     )
     from ncclient.operations.errors import TimeoutExpiredError
     from ncclient.transport.third_party.junos.ioproc import IOProc
@@ -66,6 +63,20 @@ __proxyenabled__ = ["junos"]
 thisproxy = {}
 
 log = logging.getLogger(__name__)
+
+
+class RebootActive:
+    """
+    Class to get static variable, to indicate when a reboot/shutdown
+    is being processed and the keep_alive should not probe the
+    connection since it interferes with the shutdown process.
+    """
+
+    reboot_shutdown = False
+
+    def __init__(self, **kwargs):
+        pass
+
 
 # Define the module's virtual name
 __virtualname__ = "junos"
@@ -98,7 +109,6 @@ def init(opts):
         "username",
         "password",
         "passwd",
-        "port",
         "gather_facts",
         "mode",
         "baud",
@@ -160,6 +170,18 @@ def conn():
     return thisproxy["conn"]
 
 
+def reboot_active():
+    RebootActive.reboot_shutdown = True
+
+
+def reboot_clear():
+    RebootActive.reboot_shutdown = False
+
+
+def get_reboot_active():
+    return RebootActive.reboot_shutdown
+
+
 def alive(opts):
     """
     Validate and return the connection status with the remote device.
@@ -169,13 +191,15 @@ def alive(opts):
 
     dev = conn()
 
+    # check if SessionListener sets a TransportError if there is a RpcTimeoutError
     thisproxy["conn"].connected = ping()
 
-    if not dev.connected:
+    local_connected = dev.connected
+    if not local_connected:
         __salt__["event.fire_master"](
             {}, "junos/proxy/{}/stop".format(opts["proxy"]["host"])
         )
-    return dev.connected
+    return local_connected
 
 
 def ping():
@@ -251,7 +275,7 @@ def shutdown(opts):
     This is called when the proxy-minion is exiting to make sure the
     connection to the device is closed cleanly.
     """
-    log.debug("Proxy module %s shutting down!!", opts["id"])
+    log.debug("Proxy module {} shutting down!!".format(opts["id"]))
     try:
         thisproxy["conn"].close()
 

--- a/salt/states/junos.py
+++ b/salt/states/junos.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 State modules to interact with Junos devices.
 ==============================================
@@ -13,8 +12,6 @@ State modules to interact with Junos devices.
 
 Refer to :mod:`junos <salt.proxy.junos>` for information on connecting to junos proxy.
 """
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 from functools import wraps
@@ -98,7 +95,7 @@ def set_hostname(name, **kwargs):
 
     Parameters:
      Required
-        * hostname: The name to be set. (default = None)
+        * name: The name to be set. (default = None)
      Optional
         * kwargs: Keyworded arguments which can be provided like-
             * timeout:
@@ -161,7 +158,7 @@ def commit(name, **kwargs):
 
 
 @resultdecorator
-def rollback(name, id, **kwargs):
+def rollback(name, d_id, **kwargs):
     """
     Rollbacks the committed changes.
 
@@ -174,7 +171,11 @@ def rollback(name, id, **kwargs):
     Parameters:
       Optional
         * id:
+        * d_id:
           The rollback id value [0-49]. (default = 0)
+          (this variable cannot be named `id`, it conflicts
+          with the state compiler's internal id)
+
         * kwargs: Keyworded arguments which can be provided like-
             * timeout:
               Set NETCONF RPC timeout. Can be used for commands which
@@ -190,7 +191,7 @@ def rollback(name, id, **kwargs):
 
     """
     ret = {"name": name, "changes": {}, "result": True, "comment": ""}
-    ret["changes"] = __salt__["junos.rollback"](id=id, **kwargs)
+    ret["changes"] = __salt__["junos.rollback"](d_id=d_id, **kwargs)
     return ret
 
 
@@ -237,7 +238,7 @@ def cli(name, **kwargs):
     Parameters:
       Required
         * name:
-          The command that need to be executed on Junos CLI.
+          The command that need to be executed on Junos CLI. (default = None)
       Optional
         * kwargs: Keyworded arguments which can be provided like-
             * format:
@@ -385,7 +386,7 @@ def install_os(name, **kwargs):
 
     Parameters:
       Required
-        * path:
+        * name:
           Path where the image file is present on the pro\
           xy minion.
       Optional
@@ -418,7 +419,7 @@ def file_copy(name, dest=None, **kwargs):
 
     Parameters:
       Required
-        * src:
+        * name:
           The sorce path where the file is kept.
         * dest:
           The destination path where the file will be copied.

--- a/salt/syspaths.py
+++ b/salt/syspaths.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
     salt.syspaths
     ~~~~~~~~~~~~~
@@ -14,14 +13,18 @@
     paths that are set in the master/minion config files.
 """
 
-# Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 import os.path
 import sys
 
-__PLATFORM = sys.platform.lower()
+import salt.utils.platform
+
+if salt.utils.platform.is_junos():
+    __PLATFORM = "junos"
+else:
+    __PLATFORM = sys.platform.lower()
+
 typo_warning = True
 log = logging.getLogger(__name__)
 EXPECTED_VARIABLES = (
@@ -52,7 +55,7 @@ except ImportError:
     import types
 
     __generated_syspaths = types.ModuleType(
-        str("salt._syspaths")
+        "salt._syspaths"
     )  # future lint: blacklisted-function
     for key in EXPECTED_VARIABLES:
         setattr(__generated_syspaths, key, None)
@@ -101,6 +104,8 @@ if CONFIG_DIR is None:
         CONFIG_DIR = os.path.join(ROOT_DIR, "conf")
     elif "freebsd" in __PLATFORM:
         CONFIG_DIR = os.path.join(ROOT_DIR, "usr", "local", "etc", "salt")
+    elif "junos" in __PLATFORM:
+        CONFIG_DIR = os.path.join(ROOT_DIR, "var", "local", "salt", "etc")
     elif "netbsd" in __PLATFORM:
         CONFIG_DIR = os.path.join(ROOT_DIR, "usr", "pkg", "etc", "salt")
     elif "sunos5" in __PLATFORM:
@@ -114,6 +119,8 @@ if SHARE_DIR is None:
         SHARE_DIR = os.path.join(ROOT_DIR, "share")
     elif "freebsd" in __PLATFORM:
         SHARE_DIR = os.path.join(ROOT_DIR, "usr", "local", "share", "salt")
+    elif "junos" in __PLATFORM:
+        SHARE_DIR = os.path.join(ROOT_DIR, "var", "local", "salt", "share")
     elif "netbsd" in __PLATFORM:
         SHARE_DIR = os.path.join(ROOT_DIR, "usr", "share", "salt")
     elif "sunos5" in __PLATFORM:
@@ -123,11 +130,17 @@ if SHARE_DIR is None:
 
 CACHE_DIR = __generated_syspaths.CACHE_DIR
 if CACHE_DIR is None:
-    CACHE_DIR = os.path.join(ROOT_DIR, "var", "cache", "salt")
+    if "junos" in __PLATFORM:
+        CACHE_DIR = os.path.join(ROOT_DIR, "var", "local", "salt", "cache")
+    else:
+        CACHE_DIR = os.path.join(ROOT_DIR, "var", "cache", "salt")
 
 SOCK_DIR = __generated_syspaths.SOCK_DIR
 if SOCK_DIR is None:
-    SOCK_DIR = os.path.join(ROOT_DIR, "var", "run", "salt")
+    if "junos" in __PLATFORM:
+        SOCK_DIR = os.path.join(ROOT_DIR, "var", "local", "salt", "run")
+    else:
+        SOCK_DIR = os.path.join(ROOT_DIR, "var", "run", "salt")
 
 SRV_ROOT_DIR = __generated_syspaths.SRV_ROOT_DIR
 if SRV_ROOT_DIR is None:
@@ -155,7 +168,10 @@ if LOGS_DIR is None:
 
 PIDFILE_DIR = __generated_syspaths.PIDFILE_DIR
 if PIDFILE_DIR is None:
-    PIDFILE_DIR = os.path.join(ROOT_DIR, "var", "run")
+    if "junos" in __PLATFORM:
+        PIDFILE_DIR = os.path.join(ROOT_DIR, "var", "local", "salt", "run")
+    else:
+        PIDFILE_DIR = os.path.join(ROOT_DIR, "var", "run")
 
 SPM_PARENT_PATH = __generated_syspaths.SPM_PARENT_PATH
 if SPM_PARENT_PATH is None:

--- a/salt/utils/platform.py
+++ b/salt/utils/platform.py
@@ -137,6 +137,14 @@ def is_smartos_zone():
 
 
 @real_memoize
+def is_junos():
+    """
+    Simple function to return if host is Junos or not
+    """
+    return sys.platform.startswith("freebsd") and os.uname().release.startswith("JNPR")
+
+
+@real_memoize
 def is_freebsd():
     """
     Simple function to return if host is FreeBSD or not

--- a/tests/unit/modules/test_junos.py
+++ b/tests/unit/modules/test_junos.py
@@ -46,7 +46,8 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                     ),
                     "event.fire_master": MagicMock(return_value=None),
                 },
-            }
+                "_restart_connection": MagicMock(return_value=None),
+            },
         }
 
     def mock_cp(self, *args, **kwargs):

--- a/tests/unit/modules/test_junos.py
+++ b/tests/unit/modules/test_junos.py
@@ -1,22 +1,15 @@
-# -*- coding: utf-8 -*-
 """
     :codeauthor: Rajvi Dhimar <rajvidhimar95@gmail.com>
 """
-# Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 
 # Import salt modules
 import salt.modules.junos as junos
-from salt.ext import six
-
-# Import test libs
 from tests.support.mixins import LoaderModuleMockMixin, XMLEqualityMixin
 from tests.support.mock import ANY, MagicMock, PropertyMock, call, mock_open, patch
 from tests.support.unit import TestCase, skipIf
 
-# Import 3rd-party libs
 try:
     from lxml import etree
 except ImportError:
@@ -51,6 +44,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                     "slsutil.renderer": MagicMock(
                         return_value="set system host-name dummy"
                     ),
+                    "event.fire_master": MagicMock(return_value=None),
                 },
             }
         }
@@ -2462,14 +2456,14 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             self.assertEqual(ret, ret_exp)
 
     def test_get_table_api_error(self):
-        table = str("sample")
+        table = "sample"
         file = "inventory.yml"
         ret_exp = {
             "out": False,
             "hostname": "1.1.1.1",
             "tablename": "sample",
             "message": "Uncaught exception during get API call - please report:"
-            " '{}'".format(six.text_type(table)),
+            " '{}'".format(str(table)),
         }
         with patch("jnpr.junos.device.Device.execute") as mock_execute:
             ret = junos.get_table(table, file)

--- a/tests/unit/modules/test_junos.py
+++ b/tests/unit/modules/test_junos.py
@@ -36,6 +36,8 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 "__proxy__": {
                     "junos.conn": self.make_connect,
                     "junos.get_serialized_facts": self.get_facts,
+                    "junos.reboot_active": MagicMock(return_value=None),
+                    "junos.reboot_clear": MagicMock(return_value=None),
                 },
                 "__salt__": {
                     "cp.get_template": self.mock_cp,
@@ -1106,7 +1108,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 "__pub_ret": "",
             }
             ret = dict()
-            ret["message"] = 'Could not poweroff/reboot beacause "Test exception"'
+            ret["message"] = 'Could not poweroff/reboot because "Test exception"'
             ret["out"] = False
             self.assertEqual(junos.shutdown(**args), ret)
 

--- a/tests/unit/modules/test_junos.py
+++ b/tests/unit/modules/test_junos.py
@@ -36,8 +36,8 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 "__proxy__": {
                     "junos.conn": self.make_connect,
                     "junos.get_serialized_facts": self.get_facts,
-                    "junos.reboot_active": MagicMock(return_value=None),
-                    "junos.reboot_clear": MagicMock(return_value=None),
+                    "junos.reboot_active": MagicMock(return_value=True),
+                    "junos.reboot_clear": MagicMock(return_value=True),
                 },
                 "__salt__": {
                     "cp.get_template": self.mock_cp,

--- a/tests/unit/modules/test_junos.py
+++ b/tests/unit/modules/test_junos.py
@@ -180,6 +180,20 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             calls = [call(), call(10), call(30)]
             mock_timeout.assert_has_calls(calls)
 
+    def test_timeout_cleankwargs_decorator(self):
+        with patch(
+            "jnpr.junos.Device.timeout", new_callable=PropertyMock
+        ) as mock_timeout:
+            mock_timeout.return_value = 30
+
+            def function(x):
+                return x
+
+            decorator = junos.timeoutDecorator_cleankwargs(function)
+            decorator("Test Mock", dev_timeout=10, __pub_args="abc")
+            calls = [call(), call(10), call(30)]
+            mock_timeout.assert_has_calls(calls)
+
     def test_facts_refresh(self):
         with patch("salt.modules.saltutil.sync_grains") as mock_sync_grains:
             ret = dict()
@@ -1836,7 +1850,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         ) as mock_getsize:
             mock_getsize.return_value = 10
             mock_isfile.return_value = True
-            mock_install.return_value = True
+            mock_install.return_value = True, "installed"
             ret = dict()
             ret["out"] = True
             ret["message"] = "Installed the os."
@@ -1852,10 +1866,12 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         ) as mock_getsize:
             mock_getsize.return_value = 10
             mock_isfile.return_value = True
-            mock_install.return_value = False
+            mock_install.return_value = False, "because we are testing failure"
             ret = dict()
             ret["out"] = False
-            ret["message"] = "Installation failed."
+            ret[
+                "message"
+            ] = "Installation failed. Reason: because we are testing failure"
             self.assertEqual(junos.install_os("path"), ret)
 
     def test_install_os_with_reboot_arg(self):
@@ -1870,7 +1886,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         ) as mock_getsize:
             mock_getsize.return_value = 10
             mock_isfile.return_value = True
-            mock_install.return_value = True
+            mock_install.return_value = True, "installed"
             args = {
                 "__pub_user": "root",
                 "__pub_arg": [{"reboot": True}],
@@ -1914,7 +1930,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         ) as mock_getsize:
             mock_getsize.return_value = 10
             mock_isfile.return_value = True
-            mock_install.return_value = True
+            mock_install.return_value = True, "installed"
             mock_reboot.side_effect = self.raise_exception
             args = {
                 "__pub_user": "root",
@@ -1943,7 +1959,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         ) as mock_getsize:
             mock_getsize.return_value = 10
             mock_isfile.return_value = True
-            mock_install.return_value = True
+            mock_install.return_value = True, "installed"
             ret = dict()
             ret["out"] = True
             ret["message"] = "Installed the os."
@@ -1964,7 +1980,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         ) as mock_getsize:
             mock_getsize.return_value = 10
             mock_isfile.return_value = True
-            mock_install.return_value = True
+            mock_install.return_value = True, "installed"
             ret = dict()
             ret["out"] = True
             ret["message"] = "Installed the os."
@@ -1981,7 +1997,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         ) as mock_getsize:
             mock_getsize.return_value = 10
             mock_isfile.return_value = True
-            mock_install.return_value = True
+            mock_install.return_value = True, "installed"
             ret = dict()
             ret["out"] = True
             ret["message"] = "Installed the os."


### PR DESCRIPTION
### What does this PR do?
Eventually brings in changes to support Juniper native minions previously released for Salt 3001 and 3002 branches into the master branch

### What issues does this PR fix or reference?
Fixes: Finally getting Juniper native minion support into the Salt master branch which was delayed for Neon, Sodium, and Magnesium.  These changes have been previously been made available from private branches for these releases, and tested by Juniper and certified. Adding now to master branch to so CI/CD can be enabled easily for Juniper builds.

### Previous Behavior
Salt was missing functionality to allow for proper operation on Juniper routers, for example: grains, handling exceptions

### New Behavior
Salt now has correct functionality to allow for proper operation on Juniper routers, for example: correct reporting in grains for Junos, correct handling of exceptions, supports keywords correctly

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
