### PR TITLE
add debian 11 to ci tests

### DIFF
--- a/cicd/jenkins/pr-alma-8-x86_64-py3-pytest
+++ b/cicd/jenkins/pr-alma-8-x86_64-py3-pytest
@@ -12,10 +12,8 @@ runTestSuite(
     nox_env_name: 'pytest-zeromq',
     nox_passthrough_opts: '--ssh-tests',
     python_version: 'py3',
-    //splits: ['unit', 'integration', 'multimaster'],
     testrun_timeout: 6,
     use_spot_instances: true,
-    //fast_slow_staged_testrun: true
 )
 
 // vim: ft=groovy

--- a/cicd/jenkins/pr-amazon-2-x86_64-py3-pytest
+++ b/cicd/jenkins/pr-amazon-2-x86_64-py3-pytest
@@ -12,10 +12,8 @@ runTestSuite(
     nox_env_name: 'pytest-zeromq',
     nox_passthrough_opts: '--ssh-tests',
     python_version: 'py3',
-    //splits: ['unit', 'integration', 'multimaster'],
     testrun_timeout: 6,
     use_spot_instances: true,
-    //fast_slow_staged_testrun: true
 )
 
 // vim: ft=groovy

--- a/cicd/jenkins/pr-centos-7-x86_64-py3-m2crypto-pytest
+++ b/cicd/jenkins/pr-centos-7-x86_64-py3-m2crypto-pytest
@@ -12,10 +12,8 @@ runTestSuite(
     nox_env_name: 'pytest-zeromq-m2crypto',
     nox_passthrough_opts: '--ssh-tests',
     python_version: 'py3',
-    //splits: ['unit', 'integration', 'multimaster'],
     testrun_timeout: 6,
     use_spot_instances: true,
-    //fast_slow_staged_testrun: true
 )
 
 // vim: ft=groovy

--- a/cicd/jenkins/pr-centos-7-x86_64-py3-pytest
+++ b/cicd/jenkins/pr-centos-7-x86_64-py3-pytest
@@ -12,10 +12,8 @@ runTestSuite(
     nox_env_name: 'pytest-zeromq',
     nox_passthrough_opts: '--ssh-tests',
     python_version: 'py3',
-    //splits: ['unit', 'integration', 'multimaster'],
     testrun_timeout: 6,
     use_spot_instances: true,
-    //fast_slow_staged_testrun: true
 )
 
 // vim: ft=groovy

--- a/cicd/jenkins/pr-centos-7-x86_64-py3-tcp-pytest
+++ b/cicd/jenkins/pr-centos-7-x86_64-py3-tcp-pytest
@@ -12,10 +12,8 @@ runTestSuite(
     nox_env_name: 'pytest-tcp',
     nox_passthrough_opts: '--ssh-tests',
     python_version: 'py3',
-    //splits: ['unit', 'integration', 'multimaster'],
     testrun_timeout: 6,
     use_spot_instances: true,
-    //fast_slow_staged_testrun: true
 )
 
 // vim: ft=groovy

--- a/cicd/jenkins/pr-centos-8-x86_64-py3-pytest
+++ b/cicd/jenkins/pr-centos-8-x86_64-py3-pytest
@@ -12,10 +12,8 @@ runTestSuite(
     nox_env_name: 'pytest-zeromq',
     nox_passthrough_opts: '--ssh-tests',
     python_version: 'py3',
-    //splits: ['unit', 'integration', 'multimaster'],
     testrun_timeout: 6,
     use_spot_instances: true,
-    //fast_slow_staged_testrun: true
 )
 
 // vim: ft=groovy

--- a/cicd/jenkins/pr-debian-10-amd64-py3-pytest
+++ b/cicd/jenkins/pr-debian-10-amd64-py3-pytest
@@ -12,10 +12,8 @@ runTestSuite(
     nox_env_name: 'pytest-zeromq',
     nox_passthrough_opts: '--ssh-tests',
     python_version: 'py3',
-    //splits: ['unit', 'integration', 'multimaster'],
     testrun_timeout: 6,
     use_spot_instances: true,
-    //fast_slow_staged_testrun: true
 )
 
 // vim: ft=groovy

--- a/cicd/jenkins/pr-debian-11-amd64-py3-pytest
+++ b/cicd/jenkins/pr-debian-11-amd64-py3-pytest
@@ -1,0 +1,19 @@
+@Library('salt@master-1.10') _
+
+runTestSuite(
+    ami_image_id: 'ami-08bf6df84b4488e8a',
+    concurrent_builds: 1,
+    distro_name: 'debian',
+    distro_version: '11',
+    distro_arch: 'amd64',
+    env: env,
+    golden_images_branch: 'master',
+    jenkins_slave_label: 'kitchen-slave',
+    nox_env_name: 'pytest-zeromq',
+    nox_passthrough_opts: '--ssh-tests',
+    python_version: 'py3',
+    testrun_timeout: 6,
+    use_spot_instances: true,
+)
+
+// vim: ft=groovy

--- a/cicd/jenkins/pr-debian-9-amd64-py3-pytest
+++ b/cicd/jenkins/pr-debian-9-amd64-py3-pytest
@@ -12,10 +12,8 @@ runTestSuite(
     nox_env_name: 'pytest-zeromq',
     nox_passthrough_opts: '--ssh-tests',
     python_version: 'py3',
-    //splits: ['unit', 'integration', 'multimaster'],
     testrun_timeout: 6,
     use_spot_instances: true,
-    //fast_slow_staged_testrun: true
 )
 
 // vim: ft=groovy

--- a/cicd/jenkins/pr-fedora-33-x86_64-py3-pytest
+++ b/cicd/jenkins/pr-fedora-33-x86_64-py3-pytest
@@ -12,10 +12,8 @@ runTestSuite(
     nox_env_name: 'pytest-zeromq',
     nox_passthrough_opts: '--ssh-tests',
     python_version: 'py3',
-    //splits: ['unit', 'integration', 'multimaster'],
     testrun_timeout: 6,
     use_spot_instances: true,
-    //fast_slow_staged_testrun: true
 )
 
 // vim: ft=groovy

--- a/cicd/jenkins/pr-fedora-34-x86_64-py3-pytest
+++ b/cicd/jenkins/pr-fedora-34-x86_64-py3-pytest
@@ -12,10 +12,8 @@ runTestSuite(
     nox_env_name: 'pytest-zeromq',
     nox_passthrough_opts: '--ssh-tests',
     python_version: 'py3',
-    //splits: ['unit', 'integration', 'multimaster'],
     testrun_timeout: 6,
     use_spot_instances: true,
-    //fast_slow_staged_testrun: true
 )
 
 // vim: ft=groovy

--- a/cicd/jenkins/pr-freebsd-130-amd64-py3-pytest
+++ b/cicd/jenkins/pr-freebsd-130-amd64-py3-pytest
@@ -12,10 +12,8 @@ runTestSuite(
     nox_env_name: 'pytest-zeromq',
     nox_passthrough_opts: '--ssh-tests',
     python_version: 'py3',
-    //splits: ['unit', 'integration', 'multimaster'],
     testrun_timeout: 6,
     use_spot_instances: true,
-    //fast_slow_staged_testrun: true
 )
 
 // vim: ft=groovy

--- a/cicd/jenkins/pr-macosx-catalina-x86_64-py3-pytest
+++ b/cicd/jenkins/pr-macosx-catalina-x86_64-py3-pytest
@@ -13,10 +13,8 @@ runTestSuite(
     nox_env_name: 'pytest-zeromq',
     nox_passthrough_opts: '--ssh-tests',
     python_version: 'py3',
-    //splits: ['unit', 'integration', 'multimaster'],
     testrun_timeout: 6,
     use_spot_instances: false,
-    //fast_slow_staged_testrun: true
 )
 
 // vim: ft=groovy

--- a/cicd/jenkins/pr-macosx-mojave-x86_64-py3-pytest
+++ b/cicd/jenkins/pr-macosx-mojave-x86_64-py3-pytest
@@ -13,10 +13,8 @@ runTestSuite(
     nox_env_name: 'pytest-zeromq',
     nox_passthrough_opts: '--ssh-tests',
     python_version: 'py3',
-    //splits: ['unit', 'integration', 'multimaster'],
     testrun_timeout: 8,
     use_spot_instances: false,
-    //fast_slow_staged_testrun: true
 )
 
 // vim: ft=groovy

--- a/cicd/jenkins/pr-opensuse-15-x86_64-py3-pytest
+++ b/cicd/jenkins/pr-opensuse-15-x86_64-py3-pytest
@@ -12,10 +12,8 @@ runTestSuite(
     nox_env_name: 'pytest-zeromq',
     nox_passthrough_opts: '--ssh-tests',
     python_version: 'py3',
-    //splits: ['unit', 'integration', 'multimaster'],
     testrun_timeout: 6,
     use_spot_instances: true,
-    //fast_slow_staged_testrun: true
 )
 
 // vim: ft=groovy

--- a/cicd/jenkins/pr-ubuntu-1804-amd64-py3-pytest
+++ b/cicd/jenkins/pr-ubuntu-1804-amd64-py3-pytest
@@ -12,10 +12,8 @@ runTestSuite(
     nox_env_name: 'pytest-zeromq',
     nox_passthrough_opts: '--ssh-tests',
     python_version: 'py3',
-    //splits: ['unit', 'integration', 'multimaster'],
     testrun_timeout: 6,
     use_spot_instances: true,
-    //fast_slow_staged_testrun: true
 )
 
 // vim: ft=groovy

--- a/cicd/jenkins/pr-ubuntu-2004-amd64-py3-m2crypto-pytest
+++ b/cicd/jenkins/pr-ubuntu-2004-amd64-py3-m2crypto-pytest
@@ -12,10 +12,8 @@ runTestSuite(
     nox_env_name: 'pytest-zeromq-m2crypto',
     nox_passthrough_opts: '--ssh-tests',
     python_version: 'py3',
-    //splits: ['unit', 'integration', 'multimaster'],
     testrun_timeout: 6,
     use_spot_instances: true,
-    //fast_slow_staged_testrun: true
 )
 
 // vim: ft=groovy

--- a/cicd/jenkins/pr-ubuntu-2004-amd64-py3-pytest
+++ b/cicd/jenkins/pr-ubuntu-2004-amd64-py3-pytest
@@ -12,10 +12,8 @@ runTestSuite(
     nox_env_name: 'pytest-zeromq',
     nox_passthrough_opts: '--ssh-tests',
     python_version: 'py3',
-    //splits: ['unit', 'integration', 'multimaster'],
     testrun_timeout: 6,
     use_spot_instances: true,
-    //fast_slow_staged_testrun: true
 )
 
 // vim: ft=groovy

--- a/cicd/jenkins/pr-ubuntu-2004-amd64-py3-tcp-pytest
+++ b/cicd/jenkins/pr-ubuntu-2004-amd64-py3-tcp-pytest
@@ -12,10 +12,8 @@ runTestSuite(
     nox_env_name: 'pytest-tcp',
     nox_passthrough_opts: '--ssh-tests',
     python_version: 'py3',
-    //splits: ['unit', 'integration', 'multimaster'],
     testrun_timeout: 6,
     use_spot_instances: true,
-    //fast_slow_staged_testrun: true
 )
 
 // vim: ft=groovy

--- a/cicd/jenkins/pr-ubuntu-2004-arm64-py3-pytest
+++ b/cicd/jenkins/pr-ubuntu-2004-arm64-py3-pytest
@@ -12,10 +12,8 @@ runTestSuite(
     nox_env_name: 'pytest-zeromq',
     nox_passthrough_opts: '--ssh-tests',
     python_version: 'py3',
-    //splits: ['unit', 'integration', 'multimaster'],
     testrun_timeout: 6,
     use_spot_instances: true,
-    //fast_slow_staged_testrun: true
 )
 
 // vim: ft=groovy

--- a/cicd/jenkins/pr-windows-2016-x64-py3-pytest
+++ b/cicd/jenkins/pr-windows-2016-x64-py3-pytest
@@ -12,10 +12,8 @@ runTestSuite(
     nox_env_name: 'pytest-zeromq',
     nox_passthrough_opts: '',
     python_version: 'py3',
-    //splits: ['unit', 'integration'],
     testrun_timeout: 9,
     use_spot_instances: false,
-    //fast_slow_staged_testrun: true
 )
 
 // vim: ft=groovy

--- a/cicd/jenkins/pr-windows-2019-x64-py3-pytest
+++ b/cicd/jenkins/pr-windows-2019-x64-py3-pytest
@@ -12,10 +12,8 @@ runTestSuite(
     nox_env_name: 'pytest-zeromq',
     nox_passthrough_opts: '',
     python_version: 'py3',
-    //splits: ['unit', 'integration'],
     testrun_timeout: 10,
     use_spot_instances: true,
-    //fast_slow_staged_testrun: true
 )
 
 // vim: ft=groovy


### PR DESCRIPTION
### What does this PR do?
Adds debian 11 (not released yet) to CI pipelines so we can easily release when debian 11 actually comes out.
