### PR TITLE
fix github actions jobs on branch until bullseye comes out

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,8 +14,10 @@ jobs:
 
     - name: Install System Deps
       run: |
+        echo deb "http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
         apt-get update
         apt-get install -y enchant git gcc imagemagick make zlib1g-dev libc-dev libffi-dev g++ libxml2 libxml2-dev libxslt-dev libcurl4-openssl-dev libssl-dev libgnutls28-dev xz-utils
+        apt-get install -y git/buster-backports
 
     - uses: actions/checkout@v2
 
@@ -76,8 +78,10 @@ jobs:
 
     - name: Install System Deps
       run: |
+        echo deb "http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
         apt-get update
         apt-get install -y enchant git gcc imagemagick make zlib1g-dev libc-dev libffi-dev g++ libxml2 libxml2-dev libxslt-dev libcurl4-openssl-dev libssl-dev libgnutls28-dev
+        apt-get install -y git/buster-backports
 
     - uses: actions/checkout@v2
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,8 +14,10 @@ jobs:
 
     - name: Install System Deps
       run: |
+        echo deb "http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
         apt-get update
         apt-get install -y enchant git gcc make zlib1g-dev libc-dev libffi-dev g++ libxml2 libxml2-dev libxslt-dev libcurl4-openssl-dev libssl-dev libgnutls28-dev
+        apt-get install -y git/buster-backports
 
     - uses: actions/checkout@v2
 
@@ -82,8 +84,10 @@ jobs:
 
     - name: Install System Deps
       run: |
+        echo deb "http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
         apt-get update
         apt-get install -y enchant git gcc make zlib1g-dev libc-dev libffi-dev g++ libxml2 libxml2-dev libxslt-dev libcurl4-openssl-dev libssl-dev libgnutls28-dev
+        apt-get install -y git/buster-backports
 
     - uses: actions/checkout@v2
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,8 +15,10 @@ jobs:
 
     - name: Install System Deps
       run: |
+        echo deb "http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
         apt-get update
         apt-get install -y enchant git gcc make zlib1g-dev libc-dev libffi-dev g++ libxml2 libxml2-dev libxslt-dev libcurl4-openssl-dev libssl-dev libgnutls28-dev
+        apt-get install -y git/buster-backports
 
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
### What does this PR do?
Fixes the branch jobs for github actions until https://github.com/dorny/paths-filter/issues/88 is fixed, or we upgrade to debian bullseye when that comes out.