### PR TITLE
Mention IP address if resolving FQDN fails

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -2095,9 +2095,9 @@ def fqdns():
                 # No FQDN for this IP address, so we don't need to know this all the time.
                 log.debug("Unable to resolve address %s: %s", ip, err)
             else:
-                log.error(err_message, err)
+                log.error("Failed to resolve address %s: %s", ip, err)
         except (OSError, socket.gaierror, socket.timeout) as err:
-            log.error(err_message, err)
+            log.error("Failed to resolve address %s: %s", ip, err)
 
     start = time.time()
 
@@ -2109,7 +2109,6 @@ def fqdns():
             include_loopback=False, interface_data=salt.utils.network._get_interfaces()
         )
     )
-    err_message = "Exception during resolving address: %s"
 
     # Create a ThreadPool to process the underlying calls to 'socket.gethostbyaddr' in parallel.
     # This avoid blocking the execution when the "fqdn" is not defined for certains IP addresses, which was causing

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -1878,7 +1878,7 @@ def test_fqdns_return():
 
 
 @pytest.mark.skip_unless_on_linux
-def test_fqdns_socket_error():
+def test_fqdns_socket_error(caplog):
     """
     test the behavior on non-critical socket errors of the dns grain
     """
@@ -1907,17 +1907,12 @@ def test_fqdns_socket_error():
                 mock_log.debug.assert_called()
                 mock_log.error.assert_not_called()
 
-        mock_log = MagicMock()
+        caplog.set_level(logging.WARNING)
         with patch.dict(
             core.__salt__, {"network.fqdns": salt.modules.network.fqdns}
-        ), patch.object(
-            socket, "gethostbyaddr", side_effect=_gen_gethostbyaddr(-1)
-        ), patch(
-            "salt.modules.network.log", mock_log
-        ):
+        ), patch.object(socket, "gethostbyaddr", side_effect=_gen_gethostbyaddr(-1)):
             assert core.fqdns() == {"fqdns": []}
-            mock_log.debug.assert_called_once()
-            mock_log.error.assert_called()
+        assert "Failed to resolve address 1.2.3.4:" in caplog.text
 
 
 def test_core_virtual():


### PR DESCRIPTION
Resolving the FQDN for the IPv6 address failed in my virtual machine. Salt produced an unhelpful error message:

```
[ERROR   ] Exception during resolving address: [Errno 2] Host name lookup failure
```

Change the log message to mention the IP address.