### PR TITLE
Fix boto_lambda.function_present for updates

### DIFF
--- a/salt/states/boto_lambda.py
+++ b/salt/states/boto_lambda.py
@@ -510,7 +510,7 @@ def _function_code_present(
             sha = hashlib.sha256()
             with salt.utils.files.fopen(ZipFile, "rb") as f:
                 sha.update(f.read())
-            hashed = sha.digest().encode("base64").strip()
+            hashed = sha.digest().strip()
             if hashed != func["CodeSha256"]:
                 update = True
         else:


### PR DESCRIPTION
### What does this PR do?
BUG #58857

### What issues does this PR fix or reference?
Fixes:
It fixes applying boto_lambda.function_present state in case the lamba function already exists

### Previous Behavior
It throws this exception:
`
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python3.6/site-packages/salt/state.py", line 2154, in call
                  *cdata["args"], **cdata["kwargs"]
                File "/usr/lib/python3.6/site-packages/salt/loader.py", line 2188, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python3.6/site-packages/salt/states/boto_lambda.py", line 354, in function_present
                  profile,
                File "/usr/lib/python3.6/site-packages/salt/states/boto_lambda.py", line 520, in _function_code_present
                  hashed = sha.digest().encode("base64").strip()
              AttributeError: 'bytes' object has no attribute 'encode'

`
### New Behavior
It works without an issue

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
