### PR TITLE
add psutil to re

### DIFF
--- a/changelog/60523.fixed
+++ b/changelog/60523.fixed
@@ -1,0 +1,1 @@
+Make all platforms have psutils. This prevents a minion from starting if an instance is all ready running.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,3 +5,4 @@ MarkupSafe
 requests>=1.0.0
 distro>=1.0.1
 contextvars
+psutil>=5.0.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,4 +5,4 @@ MarkupSafe
 requests>=1.0.0
 distro>=1.0.1
 contextvars
-psutil>=5.0.0
+psutil>=5.0.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,4 +5,4 @@ MarkupSafe
 requests>=1.0.0
 distro>=1.0.1
 contextvars
-psutil>=5.0.1
+psutil>=5.0.0

--- a/requirements/darwin.txt
+++ b/requirements/darwin.txt
@@ -11,7 +11,6 @@ gitpython>=2.1.15
 idna>=2.8
 linode-python>=1.1.1
 mako>=1.0.7
-psutil>=5.6.6
 pyasn1>=0.4.8
 pycparser>=2.19
 pyopenssl>=19.0.0

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -637,7 +637,7 @@ profitbricks==4.1.3
     # via -r requirements/static/ci/cloud.in
 psutil==5.8.0
     # via
-    #   -r requirements/static/pkg/linux.in
+    #   -r requirements/base.txt
     #   pytest-salt-factories
 py==1.10.0
     # via pytest

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -671,7 +671,7 @@ portend==2.6
     # via cherrypy
 psutil==5.8.0
     # via
-    #   -r requirements/darwin.txt
+    #   -r requirements/base.txt
     #   pytest-salt-factories
 py==1.10.0
     # via pytest

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -631,7 +631,7 @@ platformdirs==2.2.0
 portend==2.4
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/static/pkg/linux.in
+    # via -r requirements/base.txt
 pyasn1-modules==0.2.8
     # via google-auth
 pyasn1==0.4.8

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -668,7 +668,7 @@ portend==2.4
     # via cherrypy
 psutil==5.8.0
     # via
-    #   -r requirements/static/pkg/freebsd.in
+    #   -r requirements/base.txt
     #   pytest-salt-factories
 py==1.10.0
     # via pytest

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -636,7 +636,7 @@ platformdirs==2.2.0
 portend==2.7.1
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/static/pkg/linux.in
+    # via -r requirements/base.txt
 pyasn1-modules==0.2.8
     # via google-auth
 pyasn1==0.4.8

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -681,7 +681,7 @@ portend==2.4
     # via cherrypy
 psutil==5.8.0
     # via
-    #   -r requirements/static/pkg/linux.in
+    #   -r requirements/base.txt
     #   pytest-salt-factories
 py==1.10.0
     # via pytest

--- a/requirements/static/ci/py3.5/linux.txt
+++ b/requirements/static/ci/py3.5/linux.txt
@@ -673,7 +673,7 @@ portend==2.4
     # via cherrypy
 psutil==5.8.0
     # via
-    #   -r requirements/static/pkg/linux.in
+    #   -r requirements/base.txt
     #   pytest-salt-factories
 py==1.10.0
     # via pytest

--- a/requirements/static/ci/py3.6/cloud.txt
+++ b/requirements/static/ci/py3.6/cloud.txt
@@ -627,7 +627,7 @@ profitbricks==4.1.3
     # via -r requirements/static/ci/cloud.in
 psutil==5.8.0
     # via
-    #   -r requirements/static/pkg/linux.in
+    #   -r requirements/base.txt
     #   pytest-salt-factories
 py==1.10.0
     # via pytest

--- a/requirements/static/ci/py3.6/docs.txt
+++ b/requirements/static/ci/py3.6/docs.txt
@@ -666,7 +666,7 @@ platformdirs==2.2.0
 portend==2.4
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/static/pkg/linux.in
+    # via -r requirements/base.txt
 pyasn1-modules==0.2.8
     # via google-auth
 pyasn1==0.4.8

--- a/requirements/static/ci/py3.6/lint.txt
+++ b/requirements/static/ci/py3.6/lint.txt
@@ -625,7 +625,7 @@ platformdirs==2.2.0
 portend==2.7.1
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/static/pkg/linux.in
+    # via -r requirements/base.txt
 pyasn1-modules==0.2.8
     # via google-auth
 pyasn1==0.4.8

--- a/requirements/static/ci/py3.6/linux.txt
+++ b/requirements/static/ci/py3.6/linux.txt
@@ -673,7 +673,7 @@ portend==2.4
     # via cherrypy
 psutil==5.8.0
     # via
-    #   -r requirements/static/pkg/linux.in
+    #   -r requirements/base.txt
     #   pytest-salt-factories
 py==1.10.0
     # via pytest

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -647,7 +647,7 @@ profitbricks==4.1.3
     # via -r requirements/static/ci/cloud.in
 psutil==5.8.0
     # via
-    #   -r requirements/static/pkg/linux.in
+    #   -r requirements/base.txt
     #   pytest-salt-factories
 py==1.10.0
     # via pytest

--- a/requirements/static/ci/py3.7/darwin.txt
+++ b/requirements/static/ci/py3.7/darwin.txt
@@ -680,7 +680,7 @@ portend==2.6
     # via cherrypy
 psutil==5.8.0
     # via
-    #   -r requirements/darwin.txt
+    #   -r requirements/base.txt
     #   pytest-salt-factories
 py==1.10.0
     # via pytest

--- a/requirements/static/ci/py3.7/docs.txt
+++ b/requirements/static/ci/py3.7/docs.txt
@@ -681,7 +681,7 @@ platformdirs==2.2.0
 portend==2.4
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/static/pkg/linux.in
+    # via -r requirements/base.txt
 pyasn1-modules==0.2.8
     # via google-auth
 pyasn1==0.4.8

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -677,7 +677,7 @@ portend==2.4
     # via cherrypy
 psutil==5.8.0
     # via
-    #   -r requirements/static/pkg/freebsd.in
+    #   -r requirements/base.txt
     #   pytest-salt-factories
 py==1.10.0
     # via pytest

--- a/requirements/static/ci/py3.7/lint.txt
+++ b/requirements/static/ci/py3.7/lint.txt
@@ -644,7 +644,7 @@ platformdirs==2.2.0
 portend==2.7.1
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/static/pkg/linux.in
+    # via -r requirements/base.txt
 pyasn1-modules==0.2.8
     # via google-auth
 pyasn1==0.4.8

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -688,7 +688,7 @@ portend==2.4
     # via cherrypy
 psutil==5.8.0
     # via
-    #   -r requirements/static/pkg/linux.in
+    #   -r requirements/base.txt
     #   pytest-salt-factories
 py==1.10.0
     # via pytest

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -225,7 +225,7 @@ portend==2.6
     # via cherrypy
 psutil==5.8.0
     # via
-    #   -r requirements/windows.txt
+    #   -r requirements/base.txt
     #   pytest-salt-factories
 py==1.10.0
     # via pytest

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -639,7 +639,7 @@ profitbricks==4.1.3
     # via -r requirements/static/ci/cloud.in
 psutil==5.8.0
     # via
-    #   -r requirements/static/pkg/linux.in
+    #   -r requirements/base.txt
     #   pytest-salt-factories
 py==1.10.0
     # via pytest

--- a/requirements/static/ci/py3.8/darwin.txt
+++ b/requirements/static/ci/py3.8/darwin.txt
@@ -673,7 +673,7 @@ portend==2.6
     # via cherrypy
 psutil==5.8.0
     # via
-    #   -r requirements/darwin.txt
+    #   -r requirements/base.txt
     #   pytest-salt-factories
 py==1.10.0
     # via pytest

--- a/requirements/static/ci/py3.8/docs.txt
+++ b/requirements/static/ci/py3.8/docs.txt
@@ -641,7 +641,7 @@ platformdirs==2.2.0
 portend==2.4
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/static/pkg/linux.in
+    # via -r requirements/base.txt
 pyasn1-modules==0.2.8
     # via google-auth
 pyasn1==0.4.8

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -670,7 +670,7 @@ portend==2.4
     # via cherrypy
 psutil==5.8.0
     # via
-    #   -r requirements/static/pkg/freebsd.in
+    #   -r requirements/base.txt
     #   pytest-salt-factories
 py==1.10.0
     # via pytest

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -640,7 +640,7 @@ platformdirs==2.2.0
 portend==2.7.1
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/static/pkg/linux.in
+    # via -r requirements/base.txt
 pyasn1-modules==0.2.8
     # via google-auth
 pyasn1==0.4.8

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -681,7 +681,7 @@ portend==2.4
     # via cherrypy
 psutil==5.8.0
     # via
-    #   -r requirements/static/pkg/linux.in
+    #   -r requirements/base.txt
     #   pytest-salt-factories
 py==1.10.0
     # via pytest

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -218,7 +218,7 @@ portend==2.6
     # via cherrypy
 psutil==5.8.0
     # via
-    #   -r requirements/windows.txt
+    #   -r requirements/base.txt
     #   pytest-salt-factories
 py==1.9.0
     # via pytest

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -639,7 +639,7 @@ profitbricks==4.1.3
     # via -r requirements/static/ci/cloud.in
 psutil==5.8.0
     # via
-    #   -r requirements/static/pkg/linux.in
+    #   -r requirements/base.txt
     #   pytest-salt-factories
 py==1.10.0
     # via pytest

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -673,7 +673,7 @@ portend==2.6
     # via cherrypy
 psutil==5.8.0
     # via
-    #   -r requirements/darwin.txt
+    #   -r requirements/base.txt
     #   pytest-salt-factories
 py==1.10.0
     # via pytest

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -639,7 +639,7 @@ platformdirs==2.2.0
 portend==2.4
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/static/pkg/linux.in
+    # via -r requirements/base.txt
 pyasn1-modules==0.2.8
     # via google-auth
 pyasn1==0.4.8

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -670,7 +670,7 @@ portend==2.4
     # via cherrypy
 psutil==5.8.0
     # via
-    #   -r requirements/static/pkg/freebsd.in
+    #   -r requirements/base.txt
     #   pytest-salt-factories
 py==1.10.0
     # via pytest

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -638,7 +638,7 @@ platformdirs==2.2.0
 portend==2.7.1
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/static/pkg/linux.in
+    # via -r requirements/base.txt
 pyasn1-modules==0.2.8
     # via google-auth
 pyasn1==0.4.8

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -683,7 +683,7 @@ portend==2.4
     # via cherrypy
 psutil==5.8.0
     # via
-    #   -r requirements/static/pkg/linux.in
+    #   -r requirements/base.txt
     #   pytest-salt-factories
 py==1.10.0
     # via pytest

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -218,7 +218,7 @@ portend==2.6
     # via cherrypy
 psutil==5.8.0
     # via
-    #   -r requirements/windows.txt
+    #   -r requirements/base.txt
     #   pytest-salt-factories
 py==1.9.0
     # via pytest

--- a/requirements/static/pkg/freebsd.in
+++ b/requirements/static/pkg/freebsd.in
@@ -1,7 +1,6 @@
 # This file only exists to trigger the right static compiled requirements destination
 # Any non hard dependencies of Salt for FreeBSD can go here
 cherrypy
-psutil
 backports.ssl_match_hostname>=3.7.0.1; python_version < '3.7'
 pyopenssl>=19.0.0
 python-dateutil>=2.8.0

--- a/requirements/static/pkg/linux.in
+++ b/requirements/static/pkg/linux.in
@@ -1,7 +1,6 @@
 # This file only exists to trigger the right static compiled requirements destination.
 # Any non hard dependencies of Salt for linux can go here
 cherrypy
-psutil
 backports.ssl_match_hostname>=3.7.0.1; python_version < '3.7'
 pyopenssl>=19.0.0
 python-dateutil>=2.8.0

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -67,7 +67,7 @@ msgpack==1.0.2
 portend==2.6
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/darwin.txt
+    # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/darwin.txt
 pycparser==2.19

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -54,7 +54,7 @@ msgpack==1.0.2
 portend==2.4
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/static/pkg/freebsd.in
+    # via -r requirements/base.txt
 pycparser==2.17
     # via cffi
 pycryptodomex==3.9.8

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -52,7 +52,7 @@ msgpack==1.0.2
 portend==2.4
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/static/pkg/linux.in
+    # via -r requirements/base.txt
 pycparser==2.17
     # via cffi
 pycryptodomex==3.9.8

--- a/requirements/static/pkg/py3.5/linux.txt
+++ b/requirements/static/pkg/py3.5/linux.txt
@@ -55,7 +55,7 @@ msgpack==1.0.2
 portend==2.4
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/static/pkg/linux.in
+    # via -r requirements/base.txt
 pycparser==2.17
     # via cffi
 pycryptodomex==3.9.8

--- a/requirements/static/pkg/py3.6/linux.txt
+++ b/requirements/static/pkg/py3.6/linux.txt
@@ -58,7 +58,7 @@ msgpack==1.0.2
 portend==2.4
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/static/pkg/linux.in
+    # via -r requirements/base.txt
 pycparser==2.17
     # via cffi
 pycryptodomex==3.9.8

--- a/requirements/static/pkg/py3.7/darwin.txt
+++ b/requirements/static/pkg/py3.7/darwin.txt
@@ -69,7 +69,7 @@ msgpack==1.0.2
 portend==2.6
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/darwin.txt
+    # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/darwin.txt
 pycparser==2.19

--- a/requirements/static/pkg/py3.7/freebsd.txt
+++ b/requirements/static/pkg/py3.7/freebsd.txt
@@ -56,7 +56,7 @@ msgpack==1.0.2
 portend==2.4
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/static/pkg/freebsd.in
+    # via -r requirements/base.txt
 pycparser==2.17
     # via cffi
 pycryptodomex==3.9.8

--- a/requirements/static/pkg/py3.7/linux.txt
+++ b/requirements/static/pkg/py3.7/linux.txt
@@ -54,7 +54,7 @@ msgpack==1.0.2
 portend==2.4
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/static/pkg/linux.in
+    # via -r requirements/base.txt
 pycparser==2.17
     # via cffi
 pycryptodomex==3.9.8

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -73,7 +73,7 @@ msgpack==1.0.2
 portend==2.6
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/windows.txt
+    # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/windows.txt
 pycparser==2.20

--- a/requirements/static/pkg/py3.8/darwin.txt
+++ b/requirements/static/pkg/py3.8/darwin.txt
@@ -69,7 +69,7 @@ msgpack==1.0.2
 portend==2.6
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/darwin.txt
+    # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/darwin.txt
 pycparser==2.19

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -56,7 +56,7 @@ msgpack==1.0.2
 portend==2.4
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/static/pkg/freebsd.in
+    # via -r requirements/base.txt
 pycparser==2.17
     # via cffi
 pycryptodomex==3.9.8

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -54,7 +54,7 @@ msgpack==1.0.2
 portend==2.4
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/static/pkg/linux.in
+    # via -r requirements/base.txt
 pycparser==2.17
     # via cffi
 pycryptodomex==3.9.8

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -73,7 +73,7 @@ msgpack==0.6.2
 portend==2.6
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/windows.txt
+    # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/windows.txt
 pycparser==2.20

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -69,7 +69,7 @@ msgpack==1.0.2
 portend==2.6
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/darwin.txt
+    # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/darwin.txt
 pycparser==2.19

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -56,7 +56,7 @@ msgpack==1.0.2
 portend==2.4
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/static/pkg/freebsd.in
+    # via -r requirements/base.txt
 pycparser==2.17
     # via cffi
 pycryptodomex==3.9.8

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -54,7 +54,7 @@ msgpack==1.0.2
 portend==2.4
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/static/pkg/linux.in
+    # via -r requirements/base.txt
 pycparser==2.17
     # via cffi
 pycryptodomex==3.9.8

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -73,7 +73,7 @@ msgpack==0.6.2
 portend==2.6
     # via cherrypy
 psutil==5.8.0
-    # via -r requirements/windows.txt
+    # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/windows.txt
 pycparser==2.20

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -16,7 +16,6 @@ ioloop>=0.1a0
 libnacl>=1.8.0
 lxml>=4.6.3
 mako>=1.1.4
-psutil>=5.8.0
 pyasn1>=0.4.8
 pycparser>=2.20
 pycurl>=7.43.0.5  # PyCurl does not provide a whl file for newer versions


### PR DESCRIPTION
### What does this PR do?
Make all platforms have `psutils`. This PR will prevent a minion from starting if an instance is all ready running.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/60523

### Previous Behavior
Remove this section if not relevant
More than one minion can be started.

### New Behavior
Remove this section if not relevant
Only one minion can be stated at a time.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes
