### PR TITLE
modules/ssh.py: allow all ssh key types

### DIFF
--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -63,6 +63,21 @@ def _refine_enc(enc):
         "ecdsa-sha2-nistp256",
     ]
     ed25519 = ["ed25519", "ssh-ed25519"]
+    also_allowed = [
+        "rsa-sha2-512",
+        "rsa-sha2-256",
+        "rsa-sha2-512-cert-v01@openssh.com",
+        "rsa-sha2-256-cert-v01@openssh.com",
+        "ssh-rsa-cert-v01@openssh.com",
+        "ecdsa-sha2-nistp256-cert-v01@openssh.com",
+        "ecdsa-sha2-nistp384-cert-v01@openssh.com",
+        "ecdsa-sha2-nistp521-cert-v01@openssh.com",
+        "sk-ecdsa-sha2-nistp256@openssh.com",
+        "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com",
+        "ssh-ed25519-cert-v01@openssh.com",
+        "sk-ssh-ed25519@openssh.com",
+        "sk-ssh-ed25519-cert-v01@openssh.com",
+    ]
 
     if enc in rsa:
         return "ssh-rsa"
@@ -76,6 +91,8 @@ def _refine_enc(enc):
         return enc
     elif enc in ed25519:
         return "ssh-ed25519"
+    elif enc in also_allowed:
+        return enc
     else:
         raise CommandExecutionError("Incorrect encryption key type '{0}'.".format(enc))
 


### PR DESCRIPTION
### What does this PR do?

Propose a fix for #59429 by extending the list of allowed ssh public key types in `salt/modules/ssh.py` as of openssh 8.5.

### What issues does this PR fix or reference?
Fixes: #59429

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
