### PR TITLE
Fixing scheduler test_eval tests

### DIFF
--- a/changelog/60149.fixed
+++ b/changelog/60149.fixed
@@ -1,0 +1,1 @@
+Fixing tests/pytests/unit/utils/scheduler/test_eval.py tests so the sleep happens before the status, so the job is given time before we check it.

--- a/tests/pytests/unit/utils/scheduler/test_eval.py
+++ b/tests/pytests/unit/utils/scheduler/test_eval.py
@@ -89,19 +89,20 @@ def test_eval_multiple_whens(schedule):
     # Evaluate run time1
     schedule.eval(now=run_time1)
 
-    ret = schedule.job_status(job_name)
-
     # Give the job a chance to finish
     time.sleep(5)
+
+    ret = schedule.job_status(job_name)
 
     assert ret["_last_run"] == run_time1
 
     # Evaluate run time2
     schedule.eval(now=run_time2)
-    ret = schedule.job_status(job_name)
 
     # Give the job a chance to finish
     time.sleep(5)
+
+    ret = schedule.job_status(job_name)
 
     assert ret["_last_run"] == run_time2
 
@@ -187,10 +188,11 @@ def test_eval_multiple_whens_loop_interval(schedule):
 
     # Evaluate 1 second at the run time
     schedule.eval(now=run_time1)
-    ret = schedule.job_status(job_name)
 
     # Give the job a chance to finish
     time.sleep(5)
+
+    ret = schedule.job_status(job_name)
 
     assert ret["_last_run"] == run_time1
 
@@ -330,29 +332,32 @@ def test_eval_until(schedule):
     # eval at 3:00pm, will run.
     run_time = dateutil.parser.parse("11/29/2017 3:00pm")
     schedule.eval(now=run_time)
-    ret = schedule.job_status(job_name)
 
     # Give the job a chance to finish
     time.sleep(5)
+
+    ret = schedule.job_status(job_name)
 
     assert ret["_last_run"] == run_time
 
     # eval at 4:00pm, will run.
     run_time = dateutil.parser.parse("11/29/2017 4:00pm")
     schedule.eval(now=run_time)
-    ret = schedule.job_status(job_name)
-    assert ret["_last_run"] == run_time
 
     # Give the job a chance to finish
     time.sleep(5)
+
+    ret = schedule.job_status(job_name)
+    assert ret["_last_run"] == run_time
 
     # eval at 5:00pm, will not run
     run_time = dateutil.parser.parse("11/29/2017 5:00pm")
     schedule.eval(now=run_time)
-    ret = schedule.job_status(job_name)
 
     # Give the job a chance to finish
     time.sleep(5)
+
+    ret = schedule.job_status(job_name)
 
     assert ret["_skip_reason"] == "until_passed"
     assert ret["_skipped_time"] == run_time
@@ -852,10 +857,11 @@ def test_eval_days(schedule):
     run_time = dateutil.parser.parse("11/26/2017 2:00:00pm")
     last_run_time = run_time - datetime.timedelta(days=1)
     schedule.eval(now=run_time)
-    ret = schedule.job_status(job_name)
 
     # Give the job a chance to finish
     time.sleep(5)
+
+    ret = schedule.job_status(job_name)
 
     assert ret["_last_run"] == last_run_time
     assert ret["_next_fire_time"] == next_run_time
@@ -864,10 +870,11 @@ def test_eval_days(schedule):
     run_time = dateutil.parser.parse("11/27/2017 2:00:00pm")
     next_run_time = run_time + datetime.timedelta(days=2)
     schedule.eval(now=run_time)
-    ret = schedule.job_status(job_name)
 
     # Give the job a chance to finish
     time.sleep(5)
+
+    ret = schedule.job_status(job_name)
 
     assert ret["_last_run"] == run_time
     assert ret["_next_fire_time"] == next_run_time
@@ -876,10 +883,11 @@ def test_eval_days(schedule):
     run_time = dateutil.parser.parse("11/28/2017 2:00:00pm")
     last_run_time = run_time - datetime.timedelta(days=1)
     schedule.eval(now=run_time)
