### PR TITLE
Remove max zeromq pinned version due to issues on FreeBSD

### DIFF
--- a/requirements/zeromq.txt
+++ b/requirements/zeromq.txt
@@ -2,5 +2,5 @@
 -r crypto.txt
 
 pyzmq<=20.0.0 ; python_version < "3.6"
-pyzmq>=17.0.0,<22.0.0 ; python_version < "3.9"
-pyzmq>19.0.2,<22.0.0 ; python_version >= "3.9"
+pyzmq>=17.0.0 ; python_version < "3.9"
+pyzmq>19.0.2 ; python_version >= "3.9"


### PR DESCRIPTION
### What does this PR do?
Fixes issue described in https://github.com/saltstack/salt/commit/070597e525bb7d56ffadede1aede325dfb1b73a4 
