### PR TITLE
Fix 59758 Pass Port Number to Constructor V1ServicePort() to Support newer Version of kubernetes Python Module

### DIFF
--- a/requirements/static/ci/py3.5/darwin.txt
+++ b/requirements/static/ci/py3.5/darwin.txt
@@ -150,7 +150,7 @@ junit-xml==1.9            # via cfn-lint
 junos-eznc==2.4.0 ; sys_platform != "win32"
 jxmlease==1.0.1 ; sys_platform != "win32"
 keyring==5.7.1
-kubernetes==3.0.0
+kubernetes==11.0.0
 linode-python==1.1.1
 lxml==4.6.2               # via junos-eznc, ncclient
 mako==1.0.7
@@ -224,7 +224,7 @@ vcert==0.7.3 ; sys_platform != "win32"
 virtualenv==20.0.20
 vultr==1.0.1
 watchdog==0.9.0
-websocket-client==0.40.0  # via docker, kubernetes
+websocket-client==0.43.0  # via docker, kubernetes
 werkzeug==0.15.6          # via moto
 wrapt==1.11.1             # via aws-xray-sdk
 xmltodict==0.12.0         # via moto

--- a/requirements/static/ci/py3.5/freebsd.txt
+++ b/requirements/static/ci/py3.5/freebsd.txt
@@ -153,7 +153,7 @@ junos-eznc==2.4.0 ; sys_platform != "win32"
 jxmlease==1.0.1 ; sys_platform != "win32"
 kazoo==2.6.1 ; sys_platform != "win32" and sys_platform != "darwin"
 keyring==5.7.1
-kubernetes==3.0.0
+kubernetes==11.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
 lxml==4.6.2               # via junos-eznc, ncclient
 mako==1.1.0
@@ -228,7 +228,7 @@ urllib3==1.24.2
 vcert==0.7.3 ; sys_platform != "win32"
 virtualenv==20.0.20
 watchdog==0.9.0
-websocket-client==0.40.0  # via docker, kubernetes
+websocket-client==0.43.0  # via docker, kubernetes
 werkzeug==0.15.6          # via moto
 wrapt==1.11.1             # via aws-xray-sdk
 xmltodict==0.12.0         # via moto

--- a/requirements/static/ci/py3.5/linux.txt
+++ b/requirements/static/ci/py3.5/linux.txt
@@ -154,7 +154,7 @@ junos-eznc==2.4.0 ; sys_platform != "win32"
 jxmlease==1.0.1 ; sys_platform != "win32"
 kazoo==2.6.1 ; sys_platform != "win32" and sys_platform != "darwin"
 keyring==5.7.1
-kubernetes==3.0.0
+kubernetes==11.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
 lxml==4.6.2               # via junos-eznc, ncclient, vsphere-automation-sdk
 mako==1.1.0
@@ -241,7 +241,7 @@ vmc-client-bindings==1.32.0  # via vsphere-automation-sdk
 vmc-draas-client-bindings==1.17.0  # via vsphere-automation-sdk
 vsphere-automation-sdk==1.46.0
 watchdog==0.9.0
-websocket-client==0.40.0  # via docker, kubernetes
+websocket-client==0.43.0  # via docker, kubernetes
 werkzeug==0.15.6          # via moto
 wrapt==1.11.1             # via aws-xray-sdk
 xmltodict==0.12.0         # via moto

--- a/requirements/static/ci/py3.6/darwin.txt
+++ b/requirements/static/ci/py3.6/darwin.txt
@@ -150,7 +150,7 @@ junit-xml==1.9            # via cfn-lint
 junos-eznc==2.4.0 ; sys_platform != "win32"
 jxmlease==1.0.1 ; sys_platform != "win32"
 keyring==5.7.1
-kubernetes==3.0.0
+kubernetes==11.0.0
 linode-python==1.1.1
 lxml==4.6.2               # via junos-eznc, ncclient
 mako==1.0.7
@@ -223,7 +223,7 @@ vcert==0.7.3 ; sys_platform != "win32"
 virtualenv==20.0.20
 vultr==1.0.1
 watchdog==0.9.0
-websocket-client==0.40.0  # via docker, kubernetes
+websocket-client==0.43.0  # via docker, kubernetes
 werkzeug==0.15.6          # via moto
 wrapt==1.11.1             # via aws-xray-sdk
 xmltodict==0.12.0         # via moto

--- a/requirements/static/ci/py3.6/freebsd.txt
+++ b/requirements/static/ci/py3.6/freebsd.txt
@@ -153,7 +153,7 @@ junos-eznc==2.4.0 ; sys_platform != "win32"
 jxmlease==1.0.1 ; sys_platform != "win32"
 kazoo==2.6.1 ; sys_platform != "win32" and sys_platform != "darwin"
 keyring==5.7.1
-kubernetes==3.0.0
+kubernetes==11.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
 lxml==4.6.2               # via junos-eznc, ncclient
 mako==1.1.0
@@ -227,7 +227,7 @@ urllib3==1.24.2
 vcert==0.7.3 ; sys_platform != "win32"
 virtualenv==20.0.20
 watchdog==0.9.0
-websocket-client==0.40.0  # via docker, kubernetes
+websocket-client==0.43.0  # via docker, kubernetes
 werkzeug==0.15.6          # via moto
 wrapt==1.11.1             # via aws-xray-sdk
 xmltodict==0.12.0         # via moto

--- a/requirements/static/ci/py3.6/linux.txt
+++ b/requirements/static/ci/py3.6/linux.txt
@@ -154,7 +154,7 @@ junos-eznc==2.4.0 ; sys_platform != "win32"
 jxmlease==1.0.1 ; sys_platform != "win32"
 kazoo==2.6.1 ; sys_platform != "win32" and sys_platform != "darwin"
 keyring==5.7.1
-kubernetes==3.0.0
+kubernetes==11.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
 lxml==4.6.2               # via junos-eznc, ncclient, vsphere-automation-sdk
 mako==1.1.0
@@ -240,7 +240,7 @@ vmc-client-bindings==1.32.0  # via vsphere-automation-sdk
 vmc-draas-client-bindings==1.17.0  # via vsphere-automation-sdk
 vsphere-automation-sdk==1.46.0
 watchdog==0.9.0
-websocket-client==0.40.0  # via docker, kubernetes
+websocket-client==0.43.0  # via docker, kubernetes
 werkzeug==0.15.6          # via moto
 wrapt==1.11.1             # via aws-xray-sdk
 xmltodict==0.12.0         # via moto

--- a/requirements/static/ci/py3.6/windows.txt
+++ b/requirements/static/ci/py3.6/windows.txt
@@ -63,7 +63,7 @@ jsonpointer==2.0          # via jsonpatch
 jsonschema==3.2.0
 junit-xml==1.9            # via cfn-lint
 keyring==5.7.1
-kubernetes==3.0.0
+kubernetes==11.0.0
 libnacl==1.7.2
 lxml==4.6.2
 mako==1.1.4
@@ -127,7 +127,7 @@ toml==0.10.2
 urllib3==1.24.3
 virtualenv==20.0.20
 watchdog==0.10.3
-websocket-client==0.40.0  # via docker, kubernetes
+websocket-client==0.43.0  # via docker, kubernetes
 werkzeug==0.15.6          # via moto
 wheel==0.36.2
 wmi==1.5.1

--- a/requirements/static/ci/py3.7/darwin.txt
+++ b/requirements/static/ci/py3.7/darwin.txt
@@ -148,7 +148,7 @@ junit-xml==1.9            # via cfn-lint
 junos-eznc==2.4.0 ; sys_platform != "win32"
 jxmlease==1.0.1 ; sys_platform != "win32"
 keyring==5.7.1
-kubernetes==3.0.0
+kubernetes==11.0.0
 linode-python==1.1.1
 lxml==4.6.2               # via junos-eznc, napalm, ncclient
 mako==1.0.7
@@ -224,7 +224,7 @@ vcert==0.7.3 ; sys_platform != "win32"
 virtualenv==20.0.20
 vultr==1.0.1
 watchdog==0.9.0
-websocket-client==0.40.0  # via docker, kubernetes
+websocket-client==0.43.0  # via docker, kubernetes
 werkzeug==0.15.6          # via moto
 wrapt==1.11.1             # via aws-xray-sdk
 xmltodict==0.12.0         # via moto

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -151,7 +151,7 @@ junos-eznc==2.4.0 ; sys_platform != "win32"
 jxmlease==1.0.1 ; sys_platform != "win32"
 kazoo==2.6.1 ; sys_platform != "win32" and sys_platform != "darwin"
 keyring==5.7.1
-kubernetes==3.0.0
+kubernetes==11.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
 lxml==4.6.2               # via junos-eznc, napalm, ncclient
 mako==1.1.0
@@ -228,7 +228,7 @@ urllib3==1.24.2
 vcert==0.7.3 ; sys_platform != "win32"
 virtualenv==20.0.20
 watchdog==0.9.0
-websocket-client==0.40.0  # via docker, kubernetes
+websocket-client==0.43.0  # via docker, kubernetes
 werkzeug==0.15.6          # via moto
 wrapt==1.11.1             # via aws-xray-sdk
 xmltodict==0.12.0         # via moto

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -152,7 +152,7 @@ junos-eznc==2.4.0 ; sys_platform != "win32"
 jxmlease==1.0.1 ; sys_platform != "win32"
 kazoo==2.6.1 ; sys_platform != "win32" and sys_platform != "darwin"
 keyring==5.7.1
-kubernetes==3.0.0
+kubernetes==11.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
 lxml==4.6.2               # via junos-eznc, napalm, ncclient, vsphere-automation-sdk
 mako==1.1.0
@@ -241,7 +241,7 @@ vmc-client-bindings==1.32.0  # via vsphere-automation-sdk
 vmc-draas-client-bindings==1.17.0  # via vsphere-automation-sdk
 vsphere-automation-sdk==1.46.0
 watchdog==0.9.0
-websocket-client==0.40.0  # via docker, kubernetes
+websocket-client==0.43.0  # via docker, kubernetes
 werkzeug==0.15.6          # via moto
 wrapt==1.11.1             # via aws-xray-sdk
 xmltodict==0.12.0         # via moto

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -59,7 +59,7 @@ jsonpointer==2.0          # via jsonpatch
 jsonschema==3.2.0
 junit-xml==1.9            # via cfn-lint
 keyring==5.7.1
-kubernetes==3.0.0
+kubernetes==11.0.0
 libnacl==1.7.2
 lxml==4.6.2
 mako==1.1.4
@@ -123,7 +123,7 @@ toml==0.10.2
 urllib3==1.24.3
 virtualenv==20.0.20
 watchdog==0.10.3
-websocket-client==0.40.0  # via docker, kubernetes
+websocket-client==0.43.0  # via docker, kubernetes
 werkzeug==0.15.6          # via moto
 wheel==0.36.2
 wmi==1.5.1

--- a/requirements/static/ci/py3.8/darwin.txt
+++ b/requirements/static/ci/py3.8/darwin.txt
@@ -147,7 +147,7 @@ junit-xml==1.9            # via cfn-lint
 junos-eznc==2.4.0 ; sys_platform != "win32"
 jxmlease==1.0.1 ; sys_platform != "win32"
 keyring==5.7.1
-kubernetes==3.0.0
+kubernetes==11.0.0
 linode-python==1.1.1
 lxml==4.6.2               # via junos-eznc, napalm, ncclient
 mako==1.0.7
@@ -223,7 +223,7 @@ vcert==0.7.3 ; sys_platform != "win32"
 virtualenv==20.0.20
 vultr==1.0.1
 watchdog==0.9.0
-websocket-client==0.40.0  # via docker, kubernetes
+websocket-client==0.43.0  # via docker, kubernetes
 werkzeug==0.15.6          # via moto
 wrapt==1.11.1             # via aws-xray-sdk
 xmltodict==0.12.0         # via moto

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -150,7 +150,7 @@ junos-eznc==2.4.0 ; sys_platform != "win32"
 jxmlease==1.0.1 ; sys_platform != "win32"
 kazoo==2.6.1 ; sys_platform != "win32" and sys_platform != "darwin"
 keyring==5.7.1
-kubernetes==3.0.0
+kubernetes==11.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
 lxml==4.6.2               # via junos-eznc, napalm, ncclient
 mako==1.1.0
@@ -227,7 +227,7 @@ urllib3==1.24.2
 vcert==0.7.3 ; sys_platform != "win32"
 virtualenv==20.0.20
 watchdog==0.9.0
-websocket-client==0.40.0  # via docker, kubernetes
+websocket-client==0.43.0  # via docker, kubernetes
 werkzeug==0.15.6          # via moto
 wrapt==1.11.1             # via aws-xray-sdk
 xmltodict==0.12.0         # via moto

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -151,7 +151,7 @@ junos-eznc==2.4.0 ; sys_platform != "win32"
 jxmlease==1.0.1 ; sys_platform != "win32"
 kazoo==2.6.1 ; sys_platform != "win32" and sys_platform != "darwin"
 keyring==5.7.1
-kubernetes==3.0.0
+kubernetes==11.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
 lxml==4.6.2               # via junos-eznc, napalm, ncclient, vsphere-automation-sdk
 mako==1.1.0
@@ -240,7 +240,7 @@ vmc-client-bindings==1.32.0  # via vsphere-automation-sdk
 vmc-draas-client-bindings==1.17.0  # via vsphere-automation-sdk
 vsphere-automation-sdk==1.46.0
 watchdog==0.9.0
-websocket-client==0.40.0  # via docker, kubernetes
+websocket-client==0.43.0  # via docker, kubernetes
 werkzeug==0.15.6          # via moto
 wrapt==1.11.1             # via aws-xray-sdk
 xmltodict==0.12.0         # via moto

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -147,7 +147,7 @@ junit-xml==1.9            # via cfn-lint
 junos-eznc==2.4.0 ; sys_platform != "win32"
 jxmlease==1.0.1 ; sys_platform != "win32"
 keyring==5.7.1
-kubernetes==3.0.0
+kubernetes==11.0.0
 linode-python==1.1.1
 lxml==4.6.2               # via junos-eznc, napalm, ncclient
 mako==1.0.7
@@ -223,7 +223,7 @@ vcert==0.7.3 ; sys_platform != "win32"
 virtualenv==20.0.20
 vultr==1.0.1
 watchdog==0.9.0
-websocket-client==0.40.0  # via docker, kubernetes
+websocket-client==0.43.0  # via docker, kubernetes
 werkzeug==0.15.6          # via moto
 wrapt==1.11.1             # via aws-xray-sdk
 xmltodict==0.12.0         # via moto

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -150,7 +150,7 @@ junos-eznc==2.4.0 ; sys_platform != "win32"
 jxmlease==1.0.1 ; sys_platform != "win32"
 kazoo==2.6.1 ; sys_platform != "win32" and sys_platform != "darwin"
 keyring==5.7.1
-kubernetes==3.0.0
+kubernetes==11.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
 lxml==4.6.2               # via junos-eznc, napalm, ncclient
 mako==1.1.0
@@ -227,7 +227,7 @@ urllib3==1.24.2
 vcert==0.7.3 ; sys_platform != "win32"
 virtualenv==20.0.20
 watchdog==0.9.0
-websocket-client==0.40.0  # via docker, kubernetes
+websocket-client==0.43.0  # via docker, kubernetes
 werkzeug==0.15.6          # via moto
 wrapt==1.11.1             # via aws-xray-sdk
 xmltodict==0.12.0         # via moto

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -152,7 +152,7 @@ junos-eznc==2.4.0 ; sys_platform != "win32"
 jxmlease==1.0.1 ; sys_platform != "win32"
 kazoo==2.6.1 ; sys_platform != "win32" and sys_platform != "darwin"
 keyring==5.7.1
-kubernetes==3.0.0
+kubernetes==11.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
 lxml==4.6.2               # via junos-eznc, napalm, ncclient, vsphere-automation-sdk
 mako==1.1.0
@@ -241,7 +241,7 @@ vmc-client-bindings==1.32.0  # via vsphere-automation-sdk
 vmc-draas-client-bindings==1.17.0  # via vsphere-automation-sdk
 vsphere-automation-sdk==1.46.0
 watchdog==0.9.0
-websocket-client==0.40.0  # via docker, kubernetes
+websocket-client==0.43.0  # via docker, kubernetes
 werkzeug==0.15.6          # via moto
 wrapt==1.11.1             # via aws-xray-sdk
 xmltodict==0.12.0         # via moto

--- a/salt/modules/kubernetesmod.py
+++ b/salt/modules/kubernetesmod.py
@@ -1575,11 +1575,11 @@ def __dict_to_service_spec(spec):
     ports = spec.get('ports')
     if ports:
         spec['ports'] = [ _port_from_spec(data) for data in ports ]
-    spec = { allowedkey: spec.get(allowedkey) \
-             for allowedkey in kubernetes.client.V1ServiceSpec.attribute_map.keys() \
-           }
-    spec = {k:v for k,v in spec.items() if v is not None}
-    spec_obj =  kubernetes.client.V1ServiceSpec(**spec)
+    _spec_map = { allowedkey: spec.get(allowedkey) \
+                  for allowedkey in kubernetes.client.V1ServiceSpec.attribute_map.keys() \
+                }
+    _spec_map = {k:v for k,v in _spec_map.items() if v is not None}
+    spec_obj  =  kubernetes.client.V1ServiceSpec(**_spec_map)
     return spec_obj
 
 def __enforce_only_strings_dict(dictionary):

--- a/tests/pytests/unit/modules/test_kubernetesmod.py
+++ b/tests/pytests/unit/modules/test_kubernetesmod.py
@@ -1,0 +1,46 @@
+import salt.modules.kubernetesmod as kmod
+import pytest, collections
+
+def test_dict_to_service_spec_should_set_all_existent_attributes_on_spec():
+    expected_spec = kmod.kubernetes.client.V1ServiceSpec()
+    expected_spec.ports = []
+    expected_spec.cluster_ip = "dummy"
+    expected_spec.external_i_ps = "dummy"
+    expected_spec.external_name = "dummy"
+    expected_spec.external_traffic_policy = "dummy"
+    expected_spec.health_check_node_port = "dummy"
+    expected_spec.load_balancer_ip = "dummy"
+    expected_spec.load_balancer_source_ranges = "dummy"
+    expected_spec.selector = "dummy"
+    expected_spec.session_affinity = "dummy"
+    expected_spec.type = "dummy"
+    data = {"test": "test"}
+    data.update(expected_spec.to_dict())
+    actual_spec = kmod.__dict_to_service_spec(spec=data)
+
+    assert actual_spec.to_dict() == expected_spec.to_dict()
+
+def test_dict_to_service_spec_with_ports():
+    expected_spec = kmod.kubernetes.client.V1ServiceSpec()
+    expected_spec.ports = {'name': 'tai-tomcat-service', 'protocol': 'TCP', 'port': 18080, 'targetPort': 18080}
+    expected_spec.cluster_ip = "dummy"
+    expected_spec.external_i_ps = "dummy"
+    expected_spec.external_name = "dummy"
+    expected_spec.external_traffic_policy = "dummy"
+    expected_spec.health_check_node_port = "dummy"
+    expected_spec.load_balancer_ip = "dummy"
+    expected_spec.load_balancer_source_ranges = "dummy"
+    expected_spec.selector = "dummy"
+    expected_spec.session_affinity = "dummy"
+    expected_spec.type = "dummy"
+    data = {"test": "test"}
+    data.update(expected_spec.to_dict())
+    kmod.__dict_to_service_spec(spec=data)
+
+def test_dict_to_service_spec_should_raise_exception():
+    print(30*">", "This below should be successful")
+    kube_port = kmod.kubernetes.client.V1ServicePort(port=42)
+    print(30*">", "This below should raise exception on py module kubernetes==11.0.0")
+    with pytest.raises(ValueError) as ve:
+        kube_port = kmod.kubernetes.client.V1ServicePort()
+

--- a/tests/pytests/unit/modules/test_kubernetesmod.py
+++ b/tests/pytests/unit/modules/test_kubernetesmod.py
@@ -1,4 +1,5 @@
 import salt.modules.kubernetesmod as kmod
+import salt.exceptions as se
 import pytest, collections
 
 def test_dict_to_service_spec_should_set_all_existent_attributes_on_spec():
@@ -22,7 +23,7 @@ def test_dict_to_service_spec_should_set_all_existent_attributes_on_spec():
 
 def test_dict_to_service_spec_with_ports():
     expected_spec = kmod.kubernetes.client.V1ServiceSpec()
-    expected_spec.ports = {'name': 'tai-tomcat-service', 'protocol': 'TCP', 'port': 18080, 'targetPort': 18080}
+    expected_spec.ports = [{'name': 'tai-tomcat-service', 'protocol': 'TCP', 'port': 18080, 'target_port': 18080}]
     expected_spec.cluster_ip = "dummy"
     expected_spec.external_i_ps = "dummy"
     expected_spec.external_name = "dummy"
@@ -36,6 +37,24 @@ def test_dict_to_service_spec_with_ports():
     data = {"test": "test"}
     data.update(expected_spec.to_dict())
     kmod.__dict_to_service_spec(spec=data)
+
+def test_dict_to_service_spec_with_ports_but_missingport():
+    expected_spec = kmod.kubernetes.client.V1ServiceSpec()
+    expected_spec.ports = [{'name': 'tai-tomcat-service', 'protocol': 'TCP', 'target_port': 18080}]
+    expected_spec.cluster_ip = "dummy"
+    expected_spec.external_i_ps = "dummy"
+    expected_spec.external_name = "dummy"
+    expected_spec.external_traffic_policy = "dummy"
+    expected_spec.health_check_node_port = "dummy"
+    expected_spec.load_balancer_ip = "dummy"
+    expected_spec.load_balancer_source_ranges = "dummy"
+    expected_spec.selector = "dummy"
+    expected_spec.session_affinity = "dummy"
+    expected_spec.type = "dummy"
+    data = {"test": "test"}
+    data.update(expected_spec.to_dict())
+    with pytest.raises(se.CommandExecutionError) as cee:
+        kmod.__dict_to_service_spec(spec=data)
 
 def test_dict_to_service_spec_should_raise_exception():
     print(30*">", "This below should be successful")


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes: #59758 

### Previous Behavior
`__dict_to_service_spec(spec)` on kubernetesmod.py does not pass port number to the constructor `kube_port = kubernetes.client.V1ServicePort()`, which results error when the new kubernetes python client is used.

Current dependencies specify version 3.0 which is too old (~4 years), as opposed to the current one, which on stable version 17.17.0, as of May 2021 ([https://pypi.org/project/kubernetes/#history](https://pypi.org/project/kubernetes/#history))

### New Behavior
Performed code refactor to `__dict_to_service_spec(spec)` as per guidance from @waynew and added unit tests on it.

I also bumped the dependencies for newer kubernetes python module version 11.0.0 (release dated on Mar 13, 2020, as per release history on [https://pypi.org/project/kubernetes/11.0.0/#history](https://pypi.org/project/kubernetes/11.0.0/#history)) so that the tests can catch the error when the port number is missing from the V1ServicePort() constructor.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
