### PR TITLE
59486 defining chars get str

### DIFF
--- a/salt/modules/mod_random.py
+++ b/salt/modules/mod_random.py
@@ -122,7 +122,7 @@ def str_encode(value, encoder='base64'):
     return out
 
 
-def get_str(length=20):
+def get_str(length=20, **kwargs):
     '''
     .. versionadded:: 2014.7.0
 
@@ -131,13 +131,63 @@ def get_str(length=20):
     length : 20
         Any valid number of bytes.
 
+    chars : None
+        String with any character that should be used to generate random string.
+
+        This argument supersedes all other character controlling arguments.
+
+    lowercase : True
+        Use lowercase letters in generated random string.
+        (see https://docs.python.org/3/library/string.html#string.ascii_lowercase)
+
+        This argument is superseded by chars.
+
+    uppercase : True
+        Use uppercase letters in generated random string. (matches python string.ascii_uppercase)
+        (see https://docs.python.org/3/library/string.html#string.ascii_uppercase)
+
+        This argument is superseded by chars.
+
+    digits : True
+        Use digits in generated random string.
+        (see https://docs.python.org/3/library/string.html#string.digits)
+
+        This argument is superseded by chars.
+
+    printable : False
+        Use printable characters in generated random string and includes lowercase, uppercase,
+        digits, punctuation and whitespace.
+        (see https://docs.python.org/3/library/string.html#string.printable)
+
+        It is disabled by default as includes whitespace characters which some systems do not
+        handle well in passwords.
+
+        This argument is superseded by chars.
+
+    punctuation : True
+        Use punctuation characters in generated random string.
+        (see https://docs.python.org/3/library/string.html#string.punctuation)
+
+        This argument is superseded by chars.
+
+    whitespace : False
+        Use whitespace characters in generated random string.
+        (see https://docs.python.org/3/library/string.html#string.whitespace)
+
+        It is disabled by default as some systems do not handle whitespace characters in passwords
+        well.
+
+        This argument is superseded by chars.
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' random.get_str 128
+        salt '*' random.get_str 128 chars='abc123.!()'
+        salt '*' random.get_str 128 lowercase=False whitespace=True
     '''
-    return salt.utils.pycrypto.secure_password(length)
+    return salt.utils.pycrypto.secure_password(length, **kwargs)
 
 
 def shadow_hash(crypt_salt=None, password=None, algorithm='sha512'):

--- a/salt/utils/pycrypto.py
+++ b/salt/utils/pycrypto.py
@@ -39,10 +39,25 @@ from salt.ext import six
 log = logging.getLogger(__name__)
 
 
-def secure_password(length=20, use_random=True):
+def secure_password(length=20, use_random=True, **kwargs):
     '''
     Generate a secure password.
     '''
+    if not kwargs.get('chars'):
+        chars = ''
+        if kwargs.get('lowercase', True):
+            chars += string.ascii_lowercase
+        if kwargs.get('uppercase', True):
+            chars += string.ascii_uppercase
+        if kwargs.get('digits', True):
+            chars += string.digits
+        if kwargs.get('punctuation', True):
+            chars += string.punctuation
+        if kwargs.get('whitespace', False):
+            chars += string.whitespace
+        if kwargs.get('printable', False):
+            chars += string.printable
+    chars = ''.join(set(chars))
     try:
         length = int(length)
         pw = ''
@@ -55,12 +70,12 @@ def secure_password(length=20, use_random=True):
                     except UnicodeDecodeError:
                         continue
                 pw += re.sub(
-                    salt.utils.stringutils.to_str(r'[\W_]'),
+                    salt.utils.stringutils.to_str(r'[^{0}]'.format(chars)),
                     str(),  # future lint: disable=blacklisted-function
                     char
                 )
             else:
-                pw += random.SystemRandom().choice(string.ascii_letters + string.digits)
+                pw += random.SystemRandom().choice(chars)
         return pw
     except Exception as exc:
         log.exception('Failed to generate secure passsword')

--- a/tests/unit/modules/test_mod_random.py
+++ b/tests/unit/modules/test_mod_random.py
@@ -82,9 +82,13 @@ class ModrandomTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Test for Returns a random string of the specified length.
         '''
-        with patch.object(salt.utils.pycrypto,
-                          'secure_password', return_value='A'):
-            self.assertEqual(mod_random.get_str(), 'A')
+        self.assertEqual(mod_random.get_str(length=1, chars='A'), 'A')
+        self.assertEqual(len(mod_random.get_str(length=64)), 64)
+        ret = mod_random.get_str(
+            length=1, lowercase=False, uppercase=False, printable=False,
+            whitespace=False, punctuation=False)
+        self.assertNotRegex(ret, r'^[a-zA-Z]+$', 'Found invalid characters')
+        self.assertRegex(ret, r'^[0.9]+$', 'Not found required characters')
 
     def test_shadow_hash(self):
         '''

--- a/tests/unit/modules/test_mod_random.py
+++ b/tests/unit/modules/test_mod_random.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-'''
+"""
     :codeauthor: Rupesh Tare <rupesht@saltstack.com>
-'''
+"""
 
 # Import Python Libs
 from __future__ import absolute_import, print_function, unicode_literals
@@ -9,11 +9,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import TestCase, skipIf
-from tests.support.mock import (
-    patch,
-    NO_MOCK,
-    NO_MOCK_REASON
-)
+from tests.support.mock import patch, NO_MOCK, NO_MOCK_REASON
 
 # Import Salt Libs
 import salt.modules.mod_random as mod_random
@@ -31,9 +27,9 @@ def _test_hashlib():
         return False
 
     if six.PY2:
-        algorithms_attr_name = 'algorithms'
+        algorithms_attr_name = "algorithms"
     else:
-        algorithms_attr_name = 'algorithms_guaranteed'
+        algorithms_attr_name = "algorithms_guaranteed"
 
     if not hasattr(hashlib, algorithms_attr_name):
         return False
@@ -44,56 +40,58 @@ def _test_hashlib():
 SUPPORTED_HASHLIB = _test_hashlib()
 
 
-@skipIf(not SUPPORTED_HASHLIB, 'Hashlib does not contain needed functionality')
+@skipIf(not SUPPORTED_HASHLIB, "Hashlib does not contain needed functionality")
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class ModrandomTestCase(TestCase, LoaderModuleMockMixin):
-    '''
+    """
     Test cases for salt.modules.mod_random
-    '''
+    """
+
     def setup_loader_modules(self):
         return {mod_random: {}}
 
     def test_hash(self):
-        '''
+        """
         Test for Encodes a value with the specified encoder.
-        '''
-        self.assertEqual(mod_random.hash('value')[0:4], 'ec2c')
+        """
+        self.assertEqual(mod_random.hash("value")[0:4], "ec2c")
 
-        self.assertRaises(SaltInvocationError,
-                          mod_random.hash, 'value', 'algorithm')
+        self.assertRaises(SaltInvocationError, mod_random.hash, "value", "algorithm")
 
     def test_str_encode(self):
-        '''
+        """
         Test for The value to be encoded.
-        '''
-        self.assertRaises(SaltInvocationError,
-                          mod_random.str_encode, 'None', 'abc')
+        """
+        self.assertRaises(SaltInvocationError, mod_random.str_encode, "None", "abc")
 
-        self.assertRaises(SaltInvocationError,
-                          mod_random.str_encode, None)
+        self.assertRaises(SaltInvocationError, mod_random.str_encode, None)
 
         if six.PY2:
-            self.assertEqual(mod_random.str_encode('A'), 'QQ==\n')
+            self.assertEqual(mod_random.str_encode("A"), "QQ==\n")
         else:
             # We're using the base64 module which does not include the trailing new line
-            self.assertEqual(mod_random.str_encode('A'), 'QQ==')
+            self.assertEqual(mod_random.str_encode("A"), "QQ==")
 
     def test_get_str(self):
-        '''
+        """
         Test for Returns a random string of the specified length.
-        '''
-        self.assertEqual(mod_random.get_str(length=1, chars='A'), 'A')
+        """
+        self.assertEqual(mod_random.get_str(length=1, chars="A"), "A")
         self.assertEqual(len(mod_random.get_str(length=64)), 64)
         ret = mod_random.get_str(
-            length=1, lowercase=False, uppercase=False, printable=False,
-            whitespace=False, punctuation=False)
-        self.assertNotRegex(ret, r'^[a-zA-Z]+$', 'Found invalid characters')
-        self.assertRegex(ret, r'^[0.9]+$', 'Not found required characters')
+            length=1,
+            lowercase=False,
+            uppercase=False,
+            printable=False,
+            whitespace=False,
+            punctuation=False,
+        )
+        self.assertNotRegex(ret, r"^[a-zA-Z]+$", "Found invalid characters")
+        self.assertRegex(ret, r"^[0.9]+$", "Not found required characters")
 
     def test_shadow_hash(self):
-        '''
+        """
         Test for Generates a salted hash suitable for /etc/shadow.
-        '''
-        with patch.object(salt.utils.pycrypto,
-                          'gen_hash', return_value='A'):
-            self.assertEqual(mod_random.shadow_hash(), 'A')
+        """
+        with patch.object(salt.utils.pycrypto, "gen_hash", return_value="A"):
+            self.assertEqual(mod_random.shadow_hash(), "A")

