### PR TITLE
modules.network.fqdns: add failing IP to error msg

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -2077,9 +2077,9 @@ def fqdns():
                 # No FQDN for this IP address, so we don't need to know this all the time.
                 log.debug("Unable to resolve address %s: %s", ip, err)
             else:
-                log.error(err_message, err)
+                log.error(err_message, ip, err)
         except (OSError, socket.gaierror, socket.timeout) as err:
-            log.error(err_message, err)
+            log.error(err_message, ip, err)
 
     start = time.time()
 
@@ -2091,7 +2091,7 @@ def fqdns():
             include_loopback=False, interface_data=salt.utils.network._get_interfaces()
         )
     )
-    err_message = "Exception during resolving address: %s"
+    err_message = "Exception during resolving address '%s': %s"
 
     # Create a ThreadPool to process the underlying calls to 'socket.gethostbyaddr' in parallel.
     # This avoid blocking the execution when the "fqdn" is not defined for certains IP addresses, which was causing


### PR DESCRIPTION
### What does this PR do?
Make the error message of an failing IP-to-FQDN lookup more helpful by adding the corresponding IP.
From: `Exception during resolving address: [Errno 2] Host name lookup failure`
To:   `Exception during resolving address '172.28.5.1': [Errno 2] Host name lookup failure`

### What issues does this PR fix or reference?
None

### Previous Behavior
Error message didn't contain the IP, for which the FQDN lookup failed: `Exception during resolving address: [Errno 2] Host name lookup failure`

### New Behavior
Error message contains now the IP, for which the FQDN lookup failed:  `Exception during resolving address '172.28.5.1': [Errno 2] Host name lookup failure`

### Merge requirements satisfied?
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes