### PR TITLE
Bump to ``urllib3==1.26.6``

### DIFF
--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -51,7 +51,7 @@ six==1.16.0
     #   smbprotocol
 smbprotocol==0.1.1
     # via pypsexec
-urllib3==1.24.2
+urllib3==1.26.6
     # via requests
 xmltodict==0.12.0
     # via pywinrm

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -887,7 +887,7 @@ toml==0.10.2
     #   pytest
 transitions==0.8.1
     # via junos-eznc
-urllib3==1.26.4
+urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.10/darwin.txt
     #   botocore

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -145,7 +145,7 @@ tempora==1.14.1
     #   portend
 timelib==0.2.5
     # via -r requirements/static/pkg/py3.10/linux.txt
-urllib3==1.26.4
+urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.10/linux.txt
     #   requests

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -885,7 +885,7 @@ toml==0.10.2
     #   pytest
 transitions==0.8.1
     # via junos-eznc
-urllib3==1.26.4
+urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.10/freebsd.txt
     #   botocore

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -918,7 +918,7 @@ toml==0.10.2
     #   pytest
 transitions==0.8.1
     # via junos-eznc
-urllib3==1.26.4
+urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.10/linux.txt
     #   botocore

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -399,7 +399,7 @@ toml==0.10.2
     # via
     #   -r requirements/static/ci/common.in
     #   pytest
-urllib3==1.26.4
+urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.10/windows.txt
     #   botocore

--- a/requirements/static/ci/py3.5/cloud.txt
+++ b/requirements/static/ci/py3.5/cloud.txt
@@ -51,7 +51,7 @@ six==1.16.0
     #   smbprotocol
 smbprotocol==0.1.1
     # via pypsexec
-urllib3==1.26.4
+urllib3==1.26.6
     # via requests
 xmltodict==0.12.0
     # via pywinrm

--- a/requirements/static/ci/py3.5/docs.txt
+++ b/requirements/static/ci/py3.5/docs.txt
@@ -147,7 +147,7 @@ tempora==1.14.1
     #   portend
 timelib==0.2.5
     # via -r requirements/static/pkg/py3.5/linux.txt
-urllib3==1.26.4
+urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.5/linux.txt
     #   requests

--- a/requirements/static/ci/py3.5/linux.txt
+++ b/requirements/static/ci/py3.5/linux.txt
@@ -899,7 +899,7 @@ toml==0.10.2
     #   pytest
 transitions==0.8.1
     # via junos-eznc
-urllib3==1.26.4
+urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.5/linux.txt
     #   botocore

--- a/requirements/static/ci/py3.6/cloud.txt
+++ b/requirements/static/ci/py3.6/cloud.txt
@@ -51,7 +51,7 @@ six==1.16.0
     #   smbprotocol
 smbprotocol==0.1.1
     # via pypsexec
-urllib3==1.26.4
+urllib3==1.26.6
     # via requests
 xmltodict==0.12.0
     # via pywinrm

--- a/requirements/static/ci/py3.6/docs.txt
+++ b/requirements/static/ci/py3.6/docs.txt
@@ -147,7 +147,7 @@ tempora==1.14.1
     #   portend
 timelib==0.2.5
     # via -r requirements/static/pkg/py3.6/linux.txt
-urllib3==1.26.4
+urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.6/linux.txt
     #   requests

--- a/requirements/static/ci/py3.6/linux.txt
+++ b/requirements/static/ci/py3.6/linux.txt
@@ -896,7 +896,7 @@ toml==0.10.2
     #   pytest
 transitions==0.8.1
     # via junos-eznc
-urllib3==1.26.4
+urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.6/linux.txt
     #   botocore

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -51,7 +51,7 @@ six==1.16.0
     #   smbprotocol
 smbprotocol==0.1.1
     # via pypsexec
-urllib3==1.26.4
+urllib3==1.26.6
     # via requests
 xmltodict==0.12.0
     # via pywinrm

--- a/requirements/static/ci/py3.7/darwin.txt
+++ b/requirements/static/ci/py3.7/darwin.txt
@@ -895,7 +895,7 @@ toml==0.10.2
     #   pytest
 transitions==0.8.1
     # via junos-eznc
-urllib3==1.26.4
+urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.7/darwin.txt
     #   botocore

--- a/requirements/static/ci/py3.7/docs.txt
+++ b/requirements/static/ci/py3.7/docs.txt
@@ -145,7 +145,7 @@ tempora==1.14.1
     #   portend
 timelib==0.2.5
     # via -r requirements/static/pkg/py3.7/linux.txt
-urllib3==1.26.4
+urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.7/linux.txt
     #   requests

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -893,7 +893,7 @@ toml==0.10.2
     #   pytest
 transitions==0.8.1
     # via junos-eznc
-urllib3==1.26.4
+urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.7/freebsd.txt
     #   botocore

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -924,7 +924,7 @@ toml==0.10.2
     #   pytest
 transitions==0.8.1
     # via junos-eznc
-urllib3==1.26.4
+urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.7/linux.txt
     #   botocore

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -413,7 +413,7 @@ typing-extensions==3.10.0.0
     # via
     #   -r requirements/static/pkg/py3.7/windows.txt
     #   gitpython
-urllib3==1.26.4
+urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.7/windows.txt
     #   botocore

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -51,7 +51,7 @@ six==1.16.0
     #   smbprotocol
 smbprotocol==0.1.1
     # via pypsexec
-urllib3==1.26.4
+urllib3==1.26.6
     # via requests
 xmltodict==0.12.0
     # via pywinrm

--- a/requirements/static/ci/py3.8/darwin.txt
+++ b/requirements/static/ci/py3.8/darwin.txt
@@ -887,7 +887,7 @@ toml==0.10.2
     #   pytest
 transitions==0.8.1
     # via junos-eznc
-urllib3==1.26.4
+urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.8/darwin.txt
     #   botocore

--- a/requirements/static/ci/py3.8/docs.txt
+++ b/requirements/static/ci/py3.8/docs.txt
@@ -145,7 +145,7 @@ tempora==1.14.1
     #   portend
 timelib==0.2.5
     # via -r requirements/static/pkg/py3.8/linux.txt
-urllib3==1.26.4
+urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.8/linux.txt
     #   requests

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -885,7 +885,7 @@ toml==0.10.2
     #   pytest
 transitions==0.8.1
     # via junos-eznc
-urllib3==1.26.4
+urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.8/freebsd.txt
     #   botocore

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -916,7 +916,7 @@ toml==0.10.2
     #   pytest
 transitions==0.8.1
     # via junos-eznc
-urllib3==1.26.4
+urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.8/linux.txt
     #   botocore

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -401,7 +401,7 @@ toml==0.10.2
     # via
     #   -r requirements/static/ci/common.in
     #   pytest
-urllib3==1.26.4
+urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.8/windows.txt
     #   botocore

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -51,7 +51,7 @@ six==1.16.0
     #   smbprotocol
 smbprotocol==0.1.1
     # via pypsexec
-urllib3==1.26.4
+urllib3==1.26.6
     # via requests
 xmltodict==0.12.0
     # via pywinrm

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -887,7 +887,7 @@ toml==0.10.2
     #   pytest
 transitions==0.8.1
     # via junos-eznc
-urllib3==1.26.4
+urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.9/darwin.txt
     #   botocore

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -145,7 +145,7 @@ tempora==1.14.1
     #   portend
 timelib==0.2.5
     # via -r requirements/static/pkg/py3.9/linux.txt
-urllib3==1.26.4
+urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.9/linux.txt
     #   requests

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -885,7 +885,7 @@ toml==0.10.2
     #   pytest
 transitions==0.8.1
     # via junos-eznc
-urllib3==1.26.4
+urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.9/freebsd.txt
     #   botocore

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -918,7 +918,7 @@ toml==0.10.2
     #   pytest
 transitions==0.8.1
     # via junos-eznc
-urllib3==1.26.4
+urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.9/linux.txt
     #   botocore

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -401,7 +401,7 @@ toml==0.10.2
     # via
     #   -r requirements/static/ci/common.in
     #   pytest
-urllib3==1.26.4
+urllib3==1.26.6
     # via
     #   -r requirements/static/pkg/py3.9/windows.txt
     #   botocore

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -103,7 +103,7 @@ tempora==1.14.1
     # via portend
 timelib==0.2.5
     # via -r requirements/darwin.txt
-urllib3==1.26.4
+urllib3==1.26.6
     # via requests
 vultr==1.0.1
     # via -r requirements/darwin.txt

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -81,7 +81,7 @@ tempora==1.14.1
     # via portend
 timelib==0.2.5
     # via -r requirements/static/pkg/freebsd.in
-urllib3==1.26.4
+urllib3==1.26.6
     # via requests
 zc.lockfile==1.4
     # via cherrypy

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -79,7 +79,7 @@ tempora==1.14.1
     # via portend
 timelib==0.2.5
     # via -r requirements/static/pkg/linux.in
-urllib3==1.26.4
+urllib3==1.26.6
     # via requests
 zc.lockfile==1.4
     # via cherrypy

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -122,7 +122,7 @@ tempora==1.14.1
     # via portend
 timelib==0.2.5
     # via -r requirements/windows.txt
-urllib3==1.26.4
+urllib3==1.26.6
     # via requests
 wheel==0.36.2
     # via -r requirements/windows.txt

--- a/requirements/static/pkg/py3.5/linux.txt
+++ b/requirements/static/pkg/py3.5/linux.txt
@@ -81,7 +81,7 @@ tempora==1.14.1
     # via portend
 timelib==0.2.5
     # via -r requirements/static/pkg/linux.in
-urllib3==1.26.4
+urllib3==1.26.6
     # via requests
 zc.lockfile==1.4
     # via cherrypy

--- a/requirements/static/pkg/py3.6/linux.txt
+++ b/requirements/static/pkg/py3.6/linux.txt
@@ -81,7 +81,7 @@ tempora==1.14.1
     # via portend
 timelib==0.2.5
     # via -r requirements/static/pkg/linux.in
-urllib3==1.26.4
+urllib3==1.26.6
     # via requests
 zc.lockfile==1.4
     # via cherrypy

--- a/requirements/static/pkg/py3.7/darwin.txt
+++ b/requirements/static/pkg/py3.7/darwin.txt
@@ -103,7 +103,7 @@ tempora==1.14.1
     # via portend
 timelib==0.2.5
     # via -r requirements/darwin.txt
-urllib3==1.26.4
+urllib3==1.26.6
     # via requests
 vultr==1.0.1
     # via -r requirements/darwin.txt

--- a/requirements/static/pkg/py3.7/freebsd.txt
+++ b/requirements/static/pkg/py3.7/freebsd.txt
@@ -81,7 +81,7 @@ tempora==1.14.1
     # via portend
 timelib==0.2.5
     # via -r requirements/static/pkg/freebsd.in
-urllib3==1.26.4
+urllib3==1.26.6
     # via requests
 zc.lockfile==1.4
     # via cherrypy

--- a/requirements/static/pkg/py3.7/linux.txt
+++ b/requirements/static/pkg/py3.7/linux.txt
@@ -79,7 +79,7 @@ tempora==1.14.1
     # via portend
 timelib==0.2.5
     # via -r requirements/static/pkg/linux.in
-urllib3==1.26.4
+urllib3==1.26.6
     # via requests
 zc.lockfile==1.4
     # via cherrypy

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -126,7 +126,7 @@ timelib==0.2.5
     # via -r requirements/windows.txt
 typing-extensions==3.10.0.0
     # via gitpython
-urllib3==1.26.4
+urllib3==1.26.6
     # via requests
 wheel==0.36.2
     # via -r requirements/windows.txt

--- a/requirements/static/pkg/py3.8/darwin.txt
+++ b/requirements/static/pkg/py3.8/darwin.txt
@@ -103,7 +103,7 @@ tempora==1.14.1
     # via portend
 timelib==0.2.5
     # via -r requirements/darwin.txt
-urllib3==1.26.4
+urllib3==1.26.6
     # via requests
 vultr==1.0.1
     # via -r requirements/darwin.txt

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -81,7 +81,7 @@ tempora==1.14.1
     # via portend
 timelib==0.2.5
     # via -r requirements/static/pkg/freebsd.in
-urllib3==1.26.4
+urllib3==1.26.6
     # via requests
 zc.lockfile==1.4
     # via cherrypy

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -79,7 +79,7 @@ tempora==1.14.1
     # via portend
 timelib==0.2.5
     # via -r requirements/static/pkg/linux.in
-urllib3==1.26.4
+urllib3==1.26.6
     # via requests
 zc.lockfile==1.4
     # via cherrypy

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -124,7 +124,7 @@ tempora==1.14.1
     # via portend
 timelib==0.2.5
     # via -r requirements/windows.txt
-urllib3==1.26.4
+urllib3==1.26.6
     # via requests
 wheel==0.36.2
     # via -r requirements/windows.txt

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -103,7 +103,7 @@ tempora==1.14.1
     # via portend
 timelib==0.2.5
     # via -r requirements/darwin.txt
-urllib3==1.26.4
+urllib3==1.26.6
     # via requests
 vultr==1.0.1
     # via -r requirements/darwin.txt

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -81,7 +81,7 @@ tempora==1.14.1
     # via portend
 timelib==0.2.5
     # via -r requirements/static/pkg/freebsd.in
-urllib3==1.26.4
+urllib3==1.26.6
     # via requests
 zc.lockfile==1.4
     # via cherrypy

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -79,7 +79,7 @@ tempora==1.14.1
     # via portend
 timelib==0.2.5
     # via -r requirements/static/pkg/linux.in
-urllib3==1.26.4
+urllib3==1.26.6
     # via requests
 zc.lockfile==1.4
     # via cherrypy

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -124,7 +124,7 @@ tempora==1.14.1
     # via portend
 timelib==0.2.5
     # via -r requirements/windows.txt
-urllib3==1.26.4
+urllib3==1.26.6
     # via requests
 wheel==0.36.2
     # via -r requirements/windows.txt


### PR DESCRIPTION
### What does this PR do?

# GHSA-q2q7-5pp4-w6pg

high severity

## Vulnerable versions: < 1.26.5
## Patched version: 1.26.5

# Impact

When provided with a URL containing many @ characters in the authority component the authority regular expression exhibits
catastrophic backtracking causing a denial of service if a URL were passed as a parameter or redirected to via an HTTP redirect.

# Patches

The issue has been fixed in urllib3 v1.26.5.

# References

* [CVE-2021-33503](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33503)
* [JVNVU#92413403 (English)](https://jvn.jp/en/vu/JVNVU92413403/)
* [JVNVU#92413403 (Japanese)](https://jvn.jp/vu/JVNVU92413403/)
* [urllib3 v1.26.5](https://github.com/urllib3/urllib3/releases/tag/1.26.5)

### What issues does this PR fix or reference?
Closes https://github.com/saltstack/salt/pull/60292
Closes https://github.com/saltstack/salt/pull/60293
Closes https://github.com/saltstack/salt/pull/60294