### PR TITLE
Manjaro-ARM map to OS-family Arch

### DIFF
--- a/changelog/60186.fixed.md
+++ b/changelog/60186.fixed.md
@@ -1,0 +1,1 @@
+Add Manjaro ARM os family to grians.

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1709,6 +1709,7 @@ _OS_NAME_MAP = {
     "poky": "Poky",
     "manjaro": "Manjaro",
     "manjarolin": "Manjaro",
+    "manjaro-ar": "Manjaro",
     "univention": "Univention",
     "antergos": "Antergos",
     "sles": "SUSE",

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -3621,3 +3621,24 @@ def test_virtual_set_virtual_ec2():
 
         assert virtual_grains["virtual"] == "Nitro"
         assert virtual_grains["virtual_subtype"] == "Amazon EC2"
+
+
+@pytest.mark.skip_unless_on_linux
+def test_manjaro_arm_arch_os_family_grains():
+    """
+    Test if OS-family grains are parsed correctly in Manjaro-ARM  "Arch"
+    """
+    _os_release_map = {
+        "_linux_distribution": ("Manjaro-3", "21.05", "n/a"),
+    }
+    expectation = {
+        "os": "Manjaro-ARM",
+        "os_family": "Arch",
+        "oscodename": "n/a",
+        "osfullname": "Manjaro-ARM",
+        "osrelease": "21.05",
+        "osrelease_info": (21, 5),
+        "osmajorrelease": 21,
+        "osfinger": "Manjaro-ARM-21",
+    }
+    _run_os_grains_tests("manjaro-arm-21", _os_release_map, expectation)


### PR DESCRIPTION
# This PR maps Manjaro-ARM to OS-family Arch.

### Fixes:
This PR maps Manjaro-ARM to OS-family Arch.

### Previous Behavior:
Manjaro-ARM was its own OS-family, so it wouldn't recognize pacman as the package-manager and so on.

### New Behavior:
Manjaro-ARM is now in the Arch OS-family, so it will recognize pacman as the package-manager and so on.

### My Bug:
https://github.com/saltstack/salt/issues/60186

### Merge requirements satisfied?
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No