### PR TITLE
Update Jinja2 and lxml due to security related bugfix releases

### DIFF
--- a/requirements/static/ci/py3.10/changelog.txt
+++ b/requirements/static/ci/py3.10/changelog.txt
@@ -8,7 +8,7 @@ click==7.1.2
     # via towncrier
 incremental==17.5.0
     # via towncrier
-jinja2==2.11.2
+jinja2==2.11.3
     # via towncrier
 markupsafe==1.1.1
     # via jinja2

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -515,7 +515,7 @@ kubernetes==3.0.0
     # via -r requirements/static/ci/common.in
 linode-python==1.1.1
     # via -r requirements/static/pkg/py3.10/darwin.txt
-lxml==4.6.2
+lxml==4.6.3
     # via
     #   junos-eznc
     #   napalm

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -514,7 +514,7 @@ kubernetes==3.0.0
     # via -r requirements/static/ci/common.in
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
     # via -r requirements/static/ci/common.in
-lxml==4.6.2
+lxml==4.6.3
     # via
     #   junos-eznc
     #   napalm

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -521,7 +521,7 @@ kubernetes==3.0.0
     # via -r requirements/static/ci/common.in
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
     # via -r requirements/static/ci/common.in
-lxml==4.6.2
+lxml==4.6.3
     # via
     #   junos-eznc
     #   napalm

--- a/requirements/static/ci/py3.5/changelog.txt
+++ b/requirements/static/ci/py3.5/changelog.txt
@@ -8,7 +8,7 @@ click==7.1.1
     # via towncrier
 incremental==17.5.0
     # via towncrier
-jinja2==2.11.2
+jinja2==2.11.3
     # via towncrier
 markupsafe==1.1.1
     # via jinja2

--- a/requirements/static/ci/py3.5/linux.txt
+++ b/requirements/static/ci/py3.5/linux.txt
@@ -522,7 +522,7 @@ kubernetes==3.0.0
     # via -r requirements/static/ci/common.in
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
     # via -r requirements/static/ci/common.in
-lxml==4.6.2
+lxml==4.6.3
     # via
     #   junos-eznc
     #   ncclient

--- a/requirements/static/ci/py3.6/changelog.txt
+++ b/requirements/static/ci/py3.6/changelog.txt
@@ -8,7 +8,7 @@ click==7.1.1
     # via towncrier
 incremental==17.5.0
     # via towncrier
-jinja2==2.11.2
+jinja2==2.11.3
     # via towncrier
 markupsafe==1.1.1
     # via jinja2

--- a/requirements/static/ci/py3.6/linux.txt
+++ b/requirements/static/ci/py3.6/linux.txt
@@ -522,7 +522,7 @@ kubernetes==3.0.0
     # via -r requirements/static/ci/common.in
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
     # via -r requirements/static/ci/common.in
-lxml==4.6.2
+lxml==4.6.3
     # via
     #   junos-eznc
     #   ncclient

--- a/requirements/static/ci/py3.7/changelog.txt
+++ b/requirements/static/ci/py3.7/changelog.txt
@@ -8,7 +8,7 @@ click==7.1.1
     # via towncrier
 incremental==17.5.0
     # via towncrier
-jinja2==2.11.2
+jinja2==2.11.3
     # via towncrier
 markupsafe==1.1.1
     # via jinja2

--- a/requirements/static/ci/py3.7/darwin.txt
+++ b/requirements/static/ci/py3.7/darwin.txt
@@ -522,7 +522,7 @@ kubernetes==3.0.0
     # via -r requirements/static/ci/common.in
 linode-python==1.1.1
     # via -r requirements/static/pkg/py3.7/darwin.txt
-lxml==4.6.2
+lxml==4.6.3
     # via
     #   junos-eznc
     #   napalm

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -521,7 +521,7 @@ kubernetes==3.0.0
     # via -r requirements/static/ci/common.in
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
     # via -r requirements/static/ci/common.in
-lxml==4.6.2
+lxml==4.6.3
     # via
     #   junos-eznc
     #   napalm

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -526,7 +526,7 @@ kubernetes==3.0.0
     # via -r requirements/static/ci/common.in
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
     # via -r requirements/static/ci/common.in
-lxml==4.6.2
+lxml==4.6.3
     # via
     #   junos-eznc
     #   napalm

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -192,7 +192,7 @@ kubernetes==3.0.0
     # via -r requirements/static/ci/common.in
 libnacl==1.7.2
     # via -r requirements/static/pkg/py3.7/windows.txt
-lxml==4.6.2
+lxml==4.6.3
     # via -r requirements/static/pkg/py3.7/windows.txt
 mako==1.1.4
     # via

--- a/requirements/static/ci/py3.8/changelog.txt
+++ b/requirements/static/ci/py3.8/changelog.txt
@@ -8,7 +8,7 @@ click==7.1.2
     # via towncrier
 incremental==17.5.0
     # via towncrier
-jinja2==2.11.2
+jinja2==2.11.3
     # via towncrier
 markupsafe==1.1.1
     # via jinja2

