### PR TITLE
Do not break master_tops for minion with version lower to 3003

### DIFF
--- a/changelog/60980.deprecated
+++ b/changelog/60980.deprecated
@@ -1,0 +1,1 @@
+The _ext_nodes alias to the master_tops function was added back in 3004 to maintain backwards compatibility with older supported versions. This alias will now be removed in 3006. This change will break Master and Minion communication compatibility with Salt minions running versions 3003 and lower.

--- a/changelog/60980.fixed
+++ b/changelog/60980.fixed
@@ -1,1 +1,2 @@
 Do not break master_tops for minion with version lower to 3003
+This is going to be deprecated in Salt 3006 (Sulfur)

--- a/changelog/60980.fixed
+++ b/changelog/60980.fixed
@@ -1,2 +1,2 @@
 Do not break master_tops for minion with version lower to 3003
-This is going to be deprecated in Salt 3006 (Sulfur)
+This is going to be removed in Salt 3006 (Sulfur)

--- a/changelog/60980.fixed
+++ b/changelog/60980.fixed
@@ -1,0 +1,1 @@
+Do not break master_tops for minion with version lower to 3003

--- a/salt/master.py
+++ b/salt/master.py
@@ -1170,7 +1170,7 @@ class AESFuncs(TransportMethods):
         "_dir_list",
         "_symlink_list",
         "_file_envs",
-        "_ext_nodes",
+        "_ext_nodes",  # To be removed in 3006 (Sulfur) #60980
     )
 
     def __init__(self, opts):
@@ -1370,6 +1370,7 @@ class AESFuncs(TransportMethods):
         return self.masterapi._master_tops(load, skip_verify=True)
 
     # Needed so older minions can request master_tops
+    # To be removed in 3006 (Sulfur) #60980
     _ext_nodes = _master_tops
 
     def _master_opts(self, load):

--- a/salt/master.py
+++ b/salt/master.py
@@ -1170,6 +1170,7 @@ class AESFuncs(TransportMethods):
         "_dir_list",
         "_symlink_list",
         "_file_envs",
+        "_ext_nodes",
     )
 
     def __init__(self, opts):
@@ -1367,6 +1368,9 @@ class AESFuncs(TransportMethods):
         if load is False:
             return {}
         return self.masterapi._master_tops(load, skip_verify=True)
+
+    # Needed so older minions can request master_tops
+    _ext_nodes = _master_tops
 
     def _master_opts(self, load):
         """


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue requesting "master_tops" from minions when using Salt master version 3003 and minions with lower versions, like 3002.2.

### Previous Behavior

In an environment where I have configured a custom "master_top" module in my Salt 3003.3 master, and then I call `state.show_top` on my older 3002 minion, I got:

```console
# salt minion state.show_top
minion:
    ----------
```
and the following message on my Salt master logs:
```
2021-09-30 11:57:25,801 [salt.master      :1200][ERROR   ][11079] Requested method not exposed: _ext_nodes
```

### New Behavior

I got the expected top data coming from the "master_top" module.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
