### PR TITLE
Wrap contributor list in release documentation

### DIFF
--- a/doc/topics/releases/2014.7.6.rst
+++ b/doc/topics/releases/2014.7.6.rst
@@ -13,7 +13,14 @@ Statistics
 - Total Issue References: **66**
 - Total PR References: **166**
 
-- Contributors: **49** (`0xf10e`_, `Azidburn`_, `F30`_, `JaseFace`_, `JohannesEbke`_, `aletourneau`_, `aneeshusa`_, `basepi`_, `bastichelaar`_, `bersace`_, `cachedout`_, `cedwards`_, `cellscape`_, `chris-prince`_, `clan`_, `clinta`_, `cr1st1p`_, `cro`_, `dr4Ke`_, `ericfode`_, `ether42`_, `garethgreenaway`_, `gtmanfred`_, `hvnsweeting`_, `jfindlay`_, `jleroy`_, `joejulian`_, `justinta`_, `kaithar`_, `lorengordon`_, `martinhoefling`_, `mguegan`_, `multani`_, `notpeter`_, `panticz`_, `rallytime`_, `rominf`_, `rubic`_, `s0undt3ch`_, `skizunov`_, `slinu3d`_, `t0rrant`_, `techhat`_, `teizz`_, `terminalmage`_, `thatch45`_, `twangboy`_, `vdesjardins`_, `vr-jack`_)
+- Contributors: **49** (`0xf10e`_, `Azidburn`_, `F30`_, `JaseFace`_, `JohannesEbke`_,
+  `aletourneau`_, `aneeshusa`_, `basepi`_, `bastichelaar`_, `bersace`_, `cachedout`_, `cedwards`_,
+  `cellscape`_, `chris-prince`_, `clan`_, `clinta`_, `cr1st1p`_, `cro`_, `dr4Ke`_, `ericfode`_,
+  `ether42`_, `garethgreenaway`_, `gtmanfred`_, `hvnsweeting`_, `jfindlay`_, `jleroy`_,
+  `joejulian`_, `justinta`_, `kaithar`_, `lorengordon`_, `martinhoefling`_, `mguegan`_, `multani`_,
+  `notpeter`_, `panticz`_, `rallytime`_, `rominf`_, `rubic`_, `s0undt3ch`_, `skizunov`_,
+  `slinu3d`_, `t0rrant`_, `techhat`_, `teizz`_, `terminalmage`_, `thatch45`_, `twangboy`_,
+  `vdesjardins`_, `vr-jack`_)
 
 
 Security Fix

--- a/doc/topics/releases/2014.7.7.rst
+++ b/doc/topics/releases/2014.7.7.rst
@@ -13,7 +13,11 @@ Statistics
 - Total Issue References: **20**
 - Total PR References: **60**
 
-- Contributors: **28** (`AkhterAli`_, `BretFisher`_, `MrCitron`_, `alekti`_, `basepi`_, `bersace`_, `cachedout`_, `corux`_, `cro`_, `davidjb`_, `dumol`_, `efficks`_, `garethgreenaway`_, `hvnsweeting`_, `jacksontj`_, `jacobhammons`_, `jaybocc2`_, `jfindlay`_, `jquast`_, `justinta`_, `msteed`_, `nmadhok`_, `notpeter`_, `puneetk`_, `rallytime`_, `techhat`_, `trevor-h`_, `twangboy`_)
+- Contributors: **28** (`AkhterAli`_, `BretFisher`_, `MrCitron`_, `alekti`_, `basepi`_, `bersace`_,
+  `cachedout`_, `corux`_, `cro`_, `davidjb`_, `dumol`_, `efficks`_, `garethgreenaway`_,
+  `hvnsweeting`_, `jacksontj`_, `jacobhammons`_, `jaybocc2`_, `jfindlay`_, `jquast`_, `justinta`_,
+  `msteed`_, `nmadhok`_, `notpeter`_, `puneetk`_, `rallytime`_, `techhat`_, `trevor-h`_,
+  `twangboy`_)
 
 
 Changelog for v2014.7.6..v2014.7.7

--- a/doc/topics/releases/2015.5.1.rst
+++ b/doc/topics/releases/2015.5.1.rst
@@ -14,7 +14,14 @@ Statistics
 - Total Issue References: **30**
 - Total PR References: **177**
 
-- Contributors: **49** (`Arabus`_, `Lothiraldan`_, `Snergster`_, `TaiSHiNet`_, `The-Loeki`_, `UtahDave`_, `aboe76`_, `ahus1`_, `basepi`_, `bastiaanb`_, `bradthurber`_, `cachedout`_, `cellscape`_, `corywright`_, `cro`_, `dennisjac`_, `dmyerscough`_, `galet`_, `garethgreenaway`_, `gladiatr72`_, `gtmanfred`_, `iggy`_, `ionutbalutoiu`_, `jacobhammons`_, `jayeshka`_, `jfindlay`_, `joejulian`_, `jpic`_, `justinta`_, `kaidokert`_, `kaithar`_, `kiorky`_, `lisa2lisa`_, `msciciel`_, `nleib`_, `notpeter`_, `optix2000`_, `rahulhan`_, `rallytime`_, `rubic`_, `ryan-lane`_, `s0undt3ch`_, `slinu3d`_, `steverweber`_, `techhat`_, `terminalmage`_, `ticosax`_, `twangboy`_, `whiteinge`_)
+- Contributors: **49** (`Arabus`_, `Lothiraldan`_, `Snergster`_, `TaiSHiNet`_, `The-Loeki`_,
+  `UtahDave`_, `aboe76`_, `ahus1`_, `basepi`_, `bastiaanb`_, `bradthurber`_, `cachedout`_,
+  `cellscape`_, `corywright`_, `cro`_, `dennisjac`_, `dmyerscough`_, `galet`_, `garethgreenaway`_,
+  `gladiatr72`_, `gtmanfred`_, `iggy`_, `ionutbalutoiu`_, `jacobhammons`_, `jayeshka`_,
+  `jfindlay`_, `joejulian`_, `jpic`_, `justinta`_, `kaidokert`_, `kaithar`_, `kiorky`_,
+  `lisa2lisa`_, `msciciel`_, `nleib`_, `notpeter`_, `optix2000`_, `rahulhan`_, `rallytime`_,
+  `rubic`_, `ryan-lane`_, `s0undt3ch`_, `slinu3d`_, `steverweber`_, `techhat`_, `terminalmage`_,
+  `ticosax`_, `twangboy`_, `whiteinge`_)
 
 
 Cloud Runner Changes

--- a/doc/topics/releases/2015.5.11.rst
+++ b/doc/topics/releases/2015.5.11.rst
@@ -14,7 +14,13 @@ Statistics
 - Total Issue References: **73**
 - Total PR References: **162**
 
-- Contributors: **46** (`AndrewPashkin`_, `Ch3LL`_, `DmitryKuzmenko`_, `TheNullByte`_, `UtahDave`_, `abednarik`_, `amontalban`_, `anlutro`_, `attiasr`_, `basepi`_, `borgstrom`_, `brejoc`_, `bstevenson`_, `cachedout`_, `carlwgeorge`_, `efficks`_, `gerhardqux`_, `gtmanfred`_, `heyfife`_, `jacobhammons`_, `jfindlay`_, `justinta`_, `lomeroe`_, `lorengordon`_, `mtorromeo`_, `nmadhok`_, `notpeter`_, `paclat`_, `pcn`_, `phistrom`_, `rallytime`_, `robgott`_, `sacren`_, `sastorsl`_, `serge-p`_, `sjmh`_, `sjorge`_, `techhat`_, `terminalmage`_, `thatch45`_, `thegoodduke`_, `toanju`_, `tomwalsh`_, `twangboy`_, `whiteinge`_, `yannis666`_)
+- Contributors: **46** (`AndrewPashkin`_, `Ch3LL`_, `DmitryKuzmenko`_, `TheNullByte`_, `UtahDave`_,
+  `abednarik`_, `amontalban`_, `anlutro`_, `attiasr`_, `basepi`_, `borgstrom`_, `brejoc`_,
+  `bstevenson`_, `cachedout`_, `carlwgeorge`_, `efficks`_, `gerhardqux`_, `gtmanfred`_, `heyfife`_,
+  `jacobhammons`_, `jfindlay`_, `justinta`_, `lomeroe`_, `lorengordon`_, `mtorromeo`_, `nmadhok`_,
+  `notpeter`_, `paclat`_, `pcn`_, `phistrom`_, `rallytime`_, `robgott`_, `sacren`_, `sastorsl`_,
+  `serge-p`_, `sjmh`_, `sjorge`_, `techhat`_, `terminalmage`_, `thatch45`_, `thegoodduke`_,
+  `toanju`_, `tomwalsh`_, `twangboy`_, `whiteinge`_, `yannis666`_)
 
 
 Changelog for v2015.5.10..v2015.5.11

--- a/doc/topics/releases/2015.5.2.rst
+++ b/doc/topics/releases/2015.5.2.rst
@@ -14,7 +14,13 @@ Statistics
 - Total Issue References: **36**
 - Total PR References: **145**
 
-- Contributors: **49** (`Sacro`_, `The-Loeki`_, `YanChii`_, `aboe76`_, `anlutro`_, `awdrius`_, `basepi`_, `cdarwin`_, `cedwards`_, `clan`_, `corywright`_, `cro`_, `djcrabhat`_, `dmyerscough`_, `dr4Ke`_, `fayetted`_, `galet`_, `garethgreenaway`_, `ghost`_, `hazelesque`_, `hvnsweeting`_, `jacksontj`_, `jacobhammons`_, `jayeshka`_, `jbq`_, `jfindlay`_, `joejulian`_, `justinta`_, `kartiksubbarao`_, `kiorky`_, `merll`_, `msteed`_, `neogenix`_, `nicholascapo`_, `nleib`_, `pengyao`_, `pruiz`_, `rallytime`_, `randybias`_, `ryan-lane`_, `steverweber`_, `swdream`_, `techhat`_, `terminalmage`_, `thcipriani`_, `thusoy`_, `trevor-h`_, `twangboy`_, `whiteinge`_)
+- Contributors: **49** (`Sacro`_, `The-Loeki`_, `YanChii`_, `aboe76`_, `anlutro`_, `awdrius`_,
+  `basepi`_, `cdarwin`_, `cedwards`_, `clan`_, `corywright`_, `cro`_, `djcrabhat`_, `dmyerscough`_,
+  `dr4Ke`_, `fayetted`_, `galet`_, `garethgreenaway`_, `ghost`_, `hazelesque`_, `hvnsweeting`_,
+  `jacksontj`_, `jacobhammons`_, `jayeshka`_, `jbq`_, `jfindlay`_, `joejulian`_, `justinta`_,
+  `kartiksubbarao`_, `kiorky`_, `merll`_, `msteed`_, `neogenix`_, `nicholascapo`_, `nleib`_,
+  `pengyao`_, `pruiz`_, `rallytime`_, `randybias`_, `ryan-lane`_, `steverweber`_, `swdream`_,
+  `techhat`_, `terminalmage`_, `thcipriani`_, `thusoy`_, `trevor-h`_, `twangboy`_, `whiteinge`_)
 
 
 Changelog for v2015.5.1..v2015.5.2

--- a/doc/topics/releases/2015.5.3.rst
+++ b/doc/topics/releases/2015.5.3.rst
@@ -14,7 +14,16 @@ Statistics
 - Total Issue References: **69**
 - Total PR References: **207**
 
-- Contributors: **62** (`CameronNemo`_, `Lanzaa`_, `Starblade42`_, `The-Loeki`_, `TheScriptSage`_, `aboe76`_, `ahus1`_, `aneeshusa`_, `anlutro`_, `arthurlogilab`_, `basepi`_, `borutmrak`_, `cachedout`_, `cgtx`_, `codertux`_, `cro`_, `dkiser`_, `driskell`_, `eliasp`_, `garethgreenaway`_, `grischa`_, `gthb`_, `heewa`_, `infestdead`_, `jacksontj`_, `jacobhammons`_, `jayeshka`_, `jeanpralo`_, `jfindlay`_, `jodv`_, `joejulian`_, `justinta`_, `kartiksubbarao`_, `kev009`_, `kiorky`_, `lorengordon`_, `msciciel`_, `msteed`_, `nmadhok`_, `notpeter`_, `obestwalter`_, `pengyao`_, `pille`_, `porterjamesj`_, `pruiz`_, `quixoten`_, `rallytime`_, `rhertzog`_, `ruzarowski`_, `ryan-lane`_, `steverweber`_, `tankywoo`_, `tbaker57`_, `techhat`_, `terminalmage`_, `thatch45`_, `thenewwazoo`_, `trevor-h`_, `twangboy`_, `variia`_, `zefrog`_, `zhujinhe`_)
+- Contributors: **62** (`CameronNemo`_, `Lanzaa`_, `Starblade42`_, `The-Loeki`_, `TheScriptSage`_,
+  `aboe76`_, `ahus1`_, `aneeshusa`_, `anlutro`_, `arthurlogilab`_, `basepi`_, `borutmrak`_,
+  `cachedout`_, `cgtx`_, `codertux`_, `cro`_, `dkiser`_, `driskell`_, `eliasp`_,
+  `garethgreenaway`_, `grischa`_, `gthb`_, `heewa`_, `infestdead`_, `jacksontj`_, `jacobhammons`_,
+  `jayeshka`_, `jeanpralo`_, `jfindlay`_, `jodv`_, `joejulian`_, `justinta`_, `kartiksubbarao`_,
+  `kev009`_, `kiorky`_, `lorengordon`_, `msciciel`_, `msteed`_, `nmadhok`_, `notpeter`_,
+  `obestwalter`_, `pengyao`_, `pille`_, `porterjamesj`_, `pruiz`_, `quixoten`_, `rallytime`_,
+  `rhertzog`_, `ruzarowski`_, `ryan-lane`_, `steverweber`_, `tankywoo`_, `tbaker57`_, `techhat`_,
+  `terminalmage`_, `thatch45`_, `thenewwazoo`_, `trevor-h`_, `twangboy`_, `variia`_, `zefrog`_,
+  `zhujinhe`_)
 
 
 Changelog for v2015.5.2..v2015.5.3

--- a/doc/topics/releases/2015.5.4.rst
+++ b/doc/topics/releases/2015.5.4.rst
@@ -14,7 +14,20 @@ Statistics
 - Total Issue References: **138**
 - Total PR References: **312**
 
-- Contributors: **92** (`0xf10e`_, `AkhterAli`_, `BretFisher`_, `DmitryKuzmenko`_, `EvaSDK`_, `GideonRed-zz`_, `JohannesEbke`_, `Oro`_, `TheBigBear`_, `TronPaul`_, `UtahDave`_, `ahus1`_, `alekti`_, `alexandrsushko`_, `amontalban`_, `andre-luiz-dos-santos`_, `aneeshusa`_, `anlutro`_, `asyncsrc`_, `attiasr`_, `babilen`_, `basepi`_, `bbinet`_, `bclermont`_, `bechtoldt`_, `blackduckx`_, `bobrik`_, `cachedout`_, `colekowalski`_, `cro`_, `d--j`_, `davidjb`_, `denmat`_, `derBroBro`_, `dkiser`_, `driskell`_, `egarbi`_, `fleaflicker`_, `garethgreenaway`_, `gmcwhistler`_, `gtmanfred`_, `hasues`_, `isbm`_, `jacksontj`_, `jacobhammons`_, `jahamn`_, `jarpy`_, `jasonkeene`_, `jayeshka`_, `jfindlay`_, `jleroy`_, `jmdcal`_, `jodv`_, `joejulian`_, `jquast`_, `justinta`_, `kev009`_, `klyr`_, `l2ol33rt`_, `loa`_, `lomeroe`_, `martinhoefling`_, `mgwilliams`_, `nicholascapo`_, `niq000`_, `nmadhok`_, `nyushi`_, `oeuftete`_, `opdude`_, `pcdummy`_, `pcn`_, `peterdemin`_, `puneetk`_, `rallytime`_, `rmatulat`_, `s0undt3ch`_, `silenius`_, `sjorge`_, `stanislavb`_, `steverweber`_, `supertom`_, `t0rrant`_, `tankywoo`_, `techhat`_, `terminalmage`_, `thatch45`_, `tony-cocco`_, `twangboy`_, `uvsmtid`_, `vr-jack`_, `yanatan16`_, `zyio`_)
+- Contributors: **92** (`0xf10e`_, `AkhterAli`_, `BretFisher`_, `DmitryKuzmenko`_, `EvaSDK`_,
+  `GideonRed-zz`_, `JohannesEbke`_, `Oro`_, `TheBigBear`_, `TronPaul`_, `UtahDave`_, `ahus1`_,
+  `alekti`_, `alexandrsushko`_, `amontalban`_, `andre-luiz-dos-santos`_, `aneeshusa`_, `anlutro`_,
+  `asyncsrc`_, `attiasr`_, `babilen`_, `basepi`_, `bbinet`_, `bclermont`_, `bechtoldt`_,
+  `blackduckx`_, `bobrik`_, `cachedout`_, `colekowalski`_, `cro`_, `d--j`_, `davidjb`_, `denmat`_,
+  `derBroBro`_, `dkiser`_, `driskell`_, `egarbi`_, `fleaflicker`_, `garethgreenaway`_,
+  `gmcwhistler`_, `gtmanfred`_, `hasues`_, `isbm`_, `jacksontj`_, `jacobhammons`_, `jahamn`_,
+  `jarpy`_, `jasonkeene`_, `jayeshka`_, `jfindlay`_, `jleroy`_, `jmdcal`_, `jodv`_, `joejulian`_,
+  `jquast`_, `justinta`_, `kev009`_, `klyr`_, `l2ol33rt`_, `loa`_, `lomeroe`_, `martinhoefling`_,
+  `mgwilliams`_, `nicholascapo`_, `niq000`_, `nmadhok`_, `nyushi`_, `oeuftete`_, `opdude`_,
+  `pcdummy`_, `pcn`_, `peterdemin`_, `puneetk`_, `rallytime`_, `rmatulat`_, `s0undt3ch`_,
+  `silenius`_, `sjorge`_, `stanislavb`_, `steverweber`_, `supertom`_, `t0rrant`_, `tankywoo`_,
+  `techhat`_, `terminalmage`_, `thatch45`_, `tony-cocco`_, `twangboy`_, `uvsmtid`_, `vr-jack`_,
+  `yanatan16`_, `zyio`_)
 
 
 Bug Fixes

--- a/doc/topics/releases/2015.5.5.rst
+++ b/doc/topics/releases/2015.5.5.rst
@@ -14,7 +14,10 @@ Statistics
 - Total Issue References: **28**
 - Total PR References: **39**
 
-- Contributors: **20** (`TheBigBear`_, `arthurlogilab`_, `basepi`_, `bastiaanb`_, `cachedout`_, `driskell`_, `garethgreenaway`_, `jacobhammons`_, `jahamn`_, `jfindlay`_, `rallytime`_, `s0undt3ch`_, `scottjpack`_, `silenius`_, `sixninetynine`_, `stanislavb`_, `terminalmage`_, `thusoy`_, `twangboy`_, `vr-jack`_)
+- Contributors: **20** (`TheBigBear`_, `arthurlogilab`_, `basepi`_, `bastiaanb`_, `cachedout`_,
+  `driskell`_, `garethgreenaway`_, `jacobhammons`_, `jahamn`_, `jfindlay`_, `rallytime`_,
+  `s0undt3ch`_, `scottjpack`_, `silenius`_, `sixninetynine`_, `stanislavb`_, `terminalmage`_,
+  `thusoy`_, `twangboy`_, `vr-jack`_)
 
 
 Changelog for v2015.5.4..v2015.5.5

--- a/doc/topics/releases/2015.5.6.rst
+++ b/doc/topics/releases/2015.5.6.rst
@@ -14,7 +14,14 @@ Statistics
 - Total Issue References: **71**
 - Total PR References: **178**
 
-- Contributors: **53** (`Arabus`_, `JensRantil`_, `PierreR`_, `SaltyCharles`_, `TheBigBear`_, `abh`_, `aboe76`_, `anlutro`_, `arthurlogilab`_, `aspyatkin`_, `basepi`_, `benhosmer`_, `bersace`_, `cachedout`_, `carlpett`_, `damonzheng`_, `derphilipp`_, `dmyerscough`_, `dsumsky`_, `efficks`_, `eguven`_, `garethgreenaway`_, `hexedpackets`_, `jacksontj`_, `jacobhammons`_, `jfindlay`_, `joejulian`_, `johanek`_, `julianbrost`_, `kev009`_, `lorengordon`_, `madprog`_, `marccardinal`_, `netroby`_, `nmadhok`_, `plastikos`_, `rallytime`_, `serge-p`_, `spudfkc`_, `stanislavb`_, `styro`_, `systembell`_, `tankywoo`_, `techhat`_, `terminalmage`_, `thatch45`_, `tjstansell`_, `twangboy`_, `vakulich`_, `vtek21`_, `whiteinge`_, `zmalone`_, `zyio`_)
+- Contributors: **53** (`Arabus`_, `JensRantil`_, `PierreR`_, `SaltyCharles`_, `TheBigBear`_,
+  `abh`_, `aboe76`_, `anlutro`_, `arthurlogilab`_, `aspyatkin`_, `basepi`_, `benhosmer`_,
+  `bersace`_, `cachedout`_, `carlpett`_, `damonzheng`_, `derphilipp`_, `dmyerscough`_, `dsumsky`_,
+  `efficks`_, `eguven`_, `garethgreenaway`_, `hexedpackets`_, `jacksontj`_, `jacobhammons`_,
+  `jfindlay`_, `joejulian`_, `johanek`_, `julianbrost`_, `kev009`_, `lorengordon`_, `madprog`_,
+  `marccardinal`_, `netroby`_, `nmadhok`_, `plastikos`_, `rallytime`_, `serge-p`_, `spudfkc`_,
+  `stanislavb`_, `styro`_, `systembell`_, `tankywoo`_, `techhat`_, `terminalmage`_, `thatch45`_,
+  `tjstansell`_, `twangboy`_, `vakulich`_, `vtek21`_, `whiteinge`_, `zmalone`_, `zyio`_)
 
 
 Security Fixes

--- a/doc/topics/releases/2015.5.7.rst
+++ b/doc/topics/releases/2015.5.7.rst
@@ -14,7 +14,14 @@ Statistics
 - Total Issue References: **66**
 - Total PR References: **135**
 
-- Contributors: **46** (`0xf10e`_, `JaseFace`_, `MasterNayru`_, `MrCitron`_, `Sacro`_, `ajacoutot`_, `arthurlogilab`_, `basepi`_, `belvedere-trading`_, `beverlcl`_, `blast-hardcheese`_, `blueyed`_, `bogdanr`_, `cachedout`_, `cbuechler`_, `chrigl`_, `dmyerscough`_, `eguven`_, `eliasp`_, `erchn`_, `eyj`_, `garethgreenaway`_, `gashev`_, `gnubyexample`_, `gracinet`_, `gravyboat`_, `gwaters`_, `hedinfaok`_, `iggy`_, `jacksontj`_, `jacobhammons`_, `jfindlay`_, `lorengordon`_, `mbologna`_, `msciciel`_, `nmadhok`_, `pass-by-value`_, `plastikos`_, `rallytime`_, `rominf`_, `s0undt3ch`_, `silenius`_, `sjmh`_, `stephen144`_, `terminalmage`_, `twangboy`_)
+- Contributors: **46** (`0xf10e`_, `JaseFace`_, `MasterNayru`_, `MrCitron`_, `Sacro`_,
+  `ajacoutot`_, `arthurlogilab`_, `basepi`_, `belvedere-trading`_, `beverlcl`_,
+  `blast-hardcheese`_, `blueyed`_, `bogdanr`_, `cachedout`_, `cbuechler`_, `chrigl`_,
+  `dmyerscough`_, `eguven`_, `eliasp`_, `erchn`_, `eyj`_, `garethgreenaway`_, `gashev`_,
+  `gnubyexample`_, `gracinet`_, `gravyboat`_, `gwaters`_, `hedinfaok`_, `iggy`_, `jacksontj`_,
+  `jacobhammons`_, `jfindlay`_, `lorengordon`_, `mbologna`_, `msciciel`_, `nmadhok`_,
+  `pass-by-value`_, `plastikos`_, `rallytime`_, `rominf`_, `s0undt3ch`_, `silenius`_, `sjmh`_,
+  `stephen144`_, `terminalmage`_, `twangboy`_)
 
 
 .. important::

--- a/doc/topics/releases/2015.5.8.rst
+++ b/doc/topics/releases/2015.5.8.rst
@@ -16,7 +16,8 @@ Statistics
 - Total Issue References: **12**
 - Total PR References: **27**
 
-- Contributors: **12** (`MasterNayru`_, `TronPaul`_, `basepi`_, `cachedout`_, `cxmcc`_, `jfindlay`_, `kevinlondon`_, `messa`_, `rallytime`_, `tehmaspc`_, `twangboy`_, `whiteinge`_)
+- Contributors: **12** (`MasterNayru`_, `TronPaul`_, `basepi`_, `cachedout`_, `cxmcc`_,
+  `jfindlay`_, `kevinlondon`_, `messa`_, `rallytime`_, `tehmaspc`_, `twangboy`_, `whiteinge`_)
 
 
 Security Fix

--- a/doc/topics/releases/2015.5.9.rst
+++ b/doc/topics/releases/2015.5.9.rst
@@ -14,7 +14,10 @@ Statistics
 - Total Issue References: **21**
 - Total PR References: **48**
 
-- Contributors: **21** (`abednarik`_, `aletourneau`_, `attiasr`_, `basepi`_, `cachedout`_, `clan`_, `clarkperkins`_, `cro`_, `dmyerscough`_, `jacobhammons`_, `jfindlay`_, `jsutton`_, `justinta`_, `lorengordon`_, `markckimball`_, `mpreziuso`_, `rallytime`_, `terminalmage`_, `titilambert`_, `twangboy`_, `zmalone`_)
+- Contributors: **21** (`abednarik`_, `aletourneau`_, `attiasr`_, `basepi`_, `cachedout`_, `clan`_,
+  `clarkperkins`_, `cro`_, `dmyerscough`_, `jacobhammons`_, `jfindlay`_, `jsutton`_, `justinta`_,
+  `lorengordon`_, `markckimball`_, `mpreziuso`_, `rallytime`_, `terminalmage`_, `titilambert`_,
+  `twangboy`_, `zmalone`_)
 
 
 Changelog for v2015.5.8..v2015.5.9

--- a/doc/topics/releases/2015.8.1.rst
+++ b/doc/topics/releases/2015.8.1.rst
@@ -12,7 +12,13 @@ Statistics
 - Total Issue References: **39**
 - Total PR References: **135**
 
-- Contributors: **40** (`DmitryKuzmenko`_, `The-Loeki`_, `TheBigBear`_, `basepi`_, `bechtoldt`_, `bernieke`_, `blueyed`_, `cachedout`_, `cedwards`_, `clinta`_, `cro`_, `deuscapturus`_, `dmurphy18`_, `dsumsky`_, `eliasp`_, `flowhamster`_, `isbm`_, `jacksontj`_, `jacobhammons`_, `jfindlay`_, `justinta`_, `l2ol33rt`_, `macgyver13`_, `meggiebot`_, `msteed`_, `multani`_, `nasenbaer13`_, `perfinion`_, `pprkut`_, `rallytime`_, `rhealitycheck`_, `ruzarowski`_, `ryan-lane`_, `s0undt3ch`_, `systembell`_, `techhat`_, `terminalmage`_, `ticosax`_, `twangboy`_, `whiteinge`_)
+- Contributors: **40** (`DmitryKuzmenko`_, `The-Loeki`_, `TheBigBear`_, `basepi`_, `bechtoldt`_,
+  `bernieke`_, `blueyed`_, `cachedout`_, `cedwards`_, `clinta`_, `cro`_, `deuscapturus`_,
+  `dmurphy18`_, `dsumsky`_, `eliasp`_, `flowhamster`_, `isbm`_, `jacksontj`_, `jacobhammons`_,
+  `jfindlay`_, `justinta`_, `l2ol33rt`_, `macgyver13`_, `meggiebot`_, `msteed`_, `multani`_,
+  `nasenbaer13`_, `perfinion`_, `pprkut`_, `rallytime`_, `rhealitycheck`_, `ruzarowski`_,
+  `ryan-lane`_, `s0undt3ch`_, `systembell`_, `techhat`_, `terminalmage`_, `ticosax`_, `twangboy`_,
+  `whiteinge`_)
 
 
 Security Fixes

--- a/doc/topics/releases/2015.8.11.rst
+++ b/doc/topics/releases/2015.8.11.rst
@@ -12,7 +12,14 @@ Statistics
 - Total Issue References: **70**
 - Total PR References: **221**
 
-- Contributors: **48** (`AAbouZaid`_, `BlaineAtAffirm`_, `DmitryKuzmenko`_, `The-Loeki`_, `abednarik`_, `babilen`_, `bebehei`_, `cachedout`_, `clinta`_, `complexsplit`_, `cro`_, `danslimmon`_, `dcolish`_, `dincamihai`_, `edgan`_, `gerhardqux`_, `ghedo`_, `isbm`_, `jacobhammons`_, `jfindlay`_, `jodv`_, `justinta`_, `l13t`_, `lomeroe`_, `lorengordon`_, `lvg01`_, `mcalmer`_, `meaksh`_, `morganwillcock`_, `oeuftete`_, `opdude`_, `phistrom`_, `rallytime`_, `rmarcinik`_, `ryan-lane`_, `sacren`_, `steverweber`_, `techhat`_, `tegbert`_, `terminalmage`_, `thatch45`_, `the-glu`_, `thegoodduke`_, `ticosax`_, `tveastman`_, `twangboy`_, `vutny`_, `zer0def`_)
+- Contributors: **48** (`AAbouZaid`_, `BlaineAtAffirm`_, `DmitryKuzmenko`_, `The-Loeki`_,
+  `abednarik`_, `babilen`_, `bebehei`_, `cachedout`_, `clinta`_, `complexsplit`_, `cro`_,
+  `danslimmon`_, `dcolish`_, `dincamihai`_, `edgan`_, `gerhardqux`_, `ghedo`_, `isbm`_,
+  `jacobhammons`_, `jfindlay`_, `jodv`_, `justinta`_, `l13t`_, `lomeroe`_, `lorengordon`_,
+  `lvg01`_, `mcalmer`_, `meaksh`_, `morganwillcock`_, `oeuftete`_, `opdude`_, `phistrom`_,
+  `rallytime`_, `rmarcinik`_, `ryan-lane`_, `sacren`_, `steverweber`_, `techhat`_, `tegbert`_,
+  `terminalmage`_, `thatch45`_, `the-glu`_, `thegoodduke`_, `ticosax`_, `tveastman`_, `twangboy`_,
+  `vutny`_, `zer0def`_)
 
 
 Ubuntu 16.04 Packages

--- a/doc/topics/releases/2015.8.12.rst
+++ b/doc/topics/releases/2015.8.12.rst
@@ -12,7 +12,11 @@ Statistics
 - Total Issue References: **43**
 - Total PR References: **117**
 
-- Contributors: **29** (`Azidburn`_, `Ch3LL`_, `UtahDave`_, `bobrik`_, `cachedout`_, `cedwards`_, `deepakhj`_, `dere`_, `gongled`_, `gtmanfred`_, `hrumph`_, `hu-dabao`_, `isbm`_, `jacobhammons`_, `jfindlay`_, `jmesquita`_, `junovitch`_, `justinta`_, `kev009`_, `martinhoefling`_, `multani`_, `rallytime`_, `randomed`_, `sjorge`_, `terminalmage`_, `thatch45`_, `theothergraham`_, `twangboy`_, `whiteinge`_)
+- Contributors: **29** (`Azidburn`_, `Ch3LL`_, `UtahDave`_, `bobrik`_, `cachedout`_, `cedwards`_,
+  `deepakhj`_, `dere`_, `gongled`_, `gtmanfred`_, `hrumph`_, `hu-dabao`_, `isbm`_, `jacobhammons`_,
+  `jfindlay`_, `jmesquita`_, `junovitch`_, `justinta`_, `kev009`_, `martinhoefling`_, `multani`_,
+  `rallytime`_, `randomed`_, `sjorge`_, `terminalmage`_, `thatch45`_, `theothergraham`_,
+  `twangboy`_, `whiteinge`_)
 
 
 Changelog for v2015.8.11..v2015.8.12

--- a/doc/topics/releases/2015.8.2.rst
+++ b/doc/topics/releases/2015.8.2.rst
@@ -12,7 +12,19 @@ Statistics
 - Total Issue References: **138**
 - Total PR References: **351**
 
-- Contributors: **83** (`DmitryKuzmenko`_, `JaseFace`_, `LoveIsGrief`_, `MasterNayru`_, `Oro`_, `SmithSamuelM`_, `The-Loeki`_, `TheBigBear`_, `aboe76`_, `ajacoutot`_, `anlutro`_, `avinassh`_, `basepi`_, `bdrung`_, `bechtoldt`_, `bernieke`_, `blueyed`_, `cachedout`_, `cbuechler`_, `cedwards`_, `clarkperkins`_, `cro`_, `dkiser`_, `douglas-vaz`_, `dr4Ke`_, `eguven`_, `eliasp`_, `erchn`_, `eyj`_, `favadi`_, `flavio`_, `garethgreenaway`_, `gravyboat`_, `gtmanfred`_, `hedinfaok`_, `hexedpackets`_, `hyn-salt`_, `isbm`_, `itsamenathan`_, `jacksontj`_, `jacobhammons`_, `jeffreyctang`_, `jejenone`_, `jfindlay`_, `johnsocp`_, `justinta`_, `keesbos`_, `lathama`_, `ldobson`_, `lomeroe`_, `martinhoefling`_, `mbarrien`_, `mbologna`_, `merll`_, `mrosedale`_, `msteed`_, `multani`_, `nasenbaer13`_, `nmadhok`_, `notpeter`_, `opdude`_, `papertigers`_, `pass-by-value`_, `plastikos`_, `quantonganh`_, `rallytime`_, `redmcg`_, `rowillia`_, `ruzarowski`_, `ryan-lane`_, `s0undt3ch`_, `sdm24`_, `sjansen`_, `skizunov`_, `srkunze`_, `techhat`_, `terminalmage`_, `ticosax`_, `tkwilliams`_, `toddtomkinson`_, `twangboy`_, `twellspring`_, `whiteinge`_)
+- Contributors: **83** (`DmitryKuzmenko`_, `JaseFace`_, `LoveIsGrief`_, `MasterNayru`_, `Oro`_,
+  `SmithSamuelM`_, `The-Loeki`_, `TheBigBear`_, `aboe76`_, `ajacoutot`_, `anlutro`_, `avinassh`_,
+  `basepi`_, `bdrung`_, `bechtoldt`_, `bernieke`_, `blueyed`_, `cachedout`_, `cbuechler`_,
+  `cedwards`_, `clarkperkins`_, `cro`_, `dkiser`_, `douglas-vaz`_, `dr4Ke`_, `eguven`_, `eliasp`_,
+  `erchn`_, `eyj`_, `favadi`_, `flavio`_, `garethgreenaway`_, `gravyboat`_, `gtmanfred`_,
+  `hedinfaok`_, `hexedpackets`_, `hyn-salt`_, `isbm`_, `itsamenathan`_, `jacksontj`_,
+  `jacobhammons`_, `jeffreyctang`_, `jejenone`_, `jfindlay`_, `johnsocp`_, `justinta`_, `keesbos`_,
+  `lathama`_, `ldobson`_, `lomeroe`_, `martinhoefling`_, `mbarrien`_, `mbologna`_, `merll`_,
+  `mrosedale`_, `msteed`_, `multani`_, `nasenbaer13`_, `nmadhok`_, `notpeter`_, `opdude`_,
+  `papertigers`_, `pass-by-value`_, `plastikos`_, `quantonganh`_, `rallytime`_, `redmcg`_,
+  `rowillia`_, `ruzarowski`_, `ryan-lane`_, `s0undt3ch`_, `sdm24`_, `sjansen`_, `skizunov`_,
+  `srkunze`_, `techhat`_, `terminalmage`_, `ticosax`_, `tkwilliams`_, `toddtomkinson`_,
+  `twangboy`_, `twellspring`_, `whiteinge`_)
 
 
 .. important::

--- a/doc/topics/releases/2015.8.3.rst
+++ b/doc/topics/releases/2015.8.3.rst
@@ -14,7 +14,11 @@ Statistics
 - Total Issue References: **26**
 - Total PR References: **64**
 
-- Contributors: **30** (`DmitryKuzmenko`_, `RealKelsar`_, `alexproca`_, `anlutro`_, `basepi`_, `bogdanr`_, `cachedout`_, `cedwards`_, `chrigl`_, `cro`_, `fcrozat`_, `gtmanfred`_, `isbm`_, `jfindlay`_, `kiorky`_, `kt97679`_, `lomeroe`_, `lorengordon`_, `mhoogendoorn`_, `nmadhok`_, `optix2000`_, `paulnivin`_, `quantonganh`_, `rallytime`_, `s0undt3ch`_, `schwing`_, `sjorge`_, `tampakrap`_, `terminalmage`_, `ticosax`_)
+- Contributors: **30** (`DmitryKuzmenko`_, `RealKelsar`_, `alexproca`_, `anlutro`_, `basepi`_,
+  `bogdanr`_, `cachedout`_, `cedwards`_, `chrigl`_, `cro`_, `fcrozat`_, `gtmanfred`_, `isbm`_,
+  `jfindlay`_, `kiorky`_, `kt97679`_, `lomeroe`_, `lorengordon`_, `mhoogendoorn`_, `nmadhok`_,
+  `optix2000`_, `paulnivin`_, `quantonganh`_, `rallytime`_, `s0undt3ch`_, `schwing`_, `sjorge`_,
+  `tampakrap`_, `terminalmage`_, `ticosax`_)
 
 
 Security Fix

--- a/doc/topics/releases/2015.8.4.rst
+++ b/doc/topics/releases/2015.8.4.rst
@@ -14,7 +14,18 @@ Statistics
 - Total Issue References: **120**
 - Total PR References: **312**
 
-- Contributors: **78** (`AkhterAli`_, `DmitryKuzmenko`_, `MadsRC`_, `Oro`_, `The-Loeki`_, `abednarik`_, `akissa`_, `anlutro`_, `basepi`_, `bastiaanb`_, `bdrung`_, `borgstrom`_, `cachedout`_, `clan`_, `clinta`_, `cournape`_, `cro`_, `ctrlrsf`_, `dmacvicar`_, `dmurphy18`_, `dnd`_, `dr4Ke`_, `eliasp`_, `fcrozat`_, `frioux`_, `galet`_, `garethgreenaway`_, `gqgunhed`_, `gtmanfred`_, `hexedpackets`_, `isbm`_, `jacksontj`_, `jacobhammons`_, `jfindlay`_, `jleimbach`_, `job`_, `joejulian`_, `julianbrost`_, `justinta`_, `kingsquirrel152`_, `kiorky`_, `l2ol33rt`_, `lagesag`_, `lorengordon`_, `mbarrien`_, `mpreziuso`_, `multani`_, `nmadhok`_, `oeuftete`_, `opdude`_, `optix2000`_, `pass-by-value`_, `paulnivin`_, `plastikos`_, `pritambaral`_, `rallytime`_, `rasathus`_, `rmatulat`_, `ruxandraburtica`_, `ryan-lane`_, `s0undt3ch`_, `seanjnkns`_, `serge-p`_, `sjorge`_, `stanislavb`_, `tbaker57`_, `techhat`_, `terminalmage`_, `thatch45`_, `thegoodduke`_, `thomaso-mirodin`_, `ticosax`_, `timcharper`_, `tkunicki`_, `trevor-h`_, `twangboy`_, `whiteinge`_, `whytewolf`_)
+- Contributors: **78** (`AkhterAli`_, `DmitryKuzmenko`_, `MadsRC`_, `Oro`_, `The-Loeki`_,
+  `abednarik`_, `akissa`_, `anlutro`_, `basepi`_, `bastiaanb`_, `bdrung`_, `borgstrom`_,
+  `cachedout`_, `clan`_, `clinta`_, `cournape`_, `cro`_, `ctrlrsf`_, `dmacvicar`_, `dmurphy18`_,
+  `dnd`_, `dr4Ke`_, `eliasp`_, `fcrozat`_, `frioux`_, `galet`_, `garethgreenaway`_, `gqgunhed`_,
+  `gtmanfred`_, `hexedpackets`_, `isbm`_, `jacksontj`_, `jacobhammons`_, `jfindlay`_, `jleimbach`_,
+  `job`_, `joejulian`_, `julianbrost`_, `justinta`_, `kingsquirrel152`_, `kiorky`_, `l2ol33rt`_,
+  `lagesag`_, `lorengordon`_, `mbarrien`_, `mpreziuso`_, `multani`_, `nmadhok`_, `oeuftete`_,
+  `opdude`_, `optix2000`_, `pass-by-value`_, `paulnivin`_, `plastikos`_, `pritambaral`_,
+  `rallytime`_, `rasathus`_, `rmatulat`_, `ruxandraburtica`_, `ryan-lane`_, `s0undt3ch`_,
+  `seanjnkns`_, `serge-p`_, `sjorge`_, `stanislavb`_, `tbaker57`_, `techhat`_, `terminalmage`_,
+  `thatch45`_, `thegoodduke`_, `thomaso-mirodin`_, `ticosax`_, `timcharper`_, `tkunicki`_,
+  `trevor-h`_, `twangboy`_, `whiteinge`_, `whytewolf`_)
 
 
 Known Issues

--- a/doc/topics/releases/2015.8.8.rst
+++ b/doc/topics/releases/2015.8.8.rst
@@ -17,7 +17,17 @@ Statistics
 - Total Issue References: **146**
 - Total PR References: **312**
 
-- Contributors: **74** (`Ch3LL`_, `DmitryKuzmenko`_, `JohannesEbke`_, `RabidCicada`_, `Talkless`_, `The-Loeki`_, `abednarik`_, `anlutro`_, `basepi`_, `bdrung`_, `cachedout`_, `captaininspiration`_, `clarkperkins`_, `clinta`_, `cro`_, `darix`_, `dmacvicar`_, `dr4Ke`_, `dschaller`_, `edencrane`_, `garethgreenaway`_, `gladiatr72`_, `gtmanfred`_, `iacopo-papalini`_, `isbm`_, `jacksontj`_, `jacobhammons`_, `jakehilton`_, `jespada`_, `jfindlay`_, `joejulian`_, `justinta`_, `kiorky`_, `kraney`_, `llua`_, `mcalmer`_, `mchugh19`_, `mew1033`_, `mlalpho`_, `moltob`_, `multani`_, `myii`_, `opdude`_, `paiou`_, `pass-by-value`_, `peripatetic-sojourner`_, `pprince`_, `rallytime`_, `redmcg`_, `replicant0wnz`_, `rhansen`_, `rmtmckenzie`_, `s0undt3ch`_, `sakateka`_, `sbreidba`_, `seanjnkns`_, `sjmh`_, `sjorge`_, `skizunov`_, `szeestraten`_, `tbaker57`_, `techhat`_, `terminalmage`_, `thusoy`_, `ticosax`_, `twangboy`_, `virtualguy`_, `vutny`_, `whiteinge`_, `xmj`_, `xopher-mc`_, `yannis666`_, `youngnick`_, `zygiss`_)
+- Contributors: **74** (`Ch3LL`_, `DmitryKuzmenko`_, `JohannesEbke`_, `RabidCicada`_, `Talkless`_,
+  `The-Loeki`_, `abednarik`_, `anlutro`_, `basepi`_, `bdrung`_, `cachedout`_,
+  `captaininspiration`_, `clarkperkins`_, `clinta`_, `cro`_, `darix`_, `dmacvicar`_, `dr4Ke`_,
+  `dschaller`_, `edencrane`_, `garethgreenaway`_, `gladiatr72`_, `gtmanfred`_, `iacopo-papalini`_,
+  `isbm`_, `jacksontj`_, `jacobhammons`_, `jakehilton`_, `jespada`_, `jfindlay`_, `joejulian`_,
+  `justinta`_, `kiorky`_, `kraney`_, `llua`_, `mcalmer`_, `mchugh19`_, `mew1033`_, `mlalpho`_,
+  `moltob`_, `multani`_, `myii`_, `opdude`_, `paiou`_, `pass-by-value`_, `peripatetic-sojourner`_,
+  `pprince`_, `rallytime`_, `redmcg`_, `replicant0wnz`_, `rhansen`_, `rmtmckenzie`_, `s0undt3ch`_,
+  `sakateka`_, `sbreidba`_, `seanjnkns`_, `sjmh`_, `sjorge`_, `skizunov`_, `szeestraten`_,
+  `tbaker57`_, `techhat`_, `terminalmage`_, `thusoy`_, `ticosax`_, `twangboy`_, `virtualguy`_,
+  `vutny`_, `whiteinge`_, `xmj`_, `xopher-mc`_, `yannis666`_, `youngnick`_, `zygiss`_)
 
 
 Security Fix

--- a/doc/topics/releases/2015.8.9.rst
+++ b/doc/topics/releases/2015.8.9.rst
@@ -14,7 +14,17 @@ Statistics
 - Total Issue References: **110**
 - Total PR References: **264**
 
-- Contributors: **71** (`Ch3LL`_, `DmitryKuzmenko`_, `DylanFrese`_, `Ferbla`_, `Kurocon`_, `Lothiraldan`_, `RuriRyan`_, `Talkless`_, `The-Loeki`_, `UtahDave`_, `Xiami2012`_, `abednarik`_, `afletch`_, `ahammond`_, `ahus1`_, `aletourneau`_, `alxf`_, `amontalban`_, `anlutro`_, `arthurlogilab`_, `atengler`_, `basepi`_, `bdrung`_, `bradthurber`_, `cachedout`_, `captaininspiration`_, `cedwards`_, `clarkperkins`_, `clinta`_, `cro`_, `dmurphy18`_, `exowaucka`_, `garethgreenaway`_, `guettli`_, `idonin`_, `isbm`_, `jacobhammons`_, `jbonachera`_, `jfindlay`_, `jfray`_, `junster1`_, `justinta`_, `krak3n`_, `lalmeras`_, `lloydoliver`_, `lomeroe`_, `mcalmer`_, `mitar`_, `mrproper`_, `multani`_, `nmadhok`_, `notpeter`_, `onorua`_, `paclat`_, `papertigers`_, `rallytime`_, `rkgrunt`_, `sakateka`_, `sbreidba`_, `schancel`_, `sjorge`_, `stk0vrfl0w`_, `techhat`_, `terminalmage`_, `thatch45`_, `ticosax`_, `tomlaredo`_, `twangboy`_, `twellspring`_, `vutny`_, `whiteinge`_)
+- Contributors: **71** (`Ch3LL`_, `DmitryKuzmenko`_, `DylanFrese`_, `Ferbla`_, `Kurocon`_,
+  `Lothiraldan`_, `RuriRyan`_, `Talkless`_, `The-Loeki`_, `UtahDave`_, `Xiami2012`_, `abednarik`_,
+  `afletch`_, `ahammond`_, `ahus1`_, `aletourneau`_, `alxf`_, `amontalban`_, `anlutro`_,
+  `arthurlogilab`_, `atengler`_, `basepi`_, `bdrung`_, `bradthurber`_, `cachedout`_,
+  `captaininspiration`_, `cedwards`_, `clarkperkins`_, `clinta`_, `cro`_, `dmurphy18`_,
+  `exowaucka`_, `garethgreenaway`_, `guettli`_, `idonin`_, `isbm`_, `jacobhammons`_, `jbonachera`_,
+  `jfindlay`_, `jfray`_, `junster1`_, `justinta`_, `krak3n`_, `lalmeras`_, `lloydoliver`_,
+  `lomeroe`_, `mcalmer`_, `mitar`_, `mrproper`_, `multani`_, `nmadhok`_, `notpeter`_, `onorua`_,
+  `paclat`_, `papertigers`_, `rallytime`_, `rkgrunt`_, `sakateka`_, `sbreidba`_, `schancel`_,
+  `sjorge`_, `stk0vrfl0w`_, `techhat`_, `terminalmage`_, `thatch45`_, `ticosax`_, `tomlaredo`_,
+  `twangboy`_, `twellspring`_, `vutny`_, `whiteinge`_)
 
 
 Important Post-Upgrade Instructions for Linux Mint

--- a/doc/topics/releases/2016.11.1.rst
+++ b/doc/topics/releases/2016.11.1.rst
@@ -12,7 +12,11 @@ Statistics
 - Total Issue References: **29**
 - Total PR References: **83**
 
-- Contributors: **30** (`Ch3LL`_, `Da-Juan`_, `DmitryKuzmenko`_, `MTecknology`_, `adelcast`_, `attiasr`_, `bbinet`_, `cachedout`_, `cro`_, `dmurphy18`_, `gtmanfred`_, `isbm`_, `jeanpralo`_, `kraney`_, `kstreee`_, `lorengordon`_, `mateiw`_, `mirceaulinic`_, `morsik`_, `mschneider82`_, `rallytime`_, `rbjorklin`_, `scott-w`_, `sjorge`_, `skizunov`_, `techhat`_, `terminalmage`_, `thatch45`_, `ticosax`_, `whiteinge`_)
+- Contributors: **30** (`Ch3LL`_, `Da-Juan`_, `DmitryKuzmenko`_, `MTecknology`_, `adelcast`_,
+  `attiasr`_, `bbinet`_, `cachedout`_, `cro`_, `dmurphy18`_, `gtmanfred`_, `isbm`_, `jeanpralo`_,
+  `kraney`_, `kstreee`_, `lorengordon`_, `mateiw`_, `mirceaulinic`_, `morsik`_, `mschneider82`_,
+  `rallytime`_, `rbjorklin`_, `scott-w`_, `sjorge`_, `skizunov`_, `techhat`_, `terminalmage`_,
+  `thatch45`_, `ticosax`_, `whiteinge`_)
 
 
 Changelog for v2016.11.0..v2016.11.1

--- a/doc/topics/releases/2016.11.2.rst
+++ b/doc/topics/releases/2016.11.2.rst
@@ -12,7 +12,13 @@ Statistics
 - Total Issue References: **34**
 - Total PR References: **116**
 
-- Contributors: **45** (`Ch3LL`_, `Cybolic`_, `DmitryKuzmenko`_, `UtahDave`_, `Vaelatern`_, `alex-zel`_, `alxwr`_, `amendlik`_, `anlutro`_, `aosagie`_, `basdusee`_, `bbinet`_, `benediktwerner`_, `cachedout`_, `clinta`_, `cro`_, `dereckson`_, `disaster123`_, `ewapptus`_, `ezh`_, `folti`_, `gmacon`_, `gqgunhed`_, `gtmanfred`_, `kkoppel`_, `lorengordon`_, `martintamare`_, `mcalmer`_, `meaksh`_, `mirceaulinic`_, `mostafahussein`_, `mvdwalle`_, `rallytime`_, `rbjorklin`_, `scthi`_, `sjorge`_, `techhat`_, `terminalmage`_, `tsaridas`_, `twangboy`_, `vutny`_, `wolfpackmars2`_, `yhekma`_, `yopito`_, `yue9944882`_)
+- Contributors: **45** (`Ch3LL`_, `Cybolic`_, `DmitryKuzmenko`_, `UtahDave`_, `Vaelatern`_,
+  `alex-zel`_, `alxwr`_, `amendlik`_, `anlutro`_, `aosagie`_, `basdusee`_, `bbinet`_,
+  `benediktwerner`_, `cachedout`_, `clinta`_, `cro`_, `dereckson`_, `disaster123`_, `ewapptus`_,
+  `ezh`_, `folti`_, `gmacon`_, `gqgunhed`_, `gtmanfred`_, `kkoppel`_, `lorengordon`_,
+  `martintamare`_, `mcalmer`_, `meaksh`_, `mirceaulinic`_, `mostafahussein`_, `mvdwalle`_,
+  `rallytime`_, `rbjorklin`_, `scthi`_, `sjorge`_, `techhat`_, `terminalmage`_, `tsaridas`_,
+  `twangboy`_, `vutny`_, `wolfpackmars2`_, `yhekma`_, `yopito`_, `yue9944882`_)
 
 
 Security Fixes

--- a/doc/topics/releases/2016.11.3.rst
+++ b/doc/topics/releases/2016.11.3.rst
@@ -12,7 +12,13 @@ Statistics
 - Total Issue References: **49**
 - Total PR References: **130**
 
-- Contributors: **47** (`Ch3LL`_, `DmitryKuzmenko`_, `MTecknology`_, `The-Loeki`_, `UtahDave`_, `anlutro`_, `arthru`_, `axmetishe`_, `bailsman`_, `bobrik`_, `cachedout`_, `clinta`_, `corywright`_, `cro`_, `dmaziuk`_, `dmitrievav`_, `dmurphy18`_, `eliasp`_, `eradman`_, `ezh`_, `gtmanfred`_, `hu-dabao`_, `hujunya`_, `isbm`_, `jak3kaj`_, `janhorstmann`_, `joe-niland`_, `kevinanderson1`_, `kstreee`_, `l2ol33rt`_, `lomeroe`_, `mcalmer`_, `meaksh`_, `mirceaulinic`_, `morganwillcock`_, `nasenbaer13`_, `nicholasmhughes`_, `rallytime`_, `sakateka`_, `sergeizv`_, `sjorge`_, `techhat`_, `terminalmage`_, `thatch45`_, `toanju`_, `twangboy`_, `vutny`_)
+- Contributors: **47** (`Ch3LL`_, `DmitryKuzmenko`_, `MTecknology`_, `The-Loeki`_, `UtahDave`_,
+  `anlutro`_, `arthru`_, `axmetishe`_, `bailsman`_, `bobrik`_, `cachedout`_, `clinta`_,
+  `corywright`_, `cro`_, `dmaziuk`_, `dmitrievav`_, `dmurphy18`_, `eliasp`_, `eradman`_, `ezh`_,
+  `gtmanfred`_, `hu-dabao`_, `hujunya`_, `isbm`_, `jak3kaj`_, `janhorstmann`_, `joe-niland`_,
+  `kevinanderson1`_, `kstreee`_, `l2ol33rt`_, `lomeroe`_, `mcalmer`_, `meaksh`_, `mirceaulinic`_,
+  `morganwillcock`_, `nasenbaer13`_, `nicholasmhughes`_, `rallytime`_, `sakateka`_, `sergeizv`_,
+  `sjorge`_, `techhat`_, `terminalmage`_, `thatch45`_, `toanju`_, `twangboy`_, `vutny`_)
 
 
 Changelog for v2016.11.2..v2016.11.3

--- a/doc/topics/releases/2016.11.4.rst
+++ b/doc/topics/releases/2016.11.4.rst
@@ -12,7 +12,16 @@ Statistics
 - Total Issue References: **63**
 - Total PR References: **223**
 
-- Contributors: **62** (`Ch3LL`_, `DennisHarper`_, `DmitryKuzmenko`_, `L4rS6`_, `MasterNayru`_, `Seb-Solon`_, `The-Loeki`_, `UtahDave`_, `aabognah`_, `alankrita`_, `amontalban`_, `ardakuyumcu`_, `attiasr`_, `bdrung`_, `bewing`_, `cachedout`_, `cro`_, `defanator`_, `discountbin`_, `dmurphy18`_, `drawsmcgraw`_, `eldadru`_, `garethgreenaway`_, `githubcdr`_, `gtmanfred`_, `hkrist`_, `isbm`_, `jbadson`_, `jeanpralo`_, `jettero`_, `jinm`_, `joe-niland`_, `kaszuba`_, `lomeroe`_, `lorengordon`_, `mateiw`_, `mcalmer`_, `mchugh19`_, `meaksh`_, `mirceaulinic`_, `mlalpho`_, `narendraingale2`_, `nmadhok`_, `rallytime`_, `redbaron4`_, `roaldnefs`_, `s0undt3ch`_, `skazi0`_, `skizunov`_, `smarsching`_, `sofixa`_, `sp1r`_, `sthrasher`_, `techhat`_, `terminalmage`_, `thatch45`_, `thor`_, `ticosax`_, `twangboy`_, `vutny`_, `whiteinge`_, `zer0def`_)
+- Contributors: **62** (`Ch3LL`_, `DennisHarper`_, `DmitryKuzmenko`_, `L4rS6`_, `MasterNayru`_,
+  `Seb-Solon`_, `The-Loeki`_, `UtahDave`_, `aabognah`_, `alankrita`_, `amontalban`_,
+  `ardakuyumcu`_, `attiasr`_, `bdrung`_, `bewing`_, `cachedout`_, `cro`_, `defanator`_,
+  `discountbin`_, `dmurphy18`_, `drawsmcgraw`_, `eldadru`_, `garethgreenaway`_, `githubcdr`_,
+  `gtmanfred`_, `hkrist`_, `isbm`_, `jbadson`_, `jeanpralo`_, `jettero`_, `jinm`_, `joe-niland`_,
+  `kaszuba`_, `lomeroe`_, `lorengordon`_, `mateiw`_, `mcalmer`_, `mchugh19`_, `meaksh`_,
+  `mirceaulinic`_, `mlalpho`_, `narendraingale2`_, `nmadhok`_, `rallytime`_, `redbaron4`_,
+  `roaldnefs`_, `s0undt3ch`_, `skazi0`_, `skizunov`_, `smarsching`_, `sofixa`_, `sp1r`_,
+  `sthrasher`_, `techhat`_, `terminalmage`_, `thatch45`_, `thor`_, `ticosax`_, `twangboy`_,
+  `vutny`_, `whiteinge`_, `zer0def`_)
 
 
 AIX Support Expanded

--- a/doc/topics/releases/2016.11.5.rst
+++ b/doc/topics/releases/2016.11.5.rst
@@ -12,7 +12,11 @@ Statistics
 - Total Issue References: **23**
 - Total PR References: **80**
 
-- Contributors: **32** (`BenoitKnecht`_, `Ch3LL`_, `DmitryKuzmenko`_, `Enquier`_, `SolarisYan`_, `UtahDave`_, `alexproca`_, `benediktwerner`_, `bobrik`_, `brd`_, `cachedout`_, `clinta`_, `corywright`_, `cro`_, `danlsgiga`_, `drawsmcgraw`_, `ezh`_, `gtmanfred`_, `isbm`_, `jf`_, `jleproust`_, `lorengordon`_, `nevins-b`_, `oeuftete`_, `peter-funktionIT`_, `rallytime`_, `rkgrunt`_, `senthilkumar-e`_, `sjorge`_, `skizunov`_, `terminalmage`_, `twangboy`_)
+- Contributors: **32** (`BenoitKnecht`_, `Ch3LL`_, `DmitryKuzmenko`_, `Enquier`_, `SolarisYan`_,
+  `UtahDave`_, `alexproca`_, `benediktwerner`_, `bobrik`_, `brd`_, `cachedout`_, `clinta`_,
+  `corywright`_, `cro`_, `danlsgiga`_, `drawsmcgraw`_, `ezh`_, `gtmanfred`_, `isbm`_, `jf`_,
+  `jleproust`_, `lorengordon`_, `nevins-b`_, `oeuftete`_, `peter-funktionIT`_, `rallytime`_,
+  `rkgrunt`_, `senthilkumar-e`_, `sjorge`_, `skizunov`_, `terminalmage`_, `twangboy`_)
 
 
 Patched Packages

--- a/doc/topics/releases/2016.11.6.rst
+++ b/doc/topics/releases/2016.11.6.rst
@@ -12,7 +12,14 @@ Statistics
 - Total Issue References: **58**
 - Total PR References: **153**
 
-- Contributors: **49** (`BenoitKnecht`_, `Ch3LL`_, `Enquier`_, `F30`_, `Foxlik`_, `The-Loeki`_, `UtahDave`_, `abednarik`_, `alex-zel`_, `arif-ali`_, `automate-solutions`_, `axmetishe`_, `bdrung`_, `cachedout`_, `cro`_, `darenjacobs`_, `dmurphy18`_, `dschaller`_, `epcim`_, `garethgreenaway`_, `github-abcde`_, `gtmanfred`_, `isbm`_, `jettero`_, `jmarinaro`_, `kiorky`_, `lomeroe`_, `lordcirth`_, `lorengordon`_, `lubyou`_, `mcalmer`_, `moio`_, `onlyanegg`_, `peter-funktionIT`_, `pkazmierczak`_, `pprkut`_, `rallytime`_, `ricohouse`_, `seanjnkns`_, `sebw`_, `skizunov`_, `svinota`_, `t0fik`_, `terminalmage`_, `tmeneau`_, `tonybaloney`_, `twangboy`_, `whiteinge`_, `yannj-fr`_)
+- Contributors: **49** (`BenoitKnecht`_, `Ch3LL`_, `Enquier`_, `F30`_, `Foxlik`_, `The-Loeki`_,
+  `UtahDave`_, `abednarik`_, `alex-zel`_, `arif-ali`_, `automate-solutions`_, `axmetishe`_,
+  `bdrung`_, `cachedout`_, `cro`_, `darenjacobs`_, `dmurphy18`_, `dschaller`_, `epcim`_,
+  `garethgreenaway`_, `github-abcde`_, `gtmanfred`_, `isbm`_, `jettero`_, `jmarinaro`_, `kiorky`_,
+  `lomeroe`_, `lordcirth`_, `lorengordon`_, `lubyou`_, `mcalmer`_, `moio`_, `onlyanegg`_,
+  `peter-funktionIT`_, `pkazmierczak`_, `pprkut`_, `rallytime`_, `ricohouse`_, `seanjnkns`_,
+  `sebw`_, `skizunov`_, `svinota`_, `t0fik`_, `terminalmage`_, `tmeneau`_, `tonybaloney`_,
+  `twangboy`_, `whiteinge`_, `yannj-fr`_)
 
 
 Changelog for v2016.11.5..v2016.11.6

--- a/doc/topics/releases/2016.11.6.rst
+++ b/doc/topics/releases/2016.11.6.rst
@@ -200,7 +200,9 @@ Changelog for v2016.11.5..v2016.11.6
 
       * 687872a488 Lint
 
-      * dadf4b851c Add documentation to the example master and minion configuration files. Move minion event signing to a saner place. Enable dropping messages when signature does not verify or when minion is not adding the signature to its payloads.
+      * dadf4b851c Add documentation to the example master and minion configuration files. Move
+        minion event signing to a saner place. Enable dropping messages when signature does not
+        verify or when minion is not adding the signature to its payloads.
 
       * e44673cdae Add caching of key.
 
@@ -556,7 +558,15 @@ Changelog for v2016.11.5..v2016.11.6
 
   * d9546c6283 Merge pull request `#41599`_ from garethgreenaway/41540_fixes_to_archive_module
 
-  * 66a136e6d8 Fixing issues raised in `#41540`_ when a zip file is created on a Windows system.  The issue has two parts, first directories that end up in the archive end up in the results of aarchive.list twice as they show up as both files and directories because of the logic to handle the fact that Windows doesn't mark them as directories.  This issue shows up when an extraction is run a second time since the module verified the file types and the subdirectory is not a file.  The second issue is related to permissions, if Salt is told to extract permissions (which is the default) then the directory and files end up being unreadable since the permissions are not available.  This change sets the permissions to what the default umask for the user running Salt is.
+  * 66a136e6d8 Fixing issues raised in `#41540`_ when a zip file is created on a Windows system.
+    The issue has two parts, first directories that end up in the archive end up in the results of
+    aarchive.list twice as they show up as both files and directories because of the logic to
+    handle the fact that Windows doesn't mark them as directories. This issue shows up when an
+    extraction is run a second time since the module verified the file types and the subdirectory
+    is not a file. The second issue is related to permissions, if Salt is told to extract
+    permissions (which is the default) then the directory and files end up being unreadable since
+    the permissions are not available. This change sets the permissions to what the default umask
+    for the user running Salt is.
 
 * **ISSUE** `#40950`_: (`idokaplan`_) Import certificate (refs: `#41453`_, `#41383`_)
 
@@ -835,7 +845,9 @@ Changelog for v2016.11.5..v2016.11.6
 
   * 3f950596f4 Fixing lint issues.
 
-  * f3a6531a69 On occasion an exception will occur which results in the  event not returning properly, even though the wire_bytes  is correctly populated. In this situation, we log to trace  and continue. `#34460`_
+  * f3a6531a69 On occasion an exception will occur which results in the event not returning
+    properly, even though the wire_bytes is correctly populated. In this situation, we log to trace
+    and continue. `#34460`_
 
 * **PR** `#41421`_: (`UtahDave`_) Correct doc to actually blacklist a module
   @ *2017-05-25 21:01:46 UTC*
@@ -992,7 +1004,9 @@ Changelog for v2016.11.5..v2016.11.6
 
   * 5039fe12fb Removing chdir as it is no needed with this change
 
-  * 4550c3ce49 Updating the code that is pulling in the list of cached minions to use self.cache.list instead of relying on checking the local file system, which only works for the localfs cache method.  `#40748`_
+  * 4550c3ce49 Updating the code that is pulling in the list of cached minions to use
+    self.cache.list instead of relying on checking the local file system, which only works for the
+    localfs cache method. `#40748`_
 
 * **ISSUE** `#38894`_: (`amendlik`_) salt.runner and salt.wheel ignore test=True (refs: `#41309`_, `#41611`_)
 

--- a/doc/topics/releases/2016.11.8.rst
+++ b/doc/topics/releases/2016.11.8.rst
@@ -12,7 +12,16 @@ Statistics
 - Total Issue References: **68**
 - Total PR References: **202**
 
-- Contributors: **61** (`AFriemann`_, `Ch3LL`_, `CorvinM`_, `Da-Juan`_, `DmitryKuzmenko`_, `UtahDave`_, `abulford`_, `amalleo25`_, `amendlik`_, `aneeshusa`_, `aogier`_, `arount`_, `arthurlogilab`_, `astronouth7303`_, `binocvlar`_, `blarghmatey`_, `cachedout`_, `clem-compilatio`_, `corywright`_, `cri-epita`_, `damon-atkins`_, `davidjb`_, `dglloyd`_, `dmurphy18`_, `ferringb`_, `garethgreenaway`_, `gdubroeucq`_, `gilbsgilbs`_, `goten4`_, `gtmanfred`_, `isbm`_, `jagguli`_, `kevinanderson1`_, `kojiromike`_, `kstreee`_, `leeclemens`_, `lomeroe`_, `lorengordon`_, `lubyou`_, `mcarlton00`_, `meaksh`_, `morganwillcock`_, `nhavens`_, `pabloh007`_, `rallytime`_, `remijouannet`_, `renner`_, `root360-AndreasUlm`_, `s-sebastian`_, `sarcasticadmin`_, `sbojarski`_, `shengis`_, `tdutrion`_, `terminalmage`_, `toanju`_, `twangboy`_, `ushmodin`_, `viktorkrivak`_, `vutny`_, `whiteinge`_, `xiaoanyunfei`_)
+- Contributors: **61** (`AFriemann`_, `Ch3LL`_, `CorvinM`_, `Da-Juan`_, `DmitryKuzmenko`_,
+  `UtahDave`_, `abulford`_, `amalleo25`_, `amendlik`_, `aneeshusa`_, `aogier`_, `arount`_,
+  `arthurlogilab`_, `astronouth7303`_, `binocvlar`_, `blarghmatey`_, `cachedout`_,
+  `clem-compilatio`_, `corywright`_, `cri-epita`_, `damon-atkins`_, `davidjb`_, `dglloyd`_,
+  `dmurphy18`_, `ferringb`_, `garethgreenaway`_, `gdubroeucq`_, `gilbsgilbs`_, `goten4`_,
+  `gtmanfred`_, `isbm`_, `jagguli`_, `kevinanderson1`_, `kojiromike`_, `kstreee`_, `leeclemens`_,
+  `lomeroe`_, `lorengordon`_, `lubyou`_, `mcarlton00`_, `meaksh`_, `morganwillcock`_, `nhavens`_,
+  `pabloh007`_, `rallytime`_, `remijouannet`_, `renner`_, `root360-AndreasUlm`_, `s-sebastian`_,
+  `sarcasticadmin`_, `sbojarski`_, `shengis`_, `tdutrion`_, `terminalmage`_, `toanju`_,
+  `twangboy`_, `ushmodin`_, `viktorkrivak`_, `vutny`_, `whiteinge`_, `xiaoanyunfei`_)
 
 
 Security Fix

--- a/doc/topics/releases/2016.11.9.rst
+++ b/doc/topics/releases/2016.11.9.rst
@@ -12,7 +12,15 @@ Statistics
 - Total Issue References: **60**
 - Total PR References: **167**
 
-- Contributors: **54** (`Ch3LL`_, `UtahDave`_, `VertigoRay`_, `akissa`_, `aogier`_, `arthtux`_, `austinpapp`_, `basepi`_, `benediktwerner`_, `bobrik`_, `brejoc`_, `cachedout`_, `cetanu`_, `corywright`_, `creideiki`_, `cro`_, `cruscio`_, `damon-atkins`_, `dayid`_, `defanator`_, `dereckson`_, `dijit`_, `doesitblend`_, `garethgreenaway`_, `gtmanfred`_, `gurubert`_, `gvengel`_, `jfindlay`_, `johnj`_, `jubrad`_, `junovitch`_, `lomeroe`_, `lordcirth`_, `lorengordon`_, `mattLLVW`_, `meaksh`_, `moio`_, `msummers42`_, `mtkennerly`_, `nicholasmhughes`_, `oeuftete`_, `rallytime`_, `rasathus`_, `roaldnefs`_, `rossengeorgiev`_, `seanjnkns`_, `senthilkumar-e`_, `techhat`_, `terminalmage`_, `twangboy`_, `vernondcole`_, `vutny`_, `whiteinge`_, `whytewolf`_)
+- Contributors: **54** (`Ch3LL`_, `UtahDave`_, `VertigoRay`_, `akissa`_, `aogier`_, `arthtux`_,
+  `austinpapp`_, `basepi`_, `benediktwerner`_, `bobrik`_, `brejoc`_, `cachedout`_, `cetanu`_,
+  `corywright`_, `creideiki`_, `cro`_, `cruscio`_, `damon-atkins`_, `dayid`_, `defanator`_,
+  `dereckson`_, `dijit`_, `doesitblend`_, `garethgreenaway`_, `gtmanfred`_, `gurubert`_,
+  `gvengel`_, `jfindlay`_, `johnj`_, `jubrad`_, `junovitch`_, `lomeroe`_, `lordcirth`_,
+  `lorengordon`_, `mattLLVW`_, `meaksh`_, `moio`_, `msummers42`_, `mtkennerly`_,
+  `nicholasmhughes`_, `oeuftete`_, `rallytime`_, `rasathus`_, `roaldnefs`_, `rossengeorgiev`_,
+  `seanjnkns`_, `senthilkumar-e`_, `techhat`_, `terminalmage`_, `twangboy`_, `vernondcole`_,
+  `vutny`_, `whiteinge`_, `whytewolf`_)
 
 
 Windows Changes

--- a/doc/topics/releases/2016.3.1.rst
+++ b/doc/topics/releases/2016.3.1.rst
@@ -12,7 +12,10 @@ Statistics
 - Total Issue References: **23**
 - Total PR References: **58**
 
-- Contributors: **25** (`abednarik`_, `amontalban`_, `anlutro`_, `babilen`_, `cachedout`_, `clburlison`_, `danslimmon`_, `eliasp`_, `glomium`_, `jacobhammons`_, `jfindlay`_, `kev009`_, `lomeroe`_, `michalsuba`_, `neil-williamson`_, `onorua`_, `opdude`_, `rallytime`_, `sjorge`_, `terminalmage`_, `thatch45`_, `ticosax`_, `tomlaredo`_, `twangboy`_, `zigarn`_)
+- Contributors: **25** (`abednarik`_, `amontalban`_, `anlutro`_, `babilen`_, `cachedout`_,
+  `clburlison`_, `danslimmon`_, `eliasp`_, `glomium`_, `jacobhammons`_, `jfindlay`_, `kev009`_,
+  `lomeroe`_, `michalsuba`_, `neil-williamson`_, `onorua`_, `opdude`_, `rallytime`_, `sjorge`_,
+  `terminalmage`_, `thatch45`_, `ticosax`_, `tomlaredo`_, `twangboy`_, `zigarn`_)
 
 
 Final Release of Debian 7 Packages

--- a/doc/topics/releases/2016.3.2.rst
+++ b/doc/topics/releases/2016.3.2.rst
@@ -12,7 +12,14 @@ Statistics
 - Total Issue References: **66**
 - Total PR References: **177**
 
-- Contributors: **52** (`Ch3LL`_, `DarkKnightCZ`_, `DmitryKuzmenko`_, `Inveracity`_, `abalashov`_, `abednarik`_, `adelcast`_, `ajacoutot`_, `amendlik`_, `anlutro`_, `aphor`_, `artxki`_, `bbinet`_, `bensherman`_, `cachedout`_, `christoe`_, `clinta`_, `cro`_, `dmurphy18`_, `dongweiming`_, `eliasp`_, `eradman`_, `farcaller`_, `garethgreenaway`_, `glomium`_, `gtmanfred`_, `isbm`_, `jacobhammons`_, `jacobweinstock`_, `jfindlay`_, `jmacfar`_, `jnhmcknight`_, `justinta`_, `l2ol33rt`_, `lomeroe`_, `meaksh`_, `nulfox`_, `opdude`_, `peterdemin`_, `rallytime`_, `s0undt3ch`_, `secumod`_, `sjmh`_, `sjorge`_, `terminalmage`_, `thatch45`_, `themalkolm`_, `ticosax`_, `tmehlinger`_, `twangboy`_, `vutny`_, `whiteinge`_)
+- Contributors: **52** (`Ch3LL`_, `DarkKnightCZ`_, `DmitryKuzmenko`_, `Inveracity`_, `abalashov`_,
+  `abednarik`_, `adelcast`_, `ajacoutot`_, `amendlik`_, `anlutro`_, `aphor`_, `artxki`_, `bbinet`_,
+  `bensherman`_, `cachedout`_, `christoe`_, `clinta`_, `cro`_, `dmurphy18`_, `dongweiming`_,
+  `eliasp`_, `eradman`_, `farcaller`_, `garethgreenaway`_, `glomium`_, `gtmanfred`_, `isbm`_,
+  `jacobhammons`_, `jacobweinstock`_, `jfindlay`_, `jmacfar`_, `jnhmcknight`_, `justinta`_,
+  `l2ol33rt`_, `lomeroe`_, `meaksh`_, `nulfox`_, `opdude`_, `peterdemin`_, `rallytime`_,
+  `s0undt3ch`_, `secumod`_, `sjmh`_, `sjorge`_, `terminalmage`_, `thatch45`_, `themalkolm`_,
+  `ticosax`_, `tmehlinger`_, `twangboy`_, `vutny`_, `whiteinge`_)
 
 
 Returner Changes

--- a/doc/topics/releases/2016.3.3.rst
+++ b/doc/topics/releases/2016.3.3.rst
@@ -12,7 +12,12 @@ Statistics
 - Total Issue References: **26**
 - Total PR References: **115**
 
-- Contributors: **36** (`The-Loeki`_, `abednarik`_, `cachedout`_, `cro`_, `deniszh`_, `dkruger`_, `dmurphy18`_, `eliasp`_, `farcaller`_, `galet`_, `gtmanfred`_, `hu-dabao`_, `isbm`_, `jacobhammons`_, `jacobweinstock`_, `jfindlay`_, `justinta`_, `kstreee`_, `lubyou`_, `markuskramerIgitt`_, `meaksh`_, `miihael`_, `mzupan`_, `nishigori`_, `rallytime`_, `s0undt3ch`_, `skizunov`_, `tankywoo`_, `terminalmage`_, `thatch45`_, `theredcat`_, `ticosax`_, `tonybaloney`_, `twangboy`_, `vutny`_, `whiteinge`_)
+- Contributors: **36** (`The-Loeki`_, `abednarik`_, `cachedout`_, `cro`_, `deniszh`_, `dkruger`_,
+  `dmurphy18`_, `eliasp`_, `farcaller`_, `galet`_, `gtmanfred`_, `hu-dabao`_, `isbm`_,
+  `jacobhammons`_, `jacobweinstock`_, `jfindlay`_, `justinta`_, `kstreee`_, `lubyou`_,
+  `markuskramerIgitt`_, `meaksh`_, `miihael`_, `mzupan`_, `nishigori`_, `rallytime`_, `s0undt3ch`_,
+  `skizunov`_, `tankywoo`_, `terminalmage`_, `thatch45`_, `theredcat`_, `ticosax`_, `tonybaloney`_,
+  `twangboy`_, `vutny`_, `whiteinge`_)
 
 
 Known Issues

--- a/doc/topics/releases/2016.3.4.rst
+++ b/doc/topics/releases/2016.3.4.rst
@@ -12,7 +12,18 @@ Statistics
 - Total Issue References: **119**
 - Total PR References: **374**
 
-- Contributors: **80** (`BenoitKnecht`_, `Ch3LL`_, `DavidWittman`_, `DmitryKuzmenko`_, `Jlin317`_, `Kimamisa`_, `UtahDave`_, `aaronm-cloudtek`_, `abednarik`_, `ahammond`_, `alertedsnake`_, `alexander-bauer`_, `amontalban`_, `basepi`_, `bl4ckcontact`_, `bx2`_, `cachedout`_, `clarkperkins`_, `clinta`_, `cro`_, `damon-atkins`_, `danlsgiga`_, `darkalia`_, `dmurphy18`_, `do3meli`_, `edhgoose`_, `efficks`_, `eliasp`_, `eradman`_, `fix7`_, `galet`_, `goestin`_, `gtmanfred`_, `hrumph`_, `hu-dabao`_, `isbm`_, `jackywu`_, `jacobhammons`_, `jbonachera`_, `jf`_, `jfindlay`_, `jizhilong`_, `justinta`_, `kstreee`_, `l2ol33rt`_, `lomeroe`_, `lorengordon`_, `maximeguillet`_, `meaksh`_, `mikeadamz`_, `mirceaulinic`_, `morganwillcock`_, `mrproper`_, `multani`_, `nvtkaszpir`_, `oba11`_, `onorua`_, `opdude`_, `orymate`_, `oz123`_, `pass-by-value`_, `pbdeuchler`_, `rallytime`_, `roosri`_, `silenius`_, `skizunov`_, `slinn0`_, `stanislavb`_, `swiftgist`_, `techhat`_, `terminalmage`_, `thatch45`_, `theredcat`_, `ticosax`_, `twangboy`_, `vutny`_, `whiteinge`_, `xbglowx`_, `xiaoanyunfei`_, `yhekma`_)
+- Contributors: **80** (`BenoitKnecht`_, `Ch3LL`_, `DavidWittman`_, `DmitryKuzmenko`_, `Jlin317`_,
+  `Kimamisa`_, `UtahDave`_, `aaronm-cloudtek`_, `abednarik`_, `ahammond`_, `alertedsnake`_,
+  `alexander-bauer`_, `amontalban`_, `basepi`_, `bl4ckcontact`_, `bx2`_, `cachedout`_,
+  `clarkperkins`_, `clinta`_, `cro`_, `damon-atkins`_, `danlsgiga`_, `darkalia`_, `dmurphy18`_,
+  `do3meli`_, `edhgoose`_, `efficks`_, `eliasp`_, `eradman`_, `fix7`_, `galet`_, `goestin`_,
+  `gtmanfred`_, `hrumph`_, `hu-dabao`_, `isbm`_, `jackywu`_, `jacobhammons`_, `jbonachera`_, `jf`_,
+  `jfindlay`_, `jizhilong`_, `justinta`_, `kstreee`_, `l2ol33rt`_, `lomeroe`_, `lorengordon`_,
+  `maximeguillet`_, `meaksh`_, `mikeadamz`_, `mirceaulinic`_, `morganwillcock`_, `mrproper`_,
+  `multani`_, `nvtkaszpir`_, `oba11`_, `onorua`_, `opdude`_, `orymate`_, `oz123`_,
+  `pass-by-value`_, `pbdeuchler`_, `rallytime`_, `roosri`_, `silenius`_, `skizunov`_, `slinn0`_,
+  `stanislavb`_, `swiftgist`_, `techhat`_, `terminalmage`_, `thatch45`_, `theredcat`_, `ticosax`_,
+  `twangboy`_, `vutny`_, `whiteinge`_, `xbglowx`_, `xiaoanyunfei`_, `yhekma`_)
 
 
 Known Issues

--- a/doc/topics/releases/2016.3.5.rst
+++ b/doc/topics/releases/2016.3.5.rst
@@ -12,7 +12,17 @@ Statistics
 - Total Issue References: **112**
 - Total PR References: **281**
 
-- Contributors: **74** (`Ch3LL`_, `DmitryKuzmenko`_, `Firewire2002`_, `Mrten`_, `Talkless`_, `TronPaul`_, `UtahDave`_, `aaronm-cloudtek`_, `alex-zel`_, `alexandr-orlov`_, `alexbleotu`_, `attiasr`_, `basepi`_, `bdrung`_, `bshelton229`_, `cachedout`_, `calve`_, `clan`_, `clinta`_, `cro`_, `dere`_, `dereckson`_, `dhaines`_, `dincamihai`_, `do3meli`_, `dragon788`_, `edgan`_, `fedusia`_, `fj40crawler`_, `genuss`_, `gtmanfred`_, `haeac`_, `heewa`_, `hu-dabao`_, `jeanpralo`_, `jfindlay`_, `jinm`_, `kevinquinnyo`_, `kontrolld`_, `laleocen`_, `lorengordon`_, `m03`_, `mcalmer`_, `mchugh19`_, `meaksh`_, `mikejford`_, `moio`_, `multani`_, `nevins-b`_, `pass-by-value`_, `rallytime`_, `rbjorklin`_, `siccrusher`_, `silenius`_, `sjmh`_, `sjorge`_, `skizunov`_, `slinn0`_, `sofixa`_, `techhat`_, `tedski`_, `terminalmage`_, `thatch45`_, `thusoy`_, `toanju`_, `tobithiel`_, `twangboy`_, `tyhunt99`_, `vutny`_, `wanparo`_, `whiteinge`_, `xiaoanyunfei`_, `yhekma`_, `zwo-bot`_)
+- Contributors: **74** (`Ch3LL`_, `DmitryKuzmenko`_, `Firewire2002`_, `Mrten`_, `Talkless`_,
+  `TronPaul`_, `UtahDave`_, `aaronm-cloudtek`_, `alex-zel`_, `alexandr-orlov`_, `alexbleotu`_,
+  `attiasr`_, `basepi`_, `bdrung`_, `bshelton229`_, `cachedout`_, `calve`_, `clan`_, `clinta`_,
+  `cro`_, `dere`_, `dereckson`_, `dhaines`_, `dincamihai`_, `do3meli`_, `dragon788`_, `edgan`_,
+  `fedusia`_, `fj40crawler`_, `genuss`_, `gtmanfred`_, `haeac`_, `heewa`_, `hu-dabao`_,
+  `jeanpralo`_, `jfindlay`_, `jinm`_, `kevinquinnyo`_, `kontrolld`_, `laleocen`_, `lorengordon`_,
+  `m03`_, `mcalmer`_, `mchugh19`_, `meaksh`_, `mikejford`_, `moio`_, `multani`_, `nevins-b`_,
+  `pass-by-value`_, `rallytime`_, `rbjorklin`_, `siccrusher`_, `silenius`_, `sjmh`_, `sjorge`_,
+  `skizunov`_, `slinn0`_, `sofixa`_, `techhat`_, `tedski`_, `terminalmage`_, `thatch45`_,
+  `thusoy`_, `toanju`_, `tobithiel`_, `twangboy`_, `tyhunt99`_, `vutny`_, `wanparo`_, `whiteinge`_,
+  `xiaoanyunfei`_, `yhekma`_, `zwo-bot`_)
 
 
 Security Fixes

--- a/doc/topics/releases/2016.3.6.rst
+++ b/doc/topics/releases/2016.3.6.rst
@@ -12,7 +12,13 @@ Statistics
 - Total Issue References: **52**
 - Total PR References: **163**
 
-- Contributors: **43** (`Adaephon-GH`_, `Ch3LL`_, `DmitryKuzmenko`_, `Foxlik`_, `GideonRed-zz`_, `The-Loeki`_, `UtahDave`_, `alexbleotu`_, `anlutro`_, `bobrik`_, `cachedout`_, `cro`_, `dincamihai`_, `drawsmcgraw`_, `fboismenu`_, `galet`_, `garethgreenaway`_, `grep4linux`_, `gtmanfred`_, `jacobhammons`_, `jfindlay`_, `joe-niland`_, `lvg01`_, `mbom2004`_, `mcalmer`_, `mchugh19`_, `meaksh`_, `mirceaulinic`_, `morganwillcock`_, `narendraingale2`_, `nasenbaer13`_, `ni3mm4nd`_, `rallytime`_, `s0undt3ch`_, `sergeizv`_, `smarsching`_, `techhat`_, `terminalmage`_, `thatch45`_, `twangboy`_, `velom`_, `vutny`_, `yue9944882`_)
+- Contributors: **43** (`Adaephon-GH`_, `Ch3LL`_, `DmitryKuzmenko`_, `Foxlik`_, `GideonRed-zz`_,
+  `The-Loeki`_, `UtahDave`_, `alexbleotu`_, `anlutro`_, `bobrik`_, `cachedout`_, `cro`_,
+  `dincamihai`_, `drawsmcgraw`_, `fboismenu`_, `galet`_, `garethgreenaway`_, `grep4linux`_,
+  `gtmanfred`_, `jacobhammons`_, `jfindlay`_, `joe-niland`_, `lvg01`_, `mbom2004`_, `mcalmer`_,
+  `mchugh19`_, `meaksh`_, `mirceaulinic`_, `morganwillcock`_, `narendraingale2`_, `nasenbaer13`_,
+  `ni3mm4nd`_, `rallytime`_, `s0undt3ch`_, `sergeizv`_, `smarsching`_, `techhat`_, `terminalmage`_,
+  `thatch45`_, `twangboy`_, `velom`_, `vutny`_, `yue9944882`_)
 
 
 Security Fix

--- a/doc/topics/releases/2017.7.1.rst
+++ b/doc/topics/releases/2017.7.1.rst
@@ -12,7 +12,8 @@ Statistics
 - Total Issue References: **12**
 - Total PR References: **31**
 
-- Contributors: **11** (`Ch3LL`_, `TiteiKo`_, `garethgreenaway`_, `gtmanfred`_, `llua`_, `rallytime`_, `seedickcode`_, `skizunov`_, `terminalmage`_, `twangboy`_, `whiteinge`_)
+- Contributors: **11** (`Ch3LL`_, `TiteiKo`_, `garethgreenaway`_, `gtmanfred`_, `llua`_,
+  `rallytime`_, `seedickcode`_, `skizunov`_, `terminalmage`_, `twangboy`_, `whiteinge`_)
 
 
 Security Fix

--- a/doc/topics/releases/2017.7.2.rst
+++ b/doc/topics/releases/2017.7.2.rst
@@ -12,7 +12,14 @@ Statistics
 - Total Issue References: **73**
 - Total PR References: **236**
 
-- Contributors: **47** (`Ch3LL`_, `CorvinM`_, `DmitryKuzmenko`_, `Giandom`_, `Mapel88`_, `Mareo`_, `SuperPommeDeTerre`_, `The-Loeki`_, `abulford`_, `amendlik`_, `blarghmatey`_, `brejoc`_, `cachedout`_, `carsonoid`_, `cro`_, `damon-atkins`_, `darcoli`_, `dmurphy18`_, `frankiexyz`_, `garethgreenaway`_, `gtmanfred`_, `hibbert`_, `isbm`_, `ixs`_, `jettero`_, `jmarinaro`_, `justincbeard`_, `kkoppel`_, `llua`_, `lomeroe`_, `m03`_, `mcalmer`_, `mirceaulinic`_, `morganwillcock`_, `nhavens`_, `pabloh007`_, `rallytime`_, `seedickcode`_, `shengis`_, `skizunov`_, `terminalmage`_, `the-glu`_, `thusoy`_, `twangboy`_, `vitaliyf`_, `vutny`_, `whiteinge`_)
+- Contributors: **47** (`Ch3LL`_, `CorvinM`_, `DmitryKuzmenko`_, `Giandom`_, `Mapel88`_, `Mareo`_,
+  `SuperPommeDeTerre`_, `The-Loeki`_, `abulford`_, `amendlik`_, `blarghmatey`_, `brejoc`_,
+  `cachedout`_, `carsonoid`_, `cro`_, `damon-atkins`_, `darcoli`_, `dmurphy18`_, `frankiexyz`_,
+  `garethgreenaway`_, `gtmanfred`_, `hibbert`_, `isbm`_, `ixs`_, `jettero`_, `jmarinaro`_,
+  `justincbeard`_, `kkoppel`_, `llua`_, `lomeroe`_, `m03`_, `mcalmer`_, `mirceaulinic`_,
+  `morganwillcock`_, `nhavens`_, `pabloh007`_, `rallytime`_, `seedickcode`_, `shengis`_,
+  `skizunov`_, `terminalmage`_, `the-glu`_, `thusoy`_, `twangboy`_, `vitaliyf`_, `vutny`_,
+  `whiteinge`_)
 
 
 Security Fix

--- a/doc/topics/releases/2017.7.3.rst
+++ b/doc/topics/releases/2017.7.3.rst
@@ -462,7 +462,8 @@ Changelog for v2017.7.2..v2017.7.3
 
   * aeb5f4e248 Add state.running ssh integration test
 
-* **ISSUE** `saltstack/salt-jenkins#675`_: (`rallytime`_) [2017.7] unit.states.test_file.TestFileState.test_directory is failing on Fedora 27 and CentOS 6 (refs: `#45295`_)
+* **ISSUE** `saltstack/salt-jenkins#675`_: (`rallytime`_) [2017.7] unit.states.test_file.TestFileState.test_directory
+  is failing on Fedora 27 and CentOS 6 (refs: `#45295`_)
 
 * **PR** `#45295`_: (`gtmanfred`_) test directory that doesn't exist
   @ *2018-01-08 20:59:53 UTC*
@@ -1079,7 +1080,14 @@ Changelog for v2017.7.2..v2017.7.3
 
   * 32ef1e12ae Merge branch '2017.7' into 2017.7_replace_with_newer_2016.11_win_pkg
 
-  * 494835c3f2 I backported develop and applied a long list of fixes to 2016.11 this brings these fixes into 2017.7 - Software was not always being removed, general if & was in the string or msi was downloaded to uninstall the software - pkg.list_upgrades failed. Added support for 'latest' and 'Not Found' for version_cmp() to fix this. - output fixes - pkg.list_available no longer forces a pkg.refresh_db this is no longer required, as by default it will update if older than 6 hours - cmd /s /c is prefixed for all commands i.e. installs and removes. - cmd are now strings, instead of a list when using cmd.run. As windows only supports strings. And the " were being broken
+  * 494835c3f2 I backported develop and applied a long list of fixes to 2016.11 this brings these
+    fixes into 2017.7 - Software was not always being removed, general if & was in the string or
+    msi was downloaded to uninstall the software - pkg.list_upgrades failed. Added support for
+    'latest' and 'Not Found' for version_cmp() to fix this. - output fixes - pkg.list_available no
+    longer forces a pkg.refresh_db this is no longer required, as by default it will update if
+    older than 6 hours - cmd /s /c is prefixed for all commands i.e. installs and removes. - cmd
+    are now strings, instead of a list when using cmd.run. As windows only supports strings. And
+    the " were being broken
 
 * **PR** `#44754`_: (`twangboy`_) Fix inet_pton for Windows on Py3
   @ *2017-12-12 14:04:20 UTC*
@@ -1561,7 +1569,8 @@ Changelog for v2017.7.2..v2017.7.3
 
   * 9d43221422 Correct indentation
 
-  * d6e28ebed1 Add handling for FreeBSD in method zone_compare to avoid exception when /etc/localtime file does is absent.  This is valid configuration on FreeBSD and represents UTC.
+  * d6e28ebed1 Add handling for FreeBSD in method zone_compare to avoid exception when
+    /etc/localtime file does is absent.  This is valid configuration on FreeBSD and represents UTC.
 
 * **ISSUE** `#41869`_: (`mirceaulinic`_) Thorium: unable to execute runners (refs: `#44781`_)
 
@@ -3446,7 +3455,9 @@ Changelog for v2017.7.2..v2017.7.3
 
       * babad12d83 Revise "Contributing" docs: merge-forwards/release branches explained!
 
-* **ISSUE** `#43737`_: (`syedaali`_) salt.loaded.int.module.boto_kinesis.__virtual__() is wrongly returning `None`. It should either return `True`, `False` or a new name. If you're the developer of the module 'boto_kinesis', please fix this. (refs: `#43748`_)
+* **ISSUE** `#43737`_: (`syedaali`_) salt.loaded.int.module.boto_kinesis.__virtual__() is wrongly
+  returning `None`. It should either return `True`, `False` or a new name. If you're the developer
+  of the module 'boto_kinesis', please fix this. (refs: `#43748`_)
 
 * **PR** `#43748`_: (`rallytime`_) Add message to boto_kinesis modules if boto libs are missing
   @ *2017-09-27 13:19:33 UTC*
@@ -4401,7 +4412,11 @@ Changelog for v2017.7.2..v2017.7.3
 
     * c15bcbe1cc Merge remote-tracking branch 'upstream/2016.11' into fix-apache-config-multi-entity
 
-    * 4164047951 Fix apache.config with multiple statement At this moment when you post more than one statement in config only last is used. Also file is rewrited multiple times until last statement is written. Example: salt '*' apache.config /etc/httpd/conf.d/ports.conf config="[{'Listen': '8080'}, {'Proxy': "Something"}]" Ends only with    Proxy Something and ignore Listen 8080, This patch fix this issue.
+    * 4164047951 Fix apache.config with multiple statement At this moment when you post more than
+      one statement in config only last is used. Also file is rewrited multiple times until last
+      statement is written. Example: salt '*' apache.config /etc/httpd/conf.d/ports.conf
+      config="[{'Listen': '8080'}, {'Proxy': "Something"}]" Ends only with Proxy Something and
+      ignore Listen 8080, This patch fix this issue.
 
   * b90e59ede9 Merge pull request `#43154`_ from lomeroe/bp-43116-2016.11
 

--- a/doc/topics/releases/2017.7.3.rst
+++ b/doc/topics/releases/2017.7.3.rst
@@ -12,7 +12,19 @@ Statistics
 - Total Issue References: **94**
 - Total PR References: **423**
 
-- Contributors: **86** (`3add3287`_, `BenoitKnecht`_, `Ch3LL`_, `CorvinM`_, `Da-Juan`_, `DmitryKuzmenko`_, `Giandom`_, `The-Loeki`_, `UtahDave`_, `adelcast`_, `amendlik`_, `angeloudy`_, `anlutro`_, `arthurlogilab`_, `basepi`_, `benediktwerner`_, `brejoc`_, `cachedout`_, `campbellmc`_, `chnrxn`_, `clan`_, `corywright`_, `damon-atkins`_, `dincamihai`_, `dmurphy18`_, `eliasp`_, `eradman`_, `forksaber`_, `frogunder`_, `gaborn57`_, `garethgreenaway`_, `golmaal`_, `gracinet`_, `gtmanfred`_, `haam3r`_, `isbm`_, `jettero`_, `jf`_, `jubrad`_, `keesbos`_, `kris-anderson`_, `lomeroe`_, `mateiw`_, `mattLLVW`_, `mephi42`_, `mirceaulinic`_, `mkurtak`_, `morganwillcock`_, `msummers42`_, `mtorromeo`_, `multani`_, `mvivaldi`_, `mz-bmcqueen`_, `nasenbaer13`_, `nicholasmhughes`_, `oarmstrong`_, `pkruk`_, `pratik705`_, `psagers`_, `rallytime`_, `rbjorklin`_, `rcallphin`_, `renner`_, `rhoths`_, `richardsimko`_, `rklaren`_, `roaldnefs`_, `s0undt3ch`_, `samodid`_, `skizunov`_, `skjaro`_, `steverweber`_, `sumeetisp`_, `t0fik`_, `techhat`_, `terminalmage`_, `timfreund`_, `timka`_, `tkwilliams`_, `twangboy`_, `unthought`_, `vernondcole`_, `vutny`_, `wedge-jarrad`_, `whytewolf`_, `xuhcc`_)
+- Contributors: **86** (`3add3287`_, `BenoitKnecht`_, `Ch3LL`_, `CorvinM`_, `Da-Juan`_,
+  `DmitryKuzmenko`_, `Giandom`_, `The-Loeki`_, `UtahDave`_, `adelcast`_, `amendlik`_, `angeloudy`_,
+  `anlutro`_, `arthurlogilab`_, `basepi`_, `benediktwerner`_, `brejoc`_, `cachedout`_,
+  `campbellmc`_, `chnrxn`_, `clan`_, `corywright`_, `damon-atkins`_, `dincamihai`_, `dmurphy18`_,
+  `eliasp`_, `eradman`_, `forksaber`_, `frogunder`_, `gaborn57`_, `garethgreenaway`_, `golmaal`_,
+  `gracinet`_, `gtmanfred`_, `haam3r`_, `isbm`_, `jettero`_, `jf`_, `jubrad`_, `keesbos`_,
+  `kris-anderson`_, `lomeroe`_, `mateiw`_, `mattLLVW`_, `mephi42`_, `mirceaulinic`_, `mkurtak`_,
+  `morganwillcock`_, `msummers42`_, `mtorromeo`_, `multani`_, `mvivaldi`_, `mz-bmcqueen`_,
+  `nasenbaer13`_, `nicholasmhughes`_, `oarmstrong`_, `pkruk`_, `pratik705`_, `psagers`_,
+  `rallytime`_, `rbjorklin`_, `rcallphin`_, `renner`_, `rhoths`_, `richardsimko`_, `rklaren`_,
+  `roaldnefs`_, `s0undt3ch`_, `samodid`_, `skizunov`_, `skjaro`_, `steverweber`_, `sumeetisp`_,
+  `t0fik`_, `techhat`_, `terminalmage`_, `timfreund`_, `timka`_, `tkwilliams`_, `twangboy`_,
+  `unthought`_, `vernondcole`_, `vutny`_, `wedge-jarrad`_, `whytewolf`_, `xuhcc`_)
 
 
 Windows Changes

--- a/doc/topics/releases/2017.7.5.rst
+++ b/doc/topics/releases/2017.7.5.rst
@@ -12,7 +12,14 @@ Statistics
 - Total Issue References: **58**
 - Total PR References: **202**
 
-- Contributors: **52** (`Ch3LL`_, `DmitryKuzmenko`_, `GwiYeong`_, `L4rS6`_, `SteffenKockel`_, `The-Loeki`_, `amendlik`_, `andreaspe`_, `angeloudy`_, `aphor`_, `bdrung`_, `cebe`_, `ciiqr`_, `damon-atkins`_, `danlsgiga`_, `ddoh94`_, `dmurphy18`_, `dwoz`_, `eliasp`_, `frogunder`_, `garethgreenaway`_, `gclinch`_, `gtmanfred`_, `jfindlay`_, `kstreee`_, `marccardinal`_, `mcalmer`_, `mchugh19`_, `meaksh`_, `michelsen`_, `nullify005`_, `oarmstrong`_, `oeuftete`_, `philpep`_, `racker-markh`_, `rallytime`_, `redbaron4`_, `roaldnefs`_, `rongshengfang`_, `rongzeng54`_, `rrroo`_, `samilaine`_, `samodid`_, `skizunov`_, `terminalmage`_, `tintoy`_, `twangboy`_, `viktordaniel`_, `vutny`_, `while0pass`_, `whytewolf`_, `zer0def`_)
+- Contributors: **52** (`Ch3LL`_, `DmitryKuzmenko`_, `GwiYeong`_, `L4rS6`_, `SteffenKockel`_,
+  `The-Loeki`_, `amendlik`_, `andreaspe`_, `angeloudy`_, `aphor`_, `bdrung`_, `cebe`_, `ciiqr`_,
+  `damon-atkins`_, `danlsgiga`_, `ddoh94`_, `dmurphy18`_, `dwoz`_, `eliasp`_, `frogunder`_,
+  `garethgreenaway`_, `gclinch`_, `gtmanfred`_, `jfindlay`_, `kstreee`_, `marccardinal`_,
+  `mcalmer`_, `mchugh19`_, `meaksh`_, `michelsen`_, `nullify005`_, `oarmstrong`_, `oeuftete`_,
+  `philpep`_, `racker-markh`_, `rallytime`_, `redbaron4`_, `roaldnefs`_, `rongshengfang`_,
+  `rongzeng54`_, `rrroo`_, `samilaine`_, `samodid`_, `skizunov`_, `terminalmage`_, `tintoy`_,
+  `twangboy`_, `viktordaniel`_, `vutny`_, `while0pass`_, `whytewolf`_, `zer0def`_)
 
 
 Changes to :py:func:`file.blockreplace <salt.states.file.blockreplace>` State

--- a/doc/topics/releases/2017.7.6.rst
+++ b/doc/topics/releases/2017.7.6.rst
@@ -11,7 +11,13 @@ Statistics
 - Total Issue References: **60**
 - Total PR References: **217**
 
-- Contributors: **47** (`Ch3LL`_, `DmitryKuzmenko`_, `GwiYeong`_, `Quarky9`_, `RichardW42`_, `UtahDave`_, `amaclean199`_, `arif-ali`_, `baniobloom`_, `bdrung`_, `benediktwerner`_, `bmiguel-teixeira`_, `cachedout`_, `dafenko`_, `damon-atkins`_, `dwoz`_, `ezh`_, `folti`_, `fpicot`_, `frogunder`_, `garethgreenaway`_, `gtmanfred`_, `isbm`_, `jeroennijhof`_, `jfindlay`_, `jfoboss`_, `kstreee`_, `lomeroe`_, `mattp-`_, `meaksh`_, `mirceaulinic`_, `myinitialsarepm`_, `mzbroch`_, `nages13`_, `paclat`_, `pcjeff`_, `pruiz`_, `psyer`_, `rallytime`_, `s0undt3ch`_, `skizunov`_, `smitty42`_, `terminalmage`_, `twangboy`_, `vutny`_, `yagnik`_, `yannj-fr`_)
+- Contributors: **47** (`Ch3LL`_, `DmitryKuzmenko`_, `GwiYeong`_, `Quarky9`_, `RichardW42`_,
+  `UtahDave`_, `amaclean199`_, `arif-ali`_, `baniobloom`_, `bdrung`_, `benediktwerner`_,
+  `bmiguel-teixeira`_, `cachedout`_, `dafenko`_, `damon-atkins`_, `dwoz`_, `ezh`_, `folti`_,
+  `fpicot`_, `frogunder`_, `garethgreenaway`_, `gtmanfred`_, `isbm`_, `jeroennijhof`_, `jfindlay`_,
+  `jfoboss`_, `kstreee`_, `lomeroe`_, `mattp-`_, `meaksh`_, `mirceaulinic`_, `myinitialsarepm`_,
+  `mzbroch`_, `nages13`_, `paclat`_, `pcjeff`_, `pruiz`_, `psyer`_, `rallytime`_, `s0undt3ch`_,
+  `skizunov`_, `smitty42`_, `terminalmage`_, `twangboy`_, `vutny`_, `yagnik`_, `yannj-fr`_)
 
 Tornado 5.0 Support for Python 2 Only
 -------------------------------------

--- a/doc/topics/releases/2017.7.8.rst
+++ b/doc/topics/releases/2017.7.8.rst
@@ -11,7 +11,14 @@ Statistics
 - Total Issue References: **48**
 - Total PR References: **279**
 
-- Contributors: **52** (`AVeenstra`_, `Ch3LL`_, `Circuitsoft`_, `DmitryKuzmenko`_, `KaiSforza`_, `Martin819`_, `OrlandoArcapix`_, `UtahDave`_, `Vaelatern`_, `abednarik`_, `asnell`_, `b1naryth1ef`_, `baniobloom`_, `basepi`_, `bdrung`_, `beornf`_, `bmcorser`_, `bowmanjd-lms`_, `damon-atkins`_, `darkpixel`_, `discogestalt`_, `doesitblend`_, `dqminh`_, `dubb-b`_, `dwoz`_, `frankiexyz`_, `frogunder`_, `fzipi`_, `garethgreenaway`_, `grokrecursion`_, `gtmanfred`_, `jacksontj`_, `jagguli`_, `lejambon`_, `lomeroe`_, `lordcirth`_, `lusche`_, `mbunkus`_, `meaksh`_, `mirceaulinic`_, `nbraud`_, `pritambaral`_, `ralex`_, `rallytime`_, `rmcintosh`_, `slaws`_, `terminalmage`_, `twangboy`_, `twellspring`_, `wyardley`_, `xetix`_, `zer0def`_)
+- Contributors: **52** (`AVeenstra`_, `Ch3LL`_, `Circuitsoft`_, `DmitryKuzmenko`_, `KaiSforza`_,
+  `Martin819`_, `OrlandoArcapix`_, `UtahDave`_, `Vaelatern`_, `abednarik`_, `asnell`_,
+  `b1naryth1ef`_, `baniobloom`_, `basepi`_, `bdrung`_, `beornf`_, `bmcorser`_, `bowmanjd-lms`_,
+  `damon-atkins`_, `darkpixel`_, `discogestalt`_, `doesitblend`_, `dqminh`_, `dubb-b`_, `dwoz`_,
+  `frankiexyz`_, `frogunder`_, `fzipi`_, `garethgreenaway`_, `grokrecursion`_, `gtmanfred`_,
+  `jacksontj`_, `jagguli`_, `lejambon`_, `lomeroe`_, `lordcirth`_, `lusche`_, `mbunkus`_,
+  `meaksh`_, `mirceaulinic`_, `nbraud`_, `pritambaral`_, `ralex`_, `rallytime`_, `rmcintosh`_,
+  `slaws`_, `terminalmage`_, `twangboy`_, `twellspring`_, `wyardley`_, `xetix`_, `zer0def`_)
 
 Security Fix
 ============

--- a/doc/topics/releases/2018.3.1.rst
+++ b/doc/topics/releases/2018.3.1.rst
@@ -11,7 +11,14 @@ Statistics
 - Total Issue References: **74**
 - Total PR References: **255**
 
-- Contributors: **55** (`Ch3LL`_, `DmitryKuzmenko`_, `Giandom`_, `Kimol`_, `L4rS6`_, `LukeCarrier`_, `OrlandoArcapix`_, `TamCore`_, `The-Loeki`_, `UtahDave`_, `aesposito91`_, `bbinet`_, `bdrung`_, `boltronics`_, `bosatsu`_, `clan`_, `corywright`_, `damon-atkins`_, `dincamihai`_, `dmurphy18`_, `dnABic`_, `douglasjreynolds`_, `dwoz`_, `edgan`_, `ejparker12`_, `esell`_, `ezh`_, `femnad`_, `folti`_, `garethgreenaway`_, `gtmanfred`_, `isbm`_, `jasperla`_, `johnj`_, `mateiw`_, `mcalmer`_, `mirceaulinic`_, `morganwillcock`_, `opdude`_, `pcn`_, `pruiz`_, `psagers`_, `psyer`_, `rallytime`_, `robinro`_, `s0undt3ch`_, `samodid`_, `shengis`_, `skjaro`_, `tankywoo`_, `terminalmage`_, `twangboy`_, `vutny`_, `yannj-fr`_, `zmedico`_)
+- Contributors: **55** (`Ch3LL`_, `DmitryKuzmenko`_, `Giandom`_, `Kimol`_, `L4rS6`_,
+  `LukeCarrier`_, `OrlandoArcapix`_, `TamCore`_, `The-Loeki`_, `UtahDave`_, `aesposito91`_,
+  `bbinet`_, `bdrung`_, `boltronics`_, `bosatsu`_, `clan`_, `corywright`_, `damon-atkins`_,
+  `dincamihai`_, `dmurphy18`_, `dnABic`_, `douglasjreynolds`_, `dwoz`_, `edgan`_, `ejparker12`_,
+  `esell`_, `ezh`_, `femnad`_, `folti`_, `garethgreenaway`_, `gtmanfred`_, `isbm`_, `jasperla`_,
+  `johnj`_, `mateiw`_, `mcalmer`_, `mirceaulinic`_, `morganwillcock`_, `opdude`_, `pcn`_, `pruiz`_,
+  `psagers`_, `psyer`_, `rallytime`_, `robinro`_, `s0undt3ch`_, `samodid`_, `shengis`_, `skjaro`_,
+  `tankywoo`_, `terminalmage`_, `twangboy`_, `vutny`_, `yannj-fr`_, `zmedico`_)
 
 
 .. warning::

--- a/doc/topics/releases/2018.3.3.rst
+++ b/doc/topics/releases/2018.3.3.rst
@@ -11,7 +11,14 @@ Statistics
 - Total Issue References: **69**
 - Total PR References: **341**
 
-- Contributors: **55** (`Ch3LL`_, `FedericoCeratto`_, `KaiSforza`_, `L4rS6`_, `Lutseslav`_, `The-Loeki`_, `Vaelatern`_, `admd`_, `aesposito91`_, `asenci`_, `astorath`_, `azelezni`_, `babs`_, `bbczeuz`_, `bbinet`_, `brejoc`_, `cro`_, `daa`_, `dmurphy18`_, `dubb-b`_, `dwoz`_, `eliasp`_, `ezh`_, `garethgreenaway`_, `gtmanfred`_, `isbm`_, `jeduardo`_, `kt97679`_, `kuetrzi`_, `linoplt`_, `lomeroe`_, `lusche`_, `mateiw`_, `max-arnold`_, `maxim-sermin`_, `meaksh`_, `mmulqueen`_, `morganwillcock`_, `mtorromeo`_, `nullify005`_, `paulcollinsiii`_, `pritambaral`_, `rallytime`_, `rares-pop`_, `rmarchei`_, `rosscdh`_, `sizgiyaev`_, `sjorge`_, `t0fik`_, `terminalmage`_, `travispaul`_, `twangboy`_, `vinian`_, `weswhet`_, `zerthimon`_)
+- Contributors: **55** (`Ch3LL`_, `FedericoCeratto`_, `KaiSforza`_, `L4rS6`_, `Lutseslav`_,
+  `The-Loeki`_, `Vaelatern`_, `admd`_, `aesposito91`_, `asenci`_, `astorath`_, `azelezni`_,
+  `babs`_, `bbczeuz`_, `bbinet`_, `brejoc`_, `cro`_, `daa`_, `dmurphy18`_, `dubb-b`_, `dwoz`_,
+  `eliasp`_, `ezh`_, `garethgreenaway`_, `gtmanfred`_, `isbm`_, `jeduardo`_, `kt97679`_,
+  `kuetrzi`_, `linoplt`_, `lomeroe`_, `lusche`_, `mateiw`_, `max-arnold`_, `maxim-sermin`_,
+  `meaksh`_, `mmulqueen`_, `morganwillcock`_, `mtorromeo`_, `nullify005`_, `paulcollinsiii`_,
+  `pritambaral`_, `rallytime`_, `rares-pop`_, `rmarchei`_, `rosscdh`_, `sizgiyaev`_, `sjorge`_,
+  `t0fik`_, `terminalmage`_, `travispaul`_, `twangboy`_, `vinian`_, `weswhet`_, `zerthimon`_)
 
 
 .. warning::

--- a/doc/topics/releases/2018.3.4.rst
+++ b/doc/topics/releases/2018.3.4.rst
@@ -18,7 +18,18 @@ Statistics
 - Total Issue References: **111**
 - Total PR References: **412**
 
-- Contributors: **76** (`5uper5hoot`_, `Ch3LL`_, `ClaudiuPID`_, `Giandom`_, `KaiSforza`_, `MTecknology`_, `ManicoW`_, `OrangeDog`_, `ShantonRU`_, `The-Loeki`_, `Yxnt`_, `aarnaud`_, `amendlik`_, `angeloudy`_, `bartlaarhoven`_, `bbh-kmd`_, `bbinet`_, `bdrung`_, `bergmannf`_, `bluesliverx`_, `bornwitbugs`_, `brejoc`_, `cachedout`_, `casselt`_, `cro`_, `cstarke`_, `dgmorrisjr`_, `dmurphy18`_, `dubb-b`_, `dwoz`_, `frogunder`_, `garethgreenaway`_, `gtmanfred`_, `isbm`_, `jacobweinstock`_, `jgleissner`_, `jodok`_, `jpsv`_, `jyurdal`_, `kiemlicz`_, `kunal-bajpai`_, `lexvella`_, `lomeroe`_, `m03`_, `madrisan`_, `mat813`_, `mattp-`_, `max-arnold`_, `mchugh19`_, `meaksh`_, `michaelgibson`_, `nhavens`_, `pirogoeth`_, `rallytime`_, `rkrieger`_, `rmarcinik`_, `rongzeng54`_, `rwaweber`_, `s0undt3ch`_, `sathieu`_, `sheagcraig`_, `silenius`_, `sunyq`_, `t0fik`_, `terminalmage`_, `terrible-broom`_, `thebluesnevrdie`_, `thetaurean`_, `tlemarchand`_, `tonybaloney`_, `twangboy`_, `waynew`_, `weswhet`_, `whytewolf`_, `yosnoop`_, `zwo-bot`_)
+- Contributors: **76** (`5uper5hoot`_, `Ch3LL`_, `ClaudiuPID`_, `Giandom`_, `KaiSforza`_,
+  `MTecknology`_, `ManicoW`_, `OrangeDog`_, `ShantonRU`_, `The-Loeki`_, `Yxnt`_, `aarnaud`_,
+  `amendlik`_, `angeloudy`_, `bartlaarhoven`_, `bbh-kmd`_, `bbinet`_, `bdrung`_, `bergmannf`_,
+  `bluesliverx`_, `bornwitbugs`_, `brejoc`_, `cachedout`_, `casselt`_, `cro`_, `cstarke`_,
+  `dgmorrisjr`_, `dmurphy18`_, `dubb-b`_, `dwoz`_, `frogunder`_, `garethgreenaway`_, `gtmanfred`_,
+  `isbm`_, `jacobweinstock`_, `jgleissner`_, `jodok`_, `jpsv`_, `jyurdal`_, `kiemlicz`_,
+  `kunal-bajpai`_, `lexvella`_, `lomeroe`_, `m03`_, `madrisan`_, `mat813`_, `mattp-`_,
+  `max-arnold`_, `mchugh19`_, `meaksh`_, `michaelgibson`_, `nhavens`_, `pirogoeth`_, `rallytime`_,
+  `rkrieger`_, `rmarcinik`_, `rongzeng54`_, `rwaweber`_, `s0undt3ch`_, `sathieu`_, `sheagcraig`_,
+  `silenius`_, `sunyq`_, `t0fik`_, `terminalmage`_, `terrible-broom`_, `thebluesnevrdie`_,
+  `thetaurean`_, `tlemarchand`_, `tonybaloney`_, `twangboy`_, `waynew`_, `weswhet`_, `whytewolf`_,
+  `yosnoop`_, `zwo-bot`_)
 
 
 Changelog for v2018.3.3..v2018.3.4

--- a/doc/topics/releases/2018.3.4.rst
+++ b/doc/topics/releases/2018.3.4.rst
@@ -498,7 +498,9 @@ Changelog for v2018.3.3..v2018.3.4
 
   * f7a100c Merge pull request `#51151`_ from Ch3LL/bp_51061
 
-  * ffdae27 When writing output to stdout we want to ensure that the data is a string not bytes.  Under py2 the salt.utils.data.encode function results in a string but under py3 the result is a bytestring.  Swapping out salt.utils.data.encode for salt.utils.stringutils.to_str.
+  * ffdae27 When writing output to stdout we want to ensure that the data is a string not bytes.
+    Under py2 the salt.utils.data.encode function results in a string but under py3 the result is a
+    bytestring. Swapping out salt.utils.data.encode for salt.utils.stringutils.to_str.
 
 * **PR** `#51150`_: (`Ch3LL`_) Back-port `#49508`_ to 2018.3
   @ *2019-01-12 03:18:19 UTC*
@@ -524,7 +526,9 @@ Changelog for v2018.3.3..v2018.3.4
 
   * e8c8c0f Adding some tests to ensure "ALL PRIVILEGES" is handled correctly in 8.0 and 5.6
 
-  * b4bfd9f Add additional grants.  Adding logic to handle when ALL or ALL PRIVILEGES is passed for the grant, including some logic to handle the fact that the grants are split when show grants is run for a particular user.
+  * b4bfd9f Add additional grants.  Adding logic to handle when ALL or ALL PRIVILEGES is passed for
+    the grant, including some logic to handle the fact that the grants are split when show grants
+    is run for a particular user.
 
     * 74edfd9 Fix pylint
 
@@ -1262,11 +1266,14 @@ Changelog for v2018.3.3..v2018.3.4
 
     * 1236b51 Merge pull request `#50659`_ from garethgreenaway/49954_gem_installed_less_than_greater_than_support
 
-      * 0ec8bcf When using the gem installed state, when passing a version that includes greater than or less than symbols, ensure that the installed versions meets that requirement.
+      * 0ec8bcf When using the gem installed state, when passing a version that includes greater
+        than or less than symbols, ensure that the installed versions meets that requirement.
 
     * 6317f3a Merge pull request `#50583`_ from damon-atkins/jenkins_pylint
 
-      * 2d1f51c Fix lint only changes, full lint on merge forwards - lint only changes previous diff picked up out of data files, when the branch was out of date. - full limit on merge forward to pick up changes in the lint checks between versions. - update CODEOWNERS for .ci/*
+      * 2d1f51c Fix lint only changes, full lint on merge forwards - lint only changes previous diff
+        picked up out of data files, when the branch was out of date. - full limit on merge forward
+        to pick up changes in the lint checks between versions. - update CODEOWNERS for .ci/*
 
     * 15bf09a Merge pull request `#50605`_ from Oloremo/fix-supervisord-dead-state-idempotency
 
@@ -1315,7 +1322,8 @@ Changelog for v2018.3.3..v2018.3.4
 
   * b604785 Merge pull request `#50683`_ from garethgreenaway/48759_adding_aliases_include_expand
 
-  * 3940a0f When adding alises to an existing Certbot certificate, if we see a message about expanding in the stderr returned from cmd.run_all we should rerun the cmd with --expand included.
+  * 3940a0f When adding alises to an existing Certbot certificate, if we see a message about
+    expanding in the stderr returned from cmd.run_all we should rerun the cmd with --expand included.
 
 * **ISSUE** `#50406`_: (`glkappe`_) salt-ssh can't use Mongo returner (refs: `#50664`_)
 
@@ -1324,7 +1332,9 @@ Changelog for v2018.3.3..v2018.3.4
 
   * 15f9ae4 Merge pull request `#50664`_ from garethgreenaway/50406_salt_ssh_returner_configuration
 
-  * 3525411 When pulling values out of the available configuration for returners we should always default to using keys for those returners, eg. mongo.user for the username.  Otherwise in certain situations, eg. when using salt-ssh we will end up with the wrong value for the user.
+  * 3525411 When pulling values out of the available configuration for returners we should always
+    default to using keys for those returners, eg. mongo.user for the username. Otherwise in
+    certain situations, eg. when using salt-ssh we will end up with the wrong value for the user.
 
 * **PR** `#50652`_: (`twangboy`_) Fix `unit.utils.test_mac_utils` on Windows
   @ *2018-11-27 20:45:41 UTC*
@@ -1359,7 +1369,11 @@ Changelog for v2018.3.3..v2018.3.4
 
     * 6679242 Merge pull request `#50590`_ from garethgreenaway/bp-50333
 
-      * 1f5aa4b pkg.installed currently fails when sources is used along with hold: True.  This was due to a change in `#48426`_ that swapped out sending the pkgs variable for the desired variable instead.  This caused problems with pkg.hold because desired and sources are always populated, and pkg.hold can only include one or the other.  This change just includes desired in the call to pkg.hold since desired has the same value for sources.
+      * 1f5aa4b pkg.installed currently fails when sources is used along with hold: True.
+        This was due to a change in `#48426`_ that swapped out sending the pkgs variable for the
+        desired variable instead. This caused problems with pkg.hold because desired and sources
+        are always populated, and pkg.hold can only include one or the other. This change just
+        includes desired in the call to pkg.hold since desired has the same value for sources.
 
         * 39e811b Add issue url to tests
 
@@ -1396,7 +1410,10 @@ Changelog for v2018.3.3..v2018.3.4
 
   * 722be43 Fixing lint
 
-  * 65b4421 Adding some master specific functions to uitls/masters.py to determine if a Salt process is running.  Updating utils/schedule.py to use the appropriate running function either from utils/master.py or utils/minion.py depending on where the scheduled job is running.  Adding tests to test maxrunning in scheduled jobs for both the minion and master.
+  * 65b4421 Adding some master specific functions to uitls/masters.py to determine if a Salt
+    process is running. Updating utils/schedule.py to use the appropriate running function either
+    from utils/master.py or utils/minion.py depending on where the scheduled job is running. Adding
+    tests to test maxrunning in scheduled jobs for both the minion and master.
 
   * 0d65304 Swapping manual mocking to autodoc_mock_imports
 
@@ -1415,7 +1432,8 @@ Changelog for v2018.3.3..v2018.3.4
 
   * db89b27 Merge branch '2018.3' into 50542_mysql_ensure_verify_login_uses_connection_host
 
-  * 0284323 Ensure that verify_login is using the host from the connection_args and not the host associated with the user.  Adding a test to ensure user_exists when the passed host is the MySQL wildcard %.
+  * 0284323 Ensure that verify_login is using the host from the connection_args and not the host associated with the user.
+    Adding a test to ensure user_exists when the passed host is the MySQL wildcard %.
 
 * **PR** `#50619`_: (`s0undt3ch`_) Don't squash tracebacks and Unicode fixes
   @ *2018-11-26 17:04:31 UTC*
@@ -1578,7 +1596,10 @@ Changelog for v2018.3.3..v2018.3.4
 
   * 4f30611 lint
 
-  * 4f9eb95 Fixing a typo in the _virtual function, should be checking for existing grains in osdata not grains.  Updating the detection to look for /sys/bus/xen/drivers/xenconsole instead of specifically looking for any files under /sys/bus/xen/drivers.  Some systems that are not running as Xen PV hosts include files under that location, particular Oracle Linux.
+  * 4f9eb95 Fixing a typo in the _virtual function, should be checking for existing grains in
+    osdata not grains. Updating the detection to look for /sys/bus/xen/drivers/xenconsole instead
+    of specifically looking for any files under /sys/bus/xen/drivers. Some systems that are not
+    running as Xen PV hosts include files under that location, particular Oracle Linux.
 
 * **ISSUE** `#50224`_: (`mruepp`_) Augeas changes state with setm not working (refs: `#50526`_)
 
@@ -1825,7 +1846,8 @@ Changelog for v2018.3.3..v2018.3.4
 
   * 3aaad17 Merge pull request `#50468`_ from garethgreenaway/50461_fix_elementary_os_family_grain
 
-  * 77e8dcc On later versions of elementary, the os_family is being populated as elementary.  In order for the aptpkg module to function, we need to override is to be Debian.
+  * 77e8dcc On later versions of elementary, the os_family is being populated as elementary.
+    In order for the aptpkg module to function, we need to override is to be Debian.
 
 * **ISSUE** `#50311`_: (`marek-obuchowicz`_) pkg.installed state fails even though it suceeded (refs: `#50590`_, `#50333`_)
 
@@ -1840,7 +1862,11 @@ Changelog for v2018.3.3..v2018.3.4
 
   * 7bc9b3d Merge branch '2018.3' into 50311_pkg_installed_fails_sources_hold
 
-  * 6e96728 pkg.installed currently fails when sources is used along with hold: True.  This was due to a change in `#48426`_ that swapped out sending the pkgs variable for the desired variable instead.  This caused problems with pkg.hold because desired and sources are always populated, and pkg.hold can only include one or the other.  This change just includes desired in the call to pkg.hold since desired has the same value for sources.
+  * 6e96728 pkg.installed currently fails when sources is used along with hold: True.  This was due
+    to a change in `#48426`_ that swapped out sending the pkgs variable for the desired variable
+    instead. This caused problems with pkg.hold because desired and sources are always populated,
+    and pkg.hold can only include one or the other. This change just includes desired in the call
+    to pkg.hold since desired has the same value for sources.
 
 * **PR** `#50434`_: (`rallytime`_) [2018.3] Merge forward from 2017.7 to 2018.3
   @ *2018-11-08 17:40:39 UTC*
@@ -2484,7 +2510,11 @@ Changelog for v2018.3.3..v2018.3.4
 
   * 51b3fa4 Merge pull request `#50216`_ from garethgreenaway/50162_when_plus_splay_endless_loop
 
-  * 685509f Fixing an issue when a combination of the when parameter as a list plus using the splay parameter would cause the schedule to continuously run jobs in an endless loop, regardless of if their scheduled time had been receached.  Also fixing a related issue where scheduled jobs that rely on _next_fire_time were not being run as the corrected splayed time but rather running at the original scheduled time.  Adding new tests.
+  * 685509f Fixing an issue when a combination of the when parameter as a list plus using the splay
+    parameter would cause the schedule to continuously run jobs in an endless loop, regardless of
+    if their scheduled time had been receached. Also fixing a related issue where scheduled jobs
+    that rely on _next_fire_time were not being run as the corrected splayed time but rather
+    running at the original scheduled time. Adding new tests.
 
 * **PR** `#50190`_: (`dwoz`_) Fix test_managed_file_with_grains_data on Windows
   @ *2018-10-24 22:43:35 UTC*
@@ -2837,7 +2867,14 @@ Changelog for v2018.3.3..v2018.3.4
 
   * eedeacb Updating another reference to salt.utils.mac_utils to use __utils__
 
-                            * 6ef5ce4 Due to a previous PR the test_sdb_runner in sdb.test_vault was failing because of a exception that was being swallowed in the test run_run function.  The cause was that when vault related functions were being run, if they were being run on the master then they were being forced to run through the _get_token_and_url_from_master() function, which is pull the id element out of the grains dictionary.  When the call was taking place from a runner, the exception was popping up since there is no id when called from a runner.  This fix checks to see if the id exists in the dictionary first, if it is there then _get_token_and_url_from_master() is called, otherwise _use_local_config is called.
+  * 6ef5ce4 Due to a previous PR the test_sdb_runner in sdb.test_vault was failing because of a
+    exception that was being swallowed in the test run_run function. The cause was that when vault
+    related functions were being run, if they were being run on the master then they were being
+    forced to run through the _get_token_and_url_from_master() function, which is pull the id
+    element out of the grains dictionary. When the call was taking place from a runner, the
+    exception was popping up since there is no id when called from a runner. This fix checks to see
+    if the id exists in the dictionary first, if it is there then _get_token_and_url_from_master()
+    is called, otherwise _use_local_config is called.
 
 * **PR** `#49987`_: (`terminalmage`_) Make Pillar no longer munge file_roots
   @ *2018-10-15 21:58:08 UTC*

--- a/doc/topics/releases/2019.2.1.rst
+++ b/doc/topics/releases/2019.2.1.rst
@@ -295,7 +295,9 @@ Changelog for v2019.2.0..v2019.2.1
 
   * 993c341 Merge pull request `#54235`_ from ogd-software/fix_46034-2019.2.1
 
-  * 93bd30d Add alternative fix for "!" stomping Apparently (after watching Jenkins tests fail), what yaml.safe_load returns depends not on the version of salt, but on some other external dependency. Because of this, fix both possible return values.
+  * 93bd30d Add alternative fix for "!" stomping Apparently (after watching Jenkins tests fail),
+    what yaml.safe_load returns depends not on the version of salt, but on some other external
+    dependency. Because of this, fix both possible return values.
 
   * c95dd4d Add test for this specific bugfix
 

--- a/doc/topics/releases/2019.2.1.rst
+++ b/doc/topics/releases/2019.2.1.rst
@@ -60,7 +60,14 @@ Statistics
 - Total Issue References: **70**
 - Total PR References: **355**
 
-- Contributors: **49** (`Akm0d`_, `Ch3LL`_, `DmitryKuzmenko`_, `Ethyling`_, `FireGrace`_, `KChandrashekhar`_, `ScoreUnder`_, `amendlik`_, `aplanas`_, `arsiesys`_, `bbinet`_, `bryceml`_, `cbosdo`_, `cdalvaro`_, `chdamianos`_, `cmcmarrow`_, `cro`_, `damianosSemmle`_, `dmurphy18`_, `doesitblend`_, `dwoz`_, `felippeb`_, `frogunder`_, `garethgreenaway`_, `github-abcde`_, `isbm`_, `jfindlay`_, `lomeroe`_, `mattLLVW`_, `mattp-`_, `mirceaulinic`_, `nicholasmhughes`_, `rbthomp`_, `rombert`_, `rsmekala`_, `s0undt3ch`_, `sathieu`_, `sbrennan4`_, `sdodsley`_, `simonflood`_, `sjorge`_, `soer7022`_, `stratusjerry`_, `tanlingyun2005`_, `terminalmage`_, `twangboy`_, `waynew`_, `weswhet`_, `xuhcc`_)
+- Contributors: **49** (`Akm0d`_, `Ch3LL`_, `DmitryKuzmenko`_, `Ethyling`_, `FireGrace`_,
+  `KChandrashekhar`_, `ScoreUnder`_, `amendlik`_, `aplanas`_, `arsiesys`_, `bbinet`_, `bryceml`_,
+  `cbosdo`_, `cdalvaro`_, `chdamianos`_, `cmcmarrow`_, `cro`_, `damianosSemmle`_, `dmurphy18`_,
+  `doesitblend`_, `dwoz`_, `felippeb`_, `frogunder`_, `garethgreenaway`_, `github-abcde`_, `isbm`_,
+  `jfindlay`_, `lomeroe`_, `mattLLVW`_, `mattp-`_, `mirceaulinic`_, `nicholasmhughes`_, `rbthomp`_,
+  `rombert`_, `rsmekala`_, `s0undt3ch`_, `sathieu`_, `sbrennan4`_, `sdodsley`_, `simonflood`_,
+  `sjorge`_, `soer7022`_, `stratusjerry`_, `tanlingyun2005`_, `terminalmage`_, `twangboy`_,
+  `waynew`_, `weswhet`_, `xuhcc`_)
 
 Changelog for v2019.2.0..v2019.2.1
 ==================================

--- a/doc/topics/releases/2019.2.2.rst
+++ b/doc/topics/releases/2019.2.2.rst
@@ -13,7 +13,8 @@ Statistics
 - Total Issue References: **12**
 - Total PR References: **26**
 
-- Contributors: **13** (`Akm0d`_, `Ch3LL`_, `Oloremo`_, `OrlandoArcapix`_, `bryceml`_, `dhiltonp`_, `dwoz`_, `frogunder`_, `garethgreenaway`_, `javierbertoli`_, `pizzapanther`_, `s0undt3ch`_, `twangboy`_)
+- Contributors: **13** (`Akm0d`_, `Ch3LL`_, `Oloremo`_, `OrlandoArcapix`_, `bryceml`_, `dhiltonp`_, `dwoz`_,
+  `frogunder`_, `garethgreenaway`_, `javierbertoli`_, `pizzapanther`_, `s0undt3ch`_, `twangboy`_)
 
 Changelog for v2019.2.1..v2019.2.2
 ==================================

--- a/doc/topics/releases/3000.1.rst
+++ b/doc/topics/releases/3000.1.rst
@@ -13,7 +13,9 @@ Statistics
 - Total Issue References: **15**
 - Total PR References: **54**
 
-- Contributors: **16** (`Ch3LL`_, `UtahDave`_, `bryceml`_, `cmcmarrow`_, `dwoz`_, `frogunder`_, `garethgreenaway`_, `lorengordon`_, `mchugh19`_, `oeuftete`_, `raddessi`_, `s0undt3ch`_, `sjorge`_, `terminalmage`_, `twangboy`_, `waynew`_)
+- Contributors: **16** (`Ch3LL`_, `UtahDave`_, `bryceml`_, `cmcmarrow`_, `dwoz`_, `frogunder`_,
+  `garethgreenaway`_, `lorengordon`_, `mchugh19`_, `oeuftete`_, `raddessi`_, `s0undt3ch`_,
+  `sjorge`_, `terminalmage`_, `twangboy`_, `waynew`_)
 
 Changelog for v3000..v3000.1
 ============================


### PR DESCRIPTION
The release documentation files contain a list of contributors for the release. This list is written in one line and can become very long, which makes reading source file uneasy.

So wrap the list of contributions in the release documentation files.