### PR TITLE
lxd: fix possible race condition when adding multiple devices

### DIFF
--- a/changelog/59145.fixed
+++ b/changelog/59145.fixed
@@ -1,0 +1,1 @@
+Fix a race condition in the ldx module which sometimes caused devices not to be created during container creation.

--- a/salt/modules/lxd.py
+++ b/salt/modules/lxd.py
@@ -387,7 +387,7 @@ def pylxd_save_object(obj):
     This is an internal method, no CLI Example.
     """
     try:
-        obj.save()
+        obj.save(wait=True)
     except pylxd.exceptions.LXDAPIException as e:
         raise CommandExecutionError(str(e))
 


### PR DESCRIPTION
### What does this PR do?
Makes the lxd module wait on PyLXD to actually write the changes (see #59145 )

### What issues does this PR fix or reference?
Fixes: #59145

### Previous Behavior
Sometimes not all devices would be created during container creation

### New Behavior
All devices are now correctly added

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes