### PR TITLE
Prevent get_tops from performing a Set operation on a List

### DIFF
--- a/changelog/61176.fixed
+++ b/changelog/61176.fixed
@@ -1,0 +1,1 @@
+Prevent get_tops from performing a Set operation on a List

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -692,7 +692,7 @@ class Pillar:
                 else:
                     saltenvs.add(self.opts["pillarenv"])
             else:
-                saltenvs = {*self._get_envs()}
+                saltenvs.update(self._get_envs())
                 if self.opts.get("pillar_source_merging_strategy", None) == "none":
                     saltenvs &= {self.saltenv or "base"}
 

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -692,7 +692,7 @@ class Pillar:
                 else:
                     saltenvs.add(self.opts["pillarenv"])
             else:
-                saltenvs = self._get_envs()
+                saltenvs = {*self._get_envs()}
                 if self.opts.get("pillar_source_merging_strategy", None) == "none":
                     saltenvs &= {self.saltenv or "base"}
 

--- a/tests/pytests/unit/pillar/test_pillar.py
+++ b/tests/pytests/unit/pillar/test_pillar.py
@@ -27,3 +27,19 @@ def test_pillar_envs_order(envs, temp_salt_minion, tmp_path):
     )
     # The base environment is always present and as the first environment name
     assert pillar._get_envs() == ["base"] + envs
+
+
+def test_pillar_get_tops_should_not_error_when_merging_strategy_is_none_and_no_pillarenv(
+    temp_salt_minion,
+):
+    opts = temp_salt_minion.config.copy()
+    opts["pillarenv"] = None
+    opts["pillar_source_merging_strategy"] = "none"
+    pillar = salt.pillar.Pillar(
+        opts=opts,
+        grains=salt.loader.grains(opts),
+        minion_id=temp_salt_minion.id,
+        saltenv="base",
+    )
+    tops, errors = pillar.get_tops()
+    assert not errors


### PR DESCRIPTION
### What does this PR do?

Prior to this commit, `get_tops` attempted to perform a Set
intersection_update (`&=`) using the List returned by the `_get_envs`
method as the right-hand operand (this raises `TypeError`). When this
code was evaluated, it would result in the following error:

```
Rendering Primary Top file failed, render error: unsupported operand
type(s) for &=: 'list' and 'set'
```

Unpack the list into a new Set to permit the intersection update to
succeed.

See https://github.com/saltstack/salt/issues/61176

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/61176

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

No tests have been written here, however, this change seems locally constrained, and simply fixes a `TypeError`.

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
