### PR TITLE
device_type is not valid for lxd and it generate change all time

### DIFF
--- a/salt/modules/lxd.py
+++ b/salt/modules/lxd.py
@@ -1364,14 +1364,7 @@ def container_device_get(
 
 
 def container_device_add(
-    name,
-    device_name,
-    device_type="disk",
-    remote_addr=None,
-    cert=None,
-    key=None,
-    verify_cert=True,
-    **kwargs
+    name, device_name, remote_addr=None, cert=None, key=None, verify_cert=True, **kwargs
 ):
     """
     Add a container device
@@ -1381,9 +1374,6 @@ def container_device_add(
 
     device_name :
         The device name to add
-
-    device_type :
-        Type of the device
 
     ** kwargs :
         Additional device args
@@ -1415,7 +1405,14 @@ def container_device_add(
     """
     container = container_get(name, remote_addr, cert, key, verify_cert, _raw=True)
 
-    kwargs["type"] = device_type
+    if "type" not in kwargs:
+        kwargs["type"] = "disk"
+
+    # retro compatibility
+    if "device_type" in kwargs:
+        kwargs["type"] = kwargs["device_type"]
+        del kwargs["device_type"]
+
     return _set_property_dict_item(container, "devices", device_name, kwargs)
 
 

--- a/tests/integration/states/test_lxd_container.py
+++ b/tests/integration/states/test_lxd_container.py
@@ -52,6 +52,11 @@ class LxdContainerTestCase(ModuleCase, SaltReturnAssertsMixin):
             name="test-container",
             running=True,
             source={"type": "image", "alias": "images:centos/7"},
+            devices={
+                "data1": {"type": "disk", "source": "/tmp", "path": "/mnt/data"},
+                "data2": {"type": "disk", "source": "/tmp", "path": "/mnt/data2"},
+                "data3": {"type": "disk", "source": "/tmp", "path": "/mnt/data3"},
+            },
         )
         ret = self.run_state(
             "lxd_container.present",
@@ -63,6 +68,12 @@ class LxdContainerTestCase(ModuleCase, SaltReturnAssertsMixin):
                 {"key": "boot.autostart", "value": 1},
                 {"key": "security.privileged", "value": "1"},
             ],
+            devices={
+                "eth1": {"nictype": "bridged", "parent": "lxdbr0", "type": "nic"},
+                "data1": {"type": "disk", "source": "/tmp", "path": "/mnt/data1"},
+                "data2": {"type": "disk", "source": "/tmp", "path": "/mnt/data2"},
+                "data4": {"type": "disk", "source": "/tmp", "path": "/mnt/data4"},
+            },
         )
         name = "lxd_container_|-test-container_|-test-container_|-present"
         self.assertSaltTrueReturn(ret)
@@ -70,6 +81,12 @@ class LxdContainerTestCase(ModuleCase, SaltReturnAssertsMixin):
         assert ret[name]["changes"]["config"] == {
             "boot.autostart": 'Added config key "boot.autostart" = "1"',
             "security.privileged": 'Added config key "security.privileged" = "1"',
+        }
+        assert ret[name]["changes"]["devices"] == {
+            "eth1": 'Added device "eth1"',
+            "data1": 'Changed device "data1"',
+            "data3": 'Removed device "data3"',
+            "data4": 'Added device "data4"',
         }
 
     def test_08__running_container(self):


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes:
```
Comment: Invalid devices: Device validation failed for "eth0": Missing device type for device "eth0"
```
or changed all time because `device_type` doesn't exist and with LXD API return there is always diff.
```
              devices:
                  ----------
                  eth0:
                      Changed device "eth0"
```

### Previous Behavior
```
Comment: Invalid devices: Device validation failed for "eth0": Missing device type for device "eth0"
```
or
```
              devices:
                  ----------
                  eth0:
                      Changed device "eth0"
```

### New Behavior

Not errors or changes if not needs

### Merge requirements satisfied?
- [X] Tests updated

### Commits signed with GPG?
Yes
