### PR TITLE
Change "Window's" to "Windows" in documentation

### DIFF
--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -404,8 +404,8 @@ def wait(
                   - PATH: {{ [current_path, '/my/special/bin']|join(':') }}
 
         .. note::
-            When using environment variables on Window's, case-sensitivity
-            matters, i.e. Window's uses `Path` as opposed to `PATH` for other
+            When using environment variables on Windows, case-sensitivity
+            matters, i.e. Windows uses `Path` as opposed to `PATH` for other
             systems.
 
     umask
@@ -561,8 +561,8 @@ def wait_script(
                   - PATH: {{ [current_path, '/my/special/bin']|join(':') }}
 
         .. note::
-            When using environment variables on Window's, case-sensitivity
-            matters, i.e. Window's uses `Path` as opposed to `PATH` for other
+            When using environment variables on Windows, case-sensitivity
+            matters, i.e. Windows uses `Path` as opposed to `PATH` for other
             systems.
 
     umask
@@ -702,8 +702,8 @@ def run(
                   - PATH: {{ [current_path, '/my/special/bin']|join(':') }}
 
         .. note::
-            When using environment variables on Window's, case-sensitivity
-            matters, i.e. Window's uses `Path` as opposed to `PATH` for other
+            When using environment variables on Windows, case-sensitivity
+            matters, i.e. Windows uses `Path` as opposed to `PATH` for other
             systems.
 
     prepend_path
@@ -935,7 +935,7 @@ def script(
 
         .. note::
 
-            For Window's users, specifically Server users, it may be necessary
+            For Windows users, specifically Server users, it may be necessary
             to specify your runas user using the User Logon Name instead of the
             legacy logon name. Traditionally, logons would be in the following
             format.
@@ -1000,8 +1000,8 @@ def script(
                   - PATH: {{ [current_path, '/my/special/bin']|join(':') }}
 
         .. note::
-            When using environment variables on Window's, case-sensitivity
-            matters, i.e. Window's uses `Path` as opposed to `PATH` for other
+            When using environment variables on Windows, case-sensitivity
+            matters, i.e. Windows uses `Path` as opposed to `PATH` for other
             systems.
 
     saltenv : ``base``


### PR DESCRIPTION
It annoyed me..

### What does this PR do?
It updates the documentation for the `cmd` state and fixes the typo of "Window's" to the correct "Windows".

### What issues does this PR fix or reference?
Fixes: none, I just noticed it and it annoyed me

### Previous Behavior
Documentation contained "Window's" at some places

### New Behavior
Documentation contains less "Window's".

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [X] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
