### PR TITLE
Move README contents; fix TOC for pdfs/epubs; revert saltstack2 TOC modification

### DIFF
--- a/doc/_themes/saltstack2/layout.html
+++ b/doc/_themes/saltstack2/layout.html
@@ -33,13 +33,7 @@
 
         {%- for rellink in rellinks|reverse %}
         <li>
-            {%- if rellink[3] == "Table of Contents" and pathto(rellink[0]) != '#' %}
-            <a href="{{ pathto(rellink[0]) }}#table-of-contents" title="{{ rellink[1]|striptags|e }}">{{ rellink[3] }}</a>
-            {%- elif rellink[3] == "Table of Contents" and pathto(rellink[0]) == '#' %}
-            <a href="{{ pathto(rellink[0]) }}table-of-contents" title="{{ rellink[1]|striptags|e }}">{{ rellink[3] }}</a>
-            {%- else %}
             <a href="{{ pathto(rellink[0]) }}" title="{{ rellink[1]|striptags|e }}">{{ rellink[3] }}</a>
-            {% endif %}
             {#
             {%- if not loop.last %}{{ reldelim2 }}{% endif %}
             #}

--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -1,17 +1,13 @@
-==========================
-Salt Project Documentation
-==========================
-
-.. include:: ../README.rst
-
 .. _table-of-contents:
 
+======================
 Salt Table of Contents
 ======================
 
 .. toctree::
     :maxdepth: 2
 
+    topics/about_salt_project
     topics/index
     topics/salt_system_architecture
     topics/installation/index

--- a/doc/topics/about_salt_project.rst
+++ b/doc/topics/about_salt_project.rst
@@ -1,0 +1,7 @@
+.. _about-salt-project:
+
+============
+Salt Project
+============
+
+.. include:: ../../README.rst


### PR DESCRIPTION
### What does this PR do?

Fixes the TOC in the PDF and EPUB output by moving the `README.rst` project file injection to a newly dedicated page. This was a secondary issue discovered downstream with our `builddocs` repo on GitLab:

- https://gitlab.com/saltstack/open/docs/builddocs

### What issues does this PR fix or reference?

Is part of a combined effort with:

- https://gitlab.com/saltstack/open/docs/builddocs/-/merge_requests/15
- #59445

This problem was introduced with the following PR:

- #59289

### Previous Behavior

The TOC breaks in PDFs, to where the TOC ends up having only a few chapters, with almost all of the Salt docs being contained in a single chapter.

### New Behavior

TOC is fixed in PDF output.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs

### Commits signed with GPG?
Yes