### PR TITLE
Just run the command on Windows

### DIFF
--- a/run.py
+++ b/run.py
@@ -80,6 +80,8 @@ def redirect(argv):
     if not sys.platform.startswith("win"):
         with tiamatpip.utils.patched_sys_argv(args):
             s_fun()
+    else:
+        s_run()
 
 
 def py_shell():

--- a/run.py
+++ b/run.py
@@ -81,7 +81,7 @@ def redirect(argv):
         with tiamatpip.utils.patched_sys_argv(args):
             s_fun()
     else:
-        s_run()
+        s_fun()
 
 
 def py_shell():


### PR DESCRIPTION
### What does this PR do?
Final (hopefully) fix for run.py. I accidentally gated the `s_run` function for windows in a previous PR. This will run the called function on Windows.