### PR TITLE
Fix 'PathDistribution' object has no attribute '_normalized_name' - Issue 61062

### DIFF
--- a/changelog/61062.fixed
+++ b/changelog/61062.fixed
@@ -1,0 +1,1 @@
+Fixed conflict between importlib_metada from Salt and importlib.metadata from Python 3.10

--- a/salt/_compat.py
+++ b/salt/_compat.py
@@ -11,19 +11,23 @@ if sys.version_info >= (3, 9, 5):
 else:
     import salt.ext.ipaddress as ipaddress
 
+if sys.version_info >= (3, 10):
+    # Python 3.10 will include a fix in importlib.metadata which allows us to
+    # get the distribution of a loaded entry-point
+    import importlib.metadata  # pylint: disable=no-member,no-name-in-module
+else:
+    # importlib_metadata before version 3.3.0 does not include the functionality we need.
+    try:
+        import importlib_metadata
 
-# importlib_metadata before version 3.3.0 does not include the functionality we need.
-try:
-    import importlib_metadata
-
-    importlib_metadata_version = [
-        int(part)
-        for part in importlib_metadata.version("importlib_metadata").split(".")
-        if part.isdigit()
-    ]
-    if tuple(importlib_metadata_version) < (3, 3, 0):
+        importlib_metadata_version = [
+            int(part)
+            for part in importlib_metadata.version("importlib_metadata").split(".")
+            if part.isdigit()
+        ]
+        if tuple(importlib_metadata_version) < (3, 3, 0):
+            # Use the vendored importlib_metadata
+            import salt.ext.importlib_metadata as importlib_metadata
+    except ImportError:
         # Use the vendored importlib_metadata
         import salt.ext.importlib_metadata as importlib_metadata
-except ImportError:
-    # Use the vendored importlib_metadata
-    import salt.ext.importlib_metadata as importlib_metadata


### PR DESCRIPTION
### What does this PR do?
`salt/utils/entrypoints.py` was changed to use `importlib.metadata` when Python version is equal or higher than 3.10. For other cases, it uses `importlib_metadata` provided by Salt. But, in `salt/_compat.py` it always uses the `importlib_metadata` from Salt, which causes an exception.

This PR changes `salt/_compat.py` to use the same logic as `salt/utils/entrypoints.py` to choose between `importlib.metadata` or `importlib_metadata`.

### What issues does this PR fix or reference?
Fixes: #61062 

### Previous Behavior
Salt commands execution fails with:
```
Traceback (most recent call last):
  File "/usr/lib64/python3.10/site-packages/salt/utils/parsers.py", line 210, in parse_args
    mixin_after_parsed_func(self)
  File "/usr/lib64/python3.10/site-packages/salt/utils/parsers.py", line 887, in __setup_extended_logging
    log.setup_extended_logging(self.config)
  File "/usr/lib64/python3.10/site-packages/salt/log/setup.py", line 414, in setup_extended_logging
    providers = salt.loader.log_handlers(opts)
  File "/usr/lib64/python3.10/site-packages/salt/loader/__init__.py", line 686, in log_handlers
    _module_dirs(
  File "/usr/lib64/python3.10/site-packages/salt/loader/__init__.py", line 148, in _module_dirs
    for entry_point in entrypoints.iter_entry_points("salt.loader"):
  File "/usr/lib64/python3.10/site-packages/salt/utils/entrypoints.py", line 43, in _wrapped
    return f(*args, **kwargs)
  File "/usr/lib64/python3.10/site-packages/salt/utils/entrypoints.py", line 55, in iter_entry_points
    entry_points = importlib.metadata.entry_points()
  File "/usr/lib64/python3.10/importlib/metadata/__init__.py", line 971, in entry_points
    return SelectableGroups.load(eps).select(**params)
  File "/usr/lib64/python3.10/importlib/metadata/__init__.py", line 429, in load
    ordered = sorted(eps, key=by_group)
  File "/usr/lib64/python3.10/importlib/metadata/__init__.py", line 968, in <genexpr>
    eps = itertools.chain.from_iterable(
  File "/usr/lib64/python3.10/importlib/metadata/_itertools.py", line 16, in unique_everseen
    k = key(element)
AttributeError: 'PathDistribution' object has no attribute '_normalized_name'
```

### New Behavior
Salt commands runs without `AttributeError: 'PathDistribution' object has no attribute '_normalized_name'` error

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No