### PR TITLE
feat: enable pkg module on almalinux (centos clone)

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -83,7 +83,7 @@ def __virtual__():
         "openeuler",
     )
 
-    if os_family == "redhat" or os_grain in enabled:
+    if os_family in ["almalinux", "redhat"] or os_grain in enabled:
         if _yum() is None:
             return (False, "DNF nor YUM found")
         return __virtualname__


### PR DESCRIPTION
### What does this PR do?
Enabled use of the pkg module on [AlmaLinux](https://almalinux.org/) which is binary-compatible with centos/redhat.

### What issues does this PR fix or reference?
Fixes: N/A

### Previous Behavior
The `pkg` module would not be available.

### New Behavior
The `pkg` module works.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

If any of these are relevant let me know

### Commits signed with GPG?
Yes

