### PR TITLE
Fix Consul module PUT request

### DIFF
--- a/salt/modules/consul.py
+++ b/salt/modules/consul.py
@@ -269,7 +269,9 @@ def put(consul_url=None, token=None, key=None, value=None, **kwargs):
 
     query_params = {}
 
-    available_sessions = session_list(consul_url=consul_url, token=token, return_list=True)
+    available_sessions = session_list(
+        consul_url=consul_url, token=token, return_list=True
+    )
     _current = get(consul_url=consul_url, token=token, key=key)
 
     if "flags" in kwargs:

--- a/salt/modules/consul.py
+++ b/salt/modules/consul.py
@@ -334,7 +334,7 @@ def put(consul_url=None, token=None, key=None, value=None, **kwargs):
         query_params=query_params,
     )
 
-    if ret["res"] and ret["data"]::
+    if ret["res"] and ret["data"]:
         ret["res"] = True
         ret["data"] = "Added key {} with value {}.".format(key, value)
     else:


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes: Issues when using **salt.modules.consul.put** with a token or other params.

### Previous Behavior
When using the put method of the consule module, it can fail in 3 ways:
- The token is not propagated, causing error 403 when token is valid.
- When *kas* or *release* param is set, it handles a previous response from Consul as an object, making it impossible to release a lock this way. Consul returns a list of objects. The size can be bigger on GET operations with the recurse param.
- If the response body of the PUT operation is false, it is showing a success message, despite the write failure. Even if http response code is 200, the body must be checked.

References: https://www.consul.io/api-docs/kv

### New Behavior
- Propagate token and authenticate with success
- Able to use *kas* or *release* params with success
- Show error if write failed

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
