### PR TITLE
Change slightly order of doc/ref/index.rst

### DIFF
--- a/doc/ref/index.rst
+++ b/doc/ref/index.rst
@@ -14,10 +14,10 @@ This section contains a list of the Python modules that are used to extend the v
     ../ref/clouds/all/index
     ../ref/configuration/index
     ../ref/engines/all/index
+    ../ref/modules/all/index
     ../ref/executors/all/index
     ../ref/file_server/all/index
     ../ref/grains/all/index
-    ../ref/modules/all/index
     ../ref/netapi/all/index
     ../ref/output/all/index
     ../ref/pillar/all/index


### PR DESCRIPTION
I think this change will cause the table of contents for the Salt Module Reference to list execution modules just after engine modules, which is in alphabetical order. Currently the execution modules are slighly lower in the table of contents, and seems to be the only entry that is not in alphabetical order (at least, as an English reader).

I've just clicked through on the github edit links, so I haven't rendered this myself. I'll need someone else to do a documentation build, and verify the PR is suitable for merging.

### What does this PR do?

A very minor documentation edit.


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

