### PR TITLE
Update set path for tiamatpip

### DIFF
--- a/run.py
+++ b/run.py
@@ -43,7 +43,7 @@ if not sys.platform.startswith("win"):
     PIP_PATH = pathlib.Path(f"{os.sep}opt", "saltstack", "salt", "pypath")
     with contextlib.suppress(PermissionError):
         PIP_PATH.mkdir(mode=0o755, parents=True, exist_ok=True)
-    tiamatpip.configure.set_user_site_packages_path(PIP_PATH)
+    tiamatpip.configure.set_user_base_path(PIP_PATH)
 
 
 def redirect(argv):


### PR DESCRIPTION
The tiamat packages are failing with this error:

```
Nov 09 12:06:16 0b9fd67cde70 systemd[1]: Starting The Salt Master Server...
Nov 09 12:06:17 0b9fd67cde70 salt-master[13480]: [13481] Failed to execute script salt
Nov 09 12:06:17 0b9fd67cde70 salt-master[13480]: Traceback (most recent call last):
Nov 09 12:06:17 0b9fd67cde70 salt-master[13480]:   File "salt", line 46, in <module>
Nov 09 12:06:17 0b9fd67cde70 salt-master[13480]: AttributeError: module 'tiamatpip.configure' has no attribute 'set_user_site_packages_path'
```

tiamat-pip had a new release (1.2.2) and updated the function name.