### PR TITLE
Add SSL support for InfluxDB

### DIFF
--- a/salt/modules/influxdbmod.py
+++ b/salt/modules/influxdbmod.py
@@ -14,6 +14,8 @@ version 0.9+)
         influxdb.port: 8086
         influxdb.user: 'root'
         influxdb.password: 'root'
+        influxdb.ssl: False
+        influxdb.verify_ssl: False
 
     This data can also be passed into pillar. Options passed into opts will
     overwrite options passed into pillar.
@@ -66,6 +68,8 @@ def _client(
     influxdb_password=None,
     influxdb_host=None,
     influxdb_port=None,
+    influxdb_ssl=None,
+    influxdb_verify_ssl=None,
     **client_args
 ):
     if not influxdb_user:
@@ -76,6 +80,10 @@ def _client(
         influxdb_host = __salt__["config.option"]("influxdb.host", "localhost")
     if not influxdb_port:
         influxdb_port = __salt__["config.option"]("influxdb.port", 8086)
+    if not influxdb_ssl:
+        influxdb_ssl = __salt__["config.option"]("influxdb.ssl", False)
+    if not influxdb_verify_ssl:
+        influxdb_ssl = __salt__["config.option"]("influxdb.verify_ssl", False)
     for ignore in _STATE_INTERNAL_KEYWORDS:
         if ignore in client_args:
             del client_args[ignore]
@@ -84,6 +92,8 @@ def _client(
         port=influxdb_port,
         username=influxdb_user,
         password=influxdb_password,
+        ssl=influxdb_ssl,
+        verify_ssl=influxdb_verify_ssl,
         **client_args
     )
 


### PR DESCRIPTION
### What does this PR do?
Adds support for SSL/HTTPS connections to InfluxDB

Documentation can be found here: https://influxdb-python.readthedocs.io/en/latest/api-documentation.html#influxdbclient

### What issues does this PR fix or reference?
N/A

### Previous Behavior
Without this one gets `influxdb.exceptions.InfluxDBClientError: 400: Client sent an HTTP request to an HTTPS server.`

The option did exist to specify in commandline Ex: `salt-call influxdb.list_dbs ssl=True` but this is not ideal and does not address returners.

### New Behavior
System connects to SSL-secured InfluxDB correctly
```
[DEBUG   ] Starting new HTTPS connection (1): 127.0.0.1:8086                                                                                                                                                                                                                                                                                                                                  
[DEBUG   ] https://127.0.0.1:8086 "GET /query?q=SHOW+DATABASES HTTP/1.1" 200 None
```
One issue though is if a user specifies `ssl=True` or `verify_ssl=True` on the command line and the config file also has the option they will get the error: `TypeError: type object got multiple values for keyword argument 'ssl'` NOTE: This also happens for all of the other options such as host.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
