### PR TITLE
Update runner.py

### DIFF
--- a/salt/runner.py
+++ b/salt/runner.py
@@ -114,7 +114,7 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin):
 
         .. code-block:: python
 
-            runner.eauth_async({
+            runner.cmd_async({
                 'fun': 'jobs.list_jobs',
                 'username': 'saltdev',
                 'password': 'saltdev',
@@ -134,7 +134,7 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin):
 
         .. code-block:: python
 
-            runner.eauth_sync({
+            runner.cmd_sync({
                 'fun': 'jobs.list_jobs',
                 'username': 'saltdev',
                 'password': 'saltdev',


### PR DESCRIPTION
Address typos in the documentation. The code probably changed and the documentation never caught up to the correct function name. 
