### PR TITLE
Fix "aptpkg.normalize_name" in case the arch is "all" for DEB packages

### DIFF
--- a/changelog/59269.fixed
+++ b/changelog/59269.fixed
@@ -1,0 +1,1 @@
+Fix "aptpkg.normalize_name" in case the arch is "all" for DEB packages

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -207,7 +207,7 @@ def normalize_name(name):
         pkgname = name
         pkgarch = __grains__["osarch"]
 
-    return pkgname if pkgarch in (__grains__["osarch"], "any") else name
+    return pkgname if pkgarch in (__grains__["osarch"], "all", "any") else name
 
 
 def parse_arch(name):

--- a/tests/pytests/unit/modules/test_aptpkg.py
+++ b/tests/pytests/unit/modules/test_aptpkg.py
@@ -724,6 +724,8 @@ def test_normalize_name():
         assert result == "foo", result
         result = aptpkg.normalize_name("foo:any")
         assert result == "foo", result
+        result = aptpkg.normalize_name("foo:all")
+        assert result == "foo", result
         result = aptpkg.normalize_name("foo:i386")
         assert result == "foo:i386", result
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue in `aptpkg.normalize_name` when the target package has `all` arch.

In those cases, as it also happens when arch is `any`, the "arch" needs to be stripped from the package name to avoid errors when applying `pkg.installed` states.

### Previous Behavior

Without this PR the results from a `pkg.installed` state is wrong:
```console
...
  "pkg_|-pkg_installed_|-pkg_installed_|-installed": {
    "name": "pkg_installed",
    "changes": {
      "orion-dummy": {
        "old": "",
        "new": "1.1"
      }
    },
    "result": false,
    "comment": "The following packages failed to install/update: orion-dummy:all=1.1",
    "__sls__": "packages.pkginstall",
    "__run_num__": 2.0,
    "start_time": "13:38:03.062743",
    "duration": 1170.106,
    "__id__": "pkg_installed"
  }
...
```

Notice the `orion-dummy` package got installed while it reported a failure. 

### New Behavior
This PR fix `aptpkg.normalize_name` to also strip the "arch" when this is `all`, so we won't get inconsistent results from `pkg.installed` when dealing with such arch:

```console
...
  "pkg_|-pkg_installed_|-pkg_installed_|-installed": {
    "name": "pkg_installed",
    "changes": {
      "orion-dummy": {
        "old": "",
        "new": "1.1"
      }
    },
    "result": true,
    "comment": "The following packages were installed/updated: orion-dummy=1.1",
    "__sls__": "packages.pkginstall",
    "__run_num__": 2.0,
    "start_time": "16:59:12.071349",
    "duration": 1618.993,
    "__id__": "pkg_installed"
  }
...
```

### Merge requirements satisfied?
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes