### PR TITLE
Improving error message in case of multiple ID on salt 'x' state.high…

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1628,7 +1628,7 @@ class State:
                 if name not in high or state_type not in high[name]:
                     # Check for a matching 'name' override in high data
                     ids = find_name(name, state_type, high)
-                    if len(ids) != 1:
+                    if len(ids) == 0:
                         errors.append(
                             "Cannot extend ID '{0}' in '{1}:{2}'. It is not "
                             "part of the high state.\n"
@@ -1639,6 +1639,25 @@ class State:
                                 name,
                                 body.get("__env__", "base"),
                                 body.get("__sls__", "base"),
+                            )
+                        )
+                        continue
+                    elif len(ids) != 1:
+                        #log.debug("WARNING : ID '{0}' in '{1}:{2}' defined '{3}' times, see below :".format(name,body.get("__env__", "base"),body.get("__sls__", "base"),len(ids)))
+                        msg = ""
+                        for x in range(len(ids)):
+                            msg = msg + "{0}) {1}".format(x+1, ids[x][0]) + "\n"
+                            #log.debug("WARNING : {0}) {1}".format(x+1, ids[x][0]))
+                        errors.append(
+                            "ID '{0}' in '{1}:{2}' defined '{3}' times.\n"
+                            #"Report to minion debug information for more details.\n"
+                            "This is likely due to the '{3}' following states with an ID of '{0}'\n"
+                            "in environment '{1}' and to SLS '{2}' :\n{4}".format(
+                                name,
+                                body.get("__env__", "base"),
+                                body.get("__sls__", "base"),
+                                len(ids),
+                                msg,
                             )
                         )
                         continue


### PR DESCRIPTION
### What does this PR do?
Improve error message generated on "salt 'xxx' state.highstate" command, in case of multiple ID definition.

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
In case of multiple ID definition, calling "salt 'xxx' state.highstate" generates following misleading error message :

Cannot extend ID 'id' in 'env:sls'. It is not part of the high state.
This is likely due to a missing include statement or an incorrectly typed ID.
Ensure that a state with an ID of 'id' is available in environment 'env' and to SLS 'sls'

### New Behavior
Improved error message :

ID 'id' in 'env:sls' defined 'n' times.
This is likely due to the 'n' following states with an ID of 'id'
in environment 'env' and to SLS 'env:sls' :
1) ID1
2) ID2

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

## Example

### setup
Debian 10 master and CentOs 7 or CentOs 8 minion  (using salt 3003 on master and minion)

top.sls
```python
base:
  '*':
    - permit-root-login-yes
    - openssh.config
```
permit-root-login-yes.sls
```python
{% set file = '/etc/ssh/sshd_config' %}
{{ file }}:
  file.line:
    - content: "PermitRootLogin yes"
    - match: "PermitRootLogin *"
    - mode: "replace"

OpenSSH server daemon running:
  service.running:
    - name: sshd
    - reload: True
    - watch:
      - file: {{ file }}
```

### Steps to Reproduce the behavior
Calling on master :
```
salt '[CentOs_Minion]' state.highstate
```
### Previous Behavior
Misleading error message: 
```
    Cannot extend ID 'sshd' in 'base:openssh.config'. It is not part of the high state.
This is likely due to a missing include statement or an incorrectly typed ID.
Ensure that a state with an ID of 'sshd' is available in environment 'base' and to SLS 'openssh.config'
```
### New Behavior
Improved error message: 
```
    ID 'sshd' in 'base:openssh.config' defined '2' times.
This is likely due to the '2' following states with an ID of 'sshd'
in environment 'base' and to SLS 'openssh.config' :
1) OpenSSH server daemon running
2) openssh
```
<details><summary>salt --versions-report used for example</summary>

```
Salt Version:
          Salt: 3003

Dependency Versions:
          cffi: Not Installed
      cherrypy: Not Installed
      dateutil: 2.7.3
     docker-py: Not Installed
         gitdb: 2.0.5
     gitpython: 2.1.11
        Jinja2: 2.10
       libgit2: Not Installed
      M2Crypto: Not Installed
          Mako: Not Installed
       msgpack: 0.5.6
  msgpack-pure: Not Installed
  mysql-python: Not Installed
     pycparser: Not Installed
      pycrypto: Not Installed
  pycryptodome: 3.6.1
        pygit2: Not Installed
        Python: 3.7.3 (default, Jul 25 2020, 13:03:44)
  python-gnupg: Not Installed
        PyYAML: 3.13
         PyZMQ: 17.1.2
         smmap: 2.0.5
       timelib: Not Installed
       Tornado: 4.5.3
           ZMQ: 4.3.1

System Versions:
          dist: debian 10 buster
        locale: utf-8
       machine: x86_64
       release: 5.4.106-1-pve
        system: Linux
       version: Debian GNU/Linux 10 buster

```
</details>