### PR TITLE
Implementation of held/unheld functions for state pkg

### DIFF
--- a/changelog/60432.added
+++ b/changelog/60432.added
@@ -1,0 +1,1 @@
+Added `pkg.held` and `pkg.unheld` state functions for Zypper, YUM/DNF and APT. Improved `zypperpkg.hold` and `zypperpkg.unhold` functions.

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -2016,6 +2016,73 @@ def purge(name=None, pkgs=None, root=None, **kwargs):  # pylint: disable=unused-
     return _uninstall(name=name, pkgs=pkgs, root=root)
 
 
+def list_holds(pattern=None, full=True, root=None, **kwargs):
+    """
+    List information on locked packages.
+
+    .. note::
+        This function returns the computed output of ``list_locks``
+        to show exact locked packages.
+
+    pattern
+        Regular expression used to match the package name
+
+    full : True
+        Show the full hold definition including version and epoch. Set to
+        ``False`` to return just the name of the package(s) being held.
+
+    root
+        Operate on a different root directory.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.list_holds
+        salt '*' pkg.list_holds full=False
+    """
+    locks = list_locks(root=root)
+    ret = []
+    inst_pkgs = {}
+    for solv_name, lock in locks.items():
+        if lock.get("type", "package") != "package":
+            continue
+        try:
+            found_pkgs = search(
+                solv_name,
+                root=root,
+                match=None if "*" in solv_name else "exact",
+                case_sensitive=(lock.get("case_sensitive", "on") == "on"),
+                installed_only=True,
+                details=True,
+            )
+        except CommandExecutionError:
+            continue
+        if found_pkgs:
+            for pkg in found_pkgs:
+                if pkg not in inst_pkgs:
+                    inst_pkgs.update(
+                        info_installed(
+                            pkg, root=root, attr="edition,epoch", all_versions=True
+                        )
+                    )
+
+    ptrn_re = re.compile(r"{}-\S+".format(pattern)) if pattern else None
+    for pkg_name, pkg_editions in inst_pkgs.items():
+        for pkg_info in pkg_editions:
+            pkg_ret = (
+                "{}-{}:{}.*".format(
+                    pkg_name, pkg_info.get("epoch", 0), pkg_info.get("edition")
+                )
+                if full
+                else pkg_name
+            )
+            if pkg_ret not in ret and (not ptrn_re or ptrn_re.match(pkg_ret)):
+                ret.append(pkg_ret)
+
+    return ret
+
+
 def list_locks(root=None):
     """
     List current package locks.
@@ -2086,7 +2153,7 @@ def clean_locks(root=None):
     return out
 
 
-def unhold(name=None, pkgs=None, **kwargs):
+def unhold(name=None, pkgs=None, root=None, **kwargs):
     """
     .. versionadded:: 3003
 
@@ -2099,6 +2166,9 @@ def unhold(name=None, pkgs=None, **kwargs):
     pkgs
         A list of packages to unhold.  The ``name`` parameter will be ignored if
         this option is passed.
+
+    root
+        operate on a different root directory.
 
     CLI Example:
 
@@ -2114,33 +2184,47 @@ def unhold(name=None, pkgs=None, **kwargs):
 
     targets = []
     if pkgs:
-        for pkg in salt.utils.data.repack_dictlist(pkgs):
-            targets.append(pkg)
+        targets.extend(pkgs)
     else:
         targets.append(name)
 
-    locks = list_locks()
+    locks = list_locks(root=root)
     removed = []
-    missing = []
 
     for target in targets:
+        version = None
+        if isinstance(target, dict):
+            (target, version) = next(iter(target.items()))
         ret[target] = {"name": target, "changes": {}, "result": True, "comment": ""}
         if locks.get(target):
-            removed.append(target)
-            ret[target]["changes"]["new"] = ""
-            ret[target]["changes"]["old"] = "hold"
-            ret[target]["comment"] = "Package {} is no longer held.".format(target)
+            lock_ver = None
+            if "version" in locks.get(target):
+                lock_ver = locks.get(target)["version"]
+                lock_ver = lock_ver.lstrip("= ")
+            if version and lock_ver != version:
+                ret[target]["result"] = False
+                ret[target][
+                    "comment"
+                ] = "Unable to unhold package {} as it is held with the other version.".format(
+                    target
+                )
+            else:
+                removed.append(
+                    target if not lock_ver else "{}={}".format(target, lock_ver)
+                )
+                ret[target]["changes"]["new"] = ""
+                ret[target]["changes"]["old"] = "hold"
+                ret[target]["comment"] = "Package {} is no longer held.".format(target)
         else:
-            missing.append(target)
             ret[target]["comment"] = "Package {} was already unheld.".format(target)
 
     if removed:
-        __zypper__.call("rl", *removed)
+        __zypper__(root=root).call("rl", *removed)
 
     return ret
 
 
-def hold(name=None, pkgs=None, **kwargs):
+def hold(name=None, pkgs=None, root=None, **kwargs):
     """
     .. versionadded:: 3003
 
@@ -2153,6 +2237,9 @@ def hold(name=None, pkgs=None, **kwargs):
     pkgs
         A list of packages to hold.  The ``name`` parameter will be ignored if
         this option is passed.
+
+    root
+        operate on a different root directory.
 
     CLI Example:
 
@@ -2168,18 +2255,20 @@ def hold(name=None, pkgs=None, **kwargs):
 
     targets = []
     if pkgs:
-        for pkg in salt.utils.data.repack_dictlist(pkgs):
-            targets.append(pkg)
+        targets.extend(pkgs)
     else:
         targets.append(name)
 
-    locks = list_locks()
+    locks = list_locks(root=root)
     added = []
 
     for target in targets:
+        version = None
+        if isinstance(target, dict):
+            (target, version) = next(iter(target.items()))
         ret[target] = {"name": target, "changes": {}, "result": True, "comment": ""}
         if not locks.get(target):
-            added.append(target)
+            added.append(target if not version else "{}={}".format(target, version))
             ret[target]["changes"]["new"] = "hold"
             ret[target]["changes"]["old"] = ""
             ret[target]["comment"] = "Package {} is now being held.".format(target)
@@ -2189,7 +2278,7 @@ def hold(name=None, pkgs=None, **kwargs):
             )
 
     if added:
-        __zypper__.call("al", *added)
+        __zypper__(root=root).call("al", *added)
 
     return ret
 

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -2018,6 +2018,8 @@ def purge(name=None, pkgs=None, root=None, **kwargs):  # pylint: disable=unused-
 
 def list_holds(pattern=None, full=True, root=None, **kwargs):
     """
+    .. versionadded:: 3005
+
     List information on locked packages.
 
     .. note::

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -3646,6 +3646,8 @@ def mod_beacon(name, **kwargs):
 
 def held(name, version=None, pkgs=None, replace=False, **kwargs):
     """
+    .. versionadded:: 3005
+
     Set package in 'hold' state, meaning it will not be changed.
 
     :param str name:
@@ -3823,6 +3825,8 @@ def held(name, version=None, pkgs=None, replace=False, **kwargs):
 
 def unheld(name, version=None, pkgs=None, all=False, **kwargs):
     """
+    .. versionadded:: 3005
+
     Unset package from 'hold' state, to allow operations with the package.
 
     :param str name:

--- a/tests/pytests/unit/modules/test_zypperpkg.py
+++ b/tests/pytests/unit/modules/test_zypperpkg.py
@@ -78,3 +78,136 @@ def test_normalize_name():
         assert result == "foo", result
         result = zypper.normalize_name("foo.noarch")
         assert result == "foo", result
+
+
+def test_pkg_hold():
+    """
+    Tests holding packages with Zypper
+    """
+
+    # Test openSUSE 15.3
+    list_locks_mock = {
+        "bar": {"type": "package", "match_type": "glob", "case_sensitive": "on"},
+        "minimal_base": {
+            "type": "pattern",
+            "match_type": "glob",
+            "case_sensitive": "on",
+        },
+        "baz": {"type": "package", "match_type": "glob", "case_sensitive": "on"},
+    }
+
+    cmd = MagicMock(
+        return_value={
+            "pid": 1234,
+            "retcode": 0,
+            "stdout": "Specified lock has been successfully added.",
+            "stderr": "",
+        }
+    )
+    with patch.object(
+        zypper, "list_locks", MagicMock(return_value=list_locks_mock)
+    ), patch.dict(zypper.__salt__, {"cmd.run_all": cmd}):
+        ret = zypper.hold("foo")
+        assert ret["foo"]["changes"]["old"] == ""
+        assert ret["foo"]["changes"]["new"] == "hold"
+        assert ret["foo"]["comment"] == "Package foo is now being held."
+        cmd.assert_called_once_with(
+            ["zypper", "--non-interactive", "--no-refresh", "al", "foo"],
+            env={},
+            output_loglevel="trace",
+            python_shell=False,
+        )
+        cmd.reset_mock()
+        ret = zypper.hold(pkgs=["foo", "bar"])
+        assert ret["foo"]["changes"]["old"] == ""
+        assert ret["foo"]["changes"]["new"] == "hold"
+        assert ret["foo"]["comment"] == "Package foo is now being held."
+        assert ret["bar"]["changes"] == {}
+        assert ret["bar"]["comment"] == "Package bar is already set to be held."
+        cmd.assert_called_once_with(
+            ["zypper", "--non-interactive", "--no-refresh", "al", "foo"],
+            env={},
+            output_loglevel="trace",
+            python_shell=False,
+        )
+
+
+def test_pkg_unhold():
+    """
+    Tests unholding packages with Zypper
+    """
+
+    # Test openSUSE 15.3
+    list_locks_mock = {
+        "bar": {"type": "package", "match_type": "glob", "case_sensitive": "on"},
+        "minimal_base": {
+            "type": "pattern",
+            "match_type": "glob",
+            "case_sensitive": "on",
+        },
+        "baz": {"type": "package", "match_type": "glob", "case_sensitive": "on"},
+    }
+
+    cmd = MagicMock(
+        return_value={
+            "pid": 1234,
+            "retcode": 0,
+            "stdout": "1 lock has been successfully removed.",
+            "stderr": "",
+        }
+    )
+    with patch.object(
+        zypper, "list_locks", MagicMock(return_value=list_locks_mock)
+    ), patch.dict(zypper.__salt__, {"cmd.run_all": cmd}):
+        ret = zypper.unhold("foo")
+        assert ret["foo"]["comment"] == "Package foo was already unheld."
+        cmd.assert_not_called()
+        cmd.reset_mock()
+        ret = zypper.unhold(pkgs=["foo", "bar"])
+        assert ret["foo"]["changes"] == {}
+        assert ret["foo"]["comment"] == "Package foo was already unheld."
+        assert ret["bar"]["changes"]["old"] == "hold"
+        assert ret["bar"]["changes"]["new"] == ""
+        assert ret["bar"]["comment"] == "Package bar is no longer held."
+        cmd.assert_called_once_with(
+            ["zypper", "--non-interactive", "--no-refresh", "rl", "bar"],
+            env={},
+            output_loglevel="trace",
+            python_shell=False,
+        )
+
+
+def test_pkg_list_holds():
+    """
+    Tests listing of calculated held packages with Zypper
+    """
+
+    # Test openSUSE 15.3
+    list_locks_mock = {
+        "bar": {"type": "package", "match_type": "glob", "case_sensitive": "on"},
+        "minimal_base": {
+            "type": "pattern",
+            "match_type": "glob",
+            "case_sensitive": "on",
+        },
+        "baz": {"type": "package", "match_type": "glob", "case_sensitive": "on"},
+    }
+    installed_pkgs = {
+        "foo": [{"edition": "1.2.3-1.1"}],
+        "bar": [{"edition": "2.3.4-2.1", "epoch": "2"}],
+    }
+
+    def zypper_search_mock(name, *_args, **_kwargs):
+        if name in installed_pkgs:
+            return {name: installed_pkgs.get(name)}
+
+    with patch.object(
+        zypper, "list_locks", MagicMock(return_value=list_locks_mock)
+    ), patch.object(
+        zypper, "search", MagicMock(side_effect=zypper_search_mock)
+    ), patch.object(
+        zypper, "info_installed", MagicMock(side_effect=zypper_search_mock)
+    ):
+        ret = zypper.list_holds()
+        assert len(ret) == 1
+        assert "bar-2:2.3.4-2.1.*" in ret

--- a/tests/pytests/unit/states/test_pkg.py
+++ b/tests/pytests/unit/states/test_pkg.py
@@ -578,3 +578,141 @@ def test_removed_purged_with_changes_test_true(list_pkgs, action):
             ret = pkg_actions[action]("pkga", test=True)
             assert ret["result"] is None
             assert ret["changes"] == expected
+
+
+@pytest.mark.parametrize(
+    "package_manager",
+    [("Zypper"), ("YUM/DNF"), ("APT")],
+)
+def test_held_unheld(package_manager):
+    """
+    Test pkg.held and pkg.unheld with Zypper, YUM/DNF and APT
+    """
+
+    if package_manager == "Zypper":
+        list_holds_func = "pkg.list_locks"
+        list_holds_mock = MagicMock(
+            return_value={
+                "bar": {
+                    "type": "package",
+                    "match_type": "glob",
+                    "case_sensitive": "on",
+                },
+                "minimal_base": {
+                    "type": "pattern",
+                    "match_type": "glob",
+                    "case_sensitive": "on",
+                },
+                "baz": {
+                    "type": "package",
+                    "match_type": "glob",
+                    "case_sensitive": "on",
+                },
+            }
+        )
+    elif package_manager == "YUM/DNF":
+        list_holds_func = "pkg.list_holds"
+        list_holds_mock = MagicMock(
+            return_value=["bar-0:1.2.3-1.1.*", "baz-0:2.3.4-2.1.*",]
+        )
+    elif package_manager == "APT":
+        list_holds_func = "pkg.get_selections"
+        list_holds_mock = MagicMock(return_value={"hold": ["bar", "baz",]})
+
+    def pkg_hold(name, pkgs=None, *_args, **__kwargs):
+        if name and pkgs is None:
+            pkgs = [name]
+        ret = {}
+        for pkg in pkgs:
+            ret.update(
+                {
+                    pkg: {
+                        "name": pkg,
+                        "changes": {"new": "hold", "old": ""},
+                        "result": True,
+                        "comment": "Package {} is now being held.".format(pkg),
+                    }
+                }
+            )
+        return ret
+
+    def pkg_unhold(name, pkgs=None, *_args, **__kwargs):
+        if name and pkgs is None:
+            pkgs = [name]
+        ret = {}
+        for pkg in pkgs:
+            ret.update(
+                {
+                    pkg: {
+                        "name": pkg,
+                        "changes": {"new": "", "old": "hold"},
+                        "result": True,
+                        "comment": "Package {} is no longer held.".format(pkg),
+                    }
+                }
+            )
+        return ret
+
+    hold_mock = MagicMock(side_effect=pkg_hold)
+    unhold_mock = MagicMock(side_effect=pkg_unhold)
+
+    # Testing with Zypper
+    with patch.dict(
+        pkg.__salt__,
+        {
+            list_holds_func: list_holds_mock,
+            "pkg.hold": hold_mock,
+            "pkg.unhold": unhold_mock,
+        },
+    ):
+        # Holding one of two packages
+        ret = pkg.held("held-test", pkgs=["foo", "bar"])
+        assert "foo" in ret["changes"]
+        assert len(ret["changes"]) == 1
+        hold_mock.assert_called_once_with(name="held-test", pkgs=["foo"])
+        unhold_mock.assert_not_called()
+
+        hold_mock.reset_mock()
+        unhold_mock.reset_mock()
+
+        # Holding one of two packages and replacing all the rest held packages
+        ret = pkg.held("held-test", pkgs=["foo", "bar"], replace=True)
+        assert "foo" in ret["changes"]
+        assert "baz" in ret["changes"]
+        assert len(ret["changes"]) == 2
+        hold_mock.assert_called_once_with(name="held-test", pkgs=["foo"])
+        unhold_mock.assert_called_once_with(name="held-test", pkgs=["baz"])
+
+        hold_mock.reset_mock()
+        unhold_mock.reset_mock()
+
+        # Remove all holds
+        ret = pkg.held("held-test", pkgs=[], replace=True)
+        assert "bar" in ret["changes"]
+        assert "baz" in ret["changes"]
+        assert len(ret["changes"]) == 2
+        hold_mock.assert_not_called()
+        unhold_mock.assert_any_call(name="held-test", pkgs=["baz"])
+        unhold_mock.assert_any_call(name="held-test", pkgs=["bar"])
+
+        hold_mock.reset_mock()
+        unhold_mock.reset_mock()
+
+        # Unolding one of two packages
+        ret = pkg.unheld("held-test", pkgs=["foo", "bar"])
+        assert "bar" in ret["changes"]
+        assert len(ret["changes"]) == 1
+        unhold_mock.assert_called_once_with(name="held-test", pkgs=["bar"])
+        hold_mock.assert_not_called()
+
+        hold_mock.reset_mock()
+        unhold_mock.reset_mock()
+
+        # Remove all holds
+        ret = pkg.unheld("held-test", all=True)
+        assert "bar" in ret["changes"]
+        assert "baz" in ret["changes"]
+        assert len(ret["changes"]) == 2
+        hold_mock.assert_not_called()
+        unhold_mock.assert_any_call(name="held-test", pkgs=["baz"])
+        unhold_mock.assert_any_call(name="held-test", pkgs=["bar"])

