### PR TITLE
Allow the discovery of salt extensions installed while salt is running

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,4 +5,3 @@ MarkupSafe
 requests>=1.0.0
 distro>=1.0.1
 contextvars
-importlib_metadata>=3.3.0; python_version >= '3.6' and python_version < '3.10'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,3 +5,4 @@ MarkupSafe
 requests>=1.0.0
 distro>=1.0.1
 contextvars
+importlib_metadata>=3.3.0; python_version >= '3.6' and python_version < '3.10'

--- a/requirements/darwin.txt
+++ b/requirements/darwin.txt
@@ -20,3 +20,5 @@ python-gnupg>=0.4.4
 setproctitle>=1.1.10
 timelib>=0.2.5
 vultr>=1.0.1
+
+importlib_metadata>=3.3.0; python_version >= '3.6' and python_version < '3.10'

--- a/requirements/static/ci/common.in
+++ b/requirements/static/ci/common.in
@@ -37,7 +37,7 @@ sqlparse
 strict_rfc3339>=0.7
 toml
 vcert~=0.7.0; sys_platform != 'win32'
-virtualenv>=20.0.2
+virtualenv>=20.3.0
 watchdog>=0.9.0
 # Available template libraries that can be used
 genshi>=0.7.3

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -12,8 +12,6 @@ apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/py3.10/darwin.txt
-appdirs==1.4.3
-    # via virtualenv
 argh==0.26.2
     # via watchdog
 asn1crypto==1.3.0
@@ -327,6 +325,8 @@ azure-storage-queue==1.4.0
     # via azure
 azure==4.0.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
+backports.entry-points-selectable==1.1.0
+    # via virtualenv
 bcrypt==3.1.6
     # via paramiko
 boto3==1.17.67 ; python_version >= "3.6"
@@ -415,7 +415,7 @@ cryptography==3.3.2
     #   vcert
 decorator==4.4.2
     # via networkx
-distlib==0.3.0
+distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via -r requirements/static/pkg/py3.10/darwin.txt
@@ -673,6 +673,8 @@ passlib==1.7.2 ; sys_platform != "win32"
     #   ciscoconfparse
 pathtools==0.1.2
     # via watchdog
+platformdirs==2.2.0
+    # via virtualenv
 pluggy==0.13.1
     # via pytest
 portend==2.6
@@ -896,7 +898,7 @@ urllib3==1.26.6
     #   requests
 vcert==0.7.3 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-virtualenv==20.0.20
+virtualenv==20.7.2
     # via
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -10,8 +10,6 @@ adal==1.2.5
     #   msrestazure
 apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-appdirs==1.4.4
-    # via virtualenv
 argh==0.26.2
     # via watchdog
 asn1crypto==1.3.0
@@ -325,6 +323,8 @@ azure-storage-queue==1.4.0
     # via azure
 azure==4.0.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
+backports.entry-points-selectable==1.1.0
+    # via virtualenv
 backports.functools-lru-cache==1.5
     # via
     #   -r requirements/static/pkg/py3.10/freebsd.txt
@@ -417,7 +417,7 @@ cryptography==3.3.2
     #   vcert
 decorator==4.4.2
     # via networkx
-distlib==0.3.0
+distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via -r requirements/static/pkg/py3.10/freebsd.txt
@@ -671,6 +671,8 @@ passlib==1.7.2 ; sys_platform != "win32"
     #   ciscoconfparse
 pathtools==0.1.2
     # via watchdog
+platformdirs==2.2.0
+    # via virtualenv
 pluggy==0.13.0
     # via pytest
 portend==2.4
@@ -894,7 +896,7 @@ urllib3==1.26.6
     #   requests
 vcert==0.7.3 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-virtualenv==20.0.20
+virtualenv==20.7.2
     # via
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -16,8 +16,6 @@ ansible==3.4.0
     # via -r requirements/static/ci/linux.in
 apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-appdirs==1.4.4
-    # via virtualenv
 apscheduler==3.6.3
     # via python-telegram-bot
 argh==0.26.2
@@ -338,6 +336,8 @@ azure-storage-queue==1.4.0
     # via azure
 azure==4.0.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
+backports.entry-points-selectable==1.1.0
+    # via virtualenv
 backports.functools-lru-cache==1.5
     # via
     #   -r requirements/static/pkg/py3.10/linux.txt
@@ -434,7 +434,7 @@ cryptography==3.3.2
     #   vcert
 decorator==4.4.2
     # via networkx
-distlib==0.3.0
+distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via -r requirements/static/pkg/py3.10/linux.txt
@@ -697,6 +697,8 @@ passlib==1.7.2 ; sys_platform != "win32"
     #   ciscoconfparse
 pathtools==0.1.2
     # via watchdog
+platformdirs==2.2.0
+    # via virtualenv
 pluggy==0.13.0
     # via pytest
 portend==2.4
@@ -971,7 +973,7 @@ vapi-runtime==2.19.0
     #   vsphere-automation-sdk
 vcert==0.7.3 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-virtualenv==20.0.20
+virtualenv==20.7.2
     # via
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.5/linux.txt
+++ b/requirements/static/ci/py3.5/linux.txt
@@ -16,8 +16,6 @@ ansible==3.4.0
     # via -r requirements/static/ci/linux.in
 apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-appdirs==1.4.4
-    # via virtualenv
 argh==0.26.2
     # via watchdog
 asn1crypto==1.3.0
@@ -336,6 +334,8 @@ azure-storage-queue==1.4.0
     # via azure
 azure==4.0.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
+backports.entry-points-selectable==1.1.0
+    # via virtualenv
 backports.functools-lru-cache==1.5
     # via
     #   -r requirements/static/pkg/py3.5/linux.txt
@@ -428,7 +428,7 @@ decorator==4.4.2
     # via
     #   networkx
     #   python-telegram-bot
-distlib==0.3.0
+distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via -r requirements/static/pkg/py3.5/linux.txt
@@ -474,6 +474,7 @@ immutables==0.14
     #   contextvars
 importlib-metadata==0.23
     # via
+    #   backports.entry-points-selectable
     #   importlib-resources
     #   jsonpickle
     #   jsonschema
@@ -688,6 +689,8 @@ pathlib2==2.3.5
     # via pytest
 pathtools==0.1.2
     # via watchdog
+platformdirs==2.0.2
+    # via virtualenv
 pluggy==0.13.0
     # via pytest
 portend==2.4
@@ -945,7 +948,7 @@ vapi-runtime==2.19.0
     #   vsphere-automation-sdk
 vcert==0.7.3 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-virtualenv==20.0.20
+virtualenv==20.7.2
     # via
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.6/docs.txt
+++ b/requirements/static/ci/py3.6/docs.txt
@@ -56,6 +56,8 @@ immutables==0.14
     # via
     #   -r requirements/static/pkg/py3.6/linux.txt
     #   contextvars
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
+    # via -r requirements/static/pkg/py3.6/linux.txt
 jaraco.functools==2.0
     # via
     #   -r requirements/static/pkg/py3.6/linux.txt
@@ -147,6 +149,10 @@ tempora==1.14.1
     #   portend
 timelib==0.2.5
     # via -r requirements/static/pkg/py3.6/linux.txt
+typing-extensions==3.10.0.0
+    # via
+    #   -r requirements/static/pkg/py3.6/linux.txt
+    #   importlib-metadata
 urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.6/linux.txt
@@ -155,6 +161,10 @@ zc.lockfile==1.4
     # via
     #   -r requirements/static/pkg/py3.6/linux.txt
     #   cherrypy
+zipp==3.5.0
+    # via
+    #   -r requirements/static/pkg/py3.6/linux.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.6/linux.txt
+++ b/requirements/static/ci/py3.6/linux.txt
@@ -16,8 +16,6 @@ ansible==3.4.0
     # via -r requirements/static/ci/linux.in
 apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-appdirs==1.4.4
-    # via virtualenv
 apscheduler==3.6.3
     # via python-telegram-bot
 argh==0.26.2
@@ -338,6 +336,8 @@ azure-storage-queue==1.4.0
     # via azure
 azure==4.0.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
+backports.entry-points-selectable==1.1.0
+    # via virtualenv
 backports.functools-lru-cache==1.5
     # via
     #   -r requirements/static/pkg/py3.6/linux.txt
@@ -429,7 +429,7 @@ cryptography==3.3.2
     #   vcert
 decorator==4.4.2
     # via networkx
-distlib==0.3.0
+distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via -r requirements/static/pkg/py3.6/linux.txt
@@ -473,8 +473,10 @@ immutables==0.14
     # via
     #   -r requirements/static/pkg/py3.6/linux.txt
     #   contextvars
-importlib-metadata==0.23
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
     # via
+    #   -r requirements/static/pkg/py3.6/linux.txt
+    #   backports.entry-points-selectable
     #   importlib-resources
     #   jsonpickle
     #   jsonschema
@@ -557,7 +559,6 @@ more-itertools==5.0.0
     #   cherrypy
     #   jaraco.functools
     #   moto
-    #   zipp
 moto==1.3.16
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
@@ -687,6 +688,8 @@ passlib==1.7.2 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 pathtools==0.1.2
     # via watchdog
+platformdirs==2.2.0
+    # via virtualenv
 pluggy==0.13.0
     # via pytest
 portend==2.4
@@ -916,6 +919,10 @@ transitions==0.8.1
     # via junos-eznc
 twilio==6.63.0
     # via -r requirements/static/ci/linux.in
+typing-extensions==3.10.0.0
+    # via
+    #   -r requirements/static/pkg/py3.6/linux.txt
+    #   importlib-metadata
 tzlocal==2.1
     # via apscheduler
 urllib3==1.26.6
@@ -949,7 +956,7 @@ vapi-runtime==2.19.0
     #   vsphere-automation-sdk
 vcert==0.7.3 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-virtualenv==20.0.20
+virtualenv==20.7.2
     # via
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
@@ -977,8 +984,9 @@ zc.lockfile==1.4
     # via
     #   -r requirements/static/pkg/py3.6/linux.txt
     #   cherrypy
-zipp==0.6.0
+zipp==3.5.0
     # via
+    #   -r requirements/static/pkg/py3.6/linux.txt
     #   importlib-metadata
     #   importlib-resources
     #   moto

--- a/requirements/static/ci/py3.7/darwin.txt
+++ b/requirements/static/ci/py3.7/darwin.txt
@@ -12,8 +12,6 @@ apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/py3.7/darwin.txt
-appdirs==1.4.3
-    # via virtualenv
 argh==0.26.2
     # via watchdog
 asn1crypto==1.3.0
@@ -327,6 +325,8 @@ azure-storage-queue==1.4.0
     # via azure
 azure==4.0.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
+backports.entry-points-selectable==1.1.0
+    # via virtualenv
 bcrypt==3.1.6
     # via paramiko
 boto3==1.17.67 ; python_version >= "3.6"
@@ -415,7 +415,7 @@ cryptography==3.3.2
     #   vcert
 decorator==4.4.2
     # via networkx
-distlib==0.3.0
+distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via -r requirements/static/pkg/py3.7/darwin.txt
@@ -466,8 +466,10 @@ immutables==0.15
     # via
     #   -r requirements/static/pkg/py3.7/darwin.txt
     #   contextvars
-importlib-metadata==0.23
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
     # via
+    #   -r requirements/static/pkg/py3.7/darwin.txt
+    #   backports.entry-points-selectable
     #   jsonpickle
     #   jsonschema
     #   pluggy
@@ -548,7 +550,6 @@ more-itertools==8.2.0
     #   cherrypy
     #   jaraco.functools
     #   moto
-    #   zipp
 moto==1.3.16
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
@@ -681,6 +682,8 @@ passlib==1.7.2 ; sys_platform != "win32"
     #   ciscoconfparse
 pathtools==0.1.2
     # via watchdog
+platformdirs==2.2.0
+    # via virtualenv
 pluggy==0.13.1
     # via pytest
 portend==2.6
@@ -895,6 +898,10 @@ toml==0.10.2
     #   pytest
 transitions==0.8.1
     # via junos-eznc
+typing-extensions==3.10.0.0
+    # via
+    #   -r requirements/static/pkg/py3.7/darwin.txt
+    #   importlib-metadata
 urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.7/darwin.txt
@@ -904,7 +911,7 @@ urllib3==1.26.6
     #   requests
 vcert==0.7.3 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-virtualenv==20.0.20
+virtualenv==20.7.2
     # via
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
@@ -930,8 +937,9 @@ zc.lockfile==2.0
     # via
     #   -r requirements/static/pkg/py3.7/darwin.txt
     #   cherrypy
-zipp==0.6.0
+zipp==3.5.0
     # via
+    #   -r requirements/static/pkg/py3.7/darwin.txt
     #   importlib-metadata
     #   moto
 

--- a/requirements/static/ci/py3.7/docs.txt
+++ b/requirements/static/ci/py3.7/docs.txt
@@ -54,6 +54,8 @@ immutables==0.15
     # via
     #   -r requirements/static/pkg/py3.7/linux.txt
     #   contextvars
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
+    # via -r requirements/static/pkg/py3.7/linux.txt
 jaraco.functools==2.0
     # via
     #   -r requirements/static/pkg/py3.7/linux.txt
@@ -145,6 +147,10 @@ tempora==1.14.1
     #   portend
 timelib==0.2.5
     # via -r requirements/static/pkg/py3.7/linux.txt
+typing-extensions==3.10.0.0
+    # via
+    #   -r requirements/static/pkg/py3.7/linux.txt
+    #   importlib-metadata
 urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.7/linux.txt
@@ -153,6 +159,10 @@ zc.lockfile==1.4
     # via
     #   -r requirements/static/pkg/py3.7/linux.txt
     #   cherrypy
+zipp==3.5.0
+    # via
+    #   -r requirements/static/pkg/py3.7/linux.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -10,8 +10,6 @@ adal==1.2.5
     #   msrestazure
 apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-appdirs==1.4.4
-    # via virtualenv
 argh==0.26.2
     # via watchdog
 asn1crypto==1.3.0
@@ -325,6 +323,8 @@ azure-storage-queue==1.4.0
     # via azure
 azure==4.0.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
+backports.entry-points-selectable==1.1.0
+    # via virtualenv
 backports.functools-lru-cache==1.5
     # via
     #   -r requirements/static/pkg/py3.7/freebsd.txt
@@ -417,7 +417,7 @@ cryptography==3.3.2
     #   vcert
 decorator==4.4.2
     # via networkx
-distlib==0.3.0
+distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via -r requirements/static/pkg/py3.7/freebsd.txt
@@ -464,8 +464,10 @@ immutables==0.15
     # via
     #   -r requirements/static/pkg/py3.7/freebsd.txt
     #   contextvars
-importlib-metadata==0.23
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
     # via
+    #   -r requirements/static/pkg/py3.7/freebsd.txt
+    #   backports.entry-points-selectable
     #   jsonpickle
     #   jsonschema
     #   pluggy
@@ -545,7 +547,6 @@ more-itertools==5.0.0
     #   cherrypy
     #   jaraco.functools
     #   moto
-    #   zipp
 moto==1.3.16
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
@@ -679,6 +680,8 @@ passlib==1.7.2 ; sys_platform != "win32"
     #   ciscoconfparse
 pathtools==0.1.2
     # via watchdog
+platformdirs==2.2.0
+    # via virtualenv
 pluggy==0.13.0
     # via pytest
 portend==2.4
@@ -893,6 +896,10 @@ toml==0.10.2
     #   pytest
 transitions==0.8.1
     # via junos-eznc
+typing-extensions==3.10.0.0
+    # via
+    #   -r requirements/static/pkg/py3.7/freebsd.txt
+    #   importlib-metadata
 urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.7/freebsd.txt
@@ -902,7 +909,7 @@ urllib3==1.26.6
     #   requests
 vcert==0.7.3 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-virtualenv==20.0.20
+virtualenv==20.7.2
     # via
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
@@ -924,8 +931,9 @@ zc.lockfile==1.4
     # via
     #   -r requirements/static/pkg/py3.7/freebsd.txt
     #   cherrypy
-zipp==0.6.0
+zipp==3.5.0
     # via
+    #   -r requirements/static/pkg/py3.7/freebsd.txt
     #   importlib-metadata
     #   moto
 

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -16,8 +16,6 @@ ansible==3.4.0
     # via -r requirements/static/ci/linux.in
 apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-appdirs==1.4.4
-    # via virtualenv
 apscheduler==3.6.3
     # via python-telegram-bot
 argh==0.26.2
@@ -338,6 +336,8 @@ azure-storage-queue==1.4.0
     # via azure
 azure==4.0.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
+backports.entry-points-selectable==1.1.0
+    # via virtualenv
 backports.functools-lru-cache==1.5
     # via
     #   -r requirements/static/pkg/py3.7/linux.txt
@@ -432,7 +432,7 @@ cryptography==3.3.2
     #   vcert
 decorator==4.4.2
     # via networkx
-distlib==0.3.0
+distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via -r requirements/static/pkg/py3.7/linux.txt
@@ -479,8 +479,10 @@ immutables==0.15
     # via
     #   -r requirements/static/pkg/py3.7/linux.txt
     #   contextvars
-importlib-metadata==0.23
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
     # via
+    #   -r requirements/static/pkg/py3.7/linux.txt
+    #   backports.entry-points-selectable
     #   jsonpickle
     #   jsonschema
     #   pluggy
@@ -562,7 +564,6 @@ more-itertools==5.0.0
     #   cherrypy
     #   jaraco.functools
     #   moto
-    #   zipp
 moto==1.3.16
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
@@ -703,6 +704,8 @@ passlib==1.7.2 ; sys_platform != "win32"
     #   ciscoconfparse
 pathtools==0.1.2
     # via watchdog
+platformdirs==2.2.0
+    # via virtualenv
 pluggy==0.13.0
     # via pytest
 portend==2.4
@@ -944,6 +947,10 @@ transitions==0.8.1
     # via junos-eznc
 twilio==6.63.0
     # via -r requirements/static/ci/linux.in
+typing-extensions==3.10.0.0
+    # via
+    #   -r requirements/static/pkg/py3.7/linux.txt
+    #   importlib-metadata
 tzlocal==2.1
     # via apscheduler
 urllib3==1.26.6
@@ -977,7 +984,7 @@ vapi-runtime==2.19.0
     #   vsphere-automation-sdk
 vcert==0.7.3 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-virtualenv==20.0.20
+virtualenv==20.7.2
     # via
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
@@ -1005,8 +1012,9 @@ zc.lockfile==1.4
     # via
     #   -r requirements/static/pkg/py3.7/linux.txt
     #   cherrypy
-zipp==0.6.0
+zipp==3.5.0
     # via
+    #   -r requirements/static/pkg/py3.7/linux.txt
     #   importlib-metadata
     #   moto
 

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile --output-file=requirements/static/ci/py3.7/windows.txt requirements/pytest.txt requirements/static/ci/common.in requirements/static/ci/windows.in requirements/static/pkg/py3.7/windows.txt
 #
-appdirs==1.4.4
-    # via virtualenv
 atomicwrites==1.3.0
     # via pytest
 attrs==20.3.0
@@ -17,6 +15,8 @@ aws-sam-translator==1.33.0
     # via cfn-lint
 aws-xray-sdk==0.95
     # via moto
+backports.entry-points-selectable==1.1.0
+    # via virtualenv
 boto3==1.17.67 ; python_version >= "3.6"
     # via
     #   -r requirements/static/ci/common.in
@@ -83,7 +83,7 @@ cryptography==3.4.7
     #   sshpubkeys
 decorator==4.4.2
     # via networkx
-distlib==0.3.0
+distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via -r requirements/static/pkg/py3.7/windows.txt
@@ -131,8 +131,10 @@ immutables==0.15
     # via
     #   -r requirements/static/pkg/py3.7/windows.txt
     #   contextvars
-importlib-metadata==0.23
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
     # via
+    #   -r requirements/static/pkg/py3.7/windows.txt
+    #   backports.entry-points-selectable
     #   jsonpickle
     #   jsonschema
     #   pluggy
@@ -216,7 +218,6 @@ more-itertools==8.2.0
     #   jaraco.classes
     #   jaraco.functools
     #   moto
-    #   zipp
 moto==1.3.16
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
@@ -233,6 +234,8 @@ patch==1.16
     # via -r requirements/static/ci/windows.in
 pathtools==0.1.2
     # via watchdog
+platformdirs==2.2.0
+    # via virtualenv
 pluggy==0.13.0
     # via pytest
 portend==2.6
@@ -413,6 +416,7 @@ typing-extensions==3.10.0.0
     # via
     #   -r requirements/static/pkg/py3.7/windows.txt
     #   gitpython
+    #   importlib-metadata
 urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.7/windows.txt
@@ -420,7 +424,7 @@ urllib3==1.26.6
     #   kubernetes
     #   python-etcd
     #   requests
-virtualenv==20.0.20
+virtualenv==20.7.2
     # via
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
@@ -446,8 +450,9 @@ zc.lockfile==2.0
     # via
     #   -r requirements/static/pkg/py3.7/windows.txt
     #   cherrypy
-zipp==0.6.0
+zipp==3.5.0
     # via
+    #   -r requirements/static/pkg/py3.7/windows.txt
     #   importlib-metadata
     #   moto
 

--- a/requirements/static/ci/py3.8/darwin.txt
+++ b/requirements/static/ci/py3.8/darwin.txt
@@ -12,8 +12,6 @@ apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/py3.8/darwin.txt
-appdirs==1.4.3
-    # via virtualenv
 argh==0.26.2
     # via watchdog
 asn1crypto==1.3.0
@@ -327,6 +325,8 @@ azure-storage-queue==1.4.0
     # via azure
 azure==4.0.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
+backports.entry-points-selectable==1.1.0
+    # via virtualenv
 bcrypt==3.1.6
     # via paramiko
 boto3==1.17.67 ; python_version >= "3.6"
@@ -415,7 +415,7 @@ cryptography==3.3.2
     #   vcert
 decorator==4.4.2
     # via networkx
-distlib==0.3.0
+distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via -r requirements/static/pkg/py3.8/darwin.txt
@@ -466,6 +466,8 @@ immutables==0.15
     # via
     #   -r requirements/static/pkg/py3.8/darwin.txt
     #   contextvars
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
+    # via -r requirements/static/pkg/py3.8/darwin.txt
 iniconfig==1.0.1
     # via pytest
 ipaddress==1.0.22
@@ -673,6 +675,8 @@ passlib==1.7.2 ; sys_platform != "win32"
     #   ciscoconfparse
 pathtools==0.1.2
     # via watchdog
+platformdirs==2.2.0
+    # via virtualenv
 pluggy==0.13.1
     # via pytest
 portend==2.6
@@ -896,7 +900,7 @@ urllib3==1.26.6
     #   requests
 vcert==0.7.3 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-virtualenv==20.0.20
+virtualenv==20.7.2
     # via
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
@@ -922,8 +926,11 @@ zc.lockfile==2.0
     # via
     #   -r requirements/static/pkg/py3.8/darwin.txt
     #   cherrypy
-zipp==3.4.0
-    # via moto
+zipp==3.5.0
+    # via
+    #   -r requirements/static/pkg/py3.8/darwin.txt
+    #   importlib-metadata
+    #   moto
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.8/docs.txt
+++ b/requirements/static/ci/py3.8/docs.txt
@@ -54,6 +54,8 @@ immutables==0.15
     # via
     #   -r requirements/static/pkg/py3.8/linux.txt
     #   contextvars
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
+    # via -r requirements/static/pkg/py3.8/linux.txt
 jaraco.functools==2.0
     # via
     #   -r requirements/static/pkg/py3.8/linux.txt
@@ -153,6 +155,10 @@ zc.lockfile==1.4
     # via
     #   -r requirements/static/pkg/py3.8/linux.txt
     #   cherrypy
+zipp==3.5.0
+    # via
+    #   -r requirements/static/pkg/py3.8/linux.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -10,8 +10,6 @@ adal==1.2.5
     #   msrestazure
 apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-appdirs==1.4.4
-    # via virtualenv
 argh==0.26.2
     # via watchdog
 asn1crypto==1.3.0
@@ -325,6 +323,8 @@ azure-storage-queue==1.4.0
     # via azure
 azure==4.0.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
+backports.entry-points-selectable==1.1.0
+    # via virtualenv
 backports.functools-lru-cache==1.5
     # via
     #   -r requirements/static/pkg/py3.8/freebsd.txt
@@ -417,7 +417,7 @@ cryptography==3.3.2
     #   vcert
 decorator==4.4.2
     # via networkx
-distlib==0.3.0
+distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via -r requirements/static/pkg/py3.8/freebsd.txt
@@ -464,6 +464,8 @@ immutables==0.15
     # via
     #   -r requirements/static/pkg/py3.8/freebsd.txt
     #   contextvars
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
+    # via -r requirements/static/pkg/py3.8/freebsd.txt
 iniconfig==1.0.1
     # via pytest
 ipaddress==1.0.22
@@ -671,6 +673,8 @@ passlib==1.7.2 ; sys_platform != "win32"
     #   ciscoconfparse
 pathtools==0.1.2
     # via watchdog
+platformdirs==2.2.0
+    # via virtualenv
 pluggy==0.13.0
     # via pytest
 portend==2.4
@@ -894,7 +898,7 @@ urllib3==1.26.6
     #   requests
 vcert==0.7.3 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-virtualenv==20.0.20
+virtualenv==20.7.2
     # via
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
@@ -916,8 +920,11 @@ zc.lockfile==1.4
     # via
     #   -r requirements/static/pkg/py3.8/freebsd.txt
     #   cherrypy
-zipp==3.4.0
-    # via moto
+zipp==3.5.0
+    # via
+    #   -r requirements/static/pkg/py3.8/freebsd.txt
+    #   importlib-metadata
+    #   moto
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -16,8 +16,6 @@ ansible==3.4.0
     # via -r requirements/static/ci/linux.in
 apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-appdirs==1.4.4
-    # via virtualenv
 apscheduler==3.6.3
     # via python-telegram-bot
 argh==0.26.2
@@ -338,6 +336,8 @@ azure-storage-queue==1.4.0
     # via azure
 azure==4.0.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
+backports.entry-points-selectable==1.1.0
+    # via virtualenv
 backports.functools-lru-cache==1.5
     # via
     #   -r requirements/static/pkg/py3.8/linux.txt
@@ -432,7 +432,7 @@ cryptography==3.3.2
     #   vcert
 decorator==4.4.2
     # via networkx
-distlib==0.3.0
+distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via -r requirements/static/pkg/py3.8/linux.txt
@@ -479,6 +479,8 @@ immutables==0.15
     # via
     #   -r requirements/static/pkg/py3.8/linux.txt
     #   contextvars
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
+    # via -r requirements/static/pkg/py3.8/linux.txt
 iniconfig==1.0.1
     # via pytest
 ipaddress==1.0.22
