### PR TITLE
Fix mysql module to return bytes instead strings

### DIFF
--- a/changelog/59754.fixed
+++ b/changelog/59754.fixed
@@ -1,0 +1,1 @@
+Fixed mysql module to return `bytes` again.

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -929,7 +929,7 @@ def status(**connection_args):
     ret = {}
     for _ in range(cur.rowcount):
         row = cur.fetchone()
-        ret[row[0]] = row[1]
+        ret[salt.utils.data.decode(row[0])] = row[1]
     return ret
 
 

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -414,13 +414,6 @@ def _connect(**kwargs):
     _connarg("connection_unix_socket", "unix_socket", get_opts)
     _connarg("connection_default_file", "read_default_file", get_opts)
     _connarg("connection_default_group", "read_default_group", get_opts)
-    # MySQLdb states that this is required for charset usage
-    # but in fact it's more than it's internally activated
-    # when charset is used, activating use_unicode here would
-    # retrieve utf8 strings as unicode() objects in salt
-    # and we do not want that.
-    # _connarg('connection_use_unicode', 'use_unicode')
-    connargs["use_unicode"] = False
     _connarg("connection_charset", "charset")
     # Ensure MySQldb knows the format we use for queries with arguments
     MySQLdb.paramstyle = "pyformat"
@@ -428,6 +421,13 @@ def _connect(**kwargs):
     for key in copy.deepcopy(connargs):
         if not connargs[key]:
             del connargs[key]
+
+    # MySQLdb states that this is required for charset usage
+    # but in fact it's more than it's internally activated
+    # when charset is used, activating use_unicode here would
+    # retrieve utf8 strings as unicode() objects in salt
+    # and we do not want that. So we'll force it to False.
+    connargs["use_unicode"] = False
 
     if (
         connargs.get("passwd", True) is None

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -679,6 +679,31 @@ def _sanitize_comments(content):
     return sqlparse.format(content, strip_comments=True)
 
 
+def _disable_conversions():
+    # The following 3 lines stops MySQLdb from converting the MySQL results
+    # into Python objects. It leaves them as strings.
+    orig_conv = MySQLdb.converters.conversions
+    conv_iter = iter(orig_conv)
+    conv = dict(zip(conv_iter, [str] * len(orig_conv)))
+
+    # some converters are lists, do not break theses
+    conv_mysqldb = {"MYSQLDB": True}
+    if conv_mysqldb.get(MySQLdb.__package__.upper()):
+        conv[FIELD_TYPE.BLOB] = [
+            (FLAG.BINARY, str),
+        ]
+        conv[FIELD_TYPE.STRING] = [
+            (FLAG.BINARY, str),
+        ]
+        conv[FIELD_TYPE.VAR_STRING] = [
+            (FLAG.BINARY, str),
+        ]
+        conv[FIELD_TYPE.VARCHAR] = [
+            (FLAG.BINARY, str),
+        ]
+    return conv
+
+
 def query(database, query, **connection_args):
     """
     Run an arbitrary SQL query and return the results or
@@ -747,29 +772,9 @@ def query(database, query, **connection_args):
     # I don't think it handles multiple queries at once, so adding "commit"
     # might not work.
 
-    # The following 3 lines stops MySQLdb from converting the MySQL results
-    # into Python objects. It leaves them as strings.
-    orig_conv = MySQLdb.converters.conversions
-    conv_iter = iter(orig_conv)
-    conv = dict(zip(conv_iter, [str] * len(orig_conv)))
-
-    # some converters are lists, do not break theses
-    conv_mysqldb = {"MYSQLDB": True}
-    if conv_mysqldb.get(MySQLdb.__package__.upper()):
-        conv[FIELD_TYPE.BLOB] = [
-            (FLAG.BINARY, str),
-        ]
-        conv[FIELD_TYPE.STRING] = [
-            (FLAG.BINARY, str),
-        ]
-        conv[FIELD_TYPE.VAR_STRING] = [
-            (FLAG.BINARY, str),
-        ]
-        conv[FIELD_TYPE.VARCHAR] = [
-            (FLAG.BINARY, str),
-        ]
-
-    connection_args.update({"connection_db": database, "connection_conv": conv})
+    connection_args.update(
+        {"connection_db": database, "connection_conv": _disable_conversions()}
+    )
     dbc = _connect(**connection_args)
     if dbc is None:
         return {}
@@ -1544,6 +1549,8 @@ def user_info(user, host="localhost", **connection_args):
 
         salt '*' mysql.user_info root localhost
     """
+    connection_args.update({"connection_conv": _disable_conversions()})
+
     dbc = _connect(**connection_args)
     if dbc is None:
         return False

--- a/tests/pytests/integration/modules/test_mysql.py
+++ b/tests/pytests/integration/modules/test_mysql.py
@@ -41,7 +41,7 @@ def salt_call_cli_wrapper(salt_call_cli, mysql_container):
 def test_query(salt_call_cli_wrapper):
     ret = salt_call_cli_wrapper("mysql.query", "mysql", "SELECT 1")
     assert ret.json
-    assert ret.json["results"] == [[b"1"]]
+    assert ret.json["results"] == [["b'1'"]]
 
 
 def test_version(salt_call_cli_wrapper, mysql_container):
@@ -60,7 +60,7 @@ def test_db_list(salt_call_cli_wrapper):
     ret = salt_call_cli_wrapper("mysql.db_list")
 
     assert ret.json
-    assert b"mysql" in ret.json
+    assert "b'mysql'" in ret.json
 
 
 def test_db_create_alter_remove(salt_call_cli_wrapper):
@@ -82,7 +82,7 @@ def test_db_create_alter_remove(salt_call_cli_wrapper):
 def test_user_list(salt_call_cli_wrapper):
     ret = salt_call_cli_wrapper("mysql.user_list")
     assert ret.json
-    assert {"User": b"root", "Host": b"%"} in ret.json
+    assert {"User": "b'root'", "Host": "b'%'"} in ret.json
 
 
 def test_user_exists(salt_call_cli_wrapper):
@@ -102,37 +102,37 @@ def test_user_info(salt_call_cli_wrapper):
     # Check that a subset of the information
     # is available in the returned user information.
     expected = {
-        "Host": b"%",
-        "User": b"root",
-        "Select_priv": b"Y",
-        "Insert_priv": b"Y",
-        "Update_priv": b"Y",
-        "Delete_priv": b"Y",
-        "Create_priv": b"Y",
-        "Drop_priv": b"Y",
-        "Reload_priv": b"Y",
-        "Shutdown_priv": b"Y",
-        "Process_priv": b"Y",
-        "File_priv": b"Y",
-        "Grant_priv": b"Y",
-        "References_priv": b"Y",
-        "Index_priv": b"Y",
-        "Alter_priv": b"Y",
-        "Show_db_priv": b"Y",
-        "Super_priv": b"Y",
-        "Create_tmp_table_priv": b"Y",
-        "Lock_tables_priv": b"Y",
-        "Execute_priv": b"Y",
-        "Repl_slave_priv": b"Y",
-        "Repl_client_priv": b"Y",
-        "Create_view_priv": b"Y",
-        "Show_view_priv": b"Y",
-        "Create_routine_priv": b"Y",
-        "Alter_routine_priv": b"Y",
-        "Create_user_priv": b"Y",
-        "Event_priv": b"Y",
-        "Trigger_priv": b"Y",
-        "Create_tablespace_priv": b"Y",
+        "Host": "b'%'",
+        "User": "b'root'",
+        "Select_priv": "b'Y'",
+        "Insert_priv": "b'Y'",
+        "Update_priv": "b'Y'",
+        "Delete_priv": "b'Y'",
+        "Create_priv": "b'Y'",
+        "Drop_priv": "b'Y'",
+        "Reload_priv": "b'Y'",
+        "Shutdown_priv": "b'Y'",
+        "Process_priv": "b'Y'",
+        "File_priv": "b'Y'",
+        "Grant_priv": "b'Y'",
+        "References_priv": "b'Y'",
+        "Index_priv": "b'Y'",
+        "Alter_priv": "b'Y'",
+        "Show_db_priv": "b'Y'",
+        "Super_priv": "b'Y'",
+        "Create_tmp_table_priv": "b'Y'",
+        "Lock_tables_priv": "b'Y'",
+        "Execute_priv": "b'Y'",
+        "Repl_slave_priv": "b'Y'",
+        "Repl_client_priv": "b'Y'",
+        "Create_view_priv": "b'Y'",
+        "Show_view_priv": "b'Y'",
+        "Create_routine_priv": "b'Y'",
+        "Alter_routine_priv": "b'Y'",
+        "Create_user_priv": "b'Y'",
+        "Event_priv": "b'Y'",
+        "Trigger_priv": "b'Y'",
+        "Create_tablespace_priv": "b'Y'",
     }
     assert all(ret.json.get(key, None) == val for key, val in expected.items())
 
@@ -272,7 +272,7 @@ def test_plugin_add_status_remove(salt_call_cli_wrapper, mysql_container):
 
     ret = salt_call_cli_wrapper("mysql.plugin_status", plugin, host="%")
     assert ret.json
-    assert ret.json == b"ACTIVE"
+    assert ret.json == "b'ACTIVE'"
 
     ret = salt_call_cli_wrapper("mysql.plugin_remove", plugin)
     assert ret.json
@@ -288,7 +288,7 @@ def test_plugin_list(salt_call_cli_wrapper, mysql_container):
         plugin = "auth_socket"
 
     ret = salt_call_cli_wrapper("mysql.plugins_list")
-    assert {"name": plugin, "status": b"ACTIVE"} not in ret.json
+    assert {"name": "b'{}'".format(plugin), "status": "b'ACTIVE'"} not in ret.json
     assert ret.json
 
     ret = salt_call_cli_wrapper("mysql.plugin_add", plugin)
@@ -296,7 +296,7 @@ def test_plugin_list(salt_call_cli_wrapper, mysql_container):
 
     ret = salt_call_cli_wrapper("mysql.plugins_list")
     assert ret.json
-    assert {"name": plugin, "status": b"ACTIVE"} in ret.json
+    assert {"name": "b'{}'".format(plugin), "status": "b'ACTIVE'"} in ret.json
 
     ret = salt_call_cli_wrapper("mysql.plugin_remove", plugin)
     assert ret.json

--- a/tests/pytests/integration/modules/test_mysql.py
+++ b/tests/pytests/integration/modules/test_mysql.py
@@ -41,7 +41,7 @@ def salt_call_cli_wrapper(salt_call_cli, mysql_container):
 def test_query(salt_call_cli_wrapper):
     ret = salt_call_cli_wrapper("mysql.query", "mysql", "SELECT 1")
     assert ret.json
-    assert ret.json["results"] == [["1"]]
+    assert ret.json["results"] == [[b"1"]]
 
 
 def test_version(salt_call_cli_wrapper, mysql_container):
@@ -60,7 +60,7 @@ def test_db_list(salt_call_cli_wrapper):
     ret = salt_call_cli_wrapper("mysql.db_list")
 
     assert ret.json
-    assert "mysql" in ret.json
+    assert b"mysql" in ret.json
 
 
 def test_db_create_alter_remove(salt_call_cli_wrapper):
@@ -82,7 +82,7 @@ def test_db_create_alter_remove(salt_call_cli_wrapper):
 def test_user_list(salt_call_cli_wrapper):
     ret = salt_call_cli_wrapper("mysql.user_list")
     assert ret.json
-    assert {"User": "root", "Host": "%"} in ret.json
+    assert {"User": b"root", "Host": b"%"} in ret.json
 
 
 def test_user_exists(salt_call_cli_wrapper):
@@ -102,37 +102,37 @@ def test_user_info(salt_call_cli_wrapper):
     # Check that a subset of the information
     # is available in the returned user information.
     expected = {
-        "Host": "%",
-        "User": "root",
-        "Select_priv": "Y",
-        "Insert_priv": "Y",
-        "Update_priv": "Y",
-        "Delete_priv": "Y",
-        "Create_priv": "Y",
-        "Drop_priv": "Y",
-        "Reload_priv": "Y",
-        "Shutdown_priv": "Y",
-        "Process_priv": "Y",
-        "File_priv": "Y",
-        "Grant_priv": "Y",
-        "References_priv": "Y",
-        "Index_priv": "Y",
-        "Alter_priv": "Y",
-        "Show_db_priv": "Y",
-        "Super_priv": "Y",
-        "Create_tmp_table_priv": "Y",
-        "Lock_tables_priv": "Y",
-        "Execute_priv": "Y",
-        "Repl_slave_priv": "Y",
-        "Repl_client_priv": "Y",
-        "Create_view_priv": "Y",
-        "Show_view_priv": "Y",
-        "Create_routine_priv": "Y",
-        "Alter_routine_priv": "Y",
-        "Create_user_priv": "Y",
-        "Event_priv": "Y",
-        "Trigger_priv": "Y",
-        "Create_tablespace_priv": "Y",
+        "Host": b"%",
+        "User": b"root",
+        "Select_priv": b"Y",
+        "Insert_priv": b"Y",
+        "Update_priv": b"Y",
+        "Delete_priv": b"Y",
+        "Create_priv": b"Y",
+        "Drop_priv": b"Y",
+        "Reload_priv": b"Y",
+        "Shutdown_priv": b"Y",
+        "Process_priv": b"Y",
+        "File_priv": b"Y",
+        "Grant_priv": b"Y",
+        "References_priv": b"Y",
+        "Index_priv": b"Y",
+        "Alter_priv": b"Y",
+        "Show_db_priv": b"Y",
+        "Super_priv": b"Y",
+        "Create_tmp_table_priv": b"Y",
+        "Lock_tables_priv": b"Y",
+        "Execute_priv": b"Y",
+        "Repl_slave_priv": b"Y",
+        "Repl_client_priv": b"Y",
+        "Create_view_priv": b"Y",
+        "Show_view_priv": b"Y",
+        "Create_routine_priv": b"Y",
+        "Alter_routine_priv": b"Y",
+        "Create_user_priv": b"Y",
+        "Event_priv": b"Y",
+        "Trigger_priv": b"Y",
+        "Create_tablespace_priv": b"Y",
     }
     assert all(ret.json.get(key, None) == val for key, val in expected.items())
 
@@ -272,7 +272,7 @@ def test_plugin_add_status_remove(salt_call_cli_wrapper, mysql_container):
 
     ret = salt_call_cli_wrapper("mysql.plugin_status", plugin, host="%")
     assert ret.json
-    assert ret.json == "ACTIVE"
+    assert ret.json == b"ACTIVE"
 
     ret = salt_call_cli_wrapper("mysql.plugin_remove", plugin)
     assert ret.json
@@ -288,7 +288,7 @@ def test_plugin_list(salt_call_cli_wrapper, mysql_container):
         plugin = "auth_socket"
 
     ret = salt_call_cli_wrapper("mysql.plugins_list")
-    assert {"name": plugin, "status": "ACTIVE"} not in ret.json
+    assert {"name": plugin, "status": b"ACTIVE"} not in ret.json
     assert ret.json
 
     ret = salt_call_cli_wrapper("mysql.plugin_add", plugin)
@@ -296,7 +296,7 @@ def test_plugin_list(salt_call_cli_wrapper, mysql_container):
 
     ret = salt_call_cli_wrapper("mysql.plugins_list")
     assert ret.json
-    assert {"name": plugin, "status": "ACTIVE"} in ret.json
+    assert {"name": plugin, "status": b"ACTIVE"} in ret.json
 
     ret = salt_call_cli_wrapper("mysql.plugin_remove", plugin)
     assert ret.json

--- a/tests/pytests/unit/modules/test_mysql.py
+++ b/tests/pytests/unit/modules/test_mysql.py
@@ -927,7 +927,13 @@ def test__connect_mysqldb():
     """
     Test the _connect function in the MySQL module
     """
+    mysqldb_connect_mock = MagicMock(autospec=True, return_value=MockMySQLConnect())
     with patch.dict(mysql.__salt__, {"config.option": MagicMock()}):
-        with patch("MySQLdb.connect", return_value=MockMySQLConnect()):
+        with patch("MySQLdb.connect", mysqldb_connect_mock):
             ret = mysql._connect()
             assert "mysql.error" not in mysql.__context__
+            # If 'use_unicode' is activated here, it would retrieve utf8 strings
+            # as unicode() objects in salt and we do not want that. So it needs
+            # to be False
+            _, connargs = mysqldb_connect_mock.call_args
+            assert connargs["use_unicode"] is False


### PR DESCRIPTION
### What does this PR do?
Fixes `mysql` module to return bytes instead strings.

The `use_unicode` was being set to `False` but after set it was deleted. The fix moves the `use_unicode` set to avoid deletion and preserves the intended behaviour.

### What issues does this PR fix or reference?
Fixes: #59754

### Previous Behavior
`mysql` module is returning strings in its queries:
```
[DEBUG   ] Doing query: SHOW DATABASES
[DEBUG   ] ['information_schema', 'mysql', 'oxidized', 'performance_schema', 'zabbix']
```
### New Behavior
The return now is in bytes:
```
[DEBUG   ] Doing query: SHOW DATABASES
[DEBUG   ] [b'information_schema', b'mysql', b'oxidized', b'performance_schema', b'zabbix']
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No