### PR TITLE
Fix multiple issues with modules.pkgng.latest_version

### DIFF
--- a/changelog/60105.fixed
+++ b/changelog/60105.fixed
@@ -1,0 +1,1 @@
+Fixed an IndexError in pkgng.latest_version when querying an unknown package.

--- a/changelog/60108.fixed
+++ b/changelog/60108.fixed
@@ -1,0 +1,1 @@
+Fixed pkgng.latest_version when querying by origin (e.g. "shells/bash").

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -296,7 +296,7 @@ def latest_version(*names, **kwargs):
     chroot = kwargs.get("chroot")
     refresh = kwargs.get("refresh")
     root = kwargs.get("root")
-    pkgs = list_pkgs(versions_as_list=True, jail=jail, chroot=chroot, root=root)
+    pkgs = list_pkgs(jail=jail, chroot=chroot, root=root)
 
     for name in names:
         cmd = _pkg(jail, chroot, root) + ["search", "-eqS"]
@@ -314,14 +314,11 @@ def latest_version(*names, **kwargs):
         );
         if pkg_output != "":
             pkgver = pkg_output.rsplit("-", 1)[1]
-            installed = pkgs.get(name, [])
+            installed = pkgs.get(name)
             if not installed:
                 ret[name] = pkgver
             else:
-                if not any(
-                    salt.utils.versions.compare(ver1=x, oper=">=", ver2=pkgver)
-                    for x in installed
-                ):
+                if not salt.utils.versions.compare(ver1=installed, oper=">=", ver2=pkgver):
                     ret[name] = pkgver
 
     # Return a string if only one package name passed

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -298,13 +298,6 @@ def latest_version(*names, **kwargs):
     root = kwargs.get("root")
     pkgs = list_pkgs(versions_as_list=True, jail=jail, chroot=chroot, root=root)
 
-    if salt.utils.versions.compare(
-        _get_pkgng_version(jail, chroot, root), ">=", "1.6.0"
-    ):
-        quiet = True
-    else:
-        quiet = False
-
     for name in names:
         # FreeBSD supports packages in format java/openjdk7
         if "/" in name:
@@ -314,12 +307,9 @@ def latest_version(*names, **kwargs):
                 "search",
                 "-S",
                 "name",
-                "-Q",
-                "version",
                 "-e",
             ]
-        if quiet:
-            cmd.append("-q")
+        cmd.append("-q")
         if not salt.utils.data.is_true(refresh):
             cmd.append("-U")
         cmd.append(name)

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -311,14 +311,16 @@ def latest_version(*names, **kwargs):
 
         pkg_output = __salt__["cmd.run"](
             cmd, python_shell=False, output_loglevel="trace"
-        );
+        )
         if pkg_output != "":
             pkgver = pkg_output.rsplit("-", 1)[1]
             installed = pkgs.get(name)
             if not installed:
                 ret[name] = pkgver
             else:
-                if not salt.utils.versions.compare(ver1=installed, oper=">=", ver2=pkgver):
+                if not salt.utils.versions.compare(
+                    ver1=installed, oper=">=", ver2=pkgver
+                ):
                     ret[name] = pkgver
 
     # Return a string if only one package name passed

--- a/tests/pytests/unit/modules/test_pkgng.py
+++ b/tests/pytests/unit/modules/test_pkgng.py
@@ -34,24 +34,19 @@ def test_latest_version(pkgs_as_list):
         with patch.dict(pkgng.__salt__, {"cmd.run": search_cmd}):
             result = pkgng.latest_version("bash")
             search_cmd.assert_called_with(
-                ["pkg", "search", "-S", "name", "-e", "-q", "-U", "bash"], output_loglevel='trace', python_shell=False
+                ["pkg", "search", "-eqS", "name", "-U", "bash"], output_loglevel='trace', python_shell=False
             )
             assert result == "5.1.4"
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="https://github.com/saltstack/salt/issues/60108"
-)
 def test_latest_version_origin(pkgs_as_list):
     "Test pkgng.latest_version with a specific package origin"
     pkgs_mock = MagicMock(side_effect=pkgs_as_list)
-    search_cmd = MagicMock(return_value="bash-5.1.4_2\nbash-completion-2.11,2\nbash-static-5.1.4_2,bashc-5.0.9")
+    search_cmd = MagicMock(return_value="bash-5.1.4_2")
     with patch("salt.modules.pkgng.list_pkgs", pkgs_mock):
         with patch.dict(pkgng.__salt__, {"cmd.run": search_cmd}):
             result = pkgng.latest_version("shells/bash")
             search_cmd.assert_called_with(
-                # TODO: use -S origin.  See #60108
-                ["pkg", "search", "-q", "-U", "shells/bash"], output_loglevel='trace', python_shell=False
+                ["pkg", "search", "-eqS", "origin", "-U", "shells/bash"], output_loglevel='trace', python_shell=False
             )
             assert result == "5.1.4_2"
 
@@ -63,14 +58,10 @@ def test_latest_version_outofdatedate(pkgs_as_list):
         with patch.dict(pkgng.__salt__, {"cmd.run": search_cmd}):
             result = pkgng.latest_version("openvpn")
             search_cmd.assert_called_with(
-                ["pkg", "search", "-S", "name", "-e", "-q", "-U", "openvpn"], output_loglevel='trace', python_shell=False
+                ["pkg", "search", "-eqS", "name", "-U", "openvpn"], output_loglevel='trace', python_shell=False
             )
             assert result == "2.4.8_3"
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="https://github.com/saltstack/salt/issues/60105"
-)
 def test_latest_version_unavailable(pkgs_as_list):
     "Test pkgng.latest_version when the requested package is not available"
     pkgs_mock = MagicMock(side_effect=pkgs_as_list)
@@ -79,7 +70,7 @@ def test_latest_version_unavailable(pkgs_as_list):
         with patch.dict(pkgng.__salt__, {"cmd.run": search_cmd}):
             result = pkgng.latest_version("does_not_exist")
             search_cmd.assert_called_with(
-                ["pkg", "search", "-S", "name", "-e", "-q", "-U", "does_not_exist"], output_loglevel='trace', python_shell=False
+                ["pkg", "search", "-eqS", "name", "-U", "does_not_exist"], output_loglevel='trace', python_shell=False
             )
 
 def test_latest_version_uptodate(pkgs_as_list):
@@ -90,7 +81,7 @@ def test_latest_version_uptodate(pkgs_as_list):
         with patch.dict(pkgng.__salt__, {"cmd.run": search_cmd}):
             result = pkgng.latest_version("openvpn")
             search_cmd.assert_called_with(
-                ["pkg", "search", "-S", "name", "-e", "-q", "-U", "openvpn"], output_loglevel='trace', python_shell=False
+                ["pkg", "search", "-eqS", "name", "-U", "openvpn"], output_loglevel='trace', python_shell=False
             )
             assert result == ""
 

--- a/tests/pytests/unit/modules/test_pkgng.py
+++ b/tests/pytests/unit/modules/test_pkgng.py
@@ -20,61 +20,85 @@ def pkgs():
 
 
 def test_latest_version(pkgs):
-    "Test basic usage of pkgng.latest_version"
+    """
+    Test basic usage of pkgng.latest_version
+    """
     pkgs_mock = MagicMock(side_effect=pkgs)
     search_cmd = MagicMock(return_value="bash-5.1.4")
     with patch("salt.modules.pkgng.list_pkgs", pkgs_mock):
         with patch.dict(pkgng.__salt__, {"cmd.run": search_cmd}):
             result = pkgng.latest_version("bash")
             search_cmd.assert_called_with(
-                ["pkg", "search", "-eqS", "name", "-U", "bash"], output_loglevel='trace', python_shell=False
+                ["pkg", "search", "-eqS", "name", "-U", "bash"],
+                output_loglevel="trace",
+                python_shell=False,
             )
             assert result == "5.1.4"
 
+
 def test_latest_version_origin(pkgs):
-    "Test pkgng.latest_version with a specific package origin"
+    """
+    Test pkgng.latest_version with a specific package origin
+    """
     pkgs_mock = MagicMock(side_effect=pkgs)
     search_cmd = MagicMock(return_value="bash-5.1.4_2")
     with patch("salt.modules.pkgng.list_pkgs", pkgs_mock):
         with patch.dict(pkgng.__salt__, {"cmd.run": search_cmd}):
             result = pkgng.latest_version("shells/bash")
             search_cmd.assert_called_with(
-                ["pkg", "search", "-eqS", "origin", "-U", "shells/bash"], output_loglevel='trace', python_shell=False
+                ["pkg", "search", "-eqS", "origin", "-U", "shells/bash"],
+                output_loglevel="trace",
+                python_shell=False,
             )
             assert result == "5.1.4_2"
 
+
 def test_latest_version_outofdatedate(pkgs):
-    "Test pkgng.latest_version with an out-of-date package"
+    """
+    Test pkgng.latest_version with an out-of-date package
+    """
     pkgs_mock = MagicMock(side_effect=pkgs)
     search_cmd = MagicMock(return_value="openvpn-2.4.8_3")
     with patch("salt.modules.pkgng.list_pkgs", pkgs_mock):
         with patch.dict(pkgng.__salt__, {"cmd.run": search_cmd}):
             result = pkgng.latest_version("openvpn")
             search_cmd.assert_called_with(
-                ["pkg", "search", "-eqS", "name", "-U", "openvpn"], output_loglevel='trace', python_shell=False
+                ["pkg", "search", "-eqS", "name", "-U", "openvpn"],
+                output_loglevel="trace",
+                python_shell=False,
             )
             assert result == "2.4.8_3"
 
