### PR TITLE
Reverting service state changes, return changes in pkg state

### DIFF
--- a/changelog/60995.fixed
+++ b/changelog/60995.fixed
@@ -1,0 +1,1 @@
+Reverting changes in PR #60150. Updating installed and removed functions to return changes when test=True.

--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -508,19 +508,6 @@ def running(name, enable=None, sig=None, init_delay=None, **kwargs):
             ret.update(_enable(name, None, **kwargs))
         elif enable is False and before_toggle_enable_status:
             ret.update(_disable(name, None, **kwargs))
-        else:
-            if __opts__["test"]:
-                ret["result"] = None
-                ret["comment"] = "\n".join(
-                    [
-                        _f
-                        for _f in [
-                            "The service {} is set to restart".format(name),
-                            unmask_ret["comment"],
-                        ]
-                        if _f
-                    ]
-                )
         return ret
 
     # Run the tests

--- a/tests/pytests/unit/states/test_service.py
+++ b/tests/pytests/unit/states/test_service.py
@@ -244,7 +244,7 @@ def test_running():
 
         with patch.dict(service.__opts__, {"test": True}):
             with patch.dict(service.__salt__, {"service.status": tmock}):
-                assert service.running("salt") == ret[10]
+                assert service.running("salt") == ret[5]
 
             with patch.dict(service.__salt__, {"service.status": fmock}):
                 assert service.running("salt") == ret[3]


### PR DESCRIPTION
### What does this PR do?
Reverting changes in PR #60150. Updating installed and removed functions to return changes when test=True.

### What issues does this PR fix or reference?
Fixes: #60995 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
