### PR TITLE
modules/match: add missing "minion_id" in Pillar example

### DIFF
--- a/salt/modules/match.py
+++ b/salt/modules/match.py
@@ -325,7 +325,7 @@ def filter_by(
         {% set roles = salt['match.filter_by']({
             'web*': ['app', 'caching'],
             'db*': ['db'],
-        }, default='web*') %}
+        }, minion_id=grains['id'], default='web*') %}
 
         # Make the filtered data available to Pillar:
         roles: {{ roles | yaml() }}


### PR DESCRIPTION
### What does this PR do?
The documented Pillar example for `match.filter_by` lacks the `minion_id` parameter. Without it, the assignment won't work as expected.
- fix documentation
- add tests:
  - to prove the misbehavior of the documented example
  - to prove the proper behaviour when supplying `minion_id`

### What issues does this PR fix or reference?
None

### Merge requirements satisfied?
- [x] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes