### PR TITLE
Adds the grains.uuid on Windows - Issue 59888

### DIFF
--- a/changelog/59888.added
+++ b/changelog/59888.added
@@ -1,0 +1,1 @@
+Added the grains.uuid on Windows platform

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1387,6 +1387,7 @@ def _windows_platform_data():
     #    serialnumber
     #    osfullname
     #    timezone
+    #    uuid
     #    windowsdomain
     #    windowsdomaintype
     #    motherboard.productname
@@ -1406,6 +1407,8 @@ def _windows_platform_data():
         biosinfo = wmi_c.Win32_BIOS()[0]
         # http://msdn.microsoft.com/en-us/library/windows/desktop/aa394498(v=vs.85).aspx
         timeinfo = wmi_c.Win32_TimeZone()[0]
+        # https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/win32-computersystemproduct
+        csproductinfo = wmi_c.Win32_ComputerSystemProduct()[0]
 
         # http://msdn.microsoft.com/en-us/library/windows/desktop/aa394072(v=vs.85).aspx
         motherboard = {"product": None, "serial": None}
@@ -1443,6 +1446,7 @@ def _windows_platform_data():
             "serialnumber": _clean_value("serialnumber", biosinfo.SerialNumber),
             "osfullname": _clean_value("osfullname", osinfo.Caption),
             "timezone": _clean_value("timezone", timeinfo.Description),
+            "uuid": _clean_value("uuid", csproductinfo.UUID.lower()),
             "windowsdomain": _clean_value("windowsdomain", net_info["Domain"]),
             "windowsdomaintype": _clean_value(
                 "windowsdomaintype", net_info["DomainType"]

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -186,6 +186,7 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
             "motherboard",
             "serialnumber",
             "timezone",
+            "uuid",
             "manufacturer",
             "kernelversion",
             "osservicepack",


### PR DESCRIPTION
### What does this PR do?
Adds the grain "uuid" on Windows, like the one already present on Linux.

### What issues does this PR fix or reference?
Fixes: #59888

### Previous Behavior
The grain is no existent.

### New Behavior
Returns the system's UUID:
```
    uuid:
        f62af381-0927-408b-914d-c32fa7dc9b68
```

### Merge requirements satisfied?
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No