### PR TITLE
Enhance logging when inotify beacon is missing pyinotify

### DIFF
--- a/changelog/60402.changed
+++ b/changelog/60402.changed
@@ -1,0 +1,1 @@
+Enhance logging when there are errors at loading beacons

--- a/changelog/60402.fixed
+++ b/changelog/60402.fixed
@@ -1,1 +1,0 @@
-Enhance logging when inotify beacon is missing pyinotify

--- a/changelog/60402.fixed
+++ b/changelog/60402.fixed
@@ -1,0 +1,1 @@
+Enhance logging when inotify beacon is missing pyinotify

--- a/salt/beacons/adb.py
+++ b/salt/beacons/adb.py
@@ -19,7 +19,9 @@ last_state_extra = {"value": False, "no_devices": False}
 def __virtual__():
     which_result = salt.utils.path.which("adb")
     if which_result is None:
-        return False
+        err_msg = "adb is missing."
+        log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+        return False, err_msg
     else:
         return __virtualname__
 

--- a/salt/beacons/aix_account.py
+++ b/salt/beacons/aix_account.py
@@ -19,10 +19,9 @@ def __virtual__():
     if __grains__["kernel"] == "AIX":
         return __virtualname__
 
-    return (
-        False,
-        "The aix_account beacon module failed to load: only available on AIX systems.",
-    )
+    err_msg = "Only available on AIX systems."
+    log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+    return False, err_msg
 
 
 def validate(config):

--- a/salt/beacons/avahi_announce.py
+++ b/salt/beacons/avahi_announce.py
@@ -54,18 +54,13 @@ def __virtual__():
     if HAS_PYAVAHI:
         if HAS_DBUS:
             return __virtualname__
-        return (
-            False,
-            "The {} beacon cannot be loaded. The 'python-dbus' dependency is missing.".format(
-                __virtualname__
-            ),
-        )
-    return (
-        False,
-        "The {} beacon cannot be loaded. The 'python-avahi' dependency is missing.".format(
-            __virtualname__
-        ),
-    )
+        err_msg = "The 'python-dbus' dependency is missing."
+        log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+        return False, err_msg
+
+    err_msg = "The 'python-avahi' dependency is missing."
+    log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+    return False, err_msg
 
 
 def validate(config):

--- a/salt/beacons/bonjour_announce.py
+++ b/salt/beacons/bonjour_announce.py
@@ -27,7 +27,9 @@ SD_REF = None
 def __virtual__():
     if HAS_PYBONJOUR:
         return __virtualname__
-    return False
+    err_msg = "pybonjour library is missing."
+    log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+    return False, err_msg
 
 
 def _close_sd_ref():

--- a/salt/beacons/btmp.py
+++ b/salt/beacons/btmp.py
@@ -130,7 +130,9 @@ except ImportError:
 def __virtual__():
     if os.path.isfile(BTMP):
         return __virtualname__
-    return False
+    err_msg = "{} does not exist.".format(BTMP)
+    log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+    return False, err_msg
 
 
 def _validate_time_range(trange, status, msg):

--- a/salt/beacons/cert_info.py
+++ b/salt/beacons/cert_info.py
@@ -29,7 +29,9 @@ __virtualname__ = "cert_info"
 
 def __virtual__():
     if HAS_OPENSSL is False:
-        return False
+        err_msg = "OpenSSL library is missing."
+        log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+        return False, err_msg
 
     return __virtualname__
 

--- a/salt/beacons/diskusage.py
+++ b/salt/beacons/diskusage.py
@@ -25,7 +25,9 @@ __virtualname__ = "diskusage"
 
 def __virtual__():
     if HAS_PSUTIL is False:
-        return False
+        err_msg = "psutil library is missing."
+        log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+        return False, err_msg
     else:
         return __virtualname__
 

--- a/salt/beacons/glxinfo.py
+++ b/salt/beacons/glxinfo.py
@@ -19,7 +19,9 @@ def __virtual__():
 
     which_result = salt.utils.path.which("glxinfo")
     if which_result is None:
-        return False
+        err_msg = "glxinfo is missing."
+        log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+        return False, err_msg
     else:
         return __virtualname__
 

--- a/salt/beacons/haproxy.py
+++ b/salt/beacons/haproxy.py
@@ -20,8 +20,9 @@ def __virtual__():
     if "haproxy.get_sessions" in __salt__:
         return __virtualname__
     else:
