### PR TITLE
Only try to get a list of files on directories.

### DIFF
--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -360,11 +360,12 @@ def _file_lists(load, form):
                 if salt.fileserver.is_file_ignored(__opts__, rel_path):
                     continue
                 tgt.add(rel_path)
-                try:
-                    if not os.listdir(abs_path):
-                        ret["empty_dirs"].add(rel_path)
-                except OSError:
-                    log.debug("Unable to list dir: %s", abs_path)
+                if os.path.isdir(abs_path):
+                    try:
+                        if not os.listdir(abs_path):
+                            ret["empty_dirs"].add(rel_path)
+                    except OSError:
+                        log.debug("Unable to list dir: %s", abs_path)
                 if is_link:
                     link_dest = salt.utils.path.readlink(abs_path)
                     log.trace(


### PR DESCRIPTION
### What does this PR do?

This reduces the amount of log messages introduced in 40af4ff09861d36ddb923f0bb441d0df8d9e4bd0, for example:
```
18:07:56,207 [salt.loaded.int.fileserver.roots                                                      :367 ][DEBUG   ][MWorker-1(1301)] [SaltMaster(id='master-4vVzD3')] Unable to list dir: /home/vampas/projects/Salt
Stack/salt/hotfix/netapi-pytest/tests/integration/files/file/base/win/repo-ng/putty.sls
18:07:56,207 [salt.loaded.int.fileserver.roots                                                      :367 ][DEBUG   ][MWorker-1(1301)] [SaltMaster(id='master-4vVzD3')] Unable to list dir: /home/vampas/projects/Salt
Stack/salt/hotfix/netapi-pytest/tests/integration/files/file/base/x509_compound_match/gen_ca.sls
18:07:56,208 [salt.loaded.int.fileserver.roots                                                      :367 ][DEBUG   ][MWorker-1(1301)] [SaltMaster(id='master-4vVzD3')] Unable to list dir: /home/vampas/projects/Salt
Stack/salt/hotfix/netapi-pytest/tests/integration/files/file/base/x509_compound_match/check.sls
18:07:56,209 [salt.loaded.int.fileserver.roots                                                      :367 ][DEBUG   ][MWorker-1(1301)] [SaltMaster(id='master-4vVzD3')] Unable to list dir: /home/vampas/projects/Salt
Stack/salt/hotfix/netapi-pytest/tests/integration/files/file/base/templates/hello_include
18:07:56,209 [salt.loaded.int.fileserver.roots                                                      :367 ][DEBUG   ][MWorker-1(1301)] [SaltMaster(id='master-4vVzD3')] Unable to list dir: /home/vampas/projects/Salt
Stack/salt/hotfix/netapi-pytest/tests/integration/files/file/base/templates/macroerror
18:07:56,210 [salt.loaded.int.fileserver.roots                                                      :367 ][DEBUG   ][MWorker-1(1301)] [SaltMaster(id='master-4vVzD3')] Unable to list dir: /home/vampas/projects/Salt
Stack/salt/hotfix/netapi-pytest/tests/integration/files/file/base/templates/hello_import_error
18:07:56,210 [salt.loaded.int.fileserver.roots                                                      :367 ][DEBUG   ][MWorker-1(1301)] [SaltMaster(id='master-4vVzD3')] Unable to list dir: /home/vampas/projects/Salt
Stack/salt/hotfix/netapi-pytest/tests/integration/files/file/base/templates/hello_import_generalerror
18:07:56,211 [salt.loaded.int.fileserver.roots                                                      :367 ][DEBUG   ][MWorker-1(1301)] [SaltMaster(id='master-4vVzD3')] Unable to list dir: /home/vampas/projects/Salt
Stack/salt/hotfix/netapi-pytest/tests/integration/files/file/base/templates/hello_import_undefined
18:07:56,211 [salt.loaded.int.fileserver.roots                                                      :367 ][DEBUG   ][MWorker-1(1301)] [SaltMaster(id='master-4vVzD3')] Unable to list dir: /home/vampas/projects/Salt
Stack/salt/hotfix/netapi-pytest/tests/integration/files/file/base/templates/hello_import
18:07:56,212 [salt.loaded.int.fileserver.roots                                                      :367 ][DEBUG   ][MWorker-1(1301)] [SaltMaster(id='master-4vVzD3')] Unable to list dir: /home/vampas/projects/Salt
Stack/salt/hotfix/netapi-pytest/tests/integration/files/file/base/templates/macroundefined
18:07:56,212 [salt.loaded.int.fileserver.roots                                                      :367 ][DEBUG   ][MWorker-1(1301)] [SaltMaster(id='master-4vVzD3')] Unable to list dir: /home/vampas/projects/Salt
Stack/salt/hotfix/netapi-pytest/tests/integration/files/file/base/templates/macro
18:07:56,213 [salt.loaded.int.fileserver.roots                                                      :367 ][DEBUG   ][MWorker-1(1301)] [SaltMaster(id='master-4vVzD3')] Unable to list dir: /home/vampas/projects/Salt
Stack/salt/hotfix/netapi-pytest/tests/integration/files/file/base/templates/hello_simple
18:07:56,213 [salt.loaded.int.fileserver.roots                                                      :367 ][DEBUG   ][MWorker-1(1301)] [SaltMaster(id='master-4vVzD3')] Unable to list dir: /home/vampas/projects/Salt
Stack/salt/hotfix/netapi-pytest/tests/integration/files/file/base/templates/non_ascii
18:07:56,213 [salt.loaded.int.fileserver.roots                                                      :367 ][DEBUG   ][MWorker-1(1301)] [SaltMaster(id='master-4vVzD3')] Unable to list dir: /home/vampas/projects/Salt
Stack/salt/hotfix/netapi-pytest/tests/integration/files/file/base/templates/macrogeneral
```
