### PR TITLE
fix: metaproxy defaulting to proxy is very chatty

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -3715,7 +3715,7 @@ def _metaproxy_call(opts, fn_name):
         metaproxy_name = opts["metaproxy"]
     except KeyError:
         metaproxy_name = "proxy"
-        log.error(
+        log.debug(
             "No metaproxy key found in opts for id %s. Defaulting to standard proxy minion",
             opts["id"],
         )


### PR DESCRIPTION
### What does this PR do?
Drops the log level of the message about the `metaproxy` defaulting to `proxy` mode down to a debug level rather than error. This may not be what you all want but I thought I should at least try to send it up, it seems overly chatty. My salt-proxy log file is spammed with messages like
```
2021-05-06 00:28:16,792 [salt.minion      :3639][ERROR   ][23098] No metaproxy key found in opts for id <minion id>. Defaulting to standard proxy minion
```

### What issues does this PR fix or reference?
Fixes:
n/a

### Previous Behavior
The proxy log is full of messages I wouldn't care about at all since running as a regular proxy minion rather than metaproxy is actually the default is it not?

### New Behavior
The log message would only be emitted if debug level or higher

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

I'm not sure hot any of these would apply here, let me know what does and I'll do them.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
