### PR TITLE
Fix pillar roots order

### DIFF
--- a/changelog/24501.fixed
+++ b/changelog/24501.fixed
@@ -1,0 +1,1 @@
+Fixing _get_envs() to preserve the order of pillar_roots. _get_envs() returned pillar_roots in a non-deterministic order.

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -2,11 +2,9 @@
 Render the pillar data
 """
 
-
 import collections
 import copy
 import fnmatch
-import inspect
 import logging
 import os
 import sys
@@ -629,8 +627,7 @@ class Pillar:
                 opts["pillar_roots"][env] = opts["pillar_roots"].pop("__env__")
             else:
                 log.debug(
-                    "pillar_roots __env__ ignored (environment '%s' found in"
-                    " pillar_roots)",
+                    "pillar_roots __env__ ignored (environment '%s' found in pillar_roots)",
                     env,
                 )
                 opts["pillar_roots"].pop("__env__")

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -640,9 +640,9 @@ class Pillar:
         """
         Pull the file server environments out of the master options
         """
-        envs = {"base"}
+        envs = ["base"]
         if "pillar_roots" in self.opts:
-            envs.update(list(self.opts["pillar_roots"]))
+            envs.extend([x for x in list(self.opts["pillar_roots"]) if x not in envs])
         return envs
 
     def get_tops(self):

--- a/tests/pytests/unit/pillar/test_pillar.py
+++ b/tests/pytests/unit/pillar/test_pillar.py
@@ -1,0 +1,29 @@
+import pytest
+import salt.loader
+import salt.pillar
+from salt.utils.odict import OrderedDict
+
+
+@pytest.mark.parametrize(
+    "envs",
+    (
+        ["a", "b", "c"],
+        ["c", "b", "a"],
+        ["b", "a", "c"],
+    ),
+)
+def test_pillar_envs_order(envs, temp_salt_minion, tmp_path):
+    opts = temp_salt_minion.config.copy()
+    # Stop using OrderedDict once we drop Py3.5 support
+    opts["pillar_roots"] = OrderedDict()
+    for envname in envs:
+        opts["pillar_roots"][envname] = [str(tmp_path / envname)]
+    grains = salt.loader.grains(opts)
+    pillar = salt.pillar.Pillar(
+        opts,
+        grains,
+        temp_salt_minion.id,
+        "base",
+    )
+    # The base environment is always present and as the first environment name
+    assert pillar._get_envs() == ["base"] + envs


### PR DESCRIPTION
### What does this PR do?

_get_envs() returns pillar_roots in a non-deterministic order. Update _get_envs() to preserve the order of pillar_roots similar to https://github.com/saltstack/salt/commit/e36d6839d19a669d85ad424aa722d16abd8fc219 for file_roots in state.py.

### What issues does this PR fix or reference?
Fixes: #24501

### Previous Behavior
_get_envs() returns pillar_roots in a non-deterministic order

### New Behavior
_get_envs() preserves the order of pillar_roots

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [N/A] Docs
- [X] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No
