### PR TITLE
Let Mac OS Mojave run for 8 hours to avoid timeout

### DIFF
--- a/cicd/jenkins/pr-macosx-mojave-x86_64-py3-pytest
+++ b/cicd/jenkins/pr-macosx-mojave-x86_64-py3-pytest
@@ -14,7 +14,7 @@ runTestSuite(
     nox_passthrough_opts: '--ssh-tests',
     python_version: 'py3',
     //splits: ['unit', 'integration', 'multimaster'],
-    testrun_timeout: 6,
+    testrun_timeout: 8,
     use_spot_instances: false,
     //fast_slow_staged_testrun: true
 )


### PR DESCRIPTION
### What does this PR do?
Increases the timeout for the MacOSX Mojave builds so that they (hopefully) stop timing out. This is so that we can see which tests are still failing.

https://jenkins.saltproject.io/job/pr-macosx-mojave-x86_64-py3-pytest-slow/job/master/

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/59476

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes