### PR TITLE
Fix man pages test in GitHub Actions workflow with imagemagick package

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Install System Deps
       run: |
         apt-get update
-        apt-get install -y enchant git gcc make zlib1g-dev libc-dev libffi-dev g++ libxml2 libxml2-dev libxslt-dev libcurl4-openssl-dev libssl-dev libgnutls28-dev
+        apt-get install -y enchant git gcc imagemagick make zlib1g-dev libc-dev libffi-dev g++ libxml2 libxml2-dev libxslt-dev libcurl4-openssl-dev libssl-dev libgnutls28-dev
 
     - uses: actions/checkout@v2
 

--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -4,6 +4,8 @@
 Salt Table of Contents
 ======================
 
+This is to trigger the man pages GitHub Actions test.
+
 .. toctree::
     :maxdepth: 2
 

--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -4,8 +4,6 @@
 Salt Table of Contents
 ======================
 
-This is to trigger the man pages GitHub Actions test.
-
 .. toctree::
     :maxdepth: 2
 


### PR DESCRIPTION
### What does this PR do?

Fixes broken man pages testing in docs workflow via GitHub Actions.

### What issues does this PR fix or reference?

Is part of a combined effort with:

- https://gitlab.com/saltstack/open/docs/builddocs/-/merge_requests/15
- #59445

This problem was introduced with the following PR:

- #59289

### Previous Behavior

The following job is broken:
- https://github.com/saltstack/salt/blob/master/.github/workflows/docs.yml#L69

### New Behavior

The following job will work:
- https://github.com/saltstack/salt/blob/master/.github/workflows/docs.yml#L69

### Commits signed with GPG?
Yes

### Additional information

To see the job running all the way through, here is a preview of the job running to completion upon seeing changes in docs:
- https://github.com/ScriptAutomate/salt/runs/1866467305?check_suite_focus=true