### PR TITLE
netapi/rest_cherrypy: fix doc for access/error log config

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -75,12 +75,12 @@ A REST API for Salt
     debug : ``False``
         Starts the web server in development mode. It will reload itself when
         the underlying code is changed and will output more debugging info.
-    log.access_file
+    log_access_file
         Path to a file to write HTTP access logs.
 
         .. versionadded:: 2016.11.0
 
-    log.error_file
+    log_error_file
         Path to a file to write HTTP error logs.
 
         .. versionadded:: 2016.11.0


### PR DESCRIPTION
### What does this PR do?
The correct configuration options for defining an access and error log file within the `rest_cherrypy` section are `log_access_file` and `log_error_file`, not `log.access_file` and `log.error_file`.
This is only the internal form of CherryPy which will continue to be used:
```python
"log.access_file": self.apiopts.get("log_access_file", ""),
"log.error_file": self.apiopts.get("log_error_file", ""),
```

- 6a69136080 introduced the options `log_access_file` and `log_error_file` for the `rest_cherrypy` section
- 5e6c14d3b1 wrongly changed those to `log.access_file` and `log.error_file` due to a misinterpreted error message of CherryPy where those options were renamed internally
- d8314b5897 ported 5e6c14d3b1 from `develop` to `master`

### What issues does this PR fix or reference?
Fixes:
- a local issue, where I was unable to set custom paths for the API's access/error logs when following the documentation
- https://github.com/saltstack/salt/issues/49247#issuecomment-601570184

### Previous Behavior
The path of the API's access/error log couldn't be customized when following the documentation

### New Behavior
Using a custom path for the API's access/error log works now

### Merge requirements satisfied?
- [x] Docs
- [x] (N/A) Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] (N/A) Tests written/updated

### Commits signed with GPG?
Yes