### PR TITLE
Change thread.isAlive() to thread.is_alive()

### DIFF
--- a/salt/utils/timed_subprocess.py
+++ b/salt/utils/timed_subprocess.py
@@ -8,7 +8,6 @@ import threading
 
 import salt.exceptions
 import salt.utils.data
-from salt.ext import six
 
 
 class TimedProc:
@@ -75,10 +74,6 @@ class TimedProc:
                     kwargs["env"][key] = str(val)
                 if not isinstance(key, str):
                     kwargs["env"][str(key)] = kwargs["env"].pop(key)
-            if six.PY2 and "env" in kwargs:
-                # Ensure no unicode in custom env dict, as it can cause
-                # problems with subprocess.
-                kwargs["env"] = salt.utils.data.encode_dict(kwargs["env"])
             args = salt.utils.data.decode(args)
             self.process = subprocess.Popen(args, **kwargs)
         self.command = args

--- a/salt/utils/timed_subprocess.py
+++ b/salt/utils/timed_subprocess.py
@@ -66,7 +66,7 @@ class TimedProc:
                         str_args.append(arg)
                 args = str_args
             else:
-                if not isinstance(args, (list, tuple, (str,))):
+                if not isinstance(args, (list, tuple, str)):
                     # Handle corner case where someone does a 'cmd.run 3'
                     args = str(args)
             # Ensure that environment variables are strings

--- a/salt/utils/timed_subprocess.py
+++ b/salt/utils/timed_subprocess.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
 """
 For running command line executables with a timeout
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
 import shlex
 import subprocess
@@ -13,7 +11,7 @@ import salt.utils.data
 from salt.ext import six
 
 
-class TimedProc(object):
+class TimedProc:
     """
     Create a TimedProc object, calls subprocess.Popen with passed args and **kwargs
     """
@@ -46,7 +44,7 @@ class TimedProc(object):
 
         if self.timeout and not isinstance(self.timeout, (int, float)):
             raise salt.exceptions.TimedProcTimeoutError(
-                "Error: timeout {0} must be a number".format(self.timeout)
+                "Error: timeout {} must be a number".format(self.timeout)
             )
         if kwargs.get("shell", False):
             args = salt.utils.data.decode(args, to_str=True)
@@ -59,24 +57,24 @@ class TimedProc(object):
                     try:
                         args = shlex.split(args)
                     except AttributeError:
-                        args = shlex.split(six.text_type(args))
+                        args = shlex.split(str(args))
                 str_args = []
                 for arg in args:
-                    if not isinstance(arg, six.string_types):
-                        str_args.append(six.text_type(arg))
+                    if not isinstance(arg, str):
+                        str_args.append(str(arg))
                     else:
                         str_args.append(arg)
                 args = str_args
             else:
-                if not isinstance(args, (list, tuple, six.string_types)):
+                if not isinstance(args, (list, tuple, (str,))):
                     # Handle corner case where someone does a 'cmd.run 3'
-                    args = six.text_type(args)
+                    args = str(args)
             # Ensure that environment variables are strings
-            for key, val in six.iteritems(kwargs.get("env", {})):
-                if not isinstance(val, six.string_types):
-                    kwargs["env"][key] = six.text_type(val)
-                if not isinstance(key, six.string_types):
-                    kwargs["env"][six.text_type(key)] = kwargs["env"].pop(key)
+            for key, val in kwargs.get("env", {}).items():
+                if not isinstance(val, str):
+                    kwargs["env"][key] = str(val)
+                if not isinstance(key, str):
+                    kwargs["env"][str(key)] = kwargs["env"].pop(key)
             if six.PY2 and "env" in kwargs:
                 # Ensure no unicode in custom env dict, as it can cause
                 # problems with subprocess.
@@ -113,8 +111,8 @@ class TimedProc(object):
 
                 threading.Timer(10, terminate).start()
                 raise salt.exceptions.TimedProcTimeoutError(
-                    "{0} : Timed out after {1} seconds".format(
-                        self.command, six.text_type(self.timeout),
+                    "{} : Timed out after {} seconds".format(
+                        self.command, str(self.timeout),
                     )
                 )
         return self.process.returncode

--- a/salt/utils/timed_subprocess.py
+++ b/salt/utils/timed_subprocess.py
@@ -103,12 +103,12 @@ class TimedProc(object):
             rt = threading.Thread(target=receive)
             rt.start()
             rt.join(self.timeout)
-            if rt.isAlive():
+            if rt.is_alive():
                 # Subprocess cleanup (best effort)
                 self.process.kill()
 
                 def terminate():
-                    if rt.isAlive():
+                    if rt.is_alive():
                         self.process.terminate()
 
                 threading.Timer(10, terminate).start()


### PR DESCRIPTION
`thread.isAlive()` was removed in Python 3.9. It was not even mentioned in the Python 3 docs.

`thread.is_alive()` was added in Python 2.6 as (then) new spelling of isAlive.

Fixes #59534.