### PR TITLE
Fix test output for running services

### DIFF
--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -485,6 +485,19 @@ def running(name, enable=None, sig=None, init_delay=None, **kwargs):
             ret.update(_enable(name, None, **kwargs))
         elif enable is False and before_toggle_enable_status:
             ret.update(_disable(name, None, **kwargs))
+        else:
+            if __opts__["test"]:
+                ret["result"] = None
+                ret["comment"] = "\n".join(
+                    [
+                        _f
+                        for _f in [
+                            "The service {} is set to restart".format(name),
+                            unmask_ret["comment"],
+                        ]
+                        if _f
+                    ]
+                )
         return ret
 
     # Run the tests

--- a/tests/pytests/unit/states/test_service.py
+++ b/tests/pytests/unit/states/test_service.py
@@ -159,6 +159,12 @@ def test_running():
             "name": "salt",
             "result": False,
         },
+        {
+            "changes": {},
+            "comment": "The service salt is set to restart",
+            "name": "salt",
+            "result": None,
+        },
     ]
 
     tmock = MagicMock(return_value=True)
@@ -231,7 +237,7 @@ def test_running():
 
         with patch.dict(service.__opts__, {"test": True}):
             with patch.dict(service.__salt__, {"service.status": tmock}):
-                assert service.running("salt") == ret[5]
+                assert service.running("salt") == ret[10]
 
             with patch.dict(service.__salt__, {"service.status": fmock}):
                 assert service.running("salt") == ret[3]


### PR DESCRIPTION
### What does this PR do?
When using test=True with service running, output correctly what will happen to a service that is already running, namely restart

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/60120

### Previous Behavior
With test=True, the service.running output showed what status the service was in and not what would happen to it
```
Comment: The service nginx is already running
```

### New Behavior
With test=True, the service output now reflects that the service will be restarted when appropriate.
```
Comment: The service nginx is set to restart
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
