### PR TITLE
Mark test_state_retry as flaky

### DIFF
--- a/tests/pytests/functional/modules/state/test_state.py
+++ b/tests/pytests/functional/modules/state/test_state.py
@@ -670,6 +670,7 @@ def test_retry_option(state, state_tree):
             assert entry >= 3
 
 
+@pytest.mark.flaky(max_runs=4)
 def test_retry_option_success(state, state_tree, tmp_path):
     """
     test a state with the retry option that should return True immedietly (i.e. no retries)

--- a/tests/pytests/functional/modules/state/test_state.py
+++ b/tests/pytests/functional/modules/state/test_state.py
@@ -670,7 +670,7 @@ def test_retry_option(state, state_tree):
             assert entry >= 3
 
 
-@pytest.mark.flaky(max_runs=4)
+@pytest.mark.flaky(max_runs=4, rerun_filter=lambda *a: salt.utils.platform.is_windows())
 def test_retry_option_success(state, state_tree, tmp_path):
     """
     test a state with the retry option that should return True immedietly (i.e. no retries)


### PR DESCRIPTION
### What does this PR do?
Marks the `test.pytest.functional.modules.state.test_retry_option_success` test as flaky. It seems to be failing... in a flaky manner... on Windows. About 1 in 10 runs with the following error:
```
            for entry in ret.get_within_state_return("duration"):
>               assert entry < 4
E               assert 15.634 < 4
```
So, sometimes Windows takes a little longer to respond and the test fails.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes