### PR TITLE
Netbox execution module add VM support

### DIFF
--- a/salt/modules/netbox.py
+++ b/salt/modules/netbox.py
@@ -1011,10 +1011,6 @@ def create_ipaddress(
     app = ""
     endpoint = ""
     search_kwargs = {}
-    # check not working in both entered screnario
-    if not (device or virtual_machine):
-        log.error("Either device or virtual_machine must be supplied.")
-        return False
 
     if device:
         app = "dcim"
@@ -1028,23 +1024,28 @@ def create_ipaddress(
         search_kwargs['tenant'] = tenant
         search_kwargs['cluster'] = cluster
 
-    nb_object = get_(app, endpoint, **search_kwargs)
-    if not nb_object:
-        log.error("No device or virtual_machine found.")
-        return False
+    if device or virtual_machine:
+        if not interface:
+            log.error("Interface is mandatory when specifying device or virtual_machine")
+            return False
 
-    # Fetch the specified interface name from nb_object and
-    # store it in nb_object_iface
-    search_kwargs={'name': interface}
-    if device:
-        search_kwargs['device_id'] = nb_object['id']
-    elif virtual_machine:
-        search_kwargs['virtual_machine_id'] = nb_object['id']
-    nb_object_iface = get_(app, "interfaces", **search_kwargs)
-    if not nb_object_iface:
-        msg = "No interface {} found for {}".format(interface, nb_object['name'])
-        log.error(msg)
-        return False
+        nb_object = get_(app, endpoint, **search_kwargs)
+        if not nb_object:
+            log.error("No device or virtual_machine found.")
+            return False
+
+        # Fetch the specified interface name from nb_object and
+        # store it in nb_object_iface
+        search_kwargs={'name': interface}
+        if device:
+            search_kwargs['device_id'] = nb_object['id']
+        elif virtual_machine:
+            search_kwargs['virtual_machine_id'] = nb_object['id']
+        nb_object_iface = get_(app, "interfaces", **search_kwargs)
+        if not nb_object_iface:
+            msg = "No interface {} found for {}".format(interface, nb_object['name'])
+            log.error(msg)
+            return False
 
     # Construct the configuration for the interface.
     payload = {}
@@ -1121,8 +1122,6 @@ def create_ipaddress(
         vrf=vrf,
     )
     return nb_addr
-
-
 
 def delete_ipaddress(ipaddr_id):
     """


### PR DESCRIPTION
### What does this PR do? 

Add lacking VM support in the netbox execution module. Also the `create_ipaddress` seemed broken because it could not assign a IP address to a device (as the documentation states). This PR resolves that and also allows the execution module to 
assign ip addresses to virtual machine objects in Netbox.

Fixes:
 - `netbox.create_ipaddress` does not assign ip address to device.
 
Adds:
- `netbox.create_virtual_machine` to create virtual machine objects in netbox
- `netbox.create_virtual_machine_interface` to create virtual machine network interfaces in netbox
- `netbox.create_ipaddress` full api implementatie of "ipam/ip-addresses".

### Previous Behavior
#### `netbox.create_ipaddress`
- Before this PR the `create_ipaddress` method did not assign the ip address to a device at all, allthough the documentation implies that it does.
- Before this PR the `create_ipaddress` method required a possitional argument `family` that indicated ipv4 or ipv6. This information is not needed by netbox (nor defined in it's API). 

### New Behavior
#### `netbox.create_ipaddress`
Previous invocation:
```bash
salt-call netbox.create_ipaddress 192.168.13.37/24 4 device=server01 interface=eth0
```
New invocation:
```bash
salt-call netbox.create_ipaddress 192.168.13.37/24 device=server01 interface=eth0
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. --> 
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

