### PR TITLE
Fix pkg.upgrade with -U arg on FreeBSD, -L flag was deprecated long time

### DIFF
--- a/changelog/59565.fixed
+++ b/changelog/59565.fixed
@@ -1,0 +1,1 @@
+Fix pkg.upgrade with -U arg on FreeBSD, -L flag was deprecated long time.

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -1211,7 +1211,7 @@ def upgrade(*names, **kwargs):
     if force:
         opts += "f"
     if local:
-        opts += "L"
+        opts += "U"
     if fetchonly:
         opts += "F"
     if dryrun:


### PR DESCRIPTION
Fix pkg.upgrade with -U arg on FreeBSD, -L flag was deprecated long time
-U suppresses the automatic update of the local copy of the repository
catalogue from remote.