### PR TITLE
members of github.team_present broken after update

### DIFF
--- a/salt/states/github.py
+++ b/salt/states/github.py
@@ -341,13 +341,13 @@ def team_present(
     members_no_mfa = __salt__["github.list_members_without_mfa"](profile=profile)
 
     members_lower = {}
-    for member_name, info in members or {}.items():
+    for member_name, info in members.items() or {}.items():
         members_lower[member_name.lower()] = info
 
     member_change = False
     current_members = __salt__["github.list_team_members"](name, profile=profile)
 
-    for member, member_info in members or {}.items():
+    for member, member_info in members.items() or {}.items():
         log.info("Checking member %s in team %s", member, name)
 
         if member.lower() not in current_members:


### PR DESCRIPTION
Since the last update to:
Salt Version:
          Salt: 3003

Dependency Versions:
          cffi: 1.14.0
      cherrypy: Not Installed
      dateutil: 2.7.3
     docker-py: Not Installed
         gitdb: 4.0.5
     gitpython: 3.1.2
        Jinja2: 2.10
       libgit2: Not Installed
      M2Crypto: Not Installed
          Mako: 1.1.2
       msgpack: 0.5.6
  msgpack-pure: Not Installed
  mysql-python: Not Installed
     pycparser: 2.19
      pycrypto: 2.6.1
  pycryptodome: 3.6.1
        pygit2: Not Installed
        Python: 3.7.3 (default, Jan 22 2021, 20:04:44)
  python-gnupg: Not Installed
        PyYAML: 3.13
         PyZMQ: 17.1.2
         smmap: 3.0.4
       timelib: Not Installed
       Tornado: 4.5.3
           ZMQ: 4.3.1

System Versions:
          dist: debian 10 buster
        locale: UTF-8
       machine: x86_64
       release: 4.19.0-16-amd64
        system: Linux
       version: Debian GNU/Linux 10 buster


We got an error in execution of the github.team_present state, see Behavior for the error.

I could work around it by changing the expansion of the members variable.

I am lacking knowledge of the other involved code parts, so it might not be the right way to fix it, but it made it work again like before in our system, without changing our existing pillars.

### What issues does this PR fix or reference?
Fixes: see Behavior

### Previous Behavior
Executing state github.team_present with pillar:
```yaml
project1_read:
  github.team_present:
    - name: project1-read
    - permission: pull
    - privacy: secret
    - repo_names:
      - repo1
      - repo2
    - members:
        user1: {}
        user2: {}
```
yields
2021-04-07 16:45:48,849 [salt.state       :321 ][ERROR   ][17548] An exception occurred in this state: Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/salt/state.py", line 2172, in call
    *cdata["args"], **cdata["kwargs"]
  File "/usr/lib/python3/dist-packages/salt/loader.py", line 1235, in __call__
    return self.loader.run(run_func, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/salt/loader.py", line 2268, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/salt/loader.py", line 2283, in _run_as
    return _func_or_method(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/salt/loader.py", line 2316, in wrapper
    return f(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/salt/states/github.py", line 342, in team_present
    for member_name, info in members or {}.items():
ValueError: too many values to unpack (expected 2)

### New Behavior
works without the error, like before the update

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

I hope without adding new code, no new tests are required, correct?

### Commits signed with GPG?
Yes


Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.


