### PR TITLE
Fix find_library paths for Solaris and AIX tiamat based salt-minions

### DIFF
--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -1,21 +1,15 @@
-# -*- coding: utf-8 -*-
 """
 Create and verify ANSI X9.31 RSA signatures using OpenSSL libcrypto
 """
 
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import ctypes.util
 import glob
 import os
 import platform
 import sys
-
-# Import 3rd-party libs
 from ctypes import c_char_p, c_int, c_void_p, cdll, create_string_buffer, pointer
 
-# Import Salt libs
 import salt.utils.platform
 import salt.utils.stringutils
 
@@ -53,19 +47,32 @@ def _find_libcrypto():
         lib = glob.glob(os.path.join(os.path.dirname(sys.executable), "libcrypto.so*"))
         lib = lib[0] if lib else None
     else:
+        print(
+            "DGM _find_libcrypto start is sunos '{}', is aix '{}'".format(
+                salt.utils.platform.is_sunos(), salt.utils.platform.is_aix()
+            )
+        )
         lib = ctypes.util.find_library("crypto")
         if not lib:
             if salt.utils.platform.is_sunos():
+                print("DGM _find_libcrypto failed to find libcrypto for Solaris")
                 # Solaris-like distribution that use pkgsrc have libraries
                 # in a non standard location.
                 # (SmartOS, OmniOS, OpenIndiana, ...)
                 # This could be /opt/tools/lib (Global Zone) or
                 # /opt/local/lib (non-Global Zone), thus the two checks
                 # below
-                lib = glob.glob("/opt/local/lib/libcrypto.so*")
+                ## DGM lib = glob.glob("/opt/local/lib/libcrypto.so*")
+                lib = glob.glob("/usr/local/openssl/lib/libcrypto.so*")
+                if lib:
+                    print(
+                        "DGM _find_libcrypto found libcrypto for Solaris in /usr/local/openssl/lib/"
+                    )
+
                 lib = lib or glob.glob("/opt/tools/lib/libcrypto.so*")
                 lib = lib[0] if lib else None
             elif salt.utils.platform.is_aix():
+                print("DGM _find_libcrypto failed to find libcrypto for AIX")
                 if os.path.isdir("/opt/salt/lib"):
                     # preference for Salt installed fileset
                     lib = glob.glob("/opt/salt/lib/libcrypto.so*")
@@ -141,7 +148,7 @@ libcrypto = _init_libcrypto()
 RSA_X931_PADDING = 5
 
 
-class RSAX931Signer(object):
+class RSAX931Signer:
     """
     Create ANSI X9.31 RSA signatures using OpenSSL libcrypto
     """
@@ -186,7 +193,7 @@ class RSAX931Signer(object):
         return buf[0:size]
 
 
-class RSAX931Verifier(object):
+class RSAX931Verifier:
     """
     Verify ANSI X9.31 RSA signatures using OpenSSL libcrypto
     """

--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -47,35 +47,26 @@ def _find_libcrypto():
         lib = glob.glob(os.path.join(os.path.dirname(sys.executable), "libcrypto.so*"))
         lib = lib[0] if lib else None
     else:
-        print(
-            "DGM _find_libcrypto start is sunos '{}', is aix '{}'".format(
-                salt.utils.platform.is_sunos(), salt.utils.platform.is_aix()
-            )
-        )
         lib = ctypes.util.find_library("crypto")
         if not lib:
             if salt.utils.platform.is_sunos():
-                print("DGM _find_libcrypto failed to find libcrypto for Solaris")
                 # Solaris-like distribution that use pkgsrc have libraries
                 # in a non standard location.
                 # (SmartOS, OmniOS, OpenIndiana, ...)
                 # This could be /opt/tools/lib (Global Zone) or
                 # /opt/local/lib (non-Global Zone), thus the two checks
                 # below
-                ## DGM lib = glob.glob("/opt/local/lib/libcrypto.so*")
-                lib = glob.glob("/usr/local/openssl/lib/libcrypto.so*")
-                if lib:
-                    print(
-                        "DGM _find_libcrypto found libcrypto for Solaris in /usr/local/openssl/lib/"
-                    )
-
+                lib = glob.glob("/opt/saltstack/salt/run/libcrypto.so*")
+                lib = lib or glob.glob("/opt/local/lib/libcrypto.so*")
                 lib = lib or glob.glob("/opt/tools/lib/libcrypto.so*")
                 lib = lib[0] if lib else None
             elif salt.utils.platform.is_aix():
-                print("DGM _find_libcrypto failed to find libcrypto for AIX")
-                if os.path.isdir("/opt/salt/lib"):
+                if os.path.isdir("/opt/saltstack/salt/run") or os.path.isdir(
+                    "/opt/salt/lib"
+                ):
                     # preference for Salt installed fileset
-                    lib = glob.glob("/opt/salt/lib/libcrypto.so*")
+                    lib = glob.glob("/opt/saltstack/salt/run/libcrypto.so*")
+                    lib = lib or glob.glob("/opt/salt/lib/libcrypto.so*")
                 else:
                     lib = glob.glob("/opt/freeware/lib/libcrypto.so*")
                 lib = lib[0] if lib else None


### PR DESCRIPTION
### What does this PR do?
Adds the default library paths for for Solaris and AIX tiamat based salt-minions, namely /opt/saltstack/salt/run

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/59256

### Previous Behavior
Remove this section if not relevant
libcrypto would not be found if the tiamat based code had bundled it, for example: an updated OpenSSL version 1.1.1 rather than a shipping OpenSSL 1.0.1 for the platform

### New Behavior
libcrypto is now found when bundled with tiamat based code

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
