### PR TITLE
update PULL_REQUEST_TEMPLATE with docs.saltproject.io urls

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,14 +11,14 @@ Remove this section if not relevant
 
 ### Merge requirements satisfied?
 **[NOTICE] Bug fixes or features added to Salt require tests.**
-<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
+<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
 - [ ] Docs
-- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
+- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
 - [ ] Tests written/updated
 
 ### Commits signed with GPG?
 Yes/No
 
-Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.
+Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.
 
 See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.


### PR DESCRIPTION
### What does this PR do?
updates PULL_REQUEST_TEMPLATE with docs.saltproject.io urls rather than docs.saltstack.com