### PR TITLE
Drop MySQL-python support

### DIFF
--- a/tests/unit/states/test_mysql_query.py
+++ b/tests/unit/states/test_mysql_query.py
@@ -12,19 +12,14 @@ from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase, skipIf
 
 log = logging.getLogger(__name__)
-NO_MYSQL = False
 NO_PyMYSQL = False
-try:
-    import MySQLdb  # pylint: disable=W0611
-except ImportError:
-    NO_MYSQL = True
 
 try:
-    # MySQLdb import failed, try to import PyMySQL
+    # try to import PyMySQL
     import pymysql
 
     pymysql.install_as_MySQLdb()
-    import MySQLdb
+    import MySQLdb  # pylint: disable=W0611
 except ImportError:
     NO_PyMYSQL = True
 
@@ -173,8 +168,7 @@ class MysqlQueryTestCase(TestCase, LoaderModuleMockMixin):
                 self.assertDictEqual(mysql_query.run(name, database, query), ret)
 
     @skipIf(
-        NO_MYSQL and NO_PyMYSQL,
-        "Install MySQL bindings before running MySQL unit tests.",
+        NO_PyMYSQL, "Install MySQL bindings before running MySQL unit tests.",
     )
     def test_run_multiple_statements(self):
         """


### PR DESCRIPTION
This PR is still heavily WIP - feel free to pick it up anytime and take it from here... I'll add more changes whenever I get around to it, as it seems those changes need to be done at quite a few places.

### What does this PR do?
It drops support for MySQL-python, as:
- the last release of MySQL-python is from 2014-01-02
- it only supports Python 2.4/2.7, which is EOL and not supported by SaltStack anymore

### What issues does this PR fix or reference?
Fixes: None

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes