### PR TITLE
Use new vcpp build tools from VS2017

### DIFF
--- a/pkg/windows/build_env.ps1
+++ b/pkg/windows/build_env.ps1
@@ -230,25 +230,29 @@ If ( (Test-Path "$($ini[$bitPaths]['NSISPluginsDirA'])\EnVar.dll") -and (Test-Pa
 }
 
 #------------------------------------------------------------------------------
-# Check for installation of Microsoft Visual C++ Build Tools
+# Check for installation of Microsoft Visual Studio 2015 Build Tools
 #------------------------------------------------------------------------------
-Write-Output " - Checking for Microsoft Visual C++ Build Tools installation . . ."
-If (Test-Path "$($ini[$bitPaths]['VCppBuildToolsDir'])\vcbuildtools.bat") {
-    # Found Microsoft Visual C++ Build Tools, do nothing
-    Write-Output " - Microsoft Visual C++ Build Tools Found . . ."
+Write-Output " - Checking for Microsoft Visual Studio 2015 Build Tools installation . . ."
+If (Test-Path "$($ini[$bitPaths]['VS2015BuildToolsDir'])\cl.exe") {
+    # Found Microsoft Visual Studio 2015 Build Tools, do nothing
+    Write-Output " - Microsoft Visual Studio 2015 Build Tools Found . . ."
 } Else {
-    # Microsoft Visual C++ Build Tools not found, install
-    Write-Output " - Microsoft Visual C++ Build Tools Not Found . . ."
-    Write-Output " - Downloading $($ini['Prerequisites']['VCppBuildTools']) . . ."
-    $file = "$($ini['Prerequisites']['VCppBuildTools'])"
+    # Microsoft Visual Studio 2015 Build Tools not found, install
+    Write-Output " - Microsoft Visual Studio 2015 Build Tools Not Found . . ."
+    Write-Output " - Downloading $($ini['Prerequisites']['VS2015BuildTools']) . . ."
+    $file = "$($ini['Prerequisites']['VS2015BuildTools'])"
     $url  = "$($ini['Settings']['SaltRepo'])/$file"
     $file = "$($ini['Settings']['DownloadDir'])\$file"
     DownloadFileWithProgress $url $file
 
+    # Extract Zip File
+    Write-Output " - Extracting . . ."
+    Expand-ZipFile $file "$($ini['Settings']['DownloadDir'])\vs2015buildtools"
+
     # Install Microsoft Visual C++ Build Tools
-    Write-Output " - Installing $($ini['Prerequisites']['VCppBuildTools']) . . ."
-    $file = "$($ini['Settings']['DownloadDir'])\$($ini['Prerequisites']['VCppBuildTools'])"
-    $p    = Start-Process $file -ArgumentList '/Quiet' -Wait -NoNewWindow -PassThru
+    Write-Output " - Installing $($ini['Prerequisites']['VS2015BuildTools']) . . ."
+    $file = "$($ini['Settings']['DownloadDir'])\vs2015buildtools\install.bat"
+    $p    = Start-Process $file -Wait -NoNewWindow -PassThru
 }
 
 #------------------------------------------------------------------------------

--- a/pkg/windows/modules/get-settings.psm1
+++ b/pkg/windows/modules/get-settings.psm1
@@ -41,27 +41,27 @@ Function Get-Settings {
             "NSISPluginEnVar"  = "nsis-plugin-envar.zip"
             "NSISPluginUnzipA" = "nsis-plugin-nsisunz.zip"
             "NSISPluginUnzipU" = "nsis-plugin-nsisunzu.zip"
-            "VCppBuildTools"   = "visualcppbuildtools_full.exe"
+            "VS2015BuildTools" = "vcppbuildtools_full.zip"
         }
         $ini.Add("Prerequisites", $Prerequisites)
 
         # Location of programs on 64 bit Windows
         $64bitPaths = @{
-            "NSISDir"           = "C:\Program Files (x86)\NSIS"
-            "NSISPluginsDirA"   = "C:\Program Files (x86)\NSIS\Plugins\x86-ansi"
-            "NSISPluginsDirU"   = "C:\Program Files (x86)\NSIS\Plugins\x86-unicode"
-            "VCforPythonDir"    = "C:\Program Files (x86)\Common Files\Microsoft\Visual C++ for Python\9.0"
-            "VCppBuildToolsDir" = "C:\Program Files (x86)\Microsoft Visual C++ Build Tools"
+            "NSISDir"              = "C:\Program Files (x86)\NSIS"
+            "NSISPluginsDirA"      = "C:\Program Files (x86)\NSIS\Plugins\x86-ansi"
+            "NSISPluginsDirU"      = "C:\Program Files (x86)\NSIS\Plugins\x86-unicode"
+            "VCforPythonDir"       = "C:\Program Files (x86)\Common Files\Microsoft\Visual C++ for Python\9.0"
+            "VS2015BuildToolsDir"  = "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin"
         }
         $ini.Add("64bitPaths", $64bitPaths)
 
         # Location of programs on 32 bit Windows
         $32bitPaths = @{
-            "NSISDir"           = "C:\Program Files\NSIS"
-            "NSISPluginsDirA"   = "C:\Program Files\NSIS\Plugins\x86-ansi"
-            "NSISPluginsDirU"   = "C:\Program Files\NSIS\Plugins\x86-unicode"
-            "VCforPythonDir"    = "C:\Program Files\Common Files\Microsoft\Visual C++ for Python\9.0"
-            "VCppBuildToolsDir" = "C:\Program Files\Microsoft Visual C++ Build Tools"
+            "NSISDir"              = "C:\Program Files\NSIS"
+            "NSISPluginsDirA"      = "C:\Program Files\NSIS\Plugins\x86-ansi"
+            "NSISPluginsDirU"      = "C:\Program Files\NSIS\Plugins\x86-unicode"
+            "VCforPythonDir"       = "C:\Program Files\Common Files\Microsoft\Visual C++ for Python\9.0"
+            "VS2015BuildToolsDir"  = "C:\Program Files\Microsoft Visual Studio 14.0\VC\bin"
         }
         $ini.Add("32bitPaths", $32bitPaths)
 


### PR DESCRIPTION
### What does this PR do?
Updates the build scripts to use a standalone installer for Visual C++ Build Tools 2015 that is a part of VS Build Tools 2017. 

Microsoft seems to have deprecated the hosting of files required by the Microsoft Build Tools 2015 Update 3 binary as hosted here:

https://visualstudio.microsoft.com/vs/older-downloads/

Direct download here:

https://download.microsoft.com/download/5/F/7/5F7ACAEB-8363-451F-9425-68A90F98B238/visualcppbuildtools_full.exe

Therefore we can no longer create a valid build environment for Salt using that method. I can find no documentation about exactly when or why Microsoft stopped hosting those files.

A new zip file has been created and is being hosted at repo.saltproject.io/windows/dependencies called `vcppbuildtools_full.zip`. This file was created using ideas from https://stackoverflow.com/questions/46684230/visualstudio-build-tools-2017-offline-installer

This zipfile contains all the modules needed to install the Visual C++ Build Tools for 2015. This is required to compile some of the pip dependencies for Salt. The main binary `vs_BuildTools.exe` was obtained from msdn. Everything was created in this zipfile by running the following command and zipping it up:

```
vs_BuildTools.exe --layout --add Microsoft.VisualStudio.Workload.MSBuildTools --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.Windows81SDK --add Microsoft.VisualStudio.Component.VC.140 --add Microsoft.Component.VC.Runtime.UCRTSDK --lang en-US
```

If it is a new install you will probably need to install the certificates in the certificates directory:
```
cd certificates
certutil -addstore "Root" manifestCounterSignRootCertificate.cer
certutil -addstore "Root" manifestRootCertificate.cer
```

This one seems to be a duplicate of the first one:
```
certutil -addstore "Root" vs_installer_opc.RootCertificate.cer
```

To install the Visual C++ Build Tools run one of the following commands:
```
vs_setup.exe --noweb --passive
vs_setup.exe --noweb --quiet
```

Silent Installer Options:
https://docs.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio?view=vs-2017

Component IDs:
https://docs.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2017

There is also included a batch file called `install.bat` that will install the certificates and install the build tools.

It takes a long time to download the zipfile, unzip it, and install the Build Tools. But this only occurs the first time it is run on the system.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes