### PR TITLE
Remove check for TIAMAT_BUILD enforcing USE_STATIC_REQUIREMENTS, now controlled by Tiamat v7.10.1 and above

### DIFF
--- a/changelog/60559.fixed
+++ b/changelog/60559.fixed
@@ -1,0 +1,1 @@
+Remove check for TIAMAT_BUILD enforcing USE_STATIC_REQUIREMENTS, this is now controled by Tiamat v7.10.1 and above

--- a/setup.py
+++ b/setup.py
@@ -94,9 +94,6 @@ else:
 USE_STATIC_REQUIREMENTS = os.environ.get("USE_STATIC_REQUIREMENTS")
 if USE_STATIC_REQUIREMENTS is not None:
     USE_STATIC_REQUIREMENTS = USE_STATIC_REQUIREMENTS == "1"
-# Are we running pop-build
-if "TIAMAT_BUILD" in os.environ:
-    USE_STATIC_REQUIREMENTS = True
 
 try:
     # Add the esky bdist target if the module is available


### PR DESCRIPTION
### What does this PR do?
Removes the check for TIAMAT_BUILD environment variable and it's enforcement of USE_STATIC_REQUIREMENTS, as USE_STATIC_REQUIREMENTS is now enforced by Tiamat v7.10.1 and above.  Tiamat now has this a configurable option which defaults to USE_STATIC_REQUIREMENTS = "1".

Not all platforms which use Tiamat can use static requirements, for example: latest required cryptography requires Rust libraries, these are not available for AIX and Solaris 10, nor on FreeBSD v10.x required for building Juniper support.

Note: could add static requirements for these OS's and their supported version of Python 3, but support on these platforms often use OS supplied versions of Python modules which are required to be used without wheel rebuilding (some modules require Linux headers which are not available on some non-Linux platforms)
These OS supplied packages for modules are subject to change, and older versions may not be easily available after their update.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/60559

### Previous Behavior
Building would fail when the versions of pip later than 20.2.4 where used (20.2.4 and earlier used a different resolver which did not check static requirements)

### New Behavior
OS platforms can now disable using static requirements and build with the latest versions of pip.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
