### PR TITLE
Fix salt-call --local modules without function

### DIFF
--- a/changelog/59331.fixed
+++ b/changelog/59331.fixed
@@ -1,0 +1,1 @@
+Swap ret["retcode"] for ret.get("retcode") in the event that there is no retcode, eg. when a function is not passed with a module.

--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -130,7 +130,7 @@ class BaseCaller:
             # _retcode will be available in the kwargs of the outputter function
             if self.opts.get("retcode_passthrough", False):
                 sys.exit(ret["retcode"])
-            elif ret["retcode"] != salt.defaults.exitcodes.EX_OK:
+            elif ret.get("retcode") != salt.defaults.exitcodes.EX_OK:
                 sys.exit(salt.defaults.exitcodes.EX_GENERIC)
         except SaltInvocationError as err:
             raise SystemExit(err)

--- a/tests/pytests/integration/cli/test_salt_call.py
+++ b/tests/pytests/integration/cli/test_salt_call.py
@@ -412,3 +412,34 @@ def test_salt_call_error(salt_call_cli):
 
     ret = salt_call_cli.run("test.echo", "{foo: bar, result: False}")
     assert ret.exitcode == salt.defaults.exitcodes.EX_GENERIC, ret
+
+
+def test_local_salt_call_no_function_no_retcode(salt_call_cli):
+    """
+    This tests ensures that when salt-call --local is called
+    with a module but without a function the return code is 1
+    and we receive the docs for all module functions.
+
+    Also ensure we don't get an exception.
+    """
+    with pytest.helpers.temp_file() as filename:
+
+        ret = salt_call_cli.run("--local", "test")
+        assert ret.exitcode == 1
+
+        state_run_dict = ret.json
+        assert "test" in state_run_dict
+        assert state_run_dict["test"] == "'test' is not available."
+
+        assert "test.recho" in state_run_dict
+
+        expected = """
+    Return a reversed string
+
+    CLI Example:
+
+        salt '*' test.recho 'foo bar baz quo qux'
+    """
+        a = state_run_dict["test.recho"]
+        b = expected
+        assert state_run_dict["test.recho"] == expected


### PR DESCRIPTION
### What does this PR do?
Swap ret["retcode"] for ret.get("retcode") in the event that there is no retcode, eg. when a function is not passed with a module.

### What issues does this PR fix or reference?
Fixes: #59331 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
