### PR TITLE
Fix test_run_with_tuple if home directory does not exist

### DIFF
--- a/tests/pytests/unit/modules/test_cmdmod.py
+++ b/tests/pytests/unit/modules/test_cmdmod.py
@@ -155,7 +155,7 @@ def test_run_with_tuple():
         with patch("salt.utils.platform.is_windows", MagicMock(return_value=False)):
             with patch("os.path.isfile", mock_true):
                 with patch("os.access", mock_true):
-                    cmdmod._run(("echo", "foo"), python_shell=True)
+                    cmdmod._run(("echo", "foo"), python_shell=True, cwd="/")
 
 
 def test_run_user_not_available():


### PR DESCRIPTION
When the home directory points to a directory that does not exist (e.g. when building salt with sbuild), some test cases will fail:

```
_____________________________ test_run_with_tuple ______________________________
    def test_run_with_tuple():
        """
        Tests return when cmd is a tuple
        """
        mock_true = MagicMock(return_value=True)
        with patch("salt.modules.cmdmod._is_valid_shell", mock_true):
            with patch("salt.utils.platform.is_windows", MagicMock(return_value=False)):
                with patch("os.path.isfile", mock_true):
                    with patch("os.access", mock_true):
>                       cmdmod._run(("echo", "foo"), python_shell=True)

tests/pytests/unit/modules/test_cmdmod.py:159:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
        if not os.path.isabs(cwd) or not os.path.isdir(cwd):
>           raise CommandExecutionError(
                "Specified cwd '{}' either not absolute or does not exist".format(cwd)
            )
E           salt.exceptions.CommandExecutionError: Specified cwd '/sbuild-nonexistent' either not absolute or does not exist

salt/modules/cmdmod.py:665: CommandExecutionError
```

So change to `/`, because this directory exists on every system.