### PR TITLE
Skip MySQL Docker tests on CentOS7

### DIFF
--- a/tests/pytests/integration/modules/test_mysql.py
+++ b/tests/pytests/integration/modules/test_mysql.py
@@ -5,6 +5,7 @@ import logging
 
 import pytest
 import salt.modules.mysql as mysql
+from tests.support.helpers import requires_system_grains
 from tests.support.pytest.mysql import mysql_container  # pylint: disable=unused-import
 
 log = logging.getLogger(__name__)
@@ -16,6 +17,15 @@ pytestmark = [
         mysql.MySQLdb is None, reason="No python mysql client installed."
     ),
 ]
+
+
+@pytest.fixture(autouse=True)
+@requires_system_grains
+def skip_on_centos_7(grains):
+    if grains.get("os") == "CentOS" and grains.get("osmajorrelease") == "7":
+        pytest.skip(
+            "Skip MySQL Integration tests on CentOS due to frequently Docker related failures."
+        )
 
 
 @pytest.fixture(scope="module")

--- a/tests/pytests/integration/modules/test_mysql.py
+++ b/tests/pytests/integration/modules/test_mysql.py
@@ -5,7 +5,6 @@ import logging
 
 import pytest
 import salt.modules.mysql as mysql
-from tests.support.helpers import requires_system_grains
 from tests.support.pytest.mysql import mysql_container  # pylint: disable=unused-import
 
 log = logging.getLogger(__name__)
@@ -20,7 +19,6 @@ pytestmark = [
 
 
 @pytest.fixture(autouse=True)
-@requires_system_grains
 def skip_on_centos_7(grains):
     if grains.get("os") == "CentOS" and grains.get("osmajorrelease") == "7":
         pytest.skip(


### PR DESCRIPTION
### What does this PR do?
Skip MySQL Docker tests on CentOS7 due to frequent Docker related failures.

### What issues does this PR fix or reference?
Fixes: N/A

### Previous Behavior
MySQL integration tests that are running in Docker are frequently failing on CentOS 7.

### New Behavior
Skip the MySQL Integration tests that are running in Docker when run on CentOS 7.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
