### PR TITLE
Upgrade ext/ipaddress.py to 3.9.5 version

### DIFF
--- a/changelog/60168.fixed
+++ b/changelog/60168.fixed
@@ -1,0 +1,1 @@
+Update the external ipaddress to the latest 3.9.5 version which has some security fixes. Updating the compat.p to use the vendored version if the python version is below 3.9.5 and only run the test_ipaddress.py tests if below 3.9.5.

--- a/salt/_compat.py
+++ b/salt/_compat.py
@@ -5,7 +5,7 @@ Salt compatibility code
 import sys
 
 # The ipaddress module included in Salt is from Python 3.9.5.
-# When running from Py3.9.1+ use the standard library module, use ours otherwise
+# When running from Py3.9.5+ use the standard library module, use ours otherwise
 if sys.version_info >= (3, 9, 5):
     import ipaddress
 else:

--- a/salt/_compat.py
+++ b/salt/_compat.py
@@ -4,9 +4,9 @@ Salt compatibility code
 # pylint: disable=unused-import
 import sys
 
-# The ipaddress module included in Salt is from Python 3.9.1.
+# The ipaddress module included in Salt is from Python 3.9.5.
 # When running from Py3.9.1+ use the standard library module, use ours otherwise
-if sys.version_info >= (3, 9, 1):
+if sys.version_info >= (3, 9, 5):
     import ipaddress
 else:
     import salt.ext.ipaddress as ipaddress

--- a/salt/ext/ipaddress.py
+++ b/salt/ext/ipaddress.py
@@ -1,8 +1,8 @@
 # Copyright 2007 Google Inc.
 #  Licensed to PSF under a Contributor Agreement.
 
-# This is ipaddress.py from Python 3.9.1, verbatim, with minor compatility changes
-#    https://github.com/python/cpython/blob/v3.9.1/Lib/ipaddress.py
+# This is ipaddress.py from Python 3.9.5, verbatim, with minor compatility changes
+#    https://github.com/python/cpython/blob/v3.9.5/Lib/ipaddress.py
 #
 # Modifications:
 #  - add `_cache` dictionary attribute because cached_property does not exist
@@ -1276,6 +1276,11 @@ class _BaseV4:
         # is likely to be more informative for the user
         if len(octet_str) > 3:
             msg = "At most 3 characters permitted in %r"
+            raise ValueError(msg % octet_str)
+        # Handle leading zeros as strict as glibc's inet_pton()
+        # See security bug bpo-36384
+        if octet_str != '0' and octet_str[0] == '0':
+            msg = "Leading zeros are not permitted in %r"
             raise ValueError(msg % octet_str)
         # Convert to integer (we know digits are legal)
         octet_int = int(octet_str, 10)

--- a/tests/unit/ext/test_ipaddress.py
+++ b/tests/unit/ext/test_ipaddress.py
@@ -112,7 +112,7 @@ class BaseTestCase(TestCase):
         self.assertEqual(self.factory(lhs), self.factory(rhs))
 
 
-@skipIf(sys.version_info >= (3, 9, 5), "Only run on Python versions below 3.9.5")
+@skipIf(sys.version_info >= (3, 9, 5), "We use builtin ipaddress on Python >= 3.9.5")
 class CommonTestMixin:
     def test_empty_address(self):
         with self.assertAddressError("Address cannot be empty"):
@@ -137,7 +137,7 @@ class CommonTestMixin:
                 self.assertEqual(y, x)
 
 
-@skipIf(sys.version_info >= (3, 9, 5), "Only run on Python versions below 3.9.5")
+@skipIf(sys.version_info >= (3, 9, 5), "We use builtin ipaddress on Python >= 3.9.5")
 class CommonTestMixin_v4(CommonTestMixin):
     def test_leading_zeros(self):
         # bpo-36384: no leading zeros to avoid ambiguity with octal notation
@@ -187,7 +187,7 @@ class CommonTestMixin_v4(CommonTestMixin):
         assertBadLength(5)
 
 
-@skipIf(sys.version_info >= (3, 9, 5), "Only run on Python versions below 3.9.5")
+@skipIf(sys.version_info >= (3, 9, 5), "We use builtin ipaddress on Python >= 3.9.5")
 class CommonTestMixin_v6(CommonTestMixin):
     def test_leading_zeros(self):
         self.assertInstancesEqual("0000::0000", "::")
@@ -237,7 +237,7 @@ class CommonTestMixin_v6(CommonTestMixin):
             self.factory(address)
 
 
-@skipIf(sys.version_info >= (3, 9, 5), "Only run on Python versions below 3.9.5")
+@skipIf(sys.version_info >= (3, 9, 5), "We use builtin ipaddress on Python >= 3.9.5")
 class AddressTestCase_v4(BaseTestCase, CommonTestMixin_v4):
     factory = ipaddress.IPv4Address
 
@@ -350,7 +350,7 @@ class AddressTestCase_v4(BaseTestCase, CommonTestMixin_v4):
         weakref.ref(self.factory("192.0.2.1"))
 
 
-@skipIf(sys.version_info >= (3, 9, 5), "Only run on Python versions below 3.9.5")
+@skipIf(sys.version_info >= (3, 9, 5), "We use builtin ipaddress on Python >= 3.9.5")
 class AddressTestCase_v6(BaseTestCase, CommonTestMixin_v6):
     factory = ipaddress.IPv6Address
 
@@ -604,7 +604,7 @@ class AddressTestCase_v6(BaseTestCase, CommonTestMixin_v6):
         weakref.ref(self.factory("2001:db8::%scope"))
 
 
-@skipIf(sys.version_info >= (3, 9, 5), "Only run on Python versions below 3.9.5")
+@skipIf(sys.version_info >= (3, 9, 5), "We use builtin ipaddress on Python >= 3.9.5")
 class NetmaskTestMixin_v4(CommonTestMixin_v4):
     """Input validation on interfaces and networks is very similar"""
 
@@ -692,7 +692,7 @@ class InterfaceTestCase_v4(BaseTestCase, NetmaskTestMixin_v4):
     factory = ipaddress.IPv4Interface
 
 
-@skipIf(sys.version_info >= (3, 9, 5), "Only run on Python versions below 3.9.5")
+@skipIf(sys.version_info >= (3, 9, 5), "We use builtin ipaddress on Python >= 3.9.5")
 class NetworkTestCase_v4(BaseTestCase, NetmaskTestMixin_v4):
     factory = ipaddress.IPv4Network
 
@@ -751,7 +751,7 @@ class NetworkTestCase_v4(BaseTestCase, NetmaskTestMixin_v4):
             )
 
 
-@skipIf(sys.version_info >= (3, 9, 5), "Only run on Python versions below 3.9.5")
+@skipIf(sys.version_info >= (3, 9, 5), "We use builtin ipaddress on Python >= 3.9.5")
 class NetmaskTestMixin_v6(CommonTestMixin_v6):
     """Input validation on interfaces and networks is very similar"""
 
@@ -864,7 +864,7 @@ class InterfaceTestCase_v6(BaseTestCase, NetmaskTestMixin_v6):
     factory = ipaddress.IPv6Interface
 
 
-@skipIf(sys.version_info >= (3, 9, 5), "Only run on Python versions below 3.9.5")
+@skipIf(sys.version_info >= (3, 9, 5), "We use builtin ipaddress on Python >= 3.9.5")
 class NetworkTestCase_v6(BaseTestCase, NetmaskTestMixin_v6):
     factory = ipaddress.IPv6Network
 
@@ -916,7 +916,7 @@ class NetworkTestCase_v6(BaseTestCase, NetmaskTestMixin_v6):
         )
 
 
-@skipIf(sys.version_info >= (3, 9, 5), "Only run on Python versions below 3.9.5")
+@skipIf(sys.version_info >= (3, 9, 5), "We use builtin ipaddress on Python >= 3.9.5")
 class FactoryFunctionErrors(BaseTestCase):
     def assertFactoryError(self, factory, kind):
         """Ensure a clean ValueError with the expected message"""
@@ -935,7 +935,7 @@ class FactoryFunctionErrors(BaseTestCase):
         self.assertFactoryError(ipaddress.ip_network, "network")
 
 
-@skipIf(sys.version_info >= (3, 9, 5), "Only run on Python versions below 3.9.5")
+@skipIf(sys.version_info >= (3, 9, 5), "We use builtin ipaddress on Python >= 3.9.5")
 class ComparisonTests(TestCase):
 
     v4addr = ipaddress.IPv4Address(1)
@@ -1122,7 +1122,7 @@ class ComparisonTests(TestCase):
         self.assertRaises(TypeError, v6net_scoped.__gt__, v4net)
 
 
-@skipIf(sys.version_info >= (3, 9, 5), "Only run on Python versions below 3.9.5")
+@skipIf(sys.version_info >= (3, 9, 5), "We use builtin ipaddress on Python >= 3.9.5")
 class IpaddrUnitTest(TestCase):
     def setUp(self):
         self.ipv4_address = ipaddress.IPv4Address("1.2.3.4")

--- a/tests/unit/ext/test_ipaddress.py
+++ b/tests/unit/ext/test_ipaddress.py
@@ -3,8 +3,8 @@
 #
 #
 
-# This is test_ipaddress.py from Python 3.9.1, verbatim, with minor compatility changes
-#    https://github.com/python/cpython/blob/v3.9.1/Lib/test/test_ipaddress.py
+# This is test_ipaddress.py from Python 3.9.5, verbatim, with minor compatility changes
+#    https://github.com/python/cpython/blob/v3.9.5/Lib/test/test_ipaddress.py
 #
 # Modifications:
 #  - Switch the ipaddress import to salt._compat
@@ -25,7 +25,7 @@ import weakref
 
 import pytest
 from salt._compat import ipaddress
-from tests.support.unit import TestCase
+from tests.support.unit import TestCase, skipIf
 
 
 @functools.total_ordering
@@ -112,6 +112,7 @@ class BaseTestCase(TestCase):
         self.assertEqual(self.factory(lhs), self.factory(rhs))
 
 
+@skipIf(sys.version_info >= (3, 9, 5), "Only run on Python versions below 3.9.5")
 class CommonTestMixin:
     def test_empty_address(self):
         with self.assertAddressError("Address cannot be empty"):
@@ -136,12 +137,26 @@ class CommonTestMixin:
                 self.assertEqual(y, x)
 
 
+@skipIf(sys.version_info >= (3, 9, 5), "Only run on Python versions below 3.9.5")
 class CommonTestMixin_v4(CommonTestMixin):
     def test_leading_zeros(self):
-        self.assertInstancesEqual("000.000.000.000", "0.0.0.0")
-        self.assertInstancesEqual("192.168.000.001", "192.168.0.1")
-        self.assertInstancesEqual("016.016.016.016", "16.16.16.16")
-        self.assertInstancesEqual("001.000.008.016", "1.0.8.16")
+        # bpo-36384: no leading zeros to avoid ambiguity with octal notation
+        msg = r"Leading zeros are not permitted in '\d+'"
+        addresses = [
+            "000.000.000.000",
+            "192.168.000.001",
+            "016.016.016.016",
+            "192.168.000.001",
+            "001.000.008.016",
+            "01.2.3.40",
+            "1.02.3.40",
+            "1.2.03.40",
+            "1.2.3.040",
+        ]
+        for address in addresses:
+            with self.subTest(address=address):
+                with self.assertAddressError(msg):
+                    self.factory(address)
 
     def test_int(self):
         self.assertInstancesEqual(0, "0.0.0.0")
@@ -172,6 +187,7 @@ class CommonTestMixin_v4(CommonTestMixin):
         assertBadLength(5)
 
 
+@skipIf(sys.version_info >= (3, 9, 5), "Only run on Python versions below 3.9.5")
 class CommonTestMixin_v6(CommonTestMixin):
     def test_leading_zeros(self):
         self.assertInstancesEqual("0000::0000", "::")
