### PR TITLE
Accept empty list of includes

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -4000,11 +4000,12 @@ class BaseHighState:
                 include = []
                 if "include" in state:
                     if not isinstance(state["include"], list):
-                        err = (
-                            "Include Declaration in SLS {} is not formed "
-                            "as a list".format(sls)
-                        )
-                        errors.append(err)
+                        if state["include"] is not None:
+                            err = (
+                                "Include Declaration in SLS {} is not formed "
+                                "as a list".format(sls)
+                            )
+                            errors.append(err)
                     else:
                         include = state.pop("include")
 


### PR DESCRIPTION
### What does this PR do?

Example usage:
```jinja
include:
{%- if grains[foo] is true %}
  - foo
{%- endif %}
{%- if grains[bar] is true %}
  - bar
{%- endif %}
```
### What issues does this PR fix or reference?
None

### Previous Behavior

```
    Data failed to compile:
    Include Declaration is SLS mysls is not formed as a list
```

### New Behavior
Those two are equivalent:
```yaml
include:
```
and:
```yaml
# nothing
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No