### PR TITLE
The `event_listener` fixture is now provided by `pytest-salt-factories`

### DIFF
--- a/tests/pytests/integration/master/test_clear_funcs.py
+++ b/tests/pytests/integration/master/test_clear_funcs.py
@@ -53,11 +53,6 @@ def user_info(salt_master):
 
 
 @pytest.fixture(scope="module")
-def event_listener(salt_factories):
-    return salt_factories.event_listener
-
-
-@pytest.fixture(scope="module")
 def client_config(salt_minion, salt_master):
     opts = salt_minion.config.copy()
     opts.update(

--- a/tests/pytests/integration/modules/grains/conftest.py
+++ b/tests/pytests/integration/modules/grains/conftest.py
@@ -18,11 +18,6 @@ class PillarRefreshComplete:
 
 
 @pytest.fixture(scope="module")
-def event_listener(salt_factories):
-    return salt_factories.event_listener
-
-
-@pytest.fixture(scope="module")
 def wait_for_pillar_refresh_complete(event_listener, salt_minion):
     return PillarRefreshComplete(
         event_listener=event_listener, minion_id=salt_minion.id

--- a/tests/pytests/integration/modules/saltutil/test_pillar.py
+++ b/tests/pytests/integration/modules/saltutil/test_pillar.py
@@ -27,11 +27,6 @@ def refresh_pillar(salt_call_cli, salt_minion):
         assert ret.json
 
 
-@pytest.fixture(scope="module")
-def event_listener(salt_factories):
-    return salt_factories.event_listener
-
-
 @pytest.mark.slow_test
 @pytest.mark.parametrize("sync_refresh", [False, True])
 def test_pillar_refresh(

--- a/tests/pytests/integration/modules/test_event.py
+++ b/tests/pytests/integration/modules/test_event.py
@@ -13,11 +13,6 @@ pytestmark = [
 ]
 
 
-@pytest.fixture(scope="module")
-def event_listener(salt_factories):
-    return salt_factories.event_listener
-
-
 def test_fire_master(event_listener, salt_master, salt_minion, salt_call_cli):
     """
     Test firing an event on the master event bus

--- a/tests/pytests/integration/reactor/test_reactor.py
+++ b/tests/pytests/integration/reactor/test_reactor.py
@@ -23,11 +23,6 @@ pytestmark = [
 log = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope="module")
-def event_listener(salt_factories):
-    return salt_factories.event_listener
-
-
 @pytest.fixture
 def master_event_bus(salt_master):
     with salt.utils.event.get_master_event(

--- a/tests/pytests/scenarios/multimaster/beacons/test_inotify.py
+++ b/tests/pytests/scenarios/multimaster/beacons/test_inotify.py
@@ -36,11 +36,6 @@ def inotify_test_path(tmp_path_factory):
 
 
 @pytest.fixture(scope="module")
-def event_listener(salt_factories):
-    return salt_factories.event_listener
-
-
-@pytest.fixture(scope="module")
 def setup_beacons(mm_master_1_salt_cli, salt_mm_minion_1, inotify_test_path):
     start_time = time.time()
     try:

--- a/tests/pytests/scenarios/multimaster/test_offline_master.py
+++ b/tests/pytests/scenarios/multimaster/test_offline_master.py
@@ -3,11 +3,6 @@ import time
 import pytest
 
 
-@pytest.fixture(scope="module")
-def event_listener(salt_factories):
-    return salt_factories.event_listener
-
-
 @pytest.mark.slow_test
 def test_minion_hangs_on_master_failure_50814(
     event_listener,


### PR DESCRIPTION
### What does this PR do?
See title