### PR TITLE
Update pip-tools-compile-impersonate to 4.1 & Doc improvement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ default_language_version:
 exclude: ^(doc/_static/.*|doc/_themes/.*)$
 repos:
   - repo: https://github.com/saltstack/pip-tools-compile-impersonate
-    rev: "3.0"
+    rev: "4.1"
     hooks:
 
   # ----- Packaging Requirements ------------------------------------------------------------------------------------>

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1018,7 +1018,7 @@ repos:
       - id: pip-tools-compile
         alias: compile-ci-invoke-py3.5-requirements
         name: Linux CI Py3.5 Invoke Requirements
-        files: ^requirements/static/ci/invoke\.in$
+        files: ^requirements/static/ci/(invoke\.in|py3.5/invoke\.txt)$
         pass_filenames: false
         args:
           - -v
@@ -1028,7 +1028,7 @@ repos:
       - id: pip-tools-compile
         alias: compile-ci-invoke-py3.6-requirements
         name: Linux CI Py3.6 Invoke Requirements
-        files: ^requirements/static/ci/invoke\.in$
+        files: ^requirements/static/ci/(invoke\.in|py3.6/invoke\.txt)$
         pass_filenames: false
         args:
           - -v
@@ -1038,7 +1038,7 @@ repos:
       - id: pip-tools-compile
         alias: compile-ci-invoke-py3.7-requirements
         name: Linux CI Py3.7 Invoke Requirements
-        files: ^requirements/static/ci/invoke\.in$
+        files: ^requirements/static/ci/(invoke\.in|py3.7/invoke\.txt)$
         pass_filenames: false
         args:
           - -v
@@ -1048,7 +1048,7 @@ repos:
       - id: pip-tools-compile
         alias: compile-ci-invoke-py3.8-requirements
         name: Linux CI Py3.8 Invoke Requirements
-        files: ^requirements/static/ci/invoke\.in$
+        files: ^requirements/static/ci/(invoke\.in|py3.8/invoke\.txt)$
         pass_filenames: false
         args:
           - -v
@@ -1058,7 +1058,7 @@ repos:
       - id: pip-tools-compile
         alias: compile-ci-invoke-py3.9-requirements
         name: Linux CI Py3.9 Invoke Requirements
-        files: ^requirements/static/ci/invoke\.in$
+        files: ^requirements/static/ci/(invoke\.in|py3.9/invoke\.txt)$
         pass_filenames: false
         args:
           - -v
@@ -1068,7 +1068,7 @@ repos:
       - id: pip-tools-compile
         alias: compile-ci-invoke-py3.10-requirements
         name: Linux CI Py3.10 Invoke Requirements
-        files: ^requirements/static/ci/invoke\.in$
+        files: ^requirements/static/ci/(invoke\.in|py3.10/invoke\.txt)$
         pass_filenames: false
         args:
           - -v

--- a/doc/topics/development/conventions/style.rst
+++ b/doc/topics/development/conventions/style.rst
@@ -19,8 +19,11 @@ Linting
 =======
 
 Most Salt style conventions are codified in Salt's ``.pylintrc`` file.
-Salt's pylint file has two dependencies: pylint_ and saltpylint_, however, linting should
-be done using :ref:`nox <getting_set_up_for_tests>`.
+Salt's linting has two major dependencies: pylint_ and saltpylint_, the full lint
+requirements can be found under ``requirements/static/ci/lint.in`` and the pinned
+requirements at ``requirements/static/ci/py3.<minor-version>/lint.txt``, however,
+linting should be done using :ref:`nox <getting_set_up_for_tests>`, which is how
+pull requests are checked.
 
 .. code-block:: bash
 

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -42,7 +42,7 @@ requests==2.21.0
     #   profitbricks
     #   pywinrm
     #   requests-ntlm
-six==1.15.0
+six==1.16.0
     # via
     #   cryptography
     #   profitbricks

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -819,7 +819,7 @@ scp==0.13.2
     #   netmiko
 setproctitle==1.1.10
     # via -r requirements/static/pkg/py3.10/darwin.txt
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.10/darwin.txt
     #   aws-sam-translator

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -113,7 +113,7 @@ requests==2.25.1
     #   sphinx
 setproctitle==1.1.10
     # via -r requirements/static/pkg/py3.10/linux.txt
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.10/linux.txt
     #   cheroot

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -817,7 +817,7 @@ scp==0.13.2
     #   netmiko
 setproctitle==1.1.10
     # via -r requirements/static/pkg/py3.10/freebsd.txt
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.10/freebsd.txt
     #   aws-sam-translator