--- a/tests/unit/utils/test_pycrypto.py
+++ b/tests/unit/utils/test_pycrypto.py
@@ -16,36 +16,36 @@ log = logging.getLogger(__name__)
 
 
 class PycryptoTestCase(TestCase):
-    '''
+    """
     TestCase for salt.utils.pycrypto module
-    '''
+    """
 
-    @skipIf(not salt.utils.pycrypto.HAS_CRYPT, 'No crypto library available')
+    @skipIf(not salt.utils.pycrypto.HAS_CRYPT, "No crypto library available")
     def test_gen_hash(self):
-        '''
+        """
         Test gen_hash
-        '''
-        passwd = 'test_password'
+        """
+        passwd = "test_password"
         ret = salt.utils.pycrypto.gen_hash(password=passwd)
-        self.assertTrue(ret.startswith('$6$'))
+        self.assertTrue(ret.startswith("$6$"))
 
-        ret = salt.utils.pycrypto.gen_hash(password=passwd, algorithm='md5')
-        self.assertTrue(ret.startswith('$1$'))
+        ret = salt.utils.pycrypto.gen_hash(password=passwd, algorithm="md5")
+        self.assertTrue(ret.startswith("$1$"))
 
-        ret = salt.utils.pycrypto.gen_hash(password=passwd, algorithm='sha256')
-        self.assertTrue(ret.startswith('$5$'))
+        ret = salt.utils.pycrypto.gen_hash(password=passwd, algorithm="sha256")
+        self.assertTrue(ret.startswith("$5$"))
 
     def test_secure_password(self):
-        '''
+        """
         test secure_password
-        '''
+        """
         ret = salt.utils.pycrypto.secure_password()
-        check_printable = re.compile(r'[^{0}]'.format(
-            string.ascii_letters + string.digits + string.punctuation)
+        check_printable = re.compile(
+            r"[^{0}]".format(string.ascii_letters + string.digits + string.punctuation)
         )
         assert check_printable.search(ret) is None
-        check_whitespace = re.compile(r'[{0}]'.format(string.whitespace))
+        check_whitespace = re.compile(r"[{0}]".format(string.whitespace))
         assert check_whitespace.search(ret) is None
         assert ret
-        self.assertEqual(salt.utils.pycrypto.secure_password(length=1, chars='A'), 'A')
+        self.assertEqual(salt.utils.pycrypto.secure_password(length=1, chars="A"), "A")
         self.assertEqual(len(salt.utils.pycrypto.secure_password(length=64)), 64)

--- a/tests/unit/utils/test_pycrypto.py
+++ b/tests/unit/utils/test_pycrypto.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 import logging
 import re
+import string
 
 # Import Salt Libs
 import salt.utils.pycrypto
@@ -39,6 +40,12 @@ class PycryptoTestCase(TestCase):
         test secure_password
         '''
         ret = salt.utils.pycrypto.secure_password()
-        check = re.compile(r'[!@#$%^&*()_=+]')
-        assert check.search(ret) is None
+        check_printable = re.compile(r'[^{0}]'.format(
+            string.ascii_letters + string.digits + string.punctuation)
+        )
+        assert check_printable.search(ret) is None
+        check_whitespace = re.compile(r'[{0}]'.format(string.whitespace))
+        assert check_whitespace.search(ret) is None
         assert ret
+        self.assertEqual(salt.utils.pycrypto.secure_password(length=1, chars='A'), 'A')
+        self.assertEqual(len(salt.utils.pycrypto.secure_password(length=64)), 64)


### PR DESCRIPTION
### What does this PR do?

This PR changes the default character set used by `utils.pycrypto.secure_password()` and implements arguments to control the used character set. (see #59486)

### What issues does this PR fix or reference?
Fixes: None

### Previous Behavior

`utils.pycrypto.secure_password()` generated random string based on `string.ascii_letters + string.digits`.

### New Behavior

`utils.pycrypto.secure_password()` generates random string based on given character controlling arguments.
The default is now `string.ascii_lowercase + string.ascii_uppercase + string.digits + string.punctuation`.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes
