### PR TITLE
Update tls uri for virt tests

### DIFF
--- a/tests/support/virt.py
+++ b/tests/support/virt.py
@@ -31,7 +31,7 @@ class SaltVirtMinionContainerFactory(SaltMinion):
         self.uri = "localhost:{}".format(self.sshd_port)
         self.ssh_uri = "qemu+ssh://{}/system".format(self.uri)
         self.tcp_uri = "qemu+tcp://localhost:{}/system".format(self.libvirt_tcp_port)
-        self.tls_uri = "qemu+tls://localhost:{}/system".format(self.libvirt_tls_port)
+        self.tls_uri = "qemu+tls://127.0.0.1:{}/system".format(self.libvirt_tls_port)
 
         if self.check_ports is None:
             self.check_ports = []


### PR DESCRIPTION
Fix failing test:  tests.pytests.integration.modules.test_virt.TestVirtMigrateTest.test_tls_migration