### PR TITLE
Fixed cron.present for non-root crons

### DIFF
--- a/changelog/59920.fixed
+++ b/changelog/59920.fixed
@@ -1,0 +1,1 @@
+Fixed writing crons for users other than the user that is running salt.

--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Work with cron
 
@@ -7,21 +6,16 @@ Work with cron
     backslash-escape percent characters and any other metacharacters that might
     be interpreted incorrectly by the shell.
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
-
-# Import python libs
 import os
 import random
 
-# Import salt libs
 import salt.utils.data
 import salt.utils.files
 import salt.utils.functools
 import salt.utils.path
 import salt.utils.stringutils
-from salt.ext import six
 from salt.ext.six.moves import range
 
 TAG = "# Lines below here are managed by Salt, do not edit\n"
@@ -41,7 +35,7 @@ def __virtual__():
 def _ensure_string(val):
     # Account for cases where the identifier is not a string
     # which would cause to_unicode to fail.
-    if not isinstance(val, six.string_types):
+    if not isinstance(val, str):
         val = str(val)  # future lint: enable=blacklisted-function
     try:
         return salt.utils.stringutils.to_unicode(val)
@@ -120,7 +114,7 @@ def _render_tab(lst):
     """
     ret = []
     for pre in lst["pre"]:
-        ret.append("{0}\n".format(pre))
+        ret.append("{}\n".format(pre))
     if ret:
         if ret[-1] != TAG:
             ret.append(TAG)
@@ -128,21 +122,21 @@ def _render_tab(lst):
         ret.append(TAG)
     for env in lst["env"]:
         if (env["value"] is None) or (env["value"] == ""):
-            ret.append('{0}=""\n'.format(env["name"]))
+            ret.append('{}=""\n'.format(env["name"]))
         else:
-            ret.append("{0}={1}\n".format(env["name"], env["value"]))
+            ret.append("{}={}\n".format(env["name"], env["value"]))
     for cron in lst["crons"]:
         if cron["comment"] is not None or cron["identifier"] is not None:
             comment = "#"
             if cron["comment"]:
-                comment += " {0}".format(cron["comment"].replace("\n", "\n# "))
+                comment += " {}".format(cron["comment"].replace("\n", "\n# "))
             if cron["identifier"]:
-                comment += " {0}:{1}".format(SALT_CRON_IDENTIFIER, cron["identifier"])
+                comment += " {}:{}".format(SALT_CRON_IDENTIFIER, cron["identifier"])
 
             comment += "\n"
             ret.append(comment)
         ret.append(
-            "{0}{1} {2} {3} {4} {5} {6}\n".format(
+            "{}{} {} {} {} {} {}\n".format(
                 cron["commented"] is True and "#DISABLED#" or "",
                 cron["minute"],
                 cron["hour"],
@@ -156,14 +150,14 @@ def _render_tab(lst):
         if cron["comment"] is not None or cron["identifier"] is not None:
             comment = "#"
             if cron["comment"]:
-                comment += " {0}".format(cron["comment"].rstrip().replace("\n", "\n# "))
+                comment += " {}".format(cron["comment"].rstrip().replace("\n", "\n# "))
             if cron["identifier"]:
-                comment += " {0}:{1}".format(SALT_CRON_IDENTIFIER, cron["identifier"])
+                comment += " {}:{}".format(SALT_CRON_IDENTIFIER, cron["identifier"])
 
             comment += "\n"
             ret.append(comment)
         ret.append(
-            "{0}{1} {2}\n".format(
+            "{}{} {}\n".format(
                 cron["commented"] is True and "#DISABLED#" or "",
                 cron["spec"],
                 cron["cmd"],
@@ -177,10 +171,10 @@ def _get_cron_cmdstr(path, user=None):
     Returns a format string, to be used to build a crontab command.
     """
     if user:
-        cmd = "crontab -u {0}".format(user)
+        cmd = "crontab -u {}".format(user)
     else:
         cmd = "crontab"
-    return "{0} {1}".format(cmd, path)
+    return "{} {}".format(cmd, path)
 
 
 def _check_instance_uid_match(user):
@@ -301,8 +295,8 @@ def _date_time_match(cron, **kwargs):
     return all(
         [
             kwargs.get(x) is None
-            or cron[x] == six.text_type(kwargs[x])
-            or (six.text_type(kwargs[x]).lower() == "random" and cron[x] != "*")
+            or cron[x] == str(kwargs[x])
+            or (str(kwargs[x]).lower() == "random" and cron[x] != "*")
             for x in ("minute", "hour", "daymonth", "month", "dayweek")
         ]
     )
@@ -338,7 +332,7 @@ def raw_cron(user):
         ).splitlines(True)
     # If Salt is running from root user it could modify any user's crontab
     elif _check_instance_uid_match("root"):
-        cmd = "crontab -u {0} -l".format(user)
+        cmd = "crontab -u {} -l".format(user)
         # Preserve line endings
         lines = salt.utils.data.decode(
             __salt__["cmd.run_stdout"](
@@ -588,13 +582,13 @@ def _get_cron_date_time(**kwargs):
 
     ret = {}
     for param in ("minute", "hour", "month", "dayweek"):
-        value = six.text_type(kwargs.get(param, "1")).lower()
+        value = str(kwargs.get(param, "1")).lower()
         if value == "random":
-            ret[param] = six.text_type(random.sample(range_max[param], 1)[0])
+            ret[param] = str(random.sample(range_max[param], 1)[0])
         elif len(value.split(":")) == 2:
             cron_range = sorted(value.split(":"))
             start, end = int(cron_range[0]), int(cron_range[1])
-            ret[param] = six.text_type(random.randint(start, end))
+            ret[param] = str(random.randint(start, end))
         else:
             ret[param] = value
 
@@ -606,9 +600,9 @@ def _get_cron_date_time(**kwargs):
         # This catches both '2' and '*'
         daymonth_max = 28
 
-    daymonth = six.text_type(kwargs.get("daymonth", "1")).lower()
+    daymonth = str(kwargs.get("daymonth", "1")).lower()
     if daymonth == "random":
-        ret["daymonth"] = six.text_type(
+        ret["daymonth"] = str(
             random.sample(list(list(range(1, (daymonth_max + 1)))), 1)[0]
         )
     else:
@@ -639,11 +633,11 @@ def set_job(
         salt '*' cron.set_job root '*' '*' '*' '*' 1 /usr/local/weekly
     """
     # Scrub the types
-    minute = six.text_type(minute).lower()
-    hour = six.text_type(hour).lower()
-    daymonth = six.text_type(daymonth).lower()
-    month = six.text_type(month).lower()
-    dayweek = six.text_type(dayweek).lower()
+    minute = str(minute).lower()
+    hour = str(hour).lower()
+    daymonth = str(daymonth).lower()
+    month = str(month).lower()
+    dayweek = str(dayweek).lower()
     lst = list_tab(user)
     for cron in lst["crons"]:
         cid = _cron_id(cron)

--- a/tests/unit/modules/test_cron.py
+++ b/tests/unit/modules/test_cron.py
@@ -1,16 +1,10 @@
-# -*- coding: utf-8 -*-
 """
     :codeauthor: Mike Place <mp@saltstack.com>
 """
 
-# Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
-# Import Salt libs
 import salt.modules.cron as cron
 from salt.ext.six.moves import StringIO, builtins, range
-
-# Import Salt Testing libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, call, mock_open, patch
 from tests.support.unit import TestCase
@@ -881,7 +875,7 @@ class CronTestCase(TestCase, LoaderModuleMockMixin):
                     (L + "# foo\n" "* * * * * ls\n"),
                     (
                         L
-                        + "# foo {0}:blah\n".format(cron.SALT_CRON_IDENTIFIER)
+                        + "# foo {}:blah\n".format(cron.SALT_CRON_IDENTIFIER)
                         + "* * * * * ls\n"
                     ),
                 ]


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes: #59920

### Previous Behavior
Incorrectly tried using crontab (with runas) to set a user's (other than the user that is running salt) crontab.

### New Behavior
This makes salt use `crontab -u` where appropriate in `salt.modules.cron._write_cron_lines`, similar to the logic in `salt.modules.cron.write_cron_file_verbose` or `salt.modules.cron.write_cron_file`, while preserving the change done in 60f13034716566dcb085c81a7ae009f552cd887b.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No