### PR TITLE
To fix the issue when it use assume role to create EC2 instance

### DIFF
--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -87,13 +87,16 @@ def creds(provider):
     ## if needed
     if provider["id"] == IROLE_CODE or provider["key"] == IROLE_CODE:
         # Check to see if we have cache credentials that are still good
-        if not __Expiration__ or __Expiration__ < datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"):
+        if not __Expiration__ or __Expiration__ < datetime.utcnow().strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        ):            
             # We don't have any cached credentials, or they are expired, get them
             # Connections to instance meta-data must fail fast and never be proxied
             try:
                 result = requests.get(
                     "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
-                    proxies={"http": ""}, timeout=AWS_METADATA_TIMEOUT,
+                    proxies={"http": ""},
+                    timeout=AWS_METADATA_TIMEOUT,
                 )
                 result.raise_for_status()
                 role = result.text
@@ -102,8 +105,11 @@ def creds(provider):
 
             try:
                 result = requests.get(
-                    "http://169.254.169.254/latest/meta-data/iam/security-credentials/{0}".format(role),
-                    proxies={"http": ""}, timeout=AWS_METADATA_TIMEOUT,
+                    "http://169.254.169.254/latest/meta-data/iam/security-credentials/{}".format(
+                        role
+                    ),
+                    proxies={"http": ""},
+                    timeout=AWS_METADATA_TIMEOUT,
                 )
                 result.raise_for_status()
             except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError):

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -87,43 +87,33 @@ def creds(provider):
     ## if needed
     if provider["id"] == IROLE_CODE or provider["key"] == IROLE_CODE:
         # Check to see if we have cache credentials that are still good
-        if __Expiration__ != "":
-            timenow = datetime.utcnow()
-            timestamp = timenow.strftime("%Y-%m-%dT%H:%M:%SZ")
-            if timestamp < __Expiration__:
-                # Current timestamp less than expiration fo cached credentials
-                return __AccessKeyId__, __SecretAccessKey__, __Token__
-        # We don't have any cached credentials, or they are expired, get them
+        if not __Expiration__ or __Expiration__ < datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"):
+            # We don't have any cached credentials, or they are expired, get them
+            # Connections to instance meta-data must fail fast and never be proxied
+            try:
+                result = requests.get(
+                    "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+                    proxies={"http": ""}, timeout=AWS_METADATA_TIMEOUT,
+                )
+                result.raise_for_status()
+                role = result.text
+            except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError):
+                return provider["id"], provider["key"], ""
 
-        # Connections to instance meta-data must fail fast and never be proxied
-        try:
-            result = requests.get(
-                "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
-                proxies={"http": ""},
-                timeout=AWS_METADATA_TIMEOUT,
-            )
-            result.raise_for_status()
-            role = result.text
-        except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError):
-            return provider["id"], provider["key"], ""
+            try:
+                result = requests.get(
+                    "http://169.254.169.254/latest/meta-data/iam/security-credentials/{0}".format(role),
+                    proxies={"http": ""}, timeout=AWS_METADATA_TIMEOUT,
+                )
+                result.raise_for_status()
+            except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError):
+                return provider["id"], provider["key"], ""
 
-        try:
-            result = requests.get(
-                "http://169.254.169.254/latest/meta-data/iam/security-credentials/{}".format(
-                    role
-                ),
-                proxies={"http": ""},
-                timeout=AWS_METADATA_TIMEOUT,
-            )
-            result.raise_for_status()
-        except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError):
-            return provider["id"], provider["key"], ""
-
-        data = result.json()
-        __AccessKeyId__ = data["AccessKeyId"]
-        __SecretAccessKey__ = data["SecretAccessKey"]
-        __Token__ = data["Token"]
-        __Expiration__ = data["Expiration"]
+            data = result.json()
+            __AccessKeyId__ = data["AccessKeyId"]
+            __SecretAccessKey__ = data["SecretAccessKey"]
+            __Token__ = data["Token"]
+            __Expiration__ = data["Expiration"]
 
         ret_credentials = __AccessKeyId__, __SecretAccessKey__, __Token__
     else:

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -89,7 +89,7 @@ def creds(provider):
         # Check to see if we have cache credentials that are still good
         if not __Expiration__ or __Expiration__ < datetime.utcnow().strftime(
             "%Y-%m-%dT%H:%M:%SZ"
-        ):            
+        ):
             # We don't have any cached credentials, or they are expired, get them
             # Connections to instance meta-data must fail fast and never be proxied
             try:


### PR DESCRIPTION
### What does this PR do?

To fix the issue when it use assume role to create AWS resources in another AWS account. The issue in #52501 is because when the variable `__Expiration__` isn't equal to '', it will always return from the function directly.  It won't have chance to execute `provider.get('role_arn')` and then get credential from assume role again.  

### What issues does this PR fix or reference?

Fix https://github.com/saltstack/salt/issues/52501

### Tests written?

No

### Commits signed with GPG?

No
