### PR TITLE
Better list of FreeBSD ami for EC2

### DIFF
--- a/doc/topics/cloud/aws.rst
+++ b/doc/topics/cloud/aws.rst
@@ -758,7 +758,7 @@ them have never been used, much less tested, by the Salt Stack team.
 
 * `FreeBSD`__
 
-.. __: http://www.daemonology.net/freebsd-on-ec2/
+.. __: https://aws.amazon.com/marketplace/search/results?filters=vendor_id&vendor_id=92bb514d-02bc-49fd-9727-c474863f63da
 
 * `Fedora`__
 


### PR DESCRIPTION
The old list was many many years out of date.

Just a simple documentation fix.