+
 def test_latest_version_unavailable(pkgs):
-    "Test pkgng.latest_version when the requested package is not available"
+    """
+    Test pkgng.latest_version when the requested package is not available
+    """
     pkgs_mock = MagicMock(side_effect=pkgs)
-    search_cmd = MagicMock( return_value="")
+    search_cmd = MagicMock(return_value="")
     with patch("salt.modules.pkgng.list_pkgs", pkgs_mock):
         with patch.dict(pkgng.__salt__, {"cmd.run": search_cmd}):
             result = pkgng.latest_version("does_not_exist")
             search_cmd.assert_called_with(
-                ["pkg", "search", "-eqS", "name", "-U", "does_not_exist"], output_loglevel='trace', python_shell=False
+                ["pkg", "search", "-eqS", "name", "-U", "does_not_exist"],
+                output_loglevel="trace",
+                python_shell=False,
             )
 
+
 def test_latest_version_uptodate(pkgs):
-    "Test pkgng.latest_version with an up-to-date package"
+    """
+    Test pkgng.latest_version with an up-to-date package
+    """
     pkgs_mock = MagicMock(side_effect=pkgs)
     search_cmd = MagicMock(return_value="openvpn-2.4.8_2")
     with patch("salt.modules.pkgng.list_pkgs", pkgs_mock):
         with patch.dict(pkgng.__salt__, {"cmd.run": search_cmd}):
             result = pkgng.latest_version("openvpn")
             search_cmd.assert_called_with(
-                ["pkg", "search", "-eqS", "name", "-U", "openvpn"], output_loglevel='trace', python_shell=False
+                ["pkg", "search", "-eqS", "name", "-U", "openvpn"],
+                output_loglevel="trace",
+                python_shell=False,
             )
             assert result == ""
 

--- a/tests/pytests/unit/modules/test_pkgng.py
+++ b/tests/pytests/unit/modules/test_pkgng.py
@@ -18,17 +18,10 @@ def pkgs():
         {"openvpn": "2.4.8_2", "gettext-runtime": "0.20.1", "p5-Mojolicious": "8.40"},
     ]
 
-@pytest.fixture
-def pkgs_as_list():
-    return [
-        {"openvpn": ["2.4.8_2"]},
-        {"openvpn": ["2.4.8_2"], "gettext-runtime": ["0.20.1"], "p5-Mojolicious": ["8.40"]},
-    ]
 
-
-def test_latest_version(pkgs_as_list):
+def test_latest_version(pkgs):
     "Test basic usage of pkgng.latest_version"
-    pkgs_mock = MagicMock(side_effect=pkgs_as_list)
+    pkgs_mock = MagicMock(side_effect=pkgs)
     search_cmd = MagicMock(return_value="bash-5.1.4")
     with patch("salt.modules.pkgng.list_pkgs", pkgs_mock):
         with patch.dict(pkgng.__salt__, {"cmd.run": search_cmd}):
@@ -38,9 +31,9 @@ def test_latest_version(pkgs_as_list):
             )
             assert result == "5.1.4"
 
-def test_latest_version_origin(pkgs_as_list):
+def test_latest_version_origin(pkgs):
     "Test pkgng.latest_version with a specific package origin"
-    pkgs_mock = MagicMock(side_effect=pkgs_as_list)
+    pkgs_mock = MagicMock(side_effect=pkgs)
     search_cmd = MagicMock(return_value="bash-5.1.4_2")
     with patch("salt.modules.pkgng.list_pkgs", pkgs_mock):
         with patch.dict(pkgng.__salt__, {"cmd.run": search_cmd}):
@@ -50,9 +43,9 @@ def test_latest_version_origin(pkgs_as_list):
             )
             assert result == "5.1.4_2"
 
-def test_latest_version_outofdatedate(pkgs_as_list):
+def test_latest_version_outofdatedate(pkgs):
     "Test pkgng.latest_version with an out-of-date package"
-    pkgs_mock = MagicMock(side_effect=pkgs_as_list)
+    pkgs_mock = MagicMock(side_effect=pkgs)
     search_cmd = MagicMock(return_value="openvpn-2.4.8_3")
     with patch("salt.modules.pkgng.list_pkgs", pkgs_mock):
         with patch.dict(pkgng.__salt__, {"cmd.run": search_cmd}):
