### PR TITLE
Support sphinx 4.2

### DIFF
--- a/doc/_themes/saltstack/layout.html
+++ b/doc/_themes/saltstack/layout.html
@@ -74,9 +74,14 @@
         var DOCUMENTATION_OPTIONS = {
             URL_ROOT:    '{{ url_root }}',
             VERSION:     '{{ release|e }}',
+            LANGUAGE: '{{ language }}',
             COLLAPSE_INDEX: false,
+            BUILDER: '{{ builder }}',
             FILE_SUFFIX: '{{ '' if no_search_suffix else file_suffix }}',
-            HAS_SOURCE:  {{ has_source|lower }}
+            LINK_SUFFIX: '{{ link_suffix }}',
+            HAS_SOURCE: {{ has_source|lower }},
+            SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}',
+            NAVIGATION_WITH_KEYS: {{ 'true' if theme_navigation_with_keys|tobool else 'false'}}
         };
     </script>
     {%- for scriptfile in script_files %}


### PR DESCRIPTION
Add the sphinx documentation options provided by sphinx 4.2. Otherwise the search will produce URLs with `undefined` instead of `.html`:

```
ref/states/all/salt.states.fileundefined?highlight=file#module-salt.states.file
```