@@ -695,6 +697,8 @@ passlib==1.7.2 ; sys_platform != "win32"
     #   ciscoconfparse
 pathtools==0.1.2
     # via watchdog
+platformdirs==2.2.0
+    # via virtualenv
 pluggy==0.13.0
     # via pytest
 portend==2.4
@@ -969,7 +973,7 @@ vapi-runtime==2.19.0
     #   vsphere-automation-sdk
 vcert==0.7.3 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-virtualenv==20.0.20
+virtualenv==20.7.2
     # via
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
@@ -997,8 +1001,11 @@ zc.lockfile==1.4
     # via
     #   -r requirements/static/pkg/py3.8/linux.txt
     #   cherrypy
-zipp==3.4.0
-    # via moto
+zipp==3.5.0
+    # via
+    #   -r requirements/static/pkg/py3.8/linux.txt
+    #   importlib-metadata
+    #   moto
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile --output-file=requirements/static/ci/py3.8/windows.txt requirements/pytest.txt requirements/static/ci/common.in requirements/static/ci/windows.in requirements/static/pkg/py3.8/windows.txt
 #
-appdirs==1.4.4
-    # via virtualenv
 atomicwrites==1.3.0
     # via pytest
 attrs==20.3.0
@@ -17,6 +15,8 @@ aws-sam-translator==1.33.0
     # via cfn-lint
 aws-xray-sdk==0.95
     # via moto
+backports.entry-points-selectable==1.1.0
+    # via virtualenv
 boto3==1.17.80 ; python_version >= "3.6"
     # via
     #   -r requirements/static/ci/common.in
@@ -83,7 +83,7 @@ cryptography==3.4.7
     #   sshpubkeys
 decorator==4.4.2
     # via networkx
-distlib==0.3.0
+distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via -r requirements/static/pkg/py3.8/windows.txt
@@ -131,6 +131,8 @@ immutables==0.15
     # via
     #   -r requirements/static/pkg/py3.8/windows.txt
     #   contextvars
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
+    # via -r requirements/static/pkg/py3.8/windows.txt
 iniconfig==1.0.1
     # via pytest
 ioloop==0.1a0
@@ -209,7 +211,6 @@ more-itertools==8.2.0
     #   jaraco.classes
     #   jaraco.functools
     #   moto
-    #   zipp
 moto==1.3.16
     # via -r requirements/static/ci/common.in
 msgpack==0.6.2
@@ -226,6 +227,8 @@ patch==1.16
     # via -r requirements/static/ci/windows.in
 pathtools==0.1.2
     # via watchdog
+platformdirs==2.2.0
+    # via virtualenv
 pluggy==0.13.0
     # via pytest
 portend==2.6
@@ -408,7 +411,7 @@ urllib3==1.26.6
     #   kubernetes
     #   python-etcd
     #   requests
-virtualenv==20.0.20
+virtualenv==20.7.2
     # via
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
@@ -434,8 +437,11 @@ zc.lockfile==2.0
     # via
     #   -r requirements/static/pkg/py3.8/windows.txt
     #   cherrypy
-zipp==0.6.0
-    # via moto
+zipp==3.5.0
+    # via
+    #   -r requirements/static/pkg/py3.8/windows.txt
+    #   importlib-metadata
+    #   moto
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -12,8 +12,6 @@ apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/py3.9/darwin.txt
-appdirs==1.4.3
-    # via virtualenv
 argh==0.26.2
     # via watchdog
 asn1crypto==1.3.0
@@ -327,6 +325,8 @@ azure-storage-queue==1.4.0
     # via azure
 azure==4.0.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
+backports.entry-points-selectable==1.1.0
+    # via virtualenv
 bcrypt==3.1.6
     # via paramiko
 boto3==1.17.67 ; python_version >= "3.6"
@@ -415,7 +415,7 @@ cryptography==3.3.2
     #   vcert
 decorator==4.4.2
     # via networkx
-distlib==0.3.0
+distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via -r requirements/static/pkg/py3.9/darwin.txt
@@ -466,6 +466,8 @@ immutables==0.15
     # via
     #   -r requirements/static/pkg/py3.9/darwin.txt
     #   contextvars
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
+    # via -r requirements/static/pkg/py3.9/darwin.txt
 iniconfig==1.0.1
     # via pytest
 ipaddress==1.0.22
@@ -673,6 +675,8 @@ passlib==1.7.2 ; sys_platform != "win32"
     #   ciscoconfparse
 pathtools==0.1.2
     # via watchdog
+platformdirs==2.2.0
+    # via virtualenv
 pluggy==0.13.1
     # via pytest
 portend==2.6
@@ -896,7 +900,7 @@ urllib3==1.26.6
     #   requests
 vcert==0.7.3 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-virtualenv==20.0.20
+virtualenv==20.7.2
     # via
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
@@ -922,8 +926,11 @@ zc.lockfile==2.0
     # via
     #   -r requirements/static/pkg/py3.9/darwin.txt
     #   cherrypy
-zipp==3.4.0
-    # via moto
+zipp==3.5.0
+    # via
+    #   -r requirements/static/pkg/py3.9/darwin.txt
+    #   importlib-metadata
+    #   moto
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -54,6 +54,8 @@ immutables==0.15
     # via
     #   -r requirements/static/pkg/py3.9/linux.txt
     #   contextvars
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
+    # via -r requirements/static/pkg/py3.9/linux.txt
 jaraco.functools==2.0
     # via
     #   -r requirements/static/pkg/py3.9/linux.txt
@@ -153,6 +155,10 @@ zc.lockfile==1.4
     # via
     #   -r requirements/static/pkg/py3.9/linux.txt
     #   cherrypy
+zipp==3.5.0
+    # via
+    #   -r requirements/static/pkg/py3.9/linux.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -10,8 +10,6 @@ adal==1.2.5
     #   msrestazure
 apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-appdirs==1.4.4
-    # via virtualenv
 argh==0.26.2
     # via watchdog
 asn1crypto==1.3.0
@@ -325,6 +323,8 @@ azure-storage-queue==1.4.0
     # via azure
 azure==4.0.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
+backports.entry-points-selectable==1.1.0
+    # via virtualenv
 backports.functools-lru-cache==1.5
     # via
     #   -r requirements/static/pkg/py3.9/freebsd.txt
@@ -417,7 +417,7 @@ cryptography==3.3.2
     #   vcert
 decorator==4.4.2
     # via networkx
-distlib==0.3.0
+distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via -r requirements/static/pkg/py3.9/freebsd.txt
@@ -464,6 +464,8 @@ immutables==0.15
     # via
     #   -r requirements/static/pkg/py3.9/freebsd.txt
     #   contextvars
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
+    # via -r requirements/static/pkg/py3.9/freebsd.txt
 iniconfig==1.0.1
     # via pytest
 ipaddress==1.0.22
@@ -671,6 +673,8 @@ passlib==1.7.2 ; sys_platform != "win32"
     #   ciscoconfparse
 pathtools==0.1.2
     # via watchdog
+platformdirs==2.2.0
+    # via virtualenv
 pluggy==0.13.0
     # via pytest
 portend==2.4
@@ -894,7 +898,7 @@ urllib3==1.26.6
     #   requests
 vcert==0.7.3 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-virtualenv==20.0.20
+virtualenv==20.7.2
     # via
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
@@ -916,8 +920,11 @@ zc.lockfile==1.4
     # via
     #   -r requirements/static/pkg/py3.9/freebsd.txt
     #   cherrypy
-zipp==3.4.0
-    # via moto
+zipp==3.5.0
+    # via
+    #   -r requirements/static/pkg/py3.9/freebsd.txt
+    #   importlib-metadata
+    #   moto
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -16,8 +16,6 @@ ansible==3.4.0
     # via -r requirements/static/ci/linux.in
 apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-appdirs==1.4.4
-    # via virtualenv
 apscheduler==3.6.3
     # via python-telegram-bot
 argh==0.26.2
@@ -338,6 +336,8 @@ azure-storage-queue==1.4.0
     # via azure
 azure==4.0.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
+backports.entry-points-selectable==1.1.0
+    # via virtualenv
 backports.functools-lru-cache==1.5
     # via
     #   -r requirements/static/pkg/py3.9/linux.txt
@@ -434,7 +434,7 @@ cryptography==3.3.2
     #   vcert
 decorator==4.4.2
     # via networkx
-distlib==0.3.0
+distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via -r requirements/static/pkg/py3.9/linux.txt
@@ -481,6 +481,8 @@ immutables==0.15
     # via
     #   -r requirements/static/pkg/py3.9/linux.txt
     #   contextvars
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
+    # via -r requirements/static/pkg/py3.9/linux.txt
 iniconfig==1.0.1
     # via pytest
 ipaddress==1.0.22
@@ -697,6 +699,8 @@ passlib==1.7.2 ; sys_platform != "win32"
     #   ciscoconfparse
 pathtools==0.1.2
     # via watchdog
+platformdirs==2.2.0
+    # via virtualenv
 pluggy==0.13.0
     # via pytest
 portend==2.4
@@ -971,7 +975,7 @@ vapi-runtime==2.19.0
     #   vsphere-automation-sdk
 vcert==0.7.3 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-virtualenv==20.0.20
+virtualenv==20.7.2
     # via
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
@@ -999,8 +1003,11 @@ zc.lockfile==1.4
     # via
     #   -r requirements/static/pkg/py3.9/linux.txt
     #   cherrypy
-zipp==3.4.0
-    # via moto
+zipp==3.5.0
+    # via
+    #   -r requirements/static/pkg/py3.9/linux.txt
+    #   importlib-metadata
+    #   moto
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile --output-file=requirements/static/ci/py3.9/windows.txt requirements/pytest.txt requirements/static/ci/common.in requirements/static/ci/windows.in requirements/static/pkg/py3.9/windows.txt
 #
-appdirs==1.4.4
-    # via virtualenv
 atomicwrites==1.3.0
     # via pytest
 attrs==20.3.0
@@ -17,6 +15,8 @@ aws-sam-translator==1.33.0
     # via cfn-lint
 aws-xray-sdk==0.95
     # via moto
+backports.entry-points-selectable==1.1.0
+    # via virtualenv
 boto3==1.17.80 ; python_version >= "3.6"
     # via
     #   -r requirements/static/ci/common.in
@@ -83,7 +83,7 @@ cryptography==3.4.7
     #   sshpubkeys
 decorator==4.4.2
     # via networkx
-distlib==0.3.0
+distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via -r requirements/static/pkg/py3.9/windows.txt
@@ -131,6 +131,8 @@ immutables==0.15
     # via
     #   -r requirements/static/pkg/py3.9/windows.txt
     #   contextvars
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
+    # via -r requirements/static/pkg/py3.9/windows.txt
 iniconfig==1.0.1
     # via pytest
 ioloop==0.1a0
@@ -209,7 +211,6 @@ more-itertools==8.2.0
     #   jaraco.classes
     #   jaraco.functools
     #   moto
-    #   zipp
 moto==1.3.16
     # via -r requirements/static/ci/common.in
 msgpack==0.6.2
@@ -226,6 +227,8 @@ patch==1.16
     # via -r requirements/static/ci/windows.in
 pathtools==0.1.2
     # via watchdog
+platformdirs==2.2.0
+    # via virtualenv
 pluggy==0.13.0
     # via pytest
 portend==2.6
@@ -408,7 +411,7 @@ urllib3==1.26.6
     #   kubernetes
     #   python-etcd
     #   requests
-virtualenv==20.0.20
+virtualenv==20.7.2
     # via
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
@@ -434,8 +437,11 @@ zc.lockfile==2.0
     # via
     #   -r requirements/static/pkg/py3.9/windows.txt
     #   cherrypy
-zipp==0.6.0
-    # via moto
+zipp==3.5.0
+    # via
+    #   -r requirements/static/pkg/py3.9/windows.txt
+    #   importlib-metadata
+    #   moto
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/pkg/freebsd.in
+++ b/requirements/static/pkg/freebsd.in
@@ -9,3 +9,4 @@ python-gnupg>=0.4.4
 setproctitle>=1.1.10
 timelib>=0.2.5
 distro>=1.3.0
+importlib_metadata>=3.3.0; python_version >= '3.6' and python_version < '3.10'

--- a/requirements/static/pkg/linux.in
+++ b/requirements/static/pkg/linux.in
@@ -8,3 +8,4 @@ python-dateutil>=2.8.0
 python-gnupg>=0.4.4
 setproctitle>=1.1.10
 timelib>=0.2.5
+importlib_metadata>=3.3.0; python_version >= '3.6' and python_version < '3.10'

--- a/requirements/static/pkg/py3.6/linux.txt
+++ b/requirements/static/pkg/py3.6/linux.txt
@@ -31,7 +31,7 @@ idna==2.8
 immutables==0.14
     # via contextvars
 importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
-    # via -r requirements/base.txt
+    # via -r requirements/static/pkg/linux.in
 jaraco.functools==2.0
     # via tempora
 jinja2==2.11.3

--- a/requirements/static/pkg/py3.6/linux.txt
+++ b/requirements/static/pkg/py3.6/linux.txt
@@ -30,6 +30,8 @@ idna==2.8
     # via requests
 immutables==0.14
     # via contextvars
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
+    # via -r requirements/base.txt
 jaraco.functools==2.0
     # via tempora
 jinja2==2.11.3
@@ -81,10 +83,14 @@ tempora==1.14.1
     # via portend
 timelib==0.2.5
     # via -r requirements/static/pkg/linux.in
+typing-extensions==3.10.0.0
+    # via importlib-metadata
 urllib3==1.26.6
     # via requests
 zc.lockfile==1.4
     # via cherrypy
+zipp==3.5.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/pkg/py3.7/darwin.txt
+++ b/requirements/static/pkg/py3.7/darwin.txt
@@ -37,7 +37,7 @@ idna==2.8
 immutables==0.15
     # via contextvars
 importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
-    # via -r requirements/base.txt
+    # via -r requirements/darwin.txt
 jaraco.functools==2.0
     # via
     #   cheroot

--- a/requirements/static/pkg/py3.7/darwin.txt
+++ b/requirements/static/pkg/py3.7/darwin.txt
@@ -36,6 +36,8 @@ idna==2.8
     #   requests
 immutables==0.15
     # via contextvars
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
+    # via -r requirements/base.txt
 jaraco.functools==2.0
     # via
     #   cheroot
@@ -103,12 +105,16 @@ tempora==1.14.1
     # via portend
 timelib==0.2.5
     # via -r requirements/darwin.txt
+typing-extensions==3.10.0.0
+    # via importlib-metadata
 urllib3==1.26.6
     # via requests
 vultr==1.0.1
     # via -r requirements/darwin.txt
 zc.lockfile==2.0
     # via cherrypy
+zipp==3.5.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/pkg/py3.7/freebsd.txt
+++ b/requirements/static/pkg/py3.7/freebsd.txt
@@ -30,6 +30,8 @@ idna==2.8
     # via requests
 immutables==0.15
     # via contextvars
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
+    # via -r requirements/base.txt
 jaraco.functools==2.0
     # via tempora
 jinja2==2.11.3
@@ -81,10 +83,14 @@ tempora==1.14.1
     # via portend
 timelib==0.2.5
     # via -r requirements/static/pkg/freebsd.in
+typing-extensions==3.10.0.0
+    # via importlib-metadata
 urllib3==1.26.6
     # via requests
 zc.lockfile==1.4
     # via cherrypy
+zipp==3.5.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/pkg/py3.7/freebsd.txt
+++ b/requirements/static/pkg/py3.7/freebsd.txt
@@ -31,7 +31,7 @@ idna==2.8
 immutables==0.15
     # via contextvars
 importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
-    # via -r requirements/base.txt
+    # via -r requirements/static/pkg/freebsd.in
 jaraco.functools==2.0
     # via tempora
 jinja2==2.11.3

--- a/requirements/static/pkg/py3.7/linux.txt
+++ b/requirements/static/pkg/py3.7/linux.txt
@@ -28,6 +28,8 @@ idna==2.8
     # via requests
 immutables==0.15
     # via contextvars
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
+    # via -r requirements/base.txt
 jaraco.functools==2.0
     # via tempora
 jinja2==2.11.3
@@ -79,10 +81,14 @@ tempora==1.14.1
     # via portend
 timelib==0.2.5
     # via -r requirements/static/pkg/linux.in
+typing-extensions==3.10.0.0
+    # via importlib-metadata
 urllib3==1.26.6
     # via requests
 zc.lockfile==1.4
     # via cherrypy
+zipp==3.5.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/pkg/py3.7/linux.txt
+++ b/requirements/static/pkg/py3.7/linux.txt
@@ -29,7 +29,7 @@ idna==2.8
 immutables==0.15
     # via contextvars
 importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
-    # via -r requirements/base.txt
+    # via -r requirements/static/pkg/linux.in
 jaraco.functools==2.0
     # via tempora
 jinja2==2.11.3

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -34,6 +34,8 @@ idna==2.8
     # via requests
 immutables==0.15
     # via contextvars
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
+    # via -r requirements/base.txt
 ioloop==0.1a0
     # via -r requirements/windows.txt
 jaraco.classes==3.2.1
@@ -125,7 +127,9 @@ tempora==1.14.1
 timelib==0.2.5
     # via -r requirements/windows.txt
 typing-extensions==3.10.0.0
-    # via gitpython
+    # via
+    #   gitpython
+    #   importlib-metadata
 urllib3==1.26.6
     # via requests
 wheel==0.36.2
@@ -134,6 +138,8 @@ wmi==1.5.1
     # via -r requirements/windows.txt
 zc.lockfile==2.0
     # via cherrypy
+zipp==3.5.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -35,7 +35,7 @@ idna==2.8
 immutables==0.15
     # via contextvars
 importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
-    # via -r requirements/base.txt
+    # via -r requirements/windows.txt
 ioloop==0.1a0
     # via -r requirements/windows.txt
 jaraco.classes==3.2.1

--- a/requirements/static/pkg/py3.8/darwin.txt
+++ b/requirements/static/pkg/py3.8/darwin.txt
@@ -36,6 +36,8 @@ idna==2.8
     #   requests
 immutables==0.15
     # via contextvars
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
+    # via -r requirements/base.txt
 jaraco.functools==2.0
     # via
     #   cheroot
@@ -109,6 +111,8 @@ vultr==1.0.1
     # via -r requirements/darwin.txt
 zc.lockfile==2.0
     # via cherrypy
+zipp==3.5.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/pkg/py3.8/darwin.txt
+++ b/requirements/static/pkg/py3.8/darwin.txt
@@ -37,7 +37,7 @@ idna==2.8
 immutables==0.15
     # via contextvars
 importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
-    # via -r requirements/base.txt
+    # via -r requirements/darwin.txt
 jaraco.functools==2.0
     # via
     #   cheroot

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -30,6 +30,8 @@ idna==2.8
     # via requests
 immutables==0.15
     # via contextvars
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
+    # via -r requirements/base.txt
 jaraco.functools==2.0
     # via tempora
 jinja2==2.11.3
@@ -85,6 +87,8 @@ urllib3==1.26.6
     # via requests
 zc.lockfile==1.4
     # via cherrypy
+zipp==3.5.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -31,7 +31,7 @@ idna==2.8
 immutables==0.15
     # via contextvars
 importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
-    # via -r requirements/base.txt
+    # via -r requirements/static/pkg/freebsd.in
 jaraco.functools==2.0
     # via tempora
 jinja2==2.11.3

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -29,7 +29,7 @@ idna==2.8
 immutables==0.15
     # via contextvars
 importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
-    # via -r requirements/base.txt
+    # via -r requirements/static/pkg/linux.in
 jaraco.functools==2.0
     # via tempora
 jinja2==2.11.3

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -28,6 +28,8 @@ idna==2.8
     # via requests
 immutables==0.15
     # via contextvars
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
+    # via -r requirements/base.txt
 jaraco.functools==2.0
     # via tempora
 jinja2==2.11.3
@@ -83,6 +85,8 @@ urllib3==1.26.6
     # via requests
 zc.lockfile==1.4
     # via cherrypy
+zipp==3.5.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -35,7 +35,7 @@ idna==2.8
 immutables==0.15
     # via contextvars
 importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
-    # via -r requirements/base.txt
+    # via -r requirements/windows.txt
 ioloop==0.1a0
     # via -r requirements/windows.txt
 jaraco.classes==3.2.1

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -34,6 +34,8 @@ idna==2.8
     # via requests
 immutables==0.15
     # via contextvars
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
+    # via -r requirements/base.txt
 ioloop==0.1a0
     # via -r requirements/windows.txt
 jaraco.classes==3.2.1
@@ -132,6 +134,8 @@ wmi==1.5.1
     # via -r requirements/windows.txt
 zc.lockfile==2.0
     # via cherrypy
+zipp==3.5.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -36,6 +36,8 @@ idna==2.8
     #   requests
 immutables==0.15
     # via contextvars
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
+    # via -r requirements/base.txt
 jaraco.functools==2.0
     # via
     #   cheroot
@@ -109,6 +111,8 @@ vultr==1.0.1
     # via -r requirements/darwin.txt
 zc.lockfile==2.0
     # via cherrypy
+zipp==3.5.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -37,7 +37,7 @@ idna==2.8
 immutables==0.15
     # via contextvars
 importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
-    # via -r requirements/base.txt
+    # via -r requirements/darwin.txt
 jaraco.functools==2.0
     # via
     #   cheroot

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -30,6 +30,8 @@ idna==2.8
     # via requests
 immutables==0.15
     # via contextvars
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
+    # via -r requirements/base.txt
 jaraco.functools==2.0
     # via tempora
 jinja2==2.11.3
@@ -85,6 +87,8 @@ urllib3==1.26.6
     # via requests
 zc.lockfile==1.4
     # via cherrypy
+zipp==3.5.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -31,7 +31,7 @@ idna==2.8
 immutables==0.15
     # via contextvars
 importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
-    # via -r requirements/base.txt
+    # via -r requirements/static/pkg/freebsd.in
 jaraco.functools==2.0
     # via tempora
 jinja2==2.11.3

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -29,7 +29,7 @@ idna==2.8
 immutables==0.15
     # via contextvars
 importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
-    # via -r requirements/base.txt
+    # via -r requirements/static/pkg/linux.in
 jaraco.functools==2.0
     # via tempora
 jinja2==2.11.3

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -28,6 +28,8 @@ idna==2.8
     # via requests
 immutables==0.15
     # via contextvars
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
+    # via -r requirements/base.txt
 jaraco.functools==2.0
     # via tempora
 jinja2==2.11.3
@@ -83,6 +85,8 @@ urllib3==1.26.6
     # via requests
 zc.lockfile==1.4
     # via cherrypy
+zipp==3.5.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -35,7 +35,7 @@ idna==2.8
 immutables==0.15
     # via contextvars
 importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
-    # via -r requirements/base.txt
+    # via -r requirements/windows.txt
 ioloop==0.1a0
     # via -r requirements/windows.txt
 jaraco.classes==3.2.1

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -34,6 +34,8 @@ idna==2.8
     # via requests
 immutables==0.15
     # via contextvars
+importlib-metadata==4.6.4 ; python_version >= "3.6" and python_version < "3.10"
+    # via -r requirements/base.txt
 ioloop==0.1a0
     # via -r requirements/windows.txt
 jaraco.classes==3.2.1
@@ -132,6 +134,8 @@ wmi==1.5.1
     # via -r requirements/windows.txt
 zc.lockfile==2.0
     # via cherrypy
+zipp==3.5.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -33,3 +33,5 @@ timelib>=0.2.5
 #
 # watchdog>=2.1.3
 wheel>=0.36.2
+
+importlib_metadata>=3.3.0; python_version >= '3.6' and python_version < '3.10'

--- a/salt/_compat.py
+++ b/salt/_compat.py
@@ -10,3 +10,22 @@ if sys.version_info >= (3, 9, 5):
     import ipaddress
 else:
     import salt.ext.ipaddress as ipaddress
+
+
+if sys.version_info >= (3, 6):
+    # importlib_metadata available for python version lower than 3.6 do not
+    # include the functionality we need.
+    try:
+        import importlib_metadata
+
+        importlib_metadata_version = [
+            int(part)
+            for part in importlib_metadata.version("importlib_metadata").split(".")
+            if part.isdigit()
+        ]
+        if tuple(importlib_metadata_version) < (3, 3, 0):
+            # Use the vendored importlib_metadata
+            import salt.ext.importlib_metadata as importlib_metadata
+    except ImportError:
+        # Use the vendored importlib_metadata
+        import salt.ext.importlib_metadata as importlib_metadata

