### PR TITLE
Check dict key get_reboot_active exists before attempting to use, not all proxy implement it

### DIFF
--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -1790,7 +1790,8 @@ def proxy_reconnect(proxy_name, opts=None):
     if proxy_keepalive_fn not in __proxy__:
         return False  # fail
 
-    if __proxy__[proxy_name + ".get_reboot_active"]():
+    chk_reboot_active_key = proxy_name + ".get_reboot_active"
+    if chk_reboot_active_key in __proxy__ and __proxy__[chk_reboot_active_key]():
         # if rebooting or shutting down, don't run proxy_reconnect
         # it interferes with the connection and disrupts the shutdown/reboot
         # especially


### PR DESCRIPTION
### What does this PR do?
Fixes issue with proxy get_boot_active key missing error in logs, by checking if key exists first before trying it.
This is necessary since not all proxy's implement 'get_reboot_active', for example: napalm
Originally added to fix issue with junos keep alive

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/60025

### Previous Behavior
KeyError: 'napalm.get_reboot_active' traceback error in logs

### New Behavior
no message output to logs, since key now only accessed if exists.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
