### PR TITLE
Supress noisy warnings

### DIFF
--- a/changelog/50327.fixed
+++ b/changelog/50327.fixed
@@ -1,0 +1,1 @@
+Supress noisy warnings when very old pyzmq is used.

--- a/salt/transport/__init__.py
+++ b/salt/transport/__init__.py
@@ -4,8 +4,15 @@ Encapsulate the different transports available to Salt.
 
 
 import logging
+import warnings
 
 log = logging.getLogger(__name__)
+
+# Supress warnings when running with a very old pyzmq. This can be removed
+# after we drop support for Ubuntu 16.04 and Debian 9
+warnings.filterwarnings(
+    "ignore", message="IOLoop.current expected instance.*", category=RuntimeWarning
+)
 
 
 def iter_transport_opts(opts):


### PR DESCRIPTION
Supress noisy warnings when running with very old pyzmq versions.
Fixes: #50327
