### PR TITLE
Return error if patch file passed to state file.patch is malformed

### DIFF
--- a/changelog/59806.fixed.md
+++ b/changelog/59806.fixed.md
@@ -1,0 +1,1 @@
+Return error if patch file passed to state file.patch is malformed.

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -7265,6 +7265,10 @@ def patch(
 
         pre_check = _patch(patch_file, patch_opts)
         if pre_check["retcode"] != 0:
+            if not os.path.exists(patch_rejects) or os.path.getsize(patch_rejects) == 0:
+                ret["comment"] = pre_check["stderr"]
+                ret["result"] = False
+                return ret
             # Try to reverse-apply hunks from rejects file using a dry-run.
             # If this returns a retcode of 0, we know that the patch was
             # already applied. Rejects are written from the base of the

--- a/tests/pytests/integration/states/test_file.py
+++ b/tests/pytests/integration/states/test_file.py
@@ -929,6 +929,7 @@ def test_patch_directory_template(
             - source: {all_patch_template}
             - template: "jinja"
             - context: {context}
+            - strip: 1
         """.format(
         base_dir=tmp_path, all_patch_template=all_patch_template, context=context
     )
@@ -945,7 +946,7 @@ def test_patch_directory_template(
         # Check to make sure the patch was applied okay
         state_run = next(iter(ret.data.values()))
         assert state_run["result"] is True
-        assert state_run["comment"] == "Patch was already applied"
+        assert state_run["comment"] == "Patch successfully applied"
 
         # Re-run the state, should succeed and there should be a message about
         # a partially-applied hunk.


### PR DESCRIPTION
### What does this PR do?
If patch file provided for file.patch state is malformed then state
returns `Patch was already applied` but patch is not applied.
It is better to return error in such case.

### What issues does this PR fix or reference?
Fixes: #59805

### Previous Behavior
```
          ID: patch_example
    Function: file.patch
        Name: /tmp/example
      Result: True
     Comment: Patch was already applied
     Started: 12:20:50.953163
    Duration: 61.558 ms
     Changes:
```

### New Behavior
```
          ID: patch_example
    Function: file.patch
        Name: /tmp/example
      Result: False
     Comment: /usr/bin/patch: **** malformed patch at line 7:
     Started: 12:33:44.915605
    Duration: 59.202 ms
     Changes:
```

Test needs to be fixed also because it return OK(false positive) with original code but log file contains and patch is not applied:
```
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|diff -ur a/foo/bar/math.txt b/foo/bar/math.txt
|--- a/foo/bar/math.txt	2018-04-09 18:43:52.883205365 -0500
|+++ b/foo/bar/math.txt	2018-04-09 18:44:58.525061654 -0500
--------------------------
File to patch: 
Skip this patch? [y] 
Skipping patch.
1 out of 1 hunk ignored
can't find file to patch at input line 13
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|diff -ur a/foo/numbers.txt b/foo/numbers.txt
|--- a/foo/numbers.txt	2018-04-09 18:43:58.014272504 -0500
|+++ b/foo/numbers.txt	2018-04-09 18:44:46.487905044 -0500
--------------------------
File to patch: 
Skip this patch? [y] 
Skipping patch.
1 out of 1 hunk ignored
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No
