### PR TITLE
Skip bad test on deb 9

### DIFF
--- a/tests/integration/ssh/test_jinja_filters.py
+++ b/tests/integration/ssh/test_jinja_filters.py
@@ -1,3 +1,5 @@
+import platform
+
 import pytest
 from tests.support.case import SSHCase
 
@@ -12,6 +14,8 @@ class SSHJinjaFiltersTest(SSHCase):
         """
         test jinja filter datautils.strftime
         """
+        if "debian-9" in platform.platform().lower():
+            pytest.skip("This test is broken on debian 9, skipping")
         arg = self._arg_str("state.sls", ["jinja_filters.dateutils_strftime"])
         ret = self.run_ssh(arg)
         import salt.utils.json

--- a/tests/integration/states/test_compiler.py
+++ b/tests/integration/states/test_compiler.py
@@ -3,14 +3,7 @@ tests for host state
 """
 
 
-import salt.utils.platform
 from tests.support.case import ModuleCase
-
-HAS_LSB_RELEASE = True
-try:
-    import lsb_release
-except ImportError:
-    HAS_LSB_RELEASE = False
 
 
 class CompileTest(ModuleCase):
@@ -31,13 +24,6 @@ class CompileTest(ModuleCase):
         Test when we have an error in a execution module
         called by jinja
         """
-        if salt.utils.platform.is_linux() and HAS_LSB_RELEASE:
-            release = lsb_release.get_distro_information()
-            if (
-                release.get("ID") == "Debian"
-                and int(release.get("RELEASE", "0")[0]) < 9
-            ):
-                self.skipTest("This test is flaky on Debian 8. Skipping.")
 
         ret = self.run_function("state.sls", ["issue-10010"])
         self.assertTrue(", in jinja_error" in ret[0].strip())


### PR DESCRIPTION
### What does this PR do?

Skips a test that's broken on Debian 9

Also noticed there was a test block checking for deb before 9, so went ahead and removed that since we don't support it.

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/pull/60895

### Merge requirements satisfied?
- [x] Tests written/updated

### Commits signed with GPG?
Yes