### PR TITLE
Bump `cryptography` requirement to 3.3.2 due to CVE-2020-36242

### DIFF
--- a/requirements/static/ci/py3.5/cloud.txt
+++ b/requirements/static/ci/py3.5/cloud.txt
@@ -8,7 +8,7 @@ apache-libcloud==2.5.0
 certifi==2019.3.9         # via requests
 cffi==1.12.2              # via cryptography
 chardet==3.0.4            # via requests
-cryptography==3.2.1       # via requests-ntlm, smbprotocol
+cryptography==3.0         # via requests-ntlm, smbprotocol
 idna==2.8                 # via requests
 netaddr==0.7.19
 ntlm-auth==1.3.0          # via requests-ntlm, smbprotocol

--- a/requirements/static/ci/py3.5/darwin.txt
+++ b/requirements/static/ci/py3.5/darwin.txt
@@ -114,7 +114,7 @@ clustershell==1.8.1
 contextlib2==0.6.0.post1
 contextvars==2.4 ; python_version < "3.7"
 croniter==0.3.29 ; sys_platform != "win32"
-cryptography==3.2
+cryptography==3.0
 decorator==4.4.2          # via networkx
 distlib==0.3.0            # via virtualenv
 distro==1.5.0

--- a/requirements/static/ci/py3.5/freebsd.txt
+++ b/requirements/static/ci/py3.5/freebsd.txt
@@ -116,7 +116,7 @@ clustershell==1.8.3
 contextlib2==0.5.5
 contextvars==2.4 ; python_version < "3.7"
 croniter==0.3.29 ; sys_platform != "win32"
-cryptography==3.2
+cryptography==3.0
 decorator==4.4.2          # via networkx
 distlib==0.3.0            # via virtualenv
 distro==1.5.0

--- a/requirements/static/ci/py3.5/linux.txt
+++ b/requirements/static/ci/py3.5/linux.txt
@@ -115,7 +115,7 @@ clustershell==1.8.3
 contextlib2==0.5.5
 contextvars==2.4 ; python_version < "3.7"
 croniter==0.3.29 ; sys_platform != "win32"
-cryptography==3.2
+cryptography==3.0
 decorator==4.4.2          # via networkx
 distlib==0.3.0            # via virtualenv
 distro==1.5.0

--- a/requirements/static/ci/py3.5/windows.txt
+++ b/requirements/static/ci/py3.5/windows.txt
@@ -27,7 +27,7 @@ clustershell==1.8.3
 colorama==0.4.1           # via pytest
 contextlib2==0.6.0.post1
 contextvars==2.4 ; python_version < "3.7"
-cryptography==3.2
+cryptography==3.0
 decorator==4.4.2          # via networkx
 distlib==0.3.0            # via virtualenv
 distro==1.5.0

--- a/requirements/static/ci/py3.6/cloud.txt
+++ b/requirements/static/ci/py3.6/cloud.txt
@@ -8,7 +8,7 @@ apache-libcloud==2.5.0
 certifi==2019.3.9         # via requests
 cffi==1.12.2              # via cryptography
 chardet==3.0.4            # via requests
-cryptography==3.2.1       # via requests-ntlm, smbprotocol
+cryptography==3.3.2       # via requests-ntlm, smbprotocol
 idna==2.8                 # via requests
 netaddr==0.7.19
 ntlm-auth==1.3.0          # via requests-ntlm, smbprotocol

--- a/requirements/static/ci/py3.6/darwin.txt
+++ b/requirements/static/ci/py3.6/darwin.txt
@@ -114,7 +114,7 @@ clustershell==1.8.1
 contextlib2==0.6.0.post1
 contextvars==2.4 ; python_version < "3.7"
 croniter==0.3.29 ; sys_platform != "win32"
-cryptography==3.2
+cryptography==3.3.2
 decorator==4.4.2          # via networkx
 distlib==0.3.0            # via virtualenv
 distro==1.5.0

--- a/requirements/static/ci/py3.6/freebsd.txt
+++ b/requirements/static/ci/py3.6/freebsd.txt
@@ -116,7 +116,7 @@ clustershell==1.8.3
 contextlib2==0.5.5
 contextvars==2.4 ; python_version < "3.7"
 croniter==0.3.29 ; sys_platform != "win32"
-cryptography==3.2
+cryptography==3.3.2
 decorator==4.4.2          # via networkx
 distlib==0.3.0            # via virtualenv
 distro==1.5.0

--- a/requirements/static/ci/py3.6/linux.txt
+++ b/requirements/static/ci/py3.6/linux.txt
@@ -115,7 +115,7 @@ clustershell==1.8.3
 contextlib2==0.5.5
 contextvars==2.4 ; python_version < "3.7"
 croniter==0.3.29 ; sys_platform != "win32"
-cryptography==3.2
+cryptography==3.3.2
 decorator==4.4.2          # via networkx
 distlib==0.3.0            # via virtualenv
 distro==1.5.0

--- a/requirements/static/ci/py3.6/windows.txt
+++ b/requirements/static/ci/py3.6/windows.txt
@@ -27,7 +27,7 @@ clustershell==1.8.3
 colorama==0.4.1           # via pytest
 contextlib2==0.6.0.post1
 contextvars==2.4 ; python_version < "3.7"
-cryptography==3.2
+cryptography==3.3.2
 decorator==4.4.2          # via networkx
 distlib==0.3.0            # via virtualenv
 distro==1.5.0

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -8,7 +8,7 @@ apache-libcloud==2.5.0
 certifi==2019.3.9         # via requests
 cffi==1.12.2              # via cryptography
 chardet==3.0.4            # via requests
-cryptography==3.2.1       # via requests-ntlm, smbprotocol
+cryptography==3.3.2       # via requests-ntlm, smbprotocol
 idna==2.8                 # via requests
 netaddr==0.7.19
 ntlm-auth==1.3.0          # via requests-ntlm, smbprotocol

--- a/requirements/static/ci/py3.7/darwin.txt
+++ b/requirements/static/ci/py3.7/darwin.txt
@@ -114,7 +114,7 @@ clustershell==1.8.1
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.6.0.post1
 croniter==0.3.29 ; sys_platform != "win32"
-cryptography==3.2
+cryptography==3.3.2
 decorator==4.4.2          # via networkx
 distlib==0.3.0            # via virtualenv
 distro==1.5.0

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -116,7 +116,7 @@ clustershell==1.8.3
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
 croniter==0.3.29 ; sys_platform != "win32"
-cryptography==3.2
+cryptography==3.3.2
 decorator==4.4.2          # via networkx
 distlib==0.3.0            # via virtualenv
 distro==1.5.0

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -115,7 +115,7 @@ clustershell==1.8.3
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
 croniter==0.3.29 ; sys_platform != "win32"
-cryptography==3.2
+cryptography==3.3.2
 decorator==4.4.2          # via networkx
 distlib==0.3.0            # via virtualenv
 distro==1.5.0

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -25,7 +25,7 @@ click==7.1.2              # via geomet
 clustershell==1.8.3
 colorama==0.4.1           # via pytest
 contextlib2==0.6.0.post1
-cryptography==3.2
+cryptography==3.3.2
 decorator==4.4.2          # via networkx
 distlib==0.3.0            # via virtualenv
 distro==1.5.0

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -8,7 +8,7 @@ apache-libcloud==2.5.0
 certifi==2019.3.9         # via requests
 cffi==1.12.2              # via cryptography
 chardet==3.0.4            # via requests
-cryptography==3.2.1       # via requests-ntlm, smbprotocol
+cryptography==3.3.2       # via requests-ntlm, smbprotocol
 idna==2.8                 # via requests
 netaddr==0.7.19
 ntlm-auth==1.3.0          # via requests-ntlm, smbprotocol

--- a/requirements/static/ci/py3.8/darwin.txt
+++ b/requirements/static/ci/py3.8/darwin.txt
@@ -114,7 +114,7 @@ clustershell==1.8.1
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.6.0.post1
 croniter==0.3.29 ; sys_platform != "win32"
-cryptography==3.2
+cryptography==3.3.2
 decorator==4.4.2          # via networkx
 distlib==0.3.0            # via virtualenv
 distro==1.5.0

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -116,7 +116,7 @@ clustershell==1.8.3
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
 croniter==0.3.29 ; sys_platform != "win32"
-cryptography==3.2
+cryptography==3.3.2
 decorator==4.4.2          # via networkx
 distlib==0.3.0            # via virtualenv
 distro==1.5.0

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -115,7 +115,7 @@ clustershell==1.8.3
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
 croniter==0.3.29 ; sys_platform != "win32"
-cryptography==3.2
+cryptography==3.3.2
 decorator==4.4.2          # via networkx
 distlib==0.3.0            # via virtualenv
 distro==1.5.0

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -8,7 +8,7 @@ apache-libcloud==2.5.0
 certifi==2019.3.9         # via requests
 cffi==1.14.4              # via cryptography
 chardet==3.0.4            # via requests
-cryptography==3.2.1       # via requests-ntlm, smbprotocol
+cryptography==3.3.2       # via requests-ntlm, smbprotocol
 idna==2.8                 # via requests
 netaddr==0.7.19
 ntlm-auth==1.3.0          # via requests-ntlm, smbprotocol

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -114,7 +114,7 @@ clustershell==1.8.1
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.6.0.post1
 croniter==0.3.29 ; sys_platform != "win32"
-cryptography==3.2
+cryptography==3.3.2
 decorator==4.4.2          # via networkx
 distlib==0.3.0            # via virtualenv
 distro==1.5.0

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -116,7 +116,7 @@ clustershell==1.8.3
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
 croniter==0.3.29 ; sys_platform != "win32"
-cryptography==3.2
+cryptography==3.3.2
 decorator==4.4.2          # via networkx
 distlib==0.3.0            # via virtualenv
 distro==1.5.0

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -116,7 +116,7 @@ clustershell==1.8.3
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
 croniter==0.3.29 ; sys_platform != "win32"
-cryptography==3.2
+cryptography==3.3.2
 decorator==4.4.2          # via networkx
 distlib==0.3.0            # via virtualenv
 distro==1.5.0

--- a/requirements/static/pkg/py3.5/darwin.txt
+++ b/requirements/static/pkg/py3.5/darwin.txt
@@ -13,7 +13,7 @@ cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
 contextvars==2.4 ; python_version < "3.7"
-cryptography==3.2
+cryptography==3.0
 distro==1.5.0
 gitdb==4.0.5              # via gitpython
 gitpython==3.1.12

--- a/requirements/static/pkg/py3.5/freebsd.txt
+++ b/requirements/static/pkg/py3.5/freebsd.txt
@@ -13,7 +13,7 @@ cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
 contextvars==2.4 ; python_version < "3.7"
-cryptography==3.2         # via pyopenssl
+cryptography==3.0         # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
 immutables==0.14          # via contextvars

--- a/requirements/static/pkg/py3.5/linux.txt
+++ b/requirements/static/pkg/py3.5/linux.txt
@@ -13,7 +13,7 @@ cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
 contextvars==2.4 ; python_version < "3.7"
-cryptography==3.2         # via pyopenssl
+cryptography==3.0         # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
 immutables==0.14          # via contextvars

--- a/requirements/static/pkg/py3.5/windows.txt
+++ b/requirements/static/pkg/py3.5/windows.txt
@@ -12,7 +12,7 @@ cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
 contextvars==2.4 ; python_version < "3.7"
-cryptography==3.2
+cryptography==3.0
 distro==1.5.0
 gitdb==4.0.5              # via gitpython
 gitpython==3.1.12

--- a/requirements/static/pkg/py3.6/darwin.txt
+++ b/requirements/static/pkg/py3.6/darwin.txt
@@ -13,7 +13,7 @@ cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
 contextvars==2.4 ; python_version < "3.7"
-cryptography==3.2
+cryptography==3.3.2
 distro==1.5.0
 gitdb==4.0.5              # via gitpython
 gitpython==3.1.12

--- a/requirements/static/pkg/py3.6/freebsd.txt
+++ b/requirements/static/pkg/py3.6/freebsd.txt
@@ -13,7 +13,7 @@ cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
 contextvars==2.4 ; python_version < "3.7"
-cryptography==3.2         # via pyopenssl
+cryptography==3.3.2       # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
 immutables==0.14          # via contextvars

--- a/requirements/static/pkg/py3.6/linux.txt
+++ b/requirements/static/pkg/py3.6/linux.txt
@@ -13,7 +13,7 @@ cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
 contextvars==2.4 ; python_version < "3.7"
-cryptography==3.2         # via pyopenssl
+cryptography==3.3.2       # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
 immutables==0.14          # via contextvars

--- a/requirements/static/pkg/py3.6/windows.txt
+++ b/requirements/static/pkg/py3.6/windows.txt
@@ -12,7 +12,7 @@ cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
 contextvars==2.4 ; python_version < "3.7"
-cryptography==3.2
+cryptography==3.3.2
 distro==1.5.0
 gitdb==4.0.5              # via gitpython
 gitpython==3.1.12

--- a/requirements/static/pkg/py3.7/darwin.txt
+++ b/requirements/static/pkg/py3.7/darwin.txt
@@ -11,7 +11,7 @@ chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
-cryptography==3.2
+cryptography==3.3.2
 distro==1.5.0
 gitdb==4.0.5              # via gitpython
 gitpython==3.1.12

--- a/requirements/static/pkg/py3.7/freebsd.txt
+++ b/requirements/static/pkg/py3.7/freebsd.txt
@@ -11,7 +11,7 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
-cryptography==3.2         # via pyopenssl
+cryptography==3.3.2       # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
 jaraco.functools==2.0     # via tempora

--- a/requirements/static/pkg/py3.7/linux.txt
+++ b/requirements/static/pkg/py3.7/linux.txt
@@ -11,7 +11,7 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
-cryptography==3.2         # via pyopenssl
+cryptography==3.3.2       # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
 jaraco.functools==2.0     # via tempora

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -10,7 +10,7 @@ chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
-cryptography==3.2
+cryptography==3.3.2
 distro==1.5.0
 gitdb==4.0.5              # via gitpython
 gitpython==3.1.12

--- a/requirements/static/pkg/py3.8/darwin.txt
+++ b/requirements/static/pkg/py3.8/darwin.txt
@@ -11,7 +11,7 @@ chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
-cryptography==3.2
+cryptography==3.3.2
 distro==1.5.0
 gitdb==4.0.5              # via gitpython
 gitpython==3.1.12

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -11,7 +11,7 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
-cryptography==3.2         # via pyopenssl
+cryptography==3.3.2       # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
 jaraco.functools==2.0     # via tempora

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -11,7 +11,7 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
-cryptography==3.2         # via pyopenssl
+cryptography==3.3.2       # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
 jaraco.functools==2.0     # via tempora

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -13,7 +13,7 @@ chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
-cryptography==3.2
+cryptography==3.3.2
 distro==1.5.0
 gitdb2==2.0.5
 gitpython==3.1.12

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -11,7 +11,7 @@ chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
-cryptography==3.2
+cryptography==3.3.2
 distro==1.5.0
 gitdb==4.0.5              # via gitpython
 gitpython==3.1.12

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -11,7 +11,7 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
-cryptography==3.2         # via pyopenssl
+cryptography==3.3.2       # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
 jaraco.functools==2.0     # via tempora

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -11,7 +11,7 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
-cryptography==3.2         # via pyopenssl
+cryptography==3.3.2       # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
 jaraco.functools==2.0     # via tempora

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -13,7 +13,7 @@ chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
-cryptography==3.2
+cryptography==3.3.2
 distro==1.5.0
 gitdb2==2.0.5
 gitpython==3.1.12


### PR DESCRIPTION
### What does this PR do?
Bump `cryptography` requirement to 3.3.2 due to CVE-2020-36242

Vulnerable versions: >= 3.1, < 3.3.2
Patched version: 3.3.2
Impact: When certain sequences of update() calls with large values (multiple GBs) for symetric encryption or decryption occur, it's possible for an integer overflow to happen, leading to mishandling of buffers.
References:
 - pyca/cryptography#5615

---
For Py3.5 requirements we dropped `cryptography` to version 3.0 which is not vulnerable to the CVE in question.
This decision was made consciously because the Salt Project creates packages for the supported distributions which still use Py3.5 and those even rely on an even older version of `cryptography`.
Upgrading to the latest version was not possible because the `cryptography` project dropped Py3.5 support.

---
Closes https://github.com/saltstack/salt/pull/59466
Closes https://github.com/saltstack/salt/pull/59467