### PR TITLE
The ``salt-run`` CLI now accepts ``--jid`` which allows scripting against it

### DIFF
--- a/changelog/59527.added
+++ b/changelog/59527.added
@@ -1,0 +1,1 @@
+The `salt-run` CLI now accepts `--jid`

--- a/doc/topics/releases/3003.rst
+++ b/doc/topics/releases/3003.rst
@@ -23,3 +23,4 @@ Added
 -----
 
 - Firewall groups support to Vultr Salt Cloud provider
+- The ``salt-run`` CLI now accepts ``--jid`` which allows scripting against it.

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -202,7 +202,7 @@ class Runner(RunnerClient):
             low = {"fun": self.opts["fun"]}
             try:
                 # Allocate a jid
-                async_pub = self._gen_async_pub()
+                async_pub = self._gen_async_pub(jid=self.opts.get("jid"))
                 self.jid = async_pub["jid"]
 
                 fun_args = salt.utils.args.parse_input(
@@ -263,7 +263,7 @@ class Runner(RunnerClient):
                     log.warning(
                         "Running in asynchronous mode. Results of this execution may "
                         "be collected by attaching to the master event bus or "
-                        "by examing the master job cache, if configured. "
+                        "by examining the master job cache, if configured. "
                         "This execution is running under tag %s",
                         async_pub["tag"],
                     )

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1925,6 +1925,23 @@ class EAuthMixIn(metaclass=MixInMeta):
         self.add_option_group(group)
 
 
+class JIDMixin:
+
+    _mixin_prio_ = 30
+
+    def _mixin_setup(self):
+        self.add_option(
+            "--jid",
+            default=None,
+            help="Pass a JID to be used instead of generating one.",
+        )
+
+    def process_jid(self):
+        if self.options.jid is not None:
+            if not salt.utils.jid.is_jid(self.options.jid):
+                self.error("'{}' is not a valid JID".format(self.options.jid))
+
+
 class MasterOptionParser(
     OptionParser,
     ConfigDirMixIn,
@@ -3023,6 +3040,7 @@ class SaltRunOptionParser(
     ProfilingPMixIn,
     EAuthMixIn,
     NoParseMixin,
+    JIDMixin,
     metaclass=OptionParserMeta,
 ):
 
@@ -3109,6 +3127,7 @@ class SaltSSHOptionParser(
     SaltfileMixIn,
     HardCrashMixin,
     NoParseMixin,
+    JIDMixin,
     metaclass=OptionParserMeta,
 ):
 
@@ -3254,11 +3273,6 @@ class SaltSSHOptionParser(
             "--python3-bin",
             default="python3",
             help="Path to a python3 binary which has salt installed.",
-        )
-        self.add_option(
-            "--jid",
-            default=None,
-            help="Pass a JID to be used instead of generating one.",
         )
 
         self.add_option(
@@ -3423,11 +3437,6 @@ class SaltSSHOptionParser(
         opts = config.master_config(self.get_config_file_path())
         salt.features.setup_features(opts)
         return opts
-
-    def process_jid(self):
-        if self.options.jid is not None:
-            if not salt.utils.jid.is_jid(self.options.jid):
-                self.error("'{}' is not a valid JID".format(self.options.jid))
 
 
 class SaltCloudParser(


### PR DESCRIPTION
### What does this PR do?
See title.

This helps with proper testing under PyTest