### PR TITLE
Fix #59935: pillar_roots.write on pillar subdirs

### DIFF
--- a/changelog/59935.fixed
+++ b/changelog/59935.fixed
@@ -1,0 +1,1 @@
+Fix pillar_roots.write on subdirectories broken after CVE-2021-25282 patch.

--- a/salt/wheel/pillar_roots.py
+++ b/salt/wheel/pillar_roots.py
@@ -104,7 +104,7 @@ def write(data, path, saltenv="base", index=0):
         )
     roots_dir = __opts__["pillar_roots"][saltenv][index]
     dest = os.path.join(roots_dir, path)
-    if not salt.utils.verify.clean_path(roots_dir, dest):
+    if not salt.utils.verify.clean_path(roots_dir, dest, subdir=True):
         return "Invalid path"
     dest = os.path.join(__opts__["pillar_roots"][saltenv][index], path)
     dest_dir = os.path.dirname(dest)

--- a/tests/integration/wheel/test_pillar_roots.py
+++ b/tests/integration/wheel/test_pillar_roots.py
@@ -29,9 +29,23 @@ class WheelPillarRootsTest(TestCase, AdaptedConfigurationTestCaseMixin):
         assert os.path.exists(os.path.join(self.pillar_dir, "foo"))
         assert ret.find("Wrote data to file") != -1
 
+    def test_write_subdir(self):
+        ret = self.wheel.cmd(
+            "pillar_roots.write", kwarg={"data": "foo: bar", "path": "sub/dir/file"}
+        )
+        assert os.path.exists(os.path.join(self.pillar_dir, "sub/dir/file"))
+        assert ret.find("Wrote data to file") != -1
+
     def test_cvr_2021_25282(self):
         ret = self.wheel.cmd(
             "pillar_roots.write", kwarg={"data": "foo", "path": "../foo"}
+        )
+        assert not os.path.exists(os.path.join(self.traversed_dir, "foo"))
+        assert ret.find("Invalid path") != -1
+
+    def test_cvr_2021_25282_subdir(self):
+        ret = self.wheel.cmd(
+            "pillar_roots.write", kwarg={"data": "foo", "path": "sub/../../foo"}
         )
         assert not os.path.exists(os.path.join(self.traversed_dir, "foo"))
         assert ret.find("Invalid path") != -1


### PR DESCRIPTION
### What does this PR do?
Fixes the `pillar_roots.write`'s call to `salt.utils.verify.clean_path` to account for subdirectory writes.

### What issues does this PR fix or reference?
Fixes: #59935

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
No