### PR TITLE
Fix pillar propagation error for "chroot" and "transactional_update" modules

### DIFF
--- a/salt/modules/chroot.py
+++ b/salt/modules/chroot.py
@@ -242,7 +242,11 @@ def _create_and_execute_salt_state(root, chunks, file_refs, test, hash_type):
     # Create the tar containing the state pkg and relevant files.
     salt.client.ssh.wrapper.state._cleanup_slsmod_low_data(chunks)
     trans_tar = salt.client.ssh.state.prep_trans_tar(
-        salt.fileclient.get_file_client(__opts__), chunks, file_refs, __pillar__.value(), root
+        salt.fileclient.get_file_client(__opts__),
+        chunks,
+        file_refs,
+        __pillar__.value(),
+        root,
     )
     trans_tar_sum = salt.utils.hashutils.get_hash(trans_tar, hash_type)
 

--- a/salt/modules/chroot.py
+++ b/salt/modules/chroot.py
@@ -242,7 +242,7 @@ def _create_and_execute_salt_state(root, chunks, file_refs, test, hash_type):
     # Create the tar containing the state pkg and relevant files.
     salt.client.ssh.wrapper.state._cleanup_slsmod_low_data(chunks)
     trans_tar = salt.client.ssh.state.prep_trans_tar(
-        salt.fileclient.get_file_client(__opts__), chunks, file_refs, __pillar__, root
+        salt.fileclient.get_file_client(__opts__), chunks, file_refs, __pillar__.value(), root
     )
     trans_tar_sum = salt.utils.hashutils.get_hash(trans_tar, hash_type)
 
@@ -303,7 +303,7 @@ def sls(root, mods, saltenv="base", test=None, exclude=None, **kwargs):
     """
     # Get a copy of the pillar data, to avoid overwriting the current
     # pillar, instead the one delegated
-    pillar = copy.deepcopy(__pillar__)
+    pillar = copy.deepcopy(__pillar__.value())
     pillar.update(kwargs.get("pillar", {}))
 
     # Clone the options data and apply some default values. May not be
@@ -372,7 +372,7 @@ def highstate(root, **kwargs):
     """
     # Get a copy of the pillar data, to avoid overwriting the current
     # pillar, instead the one delegated
-    pillar = copy.deepcopy(__pillar__)
+    pillar = copy.deepcopy(__pillar__.value())
     pillar.update(kwargs.get("pillar", {}))
 
     # Clone the options data and apply some default values. May not be

--- a/salt/modules/transactional_update.py
+++ b/salt/modules/transactional_update.py
@@ -1052,7 +1052,7 @@ def _create_and_execute_salt_state(
     # Create the tar containing the state pkg and relevant files.
     salt.client.ssh.wrapper.state._cleanup_slsmod_low_data(chunks)
     trans_tar = salt.client.ssh.state.prep_trans_tar(
-        salt.fileclient.get_file_client(__opts__), chunks, file_refs, __pillar__
+        salt.fileclient.get_file_client(__opts__), chunks, file_refs, __pillar__.value()
     )
     trans_tar_sum = salt.utils.hashutils.get_hash(trans_tar, hash_type)
 
@@ -1134,7 +1134,7 @@ def sls(
 
     # Get a copy of the pillar data, to avoid overwriting the current
     # pillar, instead the one delegated
-    pillar = copy.deepcopy(__pillar__)
+    pillar = copy.deepcopy(__pillar__.value())
     pillar.update(kwargs.get("pillar", {}))
 
     # Clone the options data and apply some default values. May not be
@@ -1218,7 +1218,7 @@ def highstate(activate_transaction=False, queue=False, **kwargs):
 
     # Get a copy of the pillar data, to avoid overwriting the current
     # pillar, instead the one delegated
-    pillar = copy.deepcopy(__pillar__)
+    pillar = copy.deepcopy(__pillar__.value())
     pillar.update(kwargs.get("pillar", {}))
 
     # Clone the options data and apply some default values. May not be
@@ -1284,7 +1284,7 @@ def single(fun, name, test=None, activate_transaction=False, queue=False, **kwar
 
     # Get a copy of the pillar data, to avoid overwriting the current
     # pillar, instead the one delegated
-    pillar = copy.deepcopy(__pillar__)
+    pillar = copy.deepcopy(__pillar__.value())
     pillar.update(kwargs.get("pillar", {}))
 
     # Clone the options data and apply some default values. May not be

--- a/tests/pytests/unit/modules/test_transactional_update.py
+++ b/tests/pytests/unit/modules/test_transactional_update.py
@@ -1,6 +1,7 @@
 import sys
 
 import pytest
+import salt.loader.context
 import salt.modules.state as statemod
 import salt.modules.transactional_update as tu
 from salt.exceptions import CommandExecutionError
@@ -13,8 +14,15 @@ pytestmark = [
 
 @pytest.fixture
 def configure_loader_modules():
+    loader_context = salt.loader.context.LoaderContext()
     return {
-        tu: {"__salt__": {}, "__utils__": {}},
+        tu: {
+            "__salt__": {},
+            "__utils__": {},
+            "__pillar__": salt.loader.context.NamedLoaderContext(
+                "__pillar__", loader_context, {}
+            ),
+        },
         statemod: {"__salt__": {}, "__context__": {}},
     }
 

--- a/tests/pytests/unit/modules/test_transactional_update.py
+++ b/tests/pytests/unit/modules/test_transactional_update.py
@@ -18,13 +18,22 @@ def configure_loader_modules():
     return {
         tu: {
             "__salt__": {},
-            "__utils__": {},
+            "__utils__": {"files.rm_rf": MagicMock()},
             "__pillar__": salt.loader.context.NamedLoaderContext(
                 "__pillar__", loader_context, {}
             ),
+            "__opts__": {"extension_modules": "", "cachedir": "/tmp/"},
         },
         statemod: {"__salt__": {}, "__context__": {}},
     }
+
+
+def test__create_and_execute_salt_state():
+    with patch("salt.client.ssh.wrapper.state._cleanup_slsmod_low_data", MagicMock()):
+        with patch("salt.utils.hashutils.get_hash", MagicMock(return_value="deadbeaf")):
+            with patch("salt.fileclient.get_file_client", MagicMock()):
+                with patch("salt.modules.transactional_update.call", MagicMock()):
+                    tu._create_and_execute_salt_state({}, {}, False, "md5", False)
 
 
 def test__global_params_no_self_update():

--- a/tests/unit/modules/test_chroot.py
+++ b/tests/unit/modules/test_chroot.py
@@ -27,6 +27,7 @@
 
 import sys
 
+import salt.loader.context
 import salt.modules.chroot as chroot
 import salt.utils.platform
 from salt.exceptions import CommandExecutionError
@@ -42,7 +43,17 @@ class ChrootTestCase(TestCase, LoaderModuleMockMixin):
     """
 
     def setup_loader_modules(self):
-        return {chroot: {"__salt__": {}, "__utils__": {}, "__opts__": {"cachedir": ""}}}
+        loader_context = salt.loader.context.LoaderContext()
+        return {
+            chroot: {
+                "__salt__": {},
+                "__utils__": {},
+                "__opts__": {"cachedir": ""},
+                "__pillar__": salt.loader.context.NamedLoaderContext(
+                    "__pillar__", loader_context, {}
+                ),
+            }
+        }
 
     @patch("os.path.isdir")
     def test_exist(self, isdir):

--- a/tests/unit/modules/test_chroot.py
+++ b/tests/unit/modules/test_chroot.py
@@ -47,13 +47,24 @@ class ChrootTestCase(TestCase, LoaderModuleMockMixin):
         return {
             chroot: {
                 "__salt__": {},
-                "__utils__": {},
-                "__opts__": {"cachedir": ""},
+                "__utils__": {"files.rm_rf": MagicMock()},
+                "__opts__": {"extension_modules": "", "cachedir": "/tmp/"},
                 "__pillar__": salt.loader.context.NamedLoaderContext(
                     "__pillar__", loader_context, {}
                 ),
             }
         }
+
+    def test__create_and_execute_salt_state(self):
+        with patch(
+            "salt.client.ssh.wrapper.state._cleanup_slsmod_low_data", MagicMock()
+        ):
+            with patch(
+                "salt.utils.hashutils.get_hash", MagicMock(return_value="deadbeaf")
+            ):
+                with patch("salt.fileclient.get_file_client", MagicMock()):
+                    with patch("salt.modules.chroot.call", MagicMock()):
+                        chroot._create_and_execute_salt_state("", {}, {}, False, "md5")
 
     @patch("os.path.isdir")
     def test_exist(self, isdir):


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue with pillar propagation inside `transactional-update` and `chroot` modules on Salt 3003 and greater. Same code was working for 3002 codebase.

```
# salt-call transactional_update.apply foobarstate
...
2021-09-21 13:09:03,005 [salt.minion      :1980][WARNING ][1439] Passed invalid arguments to state.apply: Object of type 'NamedLoaderContext' is not JSON serializable
...
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/salt/minion.py", line 1909, in _thread_return
    function_name, function_args, executors, opts, data
  File "/usr/lib/python3.6/site-packages/salt/minion.py", line 1865, in _execute_job_function
    return_data = self.executors[fname](opts, data, func, args, kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader.py", line 1241, in __call__
    return self.loader.run(run_func, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader.py", line 2276, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/contextvars/__init__.py", line 38, in run
    return callable(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader.py", line 2291, in _run_as
    return _func_or_method(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/executors/transactional_update.py", line 123, in execute
    opts, data, __salt__[DELEGATION_MAP[fun]], args, kwargs
  File "/usr/lib/python3.6/site-packages/salt/loader.py", line 1241, in __call__
    return self.loader.run(run_func, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader.py", line 2276, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/contextvars/__init__.py", line 38, in run
    return callable(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader.py", line 2291, in _run_as
    return _func_or_method(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/executors/direct_call.py", line 12, in execute
    return func(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader.py", line 1241, in __call__
    return self.loader.run(run_func, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader.py", line 2276, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/contextvars/__init__.py", line 38, in run
    return callable(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader.py", line 2291, in _run_as
    return _func_or_method(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/modules/transactional_update.py", line 1043, in apply_
    return sls(mods, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/modules/transactional_update.py", line 1183, in sls
    chunks, file_refs, test, hash_type, activate_transaction
  File "/usr/lib/python3.6/site-packages/salt/modules/transactional_update.py", line 1055, in _create_and_execute_salt_state
    salt.fileclient.get_file_client(__opts__), chunks, file_refs, __pillar__
  File "/usr/lib/python3.6/site-packages/salt/client/ssh/state.py", line 203, in prep_trans_tar
    salt.utils.json.dump(pillar, fp_)
  File "/usr/lib/python3.6/site-packages/salt/utils/json.py", line 126, in dump
    return json_module.dump(obj, fp, **kwargs)  # future lint: blacklisted-function
  File "/usr/lib64/python3.6/json/__init__.py", line 179, in dump
    for chunk in iterable:
  File "/usr/lib64/python3.6/json/encoder.py", line 437, in _iterencode
    o = _default(o)
  File "/usr/lib64/python3.6/json/encoder.py", line 180, in default
    o.__class__.__name__)
TypeError: Object of type 'NamedLoaderContext' is not JSON serializable
```

### New Behavior
After this PR, the `transactional_update` module is able to proceed and execute the corresponding state successfully.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
