### PR TITLE
Fix regression, allow for templates without keywords specified

### DIFF
--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -123,7 +123,7 @@ class HandleFileCopy:
                         fp.write(template_string)
                     return self._cached_file
 
-                # continue for else part
+            # continue for else part
             self._cached_file = salt.utils.files.mkstemp()
             __salt__["cp.get_template"](
                 self._file_path, self._cached_file, **self._kwargs

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -18,7 +18,6 @@ import json
 import logging
 import os
 import re
-import tempfile
 from functools import wraps
 
 import salt.utils.args
@@ -111,52 +110,36 @@ class HandleFileCopy:
                 master_hash = __salt__["cp.hash_file"](self._file_path)
                 proxy_hash = __salt__["file.get_hash"](local_cache_path)
                 # check if hash is same, else copy newly
+                mhash = master_hash.get("hsum")
                 if master_hash.get("hsum") == proxy_hash:
-                    # kwargs will have values when path is a template
-                    if self._kwargs:
-                        self._cached_file = salt.utils.files.mkstemp()
-                        # local copy is a template, hence need to render
-                        with salt.utils.files.fopen(self._cached_file, "w") as fp:
-                            template_string = __salt__["slsutil.renderer"](
-                                path=local_cache_path,
-                                default_renderer="jinja",
-                                **self._kwargs
-                            )
-                            fp.write(template_string)
-                        return self._cached_file
-                    else:
-                        return local_cache_path
+                    self._cached_file = salt.utils.files.mkstemp()
+                    # local copy is a template, hence need to render
+                    with salt.utils.files.fopen(self._cached_file, "w") as fp:
+                        template_string = __salt__["slsutil.renderer"](
+                            path=local_cache_path,
+                            default_renderer="jinja",
+                            **self._kwargs,
+                        )
+                        fp.write(template_string)
+                    return self._cached_file
+
                 # continue for else part
-            if self._kwargs:
-                self._cached_file = salt.utils.files.mkstemp()
-                __salt__["cp.get_template"](
-                    self._file_path, self._cached_file, **self._kwargs
-                )
-            else:
-                self._cached_folder = tempfile.mkdtemp()
-                log.debug(
-                    "Caching file {} at {}".format(self._file_path, self._cached_folder)
-                )
-                self._cached_file = __salt__["cp.get_file"](
-                    self._file_path, self._cached_folder
-                )
+            self._cached_file = salt.utils.files.mkstemp()
+            __salt__["cp.get_template"](
+                self._file_path, self._cached_file, **self._kwargs
+            )
             if self._cached_file != "":
                 return self._cached_file
         else:
             # check for local location of file
             if __salt__["file.file_exists"](self._file_path):
-                if self._kwargs:
-                    self._cached_file = salt.utils.files.mkstemp()
-                    with salt.utils.files.fopen(self._cached_file, "w") as fp:
-                        template_string = __salt__["slsutil.renderer"](
-                            path=self._file_path,
-                            default_renderer="jinja",
-                            **self._kwargs
-                        )
-                        fp.write(template_string)
-                    return self._cached_file
-                else:
-                    return self._file_path
+                self._cached_file = salt.utils.files.mkstemp()
+                with salt.utils.files.fopen(self._cached_file, "w") as fp:
+                    template_string = __salt__["slsutil.renderer"](
+                        path=self._file_path, default_renderer="jinja", **self._kwargs
+                    )
+                    fp.write(template_string)
+                return self._cached_file
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         if self._cached_file is not None:
@@ -1261,7 +1244,7 @@ def install_config(path=None, **kwargs):
                 except Exception as exception:  # pylint: disable=broad-except
                     ret[
                         "message"
-                    ] = 'Could not write into diffs_file due to: "{}"'.format(exception)
+                    ] = "Could not write into diffs_file due to: '{}'".format(exception)
                     ret["out"] = False
 
         except ValueError as ex:
