### PR TITLE
Fix pagerduty API pagination.

### DIFF
--- a/salt/modules/pagerduty_util.py
+++ b/salt/modules/pagerduty_util.py
@@ -138,6 +138,9 @@ def _query(
     if params is None:
         params = {}
 
+    # Ask for the total parameter to be returned, so the pagination logic below will work properly.
+    params["total"] = "true"
+
     if data is None:
         data = {}
 


### PR DESCRIPTION
### What does this PR do?
Request the total from pagerduty requests, which is now only provided by request. The existing code relies on it for handling paginated requests.

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
Various functions related to pagerduty would behave as if objects didn't exist in pagerduty because requests to the API were not requesting remaining paginated results.

### New Behavior
All objects are returned from pagerduty.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
