### PR TITLE
Fixing missing architecture in aptpkg expand_repo_def

### DIFF
--- a/changelog/57600.fixed
+++ b/changelog/57600.fixed
@@ -1,0 +1,1 @@
+Fixing expand_repo_def in aptpkg module to include the architecture in the line attribute when it is passed in.

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2553,6 +2553,15 @@ def expand_repo_def(**kwargs):
         if kwarg in kwargs:
             setattr(source_entry, kwarg, kwargs[kwarg])
 
+    source_list = sourceslist.SourcesList()
+    source_entry = source_list.add(
+        type=source_entry.type,
+        uri=source_entry.uri,
+        dist=source_entry.dist,
+        orig_comps=kwargs.get("comps", []),
+        architectures=kwargs.get("architectures", []),
+    )
+
     sanitized["file"] = source_entry.file
     sanitized["comps"] = getattr(source_entry, "comps", [])
     sanitized["disabled"] = source_entry.disabled

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2558,8 +2558,8 @@ def expand_repo_def(**kwargs):
         type=source_entry.type,
         uri=source_entry.uri,
         dist=source_entry.dist,
-        orig_comps=kwargs.get("comps", []),
-        architectures=kwargs.get("architectures", []),
+        orig_comps=getattr(source_entry, "comps", []),
+        architectures=getattr(source_entry, "architectures", []),
     )
 
     sanitized["file"] = source_entry.file

--- a/tests/unit/modules/test_aptpkg.py
+++ b/tests/unit/modules/test_aptpkg.py
@@ -752,7 +752,7 @@ class AptPkgTestCase(TestCase, LoaderModuleMockMixin):
             # Make sure the architecture is in line
             self.assertEqual(
                 sanitized["line"],
-                "deb [arch=amd64] http://cdn-aws.deb.debian.org/debian/ stretch",
+                "deb [arch=amd64] http://cdn-aws.deb.debian.org/debian/ stretch main",
             )
 
 

--- a/tests/unit/modules/test_aptpkg.py
+++ b/tests/unit/modules/test_aptpkg.py
@@ -17,6 +17,13 @@ from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, Mock, call, patch
 from tests.support.unit import TestCase, skipIf
 
+try:
+    from aptsources import sourceslist  # pylint: disable=unused-import
+
+    HAS_APTSOURCES = True
+except ImportError:
+    HAS_APTSOURCES = False
+
 log = logging.getLogger(__name__)
 
 
@@ -711,6 +718,7 @@ class AptPkgTestCase(TestCase, LoaderModuleMockMixin):
                     self.assertIn("uri", repos[source_uri][0])
                     self.assertEqual(repos[source_uri][0]["uri"][-1], "/")
 
+    @skipIf(HAS_APTSOURCES is False, "The 'aptsources' library is missing.")
     def test_expand_repo_def(self):
         """
         Checks results from expand_repo_def
@@ -720,26 +728,32 @@ class AptPkgTestCase(TestCase, LoaderModuleMockMixin):
         source_line = "deb http://cdn-aws.deb.debian.org/debian/ stretch main\n"
         source_file = "/etc/apt/sources.list"
 
-        mock_source = MockSourceEntry(
-            source_uri, source_type, source_line, False, file=source_file
-        )
-
         # Valid source
         with patch("salt.modules.aptpkg._check_apt", MagicMock(return_value=True)):
-            with patch("salt.modules.aptpkg.sourceslist", MagicMock(), create=True):
-                with patch(
-                    "salt.modules.aptpkg.sourceslist.SourceEntry",
-                    MagicMock(return_value=mock_source),
-                    create=True,
-                ):
-                    repo = "deb http://cdn-aws.deb.debian.org/debian/ stretch main\n"
-                    sanitized = aptpkg.expand_repo_def(repo=repo, file=source_file)
+            repo = "deb http://cdn-aws.deb.debian.org/debian/ stretch main\n"
+            sanitized = aptpkg.expand_repo_def(repo=repo, file=source_file)
 
-                    assert isinstance(sanitized, dict)
-                    self.assertIn("uri", sanitized)
+            assert isinstance(sanitized, dict)
+            self.assertIn("uri", sanitized)
 
-                    # Make sure last character in of the URI is still a /
-                    self.assertEqual(sanitized["uri"][-1], "/")
+            # Make sure last character in of the URI is still a /
+            self.assertEqual(sanitized["uri"][-1], "/")
+
+            # Pass the architecture and make sure it is added the the line attribute
+            repo = "deb http://cdn-aws.deb.debian.org/debian/ stretch main\n"
+            sanitized = aptpkg.expand_repo_def(
+                repo=repo, file=source_file, architectures="amd64"
+            )
+
+            # Make sure line is in the dict
+            assert isinstance(sanitized, dict)
+            self.assertIn("line", sanitized)
+
+            # Make sure the architecture is in line
+            self.assertEqual(
+                sanitized["line"],
+                "deb [arch=amd64] http://cdn-aws.deb.debian.org/debian/ stretch",
+            )
 
 
 @skipIf(pytest is None, "PyTest is missing")


### PR DESCRIPTION
### What does this PR do?
Fixing expand_repo_def in aptpkg module to include the architecture in the line attribute when it is passed in.

### What issues does this PR fix or reference?
Fixes: #57600 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
