### PR TITLE
Fix REST CherryPY append the default permissions every request

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -1881,7 +1881,7 @@ class Login(LowDataAdapter):
                 perms = token["auth_list"]
             else:
                 # Get sum of '*' perms, user-specific perms, and group-specific perms
-                perms = eauth.get(token["name"], [])
+                perms = eauth.get(token["name"], []).copy()
                 perms.extend(eauth.get("*", []))
 
                 if "groups" in token and token["groups"]:


### PR DESCRIPTION
- Use copy() to copy dictionary object

### What does this PR do?

Fix REST CherryPy append the default permisions every request.

### What issues does this PR fix or reference?
Fixes: #60955

### Previous Behavior
```json
{
  "return": [
    {
      "token": "752a9004db630b48a314fc68e1fbe2c23e00c9dd",
      "expire": 1629491964.8055215,
      "start": 1629448764.8055215,
      "user": "test@example.com",
      "eauth": "rest",
      "perms": [
        {
          "centOS-*": [
            "cmd.run_all",
            {
              "cp.get_url": {
                "kwargs": {
                  "path": "https://example.com/.*"
                }
              }
            }
          ]
        },
        {
          "default-*": [
            "grains.items",
            "test.ping",
            "test.arg",
            "status.uptime",
            "cmd.run_all",
            {
              "cmd.script": {
                "kwargs": {
                  "source": "https://google.com/.*"
                }
              }
            }
          ]
        },
        {
          "default-*": [
            "grains.items",
            "test.ping",
            "test.arg",
            "status.uptime",
            "cmd.run_all",
            {
              "cmd.script": {
                "kwargs": {
                  "source": "https://google.com/.*"
                }
              }
            }
          ]
        },
        {
          "default-*": [
            "grains.items",
            "test.ping",
            "test.arg",
            "status.uptime",
            "cmd.run_all",
            {
              "cmd.script": {
                "kwargs": {
                  "source": "https://google.com/.*"
                }
              }
            }
          ]
        }
      ]
    }
  ]
}
``

### New Behavior
```json
{
  "return": [
    {
      "token": "752a9004db630b48a314fc68e1fbe2c23e00c9dd",
      "expire": 1629491964.8055215,
      "start": 1629448764.8055215,
      "user": "test@example.com",
      "eauth": "rest",
      "perms": [
        {
          "centOS-*": [
            "cmd.run_all",
            {
              "cp.get_url": {
                "kwargs": {
                  "path": "https://example.com/.*"
                }
              }
            }
          ]
        },
        {
          "default-*": [
            "grains.items",
            "test.ping",
            "test.arg",
            "status.uptime",
            "cmd.run_all",
            {
              "cmd.script": {
                "kwargs": {
                  "source": "https://google.com/.*"
                }
              }
            }
          ]
        }
      ]
    }
  ]
}
```