### PR TITLE
Let Mac OS Mojave run for 8 hours to avoid timeout

### DIFF
--- a/cicd/jenkins/pr-macosx-mojave-x86_64-py3-pytest
+++ b/cicd/jenkins/pr-macosx-mojave-x86_64-py3-pytest
@@ -14,7 +14,7 @@ runTestSuite(
     nox_passthrough_opts: '--ssh-tests',
     python_version: 'py3',
     //splits: ['unit', 'integration', 'multimaster'],
-    testrun_timeout: 6,
+    testrun_timeout: 8,
     use_spot_instances: false,
     //fast_slow_staged_testrun: true
 )


### PR DESCRIPTION
### What does this PR do?
Increase the CI Mojave timeout time from 6 hours to 8 hours.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/60067

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
