### PR TITLE
[3003.2] Migrate Terminal off os.fork in favor of Popen

### DIFF
--- a/changelog/60504.fixed
+++ b/changelog/60504.fixed
@@ -1,0 +1,1 @@
+Improve reliability of Terminal class

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -78,8 +78,8 @@ def _get_top_file_envs():
     try:
         return __context__["saltutil._top_file_envs"]
     except KeyError:
+        st_ = salt.state.HighState(__opts__, initial_pillar=__pillar__.value())
         try:
-            st_ = salt.state.HighState(__opts__, initial_pillar=__pillar__.value())
             top = st_.get_top()
             if top:
                 envs = list(st_.top_matches(top).keys()) or "base"
@@ -87,6 +87,8 @@ def _get_top_file_envs():
                 envs = "base"
         except SaltRenderError as exc:
             raise CommandExecutionError("Unable to render top file(s): {}".format(exc))
+        finally:
+            st_.client.destroy()
         __context__["saltutil._top_file_envs"] = envs
         return envs
 

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -456,6 +456,7 @@ class Terminal:
                 args = [self.args]
             #if isinstance(self.args, string_types):
             #    args = shlex.split(self.args)
+            #    args = self.args.split()
             elif self.args:
                 args = list(self.args)
             else:

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -28,7 +28,8 @@ import logging
 # Import python libs
 import os
 import select
-import shlex
+
+# import shlex
 import signal
 import subprocess
 import sys
@@ -316,7 +317,7 @@ class Terminal:
         self.stderr_logger_level = LOG_LEVELS.get(log_stderr_level, log_stderr_level)
         if log_stderr is True:
             self.stderr_logger = logging.getLogger(
-                "{0}.{1}.PID-{2}.STDERR".format(
+                "{}.{}.PID-{}.STDERR".format(
                     __name__, self.__class__.__name__, self.pid
                 )
             )
@@ -454,7 +455,7 @@ class Terminal:
             # TODO: Get rid of this logic, just use the same api as Popen
             if isinstance(self.args, str):
                 args = [self.args]
-            #if isinstance(self.args, string_types):
+            # if isinstance(self.args, string_types):
             #    args = shlex.split(self.args)
             #    args = self.args.split()
             elif self.args:
@@ -570,6 +571,7 @@ class Terminal:
 
             if not self.isalive():
                 if not rfds:
+                    self.close()
                     return None, None
                 rlist, _, _ = select.select(rfds, [], [], 0)
                 if not rlist:
@@ -579,10 +581,12 @@ class Terminal:
                         # There is data that was received but for which
                         # decoding failed, attempt decoding again to generate
                         # relevant exception
+                        self.close()
                         return (
                             salt.utils.stringutils.to_unicode(self.partial_data_stdout),
                             salt.utils.stringutils.to_unicode(self.partial_data_stderr),
                         )
+                    self.close()
                     return None, None
             elif self.__irix_hack:
                 # Irix takes a long time before it realizes a child was
@@ -855,11 +859,13 @@ class Terminal:
                 self.exitstatus = _wexitstatus(status)
                 self.signalstatus = None
                 self.terminated = True
+                self.close()
             elif _wifsignaled(status):
                 self.status = status
                 self.exitstatus = None
                 self.signalstatus = _wtermsig(status)
                 self.terminated = True
+                self.close()
             elif _wifstopped(status):
                 raise _terminal_exception(
                     "isalive() encountered condition where child process is "

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -531,6 +531,9 @@ class Terminal:
                     raise TerminalException("Could not open controlling tty, /dev/tty")
                 else:
                     os.close(tty_fd)
+
+            salt.utils.crypt.reinit_crypto()
+
             if preexec_fn is not None:
                 preexec_fn()
 

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -29,7 +29,6 @@ import logging
 import os
 import select
 
-# import shlex
 import signal
 import subprocess
 import sys
@@ -71,33 +70,6 @@ class TerminalException(Exception):
     """
     Terminal specific exception
     """
-
-
-# ----- Cleanup Running Instances ------------------------------------------->
-# This lists holds Terminal instances for which the underlying process had
-# not exited at the time its __del__ method got called: those processes are
-# wait()ed for synchronously from _cleanup() when a new Terminal object is
-# created, to avoid zombie processes.
-_ACTIVE = []
-
-
-def _cleanup():
-    """
-    Make sure that any terminal processes still running when __del__ was called
-    to the waited and cleaned up.
-    """
-    for inst in _ACTIVE[:]:
-        res = inst.isalive()
-        if res is not True:
-            try:
-                _ACTIVE.remove(inst)
-            except ValueError:
-                # This can happen if two threads create a new Terminal instance
-                # It's harmless that it was already removed, so ignore.
-                pass
-
-
-# <---- Cleanup Running Instances --------------------------------------------
 
 
 def setwinsize(child, rows=80, cols=80):
@@ -178,7 +150,6 @@ class Terminal:
         self.preexec_fn = preexec_fn
         self.receive_encoding = force_receive_encoding
 
-        # ----- Set the desired terminal size ------------------------------->
         if rows is None and cols is None:
             rows, cols = self.__detect_parent_terminal_size()
         elif rows is not None and cols is None:
@@ -187,9 +158,6 @@ class Terminal:
             rows, _ = self.__detect_parent_terminal_size()
         self.rows = rows
         self.cols = cols
-        # <---- Set the desired terminal size --------------------------------
-
-        # ----- Internally Set Attributes ----------------------------------->
         self.pid = None
         self.stdin = None
         self.stdout = None
@@ -210,9 +178,7 @@ class Terminal:
         # status returned by os.waitpid
         self.status = None
         self.__irix_hack = "irix" in sys.platform.lower()
-        # <---- Internally Set Attributes ------------------------------------
 
-        # ----- Direct Streaming Setup -------------------------------------->
         if stream_stdout is True:
             self.stream_stdout = sys.stdout
         elif stream_stdout is False:
@@ -254,9 +220,7 @@ class Terminal:
                 "Don't know how to handle '{0}' as the VT's "
                 "'stream_stderr' parameter.".format(stream_stderr)
             )
-        # <---- Direct Streaming Setup ---------------------------------------
 
-        # ----- Spawn our terminal ------------------------------------------>
         try:
             self._spawn()
         except Exception as err:  # pylint: disable=W0703
@@ -282,9 +246,7 @@ class Terminal:
             log.trace("Terminal Command: %s", terminal_command)
         else:
             log.debug("Terminal Command: %s", terminal_command)
-        # <---- Spawn our terminal -------------------------------------------
 
-        # ----- Setup Logging ----------------------------------------------->
         # Setup logging after spawned in order to have a pid value
         self.stdin_logger_level = LOG_LEVELS.get(log_stdin_level, log_stdin_level)
         if log_stdin is True:
@@ -327,9 +289,7 @@ class Terminal:
             self.stderr_logger = log_stderr
         else:
             self.stderr_logger = None
-        # <---- Setup Logging ------------------------------------------------
 
-    # ----- Common Public API ----------------------------------------------->
     def send(self, data):
         """
         Send data to the terminal. You are responsible to send any required
@@ -379,18 +339,12 @@ class Terminal:
     def has_unread_data(self):
         return self.flag_eof_stderr is False or self.flag_eof_stdout is False
 
-    # <---- Common Public API ------------------------------------------------
-
-    # ----- Common Internal API --------------------------------------------->
     def _translate_newlines(self, data):
         if data is None or not data:
             return
         # PTY's always return \r\n as the line feeds
         return data.replace("\r\n", os.linesep)
 
-    # <---- Common Internal API ----------------------------------------------
-
-    # ----- Context Manager Methods ----------------------------------------->
     def __enter__(self):
         return self
 
@@ -400,11 +354,7 @@ class Terminal:
         if self.isalive():
             self.wait()
 
-    # <---- Context Manager Methods ------------------------------------------
-
-    # ----- Platform Specific Methods ------------------------------------------->
     if mswindows:
-        # ----- Windows Methods --------------------------------------------->
         def _execute(self):
             raise NotImplementedError
 
@@ -447,17 +397,11 @@ class Terminal:
                 self.exitstatus = ecode
 
         kill = terminate
-    # <---- Windows Methods --------------------------------------------------
     else:
-        # ----- Linux Methods ----------------------------------------------->
-        # ----- Internal API ------------------------------------------------>
         def _spawn(self):
             # TODO: Get rid of this logic, just use the same api as Popen
             if isinstance(self.args, str):
                 args = [self.args]
-            # if isinstance(self.args, string_types):
-            #    args = shlex.split(self.args)
-            #    args = self.args.split()
             elif self.args:
                 args = list(self.args)
             else:
@@ -611,33 +555,23 @@ class Terminal:
             stderr = ""
             stdout = ""
 
-            # ----- Store FD Flags ------------------------------------------>
             if self.child_fd:
                 fd_flags = fcntl.fcntl(self.child_fd, fcntl.F_GETFL)
             if self.child_fde:
                 fde_flags = fcntl.fcntl(self.child_fde, fcntl.F_GETFL)
-            # <---- Store FD Flags -------------------------------------------
-
-            # ----- Non blocking Reads -------------------------------------->
             if self.child_fd:
                 fcntl.fcntl(self.child_fd, fcntl.F_SETFL, fd_flags | os.O_NONBLOCK)
             if self.child_fde:
                 fcntl.fcntl(self.child_fde, fcntl.F_SETFL, fde_flags | os.O_NONBLOCK)
-            # <---- Non blocking Reads ---------------------------------------
 
-            # ----- Check for any incoming data ----------------------------->
             rlist, _, _ = select.select(rfds, [], [], 0)
-            # <---- Check for any incoming data ------------------------------
 
-            # ----- Nothing to Process!? ------------------------------------>
             if not rlist:
                 if not self.isalive():
                     self.flag_eof_stdout = self.flag_eof_stderr = True
                     log.debug("End of file(EOL). Very slow platform.")
                     return None, None
-            # <---- Nothing to Process!? -------------------------------------
 
-            # ----- Helper function for processing STDERR and STDOUT -------->
             def read_and_decode_fd(fd, maxsize, partial_data_attr=None):
                 bytes_read = getattr(self, partial_data_attr, b"")
                 # Only read one byte if we already have some existing data
@@ -677,9 +611,6 @@ class Terminal:
                     else:
                         raise
 
-            # <---- Helper function for processing STDERR and STDOUT ---------
-
-            # ----- Process STDERR ------------------------------------------>
             if self.child_fde in rlist and not self.flag_eof_stderr:
                 try:
                     stderr, partial_data = read_and_decode_fd(
@@ -710,9 +641,7 @@ class Terminal:
                 finally:
                     if self.child_fde is not None:
                         fcntl.fcntl(self.child_fde, fcntl.F_SETFL, fde_flags)
-            # <---- Process STDERR -------------------------------------------
 
-            # ----- Process STDOUT ------------------------------------------>
             if self.child_fd in rlist and not self.flag_eof_stdout:
                 try:
                     stdout, partial_data = read_and_decode_fd(
@@ -944,29 +873,3 @@ class Terminal:
             Kill the process with SIGKILL
             """
             self.send_signal(signal.SIGKILL)
-
-        # <---- Public API ---------------------------------------------------
-    # <---- Linux Methods ----------------------------------------------------
-
-    # ----- Cleanup!!! ------------------------------------------------------>
-    # pylint: disable=W1701
-    def __del__(self, _maxsize=sys.maxsize, _active=_ACTIVE):  # pylint: disable=W0102
-        # I've disabled W0102 above which is regarding a dangerous default
-        # value of [] for _ACTIVE, though, this is how Python itself handles
-        # their subprocess clean up code.
-        # XXX: Revisit this cleanup code to make it less dangerous.
-
-        if self.pid is None:
-            # We didn't get to successfully create a child process.
-            return
-
-        # In case the child hasn't been waited on, check if it's done.
-        if self.isalive() and _ACTIVE is not None:
-            # Child is still running, keep us alive until we can wait on it.
-            _ACTIVE.append(self)
-
-    # pylint: enable=W1701
-    # <---- Cleanup!!! -------------------------------------------------------
-
-
-# <---- Platform Specific Methods --------------------------------------------

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -476,7 +476,7 @@ class Terminal:
                 preexec_fn=functools.partial(
                     self._preexec, child_name, self.rows, self.cols, self.preexec_fn
                 ),
-                shell=self.shell,
+                shell=self.shell,  # nosec
                 cwd=self.cwd,
                 stdin=child,
                 stdout=child,

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -859,13 +859,11 @@ class Terminal:
                 self.exitstatus = _wexitstatus(status)
                 self.signalstatus = None
                 self.terminated = True
-                self.close()
             elif _wifsignaled(status):
                 self.status = status
                 self.exitstatus = None
                 self.signalstatus = _wtermsig(status)
                 self.terminated = True
-                self.close()
             elif _wifstopped(status):
                 raise _terminal_exception(
                     "isalive() encountered condition where child process is "

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -311,7 +311,7 @@ class Terminal:
             if self.child_fde is not None:
                 os.close(self.child_fde)
                 self.child_fde = None
-            time.sleep(0.1)
+            time.sleep(0.3)
             if terminate:
                 if not self.terminate(kill):
                     raise TerminalException("Failed to terminate child process.")
@@ -399,6 +399,9 @@ class Terminal:
                 self.args = " ".join(self.args)
 
             parent, child = pty.openpty()
+            # Adding a small sleep for the underlying os operation to complete.
+            # Without this we will see intermitant OSError from Popen.
+            time.sleep(0.3)
             child_name = os.ttyname(child)
             os.set_inheritable(child, True)
             proc = subprocess.Popen(  # pylint: disable=subprocess-popen-preexec-fn

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -177,7 +177,6 @@ class Terminal:
         self.signalstatus = None
         # status returned by os.waitpid
         self.status = None
-        self.__irix_hack = "irix" in sys.platform.lower()
 
         if stream_stdout is True:
             self.stream_stdout = sys.stdout
@@ -531,25 +530,6 @@ class Terminal:
                             salt.utils.stringutils.to_unicode(self.partial_data_stderr),
                         )
                     self.close()
-                    return None, None
-            elif self.__irix_hack:
-                # Irix takes a long time before it realizes a child was
-                # terminated.
-                # FIXME So does this mean Irix systems are forced to always
-                # have a 2 second delay when calling read_nonblocking?
-                # That sucks.
-                rlist, _, _ = select.select(rfds, [], [], 2)
-                if not rlist:
-                    self.flag_eof_stdout = self.flag_eof_stderr = True
-                    log.debug("End of file(EOL). Slow platform.")
-                    if self.partial_data_stdout or self.partial_data_stderr:
-                        # There is data that was received but for which
-                        # decoding failed, attempt decoding again to generate
-                        # relevant exception
-                        return (
-                            salt.utils.stringutils.to_unicode(self.partial_data_stdout),
-                            salt.utils.stringutils.to_unicode(self.partial_data_stderr),
-                        )
                     return None, None
 
             stderr = ""

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -383,21 +383,8 @@ class Terminal:
     else:
 
         def _spawn(self):
-            # TODO: Get rid of this logic, just use the same api as Popen
-            if isinstance(self.args, str):
-                args = [self.args]
-            elif self.args:
-                args = list(self.args)
-            else:
-                args = []
-            self.args = args
-            if self.executable:
-                self.args[0] = self.executable
-            if self.executable is None:
-                self.executable = self.args[0]
-            if self.shell:
+            if not isinstance(self.args, str) and self.shell is True:
                 self.args = " ".join(self.args)
-
             parent, child = pty.openpty()
             # Adding a small sleep for the underlying os operation to complete.
             # Without this we will see intermitant OSError from Popen.
@@ -410,10 +397,12 @@ class Terminal:
                     self._preexec, child_name, self.rows, self.cols, self.preexec_fn
                 ),
                 shell=self.shell,  # nosec
+                executable=self.executable,
                 cwd=self.cwd,
                 stdin=child,
                 stdout=child,
                 stderr=subprocess.PIPE,
+                env=self.env,
             )
             os.close(child)
             self.child_fd = parent

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -28,7 +28,6 @@ import logging
 # Import python libs
 import os
 import select
