### PR TITLE
Prevent salt-minion systemd unit stuck on reloading with calling apache module functions

### DIFF
--- a/changelog/61375.fixed
+++ b/changelog/61375.fixed
@@ -1,0 +1,1 @@
+Prevent salt-minion systemd unit stuck on reloading state after calling some of apache module functions.

--- a/salt/modules/apache.py
+++ b/salt/modules/apache.py
@@ -11,6 +11,7 @@ Support for Apache
 
 import io
 import logging
+import os
 import re
 import urllib.error
 import urllib.request
@@ -110,7 +111,9 @@ def modules():
     ret = {}
     ret["static"] = []
     ret["shared"] = []
-    out = __salt__["cmd.run"](cmd).splitlines()
+    out = __salt__["cmd.run"](
+        cmd, env={"PATH": os.getenv("PATH")}, clean_env=True
+    ).splitlines()
     for line in out:
         comps = line.split()
         if not comps:
@@ -156,7 +159,7 @@ def directives():
     """
     cmd = "{} -L".format(_detect_os())
     ret = {}
-    out = __salt__["cmd.run"](cmd)
+    out = __salt__["cmd.run"](cmd, env={"PATH": os.getenv("PATH")}, clean_env=True)
     out = out.replace("\n\t", "\t")
     for line in out.splitlines():
         if not line:
@@ -184,7 +187,7 @@ def vhosts():
     cmd = "{} -S".format(_detect_os())
     ret = {}
     namevhost = ""
-    out = __salt__["cmd.run"](cmd)
+    out = __salt__["cmd.run"](cmd, env={"PATH": os.getenv("PATH")}, clean_env=True)
     for line in out.splitlines():
         if not line:
             continue
@@ -226,7 +229,7 @@ def signal(signal=None):
     else:
         arguments = " {}".format(signal)
     cmd = _detect_os() + arguments
-    out = __salt__["cmd.run_all"](cmd)
+    out = __salt__["cmd.run_all"](cmd, env={"PATH": os.getenv("PATH")}, clean_env=True)
 
     # A non-zero return code means fail
     if out["retcode"] and out["stderr"]:


### PR DESCRIPTION
### What does this PR do?

For some reason on calling `apache2ctl` from `salt-minion` with some `apache` module functions under systemd service, the service shown as reloading, it doesn't affect the `salt-minion` process, but only the service status shown.

The root cause is the side effect on changing some environment variables with `apache2ctl`.

### Previous Behavior
`salt-minion` shown as `reloading` forewer after calling `apache2ctl` with `apache.modules` and some other `apache` module functions

### New Behavior
Normal systemd service behavior

### Tests

Not sure if the tests really possible as `apache2ctl` is changing behaviour of systemd unit, but not the `salt-minion` process itself.
