### PR TITLE
Skip '-t' type for zfs get if Solaris as not valid parameter on that platform

### DIFF
--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -1096,7 +1096,7 @@ def get(*dataset, **kwargs):
         comma-separated list of types to display, where type is one of
         filesystem, snapshot, volume, bookmark, or all.
 
-        .. versionedited:: Silicon
+        .. versionchanged:: Silicon
 
         type is ignored on Solaris 10 and 11 since not a valid parameter on those platforms
 

--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -18,6 +18,7 @@ import logging
 import salt.modules.cmdmod
 import salt.utils.args
 import salt.utils.path
+import salt.utils.platform
 import salt.utils.versions
 from salt.ext.six.moves import zip
 from salt.utils.odict import OrderedDict
@@ -1094,6 +1095,11 @@ def get(*dataset, **kwargs):
     type : string
         comma-separated list of types to display, where type is one of
         filesystem, snapshot, volume, bookmark, or all.
+
+        .. versionedited:: Silicon
+
+        type is ignored on Solaris 10 and 11 since not a valid parameter on those platforms
+
     source : string
         comma-separated list of sources to display. Must be one of the following:
         local, default, inherited, temporary, and none. The default value is all sources.
@@ -1135,8 +1141,11 @@ def get(*dataset, **kwargs):
     fields.insert(0, "name")
     fields.insert(1, "property")
     opts["-o"] = ",".join(fields)
-    if kwargs.get("type", False):
-        opts["-t"] = kwargs.get("type")
+
+    if not salt.utils.platform.is_sunos():
+        if kwargs.get("type", False):
+            opts["-t"] = kwargs.get("type")
+
     if kwargs.get("source", False):
         opts["-s"] = kwargs.get("source")
 

--- a/tests/pytests/unit/modules/test_zfs_solaris10.py
+++ b/tests/pytests/unit/modules/test_zfs_solaris10.py
@@ -1,0 +1,67 @@
+"""
+Tests for salt.modules.zfs on Solaris
+"""
+
+import pytest
+import salt.config
+import salt.loader
+import salt.modules.zfs as zfs
+import salt.utils.zfs
+from tests.support.mock import MagicMock, patch
+from tests.support.zfs import ZFSMockData
+
+
+@pytest.fixture
+def utils_patch():
+    return ZFSMockData().get_patched_utils()
+
+
+@pytest.fixture
+def configure_loader_modules():
+    opts = salt.config.DEFAULT_MINION_OPTS.copy()
+    utils = salt.loader.utils(opts, whitelist=["zfs"])
+    zfs_obj = {
+        zfs: {
+            "__opts__": opts,
+            "__grains__": {
+                "osarch": "sparcv9",
+                "os_family": "Solaris",
+                "osmajorrelease": 10,
+                "kernel": "SunOS",
+                "kernelrelease": 5.10,
+            },
+            "__utils__": utils,
+        }
+    }
+
+    return zfs_obj
+
+
+def test_get_success_solaris():
+    """
+    Tests zfs get success
+    """
+
+    cmd_out = {
+        "pid": 7278,
+        "retcode": 0,
+        "stdout": "testpool\tmountpoint\t/testpool\tdefault",
+        "stderr": "",
+    }
+
+    run_all_mock = MagicMock(return_value=cmd_out)
+    patches = {
+        "cmd.run_all": run_all_mock,
+    }
+    with patch.dict(zfs.__salt__, patches):
+        with patch("sys.platform", MagicMock(return_value="sunos5")):
+            result = zfs.get("testpool", type="filesystem", properties="mountpoint")
+            assert result == {
+                "testpool": {
+                    "mountpoint": {"value": "/testpool", "source": "default"},
+                },
+            }
+    run_all_mock.assert_called_once_with(
+        "/usr/sbin/zfs get -H -o name,property,value,source mountpoint testpool",
+        python_shell=False,
+    )

--- a/tests/pytests/unit/modules/test_zfs_solaris10.py
+++ b/tests/pytests/unit/modules/test_zfs_solaris10.py
@@ -37,6 +37,7 @@ def configure_loader_modules():
     return zfs_obj
 
 
+@pytest.mark.skip_unless_on_sunos(reason="test to ensure no -t only applies to Solaris")
 def test_get_success_solaris():
     """
     Tests zfs get success

--- a/tests/pytests/unit/modules/test_zfs_solaris11.py
+++ b/tests/pytests/unit/modules/test_zfs_solaris11.py
@@ -37,6 +37,7 @@ def configure_loader_modules():
     return zfs_obj
 
 
+@pytest.mark.skip_unless_on_sunos(reason="test to ensure no -t only applies to Solaris")
 def test_get_success_solaris():
     """
     Tests zfs get success

--- a/tests/pytests/unit/modules/test_zfs_solaris11.py
+++ b/tests/pytests/unit/modules/test_zfs_solaris11.py
@@ -1,0 +1,67 @@
+"""
+Tests for salt.modules.zfs on Solaris
+"""
+
+import pytest
+import salt.config
+import salt.loader
+import salt.modules.zfs as zfs
+import salt.utils.zfs
+from tests.support.mock import MagicMock, patch
+from tests.support.zfs import ZFSMockData
+
+
+@pytest.fixture
+def utils_patch():
+    return ZFSMockData().get_patched_utils()
+
+
+@pytest.fixture
+def configure_loader_modules():
+    opts = salt.config.DEFAULT_MINION_OPTS.copy()
+    utils = salt.loader.utils(opts, whitelist=["zfs"])
+    zfs_obj = {
+        zfs: {
+            "__opts__": opts,
+            "__grains__": {
+                "osarch": "sparcv9",
+                "os_family": "Solaris",
+                "osmajorrelease": 11,
+                "kernel": "SunOS",
+                "kernelrelease": 5.11,
+            },
+            "__utils__": utils,
+        }
+    }
+
+    return zfs_obj
+
+
+def test_get_success_solaris():
+    """
+    Tests zfs get success
+    """
+
+    cmd_out = {
+        "pid": 7278,
+        "retcode": 0,
+        "stdout": "testpool\tmountpoint\t/testpool\tdefault",
+        "stderr": "",
+    }
+
+    run_all_mock = MagicMock(return_value=cmd_out)
+    patches = {
+        "cmd.run_all": run_all_mock,
+    }
+    with patch.dict(zfs.__salt__, patches):
+        with patch("sys.platform", MagicMock(return_value="sunos5")):
+            result = zfs.get("testpool", type="filesystem", properties="mountpoint")
+            assert result == {
+                "testpool": {
+                    "mountpoint": {"value": "/testpool", "source": "default"},
+                },
+            }
+    run_all_mock.assert_called_once_with(
+        "/usr/sbin/zfs get -H -o name,property,value,source mountpoint testpool",
+        python_shell=False,
+    )


### PR DESCRIPTION
### What does this PR do?
When executing zfs.get, skips '-t' type if on Solaris 10 or 11, as not a valid parameter on those platforms
Note: zfs.get parameter '-t' type is valid for FreeBSD, Illumos and Linux implementations

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/59303

### Previous Behavior
The function executed correctly but errors where thrown in the log files and console, for example:
```
[ERROR   ] Command '/usr/sbin/zfs' failed with return code: 2
[ERROR   ] stderr: invalid option 't'
usage:
        get [-rHp] [-d max] [-o field[,...]] [-s source[,...]]
            <"all" | property[,...]> [filesystem|volume|snapshot] ...

The following properties are supported:

        PROPERTY       EDIT  INHERIT   VALUES

        available        NO       NO   <size>
        compressratio    NO       NO   <1.00x or higher if compressed>
.
.
        userquota@...   YES       NO   <size> | none
        groupquota@...  YES       NO   <size> | none

Sizes are specified in bytes with standard units such as K, M, G, etc.

User-defined properties can be specified by using a name containing a colon (:).

The {user|group}{used|quota}@ properties must be appended with
a user or group specifier of one of these forms:
    POSIX name      (eg: "matt")
    POSIX id        (eg: "126829")
    SMB name@domain (eg: "matt@sun")
    SMB SID         (eg: "S-1-234-567-89")
[ERROR   ] retcode: 2
```

### New Behavior
No more errors are thrown in the log files or console.

Note: this error is not caught by the existing tests due to mocking or not testing the '-t' parameter
tests/pytests/unit/states/test_zfs.py, function test_filesystem_present.
tests/unit/module/test_zfs.py (do not test -t parameter)
tests/unit/utils/test_zfs.py (do not test -t parameter)

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes
Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
