### PR TITLE
Use latest Twine and regen cache due to workflow update in GitHub Actions

### DIFF
--- a/.github/workflows/twine-check.yml
+++ b/.github/workflows/twine-check.yml
@@ -20,8 +20,7 @@ jobs:
         key: ${{ env.pythonLocation }}-${{ hashFiles('README.rst') }}-${{ hashFiles('.github/workflows/twine-check.yml') }}
     - name: Install dependencies
       run: |
-        pip install --upgrade pip setuptools wheel
-        pip install twine==3.3.0
+        pip install twine>=3.4.1
     - name: Python setup
       run: |
         python3 setup.py sdist

--- a/.github/workflows/twine-check.yml
+++ b/.github/workflows/twine-check.yml
@@ -20,6 +20,7 @@ jobs:
         key: ${{ env.pythonLocation }}-${{ hashFiles('README.rst') }}-${{ hashFiles('.github/workflows/twine-check.yml') }}
     - name: Install dependencies
       run: |
+        pip install --upgrade pip setuptools wheel
         pip install twine>=3.4.1
     - name: Python setup
       run: |


### PR DESCRIPTION
### What does this PR do?

Fixes GitHub Action for twine check by clearing the cache.

Fixes https://github.com/saltstack/salt/issues/60101

### Previous Behavior

There is currently no way to clear the cache easily:

- https://github.com/actions/cache/issues/2

This is a problem, as we need to regen the cache to resolve a Python/pip related issue. Example failing test: https://github.com/saltstack/salt/runs/2461398554?check_suite_focus=true

```
> Run pip install --upgrade pip setuptools wheel
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.9/x64/bin/pip", line 5, in <module>
    from pip._internal.cli.main import main
  File "/opt/hostedtoolcache/Python/3.8.9/x64/lib/python3.8/site-packages/pip/_internal/cli/main.py", line 8, in <module>
    from pip._internal.cli.autocompletion import autocomplete
  File "/opt/hostedtoolcache/Python/3.8.9/x64/lib/python3.8/site-packages/pip/_internal/cli/autocompletion.py", line 9, in <module>
    from pip._internal.cli.main_parser import create_main_parser
  File "/opt/hostedtoolcache/Python/3.8.9/x64/lib/python3.8/site-packages/pip/_internal/cli/main_parser.py", line 7, in <module>
    from pip._internal.cli import cmdoptions
  File "/opt/hostedtoolcache/Python/3.8.9/x64/lib/python3.8/site-packages/pip/_internal/cli/cmdoptions.py", line 22, in <module>
    from pip._internal.cli.progress_bars import BAR_TYPES
  File "/opt/hostedtoolcache/Python/3.8.9/x64/lib/python3.8/site-packages/pip/_internal/cli/progress_bars.py", line 9, in <module>
    from pip._internal.utils.logging import get_indentation
  File "/opt/hostedtoolcache/Python/3.8.9/x64/lib/python3.8/site-packages/pip/_internal/utils/logging.py", line 14, in <module>
    from pip._internal.utils.misc import ensure_dir
  File "/opt/hostedtoolcache/Python/3.8.9/x64/lib/python3.8/site-packages/pip/_internal/utils/misc.py", line 29, in <module>
    from pip._internal.locations import get_major_minor_version, site_packages, user_site
  File "/opt/hostedtoolcache/Python/3.8.9/x64/lib/python3.8/site-packages/pip/_internal/locations/__init__.py", line 9, in <module>
    from . import _distutils, _sysconfig
  File "/opt/hostedtoolcache/Python/3.8.9/x64/lib/python3.8/site-packages/pip/_internal/locations/_sysconfig.py", line 8, in <module>
    from pip._internal.exceptions import InvalidSchemeCombination, UserInstallationInvalid
ImportError: cannot import name 'InvalidSchemeCombination' from 'pip._internal.exceptions' (/opt/hostedtoolcache/Python/3.8.9/x64/lib/python3.8/site-packages/pip/_internal/exceptions.py)
```

Looks related to https://github.com/pypa/pip/issues/9880 (clearing caches helped resolve problems for people).

Though, even with this fix, we will see this warning (that we can ignore):

```
WARNING: Value for scheme.headers does not match. Please report this to <https://github.com/pypa/pip/issues/9617>
```

See https://github.com/pypa/pip/issues/9617 for more information.

### New Behavior

Twine check runs without `pip` failures.

### Commits signed with GPG?
Yes
