### PR TITLE
[WIP] Disable fqdns_grains during tests

### DIFF
--- a/tests/integration/files/conf/master
+++ b/tests/integration/files/conf/master
@@ -148,3 +148,5 @@ sdbetcd:
   etcd.port: 2379
 venafi:
   fake: "true"
+
+enable_fqdns_grains: False

--- a/tests/integration/files/conf/minion
+++ b/tests/integration/files/conf/minion
@@ -126,3 +126,5 @@ sdbetcd:
   driver: etcd
   etcd.host: 127.0.0.1
   etcd.port: 2379
+
+enable_fqdns_grains: False


### PR DESCRIPTION
### What does this PR do?
Set `enable_fqdns_grains` to False to disable this grain generation during test runs.

### What issues does this PR fix or reference?
Fixes: N/A

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
