### PR TITLE
[freeze] Issue #59975

### DIFF
--- a/changelog/59975.fixed
+++ b/changelog/59975.fixed
@@ -1,0 +1,1 @@
+Pass the value of the `__grains__` NamedContext to salt.pillar.get_pillar, instead of the NamedContext object itself.

--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -503,7 +503,7 @@ def ext(external, pillar=None):
         external = salt.utils.yaml.safe_load(external)
     pillar_obj = salt.pillar.get_pillar(
         __opts__,
-        __grains__,
+        __grains__.value(),
         __opts__["id"],
         __opts__["saltenv"],
         ext=external,

--- a/tests/pytests/integration/modules/test_pillar.py
+++ b/tests/pytests/integration/modules/test_pillar.py
@@ -501,7 +501,7 @@ def test_pillar_match_filter_by_minion_id(salt_cli, salt_minion):
         'web*': ['app', 'caching'],
         '{}*': ['db'],
     }}, default='web*') %}}
-    
+
     # Make the filtered data available to Pillar:
     roles: {{{{ roles | yaml() }}}}
     """.format(
@@ -514,7 +514,7 @@ def test_pillar_match_filter_by_minion_id(salt_cli, salt_minion):
         'web*': ['app', 'caching'],
         '{}*': ['db'],
     }}, minion_id=grains['id'], default='web*') %}}
-    
+
     # Make the filtered data available to Pillar:
     roles: {{{{ roles | yaml() }}}}
     """.format(
@@ -527,7 +527,7 @@ def test_pillar_match_filter_by_minion_id(salt_cli, salt_minion):
         'web*': ['app', 'caching'],
         'E@{}': ['db'],
     }}, minion_id=grains['id'], default='web*') %}}
-    
+
     # Make the filtered data available to Pillar:
     roles: {{{{ roles | yaml() }}}}
     """.format(
@@ -593,3 +593,12 @@ def test_pillar_match_filter_by_minion_id(salt_cli, salt_minion):
 
     # Refresh pillar once we're done
     salt_cli.run("saltutil.refresh_pillar", wait=True, minion_tgt=salt_minion.id)
+
+
+@pytest.mark.slow_test
+def test_pillar_ext_59975(salt_call_cli):
+    """
+    pillar.ext returns result. Issue #59975
+    """
+    ret = salt_call_cli.run("pillar.ext", '{"libvert": _}')
+    assert "ext_pillar_opts" in ret.json


### PR DESCRIPTION
### What does this PR do?

Pass the value of the `__grains__` NamedContext to salt.pillar.get_pillar, instead of the NamedContext object itself.

### What issues does this PR fix or reference?
Fixes: #59975 

