### PR TITLE
Restrict state.orchestrate_single to pass a pillar value if it exists

### DIFF
--- a/changelog/61092.fixed
+++ b/changelog/61092.fixed
@@ -1,0 +1,3 @@
+state.orchestrate_single only passes a pillar if it is set to the state
+function. This allows it to be used with state functions that don't accept a
+pillar keyword argument.

--- a/salt/runners/state.py
+++ b/salt/runners/state.py
@@ -150,12 +150,16 @@ def orchestrate_single(fun, name, test=None, queue=False, pillar=None, **kwargs)
 
         salt-run state.orchestrate_single fun=salt.wheel name=key.list_all
     """
-    if pillar is not None and not isinstance(pillar, dict):
-        raise SaltInvocationError("Pillar data must be formatted as a dictionary")
+    if pillar is not None:
+        if isinstance(pillar, dict):
+            kwargs["pillar"] = pillar
+        else:
+            raise SaltInvocationError("Pillar data must be formatted as a dictionary")
+
     __opts__["file_client"] = "local"
     minion = salt.minion.MasterMinion(__opts__)
     running = minion.functions["state.single"](
-        fun, name, test=None, queue=False, pillar=pillar, **kwargs
+        fun, name, test=None, queue=False, **kwargs
     )
     ret = {minion.opts["id"]: running}
     __jid_event__.fire_event({"data": ret, "outputter": "highstate"}, "progress")

--- a/tests/pytests/unit/runners/test_state.py
+++ b/tests/pytests/unit/runners/test_state.py
@@ -1,0 +1,40 @@
+import pytest
+
+from salt.runners import state as state_runner
+from tests.support.mock import Mock, patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {state_runner: {"__opts__": {}, "__jid_event__": Mock()}}
+
+
+def test_orchestrate_single_passes_pillar():
+    """
+    test state.orchestrate_single passes given pillar to state.single
+    """
+    mock_master_minion = Mock()
+    mock_state_single = Mock()
+    mock_master_minion.functions = {"state.single": mock_state_single}
+    mock_master_minion.opts = {"id": "dummy"}
+    test_pillar = {"test_entry": "exists"}
+    with patch("salt.minion.MasterMinion", Mock(return_value=mock_master_minion)):
+        state_runner.orchestrate_single(
+            fun="pillar.get", name="test_entry", pillar=test_pillar
+        )
+        assert mock_state_single.call_args.kwargs["pillar"] == test_pillar
+
+
+def test_orchestrate_single_does_not_pass_none_pillar():
+    """
+    test state.orchestrate_single does not pass pillar=None to state.single
+    """
+    mock_master_minion = Mock()
+    mock_state_single = Mock()
+    mock_master_minion.functions = {"state.single": mock_state_single}
+    mock_master_minion.opts = {"id": "dummy"}
+    with patch("salt.minion.MasterMinion", Mock(return_value=mock_master_minion)):
+        state_runner.orchestrate_single(
+            fun="pillar.get", name="test_entry", pillar=None
+        )
+        assert "pillar" not in mock_state_single.call_args.kwargs


### PR DESCRIPTION
### What does this PR do?

By accepting any kwargs, even if they aren't used, salt.wait_for_event can be used with state.orchestrate_single. The latter passes a "pillar" argument which raises an error without this patch.


### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/61092

### Previous Behavior
```
[root@upstream-master ~]# salt-run state.orchestrate_single fun=salt.wait_for_event name='/salt/minion/*/start' id_list='[minion1]'

Passed invalid arguments: 'pillar' is an invalid keyword argument for 'salt.wait_for_event'

Usage:

    Execute a single state orchestration routine   
   
    .. versionadded:: 2015.5.0   
                                                 
    CLI Example:     

    .. code-block:: bash                                                                   

        salt-run state.orchestrate_single fun=salt.wheel name=key.list_all  
```
### New Behavior
```
[root@upstream-master ~]# salt-run state.orchestrate_single fun=salt.wait_for_event name='/salt/minion/*/start' id_list='[minion1]' 
# waits
```

### Merge requirements satisfied?

- [x] Docs: Just a bug fix, does not need docs changes IMO.
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated: Not yet, old test is not moved to pytest yet. I want to wait for feedback on the fix before migrating the test.

### Commits signed with GPG?
Yes