### PR TITLE
Fix bad keyword argument in run.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -47,7 +47,7 @@ def redirect(argv):
         msg = "Must pass in a salt command, available commands are:"
         for cmd in AVAIL:
             msg += f"\n{cmd}"
-        print(msg, stream=sys.stderr, flush=True)
+        print(msg, file=sys.stderr, flush=True)
         sys.exit(1)
     cmd = sys.argv[1]
     if cmd == "shell":


### PR DESCRIPTION
### What does this PR do?
Fixes run.py. If you just run the `run.exe` binary you get a stacktrace saying `stream` is an invalid keyword argument for `print()`

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes