### PR TITLE
doc: Exclude documentation_options.js from default theme

### DIFF
--- a/doc/_themes/saltstack/layout.html
+++ b/doc/_themes/saltstack/layout.html
@@ -21,6 +21,7 @@
 
 {# Remove old version of jQuery #}
 {% set js_blacklist = [
+    '_static/documentation_options.js',
     '_static/jquery.js',
 ] %}
 


### PR DESCRIPTION
`documentation_options.js` from the default theme sets the option `URL_ROOT` to:

```
document.getElementById("documentation_options").getAttribute('data-url_root')
```

This requires that the script element for `documentation_options.js` includes the tag `id="documentation_options"` and sets the
`data-url_root` tag. Otherwise evaluating `URL_ROOT` will fail and building the documentation during the Debian package build will fail:

```
dh_sphinxdoc: error: DOCUMENTATION_OPTIONS does not define URL_ROOT
```

The variable `DOCUMENTATION_OPTIONS` is directly set `layout.html` and  therefore `documentation_options.js` does not need to be included. So just exclude it.
