### PR TITLE
Fix test test_shell_inject_ssh_priv

### DIFF
--- a/tests/integration/netapi/test_client.py
+++ b/tests/integration/netapi/test_client.py
@@ -289,20 +289,23 @@ class NetapiSSHClientTest(SSHCase):
         self.addCleanup(self.cleanup_file, "aaa")
         self.addCleanup(self.cleanup_file, "aaa.pub")
         self.addCleanup(self.cleanup_dir, "aaa|id>")
-        tgt = "www.zerodayinitiative.com"
-        low = {
-            "roster": "cache",
-            "client": "ssh",
-            "tgt": tgt,
-            "ssh_priv": "aaa|id>{} #".format(path),
-            "fun": "test.ping",
-            "eauth": "auto",
-            "username": "saltdev_auto",
-            "password": "saltdev",
-            "roster_file": self.roster_file,
-            "rosters": self.rosters,
-        }
-        ret = self.netapi.run(low)
+        tgts = ["repo.saltproject.io", "www.zerodayinitiative.com"]
+        for tgt in tgts:
+            low = {
+                "roster": "cache",
+                "client": "ssh",
+                "tgt": tgt,
+                "ssh_priv": "aaa|id>{} #".format(path),
+                "fun": "test.ping",
+                "eauth": "auto",
+                "username": "saltdev_auto",
+                "password": "saltdev",
+                "roster_file": self.roster_file,
+                "rosters": self.rosters,
+            }
+            ret = self.netapi.run(low)
+            if ret.get(tgt):
+                break
         self.assertFalse(ret[tgt]["stdout"])
         self.assertTrue(ret[tgt]["stderr"])
         self.assertFalse(os.path.exists(path))


### PR DESCRIPTION
Only fixing the test and not migrating to pytest since that work is being done here: https://github.com/saltstack/salt/pull/60544

I also suggested in that PR that we do not use an external resource so we do not run into this again. I think that solution would be much easier when migrated to pytest.