### PR TITLE
[freeze] Add contextvars from site-packages to thin tarball

### DIFF
--- a/changelog/59942.fixed
+++ b/changelog/59942.fixed
@@ -1,0 +1,1 @@
+Use contextvars libary from site-packages if it is intalled. Fixes salt ssh for targets with python <=3.6

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,4 +4,4 @@ PyYAML
 MarkupSafe
 requests>=1.0.0
 distro>=1.0.1
-contextvars; python_version < '3.7'
+contextvars

--- a/requirements/static/ci/py3.5/darwin.txt
+++ b/requirements/static/ci/py3.5/darwin.txt
@@ -112,7 +112,7 @@ cherrypy==17.4.1
 click==7.0                # via geomet
 clustershell==1.8.1
 contextlib2==0.6.0.post1
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.0
 decorator==4.4.2          # via networkx

--- a/requirements/static/ci/py3.5/freebsd.txt
+++ b/requirements/static/ci/py3.5/freebsd.txt
@@ -114,7 +114,7 @@ cherrypy==17.4.1
 click==7.1.2              # via geomet
 clustershell==1.8.3
 contextlib2==0.5.5
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.0
 decorator==4.4.2          # via networkx

--- a/requirements/static/ci/py3.5/linux.txt
+++ b/requirements/static/ci/py3.5/linux.txt
@@ -115,7 +115,7 @@ cherrypy==17.4.1
 click==7.1.1              # via geomet
 clustershell==1.8.3
 contextlib2==0.5.5
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.0
 decorator==4.4.2          # via networkx

--- a/requirements/static/ci/py3.6/darwin.txt
+++ b/requirements/static/ci/py3.6/darwin.txt
@@ -112,7 +112,7 @@ cherrypy==17.4.1
 click==7.0                # via geomet
 clustershell==1.8.1
 contextlib2==0.6.0.post1
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.3.2
 decorator==4.4.2          # via networkx

--- a/requirements/static/ci/py3.6/freebsd.txt
+++ b/requirements/static/ci/py3.6/freebsd.txt
@@ -114,7 +114,7 @@ cherrypy==17.4.1
 click==7.1.2              # via geomet
 clustershell==1.8.3
 contextlib2==0.5.5
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.3.2
 decorator==4.4.2          # via networkx

--- a/requirements/static/ci/py3.6/linux.txt
+++ b/requirements/static/ci/py3.6/linux.txt
@@ -115,7 +115,7 @@ cherrypy==17.4.1
 click==7.1.1              # via geomet
 clustershell==1.8.3
 contextlib2==0.5.5
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.3.2
 decorator==4.4.2          # via networkx

--- a/requirements/static/ci/py3.6/windows.txt
+++ b/requirements/static/ci/py3.6/windows.txt
@@ -25,7 +25,7 @@ cherrypy==18.6.0
 click==7.1.2              # via geomet
 clustershell==1.8.3
 colorama==0.4.1           # via pytest
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 cryptography==3.4.6
 decorator==4.4.2          # via networkx
 distlib==0.3.0            # via virtualenv

--- a/requirements/static/ci/py3.7/darwin.txt
+++ b/requirements/static/ci/py3.7/darwin.txt
@@ -113,6 +113,7 @@ click==7.0                # via geomet
 clustershell==1.8.1
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.6.0.post1
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.3.2
 decorator==4.4.2          # via networkx
@@ -132,6 +133,7 @@ gitdb==4.0.5
 gitpython==3.1.12
 google-auth==1.6.3        # via kubernetes
 idna==2.8
+immutables==0.15
 importlib-metadata==0.23  # via jsonschema, pluggy, pytest, virtualenv
 iniconfig==1.0.1          # via pytest
 ipaddress==1.0.22         # via kubernetes

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -115,6 +115,7 @@ click==7.1.2              # via geomet
 clustershell==1.8.3
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.3.2
 decorator==4.4.2          # via networkx
@@ -134,6 +135,7 @@ gitdb==4.0.5              # via gitpython
 gitpython==3.1.12
 google-auth==1.6.3        # via kubernetes
 idna==2.8
+immutables==0.15
 importlib-metadata==0.23  # via jsonschema, pluggy, pytest, virtualenv
 iniconfig==1.0.1          # via pytest
 ipaddress==1.0.22         # via kubernetes

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -116,6 +116,7 @@ click==7.1.1              # via geomet
 clustershell==1.8.3
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.3.2
 decorator==4.4.2          # via networkx
@@ -135,6 +136,7 @@ gitdb==4.0.5              # via gitpython
 gitpython==3.1.12
 google-auth==1.6.3        # via kubernetes
 idna==2.8
+immutables==0.15
 importlib-metadata==0.23  # via jsonschema, pluggy, pytest, virtualenv
 iniconfig==1.0.1          # via pytest
 ipaddress==1.0.22         # via kubernetes

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -24,6 +24,7 @@ cherrypy==18.6.0
 click==7.1.2              # via geomet
 clustershell==1.8.3
 colorama==0.4.1           # via pytest
+contextvars==2.4
 cryptography==3.4.6
 decorator==4.4.2          # via networkx
 distlib==0.3.0            # via virtualenv
@@ -42,6 +43,7 @@ gitdb==4.0.5
 gitpython==3.1.13
 google-auth==1.6.3        # via kubernetes
 idna==2.8
+immutables==0.15
 importlib-metadata==0.23  # via jsonschema, pluggy, pytest, virtualenv
 iniconfig==1.0.1          # via pytest
 ioloop==0.1a0

--- a/requirements/static/ci/py3.8/darwin.txt
+++ b/requirements/static/ci/py3.8/darwin.txt
@@ -113,6 +113,7 @@ click==7.0                # via geomet
 clustershell==1.8.1
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.6.0.post1
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.3.2
 decorator==4.4.2          # via networkx
@@ -132,6 +133,7 @@ gitdb==4.0.5
 gitpython==3.1.12
 google-auth==1.6.3        # via kubernetes
 idna==2.8
+immutables==0.15
 iniconfig==1.0.1          # via pytest
 ipaddress==1.0.22         # via kubernetes
 isodate==0.6.0            # via msrest

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -115,6 +115,7 @@ click==7.1.2              # via geomet
 clustershell==1.8.3
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.3.2
 decorator==4.4.2          # via networkx
@@ -134,6 +135,7 @@ gitdb==4.0.5              # via gitpython
 gitpython==3.1.12
 google-auth==1.6.3        # via kubernetes
 idna==2.8
+immutables==0.15
 iniconfig==1.0.1          # via pytest
 ipaddress==1.0.22         # via kubernetes
 isodate==0.6.0            # via msrest

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -116,6 +116,7 @@ click==7.1.1              # via geomet
 clustershell==1.8.3
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.3.2
 decorator==4.4.2          # via networkx
@@ -135,6 +136,7 @@ gitdb==4.0.5              # via gitpython
 gitpython==3.1.12
 google-auth==1.6.3        # via kubernetes
 idna==2.8
+immutables==0.15
 iniconfig==1.0.1          # via pytest
 ipaddress==1.0.22         # via kubernetes
 isodate==0.6.0            # via msrest

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -113,6 +113,7 @@ click==7.0                # via geomet
 clustershell==1.8.1
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.6.0.post1
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.3.2
 decorator==4.4.2          # via networkx
@@ -132,6 +133,7 @@ gitdb==4.0.5
 gitpython==3.1.12
 google-auth==1.6.3        # via kubernetes
 idna==2.8
+immutables==0.15
 iniconfig==1.0.1          # via pytest
 ipaddress==1.0.22         # via kubernetes
 isodate==0.6.0            # via msrest

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -115,6 +115,7 @@ click==7.1.2              # via geomet
 clustershell==1.8.3
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.3.2
 decorator==4.4.2          # via networkx
@@ -134,6 +135,7 @@ gitdb==4.0.5              # via gitpython
 gitpython==3.1.12
 google-auth==1.6.3        # via kubernetes
 idna==2.8
+immutables==0.15
 iniconfig==1.0.1          # via pytest
 ipaddress==1.0.22         # via kubernetes
 isodate==0.6.0            # via msrest

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -117,6 +117,7 @@ click==7.1.1              # via geomet
 clustershell==1.8.3
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.3.2
 decorator==4.4.2          # via networkx
@@ -136,6 +137,7 @@ gitdb==4.0.5              # via gitpython
 gitpython==3.1.12
 google-auth==1.6.3        # via kubernetes
 idna==2.8
+immutables==0.15
 iniconfig==1.0.1          # via pytest
 ipaddress==1.0.22         # via kubernetes
 isodate==0.6.0            # via msrest

