### PR TITLE
Added custom auth path for the vault

### DIFF
--- a/salt/modules/vault.py
+++ b/salt/modules/vault.py
@@ -29,6 +29,7 @@ Functions to interact with Hashicorp Vault.
                 method: approle
                 role_id: 11111111-2222-3333-4444-1111111111111
                 secret_id: 11111111-1111-1111-1111-1111111111111
+            auth_path: auth/approle/login
             policies:
                 - saltstack/minions
                 - saltstack/minion/{minion}
@@ -114,6 +115,11 @@ Functions to interact with Hashicorp Vault.
               token_backend: disk
 
             .. versionchanged:: 3001
+
+    auth_path
+        By default, auth methods are mounted to auth/approle/login.
+        However, in Vault this path is customizable.
+        https://www.vaultproject.io/docs/auth/approle
 
     policies
         Policies that are assigned to minions when requesting a token. These can

--- a/salt/utils/vault.py
+++ b/salt/utils/vault.py
@@ -123,8 +123,9 @@ def get_vault_connection():
                 verify = __opts__["vault"].get("verify", None)
                 if _selftoken_expired():
                     log.debug("Vault token expired. Recreating one")
+                    auth_path = __opts__["vault"].get("auth_path", "auth/approle/login")
                     # Requesting a short ttl token
-                    url = "{}/v1/auth/approle/login".format(__opts__["vault"]["url"])
+                    url = "{}/v1/{}".format(__opts__["vault"]["url"], auth_path)
                     payload = {"role_id": __opts__["vault"]["auth"]["role_id"]}
                     if "secret_id" in __opts__["vault"]["auth"]:
                         payload["secret_id"] = __opts__["vault"]["auth"]["secret_id"]


### PR DESCRIPTION
### What does this PR do?
PR allows Saltstack users to use different authorization paths for Hashicorp Vault
