### PR TITLE
do not limit the version with `--first-parent`

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -599,7 +599,6 @@ def __discover_version(saltstack_version):
                 "describe",
                 "--tags",
                 "--long",
-                "--first-parent",
                 "--match",
                 "v[0-9]*",
                 "--always",
@@ -609,22 +608,6 @@ def __discover_version(saltstack_version):
 
         out, err = process.communicate()
 
-        if process.returncode != 0:
-            # The git version running this might not support --first-parent
-            # Revert to old command
-            process = subprocess.Popen(
-                [
-                    "git",
-                    "describe",
-                    "--tags",
-                    "--long",
-                    "--match",
-                    "v[0-9]*",
-                    "--always",
-                ],
-                **kwargs
-            )
-            out, err = process.communicate()
         out = out.decode().strip()
         err = err.decode().strip()
 


### PR DESCRIPTION
--first-parent is no longer needed now that we do not merge forward from
all old branches.  This will give the correct behavior if we merge
forward the freeze branch into master as a merge commit, and anything
from any older branches is only "merged" forward using cherry-picks.

This reverts 818584994bae167aa94e7b21ba80899eb82eed09

This fixes https://github.com/saltstack/salt/issues/60639 and makes it
so that development builds give more accurate version numbers that sort
more correctly.

The previous behavior was that development builds had versions like
3003rc1+1004.ge811078529-1 after 3004 had already been released.  They
will now have versions like 3004+92.ge17c084cb8 after 3004 has been
released.