### PR TITLE
Fix race conditions for corner cases when handling SIGTERM by minion

### DIFF
--- a/changelog/59524.fixed
+++ b/changelog/59524.fixed
@@ -1,0 +1,1 @@
+Fix minion race conditions handling SIGTERM signal when loading modules

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1802,12 +1802,17 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             except Exception:  # pylint: disable=broad-except
                 pass
             else:
-                tgt_fn = os.path.join("salt", "utils", "process.py")
-                if fn_.endswith(tgt_fn) and "_handle_signals" in caller:
-                    # Race conditon, SIGTERM or SIGINT received while loader
-                    # was in process of loading a module. Call sys.exit to
-                    # ensure that the process is killed.
-                    sys.exit(salt.defaults.exitcodes.EX_OK)
+                tgt_fns = [
+                    os.path.join("salt", "utils", "process.py"),
+                    os.path.join("salt", "cli", "daemons.py"),
+                    os.path.join("salt", "cli", "api.py"),
+                ]
+                for tgt_fn in tgt_fns:
+                    if fn_.endswith(tgt_fn) and "_handle_signals" in caller:
+                        # Race conditon, SIGTERM or SIGINT received while loader
+                        # was in process of loading a module. Call sys.exit to
+                        # ensure that the process is killed.
+                        sys.exit(salt.defaults.exitcodes.EX_OK)
             log.error(
                 "Failed to import %s %s as the module called exit()\n",
                 self.tag,

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2396,6 +2396,8 @@ class Minion(MinionBase):
         """
         Refresh the functions and returners.
         """
+        if not hasattr(self, "schedule"):
+            return
         log.debug("Refreshing modules. Notify=%s", notify)
         self.functions, self.returners, _, self.executors = self._load_modules(
             force_refresh, notify=notify


### PR DESCRIPTION
### What does this PR do?

This PR fixes some race conditions that we have identified and may happen when "minion" is handling a SIGTERM signal, particularly in the context of CLI and "salt-call" execution when "LazyLoader" is loading modules: 

In some cases, when sending the SIGTERM signal to the minion process, we got the following exceptions:

```console
2020-05-25 17:21:43,162 [salt.utils.parsers                                                                :1084][WARNING ][627] Minion received a SIGTERM. Exiting.
2020-05-25 17:21:43,162 [salt.cli.daemons                                                                  :85  ][INFO    ][627] Shutting down the Salt Minion
2020-05-25 17:21:43,163 [salt.loader                                                                       :1692][ERROR   ][627] Failed to import module win_path as the module called exit()
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/salt/loader.py", line 1650, in _load_module
    mod = spec.loader.load_module()
  File "<frozen importlib._bootstrap_external>", line 399, in _check_name_wrapper
  File "<frozen importlib._bootstrap_external>", line 823, in load_module
  File "<frozen importlib._bootstrap_external>", line 682, in load_module
  File "<frozen importlib._bootstrap>", line 265, in _load_module_shim
  File "<frozen importlib._bootstrap>", line 684, in _load
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 674, in exec_module
  File "<frozen importlib._bootstrap_external>", line 781, in get_code
  File "<frozen importlib._bootstrap_external>", line 741, in source_to_code
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/usr/lib/python3.6/site-packages/salt/cli/daemons.py", line 230, in _handle_signals
    super(Minion, self)._handle_signals(signum, sigframe)
  File "/usr/lib/python3.6/site-packages/salt/utils/parsers.py", line 1085, in _handle_signals
    self.shutdown(exitmsg='{0} Exited.'.format(msg))
  File "/usr/lib/python3.6/site-packages/salt/cli/daemons.py", line 389, in shutdown
    self.__class__.__name__, (exitmsg or '')).strip()))
  File "/usr/lib/python3.6/site-packages/salt/utils/parsers.py", line 1088, in shutdown
    self.exit(exitcode, exitmsg)
  File "/usr/lib/python3.6/site-packages/salt/utils/parsers.py", line 289, in exit
    optparse.OptionParser.exit(self, status, msg)
  File "/usr/lib64/python3.6/optparse.py", line 1559, in exit
    sys.exit(status)
SystemExit: 0
```

And also this other one:
```console
2020-05-25 17:21:45,220 [tornado.application                                                               :345 ][ERROR   ][627] Future <salt.ext.tornado.concurrent.Future object at 0x7ff01da09160> exception was never retrieved: Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/salt/ext/tornado/gen.py", line 309, in wrapper
    yielded = next(result)
  File "/usr/lib/python3.6/site-packages/salt/minion.py", line 2390, in handle_event
    notify=data.get('notify', False)
  File "/usr/lib/python3.6/site-packages/salt/minion.py", line 2189, in module_refresh
    self.schedule.functions = self.functions
AttributeError: 'Minion' object has no attribute 'schedule'
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
