### PR TITLE
Allow cron.present to change a timespec from non-special to special

### DIFF
--- a/changelog/60997.fixed
+++ b/changelog/60997.fixed
@@ -1,0 +1,1 @@
+Fix cron.present duplicating entries when changing timespec to special.

--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -498,7 +498,7 @@ def set_special(user, special, cmd, commented=False, comment=None, identifier=No
         salt '*' cron.set_special root @hourly 'echo foobar'
     """
     lst = list_tab(user)
-    for cron in lst["special"]:
+    for cron in lst["crons"] + lst["special"]:
         cid = _cron_id(cron)
         if _cron_matched(cron, cmd, identifier):
             test_setted_id = (
@@ -510,21 +510,29 @@ def set_special(user, special, cmd, commented=False, comment=None, identifier=No
                 (cron["comment"], comment),
                 (cron["commented"], commented),
                 (identifier, test_setted_id),
-                (cron["spec"], special),
+                (cron.get("minute"), None),
+                (cron.get("hour"), None),
+                (cron.get("daymonth"), None),
+                (cron.get("month"), None),
+                (cron.get("dayweek"), None),
+                (cron.get("spec"), special),
             ]
             if cid or identifier:
                 tests.append((cron["cmd"], cmd))
             if any([_needs_change(x, y) for x, y in tests]):
-                rm_special(user, cmd, identifier=cid)
+                if "spec" in cron:
+                    rm_special(user, cmd, identifier=cid)
+                else:
+                    rm_job(user, cmd, identifier=cid)
 
                 # Use old values when setting the new job if there was no
                 # change needed for a given parameter
-                if not _needs_change(cron["spec"], special):
-                    special = cron["spec"]
-                if not _needs_change(cron["commented"], commented):
-                    commented = cron["commented"]
-                if not _needs_change(cron["comment"], comment):
-                    comment = cron["comment"]
+                if not _needs_change(cron.get("spec"), special):
+                    special = cron.get("spec")
+                if not _needs_change(cron.get("commented"), commented):
+                    commented = cron.get("commented")
+                if not _needs_change(cron.get("comment"), comment):
+                    comment = cron.get("comment")
                 if not _needs_change(cron["cmd"], cmd):
                     cmd = cron["cmd"]
                     if cid == SALT_CRON_NO_IDENTIFIER:
@@ -638,7 +646,7 @@ def set_job(
     month = str(month).lower()
     dayweek = str(dayweek).lower()
     lst = list_tab(user)
-    for cron in lst["crons"]:
+    for cron in lst["crons"] + lst["special"]:
         cid = _cron_id(cron)
         if _cron_matched(cron, cmd, identifier):
             test_setted_id = (
@@ -650,29 +658,33 @@ def set_job(
                 (cron["comment"], comment),
                 (cron["commented"], commented),
                 (identifier, test_setted_id),
-                (cron["minute"], minute),
-                (cron["hour"], hour),
-                (cron["daymonth"], daymonth),
-                (cron["month"], month),
-                (cron["dayweek"], dayweek),
+                (cron.get("minute"), minute),
+                (cron.get("hour"), hour),
+                (cron.get("daymonth"), daymonth),
+                (cron.get("month"), month),
+                (cron.get("dayweek"), dayweek),
+                (cron.get("spec"), None),
             ]
             if cid or identifier:
                 tests.append((cron["cmd"], cmd))
             if any([_needs_change(x, y) for x, y in tests]):
-                rm_job(user, cmd, identifier=cid)
+                if "spec" in cron:
+                    rm_special(user, cmd, identifier=cid)
+                else:
+                    rm_job(user, cmd, identifier=cid)
 
                 # Use old values when setting the new job if there was no
                 # change needed for a given parameter
-                if not _needs_change(cron["minute"], minute):
-                    minute = cron["minute"]
-                if not _needs_change(cron["hour"], hour):
-                    hour = cron["hour"]
-                if not _needs_change(cron["daymonth"], daymonth):
-                    daymonth = cron["daymonth"]
-                if not _needs_change(cron["month"], month):
-                    month = cron["month"]
-                if not _needs_change(cron["dayweek"], dayweek):
-                    dayweek = cron["dayweek"]
+                if not _needs_change(cron.get("minute"), minute):
+                    minute = cron.get("minute")
+                if not _needs_change(cron.get("hour"), hour):
+                    hour = cron.get("hour")
+                if not _needs_change(cron.get("daymonth"), daymonth):
+                    daymonth = cron.get("daymonth")
+                if not _needs_change(cron.get("month"), month):
+                    month = cron.get("month")
+                if not _needs_change(cron.get("dayweek"), dayweek):
+                    dayweek = cron.get("dayweek")
                 if not _needs_change(cron["commented"], commented):
                     commented = cron["commented"]
                 if not _needs_change(cron["comment"], comment):

--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -355,9 +355,6 @@ def present(
         return ret
 
     if special is None:
-        antidata = __salt__["cron.rm_special"](
-            user, name, special=special, identifier=identifier
-        )
         data = __salt__["cron.set_job"](
             user=user,
             minute=minute,
@@ -371,7 +368,6 @@ def present(
             identifier=identifier,
         )
     else:
-        antidata = __salt__["cron.rm_job"](user, name, identifier=identifier)
         data = __salt__["cron.set_special"](
             user=user,
             special=special,
@@ -380,22 +376,14 @@ def present(
             commented=commented,
             identifier=identifier,
         )
-
-    if data == "present" and antidata == "removed":
-        ret["comment"] = "Duplicate Cron {} removed".format(name)
-        return ret
-
-    if data == "present" and antidata == "absent":
+    if data == "present":
         ret["comment"] = "Cron {} already present".format(name)
         return ret
 
-    if data == "new" and antidata == "absent":
+    if data == "new":
         ret["comment"] = "Cron {} added to {}'s crontab".format(name, user)
         ret["changes"] = {user: name}
         return ret
-
-    if data == "new" and antidata == "removed":
-        ret["comment"] = "Cron {} time specification changed".format(name)
 
     if data == "updated":
         ret["comment"] = "Cron {} updated".format(name)

--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -355,6 +355,9 @@ def present(
         return ret
 
     if special is None:
+        antidata = __salt__["cron.rm_special"](
+            user, name, special=special, identifier=identifier
+        )
         data = __salt__["cron.set_job"](
             user=user,
             minute=minute,
@@ -368,6 +371,7 @@ def present(
             identifier=identifier,
         )
     else:
+        antidata = __salt__["cron.rm_job"](user, name, identifier=identifier)
         data = __salt__["cron.set_special"](
             user=user,
             special=special,
@@ -376,14 +380,22 @@ def present(
             commented=commented,
             identifier=identifier,
         )
-    if data == "present":
+
+    if data == "present" and antidata == "removed":
+        ret["comment"] = "Duplicate Cron {} removed".format(name)
+        return ret
+
+    if data == "present" and antidata == "absent":
         ret["comment"] = "Cron {} already present".format(name)
         return ret
 
-    if data == "new":
+    if data == "new" and antidata == "absent":
         ret["comment"] = "Cron {} added to {}'s crontab".format(name, user)
         ret["changes"] = {user: name}
         return ret
+
+    if data == "new" and antidata == "removed":
+        ret["comment"] = "Cron {} time specification changed".format(name)
 
     if data == "updated":
         ret["comment"] = "Cron {} updated".format(name)

--- a/tests/unit/modules/test_cron.py
+++ b/tests/unit/modules/test_cron.py
@@ -1299,7 +1299,7 @@ class PsTestCase(TestCase, LoaderModuleMockMixin):
                 4,
                 5,
                 "/bin/echo NOT A DROID",
-                "WERE YOU LOOKING FOR ME?",
+                comment = "WERE YOU LOOKING FOR ME?",
             )
             expected_call = call(
                 "DUMMY_USER",
@@ -1310,7 +1310,9 @@ class PsTestCase(TestCase, LoaderModuleMockMixin):
                     "1 2 3 4 5 /bin/echo NOT A DROID\n",
                 ],
             )
-            cron._write_cron_lines.call_args.assert_called_with(expected_call)
+            cron._write_cron_lines.assert_has_calls(
+                (expected_call,), any_order=True
+            )
 
     def test_rm_special(self):
         with patch.dict(cron.__grains__, {"os": None}), patch(

--- a/tests/unit/modules/test_cron.py
+++ b/tests/unit/modules/test_cron.py
@@ -40,6 +40,11 @@ STUB_AT_SIGN = """
 @daily echo "cron with @ sign"
 @daily
 """
+STUB_NO_AT_SIGN = """
+# Lines below here are managed by Salt, do not edit
+# SALT_CRON_IDENTIFIER:echo "cron without @ sign"
+1 2 3 4 5 echo "cron without @ sign"
+"""
 
 L = "# Lines below here are managed by Salt, do not edit\n"
 
@@ -1259,6 +1264,31 @@ class PsTestCase(TestCase, LoaderModuleMockMixin):
                 (expected_write_call,), any_order=True
             )
 
+    def test_set_special_from_job(self):
+        """Use set_special to turn a non-special entry into a special one"""
+        with patch.dict(cron.__grains__, {"os": None}), patch(
+            "salt.modules.cron._write_cron_lines",
+            new=MagicMock(return_value={"retcode": False}),
+        ), patch(
+            "salt.modules.cron.raw_cron",
+            new=MagicMock(side_effect=[STUB_NO_AT_SIGN, STUB_NO_AT_SIGN, L]),
+        ):
+            expected_call = call(
+                "DUMMY_USER",
+                [
+                    "# Lines below here are managed by Salt, do not edit\n",
+                    '# SALT_CRON_IDENTIFIER:echo "cron without @ sign"\n',
+                    '@daily echo "cron without @ sign"\n',
+                ],
+            )
+            ret = cron.set_special(
+                "DUMMY_USER",
+                "@daily",
+                'echo "cron without @ sign"',
+                identifier='echo "cron without @ sign"',
+            )
+            cron._write_cron_lines.assert_has_calls((expected_call,), any_order=True)
+
     def test__get_cron_date_time(self):
         ret = cron._get_cron_date_time(
             minute=STUB_CRON_TIMESTAMP["minute"],
@@ -1299,7 +1329,7 @@ class PsTestCase(TestCase, LoaderModuleMockMixin):
                 4,
                 5,
                 "/bin/echo NOT A DROID",
-                comment = "WERE YOU LOOKING FOR ME?",
+                comment="WERE YOU LOOKING FOR ME?",
             )
             expected_call = call(
                 "DUMMY_USER",
@@ -1310,9 +1340,36 @@ class PsTestCase(TestCase, LoaderModuleMockMixin):
                     "1 2 3 4 5 /bin/echo NOT A DROID\n",
                 ],
             )
-            cron._write_cron_lines.assert_has_calls(
-                (expected_call,), any_order=True
+            cron._write_cron_lines.assert_has_calls((expected_call,), any_order=True)
+
+    def test_set_job_from_special(self):
+        """Use set_job to turn a special entry into a non-special one"""
+        with patch.dict(cron.__grains__, {"os": None}), patch(
+            "salt.modules.cron._write_cron_lines",
+            new=MagicMock(return_value={"retcode": False}),
+        ), patch(
+            "salt.modules.cron.raw_cron",
+            new=MagicMock(side_effect=[STUB_AT_SIGN, STUB_AT_SIGN, L]),
+        ):
+            cron.set_job(
+                "DUMMY_USER",
+                1,
+                2,
+                3,
+                4,
+                5,
+                'echo "cron with @ sign"',
+                identifier='echo "cron with @ sign"',
             )
+            expected_call = call(
+                "DUMMY_USER",
+                [
+                    "# Lines below here are managed by Salt, do not edit\n",
+                    '# SALT_CRON_IDENTIFIER:echo "cron with @ sign"\n',
+                    '1 2 3 4 5 echo "cron with @ sign"\n',
+                ],
+            )
+            cron._write_cron_lines.assert_has_calls((expected_call,), any_order=True)
 
     def test_rm_special(self):
         with patch.dict(cron.__grains__, {"os": None}), patch(


### PR DESCRIPTION

### What does this PR do?

Previously when changing a cron.present job from using a normal time
specification to special or vice-versa, it would duplicate the entry in
the crontab.

### What issues does this PR fix or reference?
Fixes: #60997

### Previous Behavior
cron.present would duplicate cron jobs when changing timespec from non-special to special

### New Behavior
cron.present will delete the old non-special cronjob when creating a special one with the same identifier

### Merge requirements satisfied?
- [N/A] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes