### PR TITLE
Removed an unused assignment in file.patch

### DIFF
--- a/changelog/57204.fixed
+++ b/changelog/57204.fixed
@@ -1,0 +1,1 @@
+Removed an unused assignment in file.patch

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -7165,8 +7165,6 @@ def patch(
         )
         return ret
 
-    options = sanitized_options
-
     try:
         source_match = __salt__["file.source_list"](source, source_hash, __env__)[0]
     except CommandExecutionError as exc:


### PR DESCRIPTION
### What does this PR do?
Removes an `options = sanitized_options` statement that is in `file.patch` but not used. 
The code following the statement still uses the original `sanitized_options`.

### What issues does this PR fix or reference?
Fixes: #57204

### Previous and New Behavior
There isn't any changes in the behavior. It only enhances the readability so a confusion like #57204 won't happens again.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

Is there really a necessity to write a test for it? How this can be tested?

I just ran the existing file tests, both integration and unit tests: 

#### Integration tests
```
======================================================= test session starts ========================================================
platform linux -- Python 3.9.5, pytest-6.1.2, py-1.10.0, pluggy-0.13.0
tempdir: /tmp/salt-tests-tmpdir
max open files; soft: 3072; hard: 4096
rootdir: /home/punk/Desktop/Projects/Software/External/salt, configfile: pytest.ini
plugins: flaky-3.7.0, tempdir-2019.10.12, helpers-namespace-2019.1.8, salt-factories-0.121.1, subtests-0.4.0
collected 144 items                                                                                                                

tests/integration/states/test_file.py ................s.s...sss.....s.....s...s....................s.............................................................................sssss

========================================================= warnings summary =========================================================
salt/ext/tornado/web.py:1805
  /home/punk/Desktop/Projects/Software/External/salt/salt/ext/tornado/web.py:1805: DeprecationWarning: invalid escape sequence \.
    """A collection of request handlers that make up a web application.

-- Docs: https://docs.pytest.org/en/stable/warnings.html
===================================================== short test summary info ======================================================
SKIPPED [1] tests/integration/states/test_file.py:1079: You must be logged in as root to run this test
SKIPPED [1] tests/integration/states/test_file.py:2845: Destructive tests are disabled
SKIPPED [1] tests/integration/states/test_file.py:2706: You must be logged in as root to run this test
SKIPPED [1] tests/integration/states/test_file.py:2748: You must be logged in as root to run this test
SKIPPED [1] tests/integration/states/test_file.py:3074: Slow tests are disabled!
SKIPPED [1] tests/integration/states/test_file.py:2949: You must be logged in as root to run this test
SKIPPED [1] tests/integration/states/test_file.py:728: You must be logged in as root to run this test
SKIPPED [1] tests/integration/states/test_file.py:400: You must be logged in as root to run this test
SKIPPED [1] tests/integration/states/test_file.py:2877: You must be logged in as root to run this test
SKIPPED [1] tests/integration/states/test_file.py:5267: Destructive tests are disabled
SKIPPED [1] tests/integration/states/test_file.py:5249: Destructive tests are disabled
SKIPPED [1] tests/integration/states/test_file.py:5240: Destructive tests are disabled
SKIPPED [1] tests/integration/states/test_file.py:5234: Destructive tests are disabled
SKIPPED [1] tests/integration/states/test_file.py:5257: Destructive tests are disabled
====================================== 130 passed, 14 skipped, 1 warning in 182.38s (0:03:02) ======================================
nox > Session pytest-parametrized-3(crypto=None, transport='zeromq', coverage=False) was successful.
nox > Ran multiple sessions:
nox > * pytest-zeromq-3(coverage=False): success
nox > * pytest-parametrized-3(crypto=None, transport='zeromq', coverage=False): success
```
#### Unit tests
```
======================================================= test session starts ========================================================
platform linux -- Python 3.9.5, pytest-6.1.2, py-1.10.0, pluggy-0.13.0
tempdir: /tmp/salt-tests-tmpdir
max open files; soft: 3072; hard: 4096
rootdir: /home/punk/Desktop/Projects/Software/External/salt, configfile: pytest.ini
plugins: flaky-3.7.0, tempdir-2019.10.12, helpers-namespace-2019.1.8, salt-factories-0.121.1, subtests-0.4.0
collected 33 items                                                                                                                 

tests/unit/states/test_file.py ......................s.....s..s.

========================================================= warnings summary =========================================================
salt/ext/tornado/web.py:1805
  /home/punk/Desktop/Projects/Software/External/salt/salt/ext/tornado/web.py:1805: DeprecationWarning: invalid escape sequence \.
    """A collection of request handlers that make up a web application.

-- Docs: https://docs.pytest.org/en/stable/warnings.html
===================================================== short test summary info ======================================================
SKIPPED [1] tests/unit/states/test_file.py:2599: Slow tests are disabled!
SKIPPED [1] tests/unit/states/test_file.py:2897: Only run on Windows
SKIPPED [1] tests/unit/states/test_file.py:3021: Destructive tests are disabled
============================================= 30 passed, 3 skipped, 1 warning in 1.03s =============================================
nox > Session pytest-parametrized-3(crypto=None, transport='zeromq', coverage=False) was successful.
nox > Ran multiple sessions:
nox > * pytest-zeromq-3(coverage=False): success
nox > * pytest-parametrized-3(crypto=None, transport='zeromq', coverage=False): success
```

### Commits signed with GPG?
No