### PR TITLE
[Backport 50920]: Adds ability to override return code based on stdout or stderr

### DIFF
--- a/changelog/50597.added
+++ b/changelog/50597.added
@@ -1,4 +1,1 @@
-Adds arguments `success_stdout` and `success_stderr` to execution modules and states
-that use the underlying `cmd._run` functionality. These arguments allow the user
-to override the return code of the command depending on the contents of stdout
-or stderr.
+Added `success_stdout` and `success_stderr` arguments to `cmd.run`, to override default return code behavior.

--- a/changelog/50597.added
+++ b/changelog/50597.added
@@ -1,0 +1,4 @@
+Adds arguments `success_stdout` and `success_stderr` to execution modules and states
+that use the underlying `cmd._run` functionality. These arguments allow the user
+to override the return code of the command depending on the contents of stdout
+or stderr.

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -1185,26 +1185,26 @@ def run(
         Be absolutely certain that you have sanitized your input prior to using
         python_shell=True
 
-    :param list success_retcodes: This parameter will be allow a list of
+    :param list success_retcodes: This parameter will allow a list of
         non-zero return codes that should be considered a success.  If the
         return code returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
       .. versionadded:: 2019.2.0
 
-    :param list success_stdout: This parameter will be allow a list of
+    :param list success_stdout: This parameter will allow a list of
         strings that when found in standard out should be considered a success.
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
-    :param list success_stderr: This parameter will be allow a list of
+    :param list success_stderr: This parameter will allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
@@ -1467,26 +1467,26 @@ def shell(
         processing! Be absolutely sure that you have properly sanitized the
         command passed to this function and do not use untrusted inputs.
 
-    :param list success_retcodes: This parameter will be allow a list of
+    :param list success_retcodes: This parameter will allow a list of
         non-zero return codes that should be considered a success.  If the
         return code returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
       .. versionadded:: 2019.2.0
 
-    :param list success_stdout: This parameter will be allow a list of
+    :param list success_stdout: This parameter will allow a list of
         strings that when found in standard out should be considered a success.
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
-    :param list success_stderr: This parameter will be allow a list of
+    :param list success_stderr: This parameter will allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
@@ -1719,26 +1719,26 @@ def run_stdout(
     :param bool use_vt: Use VT utils (saltstack) to stream the command output
         more interactively to the console and the logs. This is experimental.
 
-    :param list success_retcodes: This parameter will be allow a list of
+    :param list success_retcodes: This parameter will allow a list of
         non-zero return codes that should be considered a success.  If the
         return code returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
       .. versionadded:: 2019.2.0
 
-    :param list success_stdout: This parameter will be allow a list of
+    :param list success_stdout: This parameter will allow a list of
         strings that when found in standard out should be considered a success.
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
-    :param list success_stderr: This parameter will be allow a list of
+    :param list success_stderr: This parameter will allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
@@ -1953,26 +1953,26 @@ def run_stderr(
     :param bool use_vt: Use VT utils (saltstack) to stream the command output
         more interactively to the console and the logs. This is experimental.
 
-    :param list success_retcodes: This parameter will be allow a list of
+    :param list success_retcodes: This parameter will allow a list of
         non-zero return codes that should be considered a success.  If the
         return code returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
       .. versionadded:: 2019.2.0
 
-    :param list success_stdout: This parameter will be allow a list of
+    :param list success_stdout: This parameter will allow a list of
         strings that when found in standard out should be considered a success.
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
-    :param list success_stderr: This parameter will be allow a list of
+    :param list success_stderr: This parameter will allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
@@ -2230,26 +2230,26 @@ def run_all(
 
         .. versionadded:: 2016.3.6
 
-    :param list success_retcodes: This parameter will be allow a list of
+    :param list success_retcodes: This parameter will allow a list of
         non-zero return codes that should be considered a success.  If the
         return code returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
       .. versionadded:: 2019.2.0
 
-    :param list success_stdout: This parameter will be allow a list of
+    :param list success_stdout: This parameter will allow a list of
         strings that when found in standard out should be considered a success.
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
-    :param list success_stderr: This parameter will be allow a list of
+    :param list success_stderr: This parameter will allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
@@ -2455,26 +2455,26 @@ def retcode(
     :rtype: None
     :returns: Return Code as an int or None if there was an exception.
 
-    :param list success_retcodes: This parameter will be allow a list of
+    :param list success_retcodes: This parameter will allow a list of
         non-zero return codes that should be considered a success.  If the
         return code returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
       .. versionadded:: 2019.2.0
 
-    :param list success_stdout: This parameter will be allow a list of
+    :param list success_stdout: This parameter will allow a list of
         strings that when found in standard out should be considered a success.
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
-    :param list success_stderr: This parameter will be allow a list of
+    :param list success_stderr: This parameter will allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
@@ -2754,26 +2754,26 @@ def script(
     :param bool use_vt: Use VT utils (saltstack) to stream the command output
         more interactively to the console and the logs. This is experimental.
 
-    :param list success_retcodes: This parameter will be allow a list of
+    :param list success_retcodes: This parameter will allow a list of
         non-zero return codes that should be considered a success.  If the
         return code returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
       .. versionadded:: 2019.2.0
 
-    :param list success_stdout: This parameter will be allow a list of
+    :param list success_stdout: This parameter will allow a list of
         strings that when found in standard out should be considered a success.
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
-    :param list success_stderr: This parameter will be allow a list of
+    :param list success_stderr: This parameter will allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
@@ -3031,26 +3031,26 @@ def script_retcode(
     :param bool use_vt: Use VT utils (saltstack) to stream the command output
         more interactively to the console and the logs. This is experimental.
 
-    :param list success_retcodes: This parameter will be allow a list of
+    :param list success_retcodes: This parameter will allow a list of
         non-zero return codes that should be considered a success.  If the
         return code returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
       .. versionadded:: 2019.2.0
 
-    :param list success_stdout: This parameter will be allow a list of
+    :param list success_stdout: This parameter will allow a list of
         strings that when found in standard out should be considered a success.
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
-    :param list success_stderr: This parameter will be allow a list of
+    :param list success_stderr: This parameter will allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
@@ -3380,26 +3380,26 @@ def run_chroot(
         Use VT utils (saltstack) to stream the command output more
         interactively to the console and the logs. This is experimental.
 
-    :param success_retcodes: This parameter will be allow a list of
+    :param success_retcodes: This parameter will allow a list of
         non-zero return codes that should be considered a success.  If the
         return code returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
       .. versionadded:: 2019.2.0
 
-    :param list success_stdout: This parameter will be allow a list of
+    :param list success_stdout: This parameter will allow a list of
         strings that when found in standard out should be considered a success.
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
-    :param list success_stderr: This parameter will be allow a list of
+    :param list success_stderr: This parameter will allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
     CLI Example:
 
@@ -3942,26 +3942,26 @@ def powershell(
         where characters may be dropped or incorrectly converted when executed.
         Default is False.
 
-    :param list success_retcodes: This parameter will be allow a list of
+    :param list success_retcodes: This parameter will allow a list of
         non-zero return codes that should be considered a success.  If the
         return code returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
       .. versionadded:: 2019.2.0
 
-    :param list success_stdout: This parameter will be allow a list of
+    :param list success_stdout: This parameter will allow a list of
         strings that when found in standard out should be considered a success.
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
-    :param list success_stderr: This parameter will be allow a list of
+    :param list success_stderr: This parameter will allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
@@ -4281,26 +4281,26 @@ def powershell_all(
     :param bool force_list: The purpose of this parameter is described in the
         preamble of this function's documentation. Default value is False.
 
-    :param list success_retcodes: This parameter will be allow a list of
+    :param list success_retcodes: This parameter will allow a list of
         non-zero return codes that should be considered a success.  If the
         return code returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
       .. versionadded:: 2019.2.0
 
-    :param list success_stdout: This parameter will be allow a list of
+    :param list success_stdout: This parameter will allow a list of
         strings that when found in standard out should be considered a success.
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
-    :param list success_stderr: This parameter will be allow a list of
+    :param list success_stderr: This parameter will allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
@@ -4580,26 +4580,26 @@ def run_bg(
         -rf /'.  Be absolutely certain that you have sanitized your input prior
         to using ``python_shell=True``.
 
-    :param list success_retcodes: This parameter will be allow a list of
+    :param list success_retcodes: This parameter will allow a list of
         non-zero return codes that should be considered a success.  If the
         return code returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
       .. versionadded:: 2019.2.0
 
-    :param list success_stdout: This parameter will be allow a list of
+    :param list success_stdout: This parameter will allow a list of
         strings that when found in standard out should be considered a success.
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
-    :param list success_stderr: This parameter will be allow a list of
+    :param list success_stderr: This parameter will allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -1197,14 +1197,14 @@ def run(
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     :param list success_stderr: This parameter will be allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
@@ -1479,14 +1479,14 @@ def shell(
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     :param list success_stderr: This parameter will be allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
@@ -1731,14 +1731,14 @@ def run_stdout(
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     :param list success_stderr: This parameter will be allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
@@ -1965,14 +1965,14 @@ def run_stderr(
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     :param list success_stderr: This parameter will be allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
@@ -2242,14 +2242,14 @@ def run_all(
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     :param list success_stderr: This parameter will be allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
@@ -2467,14 +2467,14 @@ def retcode(
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     :param list success_stderr: This parameter will be allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
@@ -2766,14 +2766,14 @@ def script(
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     :param list success_stderr: This parameter will be allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
@@ -3043,14 +3043,14 @@ def script_retcode(
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     :param list success_stderr: This parameter will be allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
@@ -3392,14 +3392,14 @@ def run_chroot(
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     :param list success_stderr: This parameter will be allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     CLI Example:
 
@@ -3954,14 +3954,14 @@ def powershell(
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     :param list success_stderr: This parameter will be allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
@@ -4293,14 +4293,14 @@ def powershell_all(
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     :param list success_stderr: This parameter will be allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
@@ -4592,14 +4592,14 @@ def run_bg(
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     :param list success_stderr: This parameter will be allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -1980,7 +1980,7 @@ def run_stderr(
         the return code will be overridden with zero.
 
       .. versionadded:: Neon
- 
+
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
         present in the ``stdin`` value to newlines.
@@ -2257,7 +2257,7 @@ def run_all(
         the return code will be overridden with zero.
 
       .. versionadded:: Neon
- 
+
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
         present in the ``stdin`` value to newlines.
@@ -2482,7 +2482,7 @@ def retcode(
         the return code will be overridden with zero.
 
       .. versionadded:: Neon
- 
+
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
         present in the ``stdin`` value to newlines.
@@ -2781,7 +2781,7 @@ def script(
         the return code will be overridden with zero.
 
       .. versionadded:: Neon
- 
+
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
         present in the ``stdin`` value to newlines.
@@ -3058,7 +3058,7 @@ def script_retcode(
         the return code will be overridden with zero.
 
       .. versionadded:: Neon
- 
+
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
         present in the ``stdin`` value to newlines.
@@ -3407,7 +3407,7 @@ def run_chroot(
         the return code will be overridden with zero.
 
       .. versionadded:: Neon
- 
+
     CLI Example:
 
     .. code-block:: bash
@@ -3969,7 +3969,7 @@ def powershell(
         the return code will be overridden with zero.
 
       .. versionadded:: Neon
- 
+
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
         present in the ``stdin`` value to newlines.
@@ -4308,7 +4308,7 @@ def powershell_all(
         the return code will be overridden with zero.
 
       .. versionadded:: Neon
- 
+
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
         present in the ``stdin`` value to newlines.

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -774,7 +774,10 @@ def _run(
             ret["retcode"] = 0
         ret["stdout"] = out
         ret["stderr"] = err
-        if ret["stdout"] in success_stdout or ret["stderr"] in success_stderr:
+        if any(
+            [stdo in ret["stdout"] for stdo in success_stdout]
+            + [stde in ret["stderr"] for stde in success_stderr]
+        ):
             ret["retcode"] = 0
     else:
         formatted_timeout = ""
@@ -845,9 +848,9 @@ def _run(
                     ret["retcode"] = proc.exitstatus
                     if ret["retcode"] in success_retcodes:
                         ret["retcode"] = 0
-                    if (
-                        ret["stdout"] in success_stdout
-                        or ret["stderr"] in success_stderr
+                    if any(
+                        [stdo in ret["stdout"] for stdo in success_stdout]
+                        + [stde in ret["stderr"] for stde in success_stderr]
                     ):
                         ret["retcode"] = 0
                 ret["pid"] = proc.pid

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -686,18 +686,12 @@ def _run(
     if success_stdout is None:
         success_stdout = []
     else:
-        try:
-            success_stdout = [i for i in salt.utils.args.split_input(success_stdout)]
-        except ValueError:
-            raise SaltInvocationError("success_stdout must be a list of integers")
+        success_stdout = salt.utils.args.split_input(success_stdout)
 
     if success_stderr is None:
         success_stderr = []
     else:
-        try:
-            success_stderr = [i for i in salt.utils.args.split_input(success_stderr)]
-        except ValueError:
-            raise SaltInvocationError("success_stderr must be a list of integers")
+        success_stderr = salt.utils.args.split_input(success_stderr)
 
     if not use_vt:
         # This is where the magic happens

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -282,6 +282,8 @@ def _run(
     bg=False,
     encoded_cmd=False,
     success_retcodes=None,
+    success_stdout=None,
+    success_stderr=None,
     windows_codepage=65001,
     **kwargs
 ):
@@ -680,6 +682,33 @@ def _run(
             ]
         except ValueError:
             raise SaltInvocationError("success_retcodes must be a list of integers")
+
+    if success_stdout is None:
+        success_stdout = []
+    else:
+        try:
+            success_stdout = [i for i in
+                              salt.utils.args.split_input(
+                                 success_stdout
+                              )]
+        except ValueError:
+            raise SaltInvocationError(
+                'success_stdout must be a list of integers'
+            )
+
+    if success_stderr is None:
+        success_stderr = []
+    else:
+        try:
+            success_stderr = [i for i in
+                              salt.utils.args.split_input(
+                                 success_stderr
+                              )]
+        except ValueError:
+            raise SaltInvocationError(
+                'success_stderr must be a list of integers'
+            )
+
     if not use_vt:
         # This is where the magic happens
         try:
@@ -761,6 +790,8 @@ def _run(
             ret["retcode"] = 0
         ret["stdout"] = out
         ret["stderr"] = err
+        if ret['stdout'] in success_stdout or ret['stderr'] in success_stderr:
+            ret['retcode'] = 0
     else:
         formatted_timeout = ""
         if timeout:
@@ -830,6 +861,8 @@ def _run(
                     ret["retcode"] = proc.exitstatus
                     if ret["retcode"] in success_retcodes:
                         ret["retcode"] = 0
+                    if ret['stdout'] in success_stdout or ret['stderr'] in success_stderr:
+                        ret['retcode'] = 0
                 ret["pid"] = proc.pid
         finally:
             proc.close(terminate=True, kill=True)
@@ -878,6 +911,8 @@ def _run_quiet(
     pillarenv=None,
     pillar_override=None,
     success_retcodes=None,
+    success_stdout=None,
+    success_stderr=None,
 ):
     """
     Helper for running commands quietly for minion startup
@@ -902,6 +937,8 @@ def _run_quiet(
         pillarenv=pillarenv,
         pillar_override=pillar_override,
         success_retcodes=success_retcodes,
+        success_stdout=success_stdout,
+        success_stderr=success_stderr,
     )["stdout"]
 
 
@@ -922,6 +959,8 @@ def _run_all_quiet(
     pillar_override=None,
     output_encoding=None,
     success_retcodes=None,
+    success_stdout=None,
+    success_stderr=None,
 ):
 
     """
@@ -952,6 +991,8 @@ def _run_all_quiet(
         pillarenv=pillarenv,
         pillar_override=pillar_override,
         success_retcodes=success_retcodes,
+        success_stdout=success_stdout,
+        success_stderr=success_stderr,
     )
 
 
@@ -983,6 +1024,8 @@ def run(
     raise_err=False,
     prepend_path=None,
     success_retcodes=None,
+    success_stdout=None,
+    success_stderr=None,
     **kwargs
 ):
     r"""
@@ -1156,6 +1199,20 @@ def run(
 
       .. versionadded:: 2019.2.0
 
+    :param list success_stdout: This parameter will be allow a list of
+        strings that when found in standard out should be considered a success.
+        If stdout returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+
+    :param list success_stderr: This parameter will be allow a list of
+        strings that when found in standard error should be considered a success.
+        If stderr returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
         present in the ``stdin`` value to newlines.
@@ -1234,6 +1291,8 @@ def run(
         password=password,
         encoded_cmd=encoded_cmd,
         success_retcodes=success_retcodes,
+        success_stdout=success_stdout,
+        success_stderr=success_stderr,
         **kwargs
     )
 
@@ -1281,6 +1340,8 @@ def shell(
     password=None,
     prepend_path=None,
     success_retcodes=None,
+    success_stdout=None,
+    success_stderr=None,
     **kwargs
 ):
     """
@@ -1420,6 +1481,20 @@ def shell(
 
       .. versionadded:: 2019.2.0
 
+    :param list success_stdout: This parameter will be allow a list of
+        strings that when found in standard out should be considered a success.
+        If stdout returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+
+    :param list success_stderr: This parameter will be allow a list of
+        strings that when found in standard error should be considered a success.
+        If stderr returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
         present in the ``stdin`` value to newlines.
@@ -1493,6 +1568,8 @@ def shell(
         bg=bg,
         password=password,
         success_retcodes=success_retcodes,
+        success_stdout=success_stdout,
+        success_stderr=success_stderr,
         **kwargs
     )
 
@@ -1522,6 +1599,8 @@ def run_stdout(
     password=None,
     prepend_path=None,
     success_retcodes=None,
+    success_stdout=None,
+    success_stderr=None,
     **kwargs
 ):
     """
@@ -1654,6 +1733,20 @@ def run_stdout(
 
       .. versionadded:: 2019.2.0
 
+    :param list success_stdout: This parameter will be allow a list of
+        strings that when found in standard out should be considered a success.
+        If stdout returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+
+    :param list success_stderr: This parameter will be allow a list of
+        strings that when found in standard error should be considered a success.
+        If stderr returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
         present in the ``stdin`` value to newlines.
@@ -1707,6 +1800,8 @@ def run_stdout(
         use_vt=use_vt,
         password=password,
         success_retcodes=success_retcodes,
+        success_stdout=success_stdout,
+        success_stderr=success_stderr,
         **kwargs
     )
 
@@ -1738,6 +1833,8 @@ def run_stderr(
     password=None,
     prepend_path=None,
     success_retcodes=None,
+    success_stdout=None,
+    success_stderr=None,
     **kwargs
 ):
     """
@@ -1870,6 +1967,20 @@ def run_stderr(
 
       .. versionadded:: 2019.2.0
 
+    :param list success_stdout: This parameter will be allow a list of
+        strings that when found in standard out should be considered a success.
+        If stdout returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+
+    :param list success_stderr: This parameter will be allow a list of
+        strings that when found in standard error should be considered a success.
+        If stderr returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+ 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
         present in the ``stdin`` value to newlines.
@@ -1923,6 +2034,8 @@ def run_stderr(
         saltenv=saltenv,
         password=password,
         success_retcodes=success_retcodes,
+        success_stdout=success_stdout,
+        success_stderr=success_stderr,
         **kwargs
     )
 
@@ -1956,6 +2069,8 @@ def run_all(
     encoded_cmd=False,
     prepend_path=None,
     success_retcodes=None,
+    success_stdout=None,
+    success_stderr=None,
     **kwargs
 ):
     """
@@ -2129,6 +2244,20 @@ def run_all(
 
       .. versionadded:: 2019.2.0
 
+    :param list success_stdout: This parameter will be allow a list of
+        strings that when found in standard out should be considered a success.
+        If stdout returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+
+    :param list success_stderr: This parameter will be allow a list of
+        strings that when found in standard error should be considered a success.
+        If stderr returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+ 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
         present in the ``stdin`` value to newlines.
@@ -2185,6 +2314,8 @@ def run_all(
         password=password,
         encoded_cmd=encoded_cmd,
         success_retcodes=success_retcodes,
+        success_stdout=success_stdout,
+        success_stderr=success_stderr,
         **kwargs
     )
 
@@ -2215,6 +2346,8 @@ def retcode(
     use_vt=False,
     password=None,
     success_retcodes=None,
+    success_stdout=None,
+    success_stderr=None,
     **kwargs
 ):
     """
@@ -2336,6 +2469,20 @@ def retcode(
 
       .. versionadded:: 2019.2.0
 
+    :param list success_stdout: This parameter will be allow a list of
+        strings that when found in standard out should be considered a success.
+        If stdout returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+
+    :param list success_stderr: This parameter will be allow a list of
+        strings that when found in standard error should be considered a success.
+        If stderr returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+ 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
         present in the ``stdin`` value to newlines.
@@ -2389,6 +2536,8 @@ def retcode(
         use_vt=use_vt,
         password=password,
         success_retcodes=success_retcodes,
+        success_stdout=success_stdout,
+        success_stderr=success_stderr,
         **kwargs
     )
     return ret["retcode"]
@@ -2415,6 +2564,8 @@ def _retcode_quiet(
     use_vt=False,
     password=None,
     success_retcodes=None,
+    success_stdout=None,
+    success_stderr=None,
     **kwargs
 ):
     """
@@ -2443,6 +2594,8 @@ def _retcode_quiet(
         use_vt=use_vt,
         password=password,
         success_retcodes=success_retcodes,
+        success_stdout=success_stdout,
+        success_stderr=success_stderr,
         **kwargs
     )
 
@@ -2470,6 +2623,8 @@ def script(
     bg=False,
     password=None,
     success_retcodes=None,
+    success_stdout=None,
+    success_stderr=None,
     **kwargs
 ):
     """
@@ -2613,6 +2768,20 @@ def script(
 
       .. versionadded:: 2019.2.0
 
+    :param list success_stdout: This parameter will be allow a list of
+        strings that when found in standard out should be considered a success.
+        If stdout returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+
+    :param list success_stderr: This parameter will be allow a list of
+        strings that when found in standard error should be considered a success.
+        If stderr returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+ 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
         present in the ``stdin`` value to newlines.
@@ -2723,6 +2892,8 @@ def script(
         bg=bg,
         password=password,
         success_retcodes=success_retcodes,
+        success_stdout=success_stdout,
+        success_stderr=success_stderr,
         **kwargs
     )
     _cleanup_tempfile(path)
@@ -2756,6 +2927,8 @@ def script_retcode(
     use_vt=False,
     password=None,
     success_retcodes=None,
+    success_stdout=None,
+    success_stderr=None,
     **kwargs
 ):
     """
@@ -2872,6 +3045,20 @@ def script_retcode(
 
       .. versionadded:: 2019.2.0
 
+    :param list success_stdout: This parameter will be allow a list of
+        strings that when found in standard out should be considered a success.
+        If stdout returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+
+    :param list success_stderr: This parameter will be allow a list of
+        strings that when found in standard error should be considered a success.
+        If stderr returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+ 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
         present in the ``stdin`` value to newlines.
@@ -2919,6 +3106,8 @@ def script_retcode(
         use_vt=use_vt,
         password=password,
         success_retcodes=success_retcodes,
+        success_stdout=success_stdout,
+        success_stderr=success_stderr,
         **kwargs
     )["retcode"]
 
@@ -3072,6 +3261,8 @@ def run_chroot(
     use_vt=False,
     bg=False,
     success_retcodes=None,
+    success_stdout=None,
+    success_stderr=None,
     **kwargs
 ):
     """
@@ -3196,13 +3387,27 @@ def run_chroot(
         Use VT utils (saltstack) to stream the command output more
         interactively to the console and the logs. This is experimental.
 
-    success_retcodes: This parameter will be allow a list of
+    :param success_retcodes: This parameter will be allow a list of
         non-zero return codes that should be considered a success.  If the
         return code returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
       .. versionadded:: 2019.2.0
 
+    :param list success_stdout: This parameter will be allow a list of
+        strings that when found in standard out should be considered a success.
+        If stdout returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+
+    :param list success_stderr: This parameter will be allow a list of
+        strings that when found in standard error should be considered a success.
+        If stderr returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+ 
     CLI Example:
 
     .. code-block:: bash
@@ -3260,6 +3465,8 @@ def run_chroot(
         pillar=kwargs.get("pillar"),
         use_vt=use_vt,
         success_retcodes=success_retcodes,
+        success_stdout=success_stdout,
+        success_stderr=success_stderr,
         bg=bg,
     )
 
@@ -3589,6 +3796,8 @@ def powershell(
     depth=None,
     encode_cmd=False,
     success_retcodes=None,
+    success_stdout=None,
+    success_stderr=None,
     **kwargs
 ):
     """
@@ -3747,6 +3956,20 @@ def powershell(
 
       .. versionadded:: 2019.2.0
 
+    :param list success_stdout: This parameter will be allow a list of
+        strings that when found in standard out should be considered a success.
+        If stdout returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+
+    :param list success_stderr: This parameter will be allow a list of
+        strings that when found in standard error should be considered a success.
+        If stderr returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+ 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
         present in the ``stdin`` value to newlines.
@@ -3823,6 +4046,8 @@ def powershell(
         password=password,
         encoded_cmd=encoded_cmd,
         success_retcodes=success_retcodes,
+        success_stdout=success_stdout,
+        success_stderr=success_stderr,
         **kwargs
     )
 
@@ -3860,6 +4085,8 @@ def powershell_all(
     encode_cmd=False,
     force_list=False,
     success_retcodes=None,
+    success_stdout=None,
+    success_stderr=None,
     **kwargs
 ):
     """
@@ -4068,6 +4295,20 @@ def powershell_all(
 
       .. versionadded:: 2019.2.0
 
+    :param list success_stdout: This parameter will be allow a list of
+        strings that when found in standard out should be considered a success.
+        If stdout returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+
+    :param list success_stderr: This parameter will be allow a list of
+        strings that when found in standard error should be considered a success.
+        If stderr returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+ 
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
         present in the ``stdin`` value to newlines.
@@ -4157,6 +4398,8 @@ def powershell_all(
         password=password,
         encoded_cmd=encoded_cmd,
         success_retcodes=success_retcodes,
+        success_stdout=success_stdout,
+        success_stderr=success_stderr,
         **kwargs
     )
     stdoutput = response["stdout"]
@@ -4211,6 +4454,8 @@ def run_bg(
     password=None,
     prepend_path=None,
     success_retcodes=None,
+    success_stdout=None,
+    success_stderr=None,
     **kwargs
 ):
     r"""
@@ -4349,6 +4594,20 @@ def run_bg(
 
       .. versionadded:: 2019.2.0
 
+    :param list success_stdout: This parameter will be allow a list of
+        strings that when found in standard out should be considered a success.
+        If stdout returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+
+    :param list success_stderr: This parameter will be allow a list of
+        strings that when found in standard error should be considered a success.
+        If stderr returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+
     :param bool stdin_raw_newlines: False
         If ``True``, Salt will not automatically convert the characters ``\\n``
         present in the ``stdin`` value to newlines.
@@ -4413,6 +4672,8 @@ def run_bg(
         saltenv=saltenv,
         password=password,
         success_retcodes=success_retcodes,
+        success_stdout=success_stdout,
+        success_stderr=success_stderr,
         **kwargs
     )
 

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -687,27 +687,17 @@ def _run(
         success_stdout = []
     else:
         try:
-            success_stdout = [i for i in
-                              salt.utils.args.split_input(
-                                 success_stdout
-                              )]
+            success_stdout = [i for i in salt.utils.args.split_input(success_stdout)]
         except ValueError:
-            raise SaltInvocationError(
-                'success_stdout must be a list of integers'
-            )
+            raise SaltInvocationError("success_stdout must be a list of integers")
 
     if success_stderr is None:
         success_stderr = []
     else:
         try:
-            success_stderr = [i for i in
-                              salt.utils.args.split_input(
-                                 success_stderr
-                              )]
+            success_stderr = [i for i in salt.utils.args.split_input(success_stderr)]
         except ValueError:
-            raise SaltInvocationError(
-                'success_stderr must be a list of integers'
-            )
+            raise SaltInvocationError("success_stderr must be a list of integers")
 
     if not use_vt:
         # This is where the magic happens
@@ -790,8 +780,8 @@ def _run(
             ret["retcode"] = 0
         ret["stdout"] = out
         ret["stderr"] = err
-        if ret['stdout'] in success_stdout or ret['stderr'] in success_stderr:
-            ret['retcode'] = 0
+        if ret["stdout"] in success_stdout or ret["stderr"] in success_stderr:
+            ret["retcode"] = 0
     else:
         formatted_timeout = ""
         if timeout:
@@ -861,8 +851,11 @@ def _run(
                     ret["retcode"] = proc.exitstatus
                     if ret["retcode"] in success_retcodes:
                         ret["retcode"] = 0
-                    if ret['stdout'] in success_stdout or ret['stderr'] in success_stderr:
-                        ret['retcode'] = 0
+                    if (
+                        ret["stdout"] in success_stdout
+                        or ret["stderr"] in success_stderr
+                    ):
+                        ret["retcode"] = 0
                 ret["pid"] = proc.pid
         finally:
             proc.close(terminate=True, kill=True)

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -444,26 +444,26 @@ def wait(
         interactively to the console and the logs.
         This is experimental.
 
-    success_retcodes: This parameter will be allow a list of
+    success_retcodes: This parameter will allow a list of
         non-zero return codes that should be considered a success.  If the
         return code returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
       .. versionadded:: 2019.2.0
 
-    success_stdout: This parameter will be allow a list of
+    success_stdout: This parameter will allow a list of
         strings that when found in standard out should be considered a success.
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
-    success_stderr: This parameter will be allow a list of
+    success_stderr: This parameter will allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
     """
     # Ignoring our arguments is intentional.
     return {"name": name, "changes": {}, "result": True, "comment": ""}
@@ -594,26 +594,26 @@ def wait_script(
 
         .. versionadded:: 2018.3.0
 
-    success_retcodes: This parameter will be allow a list of
+    success_retcodes: This parameter will allow a list of
         non-zero return codes that should be considered a success.  If the
         return code returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
       .. versionadded:: 2019.2.0
 
-    success_stdout: This parameter will be allow a list of
+    success_stdout: This parameter will allow a list of
         strings that when found in standard out should be considered a success.
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
-    success_stderr: This parameter will be allow a list of
+    success_stderr: This parameter will allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
     """
     # Ignoring our arguments is intentional.
     return {"name": name, "changes": {}, "result": True, "comment": ""}
@@ -764,26 +764,26 @@ def run(
 
         .. versionadded:: 2016.3.6
 
-    success_retcodes: This parameter will be allow a list of
+    success_retcodes: This parameter will allow a list of
         non-zero return codes that should be considered a success.  If the
         return code returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
       .. versionadded:: 2019.2.0
 
-    success_stdout: This parameter will be allow a list of
+    success_stdout: This parameter will allow a list of
         strings that when found in standard out should be considered a success.
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
-    success_stderr: This parameter will be allow a list of
+    success_stderr: This parameter will allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
     .. note::
 
@@ -1065,26 +1065,26 @@ def script(
 
         .. versionadded:: 2018.3.0
 
-    success_retcodes: This parameter will be allow a list of
+    success_retcodes: This parameter will allow a list of
         non-zero return codes that should be considered a success.  If the
         return code returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
       .. versionadded:: 2019.2.0
 
-    success_stdout: This parameter will be allow a list of
+    success_stdout: This parameter will allow a list of
         strings that when found in standard out should be considered a success.
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
 
-    success_stderr: This parameter will be allow a list of
+    success_stderr: This parameter will allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Silicon
+      .. versionadded:: 3004
     """
     test_name = None
     if not isinstance(stateful, list):

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -456,14 +456,14 @@ def wait(
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     success_stderr: This parameter will be allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
     """
     # Ignoring our arguments is intentional.
     return {"name": name, "changes": {}, "result": True, "comment": ""}
@@ -606,14 +606,14 @@ def wait_script(
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     success_stderr: This parameter will be allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
     """
     # Ignoring our arguments is intentional.
     return {"name": name, "changes": {}, "result": True, "comment": ""}
@@ -776,14 +776,14 @@ def run(
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     success_stderr: This parameter will be allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     .. note::
 
@@ -1077,14 +1077,14 @@ def script(
         If stdout returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
 
     success_stderr: This parameter will be allow a list of
         strings that when found in standard error should be considered a success.
         If stderr returned from the run matches any in the provided list,
         the return code will be overridden with zero.
 
-      .. versionadded:: Neon
+      .. versionadded:: Silicon
     """
     test_name = None
     if not isinstance(stateful, list):

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -333,6 +333,8 @@ def wait(
     hide_output=False,
     use_vt=False,
     success_retcodes=None,
+    success_stdout=None,
+    success_stderr=None,
     **kwargs
 ):
     """
@@ -448,6 +450,20 @@ def wait(
         the return code will be overridden with zero.
 
       .. versionadded:: 2019.2.0
+
+    success_stdout: This parameter will be allow a list of
+        strings that when found in standard out should be considered a success.
+        If stdout returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+
+    success_stderr: This parameter will be allow a list of
+        strings that when found in standard error should be considered a success.
+        If stderr returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
     """
     # Ignoring our arguments is intentional.
     return {"name": name, "changes": {}, "result": True, "comment": ""}
@@ -470,6 +486,9 @@ def wait_script(
     use_vt=False,
     output_loglevel="debug",
     hide_output=False,
+    success_retcodes=None,
+    success_stdout=None,
+    success_stderr=None,
     **kwargs
 ):
     """
@@ -581,6 +600,20 @@ def wait_script(
         the return code will be overridden with zero.
 
       .. versionadded:: 2019.2.0
+
+    success_stdout: This parameter will be allow a list of
+        strings that when found in standard out should be considered a success.
+        If stdout returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+
+    success_stderr: This parameter will be allow a list of
+        strings that when found in standard error should be considered a success.
+        If stderr returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
     """
     # Ignoring our arguments is intentional.
     return {"name": name, "changes": {}, "result": True, "comment": ""}
@@ -602,6 +635,8 @@ def run(
     ignore_timeout=False,
     use_vt=False,
     success_retcodes=None,
+    success_stdout=None,
+    success_stderr=None,
     **kwargs
 ):
     """
@@ -736,6 +771,20 @@ def run(
 
       .. versionadded:: 2019.2.0
 
+    success_stdout: This parameter will be allow a list of
+        strings that when found in standard out should be considered a success.
+        If stdout returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+
+    success_stderr: This parameter will be allow a list of
+        strings that when found in standard error should be considered a success.
+        If stderr returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+
     .. note::
 
         cmd.run supports the usage of ``reload_modules``. This functionality
@@ -791,6 +840,8 @@ def run(
             "output_loglevel": output_loglevel,
             "hide_output": hide_output,
             "success_retcodes": success_retcodes,
+            'success_stdout': success_stdout,
+            'success_stderr': success_stderr,
         }
     )
 
@@ -853,6 +904,8 @@ def script(
     defaults=None,
     context=None,
     success_retcodes=None,
+    success_stdout=NOne,
+    success_stderr=None,
     **kwargs
 ):
     """
@@ -1019,6 +1072,19 @@ def script(
 
       .. versionadded:: 2019.2.0
 
+    success_stdout: This parameter will be allow a list of
+        strings that when found in standard out should be considered a success.
+        If stdout returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
+
+    success_stderr: This parameter will be allow a list of
+        strings that when found in standard error should be considered a success.
+        If stderr returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: Neon
     """
     test_name = None
     if not isinstance(stateful, list):
@@ -1072,6 +1138,8 @@ def script(
             "context": tmpctx,
             "saltenv": __env__,
             "success_retcodes": success_retcodes,
+            'success_stdout': success_stdout,
+            'success_stderr': success_stderr,
         }
     )
 

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -840,8 +840,8 @@ def run(
             "output_loglevel": output_loglevel,
             "hide_output": hide_output,
             "success_retcodes": success_retcodes,
-            'success_stdout': success_stdout,
-            'success_stderr': success_stderr,
+            "success_stdout": success_stdout,
+            "success_stderr": success_stderr,
         }
     )
 
@@ -1138,8 +1138,8 @@ def script(
             "context": tmpctx,
             "saltenv": __env__,
             "success_retcodes": success_retcodes,
-            'success_stdout': success_stdout,
-            'success_stderr': success_stderr,
+            "success_stdout": success_stdout,
+            "success_stderr": success_stderr,
         }
     )
 

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -904,7 +904,7 @@ def script(
     defaults=None,
     context=None,
     success_retcodes=None,
-    success_stdout=NOne,
+    success_stdout=None,
     success_stderr=None,
     **kwargs
 ):

--- a/tests/integration/modules/test_cmdmod.py
+++ b/tests/integration/modules/test_cmdmod.py
@@ -1,4 +1,5 @@
 import os
+import random
 import sys
 import tempfile
 from contextlib import contextmanager
@@ -173,6 +174,23 @@ class CMDModuleTest(ModuleCase):
         )
 
         self.assertEqual(ret, 0)
+
+    @pytest.mark.slow_test
+    def test_run_all_with_success_stderr(self):
+        '''
+        cmd.run with success_retcodes
+        '''
+        random_file = "{0}{1}{2}".format(RUNTIME_VARS.TMP_ROOT_DIR,
+                                         os.path.sep,
+                                         random.random())
+        expected_stderr = 'cat: /tmp/{0}: No such file or directory'.format(random_file)
+        ret = self.run_function('cmd.run_all',
+                                ['cat /tmp/{0}'.format(random_file)],
+                                success_stderr=[expected_stderr],
+                                python_shell=True)
+
+        self.assertTrue('retcode' in ret)
+        self.assertEqual(ret.get('retcode'), 0)
 
     @pytest.mark.slow_test
     def test_blacklist_glob(self):

--- a/tests/integration/modules/test_cmdmod.py
+++ b/tests/integration/modules/test_cmdmod.py
@@ -186,10 +186,10 @@ class CMDModuleTest(ModuleCase):
 
         if salt.utils.platform.is_windows():
             func = "type"
-            expected_stderr = "The system cannot find the file specified."
+            expected_stderr = "cannot find the file specified"
         else:
             func = "cat"
-            expected_stderr = "cat: {}: No such file or directory".format(random_file)
+            expected_stderr = "No such file or directory"
         ret = self.run_function(
             "cmd.run_all",
             ["{} {}".format(func, random_file)],

--- a/tests/integration/modules/test_cmdmod.py
+++ b/tests/integration/modules/test_cmdmod.py
@@ -183,9 +183,15 @@ class CMDModuleTest(ModuleCase):
         random_file = "{0}{1}{2}".format(RUNTIME_VARS.TMP_ROOT_DIR,
                                          os.path.sep,
                                          random.random())
-        expected_stderr = 'cat: /tmp/{0}: No such file or directory'.format(random_file)
+
+        if salt.utils.platform.is_windows():
+            func = 'type'
+            expected_stderr = 'The system cannot find the file specified.'
+        else:
+            func = 'cat'
+            expected_stderr = 'cat: {0}: No such file or directory'.format(random_file)
         ret = self.run_function('cmd.run_all',
-                                ['cat /tmp/{0}'.format(random_file)],
+                                ['{0} {1}'.format(func, random_file)],
                                 success_stderr=[expected_stderr],
                                 python_shell=True)
 

--- a/tests/integration/modules/test_cmdmod.py
+++ b/tests/integration/modules/test_cmdmod.py
@@ -177,26 +177,28 @@ class CMDModuleTest(ModuleCase):
 
     @pytest.mark.slow_test
     def test_run_all_with_success_stderr(self):
-        '''
+        """
         cmd.run with success_retcodes
-        '''
-        random_file = "{0}{1}{2}".format(RUNTIME_VARS.TMP_ROOT_DIR,
-                                         os.path.sep,
-                                         random.random())
+        """
+        random_file = "{}{}{}".format(
+            RUNTIME_VARS.TMP_ROOT_DIR, os.path.sep, random.random()
+        )
 
         if salt.utils.platform.is_windows():
-            func = 'type'
-            expected_stderr = 'The system cannot find the file specified.'
+            func = "type"
+            expected_stderr = "The system cannot find the file specified."
         else:
-            func = 'cat'
-            expected_stderr = 'cat: {0}: No such file or directory'.format(random_file)
-        ret = self.run_function('cmd.run_all',
-                                ['{0} {1}'.format(func, random_file)],
-                                success_stderr=[expected_stderr],
-                                python_shell=True)
+            func = "cat"
+            expected_stderr = "cat: {}: No such file or directory".format(random_file)
+        ret = self.run_function(
+            "cmd.run_all",
+            ["{} {}".format(func, random_file)],
+            success_stderr=[expected_stderr],
+            python_shell=True,
+        )
 
-        self.assertTrue('retcode' in ret)
-        self.assertEqual(ret.get('retcode'), 0)
+        self.assertTrue("retcode" in ret)
+        self.assertEqual(ret.get("retcode"), 0)
 
     @pytest.mark.slow_test
     def test_blacklist_glob(self):

--- a/tests/pytests/unit/modules/test_cmdmod.py
+++ b/tests/pytests/unit/modules/test_cmdmod.py
@@ -643,6 +643,8 @@ def test_run_chroot_runas():
         shell="/bin/sh",
         stdin=None,
         success_retcodes=None,
+        success_stdout=None,
+        success_stderr=None,
         template=None,
         timeout=None,
         umask=None,


### PR DESCRIPTION
### What does this PR do?

This is a backport of https://github.com/saltstack/salt/pull/50920.
The original PR was merged to develop and did not get backported to
master.

### What issues does this PR fix or reference?
Fixes #50597

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