@@ -1277,6 +1260,11 @@ def install_config(path=None, **kwargs):
             message = "install_config failed due to timeout error : {}".format(str(ex))
             log.error(message)
             ret["message"] = message
+            ret["out"] = False
+        except Exception as exception:  # pylint: disable=broad-except
+            ret["message"] = "install_config failed due to exception: '{}'".format(
+                exception
+            )
             ret["out"] = False
 
         return ret

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -1261,7 +1261,7 @@ def install_config(path=None, **kwargs):
             log.error(message)
             ret["message"] = message
             ret["out"] = False
-        except Exception as exception:  # pylint: disable=broad-except
+        except Exception as exc:  # pylint: disable=broad-except
             ret["message"] = "install_config failed due to exception: '{}'".format(
                 exception
             )

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -110,7 +110,6 @@ class HandleFileCopy:
                 master_hash = __salt__["cp.hash_file"](self._file_path)
                 proxy_hash = __salt__["file.get_hash"](local_cache_path)
                 # check if hash is same, else copy newly
-                mhash = master_hash.get("hsum")
                 if master_hash.get("hsum") == proxy_hash:
                     self._cached_file = salt.utils.files.mkstemp()
                     # local copy is a template, hence need to render

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -1262,9 +1262,7 @@ def install_config(path=None, **kwargs):
             ret["message"] = message
             ret["out"] = False
         except Exception as exc:  # pylint: disable=broad-except
-            ret["message"] = "install_config failed due to exception: '{}'".format(
-                exc
-            )
+            ret["message"] = "install_config failed due to exception: '{}'".format(exc)
             ret["out"] = False
 
         return ret

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -1263,7 +1263,7 @@ def install_config(path=None, **kwargs):
             ret["out"] = False
         except Exception as exc:  # pylint: disable=broad-except
             ret["message"] = "install_config failed due to exception: '{}'".format(
-                exception
+                exc
             )
             ret["out"] = False
 

--- a/tests/unit/modules/templates/basic2.j2
+++ b/tests/unit/modules/templates/basic2.j2
@@ -1,0 +1,5 @@
+{% if proxytype == 'junos' %}
+set system = 2
+set system = 3
+{%- endif %}
+

--- a/tests/unit/modules/test_junos.py
+++ b/tests/unit/modules/test_junos.py
@@ -1,10 +1,10 @@
 """
     :codeauthor: Rajvi Dhimar <rajvidhimar95@gmail.com>
 """
-
 import os
 
 import salt.modules.junos as junos
+import yaml
 from tests.support.mixins import LoaderModuleMockMixin, XMLEqualityMixin
 from tests.support.mock import ANY, MagicMock, PropertyMock, call, mock_open, patch
 from tests.support.unit import TestCase, skipIf
@@ -1175,6 +1175,8 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             ) as mock_safe_rm, patch(
                 "salt.utils.files.mkstemp"
             ) as mock_mkstemp, patch(
+                "salt.utils.files.fopen", mock_open(), create=True
+            ) as m_open, patch(
                 "os.path.isfile"
             ) as mock_isfile, patch(
                 "os.path.getsize"
@@ -1217,6 +1219,8 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             ) as mock_mkstemp, patch(
                 "os.path.isfile"
             ) as mock_isfile, patch(
+                "salt.utils.files.fopen", mock_open(), create=True
+            ) as m_open, patch(
                 "os.path.getsize"
             ) as mock_getsize:
                 mock_isfile.return_value = True
@@ -1257,6 +1261,8 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             ) as mock_mkstemp, patch(
                 "os.path.isfile"
             ) as mock_isfile, patch(
+                "salt.utils.files.fopen", mock_open(), create=True
+            ) as m_open, patch(
                 "os.path.getsize"
             ) as mock_getsize:
                 mock_isfile.return_value = True
@@ -1294,6 +1300,8 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             ) as mock_mkdtemp, patch(
                 "os.path.isfile"
             ) as mock_isfile, patch(
+                "salt.utils.files.fopen", mock_open(), create=True
+            ) as m_open, patch(
                 "os.path.getsize"
             ) as mock_getsize:
                 mock_isfile.return_value = True
@@ -1338,6 +1346,8 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             ) as mock_mkstemp, patch(
                 "os.path.isfile"
             ) as mock_isfile, patch(
+                "salt.utils.files.fopen", mock_open(), create=True
+            ) as m_open, patch(
                 "os.path.getsize"
             ) as mock_getsize:
                 mock_isfile.return_value = True
@@ -1391,6 +1401,8 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             ) as mock_mkstemp, patch(
                 "os.path.isfile"
             ) as mock_isfile, patch(
+                "salt.utils.files.fopen", mock_open(), create=True
+            ) as m_open, patch(
                 "os.path.getsize"
             ) as mock_getsize:
                 mock_isfile.return_value = True
@@ -1444,6 +1456,8 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             ) as mock_mkstemp, patch(
                 "os.path.isfile"
             ) as mock_isfile, patch(
+                "salt.utils.files.fopen", mock_open(), create=True
+            ) as m_open, patch(
                 "os.path.getsize"
             ) as mock_getsize:
                 mock_isfile.return_value = True
@@ -1481,6 +1495,8 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         ) as mock_mkstemp, patch(
             "os.path.isfile"
         ) as mock_isfile, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open, patch(
             "os.path.getsize"
         ) as mock_getsize:
             mock_isfile.return_value = True
@@ -1501,6 +1517,8 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         ) as mock_mkstemp, patch(
             "os.path.isfile"
         ) as mock_isfile, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open, patch(
             "os.path.getsize"
         ) as mock_getsize:
             mock_isfile.return_value = True
@@ -1567,8 +1585,10 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         ) as mock_mkstemp, patch(
             "os.path.isfile"
         ) as mock_isfile, patch(
-            "salt.utils.files.fopen"
+            "salt.utils.files.fopen", mock_open(), create=True
         ) as mock_fopen, patch(
+            "salt.utils.stringutils.to_str"
+        ) as mock_strgutils, patch(
             "os.path.getsize"
         ) as mock_getsize:
             mock_isfile.return_value = True
@@ -1576,7 +1596,7 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             mock_mkstemp.return_value = "test/path/config"
             mock_diff.return_value = "diff"
             mock_commit_check.return_value = True
-            mock_fopen.side_effect = self.raise_exception
+            mock_strgutils.side_effect = self.raise_exception
 
             args = {
                 "__pub_user": "root",
@@ -1590,10 +1610,9 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             }
 
             ret = dict()
-            ret["message"] = 'Could not write into diffs_file due to: "Test exception"'
+            ret["message"] = "Could not write into diffs_file due to: 'Test exception'"
             ret["out"] = False
             self.assertEqual(junos.install_config("actual/path/config", **args), ret)
-            mock_fopen.assert_called_with("copy/config/here", "w")
 
     def test_install_config_commit_params(self):
         with patch("jnpr.junos.utils.config.Config.commit") as mock_commit, patch(
@@ -1609,6 +1628,8 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         ) as mock_mkstemp, patch(
             "os.path.isfile"
         ) as mock_isfile, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open, patch(
             "os.path.getsize"
         ) as mock_getsize:
             mock_isfile.return_value = True
@@ -1647,6 +1668,8 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         ) as mock_mkstemp, patch(
             "os.path.isfile"
         ) as mock_isfile, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open, patch(
             "os.path.getsize"
         ) as mock_getsize:
             mock_isfile.return_value = True
@@ -1676,6 +1699,8 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         ) as mock_mkstemp, patch(
             "os.path.isfile"
         ) as mock_isfile, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open, patch(
             "os.path.getsize"
         ) as mock_getsize:
             mock_isfile.return_value = True
@@ -1705,6 +1730,8 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         ) as mock_mkstemp, patch(
             "os.path.isfile"
         ) as mock_isfile, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open, patch(
             "os.path.getsize"
         ) as mock_getsize:
             mock_isfile.return_value = True
@@ -1734,6 +1761,8 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         ) as mock_mkstemp, patch(
             "os.path.isfile"
         ) as mock_isfile, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open, patch(
             "os.path.getsize"
         ) as mock_getsize:
             mock_isfile.return_value = True
@@ -1768,6 +1797,8 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         ) as mock_mkstemp, patch(
             "os.path.isfile"
         ) as mock_isfile, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open, patch(
             "os.path.getsize"
         ) as mock_getsize:
             mock_isfile.return_value = True
@@ -1820,13 +1851,27 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 "file.rmdir": MagicMock(return_value="True"),
             },
         ):
-            with patch("os.path.isfile") as mock_isfile, patch(
+            with patch("jnpr.junos.utils.sw.SW.install") as mock_install, patch(
+                "salt.utils.files.safe_rm"
+            ) as mock_safe_rm, patch(
+                "salt.utils.files.fopen", mock_open(), create=True
+            ) as m_open, patch(
+                "salt.utils.files.mkstemp"
+            ) as mock_mkstemp, patch(
+                "os.path.isfile"
+            ) as mock_isfile, patch(
                 "os.path.getsize"
             ) as mock_getsize:
                 mock_getsize.return_value = 10
                 mock_isfile.return_value = False
+                mock_install.return_value = (
+                    False,
+                    "Invalid path. Please provide a valid image path",
+                )
                 ret = dict()
-                ret["message"] = "Invalid path. Please provide a valid image path"
+                ret[
+                    "message"
+                ] = "Installation failed. Reason: Invalid path. Please provide a valid image path"
                 ret["out"] = False
                 self.assertEqual(junos.install_os("salt://image/path/"), ret)
 
@@ -1840,25 +1885,43 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             self.assertEqual(junos.install_os("/image/path/"), ret)
 
     def test_install_os(self):
-        with patch("jnpr.junos.utils.sw.SW.install") as mock_install, patch(
-            "salt.utils.files.safe_rm"
-        ) as mock_safe_rm, patch("salt.utils.files.mkstemp") as mock_mkstemp, patch(
-            "os.path.isfile"
-        ) as mock_isfile, patch(
-            "os.path.getsize"
-        ) as mock_getsize:
-            mock_getsize.return_value = 10
-            mock_isfile.return_value = True
-            mock_install.return_value = True, "installed"
-            ret = dict()
-            ret["out"] = True
-            ret["message"] = "Installed the os."
-            self.assertEqual(junos.install_os("path"), ret)
+        with patch.dict(
+            junos.__salt__,
+            {
+                "cp.is_cached": MagicMock(return_value="test/path/config"),
+                "cp.hash_file": MagicMock(
+                    return_value={"hash_type": "sha256", "hsum": "a386e49c17"}
+                ),
+                "file.get_hash": MagicMock(return_value="a386e49c17"),
+            },
+        ):
+            with patch("jnpr.junos.utils.sw.SW.install") as mock_install, patch(
+                "salt.utils.files.safe_rm"
+            ) as mock_safe_rm, patch(
+                "salt.utils.files.fopen", mock_open(), create=True
+            ) as m_open, patch(
+                "salt.utils.files.mkstemp"
+            ) as mock_mkstemp, patch(
+                "os.path.isfile"
+            ) as mock_isfile, patch(
+                "os.path.getsize"
+            ) as mock_getsize:
+                mock_getsize.return_value = 10
+                mock_isfile.return_value = True
+                mock_install.return_value = True, "installed"
+                ret = dict()
+                ret["out"] = True
+                ret["message"] = "Installed the os."
+                self.assertEqual(junos.install_os("path"), ret)
 
     def test_install_os_failure(self):
         with patch("jnpr.junos.utils.sw.SW.install") as mock_install, patch(
             "salt.utils.files.safe_rm"
-        ) as mock_safe_rm, patch("salt.utils.files.mkstemp") as mock_mkstemp, patch(
+        ) as mock_safe_rm, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open, patch(
+            "salt.utils.files.mkstemp"
+        ) as mock_mkstemp, patch(
             "os.path.isfile"
         ) as mock_isfile, patch(
             "os.path.getsize"
@@ -1877,6 +1940,8 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         with patch("jnpr.junos.utils.sw.SW.install") as mock_install, patch(
             "jnpr.junos.utils.sw.SW.reboot"
         ) as mock_reboot, patch("salt.utils.files.safe_rm") as mock_safe_rm, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open, patch(
             "salt.utils.files.mkstemp"
         ) as mock_mkstemp, patch(
             "os.path.isfile"
@@ -1904,7 +1969,11 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
     def test_install_os_pyez_install_throws_exception(self):
         with patch("jnpr.junos.utils.sw.SW.install") as mock_install, patch(
             "salt.utils.files.safe_rm"
-        ) as mock_safe_rm, patch("salt.utils.files.mkstemp") as mock_mkstemp, patch(
+        ) as mock_safe_rm, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open, patch(
+            "salt.utils.files.mkstemp"
+        ) as mock_mkstemp, patch(
             "os.path.isfile"
         ) as mock_isfile, patch(
             "os.path.getsize"
@@ -1921,6 +1990,8 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         with patch("jnpr.junos.utils.sw.SW.install") as mock_install, patch(
             "jnpr.junos.utils.sw.SW.reboot"
         ) as mock_reboot, patch("salt.utils.files.safe_rm") as mock_safe_rm, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open, patch(
             "salt.utils.files.mkstemp"
         ) as mock_mkstemp, patch(
             "os.path.isfile"
@@ -1951,7 +2022,11 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
     def test_install_os_no_copy(self):
         with patch("jnpr.junos.utils.sw.SW.install") as mock_install, patch(
             "salt.utils.files.safe_rm"
-        ) as mock_safe_rm, patch("salt.utils.files.mkstemp") as mock_mkstemp, patch(
+        ) as mock_safe_rm, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open, patch(
+            "salt.utils.files.mkstemp"
+        ) as mock_mkstemp, patch(
             "os.path.isfile"
         ) as mock_isfile, patch(
             "os.path.getsize"
@@ -1972,7 +2047,11 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
     def test_install_os_issu(self):
         with patch("jnpr.junos.utils.sw.SW.install") as mock_install, patch(
             "salt.utils.files.safe_rm"
-        ) as mock_safe_rm, patch("salt.utils.files.mkstemp") as mock_mkstemp, patch(
+        ) as mock_safe_rm, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open, patch(
+            "salt.utils.files.mkstemp"
+        ) as mock_mkstemp, patch(
             "os.path.isfile"
         ) as mock_isfile, patch(
             "os.path.getsize"
@@ -1989,7 +2068,11 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
     def test_install_os_add_params(self):
         with patch("jnpr.junos.utils.sw.SW.install") as mock_install, patch(
             "salt.utils.files.safe_rm"
-        ) as mock_safe_rm, patch("salt.utils.files.mkstemp") as mock_mkstemp, patch(
+        ) as mock_safe_rm, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open, patch(
+            "salt.utils.files.mkstemp"
+        ) as mock_mkstemp, patch(
             "os.path.isfile"
         ) as mock_isfile, patch(
             "os.path.getsize"
@@ -2252,19 +2335,30 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 "file.get_hash": MagicMock(return_value="a386e49c17"),
             },
         ):
-            with patch("os.path.getsize") as mock_getsize:
+            with patch(
+                "salt.utils.files.fopen", mock_open(), create=True
+            ) as m_open, patch("os.path.getsize") as mock_getsize, patch(
+                "salt.utils.files.mkstemp"
+            ) as mock_mkstmp:
+                mock_mkstmp.return_value = "/pat/to/tmp/file"
                 mock_getsize.return_value = 1000
                 ret = junos.load("salt://path/to/file")
                 self.assertEqual(ret, ret_exp)
 
     def test_load_invalid_path(self):
-        self.assertRaises(FileNotFoundError, junos.load, path="/path/to/file")
+        with patch("salt.utils.files.mkstemp") as mock_mkstmp:
+            mock_mkstmp.return_value = "/path/to/file"
+            self.assertRaises(FileNotFoundError, junos.load, path="/path/to/file")
 
     def test_load_no_extension(self):
         ret_exp = {"out": True, "message": "Successfully loaded the configuration."}
         with patch("os.path.getsize") as mock_getsize, patch(
             "jnpr.junos.utils.config.Config.load"
-        ) as mock_load, patch("salt.utils.files.mkstemp") as mock_mkstmp, patch(
+        ) as mock_load, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open, patch(
+            "salt.utils.files.mkstemp"
+        ) as mock_mkstmp, patch(
             "os.path.isfile"
         ) as mock_isfile:
             mock_getsize.return_value = 1000
@@ -2278,8 +2372,13 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         ret_exp = {"out": True, "message": "Successfully loaded the configuration."}
         with patch("os.path.getsize") as mock_getsize, patch(
             "jnpr.junos.utils.config.Config.load"
-        ) as mock_load, patch("os.path.isfile") as mock_isfile:
+        ) as mock_load, patch("os.path.isfile") as mock_isfile, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open, patch(
+            "salt.utils.files.mkstemp"
+        ) as mock_mkstmp:
             mock_getsize.return_value = 1000
+            mock_mkstmp.return_value = "/path/to/file.xml"
             mock_isfile.return_value = True
             ret = junos.load("/path/to/file.xml")
             mock_load.assert_called_with(format="xml", path="/path/to/file.xml")
@@ -2293,8 +2392,9 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             "os.path.isfile"
         ) as mock_isfile, patch(
             "salt.utils.files.fopen"
-        ) as fopen:
-            mock_getsize.return_value = 1000
+        ) as fopen, patch(
+            "salt.utils.files.mkstemp"
+        ) as mock_mkstmp:
             mock_mkstmp.return_value = "/path/to/file"
             mock_isfile.return_value = True
             ret = junos.load("/path/to/file.xml", template_vars=dict(hostname="test"))
@@ -2308,10 +2408,12 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         with patch("os.path.getsize") as mock_getsize, patch(
             "jnpr.junos.utils.config.Config.load"
         ) as mock_load, patch("salt.utils.files.mkstemp") as mock_mkstmp, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open, patch(
             "os.path.isfile"
         ) as mock_isfile:
             mock_getsize.return_value = 1000
-            mock_mkstmp.return_value = "/path/to/file"
+            mock_mkstmp.return_value = "/path/to/file.set"
             mock_isfile.return_value = True
             ret = junos.load("/path/to/file.set")
             mock_load.assert_called_with(format="set", path="/path/to/file.set")
@@ -2322,6 +2424,8 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         with patch("os.path.getsize") as mock_getsize, patch(
             "jnpr.junos.utils.config.Config.load"
         ) as mock_load, patch("salt.utils.files.mkstemp") as mock_mkstmp, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open, patch(
             "os.path.isfile"
         ) as mock_isfile:
             mock_getsize.return_value = 1000
@@ -2338,6 +2442,8 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         with patch("os.path.getsize") as mock_getsize, patch(
             "jnpr.junos.utils.config.Config.load"
         ) as mock_load, patch("salt.utils.files.mkstemp") as mock_mkstmp, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open, patch(
             "os.path.isfile"
         ) as mock_isfile:
             mock_getsize.return_value = 1000
@@ -2354,6 +2460,8 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         with patch("os.path.getsize") as mock_getsize, patch(
             "jnpr.junos.utils.config.Config.load"
         ) as mock_load, patch("salt.utils.files.mkstemp") as mock_mkstmp, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open, patch(
             "os.path.isfile"
         ) as mock_isfile:
             mock_getsize.return_value = 1000
@@ -2369,7 +2477,11 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         ret_exp = {"out": True, "message": "Successfully loaded the configuration."}
         with patch("os.path.getsize") as mock_getsize, patch(
             "jnpr.junos.utils.config.Config.load"
-        ) as mock_load, patch("salt.utils.files.mkstemp") as mock_mkstmp, patch(
+        ) as mock_load, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open, patch(
+            "salt.utils.files.mkstemp"
+        ) as mock_mkstmp, patch(
             "os.path.isfile"
         ) as mock_isfile:
             mock_getsize.return_value = 1000
@@ -2390,6 +2502,8 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         with patch("os.path.getsize") as mock_getsize, patch(
             "jnpr.junos.utils.config.Config.load"
         ) as mock_load, patch("salt.utils.files.mkstemp") as mock_mkstmp, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open, patch(
             "os.path.isfile"
         ) as mock_isfile:
             mock_getsize.return_value = 1000
@@ -2397,6 +2511,17 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             mock_isfile.return_value = True
             mock_load.side_effect = Exception("Test Error")
             ret = junos.load("/path/to/file")
+            self.assertEqual(ret, ret_exp)
+
+    def test_load_template(self):
+        ret_exp = {
+            "out": True,
+            "message": "Successfully loaded the configuration.",
+        }
+        with patch("os.path.getsize") as mock_getsize, patch(
+            "jnpr.junos.utils.config.Config.load"
+        ) as mock_load:
+            ret = junos.load("tests/unit/modules/templates/basic2.j2", test=True)
             self.assertEqual(ret, ret_exp)
 
     def test_commit_check_success(self):
@@ -2467,15 +2592,35 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             ),
         }
         with patch(
-            "salt.utils.files.fopen", mock_open(IOError(message))
-        ) as mock_file, patch("glob.glob") as mock_fopen:
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as mock_file, patch("glob.glob") as mock_fopen, patch.object(
+            yaml, "load"
+        ) as mock_yamlload:
             mock_fopen.return_value = ["/path/to/file"]
+            mock_yamlload.side_effect = OSError(message)
             ret = junos.get_table(table, file, path)
             self.assertEqual(ret, ret_exp)
 
     def test_get_table_api_error(self):
         table = "sample"
         file = "inventory.yml"
+        table_yamlload = {
+            "ModuleTable": {
+                "item": ".//chassis-sub-module|.//chassis-module|.//chassis-sub-sub-module",
+                "key": "name",
+                "rpc": "get-chassis-inventory",
+                "view": "ModuleTableView",
+            },
+            "ModuleTableView": {
+                "fields": {
+                    "jname": "name",
+                    "pn": "part-number",
+                    "sn": "serial-number",
+                    "type": "description",
+                    "ver": "version",
+                },
+            },
+        }
         ret_exp = {
             "out": False,
             "hostname": "1.1.1.1",
@@ -2483,7 +2628,12 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
             "message": "Uncaught exception during get API call - please report:"
             " '{}'".format(str(table)),
         }
-        with patch("jnpr.junos.device.Device.execute") as mock_execute:
+        with patch("jnpr.junos.device.Device.execute") as mock_execute, patch(
+            "yaml.load"
+        ) as mock_yamlload, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open:
+            mock_yamlload.return_value = table_yamlload
             ret = junos.get_table(table, file)
             self.assertEqual(ret["out"], ret_exp["out"])
             self.assertEqual(ret["tablename"], ret_exp["tablename"])
@@ -2492,15 +2642,37 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
     def test_get_table_connect_closed_error(self):
         table = "ModuleTable"
         file = "inventory.yml"
+        table_yamlload = {
+            "ModuleTable": {
+                "item": ".//chassis-sub-module|.//chassis-module|.//chassis-sub-sub-module",
+                "key": "name",
+                "rpc": "get-chassis-inventory",
+                "view": "ModuleTableView",
+            },
+            "ModuleTableView": {
+                "fields": {
+                    "jname": "name",
+                    "pn": "part-number",
+                    "sn": "serial-number",
+                    "type": "description",
+                    "ver": "version",
+                },
+            },
+        }
         ret_exp = {
             "out": False,
             "hostname": "1.1.1.1",
             "tablename": "ModuleTable",
             "message": "Got ConnectClosedError exception. Connection lost with Device(1.1.1.1)",
         }
-        with patch("jnpr.junos.factory.optable.OpTable.get") as mock_load:
+        with patch("jnpr.junos.factory.optable.OpTable.get") as mock_load, patch(
+            "yaml.load"
+        ) as mock_yamlload, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open:
             dev = Device(host="1.1.1.1", user="rick")
             mock_load.side_effect = ConnectClosedError(dev)
+            mock_yamlload.return_value = table_yamlload
             ret = junos.get_table(table, file)
             self.assertEqual(ret["out"], ret_exp["out"])
             self.assertEqual(ret["tablename"], ret_exp["tablename"])
@@ -2511,21 +2683,59 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
         file = "inventory.yml"
         pyez_tables_path = os.path.dirname(os.path.abspath(tables_dir.__file__))
         path = pyez_tables_path
+        table_yamlload = {
+            "ModuleTable": {
+                "item": ".//chassis-sub-module|.//chassis-module|.//chassis-sub-sub-module",
+                "key": "name",
+                "rpc": "get-chassis-inventory",
+                "view": "ModuleTableView",
+            },
+            "ModuleTableView": {
+                "fields": {
+                    "jname": "name",
+                    "pn": "part-number",
+                    "sn": "serial-number",
+                    "type": "description",
+                    "ver": "version",
+                },
+            },
+        }
         with patch("jnpr.junos.device.Device.execute") as mock_execute, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open, patch("yaml.load") as mock_yamlload, patch(
             "salt.utils.json.dumps"
         ) as mock_dumps:
             mock_dumps.return_value = "json rpc reply"
-            m = mock_open()
+            mock_yamlload.return_value = table_yamlload
             ret = junos.get_table(table, file, path)
             self.assertEqual(ret["out"], True)
 
     def test_get_table_no_path_inventory(self):
         table = "ModuleTable"
         file = "inventory.yml"
+        table_yamlload = {
+            "ModuleTable": {
+                "item": ".//chassis-sub-module|.//chassis-module|.//chassis-sub-sub-module",
+                "key": "name",
+                "rpc": "get-chassis-inventory",
+                "view": "ModuleTableView",
+            },
+            "ModuleTableView": {
+                "fields": {
+                    "jname": "name",
+                    "pn": "part-number",
+                    "sn": "serial-number",
+                    "type": "description",
+                    "ver": "version",
+                },
+            },
+        }
         with patch("jnpr.junos.device.Device.execute") as mock_execute, patch(
+            "salt.utils.files.fopen", mock_open(), create=True
+        ) as m_open, patch("yaml.load") as mock_yamlload, patch(
             "salt.utils.json.dumps"
         ) as mock_dumps:
             mock_dumps.return_value = "json rpc reply"
-            m = mock_open()
+            mock_yamlload.return_value = table_yamlload
             ret = junos.get_table(table, file)
             self.assertEqual(ret["out"], True)


### PR DESCRIPTION
### What does this PR do?
Fixes a regression, allows for the use of templates in files without having to specify keywords to have the template rendered.  A previous PR introduced HandleFileCopy which had the assumption that templates would only be used with keywords incorrectly.  This PR reverts this invalid assumption.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/57665 and https://github.com/saltstack/salt/issues/59333

### Previous Behavior
Files with templates, the templates were ignored unless a keyword was specified.

### New Behavior
Files with templates, the templates are rendered without the need to a specify a keyword, that is, files are now always rendered, reverting to previous mode of operation prior to the introduction of HandleFileCopy commit 5edbbe250a8960b22cb6d40613bcaaa47fc2609d

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
