### PR TITLE
Add option to disable clients in netapi

### DIFF
--- a/changelog/58872.added
+++ b/changelog/58872.added
@@ -1,0 +1,1 @@
+netapi_disable_clients option to allow disabling of clients in salt-api

--- a/conf/master
+++ b/conf/master
@@ -1340,3 +1340,6 @@
 ############################################
 # Allow the raw_shell parameter to be used when calling Salt SSH client via API
 #netapi_allow_raw_shell: True
+
+# Set a list of clients to disable in in the API
+#netapi_disable_clients: []

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -5099,6 +5099,39 @@ Used by ``salt-api`` for the master requests timeout.
 
     rest_timeout: 300
 
+.. conf_master:: netapi_disable_clients
+
+``netapi_disable_clients``
+--------------------------
+
+Default: ``[]``
+
+Used by ``salt-api`` to disable access to the listed clients. Adding a
+client to this list will cause requests to be rejected before
+authentication is attempted or processing of the low state occurs.
+
+This can be used where certain functionality is not required via
+``salt-api`` and should be disabled entirely.
+
+Configuration with all possible clients disabled:
+
+.. code-block:: yaml
+
+    netapi_disable_clients:
+      - local
+      - local_async
+      - local_batch
+      - local_subset
+      - runner
+      - runner_async
+      - ssh
+      - wheel
+      - wheel_async
+
+.. note::
+
+    Disabling all clients is not recommened as it will stop
+    the ``salt-api`` functioning.
 
 .. _syndic-server-settings:
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -954,6 +954,8 @@ VALID_OPTS = immutabletypes.freeze(
         # Allow raw_shell option when using the ssh
         # client via the Salt API
         "netapi_allow_raw_shell": bool,
+        # Disable clients in the Salt API
+        "netapi_disable_clients": list,
         "disabled_requisites": (str, list),
         # Feature flag config
         "features": dict,
@@ -1616,6 +1618,7 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze(
         "pass_strict_fetch": False,
         "pass_gnupghome": "",
         "pass_dir": "",
+        "netapi_disable_clients": [],
     }
 )
 

--- a/salt/netapi/__init__.py
+++ b/salt/netapi/__init__.py
@@ -157,6 +157,11 @@ class NetapiClient:
                 "Invalid client specified: '{}'".format(low.get("client"))
             )
 
