### PR TITLE
Fix consul module agent_service_maintenance

### DIFF
--- a/changelog/60192.fixed
+++ b/changelog/60192.fixed
@@ -1,0 +1,1 @@
+Fixed HTTP method in consul module's agent_service_maintenance function

--- a/salt/modules/consul.py
+++ b/salt/modules/consul.py
@@ -48,6 +48,7 @@ def _query(
     api_version="v1",
     data=None,
     query_params=None,
+    decode_type="auto",
 ):
     """
     Consul object method function to construct and execute on the API URL.
@@ -57,6 +58,7 @@ def _query(
     :param function:    The Consul api function to perform.
     :param method:      The HTTP method, e.g. GET or POST.
     :param data:        The data to be sent for POST method. This param is ignored for GET requests.
+    :param decode_type: The method how data returned from the API should be decoded
     :return:            The json response from the API call or False.
     """
 
@@ -85,6 +87,7 @@ def _query(
         params=query_params,
         data=data,
         decode=True,
+        decode_type=decode_type,
         status=True,
         header_dict=headers,
         opts=__opts__,
@@ -1161,7 +1164,12 @@ def agent_service_maintenance(consul_url=None, token=None, serviceid=None, **kwa
 
     function = "agent/service/maintenance/{}".format(serviceid)
     res = _query(
-        consul_url=consul_url, token=token, function=function, query_params=query_params
+        consul_url=consul_url,
+        token=token,
+        function=function,
+        method="PUT",
+        query_params=query_params,
+        decode_type="plain",
     )
 
     if res["res"]:

--- a/salt/modules/consul.py
+++ b/salt/modules/consul.py
@@ -1136,7 +1136,7 @@ def agent_service_maintenance(consul_url=None, token=None, serviceid=None, **kwa
 
     .. code-block:: bash
 
-        salt '*' consul.agent_service_deregister serviceid='redis' enable='True' reason='Down for upgrade'
+        salt '*' consul.agent_service_maintenance serviceid='redis' enable='True' reason='Down for upgrade'
 
     """
     ret = {}


### PR DESCRIPTION
### What does this PR do?
Change the method in the HTTP call for setting a consul agent into maintenance mode from GET to PUT inline with the Consul API documentation https://www.consul.io/api-docs/agent/service#enable-maintenance-mode

### What issues does this PR fix or reference?
Fixes: #60192

### Previous Behavior
HTTP GET was used to call the agent service maintenance API endpoint

### New Behavior
HTTP POST is used to call the agent service maintenance API endpoint

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html

### Commits signed with GPG?
No
