### PR TITLE
[DOCS] Fix contrib links: Point to master branch for development docs links 

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -12,7 +12,7 @@ newIssueWelcomeComment: >
   resources including:
 
     - [Community Wiki](https://github.com/saltstack/community/wiki)
-    - [Salt’s Contributor Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html)
+    - [Salt’s Contributor Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html)
     - [Join our Community Slack](https://saltstackcommunity.herokuapp.com/)
     - [IRC on Freenode](https://webchat.freenode.net/#salt)
     - [SaltStack YouTube channel](https://www.youtube.com/user/SaltStack)
@@ -38,7 +38,7 @@ newPRWelcomeComment: >
   resources including:
 
     - [Community Wiki](https://github.com/saltstack/community/wiki)
-    - [Salt’s Contributor Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html)
+    - [Salt’s Contributor Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html)
     - [Join our Community Slack](https://saltstackcommunity.herokuapp.com/)
     - [IRC on Freenode](https://webchat.freenode.net/#salt)
     - [SaltStack YouTube channel](https://www.youtube.com/user/SaltStack)

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ Salt is tested and packaged to run on CentOS, Debian, RHEL, Ubuntu, MacOS,
 Windows, and more. Download Salt and get started now.
 
 * `<https://repo.saltproject.io/>`_
-* `Installation Instructions <https://docs.saltproject.io/en/latest/topics/installation/index.html>`_
+* `Installation Instructions <https://docs.saltproject.io/en/master/topics/installation/index.html>`_
 
 Salt Project Documentation
 ==========================
@@ -72,7 +72,7 @@ documentation, and contributing to Salt.
 
 * `Getting Started with Salt <https://docs.saltproject.io/en/getstarted/>`_
 * `Latest Salt Documentation`_
-* `Salt’s Contributor Guide <https://docs.saltproject.io/en/latest/topics/development/contributing.html>`_
+* `Salt’s Contributor Guide <https://docs.saltproject.io/en/master/topics/development/contributing.html>`_
 
 Security Advisories
 ===================

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -124,6 +124,6 @@ mailing list. This list is low-traffic.
 Reference the following documentation to ensure Salt best practices are being
 implemented in your infrastructure:
 
-- [Docs: Hardening Salt](https://docs.saltproject.io/en/latest/topics/hardening.html)
-- [Docs: Salt Best Practices](https://docs.saltproject.io/en/latest/topics/best_practices.html)
+- [Docs: Hardening Salt](https://docs.saltproject.io/en/master/topics/hardening.html)
+- [Docs: Salt Best Practices](https://docs.saltproject.io/en/master/topics/best_practices.html)
 - [Blog: How I Hardened My Salt Environment](https://saltproject.io/blog/how-i-hardened-my-salt-environment/)


### PR DESCRIPTION
### What does this PR do?

Because contributor/development, best practices, and hardening guides develop at a more rapid pace than version-specific salt documentation, users want to be looking at the `master` version of those docs. This is updating a few links to ensure people are being directed to the right place from the start.

### What issues does this PR fix or reference?

Ref: https://github.com/saltstack/salt/issues/59486#issuecomment-783745613

### Previous Behavior

Some links were pointing to the `/latest/*` development docs, which are out-dated.

### New Behavior

Links are now pointing to the `/master/*` development docs, which are the most up-to-date.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes
