### PR TITLE
TextFSM module: the clitable plugin has been moved into the parent lib

### DIFF
--- a/salt/modules/textfsm_mod.py
+++ b/salt/modules/textfsm_mod.py
@@ -10,11 +10,6 @@ data, and can be easily re-used in other modules, or directly
 inside the renderer (Jinja, Mako, Genshi, etc.).
 
 :depends:   - textfsm Python library
-
-.. note::
-
-    For Python 2/3 compatibility, it is more recommended to
-    install the ``jtextfsm`` library: ``pip install jtextfsm``.
 """
 
 import logging
@@ -33,7 +28,7 @@ except ImportError:
     HAS_TEXTFSM = False
 
 try:
-    import clitable
+    from textfsm import clitable
 
     HAS_CLITABLE = True
 except ImportError:


### PR DESCRIPTION
At the same time, it's probably time to remove the Py2/3 compatibility
notice, as the main textfsm library maintained by Google has been
updated appropriately, and there's no need for the jtextfsm fork.