### PR TITLE
Fix Windows minion 'Failed to open log file'

### DIFF
--- a/changelog/61113.fixed
+++ b/changelog/61113.fixed
@@ -1,0 +1,1 @@
+Fixed v3004 windows minion failing to open log file at C:\ProgramData\Salt Project\Salt\var\log\salt\minion

--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -676,7 +676,7 @@ Section "MainSection" SEC01
     CreateDirectory "$RootDir\conf\minion.d"
     CreateDirectory "$RootDir\var\cache\salt\minion\extmods\grains"
     CreateDirectory "$RootDir\var\cache\salt\minion\proc"
-    CreateDirectory "$RootDir\var\log\salt\minion"
+    CreateDirectory "$RootDir\var\log\salt"
     CreateDirectory "$RootDir\var\run"
     File /r "..\buildenv\"
     nsExec::Exec 'icacls $RootDir /inheritance:r /grant:r "*S-1-5-32-544":(OI)(CI)F /grant:r "*S-1-5-18":(OI)(CI)F'


### PR DESCRIPTION
### What does this PR do?
Changes the windows minion installer from creating directory "$RootDir\var\log\salt\minion" to "$RootDir\var\log\salt".

### What issues does this PR fix or reference?
Fixes: #61113

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
