### PR TITLE
salt/pillar: retain pillar_roots env ordering

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -638,9 +638,9 @@ class Pillar:
         """
         Pull the file server environments out of the master options
         """
-        envs = {"base"}
-        if "pillar_roots" in self.opts:
-            envs.update(list(self.opts["pillar_roots"]))
+        envs = list(dict.fromkeys(self.opts["pillar_roots"]))
+        if "base" not in envs:
+            envs.append("base")
         return envs
 
     def get_tops(self):


### PR DESCRIPTION
### What does this PR do?
Retains the environment ordering implicitly specified in `pillar_roots`, which is necessary to produce deterministic pillar data in the event that multiple environments are in play.

### What issues does this PR fix or reference?
Fixes: 
#44937

### Previous Behavior
Environments were loaded into an unordered set and later pillar compilation could result in compiled pillars that were non-deterministic.

### New Behavior
Compiled pillars are deterministic (with CPython >= 3.6 -- let me know if this needs to work for older Pythons...) as pillar data is scanned based on the ordering denoted by `pillar_roots`.

### Merge requirements satisfied?
**Not yet.**  I'm just pushing this to share for now and to get some test coverage runs as-is.

### Commits signed with GPG?
Yes