### PR TITLE
Use "net" instead of "sc" to restart minion service

### DIFF
--- a/changelog/61413.fixed
+++ b/changelog/61413.fixed
@@ -1,0 +1,1 @@
+Use net instead of sc in salt cloud when restarting the salt service

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1389,7 +1389,6 @@ def deploy_windows(
         # Shell out to psexec to ensure salt-minion service started
         if use_winrm:
             winrm_cmd(winrm_session, "net", ["stop", "salt-minion"])
-            time.sleep(5)
             winrm_cmd(winrm_session, "net", ["start", "salt-minion"])
         else:
             stdout, stderr, ret_code = run_psexec_command(

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1388,21 +1388,19 @@ def deploy_windows(
                 salt.utils.smb.delete_directory("salttemp", "C$", conn=smb_conn)
         # Shell out to psexec to ensure salt-minion service started
         if use_winrm:
-            winrm_cmd(winrm_session, "sc", ["stop", "salt-minion"])
+            winrm_cmd(winrm_session, "net", ["stop", "salt-minion"])
             time.sleep(5)
-            winrm_cmd(winrm_session, "sc", ["start", "salt-minion"])
+            winrm_cmd(winrm_session, "net", ["start", "salt-minion"])
         else:
             stdout, stderr, ret_code = run_psexec_command(
-                "cmd.exe", "/c sc stop salt-minion", host, username, password
+                "cmd.exe", "/c net stop salt-minion", host, username, password
             )
             if ret_code != 0:
                 return False
 
-            time.sleep(5)
-
             log.debug("Run psexec: sc start salt-minion")
             stdout, stderr, ret_code = run_psexec_command(
-                "cmd.exe", "/c sc start salt-minion", host, username, password
+                "cmd.exe", "/c net start salt-minion", host, username, password
             )
             if ret_code != 0:
                 return False


### PR DESCRIPTION
### What does this PR do?
Uses `net` instead of `sc` to restart the salt-minion service on Windows. The `net` command will not return until it completes, where the `sc` command just fires the `stop` or `start` and returns. That's why there was a 5 second sleep in between the `stop` and `start` commands. Sometimes the stop command takes longer than 5 seconds and the start command then fails because the service is still shutting down. Using `net` avoids this race condition and removes the need for the sleep command.

### What issues does this PR fix or reference?
Fixes: https://jira.eng.vmware.com/browse/VRAE-8756

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes