### PR TITLE
update to pygit2>=1.4.0 for arch compatibility

### DIFF
--- a/requirements/static/ci/linux.in
+++ b/requirements/static/ci/linux.in
@@ -2,4 +2,4 @@
 pyiface
 pygit2<=0.28.2; python_version < '3.8'
 pygit2<1.1.0; python_version == '3.8'
-pygit2>=1.2.0; python_version >= '3.9'
+pygit2>=1.4.0; python_version >= '3.9'

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -183,7 +183,7 @@ pycparser==2.17
 pycryptodomex==3.9.8
 pycurl==7.43.0.6
 pyeapi==0.8.3             # via napalm
-pygit2==1.2.0 ; python_version >= "3.9"
+pygit2==1.4.0 ; python_version >= "3.9"
 pyiface==0.0.11
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin"
 pyjwt==1.7.1              # via adal


### PR DESCRIPTION
### What does this PR do?
Arch has too new of a version of libgit2.  This is the oldest version of pygit2 that has pre-built wheel's available for python3.9.  We need this in order to update amis.

it also looks like arch can build 1.4.0 from source, not sure if fedora33 can, but there's a wheel available anyway.