### PR TITLE
[DOCS] Sync state_aggregate option in minion and master config docs

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -2525,18 +2525,20 @@ states is cluttering the logs. Set it to True to ignore them.
 
 Default: ``False``
 
-Automatically aggregate all states that have support for mod_aggregate by
-setting to ``True``. Or pass a list of state module names to automatically
+Automatically aggregate all states that have support for ``mod_aggregate`` by
+setting to ``True``.
+
+.. code-block:: yaml
+
+    state_aggregate: True
+
+Or pass a list of state module names to automatically
 aggregate just those types.
 
 .. code-block:: yaml
 
     state_aggregate:
       - pkg
-
-.. code-block:: yaml
-
-    state_aggregate: True
 
 .. conf_master:: state_events
 

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -2189,6 +2189,28 @@ or just post what changes are going to be made.
 
     test: False
 
+.. conf_minion:: state_aggregate
+
+``state_aggregate``
+-------------------
+
+Default: ``False``
+
+Automatically aggregate all states that have support for ``mod_aggregate`` by
+setting to ``True``.
+
+.. code-block:: yaml
+
+    state_aggregate: True
+
+Or pass a list of state module names to automatically
+aggregate just those types.
+
+.. code-block:: yaml
+
+    state_aggregate:
+      - pkg
+
 .. conf_minion:: state_verbose
 
 ``state_verbose``


### PR DESCRIPTION
### What does this PR do?

- Adds new documentation of `state_aggregate` to `minion.rst` configuration options
- Syncs documentation across `minion.rst` and `master.rst` configuration options for `state_aggregate`

This will sync the `.rst` documentation with the `minion` and `master` yaml config files:

https://github.com/saltstack/salt/blob/318502ab651766090a4cf3ac4f7cd10f9f80d4ca/conf/minion#L579-L586

https://github.com/saltstack/salt/blob/318502ab651766090a4cf3ac4f7cd10f9f80d4ca/conf/master#L638-L645

### What issues does this PR fix or reference?

Ongoing work related to: https://github.com/saltstack/salt/issues/58112

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?

Yes