### PR TITLE
update arch ami to fix low disk space on /tmp/ problem

### DIFF
--- a/cicd/amis.yml
+++ b/cicd/amis.yml
@@ -1,6 +1,6 @@
 alma-8-x86_64: ami-0594d7cf435c3d2f7
 amazon-2-x86_64: ami-099d7623ded3199ea
-arch-lts-x86_64: ami-09a38a1d2d9fa3201
+arch-lts-x86_64: ami-0d6d180c7b3cbde31
 centos-7-x86_64: ami-05764f27cdf8f99e0
 centos-8-x86_64: ami-0d482e88fbf35072c
 centosstream-8-x86_64: ami-02fc0a57f9b1fa4ed


### PR DESCRIPTION
### What does this PR do?
updates the arch ami so /tmp/ is not a tmpfs
