### PR TITLE
Fix module network.mod_hostname for RHEL dists

### DIFF
--- a/changelog/59973.fixed
+++ b/changelog/59973.fixed
@@ -1,0 +1,1 @@
+Fixed module network.mod_hostname for RHEL dists where `HOSTNAME` in `/etc/sysconfig/network` was incorrectly set.

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -1456,10 +1456,9 @@ def mod_hostname(hostname):
                     # fmt: off
                     fh_.write(
                         __utils__["stringutils.to_str"](
-                            "HOSTNAME={}{}{}\n".format(
-                                __utils__["stringutils.dequote"](hostname),
-                                quote_type,
-                                __utils__["stringutils.dequote"](hostname),
+                            "HOSTNAME={quote}{hostname}{quote}\n".format(
+                                quote=quote_type,
+                                hostname=__utils__["stringutils.dequote"](hostname),
                             )
                         )
                     )


### PR DESCRIPTION
### What does this PR do?
Fix hostname incorrectly set when using `network.system` on RedHat family.

### What issues does this PR fix or reference?
Fixes: #59973 

### Previous Behavior
The hostname in `/etc/sysconfig/network` was incorrectly set to twice the `hostname` value, for example, "host.example" would give:
```
HOSTNAME=host.examplehost.example
```

### New Behavior
The hostname is correctly set

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes