### PR TITLE
Better handling of bad public keys from minions

### DIFF
--- a/changelog/57733.fixed
+++ b/changelog/57733.fixed
@@ -1,0 +1,1 @@
+Better handling of bad RSA public keys from minions

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -36,6 +36,7 @@ import salt.utils.verify
 import salt.version
 from salt.exceptions import (
     AuthenticationError,
+    InvalidKeyError,
     MasterExit,
     SaltClientError,
     SaltReqTimeoutError,
@@ -220,10 +221,16 @@ def get_rsa_pub_key(path):
         with salt.utils.files.fopen(path, "rb") as f:
             data = f.read().replace(b"RSA ", b"")
         bio = BIO.MemoryBuffer(data)
-        key = RSA.load_pub_key_bio(bio)
+        try:
+            key = RSA.load_pub_key_bio(bio)
+        except RSA.RSAError:
+            raise InvalidKeyError("Encountered bad RSA public key")
     else:
         with salt.utils.files.fopen(path) as f:
-            key = RSA.importKey(f.read())
+            try:
+                key = RSA.importKey(f.read())
+            except (ValueError, IndexError, TypeError):
+                raise InvalidKeyError("Encountered bad RSA public key")
     return key
 
 

--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -94,6 +94,12 @@ class AuthenticationError(SaltException):
     """
 
 
+class InvalidKeyError(SaltException):
+    """
+    Raised when we encounter an invalid RSA key.
+    """
+
+
 class CommandNotFoundError(SaltException):
     """
     Used in modules or grains when a required binary is not available

--- a/salt/key.py
+++ b/salt/key.py
@@ -9,6 +9,7 @@ import itertools
 import logging
 import os
 import shutil
+import sys
 
 import salt.cache
 import salt.client
@@ -643,17 +644,27 @@ class Key:
             keydirs.append(self.REJ)
         if include_denied:
             keydirs.append(self.DEN)
+        invalid_keys = []
         for keydir in keydirs:
             for key in matches.get(keydir, []):
+                key_path = os.path.join(self.opts["pki_dir"], keydir, key)
+                try:
+                    salt.crypt.get_rsa_pub_key(key_path)
+                except salt.exceptions.InvalidKeyError:
+                    log.error("Invalid RSA public key: %s", key)
+                    invalid_keys.append((keydir, key))
+                    continue
                 try:
                     shutil.move(
-                        os.path.join(self.opts["pki_dir"], keydir, key),
-                        os.path.join(self.opts["pki_dir"], self.ACC, key),
+                        key_path, os.path.join(self.opts["pki_dir"], self.ACC, key),
                     )
                     eload = {"result": True, "act": "accept", "id": key}
                     self.event.fire_event(eload, salt.utils.event.tagify(prefix="key"))
                 except OSError:
                     pass
+        for keydir, key in invalid_keys:
+            matches[keydir].remove(key)
+            sys.stderr.write("Unable to accept invalid key for {}.\n".format(key))
         return self.name_match(match) if match is not None else self.dict_match(matches)
 
     def accept_all(self):

--- a/salt/transport/mixins/auth.py
+++ b/salt/transport/mixins/auth.py
@@ -174,11 +174,11 @@ class AESReqServerMixin:
         tagged "auth" and returns a dict with information about the auth
         event
 
-        # Verify that the key we are receiving matches the stored key
-        # Store the key if it is not there
-        # Make an RSA key with the pub key
-        # Encrypt the AES key as an encrypted salt.payload
-        # Package the return and return it
+            - Verify that the key we are receiving matches the stored key
+            - Store the key if it is not there
+            - Make an RSA key with the pub key
+            - Encrypt the AES key as an encrypted salt.payload
+            - Package the return and return it
         """
 
         if not salt.utils.verify.valid_id(self.opts, load["id"]):
@@ -450,7 +450,7 @@ class AESReqServerMixin:
         # and an empty request comes in
         try:
             pub = salt.crypt.get_rsa_pub_key(pubfn)
-        except (ValueError, IndexError, TypeError) as err:
+        except salt.crypt.InvalidKeyError as err:
             log.error('Corrupt public key "%s": %s', pubfn, err)
             return {"enc": "clear", "load": {"ret": False}}
 

--- a/tests/pytests/integration/cli/test_salt_key.py
+++ b/tests/pytests/integration/cli/test_salt_key.py
@@ -325,7 +325,7 @@ def test_accept_bad_key(salt_master, salt_key_cli):
     key = os.path.join(pki_dir, "minions_pre", min_name)
 
     with salt.utils.files.fopen(key, "w") as fp:
-        fp.write('')
+        fp.write("")
 
     try:
         # Check Key

--- a/tests/pytests/integration/cli/test_salt_key.py
+++ b/tests/pytests/integration/cli/test_salt_key.py
@@ -314,3 +314,24 @@ def test_keys_generation_keysize_max(salt_key_cli, tmp_path):
     )
     assert ret.exitcode != 0
     assert "error: The maximum value for keysize is 32768" in ret.stderr
+
+
+def test_accept_bad_key(salt_master, salt_key_cli):
+    """
+    test salt-key -d usage
+    """
+    min_name = random_string("minibar-")
+    pki_dir = salt_master.config["pki_dir"]
+    key = os.path.join(pki_dir, "minions_pre", min_name)
+
+    with salt.utils.files.fopen(key, "w") as fp:
+        fp.write('')
+
+    try:
+        # Check Key
+        ret = salt_key_cli.run("-y", "-a", min_name)
+        assert ret.exitcode == 0
+        assert "invalid key for {}".format(min_name) in ret.stderr
+    finally:
+        if os.path.exists(key):
+            os.remove(key)


### PR DESCRIPTION
### What does this PR do?

- Handle bad RSA public key when using M2Crypto
- salt-key checks that keys are valid before accepting them

### What issues does this PR fix or reference?
Fixes: #57733

### Previous Behavior
We have code to handle invalid keys (`salt.transport.mixins.auth`) but that code only worked with pycrypto or pycryptodome.

### New Behavior
Handle bad keys when M2Crypto is installed
Add checking of keys before salt-key accepts them.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated
