### PR TITLE
Fixes #60872 - ext_nodes does not pass minion hostname

### DIFF
--- a/changelog/60872.fixed
+++ b/changelog/60872.fixed
@@ -1,0 +1,1 @@
+Fixed external node classifier not callable due to wrong parameter

--- a/salt/tops/ext_nodes.py
+++ b/salt/tops/ext_nodes.py
@@ -85,7 +85,6 @@ def top(**kwargs):
         ],
         stdout=subprocess.PIPE,
         check=True,
-        shell=True,  # nosec
     )
     ndata = salt.utils.yaml.safe_load(proc.stdout)
     if not ndata:

--- a/tests/unit/tops/test_ext_nodes.py
+++ b/tests/unit/tops/test_ext_nodes.py
@@ -42,10 +42,12 @@ class ExtNodesTestCase(TestCase, LoaderModuleMockMixin):
               - two"""
             )
         )
-        communicate_mock = MagicMock(return_value=(stdout, None))
-        with patch.object(subprocess.Popen, "communicate", communicate_mock):
+        run_mock = MagicMock()
+        run_mock.return_value.stdout = stdout
+        with patch.object(subprocess, "run", run_mock):
             ret = ext_nodes.top(opts={"id": "foo"})
         self.assertEqual(ret, {"base": ["one", "two"]})
+        run_mock.assert_called_once_with(["echo", "foo"], check=True, stdout=-1)
 
     def test_ext_nodes_with_environment(self):
         """
@@ -61,7 +63,9 @@ class ExtNodesTestCase(TestCase, LoaderModuleMockMixin):
             environment: dev"""
             )
         )
-        communicate_mock = MagicMock(return_value=(stdout, None))
-        with patch.object(subprocess.Popen, "communicate", communicate_mock):
+        run_mock = MagicMock()
+        run_mock.return_value.stdout = stdout
+        with patch.object(subprocess, "run", run_mock):
             ret = ext_nodes.top(opts={"id": "foo"})
         self.assertEqual(ret, {"dev": ["one", "two"]})
+        run_mock.assert_called_once_with(["echo", "foo"], check=True, stdout=-1)


### PR DESCRIPTION
### What issues does this PR fix or reference?
Fixes: [#60872](https://github.com/saltstack/salt/issues/60872).

When using `shell=True`, the command is supposed to be passed as a String. Otherwise, the parameters are **not** evaluated and therefore not passed to the command. More information can be found [here](https://docs.python.org/3/library/subprocess.html#popen-constructor):

> The shell argument (which defaults to False) specifies whether to use the shell as the program to execute. If shell is True, it is recommended to pass args as a string rather than as a sequence.

### Previous Behavior
Pass an array to `subprocess.run`

### New Behavior
Pass a string to `subprocess.run`

### Commits signed with GPG?
No
