### PR TITLE
Python 2.7 is gone away. Python 3.8 is now default.

### DIFF
--- a/doc/topics/installation/freebsd.rst
+++ b/doc/topics/installation/freebsd.rst
@@ -20,7 +20,7 @@ FreeBSD binary repo
 Install Salt on FreeBSD via the official package repository. Salt is packaged
 with whichever Python version is currently the `default on FreeBSD <https://cgit.freebsd.org/ports/tree/Mk/bsd.default-versions.mk>`_.
 
-In Python 3.8 is currently default, install from packages like this:
+Python 3.8 is currently default, install from packages like this:
 
 .. code-block:: bash
 

--- a/doc/topics/installation/freebsd.rst
+++ b/doc/topics/installation/freebsd.rst
@@ -18,20 +18,13 @@ FreeBSD binary repo
 
 
 Install Salt on FreeBSD via the official package repository. Salt is packaged
-both as a Python 2.7 or 3.7 version.
+with whichever Python version is currently the `default on FreeBSD <https://cgit.freebsd.org/ports/tree/Mk/bsd.default-versions.mk>`_.
 
-For Python 2.7 use:
-
-.. code-block:: bash
-
-    pkg install py27-salt
-
-
-For Python 3.7 use:
+In Python 3.8 is currently default, install from packages like this:
 
 .. code-block:: bash
 
-    pkg install py37-salt
+    pkg install py38-salt
 
 
 FreeBSD ports


### PR DESCRIPTION
### What does this PR do?
Fix bad docs.