### PR TITLE
Add ability for Windows to use the file.patch function

### DIFF
--- a/changelog/44783.added
+++ b/changelog/44783.added
@@ -1,0 +1,1 @@
+Add windows support for file.patch with patch.exe from git for windows optional packages

--- a/cicd/amis.yml
+++ b/cicd/amis.yml
@@ -15,5 +15,5 @@ opensuse-15-x86_64: ami-0b57dabce687992c3
 ubuntu-1804-amd64: ami-0decb138fa5e24979
 ubuntu-2004-amd64: ami-0468248e8ecfacd5c
 ubuntu-2004-arm64: ami-07dcde5a6a61ce72a
-windows-2016-x64: ami-08ebc2c3867dbc212
-windows-2019-x64: ami-0a0c9b4de747444a6
+windows-2016-x64: ami-018e8ade3ef00a445
+windows-2019-x64: ami-08fe22a79bd743e34

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3185,7 +3185,6 @@ def patch(originalfile, patchfile, options="", dry_run=False):
         Git\\usr\\bin\\ is in your system path. The patch.exe binary
         is typically found within this folder from Git.
 
-
     CLI Example:
 
     .. code-block:: bash

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3174,6 +3174,13 @@ def patch(originalfile, patchfile, options="", dry_run=False):
     options
         Options to pass to patch.
 
+    .. note::
+        Windows now supports this as of 3001. In order to use this
+        function in Windows, select the "Use Git and optional Unix
+        tools from the Command Prompt" option when installing Git.
+        This will put all the Unix commands in your system Path to
+        allow patch to be used.
+
     CLI Example:
 
     .. code-block:: bash

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3185,6 +3185,7 @@ def patch(originalfile, patchfile, options="", dry_run=False):
         Git\\usr\\bin\\ is in your system path. The patch.exe binary
         is typically found within this folder from Git.
 
+
     CLI Example:
 
     .. code-block:: bash

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3175,15 +3175,13 @@ def patch(originalfile, patchfile, options="", dry_run=False):
         Options to pass to patch.
 
     .. note::
-        Windows now supports this as of 3004. In order to use this
-        function in Windows, select the "Use Git and optional Unix
-        tools from the Command Prompt" option when installing Git.
-        This will put all the Unix commands in your system Path to
-        allow patch to be used.
+        Windows now supports using patch as of 3004.
 
-        If you already have git-for-windows installed, check if
-        Git\\usr\\bin\\ is in your system path. The patch.exe binary
-        is typically found within this folder from Git.
+        In order to use this function in Windows, please install the
+        patch binary through your own means and ensure it's found
+        in the system Path. If installing through git-for-windows,
+        please select the optional "Use Git and optional Unix tools
+        from the Command Prompt" option when installing Git.
 
     CLI Example:
 
@@ -3195,16 +3193,9 @@ def patch(originalfile, patchfile, options="", dry_run=False):
     """
     patchpath = salt.utils.path.which("patch")
     if not patchpath:
-        if salt.utils.platform.is_windows():
-            raise CommandExecutionError(
-                "Please check your git-for-windows installation "
-                "to ensure Git\\usr\\bin\\ is found in your "
-                "system Path variable."
-            )
-        else:
-            raise CommandExecutionError(
-                "patch executable not found. Is the distribution's patch package installed?"
-            )
+        raise CommandExecutionError(
+            "patch executable not found. Is the distribution's patch package installed?"
+        )
 
     cmd = [patchpath]
     cmd.extend(salt.utils.args.shlex_split(options))

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3175,23 +3175,36 @@ def patch(originalfile, patchfile, options="", dry_run=False):
         Options to pass to patch.
 
     .. note::
-        Windows now supports this as of 3001. In order to use this
+        Windows now supports this as of 3004. In order to use this
         function in Windows, select the "Use Git and optional Unix
         tools from the Command Prompt" option when installing Git.
         This will put all the Unix commands in your system Path to
         allow patch to be used.
+
+        If you already have git-for-windows installed, check if
+        Git\\usr\\bin\\ is in your system path. The patch.exe binary
+        is typically found within this folder from Git.
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' file.patch /opt/file.txt /tmp/file.txt.patch
+
+        salt '*' file.patch C:\\file1.txt C:\\file3.patch
     """
     patchpath = salt.utils.path.which("patch")
     if not patchpath:
-        raise CommandExecutionError(
-            "patch executable not found. Is the distribution's patch package installed?"
-        )
+        if salt.utils.platform.is_windows():
+            raise CommandExecutionError(
+                "Please check your git-for-windows installation "
+                "to ensure Git\\usr\\bin\\ is found in your "
+                "system Path variable."
+            )
+        else:
+            raise CommandExecutionError(
+                "patch executable not found. Is the distribution's patch package installed?"
+            )
 
     cmd = [patchpath]
     cmd.extend(salt.utils.args.shlex_split(options))

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -93,8 +93,8 @@ from salt.modules.file import (
 )
 from salt.modules.file import normpath as normpath_
 from salt.modules.file import (
-    patch,
     pardir,
+    patch,
     path_exists_glob,
     prepend,
     psed,

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -93,6 +93,7 @@ from salt.modules.file import (
 )
 from salt.modules.file import normpath as normpath_
 from salt.modules.file import (
+    patch,
     pardir,
     path_exists_glob,
     prepend,
@@ -149,7 +150,7 @@ def __virtual__():
     if salt.utils.platform.is_windows():
         if HAS_WINDOWS_MODULES:
             # Load functions from file.py
-            global get_managed, manage_file
+            global get_managed, manage_file, patch
             global source_list, __clean_tmp, file_exists
             global check_managed, check_managed_changes, check_file_meta
             global append, _error, directory_exists, touch, contains
@@ -238,6 +239,7 @@ def __virtual__():
             list_backups_dir = _namespaced_function(list_backups_dir, globals())
             normpath_ = _namespaced_function(normpath_, globals())
             _assert_occurrence = _namespaced_function(_assert_occurrence, globals())
+            patch = _namespaced_function(patch, globals())
 
         else:
             return False, "Module win_file: Missing Win32 modules"

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -6862,7 +6862,13 @@ def patch(
             __opts__["test"] = orig_test
             sys.modules[__salt__["file.patch"].__module__].__opts__["test"] = orig_test
 
-        if not result["result"]:
+        # TODO adding the not orig_test is just a patch
+        # The call above to managed ends up in win_dacl utility and overwrites
+        # the ret dict, specifically "result". This surfaces back here and is
+        # providing an incorrect representation of the actual value.
+        # This fix requires re-working the dacl utility when test mode is passed
+        # to it from another function, such as this one, and it overwrites ret.
+        if not orig_test and not result["result"]:
             log.debug(
                 "failed to download %s",
                 salt.utils.url.redact_http_basic_auth(source_match),
@@ -6905,6 +6911,16 @@ def patch(
             reverse_pass = _patch(patch_rejects, ["-R", "-f"], dry_run=True)
             already_applied = reverse_pass["retcode"] == 0
 
+            # Check if the patch command threw an error upon execution
+            # and return the error here. According to gnu on patch-messages
+            # patch exits with a status of 0 if successful
+            # patch exits with a status of 1 if some hunks cannot be applied
+            # patch exits with a status of 2 if something else went wrong
+            # www.gnu.org/software/diffutils/manual/html_node/patch-Messages.html
+            if pre_check["retcode"] == 2 and pre_check["stderr"]:
+                ret["comment"] = pre_check["stderr"]
+                ret["result"] = False
+                return ret
             if already_applied:
                 ret["comment"] = "Patch was already applied"
                 ret["result"] = True

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -6917,8 +6917,8 @@ def patch(
             # patch exits with a status of 1 if some hunks cannot be applied
             # patch exits with a status of 2 if something else went wrong
             # www.gnu.org/software/diffutils/manual/html_node/patch-Messages.html
-            if pre_check["retcode"] == 2 and pre_check["stderr"]:
-                ret["comment"] = pre_check["stderr"]
+            if pre_check["retcode"] == 1 or pre_check["retcode"] == 2:
+                ret["comment"] = pre_check["stderr"] or "Unable to apply patch"
                 ret["result"] = False
                 return ret
             if already_applied:

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -6917,8 +6917,8 @@ def patch(
             # patch exits with a status of 1 if some hunks cannot be applied
             # patch exits with a status of 2 if something else went wrong
             # www.gnu.org/software/diffutils/manual/html_node/patch-Messages.html
-            if pre_check["retcode"] == 1 or pre_check["retcode"] == 2:
-                ret["comment"] = pre_check["stderr"] or "Unable to apply patch"
+            if pre_check["retcode"] == 2 and pre_check["stderr"]:
+                ret["comment"] = pre_check["stderr"]
                 ret["result"] = False
                 return ret
             if already_applied:

--- a/setup.py
+++ b/setup.py
@@ -1150,6 +1150,7 @@ class SaltDistribution(distutils.dist.Distribution):
                     "doc/man/salt-api.1",
                     "doc/man/salt-cp.1",
                     "doc/man/salt-key.1",
+                    "doc/man/salt-master.1",
                     "doc/man/salt-minion.1",
                     "doc/man/salt-syndic.1",
                     "doc/man/salt-unity.1",
@@ -1232,8 +1233,10 @@ class SaltDistribution(distutils.dist.Distribution):
             scripts.extend(
                 [
                     "scripts/salt-api",
+                    "scripts/salt-cloud",
                     "scripts/salt-cp",
                     "scripts/salt-key",
+                    "scripts/salt-master",
                     "scripts/salt-minion",
                     "scripts/salt-syndic",
                     "scripts/salt-unity",
@@ -1278,9 +1281,11 @@ class SaltDistribution(distutils.dist.Distribution):
         if IS_WINDOWS_PLATFORM:
             scripts.extend(
                 [
+                    "salt = salt.scripts:salt_main",
                     "salt-api = salt.scripts:salt_api",
                     "salt-cp = salt.scripts:salt_cp",
                     "salt-key = salt.scripts:salt_key",
+                    "salt-master = salt.scripts:salt_master",
                     "salt-minion = salt.scripts:salt_minion",
                     "salt-syndic = salt.scripts:salt_syndic",
                     "salt-unity = salt.scripts:salt_unity",

--- a/setup.py
+++ b/setup.py
@@ -1150,7 +1150,6 @@ class SaltDistribution(distutils.dist.Distribution):
                     "doc/man/salt-api.1",
                     "doc/man/salt-cp.1",
                     "doc/man/salt-key.1",
-                    "doc/man/salt-master.1",
                     "doc/man/salt-minion.1",
                     "doc/man/salt-syndic.1",
                     "doc/man/salt-unity.1",
@@ -1233,10 +1232,8 @@ class SaltDistribution(distutils.dist.Distribution):
             scripts.extend(
                 [
                     "scripts/salt-api",
-                    "scripts/salt-cloud",
                     "scripts/salt-cp",
                     "scripts/salt-key",
-                    "scripts/salt-master",
                     "scripts/salt-minion",
                     "scripts/salt-syndic",
                     "scripts/salt-unity",
@@ -1281,11 +1278,9 @@ class SaltDistribution(distutils.dist.Distribution):
         if IS_WINDOWS_PLATFORM:
             scripts.extend(
                 [
-                    "salt = salt.scripts:salt_main",
                     "salt-api = salt.scripts:salt_api",
                     "salt-cp = salt.scripts:salt_cp",
                     "salt-key = salt.scripts:salt_key",
-                    "salt-master = salt.scripts:salt_master",
                     "salt-minion = salt.scripts:salt_minion",
                     "salt-syndic = salt.scripts:salt_syndic",
                     "salt-unity = salt.scripts:salt_unity",

--- a/tests/integration/modules/test_cmdmod.py
+++ b/tests/integration/modules/test_cmdmod.py
@@ -275,6 +275,7 @@ class CMDModuleTest(ModuleCase):
                 ret = self.run_function("cmd.tty", [tty, "apply salt liberally"])
                 self.assertTrue("Success" in ret)
 
+    @pytest.mark.skip_if_windows
     @pytest.mark.skip_if_binaries_missing("which")
     def test_which(self):
         """
@@ -286,6 +287,7 @@ class CMDModuleTest(ModuleCase):
         self.assertIsInstance(cmd_run, str)
         self.assertEqual(cmd_which.rstrip(), cmd_run.rstrip())
 
+    @pytest.mark.skip_if_windows
     @pytest.mark.skip_if_binaries_missing("which")
     def test_which_bin(self):
         """

--- a/tests/integration/modules/test_cmdmod.py
+++ b/tests/integration/modules/test_cmdmod.py
@@ -275,7 +275,7 @@ class CMDModuleTest(ModuleCase):
                 ret = self.run_function("cmd.tty", [tty, "apply salt liberally"])
                 self.assertTrue("Success" in ret)
 
-    @pytest.mark.skip_if_windows
+    @pytest.mark.skip_on_windows
     @pytest.mark.skip_if_binaries_missing("which")
     def test_which(self):
         """
@@ -287,7 +287,7 @@ class CMDModuleTest(ModuleCase):
         self.assertIsInstance(cmd_run, str)
         self.assertEqual(cmd_which.rstrip(), cmd_run.rstrip())
 
-    @pytest.mark.skip_if_windows
+    @pytest.mark.skip_on_windows
     @pytest.mark.skip_if_binaries_missing("which")
     def test_which_bin(self):
         """

--- a/tests/integration/modules/test_linux_acl.py
+++ b/tests/integration/modules/test_linux_acl.py
@@ -16,7 +16,6 @@ from tests.support.unit import skipIf
 
 
 @pytest.mark.skip_if_binaries_missing("getfacl")
-@pytest.mark.windows_whitelisted
 class LinuxAclModuleTest(ModuleCase, AdaptedConfigurationTestCaseMixin):
     """
     Validate the linux_acl module

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -4682,6 +4682,7 @@ class RemoteFileTest(ModuleCase, SaltReturnAssertsMixin):
 
 
 @skipIf(not salt.utils.path.which("patch"), "patch is not installed")
+@pytest.mark.windows_whitelisted
 class PatchTest(ModuleCase, SaltReturnAssertsMixin):
     def _check_patch_version(self, min_version):
         """

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -4682,7 +4682,6 @@ class RemoteFileTest(ModuleCase, SaltReturnAssertsMixin):
 
 
 @skipIf(not salt.utils.path.which("patch"), "patch is not installed")
-@pytest.mark.windows_whitelisted
 class PatchTest(ModuleCase, SaltReturnAssertsMixin):
     def _check_patch_version(self, min_version):
         """

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -4939,6 +4939,7 @@ class PatchTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertIn("Patch would not apply cleanly", ret["comment"])
         if IS_WINDOWS:
             reject_file = reject_file.replace("\\", "\\\\")
+            reject_file = "'{}'".format(reject_file)
         self.assertRegex(
             ret["comment"], "saving rejects to (file )?{}".format(reject_file)
         )
@@ -4977,6 +4978,7 @@ class PatchTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertIn("Patch would not apply cleanly", ret["comment"])
         if IS_WINDOWS:
             reject_file = reject_file.replace("\\", "\\\\")
+            reject_file = "'{}'".format(reject_file)
         self.assertRegex(
             ret["comment"], "saving rejects to (file )?{}".format(reject_file)
         )

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -4937,6 +4937,8 @@ class PatchTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertSaltFalseReturn(ret)
         ret = ret[next(iter(ret))]
         self.assertIn("Patch would not apply cleanly", ret["comment"])
+        if IS_WINDOWS:
+            reject_file = reject_file.replace("\\", "\\\\")
         self.assertRegex(
             ret["comment"], "saving rejects to (file )?{}".format(reject_file)
         )

--- a/tests/integration/states/test_file.py
+++ b/tests/integration/states/test_file.py
@@ -4973,6 +4973,8 @@ class PatchTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertSaltFalseReturn(ret)
         ret = ret[next(iter(ret))]
         self.assertIn("Patch would not apply cleanly", ret["comment"])
+        if IS_WINDOWS:
+            reject_file = reject_file.replace("\\", "\\\\")
         self.assertRegex(
             ret["comment"], "saving rejects to (file )?{}".format(reject_file)
         )

--- a/tests/pytests/functional/modules/test_archive.py
+++ b/tests/pytests/functional/modules/test_archive.py
@@ -157,6 +157,7 @@ def unicode_filename(request):
     return request.param
 
 
+@pytest.mark.skip_on_windows
 @pytest.mark.skip_if_binaries_missing("tar")
 def test_tar_pack(archive, unicode_filename):
     """
@@ -168,6 +169,7 @@ def test_tar_pack(archive, unicode_filename):
         arch.assert_artifacts_in_ret(ret)
 
 
+@pytest.mark.skip_on_windows
 @pytest.mark.skip_if_binaries_missing("tar")
 def test_tar_unpack(archive, unicode_filename):
     """
@@ -183,6 +185,7 @@ def test_tar_unpack(archive, unicode_filename):
         arch.assert_artifacts_in_ret(ret)
 
 
+@pytest.mark.skip_on_windows
 @pytest.mark.skip_if_binaries_missing("tar")
 def test_tar_list(archive, unicode_filename):
     """

--- a/tests/pytests/functional/pillar/test_gpg.py
+++ b/tests/pytests/functional/pillar/test_gpg.py
@@ -10,7 +10,6 @@ import salt.utils.stringutils
 from saltfactories.utils.processes import ProcessResult
 
 pytestmark = [
-    pytest.mark.windows_whitelisted,
     pytest.mark.skip_if_binaries_missing("gpg"),
 ]
 

--- a/tests/pytests/functional/pillar/test_gpg.py
+++ b/tests/pytests/functional/pillar/test_gpg.py
@@ -11,7 +11,6 @@ from saltfactories.utils.processes import ProcessResult
 
 pytestmark = [
     pytest.mark.skip_if_binaries_missing("gpg"),
-    pytest.mark.windows_whitelisted,
 ]
 
 log = logging.getLogger(__name__)

--- a/tests/pytests/functional/pillar/test_gpg.py
+++ b/tests/pytests/functional/pillar/test_gpg.py
@@ -11,6 +11,7 @@ from saltfactories.utils.processes import ProcessResult
 
 pytestmark = [
     pytest.mark.skip_if_binaries_missing("gpg"),
+    pytest.mark.windows_whitelisted,
 ]
 
 log = logging.getLogger(__name__)

--- a/tests/pytests/integration/states/test_file.py
+++ b/tests/pytests/integration/states/test_file.py
@@ -425,6 +425,7 @@ def _check_minimum_version(salt_call_cli, minimum_patch_ver):
         )
 
 
+@pytest.mark.skip_unless_on_windows
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
 def test_patch_single_file(salt_master, salt_call_cli, tmp_path, min_patch_ver):
     """
@@ -488,6 +489,7 @@ def test_patch_single_file(salt_master, salt_call_cli, tmp_path, min_patch_ver):
         assert state_run["changes"] == {}
 
 
+@pytest.mark.skip_unless_on_windows
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
 def test_patch_directory(
     salt_master, salt_call_cli, tmp_path, content, all_patch_file, min_patch_ver
@@ -555,6 +557,7 @@ def test_patch_directory(
         assert state_run["changes"] == {}
 
 
+@pytest.mark.skip_unless_on_windows
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
 def test_patch_strip_parsing(
     salt_master, salt_call_cli, tmp_path, content, all_patch_file, min_patch_ver
@@ -621,6 +624,7 @@ def test_patch_strip_parsing(
         assert state_run["changes"] == {}
 
 
+@pytest.mark.skip_unless_on_windows
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
 def test_patch_saltenv(
     salt_master, salt_call_cli, tmp_path, content, math_patch_file, min_patch_ver
@@ -666,6 +670,7 @@ def test_patch_saltenv(
         ] == "Source file {} not found in saltenv 'prod'".format(math_patch_file)
 
 
+@pytest.mark.skip_unless_on_windows
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
 def test_patch_single_file_failure(
     salt_master, salt_call_cli, tmp_path, content, numbers_patch_file, min_patch_ver
@@ -745,6 +750,7 @@ def test_patch_single_file_failure(
         )
 
 
+@pytest.mark.skip_unless_on_windows
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
 def test_patch_directory_failure(
     salt_master, salt_call_cli, tmp_path, content, all_patch_file, min_patch_ver
@@ -823,6 +829,7 @@ def test_patch_directory_failure(
         )
 
 
+@pytest.mark.skip_unless_on_windows
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
 def test_patch_single_file_template(
     salt_master,
@@ -884,6 +891,7 @@ def test_patch_single_file_template(
         assert state_run["changes"] == {}
 
 
+@pytest.mark.skip_unless_on_windows
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
 def test_patch_directory_template(
     salt_master,
@@ -945,6 +953,7 @@ def test_patch_directory_template(
         assert state_run["changes"] == {}
 
 
+@pytest.mark.skip_unless_on_windows
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
 def test_patch_test_mode(
     salt_master, salt_call_cli, tmp_path, content, numbers_patch_file, min_patch_ver

--- a/tests/pytests/integration/states/test_file.py
+++ b/tests/pytests/integration/states/test_file.py
@@ -36,13 +36,15 @@ def content():
     1
     2
     3
-    """)
+    """
+    )
     math_file_contents = textwrap.dedent(
         """\
     Five plus five is ten
 
     Four squared is sixteen
-    """)
+    """
+    )
     return numbers_file_contents, math_file_contents
 
 
@@ -417,8 +419,10 @@ def _check_minimum_version(salt_call_cli, minimum_patch_ver):
     version = salt_call_cli.run("--local", "cmd.run", "patch --version")
     version = version.json.split()[2]
     if _LooseVersion(version) < _LooseVersion(minimum_patch_ver):
-        pytest.xfail("Minimum version of patch not found,"
-                     " expecting {}, found {}".format(minimum_patch_ver, version))
+        pytest.xfail(
+            "Minimum version of patch not found,"
+            " expecting {}, found {}".format(minimum_patch_ver, version)
+        )
 
 
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
@@ -485,7 +489,9 @@ def test_patch_single_file(salt_master, salt_call_cli, tmp_path, min_patch_ver):
 
 
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
-def test_patch_directory(salt_master, salt_call_cli, tmp_path, content, all_patch_file, min_patch_ver):
+def test_patch_directory(
+    salt_master, salt_call_cli, tmp_path, content, all_patch_file, min_patch_ver
+):
     """
     Test file.patch using a patch applied to a directory, with changes
     spanning multiple files.
@@ -550,7 +556,9 @@ def test_patch_directory(salt_master, salt_call_cli, tmp_path, content, all_patc
 
 
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
-def test_patch_strip_parsing(salt_master, salt_call_cli, tmp_path, content, all_patch_file, min_patch_ver):
+def test_patch_strip_parsing(
+    salt_master, salt_call_cli, tmp_path, content, all_patch_file, min_patch_ver
+):
     """
     Test that we successfuly parse -p/--strip when included in the options
     """
@@ -614,7 +622,9 @@ def test_patch_strip_parsing(salt_master, salt_call_cli, tmp_path, content, all_
 
 
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
-def test_patch_saltenv(salt_master, salt_call_cli, tmp_path, content, math_patch_file, min_patch_ver):
+def test_patch_saltenv(
+    salt_master, salt_call_cli, tmp_path, content, math_patch_file, min_patch_ver
+):
     """
     Test that we attempt to download the patch from a non-base saltenv
     """
@@ -657,7 +667,9 @@ def test_patch_saltenv(salt_master, salt_call_cli, tmp_path, content, math_patch
 
 
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
-def test_patch_single_file_failure(salt_master, salt_call_cli, tmp_path, content, numbers_patch_file, min_patch_ver):
+def test_patch_single_file_failure(
+    salt_master, salt_call_cli, tmp_path, content, numbers_patch_file, min_patch_ver
+):
     """
     Test file.patch using a patch applied to a single file. This tests a
     failed patch.
@@ -696,7 +708,9 @@ def test_patch_single_file_failure(salt_master, salt_call_cli, tmp_path, content
             - reject_file: {reject_file}
             - strip: 1
         """.format(
-        numbers_file=numbers_file, numbers_patch=numbers_patch_file, reject_file=reject_file
+        numbers_file=numbers_file,
+        numbers_patch=numbers_patch_file,
+        reject_file=reject_file,
     )
     sls_patch_reject_tempfile = salt_master.state_tree.base.temp_file(
         "{}.sls".format(sls_patch_reject_name), sls_patch_reject_contents
@@ -732,7 +746,9 @@ def test_patch_single_file_failure(salt_master, salt_call_cli, tmp_path, content
 
 
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
-def test_patch_directory_failure(salt_master, salt_call_cli, tmp_path, content, all_patch_file, min_patch_ver):
+def test_patch_directory_failure(
+    salt_master, salt_call_cli, tmp_path, content, all_patch_file, min_patch_ver
+):
     """
     Test file.patch using a patch applied to a directory, with changes
     spanning multiple files.
@@ -808,7 +824,15 @@ def test_patch_directory_failure(salt_master, salt_call_cli, tmp_path, content, 
 
 
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
-def test_patch_single_file_template(salt_master, salt_call_cli, tmp_path, context, content, numbers_patch_template, min_patch_ver):
+def test_patch_single_file_template(
+    salt_master,
+    salt_call_cli,
+    tmp_path,
+    context,
+    content,
+    numbers_patch_template,
+    min_patch_ver,
+):
     """
     Test file.patch using a patch applied to a single file, with jinja
     templating applied to the patch file.
@@ -861,7 +885,15 @@ def test_patch_single_file_template(salt_master, salt_call_cli, tmp_path, contex
 
 
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
-def test_patch_directory_template(salt_master, salt_call_cli, tmp_path, context, content, all_patch_template, min_patch_ver):
+def test_patch_directory_template(
+    salt_master,
+    salt_call_cli,
+    tmp_path,
+    context,
+    content,
+    all_patch_template,
+    min_patch_ver,
+):
     """
     Test file.patch using a patch applied to a directory, with changes
     spanning multiple files, and with jinja templating applied to the patch
@@ -914,7 +946,9 @@ def test_patch_directory_template(salt_master, salt_call_cli, tmp_path, context,
 
 
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
-def test_patch_test_mode(salt_master, salt_call_cli, tmp_path, content, numbers_patch_file, min_patch_ver):
+def test_patch_test_mode(
+    salt_master, salt_call_cli, tmp_path, content, numbers_patch_file, min_patch_ver
+):
     """
     Test file.patch using test=True
     """

--- a/tests/pytests/integration/states/test_file.py
+++ b/tests/pytests/integration/states/test_file.py
@@ -507,20 +507,6 @@ def test_patch_directory(
     Test file.patch using a patch applied to a directory, with changes
     spanning multiple files.
     """
-    numbers_file_contents = """
-    one
-    two
-    three
-    
-    1
-    2
-    3
-    """
-    math_file_contents = """
-    Five plus five is ten
-    
-    Four squared is sixteen
-    """
     _check_minimum_version(salt_call_cli, min_patch_ver)
     # Create a new unpatched set of files
     os.makedirs(patch_file_dest / "foo" / "bar")

--- a/tests/pytests/integration/states/test_file.py
+++ b/tests/pytests/integration/states/test_file.py
@@ -432,8 +432,9 @@ def test_patch_single_file(salt_master, salt_call_cli, tmp_path, min_patch_ver):
     Test file.patch using a patch applied to a single file
     """
     _check_minimum_version(salt_call_cli, min_patch_ver)
-    name_file = (tmp_path / "name_file.txt").resolve()
-    source_file = (tmp_path / "source_file.patch").resolve()
+    resolved_path = tmp_path.resolve()
+    name_file = (resolved_path / "name_file.txt")
+    source_file = (resolved_path / "source_file.patch")
     name_file_contents = """
     salt
     patch

--- a/tests/pytests/integration/states/test_file.py
+++ b/tests/pytests/integration/states/test_file.py
@@ -495,7 +495,6 @@ def test_patch_single_file(salt_call_cli, min_patch_ver, patch_file_dest):
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
 def test_patch_directory(
     salt_call_cli,
-    tmp_path,
     content,
     all_patch_file,
     min_patch_ver,
@@ -521,10 +520,9 @@ def test_patch_directory(
     """
     _check_minimum_version(salt_call_cli, min_patch_ver)
     # Create a new unpatched set of files
-    base_dir = str(tmp_path)
-    os.makedirs(os.path.join(base_dir, "foo", "bar"))
-    numbers_file = os.path.join(base_dir, "foo", "numbers.txt")
-    math_file = os.path.join(base_dir, "foo", "bar", "math.txt")
+    os.makedirs(patch_file_dest / "foo" / "bar")
+    numbers_file = patch_file_dest / "foo" / "numbers.txt"
+    math_file = patch_file_dest / "foo" / "bar" / "math.txt"
 
     sls_contents = """
         do-patch:
@@ -533,12 +531,12 @@ def test_patch_directory(
             - source: {all_patch}
             - strip: 1
         """.format(
-        base_dir=base_dir, all_patch=all_patch_file
+        base_dir=patch_file_dest, all_patch=all_patch_file
     )
 
     sls_tempfile = temp_file("test_patch.sls", sls_contents, patch_file_dest)
-    numbers_tempfile = temp_file(numbers_file, content[0])
-    math_tempfile = temp_file(math_file, content[1])
+    numbers_tempfile = temp_file(numbers_file, content[0], patch_file_dest)
+    math_tempfile = temp_file(math_file, content[1], patch_file_dest)
 
     with sls_tempfile, numbers_tempfile, math_tempfile:
         # Run the state file
@@ -565,7 +563,6 @@ def test_patch_directory(
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
 def test_patch_strip_parsing(
     salt_call_cli,
-    tmp_path,
     content,
     all_patch_file,
     min_patch_ver,
@@ -576,10 +573,9 @@ def test_patch_strip_parsing(
     """
     _check_minimum_version(salt_call_cli, min_patch_ver)
     # Create a new unpatched set of files
-    base_dir = str(tmp_path)
-    os.makedirs(os.path.join(base_dir, "foo", "bar"))
-    numbers_file = os.path.join(base_dir, "foo", "numbers.txt")
-    math_file = os.path.join(base_dir, "foo", "bar", "math.txt")
+    os.makedirs(patch_file_dest / "foo" / "bar")
+    numbers_file = patch_file_dest / "foo" / "numbers.txt"
+    math_file = patch_file_dest / "foo" / "bar" / "math.txt"
 
     sls_contents = """
         do-patch:
@@ -588,7 +584,7 @@ def test_patch_strip_parsing(
             - source: {all_patch}
             - options: "-p1"
         """.format(
-        base_dir=base_dir, all_patch=all_patch_file
+        base_dir=patch_file_dest, all_patch=all_patch_file
     )
 
     sls_patch_contents = """
@@ -598,13 +594,13 @@ def test_patch_strip_parsing(
             - source: {all_patch}
             - strip: 1
         """.format(
-        base_dir=base_dir, all_patch=all_patch_file
+        base_dir=patch_file_dest, all_patch=all_patch_file
     )
 
     sls_tempfile = temp_file("test_patch.sls", sls_contents, patch_file_dest)
     sls_patch_tempfile = temp_file("test_patch_strip.sls", sls_patch_contents, patch_file_dest)
-    numbers_tempfile = temp_file(numbers_file, content[0])
-    math_tempfile = temp_file(math_file, content[1])
+    numbers_tempfile = temp_file(numbers_file, content[0], patch_file_dest)
+    math_tempfile = temp_file(math_file, content[1], patch_file_dest)
 
     with sls_tempfile, sls_patch_tempfile, numbers_tempfile, math_tempfile:
         # Run the state using -p1
@@ -631,7 +627,6 @@ def test_patch_strip_parsing(
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
 def test_patch_saltenv(
     salt_call_cli,
-    tmp_path,
     content,
     math_patch_file,
     min_patch_ver,
@@ -645,9 +640,8 @@ def test_patch_saltenv(
     # in an environment other than base.
     _check_minimum_version(salt_call_cli, min_patch_ver)
     # Create a new unpatched set of files
-    base_dir = str(tmp_path)
-    os.makedirs(os.path.join(base_dir, "foo", "bar"))
-    math_file = os.path.join(base_dir, "foo", "bar", "math.txt")
+    os.makedirs(patch_file_dest / "foo" / "bar")
+    math_file = patch_file_dest / "foo" / "bar" / "math.txt"
 
     sls_contents = """
         do-patch:
@@ -659,7 +653,7 @@ def test_patch_saltenv(
         math_file=math_file, math_patch=math_patch_file
     )
     sls_tempfile = temp_file("test_patch.sls", sls_contents, patch_file_dest)
-    math_tempfile = temp_file(math_file, content[1])
+    math_tempfile = temp_file(math_file, content[1], patch_file_dest)
 
     with sls_tempfile, math_tempfile:
         ret = salt_call_cli.run("state.apply", "test_patch")
@@ -678,7 +672,6 @@ def test_patch_saltenv(
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
 def test_patch_single_file_failure(
     salt_call_cli,
-    tmp_path,
     content,
     numbers_patch_file,
     min_patch_ver,
@@ -690,11 +683,10 @@ def test_patch_single_file_failure(
     """
     _check_minimum_version(salt_call_cli, min_patch_ver)
     # Create a new unpatched set of files
-    base_dir = str(tmp_path)
-    os.makedirs(os.path.join(base_dir, "foo", "bar"))
-    numbers_file = os.path.join(base_dir, "foo", "numbers.txt")
-    math_file = os.path.join(base_dir, "foo", "bar", "math.txt")
-    reject_file = os.path.join(base_dir, "reject.txt")
+    os.makedirs(patch_file_dest / "foo" / "bar")
+    numbers_file = patch_file_dest / "foo" / "numbers.txt"
+    math_file = patch_file_dest / "foo" / "bar" / "math.txt"
+    reject_file = patch_file_dest / "reject.txt"
 
     sls_patch_contents = """
         do-patch:
@@ -716,13 +708,14 @@ def test_patch_single_file_failure(
         numbers_patch=numbers_patch_file,
         reject_file=reject_file,
     )
-    sls_patch_tempfile = temp_file("test_patch.sls", sls_patch_contents, patch_file_dest)
-    sls_patch_reject_tempfile = temp_file("test_patch_reject.sls", sls_patch_reject_contents, patch_file_dest)
-    numbers_tempfile = temp_file(numbers_file, content[0])
-    math_tempfile = temp_file(math_file, content[1])
-    reject_tempfile = temp_file(reject_file)
 
-    with sls_patch_tempfile, sls_patch_reject_tempfile, numbers_tempfile, math_tempfile, reject_tempfile:
+    sls_tempfile = temp_file("test_patch.sls", sls_patch_contents, patch_file_dest)
+    sls_reject_tempfile = temp_file("test_patch_reject.sls", sls_patch_reject_contents, patch_file_dest)
+    numbers_tempfile = temp_file(numbers_file, content[0], patch_file_dest)
+    math_tempfile = temp_file(math_file, content[1], patch_file_dest)
+    reject_tempfile = temp_file("reject.txt", "", patch_file_dest)
+
+    with sls_tempfile, sls_reject_tempfile, numbers_tempfile, math_tempfile, reject_tempfile:
         # Empty the file to ensure that the patch doesn't apply cleanly
         with salt.utils.files.fopen(numbers_file, "w"):
             pass
@@ -755,7 +748,6 @@ def test_patch_single_file_failure(
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
 def test_patch_directory_failure(
     salt_call_cli,
-    tmp_path,
     content,
     all_patch_file,
     min_patch_ver,
@@ -767,11 +759,10 @@ def test_patch_directory_failure(
     """
     _check_minimum_version(salt_call_cli, min_patch_ver)
     # Create a new unpatched set of files
-    base_dir = str(tmp_path)
-    os.makedirs(os.path.join(base_dir, "foo", "bar"))
-    numbers_file = os.path.join(base_dir, "foo", "numbers.txt")
-    math_file = os.path.join(base_dir, "foo", "bar", "math.txt")
-    reject_file = os.path.join(base_dir, "reject.txt")
+    os.makedirs(patch_file_dest / "foo" / "bar")
+    numbers_file = patch_file_dest / "foo" / "numbers.txt"
+    math_file = patch_file_dest / "foo" / "bar" / "math.txt"
+    reject_file = patch_file_dest / "reject.txt"
 
     sls_patch_contents = """
         do-patch:
@@ -780,7 +771,7 @@ def test_patch_directory_failure(
             - source: {all_patch}
             - strip: 1
         """.format(
-        base_dir=base_dir, all_patch=all_patch_file
+        base_dir=patch_file_dest, all_patch=all_patch_file
     )
     sls_patch_reject_contents = """
         do-patch:
@@ -790,17 +781,16 @@ def test_patch_directory_failure(
             - reject_file: {reject_file}
             - strip: 1
         """.format(
-        base_dir=base_dir, all_patch=all_patch_file, reject_file=reject_file
+        base_dir=patch_file_dest, all_patch=all_patch_file, reject_file=reject_file
     )
+    sls_tempfile = temp_file("test_patch.sls", sls_patch_contents, patch_file_dest)
+    sls_reject_tempfile = temp_file("test_patch_reject.sls", sls_patch_reject_contents, patch_file_dest)
 
-    sls_patch_tempfile = temp_file("test_patch.sls", sls_patch_contents, patch_file_dest)
-    sls_patch_reject_tempfile = temp_file("test_patch_reject.sls", sls_patch_reject_contents, patch_file_dest)
+    numbers_tempfile = temp_file(numbers_file, content[0], patch_file_dest)
+    math_tempfile = temp_file(math_file, content[1], patch_file_dest)
+    reject_tempfile = temp_file("reject.txt", "", patch_file_dest)
 
-    numbers_tempfile = temp_file(numbers_file, content[0])
-    math_tempfile = temp_file(math_file, content[1])
-    reject_tempfile = temp_file(reject_file)
-
-    with sls_patch_tempfile, sls_patch_reject_tempfile, numbers_tempfile, math_tempfile, reject_tempfile:
+    with sls_tempfile, sls_reject_tempfile, numbers_tempfile, math_tempfile, reject_tempfile:
         # Empty the file to ensure that the patch doesn't apply cleanly
         with salt.utils.files.fopen(math_file, "w"):
             pass
@@ -833,7 +823,6 @@ def test_patch_directory_failure(
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
 def test_patch_single_file_template(
     salt_call_cli,
-    tmp_path,
     context,
     content,
     numbers_patch_template,
@@ -847,9 +836,8 @@ def test_patch_single_file_template(
     # Create a new unpatched set of files
     _check_minimum_version(salt_call_cli, min_patch_ver)
 
-    base_dir = str(tmp_path)
-    os.makedirs(os.path.join(base_dir, "foo", "bar"))
-    numbers_file = os.path.join(base_dir, "foo", "numbers.txt")
+    os.makedirs(patch_file_dest / "foo" / "bar", exist_ok=True)
+    numbers_file = patch_file_dest / "foo" / "numbers.txt"
 
     sls_contents = """
         do-patch:
@@ -864,8 +852,8 @@ def test_patch_single_file_template(
         context=context,
     )
 
-    sls_tempfile = temp_file( "test_patch.sls", sls_contents, patch_file_dest)
-    numbers_tempfile = temp_file(numbers_file, content[0])
+    sls_tempfile = temp_file("test_patch.sls", sls_contents, patch_file_dest)
+    numbers_tempfile = temp_file(numbers_file, content[0], patch_file_dest)
 
     with sls_tempfile, numbers_tempfile:
         ret = salt_call_cli.run("state.apply", "test_patch")
@@ -892,7 +880,6 @@ def test_patch_single_file_template(
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
 def test_patch_directory_template(
     salt_call_cli,
-    tmp_path,
     context,
     content,
     all_patch_template,
@@ -906,10 +893,9 @@ def test_patch_directory_template(
     """
     # Create a new unpatched set of files
     _check_minimum_version(salt_call_cli, min_patch_ver)
-    base_dir = str(tmp_path)
-    os.makedirs(os.path.join(base_dir, "foo", "bar"))
-    numbers_file = os.path.join(base_dir, "foo", "numbers.txt")
-    math_file = os.path.join(base_dir, "foo", "bar", "math.txt")
+    os.makedirs(patch_file_dest / "foo" / "bar", exist_ok=True)
+    numbers_file = patch_file_dest / "foo" / "numbers.txt"
+    math_file = patch_file_dest / "foo" / "bar" / "math.txt"
 
     sls_contents = """
         do-patch:
@@ -919,12 +905,12 @@ def test_patch_directory_template(
             - template: "jinja"
             - context: {context}
         """.format(
-        base_dir=base_dir, all_patch_template=all_patch_template, context=context
+        base_dir=patch_file_dest, all_patch_template=all_patch_template, context=context
     )
 
     sls_tempfile = temp_file("test_patch.sls", sls_contents, patch_file_dest)
-    numbers_tempfile = temp_file(numbers_file, content[0])
-    math_tempfile = temp_file(math_file, content[1])
+    numbers_tempfile = temp_file(numbers_file, content[0], patch_file_dest)
+    math_tempfile = temp_file(math_file, content[1], patch_file_dest)
 
     with sls_tempfile, numbers_tempfile, math_tempfile:
         ret = salt_call_cli.run("state.apply", "test_patch")
@@ -951,7 +937,6 @@ def test_patch_directory_template(
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
 def test_patch_test_mode(
     salt_call_cli,
-    tmp_path,
     content,
     numbers_patch_file,
     min_patch_ver,
@@ -962,9 +947,8 @@ def test_patch_test_mode(
     """
     _check_minimum_version(salt_call_cli, min_patch_ver)
     # Create a new unpatched set of files
-    base_dir = str(tmp_path)
-    os.makedirs(os.path.join(base_dir, "foo", "bar"))
-    numbers_file = os.path.join(base_dir, "foo", "numbers.txt")
+    os.makedirs(patch_file_dest / "foo" / "bar")
+    numbers_file = patch_file_dest / "foo" / "numbers.txt"
 
     sls_patch_contents = """
         do-patch:
@@ -976,7 +960,7 @@ def test_patch_test_mode(
     )
 
     sls_patch_tempfile = temp_file("test_patch.sls", sls_patch_contents, patch_file_dest)
-    numbers_tempfile = temp_file(numbers_file, content[0])
+    numbers_tempfile = temp_file(numbers_file, content[0], patch_file_dest)
 
     with sls_patch_tempfile, numbers_tempfile:
         # Test application with test=True mode

--- a/tests/pytests/integration/states/test_file.py
+++ b/tests/pytests/integration/states/test_file.py
@@ -466,8 +466,12 @@ def test_patch_single_file(salt_call_cli, min_patch_ver, patch_file_dest):
         name_file=name_file, source_file=source_file
     )
     sls_temp = pytest.helpers.temp_file("test_patch.sls", sls_contents, patch_file_dest)
-    name_temp = pytest.helpers.temp_file("name_file.txt", name_file_contents, patch_file_dest)
-    source_temp = pytest.helpers.temp_file("source_file.patch", source_file_contents, patch_file_dest)
+    name_temp = pytest.helpers.temp_file(
+        "name_file.txt", name_file_contents, patch_file_dest
+    )
+    source_temp = pytest.helpers.temp_file(
+        "source_file.patch", source_file_contents, patch_file_dest
+    )
 
     with sls_temp, name_temp, source_temp:
         # Store the original contents and make sure they change
@@ -533,8 +537,12 @@ def test_patch_directory(
         base_dir=patch_file_dest, all_patch=all_patch_file
     )
 
-    sls_tempfile = pytest.helpers.temp_file("test_patch.sls", sls_contents, patch_file_dest)
-    numbers_tempfile = pytest.helpers.temp_file(numbers_file, content[0], patch_file_dest)
+    sls_tempfile = pytest.helpers.temp_file(
+        "test_patch.sls", sls_contents, patch_file_dest
+    )
+    numbers_tempfile = pytest.helpers.temp_file(
+        numbers_file, content[0], patch_file_dest
+    )
     math_tempfile = pytest.helpers.temp_file(math_file, content[1], patch_file_dest)
 
     with sls_tempfile, numbers_tempfile, math_tempfile:
@@ -596,11 +604,15 @@ def test_patch_strip_parsing(
         base_dir=patch_file_dest, all_patch=all_patch_file
     )
 
-    sls_tempfile = pytest.helpers.temp_file("test_patch.sls", sls_contents, patch_file_dest)
+    sls_tempfile = pytest.helpers.temp_file(
+        "test_patch.sls", sls_contents, patch_file_dest
+    )
     sls_patch_tempfile = pytest.helpers.temp_file(
         "test_patch_strip.sls", sls_patch_contents, patch_file_dest
     )
-    numbers_tempfile = pytest.helpers.temp_file(numbers_file, content[0], patch_file_dest)
+    numbers_tempfile = pytest.helpers.temp_file(
+        numbers_file, content[0], patch_file_dest
+    )
     math_tempfile = pytest.helpers.temp_file(math_file, content[1], patch_file_dest)
 
     with sls_tempfile, sls_patch_tempfile, numbers_tempfile, math_tempfile:
@@ -653,7 +665,9 @@ def test_patch_saltenv(
         """.format(
         math_file=math_file, math_patch=math_patch_file
     )
-    sls_tempfile = pytest.helpers.temp_file("test_patch.sls", sls_contents, patch_file_dest)
+    sls_tempfile = pytest.helpers.temp_file(
+        "test_patch.sls", sls_contents, patch_file_dest
+    )
     math_tempfile = pytest.helpers.temp_file(math_file, content[1], patch_file_dest)
 
     with sls_tempfile, math_tempfile:
@@ -710,11 +724,15 @@ def test_patch_single_file_failure(
         reject_file=reject_file,
     )
 
-    sls_tempfile = pytest.helpers.temp_file("test_patch.sls", sls_patch_contents, patch_file_dest)
+    sls_tempfile = pytest.helpers.temp_file(
+        "test_patch.sls", sls_patch_contents, patch_file_dest
+    )
     sls_reject_tempfile = pytest.helpers.temp_file(
         "test_patch_reject.sls", sls_patch_reject_contents, patch_file_dest
     )
-    numbers_tempfile = pytest.helpers.temp_file(numbers_file, content[0], patch_file_dest)
+    numbers_tempfile = pytest.helpers.temp_file(
+        numbers_file, content[0], patch_file_dest
+    )
     math_tempfile = pytest.helpers.temp_file(math_file, content[1], patch_file_dest)
     reject_tempfile = pytest.helpers.temp_file("reject.txt", "", patch_file_dest)
 
@@ -786,12 +804,16 @@ def test_patch_directory_failure(
         """.format(
         base_dir=patch_file_dest, all_patch=all_patch_file, reject_file=reject_file
     )
-    sls_tempfile = pytest.helpers.temp_file("test_patch.sls", sls_patch_contents, patch_file_dest)
+    sls_tempfile = pytest.helpers.temp_file(
+        "test_patch.sls", sls_patch_contents, patch_file_dest
+    )
     sls_reject_tempfile = pytest.helpers.temp_file(
         "test_patch_reject.sls", sls_patch_reject_contents, patch_file_dest
     )
 
-    numbers_tempfile = pytest.helpers.temp_file(numbers_file, content[0], patch_file_dest)
+    numbers_tempfile = pytest.helpers.temp_file(
+        numbers_file, content[0], patch_file_dest
+    )
     math_tempfile = pytest.helpers.temp_file(math_file, content[1], patch_file_dest)
     reject_tempfile = pytest.helpers.temp_file("reject.txt", "", patch_file_dest)
 
@@ -857,8 +879,12 @@ def test_patch_single_file_template(
         context=context,
     )
 
-    sls_tempfile = pytest.helpers.temp_file("test_patch.sls", sls_contents, patch_file_dest)
-    numbers_tempfile = pytest.helpers.temp_file(numbers_file, content[0], patch_file_dest)
+    sls_tempfile = pytest.helpers.temp_file(
+        "test_patch.sls", sls_contents, patch_file_dest
+    )
+    numbers_tempfile = pytest.helpers.temp_file(
+        numbers_file, content[0], patch_file_dest
+    )
 
     with sls_tempfile, numbers_tempfile:
         ret = salt_call_cli.run("state.apply", "test_patch")
@@ -913,8 +939,12 @@ def test_patch_directory_template(
         base_dir=patch_file_dest, all_patch_template=all_patch_template, context=context
     )
 
-    sls_tempfile = pytest.helpers.temp_file("test_patch.sls", sls_contents, patch_file_dest)
-    numbers_tempfile = pytest.helpers.temp_file(numbers_file, content[0], patch_file_dest)
+    sls_tempfile = pytest.helpers.temp_file(
+        "test_patch.sls", sls_contents, patch_file_dest
+    )
+    numbers_tempfile = pytest.helpers.temp_file(
+        numbers_file, content[0], patch_file_dest
+    )
     math_tempfile = pytest.helpers.temp_file(math_file, content[1], patch_file_dest)
 
     with sls_tempfile, numbers_tempfile, math_tempfile:
@@ -967,7 +997,9 @@ def test_patch_test_mode(
     sls_patch_tempfile = pytest.helpers.temp_file(
         "test_patch.sls", sls_patch_contents, patch_file_dest
     )
-    numbers_tempfile = pytest.helpers.temp_file(numbers_file, content[0], patch_file_dest)
+    numbers_tempfile = pytest.helpers.temp_file(
+        numbers_file, content[0], patch_file_dest
+    )
 
     with sls_patch_tempfile, numbers_tempfile:
         # Test application with test=True mode

--- a/tests/pytests/integration/states/test_file.py
+++ b/tests/pytests/integration/states/test_file.py
@@ -11,7 +11,6 @@ import pytest
 import salt.utils.files
 import salt.utils.path
 from salt.utils.versions import LooseVersion as _LooseVersion
-from saltfactories.utils.tempfiles import temp_file
 
 log = logging.getLogger(__name__)
 
@@ -433,7 +432,7 @@ def _check_minimum_version(salt_call_cli, minimum_patch_ver):
 
 
 @pytest.mark.skip_unless_on_windows
-@pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
+@pytest.mark.skip_if_binaries_missing("patch")
 def test_patch_single_file(salt_call_cli, min_patch_ver, patch_file_dest):
     """
     Test file.patch using a patch applied to a single file
@@ -466,9 +465,9 @@ def test_patch_single_file(salt_call_cli, min_patch_ver, patch_file_dest):
     """.format(
         name_file=name_file, source_file=source_file
     )
-    sls_temp = temp_file("test_patch.sls", sls_contents, patch_file_dest)
-    name_temp = temp_file("name_file.txt", name_file_contents, patch_file_dest)
-    source_temp = temp_file("source_file.patch", source_file_contents, patch_file_dest)
+    sls_temp = pytest.helpers.temp_file("test_patch.sls", sls_contents, patch_file_dest)
+    name_temp = pytest.helpers.temp_file("name_file.txt", name_file_contents, patch_file_dest)
+    source_temp = pytest.helpers.temp_file("source_file.patch", source_file_contents, patch_file_dest)
 
     with sls_temp, name_temp, source_temp:
         # Store the original contents and make sure they change
@@ -534,9 +533,9 @@ def test_patch_directory(
         base_dir=patch_file_dest, all_patch=all_patch_file
     )
 
-    sls_tempfile = temp_file("test_patch.sls", sls_contents, patch_file_dest)
-    numbers_tempfile = temp_file(numbers_file, content[0], patch_file_dest)
-    math_tempfile = temp_file(math_file, content[1], patch_file_dest)
+    sls_tempfile = pytest.helpers.temp_file("test_patch.sls", sls_contents, patch_file_dest)
+    numbers_tempfile = pytest.helpers.temp_file(numbers_file, content[0], patch_file_dest)
+    math_tempfile = pytest.helpers.temp_file(math_file, content[1], patch_file_dest)
 
     with sls_tempfile, numbers_tempfile, math_tempfile:
         # Run the state file
@@ -597,12 +596,12 @@ def test_patch_strip_parsing(
         base_dir=patch_file_dest, all_patch=all_patch_file
     )
 
-    sls_tempfile = temp_file("test_patch.sls", sls_contents, patch_file_dest)
-    sls_patch_tempfile = temp_file(
+    sls_tempfile = pytest.helpers.temp_file("test_patch.sls", sls_contents, patch_file_dest)
+    sls_patch_tempfile = pytest.helpers.temp_file(
         "test_patch_strip.sls", sls_patch_contents, patch_file_dest
     )
-    numbers_tempfile = temp_file(numbers_file, content[0], patch_file_dest)
-    math_tempfile = temp_file(math_file, content[1], patch_file_dest)
+    numbers_tempfile = pytest.helpers.temp_file(numbers_file, content[0], patch_file_dest)
+    math_tempfile = pytest.helpers.temp_file(math_file, content[1], patch_file_dest)
 
     with sls_tempfile, sls_patch_tempfile, numbers_tempfile, math_tempfile:
         # Run the state using -p1
@@ -654,8 +653,8 @@ def test_patch_saltenv(
         """.format(
         math_file=math_file, math_patch=math_patch_file
     )
-    sls_tempfile = temp_file("test_patch.sls", sls_contents, patch_file_dest)
-    math_tempfile = temp_file(math_file, content[1], patch_file_dest)
+    sls_tempfile = pytest.helpers.temp_file("test_patch.sls", sls_contents, patch_file_dest)
+    math_tempfile = pytest.helpers.temp_file(math_file, content[1], patch_file_dest)
 
     with sls_tempfile, math_tempfile:
         ret = salt_call_cli.run("state.apply", "test_patch")
@@ -711,13 +710,13 @@ def test_patch_single_file_failure(
         reject_file=reject_file,
     )
 
-    sls_tempfile = temp_file("test_patch.sls", sls_patch_contents, patch_file_dest)
-    sls_reject_tempfile = temp_file(
+    sls_tempfile = pytest.helpers.temp_file("test_patch.sls", sls_patch_contents, patch_file_dest)
+    sls_reject_tempfile = pytest.helpers.temp_file(
         "test_patch_reject.sls", sls_patch_reject_contents, patch_file_dest
     )
-    numbers_tempfile = temp_file(numbers_file, content[0], patch_file_dest)
-    math_tempfile = temp_file(math_file, content[1], patch_file_dest)
-    reject_tempfile = temp_file("reject.txt", "", patch_file_dest)
+    numbers_tempfile = pytest.helpers.temp_file(numbers_file, content[0], patch_file_dest)
+    math_tempfile = pytest.helpers.temp_file(math_file, content[1], patch_file_dest)
+    reject_tempfile = pytest.helpers.temp_file("reject.txt", "", patch_file_dest)
 
     with sls_tempfile, sls_reject_tempfile, numbers_tempfile, math_tempfile, reject_tempfile:
         # Empty the file to ensure that the patch doesn't apply cleanly
@@ -787,14 +786,14 @@ def test_patch_directory_failure(
         """.format(
         base_dir=patch_file_dest, all_patch=all_patch_file, reject_file=reject_file
     )
-    sls_tempfile = temp_file("test_patch.sls", sls_patch_contents, patch_file_dest)
-    sls_reject_tempfile = temp_file(
+    sls_tempfile = pytest.helpers.temp_file("test_patch.sls", sls_patch_contents, patch_file_dest)
+    sls_reject_tempfile = pytest.helpers.temp_file(
         "test_patch_reject.sls", sls_patch_reject_contents, patch_file_dest
     )
 
-    numbers_tempfile = temp_file(numbers_file, content[0], patch_file_dest)
-    math_tempfile = temp_file(math_file, content[1], patch_file_dest)
-    reject_tempfile = temp_file("reject.txt", "", patch_file_dest)
+    numbers_tempfile = pytest.helpers.temp_file(numbers_file, content[0], patch_file_dest)
+    math_tempfile = pytest.helpers.temp_file(math_file, content[1], patch_file_dest)
+    reject_tempfile = pytest.helpers.temp_file("reject.txt", "", patch_file_dest)
 
     with sls_tempfile, sls_reject_tempfile, numbers_tempfile, math_tempfile, reject_tempfile:
         # Empty the file to ensure that the patch doesn't apply cleanly
@@ -858,8 +857,8 @@ def test_patch_single_file_template(
         context=context,
     )
 
-    sls_tempfile = temp_file("test_patch.sls", sls_contents, patch_file_dest)
-    numbers_tempfile = temp_file(numbers_file, content[0], patch_file_dest)
+    sls_tempfile = pytest.helpers.temp_file("test_patch.sls", sls_contents, patch_file_dest)
+    numbers_tempfile = pytest.helpers.temp_file(numbers_file, content[0], patch_file_dest)
 
     with sls_tempfile, numbers_tempfile:
         ret = salt_call_cli.run("state.apply", "test_patch")
@@ -914,9 +913,9 @@ def test_patch_directory_template(
         base_dir=patch_file_dest, all_patch_template=all_patch_template, context=context
     )
 
-    sls_tempfile = temp_file("test_patch.sls", sls_contents, patch_file_dest)
-    numbers_tempfile = temp_file(numbers_file, content[0], patch_file_dest)
-    math_tempfile = temp_file(math_file, content[1], patch_file_dest)
+    sls_tempfile = pytest.helpers.temp_file("test_patch.sls", sls_contents, patch_file_dest)
+    numbers_tempfile = pytest.helpers.temp_file(numbers_file, content[0], patch_file_dest)
+    math_tempfile = pytest.helpers.temp_file(math_file, content[1], patch_file_dest)
 
     with sls_tempfile, numbers_tempfile, math_tempfile:
         ret = salt_call_cli.run("state.apply", "test_patch")
@@ -965,10 +964,10 @@ def test_patch_test_mode(
         numbers_file=numbers_file, numbers_patch=numbers_patch_file
     )
 
-    sls_patch_tempfile = temp_file(
+    sls_patch_tempfile = pytest.helpers.temp_file(
         "test_patch.sls", sls_patch_contents, patch_file_dest
     )
-    numbers_tempfile = temp_file(numbers_file, content[0], patch_file_dest)
+    numbers_tempfile = pytest.helpers.temp_file(numbers_file, content[0], patch_file_dest)
 
     with sls_patch_tempfile, numbers_tempfile:
         # Test application with test=True mode

--- a/tests/pytests/integration/states/test_file.py
+++ b/tests/pytests/integration/states/test_file.py
@@ -4,10 +4,12 @@ Tests for the file state
 import logging
 import os
 import re
+import textwrap
 
 import pytest
 import salt.utils.files
 import salt.utils.path
+from salt.utils.versions import LooseVersion as _LooseVersion
 
 log = logging.getLogger(__name__)
 
@@ -25,7 +27,8 @@ def context():
 
 @pytest.fixture
 def content():
-    numbers_file_contents = """
+    numbers_file_contents = textwrap.dedent(
+        """\
     one
     two
     three
@@ -33,13 +36,39 @@ def content():
     1
     2
     3
-    """
-    math_file_contents = """
+    """)
+    math_file_contents = textwrap.dedent(
+        """\
     Five plus five is ten
 
     Four squared is sixteen
-    """
+    """)
     return numbers_file_contents, math_file_contents
+
+
+@pytest.fixture
+def all_patch_file():
+    return os.path.join("salt://", "patches/", "all.patch")
+
+
+@pytest.fixture
+def numbers_patch_file():
+    return os.path.join("salt://", "patches/", "numbers.patch")
+
+
+@pytest.fixture
+def math_patch_file():
+    return os.path.join("salt://", "patches/", "math.patch")
+
+
+@pytest.fixture
+def numbers_patch_template():
+    return os.path.join("salt://", "patches/", "numbers.patch.jinja")
+
+
+@pytest.fixture
+def all_patch_template():
+    return os.path.join("salt://", "patches/", "all.patch.jinja")
 
 
 @pytest.fixture(scope="module")
@@ -379,11 +408,25 @@ def test_issue_60203(
         )
 
 
+@pytest.fixture
+def min_patch_ver():
+    return "2.6"
+
+
+def _check_minimum_version(salt_call_cli, minimum_patch_ver):
+    version = salt_call_cli.run("--local", "cmd.run", "patch --version")
+    version = version.json.split()[2]
+    if _LooseVersion(version) < _LooseVersion(minimum_patch_ver):
+        pytest.xfail("Minimum version of patch not found,"
+                     " expecting {}, found {}".format(minimum_patch_ver, version))
+
+
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
-def test_patch_single_file(salt_master, salt_call_cli, tmp_path):
+def test_patch_single_file(salt_master, salt_call_cli, tmp_path, min_patch_ver):
     """
     Test file.patch using a patch applied to a single file
     """
+    _check_minimum_version(salt_call_cli, min_patch_ver)
     name_file = tmp_path / "name_file.txt"
     source_file = tmp_path / "source_file.patch"
     name_file_contents = """
@@ -441,33 +484,8 @@ def test_patch_single_file(salt_master, salt_call_cli, tmp_path):
         assert state_run["changes"] == {}
 
 
-@pytest.fixture
-def all_patch_file():
-    return os.path.join("salt://", "patches/", "all.patch")
-
-
-@pytest.fixture
-def numbers_patch_file():
-    return os.path.join("salt://", "patches/", "numbers.patch")
-
-
-@pytest.fixture
-def math_patch_file():
-    return os.path.join("salt://", "patches/", "math.patch")
-
-
-@pytest.fixture
-def numbers_patch_template():
-    return os.path.join("salt://", "patches/", "numbers.patch.jinja")
-
-
-@pytest.fixture
-def all_patch_template():
-    return os.path.join("salt://", "patches/", "all.patch.jinja")
-
-
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
-def test_patch_directory(salt_master, salt_call_cli, tmp_path, content, all_patch_file):
+def test_patch_directory(salt_master, salt_call_cli, tmp_path, content, all_patch_file, min_patch_ver):
     """
     Test file.patch using a patch applied to a directory, with changes
     spanning multiple files.
@@ -486,6 +504,7 @@ def test_patch_directory(salt_master, salt_call_cli, tmp_path, content, all_patc
     
     Four squared is sixteen
     """
+    _check_minimum_version(salt_call_cli, min_patch_ver)
     # Create a new unpatched set of files
     base_dir = str(tmp_path)
     os.makedirs(os.path.join(base_dir, "foo", "bar"))
@@ -531,10 +550,11 @@ def test_patch_directory(salt_master, salt_call_cli, tmp_path, content, all_patc
 
 
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
-def test_patch_strip_parsing(salt_master, salt_call_cli, tmp_path, content, all_patch_file):
+def test_patch_strip_parsing(salt_master, salt_call_cli, tmp_path, content, all_patch_file, min_patch_ver):
     """
     Test that we successfuly parse -p/--strip when included in the options
     """
+    _check_minimum_version(salt_call_cli, min_patch_ver)
     # Create a new unpatched set of files
     base_dir = str(tmp_path)
     os.makedirs(os.path.join(base_dir, "foo", "bar"))
@@ -594,13 +614,14 @@ def test_patch_strip_parsing(salt_master, salt_call_cli, tmp_path, content, all_
 
 
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
-def test_patch_saltenv(salt_master, salt_call_cli, tmp_path, content, math_patch_file):
+def test_patch_saltenv(salt_master, salt_call_cli, tmp_path, content, math_patch_file, min_patch_ver):
     """
     Test that we attempt to download the patch from a non-base saltenv
     """
     # This state will fail because we don't have a patch file in that
     # environment, but that is OK, we just want to test that we're looking
     # in an environment other than base.
+    _check_minimum_version(salt_call_cli, min_patch_ver)
     # Create a new unpatched set of files
     base_dir = str(tmp_path)
     os.makedirs(os.path.join(base_dir, "foo", "bar"))
@@ -636,11 +657,12 @@ def test_patch_saltenv(salt_master, salt_call_cli, tmp_path, content, math_patch
 
 
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
-def test_patch_single_file_failure(salt_master, salt_call_cli, tmp_path, content, numbers_patch_file):
+def test_patch_single_file_failure(salt_master, salt_call_cli, tmp_path, content, numbers_patch_file, min_patch_ver):
     """
     Test file.patch using a patch applied to a single file. This tests a
     failed patch.
     """
+    _check_minimum_version(salt_call_cli, min_patch_ver)
     # Create a new unpatched set of files
     base_dir = str(tmp_path)
     os.makedirs(os.path.join(base_dir, "foo", "bar"))
@@ -710,11 +732,12 @@ def test_patch_single_file_failure(salt_master, salt_call_cli, tmp_path, content
 
 
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
-def test_patch_directory_failure(salt_master, salt_call_cli, tmp_path, content, all_patch_file):
+def test_patch_directory_failure(salt_master, salt_call_cli, tmp_path, content, all_patch_file, min_patch_ver):
     """
     Test file.patch using a patch applied to a directory, with changes
     spanning multiple files.
     """
+    _check_minimum_version(salt_call_cli, min_patch_ver)
     # Create a new unpatched set of files
     base_dir = str(tmp_path)
     os.makedirs(os.path.join(base_dir, "foo", "bar"))
@@ -785,12 +808,13 @@ def test_patch_directory_failure(salt_master, salt_call_cli, tmp_path, content, 
 
 
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
-def test_patch_single_file_template(salt_master, salt_call_cli, tmp_path, context, content, numbers_patch_template):
+def test_patch_single_file_template(salt_master, salt_call_cli, tmp_path, context, content, numbers_patch_template, min_patch_ver):
     """
     Test file.patch using a patch applied to a single file, with jinja
     templating applied to the patch file.
     """
     # Create a new unpatched set of files
+    _check_minimum_version(salt_call_cli, min_patch_ver)
 
     base_dir = str(tmp_path)
     os.makedirs(os.path.join(base_dir, "foo", "bar"))
@@ -837,13 +861,14 @@ def test_patch_single_file_template(salt_master, salt_call_cli, tmp_path, contex
 
 
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
-def test_patch_directory_template(salt_master, salt_call_cli, tmp_path, context, content, all_patch_template):
+def test_patch_directory_template(salt_master, salt_call_cli, tmp_path, context, content, all_patch_template, min_patch_ver):
     """
     Test file.patch using a patch applied to a directory, with changes
     spanning multiple files, and with jinja templating applied to the patch
     file.
     """
     # Create a new unpatched set of files
+    _check_minimum_version(salt_call_cli, min_patch_ver)
     base_dir = str(tmp_path)
     os.makedirs(os.path.join(base_dir, "foo", "bar"))
     numbers_file = os.path.join(base_dir, "foo", "numbers.txt")
@@ -889,10 +914,11 @@ def test_patch_directory_template(salt_master, salt_call_cli, tmp_path, context,
 
 
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
-def test_patch_test_mode(salt_master, salt_call_cli, tmp_path, content, numbers_patch_file):
+def test_patch_test_mode(salt_master, salt_call_cli, tmp_path, content, numbers_patch_file, min_patch_ver):
     """
     Test file.patch using test=True
     """
+    _check_minimum_version(salt_call_cli, min_patch_ver)
     # Create a new unpatched set of files
     base_dir = str(tmp_path)
     os.makedirs(os.path.join(base_dir, "foo", "bar"))

--- a/tests/pytests/integration/states/test_file.py
+++ b/tests/pytests/integration/states/test_file.py
@@ -434,13 +434,13 @@ def _check_minimum_version(salt_call_cli, minimum_patch_ver):
 
 @pytest.mark.skip_unless_on_windows
 @pytest.mark.skipif(not salt.utils.path.which("patch"), reason="patch is not installed")
-def test_patch_single_file(salt_call_cli, tmp_path, min_patch_ver, patch_file_dest):
+def test_patch_single_file(salt_call_cli, min_patch_ver, patch_file_dest):
     """
     Test file.patch using a patch applied to a single file
     """
     _check_minimum_version(salt_call_cli, min_patch_ver)
-    name_file = (tmp_path / "name_file.txt")
-    source_file = (tmp_path / "source_file.patch")
+    name_file = patch_file_dest / "name_file.txt"
+    source_file = patch_file_dest / "source_file.patch"
     name_file_contents = """
     salt
     patch
@@ -467,8 +467,8 @@ def test_patch_single_file(salt_call_cli, tmp_path, min_patch_ver, patch_file_de
         name_file=name_file, source_file=source_file
     )
     sls_temp = temp_file("test_patch.sls", sls_contents, patch_file_dest)
-    name_temp = temp_file(name_file, name_file_contents)
-    source_temp = temp_file(source_file, source_file_contents)
+    name_temp = temp_file("name_file.txt", name_file_contents, patch_file_dest)
+    source_temp = temp_file("source_file.patch", source_file_contents, patch_file_dest)
 
     with sls_temp, name_temp, source_temp:
         # Store the original contents and make sure they change

--- a/tests/pytests/integration/states/test_file.py
+++ b/tests/pytests/integration/states/test_file.py
@@ -2,12 +2,12 @@
 Tests for the file state
 """
 import logging
-
-import pytest
 import os
 import re
-import salt.utils.path
+
+import pytest
 import salt.utils.files
+import salt.utils.path
 
 log = logging.getLogger(__name__)
 

--- a/tests/pytests/integration/states/test_file.py
+++ b/tests/pytests/integration/states/test_file.py
@@ -3,9 +3,9 @@ Tests for the file state
 """
 import logging
 import os
+import pathlib
 import re
 import textwrap
-import pathlib
 
 import pytest
 import salt.utils.files
@@ -598,7 +598,9 @@ def test_patch_strip_parsing(
     )
 
     sls_tempfile = temp_file("test_patch.sls", sls_contents, patch_file_dest)
-    sls_patch_tempfile = temp_file("test_patch_strip.sls", sls_patch_contents, patch_file_dest)
+    sls_patch_tempfile = temp_file(
+        "test_patch_strip.sls", sls_patch_contents, patch_file_dest
+    )
     numbers_tempfile = temp_file(numbers_file, content[0], patch_file_dest)
     math_tempfile = temp_file(math_file, content[1], patch_file_dest)
 
@@ -710,7 +712,9 @@ def test_patch_single_file_failure(
     )
 
     sls_tempfile = temp_file("test_patch.sls", sls_patch_contents, patch_file_dest)
-    sls_reject_tempfile = temp_file("test_patch_reject.sls", sls_patch_reject_contents, patch_file_dest)
+    sls_reject_tempfile = temp_file(
+        "test_patch_reject.sls", sls_patch_reject_contents, patch_file_dest
+    )
     numbers_tempfile = temp_file(numbers_file, content[0], patch_file_dest)
     math_tempfile = temp_file(math_file, content[1], patch_file_dest)
     reject_tempfile = temp_file("reject.txt", "", patch_file_dest)
@@ -784,7 +788,9 @@ def test_patch_directory_failure(
         base_dir=patch_file_dest, all_patch=all_patch_file, reject_file=reject_file
     )
     sls_tempfile = temp_file("test_patch.sls", sls_patch_contents, patch_file_dest)
-    sls_reject_tempfile = temp_file("test_patch_reject.sls", sls_patch_reject_contents, patch_file_dest)
+    sls_reject_tempfile = temp_file(
+        "test_patch_reject.sls", sls_patch_reject_contents, patch_file_dest
+    )
 
     numbers_tempfile = temp_file(numbers_file, content[0], patch_file_dest)
     math_tempfile = temp_file(math_file, content[1], patch_file_dest)
@@ -959,7 +965,9 @@ def test_patch_test_mode(
         numbers_file=numbers_file, numbers_patch=numbers_patch_file
     )
 
-    sls_patch_tempfile = temp_file("test_patch.sls", sls_patch_contents, patch_file_dest)
+    sls_patch_tempfile = temp_file(
+        "test_patch.sls", sls_patch_contents, patch_file_dest
+    )
     numbers_tempfile = temp_file(numbers_file, content[0], patch_file_dest)
 
     with sls_patch_tempfile, numbers_tempfile:

--- a/tests/pytests/integration/states/test_file.py
+++ b/tests/pytests/integration/states/test_file.py
@@ -432,8 +432,8 @@ def test_patch_single_file(salt_master, salt_call_cli, tmp_path, min_patch_ver):
     Test file.patch using a patch applied to a single file
     """
     _check_minimum_version(salt_call_cli, min_patch_ver)
-    name_file = tmp_path / "name_file.txt"
-    source_file = tmp_path / "source_file.patch"
+    name_file = (tmp_path / "name_file.txt").resolve()
+    source_file = (tmp_path / "source_file.patch").resolve()
     name_file_contents = """
     salt
     patch


### PR DESCRIPTION
### What does this PR do?
1. Allow Windows to use the `file.patch` function. 

2. This PR also disables a few other tests that now run because the binary is found on the system. The optional unix-for-windows installation adds many common unix binaries to the path, which now lets these tests run. However, many of the tests that are being skipped are not written with Windows in mind so they were not designed to pass on windows.

3. This PR also adds the new golden images that allow these new patch tests to run in the first place.


### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/44783

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
