### PR TITLE
modules/flatpak: Add support for user repo

### DIFF
--- a/salt/modules/flatpak.py
+++ b/salt/modules/flatpak.py
@@ -109,13 +109,14 @@ def uninstall(pkg):
     return ret
 
 
-def add_remote(name, location):
+def add_remote(name, location, user=False):
     '''
     Adds a new location to install flatpak packages from.
 
     Args:
         name (str): The repository's name.
         location (str): The location of the repository.
+        user (bool): Configure per-user installation.
 
     Returns:
         dict: The ``result`` and ``output``.
@@ -126,8 +127,10 @@ def add_remote(name, location):
 
         salt '*' flatpak.add_remote flathub https://flathub.org/repo/flathub.flatpakrepo
     '''
+    user_flag = ' --user ' if bool(user) else ''
     ret = {'result': None, 'output': ''}
-    out = __salt__['cmd.run_all'](FLATPAK_BINARY_NAME + ' remote-add ' + name + ' ' + location)
+
+    out = __salt__['cmd.run_all'](FLATPAK_BINARY_NAME + ' remote-add  --if-not-exists ' + user_flag + name + ' ' + location)
 
     if out['retcode'] and out['stderr']:
         ret['stderr'] = out['stderr'].strip()


### PR DESCRIPTION
### What does this PR do?
Allow user to install flatpak repo as user

### Previous Behavior
flatpak repo will always be installed system wide

### New Behavior
Will allow one to install repo to user account 

### Commits signed with GPG?
Yes

### Tests
- Without "--if-not-exists" option
```
salt-call --local flatpak.add_remote  flathub user=1 location=https://flathub.org/repo/flathub.flatpakrepo
[DEBUG   ] Configuration file path: /home/ritzk/Projects/gitlab.com/ritzk/linux_setup/salt/config/minion
[WARNING ] Insecure logging configuration detected! Sensitive data may be logged.
[DEBUG   ] Grains refresh requested. Refreshing grains.
[DEBUG   ] Reading configuration from /home/ritzk/Projects/gitlab.com/ritzk/linux_setup/salt/config/minion
[DEBUG   ] Elapsed time getting FQDNs: 0.2934870719909668 seconds
[INFO    ] Although 'dmidecode' was found in path, the current user cannot execute it. Grains output might not be accurate.
[DEBUG   ] LazyLoaded zfs.is_supported
[INFO    ] Executing command '/usr/sbin/zpool list -H -o name,size' in directory '/home/ritzk'
[DEBUG   ] stdout: connect: No such file or directory
Please make sure that the zfs-fuse daemon is running.
internal error: failed to initialize ZFS library
[DEBUG   ] retcode: 1
[DEBUG   ] output: connect: No such file or directory
Please make sure that the zfs-fuse daemon is running.
internal error: failed to initialize ZFS library
[DEBUG   ] Determining pillar cache
[DEBUG   ] LazyLoaded jinja.render
[DEBUG   ] LazyLoaded yaml.render
[DEBUG   ] LazyLoaded jinja.render
[DEBUG   ] LazyLoaded yaml.render
[DEBUG   ] LazyLoaded flatpak.add_remote
[DEBUG   ] LazyLoaded direct_call.execute
[DEBUG   ] LazyLoaded cmd.run_all
[INFO    ] Executing command 'flatpak remote-add  --user flathub https://flathub.org/repo/flathub.flatpakrepo' in directory '/home/ritzk'
[ERROR   ] Command '['flatpak', 'remote-add', '--user', 'flathub', 'https://flathub.org/repo/flathub.flatpakrepo']' failed with return code: 1
[ERROR   ] stderr: error: Remote flathub already exists
[ERROR   ] retcode: 1
[DEBUG   ] LazyLoaded nested.output
local:
    ----------
    output:
    result:
        False
    stderr:
        error: Remote flathub already exists

```
- Without user option
```
[ritzk@localhost linux_setup (master *%=)]$ salt-call --local flatpak.add_remote  flathub  location=https://flathub.org/repo/flathub.flatpakrepo
[DEBUG   ] Configuration file path: /home/ritzk/Projects/gitlab.com/ritzk/linux_setup/salt/config/minion
[WARNING ] Insecure logging configuration detected! Sensitive data may be logged.
[DEBUG   ] Grains refresh requested. Refreshing grains.
[DEBUG   ] Reading configuration from /home/ritzk/Projects/gitlab.com/ritzk/linux_setup/salt/config/minion
[DEBUG   ] Elapsed time getting FQDNs: 0.3278939723968506 seconds
[INFO    ] Although 'dmidecode' was found in path, the current user cannot execute it. Grains output might not be accurate.
[DEBUG   ] LazyLoaded zfs.is_supported
[INFO    ] Executing command '/usr/sbin/zpool list -H -o name,size' in directory '/home/ritzk'
[DEBUG   ] stdout: connect: No such file or directory
Please make sure that the zfs-fuse daemon is running.
internal error: failed to initialize ZFS library
[DEBUG   ] retcode: 1
[DEBUG   ] output: connect: No such file or directory
Please make sure that the zfs-fuse daemon is running.
internal error: failed to initialize ZFS library
[DEBUG   ] Determining pillar cache
[DEBUG   ] LazyLoaded jinja.render
[DEBUG   ] LazyLoaded yaml.render
[DEBUG   ] LazyLoaded jinja.render
[DEBUG   ] LazyLoaded yaml.render
[DEBUG   ] LazyLoaded flatpak.add_remote
[DEBUG   ] LazyLoaded direct_call.execute
[DEBUG   ] LazyLoaded cmd.run_all
[INFO    ] Executing command 'flatpak remote-add  --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo' in directory '/home/ritzk'
[ERROR   ] Command '['flatpak', 'remote-add', '--if-not-exists', 'flathub', 'https://flathub.org/repo/flathub.flatpakrepo']' failed with return code: 1
[ERROR   ] stderr: error: Flatpak system operation ConfigureRemote not allowed for user
[ERROR   ] retcode: 1
[DEBUG   ] LazyLoaded nested.output
local:
    ----------
    output:
    result:
        False
    stderr:
        error: Flatpak system operation ConfigureRemote not allowed for user

```

- With user option
````
[ritzk@localhost linux_setup (master *%=)]$ salt-call --local flatpak.add_remote  flathub user=1 location=https://flathub.org/repo/flathub.flatpakrepo
[DEBUG   ] Configuration file path: /home/ritzk/Projects/gitlab.com/ritzk/linux_setup/salt/config/minion
[WARNING ] Insecure logging configuration detected! Sensitive data may be logged.
[DEBUG   ] Grains refresh requested. Refreshing grains.
[DEBUG   ] Reading configuration from /home/ritzk/Projects/gitlab.com/ritzk/linux_setup/salt/config/minion
[DEBUG   ] Elapsed time getting FQDNs: 0.27693986892700195 seconds
[INFO    ] Although 'dmidecode' was found in path, the current user cannot execute it. Grains output might not be accurate.
[DEBUG   ] LazyLoaded zfs.is_supported
[INFO    ] Executing command '/usr/sbin/zpool list -H -o name,size' in directory '/home/ritzk'
[DEBUG   ] stdout: connect: No such file or directory
Please make sure that the zfs-fuse daemon is running.
internal error: failed to initialize ZFS library
[DEBUG   ] retcode: 1
[DEBUG   ] output: connect: No such file or directory
Please make sure that the zfs-fuse daemon is running.
internal error: failed to initialize ZFS library
[DEBUG   ] Determining pillar cache
[DEBUG   ] LazyLoaded jinja.render
[DEBUG   ] LazyLoaded yaml.render
[DEBUG   ] LazyLoaded jinja.render
[DEBUG   ] LazyLoaded yaml.render
[DEBUG   ] LazyLoaded flatpak.add_remote
[DEBUG   ] LazyLoaded direct_call.execute
[DEBUG   ] LazyLoaded cmd.run_all
[INFO    ] Executing command 'flatpak remote-add  --if-not-exists  --user flathub https://flathub.org/repo/flathub.flatpakrepo' in directory '/home/ritzk'
[DEBUG   ] LazyLoaded nested.output
local:
    ----------
    output:
    result:
        True
    stdout:

````