### PR TITLE
Add a modicum of error handling to sysrc.set

### DIFF
--- a/salt/modules/sysrc.py
+++ b/salt/modules/sysrc.py
@@ -1,12 +1,7 @@
-# -*- coding: utf-8 -*-
 """
 sysrc module for FreeBSD
 """
 
-# Import Python libs
-from __future__ import absolute_import
-
-# Import Salt libs
 import salt.utils.path
 from salt.exceptions import CommandExecutionError
 
@@ -109,10 +104,13 @@ def set_(name, value, **kwargs):
 
     cmd += " " + name + '="' + value + '"'
 
-    sysrcs = __salt__["cmd.run"](cmd)
+    r = __salt__["cmd.run_all"](cmd)
+
+    if r["retcode"] != 0:
+        raise CommandExecutionError("sysrc failed: {}".format(r["stderr"]))
 
     ret = {}
-    for sysrc in sysrcs.split("\n"):
+    for sysrc in r["stdout"].split("\n"):
         rcfile = sysrc.split(": ")[0]
         var = sysrc.split(": ")[1]
         oldval = sysrc.split(": ")[2].strip().split("->")[0]


### PR DESCRIPTION
### What does this PR do?
Adds basic error handling for sysrc.set

### Previous Behavior
If the sysrc could not be applied, the module would return a useless error message like:
```
          ID: Disable nfsuserd
    Function: sysrc.managed
        Name: nfsuserd_enable
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/local/lib/python3.7/site-packages/salt/state.py", line 2154, in call
                  *cdata["args"], **cdata["kwargs"]
                File "/usr/local/lib/python3.7/site-packages/salt/loader.py", line 2106, in wrapper
                  return f(*args, **kwargs)
                File "/usr/local/lib/python3.7/site-packages/salt/states/sysrc.py", line 72, in managed
                  new_state = __salt__["sysrc.set"](name=name, value=value, **kwargs)
                File "/usr/local/lib/python3.7/site-packages/salt/modules/sysrc.py", line 119, in set_
                  newval = sysrc.split(": ")[2].strip().split("->")[1]
              IndexError: list index out of range
     Started: 20:14:06.220018
    Duration: 110.487 ms
     Changes:
```

### New Behavior
Now it returns a more useful error, like:
```
[ERROR   ] Command '['sysrc', '-v', 'nfsuserd_enable=XXX']' failed with return code: 1
[ERROR   ] stdout: /etc/rc.conf:
[ERROR   ] stderr: sysrc: cannot create /etc/rc.conf: Permission denied
[ERROR   ] retcode: 1
Error running 'sysrc.set': sysrc failed: sysrc: cannot create /etc/rc.conf: Permission denied
```

### Merge requirements satisfied?
- [N/A] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

I did not write any tests.  Since this commit is really just changing the format of an error message, I didn't think it needed tests.  Tell me if you disagree.