### PR TITLE
docs: Support building documentation locally

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -33,7 +33,18 @@ import salt.version  # isort:skip
 formulas_dir = os.path.join(os.pardir, docs_basepath, "formulas")
 
 # ----- Intersphinx Settings ------------------------------------------------>
-intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
+intersphinx_mapping = {
+    "python": (
+        "https://docs.python.org/3",
+        (
+            "/usr/share/doc/python{}.{}/html/objects.inv".format(
+                sys.version_info[0], sys.version_info[1]
+            ),
+            "/usr/share/doc/python/html/objects.inv",
+            None,
+        ),
+    )
+}
 # <---- Intersphinx Settings -------------------------------------------------
 
 # -- General Configuration -----------------------------------------------------


### PR DESCRIPTION
Building the documentation locally without Internet access will fail, because sphinx will try to download the intersphinx inventory from http://docs.python.org/3/objects.inv.

Support building the documentation locally without Internet access by searching for locally installed intersphinx inventory first.

Bug-Debian: https://bugs.debian.org/755026