### PR TITLE
Sort eauth error: fixes eauth salt key tests

### DIFF
--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -535,7 +535,9 @@ class Resolver:
             )
             print(
                 "Available eauth types: {}".format(
-                    ", ".join([k[:-5] for k in self.auth if k.endswith(".auth")])
+                    ", ".join(
+                        sorted([k[:-5] for k in self.auth if k.endswith(".auth")])
+                    )
                 )
             )
             return ret


### PR DESCRIPTION
Fixes the failing tests:

tests.pytests.integration.cli.test_salt_key.test_list_acc_wrong_eauth
tests.pytests.integration.cli.test_salt_run.test_salt_run_with_wrong_eauth

This commit https://github.com/saltstack/salt/pull/60714/commits/66880de417693cf771bf6503427dc5912a62bbef started the test failures only on debian 9 which runs python 3.5.
