### PR TITLE
allow operations on held/versionlocked packages

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1715,10 +1715,7 @@ def install(
             if pkgname in holds:
                 if update_holds:
                     to_unhold[pkgname] = pkgstr
-                else:
-                    unhold_prevented.append(pkgname)
-            else:
-                targets.append(pkgstr)
+            targets.append(pkgstr)
 
         if not to_unhold:
             yield
@@ -1729,10 +1726,7 @@ def install(
                 # longer returns a list in python3.
                 unhold_names = list(to_unhold.keys())
                 for unheld_pkg, outcome in unhold(pkgs=unhold_names).items():
-                    if outcome["result"]:
-                        # Package was successfully unheld, add to targets
-                        targets.append(to_unhold[unheld_pkg])
-                    else:
+                    if not outcome["result"]:
                         # Failed to unhold package
                         errors.append(unheld_pkg)
                 yield
@@ -1796,15 +1790,6 @@ def install(
             ret.update(
                 {pkgname: {"old": old.get(pkgname, ""), "new": new.get(pkgname, "")}}
             )
-
-    if unhold_prevented:
-        errors.append(
-            "The following package(s) could not be updated because they are "
-            "being held: {}. Set 'update_holds' to True to temporarily "
-            "unhold these packages so that they can be updated.".format(
-                ", ".join(unhold_prevented)
-            )
-        )
 
     if errors:
         raise CommandExecutionError(


### PR DESCRIPTION
### What does this PR do?
Allows installation/removal/reinstallation of packages that are versionlocked 

### What issues does this PR fix or reference?
N/A

### Previous Behavior
Attempting to install (remove or reinstall) a versionlocked package, even if the version matched the versionlock would fail.

### New Behavior
Attempts to install, remove or reinstall a versionlocked package will be allowed to proceed and will rely on yum to determine if the operation is allowed.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
