### PR TITLE
fix: ensure keystore.list use the correct string encoding for X509 object attributes.

### DIFF
--- a/changelog/59503.fixed
+++ b/changelog/59503.fixed
@@ -1,0 +1,1 @@
+Use __salt_system_encoding__ when retrieving keystore certificate SHA1 str

--- a/tests/unit/states/test_keystore.py
+++ b/tests/unit/states/test_keystore.py
@@ -16,7 +16,6 @@ class KeystoreTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         return {keystore: {"__opts__": {"test": False}}}
 
-    @patch("os.path.exists", MagicMock(return_value=True))
     def test_cert_already_present(self):
         """
         Test for existing value_present
@@ -25,7 +24,9 @@ class KeystoreTestCase(TestCase, LoaderModuleMockMixin):
         cert_return = [
             {
                 "valid_until": "August 21 2017",
-                "sha1": "07:1C:B9:4F:0C:C8:51:4D:02:41:24:70:8E:E8:B2:68:7B:D7:D9:D5",
+                "sha1": "07:1C:B9:4F:0C:C8:51:4D:02:41:24:70:8E:E8:B2:68:7B:D7:D9:D5".encode(
+                    __salt_system_encoding__
+                ),
                 "valid_start": "August 22 2012",
                 "type": "TrustedCertEntry",
                 "alias": "stringhost",
@@ -37,10 +38,16 @@ class KeystoreTestCase(TestCase, LoaderModuleMockMixin):
             "Subject Hash": "97:95:14:4F",
             "Serial Number": "0D:FA",
             "SHA1 Finger Print": (
-                "07:1C:B9:4F:0C:C8:51:4D:02:41:24:70:8E:E8:B2:68:7B:D7:D9:D5"
+                "07:1C:B9:4F:0C:C8:51:4D:02:41:24:70:8E:E8:B2:68:7B:D7:D9:D5".encode(
+                    __salt_system_encoding__
+                )
             ),
-            "SHA-256 Finger Print": "5F:0F:B5:16:65:81:AA:E6:4A:10:1C:15:83:B1:BE:BE:74:E8:14:A9:1E:7A:8A:14:BA:1E:83:5D:78:F6:E9:E7",
-            "MD5 Finger Print": "80:E6:17:AF:78:D8:E4:B8:FB:5F:41:3A:27:1D:CC:F2",
+            "SHA-256 Finger Print": "5F:0F:B5:16:65:81:AA:E6:4A:10:1C:15:83:B1:BE:BE:74:E8:14:A9:1E:7A:8A:14:BA:1E:83:5D:78:F6:E9:E7".encode(
+                __salt_system_encoding__
+            ),
+            "MD5 Finger Print": "80:E6:17:AF:78:D8:E4:B8:FB:5F:41:3A:27:1D:CC:F2".encode(
+                __salt_system_encoding__
+            ),
             "Version": 1,
             "Key Size": 512,
             "Public Key": (
@@ -96,31 +103,31 @@ class KeystoreTestCase(TestCase, LoaderModuleMockMixin):
         }
 
         # with patch.dict(keystore.__opts__, {'test': False}):
-        with patch.dict(
-            keystore.__salt__, {"keystore.list": MagicMock(return_value=cert_return)}
-        ):
+        with patch("os.path.exists", return_value=True):
             with patch.dict(
                 keystore.__salt__,
-                {"x509.read_certificate": MagicMock(return_value=x509_return)},
+                {
+                    "keystore.list": MagicMock(return_value=cert_return),
+                    "x509.read_certificate": MagicMock(return_value=x509_return),
+                },
             ):
                 self.assertDictEqual(
                     keystore.managed(name, passphrase, entries), state_return
                 )
 
-        with patch.dict(keystore.__opts__, {"test": True}):
-            with patch.dict(
-                keystore.__salt__,
-                {"keystore.list": MagicMock(return_value=cert_return)},
-            ):
+        with patch("os.path.exists", return_value=True):
+            with patch.dict(keystore.__opts__, {"test": True}):
                 with patch.dict(
                     keystore.__salt__,
-                    {"x509.read_certificate": MagicMock(return_value=x509_return)},
+                    {
+                        "keystore.list": MagicMock(return_value=cert_return),
+                        "x509.read_certificate": MagicMock(return_value=x509_return),
+                    },
                 ):
                     self.assertDictEqual(
                         keystore.managed(name, passphrase, entries), state_return
                     )
 
-    @patch("os.path.exists", MagicMock(return_value=True))
     def test_cert_update(self):
         """
         Test for existing value_present
@@ -129,7 +136,9 @@ class KeystoreTestCase(TestCase, LoaderModuleMockMixin):
         cert_return = [
             {
                 "valid_until": "August 21 2017",
-                "sha1": "07:1C:B9:4F:0C:C8:51:4D:02:41:24:70:8E:E8:B2:68:7B:D7:D9:D5",
+                "sha1": "07:1C:B9:4F:0C:C8:51:4D:02:41:24:70:8E:E8:B2:68:7B:D7:D9:D5".encode(
+                    __salt_system_encoding__
+                ),
                 "valid_start": "August 22 2012",
                 "type": "TrustedCertEntry",
                 "alias": "stringhost",
@@ -141,7 +150,9 @@ class KeystoreTestCase(TestCase, LoaderModuleMockMixin):
             "Subject Hash": "97:95:14:4F",
             "Serial Number": "0D:FA",
             "SHA1 Finger Print": (
-                "07:1C:B9:4F:0C:C8:51:4D:02:41:24:70:8E:E8:B2:68:7B:D7:D9:D6"
+                "07:1C:B9:4F:0C:C8:51:4D:02:41:24:70:8E:E8:B2:68:7B:D7:D9:D6".encode(
+                    __salt_system_encoding__
+                )
             ),
             "SHA-256 Finger Print": "5F:0F:B5:16:65:81:AA:E6:4A:10:1C:15:83:B1:BE:BE:74:E8:14:A9:1E:7A:8A:14:BA:1E:83:5D:78:F6:E9:E7",
             "MD5 Finger Print": "80:E6:17:AF:78:D8:E4:B8:FB:5F:41:3A:27:1D:CC:F2",
@@ -206,37 +217,123 @@ class KeystoreTestCase(TestCase, LoaderModuleMockMixin):
         }
 
         with patch.dict(keystore.__opts__, {"test": True}):
-            with patch.dict(
-                keystore.__salt__,
-                {"keystore.list": MagicMock(return_value=cert_return)},
-            ):
+            with patch("os.path.exists", return_value=True):
                 with patch.dict(
                     keystore.__salt__,
-                    {"x509.read_certificate": MagicMock(return_value=x509_return)},
+                    {
+                        "keystore.list": MagicMock(return_value=cert_return),
+                        "x509.read_certificate": MagicMock(return_value=x509_return),
+                    },
                 ):
                     self.assertDictEqual(
                         keystore.managed(name, passphrase, entries), test_return
                     )
 
-        with patch.dict(
-            keystore.__salt__, {"keystore.list": MagicMock(return_value=cert_return)}
-        ):
+        with patch("os.path.exists", return_value=True):
             with patch.dict(
                 keystore.__salt__,
-                {"x509.read_certificate": MagicMock(return_value=x509_return)},
+                {
+                    "keystore.list": MagicMock(return_value=cert_return),
+                    "x509.read_certificate": MagicMock(return_value=x509_return),
+                    "keystore.remove": MagicMock(return_value=True),
+                    "keystore.add": MagicMock(return_value=True),
+                },
             ):
-                with patch.dict(
-                    keystore.__salt__, {"keystore.remove": MagicMock(return_value=True)}
-                ):
-                    with patch.dict(
-                        keystore.__salt__,
-                        {"keystore.add": MagicMock(return_value=True)},
-                    ):
-                        self.assertDictEqual(
-                            keystore.managed(name, passphrase, entries), state_return
-                        )
+                self.assertDictEqual(
+                    keystore.managed(name, passphrase, entries), state_return
+                )
 
-    @patch("os.path.exists", MagicMock(return_value=False))
+    def test_cert_update_no_sha1_fingerprint_in_x509(self):
+        """
+        Test for existing value_present
+        """
+
+        cert_return = [
+            {
+                "valid_until": "August 21 2017",
+                "sha1": "07:1C:B9:4F:0C:C8:51:4D:02:41:24:70:8E:E8:B2:68:7B:D7:D9:D5".encode(
+                    __salt_system_encoding__
+                ),
+                "valid_start": "August 22 2012",
+                "type": "TrustedCertEntry",
+                "alias": "stringhost",
+                "expired": True,
+            }
+        ]
+        sha1_return = b"07:1C:B9:4F:0C:C8:51:4D:02:41:24:70:8E:E8:B2:68:7B:D7:D9:D5"
+        x509_return = {
+            "Not After": "2017-08-21 05:26:54",
+            "Subject Hash": "97:95:14:4F",
+            "Serial Number": "0D:FA",
+            "SHA-256 Finger Print": "5F:0F:B5:16:65:81:AA:E6:4A:10:1C:15:83:B1:BE:BE:74:E8:14:A9:1E:7A:8A:14:BA:1E:83:5D:78:F6:E9:E7",
+            "MD5 Finger Print": "80:E6:17:AF:78:D8:E4:B8:FB:5F:41:3A:27:1D:CC:F2",
+            "Version": 1,
+            "Key Size": 512,
+            "Public Key": (
+                "-----BEGIN PUBLIC"
+                " KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAJv8ZpB5hEK7qxP9K3v43hUS5fGT4waK\ne7ix4Z4mu5UBv+cw7WSFAt0Vaag0sAbsPzU8Hhsrj/qPABvfB8asUwcCAwEAAQ==\n-----END"
+                " PUBLIC KEY-----\n"
+            ),
+            "Issuer": {
+                "C": "JP",
+                "organizationName": "Frank4DD",
+                "CN": "Frank4DD Web CA",
+                "SP": "Tokyo",
+                "L": "Chuo-ku",
+                "emailAddress": "support@frank4dd.com",
+                "OU": "WebCert Support",
+            },
+            "Issuer Hash": "92:DA:45:6B",
+            "Not Before": "2012-08-22 05:26:54",
+            "Subject": {
+                "C": "JP",
+                "SP": "Tokyo",
+                "organizationName": "Frank4DD",
+                "CN": "www.example.com",
+            },
+        }
+
+        name = "keystore.jks"
+        passphrase = "changeit"
+        entries = [
+            {
+                "alias": "stringhost",
+                "certificate": """-----BEGIN CERTIFICATE-----
+                   MIICEjCCAXsCAg36MA0GCSqGSIb3DQEBBQUAMIGbMQswCQYDVQQGEwJKUDEOMAwG
+                   A1UECBMFVG9reW8xEDAOBgNVBAcTB0NodW8ta3UxETAPBgNVBAoTCEZyYW5rNERE
+                   MRgwFgYDVQQLEw9XZWJDZXJ0IFN1cHBvcnQxGDAWBgNVBAMTD0ZyYW5rNEREIFdl
+                   YiBDQTEjMCEGCSqGSIb3DQEJARYUc3VwcG9ydEBmcmFuazRkZC5jb20wHhcNMTIw
+                   ODIyMDUyNjU0WhcNMTcwODIxMDUyNjU0WjBKMQswCQYDVQQGEwJKUDEOMAwGA1UE
+                   CAwFVG9reW8xETAPBgNVBAoMCEZyYW5rNEREMRgwFgYDVQQDDA93d3cuZXhhbXBs
+                   ZS5jb20wXDANBgkqhkiG9w0BAQEFAANLADBIAkEAm/xmkHmEQrurE/0re/jeFRLl
+                   8ZPjBop7uLHhnia7lQG/5zDtZIUC3RVpqDSwBuw/NTweGyuP+o8AG98HxqxTBwID
+                   AQABMA0GCSqGSIb3DQEBBQUAA4GBABS2TLuBeTPmcaTaUW/LCB2NYOy8GMdzR1mx
+                   8iBIu2H6/E2tiY3RIevV2OW61qY2/XRQg7YPxx3ffeUugX9F4J/iPnnu1zAxxyBy
+                   2VguKv4SWjRFoRkIfIlHX0qVviMhSlNy2ioFLy7JcPZb+v3ftDGywUqcBiVDoea0
+                   Hn+GmxZA\n-----END CERTIFICATE-----""",
+            }
+        ]
+
+        test_return = {
+            "name": name,
+            "changes": {},
+            "result": True,
+            "comment": "No changes made.\n",
+        }
+        with patch("os.path.exists", return_value=True):
+            with patch.dict(keystore.__opts__, {"test": True}):
+                with patch.dict(
+                    keystore.__salt__,
+                    {
+                        "keystore.list": MagicMock(return_value=cert_return),
+                        "x509.read_certificate": MagicMock(return_value=x509_return),
+                        "keystore.get_sha1": MagicMock(return_value=sha1_return),
+                    },
+                ):
+                    self.assertDictEqual(
+                        keystore.managed(name, passphrase, entries), test_return
+                    )
+
     def test_new_file(self):
         """
         Test for existing value_present
@@ -280,17 +377,18 @@ class KeystoreTestCase(TestCase, LoaderModuleMockMixin):
                 keystore.managed(name, passphrase, entries), test_return
             )
 
-        with patch.dict(
-            keystore.__salt__, {"keystore.remove": MagicMock(return_value=True)}
-        ):
+        with patch("os.path.exists", return_value=False):
             with patch.dict(
-                keystore.__salt__, {"keystore.add": MagicMock(return_value=True)}
+                keystore.__salt__,
+                {
+                    "keystore.remove": MagicMock(return_value=True),
+                    "keystore.add": MagicMock(return_value=True),
+                },
             ):
                 self.assertDictEqual(
                     keystore.managed(name, passphrase, entries), state_return
                 )
 
-    @patch("os.path.exists", MagicMock(return_value=True))
     def test_force_remove(self):
         """
         Test for existing value_present
@@ -299,7 +397,9 @@ class KeystoreTestCase(TestCase, LoaderModuleMockMixin):
         cert_return = [
             {
                 "valid_until": "August 21 2017",
-                "sha1": "07:1C:B9:4F:0C:C8:51:4D:02:41:24:70:8E:E8:B2:68:7B:D7:D9:D5",
+                "sha1": "07:1C:B9:4F:0C:C8:51:4D:02:41:24:70:8E:E8:B2:68:7B:D7:D9:D5".encode(
+                    __salt_system_encoding__
+                ),
                 "valid_start": "August 22 2012",
                 "type": "TrustedCertEntry",
                 "alias": "oldhost",
@@ -311,7 +411,9 @@ class KeystoreTestCase(TestCase, LoaderModuleMockMixin):
             "Subject Hash": "97:95:14:4F",
             "Serial Number": "0D:FA",
             "SHA1 Finger Print": (
-                "07:1C:B9:4F:0C:C8:51:4D:02:41:24:70:8E:E8:B2:68:7B:D7:D9:D6"
+                "07:1C:B9:4F:0C:C8:51:4D:02:41:24:70:8E:E8:B2:68:7B:D7:D9:D6".encode(
+                    __salt_system_encoding__
+                )
             ),
             "SHA-256 Finger Print": "5F:0F:B5:16:65:81:AA:E6:4A:10:1C:15:83:B1:BE:BE:74:E8:14:A9:1E:7A:8A:14:BA:1E:83:5D:78:F6:E9:E7",
             "MD5 Finger Print": "80:E6:17:AF:78:D8:E4:B8:FB:5F:41:3A:27:1D:CC:F2",
@@ -379,36 +481,30 @@ class KeystoreTestCase(TestCase, LoaderModuleMockMixin):
         }
 
         with patch.dict(keystore.__opts__, {"test": True}):
-            with patch.dict(
-                keystore.__salt__,
-                {"keystore.list": MagicMock(return_value=cert_return)},
-            ):
+            with patch("os.path.exists", return_value=True):
                 with patch.dict(
                     keystore.__salt__,
-                    {"x509.read_certificate": MagicMock(return_value=x509_return)},
+                    {
+                        "keystore.list": MagicMock(return_value=cert_return),
+                        "x509.read_certificate": MagicMock(return_value=x509_return),
+                    },
                 ):
                     self.assertDictEqual(
                         keystore.managed(name, passphrase, entries, force_remove=True),
                         test_return,
                     )
 
-        with patch.dict(
-            keystore.__salt__, {"keystore.list": MagicMock(return_value=cert_return)}
-        ):
+        with patch("os.path.exists", return_value=True):
             with patch.dict(
                 keystore.__salt__,
-                {"x509.read_certificate": MagicMock(return_value=x509_return)},
+                {
+                    "keystore.list": MagicMock(return_value=cert_return),
+                    "x509.read_certificate": MagicMock(return_value=x509_return),
+                    "keystore.remove": MagicMock(return_value=True),
+                    "keystore.add": MagicMock(return_value=True),
+                },
             ):
-                with patch.dict(
-                    keystore.__salt__, {"keystore.remove": MagicMock(return_value=True)}
-                ):
-                    with patch.dict(
-                        keystore.__salt__,
-                        {"keystore.add": MagicMock(return_value=True)},
-                    ):
-                        self.assertDictEqual(
-                            keystore.managed(
-                                name, passphrase, entries, force_remove=True
-                            ),
-                            state_return,
-                        )
+                self.assertDictEqual(
+                    keystore.managed(name, passphrase, entries, force_remove=True),
+                    state_return,
+                )


### PR DESCRIPTION
### What does this PR do?

The current salt keystore.managed state is broken because of the keystore.list function in keystore module.

The certificate passed to the module in PEM format gets added to the keystore in ASN1/DER bytes.  

The keystore.list function of keystore module then loads the keystore and if the stored cert is of type PrivateKeyEntry and then the cert_result is read from the cert_chain (ASN1/DER bytes).  When the public_cert is loaded, the OpenSSL X509 object elements are represented in bytes as per [crypto](https://www.pyopenssl.org/en/stable/api/crypto.html), for example [X509.get_notBefore](https://www.pyopenssl.org/en/stable/api/crypto.html#OpenSSL.crypto.X509.get_notBefore), so, we need decoding of those strings.

### What issues does this PR fix or reference?
Fixes: Issue #59503


### Previous Behavior
Fail to call keystore.list

### New Behavior
keystore.list now returns the dictionary and certificate if cert_return=True

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