-
 import signal
 import subprocess
 import sys
@@ -133,15 +132,10 @@ class Terminal:
         # Used for tests
         force_receive_encoding=__salt_system_encoding__,
     ):
-
-        # Let's avoid Zombies!!!
-        _cleanup()
-
         if not args and not executable:
             raise TerminalException(
                 'You need to pass at least one of "args", "executable" '
             )
-
         self.args = args
         self.executable = executable
         self.shell = shell
@@ -354,6 +348,7 @@ class Terminal:
             self.wait()
 
     if mswindows:
+
         def _execute(self):
             raise NotImplementedError
 
@@ -397,6 +392,7 @@ class Terminal:
 
         kill = terminate
     else:
+
         def _spawn(self):
             # TODO: Get rid of this logic, just use the same api as Popen
             if isinstance(self.args, str):

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -32,8 +32,6 @@ import time
 import salt.utils.crypt
 import salt.utils.data
 import salt.utils.stringutils
-from salt.ext import six
-from salt.ext.six import string_types
 from salt.log.setup import LOG_LEVELS
 
 mswindows = sys.platform == "win32"

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
     :codeauthor: Pedro Algarvio (pedro@algarvio.me)
 
@@ -19,13 +18,10 @@
     .. __: https://github.com/pexpect/pexpect
 
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
 import errno
 import functools
 import logging
-
-# Import python libs
 import os
 import select
 import signal
@@ -33,12 +29,9 @@ import subprocess
 import sys
 import time
 
-# Import salt libs
 import salt.utils.crypt
 import salt.utils.data
 import salt.utils.stringutils
-
-# Import salt libs
 from salt.ext import six
 from salt.ext.six import string_types
 from salt.log.setup import LOG_LEVELS
@@ -189,7 +182,7 @@ class Terminal:
             self.stream_stdout = stream_stdout
         else:
             raise TerminalException(
-                "Don't know how to handle '{0}' as the VT's "
+                "Don't know how to handle '{}' as the VT's "
                 "'stream_stdout' parameter.".format(stream_stdout)
             )
 
@@ -210,7 +203,7 @@ class Terminal:
             self.stream_stderr = stream_stderr
         else:
             raise TerminalException(
-                "Don't know how to handle '{0}' as the VT's "
+                "Don't know how to handle '{}' as the VT's "
                 "'stream_stderr' parameter.".format(stream_stderr)
             )
 
@@ -222,7 +215,7 @@ class Terminal:
             log.warning(
                 "Failed to spawn the VT: %s", err, exc_info_on_loglevel=logging.DEBUG
             )
-            raise TerminalException("Failed to spawn the VT. Error: {0}".format(err))
+            raise TerminalException("Failed to spawn the VT. Error: {}".format(err))
 
         log.debug(
             "Child Forked! PID: %s  STDOUT_FD: %s  STDERR_FD: %s",
@@ -244,9 +237,7 @@ class Terminal:
         self.stdin_logger_level = LOG_LEVELS.get(log_stdin_level, log_stdin_level)
         if log_stdin is True:
             self.stdin_logger = logging.getLogger(
-                "{0}.{1}.PID-{2}.STDIN".format(
-                    __name__, self.__class__.__name__, self.pid
-                )
+                "{}.{}.PID-{}.STDIN".format(__name__, self.__class__.__name__, self.pid)
             )
         elif log_stdin is not None:
             if not isinstance(log_stdin, logging.Logger):
@@ -258,7 +249,7 @@ class Terminal:
         self.stdout_logger_level = LOG_LEVELS.get(log_stdout_level, log_stdout_level)
         if log_stdout is True:
             self.stdout_logger = logging.getLogger(
-                "{0}.{1}.PID-{2}.STDOUT".format(
+                "{}.{}.PID-{}.STDOUT".format(
                     __name__, self.__class__.__name__, self.pid
                 )
             )
@@ -294,7 +285,7 @@ class Terminal:
         """
         Send the provided data to the terminal appending a line feed.
         """
-        return self.send("{0}{1}".format(data, linesep))
+        return self.send("{}{}".format(data, linesep))
 
     def recv(self, maxsize=None):
         """
@@ -373,7 +364,7 @@ class Terminal:
             elif sig == signal.CTRL_BREAK_EVENT:
                 os.kill(self.pid, signal.CTRL_BREAK_EVENT)
             else:
-                raise ValueError("Unsupported signal: {0}".format(sig))
+                raise ValueError("Unsupported signal: {}".format(sig))
             # pylint: enable=E1101
 
         def terminate(self, force=False):
@@ -451,7 +442,7 @@ class Terminal:
                 if tty_fd >= 0:
                     os.close(tty_fd)
                     raise TerminalException(
-                        "Could not open child pty, {0}".format(child_name)
+                        "Could not open child pty, {}".format(child_name)
                     )
             # which exception, shouldn't we catch explicitly .. ?
             except Exception:  # pylint: disable=broad-except
@@ -487,12 +478,7 @@ class Terminal:
             try:
                 if self.stdin_logger:
                     self.stdin_logger.log(self.stdin_logger_level, data)
-                if six.PY3:
-                    written = os.write(
-                        self.child_fd, data.encode(__salt_system_encoding__)
-                    )
-                else:
-                    written = os.write(self.child_fd, data)
+                written = os.write(self.child_fd, data.encode(__salt_system_encoding__))
             except OSError as why:
                 if why.errno == errno.EPIPE:  # broken pipe
                     os.close(self.child_fd)
@@ -659,7 +645,7 @@ class Terminal:
                 packed = struct.pack(b"HHHH", 0, 0, 0, 0)
                 ioctl = fcntl.ioctl(sys.stdin.fileno(), TIOCGWINSZ, packed)
                 return struct.unpack(b"HHHH", ioctl)[0:2]
-            except IOError:
+            except OSError:
                 # Return a default value of 24x80
                 return 24, 80
 
@@ -727,7 +713,7 @@ class Terminal:
                         "else call waitpid() on our process?"
                     )
                 else:
-                    six.reraise(*sys.exc_info())
+                    raise
 
             # I have to do this twice for Solaris.
             # I can't even believe that I figured this out...
@@ -746,7 +732,7 @@ class Terminal:
                             "someone else call waitpid() on our process?"
                         )
                     else:
-                        six.reraise(*sys.exc_info())
+                        raise
 
                 # If pid is still 0 after two calls to waitpid() then the
                 # process really is alive. This seems to work on all platforms,

--- a/tests/integration/ssh/test_state.py
+++ b/tests/integration/ssh/test_state.py
@@ -297,12 +297,12 @@ class SSHStateTest(SSHCase):
         expected = 'The function "state.pkg" is running as'
         state_ret = []
         for _ in range(30):
-            time.sleep(5)
             get_sls = self.run_function("state.running", wipe=False)
             state_ret.append(get_sls)
             if expected in " ".join(get_sls):
                 # We found the expected return
                 break
+            time.sleep(0.3)
         else:
             self.fail(
                 "Did not find '{}' in state.running return: {}".format(

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
     :codeauthor: Pedro Algarvio (pedro@algarvio.me)
 
@@ -9,8 +8,6 @@
     VirtualTerminal tests
 """
 
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
 import functools
 import io
@@ -20,17 +17,12 @@ import subprocess
 import sys
 import time
 
-# Import Salt libs
 import salt.utils
 import salt.utils.files
 import salt.utils.platform
 import salt.utils.stringutils
 import salt.utils.vt
-
-# Import 3rd-party libs
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
-
-# Import Salt Testing libs
 from tests.support.paths import CODE_DIR
 from tests.support.unit import TestCase, skipIf
 
@@ -125,7 +117,7 @@ class VTTestCase(TestCase):
                 )
                 stdout, _ = proc.communicate()
                 return int(stdout.strip())
-            except (ValueError, OSError, IOError):
+            except (ValueError, OSError):
                 if salt.utils.platform.is_darwin():
                     # We're unable to findout how many PTY's are open
                     self.skipTest(
@@ -140,7 +132,7 @@ class VTTestCase(TestCase):
         for idx in range(0, nr_ptys + n_executions):
             try:
                 with salt.utils.vt.Terminal(
-                    'echo "Run {0}"'.format(idx),
+                    'echo "Run {}"'.format(idx),
                     shell=True,
                     stream_stdout=False,
                     stream_stderr=False,
@@ -149,7 +141,7 @@ class VTTestCase(TestCase):
                 try:
                     if current_pty_count() > (nr_ptys + (n_executions / 2)):
                         self.fail("VT is not cleaning up PTY's")
-                except (ValueError, OSError, IOError):
+                except (ValueError, OSError):
                     self.fail("Unable to find out how many PTY's are open")
             except Exception as exc:  # pylint: disable=broad-except
                 if "out of pty devices" in str(exc):
@@ -162,7 +154,7 @@ class VTTestCase(TestCase):
         for idx in range(0, nr_ptys + n_executions):
             try:
                 terminal = salt.utils.vt.Terminal(
-                    'echo "Run {0}"'.format(idx),
+                    'echo "Run {}"'.format(idx),
                     shell=True,
                     stream_stdout=False,
                     stream_stderr=False,
@@ -171,7 +163,7 @@ class VTTestCase(TestCase):
                 try:
                     if current_pty_count() > (nr_ptys + (n_executions / 2)):
                         self.fail("VT is not cleaning up PTY's")
-                except (ValueError, OSError, IOError):
+                except (ValueError, OSError):
                     self.fail("Unable to find out how many PTY's are open")
             except Exception as exc:  # pylint: disable=broad-except
                 if "out of pty devices" in str(exc):

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -78,8 +78,6 @@ class VTTestCase(TestCase):
     )
     def test_vt_size(self):
         """Confirm that the terminal size is being set"""
-        #        if not sys.stdin.isatty():
-        #            self.skipTest("Not attached to a TTY. The test would fail.")
         cols = random.choice(range(80, 250))
         terminal = salt.utils.vt.Terminal(
             "stty size",

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -72,10 +72,10 @@ def fixStdOutErrFileNoIfNeeded(func):
 
 
 class VTTestCase(TestCase):
-    #    @skipIf(
-    #        True,
-    #        "Disabled until we can figure out why this fails when whole test suite runs.",
-    #    )
+    @skipIf(
+        salt.utils.platform.is_windows(),
+        "Skip on Windows because this feature is not supported",
+    )
     def test_vt_size(self):
         """Confirm that the terminal size is being set"""
         #        if not sys.stdin.isatty():

--- a/tests/unit/utils/test_vt.py
+++ b/tests/unit/utils/test_vt.py
@@ -72,27 +72,38 @@ def fixStdOutErrFileNoIfNeeded(func):
 
 
 class VTTestCase(TestCase):
-    @skipIf(
-        True,
-        "Disabled until we can figure out why this fails when whole test suite runs.",
-    )
+    #    @skipIf(
+    #        True,
+    #        "Disabled until we can figure out why this fails when whole test suite runs.",
+    #    )
     def test_vt_size(self):
         """Confirm that the terminal size is being set"""
-        if not sys.stdin.isatty():
-            self.skipTest("Not attached to a TTY. The test would fail.")
+        #        if not sys.stdin.isatty():
+        #            self.skipTest("Not attached to a TTY. The test would fail.")
         cols = random.choice(range(80, 250))
         terminal = salt.utils.vt.Terminal(
-            'echo "Foo!"',
+            "stty size",
             shell=True,
             cols=cols,
             rows=24,
             stream_stdout=False,
             stream_stderr=False,
         )
-        # First the assertion
         self.assertEqual(terminal.getwinsize(), (24, cols))
-        # Then wait for the terminal child to exit
-        terminal.wait()
+        buffer_o = buffer_e = ""
+        while terminal.has_unread_data:
+            stdout, stderr = terminal.recv()
+            if stdout:
+                buffer_o += stdout
+            if stderr:
+                buffer_e += stderr
+        assert buffer_o.strip() == "24 {}".format(cols)
+        try:
+            # Then wait for the terminal child to exit, this will raise an
+            # exception if the process has already exited.
+            terminal.wait()
+        except salt.utils.vt.TerminalException:
+            pass
         terminal.close()
 
     @skipIf(


### PR DESCRIPTION
### What does this PR do?

Changes salt.utils.vt.Terminal to use subprocess.Popen instead of calling os.fork. This avoids python's built in book keeping which happens on os.fork calls and can cause dead locks when used in multi-threaded environments.

### What issues does this PR fix or reference?

Fixes: #60504

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

