### PR TITLE
Fixed compatibility with python azure module 5.0.0

### DIFF
--- a/requirements/static/ci/common.in
+++ b/requirements/static/ci/common.in
@@ -1,7 +1,23 @@
 # Requirements in this file apply to all platforms.
 # We can also exclude platforms from the requirements using markers, but if a requirement only applies
 # to a particular platform, please add it to the corresponding `<platform>.in` file in this directory.
-azure==4.0.0; sys_platform != 'win32'
+# azure==4.0.0; sys_platform != 'win32'
+azure-core>= 1.15.0
+azure-batch>= 10.0.0
+azure-identity>= 1.6.0
+azure-common>= 1.1.27
+azure-mgmt-core>= 1.2.2
+azure-mgmt-dns>=8.0.0
+azure-mgmt-subscription>= 1.0.0
+azure-mgmt-compute>= 20.0.0
+azure-mgmt-network>= 19.0.0
+azure-mgmt-resource>= 18.0.0
+azure-mgmt-storage>= 18.0.0
+azure-mgmt-web>= 2.0.0
+azure-storage-common>= 1.4.2
+azure-storage-blob>= 12.8.1
+azure-storage-file>= 2.1.0
+azure-servicemanagement-legacy>=0.20.7
 apache-libcloud>=1.5.0; sys_platform != 'win32'
 boto3>=1.16.0,<1.17.0; python_version < '3.6'
 boto3>=1.17.67; python_version >= '3.6'

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -5,9 +5,7 @@
 #    pip-compile --output-file=requirements/static/ci/py3.10/darwin.txt requirements/pytest.txt requirements/static/ci/common.in requirements/static/ci/darwin.in requirements/static/pkg/py3.10/darwin.txt
 #
 adal==1.2.5
-    # via
-    #   azure-datalake-store
-    #   msrestazure
+    # via msrestazure
 apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via
     #   -r requirements/static/ci/common.in
@@ -29,303 +27,65 @@ aws-sam-translator==1.33.0
     # via cfn-lint
 aws-xray-sdk==0.95
     # via moto
-azure-applicationinsights==0.1.0
-    # via azure
-azure-batch==4.1.3
-    # via azure
-azure-common==1.1.26
+azure-batch==10.0.0
+    # via -r requirements/static/ci/common.in
+azure-common==1.1.27
     # via
-    #   azure-applicationinsights
+    #   -r requirements/static/ci/common.in
     #   azure-batch
-    #   azure-cosmosdb-table
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-    #   azure-servicebus
-    #   azure-servicefabric
     #   azure-servicemanagement-legacy
-    #   azure-storage-blob
     #   azure-storage-common
     #   azure-storage-file
-    #   azure-storage-queue
-azure-cosmosdb-nspkg==2.0.2
-    # via azure-cosmosdb-table
-azure-cosmosdb-table==1.0.6
-    # via azure
-azure-datalake-store==0.0.51
-    # via azure
-azure-eventgrid==1.3.0
-    # via azure
-azure-graphrbac==0.40.0
-    # via azure
-azure-keyvault==1.1.0
-    # via azure
-azure-loganalytics==0.1.0
-    # via azure
-azure-mgmt-advisor==1.0.1
-    # via azure-mgmt
-azure-mgmt-applicationinsights==0.1.1
-    # via azure-mgmt
-azure-mgmt-authorization==0.50.0
-    # via azure-mgmt
-azure-mgmt-batch==5.0.1
-    # via azure-mgmt
-azure-mgmt-batchai==2.0.0
-    # via azure-mgmt
-azure-mgmt-billing==0.2.0
-    # via azure-mgmt
-azure-mgmt-cdn==3.1.0
-    # via azure-mgmt
-azure-mgmt-cognitiveservices==3.0.0
-    # via azure-mgmt
-azure-mgmt-commerce==1.0.1
-    # via azure-mgmt
-azure-mgmt-compute==4.6.2
-    # via azure-mgmt
-azure-mgmt-consumption==2.0.0
-    # via azure-mgmt
-azure-mgmt-containerinstance==1.5.0
-    # via azure-mgmt
-azure-mgmt-containerregistry==2.8.0
-    # via azure-mgmt
-azure-mgmt-containerservice==4.4.0
-    # via azure-mgmt
-azure-mgmt-cosmosdb==0.4.1
-    # via azure-mgmt
-azure-mgmt-datafactory==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-analytics==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-nspkg==3.0.1
+azure-core==1.15.0
     # via
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-azure-mgmt-datalake-store==0.5.0
-    # via azure-mgmt
-azure-mgmt-datamigration==1.0.0
-    # via azure-mgmt
-azure-mgmt-devspaces==0.1.0
-    # via azure-mgmt
-azure-mgmt-devtestlabs==2.2.0
-    # via azure-mgmt
-azure-mgmt-dns==2.1.0
-    # via azure-mgmt
-azure-mgmt-eventgrid==1.0.0
-    # via azure-mgmt
-azure-mgmt-eventhub==2.6.0
-    # via azure-mgmt
-azure-mgmt-hanaonazure==0.1.1
-    # via azure-mgmt
-azure-mgmt-iotcentral==0.1.0
-    # via azure-mgmt
-azure-mgmt-iothub==0.5.0
-    # via azure-mgmt
-azure-mgmt-iothubprovisioningservices==0.2.0
-    # via azure-mgmt
-azure-mgmt-keyvault==1.1.0
-    # via azure-mgmt
-azure-mgmt-loganalytics==0.2.0
-    # via azure-mgmt
-azure-mgmt-logic==3.0.0
-    # via azure-mgmt
-azure-mgmt-machinelearningcompute==0.4.1
-    # via azure-mgmt
-azure-mgmt-managementgroups==0.1.0
-    # via azure-mgmt
-azure-mgmt-managementpartner==0.1.1
-    # via azure-mgmt
-azure-mgmt-maps==0.1.0
-    # via azure-mgmt
-azure-mgmt-marketplaceordering==0.1.0
-    # via azure-mgmt
-azure-mgmt-media==1.0.0
-    # via azure-mgmt
-azure-mgmt-monitor==0.5.2
-    # via azure-mgmt
-azure-mgmt-msi==0.2.0
-    # via azure-mgmt
-azure-mgmt-network==2.7.0
-    # via azure-mgmt
-azure-mgmt-notificationhubs==2.1.0
-    # via azure-mgmt
-azure-mgmt-nspkg==3.0.2
+    #   -r requirements/static/ci/common.in
+    #   azure-identity
+    #   azure-mgmt-core
+    #   azure-storage-blob
+azure-identity==1.6.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-compute==21.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-core==1.2.2
     # via
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
-    #   azure-mgmt-consumption
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-nspkg
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
+    #   -r requirements/static/ci/common.in
+    #   azure-mgmt-compute
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
+    #   azure-mgmt-network
+    #   azure-mgmt-resource
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-azure-mgmt-policyinsights==0.1.0
-    # via azure-mgmt
-azure-mgmt-powerbiembedded==2.0.0
-    # via azure-mgmt
-azure-mgmt-rdbms==1.9.0
-    # via azure-mgmt
-azure-mgmt-recoveryservices==0.3.0
-    # via azure-mgmt
-azure-mgmt-recoveryservicesbackup==0.3.0
-    # via azure-mgmt
-azure-mgmt-redis==5.0.0
-    # via azure-mgmt
-azure-mgmt-relay==0.1.0
-    # via azure-mgmt
-azure-mgmt-reservations==0.2.1
-    # via azure-mgmt
-azure-mgmt-resource==2.2.0
-    # via azure-mgmt
-azure-mgmt-scheduler==2.0.0
-    # via azure-mgmt
-azure-mgmt-search==2.1.0
-    # via azure-mgmt
-azure-mgmt-servicebus==0.5.3
-    # via azure-mgmt
-azure-mgmt-servicefabric==0.2.0
-    # via azure-mgmt
-azure-mgmt-signalr==0.1.1
-    # via azure-mgmt
-azure-mgmt-sql==0.9.1
-    # via azure-mgmt
-azure-mgmt-storage==2.0.0
-    # via azure-mgmt
-azure-mgmt-subscription==0.2.0
-    # via azure-mgmt
-azure-mgmt-trafficmanager==0.50.0
-    # via azure-mgmt
-azure-mgmt-web==0.35.0
-    # via azure-mgmt
-azure-mgmt==4.0.0
-    # via azure
+azure-mgmt-dns==8.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-network==19.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-resource==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-storage==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-subscription==1.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-web==3.0.0
+    # via -r requirements/static/ci/common.in
 azure-nspkg==3.0.2
-    # via
-    #   azure-applicationinsights
-    #   azure-batch
-    #   azure-cosmosdb-nspkg
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-nspkg
-    #   azure-servicebus
-    #   azure-servicefabric
-    #   azure-servicemanagement-legacy
-azure-servicebus==0.21.1
-    # via azure
-azure-servicefabric==6.3.0.0
-    # via azure
+    # via azure-servicemanagement-legacy
 azure-servicemanagement-legacy==0.20.7
-    # via azure
-azure-storage-blob==1.5.0
-    # via azure
-azure-storage-common==1.4.2
+    # via -r requirements/static/ci/common.in
+azure-storage-blob==12.8.1
+    # via -r requirements/static/ci/common.in
+azure-storage-common==2.1.0
     # via
-    #   azure-storage-blob
+    #   -r requirements/static/ci/common.in
     #   azure-storage-file
-    #   azure-storage-queue
-azure-storage-file==1.4.0
-    # via azure
-azure-storage-queue==1.4.0
-    # via azure
-azure==4.0.0 ; sys_platform != "win32"
+azure-storage-file==2.1.0
     # via -r requirements/static/ci/common.in
 bcrypt==3.1.6
     # via paramiko
@@ -362,7 +122,6 @@ cffi==1.14.4
     # via
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/py3.10/darwin.txt
-    #   azure-datalake-store
     #   bcrypt
     #   cryptography
     #   napalm
@@ -404,11 +163,13 @@ cryptography==3.3.2
     # via
     #   -r requirements/static/pkg/py3.10/darwin.txt
     #   adal
-    #   azure-cosmosdb-table
-    #   azure-keyvault
+    #   azure-identity
+    #   azure-storage-blob
     #   azure-storage-common
     #   moto
+    #   msal
     #   paramiko
+    #   pyjwt
     #   pyopenssl
     #   python-jose
     #   sshpubkeys
@@ -543,102 +304,30 @@ more-itertools==8.2.0
     #   moto
 moto==1.3.16
     # via -r requirements/static/ci/common.in
+msal-extensions==0.3.0
+    # via azure-identity
+msal==1.12.0
+    # via
+    #   azure-identity
+    #   msal-extensions
 msgpack==1.0.2
     # via
     #   -r requirements/static/pkg/py3.10/darwin.txt
     #   pytest-salt-factories
-msrest==0.6.19
-    # via
-    #   azure-applicationinsights
-    #   azure-eventgrid
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-cdn
-    #   azure-mgmt-compute
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-dns
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-media
-    #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-resource
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-servicefabric
-    #   msrestazure
-msrestazure==0.6.4
+msrest==0.6.21
     # via
     #   azure-batch
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
+    #   azure-storage-blob
+    #   msrestazure
+msrestazure==0.6.4
+    # via azure-batch
 napalm==3.1.0 ; sys_platform != "win32" and python_version > "3.6"
     # via -r requirements/static/ci/common.in
 ncclient==0.6.4
@@ -675,6 +364,8 @@ pathtools==0.1.2
     # via watchdog
 pluggy==0.13.1
     # via pytest
+portalocker==1.7.1
+    # via msal-extensions
 portend==2.6
     # via
     #   -r requirements/static/pkg/py3.10/darwin.txt
@@ -705,8 +396,10 @@ pyeapi==0.8.3
     # via napalm
 pygit2==1.5.0 ; python_version >= "3.7"
     # via -r requirements/static/ci/darwin.in
-pyjwt==2.0.0
-    # via adal
+pyjwt[crypto]==2.0.0
+    # via
+    #   adal
+    #   msal
 pynacl==1.3.0
     # via paramiko
 pyopenssl==19.0.0
@@ -744,7 +437,6 @@ python-dateutil==2.8.0
     # via
     #   -r requirements/static/pkg/py3.10/darwin.txt
     #   adal
-    #   azure-cosmosdb-table
     #   azure-storage-common
     #   botocore
     #   croniter
@@ -788,15 +480,13 @@ requests==2.25.1
     #   adal
     #   apache-libcloud
     #   aws-xray-sdk
-    #   azure-cosmosdb-table
-    #   azure-datalake-store
-    #   azure-keyvault
-    #   azure-servicebus
+    #   azure-core
     #   azure-servicemanagement-legacy
     #   azure-storage-common
     #   docker
     #   kubernetes
     #   moto
+    #   msal
     #   msrest
     #   napalm
     #   pyvmomi
@@ -825,6 +515,8 @@ six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.10/darwin.txt
     #   aws-sam-translator
+    #   azure-core
+    #   azure-identity
     #   bcrypt
     #   cassandra-driver
     #   cfn-lint

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -5,9 +5,7 @@
 #    pip-compile --output-file=requirements/static/ci/py3.10/freebsd.txt requirements/pytest.txt requirements/static/ci/common.in requirements/static/ci/freebsd.in requirements/static/pkg/py3.10/freebsd.txt
 #
 adal==1.2.5
-    # via
-    #   azure-datalake-store
-    #   msrestazure
+    # via msrestazure
 apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 appdirs==1.4.4
@@ -27,303 +25,65 @@ aws-sam-translator==1.33.0
     # via cfn-lint
 aws-xray-sdk==0.95
     # via moto
-azure-applicationinsights==0.1.0
-    # via azure
-azure-batch==4.1.3
-    # via azure
-azure-common==1.1.26
+azure-batch==10.0.0
+    # via -r requirements/static/ci/common.in
+azure-common==1.1.27
     # via
-    #   azure-applicationinsights
+    #   -r requirements/static/ci/common.in
     #   azure-batch
-    #   azure-cosmosdb-table
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-    #   azure-servicebus
-    #   azure-servicefabric
     #   azure-servicemanagement-legacy
-    #   azure-storage-blob
     #   azure-storage-common
     #   azure-storage-file
-    #   azure-storage-queue
-azure-cosmosdb-nspkg==2.0.2
-    # via azure-cosmosdb-table
-azure-cosmosdb-table==1.0.6
-    # via azure
-azure-datalake-store==0.0.51
-    # via azure
-azure-eventgrid==1.3.0
-    # via azure
-azure-graphrbac==0.40.0
-    # via azure
-azure-keyvault==1.1.0
-    # via azure
-azure-loganalytics==0.1.0
-    # via azure
-azure-mgmt-advisor==1.0.1
-    # via azure-mgmt
-azure-mgmt-applicationinsights==0.1.1
-    # via azure-mgmt
-azure-mgmt-authorization==0.50.0
-    # via azure-mgmt
-azure-mgmt-batch==5.0.1
-    # via azure-mgmt
-azure-mgmt-batchai==2.0.0
-    # via azure-mgmt
-azure-mgmt-billing==0.2.0
-    # via azure-mgmt
-azure-mgmt-cdn==3.1.0
-    # via azure-mgmt
-azure-mgmt-cognitiveservices==3.0.0
-    # via azure-mgmt
-azure-mgmt-commerce==1.0.1
-    # via azure-mgmt
-azure-mgmt-compute==4.6.2
-    # via azure-mgmt
-azure-mgmt-consumption==2.0.0
-    # via azure-mgmt
-azure-mgmt-containerinstance==1.5.0
-    # via azure-mgmt
-azure-mgmt-containerregistry==2.8.0
-    # via azure-mgmt
-azure-mgmt-containerservice==4.4.0
-    # via azure-mgmt
-azure-mgmt-cosmosdb==0.4.1
-    # via azure-mgmt
-azure-mgmt-datafactory==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-analytics==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-nspkg==3.0.1
+azure-core==1.15.0
     # via
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-azure-mgmt-datalake-store==0.5.0
-    # via azure-mgmt
-azure-mgmt-datamigration==1.0.0
-    # via azure-mgmt
-azure-mgmt-devspaces==0.1.0
-    # via azure-mgmt
-azure-mgmt-devtestlabs==2.2.0
-    # via azure-mgmt
-azure-mgmt-dns==2.1.0
-    # via azure-mgmt
-azure-mgmt-eventgrid==1.0.0
-    # via azure-mgmt
-azure-mgmt-eventhub==2.6.0
-    # via azure-mgmt
-azure-mgmt-hanaonazure==0.1.1
-    # via azure-mgmt
-azure-mgmt-iotcentral==0.1.0
-    # via azure-mgmt
-azure-mgmt-iothub==0.5.0
-    # via azure-mgmt
-azure-mgmt-iothubprovisioningservices==0.2.0
-    # via azure-mgmt
-azure-mgmt-keyvault==1.1.0
-    # via azure-mgmt
-azure-mgmt-loganalytics==0.2.0
-    # via azure-mgmt
-azure-mgmt-logic==3.0.0
-    # via azure-mgmt
-azure-mgmt-machinelearningcompute==0.4.1
-    # via azure-mgmt
-azure-mgmt-managementgroups==0.1.0
-    # via azure-mgmt
-azure-mgmt-managementpartner==0.1.1
-    # via azure-mgmt
-azure-mgmt-maps==0.1.0
-    # via azure-mgmt
-azure-mgmt-marketplaceordering==0.1.0
-    # via azure-mgmt
-azure-mgmt-media==1.0.0
-    # via azure-mgmt
-azure-mgmt-monitor==0.5.2
-    # via azure-mgmt
-azure-mgmt-msi==0.2.0
-    # via azure-mgmt
-azure-mgmt-network==2.7.0
-    # via azure-mgmt
-azure-mgmt-notificationhubs==2.1.0
-    # via azure-mgmt
-azure-mgmt-nspkg==3.0.2
+    #   -r requirements/static/ci/common.in
+    #   azure-identity
+    #   azure-mgmt-core
+    #   azure-storage-blob
+azure-identity==1.6.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-compute==21.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-core==1.2.2
     # via
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
-    #   azure-mgmt-consumption
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-nspkg
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
+    #   -r requirements/static/ci/common.in
+    #   azure-mgmt-compute
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
+    #   azure-mgmt-network
+    #   azure-mgmt-resource
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-azure-mgmt-policyinsights==0.1.0
-    # via azure-mgmt
-azure-mgmt-powerbiembedded==2.0.0
-    # via azure-mgmt
-azure-mgmt-rdbms==1.9.0
-    # via azure-mgmt
-azure-mgmt-recoveryservices==0.3.0
-    # via azure-mgmt
-azure-mgmt-recoveryservicesbackup==0.3.0
-    # via azure-mgmt
-azure-mgmt-redis==5.0.0
-    # via azure-mgmt
-azure-mgmt-relay==0.1.0
-    # via azure-mgmt
-azure-mgmt-reservations==0.2.1
-    # via azure-mgmt
-azure-mgmt-resource==2.2.0
-    # via azure-mgmt
-azure-mgmt-scheduler==2.0.0
-    # via azure-mgmt
-azure-mgmt-search==2.1.0
-    # via azure-mgmt
-azure-mgmt-servicebus==0.5.3
-    # via azure-mgmt
-azure-mgmt-servicefabric==0.2.0
-    # via azure-mgmt
-azure-mgmt-signalr==0.1.1
-    # via azure-mgmt
-azure-mgmt-sql==0.9.1
-    # via azure-mgmt
-azure-mgmt-storage==2.0.0
-    # via azure-mgmt
-azure-mgmt-subscription==0.2.0
-    # via azure-mgmt
-azure-mgmt-trafficmanager==0.50.0
-    # via azure-mgmt
-azure-mgmt-web==0.35.0
-    # via azure-mgmt
-azure-mgmt==4.0.0
-    # via azure
+azure-mgmt-dns==8.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-network==19.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-resource==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-storage==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-subscription==1.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-web==3.0.0
+    # via -r requirements/static/ci/common.in
 azure-nspkg==3.0.2
-    # via
-    #   azure-applicationinsights
-    #   azure-batch
-    #   azure-cosmosdb-nspkg
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-nspkg
-    #   azure-servicebus
-    #   azure-servicefabric
-    #   azure-servicemanagement-legacy
-azure-servicebus==0.21.1
-    # via azure
-azure-servicefabric==6.3.0.0
-    # via azure
+    # via azure-servicemanagement-legacy
 azure-servicemanagement-legacy==0.20.7
-    # via azure
-azure-storage-blob==1.5.0
-    # via azure
-azure-storage-common==1.4.2
+    # via -r requirements/static/ci/common.in
+azure-storage-blob==12.8.1
+    # via -r requirements/static/ci/common.in
+azure-storage-common==2.1.0
     # via
-    #   azure-storage-blob
+    #   -r requirements/static/ci/common.in
     #   azure-storage-file
-    #   azure-storage-queue
-azure-storage-file==1.4.0
-    # via azure
-azure-storage-queue==1.4.0
-    # via azure
-azure==4.0.0 ; sys_platform != "win32"
+azure-storage-file==2.1.0
     # via -r requirements/static/ci/common.in
 backports.functools-lru-cache==1.5
     # via
@@ -364,7 +124,6 @@ cffi==1.14.4
     # via
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/py3.10/freebsd.txt
-    #   azure-datalake-store
     #   bcrypt
     #   cryptography
     #   napalm
@@ -406,11 +165,13 @@ cryptography==3.3.2
     # via
     #   -r requirements/static/pkg/py3.10/freebsd.txt
     #   adal
-    #   azure-cosmosdb-table
-    #   azure-keyvault
+    #   azure-identity
+    #   azure-storage-blob
     #   azure-storage-common
     #   moto
+    #   msal
     #   paramiko
+    #   pyjwt
     #   pyopenssl
     #   python-jose
     #   sshpubkeys
@@ -540,102 +301,30 @@ more-itertools==5.0.0
     #   moto
 moto==1.3.16
     # via -r requirements/static/ci/common.in
+msal-extensions==0.3.0
+    # via azure-identity
+msal==1.12.0
+    # via
+    #   azure-identity
+    #   msal-extensions
 msgpack==1.0.2
     # via
     #   -r requirements/static/pkg/py3.10/freebsd.txt
     #   pytest-salt-factories
-msrest==0.6.19
-    # via
-    #   azure-applicationinsights
-    #   azure-eventgrid
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-cdn
-    #   azure-mgmt-compute
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-dns
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-media
-    #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-resource
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-servicefabric
-    #   msrestazure
-msrestazure==0.6.4
+msrest==0.6.21
     # via
     #   azure-batch
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
+    #   azure-storage-blob
+    #   msrestazure
+msrestazure==0.6.4
+    # via azure-batch
 napalm==3.1.0 ; sys_platform != "win32" and python_version > "3.6"
     # via -r requirements/static/ci/common.in
 ncclient==0.6.4
@@ -673,6 +362,8 @@ pathtools==0.1.2
     # via watchdog
 pluggy==0.13.0
     # via pytest
+portalocker==1.7.1
+    # via msal-extensions
 portend==2.4
     # via
     #   -r requirements/static/pkg/py3.10/freebsd.txt
@@ -704,8 +395,10 @@ pygit2==1.5.0 ; python_version >= "3.7"
     # via -r requirements/static/ci/freebsd.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==2.0.0
-    # via adal
+pyjwt[crypto]==2.0.0
+    # via
+    #   adal
+    #   msal
 pynacl==1.3.0
     # via paramiko
 pyopenssl==19.1.0
@@ -743,7 +436,6 @@ python-dateutil==2.8.1
     # via
     #   -r requirements/static/pkg/py3.10/freebsd.txt
     #   adal
-    #   azure-cosmosdb-table
     #   azure-storage-common
     #   botocore
     #   croniter
@@ -787,15 +479,13 @@ requests==2.25.1
     #   adal
     #   apache-libcloud
     #   aws-xray-sdk
-    #   azure-cosmosdb-table
-    #   azure-datalake-store
-    #   azure-keyvault
-    #   azure-servicebus
+    #   azure-core
     #   azure-servicemanagement-legacy
     #   azure-storage-common
     #   docker
     #   kubernetes
     #   moto
+    #   msal
     #   msrest
     #   napalm
     #   pyvmomi
@@ -823,6 +513,8 @@ six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.10/freebsd.txt
     #   aws-sam-translator
+    #   azure-core
+    #   azure-identity
     #   bcrypt
     #   cassandra-driver
     #   cfn-lint

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -7,9 +7,7 @@
 --extra-index-url https://cdn.githubraw.com/saltstack/vsphere-automation-sdk-python/master/lib/
 
 adal==1.2.3
-    # via
-    #   azure-datalake-store
-    #   msrestazure
+    # via msrestazure
 apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 appdirs==1.4.4
@@ -29,308 +27,65 @@ aws-sam-translator==1.33.0
     # via cfn-lint
 aws-xray-sdk==0.95
     # via moto
-azure-applicationinsights==0.1.0
-    # via azure
-azure-batch==4.1.3
-    # via azure
-azure-common==1.1.18
+azure-batch==10.0.0
+    # via -r requirements/static/ci/common.in
+azure-common==1.1.27
     # via
-    #   azure-applicationinsights
+    #   -r requirements/static/ci/common.in
     #   azure-batch
-    #   azure-cosmosdb-table
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-    #   azure-servicebus
-    #   azure-servicefabric
     #   azure-servicemanagement-legacy
-    #   azure-storage-blob
     #   azure-storage-common
     #   azure-storage-file
-    #   azure-storage-queue
-azure-cosmosdb-nspkg==2.0.2
-    # via azure-cosmosdb-table
-azure-cosmosdb-table==1.0.5
-    # via azure
-azure-datalake-store==0.0.44
-    # via azure
-azure-eventgrid==1.2.0
-    # via azure
-azure-graphrbac==0.40.0
-    # via azure
-azure-keyvault==1.1.0
-    # via azure
-azure-loganalytics==0.1.0
-    # via azure
-azure-mgmt-advisor==1.0.1
-    # via azure-mgmt
-azure-mgmt-applicationinsights==0.1.1
-    # via azure-mgmt
-azure-mgmt-authorization==0.50.0
-    # via azure-mgmt
-azure-mgmt-batch==5.0.1
-    # via azure-mgmt
-azure-mgmt-batchai==2.0.0
-    # via azure-mgmt
-azure-mgmt-billing==0.2.0
-    # via azure-mgmt
-azure-mgmt-cdn==3.1.0
-    # via azure-mgmt
-azure-mgmt-cognitiveservices==3.0.0
-    # via azure-mgmt
-azure-mgmt-commerce==1.0.1
-    # via azure-mgmt
-azure-mgmt-compute==4.6.0
-    # via azure-mgmt
-azure-mgmt-consumption==2.0.0
-    # via azure-mgmt
-azure-mgmt-containerinstance==1.4.1
-    # via azure-mgmt
-azure-mgmt-containerregistry==2.7.0
-    # via azure-mgmt
-azure-mgmt-containerservice==4.4.0
-    # via azure-mgmt
-azure-mgmt-cosmosdb==0.4.1
-    # via azure-mgmt
-azure-mgmt-datafactory==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-analytics==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-nspkg==3.0.1
+azure-core==1.15.0
     # via
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-azure-mgmt-datalake-store==0.5.0
-    # via azure-mgmt
-azure-mgmt-datamigration==1.0.0
-    # via azure-mgmt
-azure-mgmt-devspaces==0.1.0
-    # via azure-mgmt
-azure-mgmt-devtestlabs==2.2.0
-    # via azure-mgmt
-azure-mgmt-dns==2.1.0
-    # via azure-mgmt
-azure-mgmt-eventgrid==1.0.0
-    # via azure-mgmt
-azure-mgmt-eventhub==2.5.0
-    # via azure-mgmt
-azure-mgmt-hanaonazure==0.1.1
-    # via azure-mgmt
-azure-mgmt-iotcentral==0.1.0
-    # via azure-mgmt
-azure-mgmt-iothub==0.5.0
-    # via azure-mgmt
-azure-mgmt-iothubprovisioningservices==0.2.0
-    # via azure-mgmt
-azure-mgmt-keyvault==1.1.0
-    # via azure-mgmt
-azure-mgmt-loganalytics==0.2.0
-    # via azure-mgmt
-azure-mgmt-logic==3.0.0
-    # via azure-mgmt
-azure-mgmt-machinelearningcompute==0.4.1
-    # via azure-mgmt
-azure-mgmt-managementgroups==0.1.0
-    # via azure-mgmt
-azure-mgmt-managementpartner==0.1.0
-    # via azure-mgmt
-azure-mgmt-maps==0.1.0
-    # via azure-mgmt
-azure-mgmt-marketplaceordering==0.1.0
-    # via azure-mgmt
-azure-mgmt-media==1.0.0
-    # via azure-mgmt
-azure-mgmt-monitor==0.5.2
-    # via azure-mgmt
-azure-mgmt-msi==0.2.0
-    # via azure-mgmt
-azure-mgmt-network==2.6.0
-    # via azure-mgmt
-azure-mgmt-notificationhubs==2.0.0
-    # via azure-mgmt
-azure-mgmt-nspkg==3.0.2
+    #   -r requirements/static/ci/common.in
+    #   azure-identity
+    #   azure-mgmt-core
+    #   azure-storage-blob
+azure-identity==1.6.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-compute==21.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-core==1.2.2
     # via
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
-    #   azure-mgmt-consumption
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-nspkg
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
+    #   -r requirements/static/ci/common.in
+    #   azure-mgmt-compute
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
+    #   azure-mgmt-network
+    #   azure-mgmt-resource
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-azure-mgmt-policyinsights==0.1.0
-    # via azure-mgmt
-azure-mgmt-powerbiembedded==2.0.0
-    # via azure-mgmt
-azure-mgmt-rdbms==1.8.0
-    # via azure-mgmt
-azure-mgmt-recoveryservices==0.3.0
-    # via azure-mgmt
-azure-mgmt-recoveryservicesbackup==0.3.0
-    # via azure-mgmt
-azure-mgmt-redis==5.0.0
-    # via azure-mgmt
-azure-mgmt-relay==0.1.0
-    # via azure-mgmt
-azure-mgmt-reservations==0.2.1
-    # via azure-mgmt
-azure-mgmt-resource==2.1.0
-    # via azure-mgmt
-azure-mgmt-scheduler==2.0.0
-    # via azure-mgmt
-azure-mgmt-search==2.0.0
-    # via azure-mgmt
-azure-mgmt-servicebus==0.5.3
-    # via azure-mgmt
-azure-mgmt-servicefabric==0.2.0
-    # via azure-mgmt
-azure-mgmt-signalr==0.1.1
-    # via azure-mgmt
-azure-mgmt-sql==0.9.1
-    # via azure-mgmt
-azure-mgmt-storage==2.0.0
-    # via azure-mgmt
-azure-mgmt-subscription==0.2.0
-    # via azure-mgmt
-azure-mgmt-trafficmanager==0.50.0
-    # via azure-mgmt
-azure-mgmt-web==0.35.0
-    # via azure-mgmt
-azure-mgmt==4.0.0
-    # via azure
+azure-mgmt-dns==8.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-network==19.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-resource==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-storage==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-subscription==1.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-web==3.0.0
+    # via -r requirements/static/ci/common.in
 azure-nspkg==3.0.2
+    # via azure-servicemanagement-legacy
+azure-servicemanagement-legacy==0.20.7
+    # via -r requirements/static/ci/common.in
+azure-storage-blob==12.8.1
+    # via -r requirements/static/ci/common.in
+azure-storage-common==2.1.0
     # via
-    #   azure-applicationinsights
-    #   azure-batch
-    #   azure-cosmosdb-nspkg
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-nspkg
-    #   azure-servicebus
-    #   azure-servicefabric
-    #   azure-servicemanagement-legacy
-azure-servicebus==0.21.1
-    # via azure
-azure-servicefabric==6.3.0.0
-    # via azure
-azure-servicemanagement-legacy==0.20.6
-    # via azure
-azure-storage-blob==1.5.0
-    # via azure
-azure-storage-common==1.4.0
-    # via
-    #   azure-cosmosdb-table
-    #   azure-storage-blob
+    #   -r requirements/static/ci/common.in
     #   azure-storage-file
-    #   azure-storage-queue
-azure-storage-file==1.4.0
-    # via azure
-azure-storage-queue==1.4.0
-    # via azure
-azure==4.0.0 ; sys_platform != "win32"
+azure-storage-file==2.1.0
     # via -r requirements/static/ci/common.in
 backports.functools-lru-cache==1.5
     # via
@@ -371,7 +126,6 @@ cffi==1.14.4
     # via
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/py3.10/linux.txt
-    #   azure-datalake-store
     #   bcrypt
     #   cryptography
     #   napalm
@@ -413,11 +167,13 @@ cryptography==3.3.2
     # via
     #   -r requirements/static/pkg/py3.10/linux.txt
     #   adal
-    #   azure-cosmosdb-table
-    #   azure-keyvault
+    #   azure-identity
+    #   azure-storage-blob
     #   azure-storage-common
     #   moto
+    #   msal
     #   paramiko
+    #   pyjwt
     #   pyopenssl
     #   python-jose
     #   sshpubkeys
@@ -548,99 +304,30 @@ more-itertools==5.0.0
     #   moto
 moto==1.3.16
     # via -r requirements/static/ci/common.in
+msal-extensions==0.3.0
+    # via azure-identity
+msal==1.12.0
+    # via
+    #   azure-identity
+    #   msal-extensions
 msgpack==1.0.2
     # via
     #   -r requirements/static/pkg/py3.10/linux.txt
     #   pytest-salt-factories
-msrest==0.6.14
-    # via
-    #   azure-applicationinsights
-    #   azure-eventgrid
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-cdn
-    #   azure-mgmt-compute
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-dns
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-media
-    #   azure-mgmt-network
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-resource
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-servicefabric
-    #   msrestazure
-msrestazure==0.6.3
+msrest==0.6.21
     # via
     #   azure-batch
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
+    #   azure-storage-blob
+    #   msrestazure
+msrestazure==0.6.3
+    # via azure-batch
 napalm==3.1.0 ; sys_platform != "win32" and python_version > "3.6"
     # via -r requirements/static/ci/common.in
 ncclient==0.6.4
@@ -686,6 +373,8 @@ pathtools==0.1.2
     # via watchdog
 pluggy==0.13.0
     # via pytest
+portalocker==1.7.1
+    # via msal-extensions
 portend==2.4
     # via
     #   -r requirements/static/pkg/py3.10/linux.txt
@@ -719,8 +408,10 @@ pyiface==0.0.11
     # via -r requirements/static/ci/linux.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==1.7.1
-    # via adal
+pyjwt[crypto]==1.7.1
+    # via
+    #   adal
+    #   msal
 pynacl==1.3.0
     # via paramiko
 pyopenssl==19.1.0
@@ -760,7 +451,6 @@ python-dateutil==2.8.1
     # via
     #   -r requirements/static/pkg/py3.10/linux.txt
     #   adal
-    #   azure-cosmosdb-table
     #   azure-storage-common
     #   botocore
     #   croniter
@@ -806,15 +496,13 @@ requests==2.25.1
     #   adal
     #   apache-libcloud
     #   aws-xray-sdk
-    #   azure-cosmosdb-table
-    #   azure-datalake-store
-    #   azure-keyvault
-    #   azure-servicebus
+    #   azure-core
     #   azure-servicemanagement-legacy
     #   azure-storage-common
     #   docker
     #   kubernetes
     #   moto
+    #   msal
     #   msrest
     #   napalm
     #   pyvmomi
@@ -843,6 +531,8 @@ six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.10/linux.txt
     #   aws-sam-translator
+    #   azure-core
+    #   azure-identity
     #   bcrypt
     #   cassandra-driver
     #   cfn-lint

--- a/requirements/static/ci/py3.5/linux.txt
+++ b/requirements/static/ci/py3.5/linux.txt
@@ -7,9 +7,7 @@
 --extra-index-url https://cdn.githubraw.com/saltstack/vsphere-automation-sdk-python/master/lib/
 
 adal==1.2.3
-    # via
-    #   azure-datalake-store
-    #   msrestazure
+    # via msrestazure
 apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 appdirs==1.4.4
@@ -29,308 +27,65 @@ aws-sam-translator==1.33.0
     # via cfn-lint
 aws-xray-sdk==0.95
     # via moto
-azure-applicationinsights==0.1.0
-    # via azure
-azure-batch==4.1.3
-    # via azure
-azure-common==1.1.18
+azure-batch==10.0.0
+    # via -r requirements/static/ci/common.in
+azure-common==1.1.27
     # via
-    #   azure-applicationinsights
+    #   -r requirements/static/ci/common.in
     #   azure-batch
-    #   azure-cosmosdb-table
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-    #   azure-servicebus
-    #   azure-servicefabric
     #   azure-servicemanagement-legacy
-    #   azure-storage-blob
     #   azure-storage-common
     #   azure-storage-file
-    #   azure-storage-queue
-azure-cosmosdb-nspkg==2.0.2
-    # via azure-cosmosdb-table
-azure-cosmosdb-table==1.0.5
-    # via azure
-azure-datalake-store==0.0.44
-    # via azure
-azure-eventgrid==1.2.0
-    # via azure
-azure-graphrbac==0.40.0
-    # via azure
-azure-keyvault==1.1.0
-    # via azure
-azure-loganalytics==0.1.0
-    # via azure
-azure-mgmt-advisor==1.0.1
-    # via azure-mgmt
-azure-mgmt-applicationinsights==0.1.1
-    # via azure-mgmt
-azure-mgmt-authorization==0.50.0
-    # via azure-mgmt
-azure-mgmt-batch==5.0.1
-    # via azure-mgmt
-azure-mgmt-batchai==2.0.0
-    # via azure-mgmt
-azure-mgmt-billing==0.2.0
-    # via azure-mgmt
-azure-mgmt-cdn==3.1.0
-    # via azure-mgmt
-azure-mgmt-cognitiveservices==3.0.0
-    # via azure-mgmt
-azure-mgmt-commerce==1.0.1
-    # via azure-mgmt
-azure-mgmt-compute==4.6.0
-    # via azure-mgmt
-azure-mgmt-consumption==2.0.0
-    # via azure-mgmt
-azure-mgmt-containerinstance==1.4.1
-    # via azure-mgmt
-azure-mgmt-containerregistry==2.7.0
-    # via azure-mgmt
-azure-mgmt-containerservice==4.4.0
-    # via azure-mgmt
-azure-mgmt-cosmosdb==0.4.1
-    # via azure-mgmt
-azure-mgmt-datafactory==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-analytics==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-nspkg==3.0.1
+azure-core==1.15.0
     # via
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-azure-mgmt-datalake-store==0.5.0
-    # via azure-mgmt
-azure-mgmt-datamigration==1.0.0
-    # via azure-mgmt
-azure-mgmt-devspaces==0.1.0
-    # via azure-mgmt
-azure-mgmt-devtestlabs==2.2.0
-    # via azure-mgmt
-azure-mgmt-dns==2.1.0
-    # via azure-mgmt
-azure-mgmt-eventgrid==1.0.0
-    # via azure-mgmt
-azure-mgmt-eventhub==2.5.0
-    # via azure-mgmt
-azure-mgmt-hanaonazure==0.1.1
-    # via azure-mgmt
-azure-mgmt-iotcentral==0.1.0
-    # via azure-mgmt
-azure-mgmt-iothub==0.5.0
-    # via azure-mgmt
-azure-mgmt-iothubprovisioningservices==0.2.0
-    # via azure-mgmt
-azure-mgmt-keyvault==1.1.0
-    # via azure-mgmt
-azure-mgmt-loganalytics==0.2.0
-    # via azure-mgmt
-azure-mgmt-logic==3.0.0
-    # via azure-mgmt
-azure-mgmt-machinelearningcompute==0.4.1
-    # via azure-mgmt
-azure-mgmt-managementgroups==0.1.0
-    # via azure-mgmt
-azure-mgmt-managementpartner==0.1.0
-    # via azure-mgmt
-azure-mgmt-maps==0.1.0
-    # via azure-mgmt
-azure-mgmt-marketplaceordering==0.1.0
-    # via azure-mgmt
-azure-mgmt-media==1.0.0
-    # via azure-mgmt
-azure-mgmt-monitor==0.5.2
-    # via azure-mgmt
-azure-mgmt-msi==0.2.0
-    # via azure-mgmt
-azure-mgmt-network==2.6.0
-    # via azure-mgmt
-azure-mgmt-notificationhubs==2.0.0
-    # via azure-mgmt
-azure-mgmt-nspkg==3.0.2
+    #   -r requirements/static/ci/common.in
+    #   azure-identity
+    #   azure-mgmt-core
+    #   azure-storage-blob
+azure-identity==1.6.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-compute==21.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-core==1.2.2
     # via
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
-    #   azure-mgmt-consumption
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-nspkg
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
+    #   -r requirements/static/ci/common.in
+    #   azure-mgmt-compute
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
+    #   azure-mgmt-network
+    #   azure-mgmt-resource
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-azure-mgmt-policyinsights==0.1.0
-    # via azure-mgmt
-azure-mgmt-powerbiembedded==2.0.0
-    # via azure-mgmt
-azure-mgmt-rdbms==1.8.0
-    # via azure-mgmt
-azure-mgmt-recoveryservices==0.3.0
-    # via azure-mgmt
-azure-mgmt-recoveryservicesbackup==0.3.0
-    # via azure-mgmt
-azure-mgmt-redis==5.0.0
-    # via azure-mgmt
-azure-mgmt-relay==0.1.0
-    # via azure-mgmt
-azure-mgmt-reservations==0.2.1
-    # via azure-mgmt
-azure-mgmt-resource==2.1.0
-    # via azure-mgmt
-azure-mgmt-scheduler==2.0.0
-    # via azure-mgmt
-azure-mgmt-search==2.0.0
-    # via azure-mgmt
-azure-mgmt-servicebus==0.5.3
-    # via azure-mgmt
-azure-mgmt-servicefabric==0.2.0
-    # via azure-mgmt
-azure-mgmt-signalr==0.1.1
-    # via azure-mgmt
-azure-mgmt-sql==0.9.1
-    # via azure-mgmt
-azure-mgmt-storage==2.0.0
-    # via azure-mgmt
-azure-mgmt-subscription==0.2.0
-    # via azure-mgmt
-azure-mgmt-trafficmanager==0.50.0
-    # via azure-mgmt
-azure-mgmt-web==0.35.0
-    # via azure-mgmt
-azure-mgmt==4.0.0
-    # via azure
+azure-mgmt-dns==8.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-network==19.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-resource==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-storage==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-subscription==1.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-web==3.0.0
+    # via -r requirements/static/ci/common.in
 azure-nspkg==3.0.2
+    # via azure-servicemanagement-legacy
+azure-servicemanagement-legacy==0.20.7
+    # via -r requirements/static/ci/common.in
+azure-storage-blob==12.8.1
+    # via -r requirements/static/ci/common.in
+azure-storage-common==2.1.0
     # via
-    #   azure-applicationinsights
-    #   azure-batch
-    #   azure-cosmosdb-nspkg
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-nspkg
-    #   azure-servicebus
-    #   azure-servicefabric
-    #   azure-servicemanagement-legacy
-azure-servicebus==0.21.1
-    # via azure
-azure-servicefabric==6.3.0.0
-    # via azure
-azure-servicemanagement-legacy==0.20.6
-    # via azure
-azure-storage-blob==1.5.0
-    # via azure
-azure-storage-common==1.4.0
-    # via
-    #   azure-cosmosdb-table
-    #   azure-storage-blob
+    #   -r requirements/static/ci/common.in
     #   azure-storage-file
-    #   azure-storage-queue
-azure-storage-file==1.4.0
-    # via azure
-azure-storage-queue==1.4.0
-    # via azure
-azure==4.0.0 ; sys_platform != "win32"
+azure-storage-file==2.1.0
     # via -r requirements/static/ci/common.in
 backports.functools-lru-cache==1.5
     # via
@@ -371,7 +126,6 @@ cffi==1.14.4
     # via
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/py3.5/linux.txt
-    #   azure-datalake-store
     #   bcrypt
     #   cryptography
     #   pygit2
@@ -408,11 +162,13 @@ cryptography==3.0
     # via
     #   -r requirements/static/pkg/py3.5/linux.txt
     #   adal
-    #   azure-cosmosdb-table
-    #   azure-keyvault
+    #   azure-identity
+    #   azure-storage-blob
     #   azure-storage-common
     #   moto
+    #   msal
     #   paramiko
+    #   pyjwt
     #   pyopenssl
     #   python-jose
     #   sshpubkeys
@@ -549,99 +305,30 @@ more-itertools==5.0.0
     #   zipp
 moto==1.3.16
     # via -r requirements/static/ci/common.in
+msal-extensions==0.3.0
+    # via azure-identity
+msal==1.12.0
+    # via
+    #   azure-identity
+    #   msal-extensions
 msgpack==1.0.2
     # via
     #   -r requirements/static/pkg/py3.5/linux.txt
     #   pytest-salt-factories
-msrest==0.6.14
-    # via
-    #   azure-applicationinsights
-    #   azure-eventgrid
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-cdn
-    #   azure-mgmt-compute
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-dns
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-media
-    #   azure-mgmt-network
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-resource
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-servicefabric
-    #   msrestazure
-msrestazure==0.6.3
+msrest==0.6.21
     # via
     #   azure-batch
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
+    #   azure-storage-blob
+    #   msrestazure
+msrestazure==0.6.3
+    # via azure-batch
 ncclient==0.6.4
     # via junos-eznc
 netaddr==0.7.19
@@ -678,6 +365,8 @@ pathtools==0.1.2
     # via watchdog
 pluggy==0.13.0
     # via pytest
+portalocker==1.7.1
+    # via msal-extensions
 portend==2.4
     # via
     #   -r requirements/static/pkg/py3.5/linux.txt
@@ -709,8 +398,10 @@ pyiface==0.0.11
     # via -r requirements/static/ci/linux.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==1.7.1
-    # via adal
+pyjwt[crypto]==1.7.1
+    # via
+    #   adal
+    #   msal
 pynacl==1.3.0
     # via paramiko
 pyopenssl==19.1.0
@@ -748,7 +439,6 @@ python-dateutil==2.8.1
     # via
     #   -r requirements/static/pkg/py3.5/linux.txt
     #   adal
-    #   azure-cosmosdb-table
     #   azure-storage-common
     #   botocore
     #   croniter
@@ -793,15 +483,13 @@ requests==2.25.1
     #   adal
     #   apache-libcloud
     #   aws-xray-sdk
-    #   azure-cosmosdb-table
-    #   azure-datalake-store
-    #   azure-keyvault
-    #   azure-servicebus
+    #   azure-core
     #   azure-servicemanagement-legacy
     #   azure-storage-common
     #   docker
     #   kubernetes
     #   moto
+    #   msal
     #   msrest
     #   pyvmomi
     #   requests-oauthlib
@@ -826,6 +514,8 @@ six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.5/linux.txt
     #   aws-sam-translator
+    #   azure-core
+    #   azure-identity
     #   bcrypt
     #   cassandra-driver
     #   cfn-lint

--- a/requirements/static/ci/py3.6/linux.txt
+++ b/requirements/static/ci/py3.6/linux.txt
@@ -7,9 +7,7 @@
 --extra-index-url https://cdn.githubraw.com/saltstack/vsphere-automation-sdk-python/master/lib/
 
 adal==1.2.3
-    # via
-    #   azure-datalake-store
-    #   msrestazure
+    # via msrestazure
 apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 appdirs==1.4.4
@@ -29,308 +27,65 @@ aws-sam-translator==1.33.0
     # via cfn-lint
 aws-xray-sdk==0.95
     # via moto
-azure-applicationinsights==0.1.0
-    # via azure
-azure-batch==4.1.3
-    # via azure
-azure-common==1.1.18
+azure-batch==10.0.0
+    # via -r requirements/static/ci/common.in
+azure-common==1.1.27
     # via
-    #   azure-applicationinsights
+    #   -r requirements/static/ci/common.in
     #   azure-batch
-    #   azure-cosmosdb-table
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-    #   azure-servicebus
-    #   azure-servicefabric
     #   azure-servicemanagement-legacy
-    #   azure-storage-blob
     #   azure-storage-common
     #   azure-storage-file
-    #   azure-storage-queue
-azure-cosmosdb-nspkg==2.0.2
-    # via azure-cosmosdb-table
-azure-cosmosdb-table==1.0.5
-    # via azure
-azure-datalake-store==0.0.44
-    # via azure
-azure-eventgrid==1.2.0
-    # via azure
-azure-graphrbac==0.40.0
-    # via azure
-azure-keyvault==1.1.0
-    # via azure
-azure-loganalytics==0.1.0
-    # via azure
-azure-mgmt-advisor==1.0.1
-    # via azure-mgmt
-azure-mgmt-applicationinsights==0.1.1
-    # via azure-mgmt
-azure-mgmt-authorization==0.50.0
-    # via azure-mgmt
-azure-mgmt-batch==5.0.1
-    # via azure-mgmt
-azure-mgmt-batchai==2.0.0
-    # via azure-mgmt
-azure-mgmt-billing==0.2.0
-    # via azure-mgmt
-azure-mgmt-cdn==3.1.0
-    # via azure-mgmt
-azure-mgmt-cognitiveservices==3.0.0
-    # via azure-mgmt
-azure-mgmt-commerce==1.0.1
-    # via azure-mgmt
-azure-mgmt-compute==4.6.0
-    # via azure-mgmt
-azure-mgmt-consumption==2.0.0
-    # via azure-mgmt
-azure-mgmt-containerinstance==1.4.1
-    # via azure-mgmt
-azure-mgmt-containerregistry==2.7.0
-    # via azure-mgmt
-azure-mgmt-containerservice==4.4.0
-    # via azure-mgmt
-azure-mgmt-cosmosdb==0.4.1
-    # via azure-mgmt
-azure-mgmt-datafactory==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-analytics==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-nspkg==3.0.1
+azure-core==1.15.0
     # via
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-azure-mgmt-datalake-store==0.5.0
-    # via azure-mgmt
-azure-mgmt-datamigration==1.0.0
-    # via azure-mgmt
-azure-mgmt-devspaces==0.1.0
-    # via azure-mgmt
-azure-mgmt-devtestlabs==2.2.0
-    # via azure-mgmt
-azure-mgmt-dns==2.1.0
-    # via azure-mgmt
-azure-mgmt-eventgrid==1.0.0
-    # via azure-mgmt
-azure-mgmt-eventhub==2.5.0
-    # via azure-mgmt
-azure-mgmt-hanaonazure==0.1.1
-    # via azure-mgmt
-azure-mgmt-iotcentral==0.1.0
-    # via azure-mgmt
-azure-mgmt-iothub==0.5.0
-    # via azure-mgmt
-azure-mgmt-iothubprovisioningservices==0.2.0
-    # via azure-mgmt
-azure-mgmt-keyvault==1.1.0
-    # via azure-mgmt
-azure-mgmt-loganalytics==0.2.0
-    # via azure-mgmt
-azure-mgmt-logic==3.0.0
-    # via azure-mgmt
-azure-mgmt-machinelearningcompute==0.4.1
-    # via azure-mgmt
-azure-mgmt-managementgroups==0.1.0
-    # via azure-mgmt
-azure-mgmt-managementpartner==0.1.0
-    # via azure-mgmt
-azure-mgmt-maps==0.1.0
-    # via azure-mgmt
-azure-mgmt-marketplaceordering==0.1.0
-    # via azure-mgmt
-azure-mgmt-media==1.0.0
-    # via azure-mgmt
-azure-mgmt-monitor==0.5.2
-    # via azure-mgmt
-azure-mgmt-msi==0.2.0
-    # via azure-mgmt
-azure-mgmt-network==2.6.0
-    # via azure-mgmt
-azure-mgmt-notificationhubs==2.0.0
-    # via azure-mgmt
-azure-mgmt-nspkg==3.0.2
+    #   -r requirements/static/ci/common.in
+    #   azure-identity
+    #   azure-mgmt-core
+    #   azure-storage-blob
+azure-identity==1.6.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-compute==21.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-core==1.2.2
     # via
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
-    #   azure-mgmt-consumption
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-nspkg
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
+    #   -r requirements/static/ci/common.in
+    #   azure-mgmt-compute
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
+    #   azure-mgmt-network
+    #   azure-mgmt-resource
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-azure-mgmt-policyinsights==0.1.0
-    # via azure-mgmt
-azure-mgmt-powerbiembedded==2.0.0
-    # via azure-mgmt
-azure-mgmt-rdbms==1.8.0
-    # via azure-mgmt
-azure-mgmt-recoveryservices==0.3.0
-    # via azure-mgmt
-azure-mgmt-recoveryservicesbackup==0.3.0
-    # via azure-mgmt
-azure-mgmt-redis==5.0.0
-    # via azure-mgmt
-azure-mgmt-relay==0.1.0
-    # via azure-mgmt
-azure-mgmt-reservations==0.2.1
-    # via azure-mgmt
-azure-mgmt-resource==2.1.0
-    # via azure-mgmt
-azure-mgmt-scheduler==2.0.0
-    # via azure-mgmt
-azure-mgmt-search==2.0.0
-    # via azure-mgmt
-azure-mgmt-servicebus==0.5.3
-    # via azure-mgmt
-azure-mgmt-servicefabric==0.2.0
-    # via azure-mgmt
-azure-mgmt-signalr==0.1.1
-    # via azure-mgmt
-azure-mgmt-sql==0.9.1
-    # via azure-mgmt
-azure-mgmt-storage==2.0.0
-    # via azure-mgmt
-azure-mgmt-subscription==0.2.0
-    # via azure-mgmt
-azure-mgmt-trafficmanager==0.50.0
-    # via azure-mgmt
-azure-mgmt-web==0.35.0
-    # via azure-mgmt
-azure-mgmt==4.0.0
-    # via azure
+azure-mgmt-dns==8.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-network==19.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-resource==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-storage==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-subscription==1.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-web==3.0.0
+    # via -r requirements/static/ci/common.in
 azure-nspkg==3.0.2
+    # via azure-servicemanagement-legacy
+azure-servicemanagement-legacy==0.20.7
+    # via -r requirements/static/ci/common.in
+azure-storage-blob==12.8.1
+    # via -r requirements/static/ci/common.in
+azure-storage-common==2.1.0
     # via
-    #   azure-applicationinsights
-    #   azure-batch
-    #   azure-cosmosdb-nspkg
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-nspkg
-    #   azure-servicebus
-    #   azure-servicefabric
-    #   azure-servicemanagement-legacy
-azure-servicebus==0.21.1
-    # via azure
-azure-servicefabric==6.3.0.0
-    # via azure
-azure-servicemanagement-legacy==0.20.6
-    # via azure
-azure-storage-blob==1.5.0
-    # via azure
-azure-storage-common==1.4.0
-    # via
-    #   azure-cosmosdb-table
-    #   azure-storage-blob
+    #   -r requirements/static/ci/common.in
     #   azure-storage-file
-    #   azure-storage-queue
-azure-storage-file==1.4.0
-    # via azure
-azure-storage-queue==1.4.0
-    # via azure
-azure==4.0.0 ; sys_platform != "win32"
+azure-storage-file==2.1.0
     # via -r requirements/static/ci/common.in
 backports.functools-lru-cache==1.5
     # via
@@ -371,7 +126,6 @@ cffi==1.14.4
     # via
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/py3.6/linux.txt
-    #   azure-datalake-store
     #   bcrypt
     #   cryptography
     #   pygit2
@@ -408,11 +162,13 @@ cryptography==3.3.2
     # via
     #   -r requirements/static/pkg/py3.6/linux.txt
     #   adal
-    #   azure-cosmosdb-table
-    #   azure-keyvault
+    #   azure-identity
+    #   azure-storage-blob
     #   azure-storage-common
     #   moto
+    #   msal
     #   paramiko
+    #   pyjwt
     #   pyopenssl
     #   python-jose
     #   sshpubkeys
@@ -549,99 +305,30 @@ more-itertools==5.0.0
     #   zipp
 moto==1.3.16
     # via -r requirements/static/ci/common.in
+msal-extensions==0.3.0
+    # via azure-identity
+msal==1.12.0
+    # via
+    #   azure-identity
+    #   msal-extensions
 msgpack==1.0.2
     # via
     #   -r requirements/static/pkg/py3.6/linux.txt
     #   pytest-salt-factories
-msrest==0.6.14
-    # via
-    #   azure-applicationinsights
-    #   azure-eventgrid
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-cdn
-    #   azure-mgmt-compute
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-dns
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-media
-    #   azure-mgmt-network
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-resource
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-servicefabric
-    #   msrestazure
-msrestazure==0.6.3
+msrest==0.6.21
     # via
     #   azure-batch
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
+    #   azure-storage-blob
+    #   msrestazure
+msrestazure==0.6.3
+    # via azure-batch
 ncclient==0.6.4
     # via junos-eznc
 netaddr==0.7.19
@@ -676,6 +363,8 @@ pathtools==0.1.2
     # via watchdog
 pluggy==0.13.0
     # via pytest
+portalocker==1.7.1
+    # via msal-extensions
 portend==2.4
     # via
     #   -r requirements/static/pkg/py3.6/linux.txt
@@ -707,8 +396,10 @@ pyiface==0.0.11
     # via -r requirements/static/ci/linux.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==1.7.1
-    # via adal
+pyjwt[crypto]==1.7.1
+    # via
+    #   adal
+    #   msal
 pynacl==1.3.0
     # via paramiko
 pyopenssl==19.1.0
@@ -746,7 +437,6 @@ python-dateutil==2.8.1
     # via
     #   -r requirements/static/pkg/py3.6/linux.txt
     #   adal
-    #   azure-cosmosdb-table
     #   azure-storage-common
     #   botocore
     #   croniter
@@ -791,15 +481,13 @@ requests==2.25.1
     #   adal
     #   apache-libcloud
     #   aws-xray-sdk
-    #   azure-cosmosdb-table
-    #   azure-datalake-store
-    #   azure-keyvault
-    #   azure-servicebus
+    #   azure-core
     #   azure-servicemanagement-legacy
     #   azure-storage-common
     #   docker
     #   kubernetes
     #   moto
+    #   msal
     #   msrest
     #   pyvmomi
     #   requests-oauthlib
@@ -824,6 +512,8 @@ six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.6/linux.txt
     #   aws-sam-translator
+    #   azure-core
+    #   azure-identity
     #   bcrypt
     #   cassandra-driver
     #   cfn-lint

--- a/requirements/static/ci/py3.7/darwin.txt
+++ b/requirements/static/ci/py3.7/darwin.txt
@@ -5,9 +5,7 @@
 #    pip-compile --output-file=requirements/static/ci/py3.7/darwin.txt requirements/pytest.txt requirements/static/ci/common.in requirements/static/ci/darwin.in requirements/static/pkg/py3.7/darwin.txt
 #
 adal==1.2.5
-    # via
-    #   azure-datalake-store
-    #   msrestazure
+    # via msrestazure
 apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via
     #   -r requirements/static/ci/common.in
@@ -29,303 +27,65 @@ aws-sam-translator==1.33.0
     # via cfn-lint
 aws-xray-sdk==0.95
     # via moto
-azure-applicationinsights==0.1.0
-    # via azure
-azure-batch==4.1.3
-    # via azure
-azure-common==1.1.26
+azure-batch==10.0.0
+    # via -r requirements/static/ci/common.in
+azure-common==1.1.27
     # via
-    #   azure-applicationinsights
+    #   -r requirements/static/ci/common.in
     #   azure-batch
-    #   azure-cosmosdb-table
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-    #   azure-servicebus
-    #   azure-servicefabric
     #   azure-servicemanagement-legacy
-    #   azure-storage-blob
     #   azure-storage-common
     #   azure-storage-file
-    #   azure-storage-queue
-azure-cosmosdb-nspkg==2.0.2
-    # via azure-cosmosdb-table
-azure-cosmosdb-table==1.0.6
-    # via azure
-azure-datalake-store==0.0.51
-    # via azure
-azure-eventgrid==1.3.0
-    # via azure
-azure-graphrbac==0.40.0
-    # via azure
-azure-keyvault==1.1.0
-    # via azure
-azure-loganalytics==0.1.0
-    # via azure
-azure-mgmt-advisor==1.0.1
-    # via azure-mgmt
-azure-mgmt-applicationinsights==0.1.1
-    # via azure-mgmt
-azure-mgmt-authorization==0.50.0
-    # via azure-mgmt
-azure-mgmt-batch==5.0.1
-    # via azure-mgmt
-azure-mgmt-batchai==2.0.0
-    # via azure-mgmt
-azure-mgmt-billing==0.2.0
-    # via azure-mgmt
-azure-mgmt-cdn==3.1.0
-    # via azure-mgmt
-azure-mgmt-cognitiveservices==3.0.0
-    # via azure-mgmt
-azure-mgmt-commerce==1.0.1
-    # via azure-mgmt
-azure-mgmt-compute==4.6.2
-    # via azure-mgmt
-azure-mgmt-consumption==2.0.0
-    # via azure-mgmt
-azure-mgmt-containerinstance==1.5.0
-    # via azure-mgmt
-azure-mgmt-containerregistry==2.8.0
-    # via azure-mgmt
-azure-mgmt-containerservice==4.4.0
-    # via azure-mgmt
-azure-mgmt-cosmosdb==0.4.1
-    # via azure-mgmt
-azure-mgmt-datafactory==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-analytics==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-nspkg==3.0.1
+azure-core==1.15.0
     # via
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-azure-mgmt-datalake-store==0.5.0
-    # via azure-mgmt
-azure-mgmt-datamigration==1.0.0
-    # via azure-mgmt
-azure-mgmt-devspaces==0.1.0
-    # via azure-mgmt
-azure-mgmt-devtestlabs==2.2.0
-    # via azure-mgmt
-azure-mgmt-dns==2.1.0
-    # via azure-mgmt
-azure-mgmt-eventgrid==1.0.0
-    # via azure-mgmt
-azure-mgmt-eventhub==2.6.0
-    # via azure-mgmt
-azure-mgmt-hanaonazure==0.1.1
-    # via azure-mgmt
-azure-mgmt-iotcentral==0.1.0
-    # via azure-mgmt
-azure-mgmt-iothub==0.5.0
-    # via azure-mgmt
-azure-mgmt-iothubprovisioningservices==0.2.0
-    # via azure-mgmt
-azure-mgmt-keyvault==1.1.0
-    # via azure-mgmt
-azure-mgmt-loganalytics==0.2.0
-    # via azure-mgmt
-azure-mgmt-logic==3.0.0
-    # via azure-mgmt
-azure-mgmt-machinelearningcompute==0.4.1
-    # via azure-mgmt
-azure-mgmt-managementgroups==0.1.0
-    # via azure-mgmt
-azure-mgmt-managementpartner==0.1.1
-    # via azure-mgmt
-azure-mgmt-maps==0.1.0
-    # via azure-mgmt
-azure-mgmt-marketplaceordering==0.1.0
-    # via azure-mgmt
-azure-mgmt-media==1.0.0
-    # via azure-mgmt
-azure-mgmt-monitor==0.5.2
-    # via azure-mgmt
-azure-mgmt-msi==0.2.0
-    # via azure-mgmt
-azure-mgmt-network==2.7.0
-    # via azure-mgmt
-azure-mgmt-notificationhubs==2.1.0
-    # via azure-mgmt
-azure-mgmt-nspkg==3.0.2
+    #   -r requirements/static/ci/common.in
+    #   azure-identity
+    #   azure-mgmt-core
+    #   azure-storage-blob
+azure-identity==1.6.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-compute==21.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-core==1.2.2
     # via
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
-    #   azure-mgmt-consumption
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-nspkg
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
+    #   -r requirements/static/ci/common.in
+    #   azure-mgmt-compute
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
+    #   azure-mgmt-network
+    #   azure-mgmt-resource
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-azure-mgmt-policyinsights==0.1.0
-    # via azure-mgmt
-azure-mgmt-powerbiembedded==2.0.0
-    # via azure-mgmt
-azure-mgmt-rdbms==1.9.0
-    # via azure-mgmt
-azure-mgmt-recoveryservices==0.3.0
-    # via azure-mgmt
-azure-mgmt-recoveryservicesbackup==0.3.0
-    # via azure-mgmt
-azure-mgmt-redis==5.0.0
-    # via azure-mgmt
-azure-mgmt-relay==0.1.0
-    # via azure-mgmt
-azure-mgmt-reservations==0.2.1
-    # via azure-mgmt
-azure-mgmt-resource==2.2.0
-    # via azure-mgmt
-azure-mgmt-scheduler==2.0.0
-    # via azure-mgmt
-azure-mgmt-search==2.1.0
-    # via azure-mgmt
-azure-mgmt-servicebus==0.5.3
-    # via azure-mgmt
-azure-mgmt-servicefabric==0.2.0
-    # via azure-mgmt
-azure-mgmt-signalr==0.1.1
-    # via azure-mgmt
-azure-mgmt-sql==0.9.1
-    # via azure-mgmt
-azure-mgmt-storage==2.0.0
-    # via azure-mgmt
-azure-mgmt-subscription==0.2.0
-    # via azure-mgmt
-azure-mgmt-trafficmanager==0.50.0
-    # via azure-mgmt
-azure-mgmt-web==0.35.0
-    # via azure-mgmt
-azure-mgmt==4.0.0
-    # via azure
+azure-mgmt-dns==8.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-network==19.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-resource==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-storage==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-subscription==1.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-web==3.0.0
+    # via -r requirements/static/ci/common.in
 azure-nspkg==3.0.2
-    # via
-    #   azure-applicationinsights
-    #   azure-batch
-    #   azure-cosmosdb-nspkg
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-nspkg
-    #   azure-servicebus
-    #   azure-servicefabric
-    #   azure-servicemanagement-legacy
-azure-servicebus==0.21.1
-    # via azure
-azure-servicefabric==6.3.0.0
-    # via azure
+    # via azure-servicemanagement-legacy
 azure-servicemanagement-legacy==0.20.7
-    # via azure
-azure-storage-blob==1.5.0
-    # via azure
-azure-storage-common==1.4.2
+    # via -r requirements/static/ci/common.in
+azure-storage-blob==12.8.1
+    # via -r requirements/static/ci/common.in
+azure-storage-common==2.1.0
     # via
-    #   azure-storage-blob
+    #   -r requirements/static/ci/common.in
     #   azure-storage-file
-    #   azure-storage-queue
-azure-storage-file==1.4.0
-    # via azure
-azure-storage-queue==1.4.0
-    # via azure
-azure==4.0.0 ; sys_platform != "win32"
+azure-storage-file==2.1.0
     # via -r requirements/static/ci/common.in
 bcrypt==3.1.6
     # via paramiko
@@ -362,7 +122,6 @@ cffi==1.12.2
     # via
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/py3.7/darwin.txt
-    #   azure-datalake-store
     #   bcrypt
     #   cryptography
     #   napalm
@@ -404,11 +163,13 @@ cryptography==3.3.2
     # via
     #   -r requirements/static/pkg/py3.7/darwin.txt
     #   adal
-    #   azure-cosmosdb-table
-    #   azure-keyvault
+    #   azure-identity
+    #   azure-storage-blob
     #   azure-storage-common
     #   moto
+    #   msal
     #   paramiko
+    #   pyjwt
     #   pyopenssl
     #   python-jose
     #   sshpubkeys
@@ -551,102 +312,30 @@ more-itertools==8.2.0
     #   zipp
 moto==1.3.16
     # via -r requirements/static/ci/common.in
+msal-extensions==0.3.0
+    # via azure-identity
+msal==1.12.0
+    # via
+    #   azure-identity
+    #   msal-extensions
 msgpack==1.0.2
     # via
     #   -r requirements/static/pkg/py3.7/darwin.txt
     #   pytest-salt-factories
-msrest==0.6.19
-    # via
-    #   azure-applicationinsights
-    #   azure-eventgrid
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-cdn
-    #   azure-mgmt-compute
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-dns
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-media
-    #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-resource
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-servicefabric
-    #   msrestazure
-msrestazure==0.6.4
+msrest==0.6.21
     # via
     #   azure-batch
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
+    #   azure-storage-blob
+    #   msrestazure
+msrestazure==0.6.4
+    # via azure-batch
 napalm==3.1.0 ; sys_platform != "win32" and python_version > "3.6"
     # via -r requirements/static/ci/common.in
 ncclient==0.6.4
@@ -683,6 +372,8 @@ pathtools==0.1.2
     # via watchdog
 pluggy==0.13.1
     # via pytest
+portalocker==1.7.1
+    # via msal-extensions
 portend==2.6
     # via
     #   -r requirements/static/pkg/py3.7/darwin.txt
@@ -713,8 +404,10 @@ pyeapi==0.8.3
     # via napalm
 pygit2==1.5.0 ; python_version >= "3.7"
     # via -r requirements/static/ci/darwin.in
-pyjwt==2.0.0
-    # via adal
+pyjwt[crypto]==2.0.0
+    # via
+    #   adal
+    #   msal
 pynacl==1.3.0
     # via paramiko
 pyopenssl==19.0.0
@@ -752,7 +445,6 @@ python-dateutil==2.8.0
     # via
     #   -r requirements/static/pkg/py3.7/darwin.txt
     #   adal
-    #   azure-cosmosdb-table
     #   azure-storage-common
     #   botocore
     #   croniter
@@ -796,15 +488,13 @@ requests==2.25.1
     #   adal
     #   apache-libcloud
     #   aws-xray-sdk
-    #   azure-cosmosdb-table
-    #   azure-datalake-store
-    #   azure-keyvault
-    #   azure-servicebus
+    #   azure-core
     #   azure-servicemanagement-legacy
     #   azure-storage-common
     #   docker
     #   kubernetes
     #   moto
+    #   msal
     #   msrest
     #   napalm
     #   pyvmomi
@@ -833,6 +523,8 @@ six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.7/darwin.txt
     #   aws-sam-translator
+    #   azure-core
+    #   azure-identity
     #   bcrypt
     #   cassandra-driver
     #   cfn-lint

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -5,9 +5,7 @@
 #    pip-compile --output-file=requirements/static/ci/py3.7/freebsd.txt requirements/pytest.txt requirements/static/ci/common.in requirements/static/ci/freebsd.in requirements/static/pkg/py3.7/freebsd.txt
 #
 adal==1.2.5
-    # via
-    #   azure-datalake-store
-    #   msrestazure
+    # via msrestazure
 apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 appdirs==1.4.4
@@ -27,303 +25,65 @@ aws-sam-translator==1.33.0
     # via cfn-lint
 aws-xray-sdk==0.95
     # via moto
-azure-applicationinsights==0.1.0
-    # via azure
-azure-batch==4.1.3
-    # via azure
-azure-common==1.1.26
+azure-batch==10.0.0
+    # via -r requirements/static/ci/common.in
+azure-common==1.1.27
     # via
-    #   azure-applicationinsights
+    #   -r requirements/static/ci/common.in
     #   azure-batch
-    #   azure-cosmosdb-table
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-    #   azure-servicebus
-    #   azure-servicefabric
     #   azure-servicemanagement-legacy
-    #   azure-storage-blob
     #   azure-storage-common
     #   azure-storage-file
-    #   azure-storage-queue
-azure-cosmosdb-nspkg==2.0.2
-    # via azure-cosmosdb-table
-azure-cosmosdb-table==1.0.6
-    # via azure
-azure-datalake-store==0.0.51
-    # via azure
-azure-eventgrid==1.3.0
-    # via azure
-azure-graphrbac==0.40.0
-    # via azure
-azure-keyvault==1.1.0
-    # via azure
-azure-loganalytics==0.1.0
-    # via azure
-azure-mgmt-advisor==1.0.1
-    # via azure-mgmt
-azure-mgmt-applicationinsights==0.1.1
-    # via azure-mgmt
-azure-mgmt-authorization==0.50.0
-    # via azure-mgmt
-azure-mgmt-batch==5.0.1
-    # via azure-mgmt
-azure-mgmt-batchai==2.0.0
-    # via azure-mgmt
-azure-mgmt-billing==0.2.0
-    # via azure-mgmt
-azure-mgmt-cdn==3.1.0
-    # via azure-mgmt
-azure-mgmt-cognitiveservices==3.0.0
-    # via azure-mgmt
-azure-mgmt-commerce==1.0.1
-    # via azure-mgmt
-azure-mgmt-compute==4.6.2
-    # via azure-mgmt
-azure-mgmt-consumption==2.0.0
-    # via azure-mgmt
-azure-mgmt-containerinstance==1.5.0
-    # via azure-mgmt
-azure-mgmt-containerregistry==2.8.0
-    # via azure-mgmt
-azure-mgmt-containerservice==4.4.0
-    # via azure-mgmt
-azure-mgmt-cosmosdb==0.4.1
-    # via azure-mgmt
-azure-mgmt-datafactory==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-analytics==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-nspkg==3.0.1
+azure-core==1.15.0
     # via
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-azure-mgmt-datalake-store==0.5.0
-    # via azure-mgmt
-azure-mgmt-datamigration==1.0.0
-    # via azure-mgmt
-azure-mgmt-devspaces==0.1.0
-    # via azure-mgmt
-azure-mgmt-devtestlabs==2.2.0
-    # via azure-mgmt
-azure-mgmt-dns==2.1.0
-    # via azure-mgmt
-azure-mgmt-eventgrid==1.0.0
-    # via azure-mgmt
-azure-mgmt-eventhub==2.6.0
-    # via azure-mgmt
-azure-mgmt-hanaonazure==0.1.1
-    # via azure-mgmt
-azure-mgmt-iotcentral==0.1.0
-    # via azure-mgmt
-azure-mgmt-iothub==0.5.0
-    # via azure-mgmt
-azure-mgmt-iothubprovisioningservices==0.2.0
-    # via azure-mgmt
-azure-mgmt-keyvault==1.1.0
-    # via azure-mgmt
-azure-mgmt-loganalytics==0.2.0
-    # via azure-mgmt
-azure-mgmt-logic==3.0.0
-    # via azure-mgmt
-azure-mgmt-machinelearningcompute==0.4.1
-    # via azure-mgmt
-azure-mgmt-managementgroups==0.1.0
-    # via azure-mgmt
-azure-mgmt-managementpartner==0.1.1
-    # via azure-mgmt
-azure-mgmt-maps==0.1.0
-    # via azure-mgmt
-azure-mgmt-marketplaceordering==0.1.0
-    # via azure-mgmt
-azure-mgmt-media==1.0.0
-    # via azure-mgmt
-azure-mgmt-monitor==0.5.2
-    # via azure-mgmt
-azure-mgmt-msi==0.2.0
-    # via azure-mgmt
-azure-mgmt-network==2.7.0
-    # via azure-mgmt
-azure-mgmt-notificationhubs==2.1.0
-    # via azure-mgmt
-azure-mgmt-nspkg==3.0.2
+    #   -r requirements/static/ci/common.in
+    #   azure-identity
+    #   azure-mgmt-core
+    #   azure-storage-blob
+azure-identity==1.6.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-compute==21.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-core==1.2.2
     # via
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
-    #   azure-mgmt-consumption
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-nspkg
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
+    #   -r requirements/static/ci/common.in
+    #   azure-mgmt-compute
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
+    #   azure-mgmt-network
+    #   azure-mgmt-resource
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-azure-mgmt-policyinsights==0.1.0
-    # via azure-mgmt
-azure-mgmt-powerbiembedded==2.0.0
-    # via azure-mgmt
-azure-mgmt-rdbms==1.9.0
-    # via azure-mgmt
-azure-mgmt-recoveryservices==0.3.0
-    # via azure-mgmt
-azure-mgmt-recoveryservicesbackup==0.3.0
-    # via azure-mgmt
-azure-mgmt-redis==5.0.0
-    # via azure-mgmt
-azure-mgmt-relay==0.1.0
-    # via azure-mgmt
-azure-mgmt-reservations==0.2.1
-    # via azure-mgmt
-azure-mgmt-resource==2.2.0
-    # via azure-mgmt
-azure-mgmt-scheduler==2.0.0
-    # via azure-mgmt
-azure-mgmt-search==2.1.0
-    # via azure-mgmt
-azure-mgmt-servicebus==0.5.3
-    # via azure-mgmt
-azure-mgmt-servicefabric==0.2.0
-    # via azure-mgmt
-azure-mgmt-signalr==0.1.1
-    # via azure-mgmt
-azure-mgmt-sql==0.9.1
-    # via azure-mgmt
-azure-mgmt-storage==2.0.0
-    # via azure-mgmt
-azure-mgmt-subscription==0.2.0
-    # via azure-mgmt
-azure-mgmt-trafficmanager==0.50.0
-    # via azure-mgmt
-azure-mgmt-web==0.35.0
-    # via azure-mgmt
-azure-mgmt==4.0.0
-    # via azure
+azure-mgmt-dns==8.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-network==19.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-resource==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-storage==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-subscription==1.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-web==3.0.0
+    # via -r requirements/static/ci/common.in
 azure-nspkg==3.0.2
-    # via
-    #   azure-applicationinsights
-    #   azure-batch
-    #   azure-cosmosdb-nspkg
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-nspkg
-    #   azure-servicebus
-    #   azure-servicefabric
-    #   azure-servicemanagement-legacy
-azure-servicebus==0.21.1
-    # via azure
-azure-servicefabric==6.3.0.0
-    # via azure
+    # via azure-servicemanagement-legacy
 azure-servicemanagement-legacy==0.20.7
-    # via azure
-azure-storage-blob==1.5.0
-    # via azure
-azure-storage-common==1.4.2
+    # via -r requirements/static/ci/common.in
+azure-storage-blob==12.8.1
+    # via -r requirements/static/ci/common.in
+azure-storage-common==2.1.0
     # via
-    #   azure-storage-blob
+    #   -r requirements/static/ci/common.in
     #   azure-storage-file
-    #   azure-storage-queue
-azure-storage-file==1.4.0
-    # via azure
-azure-storage-queue==1.4.0
-    # via azure
-azure==4.0.0 ; sys_platform != "win32"
+azure-storage-file==2.1.0
     # via -r requirements/static/ci/common.in
 backports.functools-lru-cache==1.5
     # via
@@ -364,7 +124,6 @@ cffi==1.14.4
     # via
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/py3.7/freebsd.txt
-    #   azure-datalake-store
     #   bcrypt
     #   cryptography
     #   napalm
@@ -406,11 +165,13 @@ cryptography==3.3.2
     # via
     #   -r requirements/static/pkg/py3.7/freebsd.txt
     #   adal
-    #   azure-cosmosdb-table
-    #   azure-keyvault
+    #   azure-identity
+    #   azure-storage-blob
     #   azure-storage-common
     #   moto
+    #   msal
     #   paramiko
+    #   pyjwt
     #   pyopenssl
     #   python-jose
     #   sshpubkeys
@@ -548,102 +309,30 @@ more-itertools==5.0.0
     #   zipp
 moto==1.3.16
     # via -r requirements/static/ci/common.in
+msal-extensions==0.3.0
+    # via azure-identity
+msal==1.12.0
+    # via
+    #   azure-identity
+    #   msal-extensions
 msgpack==1.0.2
     # via
     #   -r requirements/static/pkg/py3.7/freebsd.txt
     #   pytest-salt-factories
-msrest==0.6.19
-    # via
-    #   azure-applicationinsights
-    #   azure-eventgrid
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-cdn
-    #   azure-mgmt-compute
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-dns
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-media
-    #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-resource
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-servicefabric
-    #   msrestazure
-msrestazure==0.6.4
+msrest==0.6.21
     # via
     #   azure-batch
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
+    #   azure-storage-blob
+    #   msrestazure
+msrestazure==0.6.4
+    # via azure-batch
 napalm==3.1.0 ; sys_platform != "win32" and python_version > "3.6"
     # via -r requirements/static/ci/common.in
 ncclient==0.6.4
@@ -681,6 +370,8 @@ pathtools==0.1.2
     # via watchdog
 pluggy==0.13.0
     # via pytest
+portalocker==1.7.1
+    # via msal-extensions
 portend==2.4
     # via
     #   -r requirements/static/pkg/py3.7/freebsd.txt
@@ -712,8 +403,10 @@ pygit2==1.5.0 ; python_version >= "3.7"
     # via -r requirements/static/ci/freebsd.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==2.0.0
-    # via adal
+pyjwt[crypto]==2.0.0
+    # via
+    #   adal
+    #   msal
 pynacl==1.3.0
     # via paramiko
 pyopenssl==19.1.0
@@ -751,7 +444,6 @@ python-dateutil==2.8.1
     # via
     #   -r requirements/static/pkg/py3.7/freebsd.txt
     #   adal
-    #   azure-cosmosdb-table
     #   azure-storage-common
     #   botocore
     #   croniter
@@ -795,15 +487,13 @@ requests==2.25.1
     #   adal
     #   apache-libcloud
     #   aws-xray-sdk
-    #   azure-cosmosdb-table
-    #   azure-datalake-store
-    #   azure-keyvault
-    #   azure-servicebus
+    #   azure-core
     #   azure-servicemanagement-legacy
     #   azure-storage-common
     #   docker
     #   kubernetes
     #   moto
+    #   msal
     #   msrest
     #   napalm
     #   pyvmomi
@@ -831,6 +521,8 @@ six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.7/freebsd.txt
     #   aws-sam-translator
+    #   azure-core
+    #   azure-identity
     #   bcrypt
     #   cassandra-driver
     #   cfn-lint

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -7,9 +7,7 @@
 --extra-index-url https://cdn.githubraw.com/saltstack/vsphere-automation-sdk-python/master/lib/
 
 adal==1.2.3
-    # via
-    #   azure-datalake-store
-    #   msrestazure
+    # via msrestazure
 apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 appdirs==1.4.4
@@ -29,308 +27,65 @@ aws-sam-translator==1.33.0
     # via cfn-lint
 aws-xray-sdk==0.95
     # via moto
-azure-applicationinsights==0.1.0
-    # via azure
-azure-batch==4.1.3
-    # via azure
-azure-common==1.1.18
+azure-batch==10.0.0
+    # via -r requirements/static/ci/common.in
+azure-common==1.1.27
     # via
-    #   azure-applicationinsights
+    #   -r requirements/static/ci/common.in
     #   azure-batch
-    #   azure-cosmosdb-table
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-    #   azure-servicebus
-    #   azure-servicefabric
     #   azure-servicemanagement-legacy
-    #   azure-storage-blob
     #   azure-storage-common
     #   azure-storage-file
-    #   azure-storage-queue
-azure-cosmosdb-nspkg==2.0.2
-    # via azure-cosmosdb-table
-azure-cosmosdb-table==1.0.5
-    # via azure
-azure-datalake-store==0.0.44
-    # via azure
-azure-eventgrid==1.2.0
-    # via azure
-azure-graphrbac==0.40.0
-    # via azure
-azure-keyvault==1.1.0
-    # via azure
-azure-loganalytics==0.1.0
-    # via azure
-azure-mgmt-advisor==1.0.1
-    # via azure-mgmt
-azure-mgmt-applicationinsights==0.1.1
-    # via azure-mgmt
-azure-mgmt-authorization==0.50.0
-    # via azure-mgmt
-azure-mgmt-batch==5.0.1
-    # via azure-mgmt
-azure-mgmt-batchai==2.0.0
-    # via azure-mgmt
-azure-mgmt-billing==0.2.0
-    # via azure-mgmt
-azure-mgmt-cdn==3.1.0
-    # via azure-mgmt
-azure-mgmt-cognitiveservices==3.0.0
-    # via azure-mgmt
-azure-mgmt-commerce==1.0.1
-    # via azure-mgmt
-azure-mgmt-compute==4.6.0
-    # via azure-mgmt
-azure-mgmt-consumption==2.0.0
-    # via azure-mgmt
-azure-mgmt-containerinstance==1.4.1
-    # via azure-mgmt
-azure-mgmt-containerregistry==2.7.0
-    # via azure-mgmt
-azure-mgmt-containerservice==4.4.0
-    # via azure-mgmt
-azure-mgmt-cosmosdb==0.4.1
-    # via azure-mgmt
-azure-mgmt-datafactory==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-analytics==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-nspkg==3.0.1
+azure-core==1.15.0
     # via
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-azure-mgmt-datalake-store==0.5.0
-    # via azure-mgmt
-azure-mgmt-datamigration==1.0.0
-    # via azure-mgmt
-azure-mgmt-devspaces==0.1.0
-    # via azure-mgmt
-azure-mgmt-devtestlabs==2.2.0
-    # via azure-mgmt
-azure-mgmt-dns==2.1.0
-    # via azure-mgmt
-azure-mgmt-eventgrid==1.0.0
-    # via azure-mgmt
-azure-mgmt-eventhub==2.5.0
-    # via azure-mgmt
-azure-mgmt-hanaonazure==0.1.1
-    # via azure-mgmt
-azure-mgmt-iotcentral==0.1.0
-    # via azure-mgmt
-azure-mgmt-iothub==0.5.0
-    # via azure-mgmt
-azure-mgmt-iothubprovisioningservices==0.2.0
-    # via azure-mgmt
-azure-mgmt-keyvault==1.1.0
-    # via azure-mgmt
-azure-mgmt-loganalytics==0.2.0
-    # via azure-mgmt
-azure-mgmt-logic==3.0.0
-    # via azure-mgmt
-azure-mgmt-machinelearningcompute==0.4.1
-    # via azure-mgmt
-azure-mgmt-managementgroups==0.1.0
-    # via azure-mgmt
-azure-mgmt-managementpartner==0.1.0
-    # via azure-mgmt
-azure-mgmt-maps==0.1.0
-    # via azure-mgmt
-azure-mgmt-marketplaceordering==0.1.0
-    # via azure-mgmt
-azure-mgmt-media==1.0.0
-    # via azure-mgmt
-azure-mgmt-monitor==0.5.2
-    # via azure-mgmt
-azure-mgmt-msi==0.2.0
-    # via azure-mgmt
-azure-mgmt-network==2.6.0
-    # via azure-mgmt
-azure-mgmt-notificationhubs==2.0.0
-    # via azure-mgmt
-azure-mgmt-nspkg==3.0.2
+    #   -r requirements/static/ci/common.in
+    #   azure-identity
+    #   azure-mgmt-core
+    #   azure-storage-blob
+azure-identity==1.6.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-compute==21.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-core==1.2.2
     # via
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
-    #   azure-mgmt-consumption
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-nspkg
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
+    #   -r requirements/static/ci/common.in
+    #   azure-mgmt-compute
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
+    #   azure-mgmt-network
+    #   azure-mgmt-resource
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-azure-mgmt-policyinsights==0.1.0
-    # via azure-mgmt
-azure-mgmt-powerbiembedded==2.0.0
-    # via azure-mgmt
-azure-mgmt-rdbms==1.8.0
-    # via azure-mgmt
-azure-mgmt-recoveryservices==0.3.0
-    # via azure-mgmt
-azure-mgmt-recoveryservicesbackup==0.3.0
-    # via azure-mgmt
-azure-mgmt-redis==5.0.0
-    # via azure-mgmt
-azure-mgmt-relay==0.1.0
-    # via azure-mgmt
-azure-mgmt-reservations==0.2.1
-    # via azure-mgmt
-azure-mgmt-resource==2.1.0
-    # via azure-mgmt
-azure-mgmt-scheduler==2.0.0
-    # via azure-mgmt
-azure-mgmt-search==2.0.0
-    # via azure-mgmt
-azure-mgmt-servicebus==0.5.3
-    # via azure-mgmt
-azure-mgmt-servicefabric==0.2.0
-    # via azure-mgmt
-azure-mgmt-signalr==0.1.1
-    # via azure-mgmt
-azure-mgmt-sql==0.9.1
-    # via azure-mgmt
-azure-mgmt-storage==2.0.0
-    # via azure-mgmt
-azure-mgmt-subscription==0.2.0
-    # via azure-mgmt
-azure-mgmt-trafficmanager==0.50.0
-    # via azure-mgmt
-azure-mgmt-web==0.35.0
-    # via azure-mgmt
-azure-mgmt==4.0.0
-    # via azure
+azure-mgmt-dns==8.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-network==19.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-resource==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-storage==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-subscription==1.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-web==3.0.0
+    # via -r requirements/static/ci/common.in
 azure-nspkg==3.0.2
+    # via azure-servicemanagement-legacy
+azure-servicemanagement-legacy==0.20.7
+    # via -r requirements/static/ci/common.in
+azure-storage-blob==12.8.1
+    # via -r requirements/static/ci/common.in
+azure-storage-common==2.1.0
     # via
-    #   azure-applicationinsights
-    #   azure-batch
-    #   azure-cosmosdb-nspkg
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-nspkg
-    #   azure-servicebus
-    #   azure-servicefabric
-    #   azure-servicemanagement-legacy
-azure-servicebus==0.21.1
-    # via azure
-azure-servicefabric==6.3.0.0
-    # via azure
-azure-servicemanagement-legacy==0.20.6
-    # via azure
-azure-storage-blob==1.5.0
-    # via azure
-azure-storage-common==1.4.0
-    # via
-    #   azure-cosmosdb-table
-    #   azure-storage-blob
+    #   -r requirements/static/ci/common.in
     #   azure-storage-file
-    #   azure-storage-queue
-azure-storage-file==1.4.0
-    # via azure
-azure-storage-queue==1.4.0
-    # via azure
-azure==4.0.0 ; sys_platform != "win32"
+azure-storage-file==2.1.0
     # via -r requirements/static/ci/common.in
 backports.functools-lru-cache==1.5
     # via
@@ -369,7 +124,6 @@ cffi==1.14.4
     # via
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/py3.7/linux.txt
-    #   azure-datalake-store
     #   bcrypt
     #   cryptography
     #   napalm
@@ -411,11 +165,13 @@ cryptography==3.3.2
     # via
     #   -r requirements/static/pkg/py3.7/linux.txt
     #   adal
-    #   azure-cosmosdb-table
-    #   azure-keyvault
+    #   azure-identity
+    #   azure-storage-blob
     #   azure-storage-common
     #   moto
+    #   msal
     #   paramiko
+    #   pyjwt
     #   pyopenssl
     #   python-jose
     #   sshpubkeys
@@ -554,99 +310,30 @@ more-itertools==5.0.0
     #   zipp
 moto==1.3.16
     # via -r requirements/static/ci/common.in
+msal-extensions==0.3.0
+    # via azure-identity
+msal==1.12.0
+    # via
+    #   azure-identity
+    #   msal-extensions
 msgpack==1.0.2
     # via
     #   -r requirements/static/pkg/py3.7/linux.txt
     #   pytest-salt-factories
-msrest==0.6.14
-    # via
-    #   azure-applicationinsights
-    #   azure-eventgrid
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-cdn
-    #   azure-mgmt-compute
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-dns
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-media
-    #   azure-mgmt-network
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-resource
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-servicefabric
-    #   msrestazure
-msrestazure==0.6.3
+msrest==0.6.21
     # via
     #   azure-batch
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
+    #   azure-storage-blob
+    #   msrestazure
+msrestazure==0.6.3
+    # via azure-batch
 napalm==3.1.0 ; sys_platform != "win32" and python_version > "3.6"
     # via -r requirements/static/ci/common.in
 ncclient==0.6.4
@@ -692,6 +379,8 @@ pathtools==0.1.2
     # via watchdog
 pluggy==0.13.0
     # via pytest
+portalocker==1.7.1
+    # via msal-extensions
 portend==2.4
     # via
     #   -r requirements/static/pkg/py3.7/linux.txt
@@ -725,8 +414,10 @@ pyiface==0.0.11
     # via -r requirements/static/ci/linux.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==1.7.1
-    # via adal
+pyjwt[crypto]==1.7.1
+    # via
+    #   adal
+    #   msal
 pynacl==1.3.0
     # via paramiko
 pyopenssl==19.1.0
@@ -766,7 +457,6 @@ python-dateutil==2.8.1
     # via
     #   -r requirements/static/pkg/py3.7/linux.txt
     #   adal
-    #   azure-cosmosdb-table
     #   azure-storage-common
     #   botocore
     #   croniter
@@ -812,15 +502,13 @@ requests==2.25.1
     #   adal
     #   apache-libcloud
     #   aws-xray-sdk
-    #   azure-cosmosdb-table
-    #   azure-datalake-store
-    #   azure-keyvault
-    #   azure-servicebus
+    #   azure-core
     #   azure-servicemanagement-legacy
     #   azure-storage-common
     #   docker
     #   kubernetes
     #   moto
+    #   msal
     #   msrest
     #   napalm
     #   pyvmomi
@@ -849,6 +537,8 @@ six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.7/linux.txt
     #   aws-sam-translator
+    #   azure-core
+    #   azure-identity
     #   bcrypt
     #   cassandra-driver
     #   cfn-lint

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile --output-file=requirements/static/ci/py3.7/windows.txt requirements/pytest.txt requirements/static/ci/common.in requirements/static/ci/windows.in requirements/static/pkg/py3.7/windows.txt
 #
+adal==1.2.7
+    # via msrestazure
 appdirs==1.4.4
     # via virtualenv
 atomicwrites==1.3.0
@@ -17,6 +19,66 @@ aws-sam-translator==1.33.0
     # via cfn-lint
 aws-xray-sdk==0.95
     # via moto
+azure-batch==10.0.0
+    # via -r requirements/static/ci/common.in
+azure-common==1.1.27
+    # via
+    #   -r requirements/static/ci/common.in
+    #   azure-batch
+    #   azure-mgmt-compute
+    #   azure-mgmt-dns
+    #   azure-mgmt-network
+    #   azure-mgmt-resource
+    #   azure-mgmt-storage
+    #   azure-mgmt-subscription
+    #   azure-mgmt-web
+    #   azure-servicemanagement-legacy
+    #   azure-storage-common
+    #   azure-storage-file
+azure-core==1.15.0
+    # via
+    #   -r requirements/static/ci/common.in
+    #   azure-identity
+    #   azure-mgmt-core
+    #   azure-storage-blob
+azure-identity==1.6.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-compute==21.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-core==1.2.2
+    # via
+    #   -r requirements/static/ci/common.in
+    #   azure-mgmt-compute
+    #   azure-mgmt-dns
+    #   azure-mgmt-network
+    #   azure-mgmt-resource
+    #   azure-mgmt-storage
+    #   azure-mgmt-subscription
+    #   azure-mgmt-web
+azure-mgmt-dns==8.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-network==19.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-resource==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-storage==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-subscription==1.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-web==3.0.0
+    # via -r requirements/static/ci/common.in
+azure-nspkg==3.0.2
+    # via azure-servicemanagement-legacy
+azure-servicemanagement-legacy==0.20.7
+    # via -r requirements/static/ci/common.in
+azure-storage-blob==12.8.1
+    # via -r requirements/static/ci/common.in
+azure-storage-common==2.1.0
+    # via
+    #   -r requirements/static/ci/common.in
+    #   azure-storage-file
+azure-storage-file==2.1.0
+    # via -r requirements/static/ci/common.in
 boto3==1.17.67 ; python_version >= "3.6"
     # via
     #   -r requirements/static/ci/common.in
@@ -42,6 +104,7 @@ certifi==2020.12.5
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/py3.7/windows.txt
     #   kubernetes
+    #   msrest
     #   requests
 cffi==1.14.5
     # via
@@ -76,7 +139,13 @@ contextvars==2.4
 cryptography==3.4.6
     # via
     #   -r requirements/static/pkg/py3.7/windows.txt
+    #   adal
+    #   azure-identity
+    #   azure-storage-blob
+    #   azure-storage-common
     #   moto
+    #   msal
+    #   pyjwt
     #   pyopenssl
     #   python-jose
     #   requests-ntlm
@@ -144,6 +213,8 @@ ioloop==0.1a0
     # via -r requirements/static/pkg/py3.7/windows.txt
 ipaddress==1.0.22
     # via kubernetes
+isodate==0.6.0
+    # via msrest
 jaraco.classes==3.2.1
     # via
     #   -r requirements/static/pkg/py3.7/windows.txt
@@ -219,14 +290,36 @@ more-itertools==8.2.0
     #   zipp
 moto==1.3.16
     # via -r requirements/static/ci/common.in
+msal-extensions==0.3.0
+    # via azure-identity
+msal==1.12.0
+    # via
+    #   azure-identity
+    #   msal-extensions
 msgpack==1.0.2
     # via
     #   -r requirements/static/pkg/py3.7/windows.txt
     #   pytest-salt-factories
+msrest==0.6.21
+    # via
+    #   azure-batch
+    #   azure-mgmt-compute
+    #   azure-mgmt-dns
+    #   azure-mgmt-network
+    #   azure-mgmt-resource
+    #   azure-mgmt-storage
+    #   azure-mgmt-subscription
+    #   azure-mgmt-web
+    #   azure-storage-blob
+    #   msrestazure
+msrestazure==0.6.4
+    # via azure-batch
 networkx==2.5
     # via cfn-lint
 ntlm-auth==1.5.0
     # via requests-ntlm
+oauthlib==3.1.1
+    # via requests-oauthlib
 packaging==19.2
     # via pytest
 patch==1.16
@@ -235,6 +328,8 @@ pathtools==0.1.2
     # via watchdog
 pluggy==0.13.0
     # via pytest
+portalocker==1.7.1
+    # via msal-extensions
 portend==2.6
     # via
     #   -r requirements/static/pkg/py3.7/windows.txt
@@ -266,6 +361,10 @@ pycurl==7.43.0.5
     #   -r requirements/static/pkg/py3.7/windows.txt
 pygit2==1.5.0 ; python_version >= "3.7"
     # via -r requirements/static/ci/windows.in
+pyjwt[crypto]==2.1.0
+    # via
+    #   adal
+    #   msal
 pymssql==2.1.5 ; python_version < "3.8"
     # via -r requirements/static/pkg/py3.7/windows.txt
 pymysql==1.0.2
@@ -298,6 +397,8 @@ pytest==6.1.2
 python-dateutil==2.8.1
     # via
     #   -r requirements/static/pkg/py3.7/windows.txt
+    #   adal
+    #   azure-storage-common
     #   botocore
     #   kubernetes
     #   moto
@@ -320,6 +421,7 @@ pywin32==300
     # via
     #   -r requirements/static/pkg/py3.7/windows.txt
     #   cherrypy
+    #   portalocker
     #   wmi
 pywinrm==0.4.1
     # via -r requirements/static/ci/windows.in
@@ -336,17 +438,26 @@ pyzmq==18.0.1 ; python_version < "3.9"
     #   pytest-salt-factories
 requests-ntlm==1.1.0
     # via pywinrm
+requests-oauthlib==1.3.0
+    # via msrest
 requests==2.25.1
     # via
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/py3.7/windows.txt
+    #   adal
     #   aws-xray-sdk
+    #   azure-core
+    #   azure-servicemanagement-legacy
+    #   azure-storage-common
     #   docker
     #   kubernetes
     #   moto
+    #   msal
+    #   msrest
     #   pyvmomi
     #   pywinrm
     #   requests-ntlm
+    #   requests-oauthlib
     #   responses
 responses==0.10.6
     # via moto
@@ -366,6 +477,8 @@ six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.7/windows.txt
     #   aws-sam-translator
+    #   azure-core
+    #   azure-identity
     #   cassandra-driver
     #   cfn-lint
     #   cheroot
@@ -374,11 +487,13 @@ six==1.16.0
     #   ecdsa
     #   geomet
     #   google-auth
+    #   isodate
     #   jsonschema
     #   junit-xml
     #   kubernetes
     #   mock
     #   moto
+    #   msrestazure
     #   packaging
     #   pyopenssl
     #   python-dateutil

--- a/requirements/static/ci/py3.8/darwin.txt
+++ b/requirements/static/ci/py3.8/darwin.txt
@@ -5,9 +5,7 @@
 #    pip-compile --output-file=requirements/static/ci/py3.8/darwin.txt requirements/pytest.txt requirements/static/ci/common.in requirements/static/ci/darwin.in requirements/static/pkg/py3.8/darwin.txt
 #
 adal==1.2.5
-    # via
-    #   azure-datalake-store
-    #   msrestazure
+    # via msrestazure
 apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via
     #   -r requirements/static/ci/common.in
@@ -29,303 +27,65 @@ aws-sam-translator==1.33.0
     # via cfn-lint
 aws-xray-sdk==0.95
     # via moto
-azure-applicationinsights==0.1.0
-    # via azure
-azure-batch==4.1.3
-    # via azure
-azure-common==1.1.26
+azure-batch==10.0.0
+    # via -r requirements/static/ci/common.in
+azure-common==1.1.27
     # via
-    #   azure-applicationinsights
+    #   -r requirements/static/ci/common.in
     #   azure-batch
-    #   azure-cosmosdb-table
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-    #   azure-servicebus
-    #   azure-servicefabric
     #   azure-servicemanagement-legacy
-    #   azure-storage-blob
     #   azure-storage-common
     #   azure-storage-file
-    #   azure-storage-queue
-azure-cosmosdb-nspkg==2.0.2
-    # via azure-cosmosdb-table
-azure-cosmosdb-table==1.0.6
-    # via azure
-azure-datalake-store==0.0.51
-    # via azure
-azure-eventgrid==1.3.0
-    # via azure
-azure-graphrbac==0.40.0
-    # via azure
-azure-keyvault==1.1.0
-    # via azure
-azure-loganalytics==0.1.0
-    # via azure
-azure-mgmt-advisor==1.0.1
-    # via azure-mgmt
-azure-mgmt-applicationinsights==0.1.1
-    # via azure-mgmt
-azure-mgmt-authorization==0.50.0
-    # via azure-mgmt
-azure-mgmt-batch==5.0.1
-    # via azure-mgmt
-azure-mgmt-batchai==2.0.0
-    # via azure-mgmt
-azure-mgmt-billing==0.2.0
-    # via azure-mgmt
-azure-mgmt-cdn==3.1.0
-    # via azure-mgmt
-azure-mgmt-cognitiveservices==3.0.0
-    # via azure-mgmt
-azure-mgmt-commerce==1.0.1
-    # via azure-mgmt
-azure-mgmt-compute==4.6.2
-    # via azure-mgmt
-azure-mgmt-consumption==2.0.0
-    # via azure-mgmt
-azure-mgmt-containerinstance==1.5.0
-    # via azure-mgmt
-azure-mgmt-containerregistry==2.8.0
-    # via azure-mgmt
-azure-mgmt-containerservice==4.4.0
-    # via azure-mgmt
-azure-mgmt-cosmosdb==0.4.1
-    # via azure-mgmt
-azure-mgmt-datafactory==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-analytics==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-nspkg==3.0.1
+azure-core==1.15.0
     # via
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-azure-mgmt-datalake-store==0.5.0
-    # via azure-mgmt
-azure-mgmt-datamigration==1.0.0
-    # via azure-mgmt
-azure-mgmt-devspaces==0.1.0
-    # via azure-mgmt
-azure-mgmt-devtestlabs==2.2.0
-    # via azure-mgmt
-azure-mgmt-dns==2.1.0
-    # via azure-mgmt
-azure-mgmt-eventgrid==1.0.0
-    # via azure-mgmt
-azure-mgmt-eventhub==2.6.0
-    # via azure-mgmt
-azure-mgmt-hanaonazure==0.1.1
-    # via azure-mgmt
-azure-mgmt-iotcentral==0.1.0
-    # via azure-mgmt
-azure-mgmt-iothub==0.5.0
-    # via azure-mgmt
-azure-mgmt-iothubprovisioningservices==0.2.0
-    # via azure-mgmt
-azure-mgmt-keyvault==1.1.0
-    # via azure-mgmt
-azure-mgmt-loganalytics==0.2.0
-    # via azure-mgmt
-azure-mgmt-logic==3.0.0
-    # via azure-mgmt
-azure-mgmt-machinelearningcompute==0.4.1
-    # via azure-mgmt
-azure-mgmt-managementgroups==0.1.0
-    # via azure-mgmt
-azure-mgmt-managementpartner==0.1.1
-    # via azure-mgmt
-azure-mgmt-maps==0.1.0
-    # via azure-mgmt
-azure-mgmt-marketplaceordering==0.1.0
-    # via azure-mgmt
-azure-mgmt-media==1.0.0
-    # via azure-mgmt
-azure-mgmt-monitor==0.5.2
-    # via azure-mgmt
-azure-mgmt-msi==0.2.0
-    # via azure-mgmt
-azure-mgmt-network==2.7.0
-    # via azure-mgmt
-azure-mgmt-notificationhubs==2.1.0
-    # via azure-mgmt
-azure-mgmt-nspkg==3.0.2
+    #   -r requirements/static/ci/common.in
+    #   azure-identity
+    #   azure-mgmt-core
+    #   azure-storage-blob
+azure-identity==1.6.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-compute==21.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-core==1.2.2
     # via
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
-    #   azure-mgmt-consumption
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-nspkg
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
+    #   -r requirements/static/ci/common.in
+    #   azure-mgmt-compute
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
+    #   azure-mgmt-network
+    #   azure-mgmt-resource
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-azure-mgmt-policyinsights==0.1.0
-    # via azure-mgmt
-azure-mgmt-powerbiembedded==2.0.0
-    # via azure-mgmt
-azure-mgmt-rdbms==1.9.0
-    # via azure-mgmt
-azure-mgmt-recoveryservices==0.3.0
-    # via azure-mgmt
-azure-mgmt-recoveryservicesbackup==0.3.0
-    # via azure-mgmt
-azure-mgmt-redis==5.0.0
-    # via azure-mgmt
-azure-mgmt-relay==0.1.0
-    # via azure-mgmt
-azure-mgmt-reservations==0.2.1
-    # via azure-mgmt
-azure-mgmt-resource==2.2.0
-    # via azure-mgmt
-azure-mgmt-scheduler==2.0.0
-    # via azure-mgmt
-azure-mgmt-search==2.1.0
-    # via azure-mgmt
-azure-mgmt-servicebus==0.5.3
-    # via azure-mgmt
-azure-mgmt-servicefabric==0.2.0
-    # via azure-mgmt
-azure-mgmt-signalr==0.1.1
-    # via azure-mgmt
-azure-mgmt-sql==0.9.1
-    # via azure-mgmt
-azure-mgmt-storage==2.0.0
-    # via azure-mgmt
-azure-mgmt-subscription==0.2.0
-    # via azure-mgmt
-azure-mgmt-trafficmanager==0.50.0
-    # via azure-mgmt
-azure-mgmt-web==0.35.0
-    # via azure-mgmt
-azure-mgmt==4.0.0
-    # via azure
+azure-mgmt-dns==8.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-network==19.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-resource==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-storage==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-subscription==1.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-web==3.0.0
+    # via -r requirements/static/ci/common.in
 azure-nspkg==3.0.2
-    # via
-    #   azure-applicationinsights
-    #   azure-batch
-    #   azure-cosmosdb-nspkg
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-nspkg
-    #   azure-servicebus
-    #   azure-servicefabric
-    #   azure-servicemanagement-legacy
-azure-servicebus==0.21.1
-    # via azure
-azure-servicefabric==6.3.0.0
-    # via azure
+    # via azure-servicemanagement-legacy
 azure-servicemanagement-legacy==0.20.7
-    # via azure
-azure-storage-blob==1.5.0
-    # via azure
-azure-storage-common==1.4.2
+    # via -r requirements/static/ci/common.in
+azure-storage-blob==12.8.1
+    # via -r requirements/static/ci/common.in
+azure-storage-common==2.1.0
     # via
-    #   azure-storage-blob
+    #   -r requirements/static/ci/common.in
     #   azure-storage-file
-    #   azure-storage-queue
-azure-storage-file==1.4.0
-    # via azure
-azure-storage-queue==1.4.0
-    # via azure
-azure==4.0.0 ; sys_platform != "win32"
+azure-storage-file==2.1.0
     # via -r requirements/static/ci/common.in
 bcrypt==3.1.6
     # via paramiko
@@ -362,7 +122,6 @@ cffi==1.12.2
     # via
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/py3.8/darwin.txt
-    #   azure-datalake-store
     #   bcrypt
     #   cryptography
     #   napalm
@@ -404,11 +163,13 @@ cryptography==3.3.2
     # via
     #   -r requirements/static/pkg/py3.8/darwin.txt
     #   adal
-    #   azure-cosmosdb-table
-    #   azure-keyvault
+    #   azure-identity
+    #   azure-storage-blob
     #   azure-storage-common
     #   moto
+    #   msal
     #   paramiko
+    #   pyjwt
     #   pyopenssl
     #   python-jose
     #   sshpubkeys
@@ -543,102 +304,30 @@ more-itertools==8.2.0
     #   moto
 moto==1.3.16
     # via -r requirements/static/ci/common.in
+msal-extensions==0.3.0
+    # via azure-identity
+msal==1.12.0
+    # via
+    #   azure-identity
+    #   msal-extensions
 msgpack==1.0.2
     # via
     #   -r requirements/static/pkg/py3.8/darwin.txt
     #   pytest-salt-factories
-msrest==0.6.19
-    # via
-    #   azure-applicationinsights
-    #   azure-eventgrid
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-cdn
-    #   azure-mgmt-compute
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-dns
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-media
-    #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-resource
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-servicefabric
-    #   msrestazure
-msrestazure==0.6.4
+msrest==0.6.21
     # via
     #   azure-batch
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
+    #   azure-storage-blob
+    #   msrestazure
+msrestazure==0.6.4
+    # via azure-batch
 napalm==3.1.0 ; sys_platform != "win32" and python_version > "3.6"
     # via -r requirements/static/ci/common.in
 ncclient==0.6.4
@@ -675,6 +364,8 @@ pathtools==0.1.2
     # via watchdog
 pluggy==0.13.1
     # via pytest
+portalocker==1.7.1
+    # via msal-extensions
 portend==2.6
     # via
     #   -r requirements/static/pkg/py3.8/darwin.txt
@@ -705,8 +396,10 @@ pyeapi==0.8.3
     # via napalm
 pygit2==1.5.0 ; python_version >= "3.7"
     # via -r requirements/static/ci/darwin.in
-pyjwt==2.0.0
-    # via adal
+pyjwt[crypto]==2.0.0
+    # via
+    #   adal
+    #   msal
 pynacl==1.3.0
     # via paramiko
 pyopenssl==19.0.0
@@ -744,7 +437,6 @@ python-dateutil==2.8.0
     # via
     #   -r requirements/static/pkg/py3.8/darwin.txt
     #   adal
-    #   azure-cosmosdb-table
     #   azure-storage-common
     #   botocore
     #   croniter
@@ -788,15 +480,13 @@ requests==2.25.1
     #   adal
     #   apache-libcloud
     #   aws-xray-sdk
-    #   azure-cosmosdb-table
-    #   azure-datalake-store
-    #   azure-keyvault
-    #   azure-servicebus
+    #   azure-core
     #   azure-servicemanagement-legacy
     #   azure-storage-common
     #   docker
     #   kubernetes
     #   moto
+    #   msal
     #   msrest
     #   napalm
     #   pyvmomi
@@ -825,6 +515,8 @@ six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.8/darwin.txt
     #   aws-sam-translator
+    #   azure-core
+    #   azure-identity
     #   bcrypt
     #   cassandra-driver
     #   cfn-lint

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -5,9 +5,7 @@
 #    pip-compile --output-file=requirements/static/ci/py3.8/freebsd.txt requirements/pytest.txt requirements/static/ci/common.in requirements/static/ci/freebsd.in requirements/static/pkg/py3.8/freebsd.txt
 #
 adal==1.2.5
-    # via
-    #   azure-datalake-store
-    #   msrestazure
+    # via msrestazure
 apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 appdirs==1.4.4
@@ -27,303 +25,65 @@ aws-sam-translator==1.33.0
     # via cfn-lint
 aws-xray-sdk==0.95
     # via moto
-azure-applicationinsights==0.1.0
-    # via azure
-azure-batch==4.1.3
-    # via azure
-azure-common==1.1.26
+azure-batch==10.0.0
+    # via -r requirements/static/ci/common.in
+azure-common==1.1.27
     # via
-    #   azure-applicationinsights
+    #   -r requirements/static/ci/common.in
     #   azure-batch
-    #   azure-cosmosdb-table
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-    #   azure-servicebus
-    #   azure-servicefabric
     #   azure-servicemanagement-legacy
-    #   azure-storage-blob
     #   azure-storage-common
     #   azure-storage-file
-    #   azure-storage-queue
-azure-cosmosdb-nspkg==2.0.2
-    # via azure-cosmosdb-table
-azure-cosmosdb-table==1.0.6
-    # via azure
-azure-datalake-store==0.0.51
-    # via azure
-azure-eventgrid==1.3.0
-    # via azure
-azure-graphrbac==0.40.0
-    # via azure
-azure-keyvault==1.1.0
-    # via azure
-azure-loganalytics==0.1.0
-    # via azure
-azure-mgmt-advisor==1.0.1
-    # via azure-mgmt
-azure-mgmt-applicationinsights==0.1.1
-    # via azure-mgmt
-azure-mgmt-authorization==0.50.0
-    # via azure-mgmt
-azure-mgmt-batch==5.0.1
-    # via azure-mgmt
-azure-mgmt-batchai==2.0.0
-    # via azure-mgmt
-azure-mgmt-billing==0.2.0
-    # via azure-mgmt
-azure-mgmt-cdn==3.1.0
-    # via azure-mgmt
-azure-mgmt-cognitiveservices==3.0.0
-    # via azure-mgmt
-azure-mgmt-commerce==1.0.1
-    # via azure-mgmt
-azure-mgmt-compute==4.6.2
-    # via azure-mgmt
-azure-mgmt-consumption==2.0.0
-    # via azure-mgmt
-azure-mgmt-containerinstance==1.5.0
-    # via azure-mgmt
-azure-mgmt-containerregistry==2.8.0
-    # via azure-mgmt
-azure-mgmt-containerservice==4.4.0
-    # via azure-mgmt
-azure-mgmt-cosmosdb==0.4.1
-    # via azure-mgmt
-azure-mgmt-datafactory==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-analytics==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-nspkg==3.0.1
+azure-core==1.15.0
     # via
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-azure-mgmt-datalake-store==0.5.0
-    # via azure-mgmt
-azure-mgmt-datamigration==1.0.0
-    # via azure-mgmt
-azure-mgmt-devspaces==0.1.0
-    # via azure-mgmt
-azure-mgmt-devtestlabs==2.2.0
-    # via azure-mgmt
-azure-mgmt-dns==2.1.0
-    # via azure-mgmt
-azure-mgmt-eventgrid==1.0.0
-    # via azure-mgmt
-azure-mgmt-eventhub==2.6.0
-    # via azure-mgmt
-azure-mgmt-hanaonazure==0.1.1
-    # via azure-mgmt
-azure-mgmt-iotcentral==0.1.0
-    # via azure-mgmt
-azure-mgmt-iothub==0.5.0
-    # via azure-mgmt
-azure-mgmt-iothubprovisioningservices==0.2.0
-    # via azure-mgmt
-azure-mgmt-keyvault==1.1.0
-    # via azure-mgmt
-azure-mgmt-loganalytics==0.2.0
-    # via azure-mgmt
-azure-mgmt-logic==3.0.0
-    # via azure-mgmt
-azure-mgmt-machinelearningcompute==0.4.1
-    # via azure-mgmt
-azure-mgmt-managementgroups==0.1.0
-    # via azure-mgmt
-azure-mgmt-managementpartner==0.1.1
-    # via azure-mgmt
-azure-mgmt-maps==0.1.0
-    # via azure-mgmt
-azure-mgmt-marketplaceordering==0.1.0
-    # via azure-mgmt
-azure-mgmt-media==1.0.0
-    # via azure-mgmt
-azure-mgmt-monitor==0.5.2
-    # via azure-mgmt
-azure-mgmt-msi==0.2.0
-    # via azure-mgmt
-azure-mgmt-network==2.7.0
-    # via azure-mgmt
-azure-mgmt-notificationhubs==2.1.0
-    # via azure-mgmt
-azure-mgmt-nspkg==3.0.2
+    #   -r requirements/static/ci/common.in
+    #   azure-identity
+    #   azure-mgmt-core
+    #   azure-storage-blob
+azure-identity==1.6.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-compute==21.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-core==1.2.2
     # via
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
-    #   azure-mgmt-consumption
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-nspkg
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
+    #   -r requirements/static/ci/common.in
+    #   azure-mgmt-compute
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
+    #   azure-mgmt-network
+    #   azure-mgmt-resource
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-azure-mgmt-policyinsights==0.1.0
-    # via azure-mgmt
-azure-mgmt-powerbiembedded==2.0.0
-    # via azure-mgmt
-azure-mgmt-rdbms==1.9.0
-    # via azure-mgmt
-azure-mgmt-recoveryservices==0.3.0
-    # via azure-mgmt
-azure-mgmt-recoveryservicesbackup==0.3.0
-    # via azure-mgmt
-azure-mgmt-redis==5.0.0
-    # via azure-mgmt
-azure-mgmt-relay==0.1.0
-    # via azure-mgmt
-azure-mgmt-reservations==0.2.1
-    # via azure-mgmt
-azure-mgmt-resource==2.2.0
-    # via azure-mgmt
-azure-mgmt-scheduler==2.0.0
-    # via azure-mgmt
-azure-mgmt-search==2.1.0
-    # via azure-mgmt
-azure-mgmt-servicebus==0.5.3
-    # via azure-mgmt
-azure-mgmt-servicefabric==0.2.0
-    # via azure-mgmt
-azure-mgmt-signalr==0.1.1
-    # via azure-mgmt
-azure-mgmt-sql==0.9.1
-    # via azure-mgmt
-azure-mgmt-storage==2.0.0
-    # via azure-mgmt
-azure-mgmt-subscription==0.2.0
-    # via azure-mgmt
-azure-mgmt-trafficmanager==0.50.0
-    # via azure-mgmt
-azure-mgmt-web==0.35.0
-    # via azure-mgmt
-azure-mgmt==4.0.0
-    # via azure
+azure-mgmt-dns==8.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-network==19.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-resource==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-storage==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-subscription==1.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-web==3.0.0
+    # via -r requirements/static/ci/common.in
 azure-nspkg==3.0.2
-    # via
-    #   azure-applicationinsights
-    #   azure-batch
-    #   azure-cosmosdb-nspkg
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-nspkg
-    #   azure-servicebus
-    #   azure-servicefabric
-    #   azure-servicemanagement-legacy
-azure-servicebus==0.21.1
-    # via azure
-azure-servicefabric==6.3.0.0
-    # via azure
+    # via azure-servicemanagement-legacy
 azure-servicemanagement-legacy==0.20.7
-    # via azure
-azure-storage-blob==1.5.0
-    # via azure
-azure-storage-common==1.4.2
+    # via -r requirements/static/ci/common.in
+azure-storage-blob==12.8.1
+    # via -r requirements/static/ci/common.in
+azure-storage-common==2.1.0
     # via
-    #   azure-storage-blob
+    #   -r requirements/static/ci/common.in
     #   azure-storage-file
-    #   azure-storage-queue
-azure-storage-file==1.4.0
-    # via azure
-azure-storage-queue==1.4.0
-    # via azure
-azure==4.0.0 ; sys_platform != "win32"
+azure-storage-file==2.1.0
     # via -r requirements/static/ci/common.in
 backports.functools-lru-cache==1.5
     # via
@@ -364,7 +124,6 @@ cffi==1.14.4
     # via
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/py3.8/freebsd.txt
-    #   azure-datalake-store
     #   bcrypt
     #   cryptography
     #   napalm
@@ -406,11 +165,13 @@ cryptography==3.3.2
     # via
     #   -r requirements/static/pkg/py3.8/freebsd.txt
     #   adal
-    #   azure-cosmosdb-table
-    #   azure-keyvault
+    #   azure-identity
+    #   azure-storage-blob
     #   azure-storage-common
     #   moto
+    #   msal
     #   paramiko
+    #   pyjwt
     #   pyopenssl
     #   python-jose
     #   sshpubkeys
@@ -540,102 +301,30 @@ more-itertools==5.0.0
     #   moto
 moto==1.3.16
     # via -r requirements/static/ci/common.in
+msal-extensions==0.3.0
+    # via azure-identity
+msal==1.12.0
+    # via
+    #   azure-identity
+    #   msal-extensions
 msgpack==1.0.2
     # via
     #   -r requirements/static/pkg/py3.8/freebsd.txt
     #   pytest-salt-factories
-msrest==0.6.19
-    # via
-    #   azure-applicationinsights
-    #   azure-eventgrid
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-cdn
-    #   azure-mgmt-compute
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-dns
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-media
-    #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-resource
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-servicefabric
-    #   msrestazure
-msrestazure==0.6.4
+msrest==0.6.21
     # via
     #   azure-batch
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
+    #   azure-storage-blob
+    #   msrestazure
+msrestazure==0.6.4
+    # via azure-batch
 napalm==3.1.0 ; sys_platform != "win32" and python_version > "3.6"
     # via -r requirements/static/ci/common.in
 ncclient==0.6.4
@@ -673,6 +362,8 @@ pathtools==0.1.2
     # via watchdog
 pluggy==0.13.0
     # via pytest
+portalocker==1.7.1
+    # via msal-extensions
 portend==2.4
     # via
     #   -r requirements/static/pkg/py3.8/freebsd.txt
@@ -704,8 +395,10 @@ pygit2==1.5.0 ; python_version >= "3.7"
     # via -r requirements/static/ci/freebsd.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==2.0.0
-    # via adal
+pyjwt[crypto]==2.0.0
+    # via
+    #   adal
+    #   msal
 pynacl==1.3.0
     # via paramiko
 pyopenssl==19.1.0
@@ -743,7 +436,6 @@ python-dateutil==2.8.1
     # via
     #   -r requirements/static/pkg/py3.8/freebsd.txt
     #   adal
-    #   azure-cosmosdb-table
     #   azure-storage-common
     #   botocore
     #   croniter
@@ -787,15 +479,13 @@ requests==2.25.1
     #   adal
     #   apache-libcloud
     #   aws-xray-sdk
-    #   azure-cosmosdb-table
-    #   azure-datalake-store
-    #   azure-keyvault
-    #   azure-servicebus
+    #   azure-core
     #   azure-servicemanagement-legacy
     #   azure-storage-common
     #   docker
     #   kubernetes
     #   moto
+    #   msal
     #   msrest
     #   napalm
     #   pyvmomi
@@ -823,6 +513,8 @@ six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.8/freebsd.txt
     #   aws-sam-translator
+    #   azure-core
+    #   azure-identity
     #   bcrypt
     #   cassandra-driver
     #   cfn-lint

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -7,9 +7,7 @@
 --extra-index-url https://cdn.githubraw.com/saltstack/vsphere-automation-sdk-python/master/lib/
 
 adal==1.2.3
-    # via
-    #   azure-datalake-store
-    #   msrestazure
+    # via msrestazure
 apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 appdirs==1.4.4
@@ -29,308 +27,65 @@ aws-sam-translator==1.33.0
     # via cfn-lint
 aws-xray-sdk==0.95
     # via moto
-azure-applicationinsights==0.1.0
-    # via azure
-azure-batch==4.1.3
-    # via azure
-azure-common==1.1.18
+azure-batch==10.0.0
+    # via -r requirements/static/ci/common.in
+azure-common==1.1.27
     # via
-    #   azure-applicationinsights
+    #   -r requirements/static/ci/common.in
     #   azure-batch
-    #   azure-cosmosdb-table
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-    #   azure-servicebus
-    #   azure-servicefabric
     #   azure-servicemanagement-legacy
-    #   azure-storage-blob
     #   azure-storage-common
     #   azure-storage-file
-    #   azure-storage-queue
-azure-cosmosdb-nspkg==2.0.2
-    # via azure-cosmosdb-table
-azure-cosmosdb-table==1.0.5
-    # via azure
-azure-datalake-store==0.0.44
-    # via azure
-azure-eventgrid==1.2.0
-    # via azure
-azure-graphrbac==0.40.0
-    # via azure
-azure-keyvault==1.1.0
-    # via azure
-azure-loganalytics==0.1.0
-    # via azure
-azure-mgmt-advisor==1.0.1
-    # via azure-mgmt
-azure-mgmt-applicationinsights==0.1.1
-    # via azure-mgmt
-azure-mgmt-authorization==0.50.0
-    # via azure-mgmt
-azure-mgmt-batch==5.0.1
-    # via azure-mgmt
-azure-mgmt-batchai==2.0.0
-    # via azure-mgmt
-azure-mgmt-billing==0.2.0
-    # via azure-mgmt
-azure-mgmt-cdn==3.1.0
-    # via azure-mgmt
-azure-mgmt-cognitiveservices==3.0.0
-    # via azure-mgmt
-azure-mgmt-commerce==1.0.1
-    # via azure-mgmt
-azure-mgmt-compute==4.6.0
-    # via azure-mgmt
-azure-mgmt-consumption==2.0.0
-    # via azure-mgmt
-azure-mgmt-containerinstance==1.4.1
-    # via azure-mgmt
-azure-mgmt-containerregistry==2.7.0
-    # via azure-mgmt
-azure-mgmt-containerservice==4.4.0
-    # via azure-mgmt
-azure-mgmt-cosmosdb==0.4.1
-    # via azure-mgmt
-azure-mgmt-datafactory==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-analytics==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-nspkg==3.0.1
+azure-core==1.15.0
     # via
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-azure-mgmt-datalake-store==0.5.0
-    # via azure-mgmt
-azure-mgmt-datamigration==1.0.0
-    # via azure-mgmt
-azure-mgmt-devspaces==0.1.0
-    # via azure-mgmt
-azure-mgmt-devtestlabs==2.2.0
-    # via azure-mgmt
-azure-mgmt-dns==2.1.0
-    # via azure-mgmt
-azure-mgmt-eventgrid==1.0.0
-    # via azure-mgmt
-azure-mgmt-eventhub==2.5.0
-    # via azure-mgmt
-azure-mgmt-hanaonazure==0.1.1
-    # via azure-mgmt
-azure-mgmt-iotcentral==0.1.0
-    # via azure-mgmt
-azure-mgmt-iothub==0.5.0
-    # via azure-mgmt
-azure-mgmt-iothubprovisioningservices==0.2.0
-    # via azure-mgmt
-azure-mgmt-keyvault==1.1.0
-    # via azure-mgmt
-azure-mgmt-loganalytics==0.2.0
-    # via azure-mgmt
-azure-mgmt-logic==3.0.0
-    # via azure-mgmt
-azure-mgmt-machinelearningcompute==0.4.1
-    # via azure-mgmt
-azure-mgmt-managementgroups==0.1.0
-    # via azure-mgmt
-azure-mgmt-managementpartner==0.1.0
-    # via azure-mgmt
-azure-mgmt-maps==0.1.0
-    # via azure-mgmt
-azure-mgmt-marketplaceordering==0.1.0
-    # via azure-mgmt
-azure-mgmt-media==1.0.0
-    # via azure-mgmt
-azure-mgmt-monitor==0.5.2
-    # via azure-mgmt
-azure-mgmt-msi==0.2.0
-    # via azure-mgmt
-azure-mgmt-network==2.6.0
-    # via azure-mgmt
-azure-mgmt-notificationhubs==2.0.0
-    # via azure-mgmt
-azure-mgmt-nspkg==3.0.2
+    #   -r requirements/static/ci/common.in
+    #   azure-identity
+    #   azure-mgmt-core
+    #   azure-storage-blob
+azure-identity==1.6.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-compute==21.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-core==1.2.2
     # via
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
-    #   azure-mgmt-consumption
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-nspkg
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
+    #   -r requirements/static/ci/common.in
+    #   azure-mgmt-compute
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
+    #   azure-mgmt-network
+    #   azure-mgmt-resource
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-azure-mgmt-policyinsights==0.1.0
-    # via azure-mgmt
-azure-mgmt-powerbiembedded==2.0.0
-    # via azure-mgmt
-azure-mgmt-rdbms==1.8.0
-    # via azure-mgmt
-azure-mgmt-recoveryservices==0.3.0
-    # via azure-mgmt
-azure-mgmt-recoveryservicesbackup==0.3.0
-    # via azure-mgmt
-azure-mgmt-redis==5.0.0
-    # via azure-mgmt
-azure-mgmt-relay==0.1.0
-    # via azure-mgmt
-azure-mgmt-reservations==0.2.1
-    # via azure-mgmt
-azure-mgmt-resource==2.1.0
-    # via azure-mgmt
-azure-mgmt-scheduler==2.0.0
-    # via azure-mgmt
-azure-mgmt-search==2.0.0
-    # via azure-mgmt
-azure-mgmt-servicebus==0.5.3
-    # via azure-mgmt
-azure-mgmt-servicefabric==0.2.0
-    # via azure-mgmt
-azure-mgmt-signalr==0.1.1
-    # via azure-mgmt
-azure-mgmt-sql==0.9.1
-    # via azure-mgmt
-azure-mgmt-storage==2.0.0
-    # via azure-mgmt
-azure-mgmt-subscription==0.2.0
-    # via azure-mgmt
-azure-mgmt-trafficmanager==0.50.0
-    # via azure-mgmt
-azure-mgmt-web==0.35.0
-    # via azure-mgmt
-azure-mgmt==4.0.0
-    # via azure
+azure-mgmt-dns==8.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-network==19.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-resource==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-storage==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-subscription==1.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-web==3.0.0
+    # via -r requirements/static/ci/common.in
 azure-nspkg==3.0.2
+    # via azure-servicemanagement-legacy
+azure-servicemanagement-legacy==0.20.7
+    # via -r requirements/static/ci/common.in
+azure-storage-blob==12.8.1
+    # via -r requirements/static/ci/common.in
+azure-storage-common==2.1.0
     # via
-    #   azure-applicationinsights
-    #   azure-batch
-    #   azure-cosmosdb-nspkg
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-nspkg
-    #   azure-servicebus
-    #   azure-servicefabric
-    #   azure-servicemanagement-legacy
-azure-servicebus==0.21.1
-    # via azure
-azure-servicefabric==6.3.0.0
-    # via azure
-azure-servicemanagement-legacy==0.20.6
-    # via azure
-azure-storage-blob==1.5.0
-    # via azure
-azure-storage-common==1.4.0
-    # via
-    #   azure-cosmosdb-table
-    #   azure-storage-blob
+    #   -r requirements/static/ci/common.in
     #   azure-storage-file
-    #   azure-storage-queue
-azure-storage-file==1.4.0
-    # via azure
-azure-storage-queue==1.4.0
-    # via azure
-azure==4.0.0 ; sys_platform != "win32"
+azure-storage-file==2.1.0
     # via -r requirements/static/ci/common.in
 backports.functools-lru-cache==1.5
     # via
@@ -369,7 +124,6 @@ cffi==1.14.4
     # via
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/py3.8/linux.txt
-    #   azure-datalake-store
     #   bcrypt
     #   cryptography
     #   napalm
@@ -411,11 +165,13 @@ cryptography==3.3.2
     # via
     #   -r requirements/static/pkg/py3.8/linux.txt
     #   adal
-    #   azure-cosmosdb-table
-    #   azure-keyvault
+    #   azure-identity
+    #   azure-storage-blob
     #   azure-storage-common
     #   moto
+    #   msal
     #   paramiko
+    #   pyjwt
     #   pyopenssl
     #   python-jose
     #   sshpubkeys
@@ -546,99 +302,30 @@ more-itertools==5.0.0
     #   moto
 moto==1.3.16
     # via -r requirements/static/ci/common.in
+msal-extensions==0.3.0
+    # via azure-identity
+msal==1.12.0
+    # via
+    #   azure-identity
+    #   msal-extensions
 msgpack==1.0.2
     # via
     #   -r requirements/static/pkg/py3.8/linux.txt
     #   pytest-salt-factories
-msrest==0.6.14
-    # via
-    #   azure-applicationinsights
-    #   azure-eventgrid
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-cdn
-    #   azure-mgmt-compute
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-dns
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-media
-    #   azure-mgmt-network
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-resource
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-servicefabric
-    #   msrestazure
-msrestazure==0.6.3
+msrest==0.6.21
     # via
     #   azure-batch
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
+    #   azure-storage-blob
+    #   msrestazure
+msrestazure==0.6.3
+    # via azure-batch
 napalm==3.1.0 ; sys_platform != "win32" and python_version > "3.6"
     # via -r requirements/static/ci/common.in
 ncclient==0.6.4
@@ -684,6 +371,8 @@ pathtools==0.1.2
     # via watchdog
 pluggy==0.13.0
     # via pytest
+portalocker==1.7.1
+    # via msal-extensions
 portend==2.4
     # via
     #   -r requirements/static/pkg/py3.8/linux.txt
@@ -717,8 +406,10 @@ pyiface==0.0.11
     # via -r requirements/static/ci/linux.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==1.7.1
-    # via adal
+pyjwt[crypto]==1.7.1
+    # via
+    #   adal
+    #   msal
 pynacl==1.3.0
     # via paramiko
 pyopenssl==19.1.0
@@ -758,7 +449,6 @@ python-dateutil==2.8.1
     # via
     #   -r requirements/static/pkg/py3.8/linux.txt
     #   adal
-    #   azure-cosmosdb-table
     #   azure-storage-common
     #   botocore
     #   croniter
@@ -804,15 +494,13 @@ requests==2.25.1
     #   adal
     #   apache-libcloud
     #   aws-xray-sdk
-    #   azure-cosmosdb-table
-    #   azure-datalake-store
-    #   azure-keyvault
-    #   azure-servicebus
+    #   azure-core
     #   azure-servicemanagement-legacy
     #   azure-storage-common
     #   docker
     #   kubernetes
     #   moto
+    #   msal
     #   msrest
     #   napalm
     #   pyvmomi
@@ -841,6 +529,8 @@ six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.8/linux.txt
     #   aws-sam-translator
+    #   azure-core
+    #   azure-identity
     #   bcrypt
     #   cassandra-driver
     #   cfn-lint

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -5,9 +5,7 @@
 #    pip-compile --output-file=requirements/static/ci/py3.9/darwin.txt requirements/pytest.txt requirements/static/ci/common.in requirements/static/ci/darwin.in requirements/static/pkg/py3.9/darwin.txt
 #
 adal==1.2.5
-    # via
-    #   azure-datalake-store
-    #   msrestazure
+    # via msrestazure
 apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via
     #   -r requirements/static/ci/common.in
@@ -29,303 +27,65 @@ aws-sam-translator==1.33.0
     # via cfn-lint
 aws-xray-sdk==0.95
     # via moto
-azure-applicationinsights==0.1.0
-    # via azure
-azure-batch==4.1.3
-    # via azure
-azure-common==1.1.26
+azure-batch==10.0.0
+    # via -r requirements/static/ci/common.in
+azure-common==1.1.27
     # via
-    #   azure-applicationinsights
+    #   -r requirements/static/ci/common.in
     #   azure-batch
-    #   azure-cosmosdb-table
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-    #   azure-servicebus
-    #   azure-servicefabric
     #   azure-servicemanagement-legacy
-    #   azure-storage-blob
     #   azure-storage-common
     #   azure-storage-file
-    #   azure-storage-queue
-azure-cosmosdb-nspkg==2.0.2
-    # via azure-cosmosdb-table
-azure-cosmosdb-table==1.0.6
-    # via azure
-azure-datalake-store==0.0.51
-    # via azure
-azure-eventgrid==1.3.0
-    # via azure
-azure-graphrbac==0.40.0
-    # via azure
-azure-keyvault==1.1.0
-    # via azure
-azure-loganalytics==0.1.0
-    # via azure
-azure-mgmt-advisor==1.0.1
-    # via azure-mgmt
-azure-mgmt-applicationinsights==0.1.1
-    # via azure-mgmt
-azure-mgmt-authorization==0.50.0
-    # via azure-mgmt
-azure-mgmt-batch==5.0.1
-    # via azure-mgmt
-azure-mgmt-batchai==2.0.0
-    # via azure-mgmt
-azure-mgmt-billing==0.2.0
-    # via azure-mgmt
-azure-mgmt-cdn==3.1.0
-    # via azure-mgmt
-azure-mgmt-cognitiveservices==3.0.0
-    # via azure-mgmt
-azure-mgmt-commerce==1.0.1
-    # via azure-mgmt
-azure-mgmt-compute==4.6.2
-    # via azure-mgmt
-azure-mgmt-consumption==2.0.0
-    # via azure-mgmt
-azure-mgmt-containerinstance==1.5.0
-    # via azure-mgmt
-azure-mgmt-containerregistry==2.8.0
-    # via azure-mgmt
-azure-mgmt-containerservice==4.4.0
-    # via azure-mgmt
-azure-mgmt-cosmosdb==0.4.1
-    # via azure-mgmt
-azure-mgmt-datafactory==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-analytics==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-nspkg==3.0.1
+azure-core==1.15.0
     # via
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-azure-mgmt-datalake-store==0.5.0
-    # via azure-mgmt
-azure-mgmt-datamigration==1.0.0
-    # via azure-mgmt
-azure-mgmt-devspaces==0.1.0
-    # via azure-mgmt
-azure-mgmt-devtestlabs==2.2.0
-    # via azure-mgmt
-azure-mgmt-dns==2.1.0
-    # via azure-mgmt
-azure-mgmt-eventgrid==1.0.0
-    # via azure-mgmt
-azure-mgmt-eventhub==2.6.0
-    # via azure-mgmt
-azure-mgmt-hanaonazure==0.1.1
-    # via azure-mgmt
-azure-mgmt-iotcentral==0.1.0
-    # via azure-mgmt
-azure-mgmt-iothub==0.5.0
-    # via azure-mgmt
-azure-mgmt-iothubprovisioningservices==0.2.0
-    # via azure-mgmt
-azure-mgmt-keyvault==1.1.0
-    # via azure-mgmt
-azure-mgmt-loganalytics==0.2.0
-    # via azure-mgmt
-azure-mgmt-logic==3.0.0
-    # via azure-mgmt
-azure-mgmt-machinelearningcompute==0.4.1
-    # via azure-mgmt
-azure-mgmt-managementgroups==0.1.0
-    # via azure-mgmt
-azure-mgmt-managementpartner==0.1.1
-    # via azure-mgmt
-azure-mgmt-maps==0.1.0
-    # via azure-mgmt
-azure-mgmt-marketplaceordering==0.1.0
-    # via azure-mgmt
-azure-mgmt-media==1.0.0
-    # via azure-mgmt
-azure-mgmt-monitor==0.5.2
-    # via azure-mgmt
-azure-mgmt-msi==0.2.0
-    # via azure-mgmt
-azure-mgmt-network==2.7.0
-    # via azure-mgmt
-azure-mgmt-notificationhubs==2.1.0
-    # via azure-mgmt
-azure-mgmt-nspkg==3.0.2
+    #   -r requirements/static/ci/common.in
+    #   azure-identity
+    #   azure-mgmt-core
+    #   azure-storage-blob
+azure-identity==1.6.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-compute==21.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-core==1.2.2
     # via
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
-    #   azure-mgmt-consumption
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-nspkg
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
+    #   -r requirements/static/ci/common.in
+    #   azure-mgmt-compute
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
+    #   azure-mgmt-network
+    #   azure-mgmt-resource
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-azure-mgmt-policyinsights==0.1.0
-    # via azure-mgmt
-azure-mgmt-powerbiembedded==2.0.0
-    # via azure-mgmt
-azure-mgmt-rdbms==1.9.0
-    # via azure-mgmt
-azure-mgmt-recoveryservices==0.3.0
-    # via azure-mgmt
-azure-mgmt-recoveryservicesbackup==0.3.0
-    # via azure-mgmt
-azure-mgmt-redis==5.0.0
-    # via azure-mgmt
-azure-mgmt-relay==0.1.0
-    # via azure-mgmt
-azure-mgmt-reservations==0.2.1
-    # via azure-mgmt
-azure-mgmt-resource==2.2.0
-    # via azure-mgmt
-azure-mgmt-scheduler==2.0.0
-    # via azure-mgmt
-azure-mgmt-search==2.1.0
-    # via azure-mgmt
-azure-mgmt-servicebus==0.5.3
-    # via azure-mgmt
-azure-mgmt-servicefabric==0.2.0
-    # via azure-mgmt
-azure-mgmt-signalr==0.1.1
-    # via azure-mgmt
-azure-mgmt-sql==0.9.1
-    # via azure-mgmt
-azure-mgmt-storage==2.0.0
-    # via azure-mgmt
-azure-mgmt-subscription==0.2.0
-    # via azure-mgmt
-azure-mgmt-trafficmanager==0.50.0
-    # via azure-mgmt
-azure-mgmt-web==0.35.0
-    # via azure-mgmt
-azure-mgmt==4.0.0
-    # via azure
+azure-mgmt-dns==8.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-network==19.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-resource==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-storage==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-subscription==1.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-web==3.0.0
+    # via -r requirements/static/ci/common.in
 azure-nspkg==3.0.2
-    # via
-    #   azure-applicationinsights
-    #   azure-batch
-    #   azure-cosmosdb-nspkg
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-nspkg
-    #   azure-servicebus
-    #   azure-servicefabric
-    #   azure-servicemanagement-legacy
-azure-servicebus==0.21.1
-    # via azure
-azure-servicefabric==6.3.0.0
-    # via azure
+    # via azure-servicemanagement-legacy
 azure-servicemanagement-legacy==0.20.7
-    # via azure
-azure-storage-blob==1.5.0
-    # via azure
-azure-storage-common==1.4.2
+    # via -r requirements/static/ci/common.in
+azure-storage-blob==12.8.1
+    # via -r requirements/static/ci/common.in
+azure-storage-common==2.1.0
     # via
-    #   azure-storage-blob
+    #   -r requirements/static/ci/common.in
     #   azure-storage-file
-    #   azure-storage-queue
-azure-storage-file==1.4.0
-    # via azure
-azure-storage-queue==1.4.0
-    # via azure
-azure==4.0.0 ; sys_platform != "win32"
+azure-storage-file==2.1.0
     # via -r requirements/static/ci/common.in
 bcrypt==3.1.6
     # via paramiko
@@ -362,7 +122,6 @@ cffi==1.14.4
     # via
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/py3.9/darwin.txt
-    #   azure-datalake-store
     #   bcrypt
     #   cryptography
     #   napalm
@@ -404,11 +163,13 @@ cryptography==3.3.2
     # via
     #   -r requirements/static/pkg/py3.9/darwin.txt
     #   adal
-    #   azure-cosmosdb-table
-    #   azure-keyvault
+    #   azure-identity
+    #   azure-storage-blob
     #   azure-storage-common
     #   moto
+    #   msal
     #   paramiko
+    #   pyjwt
     #   pyopenssl
     #   python-jose
     #   sshpubkeys
@@ -543,102 +304,30 @@ more-itertools==8.2.0
     #   moto
 moto==1.3.16
     # via -r requirements/static/ci/common.in
+msal-extensions==0.3.0
+    # via azure-identity
+msal==1.12.0
+    # via
+    #   azure-identity
+    #   msal-extensions
 msgpack==1.0.2
     # via
     #   -r requirements/static/pkg/py3.9/darwin.txt
     #   pytest-salt-factories
-msrest==0.6.19
-    # via
-    #   azure-applicationinsights
-    #   azure-eventgrid
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-cdn
-    #   azure-mgmt-compute
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-dns
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-media
-    #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-resource
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-servicefabric
-    #   msrestazure
-msrestazure==0.6.4
+msrest==0.6.21
     # via
     #   azure-batch
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
+    #   azure-storage-blob
+    #   msrestazure
+msrestazure==0.6.4
+    # via azure-batch
 napalm==3.1.0 ; sys_platform != "win32" and python_version > "3.6"
     # via -r requirements/static/ci/common.in
 ncclient==0.6.4
@@ -675,6 +364,8 @@ pathtools==0.1.2
     # via watchdog
 pluggy==0.13.1
     # via pytest
+portalocker==1.7.1
+    # via msal-extensions
 portend==2.6
     # via
     #   -r requirements/static/pkg/py3.9/darwin.txt
@@ -705,8 +396,10 @@ pyeapi==0.8.3
     # via napalm
 pygit2==1.5.0 ; python_version >= "3.7"
     # via -r requirements/static/ci/darwin.in
-pyjwt==2.0.0
-    # via adal
+pyjwt[crypto]==2.0.0
+    # via
+    #   adal
+    #   msal
 pynacl==1.3.0
     # via paramiko
 pyopenssl==19.0.0
@@ -744,7 +437,6 @@ python-dateutil==2.8.0
     # via
     #   -r requirements/static/pkg/py3.9/darwin.txt
     #   adal
-    #   azure-cosmosdb-table
     #   azure-storage-common
     #   botocore
     #   croniter
@@ -788,15 +480,13 @@ requests==2.25.1
     #   adal
     #   apache-libcloud
     #   aws-xray-sdk
-    #   azure-cosmosdb-table
-    #   azure-datalake-store
-    #   azure-keyvault
-    #   azure-servicebus
+    #   azure-core
     #   azure-servicemanagement-legacy
     #   azure-storage-common
     #   docker
     #   kubernetes
     #   moto
+    #   msal
     #   msrest
     #   napalm
     #   pyvmomi
@@ -825,6 +515,8 @@ six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.9/darwin.txt
     #   aws-sam-translator
+    #   azure-core
+    #   azure-identity
     #   bcrypt
     #   cassandra-driver
     #   cfn-lint

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -5,9 +5,7 @@
 #    pip-compile --output-file=requirements/static/ci/py3.9/freebsd.txt requirements/pytest.txt requirements/static/ci/common.in requirements/static/ci/freebsd.in requirements/static/pkg/py3.9/freebsd.txt
 #
 adal==1.2.5
-    # via
-    #   azure-datalake-store
-    #   msrestazure
+    # via msrestazure
 apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 appdirs==1.4.4
@@ -27,303 +25,65 @@ aws-sam-translator==1.33.0
     # via cfn-lint
 aws-xray-sdk==0.95
     # via moto
-azure-applicationinsights==0.1.0
-    # via azure
-azure-batch==4.1.3
-    # via azure
-azure-common==1.1.26
+azure-batch==10.0.0
+    # via -r requirements/static/ci/common.in
+azure-common==1.1.27
     # via
-    #   azure-applicationinsights
+    #   -r requirements/static/ci/common.in
     #   azure-batch
-    #   azure-cosmosdb-table
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-    #   azure-servicebus
-    #   azure-servicefabric
     #   azure-servicemanagement-legacy
-    #   azure-storage-blob
     #   azure-storage-common
     #   azure-storage-file
-    #   azure-storage-queue
-azure-cosmosdb-nspkg==2.0.2
-    # via azure-cosmosdb-table
-azure-cosmosdb-table==1.0.6
-    # via azure
-azure-datalake-store==0.0.51
-    # via azure
-azure-eventgrid==1.3.0
-    # via azure
-azure-graphrbac==0.40.0
-    # via azure
-azure-keyvault==1.1.0
-    # via azure
-azure-loganalytics==0.1.0
-    # via azure
-azure-mgmt-advisor==1.0.1
-    # via azure-mgmt
-azure-mgmt-applicationinsights==0.1.1
-    # via azure-mgmt
-azure-mgmt-authorization==0.50.0
-    # via azure-mgmt
-azure-mgmt-batch==5.0.1
-    # via azure-mgmt
-azure-mgmt-batchai==2.0.0
-    # via azure-mgmt
-azure-mgmt-billing==0.2.0
-    # via azure-mgmt
-azure-mgmt-cdn==3.1.0
-    # via azure-mgmt
-azure-mgmt-cognitiveservices==3.0.0
-    # via azure-mgmt
-azure-mgmt-commerce==1.0.1
-    # via azure-mgmt
-azure-mgmt-compute==4.6.2
-    # via azure-mgmt
-azure-mgmt-consumption==2.0.0
-    # via azure-mgmt
-azure-mgmt-containerinstance==1.5.0
-    # via azure-mgmt
-azure-mgmt-containerregistry==2.8.0
-    # via azure-mgmt
-azure-mgmt-containerservice==4.4.0
-    # via azure-mgmt
-azure-mgmt-cosmosdb==0.4.1
-    # via azure-mgmt
-azure-mgmt-datafactory==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-analytics==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-nspkg==3.0.1
+azure-core==1.15.0
     # via
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-azure-mgmt-datalake-store==0.5.0
-    # via azure-mgmt
-azure-mgmt-datamigration==1.0.0
-    # via azure-mgmt
-azure-mgmt-devspaces==0.1.0
-    # via azure-mgmt
-azure-mgmt-devtestlabs==2.2.0
-    # via azure-mgmt
-azure-mgmt-dns==2.1.0
-    # via azure-mgmt
-azure-mgmt-eventgrid==1.0.0
-    # via azure-mgmt
-azure-mgmt-eventhub==2.6.0
-    # via azure-mgmt
-azure-mgmt-hanaonazure==0.1.1
-    # via azure-mgmt
-azure-mgmt-iotcentral==0.1.0
-    # via azure-mgmt
-azure-mgmt-iothub==0.5.0
-    # via azure-mgmt
-azure-mgmt-iothubprovisioningservices==0.2.0
-    # via azure-mgmt
-azure-mgmt-keyvault==1.1.0
-    # via azure-mgmt
-azure-mgmt-loganalytics==0.2.0
-    # via azure-mgmt
-azure-mgmt-logic==3.0.0
-    # via azure-mgmt
-azure-mgmt-machinelearningcompute==0.4.1
-    # via azure-mgmt
-azure-mgmt-managementgroups==0.1.0
-    # via azure-mgmt
-azure-mgmt-managementpartner==0.1.1
-    # via azure-mgmt
-azure-mgmt-maps==0.1.0
-    # via azure-mgmt
-azure-mgmt-marketplaceordering==0.1.0
-    # via azure-mgmt
-azure-mgmt-media==1.0.0
-    # via azure-mgmt
-azure-mgmt-monitor==0.5.2
-    # via azure-mgmt
-azure-mgmt-msi==0.2.0
-    # via azure-mgmt
-azure-mgmt-network==2.7.0
-    # via azure-mgmt
-azure-mgmt-notificationhubs==2.1.0
-    # via azure-mgmt
-azure-mgmt-nspkg==3.0.2
+    #   -r requirements/static/ci/common.in
+    #   azure-identity
+    #   azure-mgmt-core
+    #   azure-storage-blob
+azure-identity==1.6.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-compute==21.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-core==1.2.2
     # via
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
-    #   azure-mgmt-consumption
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-nspkg
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
+    #   -r requirements/static/ci/common.in
+    #   azure-mgmt-compute
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
+    #   azure-mgmt-network
+    #   azure-mgmt-resource
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-azure-mgmt-policyinsights==0.1.0
-    # via azure-mgmt
-azure-mgmt-powerbiembedded==2.0.0
-    # via azure-mgmt
-azure-mgmt-rdbms==1.9.0
-    # via azure-mgmt
-azure-mgmt-recoveryservices==0.3.0
-    # via azure-mgmt
-azure-mgmt-recoveryservicesbackup==0.3.0
-    # via azure-mgmt
-azure-mgmt-redis==5.0.0
-    # via azure-mgmt
-azure-mgmt-relay==0.1.0
-    # via azure-mgmt
-azure-mgmt-reservations==0.2.1
-    # via azure-mgmt
-azure-mgmt-resource==2.2.0
-    # via azure-mgmt
-azure-mgmt-scheduler==2.0.0
-    # via azure-mgmt
-azure-mgmt-search==2.1.0
-    # via azure-mgmt
-azure-mgmt-servicebus==0.5.3
-    # via azure-mgmt
-azure-mgmt-servicefabric==0.2.0
-    # via azure-mgmt
-azure-mgmt-signalr==0.1.1
-    # via azure-mgmt
-azure-mgmt-sql==0.9.1
-    # via azure-mgmt
-azure-mgmt-storage==2.0.0
-    # via azure-mgmt
-azure-mgmt-subscription==0.2.0
-    # via azure-mgmt
-azure-mgmt-trafficmanager==0.50.0
-    # via azure-mgmt
-azure-mgmt-web==0.35.0
-    # via azure-mgmt
-azure-mgmt==4.0.0
-    # via azure
+azure-mgmt-dns==8.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-network==19.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-resource==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-storage==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-subscription==1.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-web==3.0.0
+    # via -r requirements/static/ci/common.in
 azure-nspkg==3.0.2
-    # via
-    #   azure-applicationinsights
-    #   azure-batch
-    #   azure-cosmosdb-nspkg
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-nspkg
-    #   azure-servicebus
-    #   azure-servicefabric
-    #   azure-servicemanagement-legacy
-azure-servicebus==0.21.1
-    # via azure
-azure-servicefabric==6.3.0.0
-    # via azure
+    # via azure-servicemanagement-legacy
 azure-servicemanagement-legacy==0.20.7
-    # via azure
-azure-storage-blob==1.5.0
-    # via azure
-azure-storage-common==1.4.2
+    # via -r requirements/static/ci/common.in
+azure-storage-blob==12.8.1
+    # via -r requirements/static/ci/common.in
+azure-storage-common==2.1.0
     # via
-    #   azure-storage-blob
+    #   -r requirements/static/ci/common.in
     #   azure-storage-file
-    #   azure-storage-queue
-azure-storage-file==1.4.0
-    # via azure
-azure-storage-queue==1.4.0
-    # via azure
-azure==4.0.0 ; sys_platform != "win32"
+azure-storage-file==2.1.0
     # via -r requirements/static/ci/common.in
 backports.functools-lru-cache==1.5
     # via
@@ -364,7 +124,6 @@ cffi==1.14.4
     # via
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/py3.9/freebsd.txt
-    #   azure-datalake-store
     #   bcrypt
     #   cryptography
     #   napalm
@@ -406,11 +165,13 @@ cryptography==3.3.2
     # via
     #   -r requirements/static/pkg/py3.9/freebsd.txt
     #   adal
-    #   azure-cosmosdb-table
-    #   azure-keyvault
+    #   azure-identity
+    #   azure-storage-blob
     #   azure-storage-common
     #   moto
+    #   msal
     #   paramiko
+    #   pyjwt
     #   pyopenssl
     #   python-jose
     #   sshpubkeys
@@ -540,102 +301,30 @@ more-itertools==5.0.0
     #   moto
 moto==1.3.16
     # via -r requirements/static/ci/common.in
+msal-extensions==0.3.0
+    # via azure-identity
+msal==1.12.0
+    # via
+    #   azure-identity
+    #   msal-extensions
 msgpack==1.0.2
     # via
     #   -r requirements/static/pkg/py3.9/freebsd.txt
     #   pytest-salt-factories
-msrest==0.6.19
-    # via
-    #   azure-applicationinsights
-    #   azure-eventgrid
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-cdn
-    #   azure-mgmt-compute
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-dns
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-media
-    #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-resource
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-servicefabric
-    #   msrestazure
-msrestazure==0.6.4
+msrest==0.6.21
     # via
     #   azure-batch
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
+    #   azure-storage-blob
+    #   msrestazure
+msrestazure==0.6.4
+    # via azure-batch
 napalm==3.1.0 ; sys_platform != "win32" and python_version > "3.6"
     # via -r requirements/static/ci/common.in
 ncclient==0.6.4
@@ -673,6 +362,8 @@ pathtools==0.1.2
     # via watchdog
 pluggy==0.13.0
     # via pytest
+portalocker==1.7.1
+    # via msal-extensions
 portend==2.4
     # via
     #   -r requirements/static/pkg/py3.9/freebsd.txt
@@ -704,8 +395,10 @@ pygit2==1.5.0 ; python_version >= "3.7"
     # via -r requirements/static/ci/freebsd.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==2.0.0
-    # via adal
+pyjwt[crypto]==2.0.0
+    # via
+    #   adal
+    #   msal
 pynacl==1.3.0
     # via paramiko
 pyopenssl==19.1.0
@@ -743,7 +436,6 @@ python-dateutil==2.8.1
     # via
     #   -r requirements/static/pkg/py3.9/freebsd.txt
     #   adal
-    #   azure-cosmosdb-table
     #   azure-storage-common
     #   botocore
     #   croniter
@@ -787,15 +479,13 @@ requests==2.25.1
     #   adal
     #   apache-libcloud
     #   aws-xray-sdk
-    #   azure-cosmosdb-table
-    #   azure-datalake-store
-    #   azure-keyvault
-    #   azure-servicebus
+    #   azure-core
     #   azure-servicemanagement-legacy
     #   azure-storage-common
     #   docker
     #   kubernetes
     #   moto
+    #   msal
     #   msrest
     #   napalm
     #   pyvmomi
@@ -823,6 +513,8 @@ six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.9/freebsd.txt
     #   aws-sam-translator
+    #   azure-core
+    #   azure-identity
     #   bcrypt
     #   cassandra-driver
     #   cfn-lint

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -7,9 +7,7 @@
 --extra-index-url https://cdn.githubraw.com/saltstack/vsphere-automation-sdk-python/master/lib/
 
 adal==1.2.3
-    # via
-    #   azure-datalake-store
-    #   msrestazure
+    # via msrestazure
 apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 appdirs==1.4.4
@@ -29,308 +27,65 @@ aws-sam-translator==1.33.0
     # via cfn-lint
 aws-xray-sdk==0.95
     # via moto
-azure-applicationinsights==0.1.0
-    # via azure
-azure-batch==4.1.3
-    # via azure
-azure-common==1.1.18
+azure-batch==10.0.0
+    # via -r requirements/static/ci/common.in
+azure-common==1.1.27
     # via
-    #   azure-applicationinsights
+    #   -r requirements/static/ci/common.in
     #   azure-batch
-    #   azure-cosmosdb-table
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-    #   azure-servicebus
-    #   azure-servicefabric
     #   azure-servicemanagement-legacy
-    #   azure-storage-blob
     #   azure-storage-common
     #   azure-storage-file
-    #   azure-storage-queue
-azure-cosmosdb-nspkg==2.0.2
-    # via azure-cosmosdb-table
-azure-cosmosdb-table==1.0.5
-    # via azure
-azure-datalake-store==0.0.44
-    # via azure
-azure-eventgrid==1.2.0
-    # via azure
-azure-graphrbac==0.40.0
-    # via azure
-azure-keyvault==1.1.0
-    # via azure
-azure-loganalytics==0.1.0
-    # via azure
-azure-mgmt-advisor==1.0.1
-    # via azure-mgmt
-azure-mgmt-applicationinsights==0.1.1
-    # via azure-mgmt
-azure-mgmt-authorization==0.50.0
-    # via azure-mgmt
-azure-mgmt-batch==5.0.1
-    # via azure-mgmt
-azure-mgmt-batchai==2.0.0
-    # via azure-mgmt
-azure-mgmt-billing==0.2.0
-    # via azure-mgmt
-azure-mgmt-cdn==3.1.0
-    # via azure-mgmt
-azure-mgmt-cognitiveservices==3.0.0
-    # via azure-mgmt
-azure-mgmt-commerce==1.0.1
-    # via azure-mgmt
-azure-mgmt-compute==4.6.0
-    # via azure-mgmt
-azure-mgmt-consumption==2.0.0
-    # via azure-mgmt
-azure-mgmt-containerinstance==1.4.1
-    # via azure-mgmt
-azure-mgmt-containerregistry==2.7.0
-    # via azure-mgmt
-azure-mgmt-containerservice==4.4.0
-    # via azure-mgmt
-azure-mgmt-cosmosdb==0.4.1
-    # via azure-mgmt
-azure-mgmt-datafactory==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-analytics==0.6.0
-    # via azure-mgmt
-azure-mgmt-datalake-nspkg==3.0.1
+azure-core==1.15.0
     # via
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-azure-mgmt-datalake-store==0.5.0
-    # via azure-mgmt
-azure-mgmt-datamigration==1.0.0
-    # via azure-mgmt
-azure-mgmt-devspaces==0.1.0
-    # via azure-mgmt
-azure-mgmt-devtestlabs==2.2.0
-    # via azure-mgmt
-azure-mgmt-dns==2.1.0
-    # via azure-mgmt
-azure-mgmt-eventgrid==1.0.0
-    # via azure-mgmt
-azure-mgmt-eventhub==2.5.0
-    # via azure-mgmt
-azure-mgmt-hanaonazure==0.1.1
-    # via azure-mgmt
-azure-mgmt-iotcentral==0.1.0
-    # via azure-mgmt
-azure-mgmt-iothub==0.5.0
-    # via azure-mgmt
-azure-mgmt-iothubprovisioningservices==0.2.0
-    # via azure-mgmt
-azure-mgmt-keyvault==1.1.0
-    # via azure-mgmt
-azure-mgmt-loganalytics==0.2.0
-    # via azure-mgmt
-azure-mgmt-logic==3.0.0
-    # via azure-mgmt
-azure-mgmt-machinelearningcompute==0.4.1
-    # via azure-mgmt
-azure-mgmt-managementgroups==0.1.0
-    # via azure-mgmt
-azure-mgmt-managementpartner==0.1.0
-    # via azure-mgmt
-azure-mgmt-maps==0.1.0
-    # via azure-mgmt
-azure-mgmt-marketplaceordering==0.1.0
-    # via azure-mgmt
-azure-mgmt-media==1.0.0
-    # via azure-mgmt
-azure-mgmt-monitor==0.5.2
-    # via azure-mgmt
-azure-mgmt-msi==0.2.0
-    # via azure-mgmt
-azure-mgmt-network==2.6.0
-    # via azure-mgmt
-azure-mgmt-notificationhubs==2.0.0
-    # via azure-mgmt
-azure-mgmt-nspkg==3.0.2
+    #   -r requirements/static/ci/common.in
+    #   azure-identity
+    #   azure-mgmt-core
+    #   azure-storage-blob
+azure-identity==1.6.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-compute==21.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-core==1.2.2
     # via
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
-    #   azure-mgmt-consumption
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-nspkg
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
+    #   -r requirements/static/ci/common.in
+    #   azure-mgmt-compute
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
+    #   azure-mgmt-network
+    #   azure-mgmt-resource
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
-azure-mgmt-policyinsights==0.1.0
-    # via azure-mgmt
-azure-mgmt-powerbiembedded==2.0.0
-    # via azure-mgmt
-azure-mgmt-rdbms==1.8.0
-    # via azure-mgmt
-azure-mgmt-recoveryservices==0.3.0
-    # via azure-mgmt
-azure-mgmt-recoveryservicesbackup==0.3.0
-    # via azure-mgmt
-azure-mgmt-redis==5.0.0
-    # via azure-mgmt
-azure-mgmt-relay==0.1.0
-    # via azure-mgmt
-azure-mgmt-reservations==0.2.1
-    # via azure-mgmt
-azure-mgmt-resource==2.1.0
-    # via azure-mgmt
-azure-mgmt-scheduler==2.0.0
-    # via azure-mgmt
-azure-mgmt-search==2.0.0
-    # via azure-mgmt
-azure-mgmt-servicebus==0.5.3
-    # via azure-mgmt
-azure-mgmt-servicefabric==0.2.0
-    # via azure-mgmt
-azure-mgmt-signalr==0.1.1
-    # via azure-mgmt
-azure-mgmt-sql==0.9.1
-    # via azure-mgmt
-azure-mgmt-storage==2.0.0
-    # via azure-mgmt
-azure-mgmt-subscription==0.2.0
-    # via azure-mgmt
-azure-mgmt-trafficmanager==0.50.0
-    # via azure-mgmt
-azure-mgmt-web==0.35.0
-    # via azure-mgmt
-azure-mgmt==4.0.0
-    # via azure
+azure-mgmt-dns==8.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-network==19.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-resource==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-storage==18.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-subscription==1.0.0
+    # via -r requirements/static/ci/common.in
+azure-mgmt-web==3.0.0
+    # via -r requirements/static/ci/common.in
 azure-nspkg==3.0.2
+    # via azure-servicemanagement-legacy
+azure-servicemanagement-legacy==0.20.7
+    # via -r requirements/static/ci/common.in
+azure-storage-blob==12.8.1
+    # via -r requirements/static/ci/common.in
+azure-storage-common==2.1.0
     # via
-    #   azure-applicationinsights
-    #   azure-batch
-    #   azure-cosmosdb-nspkg
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-nspkg
-    #   azure-servicebus
-    #   azure-servicefabric
-    #   azure-servicemanagement-legacy
-azure-servicebus==0.21.1
-    # via azure
-azure-servicefabric==6.3.0.0
-    # via azure
-azure-servicemanagement-legacy==0.20.6
-    # via azure
-azure-storage-blob==1.5.0
-    # via azure
-azure-storage-common==1.4.0
-    # via
-    #   azure-cosmosdb-table
-    #   azure-storage-blob
+    #   -r requirements/static/ci/common.in
     #   azure-storage-file
-    #   azure-storage-queue
-azure-storage-file==1.4.0
-    # via azure
-azure-storage-queue==1.4.0
-    # via azure
-azure==4.0.0 ; sys_platform != "win32"
+azure-storage-file==2.1.0
     # via -r requirements/static/ci/common.in
 backports.functools-lru-cache==1.5
     # via
@@ -371,7 +126,6 @@ cffi==1.14.4
     # via
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/py3.9/linux.txt
-    #   azure-datalake-store
     #   bcrypt
     #   cryptography
     #   napalm
@@ -413,11 +167,13 @@ cryptography==3.3.2
     # via
     #   -r requirements/static/pkg/py3.9/linux.txt
     #   adal
-    #   azure-cosmosdb-table
-    #   azure-keyvault
+    #   azure-identity
+    #   azure-storage-blob
     #   azure-storage-common
     #   moto
+    #   msal
     #   paramiko
+    #   pyjwt
     #   pyopenssl
     #   python-jose
     #   sshpubkeys
@@ -548,99 +304,30 @@ more-itertools==5.0.0
     #   moto
 moto==1.3.16
     # via -r requirements/static/ci/common.in
+msal-extensions==0.3.0
+    # via azure-identity
+msal==1.12.0
+    # via
+    #   azure-identity
+    #   msal-extensions
 msgpack==1.0.2
     # via
     #   -r requirements/static/pkg/py3.9/linux.txt
     #   pytest-salt-factories
-msrest==0.6.14
-    # via
-    #   azure-applicationinsights
-    #   azure-eventgrid
-    #   azure-keyvault
-    #   azure-loganalytics
-    #   azure-mgmt-cdn
-    #   azure-mgmt-compute
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-dns
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-media
-    #   azure-mgmt-network
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-resource
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-servicefabric
-    #   msrestazure
-msrestazure==0.6.3
+msrest==0.6.21
     # via
     #   azure-batch
-    #   azure-eventgrid
-    #   azure-graphrbac
-    #   azure-keyvault
-    #   azure-mgmt-advisor
-    #   azure-mgmt-applicationinsights
-    #   azure-mgmt-authorization
-    #   azure-mgmt-batch
-    #   azure-mgmt-batchai
-    #   azure-mgmt-billing
-    #   azure-mgmt-cdn
-    #   azure-mgmt-cognitiveservices
-    #   azure-mgmt-commerce
     #   azure-mgmt-compute
-    #   azure-mgmt-consumption
-    #   azure-mgmt-containerinstance
-    #   azure-mgmt-containerregistry
-    #   azure-mgmt-containerservice
-    #   azure-mgmt-cosmosdb
-    #   azure-mgmt-datafactory
-    #   azure-mgmt-datalake-analytics
-    #   azure-mgmt-datalake-store
-    #   azure-mgmt-datamigration
-    #   azure-mgmt-devspaces
-    #   azure-mgmt-devtestlabs
     #   azure-mgmt-dns
-    #   azure-mgmt-eventgrid
-    #   azure-mgmt-eventhub
-    #   azure-mgmt-hanaonazure
-    #   azure-mgmt-iotcentral
-    #   azure-mgmt-iothub
-    #   azure-mgmt-iothubprovisioningservices
-    #   azure-mgmt-keyvault
-    #   azure-mgmt-loganalytics
-    #   azure-mgmt-logic
-    #   azure-mgmt-machinelearningcompute
-    #   azure-mgmt-managementgroups
-    #   azure-mgmt-managementpartner
-    #   azure-mgmt-maps
-    #   azure-mgmt-marketplaceordering
-    #   azure-mgmt-media
-    #   azure-mgmt-monitor
-    #   azure-mgmt-msi
     #   azure-mgmt-network
-    #   azure-mgmt-notificationhubs
-    #   azure-mgmt-policyinsights
-    #   azure-mgmt-powerbiembedded
-    #   azure-mgmt-rdbms
-    #   azure-mgmt-recoveryservices
-    #   azure-mgmt-recoveryservicesbackup
-    #   azure-mgmt-redis
-    #   azure-mgmt-relay
-    #   azure-mgmt-reservations
     #   azure-mgmt-resource
-    #   azure-mgmt-scheduler
-    #   azure-mgmt-search
-    #   azure-mgmt-servicebus
-    #   azure-mgmt-servicefabric
-    #   azure-mgmt-signalr
-    #   azure-mgmt-sql
     #   azure-mgmt-storage
     #   azure-mgmt-subscription
-    #   azure-mgmt-trafficmanager
     #   azure-mgmt-web
+    #   azure-storage-blob
+    #   msrestazure
+msrestazure==0.6.3
+    # via azure-batch
 napalm==3.1.0 ; sys_platform != "win32" and python_version > "3.6"
     # via -r requirements/static/ci/common.in
 ncclient==0.6.4
@@ -686,6 +373,8 @@ pathtools==0.1.2
     # via watchdog
 pluggy==0.13.0
     # via pytest
+portalocker==1.7.1
+    # via msal-extensions
 portend==2.4
     # via
     #   -r requirements/static/pkg/py3.9/linux.txt
@@ -719,8 +408,10 @@ pyiface==0.0.11
     # via -r requirements/static/ci/linux.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==1.7.1
-    # via adal
+pyjwt[crypto]==1.7.1
+    # via
+    #   adal
+    #   msal
 pynacl==1.3.0
     # via paramiko
 pyopenssl==19.1.0
@@ -760,7 +451,6 @@ python-dateutil==2.8.1
     # via
     #   -r requirements/static/pkg/py3.9/linux.txt
     #   adal
-    #   azure-cosmosdb-table
     #   azure-storage-common
     #   botocore
     #   croniter
@@ -806,15 +496,13 @@ requests==2.25.1
     #   adal
     #   apache-libcloud
     #   aws-xray-sdk
-    #   azure-cosmosdb-table
-    #   azure-datalake-store
-    #   azure-keyvault
-    #   azure-servicebus
+    #   azure-core
     #   azure-servicemanagement-legacy
     #   azure-storage-common
     #   docker
     #   kubernetes
     #   moto
+    #   msal
     #   msrest
     #   napalm
     #   pyvmomi
@@ -843,6 +531,8 @@ six==1.16.0
     # via
     #   -r requirements/static/pkg/py3.9/linux.txt
     #   aws-sam-translator
+    #   azure-core
+    #   azure-identity
     #   bcrypt
     #   cassandra-driver
     #   cfn-lint

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -103,7 +103,6 @@ import time
 from multiprocessing import cpu_count
 from multiprocessing.pool import ThreadPool
 
-import azure.storage.blob
 import salt.cache
 import salt.config as config
 import salt.loader
@@ -122,6 +121,7 @@ from salt.exceptions import (
 
 HAS_LIBS = False
 try:
+    import azure.storage.blob
     import azure.mgmt.compute.models as compute_models
     import azure.mgmt.network.models as network_models
     from msrestazure.azure_exceptions import CloudError

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -9,16 +9,21 @@ Azure ARM Cloud Module
 The Azure ARM cloud module is used to control access to Microsoft Azure Resource Manager
 
 :depends:
-    * `azure <https://pypi.python.org/pypi/azure>`_ >= 2.0.0rc6
-    * `azure-common <https://pypi.python.org/pypi/azure-common>`_ >= 1.1.4
-    * `azure-mgmt <https://pypi.python.org/pypi/azure-mgmt>`_ >= 0.30.0rc6
-    * `azure-mgmt-compute <https://pypi.python.org/pypi/azure-mgmt-compute>`_ >= 0.33.0
-    * `azure-mgmt-network <https://pypi.python.org/pypi/azure-mgmt-network>`_ >= 0.30.0rc6
-    * `azure-mgmt-resource <https://pypi.python.org/pypi/azure-mgmt-resource>`_ >= 0.30.0
-    * `azure-mgmt-storage <https://pypi.python.org/pypi/azure-mgmt-storage>`_ >= 0.30.0rc6
-    * `azure-mgmt-web <https://pypi.python.org/pypi/azure-mgmt-web>`_ >= 0.30.0rc6
-    * `azure-storage <https://pypi.python.org/pypi/azure-storage>`_ >= 0.32.0
-    * `msrestazure <https://pypi.python.org/pypi/msrestazure>`_ >= 0.4.21
+    * `azure-core <https://pypi.python.org/pypi/azure-core>`_ >= 1.15.0
+    * `azure-batch <https://pypi.python.org/pypi/azure-batch>`_ >= 10.0.0
+    * `azure-identity <https://pypi.python.org/pypi/azure-identity>`_ >= 1.6.0
+    * `azure-common <https://pypi.python.org/pypi/azure-common>`_ >= 1.1.27
+    * `azure-mgmt-core <https://pypi.python.org/pypi/azure-mgmt-core>`_ >= 1.2.2
+    * `azure-mgmt-subscription <https://pypi.python.org/pypi/azure-mgmt-subscription>`_ >= 1.0.0
+    * `azure-mgmt-compute <https://pypi.python.org/pypi/azure-mgmt-compute>`_ >= 20.0.0
+    * `azure-mgmt-network <https://pypi.python.org/pypi/azure-mgmt-network>`_ >= 19.0.0
+    * `azure-mgmt-resource <https://pypi.python.org/pypi/azure-mgmt-resource>`_ >= 18.0.0
+    * `azure-mgmt-storage <https://pypi.python.org/pypi/azure-mgmt-storage>`_ >= 18.0.0
+    * `azure-mgmt-web <https://pypi.python.org/pypi/azure-mgmt-web>`_ >= 2.0.0
+    * `azure-storage-common <https://pypi.python.org/pypi/azure-storage-common>`_ >= 1.4.2
+    * `azure-storage-blob <https://pypi.python.org/pypi/azure-storage-blob>`_ >= 12.8.1
+    * `azure-storage-file <https://pypi.python.org/pypi/azure-storage-file>`_ >= 2.1.0
+    * `msrestazure <https://pypi.python.org/pypi/msrestazure>`_ >= 0.6.4
 :configuration:
     Required provider parameters:
 
@@ -98,6 +103,7 @@ import time
 from multiprocessing import cpu_count
 from multiprocessing.pool import ThreadPool
 
+import azure.storage.blob
 import salt.cache
 import salt.config as config
 import salt.loader
@@ -118,8 +124,10 @@ HAS_LIBS = False
 try:
     import azure.mgmt.compute.models as compute_models
     import azure.mgmt.network.models as network_models
-    from azure.storage.blob.blockblobservice import BlockBlobService
     from msrestazure.azure_exceptions import CloudError
+    from azure.mgmt.resource import ResourceManagementClient  # pylint: disable=W0611
+    from azure.mgmt.network import NetworkManagementClient  # pylint: disable=W0611
+    from azure.mgmt.compute import ComputeManagementClient  # pylint: disable=W0611
 
     HAS_LIBS = True
 except ImportError:
@@ -241,9 +249,9 @@ def get_dependencies():
 def get_conn(client_type):
     """
     Return a connection object for a client type.
+    Added section to globalize connections to avoid azure throttling
     """
     conn_kwargs = {}
-
     conn_kwargs["subscription_id"] = salt.utils.stringutils.to_str(
         config.get_cloud_config_value(
             "subscription_id", get_configured_provider(), __opts__, search_global=False
@@ -280,7 +288,35 @@ def get_conn(client_type):
         )
         conn_kwargs.update({"username": username, "password": password})
 
-    client = salt.utils.azurearm.get_client(client_type=client_type, **conn_kwargs)
+    if client_type == "resource":
+        if "az_conn_resouces" not in globals():
+            global az_conn_resouces  # pylint: disable=W0601
+            az_conn_resouces = salt.utils.azurearm.get_client(
+                client_type="resource", **conn_kwargs
+            )
+            client = az_conn_resouces
+        else:
+            client = az_conn_resouces
+
+    if client_type == "network":
+        if "az_conn_network" not in globals():
+            global az_conn_network  # pylint: disable=W0601
+            az_conn_network = salt.utils.azurearm.get_client(
+                client_type="network", **conn_kwargs
+            )
+            client = az_conn_network
+        else:
+            client = az_conn_network
+
+    if client_type == "compute":
+        if "az_conn_compute" not in globals():
+            global az_conn_compute  # pylint: disable=W0601
+            az_conn_compute = salt.utils.azurearm.get_client(
+                client_type="compute", **conn_kwargs
+            )
+            client = az_conn_compute
+        else:
+            client = az_conn_compute
 
     return client
 
@@ -340,8 +376,15 @@ def avail_images(call=None):
             "The avail_images function must be called with "
             "-f or --function, or with the --list-images option"
         )
-    compconn = get_conn(client_type="compute")
-    region = get_location()
+    try:
+        compconn = get_conn(client_type="compute")
+    except CloudError as exc:
+        salt.utils.azurearm.log_cloud_error("resource", exc.message)
+    try:
+        region = get_location()
+    except CloudError as exc:
+        salt.utils.azurearm.log_cloud_error("resource", exc.message)
+
     publishers = []
     ret = {}
 
@@ -385,12 +428,16 @@ def avail_images(call=None):
         return data
 
     try:
-        publishers_query = compconn.virtual_machine_images.list_publishers(
-            location=region
+        publishers = config.get_cloud_config_value(
+            "publishers", get_configured_provider(), __opts__, search_global=False
         )
-        for publisher_obj in publishers_query:
-            publisher = publisher_obj.as_dict()
-            publishers.append(publisher["name"])
+        if not publishers:
+            publishers_query = compconn.virtual_machine_images.list_publishers(
+                location=region
+            )
+            for publisher_obj in publishers_query:
+                publisher = publisher_obj.as_dict()
+                publishers.append(publisher["name"])
     except CloudError as exc:
         salt.utils.azurearm.log_cloud_error("compute", exc.message)
 
@@ -399,7 +446,6 @@ def avail_images(call=None):
     results.wait()
 
     ret = {k: v for result in results.get() for k, v in result.items()}
-
     return ret
 
 
@@ -599,13 +645,13 @@ def delete_interface(call=None, kwargs=None):  # pylint: disable=unused-argument
     for ip_ in iface.ip_configurations:
         ips.append(ip_.name)
 
-    poller = netconn.network_interfaces.delete(
+    poller = netconn.network_interfaces.begin_delete(
         kwargs["resource_group"], kwargs["iface_name"],
     )
     poller.wait()
 
     for ip_ in ips:
-        poller = netconn.public_ip_addresses.delete(kwargs["resource_group"], ip_)
+        poller = netconn.public_ip_addresses.begin_delete(kwargs["resource_group"], ip_)
         poller.wait()
 
     return {iface_name: ips}
@@ -755,7 +801,7 @@ def create_network_interface(call=None, kwargs=None):
 
     if kwargs.get("allocate_public_ip") is True:
         pub_ip_name = "{}-ip".format(kwargs["iface_name"])
-        poller = netconn.public_ip_addresses.create_or_update(
+        poller = netconn.public_ip_addresses.begin_create_or_update(
             resource_group_name=kwargs["resource_group"],
             public_ip_address_name=pub_ip_name,
             parameters=PublicIPAddress(
@@ -809,7 +855,7 @@ def create_network_interface(call=None, kwargs=None):
         ip_configurations=ip_configurations,
     )
 
-    poller = netconn.network_interfaces.create_or_update(
+    poller = netconn.network_interfaces.begin_create_or_update(
         kwargs["resource_group"], kwargs["iface_name"], iface_params
     )
     try:
@@ -1210,12 +1256,12 @@ def request_instance(vm_):
         args=__utils__["cloud.filter_event"](
             "requesting", vm_, ["name", "profile", "provider", "driver"]
         ),
-        sock_dir=__opts__["sock_dir"],
+        sock_dir=__opts__["sock_dir"],  # pylint: disable=no-value-for-parameter
         transport=__opts__["transport"],
     )
 
     try:
-        vm_create = compconn.virtual_machines.create_or_update(
+        vm_create = compconn.virtual_machines.begin_create_or_update(
             resource_group_name=vm_["resource_group"],
             vm_name=vm_["name"],
             parameters=params,
@@ -1296,7 +1342,7 @@ def create(vm_):
         return ip_address
 
     try:
-        data = salt.utils.cloud.wait_for_ip(
+        data = __utils__["cloud.wait_for_ip"](
             _query_node_data,
             update_args=(vm_["name"], vm_["bootstrap_interface"],),
             timeout=config.get_cloud_config_value(
@@ -1376,7 +1422,7 @@ def destroy(name, call=None, kwargs=None):  # pylint: disable=unused-argument
 
     ret = {name: {}}
     log.debug("Deleting VM")
-    result = compconn.virtual_machines.delete(node_data["resource_group"], name)
+    result = compconn.virtual_machines.begin_delete(node_data["resource_group"], name)
     result.wait()
 
     if __opts__.get("update_cachedir", False) is True:
@@ -1584,7 +1630,7 @@ def _get_block_blob_service(kwargs=None):
 
     endpoint_suffix = cloud_env.suffixes.storage_endpoint
 
-    return BlockBlobService(
+    return azure.storage.blob.BlobServiceClient(
         storage_account,
         storage_key,
         sas_token=sas_token,
@@ -1645,7 +1691,7 @@ def delete_managed_disk(call=None, kwargs=None):  # pylint: disable=unused-argum
     compconn = get_conn(client_type="compute")
 
     try:
-        compconn.disks.delete(kwargs["resource_group"], kwargs["blob"])
+        compconn.disks.begin_delete(kwargs["resource_group"], kwargs["blob"])
     except Exception as exc:  # pylint: disable=broad-except
         log.error(
             "Error deleting managed disk %s - %s", kwargs.get("blob"), str(exc),
@@ -1813,7 +1859,7 @@ def create_or_update_vmextension(
             settings=settings,
             protected_settings=protected_settings,
         )
-        poller = compconn.virtual_machine_extensions.create_or_update(
+        poller = compconn.virtual_machine_extensions.begin_create_or_update(
             resource_group,
             kwargs["virtual_machine_name"],
             kwargs["extension_name"],

--- a/salt/cloud/clouds/msazure.py
+++ b/salt/cloud/clouds/msazure.py
@@ -603,10 +603,10 @@ def create(vm_):
     except AzureConflictHttpError:
         log.debug("Conflict error. The deployment may already exist, trying add_role")
         # Deleting two useless keywords
-        del vm_kwargs["deployment_slot"]
-        del vm_kwargs["label"]
+        del vm_kwargs["deployment_slot"]  # pylint: disable=E1123
+        del vm_kwargs["label"]  # pylint: disable=E1123
         del vm_kwargs["virtual_network_name"]
-        result = conn.add_role(**vm_kwargs)
+        result = conn.add_role(**vm_kwargs)  # pylint: disable=E1123
         _wait_for_async(conn, result.request_id)
     except Exception as exc:  # pylint: disable=broad-except
         error = "The hosted service name is invalid."

--- a/salt/modules/azurearm_compute.py
+++ b/salt/modules/azurearm_compute.py
@@ -86,12 +86,6 @@ def __virtual__():
     return __virtualname__
 
 
-def get_config_from_cloud(cloud_provider):
-    client = salt.cloud.CloudClient(path="/etc/salt/cloud")
-    conn_kwargs = client.opts["providers"][cloud_provider]["azurearm"]
-    return conn_kwargs
-
-
 def availability_set_create_or_update(
     name, resource_group=None, cloud_provider=None, **kwargs
 ):  # pylint: disable=invalid-name
@@ -121,7 +115,7 @@ def availability_set_create_or_update(
 
     """
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         resource_group = conn_config["resource_group"]
         kwargs.update(conn_config)
 
@@ -201,7 +195,7 @@ def availability_set_delete(name, resource_group=None, cloud_provider=None, **kw
     """
     result = False
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         resource_group = conn_config["resource_group"]
         kwargs.update(conn_config)
     compconn = salt.utils.azurearm.get_client("compute", **kwargs)
@@ -244,7 +238,7 @@ def availability_set_get(name, resource_group=None, cloud_provider=None, **kwarg
 
     """
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         resource_group = conn_config["resource_group"]
         kwargs.update(conn_config)
     compconn = salt.utils.azurearm.get_client("compute", **kwargs)
@@ -287,7 +281,7 @@ def availability_sets_list(resource_group=None, cloud_provider=None, **kwargs):
     """
     result = {}
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         resource_group = conn_config["resource_group"]
         kwargs.update(conn_config)
     compconn = salt.utils.azurearm.get_client("compute", **kwargs)
@@ -337,7 +331,7 @@ def availability_sets_list_available_sizes(
     """
     result = {}
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         resource_group = conn_config["resource_group"]
         kwargs.update(conn_config)
     compconn = salt.utils.azurearm.get_client("compute", **kwargs)
@@ -399,7 +393,7 @@ def virtual_machine_capture(
 
     """
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         resource_group = conn_config["resource_group"]
         kwargs.update(conn_config)
     # pylint: disable=invalid-name
@@ -457,7 +451,7 @@ def virtual_machine_get(name, resource_group=None, cloud_provider=None, **kwargs
 
     """
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         resource_group = conn_config["resource_group"]
         kwargs.update(conn_config)
     expand = kwargs.get("expand")
@@ -505,7 +499,7 @@ def virtual_machine_convert_to_managed_disks(
 
     """
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         resource_group = conn_config["resource_group"]
         kwargs.update(conn_config)
     compconn = salt.utils.azurearm.get_client("compute", **kwargs)
@@ -553,7 +547,7 @@ def virtual_machine_deallocate(
 
     """
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         resource_group = conn_config["resource_group"]
         kwargs.update(conn_config)
     compconn = salt.utils.azurearm.get_client("compute", **kwargs)
@@ -602,7 +596,7 @@ def virtual_machine_generalize(
     """
     result = False
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         resource_group = conn_config["resource_group"]
         kwargs.update(conn_config)
     compconn = salt.utils.azurearm.get_client("compute", **kwargs)
@@ -643,7 +637,7 @@ def virtual_machines_list(resource_group=None, cloud_provider=None, **kwargs):
     """
     result = {}
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         resource_group = conn_config["resource_group"]
         kwargs.update(conn_config)
 
@@ -684,7 +678,7 @@ def virtual_machines_list_all(cloud_provider=None, **kwargs):
     """
     result = {}
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         resource_group = conn_config["resource_group"]
         kwargs.update(conn_config)
     compconn = salt.utils.azurearm.get_client("compute", **kwargs)
@@ -732,7 +726,7 @@ def virtual_machines_list_available_sizes(
     """
     result = {}
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         resource_group = conn_config["resource_group"]
         kwargs.update(conn_config)
     compconn = salt.utils.azurearm.get_client("compute", **kwargs)
@@ -778,7 +772,7 @@ def virtual_machine_power_off(name, resource_group=None, cloud_provider=None, **
 
     """
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         resource_group = conn_config["resource_group"]
         kwargs.update(conn_config)
     compconn = salt.utils.azurearm.get_client("compute", **kwargs)
@@ -824,7 +818,7 @@ def virtual_machine_restart(name, resource_group=None, cloud_provider=None, **kw
 
     """
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         resource_group = conn_config["resource_group"]
         kwargs.update(conn_config)
     compconn = salt.utils.azurearm.get_client("compute", **kwargs)
@@ -870,7 +864,7 @@ def virtual_machine_start(name, resource_group=None, cloud_provider=None, **kwar
 
     """
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         resource_group = conn_config["resource_group"]
         kwargs.update(conn_config)
     compconn = salt.utils.azurearm.get_client("compute", **kwargs)
@@ -908,7 +902,7 @@ def virtual_machine_redeploy(name, resource_group=None, cloud_provider=None, **k
 
     """
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         resource_group = conn_config["resource_group"]
         kwargs.update(conn_config)
     compconn = salt.utils.azurearm.get_client("compute", **kwargs)

--- a/salt/modules/azurearm_compute.py
+++ b/salt/modules/azurearm_compute.py
@@ -1,22 +1,26 @@
-# -*- coding: utf-8 -*-
 """
 Azure (ARM) Compute Execution Module
 
 .. versionadded:: 2019.2.0
 
-:maintainer: <devops@decisionlab.io>
+:maintainer: <devops@decisionlab.io>, <devops@l2web.ca>
 :maturity: new
 :depends:
-    * `azure <https://pypi.python.org/pypi/azure>`_ >= 2.0.0
-    * `azure-common <https://pypi.python.org/pypi/azure-common>`_ >= 1.1.8
-    * `azure-mgmt <https://pypi.python.org/pypi/azure-mgmt>`_ >= 1.0.0
-    * `azure-mgmt-compute <https://pypi.python.org/pypi/azure-mgmt-compute>`_ >= 1.0.0
-    * `azure-mgmt-network <https://pypi.python.org/pypi/azure-mgmt-network>`_ >= 1.7.1
-    * `azure-mgmt-resource <https://pypi.python.org/pypi/azure-mgmt-resource>`_ >= 1.1.0
-    * `azure-mgmt-storage <https://pypi.python.org/pypi/azure-mgmt-storage>`_ >= 1.0.0
-    * `azure-mgmt-web <https://pypi.python.org/pypi/azure-mgmt-web>`_ >= 0.32.0
-    * `azure-storage <https://pypi.python.org/pypi/azure-storage>`_ >= 0.34.3
-    * `msrestazure <https://pypi.python.org/pypi/msrestazure>`_ >= 0.4.21
+    * `azure-core <https://pypi.python.org/pypi/azure-core>`_ >= 1.15.0
+    * `azure-batch <https://pypi.python.org/pypi/azure-batch>`_ >= 10.0.0
+    * `azure-identity <https://pypi.python.org/pypi/azure-identity>`_ >= 1.6.0
+    * `azure-common <https://pypi.python.org/pypi/azure-common>`_ >= 1.1.27
+    * `azure-mgmt-core <https://pypi.python.org/pypi/azure-mgmt-core>`_ >= 1.2.2
+    * `azure-mgmt-subscription <https://pypi.python.org/pypi/azure-mgmt-subscription>`_ >= 1.0.0
+    * `azure-mgmt-compute <https://pypi.python.org/pypi/azure-mgmt-compute>`_ >= 20.0.0
+    * `azure-mgmt-network <https://pypi.python.org/pypi/azure-mgmt-network>`_ >= 19.0.0
+    * `azure-mgmt-resource <https://pypi.python.org/pypi/azure-mgmt-resource>`_ >= 18.0.0
+    * `azure-mgmt-storage <https://pypi.python.org/pypi/azure-mgmt-storage>`_ >= 18.0.0
+    * `azure-mgmt-web <https://pypi.python.org/pypi/azure-mgmt-web>`_ >= 2.0.0
+    * `azure-storage-common <https://pypi.python.org/pypi/azure-storage-common>`_ >= 1.4.2
+    * `azure-storage-blob <https://pypi.python.org/pypi/azure-storage-blob>`_ >= 12.8.1
+    * `azure-storage-file <https://pypi.python.org/pypi/azure-storage-file>`_ >= 2.1.0
+    * `msrestazure <https://pypi.python.org/pypi/msrestazure>`_ >= 0.6.41
 :platform: linux
 
 :configuration: This module requires Azure Resource Manager credentials to be passed as keyword arguments
@@ -47,9 +51,12 @@ Azure (ARM) Compute Execution Module
 """
 
 # Python libs
-from __future__ import absolute_import
 
 import logging
+
+import salt.cloud
+import salt.loader
+import salt.utils.azurearm
 
 # Azure libs
 HAS_LIBS = False
@@ -79,8 +86,14 @@ def __virtual__():
     return __virtualname__
 
 
+def get_config_from_cloud(cloud_provider):
+    client = salt.cloud.CloudClient(path="/etc/salt/cloud")
+    conn_kwargs = client.opts["providers"][cloud_provider]["azurearm"]
+    return conn_kwargs
+
+
 def availability_set_create_or_update(
-    name, resource_group, **kwargs
+    name, resource_group=None, cloud_provider=None, **kwargs
 ):  # pylint: disable=invalid-name
     """
     .. versionadded:: 2019.2.0
@@ -92,30 +105,41 @@ def availability_set_create_or_update(
     :param resource_group: The resource group name assigned to the
         availability set.
 
+    :param cloud_provider: The Cloud Provider parameter allow you to use a defined
+        provider config in /etc/salt/cloud.providers.d/
+        with this paramater, you dont have to specify ressource_group as it is already defined in the provider
+
     CLI Example:
 
     .. code-block:: bash
 
         salt-call azurearm_compute.availability_set_create_or_update testset testgroup
 
+    .. code-block:: bash
+
+        salt-call azurearm_compute.availability_set_create_or_update testset cloud_provider=my-azurearm-config
+
     """
+    if cloud_provider is not None:
+        conn_config = get_config_from_cloud(cloud_provider)
+        resource_group = conn_config["resource_group"]
+        kwargs.update(conn_config)
+
     if "location" not in kwargs:
-        rg_props = __salt__["azurearm_resource.resource_group_get"](
-            resource_group, **kwargs
-        )
+        rg_props = salt.azurearm_resource.resource_group_get(resource_group, **kwargs)
 
         if "error" in rg_props:
             log.error("Unable to determine location from resource group specified.")
             return False
         kwargs["location"] = rg_props["location"]
 
-    compconn = __utils__["azurearm.get_client"]("compute", **kwargs)
+    compconn = salt.utils.azurearm.get_client("compute", **kwargs)
 
     # Use VM names to link to the IDs of existing VMs.
     if isinstance(kwargs.get("virtual_machines"), list):
         vm_list = []
         for vm_name in kwargs.get("virtual_machines"):
-            vm_instance = __salt__["azurearm_compute.virtual_machine_get"](
+            vm_instance = salt.azurearm_compute.virtual_machine_get(
                 name=vm_name, resource_group=resource_group, **kwargs
             )
             if "error" not in vm_instance:
@@ -123,13 +147,11 @@ def availability_set_create_or_update(
         kwargs["virtual_machines"] = vm_list
 
     try:
-        setmodel = __utils__["azurearm.create_object_model"](
+        setmodel = salt.utils.azurearm.create_object_model(
             "compute", "AvailabilitySet", **kwargs
         )
     except TypeError as exc:
-        result = {
-            "error": "The object model could not be built. ({0})".format(str(exc))
-        }
+        result = {"error": "The object model could not be built. ({})".format(str(exc))}
         return result
 
     try:
@@ -141,17 +163,17 @@ def availability_set_create_or_update(
         result = av_set.as_dict()
 
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("compute", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("compute", str(exc), **kwargs)
         result = {"error": str(exc)}
     except SerializationError as exc:
         result = {
-            "error": "The object model could not be parsed. ({0})".format(str(exc))
+            "error": "The object model could not be parsed. ({})".format(str(exc))
         }
 
     return result
 
 
-def availability_set_delete(name, resource_group, **kwargs):
+def availability_set_delete(name, resource_group=None, cloud_provider=None, **kwargs):
     """
     .. versionadded:: 2019.2.0
 
@@ -162,15 +184,27 @@ def availability_set_delete(name, resource_group, **kwargs):
     :param resource_group: The resource group name assigned to the
         availability set.
 
+    :param cloud_provider: The Cloud Provider parameter allow you to use a defined
+        provider config in /etc/salt/cloud.providers.d/
+        with this paramater, you dont have to specify ressource_group as it is already defined in the provider
+
     CLI Example:
 
     .. code-block:: bash
 
         salt-call azurearm_compute.availability_set_delete testset testgroup
 
+    .. code-block:: bash
+
+        salt-call azurearm_compute.availability_set_delete testset cloud_provider=my-azurearm-config
+
     """
     result = False
-    compconn = __utils__["azurearm.get_client"]("compute", **kwargs)
+    if cloud_provider is not None:
+        conn_config = get_config_from_cloud(cloud_provider)
+        resource_group = conn_config["resource_group"]
+        kwargs.update(conn_config)
+    compconn = salt.utils.azurearm.get_client("compute", **kwargs)
     try:
         compconn.availability_sets.delete(
             resource_group_name=resource_group, availability_set_name=name
@@ -178,12 +212,12 @@ def availability_set_delete(name, resource_group, **kwargs):
         result = True
 
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("compute", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("compute", str(exc), **kwargs)
 
     return result
 
 
-def availability_set_get(name, resource_group, **kwargs):
+def availability_set_get(name, resource_group=None, cloud_provider=None, **kwargs):
     """
     .. versionadded:: 2019.2.0
 
@@ -194,14 +228,26 @@ def availability_set_get(name, resource_group, **kwargs):
     :param resource_group: The resource group name assigned to the
         availability set.
 
+    :param cloud_provider: The Cloud Provider parameter allow you to use a defined
+        provider config in /etc/salt/cloud.providers.d/
+        with this paramater, you dont have to specify ressource_group as it is already defined in the provider
+
     CLI Example:
 
     .. code-block:: bash
 
         salt-call azurearm_compute.availability_set_get testset testgroup
 
+    .. code-block:: bash
+
+        salt-call azurearm_compute.availability_set_get testset cloud_provider=my-azurearm-config
+
     """
-    compconn = __utils__["azurearm.get_client"]("compute", **kwargs)
+    if cloud_provider is not None:
+        conn_config = get_config_from_cloud(cloud_provider)
+        resource_group = conn_config["resource_group"]
+        kwargs.update(conn_config)
+    compconn = salt.utils.azurearm.get_client("compute", **kwargs)
     try:
         av_set = compconn.availability_sets.get(
             resource_group_name=resource_group, availability_set_name=name
@@ -209,13 +255,13 @@ def availability_set_get(name, resource_group, **kwargs):
         result = av_set.as_dict()
 
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("compute", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("compute", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
 
 
-def availability_sets_list(resource_group, **kwargs):
+def availability_sets_list(resource_group=None, cloud_provider=None, **kwargs):
     """
     .. versionadded:: 2019.2.0
 
@@ -224,31 +270,43 @@ def availability_sets_list(resource_group, **kwargs):
     :param resource_group: The resource group name to list availability
         sets within.
 
+    :param cloud_provider: The Cloud Provider parameter allow you to use a defined
+        provider config in /etc/salt/cloud.providers.d/
+        with this paramater, you dont have to specify ressource_group as it is already defined in the provider
+
     CLI Example:
 
     .. code-block:: bash
 
         salt-call azurearm_compute.availability_sets_list testgroup
 
+    .. code-block:: bash
+
+        salt-call azurearm_compute.availability_sets_list cloud_provider=my-azurearm-config
+
     """
     result = {}
-    compconn = __utils__["azurearm.get_client"]("compute", **kwargs)
+    if cloud_provider is not None:
+        conn_config = get_config_from_cloud(cloud_provider)
+        resource_group = conn_config["resource_group"]
+        kwargs.update(conn_config)
+    compconn = salt.utils.azurearm.get_client("compute", **kwargs)
     try:
-        avail_sets = __utils__["azurearm.paged_object_to_list"](
+        avail_sets = salt.utils.azurearm.paged_object_to_list(
             compconn.availability_sets.list(resource_group_name=resource_group)
         )
 
         for avail_set in avail_sets:
             result[avail_set["name"]] = avail_set
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("compute", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("compute", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
 
 
 def availability_sets_list_available_sizes(
-    name, resource_group, **kwargs
+    name, resource_group=None, cloud_provider=None, **kwargs
 ):  # pylint: disable=invalid-name
     """
     .. versionadded:: 2019.2.0
@@ -262,17 +320,29 @@ def availability_sets_list_available_sizes(
     :param resource_group: The resource group name to list available
         availability set sizes within.
 
+    :param cloud_provider: The Cloud Provider parameter allow you to use a defined
+        provider config in /etc/salt/cloud.providers.d/
+        with this paramater, you dont have to specify ressource_group as it is already defined in the provider
+
     CLI Example:
 
     .. code-block:: bash
 
         salt-call azurearm_compute.availability_sets_list_available_sizes testset testgroup
 
+    .. code-block:: bash
+
+        salt-call azurearm_compute.availability_sets_list_available_sizes testset cloud_provider=my-azurearm-config
+
     """
     result = {}
-    compconn = __utils__["azurearm.get_client"]("compute", **kwargs)
+    if cloud_provider is not None:
+        conn_config = get_config_from_cloud(cloud_provider)
+        resource_group = conn_config["resource_group"]
+        kwargs.update(conn_config)
+    compconn = salt.utils.azurearm.get_client("compute", **kwargs)
     try:
-        sizes = __utils__["azurearm.paged_object_to_list"](
+        sizes = salt.utils.azurearm.paged_object_to_list(
             compconn.availability_sets.list_available_sizes(
                 resource_group_name=resource_group, availability_set_name=name
             )
@@ -281,14 +351,20 @@ def availability_sets_list_available_sizes(
         for size in sizes:
             result[size["name"]] = size
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("compute", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("compute", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
 
 
 def virtual_machine_capture(
-    name, destination_name, resource_group, prefix="capture-", overwrite=False, **kwargs
+    name,
+    destination_name,
+    resource_group=None,
+    cloud_provider=None,
+    prefix="capture-",
+    overwrite=False,
+    **kwargs
 ):
     """
     .. versionadded:: 2019.2.0
@@ -307,19 +383,31 @@ def virtual_machine_capture(
 
     :param overwrite: (Default: False) Overwrite the destination disk in case of conflict.
 
+    :param cloud_provider: The Cloud Provider parameter allow you to use a defined
+        provider config in /etc/salt/cloud.providers.d/
+        with this paramater, you dont have to specify ressource_group as it is already defined in the provider
+
     CLI Example:
 
     .. code-block:: bash
 
         salt-call azurearm_compute.virtual_machine_capture testvm testcontainer testgroup
 
+    .. code-block:: bash
+
+        salt-call azurearm_compute.virtual_machine_capture testvm testcontainer cloud_provider=my-azurearm-config
+
     """
+    if cloud_provider is not None:
+        conn_config = get_config_from_cloud(cloud_provider)
+        resource_group = conn_config["resource_group"]
+        kwargs.update(conn_config)
     # pylint: disable=invalid-name
     VirtualMachineCaptureParameters = getattr(
         azure.mgmt.compute.models, "VirtualMachineCaptureParameters"
     )
 
-    compconn = __utils__["azurearm.get_client"]("compute", **kwargs)
+    compconn = salt.utils.azurearm.get_client("compute", **kwargs)
     try:
         # pylint: disable=invalid-name
         vm = compconn.virtual_machines.capture(
@@ -335,13 +423,13 @@ def virtual_machine_capture(
         vm_result = vm.result()
         result = vm_result.as_dict()
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("compute", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("compute", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
 
 
-def virtual_machine_get(name, resource_group, **kwargs):
+def virtual_machine_get(name, resource_group=None, cloud_provider=None, **kwargs):
     """
     .. versionadded:: 2019.2.0
 
@@ -353,16 +441,27 @@ def virtual_machine_get(name, resource_group, **kwargs):
     :param resource_group: The resource group name assigned to the
         virtual machine.
 
+    :param cloud_provider: The Cloud Provider parameter allow you to use a defined
+        provider config in /etc/salt/cloud.providers.d/
+        with this paramater, you dont have to specify ressource_group as it is already defined in the provider
+
     CLI Example:
 
     .. code-block:: bash
 
         salt-call azurearm_compute.virtual_machine_get testvm testgroup
 
-    """
-    expand = kwargs.get("expand")
+    .. code-block:: bash
 
-    compconn = __utils__["azurearm.get_client"]("compute", **kwargs)
+        salt-call azurearm_compute.virtual_machine_get testvm cloud_provider=my-azurearm-config
+
+    """
+    if cloud_provider is not None:
+        conn_config = get_config_from_cloud(cloud_provider)
+        resource_group = conn_config["resource_group"]
+        kwargs.update(conn_config)
+    expand = kwargs.get("expand")
+    compconn = salt.utils.azurearm.get_client("compute", **kwargs)
     try:
         # pylint: disable=invalid-name
         vm = compconn.virtual_machines.get(
@@ -370,14 +469,14 @@ def virtual_machine_get(name, resource_group, **kwargs):
         )
         result = vm.as_dict()
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("compute", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("compute", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
 
 
 def virtual_machine_convert_to_managed_disks(
-    name, resource_group, **kwargs
+    name, resource_group=None, cloud_provider=None, **kwargs
 ):  # pylint: disable=invalid-name
     """
     .. versionadded:: 2019.2.0
@@ -390,14 +489,26 @@ def virtual_machine_convert_to_managed_disks(
     :param resource_group: The resource group name assigned to the
         virtual machine.
 
+    :param cloud_provider: The Cloud Provider parameter allow you to use a defined
+        provider config in /etc/salt/cloud.providers.d/
+        with this paramater, you dont have to specify ressource_group as it is already defined in the provider
+
     CLI Example:
 
     .. code-block:: bash
 
         salt-call azurearm_compute.virtual_machine_convert_to_managed_disks testvm testgroup
 
+    .. code-block:: bash
+
+        salt-call azurearm_compute.virtual_machine_convert_to_managed_disks testvm cloud_provider=my-azurearm-config
+
     """
-    compconn = __utils__["azurearm.get_client"]("compute", **kwargs)
+    if cloud_provider is not None:
+        conn_config = get_config_from_cloud(cloud_provider)
+        resource_group = conn_config["resource_group"]
+        kwargs.update(conn_config)
+    compconn = salt.utils.azurearm.get_client("compute", **kwargs)
     try:
         # pylint: disable=invalid-name
         vm = compconn.virtual_machines.convert_to_managed_disks(
@@ -407,13 +518,15 @@ def virtual_machine_convert_to_managed_disks(
         vm_result = vm.result()
         result = vm_result.as_dict()
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("compute", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("compute", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
 
 
-def virtual_machine_deallocate(name, resource_group, **kwargs):
+def virtual_machine_deallocate(
+    name, resource_group=None, cloud_provider=None, **kwargs
+):
     """
     .. versionadded:: 2019.2.0
 
@@ -424,14 +537,26 @@ def virtual_machine_deallocate(name, resource_group, **kwargs):
     :param resource_group: The resource group name assigned to the
         virtual machine.
 
+    :param cloud_provider: The Cloud Provider parameter allow you to use a defined
+        provider config in /etc/salt/cloud.providers.d/
+        with this paramater, you dont have to specify ressource_group as it is already defined in the provider
+
     CLI Example:
 
     .. code-block:: bash
 
         salt-call azurearm_compute.virtual_machine_deallocate testvm testgroup
 
+    .. code-block:: bash
+
+        salt-call azurearm_compute.virtual_machine_deallocate testvm cloud_provider=my-azurearm-config
+
     """
-    compconn = __utils__["azurearm.get_client"]("compute", **kwargs)
+    if cloud_provider is not None:
+        conn_config = get_config_from_cloud(cloud_provider)
+        resource_group = conn_config["resource_group"]
+        kwargs.update(conn_config)
+    compconn = salt.utils.azurearm.get_client("compute", **kwargs)
     try:
         # pylint: disable=invalid-name
         vm = compconn.virtual_machines.deallocate(
@@ -441,13 +566,15 @@ def virtual_machine_deallocate(name, resource_group, **kwargs):
         vm_result = vm.result()
         result = vm_result.as_dict()
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("compute", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("compute", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
 
 
-def virtual_machine_generalize(name, resource_group, **kwargs):
+def virtual_machine_generalize(
+    name, resource_group=None, cloud_provider=None, **kwargs
+):
     """
     .. versionadded:: 2019.2.0
 
@@ -458,27 +585,39 @@ def virtual_machine_generalize(name, resource_group, **kwargs):
     :param resource_group: The resource group name assigned to the
         virtual machine.
 
+    :param cloud_provider: The Cloud Provider parameter allow you to use a defined
+        provider config in /etc/salt/cloud.providers.d/
+        with this paramater, you dont have to specify ressource_group as it is already defined in the provider
+
     CLI Example:
 
     .. code-block:: bash
 
         salt-call azurearm_compute.virtual_machine_generalize testvm testgroup
 
+    .. code-block:: bash
+
+        salt-call azurearm_compute.virtual_machine_generalize testvm cloud_provider=my-azurearm-config
+
     """
     result = False
-    compconn = __utils__["azurearm.get_client"]("compute", **kwargs)
+    if cloud_provider is not None:
+        conn_config = get_config_from_cloud(cloud_provider)
+        resource_group = conn_config["resource_group"]
+        kwargs.update(conn_config)
+    compconn = salt.utils.azurearm.get_client("compute", **kwargs)
     try:
         compconn.virtual_machines.generalize(
             resource_group_name=resource_group, vm_name=name
         )
         result = True
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("compute", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("compute", str(exc), **kwargs)
 
     return result
 
 
-def virtual_machines_list(resource_group, **kwargs):
+def virtual_machines_list(resource_group=None, cloud_provider=None, **kwargs):
     """
     .. versionadded:: 2019.2.0
 
@@ -487,33 +626,50 @@ def virtual_machines_list(resource_group, **kwargs):
     :param resource_group: The resource group name to list virtual
         machines within.
 
+    :param cloud_provider: The Cloud Provider parameter allow you to use a defined
+        provider config in /etc/salt/cloud.providers.d/
+        with this paramater, you dont have to specify ressource_group as it is already defined in the provider
+
     CLI Example:
 
     .. code-block:: bash
 
         salt-call azurearm_compute.virtual_machines_list testgroup
 
+    .. code-block:: bash
+
+        salt-call azurearm_compute.virtual_machines_list cloud_provider=my-azurearm-config
+
     """
     result = {}
-    compconn = __utils__["azurearm.get_client"]("compute", **kwargs)
+    if cloud_provider is not None:
+        conn_config = get_config_from_cloud(cloud_provider)
+        resource_group = conn_config["resource_group"]
+        kwargs.update(conn_config)
+
+    compconn = salt.utils.azurearm.get_client("compute", **kwargs)
     try:
-        vms = __utils__["azurearm.paged_object_to_list"](
+        vms = salt.utils.azurearm.paged_object_to_list(
             compconn.virtual_machines.list(resource_group_name=resource_group)
         )
         for vm in vms:  # pylint: disable=invalid-name
             result[vm["name"]] = vm
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("compute", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("compute", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
 
 
-def virtual_machines_list_all(**kwargs):
+def virtual_machines_list_all(cloud_provider=None, **kwargs):
     """
     .. versionadded:: 2019.2.0
 
     List all virtual machines within a subscription.
+
+    :param cloud_provider: The Cloud Provider parameter allow you to use a defined
+        provider config in /etc/salt/cloud.providers.d/
+        with this paramater, you dont have to specify ressource_group as it is already defined in the provider
 
     CLI Example:
 
@@ -521,24 +677,32 @@ def virtual_machines_list_all(**kwargs):
 
         salt-call azurearm_compute.virtual_machines_list_all
 
+    .. code-block:: bash
+
+        salt-call azurearm_compute.virtual_machines_list_all cloud_provider=my-azurearm-config
+
     """
     result = {}
-    compconn = __utils__["azurearm.get_client"]("compute", **kwargs)
+    if cloud_provider is not None:
+        conn_config = get_config_from_cloud(cloud_provider)
+        resource_group = conn_config["resource_group"]
+        kwargs.update(conn_config)
+    compconn = salt.utils.azurearm.get_client("compute", **kwargs)
     try:
-        vms = __utils__["azurearm.paged_object_to_list"](
+        vms = salt.utils.azurearm.paged_object_to_list(
             compconn.virtual_machines.list_all()
         )
         for vm in vms:  # pylint: disable=invalid-name
             result[vm["name"]] = vm
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("compute", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("compute", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
 
 
 def virtual_machines_list_available_sizes(
-    name, resource_group, **kwargs
+    name, resource_group=None, cloud_provider=None, **kwargs
 ):  # pylint: disable=invalid-name
     """
     .. versionadded:: 2019.2.0
@@ -551,17 +715,29 @@ def virtual_machines_list_available_sizes(
     :param resource_group: The resource group name assigned to the
         virtual machine.
 
+    :param cloud_provider: The Cloud Provider parameter allow you to use a defined
+        provider config in /etc/salt/cloud.providers.d/
+        with this paramater, you dont have to specify ressource_group as it is already defined in the provider
+
     CLI Example:
 
     .. code-block:: bash
 
         salt-call azurearm_compute.virtual_machines_list_available_sizes testvm testgroup
 
+    .. code-block:: bash
+
+        salt-call azurearm_compute.virtual_machines_list_available_sizes testvm cloud_provider=my-azurearm-config
+
     """
     result = {}
-    compconn = __utils__["azurearm.get_client"]("compute", **kwargs)
+    if cloud_provider is not None:
+        conn_config = get_config_from_cloud(cloud_provider)
+        resource_group = conn_config["resource_group"]
+        kwargs.update(conn_config)
+    compconn = salt.utils.azurearm.get_client("compute", **kwargs)
     try:
-        sizes = __utils__["azurearm.paged_object_to_list"](
+        sizes = salt.utils.azurearm.paged_object_to_list(
             compconn.virtual_machines.list_available_sizes(
                 resource_group_name=resource_group, vm_name=name
             )
@@ -569,13 +745,13 @@ def virtual_machines_list_available_sizes(
         for size in sizes:
             result[size["name"]] = size
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("compute", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("compute", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
 
 
-def virtual_machine_power_off(name, resource_group, **kwargs):
+def virtual_machine_power_off(name, resource_group=None, cloud_provider=None, **kwargs):
     """
     .. versionadded:: 2019.2.0
 
@@ -586,14 +762,26 @@ def virtual_machine_power_off(name, resource_group, **kwargs):
     :param resource_group: The resource group name assigned to the
         virtual machine.
 
+    :param cloud_provider: The Cloud Provider parameter allow you to use a defined
+        provider config in /etc/salt/cloud.providers.d/
+        with this paramater, you dont have to specify ressource_group as it is already defined in the provider
+
     CLI Example:
 
     .. code-block:: bash
 
         salt-call azurearm_compute.virtual_machine_power_off testvm testgroup
 
+    .. code-block:: bash
+
+        salt-call azurearm_compute.virtual_machine_power_off testvm cloud_provider=my-azurearm-config
+
     """
-    compconn = __utils__["azurearm.get_client"]("compute", **kwargs)
+    if cloud_provider is not None:
+        conn_config = get_config_from_cloud(cloud_provider)
+        resource_group = conn_config["resource_group"]
+        kwargs.update(conn_config)
+    compconn = salt.utils.azurearm.get_client("compute", **kwargs)
     try:
         # pylint: disable=invalid-name
         vm = compconn.virtual_machines.power_off(
@@ -603,13 +791,13 @@ def virtual_machine_power_off(name, resource_group, **kwargs):
         vm_result = vm.result()
         result = vm_result.as_dict()
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("compute", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("compute", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
 
 
-def virtual_machine_restart(name, resource_group, **kwargs):
+def virtual_machine_restart(name, resource_group=None, cloud_provider=None, **kwargs):
     """
     .. versionadded:: 2019.2.0
 
@@ -620,14 +808,26 @@ def virtual_machine_restart(name, resource_group, **kwargs):
     :param resource_group: The resource group name assigned to the
         virtual machine.
 
+    :param cloud_provider: The Cloud Provider parameter allow you to use a defined
+        provider config in /etc/salt/cloud.providers.d/
+        with this paramater, you dont have to specify ressource_group as it is already defined in the provider
+
     CLI Example:
 
     .. code-block:: bash
 
         salt-call azurearm_compute.virtual_machine_restart testvm testgroup
 
+    .. code-block:: bash
+
+        salt-call azurearm_compute.virtual_machine_restart testvm cloud_provider=my-azurearm-config
+
     """
-    compconn = __utils__["azurearm.get_client"]("compute", **kwargs)
+    if cloud_provider is not None:
+        conn_config = get_config_from_cloud(cloud_provider)
+        resource_group = conn_config["resource_group"]
+        kwargs.update(conn_config)
+    compconn = salt.utils.azurearm.get_client("compute", **kwargs)
     try:
         # pylint: disable=invalid-name
         vm = compconn.virtual_machines.restart(
@@ -637,13 +837,13 @@ def virtual_machine_restart(name, resource_group, **kwargs):
         vm_result = vm.result()
         result = vm_result.as_dict()
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("compute", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("compute", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
 
 
-def virtual_machine_start(name, resource_group, **kwargs):
+def virtual_machine_start(name, resource_group=None, cloud_provider=None, **kwargs):
     """
     .. versionadded:: 2019.2.0
 
@@ -654,14 +854,26 @@ def virtual_machine_start(name, resource_group, **kwargs):
     :param resource_group: The resource group name assigned to the
         virtual machine.
 
+    :param cloud_provider: The Cloud Provider parameter allow you to use a defined
+        provider config in /etc/salt/cloud.providers.d/
+        with this paramater, you dont have to specify ressource_group as it is already defined in the provider
+
     CLI Example:
 
     .. code-block:: bash
 
         salt-call azurearm_compute.virtual_machine_start testvm testgroup
 
+    .. code-block:: bash
+
+        salt-call azurearm_compute.virtual_machine_start testvm cloud_provider=my-azurearm-config
+
     """
-    compconn = __utils__["azurearm.get_client"]("compute", **kwargs)
+    if cloud_provider is not None:
+        conn_config = get_config_from_cloud(cloud_provider)
+        resource_group = conn_config["resource_group"]
+        kwargs.update(conn_config)
+    compconn = salt.utils.azurearm.get_client("compute", **kwargs)
     try:
         # pylint: disable=invalid-name
         vm = compconn.virtual_machines.start(
@@ -671,13 +883,13 @@ def virtual_machine_start(name, resource_group, **kwargs):
         vm_result = vm.result()
         result = vm_result.as_dict()
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("compute", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("compute", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
 
 
-def virtual_machine_redeploy(name, resource_group, **kwargs):
+def virtual_machine_redeploy(name, resource_group=None, cloud_provider=None, **kwargs):
     """
     .. versionadded:: 2019.2.0
 
@@ -695,7 +907,11 @@ def virtual_machine_redeploy(name, resource_group, **kwargs):
         salt-call azurearm_compute.virtual_machine_redeploy testvm testgroup
 
     """
-    compconn = __utils__["azurearm.get_client"]("compute", **kwargs)
+    if cloud_provider is not None:
+        conn_config = get_config_from_cloud(cloud_provider)
+        resource_group = conn_config["resource_group"]
+        kwargs.update(conn_config)
+    compconn = salt.utils.azurearm.get_client("compute", **kwargs)
     try:
         # pylint: disable=invalid-name
         vm = compconn.virtual_machines.redeploy(
@@ -705,7 +921,7 @@ def virtual_machine_redeploy(name, resource_group, **kwargs):
         vm_result = vm.result()
         result = vm_result.as_dict()
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("compute", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("compute", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result

--- a/salt/modules/azurearm_dns.py
+++ b/salt/modules/azurearm_dns.py
@@ -3,20 +3,24 @@ Azure (ARM) DNS Execution Module
 
 .. versionadded:: 3000
 
-:maintainer: <devops@eitr.tech>
+:maintainer: <devops@eitr.tech>, <devops@l2web.ca>
 :maturity: new
 :depends:
-    * `azure <https://pypi.python.org/pypi/azure>`_ >= 2.0.0
-    * `azure-common <https://pypi.python.org/pypi/azure-common>`_ >= 1.1.8
-    * `azure-mgmt <https://pypi.python.org/pypi/azure-mgmt>`_ >= 1.0.0
-    * `azure-mgmt-compute <https://pypi.python.org/pypi/azure-mgmt-compute>`_ >= 1.0.0
-    * `azure-mgmt-dns <https://pypi.python.org/pypi/azure-mgmt-dns>`_ >= 2.0.0rc1
-    * `azure-mgmt-network <https://pypi.python.org/pypi/azure-mgmt-network>`_ >= 1.7.1
-    * `azure-mgmt-resource <https://pypi.python.org/pypi/azure-mgmt-resource>`_ >= 1.1.0
-    * `azure-mgmt-storage <https://pypi.python.org/pypi/azure-mgmt-storage>`_ >= 1.0.0
-    * `azure-mgmt-web <https://pypi.python.org/pypi/azure-mgmt-web>`_ >= 0.32.0
-    * `azure-storage <https://pypi.python.org/pypi/azure-storage>`_ >= 0.34.3
-    * `msrestazure <https://pypi.python.org/pypi/msrestazure>`_ >= 0.4.21
+    * `azure-core <https://pypi.python.org/pypi/azure-core>`_ >= 1.15.0
+    * `azure-batch <https://pypi.python.org/pypi/azure-batch>`_ >= 10.0.0
+    * `azure-identity <https://pypi.python.org/pypi/azure-identity>`_ >= 1.6.0
+    * `azure-common <https://pypi.python.org/pypi/azure-common>`_ >= 1.1.27
+    * `azure-mgmt-core <https://pypi.python.org/pypi/azure-mgmt-core>`_ >= 1.2.2
+    * `azure-mgmt-subscription <https://pypi.python.org/pypi/azure-mgmt-subscription>`_ >= 1.0.0
+    * `azure-mgmt-compute <https://pypi.python.org/pypi/azure-mgmt-compute>`_ >= 20.0.0
+    * `azure-mgmt-network <https://pypi.python.org/pypi/azure-mgmt-network>`_ >= 19.0.0
+    * `azure-mgmt-resource <https://pypi.python.org/pypi/azure-mgmt-resource>`_ >= 18.0.0
+    * `azure-mgmt-storage <https://pypi.python.org/pypi/azure-mgmt-storage>`_ >= 18.0.0
+    * `azure-mgmt-web <https://pypi.python.org/pypi/azure-mgmt-web>`_ >= 2.0.0
+    * `azure-storage-common <https://pypi.python.org/pypi/azure-storage-common>`_ >= 1.4.2
+    * `azure-storage-blob <https://pypi.python.org/pypi/azure-storage-blob>`_ >= 12.8.1
+    * `azure-storage-file <https://pypi.python.org/pypi/azure-storage-file>`_ >= 2.1.0
+    * `msrestazure <https://pypi.python.org/pypi/msrestazure>`_ >= 0.6.41
 
 :platform: linux
 :configuration:
@@ -55,6 +59,7 @@ Optional provider parameters:
 
 import logging
 
+import salt.cloud
 import salt.utils.azurearm
 
 # Azure libs
@@ -85,7 +90,9 @@ def __virtual__():
     return __virtualname__
 
 
-def record_set_create_or_update(name, zone_name, resource_group, record_type, **kwargs):
+def record_set_create_or_update(
+    name, zone_name, record_type, resource_group=None, cloud_provider=None, **kwargs
+):
     """
     .. versionadded:: 3000
 
@@ -95,28 +102,46 @@ def record_set_create_or_update(name, zone_name, resource_group, record_type, **
 
     :param zone_name: The name of the DNS zone (without a terminating dot).
 
-    :param resource_group: The name of the resource group.
-
     :param record_type:
         The type of DNS record in this record set. Record sets of type SOA can be
         updated but not created (they are created when the DNS zone is created).
         Possible values include: 'A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NS', 'PTR', 'SOA', 'SRV', 'TXT'
 
+    :param resource_group: The name of the resource group.
+
+    :param cloud_provider: The Cloud Provider parameter allow you to use a defined
+        provider config in /etc/salt/cloud.providers.d/
+        with this paramater, you dont have to specify ressource_group as it is already defined in the provider.
+        If you specify the ressource_group anyway, it will overwrite the cloud ressource_group value.
+
     CLI Example:
 
     .. code-block:: bash
 
-        salt-call azurearm_dns.record_set_create_or_update myhost myzone testgroup A
-            arecords='[{ipv4_address: 10.0.0.1}]' ttl=300
+        salt-call azurearm_dns.record_set_create_or_update myhost myzone A
+            arecords='[{ipv4_address: 10.0.0.1}]' ttl=300 testgroup=
+
+    .. code-block:: bash
+
+        salt-call azurearm_dns.record_set_create_or_update myhost myzone A
+            arecords='[{ipv4_address: 10.0.0.1}]' ttl=300 cloud_provider=my-azurearm-config
 
     """
+    if cloud_provider is not None:
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
+        if "error" in conn_config:
+            return conn_config
+        else:
+            if resource_group is None:
+                resource_group = conn_config["resource_group"]
+            else:
+                conn_config["resource_group"] = resource_group
+            kwargs.update(conn_config)
 
-    if "dnsconn" not in globals():
-        global dnsconn  # pylint: disable=W0601
-        dnsconn = salt.utils.azurearm.get_client("dns", **kwargs)
+    dnsconn = __utils__["azurearm.get_client"]("dns", **kwargs)
 
     try:
-        record_set_model = salt.utils.azurearm.create_object_model(
+        record_set_model = __utils__["azurearm.create_object_model"](
             "dns", "RecordSet", **kwargs
         )
     except TypeError as exc:
@@ -125,9 +150,9 @@ def record_set_create_or_update(name, zone_name, resource_group, record_type, **
 
     try:
         record_set = dnsconn.record_sets.create_or_update(
-            resource_group_name=resource_group,
-            zone_name=zone_name,
             relative_record_set_name=name,
+            zone_name=zone_name,
+            resource_group_name=resource_group,
             record_type=record_type,
             parameters=record_set_model,
             if_match=kwargs.get("if_match"),
@@ -135,7 +160,7 @@ def record_set_create_or_update(name, zone_name, resource_group, record_type, **
         )
         result = record_set.as_dict()
     except CloudError as exc:
-        salt.utils.azurearm.log_cloud_error("dns", str(exc), **kwargs)
+        __utils__["azurearm.log_cloud_error"]("dns", str(exc), **kwargs)
         result = {"error": str(exc)}
     except SerializationError as exc:
         result = {
@@ -145,7 +170,9 @@ def record_set_create_or_update(name, zone_name, resource_group, record_type, **
     return result
 
 
-def record_set_delete(name, zone_name, resource_group, record_type, **kwargs):
+def record_set_delete(
+    name, zone_name, record_type, resource_group=None, cloud_provider=None, **kwargs
+):
     """
     .. versionadded:: 3000
 
@@ -155,38 +182,61 @@ def record_set_delete(name, zone_name, resource_group, record_type, **kwargs):
 
     :param zone_name: The name of the DNS zone (without a terminating dot).
 
-    :param resource_group: The name of the resource group.
-
     :param record_type:
         The type of DNS record in this record set. Record sets of type SOA cannot be
         deleted (they are deleted when the DNS zone is deleted).
         Possible values include: 'A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NS', 'PTR', 'SOA', 'SRV', 'TXT'
 
+    :param resource_group: The name of the resource group.
+
+    :param cloud_provider: The Cloud Provider parameter allow you to use a defined
+        provider config in /etc/salt/cloud.providers.d/
+        with this paramater, you dont have to specify ressource_group as it is already defined in the provider.
+        If you specify the ressource_group anyway, it will overwrite the cloud ressource_group value.
+
     CLI Example:
 
     .. code-block:: bash
 
-        salt-call azurearm_dns.record_set_delete myhost myzone testgroup A
+        salt-call azurearm_dns.record_set_delete myhost myzone A testgroup
+
+    .. code-block:: bash
+
+        salt-call azurearm_dns.record_set_delete myhost myzone A cloud_provider=my-azurearm-config
 
     """
     result = False
-    dnsconn = salt.utils.azurearm.get_client("dns", **kwargs)
+
+    if cloud_provider is not None:
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
+        if "error" in conn_config:
+            return conn_config
+        else:
+            if resource_group is None:
+                resource_group = conn_config["resource_group"]
+            else:
+                conn_config["resource_group"] = resource_group
+            kwargs.update(conn_config)
+
+    dnsconn = __utils__["azurearm.get_client"]("dns", **kwargs)
     try:
         record_set = dnsconn.record_sets.delete(
-            resource_group_name=resource_group,
-            zone_name=zone_name,
             relative_record_set_name=name,
+            zone_name=zone_name,
+            resource_group_name=resource_group,
             record_type=record_type,
             if_match=kwargs.get("if_match"),
         )
         result = True
     except CloudError as exc:
-        salt.utils.azurearm.log_cloud_error("dns", str(exc), **kwargs)
+        __utils__["azurearm.log_cloud_error"]("dns", str(exc), **kwargs)
 
     return result
 
 
-def record_set_get(name, zone_name, resource_group, record_type, **kwargs):
+def record_set_get(
+    name, zone_name, record_type, resource_group=None, cloud_provider=None, **kwargs
+):
     """
     .. versionadded:: 3000
 
@@ -196,20 +246,41 @@ def record_set_get(name, zone_name, resource_group, record_type, **kwargs):
 
     :param zone_name: The name of the DNS zone (without a terminating dot).
 
-    :param resource_group: The name of the resource group.
-
     :param record_type:
         The type of DNS record in this record set.
         Possible values include: 'A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NS', 'PTR', 'SOA', 'SRV', 'TXT'
+
+    :param resource_group: The name of the resource group.
+
+    :param cloud_provider: The Cloud Provider parameter allow you to use a defined
+        provider config in /etc/salt/cloud.providers.d/
+        with this paramater, you dont have to specify ressource_group as it is already defined in the provider.
+        If you specify the ressource_group anyway, it will overwrite the cloud ressource_group value.
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt-call azurearm_dns.record_set_get '@' myzone testgroup SOA
+        salt-call azurearm_dns.record_set_get '@' myzone SOA testgroup
+
+    .. code-block:: bash
+
+        salt-call azurearm_dns.record_set_get '@' myzone SOA cloud_provider=my-azurearm-config
 
     """
-    dnsconn = salt.utils.azurearm.get_client("dns", **kwargs)
+
+    if cloud_provider is not None:
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
+        if "error" in conn_config:
+            return conn_config
+        else:
+            if resource_group is None:
+                resource_group = conn_config["resource_group"]
+            else:
+                conn_config["resource_group"] = resource_group
+            kwargs.update(conn_config)
+
+    dnsconn = __utils__["azurearm.get_client"]("dns", **kwargs)
     try:
         record_set = dnsconn.record_sets.get(
             relative_record_set_name=name,
@@ -220,14 +291,20 @@ def record_set_get(name, zone_name, resource_group, record_type, **kwargs):
         result = record_set.as_dict()
 
     except CloudError as exc:
-        salt.utils.azurearm.log_cloud_error("dns", str(exc), **kwargs)
+        __utils__["azurearm.log_cloud_error"]("dns", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
 
 
 def record_sets_list_by_type(
-    zone_name, resource_group, record_type, top=None, recordsetnamesuffix=None, **kwargs
+    zone_name,
+    record_type,
+    resource_group=None,
+    cloud_provider=None,
+    top=None,
+    recordsetnamesuffix=None,
+    **kwargs
 ):
     """
     .. versionadded:: 3000
@@ -235,8 +312,6 @@ def record_sets_list_by_type(
     Lists the record sets of a specified type in a DNS zone.
 
     :param zone_name: The name of the DNS zone (without a terminating dot).
-
-    :param resource_group: The name of the resource group.
 
     :param record_type:
         The type of record sets to enumerate.
@@ -250,17 +325,40 @@ def record_sets_list_by_type(
         The suffix label of the record set name that has
         to be used to filter the record set enumerations.
 
+    :param resource_group: The name of the resource group.
+
+    :param cloud_provider: The Cloud Provider parameter allow you to use a defined
+        provider config in /etc/salt/cloud.providers.d/
+        with this paramater, you don't have to specify ressource_group as it is already defined in the provider.
+        If you specify the ressource_group anyway, it will overwrite the cloud ressource_group value.
+
     CLI Example:
 
     .. code-block:: bash
 
-        salt-call azurearm_dns.record_sets_list_by_type myzone testgroup SOA
+        salt-call azurearm_dns.record_sets_list_by_type myzone SOA testgroup
+
+    .. code-block:: bash
+
+        salt-call azurearm_dns.record_sets_list_by_type myzone SOA cloud_provider=my-azurearm-config
 
     """
     result = {}
-    dnsconn = salt.utils.azurearm.get_client("dns", **kwargs)
+
+    if cloud_provider is not None:
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
+        if "error" in conn_config:
+            return conn_config
+        else:
+            if resource_group is None:
+                resource_group = conn_config["resource_group"]
+            else:
+                conn_config["resource_group"] = resource_group
+            kwargs.update(conn_config)
+
+    dnsconn = __utils__["azurearm.get_client"]("dns", **kwargs)
     try:
-        record_sets = salt.utils.azurearm.paged_object_to_list(
+        record_sets = __utils__["azurearm.paged_object_to_list"](
             dnsconn.record_sets.list_by_type(
                 zone_name=zone_name,
                 resource_group_name=resource_group,
@@ -273,14 +371,19 @@ def record_sets_list_by_type(
         for record_set in record_sets:
             result[record_set["name"]] = record_set
     except CloudError as exc:
-        salt.utils.azurearm.log_cloud_error("dns", str(exc), **kwargs)
+        __utils__["azurearm.log_cloud_error"]("dns", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
 
 
 def record_sets_list_by_dns_zone(
-    zone_name, resource_group, top=None, recordsetnamesuffix=None, **kwargs
+    zone_name,
+    resource_group=None,
+    cloud_provider=None,
+    top=None,
+    recordsetnamesuffix=None,
+    **kwargs
 ):
     """
     .. versionadded:: 3000
@@ -299,17 +402,38 @@ def record_sets_list_by_dns_zone(
         The suffix label of the record set name that has
         to be used to filter the record set enumerations.
 
+    :param cloud_provider: The Cloud Provider parameter allow you to use a defined
+        provider config in /etc/salt/cloud.providers.d/
+        with this paramater, you dont have to specify ressource_group as it is already defined in the provider.
+        If you specify the ressource_group anyway, it will overwrite the cloud ressource_group value.
+
     CLI Example:
 
     .. code-block:: bash
 
         salt-call azurearm_dns.record_sets_list_by_dns_zone myzone testgroup
 
+    .. code-block:: bash
+
+        salt-call azurearm_dns.record_sets_list_by_dns_zone myzone cloud_provider=my-azurearm-config
+
     """
     result = {}
-    dnsconn = salt.utils.azurearm.get_client("dns", **kwargs)
+
+    if cloud_provider is not None:
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
+        if "error" in conn_config:
+            return conn_config
+        else:
+            if resource_group is None:
+                resource_group = conn_config["resource_group"]
+            else:
+                conn_config["resource_group"] = resource_group
+            kwargs.update(conn_config)
+
+    dnsconn = __utils__["azurearm.get_client"]("dns", **kwargs)
     try:
-        record_sets = salt.utils.azurearm.paged_object_to_list(
+        record_sets = __utils__["azurearm.paged_object_to_list"](
             dnsconn.record_sets.list_by_dns_zone(
                 zone_name=zone_name,
                 resource_group_name=resource_group,
@@ -321,13 +445,13 @@ def record_sets_list_by_dns_zone(
         for record_set in record_sets:
             result[record_set["name"]] = record_set
     except CloudError as exc:
-        salt.utils.azurearm.log_cloud_error("dns", str(exc), **kwargs)
+        __utils__["azurearm.log_cloud_error"]("dns", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
 
 
-def zone_create_or_update(name, resource_group, **kwargs):
+def zone_create_or_update(name, resource_group=None, cloud_provider=None, **kwargs):
     """
     .. versionadded:: 3000
 
@@ -337,17 +461,36 @@ def zone_create_or_update(name, resource_group, **kwargs):
 
     :param resource_group: The name of the resource group.
 
+    :param cloud_provider: The Cloud Provider parameter allow you to use a defined
+        provider config in /etc/salt/cloud.providers.d/
+        with this paramater, you dont have to specify ressource_group as it is already defined in the provider.
+        If you specify the ressource_group anyway, it will overwrite the cloud ressource_group value.
+
     CLI Example:
 
     .. code-block:: bash
 
         salt-call azurearm_dns.zone_create_or_update myzone testgroup
 
+    .. code-block:: bash
+
+        salt-call azurearm_dns.zone_create_or_update myzone cloud_provider=my-azurearm-config
+
     """
+    if cloud_provider is not None:
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
+        if "error" in conn_config:
+            return conn_config
+        else:
+            if resource_group is None:
+                resource_group = conn_config["resource_group"]
+            else:
+                conn_config["resource_group"] = resource_group
+            kwargs.update(conn_config)
+
     # DNS zones are global objects
     kwargs["location"] = "global"
-
-    dnsconn = salt.utils.azurearm.get_client("dns", **kwargs)
+    dnsconn = __utils__["azurearm.get_client"]("dns", **kwargs)
 
     # Convert list of ID strings to list of dictionaries with id key.
     if isinstance(kwargs.get("registration_virtual_networks"), list):
@@ -361,7 +504,7 @@ def zone_create_or_update(name, resource_group, **kwargs):
         ]
 
     try:
-        zone_model = salt.utils.azurearm.create_object_model("dns", "Zone", **kwargs)
+        zone_model = __utils__["azurearm.create_object_model"]("dns", "Zone", **kwargs)
     except TypeError as exc:
         result = {"error": "The object model could not be built. ({})".format(str(exc))}
         return result
@@ -376,7 +519,7 @@ def zone_create_or_update(name, resource_group, **kwargs):
         )
         result = zone.as_dict()
     except CloudError as exc:
-        salt.utils.azurearm.log_cloud_error("dns", str(exc), **kwargs)
+        __utils__["azurearm.log_cloud_error"]("dns", str(exc), **kwargs)
         result = {"error": str(exc)}
     except SerializationError as exc:
         result = {
@@ -386,7 +529,7 @@ def zone_create_or_update(name, resource_group, **kwargs):
     return result
 
 
-def zone_delete(name, resource_group, **kwargs):
+def zone_delete(name, resource_group=None, cloud_provider=None, **kwargs):
     """
     .. versionadded:: 3000
 
@@ -396,17 +539,38 @@ def zone_delete(name, resource_group, **kwargs):
 
     :param resource_group: The name of the resource group.
 
+    :param cloud_provider: The Cloud Provider parameter allow you to use a defined
+        provider config in /etc/salt/cloud.providers.d/
+        with this paramater, you dont have to specify ressource_group as it is already defined in the provider.
+        If you specify the ressource_group anyway, it will overwrite the cloud ressource_group value.
+
     CLI Example:
 
     .. code-block:: bash
 
         salt-call azurearm_dns.zone_delete myzone testgroup
 
+    .. code-block:: bash
+
+        salt-call azurearm_dns.zone_delete myzone cloud_provider=my-azurearm-config
+
     """
     result = False
-    dnsconn = salt.utils.azurearm.get_client("dns", **kwargs)
+
+    if cloud_provider is not None:
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
+        if "error" in conn_config:
+            return conn_config
+        else:
+            if resource_group is None:
+                resource_group = conn_config["resource_group"]
+            else:
+                conn_config["resource_group"] = resource_group
+            kwargs.update(conn_config)
+
+    dnsconn = __utils__["azurearm.get_client"]("dns", **kwargs)
     try:
-        zone = dnsconn.zones.delete(
+        zone = dnsconn.zones.begin_delete(
             zone_name=name,
             resource_group_name=resource_group,
             if_match=kwargs.get("if_match"),
@@ -414,12 +578,12 @@ def zone_delete(name, resource_group, **kwargs):
         zone.wait()
         result = True
     except CloudError as exc:
-        salt.utils.azurearm.log_cloud_error("dns", str(exc), **kwargs)
+        __utils__["azurearm.log_cloud_error"]("dns", str(exc), **kwargs)
 
     return result
 
 
-def zone_get(name, resource_group, **kwargs):
+def zone_get(name, resource_group=None, cloud_provider=None, **kwargs):
     """
     .. versionadded:: 3000
 
@@ -430,26 +594,48 @@ def zone_get(name, resource_group, **kwargs):
 
     :param resource_group: The name of the resource group.
 
+    :param cloud_provider: The Cloud Provider parameter allow you to use a defined
+        provider config in /etc/salt/cloud.providers.d/
+        with this paramater, you dont have to specify ressource_group as it is already defined in the provider.
+        If you specify the ressource_group anyway, it will overwrite the cloud ressource_group value.
+
     CLI Example:
 
     .. code-block:: bash
 
         salt-call azurearm_dns.zone_get myzone testgroup
 
+    .. code-block:: bash
+
+        salt-call azurearm_dns.zone_get myzone cloud_provider=my-azurearm-config
+
     """
-    dnsconn = salt.utils.azurearm.get_client("dns", **kwargs)
+    if cloud_provider is not None:
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
+        if "error" in conn_config:
+            return conn_config
+        else:
+            if resource_group is None:
+                resource_group = conn_config["resource_group"]
+            else:
+                conn_config["resource_group"] = resource_group
+            kwargs.update(conn_config)
+
+    dnsconn = __utils__["azurearm.get_client"]("dns", **kwargs)
     try:
         zone = dnsconn.zones.get(zone_name=name, resource_group_name=resource_group)
         result = zone.as_dict()
 
     except CloudError as exc:
-        salt.utils.azurearm.log_cloud_error("dns", str(exc), **kwargs)
+        __utils__["azurearm.log_cloud_error"]("dns", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
 
 
-def zones_list_by_resource_group(resource_group, top=None, **kwargs):
+def zones_list_by_resource_group(
+    resource_group=None, cloud_provider=None, top=None, **kwargs
+):
     """
     .. versionadded:: 3000
 
@@ -461,17 +647,38 @@ def zones_list_by_resource_group(resource_group, top=None, **kwargs):
         The maximum number of DNS zones to return. If not specified,
         returns up to 100 zones.
 
+    :param cloud_provider: The Cloud Provider parameter allow you to use a defined
+        provider config in /etc/salt/cloud.providers.d/
+        with this paramater, you dont have to specify ressource_group as it is already defined in the provider.
+        If you specify the ressource_group anyway, it will overwrite the cloud ressource_group value.
+
     CLI Example:
 
     .. code-block:: bash
 
         salt-call azurearm_dns.zones_list_by_resource_group testgroup
 
+    .. code-block:: bash
+
+        salt-call azurearm_dns.zones_list_by_resource_group cloud_provider=my-azurearm-config
+
     """
     result = {}
-    dnsconn = salt.utils.azurearm.get_client("dns", **kwargs)
+
+    if cloud_provider is not None:
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
+        if "error" in conn_config:
+            return conn_config
+        else:
+            if resource_group is None:
+                resource_group = conn_config["resource_group"]
+            else:
+                conn_config["resource_group"] = resource_group
+            kwargs.update(conn_config)
+
+    dnsconn = __utils__["azurearm.get_client"]("dns", **kwargs)
     try:
-        zones = salt.utils.azurearm.paged_object_to_list(
+        zones = __utils__["azurearm.paged_object_to_list"](
             dnsconn.zones.list_by_resource_group(
                 resource_group_name=resource_group, top=top
             )
@@ -480,13 +687,13 @@ def zones_list_by_resource_group(resource_group, top=None, **kwargs):
         for zone in zones:
             result[zone["name"]] = zone
     except CloudError as exc:
-        salt.utils.azurearm.log_cloud_error("dns", str(exc), **kwargs)
+        __utils__["azurearm.log_cloud_error"]("dns", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
 
 
-def zones_list(top=None, **kwargs):
+def zones_list(top=None, cloud_provider=None, **kwargs):
     """
     .. versionadded:: 3000
 
@@ -496,22 +703,39 @@ def zones_list(top=None, **kwargs):
         The maximum number of DNS zones to return. If not specified,
         eturns up to 100 zones.
 
+    :param cloud_provider: The Cloud Provider parameter allow you to use a defined
+        provider config in /etc/salt/cloud.providers.d/
+        with this paramater, you dont have to specify / duplicate informations already provided in the cloud
+        provider config file.
+
     CLI Example:
 
     .. code-block:: bash
 
         salt-call azurearm_dns.zones_list
 
+    .. code-block:: bash
+
+        salt-call azurearm_dns.zones_list cloud_provider=my-azurearm-config
+
     """
     result = {}
-    dnsconn = salt.utils.azurearm.get_client("dns", **kwargs)
+
+    if cloud_provider is not None:
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
+        if "error" in conn_config:
+            return conn_config
+        else:
+            kwargs.update(conn_config)
+
+    dnsconn = __utils__["azurearm.get_client"]("dns", **kwargs)
     try:
-        zones = salt.utils.azurearm.paged_object_to_list(dnsconn.zones.list(top=top))
+        zones = __utils__["azurearm.paged_object_to_list"](dnsconn.zones.list(top=top))
 
         for zone in zones:
             result[zone["name"]] = zone
     except CloudError as exc:
-        salt.utils.azurearm.log_cloud_error("dns", str(exc), **kwargs)
+        __utils__["azurearm.log_cloud_error"]("dns", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result

--- a/salt/modules/azurearm_dns.py
+++ b/salt/modules/azurearm_dns.py
@@ -20,6 +20,7 @@ Azure (ARM) DNS Execution Module
     * `azure-storage-common <https://pypi.python.org/pypi/azure-storage-common>`_ >= 1.4.2
     * `azure-storage-blob <https://pypi.python.org/pypi/azure-storage-blob>`_ >= 12.8.1
     * `azure-storage-file <https://pypi.python.org/pypi/azure-storage-file>`_ >= 2.1.0
+    * `azure-mgmt-dns <https://pypi.python.org/pypi/azure-mgmt-dns>`_ >= 8.0.0
     * `msrestazure <https://pypi.python.org/pypi/msrestazure>`_ >= 0.6.41
 
 :platform: linux
@@ -141,6 +142,8 @@ def record_set_create_or_update(
     dnsconn = __utils__["azurearm.get_client"]("dns", **kwargs)
 
     try:
+        # This is broken and doesn't return any usefull data
+        # parameters=record_set_model,
         record_set_model = __utils__["azurearm.create_object_model"](
             "dns", "RecordSet", **kwargs
         )
@@ -149,15 +152,19 @@ def record_set_create_or_update(
         return result
 
     try:
+        parameters = {}
+        parameters['ttl'] = kwargs['ttl']
+        parameters['arecords'] = kwargs['arecords']
         record_set = dnsconn.record_sets.create_or_update(
             relative_record_set_name=name,
             zone_name=zone_name,
             resource_group_name=resource_group,
             record_type=record_type,
-            parameters=record_set_model,
+            parameters=parameters,
             if_match=kwargs.get("if_match"),
             if_none_match=kwargs.get("if_none_match"),
         )
+
         result = record_set.as_dict()
     except CloudError as exc:
         __utils__["azurearm.log_cloud_error"]("dns", str(exc), **kwargs)
@@ -701,7 +708,7 @@ def zones_list(top=None, cloud_provider=None, **kwargs):
 
     :param top:
         The maximum number of DNS zones to return. If not specified,
-        eturns up to 100 zones.
+        returns up to 100 zones.
 
     :param cloud_provider: The Cloud Provider parameter allow you to use a defined
         provider config in /etc/salt/cloud.providers.d/

--- a/salt/modules/azurearm_dns.py
+++ b/salt/modules/azurearm_dns.py
@@ -153,8 +153,8 @@ def record_set_create_or_update(
 
     try:
         parameters = {}
-        parameters['ttl'] = kwargs['ttl']
-        parameters['arecords'] = kwargs['arecords']
+        parameters["ttl"] = kwargs["ttl"]
+        parameters["arecords"] = kwargs["arecords"]
         record_set = dnsconn.record_sets.create_or_update(
             relative_record_set_name=name,
             zone_name=zone_name,

--- a/salt/modules/azurearm_network.py
+++ b/salt/modules/azurearm_network.py
@@ -58,6 +58,7 @@ import logging
 import salt.cloud
 import salt.loader
 import salt.utils
+import salt.utils.azurearm
 
 # Salt libs
 from salt.exceptions import SaltInvocationError  # pylint: disable=unused-import
@@ -93,12 +94,6 @@ def __virtual__():
     return __virtualname__
 
 
-def get_config_from_cloud(cloud_provider):
-    client = salt.cloud.CloudClient(path="/etc/salt/cloud")
-    conn_kwargs = client.opts["providers"][cloud_provider]["azurearm"]
-    return conn_kwargs
-
-
 def check_dns_name_availability(name, region, cloud_provider=None, **kwargs):
     """
     .. versionadded:: 2019.2.0
@@ -121,7 +116,7 @@ def check_dns_name_availability(name, region, cloud_provider=None, **kwargs):
 
     """
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         kwargs.update(conn_config)
 
     netconn = __utils__["azurearm.get_client"]("network", **kwargs)
@@ -156,7 +151,7 @@ def check_ip_address_availability(
 
     :param cloud_provider: The Cloud Provider parameter allow you to use a defined
         provider config in /etc/salt/cloud.providers.d/
-        with this paramater, you dont have to specify ressource_group as it is already defined in the provider
+        with this paramater, you don't have to specify ressource_group as it is already defined in the provider
 
     CLI Example:
 
@@ -167,7 +162,7 @@ def check_ip_address_availability(
     """
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -219,7 +214,7 @@ def default_security_rule_get(
     result = {}
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -273,7 +268,7 @@ def default_security_rules_list(
     result = {}
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -322,7 +317,7 @@ def security_rules_list(
     """
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -454,7 +449,7 @@ def security_rule_create_or_update(
             exec("{} = None".format(params[1]))
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -537,7 +532,7 @@ def security_rule_delete(
     result = False
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -588,7 +583,7 @@ def security_rule_get(
     """
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -636,7 +631,7 @@ def network_security_group_create_or_update(
     """
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -710,7 +705,7 @@ def network_security_group_delete(
     result = False
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -756,7 +751,7 @@ def network_security_group_get(
     """
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -799,7 +794,7 @@ def network_security_groups_list(resource_group=None, cloud_provider=None, **kwa
     result = {}
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -842,7 +837,7 @@ def network_security_groups_list_all(
     result = {}
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         kwargs.update(conn_config)
 
     netconn = __utils__["azurearm.get_client"]("network", **kwargs)
@@ -884,7 +879,7 @@ def subnets_list(virtual_network, resource_group=None, cloud_provider=None, **kw
     result = {}
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -937,7 +932,7 @@ def subnet_get(
     """
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -997,7 +992,7 @@ def subnet_create_or_update(
     """
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -1087,7 +1082,7 @@ def subnet_delete(
     result = False
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -1129,7 +1124,7 @@ def virtual_networks_list_all(cloud_provider=None, **kwargs):
     result = {}
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         kwargs.update(conn_config)
 
     netconn = __utils__["azurearm.get_client"]("network", **kwargs)
@@ -1170,7 +1165,7 @@ def virtual_networks_list(resource_group=None, cloud_provider=None, **kwargs):
     result = {}
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -1224,7 +1219,7 @@ def virtual_network_create_or_update(
     """
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -1307,7 +1302,7 @@ def virtual_network_delete(name, resource_group=None, cloud_provider=None, **kwa
     result = False
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -1351,7 +1346,7 @@ def virtual_network_get(name, resource_group=None, cloud_provider=None, **kwargs
     """
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -1391,7 +1386,7 @@ def load_balancers_list_all(cloud_provider=None, **kwargs):
     result = {}
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         kwargs.update(conn_config)
 
     netconn = __utils__["azurearm.get_client"]("network", **kwargs)
@@ -1432,7 +1427,7 @@ def load_balancers_list(resource_group=None, cloud_provider=None, **kwargs):
     result = {}
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -1478,7 +1473,7 @@ def load_balancer_get(name, resource_group=None, cloud_provider=None, **kwargs):
     """
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -1524,7 +1519,7 @@ def load_balancer_create_or_update(
     """
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -1724,7 +1719,7 @@ def load_balancer_delete(name, resource_group=None, cloud_provider=None, **kwarg
     result = False
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -1765,7 +1760,7 @@ def usages_list(location, cloud_provider=None, **kwargs):
     """
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         kwargs.update(conn_config)
 
     netconn = __utils__["azurearm.get_client"]("network", **kwargs)
@@ -1805,7 +1800,7 @@ def network_interface_delete(name, resource_group=None, cloud_provider=None, **k
     result = False
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -1849,7 +1844,7 @@ def network_interface_get(name, resource_group=None, cloud_provider=None, **kwar
     """
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -1911,7 +1906,7 @@ def network_interface_create_or_update(
     """
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -2033,7 +2028,7 @@ def network_interfaces_list_all(cloud_provider=None, **kwargs):
     result = {}
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         kwargs.update(conn_config)
 
     netconn = __utils__["azurearm.get_client"]("network", **kwargs)
@@ -2074,7 +2069,7 @@ def network_interfaces_list(resource_group=None, cloud_provider=None, **kwargs):
     result = {}
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -2123,7 +2118,7 @@ def network_interface_get_effective_route_table(
     """
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -2173,7 +2168,7 @@ def network_interface_list_effective_network_security_groups(
     """
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -2226,7 +2221,7 @@ def list_virtual_machine_scale_set_vm_network_interfaces(
     result = {}
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -2280,7 +2275,7 @@ def list_virtual_machine_scale_set_network_interfaces(
     result = {}
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -2336,7 +2331,7 @@ def get_virtual_machine_scale_set_network_interface(
     """
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -2388,7 +2383,7 @@ def public_ip_address_delete(name, resource_group=None, cloud_provider=None, **k
     result = False
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -2432,7 +2427,7 @@ def public_ip_address_get(name, resource_group=None, cloud_provider=None, **kwar
     """
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -2483,7 +2478,7 @@ def public_ip_address_create_or_update(
     """
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -2550,7 +2545,7 @@ def public_ip_addresses_list_all(cloud_provider=None, **kwargs):
     result = {}
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         kwargs.update(conn_config)
 
     netconn = __utils__["azurearm.get_client"]("network", **kwargs)
@@ -2591,7 +2586,7 @@ def public_ip_addresses_list(resource_group=None, cloud_provider=None, **kwargs)
     result = {}
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -2642,7 +2637,7 @@ def route_filter_rule_delete(
     result = False
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -2693,7 +2688,7 @@ def route_filter_rule_get(
     result = {}
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -2755,7 +2750,7 @@ def route_filter_rule_create_or_update(
     """
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -2841,7 +2836,7 @@ def route_filter_rules_list(
     result = {}
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -2890,7 +2885,7 @@ def route_filter_delete(name, resource_group=None, cloud_provider=None, **kwargs
     result = False
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -2933,7 +2928,7 @@ def route_filter_get(name, resource_group=None, cloud_provider=None, **kwargs):
 
     """
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -2981,7 +2976,7 @@ def route_filter_create_or_update(
 
     """
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -3051,7 +3046,7 @@ def route_filters_list(resource_group=None, cloud_provider=None, **kwargs):
     result = {}
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -3095,7 +3090,7 @@ def route_filters_list_all(cloud_provider=None, **kwargs):
     result = {}
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         kwargs.update(conn_config)
 
     netconn = __utils__["azurearm.get_client"]("network", **kwargs)
@@ -3140,7 +3135,7 @@ def route_delete(name, route_table, resource_group=None, cloud_provider=None, **
     result = False
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -3189,7 +3184,7 @@ def route_get(name, route_table, resource_group=None, cloud_provider=None, **kwa
     result = {}
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -3256,7 +3251,7 @@ def route_create_or_update(
     netconn = __utils__["azurearm.get_client"]("network", **kwargs)
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -3322,7 +3317,7 @@ def routes_list(route_table, resource_group=None, cloud_provider=None, **kwargs)
     result = {}
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -3371,7 +3366,7 @@ def route_table_delete(name, resource_group=None, cloud_provider=None, **kwargs)
     result = False
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -3415,7 +3410,7 @@ def route_table_get(name, resource_group=None, cloud_provider=None, **kwargs):
     """
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -3464,7 +3459,7 @@ def route_table_create_or_update(
     """
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -3534,7 +3529,7 @@ def route_tables_list(resource_group=None, cloud_provider=None, **kwargs):
     result = {}
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         if resource_group is None:
             resource_group = conn_config["resource_group"]
         else:
@@ -3576,7 +3571,7 @@ def route_tables_list_all(cloud_provider=None, **kwargs):
     result = {}
 
     if cloud_provider is not None:
-        conn_config = get_config_from_cloud(cloud_provider)
+        conn_config = salt.utils.azurearm.get_config_from_cloud(cloud_provider)
         kwargs.update(conn_config)
 
     netconn = __utils__["azurearm.get_client"]("network", **kwargs)

--- a/salt/modules/azurearm_resource.py
+++ b/salt/modules/azurearm_resource.py
@@ -1,22 +1,26 @@
-# -*- coding: utf-8 -*-
 """
 Azure (ARM) Resource Execution Module
 
 .. versionadded:: 2019.2.0
 
-:maintainer: <devops@decisionlab.io>
+:maintainer: <devops@decisionlab.io>, <devops@l2web.ca>
 :maturity: new
 :depends:
-    * `azure <https://pypi.python.org/pypi/azure>`_ >= 2.0.0
-    * `azure-common <https://pypi.python.org/pypi/azure-common>`_ >= 1.1.8
-    * `azure-mgmt <https://pypi.python.org/pypi/azure-mgmt>`_ >= 1.0.0
-    * `azure-mgmt-compute <https://pypi.python.org/pypi/azure-mgmt-compute>`_ >= 1.0.0
-    * `azure-mgmt-network <https://pypi.python.org/pypi/azure-mgmt-network>`_ >= 1.7.1
-    * `azure-mgmt-resource <https://pypi.python.org/pypi/azure-mgmt-resource>`_ >= 1.1.0
-    * `azure-mgmt-storage <https://pypi.python.org/pypi/azure-mgmt-storage>`_ >= 1.0.0
-    * `azure-mgmt-web <https://pypi.python.org/pypi/azure-mgmt-web>`_ >= 0.32.0
-    * `azure-storage <https://pypi.python.org/pypi/azure-storage>`_ >= 0.34.3
-    * `msrestazure <https://pypi.python.org/pypi/msrestazure>`_ >= 0.4.21
+    * `azure-core <https://pypi.python.org/pypi/azure-core>`_ >= 1.15.0
+    * `azure-batch <https://pypi.python.org/pypi/azure-batch>`_ >= 10.0.0
+    * `azure-identity <https://pypi.python.org/pypi/azure-identity>`_ >= 1.6.0
+    * `azure-common <https://pypi.python.org/pypi/azure-common>`_ >= 1.1.27
+    * `azure-mgmt-core <https://pypi.python.org/pypi/azure-mgmt-core>`_ >= 1.2.2
+    * `azure-mgmt-subscription <https://pypi.python.org/pypi/azure-mgmt-subscription>`_ >= 1.0.0
+    * `azure-mgmt-compute <https://pypi.python.org/pypi/azure-mgmt-compute>`_ >= 20.0.0
+    * `azure-mgmt-network <https://pypi.python.org/pypi/azure-mgmt-network>`_ >= 19.0.0
+    * `azure-mgmt-resource <https://pypi.python.org/pypi/azure-mgmt-resource>`_ >= 18.0.0
+    * `azure-mgmt-storage <https://pypi.python.org/pypi/azure-mgmt-storage>`_ >= 18.0.0
+    * `azure-mgmt-web <https://pypi.python.org/pypi/azure-mgmt-web>`_ >= 2.0.0
+    * `azure-storage-common <https://pypi.python.org/pypi/azure-storage-common>`_ >= 1.4.2
+    * `azure-storage-blob <https://pypi.python.org/pypi/azure-storage-blob>`_ >= 12.8.1
+    * `azure-storage-file <https://pypi.python.org/pypi/azure-storage-file>`_ >= 2.1.0
+    * `msrestazure <https://pypi.python.org/pypi/msrestazure>`_ >= 0.6.41
 :platform: linux
 
 :configuration: This module requires Azure Resource Manager credentials to be passed as keyword arguments
@@ -47,11 +51,11 @@ Azure (ARM) Resource Execution Module
 """
 
 # Python libs
-from __future__ import absolute_import
 
 import logging
 
 # Salt Libs
+import salt.utils
 import salt.utils.json
 
 # Azure libs
@@ -96,16 +100,16 @@ def resource_groups_list(**kwargs):
 
     """
     result = {}
-    resconn = __utils__["azurearm.get_client"]("resource", **kwargs)
+    resconn = salt.utils.azurearm.get_client("resource", **kwargs)
     try:
-        groups = __utils__["azurearm.paged_object_to_list"](
+        groups = salt.utils.azurearm.paged_object_to_list(
             resconn.resource_groups.list()
         )
 
         for group in groups:
             result[group["name"]] = group
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
@@ -127,12 +131,12 @@ def resource_group_check_existence(name, **kwargs):
 
     """
     result = False
-    resconn = __utils__["azurearm.get_client"]("resource", **kwargs)
+    resconn = salt.utils.azurearm.get_client("resource", **kwargs)
     try:
         result = resconn.resource_groups.check_existence(name)
 
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
 
     return result
 
@@ -153,13 +157,13 @@ def resource_group_get(name, **kwargs):
 
     """
     result = {}
-    resconn = __utils__["azurearm.get_client"]("resource", **kwargs)
+    resconn = salt.utils.azurearm.get_client("resource", **kwargs)
     try:
         group = resconn.resource_groups.get(name)
         result = group.as_dict()
 
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
@@ -186,7 +190,7 @@ def resource_group_create_or_update(
 
     """
     result = {}
-    resconn = __utils__["azurearm.get_client"]("resource", **kwargs)
+    resconn = salt.utils.azurearm.get_client("resource", **kwargs)
     resource_group_params = {
         "location": location,
         "managed_by": kwargs.get("managed_by"),
@@ -196,7 +200,7 @@ def resource_group_create_or_update(
         group = resconn.resource_groups.create_or_update(name, resource_group_params)
         result = group.as_dict()
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
@@ -218,13 +222,13 @@ def resource_group_delete(name, **kwargs):
 
     """
     result = False
-    resconn = __utils__["azurearm.get_client"]("resource", **kwargs)
+    resconn = salt.utils.azurearm.get_client("resource", **kwargs)
     try:
         group = resconn.resource_groups.delete(name)
         group.wait()
         result = True
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
 
     return result
 
@@ -249,7 +253,7 @@ def deployment_operation_get(operation, deployment, resource_group, **kwargs):
         salt-call azurearm_resource.deployment_operation_get XXXXX testdeploy testgroup
 
     """
-    resconn = __utils__["azurearm.get_client"]("resource", **kwargs)
+    resconn = salt.utils.azurearm.get_client("resource", **kwargs)
     try:
         operation = resconn.deployment_operations.get(
             resource_group_name=resource_group,
@@ -259,7 +263,7 @@ def deployment_operation_get(operation, deployment, resource_group, **kwargs):
 
         result = operation.as_dict()
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
@@ -287,9 +291,9 @@ def deployment_operations_list(name, resource_group, result_limit=10, **kwargs):
 
     """
     result = {}
-    resconn = __utils__["azurearm.get_client"]("resource", **kwargs)
+    resconn = salt.utils.azurearm.get_client("resource", **kwargs)
     try:
-        operations = __utils__["azurearm.paged_object_to_list"](
+        operations = salt.utils.azurearm.paged_object_to_list(
             resconn.deployment_operations.list(
                 resource_group_name=resource_group,
                 deployment_name=name,
@@ -300,7 +304,7 @@ def deployment_operations_list(name, resource_group, result_limit=10, **kwargs):
         for oper in operations:
             result[oper["operation_id"]] = oper
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
@@ -325,7 +329,7 @@ def deployment_delete(name, resource_group, **kwargs):
 
     """
     result = False
-    resconn = __utils__["azurearm.get_client"]("resource", **kwargs)
+    resconn = salt.utils.azurearm.get_client("resource", **kwargs)
     try:
         deploy = resconn.deployments.delete(
             deployment_name=name, resource_group_name=resource_group
@@ -333,7 +337,7 @@ def deployment_delete(name, resource_group, **kwargs):
         deploy.wait()
         result = True
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
 
     return result
 
@@ -357,13 +361,13 @@ def deployment_check_existence(name, resource_group, **kwargs):
 
     """
     result = False
-    resconn = __utils__["azurearm.get_client"]("resource", **kwargs)
+    resconn = salt.utils.azurearm.get_client("resource", **kwargs)
     try:
         result = resconn.deployments.check_existence(
             deployment_name=name, resource_group_name=resource_group
         )
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
 
     return result
 
@@ -423,7 +427,7 @@ def deployment_create_or_update(
         salt-call azurearm_resource.deployment_create_or_update testdeploy testgroup
 
     """
-    resconn = __utils__["azurearm.get_client"]("resource", **kwargs)
+    resconn = salt.utils.azurearm.get_client("resource", **kwargs)
 
     prop_kwargs = {"mode": deploy_mode}
     prop_kwargs["debug_setting"] = {"detail_level": debug_setting}
@@ -448,13 +452,11 @@ def deployment_create_or_update(
     deploy_kwargs.update(prop_kwargs)
 
     try:
-        deploy_model = __utils__["azurearm.create_object_model"](
+        deploy_model = salt.utils.azurearm.create_object_model(
             "resource", "DeploymentProperties", **deploy_kwargs
         )
     except TypeError as exc:
-        result = {
-            "error": "The object model could not be built. ({0})".format(str(exc))
-        }
+        result = {"error": "The object model could not be built. ({})".format(str(exc))}
         return result
 
     try:
@@ -473,11 +475,11 @@ def deployment_create_or_update(
             deploy_result = deploy.result()
             result = deploy_result.as_dict()
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
         result = {"error": str(exc)}
     except SerializationError as exc:
         result = {
-            "error": "The object model could not be parsed. ({0})".format(str(exc))
+            "error": "The object model could not be parsed. ({})".format(str(exc))
         }
 
     return result
@@ -501,14 +503,14 @@ def deployment_get(name, resource_group, **kwargs):
         salt-call azurearm_resource.deployment_get testdeploy testgroup
 
     """
-    resconn = __utils__["azurearm.get_client"]("resource", **kwargs)
+    resconn = salt.utils.azurearm.get_client("resource", **kwargs)
     try:
         deploy = resconn.deployments.get(
             deployment_name=name, resource_group_name=resource_group
         )
         result = deploy.as_dict()
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
@@ -532,14 +534,14 @@ def deployment_cancel(name, resource_group, **kwargs):
         salt-call azurearm_resource.deployment_cancel testdeploy testgroup
 
     """
-    resconn = __utils__["azurearm.get_client"]("resource", **kwargs)
+    resconn = salt.utils.azurearm.get_client("resource", **kwargs)
     try:
         resconn.deployments.cancel(
             deployment_name=name, resource_group_name=resource_group
         )
         result = {"result": True}
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
         result = {"error": str(exc), "result": False}
 
     return result
@@ -601,7 +603,7 @@ def deployment_validate(
         salt-call azurearm_resource.deployment_validate testdeploy testgroup
 
     """
-    resconn = __utils__["azurearm.get_client"]("resource", **kwargs)
+    resconn = salt.utils.azurearm.get_client("resource", **kwargs)
 
     prop_kwargs = {"mode": deploy_mode}
     prop_kwargs["debug_setting"] = {"detail_level": debug_setting}
@@ -626,13 +628,11 @@ def deployment_validate(
     deploy_kwargs.update(prop_kwargs)
 
     try:
-        deploy_model = __utils__["azurearm.create_object_model"](
+        deploy_model = salt.utils.azurearm.create_object_model(
             "resource", "DeploymentProperties", **deploy_kwargs
         )
     except TypeError as exc:
-        result = {
-            "error": "The object model could not be built. ({0})".format(str(exc))
-        }
+        result = {"error": "The object model could not be built. ({})".format(str(exc))}
         return result
 
     try:
@@ -647,11 +647,11 @@ def deployment_validate(
         )
         result = deploy.as_dict()
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
         result = {"error": str(exc)}
     except SerializationError as exc:
         result = {
-            "error": "The object model could not be parsed. ({0})".format(str(exc))
+            "error": "The object model could not be parsed. ({})".format(str(exc))
         }
 
     return result
@@ -675,14 +675,14 @@ def deployment_export_template(name, resource_group, **kwargs):
         salt-call azurearm_resource.deployment_export_template testdeploy testgroup
 
     """
-    resconn = __utils__["azurearm.get_client"]("resource", **kwargs)
+    resconn = salt.utils.azurearm.get_client("resource", **kwargs)
     try:
         deploy = resconn.deployments.export_template(
             deployment_name=name, resource_group_name=resource_group
         )
         result = deploy.as_dict()
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
@@ -702,9 +702,9 @@ def deployments_list(resource_group, **kwargs):
 
     """
     result = {}
-    resconn = __utils__["azurearm.get_client"]("resource", **kwargs)
+    resconn = salt.utils.azurearm.get_client("resource", **kwargs)
     try:
-        deployments = __utils__["azurearm.paged_object_to_list"](
+        deployments = salt.utils.azurearm.paged_object_to_list(
             resconn.deployments.list_by_resource_group(
                 resource_group_name=resource_group
             )
@@ -713,7 +713,7 @@ def deployments_list(resource_group, **kwargs):
         for deploy in deployments:
             result[deploy["name"]] = deploy
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
@@ -741,9 +741,9 @@ def subscriptions_list_locations(subscription_id=None, **kwargs):
     elif not kwargs.get("subscription_id"):
         kwargs["subscription_id"] = subscription_id
 
-    subconn = __utils__["azurearm.get_client"]("subscription", **kwargs)
+    subconn = salt.utils.azurearm.get_client("subscription", **kwargs)
     try:
-        locations = __utils__["azurearm.paged_object_to_list"](
+        locations = salt.utils.azurearm.paged_object_to_list(
             subconn.subscriptions.list_locations(
                 subscription_id=kwargs["subscription_id"]
             )
@@ -752,7 +752,7 @@ def subscriptions_list_locations(subscription_id=None, **kwargs):
         for loc in locations:
             result[loc["name"]] = loc
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
@@ -780,7 +780,7 @@ def subscription_get(subscription_id=None, **kwargs):
     elif not kwargs.get("subscription_id"):
         kwargs["subscription_id"] = subscription_id
 
-    subconn = __utils__["azurearm.get_client"]("subscription", **kwargs)
+    subconn = salt.utils.azurearm.get_client("subscription", **kwargs)
     try:
         subscription = subconn.subscriptions.get(
             subscription_id=kwargs.get("subscription_id")
@@ -788,7 +788,7 @@ def subscription_get(subscription_id=None, **kwargs):
 
         result = subscription.as_dict()
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
@@ -808,14 +808,14 @@ def subscriptions_list(**kwargs):
 
     """
     result = {}
-    subconn = __utils__["azurearm.get_client"]("subscription", **kwargs)
+    subconn = salt.utils.azurearm.get_client("subscription", **kwargs)
     try:
-        subs = __utils__["azurearm.paged_object_to_list"](subconn.subscriptions.list())
+        subs = salt.utils.azurearm.paged_object_to_list(subconn.subscriptions.list())
 
         for sub in subs:
             result[sub["subscription_id"]] = sub
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
@@ -835,14 +835,14 @@ def tenants_list(**kwargs):
 
     """
     result = {}
-    subconn = __utils__["azurearm.get_client"]("subscription", **kwargs)
+    subconn = salt.utils.azurearm.get_client("subscription", **kwargs)
     try:
-        tenants = __utils__["azurearm.paged_object_to_list"](subconn.tenants.list())
+        tenants = salt.utils.azurearm.paged_object_to_list(subconn.tenants.list())
 
         for tenant in tenants:
             result[tenant["tenant_id"]] = tenant
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
@@ -867,7 +867,7 @@ def policy_assignment_delete(name, scope, **kwargs):
 
     """
     result = False
-    polconn = __utils__["azurearm.get_client"]("policy", **kwargs)
+    polconn = salt.utils.azurearm.get_client("policy", **kwargs)
     try:
         # pylint: disable=unused-variable
         policy = polconn.policy_assignments.delete(
@@ -875,7 +875,7 @@ def policy_assignment_delete(name, scope, **kwargs):
         )
         result = True
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
 
     return result
 
@@ -900,7 +900,7 @@ def policy_assignment_create(name, scope, definition_name, **kwargs):
         /subscriptions/bc75htn-a0fhsi-349b-56gh-4fghti-f84852 testpolicy
 
     """
-    polconn = __utils__["azurearm.get_client"]("policy", **kwargs)
+    polconn = salt.utils.azurearm.get_client("policy", **kwargs)
 
     # "get" doesn't work for built-in policies per https://github.com/Azure/azure-cli/issues/692
     # Uncomment this section when the ticket above is resolved.
@@ -918,7 +918,7 @@ def policy_assignment_create(name, scope, definition_name, **kwargs):
         definition = definition_list[definition_name]
     else:
         definition = {
-            "error": 'The policy definition named "{0}" could not be found.'.format(
+            "error": 'The policy definition named "{}" could not be found.'.format(
                 definition_name
             )
         }
@@ -933,12 +933,12 @@ def policy_assignment_create(name, scope, definition_name, **kwargs):
         policy_kwargs.update(prop_kwargs)
 
         try:
-            policy_model = __utils__["azurearm.create_object_model"](
+            policy_model = salt.utils.azurearm.create_object_model(
                 "resource.policy", "PolicyAssignment", **policy_kwargs
             )
         except TypeError as exc:
             result = {
-                "error": "The object model could not be built. ({0})".format(str(exc))
+                "error": "The object model could not be built. ({})".format(str(exc))
             }
             return result
 
@@ -948,15 +948,15 @@ def policy_assignment_create(name, scope, definition_name, **kwargs):
             )
             result = policy.as_dict()
         except CloudError as exc:
-            __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+            salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
             result = {"error": str(exc)}
         except SerializationError as exc:
             result = {
-                "error": "The object model could not be parsed. ({0})".format(str(exc))
+                "error": "The object model could not be parsed. ({})".format(str(exc))
             }
     else:
         result = {
-            "error": 'The policy definition named "{0}" could not be found.'.format(
+            "error": 'The policy definition named "{}" could not be found.'.format(
                 definition_name
             )
         }
@@ -982,14 +982,14 @@ def policy_assignment_get(name, scope, **kwargs):
         /subscriptions/bc75htn-a0fhsi-349b-56gh-4fghti-f84852
 
     """
-    polconn = __utils__["azurearm.get_client"]("policy", **kwargs)
+    polconn = salt.utils.azurearm.get_client("policy", **kwargs)
     try:
         policy = polconn.policy_assignments.get(
             policy_assignment_name=name, scope=scope
         )
         result = policy.as_dict()
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
@@ -1013,9 +1013,9 @@ def policy_assignments_list_for_resource_group(
 
     """
     result = {}
-    polconn = __utils__["azurearm.get_client"]("policy", **kwargs)
+    polconn = salt.utils.azurearm.get_client("policy", **kwargs)
     try:
-        policy_assign = __utils__["azurearm.paged_object_to_list"](
+        policy_assign = salt.utils.azurearm.paged_object_to_list(
             polconn.policy_assignments.list_for_resource_group(
                 resource_group_name=resource_group, filter=kwargs.get("filter")
             )
@@ -1024,7 +1024,7 @@ def policy_assignments_list_for_resource_group(
         for assign in policy_assign:
             result[assign["name"]] = assign
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
@@ -1044,16 +1044,16 @@ def policy_assignments_list(**kwargs):
 
     """
     result = {}
-    polconn = __utils__["azurearm.get_client"]("policy", **kwargs)
+    polconn = salt.utils.azurearm.get_client("policy", **kwargs)
     try:
-        policy_assign = __utils__["azurearm.paged_object_to_list"](
+        policy_assign = salt.utils.azurearm.paged_object_to_list(
             polconn.policy_assignments.list()
         )
 
         for assign in policy_assign:
             result[assign["name"]] = assign
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
@@ -1083,7 +1083,7 @@ def policy_definition_create_or_update(
         result = {"error": "The policy rule must be a dictionary!"}
         return result
 
-    polconn = __utils__["azurearm.get_client"]("policy", **kwargs)
+    polconn = salt.utils.azurearm.get_client("policy", **kwargs)
 
     # Convert OrderedDict to dict
     prop_kwargs = {
@@ -1094,13 +1094,11 @@ def policy_definition_create_or_update(
     policy_kwargs.update(prop_kwargs)
 
     try:
-        policy_model = __utils__["azurearm.create_object_model"](
+        policy_model = salt.utils.azurearm.create_object_model(
             "resource.policy", "PolicyDefinition", **policy_kwargs
         )
     except TypeError as exc:
-        result = {
-            "error": "The object model could not be built. ({0})".format(str(exc))
-        }
+        result = {"error": "The object model could not be built. ({})".format(str(exc))}
         return result
 
     try:
@@ -1109,11 +1107,11 @@ def policy_definition_create_or_update(
         )
         result = policy.as_dict()
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
         result = {"error": str(exc)}
     except SerializationError as exc:
         result = {
-            "error": "The object model could not be parsed. ({0})".format(str(exc))
+            "error": "The object model could not be parsed. ({})".format(str(exc))
         }
 
     return result
@@ -1135,13 +1133,13 @@ def policy_definition_delete(name, **kwargs):
 
     """
     result = False
-    polconn = __utils__["azurearm.get_client"]("policy", **kwargs)
+    polconn = salt.utils.azurearm.get_client("policy", **kwargs)
     try:
         # pylint: disable=unused-variable
         policy = polconn.policy_definitions.delete(policy_definition_name=name)
         result = True
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
 
     return result
 
@@ -1161,12 +1159,12 @@ def policy_definition_get(name, **kwargs):
         salt-call azurearm_resource.policy_definition_get testpolicy
 
     """
-    polconn = __utils__["azurearm.get_client"]("policy", **kwargs)
+    polconn = salt.utils.azurearm.get_client("policy", **kwargs)
     try:
         policy_def = polconn.policy_definitions.get(policy_definition_name=name)
         result = policy_def.as_dict()
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result
@@ -1188,9 +1186,9 @@ def policy_definitions_list(hide_builtin=False, **kwargs):
 
     """
     result = {}
-    polconn = __utils__["azurearm.get_client"]("policy", **kwargs)
+    polconn = salt.utils.azurearm.get_client("policy", **kwargs)
     try:
-        policy_defs = __utils__["azurearm.paged_object_to_list"](
+        policy_defs = salt.utils.azurearm.paged_object_to_list(
             polconn.policy_definitions.list()
         )
 
@@ -1198,7 +1196,7 @@ def policy_definitions_list(hide_builtin=False, **kwargs):
             if not (hide_builtin and policy["policy_type"] == "BuiltIn"):
                 result[policy["name"]] = policy
     except CloudError as exc:
-        __utils__["azurearm.log_cloud_error"]("resource", str(exc), **kwargs)
+        salt.utils.azurearm.log_cloud_error("resource", str(exc), **kwargs)
         result = {"error": str(exc)}
 
     return result

--- a/salt/utils/azurearm.py
+++ b/salt/utils/azurearm.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Azure (ARM) Utilities
 
@@ -7,30 +6,31 @@ Azure (ARM) Utilities
 :maintainer: <devops@eitr.tech>
 :maturity: new
 :depends:
-    * `azure <https://pypi.python.org/pypi/azure>`_ >= 2.0.0rc6
-    * `azure-common <https://pypi.python.org/pypi/azure-common>`_ >= 1.1.4
-    * `azure-mgmt <https://pypi.python.org/pypi/azure-mgmt>`_ >= 0.30.0rc6
-    * `azure-mgmt-compute <https://pypi.python.org/pypi/azure-mgmt-compute>`_ >= 0.33.0
-    * `azure-mgmt-network <https://pypi.python.org/pypi/azure-mgmt-network>`_ >= 0.30.0rc6
-    * `azure-mgmt-resource <https://pypi.python.org/pypi/azure-mgmt-resource>`_ >= 0.30.0
-    * `azure-mgmt-storage <https://pypi.python.org/pypi/azure-mgmt-storage>`_ >= 0.30.0rc6
-    * `azure-mgmt-web <https://pypi.python.org/pypi/azure-mgmt-web>`_ >= 0.30.0rc6
-    * `azure-storage <https://pypi.python.org/pypi/azure-storage>`_ >= 0.32.0
-    * `msrestazure <https://pypi.python.org/pypi/msrestazure>`_ >= 0.4.21
+    * `azure-core <https://pypi.python.org/pypi/azure-core>`_ >= 1.15.0
+    * `azure-batch <https://pypi.python.org/pypi/azure-batch>`_ >= 10.0.0
+    * `azure-identity <https://pypi.python.org/pypi/azure-identity>`_ >= 1.6.0
+    * `azure-common <https://pypi.python.org/pypi/azure-common>`_ >= 1.1.27
+    * `azure-mgmt-core <https://pypi.python.org/pypi/azure-mgmt-core>`_ >= 1.2.2
+    * `azure-mgmt-subscription <https://pypi.python.org/pypi/azure-mgmt-subscription>`_ >= 1.0.0
+    * `azure-mgmt-compute <https://pypi.python.org/pypi/azure-mgmt-compute>`_ >= 20.0.0
+    * `azure-mgmt-network <https://pypi.python.org/pypi/azure-mgmt-network>`_ >= 19.0.0
+    * `azure-mgmt-resource <https://pypi.python.org/pypi/azure-mgmt-resource>`_ >= 18.0.0
+    * `azure-mgmt-storage <https://pypi.python.org/pypi/azure-mgmt-storage>`_ >= 18.0.0
+    * `azure-mgmt-web <https://pypi.python.org/pypi/azure-mgmt-web>`_ >= 2.0.0
+    * `azure-storage-common <https://pypi.python.org/pypi/azure-storage-common>`_ >= 1.4.2
+    * `azure-storage-blob <https://pypi.python.org/pypi/azure-storage-blob>`_ >= 12.8.1
+    * `azure-storage-file <https://pypi.python.org/pypi/azure-storage-file>`_ >= 2.1.0
+    * `msrestazure <https://pypi.python.org/pypi/msrestazure>`_ >= 0.6.4
 :platform: linux
 
 """
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import importlib
 import logging
 import sys
 from operator import itemgetter
 
-# Import Salt libs
 import salt.config
-import salt.ext.six as six
 import salt.loader
 import salt.utils.stringutils
 import salt.version
@@ -41,7 +41,6 @@ try:
 except ImportError:
     six_range = range
 
-# Import third party libs
 try:
     from azure.common.credentials import (
         UserPassCredentials,
@@ -92,7 +91,7 @@ def _determine_auth(**kwargs):
             )
     except (AttributeError, ImportError, MetadataEndpointError):
         raise sys.exit(
-            "The Azure cloud environment {0} is not available.".format(
+            "The Azure cloud environment {} is not available.".format(
                 kwargs["cloud_environment"]
             )
         )
@@ -166,7 +165,7 @@ def get_client(client_type, **kwargs):
 
     if client_type not in client_map:
         raise SaltSystemExit(
-            msg="The Azure ARM client_type {0} specified can not be found.".format(
+            msg="The Azure ARM client_type {} specified can not be found.".format(
                 client_type
             )
         )
@@ -183,9 +182,9 @@ def get_client(client_type, **kwargs):
     try:
         client_module = importlib.import_module("azure.mgmt." + module_name)
         # pylint: disable=invalid-name
-        Client = getattr(client_module, "{0}Client".format(map_value))
+        Client = getattr(client_module, "{}Client".format(map_value))
     except ImportError:
-        raise sys.exit("The azure {0} client is not available.".format(client_type))
+        raise sys.exit("The azure {} client is not available.".format(client_type))
 
     credentials, subscription_id, cloud_env = _determine_auth(**kwargs)
 
@@ -200,7 +199,7 @@ def get_client(client_type, **kwargs):
             base_url=cloud_env.endpoints.resource_manager,
         )
 
-    client.config.add_user_agent("Salt/{0}".format(salt.version.__version__))
+    client.config.add_user_agent("Salt/{}".format(salt.version.__version__))
 
     return client
 
@@ -244,13 +243,13 @@ def create_object_model(module_name, object_name, **kwargs):
 
     try:
         model_module = importlib.import_module(
-            "azure.mgmt.{0}.models".format(module_name)
+            "azure.mgmt.{}.models".format(module_name)
         )
         # pylint: disable=invalid-name
         Model = getattr(model_module, object_name)
     except ImportError:
         raise sys.exit(
-            "The {0} model in the {1} Azure module is not available.".format(
+            "The {} model in the {} Azure module is not available.".format(
                 object_name, module_name
             )
         )
@@ -332,9 +331,9 @@ def compare_list_of_dicts(old, new, convert_id_to_name=None):
                 )
             else:
                 remote_val = remote_configs[idx].get(key)
-                if isinstance(local_val, six.string_types):
+                if isinstance(local_val, str):
                     local_val = local_val.lower()
-                if isinstance(remote_val, six.string_types):
+                if isinstance(remote_val, str):
                     remote_val = remote_val.lower()
             if local_val != remote_val:
                 ret["changes"] = {"old": remote_configs, "new": local_configs}

--- a/salt/utils/azurearm.py
+++ b/salt/utils/azurearm.py
@@ -3,7 +3,7 @@ Azure (ARM) Utilities
 
 .. versionadded:: 2019.2.0
 
-:maintainer: <devops@eitr.tech>
+:maintainer: <devops@eitr.tech>, <devops@l2web.ca>
 :maturity: new
 :depends:
     * `azure-core <https://pypi.python.org/pypi/azure-core>`_ >= 1.15.0
@@ -31,6 +31,7 @@ import sys
 from operator import itemgetter
 
 import salt.config
+import salt.ext.six as six  # pylint: disable=W0611
 import salt.loader
 import salt.utils.stringutils
 import salt.version
@@ -42,10 +43,7 @@ except ImportError:
     six_range = range
 
 try:
-    from azure.common.credentials import (
-        UserPassCredentials,
-        ServicePrincipalCredentials,
-    )
+    import azure.identity
     from msrestazure.azure_cloud import (
         MetadataEndpointError,
         get_cloud_from_metadata_endpoint,
@@ -103,10 +101,10 @@ def _determine_auth(**kwargs):
                 "populated if using service principals."
             )
         else:
-            credentials = ServicePrincipalCredentials(
-                kwargs["client_id"],
-                kwargs["secret"],
-                tenant=kwargs["tenant"],
+            credentials = azure.identity.ClientSecretCredential(
+                client_id=kwargs["client_id"],
+                client_secret=kwargs["secret"],
+                tenant_id=kwargs["tenant"],
                 cloud_environment=cloud_env,
             )
     elif set(user_pass_creds_kwargs).issubset(kwargs):
@@ -116,7 +114,7 @@ def _determine_auth(**kwargs):
                 "populated if using username/password authentication."
             )
         else:
-            credentials = UserPassCredentials(
+            credentials = azure.identity.UsernamePasswordCredential(  # pylint: disable=E1120
                 kwargs["username"], kwargs["password"], cloud_environment=cloud_env
             )
     elif "subscription_id" in kwargs:
@@ -190,16 +188,14 @@ def get_client(client_type, **kwargs):
 
     if client_type == "subscription":
         client = Client(
-            credentials=credentials, base_url=cloud_env.endpoints.resource_manager,
+            credential=credentials, base_url=cloud_env.endpoints.resource_manager,
         )
     else:
         client = Client(
-            credentials=credentials,
+            credential=credentials,
             subscription_id=subscription_id,
             base_url=cloud_env.endpoints.resource_manager,
         )
-
-    client.config.add_user_agent("Salt/{}".format(salt.version.__version__))
 
     return client
 
@@ -340,3 +336,14 @@ def compare_list_of_dicts(old, new, convert_id_to_name=None):
                 return ret
 
     return ret
+
+
+def get_config_from_cloud(cloud_provider):
+    """
+    Function use to retreive the configuration from the cloud
+    provider
+    """
+    conn_kwargs = ""
+    client = salt.cloud.CloudClient(path="/etc/salt/cloud")
+    conn_kwargs = client.opts["providers"][cloud_provider]["azurearm"]
+    return conn_kwargs

--- a/salt/utils/azurearm.py
+++ b/salt/utils/azurearm.py
@@ -114,8 +114,11 @@ def _determine_auth(**kwargs):
                 "populated if using username/password authentication."
             )
         else:
-            credentials = azure.identity.UsernamePasswordCredential(  # pylint: disable=E1120
-                kwargs["username"], kwargs["password"], cloud_environment=cloud_env
+            credentials = azure.identity.UsernamePasswordCredential(
+                client_id=kwargs["client_id"],
+                username=kwargs["username"],
+                password=kwargs["password"],
+                cloud_environment=cloud_env,
             )
     elif "subscription_id" in kwargs:
         try:

--- a/tests/pytests/unit/cloud/clouds/test_azurearm.py
+++ b/tests/pytests/unit/cloud/clouds/test_azurearm.py
@@ -82,7 +82,7 @@ def test_function_signatures():
     )
 
     # we literally only check that a final creation call occurred.
-    mock_azure.get_conn.return_value.virtual_machines.create_or_update.assert_called_once()
+    mock_azure.get_conn.return_value.virtual_machines.begin_create_or_update.assert_called_once()
 
 
 def test_get_configured_provider():

--- a/tests/pytests/unit/cloud/clouds/test_azurearm.py
+++ b/tests/pytests/unit/cloud/clouds/test_azurearm.py
@@ -151,8 +151,6 @@ def test_get_conn():
     # username and password via provider config
     expected = {
         "subscription_id": "3287abc8-f98a-c678-3bde-326766fd3617",
-        "username": "donkeymonkey",
-        "password": "monkeydonkey",
     }
     with patch(
         "salt.utils.azurearm.get_client", side_effect=lambda client_type, **kw: kw

--- a/tests/pytests/unit/modules/test_azurearm_dns.py
+++ b/tests/pytests/unit/modules/test_azurearm_dns.py
@@ -127,6 +127,7 @@ def configure_loader_modules():
     }
 
 
+# name, zone_name, record_type, resource_group=None, cloud_provider=None, **kwargs
 def test_record_set_create_or_update(credentials):
     """
     tests record set object creation
@@ -142,10 +143,10 @@ def test_record_set_create_or_update(credentials):
     }
 
     record_set_args, record_set_kwargs = azurearm_dns.record_set_create_or_update(
-        "myhost",
-        "myzone",
-        "testgroup",
-        "A",
+        name="myhost",
+        zone_name="myzone",
+        resource_group="testgroup",
+        record_type="A",
         arecords=[{"ipv4_address": "10.0.0.1"}],
         ttl=300,
         **credentials


### PR DESCRIPTION
Fixed Compatibility with python azure module 5.0.0
cloud azurearm
utils azurearm
Added cloud_provider parameter to module 
azurearm_computer
azurearm_resource
azurearm_network
azurearm_dns

Users can now use the param cloud_provider to pass all the information from a cloud provider profile 
so they dont have to duplicate informations in the pillar 


- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

