### PR TITLE
Fix netmiko proxy module multi_call to work with salt-sproxy and show cli example

### DIFF
--- a/salt/modules/netmiko_mod.py
+++ b/salt/modules/netmiko_mod.py
@@ -335,7 +335,7 @@ def multi_call(*methods, **kwargs):
     kwargs
         Key-value dictionary with the connection details (when not running
         under a Proxy Minion).
-        
+
     CLI Example:
 
     .. code-block:: bash

--- a/salt/modules/netmiko_mod.py
+++ b/salt/modules/netmiko_mod.py
@@ -335,6 +335,12 @@ def multi_call(*methods, **kwargs):
     kwargs
         Key-value dictionary with the connection details (when not running
         under a Proxy Minion).
+        
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' netmiko.multi_call "{'name': 'enable', 'args': ['sudo su']}" "{'name': 'send_command', 'kwargs': {'command_string': 'whoami'}}"
     """
     kwargs = clean_kwargs(**kwargs)
     if "netmiko.conn" in __proxy__:
@@ -346,8 +352,11 @@ def multi_call(*methods, **kwargs):
         # Explicit unpacking
         method_name = method["name"]
         method_args = method.get("args", [])
-        method_kwargs = method.get("kwargs", [])
-        ret.append(getattr(conn, method_name)(*method_args, **method_kwargs))
+        method_kwargs = method.get("kwargs", {})
+        if "netmiko.call" in __proxy__:
+          ret.append(__proxy__["netmiko.call"](method_name, *method_args, **method_kwargs))
+        else:
+          ret.append(getattr(conn, method_name)(*method_args, **method_kwargs))
     if "netmiko.conn" not in __proxy__:
         conn.disconnect()
     return ret

--- a/salt/modules/netmiko_mod.py
+++ b/salt/modules/netmiko_mod.py
@@ -354,9 +354,9 @@ def multi_call(*methods, **kwargs):
         method_args = method.get("args", [])
         method_kwargs = method.get("kwargs", {})
         if "netmiko.call" in __proxy__:
-          ret.append(__proxy__["netmiko.call"](method_name, *method_args, **method_kwargs))
+            ret.append(__proxy__["netmiko.call"](method_name, *method_args, **method_kwargs))
         else:
-          ret.append(getattr(conn, method_name)(*method_args, **method_kwargs))
+            ret.append(getattr(conn, method_name)(*method_args, **method_kwargs))
     if "netmiko.conn" not in __proxy__:
         conn.disconnect()
     return ret


### PR DESCRIPTION
### What does this PR do?

1. Default kwargs to an empty dictionary instead of an empty list
2. Call the netmiko method via the magic ```__proxy__``` method if available (in the identical fashion that netmiko.call operates)
3. Provide a CLI example of multi_call as it is not very intuitive
### What issues does this PR fix or reference?
Fixes: #59158

### Previous Behavior
Throws AttributeError and TypeError

### New Behavior
Proxy minion output is returned as a list

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

