### PR TITLE
salt-cloud ec2 fixes

### DIFF
--- a/changelog/60417.fixed
+++ b/changelog/60417.fixed
@@ -1,0 +1,1 @@
+salt-cloud ec2 logging and performance fixes if problems are encountered.

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -252,10 +252,7 @@ def optimize_providers(providers):
 
         creds = (data["id"], data["key"])
         if creds not in tmp_providers[data["location"]]:
-            tmp_providers[data["location"]][creds] = {
-                "name": name,
-                "data": data,
-            }
+            tmp_providers[data["location"]][creds] = {"name": name, "data": data}
 
     for location, tmp_data in tmp_providers.items():
         for creds, data in tmp_data.items():
@@ -585,7 +582,7 @@ def avail_sizes(call=None):
                 "hyperthread), plus 2 NVIDIA Tesla M2050 GPUs",
                 "disk": "1680 GiB (2 x 840 GiB)",
                 "ram": "22.5 GiB",
-            },
+            }
         },
         "Compute Optimized": {
             "c4.large": {
@@ -821,7 +818,7 @@ def avail_sizes(call=None):
                 "cores": "16 (2 x Intel Xeon E5-2670, eight-core)",
                 "disk": "240 GiB (2 x 120 GiB SSD)",
                 "ram": "244 GiB",
-            },
+            }
         },
         "High Storage": {
             "hs1.8xlarge": {
@@ -829,7 +826,7 @@ def avail_sizes(call=None):
                 "cores": "16 (8 cores + 8 hyperthreads)",
                 "disk": "48 TiB (24 x 2 TiB hard disk drives)",
                 "ram": "117 GiB",
-            },
+            }
         },
         "General Purpose": {
             "t2.nano": {"id": "t2.nano", "cores": "1", "disk": "EBS", "ram": "512 MiB"},
@@ -2332,7 +2329,7 @@ def query_instance(vm_=None, call=None):
 
 
 def wait_for_instance(
-    vm_=None, data=None, ip_address=None, display_ssh_output=True, call=None,
+    vm_=None, data=None, ip_address=None, display_ssh_output=True, call=None
 ):
     """
     Wait for an instance upon creation from the EC2 API, to become available
@@ -3704,7 +3701,7 @@ def list_nodes_select(call=None):
     Return a list of the VMs that are on the provider, with select fields
     """
     return salt.utils.cloud.list_nodes_select(
-        list_nodes_full(get_location()), __opts__["query.selection"], call,
+        list_nodes_full(get_location()), __opts__["query.selection"], call
     )
 
 
@@ -4810,7 +4807,7 @@ def describe_snapshots(kwargs=None, call=None):
 
 
 def get_console_output(
-    name=None, location=None, instance_id=None, call=None, kwargs=None,
+    name=None, location=None, instance_id=None, call=None, kwargs=None
 ):
     """
     Show the console output from the instance.
@@ -4858,9 +4855,7 @@ def get_console_output(
     return ret
 
 
-def get_password_data(
-    name=None, kwargs=None, instance_id=None, call=None,
-):
+def get_password_data(name=None, kwargs=None, instance_id=None, call=None):
     """
     Return password data for a Windows instance.
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -439,12 +439,7 @@ def query(
                 return {"error": data}, requesturl
             return {"error": data}
     else:
-        log.error(
-            "EC2 Response Status Code and Error: [%s %s] %s",
-            exc.response.status_code,
-            exc,
-            data,
-        )
+        log.error("Max attempts threshold (%s) reached.", aws.AWS_MAX_RETRIES)
         if return_url is True:
             return {"error": data}, requesturl
         return {"error": data}

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -506,7 +506,8 @@ def query(
                     data,
                     attempts,
                 )
-                sleep_exponential_backoff(AWS_MAX_RETRIES - attempts + 1)
+                if attempts > 0:
+                    sleep_exponential_backoff(AWS_MAX_RETRIES - attempts + 1)
                 continue
 
             log.error(

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -519,12 +519,7 @@ def query(
                 return {"error": data}, requesturl
             return {"error": data}
     else:
-        log.error(
-            "AWS Response Status Code and Error: [%s %s] %s",
-            exc.response.status_code,
-            exc,
-            data,
-        )
+        log.error("Max attempts threshold (%s) reached.", AWS_MAX_RETRIES)
         if return_url is True:
             return {"error": data}, requesturl
         return {"error": data}

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -164,7 +164,7 @@ def sig2(method, endpoint, params, provider, aws_api_version):
     querystring = urllib.parse.urlencode(list(zip(keys, values)))
 
     canonical = "{}\n{}\n/\n{}".format(
-        method.encode("utf-8"), endpoint.encode("utf-8"), querystring.encode("utf-8"),
+        method.encode("utf-8"), endpoint.encode("utf-8"), querystring.encode("utf-8")
     )
 
     hashed = hmac.new(secret_access_key, canonical, hashlib.sha256)
@@ -332,7 +332,7 @@ def sig4(
     # Add signing information to the request
     authorization_header = (
         "{} Credential={}/{}, SignedHeaders={}, Signature={}"
-    ).format(algorithm, access_key_id, credential_scope, signed_headers, signature,)
+    ).format(algorithm, access_key_id, credential_scope, signed_headers, signature)
 
     new_headers["Authorization"] = authorization_header
 


### PR DESCRIPTION
### What does this PR do?
Fixes assorted issues I encountered with `salt-cloud` today while troubleshooting a separate issue.

### What issues does this PR fix or reference?
No known issues. Mostly cosmetic - fixes what is output to the logs (ordering + exception handling failure) and avoids an unnecessary sleep. The rest is whatever the black auto-formatter did.

### Previous Behavior
```
Proceed? [N/y] y
... proceeding
[ERROR   ] AWS Response Status Code and Error: [500 500 Server Error: Internal Server Error for url: ...'; Attempts remaining: 1
[ERROR   ] AWS Response Status Code and Error: [500 500 Server Error: Internal Server Error for url: ...}; Attempts remaining: 2
[ERROR   ] AWS Response Status Code and Error: [500 500 Server Error: Internal Server Error for url: ...}; Attempts remaining: 3
[ERROR   ] AWS Response Status Code and Error: [500 500 Server Error: Internal Server Error for url: ...}; Attempts remaining: 4
[ERROR   ] AWS Response Status Code and Error: [500 500 Server Error: Internal Server Error for url: ...}; Attempts remaining: 5
[ERROR   ] AWS Response Status Code and Error: [500 500 Server Error: Internal Server Error for url: ...}; Attempts remaining: 6
[ERROR   ] AWS Response Status Code and Error: [500 500 Server Error: Internal Server Error for url: ...}; Attempts remaining: 7
[ERROR   ] There was a query error: local variable 'exc' referenced before assignment
```

### New Behavior
```
Proceed? [N/y] y
... proceeding
[ERROR   ] AWS Response Status Code and Error: [500 500 Server Error: Internal Server Error for url: ...}; Attempts remaining: 6
[ERROR   ] AWS Response Status Code and Error: [500 500 Server Error: Internal Server Error for url: ...}; Attempts remaining: 5
[ERROR   ] AWS Response Status Code and Error: [500 500 Server Error: Internal Server Error for url: ...}; Attempts remaining: 4
[ERROR   ] AWS Response Status Code and Error: [500 500 Server Error: Internal Server Error for url: ...}; Attempts remaining: 3
[ERROR   ] AWS Response Status Code and Error: [500 500 Server Error: Internal Server Error for url: ...}; Attempts remaining: 2
[ERROR   ] AWS Response Status Code and Error: [500 500 Server Error: Internal Server Error for url: ...}; Attempts remaining: 1
[ERROR   ] AWS Response Status Code and Error: [500 500 Server Error: Internal Server Error for url: ...}; Attempts remaining: 0
[ERROR   ] Max attempts threshold (7) reached.
[ERROR   ] Failed to create VM rproxy1.us-west-2b.sitepoint-staging.internal. Configuration value 1 needs to be set
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/salt/cloud/__init__.py", line 1242, in create
    output = self.clouds[func](vm_)
  File "/usr/lib/python3/dist-packages/salt/cloud/clouds/ec2.py", line 2666, in create
    data, vm_ = request_instance(vm_, location)
  File "/usr/lib/python3/dist-packages/salt/cloud/clouds/ec2.py", line 1935, in request_instance
    _new_eni = _create_eni_if_necessary(interface, vm_)
  File "/usr/lib/python3/dist-packages/salt/cloud/clouds/ec2.py", line 1481, in _create_eni_if_necessary
    eni_desc = result[1]
KeyError: 1
```
The stack trace is a separate issue, now I can better see what's going on. It also avoids a lengthy delay of up to 128 seconds by not sleeping after the final attempt.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