@@ -62,9 +55,9 @@ def test_latest_version_outofdatedate(pkgs_as_list):
             )
             assert result == "2.4.8_3"
 
-def test_latest_version_unavailable(pkgs_as_list):
+def test_latest_version_unavailable(pkgs):
     "Test pkgng.latest_version when the requested package is not available"
-    pkgs_mock = MagicMock(side_effect=pkgs_as_list)
+    pkgs_mock = MagicMock(side_effect=pkgs)
     search_cmd = MagicMock( return_value="")
     with patch("salt.modules.pkgng.list_pkgs", pkgs_mock):
         with patch.dict(pkgng.__salt__, {"cmd.run": search_cmd}):
@@ -73,9 +66,9 @@ def test_latest_version_unavailable(pkgs_as_list):
                 ["pkg", "search", "-eqS", "name", "-U", "does_not_exist"], output_loglevel='trace', python_shell=False
             )
 
-def test_latest_version_uptodate(pkgs_as_list):
+def test_latest_version_uptodate(pkgs):
     "Test pkgng.latest_version with an up-to-date package"
-    pkgs_mock = MagicMock(side_effect=pkgs_as_list)
+    pkgs_mock = MagicMock(side_effect=pkgs)
     search_cmd = MagicMock(return_value="openvpn-2.4.8_2")
     with patch("salt.modules.pkgng.list_pkgs", pkgs_mock):
         with patch.dict(pkgng.__salt__, {"cmd.run": search_cmd}):

--- a/tests/pytests/unit/modules/test_pkgng.py
+++ b/tests/pytests/unit/modules/test_pkgng.py
@@ -34,7 +34,7 @@ def test_latest_version(pkgs_as_list):
         with patch.dict(pkgng.__salt__, {"cmd.run": search_cmd}):
             result = pkgng.latest_version("bash")
             search_cmd.assert_called_with(
-                ["pkg", "search", "-S", "name", "-Q", "version", "-e", "-q", "-U", "bash"], output_loglevel='trace', python_shell=False
+                ["pkg", "search", "-S", "name", "-e", "-q", "-U", "bash"], output_loglevel='trace', python_shell=False
             )
             assert result == "5.1.4"
 
@@ -63,7 +63,7 @@ def test_latest_version_outofdatedate(pkgs_as_list):
         with patch.dict(pkgng.__salt__, {"cmd.run": search_cmd}):
             result = pkgng.latest_version("openvpn")
             search_cmd.assert_called_with(
-                ["pkg", "search", "-S", "name", "-Q", "version", "-e", "-q", "-U", "openvpn"], output_loglevel='trace', python_shell=False
+                ["pkg", "search", "-S", "name", "-e", "-q", "-U", "openvpn"], output_loglevel='trace', python_shell=False
             )
             assert result == "2.4.8_3"
 
@@ -79,7 +79,7 @@ def test_latest_version_unavailable(pkgs_as_list):
         with patch.dict(pkgng.__salt__, {"cmd.run": search_cmd}):
             result = pkgng.latest_version("does_not_exist")
             search_cmd.assert_called_with(
-                ["pkg", "search", "-S", "name", "-Q", "version", "-e", "-q", "-U", "does_not_exist"], output_loglevel='trace', python_shell=False
+                ["pkg", "search", "-S", "name", "-e", "-q", "-U", "does_not_exist"], output_loglevel='trace', python_shell=False
             )
 
 def test_latest_version_uptodate(pkgs_as_list):
@@ -90,7 +90,7 @@ def test_latest_version_uptodate(pkgs_as_list):
         with patch.dict(pkgng.__salt__, {"cmd.run": search_cmd}):
             result = pkgng.latest_version("openvpn")
             search_cmd.assert_called_with(
-                ["pkg", "search", "-S", "name", "-Q", "version", "-e", "-q", "-U", "openvpn"], output_loglevel='trace', python_shell=False
+                ["pkg", "search", "-S", "name", "-e", "-q", "-U", "openvpn"], output_loglevel='trace', python_shell=False
             )
             assert result == ""
 


### PR DESCRIPTION
### What does this PR do?
Cleans up modules.pkg.latest_version, adds tests, and fixes two bugs.

### What issues does this PR fix or reference?
Fixes: #60105
Fixes: #60108

### Previous Behavior
* 60105: pkgng.latest_version raises IndexError if the package isn't found in the repository
* 60108: pkgng.latest_version fails when the package is specified by origin

### New Behavior
* 60105: When the package isn't found, pkgng.latest_version returns "", as expected
* 60108: pkgng.latest_version works when the package is specified by origin (e.g. "shells/bash")

### Merge requirements satisfied?
- [N/A] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes