### PR TITLE
ssh: Handle `roster` in `kwargs` for SSHClient

### DIFF
--- a/salt/client/ssh/client.py
+++ b/salt/client/ssh/client.py
@@ -53,6 +53,7 @@ class SSHClient:
             ("ssh_remote_port_forwards", str),
             ("ssh_options", list),
             ("roster_file", str),
+            ("roster", str),
             ("rosters", list),
             ("ignore_host_keys", bool),
             ("raw_shell", bool),

--- a/tests/unit/client/test_ssh.py
+++ b/tests/unit/client/test_ssh.py
@@ -690,3 +690,20 @@ class SSHTests(ShellCase):
         with patch("salt.roster.get_roster_file", MagicMock(return_value=roster)):
             ssh_obj = client._prep_ssh(**opts)
             assert ssh_obj.opts.get("extra_filerefs", None) == "salt://foobar"
+
+    def test_roster_kwargs(self):
+        """
+        test "roster" are not excluded from kwargs
+        when preparing the SSH opts
+        """
+        kwargs = {
+            "tgt": "localhost",
+            "fun": "test.ping",
+            "roster": "my-custom-roster",
+        }
+        roster = os.path.join(RUNTIME_VARS.TMP_CONF_DIR, "roster")
+        client = salt.client.ssh.client.SSHClient(mopts=self.opts)
+
+        with patch("salt.roster.get_roster_file", MagicMock(return_value=roster)):
+            ssh_obj = client._prep_ssh(**kwargs)
+            assert ssh_obj.opts.get("roster") == "my-custom-roster"


### PR DESCRIPTION
### What does this PR do?

Add ability to give `roster` as part of `kwargs` for SSHClient.
NOTE: It was possible in older versions but fix about CVE-2021-3197

Sees: 5273722c2180c394bc426f731450b95809ca952e

### What issues does this PR fix or reference?
Fixes: #59657 

### Commits signed with GPG?
No
