### PR TITLE
Fix defining id_function for minion ids

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -3451,7 +3451,7 @@ def call_id_function(opts):
                 type(newid),
             )
             sys.exit(salt.defaults.exitcodes.EX_GENERIC)
-        log.info("Evaluated minion ID from module: %s", mod_fun)
+        log.info("Evaluated minion ID from module: %s %s", mod_fun, newid)
         return newid
     except TypeError:
         log.error(

--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -328,8 +328,10 @@ def raw_mod(opts, name, functions, mod="modules"):
     if name not in loader.file_mapping:
         return {}
 
-    loader._load_module(name)  # load a single module (the one passed in)
-    return dict(loader._dict)  # return a copy of *just* the funcs for `name`
+    # load a single module (the one passed in)
+    loader._load_module(name)
+    # return a copy of *just* the funcs for `name`
+    return dict({x: loader[x] for x in loader._dict})
 
 
 def metaproxy(opts, loaded_base_name=None):

--- a/tests/pytests/unit/loader/test_loader.py
+++ b/tests/pytests/unit/loader/test_loader.py
@@ -1,8 +1,15 @@
+"""
+tests.pytests.unit.loader.test_loader
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Unit tests for salt's loader
+"""
 import salt.loader
 import salt.loader.lazy
 
 
-def test_raw_mod():
+def test_raw_mod_functions():
+    "Ensure functions loaded by raw_mod are LoaderFunc instances"
     opts = {
         "extension_modules": "",
         "optimization_order": [0],

--- a/tests/pytests/unit/loader/test_loader.py
+++ b/tests/pytests/unit/loader/test_loader.py
@@ -1,0 +1,12 @@
+import salt.loader
+import salt.loader.lazy
+
+
+def test_raw_mod():
+    opts = {
+        "extension_modules": "",
+        "optimization_order": [0],
+    }
+    ret = salt.loader.raw_mod(opts, "grains", "get")
+    for k, v in ret.items():
+        assert isinstance(v, salt.loader.lazy.LoadedFunc)

--- a/tests/pytests/unit/test_config.py
+++ b/tests/pytests/unit/test_config.py
@@ -13,8 +13,8 @@ def test_call_id_function(tmp_path):
     extmods = tmp_path / "extmods"
     opts = {
         "id_function": {"grains.get": {"key": "osfinger"}},
-        "cachedir": cache_dir,
-        "extension_modules": extmods,
+        "cachedir": str(cache_dir),
+        "extension_modules": str(extmods),
         "grains": {"osfinger": "meh"},
         "optimization_order": [0],
     }

--- a/tests/pytests/unit/test_config.py
+++ b/tests/pytests/unit/test_config.py
@@ -1,0 +1,15 @@
+import salt.config
+
+
+def test_call_id_function(tmp_path):
+    cache_dir = tmp_path / "cache"
+    extmods = tmp_path / "extmods"
+    opts = {
+        "id_function": {"grains.get": {"key": "osfinger"}},
+        "cachedir": cache_dir,
+        "extension_modules": extmods,
+        "grains": {"osfinger": "meh"},
+        "optimization_order": [0],
+    }
+    ret = salt.config.call_id_function(opts)
+    assert ret == "meh"

--- a/tests/pytests/unit/test_config.py
+++ b/tests/pytests/unit/test_config.py
@@ -1,7 +1,14 @@
+"""
+tests.pytests.unit.test_config
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Unit tests for salt's config modulet
+"""
 import salt.config
 
 
 def test_call_id_function(tmp_path):
+    "Defining id_function works as expected"
     cache_dir = tmp_path / "cache"
     extmods = tmp_path / "extmods"
     opts = {


### PR DESCRIPTION
### What does this PR do?

Fix defining id_function for minion ids. The functions in the dictionary returned by `salt.loader.raw_mod` were not 'scoped' to the loader. This change makes sure those functions are LoadedFunc objects.

### What issues does this PR fix or reference?
Fixes: #60219



### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [x] Tests written/updated
