### PR TITLE
update releasenotes 3003

### DIFF
--- a/doc/topics/releases/3003.rst
+++ b/doc/topics/releases/3003.rst
@@ -16,25 +16,46 @@ and :py:func:`postgres_group.present <salt.states.postgres_group.present>`
 states. This allows migration away from the insecure and deprecated
 previous storage methods.
 
+Added
+=====
 
-Removed
--------
-
-- Removed the deprecated glance state and execution module in favor of the glance_image
-  state module and the glanceng execution module. (#59079)
-- Removing the _ext_nodes deprecation warning and alias to the master_tops function.  This change will break compatibility with a Salt master running versions 2017.7.8 and older and Salt minions running versions 3003 and newer. (#59804)
-- removed the arg `managed_private_key` from 'salt.states.x509.certificate_managed' (#59247)
-- Drop support for python 3.5 on Windows (#59479)
-
-
-Deprecated
-----------
-
-- Added deprecation warning for grains.get_or_set_hash (#59425)
-
+- Added "fips_mode" config option to master and minion configs. (#59427)
+- Firewall groups support to Vultr Salt Cloud provider
+- Adding the ability to clear and show the pillar cache enabled when pillar_cache is True. (#37080)
+- SCRAM-SHA-256 support for PostgreSQL passwords.
+  Pass encrypted=scram-sha-256 to the postgres_user.present (or postgres_group.present) state. (#51271)
+- The yumpkg module has been updated to support VMWare's Photon OS, which uses tdnf (a C implementation of dnf).  "VMware Photon OS" has been added to the "RedHat" `os_family` map as part of this change. (#51912)
+- The pkgrepo state now supports VMware Photon OS. (#52550)
+- Added firewallgroups to Vultr Salt Cloud provider (#53677)
+- Added arbitrary kwarg support for tojson filter. (#56012)
+- Add salt monitor beacon to execute salt execution module functions. (#56461)
+- Allow the nameservers to be populated from systemd-resolve. (#57618)
+- Adding reactor_niceness to the default minion configuration. (#57701)
+- CPU model, topology and NUMA node tuning (#57880)
+- Added ``pkg.services_need_restart`` which lists system services that should be restarted after package management operations. (#58261)
+- Allow handling special first boot definition on virtual machine (#58589)
+- Added vgcreate custom parameters to module call: addtag, alloc, autobackup, metadatatype, zero (#58747)
+- Enhance console and serial support in virt module (#58844)
+- Salt's versions report `salt --versions-report` now includes all installed salt extensions into its versions report. (#58938)
+- Support loading entrypoints by passing a module instead of a function. (#58939)
+- Added shadow.gen_password for BSD operating systems. (#59140)
+- Add more network and PCI/USB host devices passthrough support to virt module and states (#59143)
+- Add interface channels management support to rh_ip module. (#59147)
+- Add new minion option return_retry_tries for dynamic return retry tries (#59236)
+- Added salt-cloud support for Hetzner Cloud via the ``hcloud`` library of the provider. (#59301)
+- "AlmaLinux" has been added to the "RedHat" `os_family` map (#59404)
+- Added `blocks` and `attachments` params to the `slack_notify.post_message` function (#59428)
+- Added tcp_reconnect_backoff minion config option for specifying reconnection backoff time for TCP transport (#59431)
+- Added ``swapusage`` beacon to complement the existing ``memusage`` beacon. (#59460)
+- The `salt-run` CLI now accepts `--jid` (#59527)
+- Add bytes option for FreeBSD pkg-stats(8) module. (#59540)
+- Adding mod_beacon function to pkg, service, and file state modules. This function will act similar to the mod_watch function. This will allow supported functions in those state modules to automatically add associated beacons to monitor for changes to the respective resources in the state file and fire events to the event bus when changes occur. (#59559)
+- Add -B flag to FreeBSD pkgng.check() to regenerate the library dependency
+  metadata for a package by extracting library requirement information from the
+  binary ELF files in the package. (#59569)
 
 Changed
--------
+=======
 
 - The :py:mod:`pkg <salt.modules.yumpkg>` module now supports ``tdnf`` used by
   VMWare Photon OS.  As part of this change, ``VMWare Photon OS``'s
@@ -47,9 +68,22 @@ Changed
 - Changed package manager detection in yumpkg module (#59201)
 - Updating the pkg beacon to fire the events when there are upgrades to packages, but also when watched packages are installed or removed. Breaking out the logic for listing pkgs from context into a separate function to aid in testing. Updating tests to ensure context is not used when use_context option to list_pkgs is False. (#59463)
 
+Removed
+=======
+
+- Removed the deprecated glance state and execution module in favor of the glance_image
+  state module and the glanceng execution module. (#59079)
+- Removing the _ext_nodes deprecation warning and alias to the master_tops function.  This change will break compatibility with a Salt master running versions 2017.7.8 and older and Salt minions running versions 3003 and newer. (#59804)
+- removed the arg `managed_private_key` from 'salt.states.x509.certificate_managed' (#59247)
+- Drop support for python 3.5 on Windows (#59479)
+
+Deprecated
+==========
+
+- Added deprecation warning for grains.get_or_set_hash (#59425)
 
 Fixed
------
+=====
 
 - When instantiating the loader grab values of grains and pillars if
   they are NamedLoaderContext instances. (#59773)
@@ -150,42 +184,3 @@ Fixed
 - Fixing the virtual function for the netimiko module to allow it to run outside of a proxy minion. Adding additional tests. (#59635)
 - Allow "extra_filerefs" as sanitized kwargs for SSH client.
   Fix regression on "cmd.run" when passing tuples as cmd. (#59664)
-
-
-Added
------
-
-- Added "fips_mode" config option to master and minion configs. (#59427)
-- Firewall groups support to Vultr Salt Cloud provider
-- Adding the ability to clear and show the pillar cache enabled when pillar_cache is True. (#37080)
-- SCRAM-SHA-256 support for PostgreSQL passwords.
-  Pass encrypted=scram-sha-256 to the postgres_user.present (or postgres_group.present) state. (#51271)
-- The yumpkg module has been updated to support VMWare's Photon OS, which uses tdnf (a C implementation of dnf).  "VMware Photon OS" has been added to the "RedHat" `os_family` map as part of this change. (#51912)
-- The pkgrepo state now supports VMware Photon OS. (#52550)
-- Added firewallgroups to Vultr Salt Cloud provider (#53677)
-- Added arbitrary kwarg support for tojson filter. (#56012)
-- Add salt monitor beacon to execute salt execution module functions. (#56461)
-- Allow the nameservers to be populated from systemd-resolve. (#57618)
-- Adding reactor_niceness to the default minion configuration. (#57701)
-- CPU model, topology and NUMA node tuning (#57880)
-- Added ``pkg.services_need_restart`` which lists system services that should be restarted after package management operations. (#58261)
-- Allow handling special first boot definition on virtual machine (#58589)
-- Added vgcreate custom parameters to module call: addtag, alloc, autobackup, metadatatype, zero (#58747)
-- Enhance console and serial support in virt module (#58844)
-- Salt's versions report `salt --versions-report` now includes all installed salt extensions into its versions report. (#58938)
-- Support loading entrypoints by passing a module instead of a function. (#58939)
-- Added shadow.gen_password for BSD operating systems. (#59140)
-- Add more network and PCI/USB host devices passthrough support to virt module and states (#59143)
-- Add interface channels management support to rh_ip module. (#59147)
-- Add new minion option return_retry_tries for dynamic return retry tries (#59236)
-- Added salt-cloud support for Hetzner Cloud via the ``hcloud`` library of the provider. (#59301)
-- "AlmaLinux" has been added to the "RedHat" `os_family` map (#59404)
-- Added `blocks` and `attachments` params to the `slack_notify.post_message` function (#59428)
-- Added tcp_reconnect_backoff minion config option for specifying reconnection backoff time for TCP transport (#59431)
-- Added ``swapusage`` beacon to complement the existing ``memusage`` beacon. (#59460)
-- The `salt-run` CLI now accepts `--jid` (#59527)
-- Add bytes option for FreeBSD pkg-stats(8) module. (#59540)
-- Adding mod_beacon function to pkg, service, and file state modules. This function will act similar to the mod_watch function. This will allow supported functions in those state modules to automatically add associated beacons to monitor for changes to the respective resources in the state file and fire events to the event bus when changes occur. (#59559)
-- Add -B flag to FreeBSD pkgng.check() to regenerate the library dependency
-  metadata for a package by extracting library requirement information from the
-  binary ELF files in the package. (#59569)


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/saltstack/salt/issues/59946

Update header and order list on release notes for 3003.

Will need to get this in and create a `v3003_docs_tag` to update the docs on 3003/latest.

Docs change only.