### PR TITLE
build(requirements/zeromq): limit `pyzmq` for Python < `3.6` (e.g. Ubuntu 16.04)

### DIFF
--- a/requirements/zeromq.txt
+++ b/requirements/zeromq.txt
@@ -1,5 +1,6 @@
 -r base.txt
 -r crypto.txt
 
+pyzmq<=20.0.0 ; python_version < "3.6"
 pyzmq>=17.0.0 ; python_version < "3.9"
 pyzmq>=19.0.2 ; python_version >= "3.9"


### PR DESCRIPTION
### What does this PR do?
While preparing a new PR for the SaltStack Formulas `salt-image-builder` repo, I found that the `ubun-16.0-master-py3` was failing.  It was working for the last weekly build.

---

https://gitlab.com/myii/salt-image-builder/-/jobs/977980649#L960

```sls
  Downloading https://files.pythonhosted.org/packages/29/84/4b0e1f95a9305861507e7d60bd2368c8939766335d716b7cb05d0200a5ed/pyzmq-21.0.1.tar.gz (1.2MB)
  Saved /tmp/git/deps/pyzmq-21.0.1.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-g4g_0onl/pyzmq/setup.py", line 687
        warn(f"platform={get_platform()}, vcvars=")
                                                 ^
    SyntaxError: invalid syntax
```

* The newly introduced f-strings require Python 3.6, while Ubuntu 16.04 is based on Python 3.5.

---

https://gitlab.com/saltstack-formulas/infrastructure/salt-image-builder/-/jobs/963753336#L282

```sls
         PyZMQ: 20.0.0
```

* Checked the last successful build to find that it was still working with `20.0.0`.

---

https://github.com/zeromq/pyzmq/commit/dc76a8f7b6ef0d7cf021f5636754eb7fc7e10a5d

```sls
master (#1470) v21.0.1 v21.0.0
```

* The commit that introduced this is in `21.0.0`, [which is the version directly after](https://pypi.org/project/pyzmq/#history) `20.0.0`.

---

Confirmed that this proposed change is working by getting the `salt-image-builder` to use my fork of `salt` via. the `salt-bootstrap` script invocation (i.e. using the `-g` switch):

https://gitlab.com/myii/salt-image-builder/-/pipelines/245115063

* All working now.

### What issues does this PR fix or reference?
N/A

### Merge requirements satisfied?
N/A -- package requirements only.

### Commits signed with GPG?
Yes