### PR TITLE
Fix #61003 yumpkg fail

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2122,12 +2122,11 @@ def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=W0613
 
     for target in pkg_params:
         version_to_remove = pkg_params[target]
-        installed_versions = old[target].split(",")
 
         # Check if package version set to be removed is actually installed:
         if target in old and not version_to_remove:
             targets.append(target)
-        elif target in old and version_to_remove in installed_versions:
+        elif target in old and version_to_remove in old[target].split(","):
             arch = ""
             pkgname = target
             try:


### PR DESCRIPTION
### What does this PR do?

#### What issues does this PR fix or reference?
Fixes: #61003 

### Previous Behavior

A bug was introduced for yumpk in 3004rc1 where trying to remove a non-existent package would throw a KeyError instead of just work, like before.

### New Behavior

This PR restores the original behavior, along with adding a test to ensure that this bug will be detected if it's ever re-introduced.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
~- [ ] Docs~
~- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html~ - this bug wasn't *really* released, I don't think it needs a changelog but that opinion is weakly held.
- [x] Tests written/updated

### Commits signed with GPG?
Yes