### PR TITLE
Fix/wheel file roots find

### DIFF
--- a/salt/wheel/file_roots.py
+++ b/salt/wheel/file_roots.py
@@ -26,7 +26,7 @@ def find(path, saltenv="base"):
         return ret
     for root in __opts__["file_roots"][saltenv]:
         full = os.path.join(root, path)
-        if not salt.utils.verify.clean_path(root, full):
+        if not salt.utils.verify.clean_path(root, full, subdir=True):
             continue
         if os.path.isfile(full):
             # Add it to the dict


### PR DESCRIPTION
### What does this PR do?

Adds `subdir=True` to `wheel.file_roots.find`

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/59800

### Previous Behavior

When attempting to read a file in a subdirectory with `wheel.file_roots.read` it would fail as `wheel.file_roots.find` is not able to read from a subdirectory. 

### New Behavior

You can successfully read a file in a subdirectory

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
