### PR TITLE
Add logic for options handling when using source with ssh_auth

### DIFF
--- a/changelog/60769.fixed
+++ b/changelog/60769.fixed
@@ -1,0 +1,1 @@
+Add logic for options handling when using source with ssh_auth

--- a/tests/integration/states/test_ssh_auth.py
+++ b/tests/integration/states/test_ssh_auth.py
@@ -2,6 +2,7 @@
 Test the ssh_auth states
 """
 
+import logging
 import os
 
 import pytest
@@ -10,6 +11,9 @@ from tests.support.case import ModuleCase
 from tests.support.helpers import with_system_user
 from tests.support.mixins import SaltReturnAssertsMixin
 from tests.support.runtests import RUNTIME_VARS
+
+# Setup logging
+log = logging.getLogger(__name__)
 
 
 class SSHAuthStateTests(ModuleCase, SaltReturnAssertsMixin):
@@ -117,7 +121,7 @@ class SSHAuthStateTests(ModuleCase, SaltReturnAssertsMixin):
         try:
             os.mkdir(user_ssh_dir)
         except FileExistsError:
-            print("folder {} already exists".format(user_ssh_dir))
+            log.debug("folder %s already exists", user_ssh_dir)
         with salt.utils.files.fopen(authorized_keys_file, "w") as authf:
             authf.write("no-pty ssh-rsa AAAAB3NzaC1kc3MAAACBAL0sQ9fJ5bYTEyY== root\n")
 


### PR DESCRIPTION
### What does this PR do?
This should fix the behavior of ssh_auth when dealing with authorized_keys provided by files (source) and using the 'options' inside functions like 'ssh_auth.present'.

### What issues does this PR fix or reference?
Fixes: #60769

### Previous Behavior
Inside test functions, using `options` inside a SLS was not taken into account (ie. tests results always says that the key has to be changed).
Secondly, the `filehasoptions` variable was misleading: regular expression that is used is explicitly matching keys that has NO options. 

### Merge requirements satisfied?
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html

### Commits signed with GPG?
No