### PR TITLE
optimize salt returns purge jobs

### DIFF
--- a/salt/returners/mysql.py
+++ b/salt/returners/mysql.py
@@ -508,7 +508,7 @@ def _purge_jobs(timestamp):
     """
     with _get_serv() as cur:
         try:
-            sql = "delete from `jids` where jid in (select distinct jid from salt_returns where alter_time < %s)"
+            sql = "delete m from `jids` as m inner join `salt_returns` as n on m.jid = n.jid where n.alter_time < %s"
             cur.execute(sql, (timestamp,))
             cur.execute("COMMIT")
         except MySQLdb.Error as e:

--- a/salt/returners/pgjsonb.py
+++ b/salt/returners/pgjsonb.py
@@ -471,7 +471,7 @@ def _purge_jobs(timestamp):
     """
     with _get_serv() as cursor:
         try:
-            sql = "delete from jids where jid in (select distinct jid from salt_returns where alter_time < %s)"
+            sql = "delete m from `jids` as m inner join `salt_returns` as n on m.jid = n.jid where n.alter_time < %s"
             cursor.execute(sql, (timestamp,))
             cursor.execute("COMMIT")
         except psycopg2.DatabaseError as err:


### PR DESCRIPTION
### What does this PR do?
optimize salt returns purge jobs

### Previous Behavior
Remove this section if not relevant
If salt_returns has too many records, the salt returns _purge_jobs function(salt/salt/returners/mysql.py)，it takes a long time, because of this sql:
`delete from `jids` where jid in (select distinct jid from salt_returns where alter_time < %s)`
![image](https://user-images.githubusercontent.com/8147810/102337925-169af900-3fce-11eb-9fb8-3c232f4a517b.png)
and have too many slow log in mysql.

### New Behavior
![image](https://user-images.githubusercontent.com/8147810/102338052-45b16a80-3fce-11eb-9b3b-55f42bf37ba9.png)
Better execution of plans，and has no slow log in mysql.

