### PR TITLE
3003.2 docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Versions are `MAJOR.PATCH`.
 
 # Changelog
 
+Salt 3003.2 (2021-07-29)
+========================
+
+Fixed
+-----
+
+- Periodically restart the fileserver update process to avoid leaks (#50313)
+- Add ssh_timeout to kwargs in deploy_script (#59901)
+- Update the external ipaddress to the latest 3.9.5 version which has some security fixes. Updating the compat.p to use the vendored version if the python version is below 3.9.5 and only run the test_ipaddress.py tests if below 3.9.5. (#60168)
+- Use the right crypto libary for salt.utils.crypt.reinit_crypto (#60215)
+- Stop SSH from hanging if connection is lost. Also added args to customize grace period. (#60216)
+- Improve reliability of Terminal class (#60504)
+- Ignore configuration for 'enable_fqdns_grains' for AIX, Solaris and Juniper, assume False (#60529)
+
+
 Salt 3003.1 (2021-06-08)
 ========================
 

--- a/changelog/50313.fixed
+++ b/changelog/50313.fixed
@@ -1,1 +1,0 @@
-Periodically restart the fileserver update process to avoid leaks

--- a/changelog/59901.fixed
+++ b/changelog/59901.fixed
@@ -1,1 +1,0 @@
-Add ssh_timeout to kwargs in deploy_script

--- a/changelog/60168.fixed
+++ b/changelog/60168.fixed
@@ -1,1 +1,0 @@
-Update the external ipaddress to the latest 3.9.5 version which has some security fixes. Updating the compat.p to use the vendored version if the python version is below 3.9.5 and only run the test_ipaddress.py tests if below 3.9.5.

--- a/changelog/60215.fixed
+++ b/changelog/60215.fixed
@@ -1,1 +1,0 @@
-Use the right crypto libary for salt.utils.crypt.reinit_crypto

--- a/changelog/60216.fixed
+++ b/changelog/60216.fixed
@@ -1,1 +1,0 @@
-Stop SSH from hanging if connection is lost. Also added args to customize grace period.

--- a/changelog/60504.fixed
+++ b/changelog/60504.fixed
@@ -1,1 +1,0 @@
-Improve reliability of Terminal class

--- a/changelog/60529.fixed
+++ b/changelog/60529.fixed
@@ -1,1 +1,0 @@
-Ignore configuration for 'enable_fqdns_grains' for AIX, Solaris and Juniper, assume False

--- a/doc/man/salt-api.1
+++ b/doc/man/salt-api.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-API" "1" "Apr 20, 2021" "3003.1" "Salt"
+.TH "SALT-API" "1" "Jul 29, 2021" "3003.2" "Salt"
 .SH NAME
 salt-api \- salt-api Command
 .

--- a/doc/man/salt-call.1
+++ b/doc/man/salt-call.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-CALL" "1" "Apr 20, 2021" "3003.1" "Salt"
+.TH "SALT-CALL" "1" "Jul 29, 2021" "3003.2" "Salt"
 .SH NAME
 salt-call \- salt-call Documentation
 .

--- a/doc/man/salt-cloud.1
+++ b/doc/man/salt-cloud.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-CLOUD" "1" "Apr 20, 2021" "3003.1" "Salt"
+.TH "SALT-CLOUD" "1" "Jul 29, 2021" "3003.2" "Salt"
 .SH NAME
 salt-cloud \- Salt Cloud Command
 .

--- a/doc/man/salt-cp.1
+++ b/doc/man/salt-cp.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-CP" "1" "Apr 20, 2021" "3003.1" "Salt"
+.TH "SALT-CP" "1" "Jul 29, 2021" "3003.2" "Salt"
 .SH NAME
 salt-cp \- salt-cp Documentation
 .

--- a/doc/man/salt-key.1
+++ b/doc/man/salt-key.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-KEY" "1" "Apr 20, 2021" "3003.1" "Salt"
+.TH "SALT-KEY" "1" "Jul 29, 2021" "3003.2" "Salt"
 .SH NAME
 salt-key \- salt-key Documentation
 .

--- a/doc/man/salt-master.1
+++ b/doc/man/salt-master.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-MASTER" "1" "Apr 20, 2021" "3003.1" "Salt"
+.TH "SALT-MASTER" "1" "Jul 29, 2021" "3003.2" "Salt"
 .SH NAME
 salt-master \- salt-master Documentation
 .

--- a/doc/man/salt-minion.1
+++ b/doc/man/salt-minion.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-MINION" "1" "Apr 20, 2021" "3003.1" "Salt"
+.TH "SALT-MINION" "1" "Jul 29, 2021" "3003.2" "Salt"
 .SH NAME
 salt-minion \- salt-minion Documentation
 .

--- a/doc/man/salt-proxy.1
+++ b/doc/man/salt-proxy.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-PROXY" "1" "Apr 20, 2021" "3003.1" "Salt"
+.TH "SALT-PROXY" "1" "Jul 29, 2021" "3003.2" "Salt"
 .SH NAME
 salt-proxy \- salt-proxy Documentation
 .

--- a/doc/man/salt-run.1
+++ b/doc/man/salt-run.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-RUN" "1" "Apr 20, 2021" "3003.1" "Salt"
+.TH "SALT-RUN" "1" "Jul 29, 2021" "3003.2" "Salt"
 .SH NAME
 salt-run \- salt-run Documentation
 .

--- a/doc/man/salt-ssh.1
+++ b/doc/man/salt-ssh.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-SSH" "1" "Apr 20, 2021" "3003.1" "Salt"
+.TH "SALT-SSH" "1" "Jul 29, 2021" "3003.2" "Salt"
 .SH NAME
 salt-ssh \- salt-ssh Documentation
 .

--- a/doc/man/salt-syndic.1
+++ b/doc/man/salt-syndic.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-SYNDIC" "1" "Apr 20, 2021" "3003.1" "Salt"
+.TH "SALT-SYNDIC" "1" "Jul 29, 2021" "3003.2" "Salt"
 .SH NAME
 salt-syndic \- salt-syndic Documentation
 .

--- a/doc/man/salt-unity.1
+++ b/doc/man/salt-unity.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT-UNITY" "1" "Apr 20, 2021" "3003.1" "Salt"
+.TH "SALT-UNITY" "1" "Jul 29, 2021" "3003.2" "Salt"
 .SH NAME
 salt-unity \- salt-unity Command
 .

--- a/doc/man/salt.1
+++ b/doc/man/salt.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SALT" "1" "Apr 20, 2021" "3003.1" "Salt"
+.TH "SALT" "1" "Jul 29, 2021" "3003.2" "Salt"
 .SH NAME
 salt \- salt
 .

--- a/doc/man/spm.1
+++ b/doc/man/spm.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "SPM" "1" "Apr 20, 2021" "3003.1" "Salt"
+.TH "SPM" "1" "Jul 29, 2021" "3003.2" "Salt"
 .SH NAME
 spm \- Salt Package Manager Command
 .

--- a/doc/topics/releases/3003.2.rst
+++ b/doc/topics/releases/3003.2.rst
@@ -1,0 +1,19 @@
+.. _release-3003-2:
+
+=========================
+Salt 3003.2 Release Notes
+=========================
+
+Version 3003.2 is a bug fix release for :ref:`3003 <release-3003>`.
+
+Fixed
+-----
+
+- Periodically restart the fileserver update process to avoid leaks (#50313)
+- Add ssh_timeout to kwargs in deploy_script (#59901)
+- Update the external ipaddress to the latest 3.9.5 version which has some security fixes. Updating the compat.p to use the vendored version if the python version is below 3.9.5 and only run the test_ipaddress.py tests if below 3.9.5. (#60168)
+- Use the right crypto libary for salt.utils.crypt.reinit_crypto (#60215)
+- Stop SSH from hanging if connection is lost. Also added args to customize grace period. (#60216)
+- Improve reliability of Terminal class (#60504)
+- Ignore configuration for 'enable_fqdns_grains' for AIX, Solaris and Juniper, assume False (#60529)
+


### PR DESCRIPTION
### What does this PR do?

- CHANGELOG update for 3003.2
- Release page update for 3003.2
- man pages regen for 3003.2

#### How was this done?

`nox` helps take care of release docs:

```bash
# Update `CHANGELOG.md`
nox -e 'changelog(draft=False)' -- 3003.2

# After changelog gen, follow currently manual process of
# adding changelog entry to new (or existing) release doc
# NOTE: Currently a manual step
# Example: `doc/topics/releases/3003.2.rst`

# Generate man pages
nox -e 'docs-man(compress=False, update=True, clean=True)'
```

> The man page generator needs some tweaking, as it injects the version incorrectly within the generated man pages. Right now, it is still a manual process to find/replace the versions once generated.

### Commits signed with GPG?
Yes