### PR TITLE
Fixed the "location" parameter for list-images on Proxmox.

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -830,7 +830,7 @@ class Cloud:
                 )
         return data
 
-    def image_list(self, lookup="all"):
+    def image_list(self, lookup="all", location=None):
         """
         Return a mapping of all image data for available providers
         """
@@ -860,7 +860,7 @@ class Cloud:
                 with salt.utils.context.func_globals_inject(
                     self.clouds[fun], __active_provider_name__=":".join([alias, driver])
                 ):
-                    data[alias][driver] = self.clouds[fun]()
+                    data[alias][driver] = self.clouds[fun](location=location)
             except Exception as err:  # pylint: disable=broad-except
                 log.error(
                     "Failed to get the output of '%s()': %s",

--- a/salt/cloud/cli.py
+++ b/salt/cloud/cli.py
@@ -143,7 +143,9 @@ class SaltCloud(salt.utils.parsers.SaltCloudParser):
 
         elif self.options.list_images is not None:
             try:
-                ret = mapper.image_list(self.options.list_images)
+                ret = mapper.image_list(
+                    self.options.list_images, location=self.options.location
+                )
             except Exception as exc:  # pylint: disable=broad-except
                 msg = "There was an error listing images: {0}"
                 self.handle_exception(msg, exc)

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -425,6 +425,7 @@ def avail_images(call=None, location=None):
     .. code-block:: bash
 
         salt-cloud --list-images my-proxmox-config
+        salt-cloud --list-images my-proxmox-config --location local
     """
     if call == "action":
         raise SaltCloudSystemExit(
@@ -433,7 +434,7 @@ def avail_images(call=None, location=None):
         )
 
     if location is None:
-        locations = "local"
+        location = "local"
 
     ret = {}
     for host_name, host_details in avail_locations().items():

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -416,7 +416,7 @@ def avail_locations(call=None):
     return ret
 
 
-def avail_images(call=None, location="local"):
+def avail_images(call=None, location=None):
     """
     Return a list of the images that are on the provider
 
@@ -431,6 +431,9 @@ def avail_images(call=None, location="local"):
             "The avail_images function must be called with "
             "-f or --function, or with the --list-images option"
         )
+
+    if location is None:
+        locations = "local"
 
     ret = {}
     for host_name, host_details in avail_locations().items():


### PR DESCRIPTION
### What does this PR do?
It fixes the --location parameter for --list-images on the Proxmox server

### Previous Behavior
Remove this section if not relevant
location would not change from default "local" to specified value

### New Behavior
location defaults to "local", or uses the value passed in via the --location flag

### Merge requirements satisfied?

I'm not sure if this change needs tests, but if it does I will do my best to implement them.

**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