--- a/requirements/static/pkg/py3.5/darwin.txt
+++ b/requirements/static/pkg/py3.5/darwin.txt
@@ -12,7 +12,7 @@ chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 cryptography==3.0
 distro==1.5.0
 gitdb==4.0.5              # via gitpython

--- a/requirements/static/pkg/py3.5/freebsd.txt
+++ b/requirements/static/pkg/py3.5/freebsd.txt
@@ -12,7 +12,7 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 cryptography==3.0         # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests

--- a/requirements/static/pkg/py3.5/linux.txt
+++ b/requirements/static/pkg/py3.5/linux.txt
@@ -12,7 +12,7 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 cryptography==3.0         # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests

--- a/requirements/static/pkg/py3.6/darwin.txt
+++ b/requirements/static/pkg/py3.6/darwin.txt
@@ -12,7 +12,7 @@ chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 cryptography==3.3.2
 distro==1.5.0
 gitdb==4.0.5              # via gitpython

--- a/requirements/static/pkg/py3.6/freebsd.txt
+++ b/requirements/static/pkg/py3.6/freebsd.txt
@@ -12,7 +12,7 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 cryptography==3.3.2       # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests

--- a/requirements/static/pkg/py3.6/linux.txt
+++ b/requirements/static/pkg/py3.6/linux.txt
@@ -12,7 +12,7 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 cryptography==3.3.2       # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests

--- a/requirements/static/pkg/py3.6/windows.txt
+++ b/requirements/static/pkg/py3.6/windows.txt
@@ -10,7 +10,7 @@ cffi==1.14.5
 chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==18.6.0
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 cryptography==3.4.6
 distro==1.5.0
 gitdb==4.0.5              # via gitpython

--- a/requirements/static/pkg/py3.7/darwin.txt
+++ b/requirements/static/pkg/py3.7/darwin.txt
@@ -11,11 +11,13 @@ chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
+contextvars==2.4
 cryptography==3.3.2
 distro==1.5.0
 gitdb==4.0.5              # via gitpython
 gitpython==3.1.12
 idna==2.8
+immutables==0.15          # via contextvars
 jaraco.functools==2.0     # via cheroot, tempora
 jinja2==2.10.1
 linode-python==1.1.1

--- a/requirements/static/pkg/py3.7/freebsd.txt
+++ b/requirements/static/pkg/py3.7/freebsd.txt
@@ -11,9 +11,11 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
+contextvars==2.4
 cryptography==3.3.2       # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
+immutables==0.15          # via contextvars
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
 markupsafe==1.1.1

--- a/requirements/static/pkg/py3.7/linux.txt
+++ b/requirements/static/pkg/py3.7/linux.txt
@@ -11,9 +11,11 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
+contextvars==2.4
 cryptography==3.3.2       # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
+immutables==0.15          # via contextvars
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
 markupsafe==1.1.1

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -9,11 +9,13 @@ cffi==1.14.5
 chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==18.6.0
+contextvars==2.4
 cryptography==3.4.6
 distro==1.5.0
 gitdb==4.0.5              # via gitpython
 gitpython==3.1.13
 idna==2.8                 # via requests
+immutables==0.15          # via contextvars
 ioloop==0.1a0
 jaraco.classes==3.2.1     # via jaraco.collections
 jaraco.collections==3.2.0  # via cherrypy

--- a/requirements/static/pkg/py3.8/darwin.txt
+++ b/requirements/static/pkg/py3.8/darwin.txt
@@ -11,11 +11,13 @@ chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
+contextvars==2.4
 cryptography==3.3.2
 distro==1.5.0
 gitdb==4.0.5              # via gitpython
 gitpython==3.1.12
 idna==2.8
+immutables==0.15          # via contextvars
 jaraco.functools==2.0     # via cheroot, tempora
 jinja2==2.10.1
 linode-python==1.1.1

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -11,9 +11,11 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
+contextvars==2.4
 cryptography==3.3.2       # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
+immutables==0.15          # via contextvars
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
 markupsafe==1.1.1

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -11,9 +11,11 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
+contextvars==2.4
 cryptography==3.3.2       # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
+immutables==0.15          # via contextvars
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
 markupsafe==1.1.1

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -11,11 +11,13 @@ chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
+contextvars==2.4
 cryptography==3.3.2
 distro==1.5.0
 gitdb==4.0.5              # via gitpython
 gitpython==3.1.12
 idna==2.8
