### PR TITLE
Consul service maintenance mode

### DIFF
--- a/changelog/60192.fixed
+++ b/changelog/60192.fixed
@@ -1,0 +1,1 @@
+Fixed HTTP method in consul module's agent_service_maintenance function

--- a/salt/modules/consul.py
+++ b/salt/modules/consul.py
@@ -1161,7 +1161,7 @@ def agent_service_maintenance(consul_url=None, token=None, serviceid=None, **kwa
 
     function = "agent/service/maintenance/{}".format(serviceid)
     res = _query(
-        consul_url=consul_url, token=token, function=function, query_params=query_params
+        consul_url=consul_url, token=token, function=function, method="PUT", query_params=query_params
     )
 
     if res["res"]:

--- a/salt/modules/consul.py
+++ b/salt/modules/consul.py
@@ -1133,7 +1133,7 @@ def agent_service_maintenance(consul_url=None, token=None, serviceid=None, **kwa
 
     .. code-block:: bash
 
-        salt '*' consul.agent_service_deregister serviceid='redis' enable='True' reason='Down for upgrade'
+        salt '*' consul.agent_service_maintenance serviceid='redis' enable='True' reason='Down for upgrade'
 
     """
     ret = {}


### PR DESCRIPTION
### What does this PR do?
Change the HTTP method of the consul module's `agent_service_maintenance` function from GET to PUT in line with the Consul HTTP API documentation https://www.consul.io/api-docs/agent/service#enable-maintenance-mode

### What issues does this PR fix or reference?
Fixes: 60192

### Previous Behavior
Running the salt module function `consul.agent_service_maintenance` would execute an HTTP GET request.

### New Behavior
Running the salt module function `consul.agent_service_maintenance` executes an HTTP PUT request which is the correct behavior.

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html

### Commits signed with GPG?
No