### PR TITLE
Fix test_ssh_kwargs to not access /etc/salt/pki

### DIFF
--- a/tests/pytests/unit/client/ssh/test_ssh.py
+++ b/tests/pytests/unit/client/ssh/test_ssh.py
@@ -130,6 +130,8 @@ def test_ssh_kwargs(test_opts):
         ssh_kwargs = salt.utils.parsers.SaltSSHOptionParser().defaults
         assert opt_key in ssh_kwargs
 
-    with patch("salt.roster.get_roster_file", MagicMock(return_value="")):
+    with patch("salt.roster.get_roster_file", MagicMock(return_value="")), patch(
+        "salt.client.ssh.shell.gen_key"
+    ), patch("salt.fileserver.Fileserver.update"), patch("salt.utils.thin.gen_thin"):
         ssh_obj = client._prep_ssh(**opts)
         assert ssh_obj.opts.get(opt_key, None) == opt_value


### PR DESCRIPTION
Running the SSH unit tests without root permission fails:

```
$ python3 -m pytest tests/pytests/unit/client/ssh/test_ssh.py
[...]
Traceback (most recent call last):
  File "salt/client/ssh/__init__.py", line 264, in __init__
    salt.client.ssh.shell.gen_key(priv)
  File "salt/client/ssh/shell.py", line 36, in gen_key
    os.makedirs(os.path.dirname(path))
  File "/usr/lib/python3.9/os.py", line 215, in makedirs
    makedirs(head, exist_ok=exist_ok)
  File "/usr/lib/python3.9/os.py", line 215, in makedirs
    makedirs(head, exist_ok=exist_ok)
  File "/usr/lib/python3.9/os.py", line 225, in makedirs
    mkdir(name, mode)
PermissionError: [Errno 13] Permission denied: '/etc/salt/pki'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "tests/pytests/unit/client/ssh/test_ssh.py", line 134, in test_ssh_kwargs
    ssh_obj = client._prep_ssh(**opts)
  File "salt/client/ssh/client.py", line 125, in _prep_ssh
    return salt.client.ssh.SSH(opts)
  File "salt/client/ssh/__init__.py", line 266, in __init__
    raise salt.exceptions.SaltClientError(
salt.exceptions.SaltClientError: salt-ssh could not be run because it could not generate keys.
```

Changing the accessed directories to temporary directories would be a solution:

```python
    client.opts["pki_dir"] = tmpdir.join("pki").strpath
    client.opts["cachedir"] = tmpdir.join("cache").strpath
```

But running the 38 tests takes 130 seconds on an Intel Core i7-8850H CPU @ 2.60GHz. So mock all functions and methods that try to write to the pki or cache directory. Then the tests will succeed in a few seconds.