### PR TITLE
doc: clarify TCP usage by zmq ports

### DIFF
--- a/doc/topics/development/topology.rst
+++ b/doc/topics/development/topology.rst
@@ -10,12 +10,12 @@ Servers
 =======
 
 The Salt Master runs 2 network services. First is the ZeroMQ PUB system. This
-service by default runs on port ``4505`` and can be configured via the
+service by default runs on port ``4505/tcp`` and can be configured via the
 ``publish_port`` option in the master configuration.
 
 Second is the ZeroMQ REP system. This is a separate interface used for all
 bi-directional communication with minions. By default this system binds to
-port ``4506`` and can be configured via the ``ret_port`` option in the master.
+port ``4506/tcp`` and can be configured via the ``ret_port`` option in the master.
 
 PUB/SUB
 =======


### PR DESCRIPTION
### What does this PR do?
Make it clear in the topology docs, that SaltStack uses ZeroMQ via TCP
by default.

### What issues does this PR fix or reference?
None

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes