### PR TITLE
Fix bug #59848. Upgrade black version.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1118,7 +1118,7 @@ repos:
             )$
 
   - repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 20.8b1
     hooks:
       - id: black
         # This tells pre-commit not to pass files to black.


### PR DESCRIPTION
This PR upgrades the version of black in the pre-commit config to avoid a bug where our exclude patterns or some other issue prevented black and pre-commit from working well together, resulting in many files being skipped for blacking.