### PR TITLE
Do not require contextvars for Python >= 3.7

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,5 +5,7 @@ PyYAML
 MarkupSafe
 requests>=1.0.0
 distro>=1.0.1
-contextvars
 psutil>=5.0.0
+
+# We need contextvars for salt-ssh
+contextvars


### PR DESCRIPTION
Python >= 3.7 comes with an `contextvars` module and therefore a separate `contextvars` package is not needed. Otherwise salt will needlessly fail:

```
pkg_resources.DistributionNotFound: The 'contextvars' distribution was not found and is required by salt
```

Bug-Debian: https://bugs.debian.org/999590