### PR TITLE
Bump deprecation release for neutron

### DIFF
--- a/salt/utils/openstack/neutron.py
+++ b/salt/utils/openstack/neutron.py
@@ -1,21 +1,12 @@
-# -*- coding: utf-8 -*-
 """
 Neutron class
 """
 
 
-# Import python libs
-from __future__ import absolute_import, print_function, unicode_literals, with_statement
-
 import logging
 
 import salt.utils.versions
-
-# Import salt libs
 from salt import exceptions
-
-# Import third party libs
-from salt.ext import six
 
 # pylint: disable=import-error
 HAS_NEUTRON = False
@@ -73,7 +64,7 @@ def sanitize_neutronclient(kwargs):
         "auth",
     )
     ret = {}
-    for var in six.iterkeys(kwargs):
+    for var in kwargs.keys():
         if var in variables:
             ret[var] = kwargs[var]
 
@@ -103,7 +94,7 @@ class SaltNeutron(NeutronShell):
         Set up neutron credentials
         """
         salt.utils.versions.warn_until(
-            "Aluminium",
+            "Sulfur",
             (
                 "The neutron module has been deprecated and will be removed in {version}.  "
                 "Please update to using the neutronng module"

--- a/salt/version.py
+++ b/salt/version.py
@@ -96,8 +96,8 @@ class SaltStackVersion:
         "Aluminium": (3003,),
         "Silicon": (MAX_SIZE - 95, 0),
         "Phosphorus": (MAX_SIZE - 94, 0),
+        "Sulfur": (MAX_SIZE - 93, 0),
         # pylint: disable=E8265
-        #'Sulfur'       : (MAX_SIZE - 93, 0),
         #'Chlorine'     : (MAX_SIZE - 92, 0),
         #'Argon'        : (MAX_SIZE - 91, 0),
         #'Potassium'    : (MAX_SIZE - 90, 0),


### PR DESCRIPTION
Freeze for https://github.com/saltstack/salt/issues/55663 , but only bumping the name of the release not the message, since the new pillar will not be included in the Aluminium release.