### PR TITLE
Add missing aarch64 to rpm package architectures

### DIFF
--- a/salt/utils/pkg/rpm.py
+++ b/salt/utils/pkg/rpm.py
@@ -30,7 +30,7 @@ ARCHES_ALPHA = (
     "alphaev68",
     "alphaev7",
 )
-ARCHES_ARM = ("armv5tel", "armv5tejl", "armv6l", "armv7l")
+ARCHES_ARM = ("armv5tel", "armv5tejl", "armv6l", "armv7l", "aarch64")
 ARCHES_SH = ("sh3", "sh4", "sh4a")
 
 ARCHES = (

--- a/tests/pytests/unit/modules/test_zypperpkg.py
+++ b/tests/pytests/unit/modules/test_zypperpkg.py
@@ -56,6 +56,7 @@ def test_list_pkgs_no_context():
         list_pkgs_context_mock.assert_not_called()
         list_pkgs_context_mock.reset_mock()
 
+
 def test_normalize_name():
     """
     Test that package is normalized only when it should be

--- a/tests/pytests/unit/modules/test_zypperpkg.py
+++ b/tests/pytests/unit/modules/test_zypperpkg.py
@@ -55,3 +55,23 @@ def test_list_pkgs_no_context():
         pkgs = zypper.list_pkgs(versions_as_list=True, use_context=False)
         list_pkgs_context_mock.assert_not_called()
         list_pkgs_context_mock.reset_mock()
+
+def test_normalize_name():
+    """
+    Test that package is normalized only when it should be
+    """
+    with patch.dict(zypper.__grains__, {"osarch": "x86_64"}):
+        result = zypper.normalize_name("foo")
+        assert result == "foo", result
+        result = zypper.normalize_name("foo.x86_64")
+        assert result == "foo", result
+        result = zypper.normalize_name("foo.noarch")
+        assert result == "foo", result
+
+    with patch.dict(zypper.__grains__, {"osarch": "aarch64"}):
+        result = zypper.normalize_name("foo")
+        assert result == "foo", result
+        result = zypper.normalize_name("foo.aarch64")
+        assert result == "foo", result
+        result = zypper.normalize_name("foo.noarch")
+        assert result == "foo", result


### PR DESCRIPTION
### What does this PR do?

Fixes false negative results on using pkg.installed with architecture specification in package name (ex. `bash.aarch64`)
`zypperpkg` module unable to normalize package name if `aarch64` architecture is specified in package name.

### Previous Behavior
`False` in result and comment that the package was not installed/updated while actually it was installed/updated

### New Behavior
Normal behavior

### Merge requirements satisfied?
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [X] Tests written/updated
