### PR TITLE
Add another conditional to checking for vmware in productname

### DIFF
--- a/changelog/60593.fixed
+++ b/changelog/60593.fixed
@@ -1,0 +1,1 @@
+Properly detect VMware grains on Windows Server 2019+

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -717,7 +717,7 @@ def _windows_virtual(osdata):
     elif "Microsoft" in manufacturer and "Virtual Machine" in productname:
         grains["virtual"] = "VirtualPC"
     # Manufacturer: Parallels Software International Inc.
-    elif "Parallels Software" in manufacturer:
+    elif "Parallels" in manufacturer:
         grains["virtual"] = "Parallels"
     # Apache CloudStack
     elif "CloudStack KVM Hypervisor" in productname:

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -710,7 +710,7 @@ def _windows_virtual(osdata):
     elif "VirtualBox" in productname:
         grains["virtual"] = "VirtualBox"
     # Product Name: VMware Virtual Platform
-    elif "VMware Virtual Platform" in productname:
+    elif "VMware" in productname or "VMware Virtual Platform" in productname:
         grains["virtual"] = "VMware"
     # Manufacturer: Microsoft Corporation
     # Product Name: Virtual Machine

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -710,7 +710,7 @@ def _windows_virtual(osdata):
     elif "VirtualBox" in productname:
         grains["virtual"] = "VirtualBox"
     # Product Name: VMware Virtual Platform
-    elif "VMware" in productname or "VMware Virtual Platform" in productname:
+    elif "VMware" in productname:
         grains["virtual"] = "VMware"
     # Manufacturer: Microsoft Corporation
     # Product Name: Virtual Machine


### PR DESCRIPTION
### What does this PR do?
Add another conditional to setting the virtual grain for vmware products running on Windows systems.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/60593

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
