### PR TITLE
[freeze] Ignore configuration for 'enable_fqdns_grains' for AIX, Solaris and Juniper

### DIFF
--- a/changelog/60529.fixed
+++ b/changelog/60529.fixed
@@ -1,0 +1,1 @@
+Ignore configuration for 'enable_fqdns_grains' for AIX, Solaris and Juniper, assume False

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2399,7 +2399,11 @@ def fqdns():
     if __opts__.get(
         "enable_fqdns_grains",
         False
-        if salt.utils.platform.is_windows() or salt.utils.platform.is_proxy()
+        if salt.utils.platform.is_windows()
+        or salt.utils.platform.is_proxy()
+        or salt.utils.platform.is_sunos()
+        or salt.utils.platform.is_aix()
+        or salt.utils.platform.is_junos()
         else True,
     ):
         opt = __salt__["network.fqdns"]()

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -1472,6 +1472,42 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
                 # fqdns is disabled by default on proxy minions
                 assert core.fqdns() == {"fqdns": []}
 
+    def test_enable_fqdns_false_is_aix(self):
+        """
+        testing fqdns grains is disabled by default for minions on AIX
+        """
+        with patch("salt.utils.platform.is_aix", return_value=True, autospec=True):
+            with patch.dict(
+                "salt.grains.core.__salt__",
+                {"network.fqdns": MagicMock(return_value="my.fake.domain")},
+            ):
+                # fqdns is disabled by default on minions on AIX
+                assert core.fqdns() == {"fqdns": []}
+
+    def test_enable_fqdns_false_is_sunos(self):
+        """
+        testing fqdns grains is disabled by default for minions on Solaris platforms
+        """
+        with patch("salt.utils.platform.is_sunos", return_value=True, autospec=True):
+            with patch.dict(
+                "salt.grains.core.__salt__",
+                {"network.fqdns": MagicMock(return_value="my.fake.domain")},
+            ):
+                # fqdns is disabled by default on minions on Solaris platforms
+                assert core.fqdns() == {"fqdns": []}
+
+    def test_enable_fqdns_false_is_junos(self):
+        """
+        testing fqdns grains is disabled by default for minions on Junos
+        """
+        with patch("salt.utils.platform.is_junos", return_value=True, autospec=True):
+            with patch.dict(
+                "salt.grains.core.__salt__",
+                {"network.fqdns": MagicMock(return_value="my.fake.domain")},
+            ):
+                # fqdns is disabled by default on minions on Junos (Juniper)
+                assert core.fqdns() == {"fqdns": []}
+
     @skipIf(not salt.utils.platform.is_linux(), "System is not Linux")
     @patch(
         "salt.utils.network.ip_addrs", MagicMock(return_value=["1.2.3.4", "5.6.7.8"])


### PR DESCRIPTION
### What does this PR do?
Ignore configuration for 'enable_fqdns_grains' for AIX, Solaris and Juniper

### What issues does this PR fix or reference?
Fixes:  #60529

### Previous Behavior
'enable_fqdns_grains' default value of True was causing issues porting Salt 3003.1 (Seq Fault - Core), fixed with a patch file.

### New Behavior
Ignore 'enable_fqdns_grains' setting similar to existing Windows and Proxy checks, for AIX, Solaris and Junos (Juniper) where checking for fqdns has or will cause issues, for example: reverse DNS lookup on a Juniper router will be problematic (current native minion ships with setting defaulted to False). This change alieves this.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
