### PR TITLE
MacOS cmdmod, use sudo instead of su -l

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -433,24 +433,10 @@ def _run(
         if isinstance(cmd, (list, tuple)):
             cmd = " ".join(map(_cmd_quote, cmd))
 
-        # Ensure directory is correct before running command
-        cmd = "cd -- {dir} && {{ {cmd}\n }}".format(dir=_cmd_quote(cwd), cmd=cmd)
-
-        # Ensure environment is correct for a newly logged-in user by running
-        # the command under bash as a login shell
-        try:
-            user_shell = __salt__["user.info"](runas)["shell"]
-            if re.search("bash$", user_shell):
-                cmd = "{shell} -l -c {cmd}".format(
-                    shell=user_shell, cmd=_cmd_quote(cmd)
-                )
-        except KeyError:
-            pass
-
         # Ensure the login is simulated correctly (note: su runs sh, not bash,
         # which causes the environment to be initialised incorrectly, which is
         # fixed by the previous line of code)
-        cmd = "su -l {} -c {}".format(_cmd_quote(runas), _cmd_quote(cmd))
+        cmd = "sudo -i -n -H -u {} {}".format(_cmd_quote(runas), cmd)
 
         # Set runas to None, because if you try to run `su -l` after changing
         # user, su will prompt for the password of the user and cause salt to

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -434,7 +434,7 @@ def _run(
             cmd = " ".join(map(_cmd_quote, cmd))
 
         # Ensure directory is correct before running command
-        cmd = "cd -- {dir} && {{ {cmd}\n }}".format(dir=_cmd_quote(cwd), cmd=cmd)
+        cmd = "cd -- {dir} && {{ {cmd}; }}".format(dir=_cmd_quote(cwd), cmd=cmd)
 
         # Ensure environment is correct for a newly logged-in user by running
         # the command under the user's login shell

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -434,23 +434,27 @@ def _run(
             cmd = " ".join(map(_cmd_quote, cmd))
 
         # Ensure directory is correct before running command
-        cmd = "cd -- {dir} && {{ {cmd}; }}".format(dir=_cmd_quote(cwd), cmd=cmd)
+        cmd = "cd -- {dir} && {{ {cmd}\n }}".format(dir=_cmd_quote(cwd), cmd=cmd)
 
         # Ensure environment is correct for a newly logged-in user by running
-        # the command under bash as a login shell
+        # the command under the user's login shell
         try:
+            valid_shells = shells()
             user_shell = __salt__["user.info"](runas)["shell"]
-            if re.search("bash$", user_shell):
-                cmd = "{shell} -l -c {cmd}".format(
-                    shell=user_shell, cmd=_cmd_quote(cmd)
+
+            if user_shell not in valid_shells:
+                raise CommandExecutionError(
+                    "Shell '{}' for '{}' is not valid".format(user_shell, runas)
                 )
+
+            cmd = "{shell} -l -c {cmd}".format(shell=user_shell, cmd=_cmd_quote(cmd))
         except KeyError:
             pass
 
         # Ensure the login is simulated correctly (note: su runs sh, not bash,
         # which causes the environment to be initialised incorrectly, which is
         # fixed by the previous line of code)
-        cmd = "sudo -i -n -H -u {} {}".format(_cmd_quote(runas), cmd)
+        cmd = "sudo -i -n -H -u {} -- {}".format(_cmd_quote(runas), cmd)
 
         # Set runas to None, because if you try to run `su -l` after changing
         # user, su will prompt for the password of the user and cause salt to


### PR DESCRIPTION
### What does this PR do?
Changing the MacOS specific code in cmdmod to use sudo instead of suwhen running with runas.

### What issues does this PR fix or reference?
Fixes: N/A

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
