### PR TITLE
Improve documentation for FreeBSD pkg

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -64,10 +64,8 @@ state module
 
 .. warning::
 
-    Package names are currently case-sensitive. If the minion is using a
-    package manager which is not case-sensitive (such as :mod:`pkgng
-    <salt.modules.pkgng>`), then this state will fail if the proper case is not
-    used. This will be addressed in a future release of Salt.
+    Make sure the package name has the correct case for package managers which are
+    case-sensitive (such as :mod:`pkgng <salt.modules.pkgng>`).
 """
 
 
@@ -1393,7 +1391,7 @@ def installed(
 
     |
 
-    **MULTIPLE PACKAGE INSTALLATION OPTIONS: (not supported in pkgng)**
+    **MULTIPLE PACKAGE INSTALLATION OPTIONS:**
 
     :param list pkgs:
         A list of packages to install from a software repository. All packages


### PR DESCRIPTION
https://github.com/saltstack/salt/issues/23746 is never likely to be "fixed" and its not even clear it should be, so just simplify the warning so that it makes sense.

Package list is already supported in pkgng.