@@ -221,6 +237,7 @@ class CommonTestMixin_v6(CommonTestMixin):
             self.factory(address)
 
 
+@skipIf(sys.version_info >= (3, 9, 5), "Only run on Python versions below 3.9.5")
 class AddressTestCase_v4(BaseTestCase, CommonTestMixin_v4):
     factory = ipaddress.IPv4Address
 
@@ -333,6 +350,7 @@ class AddressTestCase_v4(BaseTestCase, CommonTestMixin_v4):
         weakref.ref(self.factory("192.0.2.1"))
 
 
+@skipIf(sys.version_info >= (3, 9, 5), "Only run on Python versions below 3.9.5")
 class AddressTestCase_v6(BaseTestCase, CommonTestMixin_v6):
     factory = ipaddress.IPv6Address
 
@@ -586,6 +604,7 @@ class AddressTestCase_v6(BaseTestCase, CommonTestMixin_v6):
         weakref.ref(self.factory("2001:db8::%scope"))
 
 
+@skipIf(sys.version_info >= (3, 9, 5), "Only run on Python versions below 3.9.5")
 class NetmaskTestMixin_v4(CommonTestMixin_v4):
     """Input validation on interfaces and networks is very similar"""
 
@@ -673,6 +692,7 @@ class InterfaceTestCase_v4(BaseTestCase, NetmaskTestMixin_v4):
     factory = ipaddress.IPv4Interface
 
 
+@skipIf(sys.version_info >= (3, 9, 5), "Only run on Python versions below 3.9.5")
 class NetworkTestCase_v4(BaseTestCase, NetmaskTestMixin_v4):
     factory = ipaddress.IPv4Network
 
@@ -731,6 +751,7 @@ class NetworkTestCase_v4(BaseTestCase, NetmaskTestMixin_v4):
             )
 
 
+@skipIf(sys.version_info >= (3, 9, 5), "Only run on Python versions below 3.9.5")
 class NetmaskTestMixin_v6(CommonTestMixin_v6):
     """Input validation on interfaces and networks is very similar"""
 
@@ -843,6 +864,7 @@ class InterfaceTestCase_v6(BaseTestCase, NetmaskTestMixin_v6):
     factory = ipaddress.IPv6Interface
 
 
+@skipIf(sys.version_info >= (3, 9, 5), "Only run on Python versions below 3.9.5")
 class NetworkTestCase_v6(BaseTestCase, NetmaskTestMixin_v6):
     factory = ipaddress.IPv6Network
 
@@ -894,6 +916,7 @@ class NetworkTestCase_v6(BaseTestCase, NetmaskTestMixin_v6):
         )
 
 
+@skipIf(sys.version_info >= (3, 9, 5), "Only run on Python versions below 3.9.5")
 class FactoryFunctionErrors(BaseTestCase):
     def assertFactoryError(self, factory, kind):
         """Ensure a clean ValueError with the expected message"""
@@ -912,6 +935,7 @@ class FactoryFunctionErrors(BaseTestCase):
         self.assertFactoryError(ipaddress.ip_network, "network")
 
 
+@skipIf(sys.version_info >= (3, 9, 5), "Only run on Python versions below 3.9.5")
 class ComparisonTests(TestCase):
 
     v4addr = ipaddress.IPv4Address(1)
@@ -1098,6 +1122,7 @@ class ComparisonTests(TestCase):
         self.assertRaises(TypeError, v6net_scoped.__gt__, v4net)
 
 
+@skipIf(sys.version_info >= (3, 9, 5), "Only run on Python versions below 3.9.5")
 class IpaddrUnitTest(TestCase):
     def setUp(self):
         self.ipv4_address = ipaddress.IPv4Address("1.2.3.4")


### PR DESCRIPTION
### What does this PR do?
Update the external ipaddress to the latest 3.9.5 version which has some security fixes.  Updating the compat.p to use the vendored version if the python version is below 3.9.5 and only run the test_ipaddress.py tests if below 3.9.5.

### What issues does this PR fix or reference?
Fixes: failures in  https://github.com/saltstack/salt/pull/60124

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
