### PR TITLE
Handle various architecture formats in aptpkg module

### DIFF
--- a/changelog/60971.fixed
+++ b/changelog/60971.fixed
@@ -1,0 +1,1 @@
+Handle all repo formats in the aptpkg module.

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -151,7 +151,7 @@ if not HAS_APT:
 
             repo_line.append(self.type)
             if self.architectures:
-                repo_line.append("[arch={}] ".format(" ".join(self.architectures)))
+                repo_line.append("[arch={}]".format(" ".join(self.architectures)))
 
             repo_line = repo_line + [self.uri, self.dist, " ".join(self.comps)]
             if self.comment:

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -175,13 +175,12 @@ if not HAS_APT:
             if repo_line[0] not in ["deb", "deb-src", "rpm", "rpm-src"]:
                 self.invalid = True
                 return False
-            self.architectures = []
             if repo_line[1].startswith("["):
                 opts = re.search(r"\[.*\]", self.line).group(0).strip("[]")
-                repo_line = [x for x in repo_line if x.strip("[]")]
+                repo_line = [x.strip("[]") for x in repo_line if x.strip("[]")]
                 for opt in opts.split():
                     if opt.startswith("arch"):
-                        self.architectures = opt.split("=", 1)[1]
+                        self.architectures.extend(opt.split("=", 1)[1].split(","))
                     try:
                         repo_line.pop(repo_line.index(opt))
                     except ValueError:

--- a/tests/pytests/functional/modules/test_aptpkg.py
+++ b/tests/pytests/functional/modules/test_aptpkg.py
@@ -147,7 +147,6 @@ def test_get_repos_doesnot_exist():
         assert not ret
 
 
-@pytest.mark.skip_if_binaries_missing("apt-add-repository")
 @pytest.mark.destructive_test
 def test_del_repo(revert_repo_file):
     """

--- a/tests/pytests/functional/states/test_pkgrepo.py
+++ b/tests/pytests/functional/states/test_pkgrepo.py
@@ -1,0 +1,10 @@
+import salt.utils.files
+
+
+def test_removed_installed_cycle(states, tmp_path):
+    repo_file = tmp_path / "stable-binary.list"
+    repo_content = "deb http://www.deb-multimedia.org stable main"
+    ret = states.pkgrepo.managed(name=repo_content, file=repo_file, clean_file=True)
+    with salt.utils.files.fopen(repo_file, "r") as fp:
+        file_content = fp.read()
+    assert file_content.strip() == repo_content

--- a/tests/pytests/functional/states/test_pkgrepo.py
+++ b/tests/pytests/functional/states/test_pkgrepo.py
@@ -1,7 +1,17 @@
+import platform
+
+import pytest
 import salt.utils.files
 
 
-def test_removed_installed_cycle(states, tmp_path):
+@pytest.mark.skipif(
+    not any([x for x in ["ubuntu", "debian"] if x in platform.platform()]),
+    reason="Test only for debian based platforms",
+)
+def test_adding_repo_file(states, tmp_path):
+    """
+    test adding a repo file using pkgrepo.managed
+    """
     repo_file = tmp_path / "stable-binary.list"
     repo_content = "deb http://www.deb-multimedia.org stable main"
     ret = states.pkgrepo.managed(name=repo_content, file=repo_file, clean_file=True)

--- a/tests/pytests/functional/states/test_pkgrepo.py
+++ b/tests/pytests/functional/states/test_pkgrepo.py
@@ -12,7 +12,7 @@ def test_adding_repo_file(states, tmp_path):
     """
     test adding a repo file using pkgrepo.managed
     """
-    repo_file = tmp_path / "stable-binary.list"
+    repo_file = str(tmp_path / "stable-binary.list")
     repo_content = "deb http://www.deb-multimedia.org stable main"
     ret = states.pkgrepo.managed(name=repo_content, file=repo_file, clean_file=True)
     with salt.utils.files.fopen(repo_file, "r") as fp:
@@ -29,7 +29,7 @@ def test_adding_repo_file_arch(states, tmp_path):
     test adding a repo file using pkgrepo.managed
     and setting architecture
     """
-    repo_file = tmp_path / "stable-binary.list"
+    repo_file = str(tmp_path / "stable-binary.list")
     repo_content = "deb [arch=amd64  ] http://www.deb-multimedia.org stable main"
     ret = states.pkgrepo.managed(name=repo_content, file=repo_file, clean_file=True)
     with salt.utils.files.fopen(repo_file, "r") as fp:

--- a/tests/pytests/functional/states/test_pkgrepo.py
+++ b/tests/pytests/functional/states/test_pkgrepo.py
@@ -18,3 +18,23 @@ def test_adding_repo_file(states, tmp_path):
     with salt.utils.files.fopen(repo_file, "r") as fp:
         file_content = fp.read()
     assert file_content.strip() == repo_content
+
+
+@pytest.mark.skipif(
+    not any([x for x in ["ubuntu", "debian"] if x in platform.platform()]),
+    reason="Test only for debian based platforms",
+)
+def test_adding_repo_file_arch(states, tmp_path):
+    """
+    test adding a repo file using pkgrepo.managed
+    and setting architecture
+    """
+    repo_file = tmp_path / "stable-binary.list"
+    repo_content = "deb [arch=amd64  ] http://www.deb-multimedia.org stable main"
+    ret = states.pkgrepo.managed(name=repo_content, file=repo_file, clean_file=True)
+    with salt.utils.files.fopen(repo_file, "r") as fp:
+        file_content = fp.read()
+        assert (
+            file_content.strip()
+            == "deb [arch=amd64] http://www.deb-multimedia.org stable main"
+        )

--- a/tests/pytests/unit/modules/test_aptpkg.py
+++ b/tests/pytests/unit/modules/test_aptpkg.py
@@ -1110,6 +1110,9 @@ SERVICE:cups-daemon,390,/usr/sbin/cupsd
         ]
 
 
+@pytest.mark.skipif(
+    HAS_APTSOURCES is True, reason="Only run test with python3-apt library is missing."
+)
 def test_sourceslist_multiple_comps():
     """
     Test SourcesList when repo has multiple comps
@@ -1126,6 +1129,9 @@ def test_sourceslist_multiple_comps():
                     assert source.dist == "focal-updates"
 
 
+@pytest.mark.skipif(
+    HAS_APTSOURCES is True, reason="Only run test with python3-apt library is missing."
+)
 @pytest.mark.parametrize(
     "repo_line",
     [
@@ -1142,16 +1148,15 @@ def test_sourceslist_architectures(repo_line):
     """
     Test SourcesList when architectures is in repo
     """
-    with patch.object(aptpkg, "HAS_APT", return_value=True):
-        with patch("salt.utils.files.fopen", mock_open(read_data=repo_line)):
-            with patch("pathlib.Path.is_file", side_effect=[True, False]):
-                sources = aptpkg.SourcesList()
-                for source in sources:
-                    assert source.type == "deb"
-                    assert source.uri == "http://archive.ubuntu.com/ubuntu/"
-                    assert source.comps == ["main", "restricted"]
-                    assert source.dist == "focal-updates"
-                    if "," in repo_line:
-                        assert source.architectures == ["amd64", "armel"]
-                    else:
-                        assert source.architectures == ["amd64"]
+    with patch("salt.utils.files.fopen", mock_open(read_data=repo_line)):
+        with patch("pathlib.Path.is_file", side_effect=[True, False]):
+            sources = aptpkg.SourcesList()
+            for source in sources:
+                assert source.type == "deb"
+                assert source.uri == "http://archive.ubuntu.com/ubuntu/"
+                assert source.comps == ["main", "restricted"]
+                assert source.dist == "focal-updates"
+                if "," in repo_line:
+                    assert source.architectures == ["amd64", "armel"]
+                else:
+                    assert source.architectures == ["amd64"]


### PR DESCRIPTION
### What does this PR do?
Handles all repo  formats in the aptpkg module

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/60971

### Previous Behavior
The architecture repo format `[arch=amd64  ]` was not  parsed correctly.

### New Behavior
`[arch=amd64  ]` is parsed correctly

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [NA ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated
