### PR TITLE
Implement possibility to retry job publish to minions that were temporarily disconnected on TCP transport

### DIFF
--- a/changelog/61184.added
+++ b/changelog/61184.added
@@ -1,0 +1,1 @@
+Implement possibility to retry job publish to minions that were temporarily disconnected from master upon job creation, while on TCP transport

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -1283,6 +1283,33 @@ supported on POSIX platforms only.
 
     reactor_niceness: 9
 
+.. conf_master:: tcp_publish_backoff
+
+``tcp_publish_backoff``
+-----------------------
+
+.. versionadded:: Phosphorus
+
+default: ``10.0``
+
+The time in seconds to wait for job republish if minion is not connected to master when the job is created. This only work for TCP transport and ``list`` target type. 
+
+
+.. conf_master:: tcp_publish_retries
+
+``tcp_publish_retries``
+-----------------------
+
+.. versionadded:: Phosphorus
+
+default: ``0``
+
+The number of retry attempts to publish job if minion is not connected to master when the job is created. This only work for TCP transport and ``list`` target type. Specify ``0`` to disable this behaviour.
+
+.. note::
+
+   Setting this option to higher value, along with large ``tcp_publish_backoff``, can have memory implications on the ``TCPPubServerChannel`` master process as the job payload is kept in memory until it's successfully published.
+
 .. _salt-ssh-configuration:
 
 Salt-SSH Configuration

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -3344,6 +3344,17 @@ Default: ``1``
 The time in seconds to wait before attempting another connection with salt master
 when the previous connection fails while on TCP transport.
 
+.. conf_minion:: tcp_recv_retry_backoff
+
+``tcp_recv_retry_backoff``
+------------------------------
+
+.. versionadded:: Phosphorus
+
+Default: ``10``
+
+The time in seconds to wait before attempting to process received event from master again, in case minion was just in the middle of authentication phase while on TCP transport.
+
 .. conf_minion:: failhard
 
 ``failhard``

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -957,6 +957,10 @@ VALID_OPTS = immutabletypes.freeze(
         # The port to be used when checking if a master is connected to a
         # minion
         "remote_minions_port": int,
+        # Backoff interval in seconds for job publish if minion is unavailable while on tcp transport
+        "tcp_publish_backoff": float,
+        # Amount of retries for job publish if minion is unavailable while on tcp transport
+        "tcp_publish_retries": int,
     }
 )
 
@@ -1597,6 +1601,8 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze(
         "fips_mode": False,
         "detect_remote_minions": False,
         "remote_minions_port": 22,
+        "tcp_publish_backoff": 10.0,
+        "tcp_publish_retries": 0,
     }
 )
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -910,6 +910,8 @@ VALID_OPTS = immutabletypes.freeze(
         "tcp_authentication_retries": int,
         # Backoff interval in seconds for minion reconnect with tcp transport
         "tcp_reconnect_backoff": float,
+        # Backoff interval in seconds for minion to try to process master event when authentication procedure was not yet completed
+        "tcp_recv_retry_backoff": float,
         # Permit or deny allowing minions to request revoke of its own key
         "allow_minion_key_revoke": bool,
         # File chunk size for salt-cp
@@ -1137,6 +1139,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze(
         "tcp_pull_port": 4511,
         "tcp_authentication_retries": 5,
         "tcp_reconnect_backoff": 1,
+        "tcp_recv_retry_backoff": 10,
         "log_file": os.path.join(salt.syspaths.LOGS_DIR, "minion"),
         "log_level": "warning",
         "log_level_logfile": None,

--- a/tests/pytests/functional/transport/tcp/test_tcp_republish.py
+++ b/tests/pytests/functional/transport/tcp/test_tcp_republish.py
@@ -1,0 +1,188 @@
+import os
+import shutil
+import stat
+import time
+
+import pytest
+import salt.utils.files
+from salt.serializers import yaml
+from saltfactories.utils import random_string
+from tests.support.runtests import RUNTIME_VARS
+
+
+@pytest.fixture
+def tcp_master_factory(
+    salt_factories,
+    salt_syndic_master_factory,
+    base_env_state_tree_root_dir,
+    base_env_pillar_tree_root_dir,
+    prod_env_state_tree_root_dir,
+    prod_env_pillar_tree_root_dir,
+    ext_pillar_file_tree_root_dir,
+):
+    root_dir = salt_factories.get_root_dir_for_daemon("master")
+    conf_dir = root_dir / "conf"
+    conf_dir.mkdir(exist_ok=True)
+
+    with salt.utils.files.fopen(os.path.join(RUNTIME_VARS.CONF_DIR, "master")) as rfh:
+        config_defaults = yaml.deserialize(rfh.read())
+
+    config_defaults["root_dir"] = str(root_dir)
+    config_defaults["transport"] = "tcp"
+    config_defaults["tcp_publish_retries"] = 600
+    config_defaults["tcp_publish_backoff"] = 0.1
+
+    config_overrides = {"log_level_logfile": "quiet"}
+
+    # We need to copy the extension modules into the new master root_dir or
+    # it will be prefixed by it
+    extension_modules_path = str(root_dir / "extension_modules")
+    if not os.path.exists(extension_modules_path):
+        shutil.copytree(
+            os.path.join(RUNTIME_VARS.FILES, "extension_modules"),
+            extension_modules_path,
+        )
+
+    # Copy the autosign_file to the new  master root_dir
+    autosign_file_path = str(root_dir / "autosign_file")
+    shutil.copyfile(
+        os.path.join(RUNTIME_VARS.FILES, "autosign_file"), autosign_file_path
+    )
+    # all read, only owner write
+    autosign_file_permissions = (
+        stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH | stat.S_IWUSR
+    )
+    os.chmod(autosign_file_path, autosign_file_permissions)
+
+    config_overrides.update(
+        {
+            "extension_modules": extension_modules_path,
+            "file_roots": {
+                "base": [
+                    str(base_env_state_tree_root_dir),
+                    os.path.join(RUNTIME_VARS.FILES, "file", "base"),
+                ],
+            },
+            "pillar_roots": {
+                "base": [
+                    str(base_env_pillar_tree_root_dir),
+                    os.path.join(RUNTIME_VARS.FILES, "pillar", "base"),
+                ],
+            },
+        }
+    )
+
+    factory = salt_syndic_master_factory.salt_master_daemon(
+        random_string("tcp-master-"),
+        defaults=config_defaults,
+        overrides=config_overrides,
+        extra_cli_arguments_after_first_start_failure=["--log-level=debug"],
+    )
+    return factory
+
+
+@pytest.fixture
+def tcp_master(tcp_master_factory):
+    """
+    A running salt-master fixture
+    """
+    with tcp_master_factory.started():
+        yield tcp_master_factory
+
+
+@pytest.fixture
+def tcp_minion_factory(tcp_master_factory):
+    with salt.utils.files.fopen(os.path.join(RUNTIME_VARS.CONF_DIR, "minion")) as rfh:
+        config_defaults = yaml.deserialize(rfh.read())
+    config_defaults["transport"] = "tcp"
+
+    config_overrides = {
+        "log_level_logfile": "quiet",
+        "file_roots": tcp_master_factory.config["file_roots"].copy(),
+        "pillar_roots": tcp_master_factory.config["pillar_roots"].copy(),
+    }
+
+    factory = tcp_master_factory.salt_minion_daemon(
+        random_string("tcp-minion-"),
+        defaults=config_defaults,
+        overrides=config_overrides,
+        extra_cli_arguments_after_first_start_failure=["--log-level=debug"],
+    )
+    return factory
+
+
+@pytest.fixture
+def tcp_minion(tcp_minion_factory):
+    """
+    A running salt-minion fixture
+    """
+    with tcp_minion_factory.started():
+        # Sync All
+        salt_call_cli = tcp_minion_factory.salt_call_cli()
+        ret = salt_call_cli.run("saltutil.sync_all", _timeout=120)
+        assert ret.exitcode == 0, ret
+        yield tcp_minion_factory
+
+
+@pytest.fixture
+def tcp_run_cli(tcp_master):
+    """
+    The ``salt-run`` CLI as a fixture against the running master
+    """
+    assert tcp_master.is_running()
+    return tcp_master.salt_run_cli()
+
+
+@pytest.fixture
+def tcp_client(tcp_master):
+    assert tcp_master.is_running()
+    return tcp_master.salt_client()
+
+
+@pytest.mark.slow_test
+def test_publish_retry_on_inaccessible_minion(tcp_client, tcp_minion, tcp_run_cli):
+    """
+    Test if minion is able to run job even if it was fired when minion was disconnected at that moment
+    """
+
+    # stop minion and run the job
+    with tcp_minion.stopped():
+        # Note: this is very ugly access of the attr.s-managed client, but the other option is using salt_cli
+        #       factory, passing "-L" as minion_tgt and actual minion id as first arg, so ... yeah
+        jid = tcp_client._LocalClient__client.cmd_async(
+            tcp_minion.id, "test.ping", tgt_type="list"
+        )
+        assert jid
+        assert int(jid)
+
+        time.sleep(1)
+
+        # fetch JID result
+        job = tcp_run_cli.run("jobs.print_job", jid)
+
+        assert jid in job.json
+        # minion result should not be in, it should be off
+        assert tcp_minion.id not in job.json[jid]["Result"]
+
+    # start minion and check few times until the job is finished
+    with tcp_minion.started():
+        for i in range(1, 60):
+            time.sleep(1)
+            job = tcp_run_cli.run("jobs.print_job", jid)
+
+            assert jid in job.json
+
+            if tcp_minion.id not in job.json[jid]["Result"]:
+                # probably not yet returned
+                continue
+
+            assert job.json[jid]["Result"][tcp_minion.id]["return"]
+
+            # all ok
+            return
+
+        assert (
+            False
+        ), "Minion return was not found in job data (minion {}, JID {})".format(
+            tcp_minion.id, jid
+        )


### PR DESCRIPTION
### What does this PR do?
Implements retry mechanism for job publish from master side when minion is disconnected (due to network flap / restart) at the moment of job creation.

Specifically, it implements following behaviour:
1. For TCP transport, when job is published with `list` target type, master exactly knows which TCP connections to target (because it keeps map of all connections, tied to minion id and `list` type uses specific minion targeting 
    1. https://github.com/saltstack/salt/blob/v3004/salt/transport/tcp.py#L1523
    2. Other target types can't really be implemented this way as their validity is evaluated on minion instead of master
2. When minion is not found in existing connections or the publish fails due to `StreamClosedError`, the payload gets sent after `tcp_publish_backoff` seconds and up to `tcp_publish_retries` tries (configurable in master file)
    1. This is implemented using existing io_loop in TCP PubServer with `call_later` -> existing job payload is kept the same, the underlying package used for `publish_payload` is modified to include only those missed minions
    2. If there are multiple connections for single minion id (which could possibly happen due to misconfiguration / early reconnect / network flap), the republish for that particular minion will happen only if no TCP stream can be written to


It also works around one "race-condition" type of issue in minion startup procedure:
1. When minion starts, it tries to connect to master (https://github.com/saltstack/salt/blob/v3004/salt/minion.py#L1140, https://github.com/saltstack/salt/blob/v3004/salt/minion.py#L824)
2. After TCP connection is established, minion tries to authenticate with master (https://github.com/saltstack/salt/blob/v3004/salt/transport/tcp.py#L495)
3. When minion is successfully connected to master and verified, it immediately gets added into presence dictionary (https://github.com/saltstack/salt/blob/v3004/salt/transport/tcp.py#L1496 ), hence marking it "available for jobs"
4. Minion, upon discovering it's successfully connected, it starts tune-in procedure (https://github.com/saltstack/salt/blob/v3004/salt/minion.py#L1141), which ultimately sets up `on_recv` callback (https://github.com/saltstack/salt/blob/v3004/salt/minion.py#L3112) for the connection
5. However when any job is received during the time window before 3 and 4 happens, minion logs error message with "cryptic" message `Got response for message_id %s that we are not tracking`, because the `SaltMessageClient` doesn't yet know how to handle that message

I've come up with similar solution to this problem as with the republish from master side:
1. New minion option `tcp_recv_retry_backoff` is added, which serves as single-use retry of processing the message, if it's not yet ready
2. When message is received, but it's not know how to process it yet, `call_later` the same logic after `tcp_recv_retry_backoff` seconds, to try to deliver the message properly (because from master side it looks like the payload was successfully delivered - because it was)


### What issues does this PR fix or reference?
Fixes: #61184 (for TCP transport only)

### Previous Behavior
When minion is temporarily disconnected from master when master publishes the job (through CLI / API / etc.), it doesn't receive the job and is treated as disconnected / not returned.

### New Behavior
Minion successfully runs the previously published job, if connected soon enough (decided by master configuration).
This however only works for TCP transport and `list` targetting (globbing, compound matching and similar are determined on minion, so master just spams all connected minions so they can decide if it's matching their patterns).

It's also impossible to implement it this way for ZeroMQ transport, as it's exposed to Salt only as publish-subscribe type of queue, however the whole delivery is handled entirely by ZMQ and the publish always suceeds even if using `zmq_filtering` and there are no minions connected to that particular topic.

There might be also memory usage consideration when using this functionality - the job payload is not immediately discarded when some minion publish fails, it's kept in memory until all minions get published the job or the number of tries is reached.Together with very large job payload this can lead to significant memory usage of the `TCPPubServerChannel` process on master.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes