### PR TITLE
[freeze] Update Jinja2 and lxml due to security related bugfix releases

### DIFF
--- a/requirements/static/ci/py3.5/changelog.txt
+++ b/requirements/static/ci/py3.5/changelog.txt
@@ -6,7 +6,7 @@
 #
 click==7.1.1              # via towncrier
 incremental==17.5.0       # via towncrier
-jinja2==2.11.2            # via towncrier
+jinja2==2.11.3            # via towncrier
 markupsafe==1.1.1         # via jinja2
 toml==0.10.2              # via towncrier
 towncrier==19.2.0

--- a/requirements/static/ci/py3.5/darwin.txt
+++ b/requirements/static/ci/py3.5/darwin.txt
@@ -151,7 +151,7 @@ jxmlease==1.0.1 ; sys_platform != "win32"
 keyring==5.7.1
 kubernetes==3.0.0
 linode-python==1.1.1
-lxml==4.6.2               # via junos-eznc, ncclient
+lxml==4.6.3               # via junos-eznc, ncclient
 mako==1.0.7
 markupsafe==1.1.1
 mock==3.0.5

--- a/requirements/static/ci/py3.5/docs.txt
+++ b/requirements/static/ci/py3.5/docs.txt
@@ -11,7 +11,7 @@ chardet==3.0.4            # via requests
 docutils==0.15.2          # via sphinx
 idna==2.9                 # via requests
 imagesize==1.2.0          # via sphinx
-jinja2==2.11.2            # via sphinx
+jinja2==2.11.3            # via sphinx
 markupsafe==1.1.1         # via jinja2
 packaging==20.3           # via sphinx
 pygments==2.6.1           # via sphinx

--- a/requirements/static/ci/py3.5/freebsd.txt
+++ b/requirements/static/ci/py3.5/freebsd.txt
@@ -154,7 +154,7 @@ kazoo==2.6.1 ; sys_platform != "win32" and sys_platform != "darwin"
 keyring==5.7.1
 kubernetes==3.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
-lxml==4.6.2               # via junos-eznc, ncclient
+lxml==4.6.3               # via junos-eznc, ncclient
 mako==1.1.0
 markupsafe==1.1.1
 mock==3.0.5

--- a/requirements/static/ci/py3.5/linux.txt
+++ b/requirements/static/ci/py3.5/linux.txt
@@ -155,7 +155,7 @@ kazoo==2.6.1 ; sys_platform != "win32" and sys_platform != "darwin"
 keyring==5.7.1
 kubernetes==3.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
-lxml==4.6.2               # via junos-eznc, ncclient, vsphere-automation-sdk
+lxml==4.6.3               # via junos-eznc, ncclient, vsphere-automation-sdk
 mako==1.1.0
 markupsafe==1.1.1
 mock==3.0.5

--- a/requirements/static/ci/py3.6/changelog.txt
+++ b/requirements/static/ci/py3.6/changelog.txt
@@ -6,7 +6,7 @@
 #
 click==7.1.1              # via towncrier
 incremental==17.5.0       # via towncrier
-jinja2==2.11.2            # via towncrier
+jinja2==2.11.3            # via towncrier
 markupsafe==1.1.1         # via jinja2
 toml==0.10.2              # via towncrier
 towncrier==19.2.0

--- a/requirements/static/ci/py3.6/darwin.txt
+++ b/requirements/static/ci/py3.6/darwin.txt
@@ -151,7 +151,7 @@ jxmlease==1.0.1 ; sys_platform != "win32"
 keyring==5.7.1
 kubernetes==3.0.0
 linode-python==1.1.1
-lxml==4.6.2               # via junos-eznc, ncclient
+lxml==4.6.3               # via junos-eznc, ncclient
 mako==1.0.7
 markupsafe==1.1.1
 mock==3.0.5

--- a/requirements/static/ci/py3.6/docs.txt
+++ b/requirements/static/ci/py3.6/docs.txt
@@ -11,7 +11,7 @@ chardet==3.0.4            # via requests
 docutils==0.15.2          # via sphinx
 idna==2.9                 # via requests
 imagesize==1.2.0          # via sphinx
-jinja2==2.11.2            # via sphinx
+jinja2==2.11.3            # via sphinx
 markupsafe==1.1.1         # via jinja2
 packaging==20.3           # via sphinx
 pygments==2.6.1           # via sphinx

--- a/requirements/static/ci/py3.6/freebsd.txt
+++ b/requirements/static/ci/py3.6/freebsd.txt
@@ -154,7 +154,7 @@ kazoo==2.6.1 ; sys_platform != "win32" and sys_platform != "darwin"
 keyring==5.7.1
 kubernetes==3.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
-lxml==4.6.2               # via junos-eznc, ncclient
+lxml==4.6.3               # via junos-eznc, ncclient
 mako==1.1.0
 markupsafe==1.1.1
 mock==3.0.5

--- a/requirements/static/ci/py3.6/linux.txt
+++ b/requirements/static/ci/py3.6/linux.txt
@@ -155,7 +155,7 @@ kazoo==2.6.1 ; sys_platform != "win32" and sys_platform != "darwin"
 keyring==5.7.1
 kubernetes==3.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
-lxml==4.6.2               # via junos-eznc, ncclient, vsphere-automation-sdk
+lxml==4.6.3               # via junos-eznc, ncclient, vsphere-automation-sdk
 mako==1.1.0
 markupsafe==1.1.1
 mock==3.0.5

--- a/requirements/static/ci/py3.6/windows.txt
+++ b/requirements/static/ci/py3.6/windows.txt
@@ -64,7 +64,7 @@ junit-xml==1.9            # via cfn-lint
 keyring==5.7.1
 kubernetes==3.0.0
 libnacl==1.7.2
-lxml==4.6.2
+lxml==4.6.3
 mako==1.1.4
 markupsafe==1.1.1
 mock==3.0.5

--- a/requirements/static/ci/py3.7/changelog.txt
+++ b/requirements/static/ci/py3.7/changelog.txt
@@ -6,7 +6,7 @@
 #
 click==7.1.1              # via towncrier
 incremental==17.5.0       # via towncrier
-jinja2==2.11.2            # via towncrier
+jinja2==2.11.3            # via towncrier
 markupsafe==1.1.1         # via jinja2
 toml==0.10.2              # via towncrier
 towncrier==19.2.0

--- a/requirements/static/ci/py3.7/darwin.txt
+++ b/requirements/static/ci/py3.7/darwin.txt
@@ -151,7 +151,7 @@ jxmlease==1.0.1 ; sys_platform != "win32"
 keyring==5.7.1
 kubernetes==3.0.0
 linode-python==1.1.1
-lxml==4.6.2               # via junos-eznc, napalm, ncclient
+lxml==4.6.3               # via junos-eznc, napalm, ncclient
 mako==1.0.7
 markupsafe==1.1.1
 mock==3.0.5

--- a/requirements/static/ci/py3.7/docs.txt
+++ b/requirements/static/ci/py3.7/docs.txt
@@ -11,7 +11,7 @@ chardet==3.0.4            # via requests
 docutils==0.15.2          # via sphinx
 idna==2.9                 # via requests
 imagesize==1.2.0          # via sphinx
-jinja2==2.11.2            # via sphinx
+jinja2==2.11.3            # via sphinx
 markupsafe==1.1.1         # via jinja2
 packaging==20.3           # via sphinx
 pygments==2.6.1           # via sphinx

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -154,7 +154,7 @@ kazoo==2.6.1 ; sys_platform != "win32" and sys_platform != "darwin"
 keyring==5.7.1
 kubernetes==3.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
-lxml==4.6.2               # via junos-eznc, napalm, ncclient
+lxml==4.6.3               # via junos-eznc, napalm, ncclient
 mako==1.1.0
 markupsafe==1.1.1
 mock==3.0.5

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -155,7 +155,7 @@ kazoo==2.6.1 ; sys_platform != "win32" and sys_platform != "darwin"
 keyring==5.7.1
 kubernetes==3.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
-lxml==4.6.2               # via junos-eznc, napalm, ncclient, vsphere-automation-sdk
+lxml==4.6.3               # via junos-eznc, napalm, ncclient, vsphere-automation-sdk
 mako==1.1.0
 markupsafe==1.1.1
 mock==3.0.5

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -62,7 +62,7 @@ junit-xml==1.9            # via cfn-lint
 keyring==5.7.1
 kubernetes==3.0.0
 libnacl==1.7.2
-lxml==4.6.2
+lxml==4.6.3
 mako==1.1.4
 markupsafe==1.1.1
 mock==3.0.5

--- a/requirements/static/ci/py3.8/changelog.txt
+++ b/requirements/static/ci/py3.8/changelog.txt
@@ -6,7 +6,7 @@
 #
 click==7.1.2              # via towncrier
 incremental==17.5.0       # via towncrier
-jinja2==2.11.2            # via towncrier
+jinja2==2.11.3            # via towncrier
 markupsafe==1.1.1         # via jinja2
 toml==0.10.1              # via towncrier
 towncrier==19.2.0

--- a/requirements/static/ci/py3.8/darwin.txt
+++ b/requirements/static/ci/py3.8/darwin.txt
@@ -150,7 +150,7 @@ jxmlease==1.0.1 ; sys_platform != "win32"
 keyring==5.7.1
 kubernetes==3.0.0
 linode-python==1.1.1
-lxml==4.6.2               # via junos-eznc, napalm, ncclient
+lxml==4.6.3               # via junos-eznc, napalm, ncclient
 mako==1.0.7
 markupsafe==1.1.1
 mock==3.0.5

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -153,7 +153,7 @@ kazoo==2.6.1 ; sys_platform != "win32" and sys_platform != "darwin"
 keyring==5.7.1
 kubernetes==3.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
-lxml==4.6.2               # via junos-eznc, napalm, ncclient
+lxml==4.6.3               # via junos-eznc, napalm, ncclient
 mako==1.1.0
 markupsafe==1.1.1
 mock==3.0.5

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -154,7 +154,7 @@ kazoo==2.6.1 ; sys_platform != "win32" and sys_platform != "darwin"
 keyring==5.7.1
 kubernetes==3.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
-lxml==4.6.2               # via junos-eznc, napalm, ncclient, vsphere-automation-sdk
+lxml==4.6.3               # via junos-eznc, napalm, ncclient, vsphere-automation-sdk
 mako==1.1.0
 markupsafe==1.1.1
 mock==3.0.5

--- a/requirements/static/ci/py3.9/changelog.txt
+++ b/requirements/static/ci/py3.9/changelog.txt
@@ -6,7 +6,7 @@
 #
 click==7.1.2              # via towncrier
 incremental==17.5.0       # via towncrier
-jinja2==2.11.2            # via towncrier
+jinja2==2.11.3            # via towncrier
 markupsafe==1.1.1         # via jinja2
 toml==0.10.1              # via towncrier
 towncrier==19.2.0

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -150,7 +150,7 @@ jxmlease==1.0.1 ; sys_platform != "win32"
 keyring==5.7.1
 kubernetes==3.0.0
 linode-python==1.1.1
-lxml==4.6.2               # via junos-eznc, napalm, ncclient
+lxml==4.6.3               # via junos-eznc, napalm, ncclient
 mako==1.0.7
 markupsafe==1.1.1
 mock==3.0.5

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -153,7 +153,7 @@ kazoo==2.6.1 ; sys_platform != "win32" and sys_platform != "darwin"
 keyring==5.7.1
 kubernetes==3.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
-lxml==4.6.2               # via junos-eznc, napalm, ncclient
+lxml==4.6.3               # via junos-eznc, napalm, ncclient
 mako==1.1.0
 markupsafe==1.1.1
 mock==3.0.5

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -155,7 +155,7 @@ kazoo==2.6.1 ; sys_platform != "win32" and sys_platform != "darwin"
 keyring==5.7.1
 kubernetes==3.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
-lxml==4.6.2               # via junos-eznc, napalm, ncclient, vsphere-automation-sdk
+lxml==4.6.3               # via junos-eznc, napalm, ncclient, vsphere-automation-sdk
 mako==1.1.0
 markupsafe==1.1.1
 mock==3.0.5

--- a/requirements/static/pkg/py3.6/windows.txt
+++ b/requirements/static/pkg/py3.6/windows.txt
@@ -26,7 +26,7 @@ jaraco.functools==2.0     # via cheroot, jaraco.text, tempora
 jaraco.text==3.5.0        # via jaraco.collections
 jinja2==2.11.3
 libnacl==1.7.2
-lxml==4.6.2
+lxml==4.6.3
 mako==1.1.4
 markupsafe==1.1.1
 more-itertools==8.2.0     # via cheroot, cherrypy, jaraco.classes, jaraco.functools

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -23,7 +23,7 @@ jaraco.functools==2.0     # via cheroot, jaraco.text, tempora
 jaraco.text==3.5.0        # via jaraco.collections
 jinja2==2.11.3
 libnacl==1.7.2
-lxml==4.6.2
+lxml==4.6.3
 mako==1.1.4
 markupsafe==1.1.1
 more-itertools==8.2.0     # via cheroot, cherrypy, jaraco.classes, jaraco.functools

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -23,7 +23,7 @@ ipaddress==1.0.22
 jaraco.functools==2.0     # via cheroot, tempora
 jinja2==2.11.3
 libnacl==1.7.1
-lxml==4.6.2
+lxml==4.6.3
 mako==1.0.7
 markupsafe==1.1.1
 more-itertools==8.2.0     # via cheroot, cherrypy, jaraco.functools

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -23,7 +23,7 @@ ipaddress==1.0.22
 jaraco.functools==2.0     # via cheroot, tempora
 jinja2==2.11.3
 libnacl==1.7.1
-lxml==4.6.2
+lxml==4.6.3
 mako==1.0.7
 markupsafe==1.1.1
 more-itertools==8.2.0     # via cheroot, cherrypy, jaraco.functools


### PR DESCRIPTION
### What does this PR do?
Update Jinja2 and lxml due to security related bugfix releases

## Jinja2

CVE-2020-28493
moderate severity
Vulnerable versions: < 2.11.3
Patched version: 2.11.3

This affects the package jinja2 from 0.0.0 and before 2.11.3. The ReDOS vulnerability of the regex is mainly due to the sub-pattern [a-zA-Z0-9.-]+.[a-zA-Z0-9.-]+ This issue can be mitigated by Markdown to format user content instead of the urlize filter, or by implementing request timeouts and limiting process memory.

## lxml


CVE-2021-28957
moderate severity
Vulnerable versions: < 4.6.3
Patched version: 4.6.3

An XSS vulnerability was discovered in the python lxml clean module versions before 4.6.3. When disabling the safe_attrs_only and forms arguments, the Cleaner class does not remove the formaction attribute allowing for JS to bypass the sanitizer. A remote attacker could exploit this flaw to run arbitrary JS code on users who interact with incorrectly sanitized HTML. This issue is patched in lxml 4.6.3.