### PR TITLE
Clear network interface cache when grains are requested or refreshed

### DIFF
--- a/changelog/59490.fixed
+++ b/changelog/59490.fixed
@@ -1,0 +1,1 @@
+Clear the cached network interface grains during minion init and grains refresh

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -40,7 +40,7 @@ import salt.utils.path
 import salt.utils.pkg.rpm
 import salt.utils.platform
 import salt.utils.stringutils
-from salt.utils.network import _get_interfaces
+from salt.utils.network import _clear_interfaces, _get_interfaces
 
 
 # rewrite distro.linux_distribution to allow best=True kwarg in version(), needed to get the minor version numbers in CentOS

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -52,6 +52,10 @@ def _linux_distribution():
     )
 
 
+def __init__(opts):
+    _clear_interfaces()
+
+
 try:
     import dateutil.tz  # pylint: disable=import-error
 

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -46,18 +46,23 @@ except (ImportError, OSError, AttributeError, TypeError):
     pass
 
 
-_INTERFACES = {}
+class Interfaces:
+    def __init__(self, interfaces=None):
+        if interfaces is None:
+            interfaces = {}
+        self.interfaces = interfaces
+
+    def __call__(self, *args, **kwargs):
+        if not self.interfaces:
+            self.interfaces = interfaces()
+        return self.interfaces
+
+    def clear(self):
+        self.interfaces = {}
 
 
-def _get_interfaces():
-    """
-    Provide a dict of the connected interfaces and their ip addresses
-    """
-
-    global _INTERFACES
-    if not _INTERFACES:
-        _INTERFACES = interfaces()
-    return _INTERFACES
+_get_interfaces = Interfaces()
+_clear_interfaces = _get_interfaces.clear
 
 
 def sanitize_host(host):

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -48,6 +48,8 @@ except (ImportError, OSError, AttributeError, TypeError):
 
 
 class Interfaces:
+    __slots__ = ("interfaces",)
+
     def __init__(self, interfaces=None):
         if interfaces is None:
             interfaces = {}

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -3,6 +3,7 @@
 Define some generic socket functions for network modules
 """
 
+
 import fnmatch
 import itertools
 import logging

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -1,4 +1,7 @@
 """
+tests.pytests.unit.grains.test_core
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
     :codeauthor: Erik Johnson <erik@saltstack.com>
     :codeauthor: David Murphy <damurphy@vmware.com>
 """
@@ -86,6 +89,9 @@ def test_parse_etc_os_release(os_release_dir):
 
 
 def test_network_grains_cache(tmp_path):
+    """
+    Network interfaces are cache is cleared by the loader
+    """
     call_1 = {
         "lo": {
             "up": True,

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -155,8 +155,9 @@ def test_network_grains_cache(tmp_path):
         "extension_modules": str(extmods),
         "optimization_order": [0],
     }
-    with patch("salt.utils.network.interfaces") as interfaces:
-        interfaces.side_effect = [call_1, call_2]
+    with patch(
+        "salt.utils.network.interfaces", side_effect=[call_1, call_2]
+    ) as interfaces:
         grains = salt.loader.grain_funcs(opts)
         assert interfaces.call_count == 0
         ret = grains["core.ip_interfaces"]()


### PR DESCRIPTION
### What does this PR do?
Clears the cached network interface grain information upon init of minion or when saltutil.refresh_grains is requested.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/59490

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
