### PR TITLE
[FIX UNIT TEST] Mock ip_addrs() in utils/minions.py unit test

### DIFF
--- a/tests/pytests/unit/utils/test_minions.py
+++ b/tests/pytests/unit/utils/test_minions.py
@@ -8,18 +8,21 @@ def test_connected_ids():
     test ckminion connected_ids when
     local_port_tcp returns 127.0.0.1
     """
-    opts = {"publish_port": 4505, "detect_remote_minions": False}
+    opts = {
+        "publish_port": 4505,
+        "detect_remote_minions": False,
+        "minion_data_cache": True,
+    }
     minion = "minion"
-    ip = salt.utils.network.ip_addrs()
-    mdata = {"grains": {"ipv4": ip, "ipv6": []}}
-    ckminions = salt.utils.minions.CkMinions({"minion_data_cache": True})
-    patch_net = patch("salt.utils.network.local_port_tcp", return_value={"127.0.0.1"})
+    ips = {"203.0.113.1", "203.0.113.2", "127.0.0.1"}
+    mdata = {"grains": {"ipv4": ips, "ipv6": []}}
+    patch_net = patch("salt.utils.network.local_port_tcp", return_value=ips)
     patch_list = patch("salt.cache.Cache.list", return_value=[minion])
     patch_fetch = patch("salt.cache.Cache.fetch", return_value=mdata)
-    with patch.dict(ckminions.opts, opts):
-        with patch_net, patch_list, patch_fetch:
-            ret = ckminions.connected_ids()
-            assert ret == {minion}
+    ckminions = salt.utils.minions.CkMinions(opts)
+    with patch_net, patch_list, patch_fetch:
+        ret = ckminions.connected_ids()
+        assert ret == {minion}
 
 
 def test_connected_ids_remote_minions():
@@ -31,21 +34,21 @@ def test_connected_ids_remote_minions():
         "publish_port": 4505,
         "detect_remote_minions": True,
         "remote_minions_port": 22,
+        "minion_data_cache": True,
     }
     minion = "minion"
     minion2 = "minion2"
     minion2_ip = "192.168.2.10"
-    ip = salt.utils.network.ip_addrs()
-    mdata = {"grains": {"ipv4": ip, "ipv6": []}}
+    minion_ips = {"203.0.113.1", "203.0.113.2", "127.0.0.1"}
+    mdata = {"grains": {"ipv4": minion_ips, "ipv6": []}}
     mdata2 = {"grains": {"ipv4": [minion2_ip], "ipv6": []}}
-    ckminions = salt.utils.minions.CkMinions({"minion_data_cache": True})
-    patch_net = patch("salt.utils.network.local_port_tcp", return_value={"127.0.0.1"})
+    patch_net = patch("salt.utils.network.local_port_tcp", return_value=minion_ips)
     patch_remote_net = patch(
         "salt.utils.network.remote_port_tcp", return_value={minion2_ip}
     )
     patch_list = patch("salt.cache.Cache.list", return_value=[minion, minion2])
     patch_fetch = patch("salt.cache.Cache.fetch", side_effect=[mdata, mdata2])
-    with patch.dict(ckminions.opts, opts):
-        with patch_net, patch_list, patch_fetch, patch_remote_net:
-            ret = ckminions.connected_ids()
-            assert ret == {minion2, minion}
+    ckminions = salt.utils.minions.CkMinions(opts)
+    with patch_net, patch_list, patch_fetch, patch_remote_net:
+        ret = ckminions.connected_ids()
+        assert ret == {minion2, minion}


### PR DESCRIPTION
### What does this PR do?

Previously the test used `salt.utils.network.ip_addrs()` in the same way that the tested code did. This worked well as long as at least one IP address was returned by `salt.utils.network.ip_addrs()`.

Since this is a unit test, it should not depend on the environment, it should just work™, even if there are no real IP addresses assigned to the system (or container) that runs the test.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/60345 (should I create one as well or is the description above enough?) Yes! Feel free to use the `Test Failure` template I have made one for you, here.

### Previous Behavior
When `salt.utils.network.ip_addrs()` returned no IPs, the test failed.

### New Behavior
`salt.utils.network.ip_addrs()` is mocked and always returns IPs. The test can't fail in this way anymore.

### Merge requirements satisfied?
- [x] Tests written/updated

### Commits signed with GPG?
Yes

