### PR TITLE
Issue 52288 Fix for MasterMinion config creation

### DIFF
--- a/changelog/52288.fixed
+++ b/changelog/52288.fixed
@@ -1,0 +1,1 @@
+Fixed fileclient cachedir path switching from master to minion due to incorrect MasterMinion configuration

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2223,6 +2223,7 @@ def mminion_config(path, overrides, ignore_config_errors=True):
     opts = minion_config(path, ignore_config_errors=ignore_config_errors, role="master")
     opts.update(overrides)
     apply_sdb(opts)
+
     _validate_opts(opts)
     opts["grains"] = salt.loader.grains(opts)
     opts["pillar"] = {}

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2213,8 +2213,19 @@ def minion_config(
         overrides, defaults, cache_minion_id=cache_minion_id, minion_id=minion_id
     )
     opts["__role"] = role
+    if role != "master":
+        apply_sdb(opts)
+        _validate_opts(opts)
+    return opts
+
+
+def mminion_config(path, overrides, ignore_config_errors=True):
+    opts = minion_config(path, ignore_config_errors=ignore_config_errors, role="master")
+    opts.update(overrides)
     apply_sdb(opts)
     _validate_opts(opts)
+    opts["grains"] = salt.loader.grains(opts)
+    opts["pillar"] = {}
     return opts
 
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -975,6 +975,7 @@ class MasterMinion:
         self.whitelist = whitelist
         self.mk_returners = returners
         self.mk_states = states
+
         self.mk_rend = rend
         self.mk_matcher = matcher
         self.gen_modules(initial_load=True)

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -969,13 +969,10 @@ class MasterMinion:
         whitelist=None,
         ignore_config_errors=True,
     ):
-        self.opts = salt.config.minion_config(
-            opts["conf_file"], ignore_config_errors=ignore_config_errors, role="master"
+        self.opts = salt.config.mminion_config(
+            opts["conf_file"], opts, ignore_config_errors=ignore_config_errors
         )
-        self.opts.update(opts)
         self.whitelist = whitelist
-        self.opts["grains"] = salt.loader.grains(opts)
-        self.opts["pillar"] = {}
         self.mk_returners = returners
         self.mk_states = states
         self.mk_rend = rend

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1895,6 +1895,7 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
         ) as validate_opts_mock:
             config = salt.config.minion_config(fpath, role="master")
             apply_sdb_mock.assert_not_called()
+
             validate_opts_mock.assert_not_called()
         self.assertEqual(config["__role"], "master")
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -265,9 +265,9 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
 
     @with_tempfile()
     def test_proper_path_joining(self, fpath):
-        temp_config = "root_dir: /\n" "key_logfile: key\n"
+        temp_config = "root_dir: /\nkey_logfile: key\n"
         if salt.utils.platform.is_windows():
-            temp_config = "root_dir: c:\\\n" "key_logfile: key\n"
+            temp_config = "root_dir: c:\\\nkey_logfile: key\n"
         with salt.utils.files.fopen(fpath, "w") as fp_:
             fp_.write(temp_config)
 
@@ -1885,6 +1885,42 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             ret = salt.config.apply_minion_config(defaults=defaults)
             self.assertNotIn("environment", ret)
             self.assertEqual(ret["saltenv"], "foo")
+
+    @with_tempfile()
+    def test_minion_config_role_master(self, fpath):
+        with salt.utils.files.fopen(fpath, "w") as wfh:
+            wfh.write("root_dir: /\n" "key_logfile: key\n")
+        with patch("salt.config.apply_sdb") as apply_sdb_mock, patch(
+            "salt.config._validate_opts"
+        ) as validate_opts_mock:
+            config = salt.config.minion_config(fpath, role="master")
+            apply_sdb_mock.assert_not_called()
+            validate_opts_mock.assert_not_called()
+        self.assertEqual(config["__role"], "master")
+
+    @with_tempfile()
+    def test_mminion_config_cache_path(self, fpath):
+        cachedir = os.path.abspath("/path/to/master/cache")
+        overrides = {}
+
+        with salt.utils.files.fopen(fpath, "w") as wfh:
+            wfh.write(
+                "root_dir: /\n" "key_logfile: key\n" "cachedir: {}".format(cachedir)
+            )
+        config = salt.config.mminion_config(fpath, overrides)
+        self.assertEqual(config["__role"], "master")
+        self.assertEqual(config["cachedir"], cachedir)
+
+    @with_tempfile()
+    def test_mminion_config_cache_path_overrides(self, fpath):
+        cachedir = os.path.abspath("/path/to/master/cache")
+        overrides = {"cachedir": cachedir}
+
+        with salt.utils.files.fopen(fpath, "w") as wfh:
+            wfh.write("root_dir: /\n" "key_logfile: key\n")
+        config = salt.config.mminion_config(fpath, overrides)
+        self.assertEqual(config["__role"], "master")
+        self.assertEqual(config["cachedir"], cachedir)
 
 
 class APIConfigTestCase(DefaultConfigsBase, TestCase):

--- a/tests/unit/test_minion.py
+++ b/tests/unit/test_minion.py
@@ -794,3 +794,12 @@ class MinionAsyncTestCase(
             with self.assertRaises(SaltClientError, msg="No master could be resolved"):
                 minion = salt.minion.Minion(mock_opts)
                 yield minion.connect_master()
+
+
+class MasterMinionTestCase(TestCase):
+    def test_config_cache_path_overrides(self):
+        cachedir = os.path.abspath("/path/to/master/cache")
+        opts = {"cachedir": cachedir, "conf_file": None}
+
+        mminion = salt.minion.MasterMinion(opts)
+        self.assertEqual(mminion.opts["cachedir"], cachedir)


### PR DESCRIPTION
pulled from https://github.com/saltstack/salt/pull/57528

### What does this PR do?
Call `apply_sdb` later, after master part of options is applied.
This fixes paths for sdb modules being used with MasterMinion.

Also moved `mminion_config` population to the `salt.config` module.


### What issues does this PR fix or reference?
Fixes: #52288

### Previous Behavior
SDB modules starts to use minion related paths after first creation of MasterMinion object in ClientMixins on master side.
Details are in #52288

### New Behavior
MasterMinion is created with correct paths related to master folders.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