--- a/salt/ext/importlib_metadata/__init__.py
+++ b/salt/ext/importlib_metadata/__init__.py
@@ -1,0 +1,687 @@
+# This is import_module version 3.3.0 vendored into Salt Project
+#
+# Copyright 2017-2019 Jason R. Coombs, Barry Warsaw
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# THIS CODE SHOULD BE REMOVED WITH importlib-metadata >= 3.3.0 IS AVAILABLE
+# AS A SYSTEM PACKAGE ON ALL THE PLATFORMS FOR WHICH SALT BUILDS PACKAGES OR
+# WHEN THE MINIMUM PYTHON VERSION IS 3.10
+
+# pylint: skip-file
+import os
+import re
+import abc
+import csv
+import sys
+import email
+import pathlib
+import operator
+import functools
+import itertools
+import posixpath
+import collections
+
+try:
+    import zipp
+except ImportError:
+    import salt.ext.zipp as zipp
+
+from ._compat import (
+    NullFinder,
+    PyPy_repr,
+    install,
+    Protocol,
+)
+
+from configparser import ConfigParser
+from contextlib import suppress
+from importlib import import_module
+from importlib.abc import MetaPathFinder
+from itertools import starmap
+from typing import Any, List, Optional, TypeVar, Union
+
+
+__all__ = [
+    'Distribution',
+    'DistributionFinder',
+    'PackageNotFoundError',
+    'distribution',
+    'distributions',
+    'entry_points',
+    'files',
+    'metadata',
+    'requires',
+    'version',
+]
+
+
+class PackageNotFoundError(ModuleNotFoundError):
+    """The package was not found."""
+
+    def __str__(self):
+        tmpl = "No package metadata was found for {self.name}"
+        return tmpl.format(**locals())
+
+    @property
+    def name(self):
+        (name,) = self.args
+        return name
+
+
+class EntryPoint(
+    PyPy_repr, collections.namedtuple('EntryPointBase', 'name value group')
+):
+    """An entry point as defined by Python packaging conventions.
+
+    See `the packaging docs on entry points
+    <https://packaging.python.org/specifications/entry-points/>`_
+    for more information.
+    """
+
+    pattern = re.compile(
+        r'(?P<module>[\w.]+)\s*'
+        r'(:\s*(?P<attr>[\w.]+))?\s*'
+        r'(?P<extras>\[.*\])?\s*$'
+    )
+    """
+    A regular expression describing the syntax for an entry point,
+    which might look like:
+
+        - module
+        - package.module
+        - package.module:attribute
+        - package.module:object.attribute
+        - package.module:attr [extra1, extra2]
+
+    Other combinations are possible as well.
+
+    The expression is lenient about whitespace around the ':',
+    following the attr, and following any extras.
+    """
+
+    dist: Optional['Distribution'] = None
+
+    def load(self):
+        """Load the entry point from its definition. If only a module
+        is indicated by the value, return that module. Otherwise,
+        return the named object.
+        """
+        match = self.pattern.match(self.value)
+        module = import_module(match.group('module'))
+        attrs = filter(None, (match.group('attr') or '').split('.'))
+        return functools.reduce(getattr, attrs, module)
+
+    @property
+    def module(self):
+        match = self.pattern.match(self.value)
+        return match.group('module')
+
+    @property
+    def attr(self):
+        match = self.pattern.match(self.value)
+        return match.group('attr')
+
+    @property
+    def extras(self):
+        match = self.pattern.match(self.value)
+        return list(re.finditer(r'\w+', match.group('extras') or ''))
+
+    @classmethod
+    def _from_config(cls, config):
+        return (
+            cls(name, value, group)
+            for group in config.sections()
+            for name, value in config.items(group)
+        )
+
+    @classmethod
+    def _from_text(cls, text):
+        config = ConfigParser(delimiters='=')
+        # case sensitive: https://stackoverflow.com/q/1611799/812183
+        config.optionxform = str
+        config.read_string(text)
+        return cls._from_config(config)
+
+    @classmethod
+    def _from_text_for(cls, text, dist):
+        return (ep._for(dist) for ep in cls._from_text(text))
+
+    def _for(self, dist):
+        self.dist = dist
+        return self
+
+    def __iter__(self):
+        """
+        Supply iter so one may construct dicts of EntryPoints easily.
+        """
+        return iter((self.name, self))
+
+    def __reduce__(self):
+        return (
+            self.__class__,
+            (self.name, self.value, self.group),
+        )
+
+
+class PackagePath(pathlib.PurePosixPath):
+    """A reference to a path in a package"""
+
+    def read_text(self, encoding='utf-8'):
+        with self.locate().open(encoding=encoding) as stream:
+            return stream.read()
+
+    def read_binary(self):
+        with self.locate().open('rb') as stream:
+            return stream.read()
+
+    def locate(self):
+        """Return a path-like object for this path"""
+        return self.dist.locate_file(self)
+
+
+class FileHash:
+    def __init__(self, spec):
+        self.mode, _, self.value = spec.partition('=')
+
+    def __repr__(self):
+        return '<FileHash mode: {} value: {}>'.format(self.mode, self.value)
+
+
+_T = TypeVar("_T")
+
+
+class PackageMetadata(Protocol):
+    def __len__(self) -> int:
+        ...  # pragma: no cover
+
+    def __contains__(self, item: str) -> bool:
+        ...  # pragma: no cover
+
+    def __getitem__(self, key: str) -> str:
+        ...  # pragma: no cover
+
+    def get_all(self, name: str, failobj: _T = ...) -> Union[List[Any], _T]:
+        """
+        Return all values associated with a possibly multi-valued key.
+        """
+
+
+class Distribution:
+    """A Python distribution package."""
+
+    @abc.abstractmethod
+    def read_text(self, filename):
+        """Attempt to load metadata file given by the name.
+
+        :param filename: The name of the file in the distribution info.
+        :return: The text if found, otherwise None.
+        """
+
+    @abc.abstractmethod
+    def locate_file(self, path):
+        """
+        Given a path to a file in this distribution, return a path
+        to it.
+        """
+
+    @classmethod
+    def from_name(cls, name):
+        """Return the Distribution for the given package name.
+
+        :param name: The name of the distribution package to search for.
+        :return: The Distribution instance (or subclass thereof) for the named
+            package, if found.
+        :raises PackageNotFoundError: When the named package's distribution
+            metadata cannot be found.
+        """
+        for resolver in cls._discover_resolvers():
+            dists = resolver(DistributionFinder.Context(name=name))
+            dist = next(iter(dists), None)
+            if dist is not None:
+                return dist
+        else:
+            raise PackageNotFoundError(name)
+
+    @classmethod
+    def discover(cls, **kwargs):
+        """Return an iterable of Distribution objects for all packages.
+
+        Pass a ``context`` or pass keyword arguments for constructing
+        a context.
+
+        :context: A ``DistributionFinder.Context`` object.
+        :return: Iterable of Distribution objects for all packages.
+        """
+        context = kwargs.pop('context', None)
+        if context and kwargs:
+            raise ValueError("cannot accept context and kwargs")
+        context = context or DistributionFinder.Context(**kwargs)
+        return itertools.chain.from_iterable(
+            resolver(context) for resolver in cls._discover_resolvers()
+        )
+
+    @staticmethod
+    def at(path):
+        """Return a Distribution for the indicated metadata path
+
+        :param path: a string or path-like object
+        :return: a concrete Distribution instance for the path
+        """
+        return PathDistribution(pathlib.Path(path))
+
+    @staticmethod
+    def _discover_resolvers():
+        """Search the meta_path for resolvers."""
+        declared = (
+            getattr(finder, 'find_distributions', None) for finder in sys.meta_path
+        )
+        return filter(None, declared)
+
+    @classmethod
+    def _local(cls, root='.'):
+        from pep517 import build, meta
+
+        system = build.compat_system(root)
+        builder = functools.partial(
+            meta.build,
+            source_dir=root,
+            system=system,
+        )
+        return PathDistribution(zipp.Path(meta.build_as_zip(builder)))
+
+    @property
+    def metadata(self) -> PackageMetadata:
+        """Return the parsed metadata for this Distribution.
+
+        The returned object will have keys that name the various bits of
+        metadata.  See PEP 566 for details.
+        """
+        text = (
+            self.read_text('METADATA')
+            or self.read_text('PKG-INFO')
+            # This last clause is here to support old egg-info files.  Its
+            # effect is to just end up using the PathDistribution's self._path
+            # (which points to the egg-info file) attribute unchanged.
+            or self.read_text('')
+        )
+        return email.message_from_string(text)
+
+    @property
+    def name(self):
+        """Return the 'Name' metadata for the distribution package."""
+        return self.metadata['Name']
+
+    @property
+    def version(self):
+        """Return the 'Version' metadata for the distribution package."""
+        return self.metadata['Version']
+
+    @property
+    def entry_points(self):
+        return list(EntryPoint._from_text_for(self.read_text('entry_points.txt'), self))
+
+    @property
+    def files(self):
+        """Files in this distribution.
+
+        :return: List of PackagePath for this distribution or None
+
+        Result is `None` if the metadata file that enumerates files
+        (i.e. RECORD for dist-info or SOURCES.txt for egg-info) is
+        missing.
+        Result may be empty if the metadata exists but is empty.
+        """
+        file_lines = self._read_files_distinfo() or self._read_files_egginfo()
+
+        def make_file(name, hash=None, size_str=None):
+            result = PackagePath(name)
+            result.hash = FileHash(hash) if hash else None
+            result.size = int(size_str) if size_str else None
+            result.dist = self
+            return result
+
+        return file_lines and list(starmap(make_file, csv.reader(file_lines)))
+
+    def _read_files_distinfo(self):
+        """
+        Read the lines of RECORD
+        """
+        text = self.read_text('RECORD')
+        return text and text.splitlines()
+
+    def _read_files_egginfo(self):
+        """
+        SOURCES.txt might contain literal commas, so wrap each line
+        in quotes.
+        """
+        text = self.read_text('SOURCES.txt')
+        return text and map('"{}"'.format, text.splitlines())
+
+    @property
+    def requires(self):
+        """Generated requirements specified for this Distribution"""
+        reqs = self._read_dist_info_reqs() or self._read_egg_info_reqs()
+        return reqs and list(reqs)
+
+    def _read_dist_info_reqs(self):
+        return self.metadata.get_all('Requires-Dist')
+
+    def _read_egg_info_reqs(self):
+        source = self.read_text('requires.txt')
+        return source and self._deps_from_requires_text(source)
+
+    @classmethod
+    def _deps_from_requires_text(cls, source):
+        section_pairs = cls._read_sections(source.splitlines())
+        sections = {
+            section: list(map(operator.itemgetter('line'), results))
+            for section, results in itertools.groupby(
+                section_pairs, operator.itemgetter('section')
+            )
+        }
+        return cls._convert_egg_info_reqs_to_simple_reqs(sections)
+
+    @staticmethod
+    def _read_sections(lines):
+        section = None
+        for line in filter(None, lines):
+            section_match = re.match(r'\[(.*)\]$', line)
+            if section_match:
+                section = section_match.group(1)
+                continue
+            yield locals()
+
+    @staticmethod
+    def _convert_egg_info_reqs_to_simple_reqs(sections):
+        """
+        Historically, setuptools would solicit and store 'extra'
+        requirements, including those with environment markers,
+        in separate sections. More modern tools expect each
+        dependency to be defined separately, with any relevant
+        extras and environment markers attached directly to that
+        requirement. This method converts the former to the
+        latter. See _test_deps_from_requires_text for an example.
+        """
+
+        def make_condition(name):
+            return name and 'extra == "{name}"'.format(name=name)
+
+        def parse_condition(section):
+            section = section or ''
+            extra, sep, markers = section.partition(':')
+            if extra and markers:
+                markers = '({markers})'.format(markers=markers)
+            conditions = list(filter(None, [markers, make_condition(extra)]))
+            return '; ' + ' and '.join(conditions) if conditions else ''
+
+        for section, deps in sections.items():
+            for dep in deps:
+                yield dep + parse_condition(section)
+
+
+class DistributionFinder(MetaPathFinder):
+    """
+    A MetaPathFinder capable of discovering installed distributions.
+    """
+
+    class Context:
+        """
+        Keyword arguments presented by the caller to
+        ``distributions()`` or ``Distribution.discover()``
+        to narrow the scope of a search for distributions
+        in all DistributionFinders.
+
+        Each DistributionFinder may expect any parameters
+        and should attempt to honor the canonical
+        parameters defined below when appropriate.
+        """
+
+        name = None
+        """
+        Specific name for which a distribution finder should match.
+        A name of ``None`` matches all distributions.
+        """
+
+        def __init__(self, **kwargs):
+            vars(self).update(kwargs)
+
+        @property
+        def path(self):
+            """
+            The path that a distribution finder should search.
+
+            Typically refers to Python package paths and defaults
+            to ``sys.path``.
+            """
+            return vars(self).get('path', sys.path)
+
+    @abc.abstractmethod
+    def find_distributions(self, context=Context()):
+        """
+        Find distributions.
+
+        Return an iterable of all Distribution instances capable of
+        loading the metadata for packages matching the ``context``,
+        a DistributionFinder.Context instance.
+        """
+
+
+class FastPath:
+    """
+    Micro-optimized class for searching a path for
+    children.
+    """
+
+    def __init__(self, root):
+        self.root = str(root)
+        self.base = os.path.basename(self.root).lower()
+
+    def joinpath(self, child):
+        return pathlib.Path(self.root, child)
+
+    def children(self):
+        with suppress(Exception):
+            return os.listdir(self.root or '')
+        with suppress(Exception):
+            return self.zip_children()
+        return []
+
+    def zip_children(self):
+        zip_path = zipp.Path(self.root)
+        names = zip_path.root.namelist()
+        self.joinpath = zip_path.joinpath
+
+        return dict.fromkeys(child.split(posixpath.sep, 1)[0] for child in names)
+
+    def search(self, name):
+        return (
+            self.joinpath(child)
+            for child in self.children()
+            if name.matches(child, self.base)
+        )
+
+
+class Prepared:
+    """
+    A prepared search for metadata on a possibly-named package.
+    """
+
+    normalized = None
+    suffixes = '.dist-info', '.egg-info'
+    exact_matches = [''][:0]
+
+    def __init__(self, name):
+        self.name = name
+        if name is None:
+            return
+        self.normalized = self.normalize(name)
+        self.exact_matches = [self.normalized + suffix for suffix in self.suffixes]
+
+    @staticmethod
+    def normalize(name):
+        """
+        PEP 503 normalization plus dashes as underscores.
+        """
+        return re.sub(r"[-_.]+", "-", name).lower().replace('-', '_')
+
+    @staticmethod
+    def legacy_normalize(name):
+        """
+        Normalize the package name as found in the convention in
+        older packaging tools versions and specs.
+        """
+        return name.lower().replace('-', '_')
+
+    def matches(self, cand, base):
+        low = cand.lower()
+        pre, ext = os.path.splitext(low)
+        name, sep, rest = pre.partition('-')
+        return (
+            low in self.exact_matches
+            or ext in self.suffixes
+            and (not self.normalized or name.replace('.', '_') == self.normalized)
+            # legacy case:
+            or self.is_egg(base)
+            and low == 'egg-info'
+        )
+
+    def is_egg(self, base):
+        normalized = self.legacy_normalize(self.name or '')
+        prefix = normalized + '-' if normalized else ''
+        versionless_egg_name = normalized + '.egg' if self.name else ''
+        return (
+            base == versionless_egg_name
+            or base.startswith(prefix)
+            and base.endswith('.egg')
+        )
+
+
+@install
+class MetadataPathFinder(NullFinder, DistributionFinder):
+    """A degenerate finder for distribution packages on the file system.
+
+    This finder supplies only a find_distributions() method for versions
+    of Python that do not have a PathFinder find_distributions().
+    """
+
+    def find_distributions(self, context=DistributionFinder.Context()):
+        """
+        Find distributions.
+
+        Return an iterable of all Distribution instances capable of
+        loading the metadata for packages matching ``context.name``
+        (or all names if ``None`` indicated) along the paths in the list
+        of directories ``context.path``.
+        """
+        found = self._search_paths(context.name, context.path)
+        return map(PathDistribution, found)
+
+    @classmethod
+    def _search_paths(cls, name, paths):
+        """Find metadata directories in paths heuristically."""
+        return itertools.chain.from_iterable(
+            path.search(Prepared(name)) for path in map(FastPath, paths)
+        )
+
+
+class PathDistribution(Distribution):
+    def __init__(self, path):
+        """Construct a distribution from a path to the metadata directory.
+
+        :param path: A pathlib.Path or similar object supporting
+                     .joinpath(), __div__, .parent, and .read_text().
+        """
+        self._path = path
+
+    def read_text(self, filename):
+        with suppress(
+            FileNotFoundError,
+            IsADirectoryError,
+            KeyError,
+            NotADirectoryError,
+            PermissionError,
+        ):
+            return self._path.joinpath(filename).read_text(encoding='utf-8')
+
+    read_text.__doc__ = Distribution.read_text.__doc__
+
+    def locate_file(self, path):
+        return self._path.parent / path
+
+
+def distribution(distribution_name):
+    """Get the ``Distribution`` instance for the named package.
+
+    :param distribution_name: The name of the distribution package as a string.
+    :return: A ``Distribution`` instance (or subclass thereof).
+    """
+    return Distribution.from_name(distribution_name)
+
+
+def distributions(**kwargs):
+    """Get all ``Distribution`` instances in the current environment.
+
+    :return: An iterable of ``Distribution`` instances.
+    """
+    return Distribution.discover(**kwargs)
+
+
+def metadata(distribution_name) -> PackageMetadata:
+    """Get the metadata for the named package.
+
+    :param distribution_name: The name of the distribution package to query.
+    :return: A PackageMetadata containing the parsed metadata.
+    """
+    return Distribution.from_name(distribution_name).metadata
+
+
+def version(distribution_name):
+    """Get the version string for the named package.
+
+    :param distribution_name: The name of the distribution package to query.
+    :return: The version string for the package as defined in the package's
+        "Version" metadata key.
+    """
+    return distribution(distribution_name).version
+
+
+def entry_points():
+    """Return EntryPoint objects for all installed packages.
+
+    :return: EntryPoint objects for all installed packages.
+    """
+    eps = itertools.chain.from_iterable(dist.entry_points for dist in distributions())
+    by_group = operator.attrgetter('group')
+    ordered = sorted(eps, key=by_group)
+    grouped = itertools.groupby(ordered, by_group)
+    return {group: tuple(eps) for group, eps in grouped}
+
+
+def files(distribution_name):
+    """Return a list of files for the named package.
+
+    :param distribution_name: The name of the distribution package to query.
+    :return: List of files composing the distribution.
+    """
+    return distribution(distribution_name).files
+
+
+def requires(distribution_name):
+    """
+    Return a list of requirements for the named package.
+
+    :return: An iterator of requirements, suitable for
+    packaging.requirement.Requirement.
+    """
+    return distribution(distribution_name).requires

--- a/salt/ext/importlib_metadata/_compat.py
+++ b/salt/ext/importlib_metadata/_compat.py
@@ -1,0 +1,107 @@
+# This is import_module version 3.3.0 vendored into Salt Project
+#
+# Copyright 2017-2019 Jason R. Coombs, Barry Warsaw
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# THIS CODE SHOULD BE REMOVED WITH importlib-metadata >= 3.3.0 IS AVAILABLE
+# AS A SYSTEM PACKAGE ON ALL THE PLATFORMS FOR WHICH SALT BUILDS PACKAGES OR
+# WHEN THE MINIMUM PYTHON VERSION IS 3.10
+
+# pylint: skip-file
+import sys
+
+
+__all__ = ['install', 'NullFinder', 'PyPy_repr', 'Protocol']
+
+
+try:
+    from typing import Protocol
+except ImportError:  # pragma: no cover
+    """
+    pytest-mypy complains here because:
+    error: Incompatible import of "Protocol" (imported name has type
+    "typing_extensions._SpecialForm", local name has type "typing._SpecialForm")
+    """
+    from salt.ext.typing_extensions import Protocol  # type: ignore
+
+
+def install(cls):
+    """
+    Class decorator for installation on sys.meta_path.
+
+    Adds the backport DistributionFinder to sys.meta_path and
+    attempts to disable the finder functionality of the stdlib
+    DistributionFinder.
+    """
+    sys.meta_path.append(cls())
+    disable_stdlib_finder()
+    return cls
+
+
+def disable_stdlib_finder():
+    """
+    Give the backport primacy for discovering path-based distributions
+    by monkey-patching the stdlib O_O.
+
+    See #91 for more background for rationale on this sketchy
+    behavior.
+    """
+
+    def matches(finder):
+        return getattr(
+            finder, '__module__', None
+        ) == '_frozen_importlib_external' and hasattr(finder, 'find_distributions')
+
+    for finder in filter(matches, sys.meta_path):  # pragma: nocover
+        del finder.find_distributions
+
+
+class NullFinder:
+    """
+    A "Finder" (aka "MetaClassFinder") that never finds any modules,
+    but may find distributions.
+    """
+
+    @staticmethod
+    def find_spec(*args, **kwargs):
+        return None
+
+    # In Python 2, the import system requires finders
+    # to have a find_module() method, but this usage
+    # is deprecated in Python 3 in favor of find_spec().
+    # For the purposes of this finder (i.e. being present
+    # on sys.meta_path but having no other import
+    # system functionality), the two methods are identical.
+    find_module = find_spec
+
+
+class PyPy_repr:
+    """
+    Override repr for EntryPoint objects on PyPy to avoid __iter__ access.
+    Ref #97, #102.
+    """
+
+    affected = hasattr(sys, 'pypy_version_info')
+
+    def __compat_repr__(self):  # pragma: nocover
+        def make_param(name):
+            value = getattr(self, name)
+            return '{name}={value!r}'.format(**locals())
+
+        params = ', '.join(map(make_param, self._fields))
+        return 'EntryPoint({params})'.format(**locals())
+
+    if affected:  # pragma: nocover
+        __repr__ = __compat_repr__
+    del affected

--- a/salt/ext/typing_extensions.py
+++ b/salt/ext/typing_extensions.py
@@ -1,0 +1,3101 @@
+# This is https://github.com/python/typing/blob/3.10.0.0/typing_extensions/src_py3/typing_extensions.py
+#
+# A. HISTORY OF THE SOFTWARE
+# ==========================
+#
+# Python was created in the early 1990s by Guido van Rossum at Stichting
+# Mathematisch Centrum (CWI, see http://www.cwi.nl) in the Netherlands
+# as a successor of a language called ABC.  Guido remains Python's
+# principal author, although it includes many contributions from others.
+#
+# In 1995, Guido continued his work on Python at the Corporation for
+# National Research Initiatives (CNRI, see http://www.cnri.reston.va.us)
+# in Reston, Virginia where he released several versions of the
+# software.
+#
+# In May 2000, Guido and the Python core development team moved to
+# BeOpen.com to form the BeOpen PythonLabs team.  In October of the same
+# year, the PythonLabs team moved to Digital Creations (now Zope
+# Corporation, see http://www.zope.com).  In 2001, the Python Software
+# Foundation (PSF, see http://www.python.org/psf/) was formed, a
+# non-profit organization created specifically to own Python-related
+# Intellectual Property.  Zope Corporation is a sponsoring member of
+# the PSF.
+#
+# All Python releases are Open Source (see http://www.opensource.org for
+# the Open Source Definition).  Historically, most, but not all, Python
+# releases have also been GPL-compatible; the table below summarizes
+# the various releases.
+#
+#     Release         Derived     Year        Owner       GPL-
+#                     from                                compatible? (1)
+#
+#     0.9.0 thru 1.2              1991-1995   CWI         yes
+#     1.3 thru 1.5.2  1.2         1995-1999   CNRI        yes
+#     1.6             1.5.2       2000        CNRI        no
+#     2.0             1.6         2000        BeOpen.com  no
+#     1.6.1           1.6         2001        CNRI        yes (2)
+#     2.1             2.0+1.6.1   2001        PSF         no
+#     2.0.1           2.0+1.6.1   2001        PSF         yes
+#     2.1.1           2.1+2.0.1   2001        PSF         yes
+#     2.1.2           2.1.1       2002        PSF         yes
+#     2.1.3           2.1.2       2002        PSF         yes
+#     2.2 and above   2.1.1       2001-now    PSF         yes
+#
+# Footnotes:
+#
+# (1) GPL-compatible doesn't mean that we're distributing Python under
+#     the GPL.  All Python licenses, unlike the GPL, let you distribute
+#     a modified version without making your changes open source.  The
+#     GPL-compatible licenses make it possible to combine Python with
+#     other software that is released under the GPL; the others don't.
+#
+# (2) According to Richard Stallman, 1.6.1 is not GPL-compatible,
+#     because its license has a choice of law clause.  According to
+#     CNRI, however, Stallman's lawyer has told CNRI's lawyer that 1.6.1
+#     is "not incompatible" with the GPL.
+#
+# Thanks to the many outside volunteers who have worked under Guido's
+# direction to make these releases possible.
+#
+#
+# B. TERMS AND CONDITIONS FOR ACCESSING OR OTHERWISE USING PYTHON
+# ===============================================================
+#
+# PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+# --------------------------------------------
+#
+# 1. This LICENSE AGREEMENT is between the Python Software Foundation
+# ("PSF"), and the Individual or Organization ("Licensee") accessing and
+# otherwise using this software ("Python") in source or binary form and
+# its associated documentation.
+#
+# 2. Subject to the terms and conditions of this License Agreement, PSF hereby
+# grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+# analyze, test, perform and/or display publicly, prepare derivative works,
+# distribute, and otherwise use Python alone or in any derivative version,
+# provided, however, that PSF's License Agreement and PSF's notice of copyright,
+# i.e., "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+# 2011, 2012, 2013, 2014 Python Software Foundation; All Rights Reserved" are
+# retained in Python alone or in any derivative version prepared by Licensee.
+#
+# 3. In the event Licensee prepares a derivative work that is based on
+# or incorporates Python or any part thereof, and wants to make
+# the derivative work available to others as provided herein, then
+# Licensee hereby agrees to include in any such work a brief summary of
+# the changes made to Python.
+#
+# 4. PSF is making Python available to Licensee on an "AS IS"
+# basis.  PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+# IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
+# DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+# FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
+# INFRINGE ANY THIRD PARTY RIGHTS.
+#
+# 5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+# FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+# A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
+# OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+#
+# 6. This License Agreement will automatically terminate upon a material
+# breach of its terms and conditions.
+#
+# 7. Nothing in this License Agreement shall be deemed to create any
+# relationship of agency, partnership, or joint venture between PSF and
+# Licensee.  This License Agreement does not grant permission to use PSF
+# trademarks or trade name in a trademark sense to endorse or promote
+# products or services of Licensee, or any third party.
+#
+# 8. By copying, installing or otherwise using Python, Licensee
+# agrees to be bound by the terms and conditions of this License
+# Agreement.
+#
+#
+# BEOPEN.COM LICENSE AGREEMENT FOR PYTHON 2.0
+# -------------------------------------------
+#
+# BEOPEN PYTHON OPEN SOURCE LICENSE AGREEMENT VERSION 1
+#
+# 1. This LICENSE AGREEMENT is between BeOpen.com ("BeOpen"), having an
+# office at 160 Saratoga Avenue, Santa Clara, CA 95051, and the
+# Individual or Organization ("Licensee") accessing and otherwise using
+# this software in source or binary form and its associated
+# documentation ("the Software").
+#
+# 2. Subject to the terms and conditions of this BeOpen Python License
+# Agreement, BeOpen hereby grants Licensee a non-exclusive,
+# royalty-free, world-wide license to reproduce, analyze, test, perform
+# and/or display publicly, prepare derivative works, distribute, and
+# otherwise use the Software alone or in any derivative version,
+# provided, however, that the BeOpen Python License is retained in the
+# Software, alone or in any derivative version prepared by Licensee.
+#
+# 3. BeOpen is making the Software available to Licensee on an "AS IS"
+# basis.  BEOPEN MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+# IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, BEOPEN MAKES NO AND
+# DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+# FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE WILL NOT
+# INFRINGE ANY THIRD PARTY RIGHTS.
+#
+# 4. BEOPEN SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF THE
+# SOFTWARE FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS
+# AS A RESULT OF USING, MODIFYING OR DISTRIBUTING THE SOFTWARE, OR ANY
+# DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+#
+# 5. This License Agreement will automatically terminate upon a material
+# breach of its terms and conditions.
+#
+# 6. This License Agreement shall be governed by and interpreted in all
+# respects by the law of the State of California, excluding conflict of
+# law provisions.  Nothing in this License Agreement shall be deemed to
+# create any relationship of agency, partnership, or joint venture
+# between BeOpen and Licensee.  This License Agreement does not grant
+# permission to use BeOpen trademarks or trade names in a trademark
+# sense to endorse or promote products or services of Licensee, or any
+# third party.  As an exception, the "BeOpen Python" logos available at
+# http://www.pythonlabs.com/logos.html may be used according to the
+# permissions granted on that web page.
+#
+# 7. By copying, installing or otherwise using the software, Licensee
+# agrees to be bound by the terms and conditions of this License
+# Agreement.
+#
+#
+# CNRI LICENSE AGREEMENT FOR PYTHON 1.6.1
+# ---------------------------------------
+#
+# 1. This LICENSE AGREEMENT is between the Corporation for National
+# Research Initiatives, having an office at 1895 Preston White Drive,
+# Reston, VA 20191 ("CNRI"), and the Individual or Organization
+# ("Licensee") accessing and otherwise using Python 1.6.1 software in
+# source or binary form and its associated documentation.
+#
+# 2. Subject to the terms and conditions of this License Agreement, CNRI
+# hereby grants Licensee a nonexclusive, royalty-free, world-wide
+# license to reproduce, analyze, test, perform and/or display publicly,
+# prepare derivative works, distribute, and otherwise use Python 1.6.1
+# alone or in any derivative version, provided, however, that CNRI's
+# License Agreement and CNRI's notice of copyright, i.e., "Copyright (c)
+# 1995-2001 Corporation for National Research Initiatives; All Rights
+# Reserved" are retained in Python 1.6.1 alone or in any derivative
+# version prepared by Licensee.  Alternately, in lieu of CNRI's License
+# Agreement, Licensee may substitute the following text (omitting the
+# quotes): "Python 1.6.1 is made available subject to the terms and
+# conditions in CNRI's License Agreement.  This Agreement together with
+# Python 1.6.1 may be located on the Internet using the following
+# unique, persistent identifier (known as a handle): 1895.22/1013.  This
+# Agreement may also be obtained from a proxy server on the Internet
+# using the following URL: http://hdl.handle.net/1895.22/1013".
+#
+# 3. In the event Licensee prepares a derivative work that is based on
+# or incorporates Python 1.6.1 or any part thereof, and wants to make
+# the derivative work available to others as provided herein, then
+# Licensee hereby agrees to include in any such work a brief summary of
+# the changes made to Python 1.6.1.
+#
+# 4. CNRI is making Python 1.6.1 available to Licensee on an "AS IS"
+# basis.  CNRI MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+# IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, CNRI MAKES NO AND
+# DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+# FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON 1.6.1 WILL NOT
+# INFRINGE ANY THIRD PARTY RIGHTS.
+#
+# 5. CNRI SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+# 1.6.1 FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+# A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 1.6.1,
+# OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+#
+# 6. This License Agreement will automatically terminate upon a material
+# breach of its terms and conditions.
+#
+# 7. This License Agreement shall be governed by the federal
+# intellectual property law of the United States, including without
+# limitation the federal copyright law, and, to the extent such
+# U.S. federal law does not apply, by the law of the Commonwealth of
+# Virginia, excluding Virginia's conflict of law provisions.
+# Notwithstanding the foregoing, with regard to derivative works based
+# on Python 1.6.1 that incorporate non-separable material that was
+# previously distributed under the GNU General Public License (GPL), the
+# law of the Commonwealth of Virginia shall govern this License
+# Agreement only as to issues arising under or with respect to
+# Paragraphs 4, 5, and 7 of this License Agreement.  Nothing in this
+# License Agreement shall be deemed to create any relationship of
+# agency, partnership, or joint venture between CNRI and Licensee.  This
+# License Agreement does not grant permission to use CNRI trademarks or
+# trade name in a trademark sense to endorse or promote products or
+# services of Licensee, or any third party.
+#
+# 8. By clicking on the "ACCEPT" button where indicated, or by copying,
+# installing or otherwise using Python 1.6.1, Licensee agrees to be
+# bound by the terms and conditions of this License Agreement.
+#
+#         ACCEPT
+#
+#
+# CWI LICENSE AGREEMENT FOR PYTHON 0.9.0 THROUGH 1.2
+# --------------------------------------------------
+#
+# Copyright (c) 1991 - 1995, Stichting Mathematisch Centrum Amsterdam,
+# The Netherlands.  All rights reserved.
+#
+# Permission to use, copy, modify, and distribute this software and its
+# documentation for any purpose and without fee is hereby granted,
+# provided that the above copyright notice appear in all copies and that
+# both that copyright notice and this permission notice appear in
+# supporting documentation, and that the name of Stichting Mathematisch
+# Centrum or CWI not be used in advertising or publicity pertaining to
+# distribution of the software without specific, written prior
+# permission.
+#
+# STICHTING MATHEMATISCH CENTRUM DISCLAIMS ALL WARRANTIES WITH REGARD TO
+# THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS, IN NO EVENT SHALL STICHTING MATHEMATISCH CENTRUM BE LIABLE
+# FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+# OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+# THIS CODE SHOULD BE REMOVED WITH importlib-metadata >= 3.3.0 IS AVAILABLE
+# AS A SYSTEM PACKAGE ON ALL THE PLATFORMS FOR WHICH SALT BUILDS PACKAGES OR
+# WHEN THE MINIMUM PYTHON VERSION IS 3.10
+
+# pylint: skip-file
+import abc
+import collections
+import contextlib
+import sys
+import typing
+import collections.abc as collections_abc
+import operator
+
+# These are used by Protocol implementation
+# We use internal typing helpers here, but this significantly reduces
+# code duplication. (Also this is only until Protocol is in typing.)
+from typing import Generic, Callable, TypeVar, Tuple
+
+# After PEP 560, internal typing API was substantially reworked.
+# This is especially important for Protocol class which uses internal APIs
+# quite extensivelly.
+PEP_560 = sys.version_info[:3] >= (3, 7, 0)
+
+if PEP_560:
+    GenericMeta = TypingMeta = type
+else:
+    from typing import GenericMeta, TypingMeta
+OLD_GENERICS = False
+try:
+    from typing import _type_vars, _next_in_mro, _type_check
+except ImportError:
+    OLD_GENERICS = True
+try:
+    from typing import _subs_tree  # noqa
+    SUBS_TREE = True
+except ImportError:
+    SUBS_TREE = False
+try:
+    from typing import _tp_cache
+except ImportError:
+    def _tp_cache(x):
+        return x
+try:
+    from typing import _TypingEllipsis, _TypingEmpty
+except ImportError:
+    class _TypingEllipsis:
+        pass
+
+    class _TypingEmpty:
+        pass
+
+
+# The two functions below are copies of typing internal helpers.
+# They are needed by _ProtocolMeta
+
+
+def _no_slots_copy(dct):
+    dict_copy = dict(dct)
+    if '__slots__' in dict_copy:
+        for slot in dict_copy['__slots__']:
+            dict_copy.pop(slot, None)
+    return dict_copy
+
+
+def _check_generic(cls, parameters):
+    if not cls.__parameters__:
+        raise TypeError("%s is not a generic class" % repr(cls))
+    alen = len(parameters)
+    elen = len(cls.__parameters__)
+    if alen != elen:
+        raise TypeError("Too %s parameters for %s; actual %s, expected %s" %
+                        ("many" if alen > elen else "few", repr(cls), alen, elen))
+
+
+if hasattr(typing, '_generic_new'):
+    _generic_new = typing._generic_new
+else:
+    # Note: The '_generic_new(...)' function is used as a part of the
+    # process of creating a generic type and was added to the typing module
+    # as of Python 3.5.3.
+    #
+    # We've defined '_generic_new(...)' below to exactly match the behavior
+    # implemented in older versions of 'typing' bundled with Python 3.5.0 to
+    # 3.5.2. This helps eliminate redundancy when defining collection types
+    # like 'Deque' later.
+    #
+    # See https://github.com/python/typing/pull/308 for more details -- in
+    # particular, compare and contrast the definition of types like
+    # 'typing.List' before and after the merge.
+
+    def _generic_new(base_cls, cls, *args, **kwargs):
+        return base_cls.__new__(cls, *args, **kwargs)
+
+# See https://github.com/python/typing/pull/439
+if hasattr(typing, '_geqv'):
+    from typing import _geqv
+    _geqv_defined = True
+else:
+    _geqv = None
+    _geqv_defined = False
+
+if sys.version_info[:2] >= (3, 6):
+    import _collections_abc
+    _check_methods_in_mro = _collections_abc._check_methods
+else:
+    def _check_methods_in_mro(C, *methods):
+        mro = C.__mro__
+        for method in methods:
+            for B in mro:
+                if method in B.__dict__:
+                    if B.__dict__[method] is None:
+                        return NotImplemented
+                    break
+            else:
+                return NotImplemented
+        return True
+
+
+# Please keep __all__ alphabetized within each category.
+__all__ = [
+    # Super-special typing primitives.
+    'ClassVar',
+    'Concatenate',
+    'Final',
+    'ParamSpec',
+    'Type',
+
+    # ABCs (from collections.abc).
+    # The following are added depending on presence
+    # of their non-generic counterparts in stdlib:
+    # 'Awaitable',
+    # 'AsyncIterator',
+    # 'AsyncIterable',
+    # 'Coroutine',
+    # 'AsyncGenerator',
+    # 'AsyncContextManager',
+    # 'ChainMap',
+
+    # Concrete collection types.
+    'ContextManager',
+    'Counter',
+    'Deque',
+    'DefaultDict',
+    'OrderedDict',
+    'TypedDict',
+
+    # Structural checks, a.k.a. protocols.
+    'SupportsIndex',
+
+    # One-off things.
+    'final',
+    'IntVar',
+    'Literal',
+    'NewType',
+    'overload',
+    'Text',
+    'TypeAlias',
+    'TypeGuard',
+    'TYPE_CHECKING',
+]
+
+# Annotated relies on substitution trees of pep 560. It will not work for
+# versions of typing older than 3.5.3
+HAVE_ANNOTATED = PEP_560 or SUBS_TREE
+
+if PEP_560:
+    __all__.extend(["get_args", "get_origin", "get_type_hints"])
+
+if HAVE_ANNOTATED:
+    __all__.append("Annotated")
+
+# Protocols are hard to backport to the original version of typing 3.5.0
+HAVE_PROTOCOLS = sys.version_info[:3] != (3, 5, 0)
+
+if HAVE_PROTOCOLS:
+    __all__.extend(['Protocol', 'runtime', 'runtime_checkable'])
+
+
+# TODO
+if hasattr(typing, 'NoReturn'):
+    NoReturn = typing.NoReturn
+elif hasattr(typing, '_FinalTypingBase'):
+    class _NoReturn(typing._FinalTypingBase, _root=True):
+        """Special type indicating functions that never return.
+        Example::
+
+          from typing import NoReturn
+
+          def stop() -> NoReturn:
+              raise Exception('no way')
+
+        This type is invalid in other positions, e.g., ``List[NoReturn]``
+        will fail in static type checkers.
+        """
+        __slots__ = ()
+
+        def __instancecheck__(self, obj):
+            raise TypeError("NoReturn cannot be used with isinstance().")
+
+        def __subclasscheck__(self, cls):
+            raise TypeError("NoReturn cannot be used with issubclass().")
+
+    NoReturn = _NoReturn(_root=True)
+else:
+    class _NoReturnMeta(typing.TypingMeta):
+        """Metaclass for NoReturn"""
+        def __new__(cls, name, bases, namespace, _root=False):
+            return super().__new__(cls, name, bases, namespace, _root=_root)
+
+        def __instancecheck__(self, obj):
+            raise TypeError("NoReturn cannot be used with isinstance().")
+
+        def __subclasscheck__(self, cls):
+            raise TypeError("NoReturn cannot be used with issubclass().")
+
+    class NoReturn(typing.Final, metaclass=_NoReturnMeta, _root=True):
+        """Special type indicating functions that never return.
+        Example::
+
+          from typing import NoReturn
+
+          def stop() -> NoReturn:
+              raise Exception('no way')
+
+        This type is invalid in other positions, e.g., ``List[NoReturn]``
+        will fail in static type checkers.
+        """
+        __slots__ = ()
+
+
+# Some unconstrained type variables.  These are used by the container types.
+# (These are not for export.)
+T = typing.TypeVar('T')  # Any type.
+KT = typing.TypeVar('KT')  # Key type.
+VT = typing.TypeVar('VT')  # Value type.
+T_co = typing.TypeVar('T_co', covariant=True)  # Any type covariant containers.
+V_co = typing.TypeVar('V_co', covariant=True)  # Any type covariant containers.
+VT_co = typing.TypeVar('VT_co', covariant=True)  # Value type covariant containers.
+T_contra = typing.TypeVar('T_contra', contravariant=True)  # Ditto contravariant.
+
+
+if hasattr(typing, 'ClassVar'):
+    ClassVar = typing.ClassVar
+elif hasattr(typing, '_FinalTypingBase'):
+    class _ClassVar(typing._FinalTypingBase, _root=True):
+        """Special type construct to mark class variables.
+
+        An annotation wrapped in ClassVar indicates that a given
+        attribute is intended to be used as a class variable and
+        should not be set on instances of that class. Usage::
+
+          class Starship:
+              stats: ClassVar[Dict[str, int]] = {} # class variable
+              damage: int = 10                     # instance variable
+
+        ClassVar accepts only types and cannot be further subscribed.
+
+        Note that ClassVar is not a class itself, and should not
+        be used with isinstance() or issubclass().
+        """
+
+        __slots__ = ('__type__',)
+
+        def __init__(self, tp=None, **kwds):
+            self.__type__ = tp
+
+        def __getitem__(self, item):
+            cls = type(self)
+            if self.__type__ is None:
+                return cls(typing._type_check(item,
+                           '{} accepts only single type.'.format(cls.__name__[1:])),
+                           _root=True)
+            raise TypeError('{} cannot be further subscripted'
+                            .format(cls.__name__[1:]))
+
+        def _eval_type(self, globalns, localns):
+            new_tp = typing._eval_type(self.__type__, globalns, localns)
+            if new_tp == self.__type__:
+                return self
+            return type(self)(new_tp, _root=True)
+
+        def __repr__(self):
+            r = super().__repr__()
+            if self.__type__ is not None:
+                r += '[{}]'.format(typing._type_repr(self.__type__))
+            return r
+
+        def __hash__(self):
+            return hash((type(self).__name__, self.__type__))
+
+        def __eq__(self, other):
+            if not isinstance(other, _ClassVar):
+                return NotImplemented
+            if self.__type__ is not None:
+                return self.__type__ == other.__type__
+            return self is other
+
+    ClassVar = _ClassVar(_root=True)
+else:
+    class _ClassVarMeta(typing.TypingMeta):
+        """Metaclass for ClassVar"""
+
+        def __new__(cls, name, bases, namespace, tp=None, _root=False):
+            self = super().__new__(cls, name, bases, namespace, _root=_root)
+            if tp is not None:
+                self.__type__ = tp
+            return self
+
+        def __instancecheck__(self, obj):
+            raise TypeError("ClassVar cannot be used with isinstance().")
+
+        def __subclasscheck__(self, cls):
+            raise TypeError("ClassVar cannot be used with issubclass().")
+
+        def __getitem__(self, item):
+            cls = type(self)
+            if self.__type__ is not None:
+                raise TypeError('{} cannot be further subscripted'
+                                .format(cls.__name__[1:]))
+
+            param = typing._type_check(
+                item,
+                '{} accepts only single type.'.format(cls.__name__[1:]))
+            return cls(self.__name__, self.__bases__,
+                       dict(self.__dict__), tp=param, _root=True)
+
+        def _eval_type(self, globalns, localns):
+            new_tp = typing._eval_type(self.__type__, globalns, localns)
+            if new_tp == self.__type__:
+                return self
+            return type(self)(self.__name__, self.__bases__,
+                              dict(self.__dict__), tp=self.__type__,
+                              _root=True)
+
+        def __repr__(self):
+            r = super().__repr__()
+            if self.__type__ is not None:
+                r += '[{}]'.format(typing._type_repr(self.__type__))
+            return r
+
+        def __hash__(self):
+            return hash((type(self).__name__, self.__type__))
+
+        def __eq__(self, other):
+            if not isinstance(other, ClassVar):
+                return NotImplemented
+            if self.__type__ is not None:
+                return self.__type__ == other.__type__
+            return self is other
+
+    class ClassVar(typing.Final, metaclass=_ClassVarMeta, _root=True):
+        """Special type construct to mark class variables.
+
+        An annotation wrapped in ClassVar indicates that a given
+        attribute is intended to be used as a class variable and
+        should not be set on instances of that class. Usage::
+
+          class Starship:
+              stats: ClassVar[Dict[str, int]] = {} # class variable
+              damage: int = 10                     # instance variable
+
+        ClassVar accepts only types and cannot be further subscribed.
+
+        Note that ClassVar is not a class itself, and should not
+        be used with isinstance() or issubclass().
+        """
+
+        __type__ = None
+
+# On older versions of typing there is an internal class named "Final".
+if hasattr(typing, 'Final') and sys.version_info[:2] >= (3, 7):
+    Final = typing.Final
+elif sys.version_info[:2] >= (3, 7):
+    class _FinalForm(typing._SpecialForm, _root=True):
+
+        def __repr__(self):
+            return 'typing_extensions.' + self._name
+
+        def __getitem__(self, parameters):
+            item = typing._type_check(parameters,
+                                      '{} accepts only single type'.format(self._name))
+            return _GenericAlias(self, (item,))
+
+    Final = _FinalForm('Final',
+                       doc="""A special typing construct to indicate that a name
+                       cannot be re-assigned or overridden in a subclass.
+                       For example:
+
+                           MAX_SIZE: Final = 9000
+                           MAX_SIZE += 1  # Error reported by type checker
+
+                           class Connection:
+                               TIMEOUT: Final[int] = 10
+                           class FastConnector(Connection):
+                               TIMEOUT = 1  # Error reported by type checker
+
+                       There is no runtime checking of these properties.""")
+elif hasattr(typing, '_FinalTypingBase'):
+    class _Final(typing._FinalTypingBase, _root=True):
+        """A special typing construct to indicate that a name
+        cannot be re-assigned or overridden in a subclass.
+        For example:
+
+            MAX_SIZE: Final = 9000
+            MAX_SIZE += 1  # Error reported by type checker
+
+            class Connection:
+                TIMEOUT: Final[int] = 10
+            class FastConnector(Connection):
+                TIMEOUT = 1  # Error reported by type checker
+
+        There is no runtime checking of these properties.
+        """
+
+        __slots__ = ('__type__',)
+
+        def __init__(self, tp=None, **kwds):
+            self.__type__ = tp
+
+        def __getitem__(self, item):
+            cls = type(self)
+            if self.__type__ is None:
+                return cls(typing._type_check(item,
+                           '{} accepts only single type.'.format(cls.__name__[1:])),
+                           _root=True)
+            raise TypeError('{} cannot be further subscripted'
+                            .format(cls.__name__[1:]))
+
+        def _eval_type(self, globalns, localns):
+            new_tp = typing._eval_type(self.__type__, globalns, localns)
+            if new_tp == self.__type__:
+                return self
+            return type(self)(new_tp, _root=True)
+
+        def __repr__(self):
+            r = super().__repr__()
+            if self.__type__ is not None:
+                r += '[{}]'.format(typing._type_repr(self.__type__))
+            return r
+
+        def __hash__(self):
+            return hash((type(self).__name__, self.__type__))
+
+        def __eq__(self, other):
+            if not isinstance(other, _Final):
+                return NotImplemented
+            if self.__type__ is not None:
+                return self.__type__ == other.__type__
+            return self is other
+
+    Final = _Final(_root=True)
+else:
+    class _FinalMeta(typing.TypingMeta):
+        """Metaclass for Final"""
+
+        def __new__(cls, name, bases, namespace, tp=None, _root=False):
+            self = super().__new__(cls, name, bases, namespace, _root=_root)
+            if tp is not None:
+                self.__type__ = tp
+            return self
+
+        def __instancecheck__(self, obj):
+            raise TypeError("Final cannot be used with isinstance().")
+
+        def __subclasscheck__(self, cls):
+            raise TypeError("Final cannot be used with issubclass().")
+
+        def __getitem__(self, item):
+            cls = type(self)
+            if self.__type__ is not None:
+                raise TypeError('{} cannot be further subscripted'
+                                .format(cls.__name__[1:]))
+
+            param = typing._type_check(
+                item,
+                '{} accepts only single type.'.format(cls.__name__[1:]))
+            return cls(self.__name__, self.__bases__,
+                       dict(self.__dict__), tp=param, _root=True)
+
+        def _eval_type(self, globalns, localns):
+            new_tp = typing._eval_type(self.__type__, globalns, localns)
+            if new_tp == self.__type__:
+                return self
+            return type(self)(self.__name__, self.__bases__,
+                              dict(self.__dict__), tp=self.__type__,
+                              _root=True)
+
+        def __repr__(self):
+            r = super().__repr__()
+            if self.__type__ is not None:
+                r += '[{}]'.format(typing._type_repr(self.__type__))
+            return r
+
+        def __hash__(self):
+            return hash((type(self).__name__, self.__type__))
+
+        def __eq__(self, other):
+            if not isinstance(other, Final):
+                return NotImplemented
+            if self.__type__ is not None:
+                return self.__type__ == other.__type__
+            return self is other
+
+    class Final(typing.Final, metaclass=_FinalMeta, _root=True):
+        """A special typing construct to indicate that a name
+        cannot be re-assigned or overridden in a subclass.
+        For example:
+
+            MAX_SIZE: Final = 9000
+            MAX_SIZE += 1  # Error reported by type checker
+
+            class Connection:
+                TIMEOUT: Final[int] = 10
+            class FastConnector(Connection):
+                TIMEOUT = 1  # Error reported by type checker
+
+        There is no runtime checking of these properties.
+        """
+
+        __type__ = None
+
+
+if hasattr(typing, 'final'):
+    final = typing.final
+else:
+    def final(f):
+        """This decorator can be used to indicate to type checkers that
+        the decorated method cannot be overridden, and decorated class
+        cannot be subclassed. For example:
+
+            class Base:
+                @final
+                def done(self) -> None:
+                    ...
+            class Sub(Base):
+                def done(self) -> None:  # Error reported by type checker
+                    ...
+            @final
+            class Leaf:
+                ...
+            class Other(Leaf):  # Error reported by type checker
+                ...
+
+        There is no runtime checking of these properties.
+        """
+        return f
+
+
+def IntVar(name):
+    return TypeVar(name)
+
+
+if hasattr(typing, 'Literal'):
+    Literal = typing.Literal
+elif sys.version_info[:2] >= (3, 7):
+    class _LiteralForm(typing._SpecialForm, _root=True):
+
+        def __repr__(self):
+            return 'typing_extensions.' + self._name
+
+        def __getitem__(self, parameters):
+            return _GenericAlias(self, parameters)
+
+    Literal = _LiteralForm('Literal',
+                           doc="""A type that can be used to indicate to type checkers
+                           that the corresponding value has a value literally equivalent
+                           to the provided parameter. For example:
+
+                               var: Literal[4] = 4
+
+                           The type checker understands that 'var' is literally equal to
+                           the value 4 and no other value.
+
+                           Literal[...] cannot be subclassed. There is no runtime
+                           checking verifying that the parameter is actually a value
+                           instead of a type.""")
+elif hasattr(typing, '_FinalTypingBase'):
+    class _Literal(typing._FinalTypingBase, _root=True):
+        """A type that can be used to indicate to type checkers that the
+        corresponding value has a value literally equivalent to the
+        provided parameter. For example:
+
+            var: Literal[4] = 4
+
+        The type checker understands that 'var' is literally equal to the
+        value 4 and no other value.
+
+        Literal[...] cannot be subclassed. There is no runtime checking
+        verifying that the parameter is actually a value instead of a type.
+        """
+
+        __slots__ = ('__values__',)
+
+        def __init__(self, values=None, **kwds):
+            self.__values__ = values
+
+        def __getitem__(self, values):
+            cls = type(self)
+            if self.__values__ is None:
+                if not isinstance(values, tuple):
+                    values = (values,)
+                return cls(values, _root=True)
+            raise TypeError('{} cannot be further subscripted'
+                            .format(cls.__name__[1:]))
+
+        def _eval_type(self, globalns, localns):
+            return self
+
+        def __repr__(self):
+            r = super().__repr__()
+            if self.__values__ is not None:
+                r += '[{}]'.format(', '.join(map(typing._type_repr, self.__values__)))
+            return r
+
+        def __hash__(self):
+            return hash((type(self).__name__, self.__values__))
+
+        def __eq__(self, other):
+            if not isinstance(other, _Literal):
+                return NotImplemented
+            if self.__values__ is not None:
+                return self.__values__ == other.__values__
+            return self is other
+
+    Literal = _Literal(_root=True)
+else:
+    class _LiteralMeta(typing.TypingMeta):
+        """Metaclass for Literal"""
+
+        def __new__(cls, name, bases, namespace, values=None, _root=False):
+            self = super().__new__(cls, name, bases, namespace, _root=_root)
+            if values is not None:
+                self.__values__ = values
+            return self
+
+        def __instancecheck__(self, obj):
+            raise TypeError("Literal cannot be used with isinstance().")
+
+        def __subclasscheck__(self, cls):
+            raise TypeError("Literal cannot be used with issubclass().")
+
+        def __getitem__(self, item):
+            cls = type(self)
+            if self.__values__ is not None:
+                raise TypeError('{} cannot be further subscripted'
+                                .format(cls.__name__[1:]))
+
+            if not isinstance(item, tuple):
+                item = (item,)
+            return cls(self.__name__, self.__bases__,
+                       dict(self.__dict__), values=item, _root=True)
+
+        def _eval_type(self, globalns, localns):
+            return self
+
+        def __repr__(self):
+            r = super().__repr__()
+            if self.__values__ is not None:
+                r += '[{}]'.format(', '.join(map(typing._type_repr, self.__values__)))
+            return r
+
+        def __hash__(self):
+            return hash((type(self).__name__, self.__values__))
+
+        def __eq__(self, other):
+            if not isinstance(other, Literal):
+                return NotImplemented
+            if self.__values__ is not None:
+                return self.__values__ == other.__values__
+            return self is other
+
+    class Literal(typing.Final, metaclass=_LiteralMeta, _root=True):
+        """A type that can be used to indicate to type checkers that the
+        corresponding value has a value literally equivalent to the
+        provided parameter. For example:
+
+            var: Literal[4] = 4
+
+        The type checker understands that 'var' is literally equal to the
+        value 4 and no other value.
+
+        Literal[...] cannot be subclassed. There is no runtime checking
+        verifying that the parameter is actually a value instead of a type.
+        """
+
+        __values__ = None
+
+
+def _overload_dummy(*args, **kwds):
+    """Helper for @overload to raise when called."""
+    raise NotImplementedError(
+        "You should not call an overloaded function. "
+        "A series of @overload-decorated functions "
+        "outside a stub module should always be followed "
+        "by an implementation that is not @overload-ed.")
+
+
+def overload(func):
+    """Decorator for overloaded functions/methods.
+
+    In a stub file, place two or more stub definitions for the same
+    function in a row, each decorated with @overload.  For example:
+
+      @overload
+      def utf8(value: None) -> None: ...
+      @overload
+      def utf8(value: bytes) -> bytes: ...
+      @overload
+      def utf8(value: str) -> bytes: ...
+
+    In a non-stub file (i.e. a regular .py file), do the same but
+    follow it with an implementation.  The implementation should *not*
+    be decorated with @overload.  For example:
+
+      @overload
+      def utf8(value: None) -> None: ...
+      @overload
+      def utf8(value: bytes) -> bytes: ...
+      @overload
+      def utf8(value: str) -> bytes: ...
+      def utf8(value):
+          # implementation goes here
+    """
+    return _overload_dummy
+
+
+# This is not a real generic class.  Don't use outside annotations.
+if hasattr(typing, 'Type'):
+    Type = typing.Type
+else:
+    # Internal type variable used for Type[].
+    CT_co = typing.TypeVar('CT_co', covariant=True, bound=type)
+
+    class Type(typing.Generic[CT_co], extra=type):
+        """A special construct usable to annotate class objects.
+
+        For example, suppose we have the following classes::
+
+          class User: ...  # Abstract base for User classes
+          class BasicUser(User): ...
+          class ProUser(User): ...
+          class TeamUser(User): ...
+
+        And a function that takes a class argument that's a subclass of
+        User and returns an instance of the corresponding class::
+
+          U = TypeVar('U', bound=User)
+          def new_user(user_class: Type[U]) -> U:
+              user = user_class()
+              # (Here we could write the user object to a database)
+              return user
+          joe = new_user(BasicUser)
+
+        At this point the type checker knows that joe has type BasicUser.
+        """
+
+        __slots__ = ()
+
+
+# Various ABCs mimicking those in collections.abc.
+# A few are simply re-exported for completeness.
+
+def _define_guard(type_name):
+    """
+    Returns True if the given type isn't defined in typing but
+    is defined in collections_abc.
+
+    Adds the type to __all__ if the collection is found in either
+    typing or collection_abc.
+    """
+    if hasattr(typing, type_name):
+        __all__.append(type_name)
+        globals()[type_name] = getattr(typing, type_name)
+        return False
+    elif hasattr(collections_abc, type_name):
+        __all__.append(type_name)
+        return True
+    else:
+        return False
+
+
+class _ExtensionsGenericMeta(GenericMeta):
+    def __subclasscheck__(self, subclass):
+        """This mimics a more modern GenericMeta.__subclasscheck__() logic
+        (that does not have problems with recursion) to work around interactions
+        between collections, typing, and typing_extensions on older
+        versions of Python, see https://github.com/python/typing/issues/501.
+        """
+        if sys.version_info[:3] >= (3, 5, 3) or sys.version_info[:3] < (3, 5, 0):
+            if self.__origin__ is not None:
+                if sys._getframe(1).f_globals['__name__'] not in ['abc', 'functools']:
+                    raise TypeError("Parameterized generics cannot be used with class "
+                                    "or instance checks")
+                return False
+        if not self.__extra__:
+            return super().__subclasscheck__(subclass)
+        res = self.__extra__.__subclasshook__(subclass)
+        if res is not NotImplemented:
+            return res
+        if self.__extra__ in subclass.__mro__:
+            return True
+        for scls in self.__extra__.__subclasses__():
+            if isinstance(scls, GenericMeta):
+                continue
+            if issubclass(subclass, scls):
+                return True
+        return False
+
+
+if _define_guard('Awaitable'):
+    class Awaitable(typing.Generic[T_co], metaclass=_ExtensionsGenericMeta,
+                    extra=collections_abc.Awaitable):
+        __slots__ = ()
+
+
+if _define_guard('Coroutine'):
+    class Coroutine(Awaitable[V_co], typing.Generic[T_co, T_contra, V_co],
+                    metaclass=_ExtensionsGenericMeta,
+                    extra=collections_abc.Coroutine):
+        __slots__ = ()
+
+
+if _define_guard('AsyncIterable'):
+    class AsyncIterable(typing.Generic[T_co],
+                        metaclass=_ExtensionsGenericMeta,
+                        extra=collections_abc.AsyncIterable):
+        __slots__ = ()
+
+
+if _define_guard('AsyncIterator'):
+    class AsyncIterator(AsyncIterable[T_co],
+                        metaclass=_ExtensionsGenericMeta,
+                        extra=collections_abc.AsyncIterator):
+        __slots__ = ()
+
+
+if hasattr(typing, 'Deque'):
+    Deque = typing.Deque
+elif _geqv_defined:
+    class Deque(collections.deque, typing.MutableSequence[T],
+                metaclass=_ExtensionsGenericMeta,
+                extra=collections.deque):
+        __slots__ = ()
+
+        def __new__(cls, *args, **kwds):
+            if _geqv(cls, Deque):
+                return collections.deque(*args, **kwds)
+            return _generic_new(collections.deque, cls, *args, **kwds)
+else:
+    class Deque(collections.deque, typing.MutableSequence[T],
+                metaclass=_ExtensionsGenericMeta,
+                extra=collections.deque):
+        __slots__ = ()
+
+        def __new__(cls, *args, **kwds):
+            if cls._gorg is Deque:
+                return collections.deque(*args, **kwds)
+            return _generic_new(collections.deque, cls, *args, **kwds)
+
+
+if hasattr(typing, 'ContextManager'):
+    ContextManager = typing.ContextManager
+elif hasattr(contextlib, 'AbstractContextManager'):
+    class ContextManager(typing.Generic[T_co],
+                         metaclass=_ExtensionsGenericMeta,
+                         extra=contextlib.AbstractContextManager):
+        __slots__ = ()
+else:
+    class ContextManager(typing.Generic[T_co]):
+        __slots__ = ()
+
+        def __enter__(self):
+            return self
+
+        @abc.abstractmethod
+        def __exit__(self, exc_type, exc_value, traceback):
+            return None
+
+        @classmethod
+        def __subclasshook__(cls, C):
+            if cls is ContextManager:
+                # In Python 3.6+, it is possible to set a method to None to
+                # explicitly indicate that the class does not implement an ABC
+                # (https://bugs.python.org/issue25958), but we do not support
+                # that pattern here because this fallback class is only used
+                # in Python 3.5 and earlier.
+                if (any("__enter__" in B.__dict__ for B in C.__mro__) and
+                    any("__exit__" in B.__dict__ for B in C.__mro__)):
+                    return True
+            return NotImplemented
+
+
+if hasattr(typing, 'AsyncContextManager'):
+    AsyncContextManager = typing.AsyncContextManager
+    __all__.append('AsyncContextManager')
+elif hasattr(contextlib, 'AbstractAsyncContextManager'):
+    class AsyncContextManager(typing.Generic[T_co],
+                              metaclass=_ExtensionsGenericMeta,
+                              extra=contextlib.AbstractAsyncContextManager):
+        __slots__ = ()
+
+    __all__.append('AsyncContextManager')
+elif sys.version_info[:2] >= (3, 5):
+    exec("""
+class AsyncContextManager(typing.Generic[T_co]):
+    __slots__ = ()
+
+    async def __aenter__(self):
+        return self
+
+    @abc.abstractmethod
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        return None
+
+    @classmethod
+    def __subclasshook__(cls, C):
+        if cls is AsyncContextManager:
+            return _check_methods_in_mro(C, "__aenter__", "__aexit__")
+        return NotImplemented
+
+__all__.append('AsyncContextManager')
+""")
+
+
+if hasattr(typing, 'DefaultDict'):
+    DefaultDict = typing.DefaultDict
+elif _geqv_defined:
+    class DefaultDict(collections.defaultdict, typing.MutableMapping[KT, VT],
+                      metaclass=_ExtensionsGenericMeta,
+                      extra=collections.defaultdict):
+
+        __slots__ = ()
+
+        def __new__(cls, *args, **kwds):
+            if _geqv(cls, DefaultDict):
+                return collections.defaultdict(*args, **kwds)
+            return _generic_new(collections.defaultdict, cls, *args, **kwds)
+else:
+    class DefaultDict(collections.defaultdict, typing.MutableMapping[KT, VT],
+                      metaclass=_ExtensionsGenericMeta,
+                      extra=collections.defaultdict):
+
+        __slots__ = ()
+
+        def __new__(cls, *args, **kwds):
+            if cls._gorg is DefaultDict:
+                return collections.defaultdict(*args, **kwds)
+            return _generic_new(collections.defaultdict, cls, *args, **kwds)
+
+
+if hasattr(typing, 'OrderedDict'):
+    OrderedDict = typing.OrderedDict
+elif (3, 7, 0) <= sys.version_info[:3] < (3, 7, 2):
+    OrderedDict = typing._alias(collections.OrderedDict, (KT, VT))
+elif _geqv_defined:
+    class OrderedDict(collections.OrderedDict, typing.MutableMapping[KT, VT],
+                      metaclass=_ExtensionsGenericMeta,
+                      extra=collections.OrderedDict):
+
+        __slots__ = ()
+
+        def __new__(cls, *args, **kwds):
+            if _geqv(cls, OrderedDict):
+                return collections.OrderedDict(*args, **kwds)
+            return _generic_new(collections.OrderedDict, cls, *args, **kwds)
+else:
+    class OrderedDict(collections.OrderedDict, typing.MutableMapping[KT, VT],
+                      metaclass=_ExtensionsGenericMeta,
+                      extra=collections.OrderedDict):
+
+        __slots__ = ()
+
+        def __new__(cls, *args, **kwds):
+            if cls._gorg is OrderedDict:
+                return collections.OrderedDict(*args, **kwds)
+            return _generic_new(collections.OrderedDict, cls, *args, **kwds)
+
+
+if hasattr(typing, 'Counter'):
+    Counter = typing.Counter
+elif (3, 5, 0) <= sys.version_info[:3] <= (3, 5, 1):
+    assert _geqv_defined
+    _TInt = typing.TypeVar('_TInt')
+
+    class _CounterMeta(typing.GenericMeta):
+        """Metaclass for Counter"""
+        def __getitem__(self, item):
+            return super().__getitem__((item, int))
+
+    class Counter(collections.Counter,
+                  typing.Dict[T, int],
+                  metaclass=_CounterMeta,
+                  extra=collections.Counter):
+
+        __slots__ = ()
+
+        def __new__(cls, *args, **kwds):
+            if _geqv(cls, Counter):
+                return collections.Counter(*args, **kwds)
+            return _generic_new(collections.Counter, cls, *args, **kwds)
+
+elif _geqv_defined:
+    class Counter(collections.Counter,
+                  typing.Dict[T, int],
+                  metaclass=_ExtensionsGenericMeta, extra=collections.Counter):
+
+        __slots__ = ()
+
+        def __new__(cls, *args, **kwds):
+            if _geqv(cls, Counter):
+                return collections.Counter(*args, **kwds)
+            return _generic_new(collections.Counter, cls, *args, **kwds)
+
+else:
+    class Counter(collections.Counter,
+                  typing.Dict[T, int],
+                  metaclass=_ExtensionsGenericMeta, extra=collections.Counter):
+
+        __slots__ = ()
+
+        def __new__(cls, *args, **kwds):
+            if cls._gorg is Counter:
+                return collections.Counter(*args, **kwds)
+            return _generic_new(collections.Counter, cls, *args, **kwds)
+
+
+if hasattr(typing, 'ChainMap'):
+    ChainMap = typing.ChainMap
+    __all__.append('ChainMap')
+elif hasattr(collections, 'ChainMap'):
+    # ChainMap only exists in 3.3+
+    if _geqv_defined:
+        class ChainMap(collections.ChainMap, typing.MutableMapping[KT, VT],
+                       metaclass=_ExtensionsGenericMeta,
+                       extra=collections.ChainMap):
+
+            __slots__ = ()
+
+            def __new__(cls, *args, **kwds):
+                if _geqv(cls, ChainMap):
+                    return collections.ChainMap(*args, **kwds)
+                return _generic_new(collections.ChainMap, cls, *args, **kwds)
+    else:
+        class ChainMap(collections.ChainMap, typing.MutableMapping[KT, VT],
+                       metaclass=_ExtensionsGenericMeta,
+                       extra=collections.ChainMap):
+
+            __slots__ = ()
+
+            def __new__(cls, *args, **kwds):
+                if cls._gorg is ChainMap:
+                    return collections.ChainMap(*args, **kwds)
+                return _generic_new(collections.ChainMap, cls, *args, **kwds)
+
+    __all__.append('ChainMap')
+
+
+if _define_guard('AsyncGenerator'):
+    class AsyncGenerator(AsyncIterator[T_co], typing.Generic[T_co, T_contra],
+                         metaclass=_ExtensionsGenericMeta,
+                         extra=collections_abc.AsyncGenerator):
+        __slots__ = ()
+
+
+if hasattr(typing, 'NewType'):
+    NewType = typing.NewType
+else:
+    def NewType(name, tp):
+        """NewType creates simple unique types with almost zero
+        runtime overhead. NewType(name, tp) is considered a subtype of tp
+        by static type checkers. At runtime, NewType(name, tp) returns
+        a dummy function that simply returns its argument. Usage::
+
+            UserId = NewType('UserId', int)
+
+            def name_by_id(user_id: UserId) -> str:
+                ...
+
+            UserId('user')          # Fails type check
+
+            name_by_id(42)          # Fails type check
+            name_by_id(UserId(42))  # OK
+
+            num = UserId(5) + 1     # type: int
+        """
+
+        def new_type(x):
+            return x
+
+        new_type.__name__ = name
+        new_type.__supertype__ = tp
+        return new_type
+
+
+if hasattr(typing, 'Text'):
+    Text = typing.Text
+else:
+    Text = str
+
+
+if hasattr(typing, 'TYPE_CHECKING'):
+    TYPE_CHECKING = typing.TYPE_CHECKING
+else:
+    # Constant that's True when type checking, but False here.
+    TYPE_CHECKING = False
+
+
+def _gorg(cls):
+    """This function exists for compatibility with old typing versions."""
+    assert isinstance(cls, GenericMeta)
+    if hasattr(cls, '_gorg'):
+        return cls._gorg
+    while cls.__origin__ is not None:
+        cls = cls.__origin__
+    return cls
+
+
+if OLD_GENERICS:
+    def _next_in_mro(cls):  # noqa
+        """This function exists for compatibility with old typing versions."""
+        next_in_mro = object
+        for i, c in enumerate(cls.__mro__[:-1]):
+            if isinstance(c, GenericMeta) and _gorg(c) is Generic:
+                next_in_mro = cls.__mro__[i + 1]
+        return next_in_mro
+
+
+_PROTO_WHITELIST = ['Callable', 'Awaitable',
+                    'Iterable', 'Iterator', 'AsyncIterable', 'AsyncIterator',
+                    'Hashable', 'Sized', 'Container', 'Collection', 'Reversible',
+                    'ContextManager', 'AsyncContextManager']
+
+
+def _get_protocol_attrs(cls):
+    attrs = set()
+    for base in cls.__mro__[:-1]:  # without object
+        if base.__name__ in ('Protocol', 'Generic'):
+            continue
+        annotations = getattr(base, '__annotations__', {})
+        for attr in list(base.__dict__.keys()) + list(annotations.keys()):
+            if (not attr.startswith('_abc_') and attr not in (
+                    '__abstractmethods__', '__annotations__', '__weakref__',
+                    '_is_protocol', '_is_runtime_protocol', '__dict__',
+                    '__args__', '__slots__',
+                    '__next_in_mro__', '__parameters__', '__origin__',
+                    '__orig_bases__', '__extra__', '__tree_hash__',
+                    '__doc__', '__subclasshook__', '__init__', '__new__',
+                    '__module__', '_MutableMapping__marker', '_gorg')):
+                attrs.add(attr)
+    return attrs
+
+
+def _is_callable_members_only(cls):
+    return all(callable(getattr(cls, attr, None)) for attr in _get_protocol_attrs(cls))
+
+
+if hasattr(typing, 'Protocol'):
+    Protocol = typing.Protocol
+elif HAVE_PROTOCOLS and not PEP_560:
+
+    def _no_init(self, *args, **kwargs):
+        if type(self)._is_protocol:
+            raise TypeError('Protocols cannot be instantiated')
+
+    class _ProtocolMeta(GenericMeta):
+        """Internal metaclass for Protocol.
+
+        This exists so Protocol classes can be generic without deriving
+        from Generic.
+        """
+        if not OLD_GENERICS:
+            def __new__(cls, name, bases, namespace,
+                        tvars=None, args=None, origin=None, extra=None, orig_bases=None):
+                # This is just a version copied from GenericMeta.__new__ that
+                # includes "Protocol" special treatment. (Comments removed for brevity.)
+                assert extra is None  # Protocols should not have extra
+                if tvars is not None:
+                    assert origin is not None
+                    assert all(isinstance(t, TypeVar) for t in tvars), tvars
+                else:
+                    tvars = _type_vars(bases)
+                    gvars = None
+                    for base in bases:
+                        if base is Generic:
+                            raise TypeError("Cannot inherit from plain Generic")
+                        if (isinstance(base, GenericMeta) and
+                                base.__origin__ in (Generic, Protocol)):
+                            if gvars is not None:
+                                raise TypeError(
+                                    "Cannot inherit from Generic[...] or"
+                                    " Protocol[...] multiple times.")
+                            gvars = base.__parameters__
+                    if gvars is None:
+                        gvars = tvars
+                    else:
+                        tvarset = set(tvars)
+                        gvarset = set(gvars)
+                        if not tvarset <= gvarset:
+                            raise TypeError(
+                                "Some type variables (%s) "
+                                "are not listed in %s[%s]" %
+                                (", ".join(str(t) for t in tvars if t not in gvarset),
+                                 "Generic" if any(b.__origin__ is Generic
+                                                  for b in bases) else "Protocol",
+                                 ", ".join(str(g) for g in gvars)))
+                        tvars = gvars
+
+                initial_bases = bases
+                if (extra is not None and type(extra) is abc.ABCMeta and
+                        extra not in bases):
+                    bases = (extra,) + bases
+                bases = tuple(_gorg(b) if isinstance(b, GenericMeta) else b
+                              for b in bases)
+                if any(isinstance(b, GenericMeta) and b is not Generic for b in bases):
+                    bases = tuple(b for b in bases if b is not Generic)
+                namespace.update({'__origin__': origin, '__extra__': extra})
+                self = super(GenericMeta, cls).__new__(cls, name, bases, namespace,
+                                                       _root=True)
+                super(GenericMeta, self).__setattr__('_gorg',
+                                                     self if not origin else
+                                                     _gorg(origin))
+                self.__parameters__ = tvars
+                self.__args__ = tuple(... if a is _TypingEllipsis else
+                                      () if a is _TypingEmpty else
+                                      a for a in args) if args else None
+                self.__next_in_mro__ = _next_in_mro(self)
+                if orig_bases is None:
+                    self.__orig_bases__ = initial_bases
+                elif origin is not None:
+                    self._abc_registry = origin._abc_registry
+                    self._abc_cache = origin._abc_cache
+                if hasattr(self, '_subs_tree'):
+                    self.__tree_hash__ = (hash(self._subs_tree()) if origin else
+                                          super(GenericMeta, self).__hash__())
+                return self
+
+        def __init__(cls, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            if not cls.__dict__.get('_is_protocol', None):
+                cls._is_protocol = any(b is Protocol or
+                                       isinstance(b, _ProtocolMeta) and
+                                       b.__origin__ is Protocol
+                                       for b in cls.__bases__)
+            if cls._is_protocol:
+                for base in cls.__mro__[1:]:
+                    if not (base in (object, Generic) or
+                            base.__module__ == 'collections.abc' and
+                            base.__name__ in _PROTO_WHITELIST or
+                            isinstance(base, TypingMeta) and base._is_protocol or
+                            isinstance(base, GenericMeta) and
+                            base.__origin__ is Generic):
+                        raise TypeError('Protocols can only inherit from other'
+                                        ' protocols, got %r' % base)
+
+                cls.__init__ = _no_init
+
+            def _proto_hook(other):
+                if not cls.__dict__.get('_is_protocol', None):
+                    return NotImplemented
+                if not isinstance(other, type):
+                    # Same error as for issubclass(1, int)
+                    raise TypeError('issubclass() arg 1 must be a class')
+                for attr in _get_protocol_attrs(cls):
+                    for base in other.__mro__:
+                        if attr in base.__dict__:
+                            if base.__dict__[attr] is None:
+                                return NotImplemented
+                            break
+                        annotations = getattr(base, '__annotations__', {})
+                        if (isinstance(annotations, typing.Mapping) and
+                                attr in annotations and
+                                isinstance(other, _ProtocolMeta) and
+                                other._is_protocol):
+                            break
+                    else:
+                        return NotImplemented
+                return True
+            if '__subclasshook__' not in cls.__dict__:
+                cls.__subclasshook__ = _proto_hook
+
+        def __instancecheck__(self, instance):
+            # We need this method for situations where attributes are
+            # assigned in __init__.
+            if ((not getattr(self, '_is_protocol', False) or
+                    _is_callable_members_only(self)) and
+                    issubclass(instance.__class__, self)):
+                return True
+            if self._is_protocol:
+                if all(hasattr(instance, attr) and
+                        (not callable(getattr(self, attr, None)) or
+                         getattr(instance, attr) is not None)
+                        for attr in _get_protocol_attrs(self)):
+                    return True
+            return super(GenericMeta, self).__instancecheck__(instance)
+
+        def __subclasscheck__(self, cls):
+            if self.__origin__ is not None:
+                if sys._getframe(1).f_globals['__name__'] not in ['abc', 'functools']:
+                    raise TypeError("Parameterized generics cannot be used with class "
+                                    "or instance checks")
+                return False
+            if (self.__dict__.get('_is_protocol', None) and
+                    not self.__dict__.get('_is_runtime_protocol', None)):
+                if sys._getframe(1).f_globals['__name__'] in ['abc',
+                                                              'functools',
+                                                              'typing']:
+                    return False
+                raise TypeError("Instance and class checks can only be used with"
+                                " @runtime protocols")
+            if (self.__dict__.get('_is_runtime_protocol', None) and
+                    not _is_callable_members_only(self)):
+                if sys._getframe(1).f_globals['__name__'] in ['abc',
+                                                              'functools',
+                                                              'typing']:
+                    return super(GenericMeta, self).__subclasscheck__(cls)
+                raise TypeError("Protocols with non-method members"
+                                " don't support issubclass()")
+            return super(GenericMeta, self).__subclasscheck__(cls)
+
+        if not OLD_GENERICS:
+            @_tp_cache
+            def __getitem__(self, params):
+                # We also need to copy this from GenericMeta.__getitem__ to get
+                # special treatment of "Protocol". (Comments removed for brevity.)
+                if not isinstance(params, tuple):
+                    params = (params,)
+                if not params and _gorg(self) is not Tuple:
+                    raise TypeError(
+                        "Parameter list to %s[...] cannot be empty" % self.__qualname__)
+                msg = "Parameters to generic types must be types."
+                params = tuple(_type_check(p, msg) for p in params)
+                if self in (Generic, Protocol):
+                    if not all(isinstance(p, TypeVar) for p in params):
+                        raise TypeError(
+                            "Parameters to %r[...] must all be type variables" % self)
+                    if len(set(params)) != len(params):
+                        raise TypeError(
+                            "Parameters to %r[...] must all be unique" % self)
+                    tvars = params
+                    args = params
+                elif self in (Tuple, Callable):
+                    tvars = _type_vars(params)
+                    args = params
+                elif self.__origin__ in (Generic, Protocol):
+                    raise TypeError("Cannot subscript already-subscripted %s" %
+                                    repr(self))
+                else:
+                    _check_generic(self, params)
+                    tvars = _type_vars(params)
+                    args = params
+
+                prepend = (self,) if self.__origin__ is None else ()
+                return self.__class__(self.__name__,
+                                      prepend + self.__bases__,
+                                      _no_slots_copy(self.__dict__),
+                                      tvars=tvars,
+                                      args=args,
+                                      origin=self,
+                                      extra=self.__extra__,
+                                      orig_bases=self.__orig_bases__)
+
+    class Protocol(metaclass=_ProtocolMeta):
+        """Base class for protocol classes. Protocol classes are defined as::
+
+          class Proto(Protocol):
+              def meth(self) -> int:
+                  ...
+
+        Such classes are primarily used with static type checkers that recognize
+        structural subtyping (static duck-typing), for example::
+
+          class C:
+              def meth(self) -> int:
+                  return 0
+
+          def func(x: Proto) -> int:
+              return x.meth()
+
+          func(C())  # Passes static type check
+
+        See PEP 544 for details. Protocol classes decorated with
+        @typing_extensions.runtime act as simple-minded runtime protocol that checks
+        only the presence of given attributes, ignoring their type signatures.
+
+        Protocol classes can be generic, they are defined as::
+
+          class GenProto({bases}):
+              def meth(self) -> T:
+                  ...
+        """
+        __slots__ = ()
+        _is_protocol = True
+
+        def __new__(cls, *args, **kwds):
+            if _gorg(cls) is Protocol:
+                raise TypeError("Type Protocol cannot be instantiated; "
+                                "it can be used only as a base class")
+            if OLD_GENERICS:
+                return _generic_new(_next_in_mro(cls), cls, *args, **kwds)
+            return _generic_new(cls.__next_in_mro__, cls, *args, **kwds)
+    if Protocol.__doc__ is not None:
+        Protocol.__doc__ = Protocol.__doc__.format(bases="Protocol, Generic[T]" if
+                                                   OLD_GENERICS else "Protocol[T]")
+
+
+elif PEP_560:
+    from typing import _type_check, _GenericAlias, _collect_type_vars  # noqa
+
+    def _no_init(self, *args, **kwargs):
+        if type(self)._is_protocol:
+            raise TypeError('Protocols cannot be instantiated')
+
+    class _ProtocolMeta(abc.ABCMeta):
+        # This metaclass is a bit unfortunate and exists only because of the lack
+        # of __instancehook__.
+        def __instancecheck__(cls, instance):
+            # We need this method for situations where attributes are
+            # assigned in __init__.
+            if ((not getattr(cls, '_is_protocol', False) or
+                    _is_callable_members_only(cls)) and
+                    issubclass(instance.__class__, cls)):
+                return True
+            if cls._is_protocol:
+                if all(hasattr(instance, attr) and
+                        (not callable(getattr(cls, attr, None)) or
+                         getattr(instance, attr) is not None)
+                        for attr in _get_protocol_attrs(cls)):
+                    return True
+            return super().__instancecheck__(instance)
+
+    class Protocol(metaclass=_ProtocolMeta):
+        # There is quite a lot of overlapping code with typing.Generic.
+        # Unfortunately it is hard to avoid this while these live in two different
+        # modules. The duplicated code will be removed when Protocol is moved to typing.
+        """Base class for protocol classes. Protocol classes are defined as::
+
+            class Proto(Protocol):
+                def meth(self) -> int:
+                    ...
+
+        Such classes are primarily used with static type checkers that recognize
+        structural subtyping (static duck-typing), for example::
+
+            class C:
+                def meth(self) -> int:
+                    return 0
+
+            def func(x: Proto) -> int:
+                return x.meth()
+
+            func(C())  # Passes static type check
+
+        See PEP 544 for details. Protocol classes decorated with
+        @typing_extensions.runtime act as simple-minded runtime protocol that checks
+        only the presence of given attributes, ignoring their type signatures.
+
+        Protocol classes can be generic, they are defined as::
+
+            class GenProto(Protocol[T]):
+                def meth(self) -> T:
+                    ...
+        """
+        __slots__ = ()
+        _is_protocol = True
+
+        def __new__(cls, *args, **kwds):
+            if cls is Protocol:
+                raise TypeError("Type Protocol cannot be instantiated; "
+                                "it can only be used as a base class")
+            return super().__new__(cls)
+
+        @_tp_cache
+        def __class_getitem__(cls, params):
+            if not isinstance(params, tuple):
+                params = (params,)
+            if not params and cls is not Tuple:
+                raise TypeError(
+                    "Parameter list to {}[...] cannot be empty".format(cls.__qualname__))
+            msg = "Parameters to generic types must be types."
+            params = tuple(_type_check(p, msg) for p in params)
+            if cls is Protocol:
+                # Generic can only be subscripted with unique type variables.
+                if not all(isinstance(p, TypeVar) for p in params):
+                    i = 0
+                    while isinstance(params[i], TypeVar):
+                        i += 1
+                    raise TypeError(
+                        "Parameters to Protocol[...] must all be type variables."
+                        " Parameter {} is {}".format(i + 1, params[i]))
+                if len(set(params)) != len(params):
+                    raise TypeError(
+                        "Parameters to Protocol[...] must all be unique")
+            else:
+                # Subscripting a regular Generic subclass.
+                _check_generic(cls, params)
+            return _GenericAlias(cls, params)
+
+        def __init_subclass__(cls, *args, **kwargs):
+            tvars = []
+            if '__orig_bases__' in cls.__dict__:
+                error = Generic in cls.__orig_bases__
+            else:
+                error = Generic in cls.__bases__
+            if error:
+                raise TypeError("Cannot inherit from plain Generic")
+            if '__orig_bases__' in cls.__dict__:
+                tvars = _collect_type_vars(cls.__orig_bases__)
+                # Look for Generic[T1, ..., Tn] or Protocol[T1, ..., Tn].
+                # If found, tvars must be a subset of it.
+                # If not found, tvars is it.
+                # Also check for and reject plain Generic,
+                # and reject multiple Generic[...] and/or Protocol[...].
+                gvars = None
+                for base in cls.__orig_bases__:
+                    if (isinstance(base, _GenericAlias) and
+                            base.__origin__ in (Generic, Protocol)):
+                        # for error messages
+                        the_base = 'Generic' if base.__origin__ is Generic else 'Protocol'
+                        if gvars is not None:
+                            raise TypeError(
+                                "Cannot inherit from Generic[...]"
+                                " and/or Protocol[...] multiple types.")
+                        gvars = base.__parameters__
+                if gvars is None:
+                    gvars = tvars
+                else:
+                    tvarset = set(tvars)
+                    gvarset = set(gvars)
+                    if not tvarset <= gvarset:
+                        s_vars = ', '.join(str(t) for t in tvars if t not in gvarset)
+                        s_args = ', '.join(str(g) for g in gvars)
+                        raise TypeError("Some type variables ({}) are"
+                                        " not listed in {}[{}]".format(s_vars,
+                                                                       the_base, s_args))
+                    tvars = gvars
+            cls.__parameters__ = tuple(tvars)
+
+            # Determine if this is a protocol or a concrete subclass.
+            if not cls.__dict__.get('_is_protocol', None):
+                cls._is_protocol = any(b is Protocol for b in cls.__bases__)
+
+            # Set (or override) the protocol subclass hook.
+            def _proto_hook(other):
+                if not cls.__dict__.get('_is_protocol', None):
+                    return NotImplemented
+                if not getattr(cls, '_is_runtime_protocol', False):
+                    if sys._getframe(2).f_globals['__name__'] in ['abc', 'functools']:
+                        return NotImplemented
+                    raise TypeError("Instance and class checks can only be used with"
+                                    " @runtime protocols")
+                if not _is_callable_members_only(cls):
+                    if sys._getframe(2).f_globals['__name__'] in ['abc', 'functools']:
+                        return NotImplemented
+                    raise TypeError("Protocols with non-method members"
+                                    " don't support issubclass()")
+                if not isinstance(other, type):
+                    # Same error as for issubclass(1, int)
+                    raise TypeError('issubclass() arg 1 must be a class')
+                for attr in _get_protocol_attrs(cls):
+                    for base in other.__mro__:
+                        if attr in base.__dict__:
+                            if base.__dict__[attr] is None:
+                                return NotImplemented
+                            break
+                        annotations = getattr(base, '__annotations__', {})
+                        if (isinstance(annotations, typing.Mapping) and
+                                attr in annotations and
+                                isinstance(other, _ProtocolMeta) and
+                                other._is_protocol):
+                            break
+                    else:
+                        return NotImplemented
+                return True
+            if '__subclasshook__' not in cls.__dict__:
+                cls.__subclasshook__ = _proto_hook
+
+            # We have nothing more to do for non-protocols.
+            if not cls._is_protocol:
+                return
+
+            # Check consistency of bases.
+            for base in cls.__bases__:
+                if not (base in (object, Generic) or
+                        base.__module__ == 'collections.abc' and
+                        base.__name__ in _PROTO_WHITELIST or
+                        isinstance(base, _ProtocolMeta) and base._is_protocol):
+                    raise TypeError('Protocols can only inherit from other'
+                                    ' protocols, got %r' % base)
+            cls.__init__ = _no_init
+
+
+if hasattr(typing, 'runtime_checkable'):
+    runtime_checkable = typing.runtime_checkable
+elif HAVE_PROTOCOLS:
+    def runtime_checkable(cls):
+        """Mark a protocol class as a runtime protocol, so that it
+        can be used with isinstance() and issubclass(). Raise TypeError
+        if applied to a non-protocol class.
+
+        This allows a simple-minded structural check very similar to the
+        one-offs in collections.abc such as Hashable.
+        """
+        if not isinstance(cls, _ProtocolMeta) or not cls._is_protocol:
+            raise TypeError('@runtime_checkable can be only applied to protocol classes,'
+                            ' got %r' % cls)
+        cls._is_runtime_protocol = True
+        return cls
+
+
+if HAVE_PROTOCOLS:
+    # Exists for backwards compatibility.
+    runtime = runtime_checkable
+
+
+if hasattr(typing, 'SupportsIndex'):
+    SupportsIndex = typing.SupportsIndex
+elif HAVE_PROTOCOLS:
+    @runtime_checkable
+    class SupportsIndex(Protocol):
+        __slots__ = ()
+
+        @abc.abstractmethod
+        def __index__(self) -> int:
+            pass
+
+
+if sys.version_info >= (3, 9, 2):
+    # The standard library TypedDict in Python 3.8 does not store runtime information
+    # about which (if any) keys are optional.  See https://bugs.python.org/issue38834
+    # The standard library TypedDict in Python 3.9.0/1 does not honour the "total"
+    # keyword with old-style TypedDict().  See https://bugs.python.org/issue42059
+    TypedDict = typing.TypedDict
+else:
+    def _check_fails(cls, other):
+        try:
+            if sys._getframe(1).f_globals['__name__'] not in ['abc',
+                                                              'functools',
+                                                              'typing']:
+                # Typed dicts are only for static structural subtyping.
+                raise TypeError('TypedDict does not support instance and class checks')
+        except (AttributeError, ValueError):
+            pass
+        return False
+
+    def _dict_new(*args, **kwargs):
+        if not args:
+            raise TypeError('TypedDict.__new__(): not enough arguments')
+        _, args = args[0], args[1:]  # allow the "cls" keyword be passed
+        return dict(*args, **kwargs)
+
+    _dict_new.__text_signature__ = '($cls, _typename, _fields=None, /, **kwargs)'
+
+    def _typeddict_new(*args, total=True, **kwargs):
+        if not args:
+            raise TypeError('TypedDict.__new__(): not enough arguments')
+        _, args = args[0], args[1:]  # allow the "cls" keyword be passed
+        if args:
+            typename, args = args[0], args[1:]  # allow the "_typename" keyword be passed
+        elif '_typename' in kwargs:
+            typename = kwargs.pop('_typename')
+            import warnings
+            warnings.warn("Passing '_typename' as keyword argument is deprecated",
+                          DeprecationWarning, stacklevel=2)
+        else:
+            raise TypeError("TypedDict.__new__() missing 1 required positional "
+                            "argument: '_typename'")
+        if args:
+            try:
+                fields, = args  # allow the "_fields" keyword be passed
+            except ValueError:
+                raise TypeError('TypedDict.__new__() takes from 2 to 3 '
+                                'positional arguments but {} '
+                                'were given'.format(len(args) + 2))
+        elif '_fields' in kwargs and len(kwargs) == 1:
+            fields = kwargs.pop('_fields')
+            import warnings
+            warnings.warn("Passing '_fields' as keyword argument is deprecated",
+                          DeprecationWarning, stacklevel=2)
+        else:
+            fields = None
+
+        if fields is None:
+            fields = kwargs
+        elif kwargs:
+            raise TypeError("TypedDict takes either a dict or keyword arguments,"
+                            " but not both")
+
+        ns = {'__annotations__': dict(fields)}
+        try:
+            # Setting correct module is necessary to make typed dict classes pickleable.
+            ns['__module__'] = sys._getframe(1).f_globals.get('__name__', '__main__')
+        except (AttributeError, ValueError):
+            pass
+
+        return _TypedDictMeta(typename, (), ns, total=total)
+
+    _typeddict_new.__text_signature__ = ('($cls, _typename, _fields=None,'
+                                         ' /, *, total=True, **kwargs)')
+
+    class _TypedDictMeta(type):
+        def __init__(cls, name, bases, ns, total=True):
+            # In Python 3.4 and 3.5 the __init__ method also needs to support the keyword arguments.
+            # See https://www.python.org/dev/peps/pep-0487/#implementation-details
+            super().__init__(name, bases, ns)
+
+        def __new__(cls, name, bases, ns, total=True):
+            # Create new typed dict class object.
+            # This method is called directly when TypedDict is subclassed,
+            # or via _typeddict_new when TypedDict is instantiated. This way
+            # TypedDict supports all three syntaxes described in its docstring.
+            # Subclasses and instances of TypedDict return actual dictionaries
+            # via _dict_new.
+            ns['__new__'] = _typeddict_new if name == 'TypedDict' else _dict_new
+            tp_dict = super().__new__(cls, name, (dict,), ns)
+
+            annotations = {}
+            own_annotations = ns.get('__annotations__', {})
+            own_annotation_keys = set(own_annotations.keys())
+            msg = "TypedDict('Name', {f0: t0, f1: t1, ...}); each t must be a type"
+            own_annotations = {
+                n: typing._type_check(tp, msg) for n, tp in own_annotations.items()
+            }
+            required_keys = set()
+            optional_keys = set()
+
+            for base in bases:
+                annotations.update(base.__dict__.get('__annotations__', {}))
+                required_keys.update(base.__dict__.get('__required_keys__', ()))
+                optional_keys.update(base.__dict__.get('__optional_keys__', ()))
+
+            annotations.update(own_annotations)
+            if total:
+                required_keys.update(own_annotation_keys)
+            else:
+                optional_keys.update(own_annotation_keys)
+
+            tp_dict.__annotations__ = annotations
+            tp_dict.__required_keys__ = frozenset(required_keys)
+            tp_dict.__optional_keys__ = frozenset(optional_keys)
+            if not hasattr(tp_dict, '__total__'):
+                tp_dict.__total__ = total
+            return tp_dict
+
+        __instancecheck__ = __subclasscheck__ = _check_fails
+
+    TypedDict = _TypedDictMeta('TypedDict', (dict,), {})
+    TypedDict.__module__ = __name__
+    TypedDict.__doc__ = \
+        """A simple typed name space. At runtime it is equivalent to a plain dict.
+
+        TypedDict creates a dictionary type that expects all of its
+        instances to have a certain set of keys, with each key
+        associated with a value of a consistent type. This expectation
+        is not checked at runtime but is only enforced by type checkers.
+        Usage::
+
+            class Point2D(TypedDict):
+                x: int
+                y: int
+                label: str
+
+            a: Point2D = {'x': 1, 'y': 2, 'label': 'good'}  # OK
+            b: Point2D = {'z': 3, 'label': 'bad'}           # Fails type check
+
+            assert Point2D(x=1, y=2, label='first') == dict(x=1, y=2, label='first')
+
+        The type info can be accessed via the Point2D.__annotations__ dict, and
+        the Point2D.__required_keys__ and Point2D.__optional_keys__ frozensets.
+        TypedDict supports two additional equivalent forms::
+
+            Point2D = TypedDict('Point2D', x=int, y=int, label=str)
+            Point2D = TypedDict('Point2D', {'x': int, 'y': int, 'label': str})
+
+        The class syntax is only supported in Python 3.6+, while two other
+        syntax forms work for Python 2.7 and 3.2+
+        """
+
+
+# Python 3.9+ has PEP 593 (Annotated and modified get_type_hints)
+if hasattr(typing, 'Annotated'):
+    Annotated = typing.Annotated
+    get_type_hints = typing.get_type_hints
+    # Not exported and not a public API, but needed for get_origin() and get_args()
+    # to work.
+    _AnnotatedAlias = typing._AnnotatedAlias
+elif PEP_560:
+    class _AnnotatedAlias(typing._GenericAlias, _root=True):
+        """Runtime representation of an annotated type.
+
+        At its core 'Annotated[t, dec1, dec2, ...]' is an alias for the type 't'
+        with extra annotations. The alias behaves like a normal typing alias,
+        instantiating is the same as instantiating the underlying type, binding
+        it to types is also the same.
+        """
+        def __init__(self, origin, metadata):
+            if isinstance(origin, _AnnotatedAlias):
+                metadata = origin.__metadata__ + metadata
+                origin = origin.__origin__
+            super().__init__(origin, origin)
+            self.__metadata__ = metadata
+
+        def copy_with(self, params):
+            assert len(params) == 1
+            new_type = params[0]
+            return _AnnotatedAlias(new_type, self.__metadata__)
+
+        def __repr__(self):
+            return "typing_extensions.Annotated[{}, {}]".format(
+                typing._type_repr(self.__origin__),
+                ", ".join(repr(a) for a in self.__metadata__)
+            )
+
+        def __reduce__(self):
+            return operator.getitem, (
+                Annotated, (self.__origin__,) + self.__metadata__
+            )
+
+        def __eq__(self, other):
+            if not isinstance(other, _AnnotatedAlias):
+                return NotImplemented
+            if self.__origin__ != other.__origin__:
+                return False
+            return self.__metadata__ == other.__metadata__
+
+        def __hash__(self):
+            return hash((self.__origin__, self.__metadata__))
+
+    class Annotated:
+        """Add context specific metadata to a type.
+
+        Example: Annotated[int, runtime_check.Unsigned] indicates to the
+        hypothetical runtime_check module that this type is an unsigned int.
+        Every other consumer of this type can ignore this metadata and treat
+        this type as int.
+
+        The first argument to Annotated must be a valid type (and will be in
+        the __origin__ field), the remaining arguments are kept as a tuple in
+        the __extra__ field.
+
+        Details:
+
+        - It's an error to call `Annotated` with less than two arguments.
+        - Nested Annotated are flattened::
+
+            Annotated[Annotated[T, Ann1, Ann2], Ann3] == Annotated[T, Ann1, Ann2, Ann3]
+
+        - Instantiating an annotated type is equivalent to instantiating the
+        underlying type::
+
+            Annotated[C, Ann1](5) == C(5)
+
+        - Annotated can be used as a generic type alias::
+
+            Optimized = Annotated[T, runtime.Optimize()]
+            Optimized[int] == Annotated[int, runtime.Optimize()]
+
+            OptimizedList = Annotated[List[T], runtime.Optimize()]
+            OptimizedList[int] == Annotated[List[int], runtime.Optimize()]
+        """
+
+        __slots__ = ()
+
+        def __new__(cls, *args, **kwargs):
+            raise TypeError("Type Annotated cannot be instantiated.")
+
+        @_tp_cache
+        def __class_getitem__(cls, params):
+            if not isinstance(params, tuple) or len(params) < 2:
+                raise TypeError("Annotated[...] should be used "
+                                "with at least two arguments (a type and an "
+                                "annotation).")
+            msg = "Annotated[t, ...]: t must be a type."
+            origin = typing._type_check(params[0], msg)
+            metadata = tuple(params[1:])
+            return _AnnotatedAlias(origin, metadata)
+
+        def __init_subclass__(cls, *args, **kwargs):
+            raise TypeError(
+                "Cannot subclass {}.Annotated".format(cls.__module__)
+            )
+
+    def _strip_annotations(t):
+        """Strips the annotations from a given type.
+        """
+        if isinstance(t, _AnnotatedAlias):
+            return _strip_annotations(t.__origin__)
+        if isinstance(t, typing._GenericAlias):
+            stripped_args = tuple(_strip_annotations(a) for a in t.__args__)
+            if stripped_args == t.__args__:
+                return t
+            res = t.copy_with(stripped_args)
+            res._special = t._special
+            return res
+        return t
+
+    def get_type_hints(obj, globalns=None, localns=None, include_extras=False):
+        """Return type hints for an object.
+
+        This is often the same as obj.__annotations__, but it handles
+        forward references encoded as string literals, adds Optional[t] if a
+        default value equal to None is set and recursively replaces all
+        'Annotated[T, ...]' with 'T' (unless 'include_extras=True').
+
+        The argument may be a module, class, method, or function. The annotations
+        are returned as a dictionary. For classes, annotations include also
+        inherited members.
+
+        TypeError is raised if the argument is not of a type that can contain
+        annotations, and an empty dictionary is returned if no annotations are
+        present.
+
+        BEWARE -- the behavior of globalns and localns is counterintuitive
+        (unless you are familiar with how eval() and exec() work).  The
+        search order is locals first, then globals.
+
+        - If no dict arguments are passed, an attempt is made to use the
+          globals from obj (or the respective module's globals for classes),
+          and these are also used as the locals.  If the object does not appear
+          to have globals, an empty dictionary is used.
+
+        - If one dict argument is passed, it is used for both globals and
+          locals.
+
+        - If two dict arguments are passed, they specify globals and
+          locals, respectively.
+        """
+        hint = typing.get_type_hints(obj, globalns=globalns, localns=localns)
+        if include_extras:
+            return hint
+        return {k: _strip_annotations(t) for k, t in hint.items()}
+
+elif HAVE_ANNOTATED:
+
+    def _is_dunder(name):
+        """Returns True if name is a __dunder_variable_name__."""
+        return len(name) > 4 and name.startswith('__') and name.endswith('__')
+
+    # Prior to Python 3.7 types did not have `copy_with`. A lot of the equality
+    # checks, argument expansion etc. are done on the _subs_tre. As a result we
+    # can't provide a get_type_hints function that strips out annotations.
+
+    class AnnotatedMeta(typing.GenericMeta):
+        """Metaclass for Annotated"""
+
+        def __new__(cls, name, bases, namespace, **kwargs):
+            if any(b is not object for b in bases):
+                raise TypeError("Cannot subclass " + str(Annotated))
+            return super().__new__(cls, name, bases, namespace, **kwargs)
+
+        @property
+        def __metadata__(self):
+            return self._subs_tree()[2]
+
+        def _tree_repr(self, tree):
+            cls, origin, metadata = tree
+            if not isinstance(origin, tuple):
+                tp_repr = typing._type_repr(origin)
+            else:
+                tp_repr = origin[0]._tree_repr(origin)
+            metadata_reprs = ", ".join(repr(arg) for arg in metadata)
+            return '{}[{}, {}]'.format(cls, tp_repr, metadata_reprs)
+
+        def _subs_tree(self, tvars=None, args=None):  # noqa
+            if self is Annotated:
+                return Annotated
+            res = super()._subs_tree(tvars=tvars, args=args)
+            # Flatten nested Annotated
+            if isinstance(res[1], tuple) and res[1][0] is Annotated:
+                sub_tp = res[1][1]
+                sub_annot = res[1][2]
+                return (Annotated, sub_tp, sub_annot + res[2])
+            return res
+
+        def _get_cons(self):
+            """Return the class used to create instance of this type."""
+            if self.__origin__ is None:
+                raise TypeError("Cannot get the underlying type of a "
+                                "non-specialized Annotated type.")
+            tree = self._subs_tree()
+            while isinstance(tree, tuple) and tree[0] is Annotated:
+                tree = tree[1]
+            if isinstance(tree, tuple):
+                return tree[0]
+            else:
+                return tree
+
+        @_tp_cache
+        def __getitem__(self, params):
+            if not isinstance(params, tuple):
+                params = (params,)
+            if self.__origin__ is not None:  # specializing an instantiated type
+                return super().__getitem__(params)
+            elif not isinstance(params, tuple) or len(params) < 2:
+                raise TypeError("Annotated[...] should be instantiated "
+                                "with at least two arguments (a type and an "
+                                "annotation).")
+            else:
+                msg = "Annotated[t, ...]: t must be a type."
+                tp = typing._type_check(params[0], msg)
+                metadata = tuple(params[1:])
+            return self.__class__(
+                self.__name__,
+                self.__bases__,
+                _no_slots_copy(self.__dict__),
+                tvars=_type_vars((tp,)),
+                # Metadata is a tuple so it won't be touched by _replace_args et al.
+                args=(tp, metadata),
+                origin=self,
+            )
+
+        def __call__(self, *args, **kwargs):
+            cons = self._get_cons()
+            result = cons(*args, **kwargs)
+            try:
+                result.__orig_class__ = self
+            except AttributeError:
+                pass
+            return result
+
+        def __getattr__(self, attr):
+            # For simplicity we just don't relay all dunder names
+            if self.__origin__ is not None and not _is_dunder(attr):
+                return getattr(self._get_cons(), attr)
+            raise AttributeError(attr)
+
+        def __setattr__(self, attr, value):
+            if _is_dunder(attr) or attr.startswith('_abc_'):
+                super().__setattr__(attr, value)
+            elif self.__origin__ is None:
+                raise AttributeError(attr)
+            else:
+                setattr(self._get_cons(), attr, value)
+
+        def __instancecheck__(self, obj):
+            raise TypeError("Annotated cannot be used with isinstance().")
+
+        def __subclasscheck__(self, cls):
+            raise TypeError("Annotated cannot be used with issubclass().")
+
+    class Annotated(metaclass=AnnotatedMeta):
+        """Add context specific metadata to a type.
+
+        Example: Annotated[int, runtime_check.Unsigned] indicates to the
+        hypothetical runtime_check module that this type is an unsigned int.
+        Every other consumer of this type can ignore this metadata and treat
+        this type as int.
+
+        The first argument to Annotated must be a valid type, the remaining
+        arguments are kept as a tuple in the __metadata__ field.
+
+        Details:
+
+        - It's an error to call `Annotated` with less than two arguments.
+        - Nested Annotated are flattened::
+
+            Annotated[Annotated[T, Ann1, Ann2], Ann3] == Annotated[T, Ann1, Ann2, Ann3]
+
+        - Instantiating an annotated type is equivalent to instantiating the
+        underlying type::
+
+            Annotated[C, Ann1](5) == C(5)
+
+        - Annotated can be used as a generic type alias::
+
+            Optimized = Annotated[T, runtime.Optimize()]
+            Optimized[int] == Annotated[int, runtime.Optimize()]
+
+            OptimizedList = Annotated[List[T], runtime.Optimize()]
+            OptimizedList[int] == Annotated[List[int], runtime.Optimize()]
+        """
+
+# Python 3.8 has get_origin() and get_args() but those implementations aren't
+# Annotated-aware, so we can't use those, only Python 3.9 versions will do.
+# Similarly, Python 3.9's implementation doesn't support ParamSpecArgs and
+# ParamSpecKwargs.
+if sys.version_info[:2] >= (3, 10):
+    get_origin = typing.get_origin
+    get_args = typing.get_args
+elif PEP_560:
+    from typing import _GenericAlias
+    try:
+        # 3.9+
+        from typing import _BaseGenericAlias
+    except ImportError:
+        _BaseGenericAlias = _GenericAlias
+    try:
+        # 3.9+
+        from typing import GenericAlias
+    except ImportError:
+        GenericAlias = _GenericAlias
+
+    def get_origin(tp):
+        """Get the unsubscripted version of a type.
+
+        This supports generic types, Callable, Tuple, Union, Literal, Final, ClassVar
+        and Annotated. Return None for unsupported types. Examples::
+
+            get_origin(Literal[42]) is Literal
+            get_origin(int) is None
+            get_origin(ClassVar[int]) is ClassVar
+            get_origin(Generic) is Generic
+            get_origin(Generic[T]) is Generic
+            get_origin(Union[T, int]) is Union
+            get_origin(List[Tuple[T, T]][int]) == list
+            get_origin(P.args) is P
+        """
+        if isinstance(tp, _AnnotatedAlias):
+            return Annotated
+        if isinstance(tp, (_GenericAlias, GenericAlias, _BaseGenericAlias,
+                           ParamSpecArgs, ParamSpecKwargs)):
+            return tp.__origin__
+        if tp is Generic:
+            return Generic
+        return None
+
+    def get_args(tp):
+        """Get type arguments with all substitutions performed.
+
+        For unions, basic simplifications used by Union constructor are performed.
+        Examples::
+            get_args(Dict[str, int]) == (str, int)
+            get_args(int) == ()
+            get_args(Union[int, Union[T, int], str][int]) == (int, str)
+            get_args(Union[int, Tuple[T, int]][str]) == (int, Tuple[str, int])
+            get_args(Callable[[], T][int]) == ([], int)
+        """
+        if isinstance(tp, _AnnotatedAlias):
+            return (tp.__origin__,) + tp.__metadata__
+        if isinstance(tp, (_GenericAlias, GenericAlias)):
+            if getattr(tp, "_special", False):
+                return ()
+            res = tp.__args__
+            if get_origin(tp) is collections.abc.Callable and res[0] is not Ellipsis:
+                res = (list(res[:-1]), res[-1])
+            return res
+        return ()
+
+
+if hasattr(typing, 'TypeAlias'):
+    TypeAlias = typing.TypeAlias
+elif sys.version_info[:2] >= (3, 9):
+    class _TypeAliasForm(typing._SpecialForm, _root=True):
+        def __repr__(self):
+            return 'typing_extensions.' + self._name
+
+    @_TypeAliasForm
+    def TypeAlias(self, parameters):
+        """Special marker indicating that an assignment should
+        be recognized as a proper type alias definition by type
+        checkers.
+
+        For example::
+
+            Predicate: TypeAlias = Callable[..., bool]
+
+        It's invalid when used anywhere except as in the example above.
+        """
+        raise TypeError("{} is not subscriptable".format(self))
+
+elif sys.version_info[:2] >= (3, 7):
+    class _TypeAliasForm(typing._SpecialForm, _root=True):
+        def __repr__(self):
+            return 'typing_extensions.' + self._name
+
+    TypeAlias = _TypeAliasForm('TypeAlias',
+                               doc="""Special marker indicating that an assignment should
+                               be recognized as a proper type alias definition by type
+                               checkers.
+
+                               For example::
+
+                                   Predicate: TypeAlias = Callable[..., bool]
+
+                               It's invalid when used anywhere except as in the example
+                               above.""")
+
+elif hasattr(typing, '_FinalTypingBase'):
+    class _TypeAliasMeta(typing.TypingMeta):
+        """Metaclass for TypeAlias"""
+
+        def __repr__(self):
+            return 'typing_extensions.TypeAlias'
+
+    class _TypeAliasBase(typing._FinalTypingBase, metaclass=_TypeAliasMeta, _root=True):
+        """Special marker indicating that an assignment should
+        be recognized as a proper type alias definition by type
+        checkers.
+
+        For example::
+
+            Predicate: TypeAlias = Callable[..., bool]
+
+        It's invalid when used anywhere except as in the example above.
+        """
+        __slots__ = ()
+
+        def __instancecheck__(self, obj):
+            raise TypeError("TypeAlias cannot be used with isinstance().")
+
+        def __subclasscheck__(self, cls):
+            raise TypeError("TypeAlias cannot be used with issubclass().")
+
+        def __repr__(self):
+            return 'typing_extensions.TypeAlias'
+
+    TypeAlias = _TypeAliasBase(_root=True)
+else:
+    class _TypeAliasMeta(typing.TypingMeta):
+        """Metaclass for TypeAlias"""
+
+        def __instancecheck__(self, obj):
+            raise TypeError("TypeAlias cannot be used with isinstance().")
+
+        def __subclasscheck__(self, cls):
+            raise TypeError("TypeAlias cannot be used with issubclass().")
+
+        def __call__(self, *args, **kwargs):
+            raise TypeError("Cannot instantiate TypeAlias")
+
+    class TypeAlias(metaclass=_TypeAliasMeta, _root=True):
+        """Special marker indicating that an assignment should
+        be recognized as a proper type alias definition by type
+        checkers.
+
+        For example::
+
+            Predicate: TypeAlias = Callable[..., bool]
+
+        It's invalid when used anywhere except as in the example above.
+        """
+        __slots__ = ()
+
+
+# Python 3.10+ has PEP 612
+if hasattr(typing, 'ParamSpecArgs'):
+    ParamSpecArgs = typing.ParamSpecArgs
+    ParamSpecKwargs = typing.ParamSpecKwargs
+else:
+    class _Immutable:
+        """Mixin to indicate that object should not be copied."""
+        __slots__ = ()
+
+        def __copy__(self):
+            return self
+
+        def __deepcopy__(self, memo):
+            return self
+
+    class ParamSpecArgs(_Immutable):
+        """The args for a ParamSpec object.
+
+        Given a ParamSpec object P, P.args is an instance of ParamSpecArgs.
+
+        ParamSpecArgs objects have a reference back to their ParamSpec:
+
+        P.args.__origin__ is P
+
+        This type is meant for runtime introspection and has no special meaning to
+        static type checkers.
+        """
+        def __init__(self, origin):
+            self.__origin__ = origin
+
+        def __repr__(self):
+            return "{}.args".format(self.__origin__.__name__)
+
+    class ParamSpecKwargs(_Immutable):
+        """The kwargs for a ParamSpec object.
+
+        Given a ParamSpec object P, P.kwargs is an instance of ParamSpecKwargs.
+
+        ParamSpecKwargs objects have a reference back to their ParamSpec:
+
+        P.kwargs.__origin__ is P
+
+        This type is meant for runtime introspection and has no special meaning to
+        static type checkers.
+        """
+        def __init__(self, origin):
+            self.__origin__ = origin
+
+        def __repr__(self):
+            return "{}.kwargs".format(self.__origin__.__name__)
+
+if hasattr(typing, 'ParamSpec'):
+    ParamSpec = typing.ParamSpec
+else:
+
+    # Inherits from list as a workaround for Callable checks in Python < 3.9.2.
+    class ParamSpec(list):
+        """Parameter specification variable.
+
+        Usage::
+
+           P = ParamSpec('P')
+
+        Parameter specification variables exist primarily for the benefit of static
+        type checkers.  They are used to forward the parameter types of one
+        callable to another callable, a pattern commonly found in higher order
+        functions and decorators.  They are only valid when used in ``Concatenate``,
+        or s the first argument to ``Callable``. In Python 3.10 and higher,
+        they are also supported in user-defined Generics at runtime.
+        See class Generic for more information on generic types.  An
+        example for annotating a decorator::
+
+           T = TypeVar('T')
+           P = ParamSpec('P')
+
+           def add_logging(f: Callable[P, T]) -> Callable[P, T]:
+               '''A type-safe decorator to add logging to a function.'''
+               def inner(*args: P.args, **kwargs: P.kwargs) -> T:
+                   logging.info(f'{f.__name__} was called')
+                   return f(*args, **kwargs)
+               return inner
+
+           @add_logging
+           def add_two(x: float, y: float) -> float:
+               '''Add two numbers together.'''
+               return x + y
+
+        Parameter specification variables defined with covariant=True or
+        contravariant=True can be used to declare covariant or contravariant
+        generic types.  These keyword arguments are valid, but their actual semantics
+        are yet to be decided.  See PEP 612 for details.
+
+        Parameter specification variables can be introspected. e.g.:
+
+           P.__name__ == 'T'
+           P.__bound__ == None
+           P.__covariant__ == False
+           P.__contravariant__ == False
+
+        Note that only parameter specification variables defined in global scope can
+        be pickled.
+        """
+
+        # Trick Generic __parameters__.
+        __class__ = TypeVar
+
+        @property
+        def args(self):
+            return ParamSpecArgs(self)
+
+        @property
+        def kwargs(self):
+            return ParamSpecKwargs(self)
+
+        def __init__(self, name, *, bound=None, covariant=False, contravariant=False):
+            super().__init__([self])
+            self.__name__ = name
+            self.__covariant__ = bool(covariant)
+            self.__contravariant__ = bool(contravariant)
+            if bound:
+                self.__bound__ = typing._type_check(bound, 'Bound must be a type.')
+            else:
+                self.__bound__ = None
+
+            # for pickling:
+            try:
+                def_mod = sys._getframe(1).f_globals.get('__name__', '__main__')
+            except (AttributeError, ValueError):
+                def_mod = None
+            if def_mod != 'typing_extensions':
+                self.__module__ = def_mod
+
+        def __repr__(self):
+            if self.__covariant__:
+                prefix = '+'
+            elif self.__contravariant__:
+                prefix = '-'
+            else:
+                prefix = '~'
+            return prefix + self.__name__
+
+        def __hash__(self):
+            return object.__hash__(self)
+
+        def __eq__(self, other):
+            return self is other
+
+        def __reduce__(self):
+            return self.__name__
+
+        # Hack to get typing._type_check to pass.
+        def __call__(self, *args, **kwargs):
+            pass
+
+        if not PEP_560:
+            # Only needed in 3.6 and lower.
+            def _get_type_vars(self, tvars):
+                if self not in tvars:
+                    tvars.append(self)
+
+# Inherits from list as a workaround for Callable checks in Python < 3.9.2.
+class _ConcatenateGenericAlias(list):
+
+    # Trick Generic into looking into this for __parameters__.
+    if PEP_560:
+        __class__ = _GenericAlias
+    elif sys.version_info[:3] == (3, 5, 2):
+        __class__ = typing.TypingMeta
+    else:
+        __class__ = typing._TypingBase
+
+    # Flag in 3.8.
+    _special = False
+    # Attribute in 3.6 and earlier.
+    if sys.version_info[:3] == (3, 5, 2):
+        _gorg = typing.GenericMeta
+    else:
+        _gorg = typing.Generic
+
+    def __init__(self, origin, args):
+        super().__init__(args)
+        self.__origin__ = origin
+        self.__args__ = args
+
+    def __repr__(self):
+        _type_repr = typing._type_repr
+        return '{origin}[{args}]' \
+               .format(origin=_type_repr(self.__origin__),
+                       args=', '.join(_type_repr(arg) for arg in self.__args__))
+
+    def __hash__(self):
+        return hash((self.__origin__, self.__args__))
+
+    # Hack to get typing._type_check to pass in Generic.
+    def __call__(self, *args, **kwargs):
+        pass
+
+    @property
+    def __parameters__(self):
+        return tuple(tp for tp in self.__args__ if isinstance(tp, (TypeVar, ParamSpec)))
+
+    if not PEP_560:
+        # Only required in 3.6 and lower.
+        def _get_type_vars(self, tvars):
+            if self.__origin__ and self.__parameters__:
+                typing._get_type_vars(self.__parameters__, tvars)
+
+@_tp_cache
+def _concatenate_getitem(self, parameters):
+    if parameters == ():
+        raise TypeError("Cannot take a Concatenate of no types.")
+    if not isinstance(parameters, tuple):
+        parameters = (parameters,)
+    if not isinstance(parameters[-1], ParamSpec):
+        raise TypeError("The last parameter to Concatenate should be a "
+                        "ParamSpec variable.")
+    msg = "Concatenate[arg, ...]: each arg must be a type."
+    parameters = tuple(typing._type_check(p, msg) for p in parameters)
+    return _ConcatenateGenericAlias(self, parameters)
+
+
+if hasattr(typing, 'Concatenate'):
+    Concatenate = typing.Concatenate
+    _ConcatenateGenericAlias = typing._ConcatenateGenericAlias # noqa
+elif sys.version_info[:2] >= (3, 9):
+    @_TypeAliasForm
+    def Concatenate(self, parameters):
+        """Used in conjunction with ``ParamSpec`` and ``Callable`` to represent a
+        higher order function which adds, removes or transforms parameters of a
+        callable.
+
+        For example::
+
+           Callable[Concatenate[int, P], int]
+
+        See PEP 612 for detailed information.
+        """
+        return _concatenate_getitem(self, parameters)
+
+elif sys.version_info[:2] >= (3, 7):
+    class _ConcatenateForm(typing._SpecialForm, _root=True):
+        def __repr__(self):
+            return 'typing_extensions.' + self._name
+
+        def __getitem__(self, parameters):
+            return _concatenate_getitem(self, parameters)
+
+    Concatenate = _ConcatenateForm('Concatenate',
+        doc="""Used in conjunction with ``ParamSpec`` and ``Callable`` to represent a
+        higher order function which adds, removes or transforms parameters of a
+        callable.
+
+        For example::
+
+           Callable[Concatenate[int, P], int]
+
+        See PEP 612 for detailed information.
+        """)
+
+elif hasattr(typing, '_FinalTypingBase'):
+    class _ConcatenateAliasMeta(typing.TypingMeta):
+        """Metaclass for Concatenate."""
+
+        def __repr__(self):
+            return 'typing_extensions.Concatenate'
+
+    class _ConcatenateAliasBase(typing._FinalTypingBase,
+                                metaclass=_ConcatenateAliasMeta,
+                                _root=True):
+        """Used in conjunction with ``ParamSpec`` and ``Callable`` to represent a
+        higher order function which adds, removes or transforms parameters of a
+        callable.
+
+        For example::
+
+           Callable[Concatenate[int, P], int]
+
+        See PEP 612 for detailed information.
+        """
+        __slots__ = ()
+
+        def __instancecheck__(self, obj):
+            raise TypeError("Concatenate cannot be used with isinstance().")
+
+        def __subclasscheck__(self, cls):
+            raise TypeError("Concatenate cannot be used with issubclass().")
+
+        def __repr__(self):
+            return 'typing_extensions.Concatenate'
+
+        def __getitem__(self, parameters):
+            return _concatenate_getitem(self, parameters)
+
+    Concatenate = _ConcatenateAliasBase(_root=True)
+# For 3.5.0 - 3.5.2
+else:
+    class _ConcatenateAliasMeta(typing.TypingMeta):
+        """Metaclass for Concatenate."""
+
+        def __instancecheck__(self, obj):
+            raise TypeError("TypeAlias cannot be used with isinstance().")
+
+        def __subclasscheck__(self, cls):
+            raise TypeError("TypeAlias cannot be used with issubclass().")
+
+        def __call__(self, *args, **kwargs):
+            raise TypeError("Cannot instantiate TypeAlias")
+
+        def __getitem__(self, parameters):
+            return _concatenate_getitem(self, parameters)
+
+    class Concatenate(metaclass=_ConcatenateAliasMeta, _root=True):
+        """Used in conjunction with ``ParamSpec`` and ``Callable`` to represent a
+        higher order function which adds, removes or transforms parameters of a
+        callable.
+
+        For example::
+
+           Callable[Concatenate[int, P], int]
+
+        See PEP 612 for detailed information.
+        """
+        __slots__ = ()
+
+if hasattr(typing, 'TypeGuard'):
+    TypeGuard = typing.TypeGuard
+elif sys.version_info[:2] >= (3, 9):
+    class _TypeGuardForm(typing._SpecialForm, _root=True):
+        def __repr__(self):
+            return 'typing_extensions.' + self._name
+
+    @_TypeGuardForm
+    def TypeGuard(self, parameters):
+        """Special typing form used to annotate the return type of a user-defined
+        type guard function.  ``TypeGuard`` only accepts a single type argument.
+        At runtime, functions marked this way should return a boolean.
+
+        ``TypeGuard`` aims to benefit *type narrowing* -- a technique used by static
+        type checkers to determine a more precise type of an expression within a
+        program's code flow.  Usually type narrowing is done by analyzing
+        conditional code flow and applying the narrowing to a block of code.  The
+        conditional expression here is sometimes referred to as a "type guard".
+
+        Sometimes it would be convenient to use a user-defined boolean function
+        as a type guard.  Such a function should use ``TypeGuard[...]`` as its
+        return type to alert static type checkers to this intention.
+
+        Using  ``-> TypeGuard`` tells the static type checker that for a given
+        function:
+
+        1. The return value is a boolean.
+        2. If the return value is ``True``, the type of its argument
+        is the type inside ``TypeGuard``.
+
+        For example::
+
+            def is_str(val: Union[str, float]):
+                # "isinstance" type guard
+                if isinstance(val, str):
+                    # Type of ``val`` is narrowed to ``str``
+                    ...
+                else:
+                    # Else, type of ``val`` is narrowed to ``float``.
+                    ...
+
+        Strict type narrowing is not enforced -- ``TypeB`` need not be a narrower
+        form of ``TypeA`` (it can even be a wider form) and this may lead to
+        type-unsafe results.  The main reason is to allow for things like
+        narrowing ``List[object]`` to ``List[str]`` even though the latter is not
+        a subtype of the former, since ``List`` is invariant.  The responsibility of
+        writing type-safe type guards is left to the user.
+
+        ``TypeGuard`` also works with type variables.  For more information, see
+        PEP 647 (User-Defined Type Guards).
+        """
+        item = typing._type_check(parameters, '{} accepts only single type.'.format(self))
+        return _GenericAlias(self, (item,))
+
+elif sys.version_info[:2] >= (3, 7):
+    class _TypeGuardForm(typing._SpecialForm, _root=True):
+
+        def __repr__(self):
+            return 'typing_extensions.' + self._name
+
+        def __getitem__(self, parameters):
+            item = typing._type_check(parameters,
+                                      '{} accepts only a single type'.format(self._name))
+            return _GenericAlias(self, (item,))
+
+    TypeGuard = _TypeGuardForm(
+            'TypeGuard',
+            doc="""Special typing form used to annotate the return type of a user-defined
+        type guard function.  ``TypeGuard`` only accepts a single type argument.
+        At runtime, functions marked this way should return a boolean.
+
+        ``TypeGuard`` aims to benefit *type narrowing* -- a technique used by static
+        type checkers to determine a more precise type of an expression within a
+        program's code flow.  Usually type narrowing is done by analyzing
+        conditional code flow and applying the narrowing to a block of code.  The
+        conditional expression here is sometimes referred to as a "type guard".
+
+        Sometimes it would be convenient to use a user-defined boolean function
+        as a type guard.  Such a function should use ``TypeGuard[...]`` as its
+        return type to alert static type checkers to this intention.
+
+        Using  ``-> TypeGuard`` tells the static type checker that for a given
+        function:
+
+        1. The return value is a boolean.
+        2. If the return value is ``True``, the type of its argument
+        is the type inside ``TypeGuard``.
+
+        For example::
+
+            def is_str(val: Union[str, float]):
+                # "isinstance" type guard
+                if isinstance(val, str):
+                    # Type of ``val`` is narrowed to ``str``
+                    ...
+                else:
+                    # Else, type of ``val`` is narrowed to ``float``.
+                    ...
+
+        Strict type narrowing is not enforced -- ``TypeB`` need not be a narrower
+        form of ``TypeA`` (it can even be a wider form) and this may lead to
+        type-unsafe results.  The main reason is to allow for things like
+        narrowing ``List[object]`` to ``List[str]`` even though the latter is not
+        a subtype of the former, since ``List`` is invariant.  The responsibility of
+        writing type-safe type guards is left to the user.
+
+        ``TypeGuard`` also works with type variables.  For more information, see
+        PEP 647 (User-Defined Type Guards).
+        """)
+elif hasattr(typing, '_FinalTypingBase'):
+    class _TypeGuard(typing._FinalTypingBase, _root=True):
+        """Special typing form used to annotate the return type of a user-defined
+        type guard function.  ``TypeGuard`` only accepts a single type argument.
+        At runtime, functions marked this way should return a boolean.
+
+        ``TypeGuard`` aims to benefit *type narrowing* -- a technique used by static
+        type checkers to determine a more precise type of an expression within a
+        program's code flow.  Usually type narrowing is done by analyzing
+        conditional code flow and applying the narrowing to a block of code.  The
+        conditional expression here is sometimes referred to as a "type guard".
+
+        Sometimes it would be convenient to use a user-defined boolean function
+        as a type guard.  Such a function should use ``TypeGuard[...]`` as its
+        return type to alert static type checkers to this intention.
+
+        Using  ``-> TypeGuard`` tells the static type checker that for a given
+        function:
+
+        1. The return value is a boolean.
+        2. If the return value is ``True``, the type of its argument
+        is the type inside ``TypeGuard``.
+
+        For example::
+
+            def is_str(val: Union[str, float]):
+                # "isinstance" type guard
+                if isinstance(val, str):
+                    # Type of ``val`` is narrowed to ``str``
+                    ...
+                else:
+                    # Else, type of ``val`` is narrowed to ``float``.
+                    ...
+
+        Strict type narrowing is not enforced -- ``TypeB`` need not be a narrower
+        form of ``TypeA`` (it can even be a wider form) and this may lead to
+        type-unsafe results.  The main reason is to allow for things like
+        narrowing ``List[object]`` to ``List[str]`` even though the latter is not
+        a subtype of the former, since ``List`` is invariant.  The responsibility of
+        writing type-safe type guards is left to the user.
+
+        ``TypeGuard`` also works with type variables.  For more information, see
+        PEP 647 (User-Defined Type Guards).
+        """
+
+        __slots__ = ('__type__',)
+
+        def __init__(self, tp=None, **kwds):
+            self.__type__ = tp
+
+        def __getitem__(self, item):
+            cls = type(self)
+            if self.__type__ is None:
+                return cls(typing._type_check(item,
+                           '{} accepts only a single type.'.format(cls.__name__[1:])),
+                           _root=True)
+            raise TypeError('{} cannot be further subscripted'
+                            .format(cls.__name__[1:]))
+
+        def _eval_type(self, globalns, localns):
+            new_tp = typing._eval_type(self.__type__, globalns, localns)
+            if new_tp == self.__type__:
+                return self
+            return type(self)(new_tp, _root=True)
+
+        def __repr__(self):
+            r = super().__repr__()
+            if self.__type__ is not None:
+                r += '[{}]'.format(typing._type_repr(self.__type__))
+            return r
+
+        def __hash__(self):
+            return hash((type(self).__name__, self.__type__))
+
+        def __eq__(self, other):
+            if not isinstance(other, _TypeGuard):
+                return NotImplemented
+            if self.__type__ is not None:
+                return self.__type__ == other.__type__
+            return self is other
+
+    TypeGuard = _TypeGuard(_root=True)
+else:
+    class _TypeGuardMeta(typing.TypingMeta):
+        """Metaclass for TypeGuard"""
+
+        def __new__(cls, name, bases, namespace, tp=None, _root=False):
+            self = super().__new__(cls, name, bases, namespace, _root=_root)
+            if tp is not None:
+                self.__type__ = tp
+            return self
+
+        def __instancecheck__(self, obj):
+            raise TypeError("TypeGuard cannot be used with isinstance().")
+
+        def __subclasscheck__(self, cls):
+            raise TypeError("TypeGuard cannot be used with issubclass().")
+
+        def __getitem__(self, item):
+            cls = type(self)
+            if self.__type__ is not None:
+                raise TypeError('{} cannot be further subscripted'
+                                .format(cls.__name__[1:]))
+
+            param = typing._type_check(
+                item,
+                '{} accepts only single type.'.format(cls.__name__[1:]))
+            return cls(self.__name__, self.__bases__,
+                       dict(self.__dict__), tp=param, _root=True)
+
+        def _eval_type(self, globalns, localns):
+            new_tp = typing._eval_type(self.__type__, globalns, localns)
+            if new_tp == self.__type__:
+                return self
+            return type(self)(self.__name__, self.__bases__,
+                              dict(self.__dict__), tp=self.__type__,
+                              _root=True)
+
+        def __repr__(self):
+            r = super().__repr__()
+            if self.__type__ is not None:
+                r += '[{}]'.format(typing._type_repr(self.__type__))
+            return r
+
+        def __hash__(self):
+            return hash((type(self).__name__, self.__type__))
+
+        def __eq__(self, other):
+            if not hasattr(other, "__type__"):
+                return NotImplemented
+            if self.__type__ is not None:
+                return self.__type__ == other.__type__
+            return self is other
+
+    class TypeGuard(typing.Final, metaclass=_TypeGuardMeta, _root=True):
+        """Special typing form used to annotate the return type of a user-defined
+        type guard function.  ``TypeGuard`` only accepts a single type argument.
+        At runtime, functions marked this way should return a boolean.
+
+        ``TypeGuard`` aims to benefit *type narrowing* -- a technique used by static
+        type checkers to determine a more precise type of an expression within a
+        program's code flow.  Usually type narrowing is done by analyzing
+        conditional code flow and applying the narrowing to a block of code.  The
+        conditional expression here is sometimes referred to as a "type guard".
+
+        Sometimes it would be convenient to use a user-defined boolean function
+        as a type guard.  Such a function should use ``TypeGuard[...]`` as its
+        return type to alert static type checkers to this intention.
+
+        Using  ``-> TypeGuard`` tells the static type checker that for a given
+        function:
+
+        1. The return value is a boolean.
+        2. If the return value is ``True``, the type of its argument
+        is the type inside ``TypeGuard``.
+
+        For example::
+
+            def is_str(val: Union[str, float]):
+                # "isinstance" type guard
+                if isinstance(val, str):
+                    # Type of ``val`` is narrowed to ``str``
+                    ...
+                else:
+                    # Else, type of ``val`` is narrowed to ``float``.
+                    ...
+
+        Strict type narrowing is not enforced -- ``TypeB`` need not be a narrower
+        form of ``TypeA`` (it can even be a wider form) and this may lead to
+        type-unsafe results.  The main reason is to allow for things like
+        narrowing ``List[object]`` to ``List[str]`` even though the latter is not
+        a subtype of the former, since ``List`` is invariant.  The responsibility of
+        writing type-safe type guards is left to the user.
+
+        ``TypeGuard`` also works with type variables.  For more information, see
+        PEP 647 (User-Defined Type Guards).
+        """
+        __type__ = None

--- a/salt/ext/zipp.py
+++ b/salt/ext/zipp.py
@@ -1,0 +1,353 @@
+# This is https://raw.githubusercontent.com/jaraco/zipp/v3.5.0/zipp.py
+#
+# Copyright Jason R. Coombs
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+# THIS CODE SHOULD BE REMOVED WITH importlib-metadata >= 3.3.0 IS AVAILABLE
+# AS A SYSTEM PACKAGE ON ALL THE PLATFORMS FOR WHICH SALT BUILDS PACKAGES OR
+# WHEN THE MINIMUM PYTHON VERSION IS 3.10
+
+# pylint: skip-file
+import io
+import posixpath
+import zipfile
+import itertools
+import contextlib
+import sys
+import pathlib
+
+if sys.version_info < (3, 7):
+    from collections import OrderedDict
+else:
+    OrderedDict = dict
+
+
+def _parents(path):
+    """
+    Given a path with elements separated by
+    posixpath.sep, generate all parents of that path.
+
+    >>> list(_parents('b/d'))
+    ['b']
+    >>> list(_parents('/b/d/'))
+    ['/b']
+    >>> list(_parents('b/d/f/'))
+    ['b/d', 'b']
+    >>> list(_parents('b'))
+    []
+    >>> list(_parents(''))
+    []
+    """
+    return itertools.islice(_ancestry(path), 1, None)
+
+
+def _ancestry(path):
+    """
+    Given a path with elements separated by
+    posixpath.sep, generate all elements of that path
+
+    >>> list(_ancestry('b/d'))
+    ['b/d', 'b']
+    >>> list(_ancestry('/b/d/'))
+    ['/b/d', '/b']
+    >>> list(_ancestry('b/d/f/'))
+    ['b/d/f', 'b/d', 'b']
+    >>> list(_ancestry('b'))
+    ['b']
+    >>> list(_ancestry(''))
+    []
+    """
+    path = path.rstrip(posixpath.sep)
+    while path and path != posixpath.sep:
+        yield path
+        path, tail = posixpath.split(path)
+
+
+_dedupe = OrderedDict.fromkeys
+"""Deduplicate an iterable in original order"""
+
+
+def _difference(minuend, subtrahend):
+    """
+    Return items in minuend not in subtrahend, retaining order
+    with O(1) lookup.
+    """
+    return itertools.filterfalse(set(subtrahend).__contains__, minuend)
+
+
+class CompleteDirs(zipfile.ZipFile):
+    """
+    A ZipFile subclass that ensures that implied directories
+    are always included in the namelist.
+    """
+
+    @staticmethod
+    def _implied_dirs(names):
+        parents = itertools.chain.from_iterable(map(_parents, names))
+        as_dirs = (p + posixpath.sep for p in parents)
+        return _dedupe(_difference(as_dirs, names))
+
+    def namelist(self):
+        names = super().namelist()
+        return names + list(self._implied_dirs(names))
+
+    def _name_set(self):
+        return set(self.namelist())
+
+    def resolve_dir(self, name):
+        """
+        If the name represents a directory, return that name
+        as a directory (with the trailing slash).
+        """
+        names = self._name_set()
+        dirname = name + '/'
+        dir_match = name not in names and dirname in names
+        return dirname if dir_match else name
+
+    @classmethod
+    def make(cls, source):
+        """
+        Given a source (filename or zipfile), return an
+        appropriate CompleteDirs subclass.
+        """
+        if isinstance(source, CompleteDirs):
+            return source
+
+        if not isinstance(source, zipfile.ZipFile):
+            return cls(_pathlib_compat(source))
+
+        # Only allow for FastLookup when supplied zipfile is read-only
+        if 'r' not in source.mode:
+            cls = CompleteDirs
+
+        source.__class__ = cls
+        return source
+
+
+class FastLookup(CompleteDirs):
+    """
+    ZipFile subclass to ensure implicit
+    dirs exist and are resolved rapidly.
+    """
+
+    def namelist(self):
+        with contextlib.suppress(AttributeError):
+            return self.__names
+        self.__names = super().namelist()
+        return self.__names
+
+    def _name_set(self):
+        with contextlib.suppress(AttributeError):
+            return self.__lookup
+        self.__lookup = super()._name_set()
+        return self.__lookup
+
+
+def _pathlib_compat(path):
+    """
+    For path-like objects, convert to a filename for compatibility
+    on Python 3.6.1 and earlier.
+    """
+    try:
+        return path.__fspath__()
+    except AttributeError:
+        return str(path)
+
+
+class Path:
+    """
+    A pathlib-compatible interface for zip files.
+
+    Consider a zip file with this structure::
+
+        .
+        ├── a.txt
+        └── b
+            ├── c.txt
+            └── d
+                └── e.txt
+
+    >>> data = io.BytesIO()
+    >>> zf = zipfile.ZipFile(data, 'w')
+    >>> zf.writestr('a.txt', 'content of a')
+    >>> zf.writestr('b/c.txt', 'content of c')
+    >>> zf.writestr('b/d/e.txt', 'content of e')
+    >>> zf.filename = 'mem/abcde.zip'
+
+    Path accepts the zipfile object itself or a filename
+
+    >>> root = Path(zf)
+
+    From there, several path operations are available.
+
+    Directory iteration (including the zip file itself):
+
+    >>> a, b = root.iterdir()
+    >>> a
+    Path('mem/abcde.zip', 'a.txt')
+    >>> b
+    Path('mem/abcde.zip', 'b/')
+
+    name property:
+
+    >>> b.name
+    'b'
+
+    join with divide operator:
+
+    >>> c = b / 'c.txt'
+    >>> c
+    Path('mem/abcde.zip', 'b/c.txt')
+    >>> c.name
+    'c.txt'
+
+    Read text:
+
+    >>> c.read_text()
+    'content of c'
+
+    existence:
+
+    >>> c.exists()
+    True
+    >>> (b / 'missing.txt').exists()
+    False
+
+    Coercion to string:
+
+    >>> import os
+    >>> str(c).replace(os.sep, posixpath.sep)
+    'mem/abcde.zip/b/c.txt'
+
+    At the root, ``name``, ``filename``, and ``parent``
+    resolve to the zipfile. Note these attributes are not
+    valid and will raise a ``ValueError`` if the zipfile
+    has no filename.
+
+    >>> root.name
+    'abcde.zip'
+    >>> str(root.filename).replace(os.sep, posixpath.sep)
+    'mem/abcde.zip'
+    >>> str(root.parent)
+    'mem'
+    """
+
+    __repr = "{self.__class__.__name__}({self.root.filename!r}, {self.at!r})"
+
+    def __init__(self, root, at=""):
+        """
+        Construct a Path from a ZipFile or filename.
+
+        Note: When the source is an existing ZipFile object,
+        its type (__class__) will be mutated to a
+        specialized type. If the caller wishes to retain the
+        original type, the caller should either create a
+        separate ZipFile object or pass a filename.
+        """
+        self.root = FastLookup.make(root)
+        self.at = at
+
+    def open(self, mode='r', *args, pwd=None, **kwargs):
+        """
+        Open this entry as text or binary following the semantics
+        of ``pathlib.Path.open()`` by passing arguments through
+        to io.TextIOWrapper().
+        """
+        if self.is_dir():
+            raise IsADirectoryError(self)
+        zip_mode = mode[0]
+        if not self.exists() and zip_mode == 'r':
+            raise FileNotFoundError(self)
+        stream = self.root.open(self.at, zip_mode, pwd=pwd)
+        if 'b' in mode:
+            if args or kwargs:
+                raise ValueError("encoding args invalid for binary operation")
+            return stream
+        return io.TextIOWrapper(stream, *args, **kwargs)
+
+    @property
+    def name(self):
+        return pathlib.Path(self.at).name or self.filename.name
+
+    @property
+    def suffix(self):
+        return pathlib.Path(self.at).suffix or self.filename.suffix
+
+    @property
+    def suffixes(self):
+        return pathlib.Path(self.at).suffixes or self.filename.suffixes
+
+    @property
+    def stem(self):
+        return pathlib.Path(self.at).stem or self.filename.stem
+
+    @property
+    def filename(self):
+        return pathlib.Path(self.root.filename).joinpath(self.at)
+
+    def read_text(self, *args, **kwargs):
+        with self.open('r', *args, **kwargs) as strm:
+            return strm.read()
+
+    def read_bytes(self):
+        with self.open('rb') as strm:
+            return strm.read()
+
+    def _is_child(self, path):
+        return posixpath.dirname(path.at.rstrip("/")) == self.at.rstrip("/")
+
+    def _next(self, at):
+        return self.__class__(self.root, at)
+
+    def is_dir(self):
+        return not self.at or self.at.endswith("/")
+
+    def is_file(self):
+        return self.exists() and not self.is_dir()
+
+    def exists(self):
+        return self.at in self.root._name_set()
+
+    def iterdir(self):
+        if not self.is_dir():
+            raise ValueError("Can't listdir a file")
+        subs = map(self._next, self.root.namelist())
+        return filter(self._is_child, subs)
+
+    def __str__(self):
+        return posixpath.join(self.root.filename, self.at)
+
+    def __repr__(self):
+        return self.__repr.format(self=self)
+
+    def joinpath(self, *other):
+        next = posixpath.join(self.at, *map(_pathlib_compat, other))
+        return self._next(self.root.resolve_dir(next))
+
+    __truediv__ = joinpath
+
+    @property
+    def parent(self):
+        if not self.at:
+            return self.filename.parent
+        parent_at = posixpath.dirname(self.at.rstrip('/'))
+        if parent_at:
+            parent_at += '/'
+        return self._next(parent_at)

--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -460,7 +460,7 @@ def returners(opts, functions, whitelist=None, context=None, proxy=None):
     )
 
 
-def utils(opts, whitelist=None, context=None, proxy=proxy, pack_self=None):
+def utils(opts, whitelist=None, context=None, proxy=None, pack_self=None):
     """
     Returns the utility modules
     """

--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -5,20 +5,10 @@ plugin interfaces used by Salt.
 """
 
 import contextlib
-import copy
-import functools
-import importlib
-import importlib.machinery
-import importlib.util
-import inspect
 import logging
 import os
 import re
-import sys
-import tempfile
-import threading
 import time
-import traceback
 import types
 
 import salt.config
@@ -40,16 +30,8 @@ import salt.utils.versions
 from salt.exceptions import LoaderError
 from salt.template import check_render_pipe_str
 from salt.utils import entrypoints
-from salt.utils.decorators import Depends
 
 from .lazy import SALT_BASE_PATH, FilterDictWrapper, LazyLoader
-
-try:
-    # Try the stdlib C extension first
-    import _contextvars as contextvars
-except ImportError:
-    # Py<3.7
-    import contextvars
 
 log = logging.getLogger(__name__)
 

--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -142,6 +142,7 @@ def _module_dirs(
     ext_dirs=True,
     ext_type_dirs=None,
     base_path=None,
+    load_extensions=True,
 ):
     if tag is None:
         tag = ext_type
@@ -161,7 +162,7 @@ def _module_dirs(
             ext_type_dirs = "{}_dirs".format(tag)
         if ext_type_dirs in opts:
             ext_type_types.extend(opts[ext_type_dirs])
-        if ext_type_dirs:
+        if ext_type_dirs and load_extensions is True:
             for entry_point in entrypoints.iter_entry_points("salt.loader"):
                 with catch_entry_points_exception(entry_point) as ctx:
                     loaded_entry_point = entry_point.load()
@@ -465,7 +466,7 @@ def utils(opts, whitelist=None, context=None, proxy=None, pack_self=None):
     Returns the utility modules
     """
     return LazyLoader(
-        _module_dirs(opts, "utils", ext_type_dirs="utils_dirs"),
+        _module_dirs(opts, "utils", ext_type_dirs="utils_dirs", load_extensions=False),
         opts,
         tag="utils",
         whitelist=whitelist,

--- a/salt/utils/entrypoints.py
+++ b/salt/utils/entrypoints.py
@@ -1,3 +1,4 @@
+import imp
 import logging
 import sys
 import types
@@ -53,6 +54,32 @@ def iter_entry_points(group, name=None):
         log.debug("Using importlib_metadata to load entry points")
         entry_points = importlib_metadata.entry_points()
     elif USE_PKG_RESOURCES:
+        # We have to reload pkg_resources because it caches information and extensions installed while
+        # salt is running are not discovered until a python process restart, or, us reloading pkg_resources
+        if "pkg_resources" in sys.modules:
+            # This is really weird, but it's because of the following traceback seen during CI testing
+            #  Traceback (most recent call last):
+            #    File "/tmp/kitchen/testing/salt/utils/parsers.py", line 210, in parse_args
+            #      mixin_after_parsed_func(self)
+            #    File "/tmp/kitchen/testing/salt/utils/parsers.py", line 880, in __setup_extended_logging
+            #      log.setup_extended_logging(self.config)
+            #    File "/tmp/kitchen/testing/salt/log/setup.py", line 414, in setup_extended_logging
+            #      providers = salt.loader.log_handlers(opts)
+            #    File "/tmp/kitchen/testing/salt/loader.py", line 674, in log_handlers
+            #      base_path=os.path.join(SALT_BASE_PATH, "log"),
+            #    File "/tmp/kitchen/testing/salt/loader.py", line 145, in _module_dirs
+            #      for entry_point in entrypoints.iter_entry_points("salt.loader"):
+            #    File "/tmp/kitchen/testing/salt/utils/entrypoints.py", line 59, in iter_entry_points
+            #      imp.reload(pkg_resources)
+            #    File "/usr/lib/python3.7/imp.py", line 314, in reload
+            #      return importlib.reload(module)
+            #    File "/usr/lib/python3.7/importlib/__init__.py", line 148, in reload
+            #      raise ImportError(msg.format(name), name=name)
+            #  ImportError: module pkg_resources not in sys.modules
+
+            # Lets re-inject it into sys.modules since we have a reference to the module
+            sys.modules["pkg_resources"] = pkg_resources
+        imp.reload(pkg_resources)
         log.debug("Using pkg_resources to load entry points")
         entry_points_listing = list(pkg_resources.iter_entry_points(group, name=name))
     else:

--- a/salt/utils/entrypoints.py
+++ b/salt/utils/entrypoints.py
@@ -12,24 +12,13 @@ if sys.version_info >= (3, 10):
 
     USE_IMPORTLIB_METADATA_STDLIB = True
 else:
-    if sys.version_info >= (3, 6):
-        # importlib_metadata available for python version lower than 3.6 do not
-        # include the functionality we need.
-        try:
-            import importlib_metadata
+    try:
+        from salt._compat import importlib_metadata
 
-            importlib_metadata_version = [
-                int(part)
-                for part in importlib_metadata.version("importlib_metadata").split(".")
-                if part.isdigit()
-            ]
-            if tuple(importlib_metadata_version) >= (3, 3, 0):
-                # Version 3.3.0 of importlib_metadata includes a fix which allows us to
-                # get the distribution of a loaded entry-point
-                USE_IMPORTLIB_METADATA = True
-        except ImportError:
-            # We don't have importlib_metadata but USE_IMPORTLIB_METADATA is set to false by default
-            pass
+        USE_IMPORTLIB_METADATA = True
+    except ImportError:
+        # We don't have importlib_metadata but USE_IMPORTLIB_METADATA is set to false by default
+        pass
 
 if not USE_IMPORTLIB_METADATA_STDLIB and not USE_IMPORTLIB_METADATA:
     # Try to use pkg_resources

--- a/tests/pytests/functional/test_loader.py
+++ b/tests/pytests/functional/test_loader.py
@@ -151,73 +151,6 @@ def test_utils_loader_does_not_load_extensions(
     assert "foobar.echo" not in loader_functions
 
 
-def test_extension_discovery_without_reload_with_pkg_resources(
-    venv, salt_extension, salt_minion_factory
-):
-    # Install our extension into the virtualenv
-    installed_packages = venv.get_installed_packages()
-    assert salt_extension.name not in installed_packages
-    if "importlib-metadata" in installed_packages:
-        importlib_metadata_version = installed_packages["importlib-metadata"]
-        if salt.utils.versions.StrictVersion(importlib_metadata_version) >= "3.3.0":
-            venv.install("-U", "importlib-metadata<3.3.0")
-    code = """
-    import sys
-    import json
-    import subprocess
-
-    # If the test fails, for debugging purposes, comment out the following 2 lines
-    import salt.log.setup
-    salt.log.setup.setup_console_logger(log_level="debug")
-
-    extension_path = "{}"
-
-    import salt.loader
-
-    minion_config = json.loads(sys.stdin.read())
-    loader = salt.loader.minion_mods(minion_config)
-    if "foobar.echo1" in loader:
-        sys.exit(1)
-
-    # Install the extension
-    proc = subprocess.run(
-        [sys.executable, "-m", "pip", "install", extension_path],
-        check=False,
-        shell=False,
-        stdout=subprocess.PIPE,
-    )
-    if proc.returncode != 0:
-        sys.exit(2)
-
-    loader = salt.loader.minion_mods(minion_config)
-    if "foobar.echo1" not in loader:
-        sys.exit(3)
-
-    print(json.dumps(list(loader)))
-    """.format(
-        salt_extension.srcdir
-    )
-    ret = venv.run_code(
-        code, input=json.dumps(salt_minion_factory.config.copy()), check=False
-    )
-    # Exitcode 1 - Extension was already installed
-    # Exitcode 2 - Failed to install the extension
-    # Exitcode 3 - Extension was not found within the same python process after being installed
-    assert ret.exitcode == 0
-    installed_packages = venv.get_installed_packages()
-    assert salt_extension.name in installed_packages
-    assert "Using pkg_resources to load entry points" in ret.stderr
-
-    loader_functions = json.loads(ret.stdout)
-
-    # A non existing module should not appear in the loader
-    assert "monty.python" not in loader_functions
-
-    # But our extension's modules should appear on the loader
-    assert "foobar.echo1" in loader_functions
-    assert "foobar.echo2" in loader_functions
-
-
 @pytest.mark.skipif(
     sys.version_info < (3, 6),
     reason="importlib-metadata>=3.3.0 does not exist for Py3.5",
@@ -275,6 +208,77 @@ def test_extension_discovery_without_reload_with_importlib_metadata(
     installed_packages = venv.get_installed_packages()
     assert salt_extension.name in installed_packages
     assert "Using pkg_resources to load entry points" not in ret.stderr
+
+    loader_functions = json.loads(ret.stdout)
+
+    # A non existing module should not appear in the loader
+    assert "monty.python" not in loader_functions
+
+    # But our extension's modules should appear on the loader
+    assert "foobar.echo1" in loader_functions
+    assert "foobar.echo2" in loader_functions
+
+
+@pytest.mark.skipif(
+    sys.version_info > (3, 6),
+    reason="Reloading with pkg_resources is only available on Py3.5",
+)
+def test_extension_discovery_without_reload_with_pkg_resources(
+    venv, salt_extension, salt_minion_factory
+):
+    # Install our extension into the virtualenv
+    installed_packages = venv.get_installed_packages()
+    assert salt_extension.name not in installed_packages
+    if "importlib-metadata" in installed_packages:
+        importlib_metadata_version = installed_packages["importlib-metadata"]
+        if salt.utils.versions.StrictVersion(importlib_metadata_version) >= "3.3.0":
+            venv.install("-U", "importlib-metadata<3.3.0")
+    code = """
+    import sys
+    import json
+    import subprocess
+
+    # If the test fails, for debugging purposes, comment out the following 2 lines
+    import salt.log.setup
+    salt.log.setup.setup_console_logger(log_level="debug")
+
+    extension_path = "{}"
+
+    import salt.loader
+
+    minion_config = json.loads(sys.stdin.read())
+    loader = salt.loader.minion_mods(minion_config)
+    if "foobar.echo1" in loader:
+        sys.exit(1)
+
+    # Install the extension
+    proc = subprocess.run(
+        [sys.executable, "-m", "pip", "install", extension_path],
+        check=False,
+        shell=False,
+        stdout=subprocess.PIPE,
+    )
+    if proc.returncode != 0:
+        sys.exit(2)
+
+    loader = salt.loader.minion_mods(minion_config)
+    if "foobar.echo1" not in loader:
+        sys.exit(3)
+
+    print(json.dumps(list(loader)))
+    """.format(
+        salt_extension.srcdir
+    )
+    ret = venv.run_code(
+        code, input=json.dumps(salt_minion_factory.config.copy()), check=False
+    )
+    # Exitcode 1 - Extension was already installed
+    # Exitcode 2 - Failed to install the extension
+    # Exitcode 3 - Extension was not found within the same python process after being installed
+    assert ret.exitcode == 0
+    installed_packages = venv.get_installed_packages()
+    assert salt_extension.name in installed_packages
+    assert "Using pkg_resources to load entry points" in ret.stderr
 
     loader_functions = json.loads(ret.stdout)
 

--- a/tests/pytests/functional/test_loader.py
+++ b/tests/pytests/functional/test_loader.py
@@ -1,6 +1,8 @@
 import json
+import sys
 
 import pytest
+import salt.utils.versions
 from tests.support.helpers import SaltVirtualEnv
 from tests.support.pytest.helpers import FakeSaltExtension
 
@@ -147,3 +149,138 @@ def test_utils_loader_does_not_load_extensions(
 
     # But our extension's modules should appear on the loader
     assert "foobar.echo" not in loader_functions
+
+
+def test_extension_discovery_without_reload_with_pkg_resources(
+    venv, salt_extension, salt_minion_factory
+):
+    # Install our extension into the virtualenv
+    installed_packages = venv.get_installed_packages()
+    assert salt_extension.name not in installed_packages
+    if "importlib-metadata" in installed_packages:
+        importlib_metadata_version = installed_packages["importlib-metadata"]
+        if salt.utils.versions.StrictVersion(importlib_metadata_version) >= "3.3.0":
+            venv.install("-U", "importlib-metadata<3.3.0")
+    code = """
+    import sys
+    import json
+    import subprocess
+
+    # If the test fails, for debugging purposes, comment out the following 2 lines
+    import salt.log.setup
+    salt.log.setup.setup_console_logger(log_level="debug")
+
+    extension_path = "{}"
+
+    import salt.loader
+
+    minion_config = json.loads(sys.stdin.read())
+    loader = salt.loader.minion_mods(minion_config)
+    if "foobar.echo1" in loader:
+        sys.exit(1)
+
+    # Install the extension
+    proc = subprocess.run(
+        [sys.executable, "-m", "pip", "install", extension_path],
+        check=False,
+        shell=False,
+        stdout=subprocess.PIPE,
+    )
+    if proc.returncode != 0:
+        sys.exit(2)
+
+    loader = salt.loader.minion_mods(minion_config)
+    if "foobar.echo1" not in loader:
+        sys.exit(3)
+
+    print(json.dumps(list(loader)))
+    """.format(
+        salt_extension.srcdir
+    )
+    ret = venv.run_code(
+        code, input=json.dumps(salt_minion_factory.config.copy()), check=False
+    )
+    # Exitcode 1 - Extension was already installed
+    # Exitcode 2 - Failed to install the extension
+    # Exitcode 3 - Extension was not found within the same python process after being installed
+    assert ret.exitcode == 0
+    installed_packages = venv.get_installed_packages()
+    assert salt_extension.name in installed_packages
+    assert "Using pkg_resources to load entry points" in ret.stderr
+
+    loader_functions = json.loads(ret.stdout)
+
+    # A non existing module should not appear in the loader
+    assert "monty.python" not in loader_functions
+
+    # But our extension's modules should appear on the loader
+    assert "foobar.echo1" in loader_functions
+    assert "foobar.echo2" in loader_functions
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 6),
+    reason="importlib-metadata>=3.3.0 does not exist for Py3.5",
+)
+def test_extension_discovery_without_reload_with_importlib_metadata(
+    venv, salt_extension, salt_minion_factory
+):
+    # Install our extension into the virtualenv
+    installed_packages = venv.get_installed_packages()
+    assert salt_extension.name not in installed_packages
+    venv.install("importlib-metadata>=3.3.0")
+    code = """
+    import sys
+    import json
+    import subprocess
+
+    # If the test fails, for debugging purposes, comment out the following 2 lines
+    import salt.log.setup
+    salt.log.setup.setup_console_logger(log_level="debug")
+
+    extension_path = "{}"
+
+    import salt.loader
+
+    minion_config = json.loads(sys.stdin.read())
+    loader = salt.loader.minion_mods(minion_config)
+    if "foobar.echo1" in loader:
+        sys.exit(1)
+
+    # Install the extension
+    proc = subprocess.run(
+        [sys.executable, "-m", "pip", "install", extension_path],
+        check=False,
+        shell=False,
+        stdout=subprocess.PIPE,
+    )
+    if proc.returncode != 0:
+        sys.exit(2)
+
+    loader = salt.loader.minion_mods(minion_config)
+    if "foobar.echo1" not in loader:
+        sys.exit(3)
+
+    print(json.dumps(list(loader)))
+    """.format(
+        salt_extension.srcdir
+    )
+    ret = venv.run_code(
+        code, input=json.dumps(salt_minion_factory.config.copy()), check=False
+    )
+    # Exitcode 1 - Extension was already installed
+    # Exitcode 2 - Failed to install the extension
+    # Exitcode 3 - Extension was not found within the same python process after being installed
+    assert ret.exitcode == 0
+    installed_packages = venv.get_installed_packages()
+    assert salt_extension.name in installed_packages
+    assert "Using pkg_resources to load entry points" not in ret.stderr
+
+    loader_functions = json.loads(ret.stdout)
+
+    # A non existing module should not appear in the loader
+    assert "monty.python" not in loader_functions
+
+    # But our extension's modules should appear on the loader
+    assert "foobar.echo1" in loader_functions
+    assert "foobar.echo2" in loader_functions

--- a/tests/pytests/functional/test_loader.py
+++ b/tests/pytests/functional/test_loader.py
@@ -72,36 +72,6 @@ def test_new_entry_points_passing_func_returning_a_dict(
     import salt.loader
 
     minion_config = json.loads(sys.stdin.read())
-    loader = salt.loader.wheels(minion_config)
-    print(json.dumps(list(loader)))
-    """
-    ret = venv.run_code(code, input=json.dumps(salt_minion_factory.config.copy()))
-    loader_functions = json.loads(ret.stdout)
-
-    # A non existing module should not appear in the loader
-    assert "monty.python" not in loader_functions
-
-    # But our extension's modules should appear on the loader
-    assert "foobar.echo1" in loader_functions
-    assert "foobar.echo2" in loader_functions
-
-
-def test_old_entry_points_returning_a_list(venv, salt_extension, salt_minion_factory):
-    # Install our extension into the virtualenv
-    venv.install(str(salt_extension.srcdir))
-    installed_packages = venv.get_installed_packages()
-    assert salt_extension.name in installed_packages
-    code = """
-    import sys
-    import json
-
-    # If the test fails, for debugging purposes, comment out the following 2 lines
-    #import salt.log.setup
-    #salt.log.setup.setup_console_logger(log_level="debug")
-
-    import salt.loader
-
-    minion_config = json.loads(sys.stdin.read())
     loader = salt.loader.runner(minion_config)
     print(json.dumps(list(loader)))
     """
@@ -146,3 +116,34 @@ def test_old_entry_points_yielding_paths(venv, salt_extension, salt_minion_facto
 
     # But our extension's modules should appear on the loader
     assert "foobar.echoed" in loader_functions
+
+
+def test_utils_loader_does_not_load_extensions(
+    venv, salt_extension, salt_minion_factory
+):
+    # Install our extension into the virtualenv
+    venv.install(str(salt_extension.srcdir))
+    installed_packages = venv.get_installed_packages()
+    assert salt_extension.name in installed_packages
+    code = """
+    import sys
+    import json
+
+    # If the test fails, for debugging purposes, comment out the following 2 lines
+    #import salt.log.setup
+    #salt.log.setup.setup_console_logger(log_level="debug")
+
+    import salt.loader
+
+    minion_config = json.loads(sys.stdin.read())
+    loader = salt.loader.utils(minion_config)
+    print(json.dumps(list(loader)))
+    """
+    ret = venv.run_code(code, input=json.dumps(salt_minion_factory.config.copy()))
+    loader_functions = json.loads(ret.stdout)
+
+    # A non existing module should not appear in the loader
+    assert "monty.python" not in loader_functions
+
+    # But our extension's modules should appear on the loader
+    assert "foobar.echo" not in loader_functions

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -1706,6 +1706,11 @@ class VirtualEnv:
     def install(self, *args, **kwargs):
         return self.run(self.venv_python, "-m", "pip", "install", *args, **kwargs)
 
+    def uninstall(self, *args, **kwargs):
+        return self.run(
+            self.venv_python, "-m", "pip", "uninstall", "-y", *args, **kwargs
+        )
+
     def run(self, *args, **kwargs):
         check = kwargs.pop("check", True)
         kwargs.setdefault("cwd", str(self.venv_dir))

--- a/tests/support/pytest/helpers.py
+++ b/tests/support/pytest/helpers.py
@@ -570,6 +570,23 @@ class FakeSaltExtension:
                 )
             )
 
+            utils_dir = extension_package_dir / "utils"
+            utils_dir.mkdir()
+            utils_dir.joinpath("__init__.py").write_text("")
+            utils_dir.joinpath("foobar1.py").write_text(
+                textwrap.dedent(
+                    """\
+            __virtualname__ = "foobar"
+
+            def __virtual__():
+                return True
+
+            def echo(string):
+                return string
+            """
+                )
+            )
+
     def __enter__(self):
         self._laydown_files()
         return self


### PR DESCRIPTION
### What does this PR do?
See title.
Additionally, it prevents loading `utils` from extensions which would be packed into `__utils__`.

### Previous Behavior
The salt daemons had to be restarted to pick up the newly installed extensions

### New Behavior
The salt daemons no longer have to be restarted to pick up the newly installed extensions.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes