### PR TITLE
Bump pyzmq minimum to more than 19.0.2

### DIFF
--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -775,7 +775,7 @@ pyyaml==5.4.1
     #   napalm
     #   watchdog
     #   yamlordereddictloader
-pyzmq==19.0.2 ; python_version >= "3.9"
+pyzmq==21.0.2 ; python_version >= "3.9"
     # via
     #   -r requirements/static/pkg/py3.10/darwin.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -105,7 +105,7 @@ pytz==2020.1
     #   tempora
 pyyaml==5.4.1
     # via -r requirements/static/pkg/py3.10/linux.txt
-pyzmq==19.0.2 ; python_version >= "3.9"
+pyzmq==21.0.2 ; python_version >= "3.9"
     # via -r requirements/static/pkg/py3.10/linux.txt
 requests==2.25.1
     # via

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -774,7 +774,7 @@ pyyaml==5.4.1
     #   napalm
     #   watchdog
     #   yamlordereddictloader
-pyzmq==19.0.2 ; python_version >= "3.9"
+pyzmq==21.0.2 ; python_version >= "3.9"
     # via
     #   -r requirements/static/pkg/py3.10/freebsd.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -817,7 +817,7 @@ pyyaml==5.4.1
     #   napalm
     #   watchdog
     #   yamlordereddictloader
-pyzmq==19.0.2 ; python_version >= "3.9"
+pyzmq==21.0.2 ; python_version >= "3.9"
     # via
     #   -r requirements/static/pkg/py3.10/linux.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -775,7 +775,7 @@ pyyaml==5.4.1
     #   napalm
     #   watchdog
     #   yamlordereddictloader
-pyzmq==19.0.2 ; python_version >= "3.9"
+pyzmq==21.0.2 ; python_version >= "3.9"
     # via
     #   -r requirements/static/pkg/py3.9/darwin.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -105,7 +105,7 @@ pytz==2020.1
     #   tempora
 pyyaml==5.4.1
     # via -r requirements/static/pkg/py3.9/linux.txt
-pyzmq==19.0.2 ; python_version >= "3.9"
+pyzmq==21.0.2 ; python_version >= "3.9"
     # via -r requirements/static/pkg/py3.9/linux.txt
 requests==2.25.1
     # via

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -774,7 +774,7 @@ pyyaml==5.4.1
     #   napalm
     #   watchdog
     #   yamlordereddictloader
-pyzmq==19.0.2 ; python_version >= "3.9"
+pyzmq==21.0.2 ; python_version >= "3.9"
     # via
     #   -r requirements/static/pkg/py3.9/freebsd.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -817,7 +817,7 @@ pyyaml==5.4.1
     #   napalm
     #   watchdog
     #   yamlordereddictloader
-pyzmq==19.0.2 ; python_version >= "3.9"
+pyzmq==21.0.2 ; python_version >= "3.9"
     # via
     #   -r requirements/static/pkg/py3.9/linux.txt
     #   pytest-salt-factories

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -80,7 +80,7 @@ pytz==2020.1
     # via tempora
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==19.0.2 ; python_version >= "3.9"
+pyzmq==21.0.2 ; python_version >= "3.9"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -62,7 +62,7 @@ pytz==2020.1
     # via tempora
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==19.0.2 ; python_version >= "3.9"
+pyzmq==21.0.2 ; python_version >= "3.9"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -60,7 +60,7 @@ pytz==2020.1
     # via tempora
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==19.0.2 ; python_version >= "3.9"
+pyzmq==21.0.2 ; python_version >= "3.9"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -80,7 +80,7 @@ pytz==2020.1
     # via tempora
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==19.0.2 ; python_version >= "3.9"
+pyzmq==21.0.2 ; python_version >= "3.9"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -62,7 +62,7 @@ pytz==2020.1
     # via tempora
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==19.0.2 ; python_version >= "3.9"
+pyzmq==21.0.2 ; python_version >= "3.9"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -60,7 +60,7 @@ pytz==2020.1
     # via tempora
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==19.0.2 ; python_version >= "3.9"
+pyzmq==21.0.2 ; python_version >= "3.9"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via -r requirements/base.txt

--- a/requirements/zeromq.txt
+++ b/requirements/zeromq.txt
@@ -3,4 +3,4 @@
 
 pyzmq<=20.0.0 ; python_version < "3.6"
 pyzmq>=17.0.0,<22.0.0 ; python_version < "3.9"
-pyzmq>=19.0.2,<22.0.0 ; python_version >= "3.9"
+pyzmq>19.0.2,<22.0.0 ; python_version >= "3.9"


### PR DESCRIPTION
I'm not 100% sure if this is entirely the correct fix, but it *does* fix the arm64 debian 11 failures.

### What does this PR do?

At least under arm64 debian 11, python 3.9, 19.0.2 is buggy.

### What issues does this PR fix or reference?

Closes #60671

### Previous Behavior

libnacl (or probably any ctypes call) would fail miserably, by segfaulting

### New Behavior

Segfault no longer occurs

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?

Yes
