### PR TITLE
Fix grains metadata on EC2

### DIFF
--- a/changelog/59541.fixed
+++ b/changelog/59541.fixed
@@ -1,0 +1,1 @@
+Fix crash when meta-data grains contains gzipped content

--- a/salt/grains/metadata.py
+++ b/salt/grains/metadata.py
@@ -61,7 +61,10 @@ def _search(prefix="latest/"):
             # (gtmanfred) The first level should have a forward slash since
             # they have stuff underneath. This will not be doubled up though,
             # because lines ending with a slash are checked first.
-            ret[line] = _search(prefix=os.path.join(prefix, line + "/"))
+            try:
+                ret[line] = _search(prefix=os.path.join(prefix, line + "/"))
+            except UnicodeDecodeError:
+                continue
         elif line.endswith(("dynamic", "meta-data")):
             ret[line] = _search(prefix=os.path.join(prefix, line))
         elif "=" in line:

--- a/salt/grains/metadata.py
+++ b/salt/grains/metadata.py
@@ -45,7 +45,10 @@ def _search(prefix="latest/"):
     Recursively look up all grains in the metadata server
     """
     ret = {}
-    linedata = http.query(os.path.join(HOST, prefix), headers=True)
+    try:
+        linedata = http.query(os.path.join(HOST, prefix), headers=True)
+    except UnicodeDecodeError:
+        linedata = ""
     if "body" not in linedata:
         return ret
     body = salt.utils.stringutils.to_unicode(linedata["body"])
@@ -61,10 +64,7 @@ def _search(prefix="latest/"):
             # (gtmanfred) The first level should have a forward slash since
             # they have stuff underneath. This will not be doubled up though,
             # because lines ending with a slash are checked first.
-            try:
-                ret[line] = _search(prefix=os.path.join(prefix, line + "/"))
-            except UnicodeDecodeError:
-                continue
+            ret[line] = _search(prefix=os.path.join(prefix, line + "/"))
         elif line.endswith(("dynamic", "meta-data")):
             ret[line] = _search(prefix=os.path.join(prefix, line))
         elif "=" in line:


### PR DESCRIPTION
### What does this PR do?

Fixes issue with `grains.get meta-data` and gzipped meta-data on AWS EC2

### What issues does this PR fix or reference?
Fixes: #59541 

### Previous Behavior

salt crashes

### New Behavior

salt continues to work and adds valuable meta-data to grains

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
