### PR TITLE
Pass and handle MAC address when cloning VM from template in VMWare

### DIFF
--- a/changelog/56294.fixed
+++ b/changelog/56294.fixed
@@ -1,0 +1,1 @@
+Pass and handle configured MAC address for VMWare VMs when they are deployed by cloning from template


### PR DESCRIPTION
When editing an existing network interface (e.g.: when instantiating
from template), the vmware related salt-cloud logic simply ignore the
MAC address.

The documentation located at
https://docs.saltproject.io/en/latest/topics/cloud/vmware.html#profiles
suggests that this should work otherwise.

When configuring the MAC address manually in the network device object,
it must be also defined that this allocation became manual address
allocation instead of automatic.

### What does this PR do?

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
