### PR TITLE
Don't set `close_fds` to `True` on FreeBSD when Py<3.9

### DIFF
--- a/requirements/pytest.txt
+++ b/requirements/pytest.txt
@@ -2,6 +2,6 @@ mock >= 3.0.0
 # PyTest
 pytest >= 6.1.0
 pytest-salt
-pytest-salt-factories >= 0.93.0
+pytest-salt-factories >= 0.98.0
 pytest-tempdir >= 2019.10.12
 pytest-helpers-namespace >= 2019.1.8

--- a/requirements/static/ci/py3.5/darwin.txt
+++ b/requirements/static/ci/py3.5/darwin.txt
@@ -8,7 +8,7 @@ apache-libcloud==2.4.0
 appdirs==1.4.3            # via virtualenv
 argh==0.26.2              # via watchdog
 asn1crypto==1.3.0         # via certvalidator, oscrypto
-attrs==19.1.0             # via pytest
+attrs==20.3.0             # via pytest, pytest-salt-factories
 aws-xray-sdk==0.95        # via moto
 backports.ssl-match-hostname==3.7.0.1 ; python_version < "3.7"
 bcrypt==3.1.6             # via paramiko
@@ -89,10 +89,10 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.93.0
+pytest-salt-factories==0.98.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.1.1
+pytest==6.1.2
 python-dateutil==2.8.0
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/ci/py3.5/freebsd.txt
+++ b/requirements/static/ci/py3.5/freebsd.txt
@@ -8,7 +8,7 @@ apache-libcloud==2.0.0
 appdirs==1.4.4            # via virtualenv
 argh==0.26.2              # via watchdog
 asn1crypto==1.3.0         # via certvalidator, oscrypto
-attrs==19.1.0             # via pytest
+attrs==20.3.0             # via pytest, pytest-salt-factories
 aws-xray-sdk==0.95        # via moto
 backports.functools-lru-cache==1.5
 backports.ssl-match-hostname==3.7.0.1 ; python_version < "3.7"
@@ -91,10 +91,10 @@ pyopenssl==19.1.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.93.0
+pytest-salt-factories==0.98.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.1.1
+pytest==6.1.2
 python-dateutil==2.8.1
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/ci/py3.5/linux.txt
+++ b/requirements/static/ci/py3.5/linux.txt
@@ -9,7 +9,7 @@ apache-libcloud==2.0.0
 appdirs==1.4.4            # via virtualenv
 argh==0.26.2              # via watchdog
 asn1crypto==1.3.0         # via certvalidator, oscrypto
-attrs==19.1.0             # via pytest
+attrs==20.3.0             # via pytest, pytest-salt-factories
 aws-xray-sdk==0.95        # via moto
 azure-applicationinsights==0.1.0  # via azure
 azure-batch==4.1.3        # via azure
@@ -184,10 +184,10 @@ pyopenssl==19.1.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.93.0
+pytest-salt-factories==0.98.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.1.1
+pytest==6.1.2
 python-dateutil==2.8.1
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/ci/py3.5/windows.txt
+++ b/requirements/static/ci/py3.5/windows.txt
@@ -6,7 +6,7 @@
 #
 appdirs==1.4.4            # via virtualenv
 atomicwrites==1.3.0       # via pytest
-attrs==19.1.0             # via pytest
+attrs==20.3.0             # via pytest, pytest-salt-factories
 aws-xray-sdk==0.95        # via moto
 backports.ssl-match-hostname==3.7.0.1 ; python_version < "3.7"
 boto3==1.13.5
@@ -82,10 +82,10 @@ pymysql==0.9.3
 pyopenssl==19.0.0
 pyparsing==2.4.5          # via packaging
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.93.0
+pytest-salt-factories==0.98.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.1.1
+pytest==6.1.2
 python-dateutil==2.8.0
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/ci/py3.6/darwin.txt
+++ b/requirements/static/ci/py3.6/darwin.txt
@@ -8,7 +8,7 @@ apache-libcloud==2.4.0
 appdirs==1.4.3            # via virtualenv
 argh==0.26.2              # via watchdog
 asn1crypto==1.3.0         # via certvalidator, oscrypto
-attrs==19.1.0             # via pytest
+attrs==20.3.0             # via pytest, pytest-salt-factories
 aws-xray-sdk==0.95        # via moto
 backports.ssl-match-hostname==3.7.0.1 ; python_version < "3.7"
 bcrypt==3.1.6             # via paramiko
@@ -94,10 +94,10 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.93.0
+pytest-salt-factories==0.98.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.1.1
+pytest==6.1.2
 python-dateutil==2.8.0
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/ci/py3.6/freebsd.txt
+++ b/requirements/static/ci/py3.6/freebsd.txt
@@ -8,7 +8,7 @@ apache-libcloud==2.0.0
 appdirs==1.4.4            # via virtualenv
 argh==0.26.2              # via watchdog
 asn1crypto==1.3.0         # via certvalidator, oscrypto
-attrs==19.1.0             # via pytest
+attrs==20.3.0             # via pytest, pytest-salt-factories
 aws-xray-sdk==0.95        # via moto
 backports.functools-lru-cache==1.5
 backports.ssl-match-hostname==3.7.0.1 ; python_version < "3.7"
@@ -96,10 +96,10 @@ pyopenssl==19.1.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.93.0
+pytest-salt-factories==0.98.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.1.1
+pytest==6.1.2
 python-dateutil==2.8.1
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/ci/py3.6/linux.txt
+++ b/requirements/static/ci/py3.6/linux.txt
@@ -9,7 +9,7 @@ apache-libcloud==2.0.0
 appdirs==1.4.4            # via virtualenv
 argh==0.26.2              # via watchdog
 asn1crypto==1.3.0         # via certvalidator, oscrypto
-attrs==19.1.0             # via pytest
+attrs==20.3.0             # via pytest, pytest-salt-factories
 aws-xray-sdk==0.95        # via moto
 azure-applicationinsights==0.1.0  # via azure
 azure-batch==4.1.3        # via azure
@@ -188,10 +188,10 @@ pyopenssl==19.1.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.93.0
+pytest-salt-factories==0.98.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.1.1
+pytest==6.1.2
 python-dateutil==2.8.1
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/ci/py3.6/windows.txt
+++ b/requirements/static/ci/py3.6/windows.txt
@@ -6,7 +6,7 @@
 #
 appdirs==1.4.4            # via virtualenv
 atomicwrites==1.3.0       # via pytest
-attrs==19.1.0             # via pytest
+attrs==20.3.0             # via pytest, pytest-salt-factories
 aws-xray-sdk==0.95        # via moto
 backports.ssl-match-hostname==3.7.0.1 ; python_version < "3.7"
 boto3==1.13.5
@@ -81,10 +81,10 @@ pymysql==0.9.3
 pyopenssl==19.0.0
 pyparsing==2.4.5          # via packaging
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.93.0
+pytest-salt-factories==0.98.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.1.1
+pytest==6.1.2
 python-dateutil==2.8.0
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/ci/py3.7/darwin.txt
+++ b/requirements/static/ci/py3.7/darwin.txt
@@ -8,7 +8,7 @@ apache-libcloud==2.4.0
 appdirs==1.4.3            # via virtualenv
 argh==0.26.2              # via watchdog
 asn1crypto==1.3.0         # via certvalidator, oscrypto
-attrs==19.1.0             # via pytest
+attrs==20.3.0             # via pytest, pytest-salt-factories
 aws-xray-sdk==0.95        # via moto
 bcrypt==3.1.6             # via paramiko
 boto3==1.13.5
@@ -92,10 +92,10 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.93.0
+pytest-salt-factories==0.98.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.1.1
+pytest==6.1.2
 python-dateutil==2.8.0
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -8,7 +8,7 @@ apache-libcloud==2.0.0
 appdirs==1.4.4            # via virtualenv
 argh==0.26.2              # via watchdog
 asn1crypto==1.3.0         # via certvalidator, oscrypto
-attrs==19.1.0             # via pytest
+attrs==20.3.0             # via pytest, pytest-salt-factories
 aws-xray-sdk==0.95        # via moto
 backports.functools-lru-cache==1.5
 bcrypt==3.1.6             # via paramiko
@@ -94,10 +94,10 @@ pyopenssl==19.1.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.93.0
+pytest-salt-factories==0.98.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.1.1
+pytest==6.1.2
 python-dateutil==2.8.1
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -9,7 +9,7 @@ apache-libcloud==2.0.0
 appdirs==1.4.4            # via virtualenv
 argh==0.26.2              # via watchdog
 asn1crypto==1.3.0         # via certvalidator, oscrypto
-attrs==19.1.0             # via pytest
+attrs==20.3.0             # via pytest, pytest-salt-factories
 aws-xray-sdk==0.95        # via moto
 azure-applicationinsights==0.1.0  # via azure
 azure-batch==4.1.3        # via azure
@@ -186,10 +186,10 @@ pyopenssl==19.1.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.93.0
+pytest-salt-factories==0.98.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.1.1
+pytest==6.1.2
 python-dateutil==2.8.1
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -6,7 +6,7 @@
 #
 appdirs==1.4.4            # via virtualenv
 atomicwrites==1.3.0       # via pytest
-attrs==19.1.0             # via pytest
+attrs==20.3.0             # via pytest, pytest-salt-factories
 aws-xray-sdk==0.95        # via moto
 boto3==1.13.5
 boto==2.49.0
@@ -79,10 +79,10 @@ pymysql==0.9.3
 pyopenssl==19.0.0
 pyparsing==2.4.5          # via packaging
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.93.0
+pytest-salt-factories==0.98.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.1.1
+pytest==6.1.2
 python-dateutil==2.8.0
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/ci/py3.8/darwin.txt
+++ b/requirements/static/ci/py3.8/darwin.txt
@@ -8,7 +8,7 @@ apache-libcloud==2.4.0
 appdirs==1.4.3            # via virtualenv
 argh==0.26.2              # via watchdog
 asn1crypto==1.3.0         # via certvalidator, oscrypto
