### PR TITLE
Prune obsolete exception handler in dictupdate.update

### DIFF
--- a/salt/utils/dictupdate.py
+++ b/salt/utils/dictupdate.py
@@ -59,13 +59,8 @@ def update(dest, upd, recursive_update=True, merge_lists=False):
             else:
                 dest[key] = upd[key]
         return dest
-    try:
-        for k in upd:
-            dest[k] = upd[k]
-    except AttributeError:
-        # this mapping is not a dict
-        for k in upd:
-            dest[k] = upd[k]
+    for k in upd:
+        dest[k] = upd[k]
     return dest
 
 


### PR DESCRIPTION
### What does this PR do?

Remove dead code. The code in the `try` block is the same as in the `except` block, and apparently there are no side effects so this is redundant.

### Merge requirements satisfied?
- [N/A] Docs
- [N/A] Changelog
- [N/A] Covered by existing tests

### Commits signed with GPG?

No

A little bit of git archaeology by @lukasraska:
 
> this is how it looked before (2015) - https://github.com/saltstack/salt/pull/24097/files, so it tried update, if that failed just loop through it (if upd wasn't dict, but something subscriptable)
> then in 2016 the update got rewritten to for loop - https://github.com/saltstack/salt/pull/34726/files because this is failing for NamespacedDictWrapper
> so probably somebody just forgot to remove the try/except block completely?

And the last commit by @s0undt3ch removed the unneeded `keys()` part: https://github.com/saltstack/salt/commit/7dc6b64689f5ea48365212dfcebfc4c46ae94607#diff-5f576cc50b33262232cc541de3fdca74f471bbc99cd3e0e3a58fab48fee6d9c5