### PR TITLE
Tests and delete() for SQLite3 SDB

### DIFF
--- a/salt/sdb/sqlite3.py
+++ b/salt/sdb/sqlite3.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 SQLite sdb Module
 
@@ -43,16 +42,11 @@ create the table(s) and get and set values.
     get_query: "SELECT d FROM advanced WHERE a=:key"
     set_query: "INSERT OR REPLACE INTO advanced (a, d) VALUES (:key, :value)"
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
 import codecs
-
-# Import python libs
 import logging
 
-# Import salt libs
 import salt.utils.msgpack
-from salt.ext import six
 
 try:
     import sqlite3
@@ -113,8 +107,8 @@ def _connect(profile):
             for sql in stmts:
                 cur.execute(sql)
         elif profile.get("create_table", True):
-            cur.execute(("CREATE TABLE {0} (key text, " "value blob)").format(table))
-            cur.execute(("CREATE UNIQUE INDEX {0} ON {1} " "(key)").format(idx, table))
+            cur.execute(("CREATE TABLE {} (key text, " "value blob)").format(table))
+            cur.execute(("CREATE UNIQUE INDEX {} ON {} " "(key)").format(idx, table))
     except sqlite3.OperationalError:
         pass
 
@@ -128,15 +122,10 @@ def set_(key, value, profile=None):
     if not profile:
         return False
     conn, cur, table = _connect(profile)
-    if six.PY2:
-        # pylint: disable=undefined-variable
-        value = buffer(salt.utils.msgpack.packb(value))
-        # pylint: enable=undefined-variable
-    else:
-        value = memoryview(salt.utils.msgpack.packb(value))
+    value = memoryview(salt.utils.msgpack.packb(value))
     q = profile.get(
         "set_query",
-        ("INSERT OR REPLACE INTO {0} VALUES " "(:key, :value)").format(table),
+        ("INSERT OR REPLACE INTO {} VALUES " "(:key, :value)").format(table),
     )
     conn.execute(q, {"key": key, "value": value})
     conn.commit()
@@ -151,7 +140,7 @@ def get(key, profile=None):
         return None
     _, cur, table = _connect(profile)
     q = profile.get(
-        "get_query", ("SELECT value FROM {0} WHERE " "key=:key".format(table))
+        "get_query", ("SELECT value FROM {} WHERE " "key=:key".format(table))
     )
     res = cur.execute(q, {"key": key})
     res = res.fetchone()
@@ -167,13 +156,11 @@ def delete(key, profile=None):
     if not profile:
         return None
     conn, cur, table = _connect(profile)
-    q = profile.get(
-        "delete_query",
-        ("DELETE FROM {0} WHERE " "key=:key".format(table))
-    )
+    q = profile.get("delete_query", ("DELETE FROM {} WHERE " "key=:key".format(table)))
     res = cur.execute(q, {"key": key})
     conn.commit()
 
     return True
+
 
 # end of file.

--- a/salt/sdb/sqlite3.py
+++ b/salt/sdb/sqlite3.py
@@ -39,6 +39,7 @@ create the table(s) and get and set values.
     create_statements:
       - "CREATE TABLE advanced (a text, b text, c blob, d blob)"
       - "CREATE INDEX myidx ON advanced (a)"
+    delete_query: "DELETE d FROM advanced WHERE a:=key"
     get_query: "SELECT d FROM advanced WHERE a=:key"
     set_query: "INSERT OR REPLACE INTO advanced (a, d) VALUES (:key, :value)"
 """
@@ -157,3 +158,22 @@ def get(key, profile=None):
     if not res:
         return None
     return salt.utils.msgpack.unpackb(res[0])
+
+
+def delete(key, profile=None):
+    """
+    Delete a key (and its corresponding value) from sqlite3.
+    """
+    if not profile:
+        return None
+    conn, cur, table = _connect(profile)
+    q = profile.get(
+        "delete_query",
+        ("DELETE FROM {0} WHERE " "key=:key".format(table))
+    )
+    res = cur.execute(q, {"key": key})
+    conn.commit()
+
+    return True
+
+# end of file.

--- a/tests/integration/files/conf/master
+++ b/tests/integration/files/conf/master
@@ -146,5 +146,26 @@ sdbetcd:
   driver: etcd
   etcd.host: 127.0.0.1
   etcd.port: 2379
+# See the file "tests/integration/sdb/test_sqlite3.py" for an explanation.
+sdbsqlite3createtrue:
+  create_table: true
+  database: sdb.sqlite3
+  driver: sqlite3
+  table: sdb
+# See the file "tests/integration/sdb/test_sqlite3.py" for an explanation.
+sdbsqlite3createdefault:
+  database: sdb.sqlite3
+  driver: sqlite3
+# See the file "tests/integration/sdb/test_sqlite3.py" for an explanation.
+sdbsqlite3createfalse:
+  create_table: false
+  database: sdb.sqlite3
+  driver: sqlite3
+# See the file "tests/integration/sdb/test_sqlite3.py" for an explanation.
+sdbsqlite3funnytablename:
+  create_table: true
+  database: sdb.sqlite3
+  driver: sqlite3
+  table: funnytablename
 venafi:
   fake: "true"

--- a/tests/integration/sdb/test_sqlite3.py
+++ b/tests/integration/sdb/test_sqlite3.py
@@ -1,10 +1,10 @@
-# -*- coding: utf-8 -*-
 """
 A test case for the SQLite3 SDB module.
 """
 
 import os
 import sqlite3
+
 from tests.support.case import ShellCase
 
 #
@@ -26,7 +26,7 @@ class Sqlite3TestCase(ShellCase):
     # Why do we think the file "sdb.sqlite3" is in the current working
     # directory of the process running the tests? Well, because that is what
     # is specified in the file "tests/integration/files/conf/master".
-    sdb_file = 'sdb.sqlite3'
+    sdb_file = "sdb.sqlite3"
 
     # Ensure a) the tests' order is of no significance, and b) that we don't
     # leave behind any unnecessary cruft.
@@ -43,9 +43,9 @@ class Sqlite3TestCase(ShellCase):
 
         try:
             # This raises sqlite3.OperationalError for a missing table.
-            q = 'SELECT {0} FROM {1} WHERE type="{2}" AND name="{3}";'.format(
-                    'name', 'sqlite_master', 'table', tablename
-                )
+            q = 'SELECT {} FROM {} WHERE type="{}" AND name="{}";'.format(
+                "name", "sqlite_master", "table", tablename
+            )
             cur.execute(q)
 
             return len(cur.fetchall()) > 0
@@ -57,24 +57,22 @@ class Sqlite3TestCase(ShellCase):
     # SQLite3 SDB driver is present and its value is True, any call to SDB
     # will create the database.
     def test_aaaa(self):
-        data = self.run_run_plus('sdb.get',
-                                 'sdb://sdbsqlite3createtrue/foo')
+        data = self.run_run_plus("sdb.get", "sdb://sdbsqlite3createtrue/foo")
 
         self.assertTrue(os.path.exists(self.sdb_file))
-        self.assertTrue(data['return'] is None)
-        self.assertTrue(self.table_exists(self.sdb_file, 'sdb'))
+        self.assertTrue(data["return"] is None)
+        self.assertTrue(self.table_exists(self.sdb_file, "sdb"))
 
     # What is this test for?
     # The test below tests that when the keyword argument "create" for the
     # SQLite3 SDB driver is not present, the default value True is honoured
     # and any call to SDB will create the database.
     def test_aaab(self):
-        data = self.run_run_plus('sdb.get',
-                                 'sdb://sdbsqlite3createdefault/foo')
+        data = self.run_run_plus("sdb.get", "sdb://sdbsqlite3createdefault/foo")
 
         self.assertTrue(os.path.exists(self.sdb_file))
-        self.assertTrue(data['return'] is None)
-        self.assertTrue(self.table_exists(self.sdb_file, 'sdb'))
+        self.assertTrue(data["return"] is None)
+        self.assertTrue(self.table_exists(self.sdb_file, "sdb"))
 
     # What is this test for?
     # The test below tests that when the keyword argument "create" for the
@@ -82,61 +80,53 @@ class Sqlite3TestCase(ShellCase):
     # not create the database tables; because SQLite3 creates a database file
     # with every "connection", the database table list has to be consulted.
     def test_aaac(self):
-        data = self.run_run_plus('sdb.get',
-                                 'sdb://sdbsqlite3createfalse/foo')
+        data = self.run_run_plus("sdb.get", "sdb://sdbsqlite3createfalse/foo")
 
         self.assertTrue(os.path.exists(self.sdb_file))
-        self.assertTrue(
-            'sqlite3.OperationalError: no such table' in data['return']
-        )
-        self.assertFalse(self.table_exists(self.sdb_file, 'sdb'))
+        self.assertTrue("sqlite3.OperationalError: no such table" in data["return"])
+        self.assertFalse(self.table_exists(self.sdb_file, "sdb"))
 
     # What is this test for?
     # The test below tests that when the keyword argument "table" doesn't
     # use the default value, the value given is honoured.
     def set_aaad(self):
-        data = self.run_run_plus('sdb.get',
-                                 'sdb://sdbsqlite3funnytablename/foo')
+        data = self.run_run_plus("sdb.get", "sdb://sdbsqlite3funnytablename/foo")
 
         self.assertTrue(os.path.exists(self.sdb_file))
-        self.assertFalse(data['return'])
-        self.assertTrue(self.table_exists(self.sdb_file,
-                                          'sdbsqlite3funnytablename'))
+        self.assertFalse(data["return"])
+        self.assertTrue(self.table_exists(self.sdb_file, "sdbsqlite3funnytablename"))
 
     # What is this test for?
     # The test below tests that when a key-value pair is set in SDB,
     # that same key-value pair can be accessed later.
     def test_bbbb(self):
-        data = self.run_run_plus('sdb.set',
-                                 'sdb://sdbsqlite3createtrue/foo',
-                                 value = 'bar')
+        data = self.run_run_plus(
+            "sdb.set", "sdb://sdbsqlite3createtrue/foo", value="bar"
+        )
         self.assertTrue(os.path.exists(self.sdb_file))
-        self.assertTrue(data['return'])
+        self.assertTrue(data["return"])
 
-        data = self.run_run_plus('sdb.get',
-                                 'sdb://sdbsqlite3createtrue/foo')
-        self.assertEqual(data['out'], ['bar'])
+        data = self.run_run_plus("sdb.get", "sdb://sdbsqlite3createtrue/foo")
+        self.assertEqual(data["out"], ["bar"])
 
     # What is this test for?
     # The test below tests that when a key-value deleted from SDB is
     # not accessible later.
     def test_cccc(self):
-        data = self.run_run_plus('sdb.set',
-                                 'sdb://sdbsqlite3createtrue/foo',
-                                 value = 'bar')
-        self.assertTrue(data['return'])
+        data = self.run_run_plus(
+            "sdb.set", "sdb://sdbsqlite3createtrue/foo", value="bar"
+        )
+        self.assertTrue(data["return"])
 
-        data = self.run_run_plus('sdb.get',
-                                 'sdb://sdbsqlite3createtrue/foo')
-        self.assertTrue(data['return'])
-        self.assertEqual(data['out'], ['bar'])
+        data = self.run_run_plus("sdb.get", "sdb://sdbsqlite3createtrue/foo")
+        self.assertTrue(data["return"])
+        self.assertEqual(data["out"], ["bar"])
 
-        data = self.run_run_plus('sdb.delete',
-                                 'sdb://sdbsqlite3createtrue/foo')
-        self.assertTrue(data['return'])
+        data = self.run_run_plus("sdb.delete", "sdb://sdbsqlite3createtrue/foo")
+        self.assertTrue(data["return"])
 
-        data = self.run_run_plus('sdb.get',
-                                 'sdb://sdbsqlite3createtrue/foo')
-        self.assertTrue(data['return'] is None)
+        data = self.run_run_plus("sdb.get", "sdb://sdbsqlite3createtrue/foo")
+        self.assertTrue(data["return"] is None)
+
 
 # end of file.

--- a/tests/integration/sdb/test_sqlite3.py
+++ b/tests/integration/sdb/test_sqlite3.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+"""
+A test case for the SQLite3 SDB module.
+"""
+
+import os
+import sqlite3
+from tests.support.case import ShellCase
+
+#
+# Why are the tests below are named that way?
+#
+# Because Pytest orders test in lexical order. There's no specific
+# reason for the tests to be run in any particular order, but I do
+# like the tidiness of having the tests run in the same order they're
+# defined in a file.
+#
+# You could argue against such a practice, but why would you? Since
+# Pytest doesn't randomize the order, any order is as good as any other.
+# Why not just run with this? It's quite reasonable and takes little
+# or no effort from your part to tolerate.
+#
+
+
+class Sqlite3TestCase(ShellCase):
+    # Why do we think the file "sdb.sqlite3" is in the current working
+    # directory of the process running the tests? Well, because that is what
+    # is specified in the file "tests/integration/files/conf/master".
+    sdb_file = 'sdb.sqlite3'
+
+    # Ensure a) the tests' order is of no significance, and b) that we don't
+    # leave behind any unnecessary cruft.
+    def tearDown(self):
+        os.remove(self.sdb_file)
+
+    # Is this absolutely necessary? No. We could live without it. However,
+    # it does give us some finer sense of what goes wrong and helps us to
+    # differentiate between the database file simply not being created
+    # because of insufficient file permissions, e.g., and other errors.
+    def table_exists(self, filename, tablename):
+        con = sqlite3.connect(filename)
+        cur = con.cursor()
+
+        try:
+            # This raises sqlite3.OperationalError for a missing table.
+            q = 'SELECT {0} FROM {1} WHERE type="{2}" AND name="{3}";'.format(
+                    'name', 'sqlite_master', 'table', tablename
+                )
+            cur.execute(q)
+
+            return len(cur.fetchall()) > 0
+        except sqlite3.OperationalError:
+            return False
+
+    # What is this test for?
+    # The test below tests that when the keyword argument "create" for the
+    # SQLite3 SDB driver is present and its value is True, any call to SDB
+    # will create the database.
+    def test_aaaa(self):
+        data = self.run_run_plus('sdb.get',
+                                 'sdb://sdbsqlite3createtrue/foo')
+
+        self.assertTrue(os.path.exists(self.sdb_file))
+        self.assertTrue(data['return'] is None)
+        self.assertTrue(self.table_exists(self.sdb_file, 'sdb'))
+
+    # What is this test for?
+    # The test below tests that when the keyword argument "create" for the
+    # SQLite3 SDB driver is not present, the default value True is honoured
+    # and any call to SDB will create the database.
+    def test_aaab(self):
+        data = self.run_run_plus('sdb.get',
+                                 'sdb://sdbsqlite3createdefault/foo')
+
+        self.assertTrue(os.path.exists(self.sdb_file))
+        self.assertTrue(data['return'] is None)
+        self.assertTrue(self.table_exists(self.sdb_file, 'sdb'))
+
+    # What is this test for?
+    # The test below tests that when the keyword argument "create" for the
+    # SQLite3 SDB driver is present and its value is False, a call to SDB will
+    # not create the database tables; because SQLite3 creates a database file
+    # with every "connection", the database table list has to be consulted.
+    def test_aaac(self):
+        data = self.run_run_plus('sdb.get',
+                                 'sdb://sdbsqlite3createfalse/foo')
+
+        self.assertTrue(os.path.exists(self.sdb_file))
+        self.assertTrue(
+            'sqlite3.OperationalError: no such table' in data['return']
+        )
+        self.assertFalse(self.table_exists(self.sdb_file, 'sdb'))
+
+    # What is this test for?
+    # The test below tests that when the keyword argument "table" doesn't
+    # use the default value, the value given is honoured.
+    def set_aaad(self):
+        data = self.run_run_plus('sdb.get',
+                                 'sdb://sdbsqlite3funnytablename/foo')
+
+        self.assertTrue(os.path.exists(self.sdb_file))
+        self.assertFalse(data['return'])
+        self.assertTrue(self.table_exists(self.sdb_file,
+                                          'sdbsqlite3funnytablename'))
+
+    # What is this test for?
+    # The test below tests that when a key-value pair is set in SDB,
+    # that same key-value pair can be accessed later.
+    def test_bbbb(self):
+        data = self.run_run_plus('sdb.set',
+                                 'sdb://sdbsqlite3createtrue/foo',
+                                 value = 'bar')
+        self.assertTrue(os.path.exists(self.sdb_file))
+        self.assertTrue(data['return'])
+
+        data = self.run_run_plus('sdb.get',
+                                 'sdb://sdbsqlite3createtrue/foo')
+        self.assertEqual(data['out'], ['bar'])
+
+    # What is this test for?
+    # The test below tests that when a key-value deleted from SDB is
+    # not accessible later.
+    def test_cccc(self):
+        data = self.run_run_plus('sdb.set',
+                                 'sdb://sdbsqlite3createtrue/foo',
+                                 value = 'bar')
+        self.assertTrue(data['return'])
+
+        data = self.run_run_plus('sdb.get',
+                                 'sdb://sdbsqlite3createtrue/foo')
+        self.assertTrue(data['return'])
+        self.assertEqual(data['out'], ['bar'])
+
+        data = self.run_run_plus('sdb.delete',
+                                 'sdb://sdbsqlite3createtrue/foo')
+        self.assertTrue(data['return'])
+
+        data = self.run_run_plus('sdb.get',
+                                 'sdb://sdbsqlite3createtrue/foo')
+        self.assertTrue(data['return'] is None)
+
+# end of file.


### PR DESCRIPTION
### What does this PR do?

Add integration tests for SQLite3 SDB. The number of tests before: 0. The number of tests now: 6.

Add delete() fro SQLite3 SDB.

### What issues does this PR fix or reference?
-

### Previous Behavior
Calls to delete() for SDB using SQLite3 driver failed.

### New Behavior
Calls to delete() for SDB using SQLite3 driver do what they're supposed to do.

### Merge requirements satisfied?
- [ ] Docs
- [ ] Changelog
- [X] Tests written/updated

### Commits signed with GPG?
No