### PR TITLE
Fix 'BuildoutOnlineTestCase' has no attribute 'ppy'

### DIFF
--- a/tests/unit/modules/test_zcbuildout.py
+++ b/tests/unit/modules/test_zcbuildout.py
@@ -353,7 +353,7 @@ class BuildoutOnlineTestCase(Base):
             )
         except subprocess.CalledProcessError:
             subprocess.check_call(
-                [salt.utils.path.which_bin(KNOWN_VIRTUALENV_BINARY_NAMES), cls.ppy.dis]
+                [salt.utils.path.which_bin(KNOWN_VIRTUALENV_BINARY_NAMES), cls.ppy_dis]
             )
 
             url = (


### PR DESCRIPTION
The setup of `BuildoutOnlineTestCase.test_buildout_bootstrap` fails:

```
AttributeError: type object 'BuildoutOnlineTestCase' has no attribute 'ppy'
```