+immutables==0.15          # via contextvars
 jaraco.functools==2.0     # via cheroot, tempora
 jinja2==2.10.1
 linode-python==1.1.1

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -11,9 +11,11 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
+contextvars==2.4
 cryptography==3.3.2       # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
+immutables==0.15          # via contextvars
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
 markupsafe==1.1.1

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -11,9 +11,11 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
+contextvars==2.4
 cryptography==3.3.2       # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
+immutables==0.15          # via contextvars
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
 markupsafe==1.1.1

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -4,7 +4,6 @@ directories for python loadable code and organizes the code into the
 plugin interfaces used by Salt.
 """
 
-import contextvars
 import copy
 import functools
 import importlib
@@ -44,6 +43,13 @@ from salt.exceptions import LoaderError
 from salt.template import check_render_pipe_str
 from salt.utils import entrypoints
 from salt.utils.decorators import Depends
+
+try:
+    # Try the stdlib C extension first
+    import _contextvars as contextvars
+except ImportError:
+    # Py<3.7
+    import contextvars
 
 log = logging.getLogger(__name__)
 

--- a/salt/loader_context.py
+++ b/salt/loader_context.py
@@ -3,8 +3,14 @@ Manage the context a module loaded by Salt's loader
 """
 import collections.abc
 import contextlib
-import contextvars
 import copy
+
+try:
+    # Try the stdlib C extension first
+    import _contextvars as contextvars
+except ImportError:
+    # Py<3.7
+    import contextvars
 
 DEFAULT_CTX_VAR = "loader_ctxvar"
 

--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -411,7 +411,7 @@ def get_tops(extra_mods="", so_mods=""):
         contextvars = modules[0]
     else:
         contextvars = py_contextvars
-    log.warn("Using contextvars %r", contextvars)
+    log.debug("Using contextvars %r", contextvars)
     mods.append(contextvars)
     if has_immutables:
         mods.append(immutables)

--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -95,6 +95,48 @@ else:
 log = logging.getLogger(__name__)
 
 
+def import_module(name, path):
+    """
+    Import a module from a specific path. Path can be a full or relative path
+    to a .py file.
+
+    :name: The name of the module to import
+    :path: The path of the module to import
+    """
+    try:
+        spec = importlib.util.spec_from_file_location(name, path)
+    except ValueError:
+        spec = None
+    if spec is not None:
+        lib = importlib.util.module_from_spec(spec)
+        try:
+            spec.loader.exec_module(lib)
+        except OSError:
+            pass
+        else:
+            return lib
+
+
+def getsitepackages():
+    """
+    Some versions of Virtualenv ship a site.py without getsitepackages. This
+    method will first try and return sitepackages from the default site module
+    if no method exists we will try importing the site module from every other
+    path in sys.paths until we find a getsitepackages method to return the
+    results from. If for some reason no gesitepackages method can be found a
+    RuntimeError will be raised
+
+    :return: A list containing all global site-packages directories.
+    """
+    if hasattr(site, "getsitepackages"):
+        return site.getsitepackages()
+    for path in sys.path:
+        lib = import_module("site", os.path.join(path, "site.py"))
+        if hasattr(lib, "getsitepackages"):
+            return lib.getsitepackages()
+    raise RuntimeError("Unable to locate a getsitepackages method")
+
+
 def find_site_modules(name):
     """
     Finds and imports a module from site packages directories.
@@ -104,33 +146,20 @@ def find_site_modules(name):
              list is returned.
     """
     libs = []
-    for site_path in site.getsitepackages():
-        module_path = os.path.join(site_path, "{}.py".format(name))
-        try:
-            spec = importlib.util.spec_from_file_location(name, module_path)
-        except ValueError:
-            spec = None
-        if spec is not None:
-            lib = importlib.util.module_from_spec(spec)
-            try:
-                spec.loader.exec_module(lib)
-            except OSError:
-                pass
-            else:
-                libs.append(lib)
-        module_path = os.path.join(site_path, name, "__init__.py")
-        try:
-            spec = importlib.util.spec_from_file_location(name, module_path)
-        except ValueError:
-            spec = None
-        if spec is not None:
-            lib = importlib.util.module_from_spec(spec)
-            try:
-                spec.loader.exec_module(lib)
-            except OSError:
-                pass
-            else:
-                libs.append(lib)
+    site_paths = []
+    try:
+        site_paths = getsitepackages()
+    except RuntimeError:
+        log.debug("No site package directories found")
+    for site_path in site_paths:
+        path = os.path.join(site_path, "{}.py".format(name))
+        lib = import_module(name, path)
+        if lib:
+            libs.append(lib)
+        path = os.path.join(site_path, name, "__init__.py")
+        lib = import_module(name, path)
+        if lib:
+            libs.append(lib)
     return libs
 
 

--- a/tests/filename_map.yml
+++ b/tests/filename_map.yml
@@ -172,6 +172,7 @@ salt/(client/ssh/.+|cli/ssh\.py):
   - pytests.integration.ssh.test_pillar
   - integration.ssh.test_raw
   - integration.ssh.test_state
+  - pytests.integration.ssh.test_py_versions
 
 salt/config/*:
   - unit.test_config

--- a/tests/pytests/conftest.py
+++ b/tests/pytests/conftest.py
@@ -76,6 +76,12 @@ def reactor_event(tmp_path_factory):
 
 
 @pytest.fixture(scope="session")
+def master_id():
+    master_id = random_string("master-")
+    yield master_id
+
+
+@pytest.fixture(scope="session")
 def salt_master_factory(
     request,
     salt_factories,
@@ -89,8 +95,8 @@ def salt_master_factory(
     sdb_etcd_port,
     vault_port,
     reactor_event,
+    master_id,
 ):
-    master_id = random_string("master-")
     root_dir = salt_factories.get_root_dir_for_daemon(master_id)
     conf_dir = root_dir / "conf"
     conf_dir.mkdir(exist_ok=True)

--- a/tests/pytests/integration/ssh/test_py_versions.py
+++ b/tests/pytests/integration/ssh/test_py_versions.py
@@ -1,0 +1,160 @@
+"""
+Integration tests for the etcd modules
+"""
+
+import logging
+import os
+import subprocess
+import tempfile
+
+import pytest
+import salt.utils.files
+from saltfactories.utils.ports import get_unused_localhost_port
+from tests.support.helpers import dedent
+from tests.support.runtests import RUNTIME_VARS
+
+log = logging.getLogger(__name__)
+
+pytestmark = [pytest.mark.skip_if_binaries_missing("dockerd")]
+
+
+class Keys:
+    """
+    Temporary ssh key pair
+    """
+
+    def __init__(self, priv_path=None):
+        if priv_path is None:
+            priv_path = tempfile.mktemp()
+        self.priv_path = priv_path
+
+    def generate(self):
+        subprocess.run(["ssh-keygen", "-q", "-N", "", "-f", self.priv_path], check=True)
+
+    @property
+    def pub_path(self):
+        return "{}.pub".format(self.priv_path)
+
+    @property
+    def pub(self):
+        with salt.utils.files.fopen(self.pub_path, "r") as fp:
+            return fp.read()
+
+    @property
+    def priv(self):
+        with salt.utils.files.fopen(self.priv_path, "r") as fp:
+            return fp.read()
+
+    def __enter__(self):
+        self.generate()
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        os.remove(self.pub_path)
+        os.remove(self.priv_path)
+
+
+@pytest.fixture(scope="module")
+def ssh_keys():
+    """
+    Temporary ssh key fixture
+    """
+    with Keys() as keys:
+        yield keys
+
+
+@pytest.fixture(scope="module")
+def ssh_port():
+    """
+    Temporary ssh port fixture
+    """
+    return get_unused_localhost_port()
+
+
+@pytest.fixture(scope="module")
+def ssh_roster(ssh_port, ssh_keys, master_id):
+    """
+    Temporary roster for ssh docker container
+    """
+    roster_path = os.path.join(RUNTIME_VARS.TMP, master_id, "conf", "roster")
+    with salt.utils.files.fopen(roster_path) as fp:
+        orig_roster = fp.read()
+    roster = orig_roster + dedent(
+        """
+    pyvertest:
+      host: localhost
+      user: centos
+      port: {}
+      priv: {}
+      ssh_options:
+        - StrictHostKeyChecking=no
+        - UserKnownHostsFile=/dev/null
+    """.format(
+            ssh_port, ssh_keys.priv_path
+        )
+    )
+    with salt.utils.files.fopen(roster_path, "w") as fp:
+        fp.write(roster)
+    try:
+        yield roster_path
+    finally:
+        with salt.utils.files.fopen(roster_path, "w") as fp:
+            fp.write(orig_roster)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ssh_docker_container(salt_call_cli, ssh_port, ssh_keys):
+    """
+    Temporary docker container with python 3.6 and ssh enabled
+    """
+    container_started = False
+    try:
+        ret = salt_call_cli.run(
+            "state.single", "docker_image.present", name="dwoz1/cicd", tag="ssh"
+        )
+        assert ret.exitcode == 0
+        assert ret.json
+        state_run = next(iter(ret.json.values()))
+        assert state_run["result"] is True
+        ret = salt_call_cli.run(
+            "state.single",
+            "docker_container.running",
+            name="ssh1",
+            image="dwoz1/cicd:ssh",
+            port_bindings='"{}:22"'.format(ssh_port),
+            environment={"SSH_USER": "centos", "SSH_AUTHORIZED_KEYS": ssh_keys.pub},
+            cap_add="IPC_LOCK",
+            timeout=300,
+        )
+        assert ret.exitcode == 0
+        assert ret.json
+        state_run = next(iter(ret.json.values()))
+        assert state_run["result"] is True
+        container_started = True
+        yield
+    finally:
+        if container_started:
+            ret = salt_call_cli.run(
+                "state.single", "docker_container.stopped", name="ssh1"
+            )
+            assert ret.exitcode == 0
+            assert ret.json
+            state_run = next(iter(ret.json.values()))
+            assert state_run["result"] is True
+            ret = salt_call_cli.run(
+                "state.single", "docker_container.absent", name="ssh1"
+            )
+            assert ret.exitcode == 0
+            assert ret.json
+            state_run = next(iter(ret.json.values()))
+            assert state_run["result"] is True
+
+
+@pytest.mark.slow_test
+def test_py36_target(salt_ssh_cli, ssh_roster):
+    """
+    Test that a python >3.6 master can salt ssh to a <3.6 target
+    """
+    ret = salt_ssh_cli.run("test.ping", minion_tgt="pyvertest")
+    assert ret.exitcode == 0
+    assert ret.json

--- a/tests/unit/utils/test_thin.py
+++ b/tests/unit/utils/test_thin.py
@@ -465,7 +465,13 @@ class SSHThinTestCase(TestCase):
         ]
         if salt.utils.thin.has_immutables:
             base_tops.extend(["immutables"])
-        tops = [_.rsplit(os.sep, 1)[-1] for _ in thin.get_tops()]
+        tops = []
+        for top in thin.get_tops(extra_mods="foo,bar"):
+            if top.find("/") != -1:
+                spl = "/"
+            else:
+                spl = os.sep
+            tops.append(top.rsplit(spl, 1)[-1])
         assert len(tops) == len(base_tops)
         assert sorted(tops) == sorted(base_tops), sorted(tops)
 
@@ -555,17 +561,20 @@ class SSHThinTestCase(TestCase):
         if salt.utils.thin.has_immutables:
             base_tops.extend(["immutables"])
         libs = salt.utils.thin.find_site_modules("contextvars")
-        builtins = sys.version_info.major == 3 and "builtins" or "__builtin__"
         foo = {"__file__": os.sep + os.path.join("custom", "foo", "__init__.py")}
         bar = {"__file__": os.sep + os.path.join("custom", "bar")}
         with patch("salt.utils.thin.find_site_modules", MagicMock(side_effect=[libs])):
             with patch(
-                "{}.__import__".format(builtins),
+                "builtins.__import__",
                 MagicMock(side_effect=[type("foo", (), foo), type("bar", (), bar)]),
             ):
-                tops = [
-                    _.rsplit(os.sep, 1)[-1] for _ in thin.get_tops(extra_mods="foo,bar")
-                ]
+                tops = []
+                for top in thin.get_tops(extra_mods="foo,bar"):
+                    if top.find("/") != -1:
+                        spl = "/"
+                    else:
+                        spl = os.sep
+                    tops.append(top.rsplit(spl, 1)[-1])
         self.assertEqual(len(tops), len(base_tops))
         self.assertListEqual(sorted(tops), sorted(base_tops))
 
@@ -655,10 +664,9 @@ class SSHThinTestCase(TestCase):
         if salt.utils.thin.has_immutables:
             base_tops.extend(["immutables"])
         libs = salt.utils.thin.find_site_modules("contextvars")
-        builtins = sys.version_info.major == 3 and "builtins" or "__builtin__"
         with patch("salt.utils.thin.find_site_modules", MagicMock(side_effect=[libs])):
             with patch(
-                "{}.__import__".format(builtins),
+                "builtins.__import__",
                 MagicMock(
                     side_effect=[
                         type("salt", (), {"__file__": "/custom/foo.so"}),
@@ -666,9 +674,13 @@ class SSHThinTestCase(TestCase):
                     ]
                 ),
             ):
-                tops = [
-                    _.rsplit(os.sep, 1)[-1] for _ in thin.get_tops(so_mods="foo,bar")
-                ]
+                tops = []
+                for top in thin.get_tops(so_mods="foo,bar"):
+                    if top.find("/") != -1:
+                        spl = "/"
+                    else:
+                        spl = os.sep
+                    tops.append(top.rsplit(spl, 1)[-1])
         assert len(tops) == len(base_tops)
         assert sorted(tops) == sorted(base_tops)
 

--- a/tests/unit/utils/test_thin.py
+++ b/tests/unit/utils/test_thin.py
@@ -433,7 +433,7 @@ class SSHThinTestCase(TestCase):
         type("concurrent", (), {"__file__": "/site-packages/concurrent"}),
     )
     @patch(
-        "salt.utils.thin.contextvars",
+        "salt.utils.thin.py_contextvars",
         type("contextvars", (), {"__file__": "/site-packages/contextvars"}),
     )
     @patch_if(
@@ -448,24 +448,24 @@ class SSHThinTestCase(TestCase):
         :return:
         """
         base_tops = [
-            "/site-packages/distro",
-            "/site-packages/salt",
-            "/site-packages/jinja2",
-            "/site-packages/yaml",
-            "/site-packages/tornado",
-            "/site-packages/msgpack",
-            "/site-packages/certifi",
-            "/site-packages/sdp",
-            "/site-packages/sdp_hlp",
-            "/site-packages/ssl_mh",
-            "/site-packages/markupsafe",
-            "/site-packages/backports_abc",
-            "/site-packages/concurrent",
-            "/site-packages/contextvars",
+            "distro",
+            "salt",
+            "jinja2",
+            "yaml",
+            "tornado",
+            "msgpack",
+            "certifi",
+            "sdp",
+            "sdp_hlp",
+            "ssl_mh",
+            "markupsafe",
+            "backports_abc",
+            "concurrent",
+            "contextvars",
         ]
         if salt.utils.thin.has_immutables:
-            base_tops.extend(["/site-packages/immutables"])
-        tops = thin.get_tops()
+            base_tops.extend(["immutables"])
+        tops = [_.rsplit(os.sep, 1)[-1] for _ in thin.get_tops()]
         assert len(tops) == len(base_tops)
         assert sorted(tops) == sorted(base_tops), sorted(tops)
 
@@ -520,7 +520,7 @@ class SSHThinTestCase(TestCase):
         type("concurrent", (), {"__file__": "/site-packages/concurrent"}),
     )
     @patch(
-        "salt.utils.thin.contextvars",
+        "salt.utils.thin.py_contextvars",
         type("contextvars", (), {"__file__": "/site-packages/contextvars"}),
     )
     @patch_if(
@@ -535,33 +535,37 @@ class SSHThinTestCase(TestCase):
         :return:
         """
         base_tops = [
-            "/site-packages/distro",
-            "/site-packages/salt",
-            "/site-packages/jinja2",
-            "/site-packages/yaml",
-            "/site-packages/tornado",
-            "/site-packages/msgpack",
-            "/site-packages/certifi",
-            "/site-packages/sdp",
-            "/site-packages/sdp_hlp",
-            "/site-packages/ssl_mh",
-            "/site-packages/concurrent",
-            "/site-packages/markupsafe",
-            "/site-packages/backports_abc",
-            "/site-packages/contextvars",
-            os.sep + os.path.join("custom", "foo"),
-            os.sep + os.path.join("custom", "bar.py"),
+            "distro",
+            "salt",
+            "jinja2",
+            "yaml",
+            "tornado",
+            "msgpack",
+            "certifi",
+            "sdp",
+            "sdp_hlp",
+            "ssl_mh",
+            "concurrent",
+            "markupsafe",
+            "backports_abc",
+            "contextvars",
+            "foo",
+            "bar.py",
         ]
         if salt.utils.thin.has_immutables:
-            base_tops.extend(["/site-packages/immutables"])
+            base_tops.extend(["immutables"])
+        libs = salt.utils.thin.find_site_modules("contextvars")
         builtins = sys.version_info.major == 3 and "builtins" or "__builtin__"
         foo = {"__file__": os.sep + os.path.join("custom", "foo", "__init__.py")}
         bar = {"__file__": os.sep + os.path.join("custom", "bar")}
-        with patch(
-            "{}.__import__".format(builtins),
-            MagicMock(side_effect=[type("foo", (), foo), type("bar", (), bar)]),
-        ):
-            tops = thin.get_tops(extra_mods="foo,bar")
+        with patch("salt.utils.thin.find_site_modules", MagicMock(side_effect=[libs])):
+            with patch(
+                "{}.__import__".format(builtins),
+                MagicMock(side_effect=[type("foo", (), foo), type("bar", (), bar)]),
+            ):
+                tops = [
+                    _.rsplit(os.sep, 1)[-1] for _ in thin.get_tops(extra_mods="foo,bar")
+                ]
         self.assertEqual(len(tops), len(base_tops))
         self.assertListEqual(sorted(tops), sorted(base_tops))
 
@@ -616,7 +620,7 @@ class SSHThinTestCase(TestCase):
         type("concurrent", (), {"__file__": "/site-packages/concurrent"}),
     )
     @patch(
-        "salt.utils.thin.contextvars",
+        "salt.utils.thin.py_contextvars",
         type("contextvars", (), {"__file__": "/site-packages/contextvars"}),
     )
     @patch_if(
@@ -631,36 +635,40 @@ class SSHThinTestCase(TestCase):
         :return:
         """
         base_tops = [
-            "/site-packages/distro",
-            "/site-packages/salt",
-            "/site-packages/jinja2",
-            "/site-packages/yaml",
-            "/site-packages/tornado",
-            "/site-packages/msgpack",
-            "/site-packages/certifi",
-            "/site-packages/sdp",
-            "/site-packages/sdp_hlp",
-            "/site-packages/ssl_mh",
-            "/site-packages/concurrent",
-            "/site-packages/markupsafe",
-            "/site-packages/backports_abc",
-            "/site-packages/contextvars",
-            "/custom/foo.so",
-            "/custom/bar.so",
+            "distro",
+            "salt",
+            "jinja2",
+            "yaml",
+            "tornado",
+            "msgpack",
+            "certifi",
+            "sdp",
+            "sdp_hlp",
+            "ssl_mh",
+            "concurrent",
+            "markupsafe",
+            "backports_abc",
+            "contextvars",
+            "foo.so",
+            "bar.so",
         ]
         if salt.utils.thin.has_immutables:
-            base_tops.extend(["/site-packages/immutables"])
+            base_tops.extend(["immutables"])
+        libs = salt.utils.thin.find_site_modules("contextvars")
         builtins = sys.version_info.major == 3 and "builtins" or "__builtin__"
-        with patch(
-            "{}.__import__".format(builtins),
-            MagicMock(
-                side_effect=[
-                    type("salt", (), {"__file__": "/custom/foo.so"}),
-                    type("salt", (), {"__file__": "/custom/bar.so"}),
+        with patch("salt.utils.thin.find_site_modules", MagicMock(side_effect=[libs])):
+            with patch(
+                "{}.__import__".format(builtins),
+                MagicMock(
+                    side_effect=[
+                        type("salt", (), {"__file__": "/custom/foo.so"}),
+                        type("salt", (), {"__file__": "/custom/bar.so"}),
+                    ]
+                ),
+            ):
+                tops = [
+                    _.rsplit(os.sep, 1)[-1] for _ in thin.get_tops(so_mods="foo,bar")
                 ]
-            ),
-        ):
-            tops = thin.get_tops(so_mods="foo,bar")
         assert len(tops) == len(base_tops)
         assert sorted(tops) == sorted(base_tops)
 


### PR DESCRIPTION
### What does this PR do?

Adds contextvars package from site-packages to thin tarball instead of python's builtin contextvars if the contextvars package from pypi is installed. This makes salt-ssh work with targets that have python <3.7

### What issues does this PR fix or reference?

Fixes: #59942

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

