### PR TITLE
Implement tcp_reconnect_backoff minion option

### DIFF
--- a/changelog/59431.added
+++ b/changelog/59431.added
@@ -1,0 +1,1 @@
+Added tcp_reconnect_backoff minion config option for specifying reconnection backoff time for TCP transport 

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -3318,7 +3318,7 @@ should be logged as the minion starts up and initially connects to the
 master. If not, check for debug log level and that the necessary version of
 ZeroMQ is installed.
 
-.. conf_minion:: failhard
+.. conf_minion:: tcp_authentication_retries
 
 ``tcp_authentication_retries``
 ------------------------------
@@ -3333,6 +3333,18 @@ reauthenticate. The tcp transport should try to connect with a new connection
 if the old one times out on reauthenticating.
 
 `-1` for infinite tries.
+
+.. conf_minion:: tcp_reconnect_backoff
+
+``tcp_reconnect_backoff``
+------------------------------
+
+Default: ``1``
+
+The time in seconds to wait before attempting another connection with salt master
+when the previous connection fails while on TCP transport.
+
+.. conf_minion:: failhard
 
 ``failhard``
 ------------

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -910,6 +910,8 @@ VALID_OPTS = immutabletypes.freeze(
         # Number of times to try to auth with the master on a reconnect with the
         # tcp transport
         "tcp_authentication_retries": int,
+        # Backoff interval in seconds for minion reconnect with tcp transport
+        "tcp_reconnect_backoff": float,
         # Permit or deny allowing minions to request revoke of its own key
         "allow_minion_key_revoke": bool,
         # File chunk size for salt-cp
@@ -1125,6 +1127,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze(
         "tcp_pub_port": 4510,
         "tcp_pull_port": 4511,
         "tcp_authentication_retries": 5,
+        "tcp_reconnect_backoff": 1,
         "log_file": os.path.join(salt.syspaths.LOGS_DIR, "minion"),
         "log_level": "warning",
         "log_level_logfile": None,

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -1111,6 +1111,8 @@ class SaltMessageClient:
         self._stream_return_future = salt.ext.tornado.concurrent.Future()
         self.io_loop.spawn_callback(self._stream_return)
 
+        self.backoff = opts.get("tcp_reconnect_backoff", 1)
+
     def _stop_io_loop(self):
         if self.io_loop is not None:
             self.io_loop.stop()
@@ -1189,7 +1191,6 @@ class SaltMessageClient:
 
         return future
 
-    # TODO: tcp backoff opts
     @salt.ext.tornado.gen.coroutine
     def _connect(self):
         """
@@ -1221,12 +1222,13 @@ class SaltMessageClient:
                 break
             except Exception as exc:  # pylint: disable=broad-except
                 log.warning(
-                    "TCP Message Client encountered an exception while connecting to %s:%s: %r",
+                    "TCP Message Client encountered an exception while connecting to %s:%s: %r, will reconnect in %d seconds",
                     self.host,
                     self.port,
                     exc,
+                    self.backoff,
                 )
-                yield salt.ext.tornado.gen.sleep(1)  # TODO: backoff
+                yield salt.ext.tornado.gen.sleep(self.backoff)
                 # self._connecting_future.set_exception(exc)
 
     @salt.ext.tornado.gen.coroutine


### PR DESCRIPTION
### What does this PR do?
Implements new `tcp_reconnect_backoff` minion config option for dynamic reconnect interval on TCP transport

### What issues does this PR fix or reference?
Fixes: #59431

### Previous Behavior
Minion would try to reconnect exactly after 1 second from previous disconnect

### New Behavior
Reconnect backoff follows `tcp_reconnect_backoff` option (with 1 second default)

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes