### PR TITLE
Cloud/DigitalOcean: Don't throw error when deleting instance, fixes #58190

### DIFF
--- a/salt/cloud/clouds/digitalocean.py
+++ b/salt/cloud/clouds/digitalocean.py
@@ -985,7 +985,7 @@ def destroy_dns_records(fqdn):
     records = response["domain_records"]
 
     if records:
-        record_ids = [r["id"] for r in records if r["name"].decode() == hostname]
+        record_ids = [r["id"] for r in records if r["name"] == hostname]
         log.debug("deleting DNS record IDs: %s", record_ids)
         for id_ in record_ids:
             try:


### PR DESCRIPTION
### What issues does this PR fix or reference?
Fixes: #58190

### Previous Behavior
Throws:
```
[ERROR   ] There was an error destroying machines: 'str' object has no attribute 'decode'
```

### New Behavior
Correctly deletes instance