### PR TITLE
Remove unused __orchestration__ ret key

### DIFF
--- a/changelog/59917.removed
+++ b/changelog/59917.removed
@@ -1,0 +1,1 @@
+Remove and deprecate the __orchestration__ key from salt.runner and salt.wheel return data. To get it back, set features.enable_deprecated_orchestration_flag master configuration option to True. The flag will be completely removed in Salt 3008 Argon.

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -32,6 +32,8 @@ import salt.output
 import salt.syspaths
 import salt.utils.data
 import salt.utils.event
+import salt.utils.versions
+from salt.features import features
 
 log = logging.getLogger(__name__)
 
@@ -802,7 +804,14 @@ def runner(name, **kwargs):
         "executed" if success else "failed",
     )
 
-    ret["__orchestration__"] = True
+    if features.get("enable_deprecated_orchestration_flag", False):
+        ret["__orchestration__"] = True
+        salt.utils.versions.warn_until(
+            "Argon",
+            "The __orchestration__ return flag will be removed in Salt Argon. "
+            "For more information see https://github.com/saltstack/salt/pull/59917.",
+        )
+
     if "jid" in out:
         ret["__jid__"] = out["jid"]
 
@@ -1044,7 +1053,14 @@ def wheel(name, **kwargs):
         "executed" if success else "failed",
     )
 
-    ret["__orchestration__"] = True
+    if features.get("enable_deprecated_orchestration_flag", False):
+        ret["__orchestration__"] = True
+        salt.utils.versions.warn_until(
+            "Argon",
+            "The __orchestration__ return flag will be removed in Salt Argon. "
+            "For more information see https://github.com/saltstack/salt/pull/59917.",
+        )
+
     if "jid" in out:
         ret["__jid__"] = out["jid"]
 

--- a/tests/pytests/unit/output/test_highstate.py
+++ b/tests/pytests/unit/output/test_highstate.py
@@ -854,7 +854,6 @@ def test_nested_output():
                 "salt_|-nested_|-state.orchestrate_|-runner": {
                     "comment": "Runner function 'state.orchestrate' executed.",
                     "name": "state.orchestrate",
-                    "__orchestration__": True,
                     "start_time": "09:22:53.158742",
                     "result": True,
                     "duration": 980.694,

--- a/tests/pytests/unit/output/test_highstate_terse.py
+++ b/tests/pytests/unit/output/test_highstate_terse.py
@@ -32,7 +32,6 @@ def test_terse_output():
                 "salt_|-nested_|-state.orchestrate_|-runner": {
                     "comment": "Runner function 'state.orchestrate' executed.",
                     "name": "state.orchestrate",
-                    "__orchestration__": True,
                     "start_time": "09:22:53.158742",
                     "result": True,
                     "duration": 980.694,

--- a/tests/unit/states/test_saltmod.py
+++ b/tests/unit/states/test_saltmod.py
@@ -394,7 +394,6 @@ class SaltmodTestCase(TestCase, LoaderModuleMockMixin):
             "name": "state",
             "result": True,
             "comment": "Runner function 'state' executed.",
-            "__orchestration__": True,
         }
         runner_mock = MagicMock(return_value={"return": True})
 
@@ -414,7 +413,6 @@ class SaltmodTestCase(TestCase, LoaderModuleMockMixin):
             "name": "state",
             "result": True,
             "comment": "Wheel function 'state' executed.",
-            "__orchestration__": True,
         }
         wheel_mock = MagicMock(return_value={"return": True})
 


### PR DESCRIPTION
### What does this PR do?

Remove obsolete `__orchestration__` key from return data.

It is set in `salt.runner` and `salt.wheel` orchestration states and was supposed to be used in the highstate outputter: https://github.com/saltstack/salt/pull/35290

However, it is no longer used in the codebase after the highstate outputter became recursive: https://github.com/saltstack/salt/pull/46022

CC: @mattp- 

### Merge requirements satisfied?

- [ ] Docs (N/A)
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?

No
