### PR TITLE
Update changelog and release notes for 3004

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versions are `MAJOR.PATCH`.
 
 # Changelog
 
-Salt 3004 (2021-09-28)
+Salt 3004 (2021-10-07)
 ======================
 
 
@@ -42,6 +42,7 @@ Changed
 Fixed
 -----
 
+- Handle signals and properly exit, instead of raising exceptions. (#60391, #60963)
 - Redirect imports of ``salt.ext.six`` to ``six`` (#60966)
 - Surface strerror to user state instead of returning false (#20789)
 - Fixing _get_envs() to preserve the order of pillar_roots. _get_envs() returned pillar_roots in a non-deterministic order. (#24501)
@@ -305,7 +306,7 @@ Fixed
   valid if Powershell 7 is installed on the system. (#58598)
 - Fixed the zabbix.host_create call on zabbix_host.present to include the
   optional parameter visible_name. Now working as documented. (#58602)
-- Fixed some bugs to allow zabbix_host.present to update a host already 
+- Fixed some bugs to allow zabbix_host.present to update a host already
   existent on Zabbix server:
 
   - Added checks before "pop" the elements "bulk" and "details" from
@@ -313,8 +314,8 @@ Fixed
     didn't works with Zabbix >= 5.0
   - Fixed the "inventory" comparison. It failed when both current and new
     inventory were missing.
-  - Rewrite of the update_interfaces routine to really "update" the 
-    interfaces and not trying to delete and recreate all interfaces, 
+  - Rewrite of the update_interfaces routine to really "update" the
+    interfaces and not trying to delete and recreate all interfaces,
     which almost always gives errors as interfaces with linked items
     can't be deleted. (#58603)
 - Added the "details" mandatory object with the properly default values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Changed
 Fixed
 -----
 
+- Set default 'bootstrap_delay' to 0 (#61005)
 - Fixed issue where multiple args to netapi were not preserved (#59182)
 - Handle all repo formats in the aptpkg module. (#60971)
 - Do not break master_tops for minion with version lower to 3003

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,8 @@ Versions are `MAJOR.PATCH`.
 
 # Changelog
 
-Salt 3004 (2021-10-07)
+Salt 3004 (2021-10-11)
 ======================
-
 
 Removed
 -------
@@ -24,6 +23,7 @@ Removed
 Deprecated
 ----------
 
+- The _ext_nodes alias to the master_tops function was added back in 3004 to maintain backwards compatibility with older supported versions. This alias will now be removed in 3006. This change will break Master and Minion communication compatibility with Salt minions running versions 3003 and lower. (#60980)
 - utils/boto3_elasticsearch is no longer needed (#59882)
 - Changed "manufacture" grain to "manufacturer" for Solaris on SPARC to unify the name across all platforms. The old "manufacture" grain is now deprecated and will be removed in Sulfur (#60511)
 - Deprecate `salt.payload.Serial` (#60953)
@@ -42,6 +42,11 @@ Changed
 Fixed
 -----
 
+- Fixed issue where multiple args to netapi were not preserved (#59182)
+- Handle all repo formats in the aptpkg module. (#60971)
+- Do not break master_tops for minion with version lower to 3003
+  This is going to be removed in Salt 3006 (Sulfur) (#60980)
+- Reverting changes in PR #60150. Updating installed and removed functions to return changes when test=True. (#60995)
 - Handle signals and properly exit, instead of raising exceptions. (#60391, #60963)
 - Redirect imports of ``salt.ext.six`` to ``six`` (#60966)
 - Surface strerror to user state instead of returning false (#20789)

--- a/changelog/59182.fixed
+++ b/changelog/59182.fixed
@@ -1,1 +1,0 @@
-fixed issue where multiple args to netapi were not preserved

--- a/changelog/60391.fixed
+++ b/changelog/60391.fixed
@@ -1,1 +1,0 @@
-Handle signals and properly exit, instead of raising exceptions.

--- a/changelog/60963.fixed
+++ b/changelog/60963.fixed
@@ -1,1 +1,0 @@
-Handle signals and properly exit, instead of raising exceptions.

--- a/changelog/60971.fixed
+++ b/changelog/60971.fixed
@@ -1,1 +1,0 @@
-Handle all repo formats in the aptpkg module.

--- a/changelog/60980.deprecated
+++ b/changelog/60980.deprecated
@@ -1,1 +1,0 @@
-The _ext_nodes alias to the master_tops function was added back in 3004 to maintain backwards compatibility with older supported versions. This alias will now be removed in 3006. This change will break Master and Minion communication compatibility with Salt minions running versions 3003 and lower.

--- a/changelog/60980.fixed
+++ b/changelog/60980.fixed
@@ -1,2 +1,0 @@
-Do not break master_tops for minion with version lower to 3003
-This is going to be removed in Salt 3006 (Sulfur)

--- a/changelog/60995.fixed
+++ b/changelog/60995.fixed
@@ -1,1 +1,0 @@
-Reverting changes in PR #60150. Updating installed and removed functions to return changes when test=True.

--- a/changelog/61005.fixed
+++ b/changelog/61005.fixed
@@ -1,1 +1,0 @@
-Set default 'bootstrap_delay' to 0

--- a/doc/topics/releases/3004.rst
+++ b/doc/topics/releases/3004.rst
@@ -55,6 +55,7 @@ Removed
 Deprecated
 ==========
 
+- The _ext_nodes alias to the master_tops function was added back in 3004 to maintain backwards compatibility with older supported versions. This alias will now be removed in 3006. This change will break Master and Minion communication compatibility with Salt minions running versions 3003 and lower. (#60980)
 - utils/boto3_elasticsearch is no longer needed (#59882)
 - Changed "manufacture" grain to "manufacturer" for Solaris on SPARC to unify the name across all platforms. The old "manufacture" grain is now deprecated and will be removed in Sulfur (#60511)
 - Deprecate ``salt.payload.Serial`` (#60953)
@@ -73,6 +74,12 @@ Changed
 Fixed
 =====
 
+- Fixed issue where multiple args to netapi were not preserved (#59182)
+- Handle all repo formats in the aptpkg module. (#60971)
+- Do not break master_tops for minion with version lower to 3003
+  This is going to be removed in Salt 3006 (Sulfur) (#60980)
+- Reverting changes in PR #60150. Updating installed and removed functions to return changes when test=True. (#60995)
+- Handle signals and properly exit, instead of raising exceptions. (#60391, #60963)
 - Redirect imports of ``salt.ext.six`` to ``six`` (#60966)
 - Surface strerror to user state instead of returning false (#20789)
 - Fixing _get_envs() to preserve the order of pillar_roots. _get_envs() returned pillar_roots in a non-deterministic order. (#24501)

--- a/doc/topics/releases/3004.rst
+++ b/doc/topics/releases/3004.rst
@@ -74,6 +74,7 @@ Changed
 Fixed
 =====
 
+- Set default 'bootstrap_delay' to 0 (#61005)
 - Fixed issue where multiple args to netapi were not preserved (#59182)
 - Handle all repo formats in the aptpkg module. (#60971)
 - Do not break master_tops for minion with version lower to 3003


### PR DESCRIPTION
### What does this PR do?
This PR includes the latest updates to the Changelog and the release notes as of October 11, 2021.