### PR TITLE
WIP - Allow bond interface's members as list or string - Issue 57785

### DIFF
--- a/changelog/57785.fixed
+++ b/changelog/57785.fixed
@@ -1,0 +1,1 @@
+Allow member list of a bond interface both as string or list.

--- a/salt/states/network.py
+++ b/salt/states/network.py
@@ -649,7 +649,10 @@ def managed(name, enabled=True, **kwargs):
             present_slaves = __salt__["cmd.run"](
                 ["cat", "/sys/class/net/{}/bonding/slaves".format(name)]
             ).split()
-            desired_slaves = kwargs["slaves"].split()
+            if isinstance(kwargs["slaves"], str):
+                desired_slaves = kwargs["slaves"].split()
+            else:
+                desired_slaves = kwargs["slaves"]
             missing_slaves = set(desired_slaves) - set(present_slaves)
 
             # Enslave only slaves missing in master


### PR DESCRIPTION
### What does this PR do?
Usually the members of a bond interface are pass as a string separated by spaces and splitted to a list. If the members are already a list, the split try generates an error.

This PR allows the members list to be passed as a list.

### What issues does this PR fix or reference?
Fixes: #57785

### Previous Behavior
If the members list is a list, the state fails with an error. This makes a bond interface state only works in the first run and fails on all subsequent ones.

### New Behavior
Allow the network.managed state for bond interfaces to works fine at every run, accepting the members list as both a string or a list.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No