### PR TITLE
pkgin was no longer loaded on OmniOS

### DIFF
--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -88,8 +88,12 @@ def __virtual__():
     Set the virtual pkg module if the os is supported by pkgin
     """
     supported = [
-        "NetBSD", "DragonFly", "Minix",
-        "Darwin", "SunOS", "SmartOS",
+        "NetBSD",
+        "DragonFly",
+        "Minix",
+        "Darwin",
+        "SunOS",
+        "SmartOS",
         "OmniOS",
     ]
 

--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -87,7 +87,11 @@ def __virtual__():
     """
     Set the virtual pkg module if the os is supported by pkgin
     """
-    supported = ["NetBSD", "SunOS", "DragonFly", "Minix", "Darwin", "SmartOS"]
+    supported = [
+        "NetBSD", "DragonFly", "Minix",
+        "Darwin", "SunOS", "SmartOS",
+        "OmniOS",
+    ]
 
     if __grains__["os"] in supported and _check_pkgin():
         return __virtualname__


### PR DESCRIPTION
### What does this PR do?


Grains changed somewhere in the 300x series and pkgin is no longer loaded on OmniOS as it now reports as os=OmniOS and no longer as os=SunOS.
This updates the __virtual__ function to include OmniOS.
### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
Not loaded on OmniOS

### New Behavior
Loaded on OmniOS if pkgin is present.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No
