### PR TITLE
Normalize virtual grain for LXC

### DIFF
--- a/changelog/53868.fixed
+++ b/changelog/53868.fixed
@@ -1,0 +1,1 @@
+Fixed the container detection inside virtual machines

--- a/changelog/59573.fixed
+++ b/changelog/59573.fixed
@@ -1,0 +1,1 @@
+Normalized grain output for LXC containers

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -857,15 +857,17 @@ def _virtual(osdata):
                 grains["virtual"] = "VirtualPC"
                 break
             elif "lxc" in output:
-                grains["virtual"] = "LXC"
-                break
-            elif "systemd-nspawn" in output:
-                grains["virtual"] = "LXC"
+                grains["virtual"] = "container"
+                grains["virtual_subtype"] = "LXC"
                 break
         elif command == "virt-what":
             for line in output.splitlines():
-                if line in ("kvm", "qemu", "uml", "xen", "lxc"):
+                if line in ("kvm", "qemu", "uml", "xen"):
                     grains["virtual"] = line
+                    break
+                elif "lxc" in line:
+                    grains["virtual"] = "container"
+                    grains["virtual_subtype"] = "LXC"
                     break
                 elif "vmware" in line:
                     grains["virtual"] = "VMware"
@@ -876,6 +878,7 @@ def _virtual(osdata):
                 elif "hyperv" in line:
                     grains["virtual"] = "HyperV"
                     break
+            break
         elif command == "dmidecode":
             # Product Name: VirtualBox
             if "Vendor: QEMU" in output:
@@ -1028,27 +1031,6 @@ def _virtual(osdata):
             # If a Dom0 or DomU was detected, obviously this is xen
             if "dom" in grains.get("virtual_subtype", "").lower():
                 grains["virtual"] = "xen"
-        # Check container type after hypervisors, to avoid variable overwrite on containers running in virtual environment.
-        if os.path.isfile("/proc/1/cgroup"):
-            try:
-                with salt.utils.files.fopen("/proc/1/cgroup", "r") as fhr:
-                    fhr_contents = fhr.read()
-                if ":/lxc/" in fhr_contents:
-                    grains["virtual"] = "container"
-                    grains["virtual_subtype"] = "LXC"
-                elif ":/kubepods/" in fhr_contents:
-                    grains["virtual_subtype"] = "kubernetes"
-                elif ":/libpod_parent/" in fhr_contents:
-                    grains["virtual_subtype"] = "libpod"
-                else:
-                    if any(
-                        x in fhr_contents
-                        for x in (":/system.slice/docker", ":/docker/", ":/docker-ce/")
-                    ):
-                        grains["virtual"] = "container"
-                        grains["virtual_subtype"] = "Docker"
-            except OSError:
-                pass
         if os.path.isfile("/proc/cpuinfo"):
             with salt.utils.files.fopen("/proc/cpuinfo", "r") as fhr:
                 if "QEMU Virtual CPU" in fhr.read():
@@ -1081,6 +1063,38 @@ def _virtual(osdata):
                 )
             except OSError:
                 pass
+        # Check container type after hypervisors, to avoid variable overwrite on containers running in virtual environment.
+        if os.path.isfile("/proc/1/cgroup"):
+            try:
+                with salt.utils.files.fopen("/proc/1/cgroup", "r") as fhr:
+                    fhr_contents = fhr.read()
+                if ":/lxc/" in fhr_contents:
+                    grains["virtual"] = "container"
+                    grains["virtual_subtype"] = "LXC"
+                elif ":/kubepods/" in fhr_contents:
+                    grains["virtual_subtype"] = "kubernetes"
+                elif ":/libpod_parent/" in fhr_contents:
+                    grains["virtual_subtype"] = "libpod"
+                else:
+                    if any(
+                        x in fhr_contents
+                        for x in (":/system.slice/docker", ":/docker/", ":/docker-ce/")
+                    ):
+                        grains["virtual"] = "container"
+                        grains["virtual_subtype"] = "Docker"
+            except OSError:
+                pass
+        # Newer versions of LXC didn't have "lxc" in /proc/1/cgroup. Check environ
+        if ("virtual_subtype" not in grains) or (grains["virtual_subtype"] != "LXC"):
+            if os.path.isfile("/proc/1/environ"):
+                try:
+                    with salt.utils.files.fopen("/proc/1/environ", "r") as fhr:
+                        fhr_contents = fhr.read()
+                    if "container=lxc" in fhr_contents:
+                        grains["virtual"] = "container"
+                        grains["virtual_subtype"] = "LXC"
+                except OSError:
+                    pass
     elif osdata["kernel"] == "FreeBSD":
         kenv = salt.utils.path.which("kenv")
         if kenv:

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -1232,6 +1232,90 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
                             grains.get("virtual"), "container",
                         )
 
+        with patch.object(os.path, "isdir", MagicMock(return_value=False)):
+            with patch.object(
+                os.path,
+                "isfile",
+                MagicMock(
+                    side_effect=lambda x: True
+                    if x in ("/proc/1/cgroup", "/proc/1/environ")
+                    else False
+                ),
+            ):
+                file_contents = {
+                    "/proc/1/cgroup": "10:memory",
+                    "/proc/1/environ": "container=lxc",
+                }
+                with patch(
+                    "salt.utils.files.fopen", mock_open(read_data=file_contents)
+                ):
+                    with patch.dict(core.__salt__, {"cmd.run_all": MagicMock()}):
+                        grains = core._virtual({"kernel": "Linux"})
+                        self.assertEqual(grains.get("virtual_subtype"), "LXC")
+                        self.assertEqual(
+                            grains.get("virtual"), "container",
+                        )
+
+    @skipIf(salt.utils.platform.is_windows(), "System is Windows")
+    def test_lxc_virtual_with_virt_what(self):
+        """
+        Test if virtual grains are parsed correctly in LXC using virt-what.
+        """
+        virt = "lxc\nkvm"
+        with patch.object(
+            salt.utils.platform, "is_windows", MagicMock(return_value=False)
+        ):
+            with patch.object(salt.utils.path, "which", MagicMock(return_value=True)):
+                with patch.dict(
+                    core.__salt__,
+                    {
+                        "cmd.run_all": MagicMock(
+                            return_value={
+                                "pid": 78,
+                                "retcode": 0,
+                                "stderr": "",
+                                "stdout": virt,
+                            }
+                        )
+                    },
+                ):
+                    osdata = {
+                        "kernel": "test",
+                    }
+                    ret = core._virtual(osdata)
+                    self.assertEqual(ret["virtual"], "container")
+                    self.assertEqual(ret["virtual_subtype"], "LXC")
+
+    @skipIf(salt.utils.platform.is_windows(), "System is Windows")
+    def test_container_inside_virtual_machine(self):
+        """
+        Test if a container inside an hypervisor is shown as a container
+        """
+        with patch.object(os.path, "isdir", MagicMock(return_value=False)):
+            with patch.object(
+                os.path,
+                "isfile",
+                MagicMock(
+                    side_effect=lambda x: True
+                    if x in ("/proc/cpuinfo", "/proc/1/cgroup", "/proc/1/environ")
+                    else False
+                ),
+            ):
+                file_contents = {
+                    "/proc/cpuinfo": "QEMU Virtual CPU",
+                    "/proc/1/cgroup": "10:memory",
+                    "/proc/1/environ": "container=lxc",
+                }
+                with patch(
+                    "salt.utils.files.fopen", mock_open(read_data=file_contents)
+                ):
+                    with patch.dict(core.__salt__, {"cmd.run_all": MagicMock()}):
+                        grains = core._virtual({"kernel": "Linux"})
+                        self.assertEqual(grains.get("virtual_subtype"), "LXC")
+                        self.assertEqual(
+                            grains.get("virtual"), "container",
+                        )
+
     @skipIf(not salt.utils.platform.is_linux(), "System is not Linux")
     def test_xen_virtual(self):
         """


### PR DESCRIPTION
### What does this PR do?
Fixes the virtual grains in LXC containers. Now it always set `grains["virtual"] = "container"` and `grains["virtual_subtype"] = "LXC"`, independent of the command used for detection and even running inside another virtual machine.

### What issues does this PR fix or reference?
Fixes #53868
Fixes #59573

### Previous Behavior
The `grains["virtual"]` is inconsistent depending with the available commands for probing:
```
root@example:~# which systemd-detect-virt
root@example:~# which virt-what
root@example:~# salt-call grains.get virtual
local:
    kvm
root@example:~# which systemd-detect-virt
/usr/bin/systemd-detect-virt
root@example:~# which virt-what
root@example:~# salt-call grains.get virtual
local:
    LXC
root@example:~# which systemd-detect-virt
/usr/bin/systemd-detect-virt
root@example:~# which virt-what
/usr/sbin/virt-what
root@example:~# salt-call grains.get virtual
local:
    kvm
```

### New Behavior
The `grains["virtual"]` and `grains["virtual_subtype"]` shows always the same output regardless the probe command.
```
root@example:~# which systemd-detect-virt
root@example:~# which virt-what
root@example:~# salt-call grains.get virtual
local:
    container
root@example:~# salt-call grains.get virtual_subtype
local:
    LXC
root@example:~# which systemd-detect-virt
/usr/bin/systemd-detect-virt
root@example:~# which virt-what
root@example:~# salt-call grains.get virtual
local:
    container
root@example:~# salt-call grains.get virtual_subtype
local:
    LXC
root@example:~# which systemd-detect-virt
/usr/bin/systemd-detect-virt
root@example:~# which virt-what
/usr/sbin/virt-what
root@example:~# salt-call grains.get virtual
local:
    container
root@example:~# salt-call grains.get virtual_subtype
local:
    LXC
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No