+        if low.get("client") in self.opts.get("netapi_disable_clients"):
+            raise salt.exceptions.SaltInvocationError(
+                "Client disabled: '{}'".format(low.get("client"))
+            )
+
         if not ("token" in low or "eauth" in low):
             raise salt.exceptions.EauthAuthenticationError(
                 "No authentication credentials given"

--- a/tests/pytests/integration/netapi/test_client.py
+++ b/tests/pytests/integration/netapi/test_client.py
@@ -1,7 +1,8 @@
 import pytest
 
 import salt.netapi
-from salt.exceptions import EauthAuthenticationError
+from salt.exceptions import EauthAuthenticationError, SaltInvocationError
+from tests.support.mock import patch
 
 
 @pytest.fixture
@@ -30,6 +31,17 @@ def test_local_batch(client, auth_creds, salt_minion, salt_sub_minion):
     assert {salt_sub_minion.id: True} in ret
 
 
+def test_local_batch_disabled(client, auth_creds):
+    low = {"client": "local_batch", "tgt": "*", "fun": "test.ping", **auth_creds}
+
+    ret = None
+    with patch.dict(client.opts, {"netapi_disable_clients": ["local_batch"]}):
+        with pytest.raises(SaltInvocationError):
+            ret = client.run(low)
+
+    assert ret is None
+
+
 def test_local_async(client, auth_creds, salt_minion, salt_sub_minion):
     low = {"client": "local_async", "tgt": "*", "fun": "test.ping", **auth_creds}
 
@@ -43,6 +55,34 @@ def test_local_unauthenticated(client):
     low = {"client": "local", "tgt": "*", "fun": "test.ping"}
     with pytest.raises(EauthAuthenticationError):
         client.run(low)
+
+
+def test_local_disabled(client, auth_creds):
+    low = {"client": "local", "tgt": "*", "fun": "test.ping", **auth_creds}
+
+    ret = None
+    with patch.dict(client.opts, {"netapi_disable_clients": ["local"]}):
+        with pytest.raises(SaltInvocationError):
+            ret = client.run(low)
+
+    assert ret is None
+
+
+def test_local_subset_disabled(client, auth_creds):
+    low = {
+        "client": "local_subset",
+        "tgt": "*",
+        "fun": "test.ping",
+        "subset": 1,
+        **auth_creds,
+    }
+
+    ret = None
+    with patch.dict(client.opts, {"netapi_disable_clients": ["local_subset"]}):
+        with pytest.raises(SaltInvocationError):
+            ret = client.run(low)
+
+    assert ret is None
 
 
 @pytest.mark.slow_test
@@ -76,7 +116,40 @@ def test_wheel_unauthenticated(client):
         client.run(low)
 
 
+def test_wheel_disabled(client, auth_creds):
+    low = {"client": "wheel", "tgt": "*", "fun": "test.ping", **auth_creds}
+
+    ret = None
+    with patch.dict(client.opts, {"netapi_disable_clients": ["wheel"]}):
+        with pytest.raises(SaltInvocationError):
+            ret = client.run(low)
+
+    assert ret is None
+
+
+def test_wheel_async_disabled(client, auth_creds):
+    low = {"client": "wheel_async", "tgt": "*", "fun": "test.ping", **auth_creds}
+
+    ret = None
+    with patch.dict(client.opts, {"netapi_disable_clients": ["wheel_async"]}):
+        with pytest.raises(SaltInvocationError):
+            ret = client.run(low)
+
+    assert ret is None
+
+
 def test_runner_unauthenticated(client):
     low = {"client": "runner", "tgt": "*", "fun": "test.ping"}
     with pytest.raises(EauthAuthenticationError):
         client.run(low)
+
+
+def test_runner_disabled(client, auth_creds):
+    low = {"client": "runner", "tgt": "*", "fun": "test.ping", **auth_creds}
+
+    ret = None
+    with patch.dict(client.opts, {"netapi_disable_clients": ["runner"]}):
+        with pytest.raises(SaltInvocationError):
+            ret = client.run(low)
+
+    assert ret is None

--- a/tests/pytests/integration/netapi/test_ssh_client.py
+++ b/tests/pytests/integration/netapi/test_ssh_client.py
@@ -1,7 +1,7 @@
 import pytest
 
 import salt.netapi
-from salt.exceptions import EauthAuthenticationError
+from salt.exceptions import EauthAuthenticationError, SaltInvocationError
 from tests.support.helpers import SaveRequestsPostHandler, Webserver
 from tests.support.mock import patch
 
@@ -115,6 +115,17 @@ def test_ssh_authenticated_raw_shell_disabled(client, tmp_path):
             client.run(low)
 
     assert badfile.exists() is False
+
+
+def test_ssh_disabled(client, auth_creds):
+    low = {"client": "ssh", "tgt": "localhost", "fun": "test.ping", **auth_creds}
+
+    ret = None
+    with patch.dict(client.opts, {"netapi_disable_clients": ["ssh"]}):
+        with pytest.raises(SaltInvocationError):
+            ret = client.run(low)
+
+    assert ret is None
 
 
 def test_shell_inject_ssh_priv(


### PR DESCRIPTION
### What does this PR do?

Adds a new config option "netapi_disable_clients" that takes a list of clients to disable in the netapi.

Checks the list early in handling the the request before authentication occurs. Should be useful where certain clients (eg ssh or wheel) aren't required and should be disabled to reduce attack surface in the salt-api.

replaces https://github.com/saltstack/salt/pull/58872

### What issues does this PR fix or reference?


### New Behavior

Adds "netapi_disable_clients" list option to the config which is checked when a request is passed to NetApiClient.run() and an exception raised if the requested client is in the list.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [X]  Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
No

