### PR TITLE
[3003.2] add ssh timeout

### DIFF
--- a/changelog/59901.fixed
+++ b/changelog/59901.fixed
@@ -1,0 +1,1 @@
+Add ssh_timeout to kwargs in deploy_script

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1490,6 +1490,7 @@ def deploy_script(
                 "port": port,
                 "username": username,
                 "timeout": ssh_timeout,
+                "ssh_timeout": ssh_timeout,
                 "display_ssh_output": display_ssh_output,
                 "sudo_password": sudo_password,
                 "sftp": opts.get("use_sftp", False),

--- a/tests/pytests/unit/utils/test_cloud.py
+++ b/tests/pytests/unit/utils/test_cloud.py
@@ -220,3 +220,16 @@ def test_winrm_pinnned_version():
             winrm_pkg = pkg_resources.get_distribution("pywinrm")
             assert winrm_pkg.version >= '0.3.0'
     # fmt: on
+
+
+@patch("salt.utils.cloud.wait_for_port", return_value=True)
+@patch("salt.utils.cloud.wait_for_passwd", return_value=True)
+@patch("salt.utils.cloud._exec_ssh_cmd")
+@patch("salt.utils.cloud.root_cmd", return_value=False)
+def test_deploy_script_ssh_timeout(root_cmd, *_):
+    cloud.deploy_script("127.0.0.1", ssh_timeout=34)
+    # verify that ssh_timeout made it into ssh_kwargs
+    assert root_cmd.call_count == 1
+    ssh_kwargs = root_cmd.call_args.kwargs
+    assert "ssh_timeout" in ssh_kwargs
+    assert ssh_kwargs["ssh_timeout"] == 34

--- a/tests/pytests/unit/utils/test_cloud.py
+++ b/tests/pytests/unit/utils/test_cloud.py
@@ -222,14 +222,14 @@ def test_winrm_pinnned_version():
     # fmt: on
 
 
-@patch("salt.utils.cloud.wait_for_port", return_value=True)
-@patch("salt.utils.cloud.wait_for_passwd", return_value=True)
-@patch("salt.utils.cloud._exec_ssh_cmd")
-@patch("salt.utils.cloud.root_cmd", return_value=False)
-def test_deploy_script_ssh_timeout(root_cmd, *_):
-    cloud.deploy_script("127.0.0.1", ssh_timeout=34)
-    # verify that ssh_timeout made it into ssh_kwargs
-    assert root_cmd.call_count == 1
-    ssh_kwargs = root_cmd.call_args.kwargs
-    assert "ssh_timeout" in ssh_kwargs
-    assert ssh_kwargs["ssh_timeout"] == 34
+def test_deploy_script_ssh_timeout():
+    with patch("salt.utils.cloud.root_cmd", return_value=False) as root_cmd:
+        with patch("salt.utils.cloud.wait_for_port", return_value=True):
+            with patch("salt.utils.cloud.wait_for_passwd", return_value=True):
+                with patch("salt.utils.cloud._exec_ssh_cmd"):
+                    cloud.deploy_script("127.0.0.1", ssh_timeout=34)
+                    # verify that ssh_timeout made it into ssh_kwargs
+                    assert root_cmd.call_count == 1
+                    ssh_kwargs = root_cmd.call_args.kwargs
+                    assert "ssh_timeout" in ssh_kwargs
+                    assert ssh_kwargs["ssh_timeout"] == 34

--- a/tests/pytests/unit/utils/test_cloud.py
+++ b/tests/pytests/unit/utils/test_cloud.py
@@ -223,13 +223,14 @@ def test_winrm_pinnned_version():
 
 
 def test_deploy_script_ssh_timeout():
-    with patch("salt.utils.cloud.root_cmd", return_value=False) as root_cmd:
-        with patch("salt.utils.cloud.wait_for_port", return_value=True):
-            with patch("salt.utils.cloud.wait_for_passwd", return_value=True):
-                with patch("salt.utils.cloud._exec_ssh_cmd"):
-                    cloud.deploy_script("127.0.0.1", ssh_timeout=34)
-                    # verify that ssh_timeout made it into ssh_kwargs
-                    assert root_cmd.call_count == 1
-                    ssh_kwargs = root_cmd.call_args.kwargs
-                    assert "ssh_timeout" in ssh_kwargs
-                    assert ssh_kwargs["ssh_timeout"] == 34
+    with patch("salt.utils.cloud.root_cmd", return_value=False) as root_cmd, patch(
+        "salt.utils.cloud.wait_for_port", return_value=True
+    ), patch("salt.utils.cloud.wait_for_passwd", return_value=True), patch(
+        "salt.utils.cloud._exec_ssh_cmd"
+    ):
+        cloud.deploy_script("127.0.0.1", ssh_timeout=34)
+        # verify that ssh_timeout made it into ssh_kwargs
+        assert root_cmd.call_count == 1
+        ssh_kwargs = root_cmd.call_args.kwargs
+        assert "ssh_timeout" in ssh_kwargs
+        assert ssh_kwargs["ssh_timeout"] == 34


### PR DESCRIPTION
### What does this PR do?
add `ssh_timeout` to ssh_kwargs in deploy script and keep `timeout` because other parts of `salt-cloud` uses it.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/59901
Fixes: https://github.com/saltstack/salt/issues/59902

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes
