### PR TITLE
Handle new MariaDB SLAVE MONITOR grant

### DIFF
--- a/changelog/61331.fixed
+++ b/changelog/61331.fixed
@@ -1,0 +1,1 @@
+Handle MariaDB 10.5+ SLAVE MONITOR grant

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -120,6 +120,7 @@ __grants__ = [
     "SHOW DATABASES",
     "SHOW VIEW",
     "SHUTDOWN",
+    "SLAVE MONITOR",
     "SUPER",
     "SYSTEM_VARIABLES_ADMIN",
     "TRIGGER",


### PR DESCRIPTION
### What does this PR do?

Handle new MariaDB SLAVE MONITOR grant

### What issues does this PR fix or reference?

Fixes: #61331 

### Previous Behavior

State mysql_grants.present fail when setting MariaDB 10.5+ [`SLAVE MONITOR`](https://mariadb.com/docs/reference/mdb/privileges/REPLICA_MONITOR/) grant

### New Behavior

`SLAVE MONITOR` grant is applied

### Merge requirements satisfied?

- [N/A] Docs (grant whitelist is not documented so far)
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [N/A] Tests written/updated (grant addition test already exist. all grants are not tested and this one require MariaDB 10.5+ specifically)

### Commits signed with GPG?

No