### PR TITLE
add namespace to http_json external pillar method

### DIFF
--- a/changelog/61335.fixed
+++ b/changelog/61335.fixed
@@ -1,0 +1,1 @@
+Add namespace option to ext_pillar.http_json

--- a/salt/pillar/http_json.py
+++ b/salt/pillar/http_json.py
@@ -12,9 +12,13 @@ Set the following Salt config to setup http json result as external pillar sourc
   ext_pillar:
     - http_json:
         url: http://example.com/api/minion_id
+        namespace: 'subkey'
         ::TODO::
         username: username
         password: password
+
+.. versionchanged:: TBD
+    If namespace is defined, the data will be added under the specified subkeys in the Pillar structure.
 
 If the with_grains parameter is set, grain keys wrapped in can be provided (wrapped
 in <> brackets) in the url in order to populate pillar data based on the grain value.
@@ -52,12 +56,13 @@ def __virtual__():
     return True
 
 
-def ext_pillar(minion_id, pillar, url, with_grains=False):  # pylint: disable=W0613
+def ext_pillar(minion_id, pillar, url, with_grains=False, namespace=None):  # pylint: disable=W0613
     """
     Read pillar data from HTTP response.
 
     :param str url: Url to request.
     :param bool with_grains: Whether to substitute strings in the url with their grain values.
+    :param str namespace: (Optional) A pillar key to namespace the values under.
 
     :return: A dictionary of the pillar data to add.
     :rtype: dict
@@ -85,7 +90,10 @@ def ext_pillar(minion_id, pillar, url, with_grains=False):  # pylint: disable=W0
     data = __salt__["http.query"](url=url, decode=True, decode_type="json")
 
     if "dict" in data:
-        return data["dict"]
+        if namespace:
+            return {namespace: data["dict"]}
+        else:
+            return data["dict"]
 
     log.error("Error on minion '%s' http query: %s\nMore Info:\n", minion_id, url)
 


### PR DESCRIPTION
### What does this PR do?

It adds a namespace option to the http_json ext_pillar method just like csvpillar

### What issues does this PR fix or reference?
Fixes: #61335 

### Previous Behavior
When using external Pillar data using ext_pillar.http_json all retrieved data is always available in the pillar root.

### New Behavior
When using the new namespace option while using ext_pillar.http_json all retrieved data is available in the specified subkey.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated
http_json does not have a test yet - trivial change though

### Commits signed with GPG?
No