### PR TITLE
Add auto_reconnect param for set_event_handler

### DIFF
--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -865,7 +865,7 @@ class SaltEvent:
                     # Minion fired a bad retcode, fire an event
                     self._fire_ret_load_specific_fun(load)
 
-    def set_event_handler(self, event_handler):
+    def set_event_handler(self, event_handler, auto_reconnect=False):
         """
         Invoke the event_handler callback each time an event arrives.
         """
@@ -874,7 +874,7 @@ class SaltEvent:
         if not self.cpub:
             self.connect_pub()
         # This will handle reconnects
-        return self.subscriber.read_async(event_handler)
+        return self.subscriber.read_async(event_handler, auto_reconnect=auto_reconnect)
 
     # pylint: disable=W1701
     def __del__(self):


### PR DESCRIPTION
### What does this PR do?

Add `auto_reconnect param` for set_event_handler.

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
`set_event_handler` method have commented "This will handle reconnects", but it will raise `StreamClosed` Exception without reconnect after stream connected.

### New Behavior
`set_event_handler` can set `auto_reconnected` to `True`. It would auto reconnect when `StreamClosed` raised after stream connected.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
