### PR TITLE
Mysql fixes - sqlparse is not mandatory; conditions for "ALL" grant check for mysql 8.0

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -861,7 +861,9 @@ def file_query(database, file_name, **connection_args):
 
     """
     if not HAS_SQLPARSE:
-        log.info("mysql.file_query unavailable, no python sqlparse library installed. Using module:re")
+        log.info(
+            "No module:sqlparse found. Using module:re for mysql.file_query"
+        )
 
     if any(
         file_name.startswith(proto)
@@ -2393,9 +2395,9 @@ def grant_exists(
         if (
             salt.utils.versions.version_cmp(server_version, "8.0") >= 0
             and "MariaDB" not in server_version
-            and database == '*.*'
+            and database == "*.*"
         ):
-            log.info("token database: %s", database)
+            # log.info("database to check: %s", database)
             # https://dev.mysql.com/doc/refman/8.0/en/show-grants.html
             # it makes sense ONLY with GLOBAL checks - "GRANT ALL PRIVILEGES TO user@host ON *.*"
             grant = ",".join([i for i in __all_privileges__])

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -2393,7 +2393,11 @@ def grant_exists(
         if (
             salt.utils.versions.version_cmp(server_version, "8.0") >= 0
             and "MariaDB" not in server_version
+            and database == '*.*'
         ):
+            log.info("token database: %s", database)
+            # https://dev.mysql.com/doc/refman/8.0/en/show-grants.html
+            # it makes sense ONLY with GLOBAL checks - "GRANT ALL PRIVILEGES TO user@host ON *.*"
             grant = ",".join([i for i in __all_privileges__])
         else:
             grant = "ALL PRIVILEGES"

--- a/tests/unit/modules/test_mysql.py
+++ b/tests/unit/modules/test_mysql.py
@@ -621,7 +621,6 @@ class MySQLTestCase(TestCase, LoaderModuleMockMixin):
                 )
                 self.assertEqual(ret, True)
 
-
     @skipIf(True, "TODO: Mock up user_grants()")
     def test_grant_add(self):
         """

--- a/tests/unit/modules/test_mysql.py
+++ b/tests/unit/modules/test_mysql.py
@@ -584,7 +584,9 @@ class MySQLTestCase(TestCase, LoaderModuleMockMixin):
             with patch.object(
                 mysql, "user_grants", return_value=mock_grants
             ) as mock_user_grants:
-                ret = mysql.grant_exists("ALL", "testdb.testtableone", "testuser", "%")
+                ret = mysql.grant_exists(
+                    "ALL", "testdb.testtableone", "testuser", "%"
+                )
                 self.assertEqual(ret, True)
 
         with patch.object(mysql, "version", return_value="8.0.10"):
@@ -594,6 +596,17 @@ class MySQLTestCase(TestCase, LoaderModuleMockMixin):
             ) as mock_user_grants:
                 ret = mysql.grant_exists(
                     "all privileges", "testdb.testtableone", "testuser", "%"
+                )
+                self.assertEqual(ret, True)
+
+        mock_grants = ["GRANT ALL PRIVILEGES ON *.* TO `root`@`localhost`"]
+        with patch.object(mysql, "version", return_value="8.0.10"):
+            mock = MagicMock(return_value=mock_grants)
+            with patch.object(
+                mysql, "user_grants", return_value=mock_grants
+            ) as mock_user_grants:
+                ret = mysql.grant_exists(
+                    "all privileges", "*.*", "root", "localhost"
                 )
                 self.assertEqual(ret, True)
 
@@ -607,6 +620,7 @@ class MySQLTestCase(TestCase, LoaderModuleMockMixin):
                     "ALL PRIVILEGES", "testdb.testtableone", "testuser", "%"
                 )
                 self.assertEqual(ret, True)
+
 
     @skipIf(True, "TODO: Mock up user_grants()")
     def test_grant_add(self):


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes: salt/module/mysql.py

### Previous Behavior
1) lib sqlparse was mandatory (module:re was replaced by module:sqlparse)
2) ALL PRIVILEGES were transformed to a list of all available privileges even NOT for GLOBAL context (`database = '*.*'`)

### New Behavior
1) lib sqlparse is not mandatory (use module:sqlparse if available, otherwise use previous realization with module:re)
2) ALL PRIVILEGES transforms to a list ONLY for GLOBAL context (`database = '*.*'`) check

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
