### PR TITLE
doc/win_repo: clarify when cache_dir/cache_file are actually effective

### DIFF
--- a/doc/topics/windows/windows-package-manager.rst
+++ b/doc/topics/windows/windows-package-manager.rst
@@ -734,8 +734,8 @@ install the software. Available parameters are:
 - ``uninstall_flags`` : The flags required to uninstall silently
 - ``msiexec`` : Use msiexec to install this package
 - ``allusers`` : If this is an MSI, install to all users
-- ``cache_dir`` : Cache the entire directory in the installer URL (``salt://``)
-- ``cache_file`` : Cache a single file in the installer URL (``salt://``)
+- ``cache_dir`` : Cache the entire directory in the installer URL if it starts with ``salt://``
+- ``cache_file`` : Cache a single file in the installer URL if it starts with ``salt://``
 - ``use_scheduler`` : Launch the installer using the task scheduler
 - ``source_hash`` : The hash sum for the installer
 


### PR DESCRIPTION
### What does this PR do?
Improves a little detail in the docs for the Win Package Manager.

I wondered why `cache_file`/`cache_dir` had no effect, until I dug through the actual implementation to discover it only applies, when the URL to be cached starts with `salt://`.

### What issues does this PR fix or reference?
none

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes