### PR TITLE
Handle Virtual Accounts properly

### DIFF
--- a/changelog/61271.fixed
+++ b/changelog/61271.fixed
@@ -1,0 +1,1 @@
+Make the salt.utils.win_dacl.get_name() function include the "NT Security" prefix for Virtual Accounts. Virtual Accounts can only be added with the fully qualified name.

--- a/salt/utils/win_dacl.py
+++ b/salt/utils/win_dacl.py
@@ -1222,8 +1222,20 @@ def get_name(principal):
                 sid_obj = principal
 
     # By now we should have a valid PySID object
+    str_sid = get_sid_string(sid_obj)
+
     try:
-        return win32security.LookupAccountSid(None, sid_obj)[0]
+        name = win32security.LookupAccountSid(None, sid_obj)[0]
+
+        # Let's Check for Virtual Service Accounts
+        # Virtual Accounts must be prepended with NT Service in order to resolve
+        # properly
+        # https://docs.microsoft.com/en-us/previous-versions/technet-magazine/cc138011(v=msdn.10)
+        # https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd548356(v=ws.10)
+        if str_sid.startswith("S-1-5-80"):
+            name = "NT Service\\{0}".format(name)
+
+        return name
     except (pywintypes.error, TypeError) as exc:
         # Microsoft introduced the concept of Capability SIDs in Windows 8
         # https://docs.microsoft.com/en-us/windows/security/identity-protection/access-control/security-identifiers#capability-sids
@@ -1232,7 +1244,6 @@ def get_name(principal):
         # These types of SIDs do not resolve, so we'll just ignore them for this
         # All capability SIDs begin with `S-1-15-3`, so we'll only throw an
         # error when the sid does not begin with `S-1-15-3`
-        str_sid = get_sid_string(sid_obj)
         if not str_sid.startswith("S-1-15-3"):
             message = 'Error resolving "{}"'.format(principal)
             if type(exc) == pywintypes.error:

--- a/salt/utils/win_dacl.py
+++ b/salt/utils/win_dacl.py
@@ -1233,7 +1233,7 @@ def get_name(principal):
         # https://docs.microsoft.com/en-us/previous-versions/technet-magazine/cc138011(v=msdn.10)
         # https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd548356(v=ws.10)
         if str_sid.startswith("S-1-5-80"):
-            name = "NT Service\\{0}".format(name)
+            name = "NT Service\\{}".format(name)
 
         return name
     except (pywintypes.error, TypeError) as exc:

--- a/tests/pytests/unit/utils/win_dacl/test_get_name.py
+++ b/tests/pytests/unit/utils/win_dacl/test_get_name.py
@@ -1,0 +1,105 @@
+"""
+tests.pytests.unit.utils.win_dacl.test_get_name
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Test the get_name function in the win_dacl utility module
+"""
+# Python libs
+import pytest
+
+# Salt libs
+import salt.exceptions
+import salt.utils.win_dacl
+
+# Third-party libs
+try:
+    import win32security
+
+    HAS_WIN32 = True
+except ImportError:
+    HAS_WIN32 = False
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+    pytest.mark.skip_unless_on_windows,
+]
+
+
+def test_get_name_normal_name():
+    """
+    Test get_name when passing a normal string name
+    """
+    result = salt.utils.win_dacl.get_name("Administrators")
+    expected = "Administrators"
+    assert result == expected
+
+
+def test_get_name_mixed_case():
+    """
+    Test get_name when passing an account name with mixed case characters
+    """
+    result = salt.utils.win_dacl.get_name("adMiniStrAtorS")
+    expected = "Administrators"
+    assert result == expected
+
+
+def test_get_name_sid():
+    """
+    Test get_name when passing a sid string
+    """
+    result = salt.utils.win_dacl.get_name("S-1-5-32-544")
+    expected = "Administrators"
+    assert result == expected
+
+
+def test_get_name_sid_object():
+    """
+    Test get_name when passing a sid object
+    """
+    # SID Object
+    sid_obj = salt.utils.win_dacl.get_sid("Administrators")
+    result = salt.utils.win_dacl.get_name(sid_obj)
+    expected = "Administrators"
+    assert result == expected
+
+
+def test_get_name_virtual_account():
+    """
+    Test get_name with a virtual account. Should prepend the name with
+    NT Security
+    """
+    result = salt.utils.win_dacl.get_name("NT Service\\EventLog")
+    expected = "NT Service\\EventLog"
+    assert result == expected
+
+
+def test_get_name_virtual_account_sid():
+    """
+    Test get_name with a virtual account using the sid. Should prepend the name
+    with NT Security
+    """
+    sid = "S-1-5-80-880578595-1860270145-482643319-2788375705-1540778122"
+    result = salt.utils.win_dacl.get_name(sid)
+    expected = "NT Service\\EventLog"
+    assert result == expected
+
+
+def test_get_name_capability_sid():
+    """
+    Test get_name with a compatibility SID. Should return `None` as we want to
+    ignore these SIDs
+    """
+    cap_sid = "S-1-15-3-1024-1065365936-1281604716-3511738428-1654721687-432734479-3232135806-4053264122-3456934681"
+    sid_obj = win32security.ConvertStringSidToSid(cap_sid)
+    assert salt.utils.win_dacl.get_name(sid_obj) is None
+
+
+def test_get_name_error():
+    """
+    Test get_name with an un mapped SID, should throw a CommandExecutionError
+    """
+    test_sid = "S-1-2-3-4"
+    sid_obj = win32security.ConvertStringSidToSid(test_sid)
+    with pytest.raises(salt.exceptions.CommandExecutionError) as exc:
+        salt.utils.win_dacl.get_name(sid_obj)
+    assert "No mapping between account names" in exc.value.message

--- a/tests/pytests/unit/utils/win_dacl/test_get_sid.py
+++ b/tests/pytests/unit/utils/win_dacl/test_get_sid.py
@@ -25,19 +25,19 @@ pytestmark = [
 ]
 
 
-def test_get_sid_string():
+@pytest.mark.skipif(not HAS_WIN32, reason="Requires Win32 libraries")
+@pytest.mark.parametrize(
+    "principal",
+    (
+        "Administrators",  # Normal
+        "adMiniStrAtorS",  # Mixed Case
+        "S-1-5-32-544",  # String SID
+    ),
+)
+def test_get_sid(principal):
     """
-    Validate getting a pysid object from a name
+    Validate getting a pysid object with various inputs
     """
-    sid_obj = salt.utils.win_dacl.get_sid("Administrators")
-    assert isinstance(sid_obj, pywintypes.SIDType)
-    assert win32security.LookupAccountSid(None, sid_obj)[0] == "Administrators"
-
-
-def test_get_sid_sid_string():
-    """
-    Validate getting a pysid object from a SID string
-    """
-    sid_obj = salt.utils.win_dacl.get_sid("S-1-5-32-544")
+    sid_obj = salt.utils.win_dacl.get_sid(principal)
     assert isinstance(sid_obj, pywintypes.SIDType)
     assert win32security.LookupAccountSid(None, sid_obj)[0] == "Administrators"

--- a/tests/pytests/unit/utils/win_dacl/test_get_sid.py
+++ b/tests/pytests/unit/utils/win_dacl/test_get_sid.py
@@ -1,0 +1,43 @@
+"""
+tests.pytests.unit.utils.win_dacl.test_get_sid
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Test the get_sid function in the win_dacl utility module
+"""
+# Python libs
+import pytest
+
+# Salt libs
+import salt.utils.win_dacl
+
+# Third-party libs
+try:
+    import pywintypes
+    import win32security
+
+    HAS_WIN32 = True
+except ImportError:
+    HAS_WIN32 = False
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+    pytest.mark.skip_unless_on_windows,
+]
+
+
+def test_get_sid_string():
+    """
+    Validate getting a pysid object from a name
+    """
+    sid_obj = salt.utils.win_dacl.get_sid("Administrators")
+    assert isinstance(sid_obj, pywintypes.SIDType)
+    assert win32security.LookupAccountSid(None, sid_obj)[0] == "Administrators"
+
+
+def test_get_sid_sid_string():
+    """
+    Validate getting a pysid object from a SID string
+    """
+    sid_obj = salt.utils.win_dacl.get_sid("S-1-5-32-544")
+    assert isinstance(sid_obj, pywintypes.SIDType)
+    assert win32security.LookupAccountSid(None, sid_obj)[0] == "Administrators"