-attrs==19.1.0             # via pytest
+attrs==20.3.0             # via pytest, pytest-salt-factories
 aws-xray-sdk==0.95        # via moto
 bcrypt==3.1.6             # via paramiko
 boto3==1.13.5
@@ -91,10 +91,10 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.93.0
+pytest-salt-factories==0.98.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.1.1
+pytest==6.1.2
 python-dateutil==2.8.0
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -8,7 +8,7 @@ apache-libcloud==2.0.0
 appdirs==1.4.4            # via virtualenv
 argh==0.26.2              # via watchdog
 asn1crypto==1.3.0         # via certvalidator, oscrypto
-attrs==19.1.0             # via pytest
+attrs==20.3.0             # via pytest, pytest-salt-factories
 aws-xray-sdk==0.95        # via moto
 backports.functools-lru-cache==1.5
 bcrypt==3.1.6             # via paramiko
@@ -93,10 +93,10 @@ pyopenssl==19.1.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.93.0
+pytest-salt-factories==0.98.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.1.1
+pytest==6.1.2
 python-dateutil==2.8.1
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -9,7 +9,7 @@ apache-libcloud==2.0.0
 appdirs==1.4.4            # via virtualenv
 argh==0.26.2              # via watchdog
 asn1crypto==1.3.0         # via certvalidator, oscrypto
-attrs==19.1.0             # via pytest
+attrs==20.3.0             # via pytest, pytest-salt-factories
 aws-xray-sdk==0.95        # via moto
 azure-applicationinsights==0.1.0  # via azure
 azure-batch==4.1.3        # via azure
@@ -185,10 +185,10 @@ pyopenssl==19.1.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.93.0
+pytest-salt-factories==0.98.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.1.1
+pytest==6.1.2
 python-dateutil==2.8.1
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -8,7 +8,7 @@ apache-libcloud==2.4.0
 appdirs==1.4.3            # via virtualenv
 argh==0.26.2              # via watchdog
 asn1crypto==1.3.0         # via certvalidator, oscrypto
-attrs==19.1.0             # via pytest
+attrs==20.3.0             # via pytest, pytest-salt-factories
 aws-xray-sdk==0.95        # via moto
 bcrypt==3.1.6             # via paramiko
 boto3==1.13.5
@@ -91,10 +91,10 @@ pyopenssl==19.0.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.93.0
+pytest-salt-factories==0.98.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.1.1
+pytest==6.1.2
 python-dateutil==2.8.0
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -8,7 +8,7 @@ apache-libcloud==2.0.0
 appdirs==1.4.4            # via virtualenv
 argh==0.26.2              # via watchdog
 asn1crypto==1.3.0         # via certvalidator, oscrypto
-attrs==19.1.0             # via pytest
+attrs==20.3.0             # via pytest, pytest-salt-factories
 aws-xray-sdk==0.95        # via moto
 backports.functools-lru-cache==1.5
 bcrypt==3.1.6             # via paramiko
@@ -93,10 +93,10 @@ pyopenssl==19.1.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.93.0
+pytest-salt-factories==0.98.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.1.1
+pytest==6.1.2
 python-dateutil==2.8.1
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -9,7 +9,7 @@ apache-libcloud==2.0.0
 appdirs==1.4.4            # via virtualenv
 argh==0.26.2              # via watchdog
 asn1crypto==1.3.0         # via certvalidator, oscrypto
-attrs==19.1.0             # via pytest
+attrs==20.3.0             # via pytest, pytest-salt-factories
 aws-xray-sdk==0.95        # via moto
 azure-applicationinsights==0.1.0  # via azure
 azure-batch==4.1.3        # via azure
@@ -186,10 +186,10 @@ pyopenssl==19.1.0
 pyparsing==2.4.5          # via junos-eznc, packaging
 pyserial==3.4             # via junos-eznc, netmiko
 pytest-helpers-namespace==2019.1.8
-pytest-salt-factories==0.93.0
+pytest-salt-factories==0.98.0
 pytest-salt==2020.1.27
 pytest-tempdir==2019.10.12
-pytest==6.1.1
+pytest==6.1.2
 python-dateutil==2.8.1
 python-etcd==0.4.5
 python-gnupg==0.4.4

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -651,7 +651,11 @@ def _run(
         # stdin/stdout/stderr
         if new_kwargs["shell"] is True:
             new_kwargs["executable"] = shell
-        new_kwargs["close_fds"] = True
+        if salt.utils.platform.is_freebsd() and sys.version_info < (3, 9):
+            # https://bugs.python.org/issue38061
+            new_kwargs["close_fds"] = False
+        else:
+            new_kwargs["close_fds"] = True
 
     if not os.path.isabs(cwd) or not os.path.isdir(cwd):
         raise CommandExecutionError(


### PR DESCRIPTION
### What does this PR do?
See title