--- a/tests/pytests/unit/states/test_pkg.py
+++ b/tests/pytests/unit/states/test_pkg.py
@@ -613,11 +613,21 @@ def test_held_unheld(package_manager):
     elif package_manager == "YUM/DNF":
         list_holds_func = "pkg.list_holds"
         list_holds_mock = MagicMock(
-            return_value=["bar-0:1.2.3-1.1.*", "baz-0:2.3.4-2.1.*",]
+            return_value=[
+                "bar-0:1.2.3-1.1.*",
+                "baz-0:2.3.4-2.1.*",
+            ]
         )
     elif package_manager == "APT":
         list_holds_func = "pkg.get_selections"
-        list_holds_mock = MagicMock(return_value={"hold": ["bar", "baz",]})
+        list_holds_mock = MagicMock(
+            return_value={
+                "hold": [
+                    "bar",
+                    "baz",
+                ]
+            }
+        )
 
     def pkg_hold(name, pkgs=None, *_args, **__kwargs):
         if name and pkgs is None:


### PR DESCRIPTION
### What does this PR do?

Implements `held`/`unheld` functions for state `pkg` module.
Examples:
```
sysstat:
  pkg.held: []
```
```
held-pkgs:
  pkg.held:
    - pkgs:
      - sysstat
      - vnstat: 1.17-bp153.1.18
```
```
held-pkgs-clear:
  pkg.held:
    - pkgs: []
    - replace: True
```
```
unheld-pkgs:
  pkg.unheld:
    - pkgs:
      - sysstat
      - vnstat: 1.17-bp153.1.18
      - test-package
```
```
unheld-all:
  pkg.unheld:
    - all: True
```

Implements `list_holds` function for `zypperpkg` module. The output is similar to `yumpkg.list_holds`. The only difference is that `zypperpkg` calculates the current locked packages from `list_locks` as the yum and zypper have different way of managing locks.

Improves `hold` function for `zypperpkg` to handle package version if specified.