### PR TITLE
Do not monkey patch yaml loaders: Prevent breaking Ansible filter modules

### DIFF
--- a/changelog/57995.fixed
+++ b/changelog/57995.fixed
@@ -1,0 +1,1 @@
+Do not monkey patch yaml loaders: Prevent breaking Ansible filter modules

--- a/salt/utils/yamlloader.py
+++ b/salt/utils/yamlloader.py
@@ -11,7 +11,7 @@ from yaml.constructor import ConstructorError
 from yaml.nodes import MappingNode, SequenceNode
 
 # prefer C bindings over python when available
-BaseLoader = getattr(yaml, 'CSafeLoader', yaml.SafeLoader)
+BaseLoader = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
 
 
 __all__ = ["SaltYamlSafeLoader", "load", "safe_load"]

--- a/salt/utils/yamlloader.py
+++ b/salt/utils/yamlloader.py
@@ -10,13 +10,8 @@ import yaml  # pylint: disable=blacklisted-import
 from yaml.constructor import ConstructorError
 from yaml.nodes import MappingNode, SequenceNode
 
-try:
-    yaml.Loader = yaml.CLoader
-    yaml.Dumper = yaml.CDumper
-    yaml.SafeLoader = yaml.CSafeLoader
-    yaml.SafeDumper = yaml.CSafeDumper
-except Exception:  # pylint: disable=broad-except
-    pass
+# prefer C bindings over python when available
+BaseLoader = getattr(yaml, 'CSafeLoader', yaml.SafeLoader)
 
 
 __all__ = ["SaltYamlSafeLoader", "load", "safe_load"]
@@ -32,7 +27,7 @@ warnings.simplefilter("always", category=DuplicateKeyWarning)
 
 
 # with code integrated from https://gist.github.com/844388
-class SaltYamlSafeLoader(yaml.SafeLoader):
+class SaltYamlSafeLoader(BaseLoader):
     """
     Create a custom YAML loader that uses the custom constructor. This allows
     for the YAML loading defaults to be manipulated based on needs within salt

--- a/tests/unit/utils/test_yamlloader.py
+++ b/tests/unit/utils/test_yamlloader.py
@@ -5,7 +5,7 @@
 import textwrap
 
 import salt.utils.files
-from salt.utils.yamlloader import SaltYamlSafeLoader
+from salt.utils.yamlloader import SaltYamlSafeLoader, yaml
 from tests.support.mock import mock_open, patch
 from tests.support.unit import TestCase
 from yaml.constructor import ConstructorError
@@ -133,3 +133,7 @@ class YamlLoaderTestCase(TestCase):
             ),
             {"foo": {"b": {"foo": "bar", "one": 1, "list": [1, "two", 3]}}},
         )
+
+    def test_not_yaml_monkey_patching(self):
+        if hasattr(yaml, "CSafeLoader"):
+            assert yaml.SafeLoader != yaml.CSafeLoader


### PR DESCRIPTION
### What does this PR do?
This PR prevents Salt from monkey patching the Python yaml loaders. We should avoid monkey patching here as it causes issues in some scenarios.

For example, it's currently breaking the Ansible yaml filters in version 2.9:

You can easily test this in a `centos:8` docker container running this:

```
dnf install -y centos-release-ansible-29
dnf install -y ansible
dnf install -y python3-pip
cat <<EOF>/tmp/fun.yml
---
- hosts: localhost
  gather_facts: false
  pre_tasks:
  - set_fact:
      ldap_result: "gidNumber: 602\ncn: Bruce Wayne\ngivenName: Bruce\nmail: bruce.wayne@mymail.com\nsn: Wayne\nuidNumber: 696"

  - name: New fact with LDAP user details
    set_fact:
      ldap_user: "{{ ldap_result|from_yaml }}"

  - name: CN of LDAP user
    debug:
        msg: "{{ ldap_user.cn }}"
EOF
ansible-playbook /tmp/fun.yml
pip3 install salt
ansible-playbook /tmp/fun.yml
```

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/57995

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
