### PR TITLE
update cmd run docstrings to include win case sensitivity

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -1039,6 +1039,11 @@ def run(
 
                 salt myminion cmd.run 'some command' env='{"FOO": "bar"}'
 
+        .. note::
+            When using environment variables on Window's, case-sensitivity
+            matters, i.e. Window's uses `Path` as opposed to `PATH` for other
+            systems.
+
     :param bool clean_env: Attempt to clean out all other shell environment
         variables and set only those provided in the 'env' argument to this
         function.
@@ -1308,6 +1313,11 @@ def shell(
 
                 salt myminion cmd.shell 'some command' env='{"FOO": "bar"}'
 
+        .. note::
+            When using environment variables on Window's, case-sensitivity
+            matters, i.e. Window's uses `Path` as opposed to `PATH` for other
+            systems.
+
     :param bool clean_env: Attempt to clean out all other shell environment
         variables and set only those provided in the 'env' argument to this
         function.
@@ -1543,6 +1553,11 @@ def run_stdout(
 
                 salt myminion cmd.run_stdout 'some command' env='{"FOO": "bar"}'
 
+        .. note::
+            When using environment variables on Window's, case-sensitivity
+            matters, i.e. Window's uses `Path` as opposed to `PATH` for other
+            systems.
+
     :param bool clean_env: Attempt to clean out all other shell environment
         variables and set only those provided in the 'env' argument to this
         function.
@@ -1753,6 +1768,11 @@ def run_stderr(
             .. code-block:: bash
 
                 salt myminion cmd.run_stderr 'some command' env='{"FOO": "bar"}'
+
+        .. note::
+            When using environment variables on Window's, case-sensitivity
+            matters, i.e. Window's uses `Path` as opposed to `PATH` for other
+            systems.
 
     :param bool clean_env: Attempt to clean out all other shell environment
         variables and set only those provided in the 'env' argument to this
@@ -1966,6 +1986,11 @@ def run_all(
             .. code-block:: bash
 
                 salt myminion cmd.run_all 'some command' env='{"FOO": "bar"}'
+
+        .. note::
+            When using environment variables on Window's, case-sensitivity
+            matters, i.e. Window's uses `Path` as opposed to `PATH` for other
+            systems.
 
     :param bool clean_env: Attempt to clean out all other shell environment
         variables and set only those provided in the 'env' argument to this
@@ -2201,6 +2226,11 @@ def retcode(
             .. code-block:: bash
 
                 salt myminion cmd.retcode 'some command' env='{"FOO": "bar"}'
+
+        .. note::
+            When using environment variables on Window's, case-sensitivity
+            matters, i.e. Window's uses `Path` as opposed to `PATH` for other
+            systems.
 
     :param bool clean_env: Attempt to clean out all other shell environment
         variables and set only those provided in the 'env' argument to this
@@ -2474,6 +2504,11 @@ def script(
 
                 salt myminion cmd.script 'some command' env='{"FOO": "bar"}'
 
+        .. note::
+            When using environment variables on Window's, case-sensitivity
+            matters, i.e. Window's uses `Path` as opposed to `PATH` for other
+            systems.
+
     :param str template: If this setting is applied then the named templating
         engine will be used to render the downloaded file. Currently jinja,
         mako, and wempy are supported.
@@ -2734,6 +2769,11 @@ def script_retcode(
             .. code-block:: bash
 
                 salt myminion cmd.script_retcode 'some command' env='{"FOO": "bar"}'
+
+        .. note::
+            When using environment variables on Window's, case-sensitivity
+            matters, i.e. Window's uses `Path` as opposed to `PATH` for other
+            systems.
 
     :param str template: If this setting is applied then the named templating
         engine will be used to render the downloaded file. Currently jinja,
@@ -3043,6 +3083,11 @@ def run_chroot(
             .. code-block:: bash
 
                 salt myminion cmd.run_chroot 'some command' env='{"FOO": "bar"}'
+
+        .. note::
+            When using environment variables on Window's, case-sensitivity
+            matters, i.e. Window's uses `Path` as opposed to `PATH` for other
+            systems.
 
     :param dict clean_env: Attempt to clean out all other shell environment
         variables and set only those provided in the 'env' argument to this
@@ -3570,6 +3615,11 @@ def powershell(
 
                 salt myminion cmd.powershell 'some command' env='{"FOO": "bar"}'
 
+        .. note::
+            When using environment variables on Window's, case-sensitivity
+            matters, i.e. Window's uses `Path` as opposed to `PATH` for other
+            systems.
+
     :param bool clean_env: Attempt to clean out all other shell environment
         variables and set only those provided in the 'env' argument to this
         function.
@@ -3878,6 +3928,11 @@ def powershell_all(
             .. code-block:: bash
 
                 salt myminion cmd.powershell_all 'some command' env='{"FOO": "bar"}'
+
+        .. note::
+            When using environment variables on Window's, case-sensitivity
+            matters, i.e. Window's uses `Path` as opposed to `PATH` for other
+            systems.
 
     :param bool clean_env: Attempt to clean out all other shell environment
         variables and set only those provided in the 'env' argument to this
@@ -4188,6 +4243,11 @@ def run_bg(
             .. code-block:: bash
 
                 salt myminion cmd.run_bg 'some command' env='{"FOO": "bar"}'
+
+        .. note::
+            When using environment variables on Window's, case-sensitivity
+            matters, i.e. Window's uses `Path` as opposed to `PATH` for other
+            systems.
 
     :param bool clean_env: Attempt to clean out all other shell environment
         variables and set only those provided in the 'env' argument to this

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Execution of arbitrary commands
 ===============================
@@ -232,20 +231,16 @@ To use it, one may pass it like this. Example:
 
 """
 
-# Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import copy
 import logging
 import os
 
-# Import salt libs
 import salt.utils.args
 import salt.utils.functools
 import salt.utils.json
 import salt.utils.platform
 from salt.exceptions import CommandExecutionError, SaltRenderError
-from salt.ext import six
 
 log = logging.getLogger(__name__)
 
@@ -318,11 +313,11 @@ def _failout(state, msg):
 
 
 def _is_true(val):
-    if val and six.text_type(val).lower() in ("true", "yes", "1"):
+    if val and str(val).lower() in ("true", "yes", "1"):
         return True
-    elif six.text_type(val).lower() in ("false", "no", "0"):
+    elif str(val).lower() in ("false", "no", "0"):
         return False
-    raise ValueError("Failed parsing boolean value: {0}".format(val))
+    raise ValueError("Failed parsing boolean value: {}".format(val))
 
 
 def wait(
@@ -801,11 +796,11 @@ def run(
 
     if __opts__["test"] and not test_name:
         ret["result"] = None
-        ret["comment"] = 'Command "{0}" would have been executed'.format(name)
+        ret["comment"] = 'Command "{}" would have been executed'.format(name)
         return _reinterpreted_state(ret) if stateful else ret
 
     if cwd and not os.path.isdir(cwd):
-        ret["comment"] = ('Desired working directory "{0}" ' "is not available").format(
+        ret["comment"] = ('Desired working directory "{}" ' "is not available").format(
             cwd
         )
         return ret
@@ -817,12 +812,12 @@ def run(
             cmd=name, timeout=timeout, python_shell=True, **cmd_kwargs
         )
     except Exception as err:  # pylint: disable=broad-except
-        ret["comment"] = six.text_type(err)
+        ret["comment"] = str(err)
         return ret
 
     ret["changes"] = cmd_all
     ret["result"] = not bool(cmd_all["retcode"])
-    ret["comment"] = 'Command "{0}" run'.format(name)
+    ret["comment"] = 'Command "{}" run'.format(name)
 
     # Ignore timeout errors if asked (for nohups) and treat cmd as a success
     if ignore_timeout:
@@ -1096,11 +1091,11 @@ def script(
 
     if __opts__["test"] and not test_name:
         ret["result"] = None
-        ret["comment"] = "Command '{0}' would have been " "executed".format(name)
+        ret["comment"] = "Command '{}' would have been " "executed".format(name)
         return _reinterpreted_state(ret) if stateful else ret
 
     if cwd and not os.path.isdir(cwd):
-        ret["comment"] = ('Desired working directory "{0}" ' "is not available").format(
+        ret["comment"] = ('Desired working directory "{}" ' "is not available").format(
             cwd
         )
         return ret
@@ -1108,8 +1103,8 @@ def script(
     # Wow, we passed the test, run this sucker!
     try:
         cmd_all = __salt__["cmd.script"](source, python_shell=True, **cmd_kwargs)
-    except (CommandExecutionError, SaltRenderError, IOError) as err:
-        ret["comment"] = six.text_type(err)
+    except (CommandExecutionError, SaltRenderError, OSError) as err:
+        ret["comment"] = str(err)
         return ret
 
     ret["changes"] = cmd_all
@@ -1118,11 +1113,11 @@ def script(
     else:
         ret["result"] = not bool(cmd_all["retcode"])
     if ret.get("changes", {}).get("cache_error"):
-        ret["comment"] = "Unable to cache script {0} from saltenv " "'{1}'".format(
+        ret["comment"] = "Unable to cache script {} from saltenv " "'{}'".format(
             source, __env__
         )
     else:
-        ret["comment"] = "Command '{0}' run".format(name)
+        ret["comment"] = "Command '{}' run".format(name)
     if stateful:
         ret = _reinterpreted_state(ret)
     if __opts__["test"] and cmd_all["retcode"] == 0 and ret["changes"]:
@@ -1188,7 +1183,7 @@ def call(
         # result must be JSON serializable else we get an error
         ret["changes"] = {"retval": result}
         ret["result"] = True if result is None else bool(result)
-        if isinstance(result, six.string_types):
+        if isinstance(result, str):
             ret["comment"] = result
         return ret
 

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -406,6 +406,11 @@ def wait(
                 - env:
                   - PATH: {{ [current_path, '/my/special/bin']|join(':') }}
 
+        .. note::
+            When using environment variables on Window's, case-sensitivity
+            matters, i.e. Window's uses `Path` as opposed to `PATH` for other
+            systems.
+
     umask
          The umask (in octal) to use when running the command.
 
@@ -541,6 +546,11 @@ def wait_script(
                 - env:
                   - PATH: {{ [current_path, '/my/special/bin']|join(':') }}
 
+        .. note::
+            When using environment variables on Window's, case-sensitivity
+            matters, i.e. Window's uses `Path` as opposed to `PATH` for other
+            systems.
+
     umask
          The umask (in octal) to use when running the command.
 
@@ -660,6 +670,11 @@ def run(
                 - name: ls -l /
                 - env:
                   - PATH: {{ [current_path, '/my/special/bin']|join(':') }}
+
+        .. note::
+            When using environment variables on Window's, case-sensitivity
+            matters, i.e. Window's uses `Path` as opposed to `PATH` for other
+            systems.
 
     prepend_path
         $PATH segment to prepend (trailing ':' not necessary) to $PATH. This is
@@ -937,6 +952,11 @@ def script(
                 - name: ls -l /
                 - env:
                   - PATH: {{ [current_path, '/my/special/bin']|join(':') }}
+
+        .. note::
+            When using environment variables on Window's, case-sensitivity
+            matters, i.e. Window's uses `Path` as opposed to `PATH` for other
+            systems.
 
     saltenv : ``base``
         The Salt environment to use


### PR DESCRIPTION
### What does this PR do?
Update docstring to indicate that case-sensitivity matters when passing Window's env vars to the `env` param.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/56199

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
