### PR TITLE
Fix ansible roster docs 60370

### DIFF
--- a/changelog/60370.fixed
+++ b/changelog/60370.fixed
@@ -1,0 +1,1 @@
+Fixed issue with ansible roster __virtual__ when ansible is not installed.

--- a/salt/roster/ansible.py
+++ b/salt/roster/ansible.py
@@ -89,7 +89,7 @@ This is the format that an inventory script needs to output to work with ansible
 .. note::
 
     A dynamic inventory script must have the executable bit set. In the above
-    excample, ``chmod +x /etc/salt/hosts``.
+    example, ``chmod +x /etc/salt/hosts``.
 
 Any of the [groups] or direct hostnames will return.  The 'all' is special, and returns everything.
 """

--- a/salt/roster/ansible.py
+++ b/salt/roster/ansible.py
@@ -1,10 +1,11 @@
 """
-Read in an Ansible inventory file or script
+Read in an Ansible inventory file or script.
 
 Flat inventory files should be in the regular ansible inventory format.
 
 .. code-block:: ini
 
+    # /tmp/example_roster
     [servers]
     salt.gtmanfred.com ansible_ssh_user=gtmanfred ansible_ssh_host=127.0.0.1 ansible_ssh_port=22 ansible_ssh_pass='password'
 
@@ -22,20 +23,20 @@ then salt-ssh can be used to hit any of them
 
 .. code-block:: bash
 
-    [~]# salt-ssh -N all test.ping
+    [~]# salt-ssh --roster=ansible --roster-file=/tmp/example_roster -N all test.ping
     salt.gtmanfred.com:
         True
     home:
         True
-    [~]# salt-ssh -N desktop test.ping
+    [~]# salt-ssh --roster=ansible --roster-file=/tmp/example_roster -N desktop test.ping
     home:
         True
-    [~]# salt-ssh -N computers test.ping
+    [~]# salt-ssh --roster=ansible --roster-file=/tmp/example_roster -N computers test.ping
     salt.gtmanfred.com:
         True
     home:
         True
-    [~]# salt-ssh salt.gtmanfred.com test.ping
+    [~]# salt-ssh --roster=ansible --roster-file=/tmp/example_roster salt.gtmanfred.com test.ping
     salt.gtmanfred.com:
         True
 
@@ -106,10 +107,10 @@ __virtualname__ = "ansible"
 
 
 def __virtual__():
-    return (
-        salt.utils.path.which("ansible-inventory") and __virtualname__,
-        "Install `ansible` to use inventory",
-    )
+    if salt.utils.path.which("ansible-inventory"):
+        return __virtualname__
+    else:
+        return False, "Install `ansible` to use inventory"
 
 
 def targets(tgt, tgt_type="glob", **kwargs):

--- a/salt/roster/ansible.py
+++ b/salt/roster/ansible.py
@@ -45,6 +45,7 @@ There is also the option of specifying a dynamic inventory, and generating it on
 .. code-block:: bash
 
     #!/bin/bash
+    # filename: /etc/salt/hosts
     echo '{
       "servers": [
         "salt.gtmanfred.com"
@@ -81,9 +82,14 @@ This is the format that an inventory script needs to output to work with ansible
 
 .. code-block:: bash
 
-    [~]# salt-ssh --roster-file /etc/salt/hosts salt.gtmanfred.com test.ping
+    [~]# salt-ssh --roster=ansible --roster-file /etc/salt/hosts salt.gtmanfred.com test.ping
     salt.gtmanfred.com:
             True
+
+.. note::
+
+    A dynamic inventory script must have the executable bit set. In the above
+    excample, ``chmod +x /etc/salt/hosts``.
 
 Any of the [groups] or direct hostnames will return.  The 'all' is special, and returns everything.
 """

--- a/tests/pytests/unit/roster/test_ansible.py
+++ b/tests/pytests/unit/roster/test_ansible.py
@@ -3,7 +3,6 @@ import salt.roster.ansible as ansible
 from tests.support.mock import patch
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize(
     "which_value",
     [False, None],

--- a/tests/pytests/unit/roster/test_ansible.py
+++ b/tests/pytests/unit/roster/test_ansible.py
@@ -1,0 +1,13 @@
+import pytest
+import salt.roster.ansible as ansible
+from tests.support.mock import patch
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize(
+    "which_value",
+    [False, None],
+)
+def test_virtual_returns_False_if_ansible_inventory_doesnt_exist(which_value):
+    with patch("salt.utils.path.which", autospec=True, return_value=which_value):
+        assert ansible.__virtual__() == (False, "Install `ansible` to use inventory")


### PR DESCRIPTION
### What does this PR do?

Adds the correct incantation for ansible roster, and fixes `__virtual__`.

### What issues does this PR fix or reference?

Fixes: #60370

### Previous Behavior

Copy/pasting commands from docs failed to work. If ansible was uninstalled, an error message was presented. 

### New Behavior

Copy/pasting commands works, and the correct failure is produced.

### Merge requirements satisfied?

- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes