### PR TITLE
More VM tuning in virt module and states

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -945,6 +945,7 @@ def _gen_xml(
     boot_dev=None,
     numatune=None,
     hypervisor_features=None,
+    clock=None,
     **kwargs
 ):
     """
@@ -954,6 +955,7 @@ def _gen_xml(
         "hypervisor": hypervisor,
         "name": name,
         "hypervisor_features": hypervisor_features or {},
+        "clock": clock or {},
     }
 
     context["to_kib"] = lambda v: int(_handle_unit(v) / 1024)
@@ -972,6 +974,12 @@ def _gen_xml(
         context["cpu"]["maximum"] = str(cpu)
     elif isinstance(cpu, dict):
         context["cpu"] = nesthash(cpu)
+
+    if clock:
+        offset = "utc" if clock.get("utc", True) else "localtime"
+        if "timezone" in clock:
+            offset = "timezone"
+        context["clock"]["offset"] = offset
 
     if hypervisor in ["qemu", "kvm"]:
         context["numatune"] = numatune if numatune else {}
@@ -1894,6 +1902,7 @@ def init(
     boot_dev=None,
     numatune=None,
     hypervisor_features=None,
+    clock=None,
     **kwargs
 ):
     """
@@ -2149,6 +2158,59 @@ def init(
 
             hypervisor_features:
               kvm-hint-dedicated: True
+
+    :param clock:
+        Configure the guest clock.
+        The value is a dictionary with the following keys:
+
+        adjustment
+            time adjustment in seconds or ``reset``
+
+        utc
+            set to ``False`` to use the host local time as the guest clock. Defaults to ``True``.
+
+        timezone
+            synchronize the guest to the correspding timezone
+
+        timers
+            a dictionary associating the timer name with its configuration.
+            This configuration is a dictionary with the properties ``track``, ``tickpolicy``,
+            ``catchup``, ``frequency``, ``mode``, ``present``, ``slew``, ``threshold`` and ``limit``.
+            See `libvirt time keeping documentation <https://libvirt.org/formatdomain.html#time-keeping>`_ for the possible values.
+
+        .. versionadded:: Aluminium
+
+        Set the clock to local time using an offset in seconds
+        .. code-block:: yaml
+
+            clock:
+              adjustment: 3600
+              utc: False
+
+        Set the clock to a specific time zone:
+
+        .. code-block:: yaml
+
+            clock:
+              timezone: CEST
+
+        Tweak guest timers:
+
+        .. code-block:: yaml
+
+            clock:
+              timers:
+                tsc:
+                  frequency: 3504000000
+                  mode: native
+                rtc:
+                  track: wall
+                  tickpolicy: catchup
+                  slew: 4636
+                  threshold: 123
+                  limit: 2342
+                hpet:
+                  present: False
 
     .. _init-cpu-def:
 
@@ -2669,6 +2731,7 @@ def init(
             boot_dev,
             numatune,
             hypervisor_features,
+            clock,
             **kwargs
         )
         log.debug("New virtual machine definition: %s", vm_xml)
@@ -2900,6 +2963,7 @@ def update(
     test=False,
     boot_dev=None,
     hypervisor_features=None,
+    clock=None,
     **kwargs
 ):
     """
@@ -3014,6 +3078,59 @@ def update(
             hypervisor_features:
               kvm-hint-dedicated: True
 
+    :param clock:
+        Configure the guest clock.
+        The value is a dictionary with the following keys:
+
+        adjustment
+            time adjustment in seconds or ``reset``
+
+        utc
+            set to ``False`` to use the host local time as the guest clock. Defaults to ``True``.
+
+        timezone
+            synchronize the guest to the correspding timezone
+
+        timers
+            a dictionary associating the timer name with its configuration.
+            This configuration is a dictionary with the properties ``track``, ``tickpolicy``,
+            ``catchup``, ``frequency``, ``mode``, ``present``, ``slew``, ``threshold`` and ``limit``.
+            See `libvirt time keeping documentation <https://libvirt.org/formatdomain.html#time-keeping>`_ for the possible values.
+
+        .. versionadded:: Aluminium
+
+        Set the clock to local time using an offset in seconds
+        .. code-block:: yaml
+
+            clock:
+              adjustment: 3600
+              utc: False
+
+        Set the clock to a specific time zone:
+
+        .. code-block:: yaml
+
+            clock:
+              timezone: CEST
+
+        Tweak guest timers:
+
+        .. code-block:: yaml
+
+            clock:
+              timers:
+                tsc:
+                  frequency: 3504000000
+                  mode: native
+                rtc:
+                  track: wall
+                  tickpolicy: catchup
+                  slew: 4636
+                  threshold: 123
+                  limit: 2342
+                hpet:
+                  present: False
+
     :return:
 
         Returns a dictionary indicating the status of what has been done. It is structured in
@@ -3075,6 +3192,12 @@ def update(
             **kwargs
         )
     )
+
+    if clock:
+        offset = "utc" if clock.get("utc", True) else "localtime"
+        if "timezone" in clock:
+            offset = "timezone"
+        clock["offset"] = offset
 
     def _set_loader(node, value):
         salt.utils.xmlutil.set_node_text(node, value)
@@ -3302,7 +3425,62 @@ def update(
             "bandwidth",
             ["id", "vcpus"],
         ),
+        xmlutil.attribute("clock:offset", "clock", "offset"),
+        xmlutil.attribute("clock:adjustment", "clock", "adjustment", convert=str),
+        xmlutil.attribute("clock:timezone", "clock", "timezone"),
     ]
+
+    timer_names = [
+        "platform",
+        "hpet",
+        "kvmclock",
+        "pit",
+        "rtc",
+        "tsc",
+        "hypervclock",
+        "armvtimer",
+    ]
+    for timer in timer_names:
+        params_mapping += [
+            xmlutil.attribute(
+                "clock:timers:{}:track".format(timer),
+                "clock/timer[@name='{}']".format(timer),
+                "track",
+                ["name"],
+            ),
+            xmlutil.attribute(
+                "clock:timers:{}:tickpolicy".format(timer),
+                "clock/timer[@name='{}']".format(timer),
+                "tickpolicy",
+                ["name"],
+            ),
+            xmlutil.int_attribute(
+                "clock:timers:{}:frequency".format(timer),
+                "clock/timer[@name='{}']".format(timer),
+                "frequency",
+                ["name"],
+            ),
+            xmlutil.attribute(
+                "clock:timers:{}:mode".format(timer),
+                "clock/timer[@name='{}']".format(timer),
+                "mode",
+                ["name"],
+            ),
+            _yesno_attribute(
+                "clock:timers:{}:present".format(timer),
+                "clock/timer[@name='{}']".format(timer),
+                "present",
+                ["name"],
+            ),
+        ]
+        for attr in ["slew", "threshold", "limit"]:
+            params_mapping.append(
+                xmlutil.int_attribute(
+                    "clock:timers:{}:{}".format(timer, attr),
+                    "clock/timer[@name='{}']/catchup".format(timer),
+                    attr,
+                )
+            )
 
     for attr in ["level", "type", "size"]:
         params_mapping.append(
@@ -3342,6 +3520,28 @@ def update(
     data = {k: v for k, v in locals().items() if bool(v)}
     if boot_dev:
         data["boot_dev"] = boot_dev.split()
+
+    # Set the missing optional attributes and timers to None in timers to help cleaning up
+    if data.get("clock", {}).get("timers"):
+        attributes = [
+            "track",
+            "tickpolicy",
+            "frequency",
+            "mode",
+            "present",
+            "slew",
+            "threshold",
+            "limit",
+        ]
+        for timer in data["clock"]["timers"].values():
+            for attribute in attributes:
+                if attribute not in timer:
+                    timer[attribute] = None
+
+        for timer_name in timer_names:
+            if timer_name not in data["clock"]["timers"]:
+                data["clock"]["timers"][timer_name] = None
+
     need_update = (
         salt.utils.xmlutil.change_xml(desc, data, params_mapping) or need_update
     )

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -944,6 +944,7 @@ def _gen_xml(
     boot=None,
     boot_dev=None,
     numatune=None,
+    hypervisor_features=None,
     **kwargs
 ):
     """
@@ -952,6 +953,7 @@ def _gen_xml(
     context = {
         "hypervisor": hypervisor,
         "name": name,
+        "hypervisor_features": hypervisor_features or {},
     }
 
     context["to_kib"] = lambda v: int(_handle_unit(v) / 1024)
@@ -1891,6 +1893,7 @@ def init(
     boot=None,
     boot_dev=None,
     numatune=None,
+    hypervisor_features=None,
     **kwargs
 ):
     """
@@ -2136,6 +2139,16 @@ def init(
                 'memory': {'mode': 'strict', 'nodeset': '0-11'},
                 'memnodes': {0: {'mode': 'strict', 'nodeset': 1}, 1: {'mode': 'preferred', 'nodeset': 2}}
             }
+
+    :param hypervisor_features:
+        Enable or disable hypervisor-specific features on the virtual machine.
+
+        .. versionadded:: Aluminium
+
+        .. code-block:: yaml
+
+            hypervisor_features:
+              kvm-hint-dedicated: True
 
     .. _init-cpu-def:
 
@@ -2655,6 +2668,7 @@ def init(
             boot,
             boot_dev,
             numatune,
+            hypervisor_features,
             **kwargs
         )
         log.debug("New virtual machine definition: %s", vm_xml)
@@ -2885,6 +2899,7 @@ def update(
     numatune=None,
     test=False,
     boot_dev=None,
+    hypervisor_features=None,
     **kwargs
 ):
     """
@@ -2988,6 +3003,16 @@ def update(
     :param test: run in dry-run mode if set to True
 
         .. versionadded:: 3001
+
+    :param hypervisor_features:
+        Enable or disable hypervisor-specific features on the virtual machine.
+
+        .. versionadded:: Aluminium
+
+        .. code-block:: yaml
+
+            hypervisor_features:
+              kvm-hint-dedicated: True
 
     :return:
 
@@ -3305,6 +3330,12 @@ def update(
                 "numatune/memnode[@cellid='$id']",
                 "nodeset",
                 ["cellid"],
+            ),
+            xmlutil.attribute(
+                "hypervisor_features:kvm-hint-dedicated",
+                "features/kvm/hint-dedicated",
+                "state",
+                convert=lambda v: "on" if v else "off",
             ),
         ]
 

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -3188,8 +3188,18 @@ def update(
             "set": lambda n, v: n.set("nodeset", v),
             "del": salt.utils.xmlutil.del_attribute("nodeset"),
         },
-        {"path": "mem:nosharepages", "xpath": "memoryBacking/nosharepages"},
-        {"path": "mem:locked", "xpath": "memoryBacking/locked"},
+        {
+            "path": "mem:nosharepages",
+            "xpath": "memoryBacking/nosharepages",
+            "get": lambda n: n is not None,
+            "set": lambda n, v: None,
+        },
+        {
+            "path": "mem:locked",
+            "xpath": "memoryBacking/locked",
+            "get": lambda n: n is not None,
+            "set": lambda n, v: None,
+        },
         {
             "path": "mem:source",
             "xpath": "memoryBacking/source",

--- a/salt/states/virt.py
+++ b/salt/states/virt.py
@@ -287,6 +287,7 @@ def defined(
     numatune=None,
     update=True,
     boot_dev=None,
+    hypervisor_features=None,
 ):
     """
     Starts an existing guest, or defines and starts a new VM with specified arguments.
@@ -516,6 +517,16 @@ def defined(
                 'memnodes': {0: {'mode': 'strict', 'nodeset': 1}, 1: {'mode': 'preferred', 'nodeset': 2}}
             }
 
+    :param hypervisor_features:
+        Enable or disable hypervisor-specific features on the virtual machine.
+
+        .. versionadded:: Aluminium
+
+        .. code-block:: yaml
+
+            hypervisor_features:
+              kvm-hint-dedicated: True
+
     .. rubric:: Example States
 
     Make sure a virtual machine called ``domain_name`` is defined:
@@ -581,6 +592,7 @@ def defined(
                     numatune=numatune,
                     test=__opts__["test"],
                     boot_dev=boot_dev,
+                    hypervisor_features=hypervisor_features,
                 )
             ret["changes"][name] = status
             if not status.get("definition"):
@@ -617,6 +629,7 @@ def defined(
                     numatune=numatune,
                     start=False,
                     boot_dev=boot_dev,
+                    hypervisor_features=hypervisor_features,
                 )
             ret["changes"][name] = {"definition": True}
             ret["comment"] = "Domain {} defined".format(name)
@@ -651,6 +664,7 @@ def running(
     boot=None,
     boot_dev=None,
     numatune=None,
+    hypervisor_features=None,
 ):
     """
     Starts an existing guest, or defines and starts a new VM with specified arguments.
@@ -800,6 +814,16 @@ def running(
 
         .. versionadded:: Aluminium
 
+    :param hypervisor_features:
+        Enable or disable hypervisor-specific features on the virtual machine.
+
+        .. versionadded:: Aluminium
+
+        .. code-block:: yaml
+
+            hypervisor_features:
+              kvm-hint-dedicated: True
+
     .. rubric:: Example States
 
     Make sure an already-defined virtual machine called ``domain_name`` is running:
@@ -869,6 +893,7 @@ def running(
         update=update,
         boot_dev=boot_dev,
         numatune=numatune,
+        hypervisor_features=hypervisor_features,
         connection=connection,
         username=username,
         password=password,

--- a/salt/states/virt.py
+++ b/salt/states/virt.py
@@ -288,6 +288,7 @@ def defined(
     update=True,
     boot_dev=None,
     hypervisor_features=None,
+    clock=None,
 ):
     """
     Starts an existing guest, or defines and starts a new VM with specified arguments.
@@ -527,6 +528,41 @@ def defined(
             hypervisor_features:
               kvm-hint-dedicated: True
 
+    :param clock:
+        Configure the guest clock.
+        The value is a dictionary with the following keys:
+
+        adjustment
+            time adjustment in seconds or ``reset``
+
+        utc
+            set to ``False`` to use the host local time as the guest clock. Defaults to ``True``.
+
+        timezone
+            synchronize the guest to the correspding timezone
+
+        timers
+            a dictionary associating the timer name with its configuration.
+            This configuration is a dictionary with the properties ``track``, ``tickpolicy``,
+            ``catchup``, ``frequency``, ``mode``, ``present``, ``slew``, ``threshold`` and ``limit``.
+            See `libvirt time keeping documentation <https://libvirt.org/formatdomain.html#time-keeping>`_ for the possible values.
+
+        .. versionadded:: Aluminium
+
+        Set the clock to local time using an offset in seconds
+        .. code-block:: yaml
+
+            clock:
+              adjustment: 3600
+              utc: False
+
+        Set the clock to a specific time zone:
+
+        .. code-block:: yaml
+
+            clock:
+              timezone: CEST
+
     .. rubric:: Example States
 
     Make sure a virtual machine called ``domain_name`` is defined:
@@ -593,6 +629,7 @@ def defined(
                     test=__opts__["test"],
                     boot_dev=boot_dev,
                     hypervisor_features=hypervisor_features,
+                    clock=clock,
                 )
             ret["changes"][name] = status
             if not status.get("definition"):
@@ -630,6 +667,7 @@ def defined(
                     start=False,
                     boot_dev=boot_dev,
                     hypervisor_features=hypervisor_features,
+                    clock=clock,
                 )
             ret["changes"][name] = {"definition": True}
             ret["comment"] = "Domain {} defined".format(name)
@@ -665,6 +703,7 @@ def running(
     boot_dev=None,
     numatune=None,
     hypervisor_features=None,
+    clock=None,
 ):
     """
     Starts an existing guest, or defines and starts a new VM with specified arguments.
@@ -824,6 +863,41 @@ def running(
             hypervisor_features:
               kvm-hint-dedicated: True
 
+    :param clock:
+        Configure the guest clock.
+        The value is a dictionary with the following keys:
+
+        adjustment
+            time adjustment in seconds or ``reset``
+
+        utc
+            set to ``False`` to use the host local time as the guest clock. Defaults to ``True``.
+
+        timezone
+            synchronize the guest to the correspding timezone
+
+        timers
+            a dictionary associating the timer name with its configuration.
+            This configuration is a dictionary with the properties ``track``, ``tickpolicy``,
+            ``catchup``, ``frequency``, ``mode``, ``present``, ``slew``, ``threshold`` and ``limit``.
+            See `libvirt time keeping documentation <https://libvirt.org/formatdomain.html#time-keeping>`_ for the possible values.
+
+        .. versionadded:: Aluminium
+
+        Set the clock to local time using an offset in seconds
+        .. code-block:: yaml
+
+            clock:
+              adjustment: 3600
+              utc: False
+
+        Set the clock to a specific time zone:
+
+        .. code-block:: yaml
+
+            clock:
+              timezone: CEST
+
     .. rubric:: Example States
 
     Make sure an already-defined virtual machine called ``domain_name`` is running:
@@ -894,6 +968,7 @@ def running(
         boot_dev=boot_dev,
         numatune=numatune,
         hypervisor_features=hypervisor_features,
+        clock=clock,
         connection=connection,
         username=username,
         password=password,

--- a/salt/templates/virt/libvirt_domain.jinja
+++ b/salt/templates/virt/libvirt_domain.jinja
@@ -328,7 +328,11 @@
                 </console>
                 {% endif %}
                 {% endif %}
-
+{%- if hypervisor in ["qemu", "kvm"] %}
+        <channel type='unix'>
+            <target type='virtio' name='org.qemu.guest_agent.0'/>
+        </channel>
+{%- endif %}
         </devices>
         <features>
                 <acpi />

--- a/salt/templates/virt/libvirt_domain.jinja
+++ b/salt/templates/virt/libvirt_domain.jinja
@@ -267,7 +267,7 @@
                         <address type='drive' controller='0' bus='0' target='0' unit='{{ disk.index }}' />
                         {% endif %}
                         {% if disk.driver -%}
-                        <driver name='qemu' type='{{ disk.format}}' cache='none' io='native'/>
+                        <driver name='qemu' type='{{ disk.format}}' cache='none' io='{{ disk.io }}'/>
                         {% endif %}
                 </disk>
                 {% endfor %}

--- a/salt/templates/virt/libvirt_domain.jinja
+++ b/salt/templates/virt/libvirt_domain.jinja
@@ -237,6 +237,18 @@
                 <boot dev='{{ dev }}' />
                 {% endfor %}
         </os>
+{%- if clock %}
+        <clock offset="{{ clock.offset }}"{{ opt_attribute(clock, "adjustment") }}{{ opt_attribute(clock, "timezone") }}>
+    {%- for timer_name in clock.timers %}
+    {%- set timer = clock.timers[timer_name] %}
+            <timer name='{{ timer_name }}'{{ opt_attribute(timer, "track") }}{{ opt_attribute(timer, "tickpolicy") }}{{ opt_attribute(timer, "frequency") }}{{ opt_attribute(timer, "mode") }}{{ opt_attribute(timer, "present", yesno) }}>
+        {%- if "threshold" in timer or "slew" in timer or "limit" in timer %}
+                <catchup{{ opt_attribute(timer, "slew") }}{{ opt_attribute(timer, "threshold") }}{{ opt_attribute(timer, "limit") }}/>
+        {%- endif %}
+            </timer>
+    {%- endfor %}
+        </clock>
+{%- endif %}
         <devices>
                 {% for disk in disks %}
                 <disk type='{{ disk.type }}' device='{{ disk.device }}'>

--- a/salt/templates/virt/libvirt_domain.jinja
+++ b/salt/templates/virt/libvirt_domain.jinja
@@ -1,6 +1,6 @@
 {%- import 'libvirt_disks.jinja' as libvirt_disks -%}
 {%- macro opt_attribute(obj, name, conv=none) %}
-{%- if obj.get(name) is not none %}{{ name }}='{{ obj[name] if conv is none else conv(obj[name]) }}'{% endif -%}
+{%- if obj.get(name) is not none %} {{ name }}='{{ obj[name] if conv is none else conv(obj[name]) }}'{% endif -%}
 {%- endmacro %}
 <domain type='{{ hypervisor }}'>
         <name>{{ name }}</name>
@@ -320,5 +320,12 @@
         </devices>
         <features>
                 <acpi />
+                <apic />
+                <pae />
+{%- if hypervisor_features.get("kvm-hint-dedicated") %}
+                <kvm>
+                  <hint-dedicated state="on"/>
+                </kvm>
+{%- endif %}
         </features>
 </domain>

--- a/salt/utils/xmlutil.py
+++ b/salt/utils/xmlutil.py
@@ -316,7 +316,9 @@ def change_xml(doc, data, mapping):
                 if convert_fn:
                     new_value = convert_fn(new_value)
 
-                if str(current_value) != str(new_value):
+                # Allow custom comparison. Can be useful for almost equal numeric values
+                compare_fn = param.get("equals", lambda o, n: str(o) == str(n))
+                if not compare_fn(current_value, new_value):
                     set_fn(node, new_value)
                     need_update = True
             else:

--- a/salt/utils/xmlutil.py
+++ b/salt/utils/xmlutil.py
@@ -211,6 +211,46 @@ def del_attribute(attribute, ignored=None):
     return _do_delete
 
 
+def attribute(path, xpath, attr_name, ignored=None, convert=None):
+    """
+    Helper function creating a change_xml mapping entry for a text XML attribute.
+
+    :param path: the path to the value in the data
+    :param xpath: the xpath to the node holding the attribute
+    :param attr_name: the attribute name
+    :param ignored: the list of attributes to ignore when cleaning up the node
+    :param convert: a function used to convert the value
+    """
+    entry = {
+        "path": path,
+        "xpath": xpath,
+        "get": lambda n: n.get(attr_name),
+        "set": lambda n, v: n.set(attr_name, str(v)),
+        "del": salt.utils.xmlutil.del_attribute(attr_name, ignored),
+    }
+    if convert:
+        entry["convert"] = convert
+    return entry
+
+
+def int_attribute(path, xpath, attr_name, ignored=None):
+    """
+    Helper function creating a change_xml mapping entry for a text XML integer attribute.
+
+    :param path: the path to the value in the data
+    :param xpath: the xpath to the node holding the attribute
+    :param attr_name: the attribute name
+    :param ignored: the list of attributes to ignore when cleaning up the node
+    """
+    return {
+        "path": path,
+        "xpath": xpath,
+        "get": lambda n: int(n.get(attr_name)) if n.get(attr_name) else None,
+        "set": lambda n, v: n.set(attr_name, str(v)),
+        "del": salt.utils.xmlutil.del_attribute(attr_name, ignored),
+    }
+
+
 def change_xml(doc, data, mapping):
     """
     Change an XML ElementTree document according.

--- a/tests/pytests/unit/modules/virt/test_domain.py
+++ b/tests/pytests/unit/modules/virt/test_domain.py
@@ -254,3 +254,25 @@ def test_get_disk_convert_volumes(make_mock_vm, make_mock_storage_pool):
                 "virtual size": 214748364800,
             },
         } == virt.get_disks("srv01")
+
+
+def test_update_approx_mem(make_mock_vm):
+    """
+    test virt.update with memory parameter unchanged thought not exactly equals to the current value.
+    This may happen since libvirt sometimes rounds the memory value.
+    """
+    xml_def = """
+        <domain type="kvm">
+          <name>my_vm</name>
+          <memory unit='KiB'>3177680</memory>
+          <currentMemory unit='KiB'>3177680</currentMemory>
+          <vcpu placement='static'>1</vcpu>
+          <os>
+            <type arch='x86_64'>hvm</type>
+          </os>
+        </domain>
+    """
+    domain_mock = make_mock_vm(xml_def)
+
+    ret = virt.update("my_vm", mem={"boot": "3253941043B", "current": "3253941043B"})
+    assert not ret["definition"]

--- a/tests/pytests/unit/modules/virt/test_domain.py
+++ b/tests/pytests/unit/modules/virt/test_domain.py
@@ -349,3 +349,165 @@ def test_update_hypervisor_features(make_mock_vm):
     assert ret["definition"]
     setxml = ET.fromstring(virt.libvirt.openAuth().defineXML.call_args[0][0])
     assert "on" == setxml.find("features/kvm/hint-dedicated").get("state")
+
+
+def test_gen_clock():
+    """
+    Test the virt._gen_xml clock property
+    """
+    # Localtime with adjustment
+    xml_data = virt._gen_xml(
+        virt.libvirt.openAuth.return_value,
+        "hello",
+        1,
+        512,
+        {},
+        {},
+        "kvm",
+        "hvm",
+        "x86_64",
+        clock={"adjustment": 3600, "utc": False},
+    )
+    root = ET.fromstring(xml_data)
+    assert "localtime" == root.find("clock").get("offset")
+    assert "3600" == root.find("clock").get("adjustment")
+
+    # Specific timezone
+    xml_data = virt._gen_xml(
+        virt.libvirt.openAuth.return_value,
+        "hello",
+        1,
+        512,
+        {},
+        {},
+        "kvm",
+        "hvm",
+        "x86_64",
+        clock={"timezone": "CEST"},
+    )
+    root = ET.fromstring(xml_data)
+    assert "timezone" == root.find("clock").get("offset")
+    assert "CEST" == root.find("clock").get("timezone")
+
+    # UTC
+    xml_data = virt._gen_xml(
+        virt.libvirt.openAuth.return_value,
+        "hello",
+        1,
+        512,
+        {},
+        {},
+        "kvm",
+        "hvm",
+        "x86_64",
+        clock={"utc": True},
+    )
+    root = ET.fromstring(xml_data)
+    assert "utc" == root.find("clock").get("offset")
+
+    # Timers
+    xml_data = virt._gen_xml(
+        virt.libvirt.openAuth.return_value,
+        "hello",
+        1,
+        512,
+        {},
+        {},
+        "kvm",
+        "hvm",
+        "x86_64",
+        clock={
+            "timers": {
+                "tsc": {"frequency": 3504000000, "mode": "native"},
+                "rtc": {
+                    "tickpolicy": "catchup",
+                    "slew": 4636,
+                    "threshold": 123,
+                    "limit": 2342,
+                },
+                "hpet": {"present": False},
+            },
+        },
+    )
+    root = ET.fromstring(xml_data)
+    assert "utc" == root.find("clock").get("offset")
+    assert "3504000000" == root.find("clock/timer[@name='tsc']").get("frequency")
+    assert "native" == root.find("clock/timer[@name='tsc']").get("mode")
+    assert "catchup" == root.find("clock/timer[@name='rtc']").get("tickpolicy")
+    assert {"slew": "4636", "threshold": "123", "limit": "2342"} == root.find(
+        "clock/timer[@name='rtc']/catchup"
+    ).attrib
+    assert "no" == root.find("clock/timer[@name='hpet']").get("present")
+
+
+def test_update_clock(make_mock_vm):
+    """
+    test virt.update with clock parameter
+    """
+    xml_def = """
+        <domain type="kvm">
+          <name>my_vm</name>
+          <memory unit='KiB'>524288</memory>
+          <currentMemory unit='KiB'>524288</currentMemory>
+          <vcpu placement='static'>1</vcpu>
+          <os>
+            <type arch='x86_64'>linux</type>
+            <kernel>/usr/lib/grub2/x86_64-xen/grub.xen</kernel>
+          </os>
+          <clock offset="localtime" adjustment="-3600">
+            <timer name="tsc" frequency="3504000000" mode="native" />
+            <timer name="kvmclock" present="no" />
+          </clock>
+        </domain>
+    """
+    domain_mock = make_mock_vm(xml_def)
+
+    # Update with no change to the features
+    ret = virt.update(
+        "my_vm",
+        clock={
+            "utc": False,
+            "adjustment": -3600,
+            "timers": {
+                "tsc": {"frequency": 3504000000, "mode": "native"},
+                "kvmclock": {"present": False},
+            },
+        },
+    )
+    assert not ret["definition"]
+
+    # Update
+    ret = virt.update(
+        "my_vm",
+        clock={
+            "timezone": "CEST",
+            "timers": {
+                "rtc": {
+                    "track": "wall",
+                    "tickpolicy": "catchup",
+                    "slew": 4636,
+                    "threshold": 123,
+                    "limit": 2342,
+                },
+                "hpet": {"present": True},
+            },
+        },
+    )
+    assert ret["definition"]
+    setxml = ET.fromstring(virt.libvirt.openAuth().defineXML.call_args[0][0])
+    assert "timezone" == setxml.find("clock").get("offset")
+    assert "CEST" == setxml.find("clock").get("timezone")
+    assert {"rtc", "hpet"} == {t.get("name") for t in setxml.findall("clock/timer")}
+    assert "catchup" == setxml.find("clock/timer[@name='rtc']").get("tickpolicy")
+    assert "wall" == setxml.find("clock/timer[@name='rtc']").get("track")
+    assert {"slew": "4636", "threshold": "123", "limit": "2342"} == setxml.find(
+        "clock/timer[@name='rtc']/catchup"
+    ).attrib
+    assert "yes" == setxml.find("clock/timer[@name='hpet']").get("present")
+
+    # Revert to UTC
+    ret = virt.update("my_vm", clock={"utc": True, "adjustment": None, "timers": None})
+    assert ret["definition"]
+    setxml = ET.fromstring(virt.libvirt.openAuth().defineXML.call_args[0][0])
+    assert {"offset": "utc"} == setxml.find("clock").attrib
+    assert setxml.find("clock/timer") is None

--- a/tests/pytests/unit/utils/test_xmlutil.py
+++ b/tests/pytests/unit/utils/test_xmlutil.py
@@ -41,6 +41,22 @@ def test_change_xml_text_nochange(xml_doc):
     assert not ret
 
 
+def test_change_xml_equals_nochange(xml_doc):
+    ret = xml.change_xml(
+        xml_doc,
+        {"mem": 1023},
+        [
+            {
+                "path": "mem",
+                "xpath": "memory",
+                "get": lambda n: int(n.text),
+                "equals": lambda o, n: abs(o - n) <= 1,
+            }
+        ],
+    )
+    assert not ret
+
+
 def test_change_xml_text_notdefined(xml_doc):
     ret = xml.change_xml(xml_doc, {}, [{"path": "name", "xpath": "name"}])
     assert not ret

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -3556,48 +3556,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 <loader>/usr/share/old/OVMF_CODE.fd</loader>
                 <nvram>/usr/share/old/OVMF_VARS.ms.fd</nvram>
               </os>
-              <devices>
-                <disk type='file' device='disk'>
-                  <driver name='qemu' type='qcow2'/>
-                  <source file='{0}{1}vm_with_boot_param_system.qcow2'/>
-                  <backingStore/>
-                  <target dev='vda' bus='virtio'/>
-                  <alias name='virtio-disk0'/>
-                  <address type='pci' domain='0x0000' bus='0x00' slot='0x07' function='0x0'/>
-                </disk>
-                <disk type='file' device='disk'>
-                  <driver name='qemu' type='qcow2'/>
-                  <source file='{0}{1}vm_with_boot_param_data.qcow2'/>
-                  <backingStore/>
-                  <target dev='vdb' bus='virtio'/>
-                  <alias name='virtio-disk1'/>
-                  <address type='pci' domain='0x0000' bus='0x00' slot='0x07' function='0x1'/>
-                </disk>
-                <interface type='network'>
-                  <mac address='52:54:00:39:02:b1'/>
-                  <source network='default' bridge='virbr0'/>
-                  <target dev='vnet0'/>
-                  <model type='virtio'/>
-                  <alias name='net0'/>
-                  <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
-                </interface>
-                <interface type='network'>
-                  <mac address='52:54:00:39:02:b2'/>
-                  <source network='oldnet' bridge='virbr1'/>
-                  <target dev='vnet1'/>
-                  <model type='virtio'/>
-                  <alias name='net1'/>
-                  <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x1'/>
-                </interface>
-                <graphics type='spice' port='5900' autoport='yes' listen='127.0.0.1'>
-                  <listen type='address' address='127.0.0.1'/>
-                </graphics>
-                <video>
-                  <model type='qxl' ram='65536' vram='65536' vgamem='16384' heads='1' primary='yes'/>
-                  <alias name='video0'/>
-                  <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
-                </video>
-              </devices>
             </domain>
         """
         domain_mock_boot = self.set_mock_vm("vm_with_boot_param", xml_boot)

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -2841,7 +2841,11 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             },
         )
         self.assertNotEqual(setxml.find("./memoryBacking/nosharepages"), None)
+        self.assertIsNone(setxml.find("./memoryBacking/nosharepages").text)
+        self.assertEqual([], setxml.find("./memoryBacking/nosharepages").keys())
         self.assertNotEqual(setxml.find("./memoryBacking/locked"), None)
+        self.assertIsNone(setxml.find("./memoryBacking/locked").text)
+        self.assertEqual([], setxml.find("./memoryBacking/locked").keys())
         self.assertEqual(setxml.find("./memoryBacking/source").attrib["type"], "file")
         self.assertEqual(setxml.find("./memoryBacking/access").attrib["mode"], "shared")
         self.assertNotEqual(setxml.find("./memoryBacking/discard"), None)

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -2323,7 +2323,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         setxml = ET.fromstring(define_mock.call_args[0][0])
         self.assertEqual(setxml.find("vcpu").text, "12")
         self.assertEqual(setxml.find("vcpu").attrib["placement"], "static")
-        self.assertEqual(setxml.find("vcpu").attrib["cpuset"], "0-11")
+        self.assertEqual(
+            setxml.find("vcpu").attrib["cpuset"], "0,1,2,3,4,5,6,7,8,9,10,11"
+        )
         self.assertEqual(setxml.find("vcpu").attrib["current"], "5")
 
         # test adding vcpus elements
@@ -2492,7 +2494,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             virt.update("my_vm", cpu=numa_cell),
         )
         setxml = ET.fromstring(define_mock.call_args[0][0])
-        self.assertEqual(setxml.find("./cpu/numa/cell/[@id='0']").attrib["cpus"], "0-3")
+        self.assertEqual(
+            setxml.find("./cpu/numa/cell/[@id='0']").attrib["cpus"], "0,1,2,3"
+        )
         self.assertEqual(
             setxml.find("./cpu/numa/cell/[@id='0']").attrib["memory"], str(1024 ** 3)
         )
@@ -2524,7 +2528,9 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             ],
             "41",
         )
-        self.assertEqual(setxml.find("./cpu/numa/cell/[@id='1']").attrib["cpus"], "4-6")
+        self.assertEqual(
+            setxml.find("./cpu/numa/cell/[@id='1']").attrib["cpus"], "4,5,6"
+        )
         self.assertEqual(
             setxml.find("./cpu/numa/cell/[@id='1']").attrib["memory"],
             str(int(1024 ** 3 / 2)),
@@ -2810,7 +2816,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         # update memory backing case
         mem_back = {
             "hugepages": [
-                {"nodeset": "1-5,4", "size": "1g"},
+                {"nodeset": "1-5,^4", "size": "1g"},
                 {"nodeset": "4", "size": "2g"},
             ],
             "nosharepages": True,
@@ -2836,7 +2842,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 for p in setxml.findall("memoryBacking/hugepages/page")
             },
             {
-                "1-5,4": {"size": str(1024 ** 3), "unit": "bytes"},
+                "1,2,3,5": {"size": str(1024 ** 3), "unit": "bytes"},
                 "4": {"size": str(2 * 1024 ** 3), "unit": "bytes"},
             },
         )
@@ -2914,7 +2920,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(setxml.find("cputune").find("iothread_quota").text, "-1")
         self.assertEqual(
             setxml.find("cputune").find("vcpupin[@vcpu='0']").attrib.get("cpuset"),
-            "1-4,^2",
+            "1,3,4",
         )
         self.assertEqual(
             setxml.find("cputune").find("vcpupin[@vcpu='1']").attrib.get("cpuset"),
@@ -2929,19 +2935,19 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             "0,4",
         )
         self.assertEqual(
-            setxml.find("cputune").find("emulatorpin").attrib.get("cpuset"), "1-3"
+            setxml.find("cputune").find("emulatorpin").attrib.get("cpuset"), "1,2,3"
         )
         self.assertEqual(
             setxml.find("cputune")
             .find("iothreadpin[@iothread='1']")
             .attrib.get("cpuset"),
-            "5-6",
+            "5,6",
         )
         self.assertEqual(
             setxml.find("cputune")
             .find("iothreadpin[@iothread='2']")
             .attrib.get("cpuset"),
-            "7-8",
+            "7,8",
         )
         self.assertEqual(
             setxml.find("cputune").find("vcpusched[@vcpus='0']").attrib.get("priority"),
@@ -2960,64 +2966,63 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             setxml.find("cputune").find("iothreadsched").attrib.get("scheduler"),
             "batch",
         )
+        self.assertIsNotNone(setxml.find("./cputune/cachetune[@vcpus='0,1,2,3']"))
         self.assertEqual(
-            setxml.find("./cputune/cachetune[@vcpus='0-3']").attrib.get("vcpus"), "0-3"
-        )
-        self.assertEqual(
-            setxml.find("./cputune/cachetune[@vcpus='0-3']/cache[@id='0']").attrib.get(
-                "level"
-            ),
+            setxml.find(
+                "./cputune/cachetune[@vcpus='0,1,2,3']/cache[@id='0']"
+            ).attrib.get("level"),
             "3",
         )
         self.assertEqual(
-            setxml.find("./cputune/cachetune[@vcpus='0-3']/cache[@id='0']").attrib.get(
-                "type"
-            ),
+            setxml.find(
+                "./cputune/cachetune[@vcpus='0,1,2,3']/cache[@id='0']"
+            ).attrib.get("type"),
             "both",
         )
         self.assertEqual(
             setxml.find(
-                "./cputune/cachetune[@vcpus='0-3']/monitor[@vcpus='1']"
+                "./cputune/cachetune[@vcpus='0,1,2,3']/monitor[@vcpus='1']"
             ).attrib.get("level"),
             "3",
         )
         self.assertNotEqual(
-            setxml.find("./cputune/cachetune[@vcpus='0-3']/monitor[@vcpus='1']"), None
+            setxml.find("./cputune/cachetune[@vcpus='0,1,2,3']/monitor[@vcpus='1']"),
+            None,
         )
         self.assertNotEqual(
-            setxml.find("./cputune/cachetune[@vcpus='4-5']").attrib.get("vcpus"), None
+            setxml.find("./cputune/cachetune[@vcpus='4,5']").attrib.get("vcpus"), None
         )
         self.assertEqual(
-            setxml.find("./cputune/cachetune[@vcpus='4-5']/cache[@id='0']"), None
+            setxml.find("./cputune/cachetune[@vcpus='4,5']/cache[@id='0']"), None
         )
         self.assertEqual(
             setxml.find(
-                "./cputune/cachetune[@vcpus='4-5']/monitor[@vcpus='4']"
+                "./cputune/cachetune[@vcpus='4,5']/monitor[@vcpus='4']"
             ).attrib.get("level"),
             "3",
         )
         self.assertEqual(
             setxml.find(
-                "./cputune/cachetune[@vcpus='4-5']/monitor[@vcpus='5']"
+                "./cputune/cachetune[@vcpus='4,5']/monitor[@vcpus='5']"
             ).attrib.get("level"),
             "2",
         )
-        self.assertNotEqual(setxml.find("./cputune/memorytune[@vcpus='0-2']"), None)
+        self.assertNotEqual(setxml.find("./cputune/memorytune[@vcpus='0,1,2']"), None)
         self.assertEqual(
-            setxml.find("./cputune/memorytune[@vcpus='0-2']/node[@id='0']").attrib.get(
-                "bandwidth"
-            ),
+            setxml.find(
+                "./cputune/memorytune[@vcpus='0,1,2']/node[@id='0']"
+            ).attrib.get("bandwidth"),
             "60",
         )
-        self.assertNotEqual(setxml.find("./cputune/memorytune[@vcpus='3-4']"), None)
+        self.assertNotEqual(setxml.find("./cputune/memorytune[@vcpus='3,4']"), None)
         self.assertEqual(
-            setxml.find("./cputune/memorytune[@vcpus='3-4']/node[@id='0']").attrib.get(
+            setxml.find("./cputune/memorytune[@vcpus='3,4']/node[@id='0']").attrib.get(
                 "bandwidth"
             ),
             "50",
         )
         self.assertEqual(
-            setxml.find("./cputune/memorytune[@vcpus='3-4']/node[@id='1']").attrib.get(
+            setxml.find("./cputune/memorytune[@vcpus='3,4']/node[@id='1']").attrib.get(
                 "bandwidth"
             ),
             "70",
@@ -3709,7 +3714,8 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         )
 
         self.assertEqual(
-            setxml.find("numatune").find("memory").attrib.get("nodeset"), "0-5"
+            setxml.find("numatune").find("memory").attrib.get("nodeset"),
+            ",".join([str(i) for i in range(0, 6)]),
         )
 
         self.assertEqual(
@@ -3801,13 +3807,14 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         )
 
         self.assertEqual(
-            setxml.find("numatune").find("memory").attrib.get("nodeset"), "0-5"
+            setxml.find("numatune").find("memory").attrib.get("nodeset"),
+            ",".join([str(i) for i in range(0, 6)]),
         )
 
         self.assertEqual(setxml.find("./numatune/memnode"), None)
 
         numatune_without_change = {
-            "memory": {"mode": "strict", "nodeset": "0-11"},
+            "memory": {"mode": "strict", "nodeset": "0-5,6,7-11"},
             "memnodes": {
                 1: {"mode": "strict", "nodeset": "3"},
                 3: {"mode": "preferred", "nodeset": "7"},
@@ -3916,7 +3923,10 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         setxml = ET.fromstring(define_mock.call_args[0][0])
         self.assertEqual(setxml.find("vcpu").text, "5")
         self.assertEqual(setxml.find("vcpu").attrib["placement"], "static")
-        self.assertEqual(setxml.find("vcpu").attrib["cpuset"], "0-5")
+        self.assertEqual(
+            setxml.find("vcpu").attrib["cpuset"],
+            ",".join([str(i) for i in range(0, 6)]),
+        )
         self.assertEqual(setxml.find("vcpu").attrib["current"], "3")
 
         # test removing vcpu attribute
@@ -4304,7 +4314,10 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             virt.update("vm_with_existing_param", cpu=numa_cell),
         )
         setxml = ET.fromstring(define_mock.call_args[0][0])
-        self.assertEqual(setxml.find("./cpu/numa/cell/[@id='0']").attrib["cpus"], "0-6")
+        self.assertEqual(
+            setxml.find("./cpu/numa/cell/[@id='0']").attrib["cpus"],
+            ",".join([str(i) for i in range(0, 7)]),
+        )
         self.assertEqual(
             setxml.find("./cpu/numa/cell/[@id='0']").attrib["memory"],
             str(512 * 1024 ** 2),
@@ -4340,7 +4353,8 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             "18",
         )
         self.assertEqual(
-            setxml.find("./cpu/numa/cell/[@id='1']").attrib["cpus"], "7-12"
+            setxml.find("./cpu/numa/cell/[@id='1']").attrib["cpus"],
+            ",".join([str(i) for i in range(7, 13)]),
         )
         self.assertEqual(
             setxml.find("./cpu/numa/cell/[@id='1']").attrib["memory"],
@@ -4406,7 +4420,10 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             virt.update("vm_with_existing_param", cpu=numa_cell_atr_none),
         )
         setxml = ET.fromstring(define_mock.call_args[0][0])
-        self.assertEqual(setxml.find("./cpu/numa/cell/[@id='0']").attrib["cpus"], "0-6")
+        self.assertEqual(
+            setxml.find("./cpu/numa/cell/[@id='0']").attrib["cpus"],
+            ",".join([str(i) for i in range(0, 7)]),
+        )
         self.assertEqual(
             setxml.find("./cpu/numa/cell/[@id='0']").attrib["memory"],
             str(512 * 1024 ** 2),
@@ -4439,7 +4456,8 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             "18",
         )
         self.assertEqual(
-            setxml.find("./cpu/numa/cell/[@id='1']").attrib["cpus"], "7-12"
+            setxml.find("./cpu/numa/cell/[@id='1']").attrib["cpus"],
+            ",".join([str(i) for i in range(7, 13)]),
         )
         self.assertEqual(
             setxml.find("./cpu/numa/cell/[@id='1']").attrib["memory"],
@@ -4471,7 +4489,8 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         )
 
         self.assertEqual(
-            setxml.find("./cpu/numa/cell/[@id='1']").attrib["cpus"], "7-12"
+            setxml.find("./cpu/numa/cell/[@id='1']").attrib["cpus"],
+            ",".join([str(i) for i in range(7, 13)]),
         )
         self.assertEqual(
             setxml.find("./cpu/numa/cell/[@id='1']").attrib["memory"],
@@ -4693,7 +4712,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
               <memoryBacking>
                 <hugepages>
                   <page size="2048" unit="KiB"/>
-                  <page size="3145728" nodeset="1-4,3" unit="KiB"/>
+                  <page size="3145728" nodeset="1-4,^3" unit="KiB"/>
                   <page size="1048576" nodeset="3" unit="KiB"/>
                 </hugepages>
                 <nosharepages/>
@@ -4715,7 +4734,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         # update memory backing case
         mem_back_param = {
             "hugepages": [
-                {"nodeset": "1-4,3", "size": "1g"},
+                {"nodeset": "1-4,^3", "size": "1g"},
                 {"nodeset": "3", "size": "2g"},
             ],
             "nosharepages": None,
@@ -4741,7 +4760,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 for p in setxml.findall("memoryBacking/hugepages/page")
             },
             {
-                "1-4,3": {"size": str(1024 ** 3), "unit": "bytes"},
+                "1,2,4": {"size": str(1024 ** 3), "unit": "bytes"},
                 "3": {"size": str(2 * 1024 ** 3), "unit": "bytes"},
             },
         )
@@ -4761,7 +4780,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         unchanged_page = {
             "hugepages": [
                 {"size": "2m"},
-                {"nodeset": "1-4,3", "size": "3g"},
+                {"nodeset": "1-4,^3", "size": "3g"},
                 {"nodeset": "3", "size": "1g"},
             ],
         }
@@ -4929,7 +4948,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(setxml.find("cputune").find("iothread_quota").text, "-5")
         self.assertEqual(
             setxml.find("cputune").find("vcpupin[@vcpu='0']").attrib.get("cpuset"),
-            "1-4,^2",
+            "1,3,4",
         )
         self.assertEqual(
             setxml.find("cputune").find("vcpupin[@vcpu='1']").attrib.get("cpuset"),
@@ -4944,19 +4963,19 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             "0,4",
         )
         self.assertEqual(
-            setxml.find("cputune").find("emulatorpin").attrib.get("cpuset"), "1-3"
+            setxml.find("cputune").find("emulatorpin").attrib.get("cpuset"), "1,2,3"
         )
         self.assertEqual(
             setxml.find("cputune")
             .find("iothreadpin[@iothread='1']")
             .attrib.get("cpuset"),
-            "5-6",
+            "5,6",
         )
         self.assertEqual(
             setxml.find("cputune")
             .find("iothreadpin[@iothread='2']")
             .attrib.get("cpuset"),
-            "7-8",
+            "7,8",
         )
         self.assertDictEqual(
             {
@@ -4980,68 +4999,67 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 }
                 for s in setxml.findall("cputune/iothreadsched")
             },
-            {"5-7": {"scheduler": "batch", "priority": "1"}},
+            {"5,6,7": {"scheduler": "batch", "priority": "1"}},
         )
         self.assertEqual(setxml.find("cputune/emulatorsched").get("scheduler"), "rr")
         self.assertEqual(setxml.find("cputune/emulatorsched").get("priority"), "2")
+        self.assertIsNotNone(setxml.find("./cputune/cachetune[@vcpus='0,1,2,3']"))
         self.assertEqual(
-            setxml.find("./cputune/cachetune[@vcpus='0-3']").attrib.get("vcpus"), "0-3"
-        )
-        self.assertEqual(
-            setxml.find("./cputune/cachetune[@vcpus='0-3']/cache[@id='0']").attrib.get(
-                "level"
-            ),
+            setxml.find(
+                "./cputune/cachetune[@vcpus='0,1,2,3']/cache[@id='0']"
+            ).attrib.get("level"),
             "3",
         )
         self.assertEqual(
-            setxml.find("./cputune/cachetune[@vcpus='0-3']/cache[@id='0']").attrib.get(
-                "type"
-            ),
+            setxml.find(
+                "./cputune/cachetune[@vcpus='0,1,2,3']/cache[@id='0']"
+            ).attrib.get("type"),
             "both",
         )
         self.assertEqual(
             setxml.find(
-                "./cputune/cachetune[@vcpus='0-3']/monitor[@vcpus='1']"
+                "./cputune/cachetune[@vcpus='0,1,2,3']/monitor[@vcpus='1']"
             ).attrib.get("level"),
             "3",
         )
         self.assertNotEqual(
-            setxml.find("./cputune/cachetune[@vcpus='0-3']/monitor[@vcpus='1']"), None
+            setxml.find("./cputune/cachetune[@vcpus='0,1,2,3']/monitor[@vcpus='1']"),
+            None,
         )
         self.assertNotEqual(
-            setxml.find("./cputune/cachetune[@vcpus='4-5']").attrib.get("vcpus"), None
+            setxml.find("./cputune/cachetune[@vcpus='4,5']").attrib.get("vcpus"), None
         )
         self.assertEqual(
-            setxml.find("./cputune/cachetune[@vcpus='4-5']/cache[@id='0']"), None
+            setxml.find("./cputune/cachetune[@vcpus='4,5']/cache[@id='0']"), None
         )
         self.assertEqual(
             setxml.find(
-                "./cputune/cachetune[@vcpus='4-5']/monitor[@vcpus='4']"
+                "./cputune/cachetune[@vcpus='4,5']/monitor[@vcpus='4']"
             ).attrib.get("level"),
             "3",
         )
         self.assertEqual(
             setxml.find(
-                "./cputune/cachetune[@vcpus='4-5']/monitor[@vcpus='5']"
+                "./cputune/cachetune[@vcpus='4,5']/monitor[@vcpus='5']"
             ).attrib.get("level"),
             "2",
         )
-        self.assertNotEqual(setxml.find("./cputune/memorytune[@vcpus='0-2']"), None)
+        self.assertNotEqual(setxml.find("./cputune/memorytune[@vcpus='0,1,2']"), None)
         self.assertEqual(
-            setxml.find("./cputune/memorytune[@vcpus='0-2']/node[@id='0']").attrib.get(
-                "bandwidth"
-            ),
+            setxml.find(
+                "./cputune/memorytune[@vcpus='0,1,2']/node[@id='0']"
+            ).attrib.get("bandwidth"),
             "60",
         )
-        self.assertNotEqual(setxml.find("./cputune/memorytune[@vcpus='3-4']"), None)
+        self.assertNotEqual(setxml.find("./cputune/memorytune[@vcpus='3,4']"), None)
         self.assertEqual(
-            setxml.find("./cputune/memorytune[@vcpus='3-4']/node[@id='0']").attrib.get(
+            setxml.find("./cputune/memorytune[@vcpus='3,4']/node[@id='0']").attrib.get(
                 "bandwidth"
             ),
             "50",
         )
         self.assertEqual(
-            setxml.find("./cputune/memorytune[@vcpus='3-4']/node[@id='1']").attrib.get(
+            setxml.find("./cputune/memorytune[@vcpus='3,4']/node[@id='1']").attrib.get(
                 "bandwidth"
             ),
             "70",
@@ -5092,7 +5110,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(setxml.find("cputune").find("iothread_quota").text, "-5")
         self.assertEqual(
             setxml.find("cputune").find("vcpupin[@vcpu='0']").attrib.get("cpuset"),
-            "1-4,^2",
+            "1,3,4",
         )
         self.assertEqual(setxml.find("cputune").find("vcpupin[@vcpu='1']"), None)
         self.assertEqual(
@@ -5105,7 +5123,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             setxml.find("cputune")
             .find("iothreadpin[@iothread='1']")
             .attrib.get("cpuset"),
-            "5-6",
+            "5,6",
         )
         self.assertEqual(
             setxml.find("cputune").find("iothreadpin[@iothread='2']"), None
@@ -5121,49 +5139,48 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             {"1": {"scheduler": "idle", "priority": "5"}},
         )
         self.assertEqual(setxml.find("cputune").find("iothreadsched"), None)
+        self.assertIsNotNone(setxml.find("./cputune/cachetune[@vcpus='0,1,2,3']"))
         self.assertEqual(
-            setxml.find("./cputune/cachetune[@vcpus='0-3']").attrib.get("vcpus"), "0-3"
-        )
-        self.assertEqual(
-            setxml.find("./cputune/cachetune[@vcpus='0-3']/cache[@id='0']").attrib.get(
-                "size"
-            ),
+            setxml.find(
+                "./cputune/cachetune[@vcpus='0,1,2,3']/cache[@id='0']"
+            ).attrib.get("size"),
             "7",
         )
         self.assertEqual(
-            setxml.find("./cputune/cachetune[@vcpus='0-3']/cache[@id='0']").attrib.get(
-                "level"
-            ),
+            setxml.find(
+                "./cputune/cachetune[@vcpus='0,1,2,3']/cache[@id='0']"
+            ).attrib.get("level"),
             "4",
         )
         self.assertEqual(
-            setxml.find("./cputune/cachetune[@vcpus='0-3']/cache[@id='0']").attrib.get(
-                "type"
-            ),
+            setxml.find(
+                "./cputune/cachetune[@vcpus='0,1,2,3']/cache[@id='0']"
+            ).attrib.get("type"),
             "data",
         )
         self.assertEqual(
             setxml.find(
-                "./cputune/cachetune[@vcpus='0-3']/monitor[@vcpus='1-2']"
+                "./cputune/cachetune[@vcpus='0,1,2,3']/monitor[@vcpus='1,2']"
             ).attrib.get("level"),
             "11",
         )
         self.assertEqual(
-            setxml.find("./cputune/cachetune[@vcpus='0-3']/monitor[@vcpus='3-4']"), None
+            setxml.find("./cputune/cachetune[@vcpus='0,1,2,3']/monitor[@vcpus='3,4']"),
+            None,
         )
         self.assertEqual(
-            setxml.find("./cputune/cachetune[@vcpus='0-3']/cache[@id='1']"), None
+            setxml.find("./cputune/cachetune[@vcpus='0,1,2,3']/cache[@id='1']"), None
         )
-        self.assertEqual(setxml.find("./cputune/cachetune[@vcpus='4-5']"), None)
-        self.assertEqual(setxml.find("./cputune/memorytune[@vcpus='0-2']"), None)
+        self.assertEqual(setxml.find("./cputune/cachetune[@vcpus='4,5']"), None)
+        self.assertEqual(setxml.find("./cputune/memorytune[@vcpus='0,1,2']"), None)
         self.assertEqual(
-            setxml.find("./cputune/memorytune[@vcpus='3-4']/node[@id='0']").attrib.get(
+            setxml.find("./cputune/memorytune[@vcpus='3,4']/node[@id='0']").attrib.get(
                 "bandwidth"
             ),
             "37",
         )
         self.assertEqual(
-            setxml.find("./cputune/memorytune[@vcpus='3-4']/node[@id='1']").attrib.get(
+            setxml.find("./cputune/memorytune[@vcpus='3,4']/node[@id='1']").attrib.get(
                 "bandwidth"
             ),
             "73",

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -3046,7 +3046,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                             "source_file": None,
                             "model": "ide",
                         },
-                        {"name": "added", "size": 2048},
+                        {"name": "added", "size": 2048, "iothreads": True},
                     ],
                 )
                 added_disk_path = os.path.join(
@@ -3077,6 +3077,11 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 )
                 self.assertEqual(devattach_mock.call_count, 2)
                 self.assertEqual(devdetach_mock.call_count, 2)
+
+                setxml = ET.fromstring(define_mock.call_args[0][0])
+                self.assertEqual(
+                    "threads", setxml.find("devices/disk[3]/driver").get("io")
+                )
 
         # Update nics case
         yaml_config = """

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -2338,7 +2338,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -2365,7 +2364,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -2387,7 +2385,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -2407,7 +2404,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -2421,7 +2417,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -2437,7 +2432,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -2452,7 +2446,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -2487,7 +2480,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -2862,7 +2854,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 "definition": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
-                "cpu": True,
             },
             virt.update("my_vm", cpu={"iothreads": 5}),
         )
@@ -2904,7 +2895,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 "definition": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
-                "cpu": True,
             },
             virt.update("my_vm", cpu={"tuning": cputune}),
         )
@@ -3957,7 +3947,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -3992,7 +3981,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -4014,7 +4002,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -4029,7 +4016,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -4043,7 +4029,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -4060,7 +4045,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -4075,7 +4059,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -4098,7 +4081,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -4118,7 +4100,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -4131,7 +4112,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -4145,7 +4125,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -4162,7 +4141,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -4179,7 +4157,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -4193,7 +4170,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -4209,7 +4185,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -4225,7 +4200,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -4239,7 +4213,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -4258,7 +4231,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -4277,7 +4249,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -4307,7 +4278,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -4413,7 +4383,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(
             {
                 "definition": True,
-                "cpu": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
             },
@@ -4824,7 +4793,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 "definition": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
-                "cpu": False,
             },
             virt.update("xml_with_iothreads_params", cpu={"iothreads": 7}),
         )
@@ -4932,7 +4900,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 "definition": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
-                "cpu": False,
             },
             virt.update("xml_with_cputune_params", cpu={"tuning": cputune}),
         )
@@ -5094,7 +5061,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 "definition": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
-                "cpu": False,
             },
             virt.update("xml_with_cputune_params", cpu={"tuning": cputune}),
         )
@@ -5200,7 +5166,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 "definition": True,
                 "disk": {"attached": [], "detached": [], "updated": []},
                 "interface": {"attached": [], "detached": []},
-                "cpu": False,
             },
             virt.update("xml_with_cputune_params", cpu={"tuning": cputune_subelement}),
         )

--- a/tests/unit/states/test_virt.py
+++ b/tests/unit/states/test_virt.py
@@ -346,6 +346,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                         pub_key="/path/to/key.pub",
                         priv_key="/path/to/key",
                         hypervisor_features={"kvm-hint-dedicated": True},
+                        clock={"utc": True},
                         connection="someconnection",
                         username="libvirtuser",
                         password="supersecret",
@@ -373,6 +374,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     pub_key="/path/to/key.pub",
                     priv_key="/path/to/key",
                     hypervisor_features={"kvm-hint-dedicated": True},
+                    clock={"utc": True},
                     connection="someconnection",
                     username="libvirtuser",
                     password="supersecret",
@@ -488,6 +490,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     numatune=None,
                     test=False,
                     hypervisor_features=None,
+                    clock=None,
                 )
 
             # Failed definition update case
@@ -602,6 +605,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     test=True,
                     boot_dev=None,
                     hypervisor_features=None,
+                    clock=None,
                 )
 
             # No changes case
@@ -639,6 +643,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     test=True,
                     boot_dev=None,
                     hypervisor_features=None,
+                    clock=None,
                 )
 
     def test_running(self):
@@ -718,6 +723,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     priv_key=None,
                     boot_dev=None,
                     hypervisor_features=None,
+                    clock=None,
                     connection=None,
                     username=None,
                     password=None,
@@ -807,6 +813,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     priv_key="/path/to/key",
                     boot_dev="network hd",
                     hypervisor_features=None,
+                    clock=None,
                     connection="someconnection",
                     username="libvirtuser",
                     password="supersecret",
@@ -954,6 +961,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     test=False,
                     boot_dev=None,
                     hypervisor_features=None,
+                    clock=None,
                 )
 
             # Failed definition update case
@@ -1075,6 +1083,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     test=True,
                     boot_dev=None,
                     hypervisor_features=None,
+                    clock=None,
                 )
                 start_mock.assert_not_called()
 
@@ -1114,6 +1123,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     test=True,
                     boot_dev=None,
                     hypervisor_features=None,
+                    clock=None,
                 )
 
     def test_stopped(self):

--- a/tests/unit/states/test_virt.py
+++ b/tests/unit/states/test_virt.py
@@ -345,6 +345,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                         install=False,
                         pub_key="/path/to/key.pub",
                         priv_key="/path/to/key",
+                        hypervisor_features={"kvm-hint-dedicated": True},
                         connection="someconnection",
                         username="libvirtuser",
                         password="supersecret",
@@ -371,6 +372,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     start=False,
                     pub_key="/path/to/key.pub",
                     priv_key="/path/to/key",
+                    hypervisor_features={"kvm-hint-dedicated": True},
                     connection="someconnection",
                     username="libvirtuser",
                     password="supersecret",
@@ -485,6 +487,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     boot=None,
                     numatune=None,
                     test=False,
+                    hypervisor_features=None,
                 )
 
             # Failed definition update case
@@ -598,6 +601,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     numatune=None,
                     test=True,
                     boot_dev=None,
+                    hypervisor_features=None,
                 )
 
             # No changes case
@@ -634,6 +638,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     numatune=None,
                     test=True,
                     boot_dev=None,
+                    hypervisor_features=None,
                 )
 
     def test_running(self):
@@ -712,6 +717,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     pub_key=None,
                     priv_key=None,
                     boot_dev=None,
+                    hypervisor_features=None,
                     connection=None,
                     username=None,
                     password=None,
@@ -800,6 +806,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     pub_key="/path/to/key.pub",
                     priv_key="/path/to/key",
                     boot_dev="network hd",
+                    hypervisor_features=None,
                     connection="someconnection",
                     username="libvirtuser",
                     password="supersecret",
@@ -946,6 +953,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     numatune=None,
                     test=False,
                     boot_dev=None,
+                    hypervisor_features=None,
                 )
 
             # Failed definition update case
@@ -1066,6 +1074,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     numatune=None,
                     test=True,
                     boot_dev=None,
+                    hypervisor_features=None,
                 )
                 start_mock.assert_not_called()
 
@@ -1104,6 +1113,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                     numatune=None,
                     test=True,
                     boot_dev=None,
+                    hypervisor_features=None,
                 )
 
     def test_stopped(self):


### PR DESCRIPTION
### What does this PR do?

In order to be able to create big performance-optimized VM, we need to expose more parameters like the kvm `hint-dedicated` feature flag or the clock configuration.

This pull request also includes a few follow up fixes from PR #58196.

### Merge requirements satisfied?
- [X] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes