### PR TITLE
fix release notes about dropping ubuntu 16.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,6 @@ Versions are `MAJOR.PATCH`.
 Salt 3003.1 (2021-06-08)
 ========================
 
-Removed
--------
-
-- Removed support for Ubuntu 16.04 (#59913)
-
-
 Fixed
 -----
 
@@ -45,6 +39,7 @@ Removed
 - Removing the _ext_nodes deprecation warning and alias to the master_tops function.  This change will break compatibility with a Salt master running versions 2017.7.8 and older and Salt minions running versions 3003 and newer. (#59804)
 - removed the arg `managed_private_key` from 'salt.states.x509.certificate_managed' (#59247)
 - Drop support for python 3.5 on Windows (#59479)
+- Removed support for Ubuntu 16.04 (#59913)
 
 
 Deprecated

--- a/doc/topics/releases/3003.1.rst
+++ b/doc/topics/releases/3003.1.rst
@@ -6,11 +6,6 @@ Salt 3003.1 Release Notes
 
 Version 3003.1 is a bug fix release for :ref:`3003 <release-3003>`.
 
-Removed
--------
-
-- Removed support for Ubuntu 16.04 (#59913)
-
 Fixed
 -----
 

--- a/doc/topics/releases/3003.rst
+++ b/doc/topics/releases/3003.rst
@@ -76,6 +76,7 @@ Removed
 - Removing the _ext_nodes deprecation warning and alias to the master_tops function.  This change will break compatibility with a Salt master running versions 2017.7.8 and older and Salt minions running versions 3003 and newer. (#59804)
 - removed the arg `managed_private_key` from 'salt.states.x509.certificate_managed' (#59247)
 - Drop support for python 3.5 on Windows (#59479)
+- Removed support for Ubuntu 16.04 (#59913)
 
 Deprecated
 ==========


### PR DESCRIPTION
### What does this PR do?
This was supposed to be in the 3003 release notes but ended up on the 3003.1 release notes.
