### PR TITLE
Ignore temporary properties during zfs.filesystem.present

### DIFF
--- a/changelog/60091.fixed
+++ b/changelog/60091.fixed
@@ -1,0 +1,1 @@
+Fix zfs.filesystem.present to ignore temporary properties

--- a/salt/states/zfs.py
+++ b/salt/states/zfs.py
@@ -462,6 +462,7 @@ def _dataset_present(
             fields="value",
             depth=0,
             parsable=True,
+            source="default,inherited,local,none,received",
         ).get(name, OrderedDict())
 
         ## NOTE: build list of properties to update

--- a/tests/pytests/unit/states/test_zfs.py
+++ b/tests/pytests/unit/states/test_zfs.py
@@ -517,6 +517,7 @@ def test_filesystem_present_properties(utils_patch):
         fields="value",
         parsable=True,
         type="filesystem",
+        source="default,inherited,local,none,received",
     )
 
 
@@ -560,6 +561,7 @@ def test_filesystem_present_update(utils_patch):
         fields="value",
         parsable=True,
         type="filesystem",
+        source="default,inherited,local,none,received",
     )
 
 
@@ -619,6 +621,7 @@ def test_volume_present(utils_patch):
         fields="value",
         parsable=True,
         type="volume",
+        source="default,inherited,local,none,received",
     )
 
 
@@ -681,6 +684,7 @@ def test_volume_present_update(utils_patch):
         fields="value",
         parsable=True,
         type="volume",
+        source="default,inherited,local,none,received",
     )
 
 


### PR DESCRIPTION
A temporary property is one that gets set by the mount command's "-o"
option and only applies for the duration of the mount.  Salt's ZFS
module cannot change these, so Salt's zfs state should ignore them.

### What does this PR do?
Ignores temporary ZFS properties during the "filesystem.present" state.

### What issues does this PR fix or reference?
If a temporary mountpoint were set contrary to the defined state, then state.apply would try to correct it, to no effect.  Also, ignoring temporary properties will soon be faster (see https://github.com/openzfs/zfs/pull/11955)

### Previous Behavior
filesystem.present would try in vain to correct a temporary property.  For example "readonly". 

### New Behavior
filesystem.present will ignore temporary properties.

### Merge requirements satisfied?
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [XXX] Tests written/updated (tests will be added after #59970 merges)

### Commits signed with GPG?
Yes