### PR TITLE
Fixed firewalld.list_zones for tabbed values

### DIFF
--- a/changelog/60033.fixed
+++ b/changelog/60033.fixed
@@ -1,0 +1,1 @@
+Fixed firewalld.list_zones when any "rich rules" is set

--- a/tests/unit/modules/test_firewalld.py
+++ b/tests/unit/modules/test_firewalld.py
@@ -103,6 +103,13 @@ class FirewalldTestCase(TestCase, LoaderModuleMockMixin):
         with patch.object(firewalld, "__firewall_cmd", return_value=firewall_cmd_ret):
             self.assertEqual(firewalld.list_zones(), ret)
 
+    def test_list_zones_empty_response(self):
+        """
+        Test list_zones if firewall-cmd call returns nothing
+        """
+        with patch.object(firewalld, "__firewall_cmd", return_value=""):
+            self.assertEqual(firewalld.list_zones(), {})
+
     def test_get_zones(self):
         """
         Test for Print predefined zones
@@ -232,6 +239,13 @@ class FirewalldTestCase(TestCase, LoaderModuleMockMixin):
         }
         with patch.object(firewalld, "__firewall_cmd", return_value=firewall_cmd_ret):
             self.assertEqual(firewalld.list_all(), ret)
+
+    def test_list_all_empty_response(self):
+        """
+        Test list_all if firewall-cmd call returns nothing
+        """
+        with patch.object(firewalld, "__firewall_cmd", return_value=""):
+            self.assertEqual(firewalld.list_all(), {})
 
     def test_list_services(self):
         """

--- a/tests/unit/modules/test_firewalld.py
+++ b/tests/unit/modules/test_firewalld.py
@@ -3,6 +3,7 @@
 """
 
 import salt.modules.firewalld as firewalld
+from tests.support.helpers import dedent
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, patch
 from tests.support.unit import TestCase
@@ -34,8 +35,73 @@ class FirewalldTestCase(TestCase, LoaderModuleMockMixin):
         """
         Test for List everything added for or enabled in all zones
         """
-        with patch.object(firewalld, "__firewall_cmd", return_value=[]):
-            self.assertEqual(firewalld.default_zone(), [])
+        # pylint: disable=trailing-whitespace
+        firewall_cmd_ret = dedent(
+            """\
+                nm-shared
+                  target: ACCEPT
+                  icmp-block-inversion: no
+                  interfaces: 
+                  sources: 
+                  services: dhcp dns ssh
+                  ports: 
+                  protocols: icmp ipv6-icmp
+                  masquerade: no
+                  forward-ports: 
+                  source-ports: 
+                  icmp-blocks: 
+                  rich rules: 
+                \trule priority="32767" reject
+
+                public
+                  target: default
+                  icmp-block-inversion: no
+                  interfaces: 
+                  sources: 
+                  services: cockpit dhcpv6-client ssh
+                  ports: 
+                  protocols: 
+                  masquerade: no
+                  forward-ports: 
+                  source-ports: 
+                  icmp-blocks: 
+                  rich rules:
+                """
+        )
+        # pylint: enable=trailing-whitespace
+        ret = {
+            "nm-shared": {
+                "forward-ports": [""],
+                "icmp-block-inversion": ["no"],
+                "icmp-blocks": [""],
+                "interfaces": [""],
+                "masquerade": ["no"],
+                "ports": [""],
+                "protocols": ["icmp ipv6-icmp"],
+                "rich rules": ["", 'rule priority="32767" reject'],
+                "services": ["dhcp dns ssh"],
+                "source-ports": [""],
+                "sources": [""],
+                "target": ["ACCEPT"],
+            },
+            "public": {
+                "forward-ports": [""],
+                "icmp-block-inversion": ["no"],
+                "icmp-blocks": [""],
+                "interfaces": [""],
+                "masquerade": ["no"],
+                "ports": [""],
+                "protocols": [""],
+                "rich rules": [""],
+                "services": ["cockpit dhcpv6-client ssh"],
+                "source-ports": [""],
+                "sources": [""],
+                "target": ["default"],
+            },
+        }
+
+        with patch.object(firewalld, "__firewall_cmd", return_value=firewall_cmd_ret):
+            self.assertEqual(firewalld.list_zones(), ret)
 
     def test_get_zones(self):
         """
@@ -129,8 +195,43 @@ class FirewalldTestCase(TestCase, LoaderModuleMockMixin):
         """
         Test for List everything added for or enabled in a zone
         """
-        with patch.object(firewalld, "__firewall_cmd", return_value=""):
-            self.assertEqual(firewalld.list_all(), {})
+        # pylint: disable=trailing-whitespace
+        firewall_cmd_ret = dedent(
+            """\
+            public
+              target: default
+              icmp-block-inversion: no
+              interfaces: eth0
+              sources: 
+              services: cockpit dhcpv6-client ssh
+              ports: 
+              protocols: 
+              masquerade: no
+              forward-ports: 
+              source-ports: 
+              icmp-blocks: 
+              rich rules: 
+            """
+        )
+        # pylint: enable=trailing-whitespace
+        ret = {
+            "public": {
+                "forward-ports": [""],
+                "icmp-block-inversion": ["no"],
+                "icmp-blocks": [""],
+                "interfaces": ["eth0"],
+                "masquerade": ["no"],
+                "ports": [""],
+                "protocols": [""],
+                "rich rules": [""],
+                "services": ["cockpit dhcpv6-client ssh"],
+                "source-ports": [""],
+                "sources": [""],
+                "target": ["default"],
+            }
+        }
+        with patch.object(firewalld, "__firewall_cmd", return_value=firewall_cmd_ret):
+            self.assertEqual(firewalld.list_all(), ret)
 
     def test_list_services(self):
         """


### PR DESCRIPTION
Some values are returned by `firewall-cmd` indented by `TAB`. These tabbed values breaks `firewalld.list_zones`. The `firewalld.list_all` parses the `firewall-cmd` correctly.


### What does this PR do?
- Splits the `firewall-cmd` zone output parsing to a separated `__parse_zone` function.
- Rewrites `firewalld.list_zones` and `firewalld.list_all` to use the new function.

### What issues does this PR fix or reference?
Fixes: #60033 

### Previous Behavior
```
# salt-call --local firewalld.list_zones
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
ValueError: not enough values to unpack (expected 2, got 1)
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    load_entry_point('salt==3003', 'console_scripts', 'salt-call')()
  File "/usr/lib/python3.6/site-packages/salt/scripts.py", line 449, in salt_call
    client.run()
  File "/usr/lib/python3.6/site-packages/salt/cli/call.py", line 58, in run
    caller.run()
  File "/usr/lib/python3.6/site-packages/salt/cli/caller.py", line 112, in run
    ret = self.call()
  File "/usr/lib/python3.6/site-packages/salt/cli/caller.py", line 220, in call
    self.opts, data, func, args, kwargs
  File "/usr/lib/python3.6/site-packages/salt/loader.py", line 1235, in __call__
    return self.loader.run(run_func, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader.py", line 2268, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/contextvars/__init__.py", line 38, in run
    return callable(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader.py", line 2283, in _run_as
    return _func_or_method(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/executors/direct_call.py", line 12, in execute
    return func(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader.py", line 1235, in __call__
    return self.loader.run(run_func, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader.py", line 2268, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/contextvars/__init__.py", line 38, in run
    return callable(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader.py", line 2283, in _run_as
    return _func_or_method(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/modules/firewalld.py", line 125, in list_zones
    (id_, val) = i.strip().split(":")
ValueError: not enough values to unpack (expected 2, got 1)
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    load_entry_point('salt==3003', 'console_scripts', 'salt-call')()
  File "/usr/lib/python3.6/site-packages/salt/scripts.py", line 449, in salt_call
    client.run()
  File "/usr/lib/python3.6/site-packages/salt/cli/call.py", line 58, in run
    caller.run()
  File "/usr/lib/python3.6/site-packages/salt/cli/caller.py", line 112, in run
    ret = self.call()
  File "/usr/lib/python3.6/site-packages/salt/cli/caller.py", line 220, in call
    self.opts, data, func, args, kwargs
  File "/usr/lib/python3.6/site-packages/salt/loader.py", line 1235, in __call__
    return self.loader.run(run_func, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader.py", line 2268, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/contextvars/__init__.py", line 38, in run
    return callable(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader.py", line 2283, in _run_as
    return _func_or_method(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/executors/direct_call.py", line 12, in execute
    return func(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader.py", line 1235, in __call__
    return self.loader.run(run_func, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader.py", line 2268, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/contextvars/__init__.py", line 38, in run
    return callable(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader.py", line 2283, in _run_as
    return _func_or_method(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/modules/firewalld.py", line 125, in list_zones
    (id_, val) = i.strip().split(":")
ValueError: not enough values to unpack (expected 2, got 1)
```

### New Behavior
```
# salt-call --local firewalld.list_zones
local:
    ----------
    block:
        ----------
        forward-ports:
        icmp-block-inversion:
            - no
        icmp-blocks:
        interfaces:
        masquerade:
            - no
        ports:
        protocols:
        rich rules:
        services:
        source-ports:
        sources:
        target:
            - %%REJECT%%
    dmz:
        ----------
        forward-ports:
        icmp-block-inversion:
            - no
        icmp-blocks:
        interfaces:
        masquerade:
            - no
        ports:
        protocols:
        rich rules:
        services:
            - ssh
        source-ports:
        sources:
        target:
            - default
    drop:
        ----------
        forward-ports:
        icmp-block-inversion:
            - no
        icmp-blocks:
        interfaces:
        masquerade:
            - no
        ports:
        protocols:
        rich rules:
        services:
        source-ports:
        sources:
        target:
            - DROP
    external:
        ----------
        forward-ports:
        icmp-block-inversion:
            - no
        icmp-blocks:
        interfaces:
        masquerade:
            - yes
        ports:
        protocols:
        rich rules:
        services:
            - ssh
        source-ports:
        sources:
        target:
            - default
    home:
        ----------
        forward-ports:
        icmp-block-inversion:
            - no
        icmp-blocks:
        interfaces:
        masquerade:
            - no
        ports:
        protocols:
        rich rules:
        services:
            - cockpit dhcpv6-client mdns samba-client ssh
        source-ports:
        sources:
        target:
            - default
    internal:
        ----------
        forward-ports:
        icmp-block-inversion:
            - no
        icmp-blocks:
        interfaces:
        masquerade:
            - no
        ports:
        protocols:
        rich rules:
        services:
            - cockpit dhcpv6-client mdns samba-client ssh
        source-ports:
        sources:
        target:
            - default
    nm-shared:
        ----------
        forward-ports:
        icmp-block-inversion:
            - no
        icmp-blocks:
        interfaces:
        masquerade:
            - no
        ports:
        protocols:
            - icmp ipv6-icmp
        rich rules:
            - rule priority="32767" reject
        services:
            - dhcp dns ssh
        source-ports:
        sources:
        target:
            - ACCEPT
    public:
        ----------
        forward-ports:
        icmp-block-inversion:
            - no
        icmp-blocks:
        interfaces:
        masquerade:
            - no
        ports:
        protocols:
        rich rules:
        services:
            - cockpit dhcpv6-client ssh
        source-ports:
        sources:
        target:
            - default
    trusted:
        ----------
        forward-ports:
        icmp-block-inversion:
            - no
        icmp-blocks:
        interfaces:
        masquerade:
            - no
        ports:
        protocols:
        rich rules:
        services:
        source-ports:
        sources:
        target:
            - ACCEPT
    work:
        ----------
        forward-ports:
            - port=22:proto=tcp:toport=2222:toaddr=10.0.0.10
        icmp-block-inversion:
            - no
        icmp-blocks:
        interfaces:
        masquerade:
            - no
        ports:
        protocols:
        rich rules:
        services:
            - cockpit dhcpv6-client ssh
        source-ports:
        sources:
        target:
            - default
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No
