### PR TITLE
[BUG] Fixes setup.py for OSX and WINDOWS when USE_STATIC_REQUIREMENTS=0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,9 +134,7 @@ SALT_LINUX_LOCKED_REQS = [
     )
 ]
 SALT_OSX_REQS = SALT_BASE_REQUIREMENTS + [
-    os.path.abspath(SETUP_DIRNAME),
-    "requirements",
-    "darwin.txt",
+    os.path.join(os.path.abspath(SETUP_DIRNAME), "requirements", "darwin.txt")
 ]
 SALT_OSX_LOCKED_REQS = [
     # OSX packages already defined locked requirements
@@ -150,9 +148,7 @@ SALT_OSX_LOCKED_REQS = [
     )
 ]
 SALT_WINDOWS_REQS = SALT_BASE_REQUIREMENTS + [
-    os.path.abspath(SETUP_DIRNAME),
-    "requirements",
-    "windows.txt",
+    os.path.join(os.path.abspath(SETUP_DIRNAME), "requirements", "windows.txt")
 ]
 SALT_WINDOWS_LOCKED_REQS = [
     # Windows packages already defined locked requirements

--- a/tests/pytests/scenarios/setup/test_install.py
+++ b/tests/pytests/scenarios/setup/test_install.py
@@ -23,6 +23,21 @@ pytestmark = [
 ]
 
 
+def use_static_requirements_ids(value):
+    return "USE_STATIC_REQUIREMENTS={}".format(value)
+
+
+@pytest.fixture(params=[1, 0], ids=use_static_requirements_ids)
+def use_static_requirements(request):
+    return str(request.param)
+
+
+@pytest.fixture
+def virtualenv(virtualenv, use_static_requirements):
+    virtualenv.environ["USE_STATIC_REQUIREMENTS"] = use_static_requirements
+    return virtualenv
+
+
 def test_wheel(virtualenv, cache_dir):
     """
     test building and installing a bdist_wheel package

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -1632,8 +1632,12 @@ patched_environ = PatchedEnviron
 
 
 class VirtualEnv:
-    def __init__(self, venv_dir=None):
+    def __init__(self, venv_dir=None, env=None):
         self.venv_dir = venv_dir or tempfile.mkdtemp(dir=RUNTIME_VARS.TMP)
+        environ = os.environ.copy()
+        if env:
+            environ.update(env)
+        self.environ = environ
         if salt.utils.platform.is_windows():
             self.venv_python = os.path.join(self.venv_dir, "Scripts", "python.exe")
         else:
@@ -1659,6 +1663,7 @@ class VirtualEnv:
         kwargs.setdefault("stdout", subprocess.PIPE)
         kwargs.setdefault("stderr", subprocess.PIPE)
         kwargs.setdefault("universal_newlines", True)
+        kwargs.setdefault("env", self.environ)
         proc = subprocess.run(args, check=False, **kwargs)
         ret = ProcessResult(
             exitcode=proc.returncode,


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes: broken setup.py when USE_STATIC_REQUIREMENTS=0 or is not set.

### Previous Behavior
On at least OSX/MacOS, setup.py fails, easily demonstrated with `python3.7 setup.py sdist`

### New Behavior
Now `python3.7 setup.py sdist` succeeds.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes
