### PR TITLE
Add support for opaque switch_type to vmware cloud provider

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -419,6 +419,20 @@ def _edit_existing_network_adapter(
             vim.vm.device.VirtualEthernetCard.DistributedVirtualPortBackingInfo()
         )
         edited_network_adapter.backing.port = dvs_port_connection
+    elif switch_type == "opaque":
+        network_ref = salt.utils.vmware.get_mor_by_property(
+            _get_si(),
+            vim.OpaqueNetwork,
+            new_network_name,
+            container_ref=container_ref,
+        )
+        edited_network_adapter.backing = (
+            vim.vm.device.VirtualEthernetCard.OpaqueNetworkBackingInfo()
+        )
+        network_id = network_ref.summary.opaqueNetworkId
+        network_type = network_ref.summary.opaqueNetworkType
+        edited_network_adapter.backing.opaqueNetworkType = network_type
+        edited_network_adapter.backing.opaqueNetworkId = network_id
     else:
         # If switch type not specified or does not match, show error and return
         if not switch_type:
@@ -506,6 +520,21 @@ def _add_new_network_adapter_helper(
             vim.vm.device.VirtualEthernetCard.DistributedVirtualPortBackingInfo()
         )
         network_spec.device.backing.port = dvs_port_connection
+    elif switch_type == "opaque":
+        network_ref = salt.utils.vmware.get_mor_by_property(
+            _get_si(),
+            vim.OpaqueNetwork,
+            network_name,
+            container_ref=container_ref,
+        )
+        network_spec.device.backing = (
+            vim.vm.device.VirtualEthernetCard.OpaqueNetworkBackingInfo()
+        )
+        network_id = network_ref.summary.opaqueNetworkId
+        network_type = network_ref.summary.opaqueNetworkType
+        network_spec.device.backing.opaqueNetworkType = network_type
+        network_spec.device.backing.opaqueNetworkId = network_id
+
     else:
         # If switch type not specified or does not match, show error and return
         if not switch_type:


### PR DESCRIPTION
### What does this PR do?
Adds supports for the 'opaque' switch type to the vmware cloud provider.
This switch type is for example used by NSX-T Segments.

### What issues does this PR fix or reference?
n/a

### Previous Behavior
It was not possible to deploy a VM on an opaque switch_type

### New Behavior
It is possible to deploy a VM on an opaque switch_type

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No
