### PR TITLE
use sphinx.ext.imgconverter

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install System Deps
       run: |
         apt-get update
-        apt-get install -y enchant git gcc make zlib1g-dev libc-dev libffi-dev g++ libxml2 libxml2-dev libxslt-dev libcurl4-openssl-dev libssl-dev libgnutls28-dev xz-utils
+        apt-get install -y enchant git gcc imagemagick make zlib1g-dev libc-dev libffi-dev g++ libxml2 libxml2-dev libxslt-dev libcurl4-openssl-dev libssl-dev libgnutls28-dev xz-utils
 
     - uses: actions/checkout@v2
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -330,6 +330,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.autosummary",
     "sphinx.ext.extlinks",
+    "sphinx.ext.imgconverter",
     "sphinx.ext.intersphinx",
     "httpdomain",
     "youtube",


### PR DESCRIPTION
### What does this PR do?
This makes it so the docs pdf generation doesn't fail.  SVGs must be converted to PNGs and this sphinx extension does it automatically.