### PR TITLE
Don't pass an object as the default value in a kwarg

### DIFF
--- a/changelog/61084.fixed
+++ b/changelog/61084.fixed
@@ -1,0 +1,1 @@
+sys.argspec now works with pillar.get, vault.read_secret, and vault.list_secrets

--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 
 def get(
     key,
-    default=KeyError,
+    default=None,
     merge=False,
     merge_nested_lists=None,
     delimiter=DEFAULT_TARGET_DELIM,
@@ -122,6 +122,8 @@ def get(
         salt '*' pillar.get pkg:apache
         salt '*' pillar.get abc::def|ghi delimiter='|'
     """
+    if default is None:
+        default = KeyError
     if not __opts__.get("pillar_raise_on_missing"):
         if default is KeyError:
             default = ""

--- a/salt/modules/vault.py
+++ b/salt/modules/vault.py
@@ -183,7 +183,7 @@ from salt.exceptions import CommandExecutionError
 log = logging.getLogger(__name__)
 
 
-def read_secret(path, key=None, metadata=False, default=CommandExecutionError):
+def read_secret(path, key=None, metadata=False, default=None):
     """
     .. versionchanged:: 3001
         The ``default`` argument has been added. When the path or path/key
@@ -211,6 +211,8 @@ def read_secret(path, key=None, metadata=False, default=CommandExecutionError):
             first: {{ supersecret.first }}
             second: {{ supersecret.second }}
     """
+    if default is None:
+        default = CommandExecutionError
     version2 = __utils__["vault.is_v2"](path)
     if version2["v2"]:
         path = version2["data"]
@@ -356,7 +358,7 @@ def destroy_secret(path, *args):
         return False
 
 
-def list_secrets(path, default=CommandExecutionError):
+def list_secrets(path, default=None):
     """
     .. versionchanged:: 3001
         The ``default`` argument has been added. When the path or path/key
@@ -372,6 +374,8 @@ def list_secrets(path, default=CommandExecutionError):
 
             salt '*' vault.list_secrets "secret/my/"
     """
+    if default is None:
+        default = CommandExecutionError
     log.debug("Listing vault secret keys for %s in %s", __grains__["id"], path)
     version2 = __utils__["vault.is_v2"](path)
     if version2["v2"]:

--- a/tests/pytests/functional/modules/test_pillar.py
+++ b/tests/pytests/functional/modules/test_pillar.py
@@ -1,0 +1,21 @@
+import pytest
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+]
+
+
+@pytest.fixture(scope="module")
+def sys_mod(modules):
+    return modules.sys
+
+
+def test_pillar_get_issue_61084(sys_mod):
+    """
+    Test issue 61084. `sys.argspec` should return valid data and not throw a
+    TypeError due to pickling
+    This should probably be a pre-commit check or something
+    """
+    result = sys_mod.argspec("pillar.get")
+    assert isinstance(result, dict)
+    assert isinstance(result.get("pillar.get"), dict)

--- a/tests/pytests/functional/modules/test_vault.py
+++ b/tests/pytests/functional/modules/test_vault.py
@@ -1,0 +1,32 @@
+import pytest
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+]
+
+
+@pytest.fixture(scope="module")
+def sys_mod(modules):
+    return modules.sys
+
+
+def test_vault_read_secret_issue_61084(sys_mod):
+    """
+    Test issue 61084. `sys.argspec` should return valid data and not throw a
+    TypeError due to pickling
+    This should probably be a pre-commit check or something
+    """
+    result = sys_mod.argspec("vault.read_secret")
+    assert isinstance(result, dict)
+    assert isinstance(result.get("vault.read_secret"), dict)
+
+
+def test_vault_list_secrets_issue_61084(sys_mod):
+    """
+    Test issue 61084. `sys.argspec` should return valid data and not throw a
+    TypeError due to pickling
+    This should probably be a pre-commit check or something
+    """
+    result = sys_mod.argspec("vault.list_secrets")
+    assert isinstance(result, dict)
+    assert isinstance(result.get("vault.list_secrets"), dict)


### PR DESCRIPTION
### What does this PR do?
An attempt to fix https://github.com/saltstack/salt/issues/61084
This probably isn't the right fix in that it only fixes the stacktrace when doing `sys.argspec` on the `pillar.get` function. We should probably figure out how to handle this in `salt.utils.args.argspec_report`.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes