### PR TITLE
Fix salt ssh's extra-filerefs 

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1133,6 +1133,7 @@ class Single:
             opts_pkg["_ssh_version"] = self.opts["_ssh_version"]
             opts_pkg["thin_dir"] = self.opts["thin_dir"]
             opts_pkg["master_tops"] = self.opts["master_tops"]
+            opts_pkg["extra_filerefs"] = self.opts.get("extra_filerefs", "")
             opts_pkg["__master_opts__"] = self.context["master_opts"]
             if "known_hosts_file" in self.opts:
                 opts_pkg["known_hosts_file"] = self.opts["known_hosts_file"]

--- a/tests/pytests/integration/ssh/test_state.py
+++ b/tests/pytests/integration/ssh/test_state.py
@@ -45,3 +45,50 @@ def test_state_with_import(salt_ssh_cli, state_tree):
     ret = salt_ssh_cli.run("state.sls", "test")
     assert ret.exitcode == 0
     assert ret.json
+
+
+@pytest.fixture
+def nested_state_tree(base_env_state_tree_root_dir, tmpdir):
+    top_file = """
+    base:
+      'localhost':
+        - basic
+      '127.0.0.1':
+        - basic
+    """
+    state_file = """
+    /{}/file.txt:
+      file.managed:
+        - source: salt://foo/file.jinja
+        - template: jinja
+    """.format(
+        tmpdir
+    )
+    file_jinja = """
+    {% from 'foo/map.jinja' import comment %}{{ comment }}
+    """
+    map_file = """
+    {% set comment = "blah blah" %}
+    """
+    statedir = base_env_state_tree_root_dir / "foo"
+    top_tempfile = pytest.helpers.temp_file(
+        "top.sls", top_file, base_env_state_tree_root_dir
+    )
+    map_tempfile = pytest.helpers.temp_file("map.jinja", map_file, statedir)
+    file_tempfile = pytest.helpers.temp_file("file.jinja", file_jinja, statedir)
+    state_tempfile = pytest.helpers.temp_file("init.sls", state_file, statedir)
+
+    with top_tempfile, map_tempfile, state_tempfile, file_tempfile:
+        yield
+
+
+@pytest.mark.slow_test
+def test_state_with_import_from_dir(salt_ssh_cli, nested_state_tree):
+    """
+    verify salt-ssh can use imported map files in states
+    """
+    ret = salt_ssh_cli.run(
+        "--extra-filerefs=salt://foo/map.jinja", "state.apply", "foo"
+    )
+    assert ret.exitcode == 0
+    assert ret.json


### PR DESCRIPTION
### What does this PR do?

- Fix salt-ssh extra-filerefs
- Add a test for salt-ssh when extra-filerefs is needed.

 ### What issues does this PR fix or reference?
Fixes: #60003

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog ** SEE #60891 **
- [X] Tests written/updated
