### PR TITLE
Fix 'write' references under the 'read' function for macdefaults.py in documentation

### DIFF
--- a/salt/modules/macdefaults.py
+++ b/salt/modules/macdefaults.py
@@ -62,7 +62,7 @@ def write(domain, key, value, type="string", user=None):
 
 def read(domain, key, user=None):
     """
-    Write a default to the system
+    Read a default from the system
 
     CLI Example:
 
@@ -79,7 +79,7 @@ def read(domain, key, user=None):
         The key of the given domain to read from
 
     user
-        The user to write the defaults to
+        The user to read the defaults as
 
     """
     cmd = 'defaults read "{}" "{}"'.format(domain, key)


### PR DESCRIPTION
### What does this PR do?
Corrects references of 'write' in the doc strings for `macdefaults.py` under the read function.

### What issues does this PR fix or reference?
Fixes: N/A

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
