### PR TITLE
Add detect_remote_minions and remote_minions_port options to detect minions connected on other ports

### DIFF
--- a/changelog/60612.added
+++ b/changelog/60612.added
@@ -1,0 +1,1 @@
+Add the `detect_remote_minions` and `remote_minions_port` options to allow the master to detect remote ports for connected minions. This will allow users to detect Heist-Salt minions the master is connected to over port 22 by default.

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -847,6 +847,39 @@ that does not send executions to minions.
 
     presence_events: False
 
+``detect_remote_minions``
+-------------------------
+
+Default: False
+
+When checking the minions connected to a master, also include the master's
+connections to minions on the port specfied in the setting `remote_minions_port`.
+This is particularly useful when checking if the master is connected to any Heist-Salt
+minions. If this setting is set to True, the master will check all connections on port 22
+by default unless a user also configures a different port with the setting
+`remote_minions_port`.
+
+Changing this setting will check the remote minions the master is connected to when using
+presence events, the manage runner, and any other parts of the code that call the
+`connected_ids` method to check the status of connected minions.
+
+.. code-block:: yaml
+
+    detect_remote_minions: True
+
+``remote_minions_port``
+-----------------------
+
+Default: 22
+
+The port to use when checking for remote minions when `detect_remote_minions` is set
+to True.
+
+.. code-block:: yaml
+
+    remote_minions_port: 2222
+
+
 .. conf_master:: ping_on_rotate
 
 ``ping_on_rotate``

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -948,6 +948,12 @@ VALID_OPTS = immutabletypes.freeze(
         # Feature flag config
         "features": dict,
         "fips_mode": bool,
+        # Feature flag to enable checking if master is connected to a host
+        # on a given port
+        "detect_remote_minions": bool,
+        # The port to be used when checking if a master is connected to a
+        # minion
+        "remote_minions_port": int,
     }
 )
 
@@ -1588,6 +1594,8 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze(
         "enable_ssh_minions": False,
         "netapi_allow_raw_shell": False,
         "fips_mode": False,
+        "detect_remote_minions": False,
+        "remote_minions_port": 22,
     }
 )
 

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -635,6 +635,10 @@ class CkMinions:
             if search is None:
                 return minions
             addrs = salt.utils.network.local_port_tcp(int(self.opts["publish_port"]))
+            if self.opts.get("detect_remote_minions", False):
+                addrs = addrs.union(
+                    salt.utils.network.remote_port_tcp(self.opts["remote_minions_port"])
+                )
             if "127.0.0.1" in addrs:
                 # Add in the address of a possible locally-connected minion.
                 addrs.discard("127.0.0.1")

--- a/tests/pytests/unit/utils/test_minions.py
+++ b/tests/pytests/unit/utils/test_minions.py
@@ -8,7 +8,7 @@ def test_connected_ids():
     test ckminion connected_ids when
     local_port_tcp returns 127.0.0.1
     """
-    opts = {"publish_port": 4505}
+    opts = {"publish_port": 4505, "detect_remote_minions": False}
     minion = "minion"
     ip = salt.utils.network.ip_addrs()
     mdata = {"grains": {"ipv4": ip, "ipv6": []}}
@@ -20,3 +20,32 @@ def test_connected_ids():
         with patch_net, patch_list, patch_fetch:
             ret = ckminions.connected_ids()
             assert ret == {minion}
+
+
+def test_connected_ids_remote_minions():
+    """
+    test ckminion connected_ids when
+    detect_remote_minions is set
+    """
+    opts = {
+        "publish_port": 4505,
+        "detect_remote_minions": True,
+        "remote_minions_port": 22,
+    }
+    minion = "minion"
+    minion2 = "minion2"
+    minion2_ip = "192.168.2.10"
+    ip = salt.utils.network.ip_addrs()
+    mdata = {"grains": {"ipv4": ip, "ipv6": []}}
+    mdata2 = {"grains": {"ipv4": [minion2_ip], "ipv6": []}}
+    ckminions = salt.utils.minions.CkMinions({"minion_data_cache": True})
+    patch_net = patch("salt.utils.network.local_port_tcp", return_value={"127.0.0.1"})
+    patch_remote_net = patch(
+        "salt.utils.network.remote_port_tcp", return_value={minion2_ip}
+    )
+    patch_list = patch("salt.cache.Cache.list", return_value=[minion, minion2])
+    patch_fetch = patch("salt.cache.Cache.fetch", side_effect=[mdata, mdata2])
+    with patch.dict(ckminions.opts, opts):
+        with patch_net, patch_list, patch_fetch, patch_remote_net:
+            ret = ckminions.connected_ids()
+            assert ret == {minion2, minion}


### PR DESCRIPTION
### What does this PR do?
Allows presence events to work with Heist-Salt minions. I'm definitely up for suggestions on what we should call these two different options. I was not certain what I picked was the best name to choose. 

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/60612

### Previous Behavior
Presence events would not work with heist-salt minions which the salt master connects to the minions over port 22.

### New Behavior
If a user sets the configurations `detect_remote_minions` to True it will try to detect connected minions over port 22 unless the port specified is changed with the configuration `remote_minions_port`

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes