### PR TITLE
Add support for get IP-address from agent

### DIFF
--- a/changelog/61146.added
+++ b/changelog/61146.added
@@ -1,0 +1,1 @@
+Add support for retrieve IP-address from qemu agent by Salt-cloud on Proxmox

--- a/doc/topics/cloud/proxmox.rst
+++ b/doc/topics/cloud/proxmox.rst
@@ -245,6 +245,9 @@ QEMU profile file (for a clone):
     # Workaround https://github.com/saltstack/salt/issues/27821
     size: ''
 
+    # Enable the use of a Qemu agent on VM to retrieve the IP-address from.
+    agent_get_ip: True
+
 More information can be found on Proxmox API under the 'POST' method of /nodes/{node}/qemu/{vmid}/clone
 
 .. note::

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -29,6 +29,7 @@ Set up the cloud configuration at ``/etc/salt/cloud.providers`` or
 import logging
 import pprint
 import re
+import socket
 import time
 
 import salt.config as config
@@ -674,17 +675,20 @@ def create(vm_):
     host = data["node"]  # host which we have received
     nodeType = data["technology"]  # VM tech (Qemu / OpenVZ)
 
-    # Determine which IP to use in order of preference:
-    if "ip_address" in vm_:
-        ip_address = str(vm_["ip_address"])
-    elif "public_ips" in data:
-        ip_address = str(data["public_ips"][0])  # first IP
-    elif "private_ips" in data:
-        ip_address = str(data["private_ips"][0])  # first IP
-    else:
-        raise SaltCloudExecutionFailure("Could not determine an IP address to use")
+    agent_get_ip = vm_.get("agent_get_ip", False)
 
-    log.debug("Using IP address %s", ip_address)
+    if agent_get_ip is False:
+        # Determine which IP to use in order of preference:
+        if "ip_address" in vm_:
+            ip_address = str(vm_["ip_address"])
+        elif "public_ips" in data:
+            ip_address = str(data["public_ips"][0])  # first IP
+        elif "private_ips" in data:
+            ip_address = str(data["private_ips"][0])  # first IP
+        else:
+            raise SaltCloudExecutionFailure("Could not determine an IP address to use")
+
+        log.debug("Using IP address %s", ip_address)
 
     # wait until the vm has been created so we can start it
     if not wait_for_created(data["upid"], timeout=300):
@@ -702,6 +706,22 @@ def create(vm_):
     log.debug('Waiting for state "running" for vm %s on %s', vmid, host)
     if not wait_for_state(vmid, "running"):
         return {"Error": "Unable to start {}, command timed out".format(name)}
+
+    if agent_get_ip is True:
+        try:
+            ip_address = salt.utils.cloud.wait_for_fun(
+                _find_agent_ip, vm_=vm_, vmid=vmid
+            )
+        except (SaltCloudExecutionTimeout, SaltCloudExecutionFailure) as exc:
+            try:
+                # If VM was created but we can't connect, destroy it.
+                destroy(vm_["name"])
+            except SaltCloudSystemExit:
+                pass
+            finally:
+                raise SaltCloudSystemExit(str(exc))
+
+        log.debug("Using IP address %s", ip_address)
 
     ssh_username = config.get_cloud_config_value(
         "ssh_username", vm_, __opts__, default="root"
@@ -735,6 +755,87 @@ def create(vm_):
     )
 
     return ret
+
+
+def preferred_ip(vm_, ips):
+    """
+    Return either an 'ipv4' (default) or 'ipv6' address depending on 'protocol' option.
+    The list of 'ipv4' IPs is filtered by ignore_cidr() to remove any unreachable private addresses.
+    """
+    proto = config.get_cloud_config_value(
+        "protocol", vm_, __opts__, default="ipv4", search_global=False
+    )
+
+    family = socket.AF_INET
+    if proto == "ipv6":
+        family = socket.AF_INET6
+    for ip in ips:
+        ignore_ip = ignore_cidr(vm_, ip)
+        if ignore_ip:
+            continue
+        try:
+            socket.inet_pton(family, ip)
+            return ip
+        except Exception:  # pylint: disable=broad-except
+            continue
+    return False
+
+
+def ignore_cidr(vm_, ip):
+    """
+    Return True if we are to ignore the specified IP.
+    """
+    from ipaddress import ip_address, ip_network
+
+    cidrs = config.get_cloud_config_value(
+        "ignore_cidr", vm_, __opts__, default=[], search_global=False
+    )
+    if cidrs and isinstance(cidrs, str):
+        cidrs = [cidrs]
+    for cidr in cidrs or []:
+        if ip_address(ip) in ip_network(cidr):
+            log.warning("IP %r found within %r; ignoring it.", ip, cidr)
+            return True
+
+    return False
+
+
+def _find_agent_ip(vm_, vmid):
+    """
+    If VM is started we would return the IP-addresses that are returned by the qemu agent on the VM.
+    """
+
+    # This functionality is only available on qemu
+    if not vm_.get("technology") == "qemu":
+        log.warning("Find agent IP is only available under `qemu`")
+        return
+
+    # Create an empty list of IP-addresses:
+    ips = []
+
+    endpoint = "nodes/{}/qemu/{}/agent/network-get-interfaces".format(vm_["host"], vmid)
+    interfaces = query("get", endpoint)
+
+    # If we get a result from the agent, parse it
+    for interface in interfaces["result"]:
+
+        # Skip interface if hardware-address is 00:00:00:00:00:00 (loopback interface)
+        if str(interface.get("hardware-address")) == "00:00:00:00:00:00":
+            continue
+
+        # Skip entries without ip-addresses information
+        if "ip-addresses" not in interface:
+            continue
+
+        for if_addr in interface["ip-addresses"]:
+            ip_addr = if_addr.get("ip-address")
+            if ip_addr is not None:
+                ips.append(str(ip_addr))
+
+    if len(ips) > 0:
+        return preferred_ip(vm_, ips)
+
+    raise SaltCloudExecutionFailure
 
 
 def _import_api():

--- a/tests/unit/cloud/clouds/test_proxmox.py
+++ b/tests/unit/cloud/clouds/test_proxmox.py
@@ -139,6 +139,59 @@ class ProxmoxTest(TestCase, LoaderModuleMockMixin):
             )
             assert result == {}
 
+    def test_find_agent_ips(self):
+        """
+        Test find_agent_ip will return an IP
+        """
+
+        with patch(
+            "salt.cloud.clouds.proxmox.query",
+            return_value={
+                "result": [
+                    {
+                        "name": "eth0",
+                        "ip-addresses": [
+                            {"ip-address": "1.2.3.4", "ip-address-type": "ipv4"},
+                            {"ip-address": "2001::1:2", "ip-address-type": "ipv6"},
+                        ],
+                    },
+                    {
+                        "name": "eth1",
+                        "ip-addresses": [
+                            {"ip-address": "2.3.4.5", "ip-address-type": "ipv4"},
+                        ],
+                    },
+                    {
+                        "name": "dummy",
+                    },
+                ]
+            },
+        ) as mock_query:
+            vm_ = {
+                "technology": "qemu",
+                "host": "myhost",
+                "driver": "proxmox",
+                "ignore_cidr": "1.0.0.0/8",
+            }
+
+            # CASE 1: Test ipv4 and ignore_cidr
+            result = proxmox._find_agent_ip(vm_, ANY)
+            mock_query.assert_any_call(
+                "get", "nodes/myhost/qemu/{}/agent/network-get-interfaces".format(ANY)
+            )
+
+            assert result == "2.3.4.5"
+
+            # CASE 2: Test ipv6
+
+            vm_["protocol"] = "ipv6"
+            result = proxmox._find_agent_ip(vm_, ANY)
+            mock_query.assert_any_call(
+                "get", "nodes/myhost/qemu/{}/agent/network-get-interfaces".format(ANY)
+            )
+
+            assert result == "2001::1:2"
+
     def test__authenticate_with_custom_port(self):
         """
         Test the use of a custom port for Proxmox connection


### PR DESCRIPTION
With this change it is possible again to use the qemu-agent of the VM to fetch the IP-address of it. The code already was in develop branch, I have migrate it back to the current master branch.

To use this option, set `agent_get_ip` in the cloud profile to `1` (integer). When the VM boots and the agent is started it will fetch the IP-adress of the Qemu VM and use that IP for the next actions for Salt-cloud.