### PR TITLE
Read auth_tries from config instead using 3

### DIFF
--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -1040,6 +1040,7 @@ class ZeroMQPubServerChannel(salt.transport.server.PubServerChannel):
                                         salt.utils.stringutils.to_bytes(topic)
                                     ).hexdigest()
                                 )
+
                                 pub_sock.send(htopic, flags=zmq.SNDMORE)
                                 pub_sock.send(payload)
                                 log.trace("Filtered data has been sent")
@@ -1373,11 +1374,16 @@ class AsyncReqMessageClient:
                 future.set_exception(SaltReqTimeoutError("Message timed out"))
 
     def send(
-        self, message, timeout=None, tries=3, future=None, callback=None, raw=False
+        self, message, timeout=None, tries=None, future=None, callback=None, raw=False
     ):
         """
         Return a future which will be completed when the message has a response
         """
+        # Retrieve auth_tries from configuration if None is passed
+        # Otherwise, use 3
+        if tries is None:
+            tries = self.opts.get("auth_tries") or 3
+
         if future is None:
             future = salt.ext.tornado.concurrent.Future()
             future.tries = tries


### PR DESCRIPTION
### What does this PR do?
There was code that was overriding the value of `auth_tries` regardless
of what was set in the configuration. It was overriding it to be 3.

### What issues does this PR fix or reference?
This change:
- has been tested to fix #59174 according to its test-procedure
- can serve as a workaround for issue #59064 (Minion throws SaltReqTimeoutError when offline)

### Previous Behavior
The send function never tried to read `auth_tries` from configuration or another source.

### New Behavior
Because the send function does read `detect_mode` from configuration, a successful attempt was made to also read `auth_tries` from configuration. 

### Merge requirements satisfied?

This Draft PR could be used as a hint or even serve as starting point for a Non-Draft Pull request.

**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