-        log.debug("Not loading haproxy beacon")
-        return False
+        err_msg = "haproxy.get_sessions is missing."
+        log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+        return False, err_msg
 
 
 def validate(config):

--- a/salt/beacons/inotify.py
+++ b/salt/beacons/inotify.py
@@ -44,7 +44,9 @@ log = logging.getLogger(__name__)
 def __virtual__():
     if HAS_PYINOTIFY:
         return __virtualname__
-    return False
+    err_msg = "pyinotify library is missing"
+    log.error("Unable to load inotify beacon: {}".format(err_msg))
+    return False, err_msg
 
 
 def _get_mask(mask):

--- a/salt/beacons/inotify.py
+++ b/salt/beacons/inotify.py
@@ -44,7 +44,7 @@ log = logging.getLogger(__name__)
 def __virtual__():
     if HAS_PYINOTIFY:
         return __virtualname__
-    err_msg = "pyinotify library is missing"
+    err_msg = "pyinotify library is missing."
     log.error("Unable to load inotify beacon: %s", err_msg)
     return False, err_msg
 

--- a/salt/beacons/inotify.py
+++ b/salt/beacons/inotify.py
@@ -45,7 +45,7 @@ def __virtual__():
     if HAS_PYINOTIFY:
         return __virtualname__
     err_msg = "pyinotify library is missing"
-    log.error("Unable to load inotify beacon: {}".format(err_msg))
+    log.error("Unable to load inotify beacon: %s", err_msg)
     return False, err_msg
 
 

--- a/salt/beacons/journald.py
+++ b/salt/beacons/journald.py
@@ -22,7 +22,9 @@ __virtualname__ = "journald"
 def __virtual__():
     if HAS_SYSTEMD:
         return __virtualname__
-    return False
+    err_msg = "systemd library is missing."
+    log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+    return False, err_msg
 
 
 def _get_journal():

--- a/salt/beacons/load.py
+++ b/salt/beacons/load.py
@@ -16,7 +16,9 @@ LAST_STATUS = {}
 
 def __virtual__():
     if salt.utils.platform.is_windows():
-        return False
+        err_msg = "Not available for Windows systems."
+        log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+        return False, err_msg
     else:
         return __virtualname__
 

--- a/salt/beacons/log_beacon.py
+++ b/salt/beacons/log_beacon.py
@@ -33,7 +33,9 @@ log = logging.getLogger(__name__)
 def __virtual__():
     if not salt.utils.platform.is_windows() and HAS_REGEX:
         return __virtualname__
-    return False
+    err_msg = "Not available for Windows systems or when regex library is missing."
+    log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+    return False, err_msg
 
 
 def _get_loc():

--- a/salt/beacons/memusage.py
+++ b/salt/beacons/memusage.py
@@ -24,7 +24,9 @@ __virtualname__ = "memusage"
 
 def __virtual__():
     if HAS_PSUTIL is False:
-        return False
+        err_msg = "psutil library is missing."
+        log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+        return False, err_msg
     else:
         return __virtualname__
 

--- a/salt/beacons/napalm_beacon.py
+++ b/salt/beacons/napalm_beacon.py
@@ -193,7 +193,12 @@ def __virtual__():
     """
     This beacon can only work when running under a regular or a proxy minion, managed through napalm.
     """
-    return salt.utils.napalm.virtual(__opts__, __virtualname__, __file__)
+    if salt.utils.napalm.virtual(__opts__, __virtualname__, __file__):
+        return __virtualname__
+    else:
+        err_msg = "NAPALM is not installed."
+        log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+        return False, err_msg
 
 
 def _compare(cur_cmp, cur_struct):

--- a/salt/beacons/network_info.py
+++ b/salt/beacons/network_info.py
@@ -45,7 +45,9 @@ def _to_list(obj):
 
 def __virtual__():
     if not HAS_PSUTIL:
-        return (False, "cannot load network_info beacon: psutil not available")
+        err_msg = "psutil not available"
+        log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+        return False, err_msg
     return __virtualname__
 
 

--- a/salt/beacons/network_settings.py
+++ b/salt/beacons/network_settings.py
@@ -24,7 +24,7 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
-__virtual_name__ = "network_settings"
+__virtualname__ = "network_settings"
 
 ATTRS = [
     "family",
@@ -67,8 +67,10 @@ class Hashabledict(dict):
 
 def __virtual__():
     if HAS_PYROUTE2:
-        return __virtual_name__
-    return False
+        return __virtualname__
+    err_msg = "pyroute2 library is missing"
+    log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+    return False, err_msg
 
 
 def validate(config):

--- a/salt/beacons/pkg.py
+++ b/salt/beacons/pkg.py
@@ -14,7 +14,12 @@ def __virtual__():
     """
     Only load if strace is installed
     """
-    return __virtualname__ if "pkg.upgrade_available" in __salt__ else False
+    if "pkg.upgrade_available" in __salt__:
+        return __virtualname__
+    else:
+        err_msg = "pkg.upgrade_available is missing."
+        log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+        return False, err_msg
 
 
 def validate(config):

--- a/salt/beacons/ps.py
+++ b/salt/beacons/ps.py
@@ -20,7 +20,9 @@ __virtualname__ = "ps"
 
 def __virtual__():
     if not HAS_PSUTIL:
-        return (False, "cannot load ps beacon: psutil not available")
+        err_msg = "psutil library is missing."
+        log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+        return False, err_msg
     return __virtualname__
 
 

--- a/salt/beacons/sensehat.py
+++ b/salt/beacons/sensehat.py
@@ -15,9 +15,16 @@ import salt.utils.beacons
 
 log = logging.getLogger(__name__)
 
+__virtualname__ = "sensehat"
+
 
 def __virtual__():
-    return "sensehat.get_pressure" in __salt__
+    if "sensehat.get_pressure" in __salt__:
+        return __virtualname__
+    else:
+        err_msg = "sensehat.get_pressure is missing."
+        log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+        return False, err_msg
 
 
 def validate(config):

--- a/salt/beacons/sh.py
+++ b/salt/beacons/sh.py
@@ -17,7 +17,12 @@ def __virtual__():
     """
     Only load if strace is installed
     """
-    return __virtualname__ if salt.utils.path.which("strace") else False
+    if salt.utils.path.which("strace"):
+        return __virtualname__
+    else:
+        err_msg = "strace is missing."
+        log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+        return False, err_msg
 
 
 def _get_shells():

--- a/salt/beacons/smartos_imgadm.py
+++ b/salt/beacons/smartos_imgadm.py
@@ -38,12 +38,9 @@ def __virtual__():
     if "imgadm.list" in __salt__:
         return True
     else:
-        return (
-            False,
-            "{} beacon can only be loaded on SmartOS compute nodes".format(
-                __virtualname__
-            ),
-        )
+        err_msg = "Only available on SmartOS compute nodes."
+        log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+        return False, err_msg
 
 
 def validate(config):

--- a/salt/beacons/smartos_vmadm.py
+++ b/salt/beacons/smartos_vmadm.py
@@ -35,7 +35,7 @@ def __virtual__():
     """
     Provides vmadm beacon on SmartOS
     """
-    if "imgadm.list" in __salt__:
+    if "vmadm.list" in __salt__:
         return True
     else:
         err_msg = "Only available on SmartOS compute nodes."

--- a/salt/beacons/smartos_vmadm.py
+++ b/salt/beacons/smartos_vmadm.py
@@ -35,15 +35,12 @@ def __virtual__():
     """
     Provides vmadm beacon on SmartOS
     """
-    if "vmadm.list" in __salt__:
+    if "imgadm.list" in __salt__:
         return True
     else:
-        return (
-            False,
-            "{} beacon can only be loaded on SmartOS compute nodes".format(
-                __virtualname__
-            ),
-        )
+        err_msg = "Only available on SmartOS compute nodes."
+        log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+        return False, err_msg
 
 
 def validate(config):

--- a/salt/beacons/swapusage.py
+++ b/salt/beacons/swapusage.py
@@ -24,7 +24,9 @@ __virtualname__ = "swapusage"
 
 def __virtual__():
     if HAS_PSUTIL is False:
-        return False
+        err_msg = "psutil library is missing."
+        log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+        return False, err_msg
     else:
         return __virtualname__
 

--- a/salt/beacons/telegram_bot_msg.py
+++ b/salt/beacons/telegram_bot_msg.py
@@ -26,7 +26,9 @@ def __virtual__():
     if HAS_TELEGRAM:
         return __virtualname__
     else:
-        return False
+        err_msg = "telegram library is missing."
+        log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+        return False, err_msg
 
 
 def validate(config):

--- a/salt/beacons/twilio_txt_msg.py
+++ b/salt/beacons/twilio_txt_msg.py
@@ -27,7 +27,9 @@ def __virtual__():
     if HAS_TWILIO:
         return __virtualname__
     else:
-        return False
+        err_msg = "twilio library is missing."
+        log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+        return False, err_msg
 
 
 def validate(config):

--- a/salt/beacons/watchdog.py
+++ b/salt/beacons/watchdog.py
@@ -70,7 +70,9 @@ class Handler(FileSystemEventHandler):
 def __virtual__():
     if HAS_WATCHDOG:
         return __virtualname__
-    return False
+    err_msg = "watchdog library is missing."
+    log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+    return False, err_msg
 
 
 def _get_queue(config):

--- a/salt/beacons/wtmp.py
+++ b/salt/beacons/wtmp.py
@@ -159,7 +159,9 @@ except ImportError:
 def __virtual__():
     if os.path.isfile(WTMP):
         return __virtualname__
-    return False
+    err_msg = "{} does not exist.".format(WTMP)
+    log.error("Unable to load %s beacon: %s", __virtualname__, err_msg)
+    return False, err_msg
 
 
 def _validate_time_range(trange, status, msg):

--- a/tests/pytests/unit/beacons/test_adb.py
+++ b/tests/pytests/unit/beacons/test_adb.py
@@ -21,7 +21,7 @@ def test_no_adb_command():
         ret = adb.__virtual__()
 
         mock.assert_called_once_with("adb")
-        assert not ret
+        assert ret == (False, "adb is missing.")
 
 
 def test_with_adb_command():

--- a/tests/pytests/unit/beacons/test_glxinfo.py
+++ b/tests/pytests/unit/beacons/test_glxinfo.py
@@ -21,7 +21,7 @@ def test_no_glxinfo_command():
         ret = glxinfo.__virtual__()
 
         mock.assert_called_once_with("glxinfo")
-        assert not ret
+        assert ret == (False, "glxinfo is missing.")
 
 
 def test_with_glxinfo_command():


### PR DESCRIPTION
### What does this PR do?

This PR simply enhances the logging for "inotify" beacon when `__virtual__` function is returning `False` due missing `pyinotify` library. 

NOTE: I'm not adding a unit test for this since it is simply a cosmetic change. Is the test required in this case?

### Previous Behavior

Without this PR, in case `pyinotify` is not installed on the system, the logs we see in the minions are like the following:

```console
...
2021-06-18 13:41:13,264 [salt.utils.lazy  :109 ][DEBUG   ][29985] Could not LazyLoad inotify.beacon: 'inotify' __virtual__ returned False
2021-06-18 13:41:13,265 [salt.beacons     :130 ][WARNING ][29985] Unable to process beacon inotify
2021-06-18 13:41:14,181 [salt.utils.lazy  :105 ][DEBUG   ][29985] LazyLoaded inotify.beacon
2021-06-18 13:41:14,182 [salt.beacons     :130 ][WARNING ][29985] Unable to process beacon inotify
2021-06-18 13:41:15,181 [salt.utils.lazy  :105 ][DEBUG   ][29985] LazyLoaded inotify.beacon
2021-06-18 13:41:15,182 [salt.beacons     :130 ][WARNING ][29985] Unable to process beacon inotify
2021-06-18 13:41:16,181 [salt.utils.lazy  :105 ][DEBUG   ][29985] LazyLoaded inotify.beacon
2021-06-18 13:41:16,182 [salt.beacons     :130 ][WARNING ][29985] Unable to process beacon inotify
```

As you can see, there is no hint, even with `log_level: debug` that indicates why the beacon cannot be loaded or processed.

### New Behavior
Now we see an indication about missing `pyinotify` library, even if not running in debug mode, so the user knows what's happening:

```console
2021-06-18 14:29:01,097 [salt.loaded.int.beacons.inotify:54  ][ERROR   ][512] Unable to load inotify beacon: pyinotify library is missing
2021-06-18 14:29:10,259 [salt.beacons     :130 ][WARNING ][512] Unable to process beacon inotify
2021-06-18 14:29:10,471 [salt.loaded.int.beacons.inotify:54  ][ERROR   ][512] Unable to load inotify beacon: pyinotify library is missing
2021-06-18 14:29:10,531 [salt.beacons     :130 ][WARNING ][512] Unable to process beacon inotify
2021-06-18 14:29:11,470 [salt.beacons     :130 ][WARNING ][512] Unable to process beacon inotify
2021-06-18 14:29:12,470 [salt.beacons     :130 ][WARNING ][512] Unable to process beacon inotify
```

### Merge requirements satisfied?
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
