### PR TITLE
Add Slackware support to timezone module - Fix Issue 59130

### DIFF
--- a/changelog/59130.fixed
+++ b/changelog/59130.fixed
@@ -1,0 +1,1 @@
+Fixed timezone module to work in Slackware Linux

--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -1,10 +1,7 @@
-# -*- coding: utf-8 -*-
 """
 Module for managing timezone on POSIX-like systems.
 """
 
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import errno
 import filecmp
@@ -13,7 +10,6 @@ import os
 import re
 import string
 
-# Import salt libs
 import salt.utils.files
 import salt.utils.hashutils
 import salt.utils.itertools
@@ -57,7 +53,7 @@ def _timedatectl():
     ret = __salt__["cmd.run_all"](["timedatectl"], python_shell=False)
 
     if ret["retcode"] != 0:
-        msg = "timedatectl failed: {0}".format(ret["stderr"])
+        msg = "timedatectl failed: {}".format(ret["stderr"])
         raise CommandExecutionError(msg)
 
     return ret
@@ -147,9 +143,9 @@ def _get_zone_etc_timezone():
     try:
         with salt.utils.files.fopen(tzfile, "r") as fp_:
             return salt.utils.stringutils.to_unicode(fp_.read()).strip()
-    except IOError as exc:
+    except OSError as exc:
         raise CommandExecutionError(
-            "Problem reading timezone file {0}: {1}".format(tzfile, exc.strerror)
+            "Problem reading timezone file {}: {}".format(tzfile, exc.strerror)
         )
 
 
@@ -193,7 +189,7 @@ def get_zone():
                 pass
 
         msg = (
-            "Failed to parse timedatectl output: {0}\n"
+            "Failed to parse timedatectl output: {}\n"
             "Please file an issue with SaltStack"
         ).format(ret["stdout"])
         raise CommandExecutionError(msg)
@@ -208,7 +204,7 @@ def get_zone():
         for family in ("Debian", "Gentoo"):
             if family in os_family:
                 return _get_zone_etc_timezone()
-        if os_family in ("FreeBSD", "OpenBSD", "NetBSD", "NILinuxRT"):
+        if os_family in ("FreeBSD", "OpenBSD", "NetBSD", "NILinuxRT", "Slackware"):
             return _get_zone_etc_localtime()
         elif "Solaris" in os_family:
             return _get_zone_solaris()
@@ -232,7 +228,7 @@ def get_zonecode():
 
 def get_offset():
     """
-    Get current numeric timezone offset from UCT (i.e. -0700)
+    Get current numeric timezone offset from UTC (i.e. -0700)
 
     CLI Example:
 
@@ -246,7 +242,7 @@ def get_offset():
     salt_path = "/opt/salt/bin/date"
 
     if not os.path.exists(salt_path):
-        return "date in salt binaries does not exist: {0}".format(salt_path)
+        return "date in salt binaries does not exist: {}".format(salt_path)
 
     return __salt__["cmd.run"]([salt_path, "+%z"], python_shell=False)
 
@@ -279,24 +275,24 @@ def set_zone(timezone):
     """
     if salt.utils.path.which("timedatectl"):
         try:
-            __salt__["cmd.run"]("timedatectl set-timezone {0}".format(timezone))
+            __salt__["cmd.run"]("timedatectl set-timezone {}".format(timezone))
         except CommandExecutionError:
             pass
 
     if "Solaris" in __grains__["os_family"] or "AIX" in __grains__["os_family"]:
-        zonepath = "/usr/share/lib/zoneinfo/{0}".format(timezone)
+        zonepath = "/usr/share/lib/zoneinfo/{}".format(timezone)
     else:
-        zonepath = "/usr/share/zoneinfo/{0}".format(timezone)
+        zonepath = "/usr/share/zoneinfo/{}".format(timezone)
 
     if not os.path.exists(zonepath) and "AIX" not in __grains__["os_family"]:
-        return "Zone does not exist: {0}".format(zonepath)
+        return "Zone does not exist: {}".format(zonepath)
 
     tzfile = _get_localtime_path()
     if os.path.exists(tzfile):
         os.unlink(tzfile)
 
     if "Solaris" in __grains__["os_family"]:
-        __salt__["file.sed"]("/etc/default/init", "^TZ=.*", "TZ={0}".format(timezone))
+        __salt__["file.sed"]("/etc/default/init", "^TZ=.*", "TZ={}".format(timezone))
     elif "AIX" in __grains__["os_family"]:
         # timezone could be Olson or Posix
         curtzstring = get_zone()
@@ -314,11 +310,11 @@ def set_zone(timezone):
 
     if "RedHat" in __grains__["os_family"]:
         __salt__["file.sed"](
-            "/etc/sysconfig/clock", "^ZONE=.*", 'ZONE="{0}"'.format(timezone)
+            "/etc/sysconfig/clock", "^ZONE=.*", 'ZONE="{}"'.format(timezone)
         )
     elif "Suse" in __grains__["os_family"]:
         __salt__["file.sed"](
-            "/etc/sysconfig/clock", "^TIMEZONE=.*", 'TIMEZONE="{0}"'.format(timezone)
+            "/etc/sysconfig/clock", "^TIMEZONE=.*", 'TIMEZONE="{}"'.format(timezone)
         )
     elif "Debian" in __grains__["os_family"] or "Gentoo" in __grains__["os_family"]:
         with salt.utils.files.fopen("/etc/timezone", "w") as ofh:
@@ -368,11 +364,11 @@ def zone_compare(timezone):
         problematic_file = exc.filename
         if problematic_file == zonepath:
             raise SaltInvocationError(
-                'Can\'t find a local timezone "{0}"'.format(timezone)
+                'Can\'t find a local timezone "{}"'.format(timezone)
             )
         elif problematic_file == tzfile:
             raise CommandExecutionError(
-                "Failed to read {0} to determine current timezone: {1}".format(
+                "Failed to read {} to determine current timezone: {}".format(
                     tzfile, exc.strerror
                 )
             )
@@ -389,7 +385,7 @@ def _get_localtime_path():
 
 
 def _get_zone_file(timezone):
-    return "/usr/share/zoneinfo/{0}".format(timezone)
+    return "/usr/share/zoneinfo/{}".format(timezone)
 
 
 def get_hwclock():
@@ -415,7 +411,7 @@ def get_hwclock():
                     pass
 
         msg = (
-            "Failed to parse timedatectl output: {0}\n"
+            "Failed to parse timedatectl output: {}\n"
             "Please file an issue with SaltStack"
         ).format(ret["stdout"])
         raise CommandExecutionError(msg)
@@ -440,7 +436,7 @@ def get_hwclock():
                                 return "UTC"
                             else:
                                 return "localtime"
-            except IOError as exc:
+            except OSError as exc:
                 pass
             # Since Wheezy
             return _get_adjtime_timezone()
@@ -460,11 +456,11 @@ def get_hwclock():
                                 if line == "local":
                                     return "LOCAL"
                         raise CommandExecutionError(
-                            "Correct offset value not found in {0}".format(offset_file)
+                            "Correct offset value not found in {}".format(offset_file)
                         )
-                except IOError as exc:
+                except OSError as exc:
                     raise CommandExecutionError(
-                        "Problem reading offset file {0}: {1}".format(
+                        "Problem reading offset file {}: {}".format(
                             offset_file, exc.strerror
                         )
                     )
@@ -479,12 +475,12 @@ def get_hwclock():
                         if line.startswith("zone_info=GMT"):
                             return "UTC"
                     return "localtime"
-            except IOError as exc:
+            except OSError as exc:
                 if exc.errno == errno.ENOENT:
                     # offset file does not exist
                     return "UTC"
                 raise CommandExecutionError(
-                    "Problem reading offset file {0}: {1}".format(
+                    "Problem reading offset file {}: {}".format(
                         offset_file, exc.strerror
                     )
                 )
@@ -498,15 +494,30 @@ def get_hwclock():
                         if line.startswith("TZ=UTC"):
                             return "UTC"
                     return "localtime"
-            except IOError as exc:
+            except OSError as exc:
                 if exc.errno == errno.ENOENT:
                     # offset file does not exist
                     return "UTC"
                 raise CommandExecutionError(
-                    "Problem reading offset file {0}: {1}".format(
+                    "Problem reading offset file {}: {}".format(
                         offset_file, exc.strerror
                     )
                 )
+
+        if "Slackware" in __grains__["os_family"]:
+            if not os.path.exists("/etc/adjtime"):
+                offset_file = "/etc/hardwareclock"
+                try:
+                    with salt.utils.files.fopen(offset_file, "r") as fp_:
+                        for line in fp_:
+                            line = salt.utils.stringutils.to_unicode(line)
+                            if line.startswith("UTC"):
+                                return "UTC"
+                        return "localtime"
+                except OSError as exc:
+                    if exc.errno == errno.ENOENT:
+                        return "UTC"
+            return _get_adjtime_timezone()
 
 
 def set_hwclock(clock):
@@ -547,10 +558,10 @@ def set_hwclock(clock):
             cmd = ["rtc", "-z", "GMT" if clock.lower() == "utc" else timezone]
             return __salt__["cmd.retcode"](cmd, python_shell=False) == 0
 
-        zonepath = "/usr/share/zoneinfo/{0}".format(timezone)
+        zonepath = "/usr/share/zoneinfo/{}".format(timezone)
 
         if not os.path.exists(zonepath):
-            raise CommandExecutionError("Zone '{0}' does not exist".format(zonepath))
+            raise CommandExecutionError("Zone '{}' does not exist".format(zonepath))
 
         os.unlink("/etc/localtime")
         os.symlink(zonepath, "/etc/localtime")
@@ -564,13 +575,13 @@ def set_hwclock(clock):
             return __salt__["cmd.retcode"](cmd, python_shell=False) == 0
         elif "RedHat" in __grains__["os_family"]:
             __salt__["file.sed"](
-                "/etc/sysconfig/clock", "^ZONE=.*", 'ZONE="{0}"'.format(timezone)
+                "/etc/sysconfig/clock", "^ZONE=.*", 'ZONE="{}"'.format(timezone)
             )
         elif "Suse" in __grains__["os_family"]:
             __salt__["file.sed"](
                 "/etc/sysconfig/clock",
                 "^TIMEZONE=.*",
-                'TIMEZONE="{0}"'.format(timezone),
+                'TIMEZONE="{}"'.format(timezone),
             )
         elif "Debian" in __grains__["os_family"]:
             if clock == "UTC":
@@ -583,7 +594,13 @@ def set_hwclock(clock):
             if clock == "localtime":
                 clock = "local"
             __salt__["file.sed"](
-                "/etc/conf.d/hwclock", "^clock=.*", 'clock="{0}"'.format(clock)
+                "/etc/conf.d/hwclock", "^clock=.*", 'clock="{}"'.format(clock)
+            )
+        elif "Slackware" in os_family:
+            if clock not in ("UTC", "localtime"):
+                raise SaltInvocationError("Only 'UTC' and 'localtime' are allowed")
+            __salt__["file.sed"](
+                "/etc/hardwareclock", "^(UTC|localtime)", "{}".format(clock)
             )
 
     return True

--- a/tests/unit/modules/test_timezone.py
+++ b/tests/unit/modules/test_timezone.py
@@ -1,20 +1,10 @@
-# -*- coding: utf-8 -*-
-
-# Import Python Libs
-from __future__ import absolute_import, print_function, unicode_literals
-
 import os
 from tempfile import NamedTemporaryFile
 
 import salt.modules.timezone as timezone
 import salt.utils.platform
 import salt.utils.stringutils
-
-# Import Salt Libs
 from salt.exceptions import CommandExecutionError, SaltInvocationError
-from salt.ext import six
-
-# Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, mock_open, patch
 from tests.support.unit import TestCase, skipIf
@@ -71,10 +61,7 @@ class TimezoneTestCase(TestCase, LoaderModuleMockMixin):
 
     def create_tempfile_with_contents(self, contents):
         temp = NamedTemporaryFile(delete=False)
-        if six.PY3:
-            temp.write(salt.utils.stringutils.to_bytes(contents))
-        else:
-            temp.write(contents)
+        temp.write(salt.utils.stringutils.to_bytes(contents))
         temp.close()
         self.tempfiles.append(temp)
         return temp
@@ -141,12 +128,12 @@ class TimezoneModuleTestCase(TestCase, LoaderModuleMockMixin):
                     assert timezone.get_zone() == self.TEST_TZ
 
     @patch("salt.utils.path.which", MagicMock(return_value=False))
-    def test_get_zone_os_family_allbsd_nilinuxrt(self):
+    def test_get_zone_os_family_allbsd_nilinuxrt_slackware(self):
         """
-        Test *BSD and NILinuxRT are recognized
+        Test *BSD, NILinuxRT and Slackware are recognized
         :return:
         """
-        for osfamily in ["FreeBSD", "OpenBSD", "NetBSD", "NILinuxRT"]:
+        for osfamily in ["FreeBSD", "OpenBSD", "NetBSD", "NILinuxRT", "Slackware"]:
             with patch.dict(timezone.__grains__, {"os_family": osfamily}):
                 with patch(
                     "salt.modules.timezone._get_zone_etc_localtime",
@@ -179,6 +166,35 @@ class TimezoneModuleTestCase(TestCase, LoaderModuleMockMixin):
                 MagicMock(return_value=self.TEST_TZ),
             ):
                 assert timezone.get_zone() == self.TEST_TZ
+
+    @skipIf(salt.utils.platform.is_windows(), "os.symlink not available in Windows")
+    @patch("salt.utils.path.which", MagicMock(return_value=False))
+    @patch("os.path.exists", MagicMock(return_value=True))
+    @patch("os.unlink", MagicMock())
+    @patch("os.symlink", MagicMock())
+    def test_set_zone_os_family_nilinuxrt(self):
+        """
+        Test zone set on NILinuxRT
+        :return:
+        """
+        with patch.dict(timezone.__grains__, {"os_family": ["NILinuxRT"]}), patch.dict(
+            timezone.__grains__, {"lsb_distrib_id": "nilrt"}
+        ):
+            assert timezone.set_zone(self.TEST_TZ)
+
+    @skipIf(salt.utils.platform.is_windows(), "os.symlink not available in Windows")
+    @patch("salt.utils.path.which", MagicMock(return_value=False))
+    @patch("os.path.exists", MagicMock(return_value=True))
+    @patch("os.unlink", MagicMock())
+    @patch("os.symlink", MagicMock())
+    def test_set_zone_os_family_allbsd_slackware(self):
+        """
+        Test zone set on *BSD and Slackware
+        :return:
+        """
+        for osfamily in ["FreeBSD", "OpenBSD", "NetBSD", "Slackware"]:
+            with patch.dict(timezone.__grains__, {"os_family": osfamily}):
+                assert timezone.set_zone(self.TEST_TZ)
 
     @skipIf(salt.utils.platform.is_windows(), "os.symlink not available in Windows")
     @patch("salt.utils.path.which", MagicMock(return_value=False))
@@ -350,6 +366,38 @@ class TimezoneModuleTestCase(TestCase, LoaderModuleMockMixin):
             assert timezone.get_hwclock() == hwclock
 
     @skipIf(salt.utils.platform.is_windows(), "os.symlink not available in Windows")
+    @patch("salt.utils.path.which", MagicMock(return_value=False))
+    @patch("os.path.exists", MagicMock(return_value=True))
+    @patch("os.unlink", MagicMock())
+    @patch("os.symlink", MagicMock())
+    def test_get_hwclock_slackware_with_adjtime(self):
+        """
+        Test get hwclock on Slackware with /etc/adjtime present
+        :return:
+        """
+        with patch.dict(timezone.__grains__, {"os_family": ["Slackware"]}):
+            timezone.get_hwclock()
+            name, args, kwarg = timezone.__salt__["cmd.run"].mock_calls[0]
+            assert args == (["tail", "-n", "1", "/etc/adjtime"],)
+            assert kwarg == {"python_shell": False}
+
+    @skipIf(salt.utils.platform.is_windows(), "os.symlink not available in Windows")
+    @patch("salt.utils.path.which", MagicMock(return_value=False))
+    @patch("os.path.exists", MagicMock(return_value=False))
+    @patch("os.unlink", MagicMock())
+    @patch("os.symlink", MagicMock())
+    def test_get_hwclock_slackware_without_adjtime(self):
+        """
+        Test get hwclock on Slackware without /etc/adjtime present
+        :return:
+        """
+        with patch.dict(timezone.__grains__, {"os_family": ["Slackware"]}):
+            with patch("salt.utils.files.fopen", mock_open(read_data="UTC")):
+                assert timezone.get_hwclock() == "UTC"
+            with patch("salt.utils.files.fopen", mock_open(read_data="localtime")):
+                assert timezone.get_hwclock() == "localtime"
+
+    @skipIf(salt.utils.platform.is_windows(), "os.symlink not available in Windows")
     @patch("salt.utils.path.which", MagicMock(return_value=True))
     def test_set_hwclock_timedatectl(self):
         """
@@ -496,3 +544,26 @@ class TimezoneModuleTestCase(TestCase, LoaderModuleMockMixin):
             timezone.set_hwclock("localtime")
             name, args, kwargs = timezone.__salt__["file.sed"].mock_calls[1]
             assert args == ("/etc/conf.d/hwclock", "^clock=.*", 'clock="local"')
+
+    @skipIf(salt.utils.platform.is_windows(), "os.symlink not available in Windows")
+    @patch("salt.utils.path.which", MagicMock(return_value=False))
+    @patch("os.path.exists", MagicMock(return_value=True))
+    @patch("os.unlink", MagicMock())
+    @patch("os.symlink", MagicMock())
+    @patch("salt.modules.timezone.get_zone", MagicMock(return_value="TEST_TIMEZONE"))
+    def test_set_hwclock_slackware(self):
+        """
+        Test set hwclock on Slackware
+        :return:
+        """
+        with patch.dict(timezone.__grains__, {"os_family": ["Slackware"]}):
+            with self.assertRaises(SaltInvocationError):
+                timezone.set_hwclock("forty two")
+
+            timezone.set_hwclock("UTC")
+            name, args, kwargs = timezone.__salt__["file.sed"].mock_calls[0]
+            assert args == ("/etc/hardwareclock", "^(UTC|localtime)", "UTC")
+
+            timezone.set_hwclock("localtime")
+            name, args, kwargs = timezone.__salt__["file.sed"].mock_calls[1]
+            assert args == ("/etc/hardwareclock", "^(UTC|localtime)", "localtime")


### PR DESCRIPTION
### What does this PR do?
Adds Slackware support to modules/timezone.py

This behaviour was catch by the timezone module integration tests.

Fixed `get_hwclock`, `set_hwclock` and `get_zone` functions.

### What issues does this PR fix or reference?
Fixes: #59130

### Previous Behavior
```
# salt-call timezone.get_hwclock
local:
    None
```

### New Behavior
```
# salt-call timezone.get_hwclock
local:
    UTC
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

The bug was caught by the current integration tests as seen in #59130 . Now it pass without failures:
```
collected 5 items                                                                                                                  

tests/integration/modules/test_timezone.py .ssss

========================================================= warnings summary =========================================================
salt/ext/tornado/web.py:1805
  /home/punk/Desktop/Projects/Software/External/salt/salt/ext/tornado/web.py:1805: DeprecationWarning: invalid escape sequence \.
    """A collection of request handlers that make up a web application.

-- Docs: https://docs.pytest.org/en/stable/warnings.html
===================================================== short test summary info ======================================================
SKIPPED [1] tests/integration/modules/test_timezone.py:53: For Solaris only
SKIPPED [1] tests/integration/modules/test_timezone.py:69: windows test only
SKIPPED [1] tests/integration/modules/test_timezone.py:92: windows test only
SKIPPED [1] tests/integration/modules/test_timezone.py:74: Destructive tests are disabled
============================================= 1 passed, 4 skipped, 1 warning in 34.26s =============================================
```

### Commits signed with GPG?
No