### PR TITLE
Added CentOS Stream to os family grain mapping

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1569,6 +1569,7 @@ _OS_FAMILY_MAP = {
     "Korora": "RedHat",
     "FedBerry": "RedHat",
     "CentOS": "RedHat",
+    "CentOS Stream": "RedHat",
     "GoOSe": "RedHat",
     "Scientific": "RedHat",
     "Amazon": "RedHat",


### PR DESCRIPTION
### What does this PR do?
Fixes CentOS Stream `os_family` recognition.

### What issues does this PR fix or reference?
Fixes: #59161

### Previous Behavior
`os_family` grain was set to 'CentOS Stream' instead 'RedHat'
