### PR TITLE
Fix failing jenkins tests

### DIFF
--- a/salt/_logging/impl.py
+++ b/salt/_logging/impl.py
@@ -11,8 +11,6 @@ import re
 import sys
 import types
 
-import salt.ext.six as six
-
 # Let's define these custom logging levels before importing the salt._logging.mixins
 # since they will be used there
 PROFILE = logging.PROFILE = 15

--- a/salt/_logging/impl.py
+++ b/salt/_logging/impl.py
@@ -132,18 +132,16 @@ class SaltColorLogRecord(SaltLogRecord):
     def __init__(self, *args, **kwargs):
         SaltLogRecord.__init__(self, *args, **kwargs)
 
-        # Make sure the name is not a None object so it will format correctly
-        if self.name is None:
-            self.name = ""
-
         reset = TextFormat("reset")
         clevel = LOG_COLORS["levels"].get(self.levelname, reset)
         cmsg = LOG_COLORS["msgs"].get(self.levelname, reset)
 
-        self.colorname = "{}[{:<17}]{}".format(LOG_COLORS["name"], self.name, reset)
-        self.colorlevel = "{}[{:<8}]{}".format(clevel, self.levelname, reset)
+        self.colorname = "{}[{:<17}]{}".format(
+            LOG_COLORS["name"], str(self.name), reset
+        )
+        self.colorlevel = "{}[{:<8}]{}".format(clevel, str(self.levelname), reset)
         self.colorprocess = "{}[{:>5}]{}".format(
-            LOG_COLORS["process"], self.process, reset
+            LOG_COLORS["process"], str(self.process), reset
         )
         self.colormsg = "{}{}{}".format(cmsg, self.getMessage(), reset)
 

--- a/salt/_logging/impl.py
+++ b/salt/_logging/impl.py
@@ -349,7 +349,7 @@ class SaltLoggingClass(
         except NameError:
             salt_system_encoding = "utf-8"
 
-        if isinstance(msg, str) and not isinstance(msg, str):
+        if isinstance(msg, bytes):
             try:
                 _msg = msg.decode(salt_system_encoding, "replace")
             except UnicodeDecodeError:
@@ -359,7 +359,7 @@ class SaltLoggingClass(
 
         _args = []
         for item in args:
-            if isinstance(item, str) and not isinstance(item, str):
+            if isinstance(item, bytes):
                 try:
                     _args.append(item.decode(salt_system_encoding, "replace"))
                 except UnicodeDecodeError:

--- a/salt/_logging/impl.py
+++ b/salt/_logging/impl.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
     salt._logging.impl
     ~~~~~~~~~~~~~~~~~~
@@ -6,15 +5,12 @@
     Salt's logging implementation classes/functionality
 """
 
-# Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 import re
 import sys
 import types
 
-# Import 3rd-party libs
 import salt.ext.six as six
 
 # Let's define these custom logging levels before importing the salt._logging.mixins
@@ -24,7 +20,6 @@ TRACE = logging.TRACE = 5
 GARBAGE = logging.GARBAGE = 1
 QUIET = logging.QUIET = 1000
 
-# Import Salt libs
 from salt._logging.handlers import StreamHandler  # isort:skip
 
 # from salt._logging.handlers import SysLogHandler  # isort:skip
@@ -52,7 +47,7 @@ LOG_LEVELS = {
     "warning": logging.WARNING,
 }
 
-LOG_VALUES_TO_LEVELS = dict((v, k) for (k, v) in LOG_LEVELS.items())
+LOG_VALUES_TO_LEVELS = {v: k for (k, v) in LOG_LEVELS.items()}
 
 LOG_COLORS = {
     "levels": {
@@ -96,9 +91,7 @@ LOG_COLORS = {
 }
 
 # Make a list of log level names sorted by log level
-SORTED_LEVEL_NAMES = [
-    l[0] for l in sorted(six.iteritems(LOG_LEVELS), key=lambda x: x[1])
-]
+SORTED_LEVEL_NAMES = [l[0] for l in sorted(LOG_LEVELS.items(), key=lambda x: x[1])]
 
 MODNAME_PATTERN = re.compile(r"(?P<name>%%\(name\)(?:\-(?P<digits>[\d]+))?s)")
 
@@ -141,6 +134,10 @@ class SaltColorLogRecord(SaltLogRecord):
     def __init__(self, *args, **kwargs):
         SaltLogRecord.__init__(self, *args, **kwargs)
 
+        # Make sure the name is not a None object so it will format correctly
+        if self.name is None:
+            self.name = ""
+
         reset = TextFormat("reset")
         clevel = LOG_COLORS["levels"].get(self.levelname, reset)
         cmsg = LOG_COLORS["msgs"].get(self.levelname, reset)
@@ -168,8 +165,7 @@ def set_log_record_factory(factory):
     Set the logging  log record factory
     """
     get_log_record_factory.__factory__ = factory
-    if not six.PY2:
-        logging.setLogRecordFactory(factory)
+    logging.setLogRecordFactory(factory)
 
 
 set_log_record_factory(SaltLogRecord)
@@ -180,7 +176,7 @@ LOGGING_LOGGER_CLASS = logging.getLoggerClass()
 
 
 class SaltLoggingClass(
-    six.with_metaclass(LoggingMixinMeta, LOGGING_LOGGER_CLASS, NewStyleClassMixin)
+    LOGGING_LOGGER_CLASS, NewStyleClassMixin, metaclass=LoggingMixinMeta
 ):
     def __new__(cls, *args):
         """
@@ -194,7 +190,7 @@ class SaltLoggingClass(
             logging.getLogger(__name__)
 
         """
-        instance = super(SaltLoggingClass, cls).__new__(cls)
+        instance = super().__new__(cls)
 
         try:
             max_logger_length = len(
@@ -279,7 +275,7 @@ class SaltLoggingClass(
                 "Only one of 'exc_info' and 'exc_info_on_loglevel' is " "permitted"
             )
         if exc_info_on_loglevel is not None:
-            if isinstance(exc_info_on_loglevel, six.string_types):
+            if isinstance(exc_info_on_loglevel, str):
                 exc_info_on_loglevel = LOG_LEVELS.get(
                     exc_info_on_loglevel, logging.ERROR
                 )
@@ -357,7 +353,7 @@ class SaltLoggingClass(
         except NameError:
             salt_system_encoding = "utf-8"
 
-        if isinstance(msg, six.string_types) and not isinstance(msg, six.text_type):
+        if isinstance(msg, str) and not isinstance(msg, str):
             try:
                 _msg = msg.decode(salt_system_encoding, "replace")
             except UnicodeDecodeError:
@@ -367,9 +363,7 @@ class SaltLoggingClass(
 
         _args = []
         for item in args:
-            if isinstance(item, six.string_types) and not isinstance(
-                item, six.text_type
-            ):
+            if isinstance(item, str) and not isinstance(item, str):
                 try:
                     _args.append(item.decode(salt_system_encoding, "replace"))
                 except UnicodeDecodeError:
@@ -378,24 +372,9 @@ class SaltLoggingClass(
                 _args.append(item)
         _args = tuple(_args)
 
-        if six.PY2:
-            # Recreate what's done for Py >= 3.5
-            _log_record_factory = get_log_record_factory()
-            logrecord = _log_record_factory(
-                name, level, fn, lno, _msg, _args, exc_info, func
-            )
-
-            if extra is not None:
-                for key in extra:
-                    if (key in ["message", "asctime"]) or (key in logrecord.__dict__):
-                        raise KeyError(
-                            "Attempt to overwrite '{}' in LogRecord".format(key)
-                        )
-                    logrecord.__dict__[key] = extra[key]
-        else:
-            logrecord = LOGGING_LOGGER_CLASS.makeRecord(
-                self, name, level, fn, lno, _msg, _args, exc_info, func, sinfo
-            )
+        logrecord = LOGGING_LOGGER_CLASS.makeRecord(
+            self, name, level, fn, lno, _msg, _args, exc_info, func, sinfo
+        )
 
         if exc_info_on_loglevel is not None:
             # Let's add some custom attributes to the LogRecord class in order

--- a/tests/pytests/functional/cli/test_api.py
+++ b/tests/pytests/functional/cli/test_api.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 import pytest
+from salt._logging.impl import get_log_record_factory, set_log_record_factory
 from salt.cli.api import SaltAPI
 
 
@@ -10,13 +11,17 @@ def test_start_shutdown(monkeypatch, tmp_path):
     pid_file = str(tmp_path / "pid_file")
     log_file = str(tmp_path / "log_file")
     api = SaltAPI()
+    orig_factory = get_log_record_factory()
     with pytest.raises(SystemExit):
         # testing environment will fail if we use default pidfile
         # overwrite sys.argv so salt-api does not use testing args
         monkeypatch.setattr(
             "sys.argv", [sys.argv[0], "--pid-file", pid_file, "--log-file", log_file]
         )
-        api.start()
-        assert os.path.isfile(pid_file)
-        assert os.path.isfile(log_file)
-        api.shutdown()
+        try:
+            api.start()
+            assert os.path.isfile(pid_file)
+            assert os.path.isfile(log_file)
+            api.shutdown()
+        finally:
+            set_log_record_factory(orig_factory)

--- a/tests/pytests/functional/cli/test_api.py
+++ b/tests/pytests/functional/cli/test_api.py
@@ -1,31 +1,22 @@
 import os
 import sys
-import tempfile
 
 import pytest
 from salt.cli.api import SaltAPI
-from tests.support.mock import patch
 
 
 @pytest.mark.slow_test
-def test_start_shutdown():
-    pidfile = tempfile.mktemp()
-    logfile = tempfile.mktemp()
+def test_start_shutdown(monkeypatch, tmp_path):
+    pid_file = str(tmp_path / "pid_file")
+    log_file = str(tmp_path / "log_file")
     api = SaltAPI()
     with pytest.raises(SystemExit):
-        try:
-            # testing environment will fail if we use default pidfile
-            # overwrite sys.argv so salt-api does not use testing args
-            with patch.object(sys, "argv", [sys.argv[0], "--pid-file", pidfile]):
-                api.start()
-                assert os.path.isfile(pidfile)
-                api.shutdown()
-        finally:
-            try:
-                os.remove(pidfile)
-            except OSError:
-                pass
-            try:
-                os.remove(logfile)
-            except OSError:
-                pass
+        # testing environment will fail if we use default pidfile
+        # overwrite sys.argv so salt-api does not use testing args
+        monkeypatch.setattr(
+            "sys.argv", [sys.argv[0], "--pid-file", pid_file, "--log-file", log_file]
+        )
+        api.start()
+        assert os.path.isfile(pid_file)
+        assert os.path.isfile(log_file)
+        api.shutdown()

--- a/tests/pytests/functional/cli/test_api.py
+++ b/tests/pytests/functional/cli/test_api.py
@@ -16,12 +16,9 @@ def test_start_shutdown():
         try:
             # testing environment will fail if we use default pidfile
             # overwrite sys.argv so salt-api does not use testing args
-            with patch.object(
-                sys, "argv", [sys.argv[0], "--pid-file", pidfile, "--log-file", logfile]
-            ):
+            with patch.object(sys, "argv", [sys.argv[0], "--pid-file", pidfile]):
                 api.start()
                 assert os.path.isfile(pidfile)
-                assert os.path.isfile(logfile)
                 api.shutdown()
         finally:
             try:

--- a/tests/pytests/integration/master/test_clear_funcs.py
+++ b/tests/pytests/integration/master/test_clear_funcs.py
@@ -130,7 +130,7 @@ def test_pub_not_allowed(
                 break
             if time.time() > stop_time:
                 pytest.fail(
-                    "Took more than {} seconds to confirm the presense of {!r} in the logs".format(
+                    "Took more than {} seconds to confirm the presence of {!r} in the logs".format(
                         timeout, expected_log_message
                     )
                 )


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where the test was setting the color logger for the api test. This was not being set back and was causing later tests to fail. Also fixes an issue with the color logger where None values we being passed to the ColorLogRecord causing the original stack trace.

Also fixes a typo in `test_pub_not_allowed`.

For reference, here's the stacktrace thrown with the ColorLogger:

```
Traceback (most recent call last):
  File "/home/shane/salt/.nox/pytest-parametrized-3-coverage-false-crypto-none-transport-zeromq/lib/python3.6/site-packages/saltfactories/plugins/log_server.py", line 151, in process_logs
    record = logging.makeLogRecord(record_dict)
  File "/usr/lib/python3.6/logging/__init__.py", line 370, in makeLogRecord
    rv = _logRecordFactory(None, None, "", 0, "", (), None, None)
  File "/home/shane/salt/salt/_logging/impl.py", line 148, in __init__
    self.colorname = "{}[{:<17}]{}".format(LOG_COLORS["name"], self.name, reset)
TypeError: unsupported format string passed to NoneType.__format__
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes