### PR TITLE
Implement return_retry_tries minion opts and use it for channel.send

### DIFF
--- a/changelog/59236.added
+++ b/changelog/59236.added
@@ -1,0 +1,1 @@
+Add new minion option return_retry_tries for dynamic return retry tries

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -1420,6 +1420,19 @@ retry timeout will be a random int between ``return_retry_timer`` and
 
     return_retry_timer_max: 10
 
+.. conf_minion:: return_retry_tries
+
+``return_retry_tries``
+--------------------------
+
+Default: ``3``
+
+The maximum number of retries for a minion return attempt.
+
+.. code-block:: yaml
+
+    return_retry_tries: 3
+
 .. conf_minion:: cache_sreqs
 
 ``cache_sreqs``

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -418,8 +418,11 @@ VALID_OPTS = immutabletypes.freeze(
         # Tells the minion to choose a bounded, random interval to have zeromq attempt to reconnect
         # in the event of a disconnect event
         "recon_randomize": bool,
+        # Configures retry interval, randomized between timer and timer_max if timer_max > 0
         "return_retry_timer": int,
         "return_retry_timer_max": int,
+        # Configures amount of return retries
+        "return_retry_tries": int,
         # Specify one or more returners in which all events will be sent to. Requires that the returners
         # in question have an event_return(event) function!
         "event_return": (list, str),
@@ -1165,6 +1168,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze(
         "recon_randomize": True,
         "return_retry_timer": 5,
         "return_retry_timer_max": 10,
+        "return_retry_tries": 3,
         "random_reauth_delay": 10,
         "winrepo_source_dir": "salt://win/repo-ng/",
         "winrepo_dir": os.path.join(salt.syspaths.BASE_FILE_ROOTS_DIR, "win", "repo"),

--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -1,5 +1,7 @@
+import pytest
+import salt.ext.tornado.gen
 import salt.minion
-from tests.support.mock import patch
+from tests.support.mock import MagicMock, patch
 
 
 def test_minion_load_grains_false():
@@ -33,3 +35,68 @@ def test_minion_load_grains_default():
         minion = salt.minion.Minion(opts)
         assert minion.opts["grains"] != {}
         grainsfunc.assert_called()
+
+
+@pytest.mark.parametrize(
+    "req_channel",
+    [
+        (
+            "salt.transport.client.AsyncReqChannel.factory",
+            lambda load, timeout, tries: salt.ext.tornado.gen.maybe_future(tries),
+        ),
+        (
+            "salt.transport.client.ReqChannel.factory",
+            lambda load, timeout, tries: tries,
+        ),
+    ],
+)
+def test_send_req_tries(req_channel):
+    channel_enter = MagicMock()
+    channel_enter.send.side_effect = req_channel[1]
+    channel = MagicMock()
+    channel.__enter__.return_value = channel_enter
+
+    with patch(req_channel[0], return_value=channel):
+        opts = {
+            "random_startup_delay": 0,
+            "grains": {},
+            "return_retry_tries": 30,
+            "minion_sign_messages": False,
+        }
+        with patch("salt.loader.grains"):
+            minion = salt.minion.Minion(opts)
+
+            load = {"load": "value"}
+            timeout = 60
+
+            if "Async" in req_channel[0]:
+                rtn = minion._send_req_async(load, timeout).result()
+            else:
+                rtn = minion._send_req_sync(load, timeout)
+
+            assert rtn == 30
+
+
+@patch("salt.transport.client.ReqChannel.factory")
+def test_mine_send_tries(req_channel_factory):
+    channel_enter = MagicMock()
+    channel_enter.send.side_effect = lambda load, timeout, tries: tries
+    channel = MagicMock()
+    channel.__enter__.return_value = channel_enter
+    req_channel_factory.return_value = channel
+
+    opts = {
+        "random_startup_delay": 0,
+        "grains": {},
+        "return_retry_tries": 20,
+        "minion_sign_messages": False,
+    }
+    with patch("salt.loader.grains"):
+        minion = salt.minion.Minion(opts)
+        minion.tok = "token"
+
+        data = {}
+        tag = "tag"
+
+        rtn = minion._mine_send(tag, data)
+        assert rtn == 20


### PR DESCRIPTION
### What does this PR do?
Implements new minion opts `return_retry_tries` which is used for dynamic configuration of minion return retries attempts

### What issues does this PR fix or reference?
Fixes #59236

### Previous Behavior
Fixed value of 3 would be used

### New Behavior
Value from `return_retry_tries` is used (with default 3)

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes


If this gets merged before #59163 the integration test there could be adapted to test this value change as well.
