### PR TITLE
fix partition resize for parted v3+

### DIFF
--- a/changelog/54936.fixed
+++ b/changelog/54936.fixed
@@ -1,0 +1,1 @@
+Fixes parted resize for parted v3+

--- a/salt/modules/parted_partition.py
+++ b/salt/modules/parted_partition.py
@@ -612,20 +612,17 @@ def rescue(device, start, end):
     return out
 
 
-def resize(device, minor, start, end):
+def resize(device, minor, end):
     """
     Resizes the partition with number <minor>.
-
-    The partition will start <start> from the beginning of the disk, and end
+    The partition will start from the current beginning of the disk, and end
     <end> from the beginning of the disk. resize never changes the minor number.
     Extended partitions can be resized, so long as the new extended partition
     completely contains all logical partitions.
-
+    <end> is the end-sector in megabytes
     CLI Example:
-
     .. code-block:: bash
-
-        salt '*' partition.resize /dev/sda 3 200 850
+        salt '*' partition.resize /dev/sda 3 850
     """
     _validate_device(device)
 
@@ -638,7 +635,7 @@ def resize(device, minor, start, end):
     _validate_partition_boundary(end)
 
     out = __salt__["cmd.run"](
-        "parted -m -s -- {} resize {} {} {}".format(device, minor, start, end)
+        "parted -m -s -- {} resize {} {}".format(device, minor, end)
     )
     return out.splitlines()
 


### PR DESCRIPTION
### What does this PR do?
Fixes the partition resize command

### What issues does this PR fix or reference?
Fixes: #54936

### Previous Behavior
You could not resize (expand) the partition

### New Behavior
Parted v3+ is now supported. However, it is not possible anymore to specify a start sector, as parted v3+ does not support this behaviour.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ x ] Docs
- [ x ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated - not needed

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
