### PR TITLE
Module rh_ip support ethtool set channels

### DIFF
--- a/changelog/59147.added
+++ b/changelog/59147.added
@@ -1,0 +1,1 @@
+Add interface channels management support to rh_ip module.

--- a/salt/states/network.py
+++ b/salt/states/network.py
@@ -127,6 +127,11 @@ Ethernet Interface
         - dns:
           - 8.8.8.8
           - 8.8.4.4
+        - channels:
+            rx: 4
+            tx: 4
+            other: 4
+            combined: 4
 
 Ranged Interfaces (RHEL/CentOS Only)
 ************************************

--- a/tests/unit/modules/test_rh_ip.py
+++ b/tests/unit/modules/test_rh_ip.py
@@ -1,18 +1,12 @@
-# -*- coding: utf-8 -*-
 """
     :codeauthor: Jayesh Kariya <jayeshk@saltstack.com>
 """
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import copy
 import os
 
-# Import 3rd-party libs
 import jinja2.exceptions
 import salt.modules.rh_ip as rh_ip
-
-# Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase
@@ -231,6 +225,20 @@ class RhipTestCase(TestCase, LoaderModuleMockMixin):
             )
         self.assertIn("macaddr", results)
         self.assertEqual(results["macaddr"], opts["macaddr"])
+
+    def test__parse_settings_eth_ethtool_channels(self):
+        """
+        Make sure channels gets added when parsing opts
+        """
+        opts = {"channels": {"rx": 4, "tx": 4, "combined": 4, "other": 4}}
+        with patch.dict(rh_ip.__grains__, {"num_cpus": 4}), patch.dict(
+            rh_ip.__salt__, {"network.interfaces": MagicMock()}
+        ):
+            results = rh_ip._parse_settings_eth(
+                opts=opts, iface_type="eth", enabled=True, iface="eth0"
+            )
+        self.assertIn("ethtool", results)
+        self.assertEqual(results["ethtool"], "-L eth0 rx 4 tx 4 other 4 combined 4")
 
     def test_up(self):
         """
@@ -473,7 +481,7 @@ class RhipTestCase(TestCase, LoaderModuleMockMixin):
                     expected = [
                         "downdelay=200",
                         "miimon=100",
-                        "mode={0}".format(mode_num),
+                        "mode={}".format(mode_num),
                         "use_carrier=0",
                     ]
                     assert bonding_opts == expected, bonding_opts
@@ -487,7 +495,7 @@ class RhipTestCase(TestCase, LoaderModuleMockMixin):
                         "arp_ip_target=1.2.3.4,5.6.7.8",
                         "downdelay=200",
                         "miimon=100",
-                        "mode={0}".format(mode_num),
+                        "mode={}".format(mode_num),
                         "use_carrier=0",
                     ]
                     assert bonding_opts == expected, bonding_opts
@@ -499,7 +507,7 @@ class RhipTestCase(TestCase, LoaderModuleMockMixin):
                     expected = [
                         "arp_interval=300",
                         "arp_ip_target=1.2.3.4,5.6.7.8",
-                        "mode={0}".format(mode_num),
+                        "mode={}".format(mode_num),
                     ]
                     assert bonding_opts == expected, bonding_opts
 
@@ -664,9 +672,9 @@ class RhipTestCase(TestCase, LoaderModuleMockMixin):
                                     raise
                             else:
                                 expected = [
-                                    "ad_select={0}".format(ad_select),
+                                    "ad_select={}".format(ad_select),
                                     "downdelay=200",
-                                    "lacp_rate={0}".format(
+                                    "lacp_rate={}".format(
                                         "1"
                                         if lacp_rate == "fast"
                                         else "0"


### PR DESCRIPTION
### What does this PR do?
Introduce ability to control network interface channels using rh_ip module and network.managed state.

### What issues does this PR fix or reference?
Fixes: #59147

### Previous Behavior
It was not possible to control network interface channels. Salt ethtool module do not support channels too because it use python ethtool module which lacks support for channels.

### New Behavior
Allow to control network interface channels. On some systems it is useful to manually control channel in order to achieve proper performance.

### Merge requirements satisfied?
It's hard to write test for this because all other ethtool related options in rh_ip module do not have tests.

### Commits signed with GPG?
No
