### PR TITLE
Add -B flag to FreeBSD pkgng.check() to regenerate the library dependency metadata

### DIFF
--- a/changelog/59569.added
+++ b/changelog/59569.added
@@ -1,0 +1,3 @@
+Add -B flag to FreeBSD pkgng.check() to regenerate the library dependency
+metadata for a package by extracting library requirement information from the
+binary ELF files in the package.

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -1346,7 +1346,13 @@ def autoremove(jail=None, chroot=None, root=None, dryrun=False):
 
 
 def check(
-    jail=None, chroot=None, root=None, depends=False, recompute=False, checksum=False
+    jail=None,
+    chroot=None,
+    root=None,
+    depends=False,
+    recompute=False,
+    checksum=False,
+    checklibs=False,
 ):
     """
     Sanity checks installed packages
@@ -1384,7 +1390,7 @@ def check(
 
         .. code-block:: bash
 
-            salt '*' pkg.check recompute=True
+            salt '*' pkg.check depends=True
 
     recompute
         Recompute sizes and checksums of installed packages.
@@ -1393,7 +1399,7 @@ def check(
 
         .. code-block:: bash
 
-            salt '*' pkg.check depends=True
+            salt '*' pkg.check recompute=True
 
     checksum
         Find invalid checksums for installed packages.
@@ -1403,9 +1409,19 @@ def check(
         .. code-block:: bash
 
             salt '*' pkg.check checksum=True
+
+    checklibs
+        Regenerates the library dependency metadata for a package.
+
+        CLI Example:
+
+        .. code-block:: bash
+
+            salt '*' pkg.check checklibs=True
+
     """
-    if not any((depends, recompute, checksum)):
-        return "One of depends, recompute, or checksum must be set to True"
+    if not any((depends, recompute, checksum, checklibs)):
+        return "One of depends, recompute, checksum or checklibs must be set to True"
 
     opts = ""
     if depends:
@@ -1414,6 +1430,8 @@ def check(
         opts += "r"
     if checksum:
         opts += "s"
+    if checklibs:
+        opts += "B"
 
     cmd = _pkg(jail, chroot, root)
     cmd.append("check")

--- a/tests/unit/modules/test_pkgng.py
+++ b/tests/unit/modules/test_pkgng.py
@@ -571,7 +571,7 @@ class PkgNgTestCase(TestCase, LoaderModuleMockMixin):
                 ["pkg", "check", "-r"], output_loglevel="trace", python_shell=False,
             )
 
-    def test_check_libs(self):
+    def test_check_checklibs(self):
         """
         Test pkgng.check to regenerate the library dependency metadata
         """

--- a/tests/unit/modules/test_pkgng.py
+++ b/tests/unit/modules/test_pkgng.py
@@ -1,21 +1,13 @@
-# -*- coding: utf-8 -*-
-
-# Import Python libs
-from __future__ import absolute_import
-
 import textwrap
 
-# Import Salt Libs
 import salt.modules.pkgng as pkgng
-
-# Import Salt Testing Libs
 from salt.utils.odict import OrderedDict
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase
 
 
-class ListPackages(object):
+class ListPackages:
     def __init__(self):
         self._iteration = 0
 
@@ -539,3 +531,55 @@ class PkgNgTestCase(TestCase, LoaderModuleMockMixin):
                     python_shell=False,
                     env={},
                 )
+
+    def test_check_depends(self):
+        """
+        Test pkgng.check to check and install missing dependencies
+        """
+        pkg_cmd = MagicMock(return_value="")
+
+        with patch.dict(pkgng.__salt__, {"cmd.run": pkg_cmd}):
+            result = pkgng.check(depends=True)
+            self.assertEqual(result, "")
+            pkg_cmd.assert_called_with(
+                ["pkg", "check", "-dy"], output_loglevel="trace", python_shell=False,
+            )
+
+    def test_check_checksum(self):
+        """
+        Test pkgng.check for packages with invalid checksums
+        """
+        pkg_cmd = MagicMock(return_value="")
+
+        with patch.dict(pkgng.__salt__, {"cmd.run": pkg_cmd}):
+            result = pkgng.check(checksum=True)
+            self.assertEqual(result, "")
+            pkg_cmd.assert_called_with(
+                ["pkg", "check", "-s"], output_loglevel="trace", python_shell=False,
+            )
+
+    def test_check_recompute(self):
+        """
+        Test pkgng.check to recalculate the checksums of installed packages
+        """
+        pkg_cmd = MagicMock(return_value="")
+
+        with patch.dict(pkgng.__salt__, {"cmd.run": pkg_cmd}):
+            result = pkgng.check(recompute=True)
+            self.assertEqual(result, "")
+            pkg_cmd.assert_called_with(
+                ["pkg", "check", "-r"], output_loglevel="trace", python_shell=False,
+            )
+
+    def test_check_libs(self):
+        """
+        Test pkgng.check to regenerate the library dependency metadata
+        """
+        pkg_cmd = MagicMock(return_value="")
+
+        with patch.dict(pkgng.__salt__, {"cmd.run": pkg_cmd}):
+            result = pkgng.check(checklibs=True)
+            self.assertEqual(result, "")
+            pkg_cmd.assert_called_with(
+                ["pkg", "check", "-B"], output_loglevel="trace", python_shell=False,
+            )


### PR DESCRIPTION
### What does this PR do?
Add -B flag to pkgng.check() to regenerate the library dependency metadata for a package by extracting library requirement information from the binary ELF files in the package.

* Fix some typos in docstrings in pkgng.check() method.
* Generate additional tests for pkgng.check() method.