### PR TITLE
Call beacon validation earlier

### DIFF
--- a/changelog/60838.fixed
+++ b/changelog/60838.fixed
@@ -1,0 +1,1 @@
+Moving the call to the validate function earlier to ensure that beacons are in the right format before we attempt to do anything to the configuration.  Adding a generic validation to ensure the beacon configuration is in the wrong format when a validation function does not exist.

--- a/salt/beacons/__init__.py
+++ b/salt/beacons/__init__.py
@@ -71,9 +71,31 @@ class Beacon:
                 beacon_name = current_beacon_config["beacon_module"]
             else:
                 beacon_name = mod
+
+            # Run the validate function if it's available,
+            # otherwise there is a warning about it being missing
+            validate_str = "{}.validate".format(beacon_name)
+            if validate_str in self.beacons:
+                valid, vcomment = self.beacons[validate_str](b_config[mod])
+
+                if not valid:
+                    log.info(
+                        "Beacon %s configuration invalid, not running.\n%s",
+                        mod,
+                        vcomment,
+                    )
+                    continue
+            else:
+                log.warn(
+                    "No validate function found for %s, running basic beacon validation.",
+                    mod,
+                )
+                if not isinstance(b_config[mod], list):
+                    log.info("Configuration for beacon must be a list.")
+                    continue
+
             b_config[mod].append({"_beacon_name": mod})
             fun_str = "{}.beacon".format(beacon_name)
-            validate_str = "{}.validate".format(beacon_name)
             if fun_str in self.beacons:
                 runonce = self._determine_beacon_config(
                     current_beacon_config, "run_once"
@@ -111,19 +133,6 @@ class Beacon:
                         continue
                 # Update __grains__ on the beacon
                 self.beacons[fun_str].__globals__["__grains__"] = grains
-
-                # Run the validate function if it's available,
-                # otherwise there is a warning about it being missing
-                if validate_str in self.beacons:
-                    valid, vcomment = self.beacons[validate_str](b_config[mod])
-
-                    if not valid:
-                        log.info(
-                            "Beacon %s configuration invalid, not running.\n%s",
-                            mod,
-                            vcomment,
-                        )
-                        continue
 
                 # Fire the beacon!
                 error = None

--- a/salt/beacons/__init__.py
+++ b/salt/beacons/__init__.py
@@ -79,7 +79,7 @@ class Beacon:
                 valid, vcomment = self.beacons[validate_str](b_config[mod])
 
                 if not valid:
-                    log.info(
+                    log.error(
                         "Beacon %s configuration invalid, not running.\n%s",
                         mod,
                         vcomment,
@@ -91,7 +91,7 @@ class Beacon:
                     mod,
                 )
                 if not isinstance(b_config[mod], list):
-                    log.info("Configuration for beacon must be a list.")
+                    log.error("Configuration for beacon must be a list.")
                     continue
 
             b_config[mod].append({"_beacon_name": mod})

--- a/tests/pytests/unit/test_beacons.py
+++ b/tests/pytests/unit/test_beacons.py
@@ -59,10 +59,10 @@ def test_beacon_process_invalid():
     beacon = salt.beacons.Beacon(mock_opts, [])
 
     with patch.object(salt.beacons, "log") as log_mock, patch.object(
-        salt.beacons.log, "info"
-    ) as log_info_mock:
+        salt.beacons.log, "error"
+    ) as log_error_mock:
         ret = beacon.process(mock_opts["beacons"], mock_opts["grains"])
-        log_info_mock.assert_called_with(
+        log_error_mock.assert_called_with(
             "Beacon %s configuration invalid, not running.\n%s",
             "status",
             "Configuration for status beacon must be a list.",
@@ -73,14 +73,14 @@ def test_beacon_process_invalid():
     beacon = salt.beacons.Beacon(mock_opts, [])
 
     with patch.object(salt.beacons.log, "warn") as log_warn_mock, patch.object(
-        salt.beacons.log, "info"
-    ) as log_info_mock:
+        salt.beacons.log, "error"
+    ) as log_error_mock:
         ret = beacon.process(mock_opts["beacons"], mock_opts["grains"])
         log_warn_mock.assert_called_with(
             "No validate function found for %s, running basic beacon validation.",
             "mybeacon",
         )
-        log_info_mock.assert_called_with("Configuration for beacon must be a list.")
+        log_error_mock.assert_called_with("Configuration for beacon must be a list.")
 
 
 def test_beacon_module():

--- a/tests/pytests/unit/test_beacons.py
+++ b/tests/pytests/unit/test_beacons.py
@@ -45,6 +45,44 @@ def test_beacon_process():
     assert ret == _expected
 
 
+def test_beacon_process_invalid():
+    """
+    Test the process function in the beacon class
+    when the configuration is invalid.
+    """
+    mock_opts = salt.config.DEFAULT_MINION_OPTS.copy()
+    mock_opts["id"] = "minion"
+    mock_opts["__role"] = "minion"
+
+    mock_opts["beacons"] = {"status": {}}
+
+    beacon = salt.beacons.Beacon(mock_opts, [])
+
+    with patch.object(salt.beacons, "log") as log_mock, patch.object(
+        salt.beacons.log, "info"
+    ) as log_info_mock:
+        ret = beacon.process(mock_opts["beacons"], mock_opts["grains"])
+        log_info_mock.assert_called_with(
+            "Beacon %s configuration invalid, not running.\n%s",
+            "status",
+            "Configuration for status beacon must be a list.",
+        )
+
+    mock_opts["beacons"] = {"mybeacon": {}}
+
+    beacon = salt.beacons.Beacon(mock_opts, [])
+
+    with patch.object(salt.beacons.log, "warn") as log_warn_mock, patch.object(
+        salt.beacons.log, "info"
+    ) as log_info_mock:
+        ret = beacon.process(mock_opts["beacons"], mock_opts["grains"])
+        log_warn_mock.assert_called_with(
+            "No validate function found for %s, running basic beacon validation.",
+            "mybeacon",
+        )
+        log_info_mock.assert_called_with("Configuration for beacon must be a list.")
+
+
 def test_beacon_module():
     """
     Test that beacon_module parameter for beacon configuration


### PR DESCRIPTION
### What does this PR do?
Moving the call to the validate function earlier to ensure that beacons are in the right format before we attempt to do anything to the configuration.  Adding a generic validation to ensure the beacon configuration is in the wrong format when a validation function does not exist.

### What issues does this PR fix or reference?
Fixes: #60838 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
