### PR TITLE
fixup nftables.build_rule for saddr/daddr

### DIFF
--- a/changelog/59958.fixed
+++ b/changelog/59958.fixed
@@ -1,0 +1,1 @@
+Added missing space for nftables.build_rule when using saddr or daddr.

--- a/salt/modules/nftables.py
+++ b/salt/modules/nftables.py
@@ -165,14 +165,14 @@ def build_rule(
         del kwargs["counter"]
 
     if "saddr" in kwargs or "source" in kwargs:
-        rule += "ip saddr {}".format(kwargs.get("saddr") or kwargs.get("source"))
+        rule += "ip saddr {} ".format(kwargs.get("saddr") or kwargs.get("source"))
         if "saddr" in kwargs:
             del kwargs["saddr"]
         if "source" in kwargs:
             del kwargs["source"]
 
     if "daddr" in kwargs or "destination" in kwargs:
-        rule += "ip daddr {}".format(kwargs.get("daddr") or kwargs.get("destination"))
+        rule += "ip daddr {} ".format(kwargs.get("daddr") or kwargs.get("destination"))
         if "daddr" in kwargs:
             del kwargs["daddr"]
         if "destination" in kwargs:

--- a/tests/unit/modules/test_nftables.py
+++ b/tests/unit/modules/test_nftables.py
@@ -2,16 +2,11 @@
     :codeauthor: Jayesh Kariya <jayeshk@saltstack.com>
 """
 
-# Import Python Libs
-
 import json
 
-# Import Salt Libs
 import salt.modules.nftables as nftables
 import salt.utils.files
 from salt.exceptions import CommandExecutionError
-
-# Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, mock_open, patch
 from tests.support.unit import TestCase
@@ -89,6 +84,25 @@ class NftablesTestCase(TestCase, LoaderModuleMockMixin):
             {
                 "result": True,
                 "rule": "nft halt rule ip filter input ",
+                "comment": "Successfully built rule",
+            },
+        )
+
+        self.assertEqual(
+            nftables.build_rule(
+                table="filter",
+                chain="input",
+                command="insert",
+                position="3",
+                full="True",
+                connstate="related,established",
+                saddr="10.0.0.1",
+                daddr="10.0.0.2",
+                jump="accept",
+            ),
+            {
+                "result": True,
+                "rule": "nft insert rule ip filter input position 3 ct state { related,established } ip saddr 10.0.0.1 ip daddr 10.0.0.2 accept",
                 "comment": "Successfully built rule",
             },
         )


### PR DESCRIPTION

### What does this PR do?

### What issues does this PR fix or reference?
Fixes:

nftables.build_rule does not correctly build nftables rules when saddr
or daddr is used due to missing whitespace. This PR adds the missing
whitespace to corretly build the rule.

### Previous Behavior
all states that use saddr or daddr fail due to invalid rule

### New Behavior
rules are built in the applicable form
