### PR TITLE
Disable metaproxy LazyLoad when no specific metaproxy requested

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -3711,6 +3711,10 @@ class ProxyMinionManager(MinionManager):
 
 
 def _metaproxy_call(opts, fn_name):
+    if "metaproxy" not in opts:
+        # Disable metaproxy LazyLoad when no specific metaproxy requested
+        import salt.metaproxy.proxy  # late import to avoid circular dependency
+        return getattr(salt.metaproxy.proxy, fn_name)
     loaded_base_name = "{}.{}".format(opts["id"], salt.loader.LOADED_BASE_NAME)
     metaproxy = salt.loader.metaproxy(opts, loaded_base_name=loaded_base_name)
     try:


### PR DESCRIPTION
### What does this PR do?

This commit adds the possibility to have the ``metaproxy`` option being
set as _disabled_ in case the user doesn't need the metaproxy feature,
but just the good old proxy.

Currently, with every job execution, this sequence is being invoked
several times, which in turn calls the lazy loader - which is known to
be awfully slow - as many times:

```
[DEBUG   ] minion return: {'success': True, 'return': True, 'retcode': 0, 'jid': '20210311124146414555', 'fun': 'test.ping', 'fun_args': []}
[DEBUG   ] Sending global request "keepalive@lag.net"
[INFO    ] No metaproxy key found in opts for id some-proxy. Defaulting to standard proxy minion
[DEBUG   ] LazyLoaded proxy.handle_payload
[INFO    ] No metaproxy key found in opts for id some-proxy. Defaulting to standard proxy minion
[DEBUG   ] LazyLoaded proxy.target_load
[INFO    ] No metaproxy key found in opts for id some-proxy. Defaulting to standard proxy minion
[DEBUG   ] LazyLoaded proxy.handle_decoded_payload
[INFO    ] User sudo_mulinic Executing command grains.get with jid 20210311124146605420
[DEBUG   ] Command details {'tgt_type': 'list', 'jid': '20210311124146605420', 'tgt': ['some-proxy'], 'ret': '', 'user': 'sudo_mircea', 'arg': ['pod'], 'fun': 'grains.get'}
[DEBUG   ] Subprocess 20210311124146605420-Job-20210311124146605420 added
[INFO    ] No metaproxy key found in opts for id some-proxy. Defaulting to standard proxy minion
[DEBUG   ] LazyLoaded proxy.target
[INFO    ] No metaproxy key found in opts for id some-proxy. Defaulting to standard proxy minion
```

This _really_, _really_ makes no sense when all you want is to use the
plain proxy (and, by the looks of it it's the only option currently) so
probably most of the users would prefer disabling something that slows
things down for no particular benefit. Obviously, if someone wants the
metaproxy functionality, they just don't have to set this option as
"disabled", that's all.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs - Not yet, will do after we discuss.
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated - Not sure what tests we can put in place for this, waiting for pointers.

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
