### PR TITLE
Fix zpool status for vdevs containing colons in names

### DIFF
--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Module for running ZFS zpool command
 
@@ -13,14 +12,10 @@ Module for running ZFS zpool command
   consistency in output.
 
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
-
-# Import Python libs
 import os
 
-# Import Salt libs
 import salt.utils.decorators
 import salt.utils.decorators.path
 import salt.utils.path
@@ -149,7 +144,7 @@ def status(zpool=None):
     for zpd in res["stdout"].splitlines():
         if zpd.strip() == "":
             continue
-        if ":" in zpd:
+        if ":" in zpd and zpd[0] != "\t":
             # NOTE: line is 'key: value' format, we just update a dict
             prop = zpd.split(":")[0].strip()
             value = ":".join(zpd.split(":")[1:]).strip()
@@ -164,7 +159,7 @@ def status(zpool=None):
             # NOTE: we append the line output to the last property
             #       this should only happens once we hit the config
             #       section
-            ret[current_pool][current_prop] = "{0}\n{1}".format(
+            ret[current_pool][current_prop] = "{}\n{}".format(
                 ret[current_pool][current_prop], zpd
             )
 

--- a/tests/unit/modules/test_zpool.py
+++ b/tests/unit/modules/test_zpool.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests for salt.modules.zpool
 
@@ -9,8 +8,6 @@ Tests for salt.modules.zpool
 :platform:      illumos,freebsd,linux
 """
 
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Salt Utils
 import salt.loader
@@ -25,8 +22,6 @@ from tests.support.helpers import slowTest
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase, skipIf
-
-# Import Salt Testing libs
 from tests.support.zfs import ZFSMockData
 
 
@@ -114,6 +109,36 @@ class ZpoolTestCase(TestCase, LoaderModuleMockMixin):
                 "\t  mirror-0  ONLINE       0     0     0",
                 "\t    c2t0d0  ONLINE       0     0     0",
                 "\t    c2t1d0  ONLINE       0     0     0",
+                "",
+                "errors: No known data errors",
+            ]
+        )
+        ret["stderr"] = ""
+        ret["retcode"] = 0
+        mock_cmd = MagicMock(return_value=ret)
+        with patch.dict(zpool.__salt__, {"cmd.run_all": mock_cmd}), patch.dict(
+            zpool.__utils__, self.utils_patch
+        ):
+            ret = zpool.status()
+            self.assertEqual("ONLINE", ret["mypool"]["state"])
+
+    def test_status_with_colons_in_vdevs(self):
+        """
+        Tests successful return of status function
+        """
+        ret = {}
+        ret["stdout"] = "\n".join(
+            [
+                "  pool: mypool",
+                " state: ONLINE",
+                "  scan: scrub repaired 0 in 0h6m with 0 errors on Mon Dec 21 02:06:17 2015",
+                "config:",
+                "",
+                "\tNAME        STATE     READ WRITE CKSUM",
+                "\tmypool      ONLINE       0     0     0",
+                "\t  mirror-0  ONLINE       0     0     0",
+                "\t    usb-WD_My_Book_Duo_25F6_....32-0:0  ONLINE       0     0     0",
+                "\t    usb-WD_My_Book_Duo_25F6_....32-0:1  ONLINE       0     0     0",
                 "",
                 "errors: No known data errors",
             ]


### PR DESCRIPTION
### What does this PR do?
Fix zpool status for vdevs containing colons in names
### What issues does this PR fix or reference?
Fixes:
https://github.com/saltstack/salt/issues/59312
