### PR TITLE
Implement setting of --recommends in zypper install and update module on Suse.

### DIFF
--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -1415,6 +1415,7 @@ def install(
     skip_verify=False,
     version=None,
     ignore_repo_failure=False,
+    recommends=False,
     no_recommends=False,
     root=None,
     **kwargs
@@ -1505,6 +1506,9 @@ def install(
     ignore_repo_failure
         Zypper returns error code 106 if one of the repositories are not available for various reasons.
         In case to set strict check, this parameter needs to be set to True. Default: False.
+
+    recommends
+        Install also recommended packages in addition to the required ones.
 
     no_recommends
         Do not install recommended packages, only required ones.
@@ -1634,6 +1638,8 @@ def install(
         cmd_install.append("--download-only")
     if fromrepo:
         cmd_install.extend(fromrepoopt)
+    if recommends:
+        cmd_install.append("--recommends")
     if no_recommends:
         cmd_install.append("--no-recommends")
 
@@ -1706,6 +1712,7 @@ def upgrade(
     fromrepo=None,
     novendorchange=False,
     skip_verify=False,
+    recommends=False,
     no_recommends=False,
     root=None,
     **kwargs
@@ -1747,6 +1754,9 @@ def upgrade(
 
     skip_verify
         Skip the GPG verification check (e.g., ``--no-gpg-checks``)
+
+    recommends
+        Install also recommended packages in addition to the required ones.
 
     no_recommends
         Do not install recommended packages, only required ones.
@@ -1800,6 +1810,10 @@ def upgrade(
                 log.warning(
                     "Disabling vendor changes is not supported on this Zypper version"
                 )
+
+        if recommends:
+            cmd_update.append("--recommends")
+            log.info("Enabling recommendations")
 
         if no_recommends:
             cmd_update.append("--no-recommends")


### PR DESCRIPTION
### What does this PR do?

There is a setting in salt to disable the recommends. This change implements the setting to enable recommends during zypper install and update on Suse.

### What issues does this PR fix or reference?
Fixes: This is needed if a user has disabled recommends. The default behavior is determined by  [zypp.conf:solver.onlyRequires]

### Previous Behavior
Not possible to use recommends in zypper install and update using the zypperpkg.py module

### New Behavior
possibility to add recommends as a parameter for Suse 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.


tested as follows with a salt recipe:
```
install documentation pattern:
  pkg.installed:
    - pkgs:
      - pattern:documentation
    - includes: [pattern]
    - recommends: true
```
This way it installs the documentation pattern with all recommends