--- a/requirements/static/ci/py3.10/invoke.txt
+++ b/requirements/static/ci/py3.10/invoke.txt
@@ -10,5 +10,5 @@ invoke==1.4.1
     # via -r requirements/static/ci/invoke.in
 pyyaml==5.3.1
     # via -r requirements/static/ci/invoke.in
-six==1.15.0
+six==1.16.0
     # via blessings

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -22,7 +22,7 @@ pylint==2.4.4
     #   saltpylint
 saltpylint==2020.9.28
     # via -r requirements/static/ci/lint.in
-six==1.15.0
+six==1.16.0
     # via astroid
 toml==0.10.2
     # via -r requirements/static/ci/lint.in

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -837,7 +837,7 @@ scp==0.13.2
     #   netmiko
 setproctitle==1.1.10
     # via -r requirements/static/pkg/py3.10/linux.txt
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.10/linux.txt
     #   aws-sam-translator

--- a/requirements/static/ci/py3.5/cloud.txt
+++ b/requirements/static/ci/py3.5/cloud.txt
@@ -42,7 +42,7 @@ requests==2.21.0
     #   profitbricks
     #   pywinrm
     #   requests-ntlm
-six==1.15.0
+six==1.16.0
     # via
     #   cryptography
     #   profitbricks

--- a/requirements/static/ci/py3.5/docs.txt
+++ b/requirements/static/ci/py3.5/docs.txt
@@ -115,7 +115,7 @@ requests==2.25.1
     #   sphinx
 setproctitle==1.1.10
     # via -r requirements/static/pkg/py3.5/linux.txt
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.5/linux.txt
     #   cheroot

--- a/requirements/static/ci/py3.5/invoke.txt
+++ b/requirements/static/ci/py3.5/invoke.txt
@@ -10,5 +10,5 @@ invoke==1.4.1
     # via -r requirements/static/ci/invoke.in
 pyyaml==5.3.1
     # via -r requirements/static/ci/invoke.in
-six==1.15.0
+six==1.16.0
     # via blessings

--- a/requirements/static/ci/py3.5/lint.txt
+++ b/requirements/static/ci/py3.5/lint.txt
@@ -22,7 +22,7 @@ pylint==2.4.4
     #   saltpylint
 saltpylint==2020.9.28
     # via -r requirements/static/ci/lint.in
-six==1.15.0
+six==1.16.0
     # via astroid
 toml==0.10.2
     # via -r requirements/static/ci/lint.in

--- a/requirements/static/ci/py3.5/linux.txt
+++ b/requirements/static/ci/py3.5/linux.txt
@@ -820,7 +820,7 @@ scp==0.13.2
     # via junos-eznc
 setproctitle==1.1.10
     # via -r requirements/static/pkg/py3.5/linux.txt
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.5/linux.txt
     #   aws-sam-translator

--- a/requirements/static/ci/py3.6/cloud.txt
+++ b/requirements/static/ci/py3.6/cloud.txt
@@ -42,7 +42,7 @@ requests==2.21.0
     #   profitbricks
     #   pywinrm
     #   requests-ntlm
-six==1.15.0
+six==1.16.0
     # via
     #   cryptography
     #   profitbricks

--- a/requirements/static/ci/py3.6/docs.txt
+++ b/requirements/static/ci/py3.6/docs.txt
@@ -115,7 +115,7 @@ requests==2.25.1
     #   sphinx
 setproctitle==1.1.10
     # via -r requirements/static/pkg/py3.6/linux.txt
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.6/linux.txt
     #   cheroot

--- a/requirements/static/ci/py3.6/invoke.txt
+++ b/requirements/static/ci/py3.6/invoke.txt
@@ -10,5 +10,5 @@ invoke==1.4.1
     # via -r requirements/static/ci/invoke.in
 pyyaml==5.3.1
     # via -r requirements/static/ci/invoke.in
-six==1.15.0
+six==1.16.0
     # via blessings

--- a/requirements/static/ci/py3.6/lint.txt
+++ b/requirements/static/ci/py3.6/lint.txt
@@ -22,7 +22,7 @@ pylint==2.4.4
     #   saltpylint
 saltpylint==2020.9.28
     # via -r requirements/static/ci/lint.in
-six==1.15.0
+six==1.16.0
     # via astroid
 toml==0.10.2
     # via -r requirements/static/ci/lint.in

--- a/requirements/static/ci/py3.6/linux.txt
+++ b/requirements/static/ci/py3.6/linux.txt
@@ -818,7 +818,7 @@ scp==0.13.2
     # via junos-eznc
 setproctitle==1.1.10
     # via -r requirements/static/pkg/py3.6/linux.txt
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.6/linux.txt
     #   aws-sam-translator

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -42,7 +42,7 @@ requests==2.21.0
     #   profitbricks
     #   pywinrm
     #   requests-ntlm
-six==1.15.0
+six==1.16.0
     # via
     #   cryptography
     #   profitbricks

--- a/requirements/static/ci/py3.7/darwin.txt
+++ b/requirements/static/ci/py3.7/darwin.txt
@@ -827,7 +827,7 @@ scp==0.13.2
     #   netmiko
 setproctitle==1.1.10
     # via -r requirements/static/pkg/py3.7/darwin.txt
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.7/darwin.txt
     #   aws-sam-translator

--- a/requirements/static/ci/py3.7/docs.txt
+++ b/requirements/static/ci/py3.7/docs.txt
@@ -113,7 +113,7 @@ requests==2.25.1
     #   sphinx
 setproctitle==1.1.10
     # via -r requirements/static/pkg/py3.7/linux.txt
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.7/linux.txt
     #   cheroot

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -825,7 +825,7 @@ scp==0.13.2
     #   netmiko
 setproctitle==1.1.10
     # via -r requirements/static/pkg/py3.7/freebsd.txt
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.7/freebsd.txt
     #   aws-sam-translator

--- a/requirements/static/ci/py3.7/invoke.txt
+++ b/requirements/static/ci/py3.7/invoke.txt
@@ -10,5 +10,5 @@ invoke==1.4.1
     # via -r requirements/static/ci/invoke.in
 pyyaml==5.3.1
     # via -r requirements/static/ci/invoke.in
-six==1.15.0
+six==1.16.0
     # via blessings

--- a/requirements/static/ci/py3.7/lint.txt
+++ b/requirements/static/ci/py3.7/lint.txt
@@ -22,7 +22,7 @@ pylint==2.4.4
     #   saltpylint
 saltpylint==2020.9.28
     # via -r requirements/static/ci/lint.in
-six==1.15.0
+six==1.16.0
     # via astroid
 toml==0.10.2
     # via -r requirements/static/ci/lint.in

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -843,7 +843,7 @@ scp==0.13.2
     #   netmiko
 setproctitle==1.1.10
     # via -r requirements/static/pkg/py3.7/linux.txt
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.7/linux.txt
     #   aws-sam-translator

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -360,7 +360,7 @@ sed==0.3.1
     # via -r requirements/static/ci/windows.in
 setproctitle==1.1.10
     # via -r requirements/static/pkg/py3.7/windows.txt
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.7/windows.txt
     #   aws-sam-translator

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -42,7 +42,7 @@ requests==2.21.0
     #   profitbricks
     #   pywinrm
     #   requests-ntlm
-six==1.15.0
+six==1.16.0
     # via
     #   cryptography
     #   profitbricks

--- a/requirements/static/ci/py3.8/darwin.txt
+++ b/requirements/static/ci/py3.8/darwin.txt
@@ -819,7 +819,7 @@ scp==0.13.2
     #   netmiko
 setproctitle==1.1.10
     # via -r requirements/static/pkg/py3.8/darwin.txt
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.8/darwin.txt
     #   aws-sam-translator

--- a/requirements/static/ci/py3.8/docs.txt
+++ b/requirements/static/ci/py3.8/docs.txt
@@ -113,7 +113,7 @@ requests==2.25.1
     #   sphinx
 setproctitle==1.1.10
     # via -r requirements/static/pkg/py3.8/linux.txt
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.8/linux.txt
     #   cheroot

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -817,7 +817,7 @@ scp==0.13.2
     #   netmiko
 setproctitle==1.1.10
     # via -r requirements/static/pkg/py3.8/freebsd.txt
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.8/freebsd.txt
     #   aws-sam-translator

--- a/requirements/static/ci/py3.8/invoke.txt
+++ b/requirements/static/ci/py3.8/invoke.txt
@@ -10,5 +10,5 @@ invoke==1.4.1
     # via -r requirements/static/ci/invoke.in
 pyyaml==5.3.1
     # via -r requirements/static/ci/invoke.in
-six==1.15.0
+six==1.16.0
     # via blessings

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -22,7 +22,7 @@ pylint==2.4.4
     #   saltpylint
 saltpylint==2020.9.28
     # via -r requirements/static/ci/lint.in
-six==1.15.0
+six==1.16.0
     # via astroid
 toml==0.10.2
     # via -r requirements/static/ci/lint.in

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -835,7 +835,7 @@ scp==0.13.2
     #   netmiko
 setproctitle==1.1.10
     # via -r requirements/static/pkg/py3.8/linux.txt
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.8/linux.txt
     #   aws-sam-translator

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -42,7 +42,7 @@ requests==2.21.0
     #   profitbricks
     #   pywinrm
     #   requests-ntlm
-six==1.15.0
+six==1.16.0
     # via
     #   cryptography
     #   profitbricks

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -819,7 +819,7 @@ scp==0.13.2
     #   netmiko
 setproctitle==1.1.10
     # via -r requirements/static/pkg/py3.9/darwin.txt
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.9/darwin.txt
     #   aws-sam-translator

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -113,7 +113,7 @@ requests==2.25.1
     #   sphinx
 setproctitle==1.1.10
     # via -r requirements/static/pkg/py3.9/linux.txt
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.9/linux.txt
     #   cheroot

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -817,7 +817,7 @@ scp==0.13.2
     #   netmiko
 setproctitle==1.1.10
     # via -r requirements/static/pkg/py3.9/freebsd.txt
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.9/freebsd.txt
     #   aws-sam-translator

--- a/requirements/static/ci/py3.9/invoke.txt
+++ b/requirements/static/ci/py3.9/invoke.txt
@@ -10,5 +10,5 @@ invoke==1.4.1
     # via -r requirements/static/ci/invoke.in
 pyyaml==5.3.1
     # via -r requirements/static/ci/invoke.in
-six==1.15.0
+six==1.16.0
     # via blessings

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -22,7 +22,7 @@ pylint==2.4.4
     #   saltpylint
 saltpylint==2020.9.28
     # via -r requirements/static/ci/lint.in
-six==1.15.0
+six==1.16.0
     # via astroid
 toml==0.10.2
     # via -r requirements/static/ci/lint.in

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -837,7 +837,7 @@ scp==0.13.2
     #   netmiko
 setproctitle==1.1.10
     # via -r requirements/static/pkg/py3.9/linux.txt
-six==1.15.0
+six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.9/linux.txt
     #   aws-sam-translator

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -89,7 +89,7 @@ requests==2.25.1
     #   vultr
 setproctitle==1.1.10
     # via -r requirements/darwin.txt
-six==1.15.0
+six==1.16.0
     # via
     #   cheroot
     #   cherrypy

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -68,7 +68,7 @@ requests==2.25.1
     # via -r requirements/base.txt
 setproctitle==1.1.10
     # via -r requirements/static/pkg/freebsd.in
-six==1.15.0
+six==1.16.0
     # via
     #   cheroot
     #   cherrypy

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -66,7 +66,7 @@ requests==2.25.1
     # via -r requirements/base.txt
 setproctitle==1.1.10
     # via -r requirements/static/pkg/linux.in
-six==1.15.0
+six==1.16.0
     # via
     #   cheroot
     #   cherrypy

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -47,7 +47,7 @@ pyyaml==5.3.1
 pyzmq==19.0.0
 requests==2.21.0
 setproctitle==1.1.10
-six==1.15.0               # via cheroot, cherrypy, cryptography, pyopenssl, python-dateutil, tempora
+six==1.16.0               # via cheroot, cherrypy, cryptography, pyopenssl, python-dateutil, tempora
 smmap2==2.0.5
 tempora==1.14.1           # via portend
 timelib==0.2.5

--- a/requirements/static/pkg/py3.5/linux.txt
+++ b/requirements/static/pkg/py3.5/linux.txt
@@ -68,7 +68,7 @@ requests==2.25.1
     # via -r requirements/base.txt
 setproctitle==1.1.10
     # via -r requirements/static/pkg/linux.in
-six==1.15.0
+six==1.16.0
     # via
     #   cheroot
     #   cherrypy

--- a/requirements/static/pkg/py3.6/linux.txt
+++ b/requirements/static/pkg/py3.6/linux.txt
@@ -68,7 +68,7 @@ requests==2.25.1
     # via -r requirements/base.txt
 setproctitle==1.1.10
     # via -r requirements/static/pkg/linux.in
-six==1.15.0
+six==1.16.0
     # via
     #   cheroot
     #   cherrypy

--- a/requirements/static/pkg/py3.7/darwin.txt
+++ b/requirements/static/pkg/py3.7/darwin.txt
@@ -89,7 +89,7 @@ requests==2.25.1
     #   vultr
 setproctitle==1.1.10
     # via -r requirements/darwin.txt
-six==1.15.0
+six==1.16.0
     # via
     #   cheroot
     #   cherrypy

--- a/requirements/static/pkg/py3.7/freebsd.txt
+++ b/requirements/static/pkg/py3.7/freebsd.txt
@@ -68,7 +68,7 @@ requests==2.25.1
     # via -r requirements/base.txt
 setproctitle==1.1.10
     # via -r requirements/static/pkg/freebsd.in
-six==1.15.0
+six==1.16.0
     # via
     #   cheroot
     #   cherrypy

--- a/requirements/static/pkg/py3.7/linux.txt
+++ b/requirements/static/pkg/py3.7/linux.txt
@@ -66,7 +66,7 @@ requests==2.25.1
     # via -r requirements/base.txt
 setproctitle==1.1.10
     # via -r requirements/static/pkg/linux.in
-six==1.15.0
+six==1.16.0
     # via
     #   cheroot
     #   cherrypy

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -112,7 +112,7 @@ requests==2.25.1
     #   -r requirements/windows.txt
 setproctitle==1.1.10
     # via -r requirements/windows.txt
-six==1.15.0
+six==1.16.0
     # via
     #   cheroot
     #   pyopenssl

--- a/requirements/static/pkg/py3.8/darwin.txt
+++ b/requirements/static/pkg/py3.8/darwin.txt
@@ -89,7 +89,7 @@ requests==2.25.1
     #   vultr
 setproctitle==1.1.10
     # via -r requirements/darwin.txt
-six==1.15.0
+six==1.16.0
     # via
     #   cheroot
     #   cherrypy

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -68,7 +68,7 @@ requests==2.25.1
     # via -r requirements/base.txt
 setproctitle==1.1.10
     # via -r requirements/static/pkg/freebsd.in
-six==1.15.0
+six==1.16.0
     # via
     #   cheroot
     #   cherrypy

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -66,7 +66,7 @@ requests==2.25.1
     # via -r requirements/base.txt
 setproctitle==1.1.10
     # via -r requirements/static/pkg/linux.in
-six==1.15.0
+six==1.16.0
     # via
     #   cheroot
     #   cherrypy

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -47,7 +47,7 @@ pyyaml==5.3.1
 pyzmq==19.0.0
 requests==2.21.0
 setproctitle==1.1.10
-six==1.15.0               # via cheroot, cherrypy, cryptography, pyopenssl, python-dateutil, tempora
+six==1.16.0               # via cheroot, cherrypy, cryptography, pyopenssl, python-dateutil, tempora
 smmap2==2.0.5
 tempora==1.14.1           # via portend
 timelib==0.2.5

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -89,7 +89,7 @@ requests==2.25.1
     #   vultr
 setproctitle==1.1.10
     # via -r requirements/darwin.txt
-six==1.15.0
+six==1.16.0
     # via
     #   cheroot
     #   cherrypy

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -68,7 +68,7 @@ requests==2.25.1
     # via -r requirements/base.txt
 setproctitle==1.1.10
     # via -r requirements/static/pkg/freebsd.in
-six==1.15.0
+six==1.16.0
     # via
     #   cheroot
     #   cherrypy

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -66,7 +66,7 @@ requests==2.25.1
     # via -r requirements/base.txt
 setproctitle==1.1.10
     # via -r requirements/static/pkg/linux.in
-six==1.15.0
+six==1.16.0
     # via
     #   cheroot
     #   cherrypy

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -47,7 +47,7 @@ pyyaml==5.3.1
 pyzmq==19.0.0
 requests==2.21.0
 setproctitle==1.1.10
-six==1.15.0               # via cheroot, cherrypy, cryptography, pyopenssl, python-dateutil, tempora
+six==1.16.0               # via cheroot, cherrypy, cryptography, pyopenssl, python-dateutil, tempora
 smmap2==2.0.5
 tempora==1.14.1           # via portend
 timelib==0.2.5


### PR DESCRIPTION
### What does this PR do?
* Update pip-tools-compile-impersonate to 4.1.
Now it also runs on Windows, macOS and FreeBSD.
* Minor lint doc clarification, improvements 
