### PR TITLE
Fix for #61261

### DIFF
--- a/salt/modules/win_dsc.py
+++ b/salt/modules/win_dsc.py
@@ -290,8 +290,9 @@ def compile_config(
     # Add any script parameters
     if script_parameters:
         cmd.append(script_parameters)
-    # Select fields to return
+    # Select properties of the generated .mof file to return, avoiding the .meta.mof
     cmd.append(
+        "| Where-Object FullName -match '(?<!\.meta)\.mof$' "
         "| Select-Object -Property FullName, Extension, Exists, "
         '@{Name="LastWriteTime";Expression={Get-Date ($_.LastWriteTime) '
         "-Format g}}"
@@ -316,6 +317,7 @@ def compile_config(
     if config_data:
         cmd.extend(["-ConfigurationData", config_data])
     cmd.append(
+        "| Where-Object FullName -match '(?<!\.meta)\.mof$' "
         "| Select-Object -Property FullName, Extension, Exists, "
         '@{Name="LastWriteTime";Expression={Get-Date ($_.LastWriteTime) '
         "-Format g}}"

--- a/salt/modules/win_dsc.py
+++ b/salt/modules/win_dsc.py
@@ -144,6 +144,8 @@ def run_config(
 
         script_parameters (str): Any additional parameters expected by the
             configuration script. These must be defined in the script itself.
+            Note that these are passed to the script (the outermost scope), and 
+            not to the dsc configuration inside the script (the inner scope). 
 
             .. versionadded:: 2017.7.0
 
@@ -166,6 +168,12 @@ def run_config(
     .. code-block:: bash
 
         salt '*' dsc.run_config C:\\DSC\\WebsiteConfig.ps1 salt://dsc/configs/WebsiteConfig.ps1
+
+    To cache a config script to the system from the master and compile it, passing in `script_parameters`:
+
+    .. code-block:: bash
+
+        salt '*' dsc.run_config path=C:\\DSC\\WebsiteConfig.ps1 source=salt://dsc/configs/WebsiteConfig.ps1 script_parameters="-hostname 'my-computer' -ip '192.168.1.10' -DnsArray '192.168.1.3','192.168.1.4','1.1.1.1'"
     """
     ret = compile_config(
         path=path,


### PR DESCRIPTION
Fix so the return value for a dsc.compile_config is a 'dict', and not a list.  

### What does this PR do?
Modifies the PowerShell command, so that only the *.mof-file, and not both the *.mof and *.meta.mof, is selected in the return object ('dict'). 
 
### What issues does this PR fix or reference?
Fixes: #61261

### Previous Behavior
The `ret` variable was handled like a `dict`, but was actually a `list` of `dict`s, because a `dict` for both of the produced files from the compilation (the *.mof and it's corresponding *.meta.mof) was returned from the powershell command. This would always give the error below, even though the compilation worked: 
```
AttributeError: 'list' object has no attribute 'get'
```

### New Behavior
Prepending the existing PowerShell command with 
```powershell
.. | Where-Object FullName -match '(?<!\.meta)\.mof$' | ..
``` 
makes sure that only an object/dict of properties from the *.mof file - and not from the *.meta.mof-file - is returned from the call. Doing that, the variable `ret` is now a `dict`, and the test of the return succeeds. 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
