### PR TITLE
Fixed zabbix mod get connection data from pillar

### DIFF
--- a/changelog/59338.fixed
+++ b/changelog/59338.fixed
@@ -1,0 +1,1 @@
+Fixed the zabbix module to read the connection data from pillar.

--- a/salt/modules/zabbix.py
+++ b/salt/modules/zabbix.py
@@ -232,7 +232,7 @@ def _login(**kwargs):
                     name = name[len(prefix) :]
                 except IndexError:
                     return
-            val = __salt__["config.option"]("zabbix.{}".format(name), None)
+            val = __salt__["config.get"]("zabbix:{}".format(name), None)
             if val is not None:
                 connargs[key] = val
 

--- a/salt/modules/zabbix.py
+++ b/salt/modules/zabbix.py
@@ -232,7 +232,9 @@ def _login(**kwargs):
                     name = name[len(prefix) :]
                 except IndexError:
                     return
-            val = __salt__["config.get"]("zabbix:{}".format(name), None)
+            val = __salt__["config.get"]("zabbix.{}".format(name), None) or __salt__[
+                "config.get"
+            ]("zabbix:{}".format(name), None)
             if val is not None:
                 connargs[key] = val
 


### PR DESCRIPTION
### What does this PR do?
Fixes the zabbix module to get the connection data from pillar.

### What issues does this PR fix or reference?
Fixes: #59338 

### Previous Behavior
zabbix execution module didn't read the connection data from pillar:
```
# salt-call pillar.get zabbix                                                            
local:
    ----------
    password:
        zabbix
    url:
        http://tst.zabbix.srv/zabbix/api_jsonrpc.php
    user:
        Admin
# salt-call zabbix.apiinfo_version                         
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
SaltException: URL is probably not correct! ()
Traceback (most recent call last):
  File "/usr/lib64/python3.9/site-packages/salt/modules/zabbix.py", line 263, in _login
    raise KeyError
KeyError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/salt-call", line 33, in <module>
    sys.exit(load_entry_point('salt==3002.2', 'console_scripts', 'salt-call')())
  File "/usr/lib64/python3.9/site-packages/salt/scripts.py", line 449, in salt_call
    client.run()
  File "/usr/lib64/python3.9/site-packages/salt/cli/call.py", line 58, in run
    caller.run()
  File "/usr/lib64/python3.9/site-packages/salt/cli/caller.py", line 112, in run
    ret = self.call()
  File "/usr/lib64/python3.9/site-packages/salt/cli/caller.py", line 219, in call
    ret["return"] = self.minion.executors[fname](
  File "/usr/lib64/python3.9/site-packages/salt/executors/direct_call.py", line 12, in execute
    return func(*args, **kwargs)
  File "/usr/lib64/python3.9/site-packages/salt/modules/zabbix.py", line 487, in apiinfo_version
    conn_args = _login(**connection_args)
  File "/usr/lib64/python3.9/site-packages/salt/modules/zabbix.py", line 265, in _login
    raise SaltException("URL is probably not correct! ({})".format(err))
salt.exceptions.SaltException: URL is probably not correct! ()
Traceback (most recent call last):
  File "/usr/lib64/python3.9/site-packages/salt/modules/zabbix.py", line 263, in _login
    raise KeyError
KeyError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/salt-call", line 33, in <module>
    sys.exit(load_entry_point('salt==3002.2', 'console_scripts', 'salt-call')())
  File "/usr/lib64/python3.9/site-packages/salt/scripts.py", line 449, in salt_call
    client.run()
  File "/usr/lib64/python3.9/site-packages/salt/cli/call.py", line 58, in run
    caller.run()
  File "/usr/lib64/python3.9/site-packages/salt/cli/caller.py", line 112, in run
    ret = self.call()
  File "/usr/lib64/python3.9/site-packages/salt/cli/caller.py", line 219, in call
    ret["return"] = self.minion.executors[fname](
  File "/usr/lib64/python3.9/site-packages/salt/executors/direct_call.py", line 12, in execute
    return func(*args, **kwargs)
  File "/usr/lib64/python3.9/site-packages/salt/modules/zabbix.py", line 487, in apiinfo_version
    conn_args = _login(**connection_args)
  File "/usr/lib64/python3.9/site-packages/salt/modules/zabbix.py", line 265, in _login
    raise SaltException("URL is probably not correct! ({})".format(err))
salt.exceptions.SaltException: URL is probably not correct! ()
```

### New Behavior
zabbix execution module can read and use the connection data from pillar: 
```
# salt-call pillar.get zabbix
local:
    ----------
    password:
        zabbix
    url:
        http://tst.zabbix.srv/zabbix/api_jsonrpc.php
    user:
        Admin
# salt-call zabbix.apiinfo_version                             
local:
    5.0.1
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No