-    ret = schedule.job_status(job_name)
 
     # Give the job a chance to finish
     time.sleep(5)
+
+    ret = schedule.job_status(job_name)
 
     assert ret["_last_run"] == last_run_time
     assert ret["_next_fire_time"] == next_run_time
@@ -888,10 +896,11 @@ def test_eval_days(schedule):
     run_time = dateutil.parser.parse("11/29/2017 2:00:00pm")
     next_run_time = run_time + datetime.timedelta(days=2)
     schedule.eval(now=run_time)
-    ret = schedule.job_status(job_name)
 
     # Give the job a chance to finish
     time.sleep(5)
+
+    ret = schedule.job_status(job_name)
 
     assert ret["_last_run"] == run_time
     assert ret["_next_fire_time"] == next_run_time

--- a/tests/pytests/unit/utils/scheduler/test_eval.py
+++ b/tests/pytests/unit/utils/scheduler/test_eval.py
@@ -7,7 +7,6 @@ import pytest
 import salt.utils.platform
 import salt.utils.schedule
 from tests.support.mock import MagicMock, patch
-from tests.support.unit import skipIf
 
 try:
     import dateutil.parser
@@ -33,6 +32,38 @@ pytestmark = [
     ),
     pytest.mark.windows_whitelisted,
 ]
+
+
+def _check_last_run(schedule, job_name, runtime=None):
+    """
+    Check that last_run time exists and
+    is not the previous run time if prev_runtime
+    is passed.
+    """
+
+    # The number of times to
+    # check before bailing out.
+    checks = 5
+
+    status = schedule.job_status(job_name)
+    count = 0
+    while "_last_run" not in status:
+        status = schedule.job_status(job_name)
+        if count == checks:
+            return False
+        time.sleep(2)
+        count += 1
+
+    if runtime:
+        count = 0
+        status = schedule.job_status(job_name)
+        while status["_last_run"] != runtime:
+            if count == checks:
+                return False
+            status = schedule.job_status(job_name)
+            time.sleep(2)
+            count += 1
+    return True
 
 
 @pytest.mark.slow_test
@@ -90,21 +121,13 @@ def test_eval_multiple_whens(schedule):
     schedule.eval(now=run_time1)
 
     # Give the job a chance to finish
-    time.sleep(5)
-
-    ret = schedule.job_status(job_name)
-
-    assert ret["_last_run"] == run_time1
+    assert _check_last_run(schedule, job_name, run_time1)
 
     # Evaluate run time2
     schedule.eval(now=run_time2)
 
-    # Give the job a chance to finish
-    time.sleep(5)
-
-    ret = schedule.job_status(job_name)
-
-    assert ret["_last_run"] == run_time2
+    # Give the job a chance to finish and check
+    assert _check_last_run(schedule, job_name, run_time2)
 
 
 @pytest.mark.slow_test
@@ -124,8 +147,7 @@ def test_eval_whens(schedule):
 
     # Evaluate run time1
     schedule.eval(now=run_time)
-    ret = schedule.job_status(job_name)
-    assert ret["_last_run"] == run_time
+    assert _check_last_run(schedule, job_name, run_time)
 
 
 @pytest.mark.slow_test
@@ -150,8 +172,9 @@ def test_eval_loop_interval(schedule):
     # Evaluate 1 second at the run time
     schedule.eval(now=run_time2 + datetime.timedelta(seconds=LOOP_INTERVAL))
 
-    ret = schedule.job_status(job_name)
-    assert ret["_last_run"] == run_time2 + datetime.timedelta(seconds=LOOP_INTERVAL)
+    assert _check_last_run(
+        schedule, job_name, run_time2 + datetime.timedelta(seconds=LOOP_INTERVAL)
+    )
 
 
 @pytest.mark.slow_test
@@ -190,20 +213,13 @@ def test_eval_multiple_whens_loop_interval(schedule):
     schedule.eval(now=run_time1)
 
     # Give the job a chance to finish
-    time.sleep(5)
-
-    ret = schedule.job_status(job_name)
-
-    assert ret["_last_run"] == run_time1
+    assert _check_last_run(schedule, job_name, run_time1)
 
     # Evaluate 1 second at the run time
     schedule.eval(now=run_time2)
 
     # Give the job a chance to finish
-    time.sleep(5)
-
-    ret = schedule.job_status(job_name)
-    assert ret["_last_run"] == run_time2
+    assert _check_last_run(schedule, job_name, run_time2)
 
 
 @pytest.mark.slow_test
@@ -224,8 +240,7 @@ def test_eval_once(schedule):
 
     # Evaluate 1 second at the run time
     schedule.eval(now=run_time)
-    ret = schedule.job_status(job_name)
-    assert ret["_last_run"] == run_time
+    assert _check_last_run(schedule, job_name, run_time)
 
 
 @pytest.mark.slow_test
@@ -252,11 +267,10 @@ def test_eval_once_loop_interval(schedule):
 
     # Evaluate at the run time
     schedule.eval(now=run_time)
-    ret = schedule.job_status(job_name)
-    assert ret["_last_run"] == run_time
+    assert _check_last_run(schedule, job_name, run_time)
 
 
-@skipIf(not HAS_CRONITER, "Cannot find croniter python module")
+@pytest.mark.skipif(not HAS_CRONITER, reason="Cannot find croniter python module")
 def test_eval_cron(schedule):
     """
     verify that scheduled job runs
@@ -271,12 +285,10 @@ def test_eval_cron(schedule):
     run_time = dateutil.parser.parse("11/29/2017 4:00pm")
     with patch("croniter.croniter.get_next", MagicMock(return_value=run_time)):
         schedule.eval(now=run_time)
-
-    ret = schedule.job_status(job_name)
-    assert ret["_last_run"] == run_time
+    assert _check_last_run(schedule, job_name, run_time)
 
 
-@skipIf(not HAS_CRONITER, "Cannot find croniter python module")
+@pytest.mark.skipif(not HAS_CRONITER, reason="Cannot find croniter python module")
 def test_eval_cron_loop_interval(schedule):
     """
     verify that scheduled job runs
@@ -294,9 +306,7 @@ def test_eval_cron_loop_interval(schedule):
     run_time = dateutil.parser.parse("11/29/2017 4:00pm")
     with patch("croniter.croniter.get_next", MagicMock(return_value=run_time)):
         schedule.eval(now=run_time)
-
-    ret = schedule.job_status(job_name)
-    assert ret["_last_run"] == run_time
+    assert _check_last_run(schedule, job_name, run_time)
 
 
 @pytest.mark.slow_test
@@ -327,35 +337,24 @@ def test_eval_until(schedule):
     # eval at 2:00pm to prime, simulate minion start up.
     run_time = dateutil.parser.parse("11/29/2017 2:00pm")
     schedule.eval(now=run_time)
-    ret = schedule.job_status(job_name)
 
     # eval at 3:00pm, will run.
     run_time = dateutil.parser.parse("11/29/2017 3:00pm")
     schedule.eval(now=run_time)
 
     # Give the job a chance to finish
-    time.sleep(5)
-
-    ret = schedule.job_status(job_name)
-
-    assert ret["_last_run"] == run_time
+    assert _check_last_run(schedule, job_name, run_time)
 
     # eval at 4:00pm, will run.
     run_time = dateutil.parser.parse("11/29/2017 4:00pm")
     schedule.eval(now=run_time)
 
     # Give the job a chance to finish
-    time.sleep(5)
-
-    ret = schedule.job_status(job_name)
-    assert ret["_last_run"] == run_time
+    assert _check_last_run(schedule, job_name, run_time)
 
     # eval at 5:00pm, will not run
     run_time = dateutil.parser.parse("11/29/2017 5:00pm")
     schedule.eval(now=run_time)
-
-    # Give the job a chance to finish
-    time.sleep(5)
 
     ret = schedule.job_status(job_name)
 
@@ -413,8 +412,7 @@ def test_eval_after(schedule):
     # eval at 6:00pm, will run
     run_time = dateutil.parser.parse("11/29/2017 6:00pm")
     schedule.eval(now=run_time)
-    ret = schedule.job_status(job_name)
-    assert ret["_last_run"] == run_time
+    assert _check_last_run(schedule, job_name, run_time)
 
 
 @pytest.mark.slow_test
@@ -437,8 +435,7 @@ def test_eval_enabled(schedule):
 
     # Evaluate 1 second at the run time
     schedule.eval(now=run_time1)
-    ret = schedule.job_status(job_name)
-    assert ret["_last_run"] == run_time1
+    assert _check_last_run(schedule, job_name, run_time1)
 
 
 @pytest.mark.slow_test
@@ -469,8 +466,7 @@ def test_eval_enabled_key(schedule):
 
     # Evaluate 1 second at the run time
     schedule.eval(now=run_time2)
-    ret = schedule.job_status("test_eval_enabled_key")
-    assert ret["_last_run"] == run_time2
+    assert _check_last_run(schedule, job_name, run_time2)
 
 
 def test_eval_disabled(schedule):
@@ -550,13 +546,12 @@ def test_eval_run_on_start(schedule):
     # eval at 2:00pm, will run.
     run_time = dateutil.parser.parse("11/29/2017 2:00pm")
     schedule.eval(now=run_time)
-    ret = schedule.job_status(job_name)
-    assert ret["_last_run"] == run_time
+    assert _check_last_run(schedule, job_name, run_time)
 
     # eval at 3:00pm, will run.
     run_time = dateutil.parser.parse("11/29/2017 3:00pm")
     schedule.eval(now=run_time)
-    ret = schedule.job_status(job_name)
+    assert _check_last_run(schedule, job_name, run_time)
 
 
 @pytest.mark.slow_test
@@ -579,13 +574,11 @@ def test_eval_splay(schedule):
         # eval at 2:00pm to prime, simulate minion start up.
         run_time = dateutil.parser.parse("11/29/2017 2:00pm")
         schedule.eval(now=run_time)
-        ret = schedule.job_status(job_name)
 
         # eval at 2:00:40pm, will run.
         run_time = dateutil.parser.parse("11/29/2017 2:00:40pm")
         schedule.eval(now=run_time)
-        ret = schedule.job_status(job_name)
-        assert ret["_last_run"] == run_time
+        assert _check_last_run(schedule, job_name, run_time)
 
 
 @pytest.mark.slow_test
@@ -612,13 +605,11 @@ def test_eval_splay_range(schedule):
         # eval at 2:00pm to prime, simulate minion start up.
         run_time = dateutil.parser.parse("11/29/2017 2:00pm")
         schedule.eval(now=run_time)
-        ret = schedule.job_status(job_name)
 
         # eval at 2:00:40pm, will run.
         run_time = dateutil.parser.parse("11/29/2017 2:00:40pm")
         schedule.eval(now=run_time)
-        ret = schedule.job_status(job_name)
-        assert ret["_last_run"] == run_time
+        assert _check_last_run(schedule, job_name, run_time)
 
 
 @pytest.mark.slow_test
@@ -642,13 +633,11 @@ def test_eval_splay_global(schedule):
         # eval at 2:00pm to prime, simulate minion start up.
         run_time = dateutil.parser.parse("11/29/2017 2:00pm")
         schedule.eval(now=run_time)
-        ret = schedule.job_status(job_name)
 
         # eval at 2:00:40pm, will run.
         run_time = dateutil.parser.parse("11/29/2017 2:00:40pm")
         schedule.eval(now=run_time)
-        ret = schedule.job_status(job_name)
-        assert ret["_last_run"] == run_time
+        assert _check_last_run(schedule, job_name, run_time)
 
 
 @pytest.mark.slow_test


### PR DESCRIPTION
### What does this PR do?
Fixing tests/pytests/unit/utils/scheduler/test_eval.py tests so the sleep happens before the status, so the job is given time before we check it.

### What issues does this PR fix or reference?
Fixes: #60149

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
