### PR TITLE
Update banner images in docs HTML output

### DIFF
--- a/doc/_themes/saltstack2/layout.html
+++ b/doc/_themes/saltstack2/layout.html
@@ -273,7 +273,7 @@
                                  <!--
                                  <a href="https://saltstack.com/saltstack-enterprise/" target="_blank"><img class="nolightbox footer-banner center" src="{{ pathto('_static/images/enterprise_ad.jpg', 1) }}"/></a>
                                  -->
-                                 <a href="https://saltconf.com/ad" target="_blank"><img class="nolightbox footer-banner center" src="https://get.saltstack.com/rs/304-PHQ-615/images/Salt-docs-ad-330x330.png"/></a>
+                                 <a href="https://saltconf.com/ad" target="_blank"><img class="nolightbox footer-banner center" src="https://gitlab.com/saltstack/open/salt-branding-guide/-/raw/master/misc/banners/try_salt_now.png"/></a>
                             </div>
                             {% endif %}
                         </div>
@@ -295,7 +295,7 @@
                 {% else %}
                 <a href="http://saltstack.com/support" target="_blank"><img class="nolightbox sidebar-banner center" src="{{ pathto('_static/images/banner-support.png', 1) }}"/></a>
                 {% endif %} #}-->
-                <a href="https://saltconf.com/menu-ad" target="_blank"><img class="nolightbox sidebar-banner center" src="https://get.saltstack.com/rs/304-PHQ-615/images/Salt-docs-menu-ad-250x63.jpg"/></a>
+                <a href="https://saltconf.com/menu-ad" target="_blank"><img class="nolightbox sidebar-banner center" src="https://gitlab.com/saltstack/open/salt-branding-guide/-/raw/master/misc/banners/saltconf.png"/></a>
 
 
                 {% if build_type=="next" %}


### PR DESCRIPTION
### What does this PR do?

Fixes broken banner images in docs.

### What issues does this PR fix or reference?
Fixes: #59936

### Previous Behavior

Images don't appear properly, as `get.saltstack.com/*` images no longer exist.

### New Behavior

Images from [`salt-branding-guide`](https://gitlab.com/saltstack/open/salt-branding-guide) are being used.

### Commits signed with GPG?
Yes