### PR TITLE
Ensure proper access to the created temporary file when ``runas`` is passed to ``cmd.exec_code_all``

### DIFF
--- a/changelog/60072.fixed
+++ b/changelog/60072.fixed
@@ -1,0 +1,1 @@
+Ensure proper access to the created temporary file when ``runas`` is passed to ``cmd.exec_code_all``

--- a/tests/pytests/integration/modules/test_cmdmod.py
+++ b/tests/pytests/integration/modules/test_cmdmod.py
@@ -1,0 +1,15 @@
+import pytest
+
+
+@pytest.fixture(scope="module")
+def non_root_account():
+    with pytest.helpers.create_account() as account:
+        yield account
+
+
+@pytest.mark.skip_if_not_root
+def test_exec_code_all(salt_call_cli, non_root_account):
+    ret = salt_call_cli.run(
+        "cmd.exec_code_all", "bash", "echo good", runas=non_root_account.username
+    )
+    assert ret.exitcode == 0


### PR DESCRIPTION
### What does this PR do?
Ensure proper access to the created temporary file when ``runas`` is passed to ``cmd.exec_code_all``

### What issues does this PR fix or reference?
Fixes #60072

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes