### PR TITLE
Use os-release ID_LIKE for the os-family grain

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1976,6 +1976,14 @@ def os_data():
                             if codename_match:
                                 codename = codename_match.group(1)
                         grains["lsb_distrib_codename"] = codename
+                    if "ID_LIKE" in os_release:
+                        # ID_LIKE returns what we call here the family of the
+                        # given distro. For example:
+                        #  - Ubuntu will return "debian"
+                        #  - CentOS will return "rhel fedora"
+                        #  - Manjaro will return "arch"
+                        # Get the closest (first) token, capitalise
+                        grains["os_family"] = _OS_NAME_MAP.get(os_release["ID_LIKE"].split(" ")[0], "")
                     if "CPE_NAME" in os_release:
                         cpe = _parse_cpe_name(os_release["CPE_NAME"])
                         if not cpe:
@@ -2238,7 +2246,7 @@ def os_data():
     if not grains["os"]:
         grains["os"] = "Unknown {}".format(grains["kernel"])
         grains["os_family"] = "Unknown"
-    else:
+    elif "os_family" not in grains or not grains["os_family"]:
         # this assigns family names based on the os name
         # family defaults to the os name if not found
         grains["os_family"] = _OS_FAMILY_MAP.get(grains["os"], grains["os"])

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1573,7 +1573,6 @@ _OS_NAME_MAP = {
 # post-_OS_NAME_MAP. If your system is having trouble with detection, please
 # make sure that the 'os' grain is capitalized and working correctly first.
 _OS_FAMILY_MAP = {
-    "Ubuntu": "Debian",
     "Fedora": "RedHat",
     "Chapeau": "RedHat",
     "Korora": "RedHat",
@@ -1617,7 +1616,6 @@ _OS_FAMILY_MAP = {
     "OpenSolaris": "Solaris",
     "Oracle Solaris": "Solaris",
     "Arch ARM": "Arch",
-    "Manjaro": "Arch",
     "Antergos": "Arch",
     "ALT": "RedHat",
     "Trisquel": "Debian",


### PR DESCRIPTION
### What does this PR do?

This MR parses the `ID_LIKE` token in the `os-release` file and uses it for the `os-family` grain, before falling back to the old heuristics.

As result this paves the way to more scale-able Linux distribution handling. In particular, today each new distro needs an entry in `_OS_FAMILY_MAP` (and potentially `_OS_NAME`), while the information is readily available within `os-release`. It also opens the path to cleanup the parsing of non `os-release` release files and remove the vast part of `_OS_NAME_MAP` and `_OS_FAMILY_MAP`.

But all those can follow in due course.

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
`os-family` grain is used based on the `os` grain and `_OS_FAMILY_MAP`

### New Behavior
`os-family` grain is set to a valid distribution entry, as based on `ID_LIKE` and `_OS_NAME_MAP`. If missing or invalid, we fallback to the old behaviour.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
