### PR TITLE
[master] Add contextvars from site-packages to thin tarball

### DIFF
--- a/changelog/59942.fixed
+++ b/changelog/59942.fixed
@@ -1,0 +1,1 @@
+Use contextvars libary from site-packages if it is intalled. Fixes salt ssh for targets with python <=3.6

--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -2,13 +2,15 @@
 Generate the salt thin tarball from the installed python files
 """
 
-import contextvars
+import contextvars as py_contextvars
 import copy
 import logging
 import os
 import shutil
 import subprocess
 import sys
+import site
+import importlib.util
 import tarfile
 import tempfile
 import zipfile
@@ -91,6 +93,46 @@ else:
 
 
 log = logging.getLogger(__name__)
+
+
+
+def find_site_modules(name):
+    """
+    Finds and imports a module from site packages directories.
+
+    :name: The name of the module to import
+    :return: A list of imported modules, if no modules are imported an empty
+             list is returned.
+    """
+    libs = []
+    for site_path in site.getsitepackages():
+        module_path = os.path.join(site_path, '{}.py'.format(name))
+        try:
+            spec = importlib.util.spec_from_file_location(name, module_path)
+        except ValueError:
+            spec = None
+        if spec is not None:
+            lib = importlib.util.module_from_spec(spec)
+            try:
+                spec.loader.exec_module(lib)
+            except OSError:
+                pass
+            else:
+                libs.append(lib)
+        module_path = os.path.join(site_path, name, '__init__.py')
+        try:
+            spec = importlib.util.spec_from_file_location(name, module_path)
+        except ValueError:
+            spec = None
+        if spec is not None:
+            lib = importlib.util.module_from_spec(spec)
+            try:
+                spec.loader.exec_module(lib)
+            except OSError:
+                pass
+            else:
+                libs.append(lib)
+    return libs
 
 
 def _get_salt_call(*dirs, **namespaces):
@@ -364,8 +406,14 @@ def get_tops(extra_mods="", so_mods=""):
         ssl_match_hostname,
         markupsafe,
         backports_abc,
-        contextvars,
     ]
+    modules = find_site_modules('contextvars')
+    if modules:
+        contextvars = modules[0]
+    else:
+        contextvars = py_contextvars
+    log.warn("Using contextvars %r", contextvars)
+    mods.append(contextvars)
     if has_immutables:
         mods.append(immutables)
     for mod in mods:

--- a/tests/pytests/conftest.py
+++ b/tests/pytests/conftest.py
@@ -76,6 +76,12 @@ def reactor_event(tmp_path_factory):
 
 
 @pytest.fixture(scope="session")
+def master_id():
+    master_id = random_string("master-")
+    yield master_id
+
+
+@pytest.fixture(scope="session")
 def salt_master_factory(
     request,
     salt_factories,
@@ -89,8 +95,8 @@ def salt_master_factory(
     sdb_etcd_port,
     vault_port,
     reactor_event,
+    master_id,
 ):
-    master_id = random_string("master-")
     root_dir = salt_factories.get_root_dir_for_daemon(master_id)
     conf_dir = root_dir / "conf"
     conf_dir.mkdir(exist_ok=True)

--- a/tests/pytests/integration/ssh/test_py_versions.py
+++ b/tests/pytests/integration/ssh/test_py_versions.py
@@ -1,0 +1,159 @@
+"""
+Integration tests for the etcd modules
+"""
+
+import logging
+import os
+import io
+import subprocess
+import base64
+import tempfile
+
+import pytest
+from tests.support.runtests import RUNTIME_VARS
+from tests.support.helpers import dedent
+from saltfactories.utils.ports import get_unused_localhost_port
+
+log = logging.getLogger(__name__)
+
+pytestmark = [pytest.mark.skip_if_binaries_missing("dockerd")]
+
+
+class Keys:
+    """
+    Temporary ssh key pair
+    """
+
+    def __init__(self, priv_path=None):
+        if priv_path is None:
+            priv_path = tempfile.mktemp()
+        self.priv_path = priv_path
+
+    def generate(self):
+        proc = subprocess.run(["ssh-keygen", "-q", "-N", "", "-f", self.priv_path])
+        if proc.returncode != 0:
+            raise Exception("ssh-keygen returned non-0 status")
+
+    @property
+    def pub_path(self):
+        return "{}.pub".format(self.priv_path)
+
+    @property
+    def pub(self):
+        with open(self.pub_path, "r") as fp:
+            return fp.read()
+
+    @property
+    def priv(self):
+        with open(self.priv_path, "r") as fp:
+            return fp.read()
+
+    def __enter__(self):
+        self.generate()
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        os.remove(self.pub_path)
+        os.remove(self.priv_path)
+
+
+@pytest.fixture(scope="module")
+def ssh_keys():
+    """
+    Temporary ssh key fixture
+    """
+    with Keys() as keys:
+        yield keys
+
+
+@pytest.fixture(scope="module")
+def ssh_port():
+    """
+    Temporary ssh port fixture
+    """
+    return get_unused_localhost_port()
+
+
+@pytest.fixture(scope="module")
+def ssh_roster(ssh_port, ssh_keys, master_id):
+    """
+    Temporary roster for ssh docker container
+    """
+    roster_path = os.path.join(RUNTIME_VARS.TMP, master_id, 'conf', 'roster')
+    with io.open(roster_path, 'r') as fp:
+        orig_roster = fp.read()
+    roster = orig_roster + dedent("""
+    pyvertest:
+      host: localhost
+      user: centos
+      port: {}
+      priv: {}
+      ssh_options:
+        - StrictHostKeyChecking=no
+        - UserKnownHostsFile=/dev/null
+    """.format(ssh_port, ssh_keys.priv_path))
+    with io.open(roster_path, 'w') as fp:
+        fp.write(roster)
+    try:
+        yield roster_path
+    finally:
+        with io.open(roster_path, 'w') as fp:
+            fp.write(orig_roster)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ssh_docker_container(salt_call_cli, ssh_port, ssh_keys):
+    """
+    Temporary docker container with python 3.6 and ssh enabled
+    """
+    container_started = False
+    try:
+        ret = salt_call_cli.run(
+            "state.single", "docker_image.present", name="dwoz1/cicd", tag="ssh"
+        )
+        assert ret.exitcode == 0
+        assert ret.json
+        state_run = next(iter(ret.json.values()))
+        assert state_run["result"] is True
+        ret = salt_call_cli.run(
+            "state.single",
+            "docker_container.running",
+            name="ssh1",
+            image="dwoz1/cicd:ssh",
+            port_bindings="\"{}:22\"".format(ssh_port),
+            environment={"SSH_USER": "centos", "SSH_AUTHORIZED_KEYS": ssh_keys.pub},
+            cap_add="IPC_LOCK",
+            timeout=300,
+        )
+        assert ret.exitcode == 0
+        assert ret.json
+        state_run = next(iter(ret.json.values()))
+        assert state_run["result"] is True
+        container_started = True
+        yield
+    finally:
+        if container_started:
+            ret = salt_call_cli.run(
+                "state.single", "docker_container.stopped", name="ssh1"
+            )
+            assert ret.exitcode == 0
+            assert ret.json
+            state_run = next(iter(ret.json.values()))
+            assert state_run["result"] is True
+            ret = salt_call_cli.run(
+                "state.single", "docker_container.absent", name="ssh1"
+            )
+            assert ret.exitcode == 0
+            assert ret.json
+            state_run = next(iter(ret.json.values()))
+            assert state_run["result"] is True
+
+
+@pytest.mark.slow_test
+def test_py36_target(salt_ssh_cli, ssh_roster):
+    """
+    Test that a python >3.6 master can salt ssh to a <3.6 target
+    """
+    ret = salt_ssh_cli.run("test.ping", minion_tgt='pyvertest')
+    assert ret.exitcode == 0
+    assert ret.json


### PR DESCRIPTION
### What does this PR do?

Adds contextvars package from site-packages to thin tarball instead of python's builtin contextvars if the contextvars package from pypi is installed. This makes salt-ssh work with targets that have python <3.7

### What issues does this PR fix or reference?

Fixes: #59942

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