--- a/tests/pytests/unit/utils/win_dacl/test_get_sid_string.py
+++ b/tests/pytests/unit/utils/win_dacl/test_get_sid_string.py
@@ -1,0 +1,43 @@
+"""
+tests.pytests.unit.utils.win_dacl.test_get_sid_string
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Test the get_sid_string function in the win_dacl utility module
+"""
+# Python libs
+import pytest
+
+# Salt libs
+import salt.utils.win_dacl
+
+# Third-party libs
+try:
+    import pywintypes
+    import win32security
+
+    HAS_WIN32 = True
+except ImportError:
+    HAS_WIN32 = False
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+    pytest.mark.skip_unless_on_windows,
+]
+
+
+def test_get_sid_string_name():
+    """
+    Validate getting a sid string from a valid pysid object
+    """
+    sid_obj = salt.utils.win_dacl.get_sid("Administrators")
+    assert isinstance(sid_obj, pywintypes.SIDType)
+    assert salt.utils.win_dacl.get_sid_string(sid_obj) == "S-1-5-32-544"
+
+
+def test_get_sid_string_none():
+    """
+    Validate getting a null sid (S-1-0-0) when a null sid is passed
+    """
+    sid_obj = salt.utils.win_dacl.get_sid(None)
+    assert isinstance(sid_obj, pywintypes.SIDType)
+    assert salt.utils.win_dacl.get_sid_string(sid_obj) == "S-1-0-0"

--- a/tests/unit/utils/test_win_dacl.py
+++ b/tests/unit/utils/test_win_dacl.py
@@ -5,22 +5,14 @@ import pytest
 import salt.utils.platform
 import salt.utils.win_dacl as win_dacl
 import salt.utils.win_reg as win_reg
-from tests.support.helpers import TstSuiteLoggingHandler, random_string
+from tests.support.helpers import random_string
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import patch
 from tests.support.unit import TestCase, skipIf
 
-try:
-    import win32security
-
-    HAS_WIN32 = True
-except ImportError:
-    HAS_WIN32 = False
-
 FAKE_KEY = "SOFTWARE\\{}".format(random_string("SaltTesting-", lowercase=False))
 
 
-@skipIf(not HAS_WIN32, "Requires pywin32")
 @skipIf(not salt.utils.platform.is_windows(), "System is not Windows")
 class WinDaclRegTestCase(TestCase, LoaderModuleMockMixin):
     obj_name = "HKLM\\" + FAKE_KEY
@@ -429,7 +421,6 @@ class WinDaclRegTestCase(TestCase, LoaderModuleMockMixin):
         self.assertDictEqual(result, expected)
 
 
-@skipIf(not HAS_WIN32, "Requires pywin32")
 @skipIf(not salt.utils.platform.is_windows(), "System is not Windows")
 class WinDaclFileTestCase(TestCase, LoaderModuleMockMixin):
     obj_name = ""

--- a/tests/unit/utils/test_win_dacl.py
+++ b/tests/unit/utils/test_win_dacl.py
@@ -5,14 +5,12 @@ import pytest
 import salt.utils.platform
 import salt.utils.win_dacl as win_dacl
 import salt.utils.win_reg as win_reg
-from salt.exceptions import CommandExecutionError
 from tests.support.helpers import TstSuiteLoggingHandler, random_string
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import patch
 from tests.support.unit import TestCase, skipIf
 
 try:
-    import pywintypes
     import win32security
 
     HAS_WIN32 = True
@@ -20,95 +18,6 @@ except ImportError:
     HAS_WIN32 = False
 
 FAKE_KEY = "SOFTWARE\\{}".format(random_string("SaltTesting-", lowercase=False))
-
-
-@skipIf(not HAS_WIN32, "Requires pywin32")
-@skipIf(not salt.utils.platform.is_windows(), "System is not Windows")
-class WinDaclTestCase(TestCase):
-    """
-    Test cases for salt.utils.win_dacl in the registry
-    """
-
-    def test_get_sid_string(self):
-        """
-        Validate getting a pysid object from a name
-        """
-        sid_obj = win_dacl.get_sid("Administrators")
-        self.assertTrue(isinstance(sid_obj, pywintypes.SIDType))
-        self.assertEqual(
-            win32security.LookupAccountSid(None, sid_obj)[0], "Administrators"
-        )
-
-    def test_get_sid_sid_string(self):
-        """
-        Validate getting a pysid object from a SID string
-        """
-        sid_obj = win_dacl.get_sid("S-1-5-32-544")
-        self.assertTrue(isinstance(sid_obj, pywintypes.SIDType))
-        self.assertEqual(
-            win32security.LookupAccountSid(None, sid_obj)[0], "Administrators"
-        )
-
-    def test_get_sid_string_name(self):
-        """
-        Validate getting a pysid object from a SID string
-        """
-        sid_obj = win_dacl.get_sid("Administrators")
-        self.assertTrue(isinstance(sid_obj, pywintypes.SIDType))
-        self.assertEqual(win_dacl.get_sid_string(sid_obj), "S-1-5-32-544")
-
-    def test_get_sid_string_none(self):
-        """
-        Validate getting a pysid object from None (NULL SID)
-        """
-        sid_obj = win_dacl.get_sid(None)
-        self.assertTrue(isinstance(sid_obj, pywintypes.SIDType))
-        self.assertEqual(win_dacl.get_sid_string(sid_obj), "S-1-0-0")
-
-    def test_get_name_odd_case(self):
-        """
-        Test get_name by passing a name with inconsistent case characters.
-        Should return the name in the correct case
-        """
-        # Case
-        self.assertEqual(win_dacl.get_name("adMiniStrAtorS"), "Administrators")
-
-    def test_get_name_using_sid(self):
-        """
-        Test get_name passing a SID String. Should return the string name
-        """
-        # SID String
-        self.assertEqual(win_dacl.get_name("S-1-5-32-544"), "Administrators")
-
-    def test_get_name_using_sid_object(self):
-        """
-        Test get_name passing a SID Object. Should return the string name
-        """
-        # SID Object
-        sid_obj = win_dacl.get_sid("Administrators")
-        self.assertTrue(isinstance(sid_obj, pywintypes.SIDType))
-        self.assertEqual(win_dacl.get_name(sid_obj), "Administrators")
-
-    def test_get_name_capability_sid(self):
-        """
-        Test get_name with a compatibility SID. Should return `None` as we want
-        to ignore these SIDs
-        """
-        cap_sid = "S-1-15-3-1024-1065365936-1281604716-3511738428-1654721687-432734479-3232135806-4053264122-3456934681"
-        sid_obj = win32security.ConvertStringSidToSid(cap_sid)
-        self.assertIsNone(win_dacl.get_name(sid_obj))
-
-    def test_get_name_error(self):
-        """
-        Test get_name with an un mapped SID, should throw a
-        CommandExecutionError
-        """
-        test_sid = "S-1-2-3-4"
-        sid_obj = win32security.ConvertStringSidToSid(test_sid)
-        with TstSuiteLoggingHandler() as handler:
-            self.assertRaises(CommandExecutionError, win_dacl.get_name, sid_obj)
-            expected_message = 'ERROR:Error resolving "PySID:S-1-2-3-4"'
-            self.assertIn(expected_message, handler.messages[0])
 
 
 @skipIf(not HAS_WIN32, "Requires pywin32")


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with the `get_name()` function in the `salt.utils.win_dacl` salt util. The `get_name()` function returns the name of the account as found in the system. This name is used for matching permissions and setting new permissions. Virtual accounts require the prefix `NT Security` in order for Windows to find the account.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/61271

### Previous Behavior
Just the virtual account name was being returned

### New Behavior
Prepends all virtual accounts with a sid that begins with `S-1-5-80` with `NT Security`

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes