### PR TITLE
Use root as owner/group in sdist generated tars

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[sdist]
+owner = root
+group = root


### PR DESCRIPTION
### What does this PR do?

By default, when packaging `salt` with `sdist`:

```bash
python3 setup.py sdist
python3 setup.py --ssh-packaging sdist
```

The generated `dist/*.tar.gz` tarballs embed the uid/gid of the archived files as matching the user that generated them. Previously, `sdist` had additional args so a command would look like:

```bash
python3 setup.py sdist --owner=root --group=root
python3 setup.py --ssh-packaging sdist --owner=root --group=root
```

These args no longer exist. Instead, these values can be picked up from `setup.cfg` as so:

```
[sdist]
owner = root
group = root
```

### What issues does this PR fix or reference?

Fixes: #60253

### Previous Behavior

`python3 setup.py sdist` would generate the tarballs with the owner/group of archived files matching the owner/group that ran the command.

### New Behavior

`python3 setup.py sdist` will generate the tarballs with the owner/group of archived files being `root:root` by default.

### Commits signed with GPG?
Yes