--- a/requirements/static/ci/py3.8/darwin.txt
+++ b/requirements/static/ci/py3.8/darwin.txt
@@ -515,7 +515,7 @@ kubernetes==3.0.0
     # via -r requirements/static/ci/common.in
 linode-python==1.1.1
     # via -r requirements/static/pkg/py3.8/darwin.txt
-lxml==4.6.2
+lxml==4.6.3
     # via
     #   junos-eznc
     #   napalm

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -514,7 +514,7 @@ kubernetes==3.0.0
     # via -r requirements/static/ci/common.in
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
     # via -r requirements/static/ci/common.in
-lxml==4.6.2
+lxml==4.6.3
     # via
     #   junos-eznc
     #   napalm

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -519,7 +519,7 @@ kubernetes==3.0.0
     # via -r requirements/static/ci/common.in
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
     # via -r requirements/static/ci/common.in
-lxml==4.6.2
+lxml==4.6.3
     # via
     #   junos-eznc
     #   napalm

--- a/requirements/static/ci/py3.9/changelog.txt
+++ b/requirements/static/ci/py3.9/changelog.txt
@@ -8,7 +8,7 @@ click==7.1.2
     # via towncrier
 incremental==17.5.0
     # via towncrier
-jinja2==2.11.2
+jinja2==2.11.3
     # via towncrier
 markupsafe==1.1.1
     # via jinja2

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -515,7 +515,7 @@ kubernetes==3.0.0
     # via -r requirements/static/ci/common.in
 linode-python==1.1.1
     # via -r requirements/static/pkg/py3.9/darwin.txt
-lxml==4.6.2
+lxml==4.6.3
     # via
     #   junos-eznc
     #   napalm

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -514,7 +514,7 @@ kubernetes==3.0.0
     # via -r requirements/static/ci/common.in
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
     # via -r requirements/static/ci/common.in
-lxml==4.6.2
+lxml==4.6.3
     # via
     #   junos-eznc
     #   napalm

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -521,7 +521,7 @@ kubernetes==3.0.0
     # via -r requirements/static/ci/common.in
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
     # via -r requirements/static/ci/common.in
-lxml==4.6.2
+lxml==4.6.3
     # via
     #   junos-eznc
     #   napalm

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -21,9 +21,9 @@ idna==2.8
 ioloop==0.1a0
 ipaddress==1.0.22
 jaraco.functools==2.0     # via cheroot, tempora
-jinja2==2.10.1
+jinja2==2.11.3
 libnacl==1.7.1
-lxml==4.6.2
+lxml==4.6.3
 mako==1.0.7
 markupsafe==1.1.1
 more-itertools==8.2.0     # via cheroot, cherrypy, jaraco.functools

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -51,7 +51,7 @@ jinja2==2.11.3
     # via -r requirements/base.txt
 libnacl==1.7.2
     # via -r requirements/windows.txt
-lxml==4.6.2
+lxml==4.6.3
     # via -r requirements/windows.txt
 mako==1.1.4
     # via -r requirements/windows.txt

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -21,9 +21,9 @@ idna==2.8
 ioloop==0.1a0
 ipaddress==1.0.22
 jaraco.functools==2.0     # via cheroot, tempora
-jinja2==2.10.1
+jinja2==2.11.3
 libnacl==1.7.1
-lxml==4.6.2
+lxml==4.6.3
 mako==1.0.7
 markupsafe==1.1.1
 more-itertools==8.2.0     # via cheroot, cherrypy, jaraco.functools

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -21,9 +21,9 @@ idna==2.8
 ioloop==0.1a0
 ipaddress==1.0.22
 jaraco.functools==2.0     # via cheroot, tempora
-jinja2==2.10.1
+jinja2==2.11.3
 libnacl==1.7.1
-lxml==4.6.2
+lxml==4.6.3
 mako==1.0.7
 markupsafe==1.1.1
 more-itertools==8.2.0     # via cheroot, cherrypy, jaraco.functools


### PR DESCRIPTION
### What does this PR do?
Update Jinja2 and lxml due to security related bugfix releases

## Jinja2

CVE-2020-28493
moderate severity
Vulnerable versions: < 2.11.3
Patched version: 2.11.3

This affects the package jinja2 from 0.0.0 and before 2.11.3. The ReDOS vulnerability of the regex is mainly due to the sub-pattern [a-zA-Z0-9.-]+.[a-zA-Z0-9.-]+ This issue can be mitigated by Markdown to format user content instead of the urlize filter, or by implementing request timeouts and limiting process memory.

## lxml


CVE-2021-28957
moderate severity
Vulnerable versions: < 4.6.3
Patched version: 4.6.3

An XSS vulnerability was discovered in the python lxml clean module versions before 4.6.3. When disabling the safe_attrs_only and forms arguments, the Cleaner class does not remove the formaction attribute allowing for JS to bypass the sanitizer. A remote attacker could exploit this flaw to run arbitrary JS code on users who interact with incorrectly sanitized HTML. This issue is patched in lxml 4.6.3.