### PR TITLE
Decrease the log level of metaproxy check from error to info

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -3717,7 +3717,7 @@ def _metaproxy_call(opts, fn_name):
         metaproxy_name = opts["metaproxy"]
     except KeyError:
         metaproxy_name = "proxy"
-        log.error(
+        log.info(
             "No metaproxy key found in opts for id %s. Defaulting to standard proxy minion",
             opts["id"],
         )


### PR DESCRIPTION
### What does this PR do?

This log currently pollutes the logs for no good reason: this error is
being thrown at every command execution, even though all I want is to be
running under a regular Proxy Minion, so I shouldn't see this, unless
using a specific metaproxy module is mandatory (which it isn't).

### Previous Behavior

Throwing some pointless error logs.

### New Behavior

No longer throwing pointless error logs.

### Merge requirements satisfied?

**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs **N/A**
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated **N/A**

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
