### PR TITLE
Add win_disk.letters module function

### DIFF
--- a/changelog/59297.added
+++ b/changelog/59297.added
@@ -1,0 +1,1 @@
+Add win_disk.letters module function

--- a/salt/modules/win_disk.py
+++ b/salt/modules/win_disk.py
@@ -40,6 +40,26 @@ def __virtual__():
     return (False, "Module win_disk: module only works on Windows systems")
 
 
+def letters():
+    """
+    Return a list of drive letters for volumes mounted on this minion
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' disk.letters
+
+    .. versionadded:: 3003
+    """
+    drives = []
+    drive_bitmask = ctypes.windll.kernel32.GetLogicalDrives()
+    for letter in UPPERCASE:
+        if drive_bitmask & 1:
+            drives.append(letter)
+        drive_bitmask >>= 1
+    return drives
+
 def usage():
     """
     Return usage information for volumes mounted on this minion
@@ -50,14 +70,9 @@ def usage():
 
         salt '*' disk.usage
     """
-    drives = []
+
     ret = {}
-    drive_bitmask = ctypes.windll.kernel32.GetLogicalDrives()
-    for letter in UPPERCASE:
-        if drive_bitmask & 1:
-            drives.append(letter)
-        drive_bitmask >>= 1
-    for drive in drives:
+    for drive in letters():
         try:
             (
                 available_bytes,

--- a/salt/modules/win_disk.py
+++ b/salt/modules/win_disk.py
@@ -1,20 +1,13 @@
-# -*- coding: utf-8 -*-
 """
 Module for gathering disk information on Windows
 
 :depends:   - win32api Python module
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
-# Import Python libs
 import ctypes
 import string
 
-# Import Salt libs
 import salt.utils.platform
-
-# Import 3rd-party libs
-from salt.ext import six
 
 try:
     import win32api
@@ -25,10 +18,7 @@ except ImportError:
 __virtualname__ = "disk"
 
 
-if six.PY3:
-    UPPERCASE = string.ascii_uppercase
-else:
-    UPPERCASE = string.uppercase
+UPPERCASE = string.ascii_uppercase
 
 
 def __virtual__():
@@ -60,6 +50,7 @@ def letters():
         drive_bitmask >>= 1
     return drives
 
+
 def usage():
     """
     Return usage information for volumes mounted on this minion
@@ -78,19 +69,19 @@ def usage():
                 available_bytes,
                 total_bytes,
                 total_free_bytes,
-            ) = win32api.GetDiskFreeSpaceEx("{0}:\\".format(drive))
+            ) = win32api.GetDiskFreeSpaceEx("{}:\\".format(drive))
             used = total_bytes - total_free_bytes
             capacity = used / float(total_bytes) * 100
-            ret["{0}:\\".format(drive)] = {
-                "filesystem": "{0}:\\".format(drive),
+            ret["{}:\\".format(drive)] = {
+                "filesystem": "{}:\\".format(drive),
                 "1K-blocks": total_bytes / 1024,
                 "used": used / 1024,
                 "available": total_free_bytes / 1024,
-                "capacity": "{0:.0f}%".format(capacity),
+                "capacity": "{:.0f}%".format(capacity),
             }
         except Exception:  # pylint: disable=broad-except
-            ret["{0}:\\".format(drive)] = {
-                "filesystem": "{0}:\\".format(drive),
+            ret["{}:\\".format(drive)] = {
+                "filesystem": "{}:\\".format(drive),
                 "1K-blocks": None,
                 "used": None,
                 "available": None,

--- a/tests/unit/modules/test_win_disk.py
+++ b/tests/unit/modules/test_win_disk.py
@@ -1,7 +1,4 @@
 # -*- coding: utf-8 -*-
-"""
-    :codeauthor: Jayesh Kariya <jayeshk@saltstack.com>
-"""
 
 # Import Python Libs
 from __future__ import absolute_import, print_function, unicode_literals
@@ -25,9 +22,9 @@ class MockKernel32(object):
     @staticmethod
     def GetLogicalDrives():
         """
-        Mock GetLogicalDrives method
+        Mock GetLogicalDrives method to return A and B.
         """
-        return 1
+        return int("11", 2)
 
 
 class MockWindll(object):
@@ -56,7 +53,8 @@ class WinDiskTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         return {win_disk: {"ctypes": MockCtypes()}}
 
-    # 'usage' function tests: 1
+    def test_letters(self):
+        self.assertListEqual(win_disk.letters(), ["A", "B"])
 
     def test_usage(self):
         """
@@ -71,6 +69,13 @@ class WinDiskTestCase(TestCase, LoaderModuleMockMixin):
                     "used": None,
                     "capacity": None,
                     "filesystem": "A:\\",
-                }
+                },
+                "B:\\": {
+                    "available": None,
+                    "1K-blocks": None,
+                    "used": None,
+                    "capacity": None,
+                    "filesystem": "B:\\",
+                },
             },
         )

--- a/tests/unit/modules/test_win_disk.py
+++ b/tests/unit/modules/test_win_disk.py
@@ -1,17 +1,9 @@
-# -*- coding: utf-8 -*-
-
-# Import Python Libs
-from __future__ import absolute_import, print_function, unicode_literals
-
-# Import Salt Libs
 import salt.modules.win_disk as win_disk
-
-# Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import TestCase
 
 
-class MockKernel32(object):
+class MockKernel32:
     """
     Mock windll class
     """
@@ -27,7 +19,7 @@ class MockKernel32(object):
         return int("11", 2)
 
 
-class MockWindll(object):
+class MockWindll:
     """
     Mock windll class
     """
@@ -36,7 +28,7 @@ class MockWindll(object):
         self.kernel32 = MockKernel32()
 
 
-class MockCtypes(object):
+class MockCtypes:
     """
     Mock ctypes class
     """


### PR DESCRIPTION
### What does this PR do?

Factors out the Windows drive letter listing from `disk.usage` to its own function.

### What issues does this PR fix or reference?

No open issues.  This would have been helpful for a recent customer case.  Current indirect ways to this involved busy command lines, or parsing the letters out of the `disk.usage` keys.

### Merge requirements satisfied?

- [x] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?

No