### PR TITLE
run.py for Windows Singlebin

### DIFF
--- a/run.py
+++ b/run.py
@@ -70,7 +70,8 @@ def redirect(argv):
 
 
 def py_shell():
-    import readline  # optional, will allow Up/Down/History in the console
+    if not sys.platform.startswith("win"):
+        import readline  # optional, will allow Up/Down/History in the console
     import code
 
     variables = globals().copy()

--- a/run.py
+++ b/run.py
@@ -9,9 +9,13 @@ import sys
 
 import salt.scripts
 import salt.utils.platform
-import tiamatpip.cli
-import tiamatpip.configure
-import tiamatpip.utils
+
+# tiamat pip breaks singlebin on Windows at the moment
+# https://gitlab.com/saltstack/pop/tiamat-pip/-/issues/4
+if not sys.platform.startswith("win"):
+    import tiamatpip.cli
+    import tiamatpip.configure
+    import tiamatpip.utils
 
 AVAIL = (
     "minion",
@@ -33,10 +37,13 @@ AVAIL = (
 )
 
 
-PIP_PATH = pathlib.Path(f"{os.sep}opt", "saltstack", "salt", "pypath")
-with contextlib.suppress(PermissionError):
-    PIP_PATH.mkdir(mode=0o755, parents=True, exist_ok=True)
-tiamatpip.configure.set_user_site_packages_path(PIP_PATH)
+# tiamat pip breaks singlebin on Windows at the moment
+# https://gitlab.com/saltstack/pop/tiamat-pip/-/issues/4
+if not sys.platform.startswith("win"):
+    PIP_PATH = pathlib.Path(f"{os.sep}opt", "saltstack", "salt", "pypath")
+    with contextlib.suppress(PermissionError):
+        PIP_PATH.mkdir(mode=0o755, parents=True, exist_ok=True)
+    tiamatpip.configure.set_user_site_packages_path(PIP_PATH)
 
 
 def redirect(argv):
@@ -53,9 +60,12 @@ def redirect(argv):
     if cmd == "shell":
         py_shell()
         return
-    if tiamatpip.cli.should_redirect_argv(argv):
-        tiamatpip.cli.process_pip_argv(argv)
-        return
+    # tiamat pip breaks singlebin on Windows at the moment
+    # https://gitlab.com/saltstack/pop/tiamat-pip/-/issues/4
+    if not sys.platform.startswith("win"):
+        if tiamatpip.cli.should_redirect_argv(argv):
+            tiamatpip.cli.process_pip_argv(argv)
+            return
     if cmd not in AVAIL:
         # Fall back to the salt command
         args = ["salt"]
@@ -65,8 +75,11 @@ def redirect(argv):
         sys.argv.pop(1)
         s_fun = getattr(salt.scripts, f"salt_{cmd}")
     args.extend(argv[1:])
-    with tiamatpip.utils.patched_sys_argv(args):
-        s_fun()
+    # tiamat pip breaks singlebin on Windows at the moment
+    # https://gitlab.com/saltstack/pop/tiamat-pip/-/issues/4
+    if not sys.platform.startswith("win"):
+        with tiamatpip.utils.patched_sys_argv(args):
+            s_fun()
 
 
 def py_shell():


### PR DESCRIPTION
### What does this PR do?
The `run.exe shell` command tries to import the `readline` module which is not available for Windows. Skip this import on Windows.

Also, tiamat-pip is messing some things up with python pathing, so we'll not use it on Windows until that is fixed.
https://gitlab.com/saltstack/pop/tiamat-pip/-/issues/4

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes