### PR TITLE
Search for grub.xen path

### DIFF
--- a/changelog/59484.fixed
+++ b/changelog/59484.fixed
@@ -1,0 +1,1 @@
+Detect and fix grub.xen path

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1024,7 +1024,14 @@ def _gen_xml(
         # Compute the Xen PV boot method
         if __grains__["os_family"] == "Suse":
             if not boot or not boot.get("kernel", None):
-                context["boot"]["kernel"] = "/usr/lib/grub2/x86_64-xen/grub.xen"
+                paths = [
+                    path
+                    for path in ["/usr/share", "/usr/lib"]
+                    if os.path.exists(path + "/grub2/x86_64-xen/grub.xen")
+                ]
+                if not paths:
+                    raise CommandExecutionError("grub-x86_64-xen needs to be installed")
+                context["boot"]["kernel"] = paths[0] + "/grub2/x86_64-xen/grub.xen"
                 context["boot_dev"] = []
 
     default_port = 23023

--- a/tests/pytests/unit/modules/virt/test_domain.py
+++ b/tests/pytests/unit/modules/virt/test_domain.py
@@ -5,7 +5,7 @@ import salt.modules.virt as virt
 import salt.syspaths
 import salt.utils.xmlutil as xmlutil
 from salt._compat import ElementTree as ET
-from salt.exceptions import SaltInvocationError
+from salt.exceptions import CommandExecutionError, SaltInvocationError
 from tests.support.mock import MagicMock, patch
 
 from .conftest import loader_modules_config
@@ -17,7 +17,15 @@ def configure_loader_modules():
     return loader_modules_config()
 
 
-def test_gen_xml_for_xen_default_profile():
+@pytest.mark.parametrize(
+    "loader",
+    [
+        "/usr/lib/grub2/x86_64-xen/grub.xen",
+        "/usr/share/grub2/x86_64-xen/grub.xen",
+        None,
+    ],
+)
+def test_gen_xml_for_xen_default_profile(loader):
     """
     Test virt._gen_xml(), XEN PV default profile case
     """
@@ -31,47 +39,62 @@ def test_gen_xml_for_xen_default_profile():
         os_mock = MagicMock(spec=virt.os)
 
         def fake_exists(path):
-            return path == "/usr/lib/grub2/x86_64-xen/grub.xen"
+            return loader and path == loader
 
         os_mock.path.exists = MagicMock(side_effect=fake_exists)
 
         with patch.dict(virt.__dict__, {"os": os_mock}):
-            xml_data = virt._gen_xml(
-                virt.libvirt.openAuth.return_value,
-                "hello",
-                1,
-                512,
-                diskp,
-                nicp,
-                "xen",
-                "xen",
-                "x86_64",
-                boot=None,
-            )
-            root = ET.fromstring(xml_data)
-            assert root.attrib["type"] == "xen"
-            assert root.find("vcpu").text == "1"
-            assert root.find("memory").text == str(512 * 1024)
-            assert root.find("memory").attrib["unit"] == "KiB"
-            assert root.find(".//kernel").text == "/usr/lib/grub2/x86_64-xen/grub.xen"
+            if loader:
+                xml_data = virt._gen_xml(
+                    virt.libvirt.openAuth.return_value,
+                    "hello",
+                    1,
+                    512,
+                    diskp,
+                    nicp,
+                    "xen",
+                    "xen",
+                    "x86_64",
+                    boot=None,
+                )
+                root = ET.fromstring(xml_data)
+                assert root.attrib["type"] == "xen"
+                assert root.find("vcpu").text == "1"
+                assert root.find("memory").text == str(512 * 1024)
+                assert root.find("memory").attrib["unit"] == "KiB"
+                assert root.find(".//kernel").text == loader
 
-            disks = root.findall(".//disk")
-            assert len(disks) == 1
-            disk = disks[0]
-            root_dir = salt.config.DEFAULT_MINION_OPTS.get("root_dir")
-            assert disk.find("source").attrib["file"].startswith(root_dir)
-            assert "hello_system" in disk.find("source").attrib["file"]
-            assert disk.find("target").attrib["dev"] == "xvda"
-            assert disk.find("target").attrib["bus"] == "xen"
-            assert disk.find("driver").attrib["name"] == "qemu"
-            assert disk.find("driver").attrib["type"] == "qcow2"
+                disks = root.findall(".//disk")
+                assert len(disks) == 1
+                disk = disks[0]
+                root_dir = salt.config.DEFAULT_MINION_OPTS.get("root_dir")
+                assert disk.find("source").attrib["file"].startswith(root_dir)
+                assert "hello_system" in disk.find("source").attrib["file"]
+                assert disk.find("target").attrib["dev"] == "xvda"
+                assert disk.find("target").attrib["bus"] == "xen"
+                assert disk.find("driver").attrib["name"] == "qemu"
+                assert disk.find("driver").attrib["type"] == "qcow2"
 
-            interfaces = root.findall(".//interface")
-            assert len(interfaces) == 1
-            iface = interfaces[0]
-            assert iface.attrib["type"] == "bridge"
-            assert iface.find("source").attrib["bridge"] == "br0"
-            assert iface.find("model") is None
+                interfaces = root.findall(".//interface")
+                assert len(interfaces) == 1
+                iface = interfaces[0]
+                assert iface.attrib["type"] == "bridge"
+                assert iface.find("source").attrib["bridge"] == "br0"
+                assert iface.find("model") is None
+            else:
+                with pytest.raises(CommandExecutionError):
+                    xml_data = virt._gen_xml(
+                        virt.libvirt.openAuth.return_value,
+                        "hello",
+                        1,
+                        512,
+                        diskp,
+                        nicp,
+                        "xen",
+                        "xen",
+                        "x86_64",
+                        boot=None,
+                    )
 
 
 def test_update_xen_disk_volumes(make_mock_vm, make_mock_storage_pool):

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -1185,54 +1185,6 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(iface.find("source").attrib["bridge"], "DEFAULT")
         self.assertEqual(iface.find("model").attrib["type"], "e1000")
 
-    def test_gen_xml_for_xen_default_profile(self):
-        """
-        Test virt._gen_xml(), XEN PV default profile case
-        """
-        diskp = virt._disk_profile(self.mock_conn, "default", "xen", [], "hello")
-        nicp = virt._nic_profile("default", "xen")
-        with patch.dict(
-            virt.__grains__, {"os_family": "Suse"}  # pylint: disable=no-member
-        ):
-            xml_data = virt._gen_xml(
-                self.mock_conn,
-                "hello",
-                1,
-                512,
-                diskp,
-                nicp,
-                "xen",
-                "xen",
-                "x86_64",
-                boot=None,
-            )
-            root = ET.fromstring(xml_data)
-            self.assertEqual(root.attrib["type"], "xen")
-            self.assertEqual(root.find("vcpu").text, "1")
-            self.assertEqual(root.find("memory").text, str(512 * 1024))
-            self.assertEqual(root.find("memory").attrib["unit"], "KiB")
-            self.assertEqual(
-                root.find(".//kernel").text, "/usr/lib/grub2/x86_64-xen/grub.xen"
-            )
-
-            disks = root.findall(".//disk")
-            self.assertEqual(len(disks), 1)
-            disk = disks[0]
-            root_dir = salt.config.DEFAULT_MINION_OPTS.get("root_dir")
-            self.assertTrue(disk.find("source").attrib["file"].startswith(root_dir))
-            self.assertTrue("hello_system" in disk.find("source").attrib["file"])
-            self.assertEqual(disk.find("target").attrib["dev"], "xvda")
-            self.assertEqual(disk.find("target").attrib["bus"], "xen")
-            self.assertEqual(disk.find("driver").attrib["name"], "qemu")
-            self.assertEqual(disk.find("driver").attrib["type"], "qcow2")
-
-            interfaces = root.findall(".//interface")
-            self.assertEqual(len(interfaces), 1)
-            iface = interfaces[0]
-            self.assertEqual(iface.attrib["type"], "bridge")
-            self.assertEqual(iface.find("source").attrib["bridge"], "br0")
-            self.assertIsNone(iface.find("model"))
-
     def test_gen_xml_for_esxi_custom_profile(self):
         """
         Test virt._gen_xml(), ESXi/vmware custom profile case


### PR DESCRIPTION
### What does this PR do?

Searches both `/usr/lib/grub2/x86_64-xen/` and `/usr/share/grub2/x86_64-xen` for `grub.xen`. If not can be found, raise an error since the generated Xen PV VM wouldn't be able to boot any way.

This PR also ports one more virt test to pytests before improving it.

### What issues does this PR fix or reference?
Fixes: #59484

### Previous Behavior

Used `/usr/lib/grub2/x86_64-xen/grub.xen` unconditionally.

### New Behavior

Check for the presence of the `grub.xen` file on the host.

### Merge requirements satisfied?
- [ ] Docs
- [X] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes