### PR TITLE
[freeze] Fix for issue #59773

### DIFF
--- a/changelog/59773.fixed
+++ b/changelog/59773.fixed
@@ -1,0 +1,2 @@
+When instantiating the loader grab values of grains and pillars if
+they are NamedLoaderContext instances.

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1314,6 +1314,12 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                 self.pack[i] = self.pack[i].value()
         if opts is None:
             opts = {}
+        opts = copy.deepcopy(opts)
+        for i in ["pillar", "grains"]:
+            if i in opts and isinstance(
+                opts[i], salt.loader_context.NamedLoaderContext
+            ):
+                opts[i] = opts[i].value()
         threadsafety = not opts.get("multiprocessing")
         self.context_dict = salt.utils.context.ContextDict(threadsafe=threadsafety)
         self.opts = self.__prep_mod_opts(opts)

--- a/salt/loader_context.py
+++ b/salt/loader_context.py
@@ -4,6 +4,7 @@ Manage the context a module loaded by Salt's loader
 import collections.abc
 import contextlib
 import contextvars
+import copy
 
 DEFAULT_CTX_VAR = "loader_ctxvar"
 
@@ -111,6 +112,10 @@ class NamedLoaderContext(collections.abc.MutableMapping):
 
     def __getattr__(self, name):
         return getattr(self.value(), name)
+
+    def __deepcopy__(self, memo):
+        default = copy.deepcopy(self.default)
+        return self.__class__(self.name, self.loader_context, default)
 
     def missing_fun_string(self, name):
         return self.loader().missing_fun_string(name)

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -38,8 +38,13 @@ import salt.utils.url
 import salt.utils.versions
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 from salt.loader import _format_cached_grains
+from salt.loader_context import LoaderContext
 from salt.runners.state import orchestrate as _orchestrate
 from salt.utils.odict import OrderedDict
+
+__salt_loader = LoaderContext()
+__pillar__ = __salt_loader.named_context("__pillar__")
+__opts__ = {}
 
 __proxyenabled__ = ["*"]
 
@@ -425,7 +430,7 @@ def _check_queue(queue, kwargs):
 
 def _get_initial_pillar(opts):
     return (
-        __pillar__
+        __pillar__.value()
         if __opts__.get("__cli", None) == "salt-call"
         and opts["pillarenv"] == __opts__["pillarenv"]
         else None

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -38,13 +38,8 @@ import salt.utils.url
 import salt.utils.versions
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 from salt.loader import _format_cached_grains
-from salt.loader_context import LoaderContext
 from salt.runners.state import orchestrate as _orchestrate
 from salt.utils.odict import OrderedDict
-
-__salt_loader = LoaderContext()
-__pillar__ = __salt_loader.named_context("__pillar__")
-__opts__ = {}
 
 __proxyenabled__ = ["*"]
 

--- a/tests/pytests/unit/modules/test_state.py
+++ b/tests/pytests/unit/modules/test_state.py
@@ -1,0 +1,22 @@
+"""
+    Unit tests for the salt.modules.state module
+"""
+
+import pytest
+import salt.loader_context
+import salt.modules.state
+from tests.support.mock import patch
+
+
+def test_get_initial_pillar():
+    """
+    _get_initial_pillar returns pillar data not named context
+    """
+    ctx = salt.loader_context.LoaderContext()
+    pillar_data = {"foo": "bar"}
+    named_ctx = ctx.named_context("__pillar__", pillar_data)
+    opts = {"__cli": "salt-call", "pillarenv": "base"}
+    with patch("salt.modules.state.__pillar__", named_ctx):
+        with patch("salt.modules.state.__opts__", opts):
+            pillar = salt.modules.state._get_initial_pillar(opts)
+            assert pillar == pillar_data

--- a/tests/pytests/unit/modules/test_state.py
+++ b/tests/pytests/unit/modules/test_state.py
@@ -2,7 +2,6 @@
     Unit tests for the salt.modules.state module
 """
 
-import pytest
 import salt.loader_context
 import salt.modules.state
 from tests.support.mock import patch

--- a/tests/pytests/unit/modules/test_state.py
+++ b/tests/pytests/unit/modules/test_state.py
@@ -15,7 +15,7 @@ def test_get_initial_pillar():
     pillar_data = {"foo": "bar"}
     named_ctx = ctx.named_context("__pillar__", pillar_data)
     opts = {"__cli": "salt-call", "pillarenv": "base"}
-    with patch("salt.modules.state.__pillar__", named_ctx):
-        with patch("salt.modules.state.__opts__", opts):
+    with patch("salt.modules.state.__pillar__", named_ctx, create=True):
+        with patch("salt.modules.state.__opts__", opts, create=True):
             pillar = salt.modules.state._get_initial_pillar(opts)
             assert pillar == pillar_data

--- a/tests/pytests/unit/test_loader.py
+++ b/tests/pytests/unit/test_loader.py
@@ -93,3 +93,24 @@ def test_loaders_create_named_loader_contexts(loader_dir):
     module_name = func.func.__module__
     module = sys.modules[module_name]
     assert isinstance(module.__context__, salt.loader_context.NamedLoaderContext)
+
+
+def test_loaders_convert_context_to_values(loader_dir):
+    """
+    LazyLoaders convert NamedLoaderContexts to values when instantiated.
+    """
+    loader_context = salt.loader_context.LoaderContext()
+    grains_default = {
+        "os": "linux",
+    }
+    grains = salt.loader_context.NamedLoaderContext(
+        "grains", loader_context, grains_default
+    )
+    opts = {
+        "optimization_order": [0, 1, 2],
+        "grains": grains,
+    }
+    loader_1 = salt.loader.LazyLoader([loader_dir], opts,)
+    assert loader_1.opts["grains"] == grains_default
+    # The loader's opts is a copy
+    assert opts["grains"] == grains

--- a/tests/pytests/unit/test_loader_context.py
+++ b/tests/pytests/unit/test_loader_context.py
@@ -1,6 +1,8 @@
 """
 Tests for salt.loader_context
 """
+import copy
+
 import salt.loader
 import salt.loader_context
 
@@ -31,3 +33,15 @@ def test_named_loader_default():
     # The loader's value is the same object as default
     assert named_context.value() is default
     assert named_context["foo"] == "bar"
+
+
+def test_named_loader_context_deepcopy():
+    loader_context = salt.loader_context.LoaderContext()
+    default_data = {"foo": "bar"}
+    named_context = salt.loader_context.NamedLoaderContext(
+        "__test__", loader_context, default_data
+    )
+    coppied = copy.deepcopy(named_context)
+    assert coppied.name == named_context.name
+    assert id(coppied.loader_context) == id(named_context.loader_context)
+    assert id(coppied.default) != id(named_context.default)


### PR DESCRIPTION
- When instantiating the loader grab values of grains and pillars if
  they are NamedLoaderContext instances.
- The loader uses a copy of opts.
- Impliment deepcopy on NamedLoaderContext instances.

### What issues does this PR fix or reference?
Fixes: #59773