### PR TITLE
Set properties on cloned VM

### DIFF
--- a/changelog/61302.added
+++ b/changelog/61302.added
@@ -1,0 +1,1 @@
+Add option to set VM properties after cloning a template on Proxmox


### PR DESCRIPTION
### What does this PR do?

With this change it is possible to set VM properties if the VM is cloned. Also the name of the VM is default set to the name that is given by salt-cloud. This can still be overwritten bij setting `clone_name`.

### Previous Behavior
Before this change it was not possible to clone a VM with more memory or CPUs as the original image. Also, when `clone_name` was not set, the VM name in Proxmox was not usable.

### New Behavior
Now you can set cores, socket, memory and more properties in de profile and it is used to reconfigure the VM before it is booting.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
No