### PR TITLE
selinux.fcontext policy fixes

### DIFF
--- a/changelog/60651.fixed
+++ b/changelog/60651.fixed
@@ -1,0 +1,1 @@
+Fixed documentation and error handling with selinux.fcontext

--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -491,8 +491,8 @@ def fcontext_get_policy(
     cmd = (
         "semanage fcontext -l | egrep "
         + "'^{filespec}{spacer}{filetype}{spacer}{sel_user}:{sel_role}:{sel_type}:{sel_level}$'".format(
-        **cmd_kwargs
-    )
+            **cmd_kwargs
+        )
     )
     current_entry_text = __salt__["cmd.shell"](cmd, ignore_retcode=True)
     if current_entry_text == "":
@@ -688,11 +688,17 @@ def fcontext_apply_policy(name, recursive=False):
                 )
             elif apply_ret["stdout"].startswith("restorecon reset"):
                 changes_list = re.findall(
-                    "restorecon reset (.*) context (.*)->(.*)$", apply_ret["stdout"], re.M
+                    "restorecon reset (.*) context (.*)->(.*)$",
+                    apply_ret["stdout"],
+                    re.M,
                 )
             else:
                 ret["retcode"] = 1
-                ret["error"] = "Unrecognized response from restorecon command. {}".format(apply_ret["stdout"])
+                ret[
+                    "error"
+                ] = "Unrecognized response from restorecon command. {}".format(
+                    apply_ret["stdout"]
+                )
                 return ret
         for item in changes_list:
             filespec = item[0]
@@ -753,8 +759,8 @@ def port_get_policy(name, sel_type=None, protocol=None, port=None):
     cmd = (
         "semanage port -l | egrep "
         + "'^{sel_type}{spacer}{protocol}{spacer}((.*)*)[ ]{port}($|,)'".format(
-        **cmd_kwargs
-    )
+            **cmd_kwargs
+        )
     )
     port_policy = __salt__["cmd.shell"](cmd, ignore_retcode=True)
     if port_policy == "":

--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -10,7 +10,6 @@ Execute calls on selinux
     proper packages are installed.
 """
 
-
 import os
 import re
 
@@ -492,8 +491,8 @@ def fcontext_get_policy(
     cmd = (
         "semanage fcontext -l | egrep "
         + "'^{filespec}{spacer}{filetype}{spacer}{sel_user}:{sel_role}:{sel_type}:{sel_level}$'".format(
-            **cmd_kwargs
-        )
+        **cmd_kwargs
+    )
     )
     current_entry_text = __salt__["cmd.shell"](cmd, ignore_retcode=True)
     if current_entry_text == "":
@@ -676,7 +675,6 @@ def fcontext_apply_policy(name, recursive=False):
         salt '*' selinux.fcontext_apply_policy pathname
     """
     ret = {}
-    changes_text = fcontext_policy_is_applied(name, recursive)
     cmd = "restorecon -v -F "
     if recursive:
         cmd += "-R "
@@ -685,17 +683,13 @@ def fcontext_apply_policy(name, recursive=False):
     ret.update(apply_ret)
     if apply_ret["retcode"] == 0:
         changes_list = []
-        if changes_text.startswith("Would relabel"):
+        if apply_ret["stdout"] and apply_ret["stdout"].startswith("restorecon reset"):
             changes_list = re.findall(
-                "Would relabel (.*) from (.*) to (.*)$", changes_text, re.M
-            )
-        elif changes_text.startswith("restorecon reset"):
-            changes_list = re.findall(
-                "restorecon reset (.*) context (.*)->(.*)$", changes_text, re.M
+                "restorecon reset (.*) context (.*)->(.*)$", apply_ret["stdout"], re.M
             )
         else:
             ret["retcode"] = 1
-            ret["error"] = "Unrecognized response from restorecon command."
+            ret["error"] = "Unrecognized response from restorecon command. {}".format(apply_ret["stdout"])
             return ret
         if changes_list:
             ret.update({"changes": {}})
@@ -758,8 +752,8 @@ def port_get_policy(name, sel_type=None, protocol=None, port=None):
     cmd = (
         "semanage port -l | egrep "
         + "'^{sel_type}{spacer}{protocol}{spacer}((.*)*)[ ]{port}($|,)'".format(
-            **cmd_kwargs
-        )
+        **cmd_kwargs
+    )
     )
     port_policy = __salt__["cmd.shell"](cmd, ignore_retcode=True)
     if port_policy == "":

--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -637,18 +637,21 @@ def fcontext_policy_is_applied(name, recursive=False):
     situation otherwise.
 
     name
-        filespec of the file or directory. Regex syntax is allowed.
+        filespec of the file or directory.
+
+    recursive
+        Recursively check SELinux policies.
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' selinux.fcontext_policy_is_applied my-policy
+        salt '*' selinux.fcontext_policy_is_applied pathname
     """
     cmd = "restorecon -n -v "
     if recursive:
         cmd += "-R "
-    cmd += re.escape(name)
+    cmd += name
     return __salt__["cmd.run_all"](cmd).get("stdout")
 
 
@@ -661,7 +664,7 @@ def fcontext_apply_policy(name, recursive=False):
     the restorecon command otherwise.
 
     name
-        filespec of the file or directory. Regex syntax is allowed.
+        filespec of the file or directory.
 
     recursive
         Recursively apply SELinux policies.
@@ -670,14 +673,14 @@ def fcontext_apply_policy(name, recursive=False):
 
     .. code-block:: bash
 
-        salt '*' selinux.fcontext_apply_policy my-policy
+        salt '*' selinux.fcontext_apply_policy pathname
     """
     ret = {}
     changes_text = fcontext_policy_is_applied(name, recursive)
     cmd = "restorecon -v -F "
     if recursive:
         cmd += "-R "
-    cmd += re.escape(name)
+    cmd += name
     apply_ret = __salt__["cmd.run_all"](cmd)
     ret.update(apply_ret)
     if apply_ret["retcode"] == 0:

--- a/salt/states/selinux.py
+++ b/salt/states/selinux.py
@@ -459,17 +459,6 @@ def fcontext_policy_applied(name, recursive=False):
     """
     ret = {"name": name, "result": False, "changes": {}, "comment": ""}
 
-    changes_text = __salt__["selinux.fcontext_policy_is_applied"](name, recursive)
-    if changes_text == "":
-        ret.update(
-            {
-                "result": True,
-                "comment": 'SElinux policies are already applied for filespec "{}"'.format(
-                    name
-                ),
-            }
-        )
-        return ret
     if __opts__["test"]:
         ret.update({"result": None})
     else:

--- a/tests/unit/modules/test_selinux.py
+++ b/tests/unit/modules/test_selinux.py
@@ -211,49 +211,74 @@ class SelinuxModuleTestCase(TestCase, LoaderModuleMockMixin):
         Test failure response for invalid restorecon data.
         """
         with patch.dict(
-            selinux.__salt__, {"cmd.run_all": MagicMock(
-                return_value={"pid": 2585008,
-                              "retcode": 255,
-                              "stdout": "",
-                              "stderr": "restorecon: SELinux: Could not get canonical path for /foo/bar restorecon:"
-                                        " No such file or directory."})}
+            selinux.__salt__,
+            {
+                "cmd.run_all": MagicMock(
+                    return_value={
+                        "pid": 2585008,
+                        "retcode": 255,
+                        "stdout": "",
+                        "stderr": "restorecon: SELinux: Could not get canonical path for /foo/bar restorecon:"
+                        " No such file or directory.",
+                    }
+                )
+            },
         ):
-            self.assertEqual(selinux.fcontext_policy_is_applied("/foo/bar")['retcode'], 255)
-            self.assertEqual(selinux.fcontext_policy_is_applied('/foo/bar')['stderr'],
-                             'restorecon: SELinux: Could not get canonical path for /foo/bar restorecon:'
-                             ' No such file or directory.')
+            self.assertEqual(
+                selinux.fcontext_policy_is_applied("/foo/bar")["retcode"], 255
+            )
+            self.assertEqual(
+                selinux.fcontext_policy_is_applied("/foo/bar")["stderr"],
+                "restorecon: SELinux: Could not get canonical path for /foo/bar restorecon:"
+                " No such file or directory.",
+            )
 
     def test_fcontext_apply_policy_fail(self):
         """
         Test failure response for invalid restorecon data.
         """
         with patch.dict(
-            selinux.__salt__, {"cmd.run_all": MagicMock(
-                return_value={"pid": 2585008,
-                              "retcode": 255,
-                              "stdout": "",
-                              "stderr": "restorecon: SELinux: Could not get canonical path for /foo/bar restorecon:"
-                                        " No such file or directory."})}
+            selinux.__salt__,
+            {
+                "cmd.run_all": MagicMock(
+                    return_value={
+                        "pid": 2585008,
+                        "retcode": 255,
+                        "stdout": "",
+                        "stderr": "restorecon: SELinux: Could not get canonical path for /foo/bar restorecon:"
+                        " No such file or directory.",
+                    }
+                )
+            },
         ):
-            self.assertEqual(selinux.fcontext_apply_policy("/foo/bar")['retcode'], 255)
-            self.assertEqual(selinux.fcontext_apply_policy('/foo/bar')['stderr'],
-                             'restorecon: SELinux: Could not get canonical path for /foo/bar restorecon:'
-                             ' No such file or directory.')
+            self.assertEqual(selinux.fcontext_apply_policy("/foo/bar")["retcode"], 255)
+            self.assertEqual(
+                selinux.fcontext_apply_policy("/foo/bar")["stderr"],
+                "restorecon: SELinux: Could not get canonical path for /foo/bar restorecon:"
+                " No such file or directory.",
+            )
 
     def test_fcontext_apply_policy_changed_new(self):
         """
         Test parsing the stdout response of restorecon used in fcontext_policy_applied, new style.
         """
         restorecon_ret = "Relabeled /foo/bar from some_u:some_r:some_t:s0 to other_u:other_r:other_t:s0"
-        with patch.dict(selinux.__salt__, {"cmd.run_all": MagicMock(
-            return_value={"pid": 2585008,
-                          "retcode": 0,
-                          "stdout": restorecon_ret,
-                          "stderr": ""})}
-                        ):
-            print('----------------------------------------------')
+        with patch.dict(
+            selinux.__salt__,
+            {
+                "cmd.run_all": MagicMock(
+                    return_value={
+                        "pid": 2585008,
+                        "retcode": 0,
+                        "stdout": restorecon_ret,
+                        "stderr": "",
+                    }
+                )
+            },
+        ):
+            print("----------------------------------------------")
             print(selinux.fcontext_apply_policy("/foo/bar"))
-            print('----------------------------------------------')
+            print("----------------------------------------------")
             self.assertEqual(
                 selinux.fcontext_apply_policy("/foo/bar"),
                 {
@@ -283,12 +308,19 @@ class SelinuxModuleTestCase(TestCase, LoaderModuleMockMixin):
         Test parsing the stdout response of restorecon used in fcontext_policy_applied, old style.
         """
         restorecon_ret = "restorecon reset /foo/bar context some_u:some_r:some_t:s0->other_u:other_r:other_t:s0"
-        with patch.dict(selinux.__salt__, {"cmd.run_all": MagicMock(
-            return_value={"pid": 2585008,
-                          "retcode": 0,
-                          "stdout": restorecon_ret,
-                          "stderr": ""})}
-                        ):
+        with patch.dict(
+            selinux.__salt__,
+            {
+                "cmd.run_all": MagicMock(
+                    return_value={
+                        "pid": 2585008,
+                        "retcode": 0,
+                        "stdout": restorecon_ret,
+                        "stderr": "",
+                    }
+                )
+            },
+        ):
             self.assertEqual(
                 selinux.fcontext_apply_policy("/foo/bar"),
                 {
@@ -318,12 +350,19 @@ class SelinuxModuleTestCase(TestCase, LoaderModuleMockMixin):
         Test parsing the stdout response of restorecon used in fcontext_policy_applied, old style.
         """
         restorecon_ret = "restorecon reset /foo/bar context some_u:some_r:some_t:s0->other_u:other_r:other_t:s0"
-        with patch.dict(selinux.__salt__, {"cmd.run_all": MagicMock(
-            return_value={"pid": 2585008,
-                          "retcode": 0,
-                          "stdout": restorecon_ret,
-                          "stderr": ""})}
-                        ):
+        with patch.dict(
+            selinux.__salt__,
+            {
+                "cmd.run_all": MagicMock(
+                    return_value={
+                        "pid": 2585008,
+                        "retcode": 0,
+                        "stdout": restorecon_ret,
+                        "stderr": "",
+                    }
+                )
+            },
+        ):
             self.assertEqual(
                 selinux.fcontext_apply_policy("/foo/bar"),
                 {


### PR DESCRIPTION
### What does this PR do?
Streamlines behavior of `modules.selinux.fcontext_apply_policy` and addresses silent failure in `modules.selinux.fcontext_policy_is_applied`. Documentation is also updated to reflect behavior of `restorecon` not using regex.

### What issues does this PR fix or reference?
Fixes: #60651

### Previous Behavior
Errors from executing `restorecon` with regex-like names fail silently, both to verify the policy is applied and to apply it.

### New Behavior
Regex is not permitted (doc) and `modules.selinux.fcontext_policy_is_applied` now returns the full dictionary for future error checking. Redundant calls to it internally were also removed for performance.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [X] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes
