### PR TITLE
Fix startup of salt-api

### DIFF
--- a/salt/client/netapi.py
+++ b/salt/client/netapi.py
@@ -48,7 +48,7 @@ class NetapiClient:
 
         for fun in self.netapi:
             if fun.endswith(".start"):
-                name = "RunNetapi({})".format(fun.__module__)
+                name = "RunNetapi({})".format(self.netapi[fun].__module__)
                 log.info("Starting %s", name)
                 self.process_manager.add_process(
                     RunNetapi, args=(self.opts, fun), name=name

--- a/tests/pytests/unit/client/test_netapi.py
+++ b/tests/pytests/unit/client/test_netapi.py
@@ -1,11 +1,11 @@
-import pytest
+import logging
+
 import salt.client.netapi
 import salt.config
-from tests.support.helpers import TstSuiteLoggingHandler
 from tests.support.mock import Mock, patch
 
 
-def test_run_log():
+def test_run_log(caplog):
     """
     test salt.client.netapi logs correct message
     """
@@ -14,16 +14,8 @@ def test_run_log():
     mock_process = Mock()
     mock_process.add_process.return_value = True
     patch_process = patch.object(salt.utils.process, "ProcessManager", mock_process)
-    exp_msg = "INFO:Starting RunNetapi(salt.loaded.int.netapi.rest_cherrypy)"
-    found = False
-    with TstSuiteLoggingHandler() as handler:
+    with caplog.at_level(logging.INFO):
         with patch_process:
             netapi = salt.client.netapi.NetapiClient(opts)
             netapi.run()
-        for message in handler.messages:
-            if "RunNetapi" in message:
-                assert exp_msg == message
-                found = True
-                break
-    if not found:
-        pytest.fail("Log message not found: {}".format(exp_msg))
+    assert "Starting RunNetapi(salt.loaded.int.netapi.rest_cherrypy)" in caplog.text

--- a/tests/pytests/unit/client/test_netapi.py
+++ b/tests/pytests/unit/client/test_netapi.py
@@ -1,0 +1,29 @@
+import pytest
+import salt.client.netapi
+import salt.config
+from tests.support.helpers import TstSuiteLoggingHandler
+from tests.support.mock import Mock, patch
+
+
+def test_run_log():
+    """
+    test salt.client.netapi logs correct message
+    """
+    opts = salt.config.DEFAULT_MASTER_OPTS.copy()
+    opts["rest_cherrypy"] = {"port": 8000}
+    mock_process = Mock()
+    mock_process.add_process.return_value = True
+    patch_process = patch.object(salt.utils.process, "ProcessManager", mock_process)
+    exp_msg = "INFO:Starting RunNetapi(salt.loaded.int.netapi.rest_cherrypy)"
+    found = False
+    with TstSuiteLoggingHandler() as handler:
+        with patch_process:
+            netapi = salt.client.netapi.NetapiClient(opts)
+            netapi.run()
+        for message in handler.messages:
+            if "RunNetapi" in message:
+                assert exp_msg == message
+                found = True
+                break
+    if not found:
+        pytest.fail("Log message not found: {}".format(exp_msg))


### PR DESCRIPTION
### What does this PR do?
https://github.com/saltstack/salt/pull/60240 introduced this stack trace on startup of salt-api:

```
(heist)  ch3ll@megan-precision5550  ~/git/salt  ➦ 4c0968e87f <B>  salt-api                                           
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
AttributeError: 'str' object has no attribute '__module__'
Traceback (most recent call last):
  File "/home/ch3ll/.pyenv/versions/heist/bin/salt-api", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/home/ch3ll/git/salt/scripts/salt-api", line 7, in <module>
    salt_api()
  File "/home/ch3ll/git/salt/salt/scripts.py", line 506, in salt_api
    sapi.start()
  File "/home/ch3ll/git/salt/salt/cli/api.py", line 66, in start
    self.api.run()
  File "/home/ch3ll/git/salt/salt/client/netapi.py", line 51, in run
    name = "RunNetapi({})".format(fun.__module__)
AttributeError: 'str' object has no attribute '__module__'
Traceback (most recent call last):
  File "/home/ch3ll/.pyenv/versions/heist/bin/salt-api", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/home/ch3ll/git/salt/scripts/salt-api", line 7, in <module>
    salt_api()
  File "/home/ch3ll/git/salt/salt/scripts.py", line 506, in salt_api
    sapi.start()
  File "/home/ch3ll/git/salt/salt/cli/api.py", line 66, in start
    self.api.run()
  File "/home/ch3ll/git/salt/salt/client/netapi.py", line 51, in run
    name = "RunNetapi({})".format(fun.__module__)
AttributeError: 'str' object has no attribute '__module__'
```


### What issues does this PR fix or reference?
No issue opened, since this does not effect a released version. Also the reason why I did not include a changelog.
