### PR TITLE
Use .conf.local in modules/freebsd_sysctl.py

### DIFF
--- a/salt/modules/freebsd_sysctl.py
+++ b/salt/modules/freebsd_sysctl.py
@@ -30,7 +30,7 @@ def __virtual__():
 
 
 def _formatfor(name, value, config, tail=""):
-    if config == "/boot/loader.conf":
+    if config == "/boot/loader.conf.local":
         return '{}="{}"{}'.format(name, value, tail)
     else:
         return "{}={}{}".format(name, value, tail)
@@ -136,7 +136,7 @@ def assign(name, value):
     return ret
 
 
-def persist(name, value, config="/etc/sysctl.conf"):
+def persist(name, value, config="/etc/sysctl.conf.local"):
     """
     Assign and persist a simple sysctl parameter for this minion
 
@@ -145,7 +145,7 @@ def persist(name, value, config="/etc/sysctl.conf"):
     .. code-block:: bash
 
         salt '*' sysctl.persist net.inet.icmp.icmplim 50
-        salt '*' sysctl.persist coretemp_load NO config=/boot/loader.conf
+        salt '*' sysctl.persist coretemp_load NO config=/boot/loader.conf.local
     """
     nlines = []
     edited = False
@@ -176,6 +176,6 @@ def persist(name, value, config="/etc/sysctl.conf"):
     with salt.utils.files.fopen(config, "w+") as ofile:
         nlines = [salt.utils.stringutils.to_str(_l) + "\n" for _l in nlines]
         ofile.writelines(nlines)
-    if config != "/boot/loader.conf":
+    if config != "/boot/loader.conf.local":
         assign(name, value)
     return "Updated"


### PR DESCRIPTION
### What does this PR do?
This PR changes the FreeBSD sysctl module to use /boot/loader.conf.local and / or /etc/sysctl.conf.local for persistent changes.
By not overwriting the default files (/boot/loader.conf and / or /etc/sysctl.conf) the changes made by Salt will survive updates applied to the base system, by e.g. the freebsd-update module.

### Previous Behavior
salt '*' sysctl.persist net.inet.icmp.icmplim 50 will set the value and write to /etc/sysctl.conf

### New Behavior
salt '*' sysctl.persist net.inet.icmp.icmplim 50 will set the value and write to /etc/sysctl.conf.local

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
