### PR TITLE
Fix join with io.BufferedReader object

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2553,7 +2553,7 @@ def replace(
                 r_data = mmap.mmap(r_file.fileno(), 0, access=mmap.ACCESS_READ)
             except (ValueError, OSError):
                 # size of file in /proc is 0, but contains data
-                r_data = salt.utils.stringutils.to_bytes("".join(r_file))
+                r_data = salt.utils.stringutils.to_bytes(b"".join(r_file))
             if search_only:
                 # Just search; bail as early as a match is found
                 if re.search(cpattern, r_data):


### PR DESCRIPTION
### What does this PR do?

Fix join with io.BufferedReader object，which need byte `b""`，or will raise error：

```
                ...
                File "/usr/lib/python3.9/site-packages/salt/modules/file.py", line 3138, in search
                  return replace(
                File "/usr/lib/python3.9/site-packages/salt/modules/file.py", line 2554, in replace
                  r_data = salt.utils.stringutils.to_bytes("".join(r_file))
              TypeError: sequence item 0: expected str instance, bytes found
```

