### PR TITLE
Fix to allow netmiko to run outside of proxy minions

### DIFF
--- a/changelog/59635.fixed
+++ b/changelog/59635.fixed
@@ -1,0 +1,1 @@
+Fixing the virtual function for the netimiko module to allow it to run outside of a proxy minion. Adding additional tests.

--- a/salt/modules/netmiko_mod.py
+++ b/salt/modules/netmiko_mod.py
@@ -226,13 +226,13 @@ def __virtual__():
             False,
             "The netmiko execution module requires netmiko library to be installed.",
         )
-    if salt.utils.platform.is_proxy() and __opts__["proxy"]["proxytype"] == "netmiko":
-        return __virtualname__
-    else:
+    if salt.utils.platform.is_proxy() and __opts__["proxy"]["proxytype"] != "netmiko":
         return (
             False,
-            "Not a proxy or a proxy of type netmiko.",
+            "Not a proxy minion of type netmiko.",
         )
+
+    return __virtualname__
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
### What does this PR do?
Fixing the virtual function for the netimiko module to allow it to run outside of a proxy minion.  Adding additional tests.

### What issues does this PR fix or reference?
Fixes: #59635

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
