### PR TITLE
docs(version_numbers): add more codenames and code link [skip ci]

### DIFF
--- a/doc/topics/releases/version_numbers.rst
+++ b/doc/topics/releases/version_numbers.rst
@@ -45,6 +45,15 @@ Assigned codenames:
 - Sodium: ``3001``
 - Magnesium: ``3002``
 - Aluminium: ``3003``
+- Silicon: ``3004``
+- Phosphorus: ``3005``
+- Sulfur: ``3006``
+- Chlorine:  ``3007``
+- Argon: ``3008``
+- Potassium: ``3009``
+
+The complete list of upcoming codenames is available in the
+`source code <https://github.com/saltstack/salt/blob/76e50885b07621e9e4c16bc3f1ebc16c93983b90/salt/version.py#L65-L182>`_.
 
 Example
 -------


### PR DESCRIPTION
### What does this PR do?

The current list of codename examples only covers up to `Aluminium: 3003` so extend that a little further.  Also provide a link to the code itself, for the complete list of codename version numbers.

### What issues does this PR fix or reference?

Not a GitHub issue but responding to a comment [in Slack](https://saltstackcommunity.slack.com/archives/CRJPRHHT3/p1633594507067600).