### PR TITLE
[Documentation] Add missing job_name to schedule.job_status example

### DIFF
--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -1347,7 +1347,7 @@ def job_status(name):
 
     .. code-block:: bash
 
-        salt '*' schedule.job_status
+        salt '*' schedule.job_status job_name
 
     """
 


### PR DESCRIPTION
The module `schedule.job_status` requires a job name, but the example does not mention that.