### PR TITLE
[FEATURE] Add Etag support for file.managed web sources

### DIFF
--- a/changelog/61270.added
+++ b/changelog/61270.added
@@ -1,0 +1,1 @@
+Add Etag support for file.managed web sources

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -681,8 +681,6 @@ class Client:
             write_body = [None, False, None]
 
             def on_header(hdr):
-                nonlocal dest_etag
-                nonlocal use_etag
                 if write_body[1] is not False and write_body[2] is None:
                     if not hdr.strip() and "Content-Type" not in write_body[1]:
                         # If write_body[0] is True, then we are not following a

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -424,7 +424,7 @@ def get_file_str(path, saltenv="base"):
     return fn_
 
 
-def cache_file(path, saltenv="base", source_hash=None, verify_ssl=True):
+def cache_file(path, saltenv="base", source_hash=None, verify_ssl=True, use_etag=False):
     """
     Used to cache a single file on the Minion
 
@@ -442,6 +442,15 @@ def cache_file(path, saltenv="base", source_hash=None, verify_ssl=True):
         will not attempt to validate the servers certificate. Default is True.
 
         .. versionadded:: 3002
+
+    use_etag
+        If ``True``, remote http/https file sources will attempt to use the
+        ETag header to determine if the remote file needs to be downloaded.
+        This provides a lightweight mechanism for promptly refreshing files
+        changed on a web server without requiring a full hash comparison via
+        the ``source_hash`` parameter.
+
+        .. versionadded:: 3005
 
     CLI Example:
 
@@ -496,9 +505,9 @@ def cache_file(path, saltenv="base", source_hash=None, verify_ssl=True):
         saltenv = senv
 
     result = _client().cache_file(
-        path, saltenv, source_hash=source_hash, verify_ssl=verify_ssl
+        path, saltenv, source_hash=source_hash, verify_ssl=verify_ssl, use_etag=use_etag
     )
-    if not result:
+    if not result and not use_etag:
         log.error("Unable to cache file '%s' from saltenv '%s'.", path, saltenv)
     if path_is_remote:
         # Cache was successful, store the result in __context__ to prevent

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -5966,6 +5966,12 @@ def manage_file(
 
     """
     name = os.path.expanduser(name)
+    check_web_source_hash = bool(
+        source
+        and urllib.parse.urlparse(source).scheme != "salt"
+        and not skip_verify
+        and not use_etag
+    )
 
     if not ret:
         ret = {"name": name, "changes": {}, "comment": "", "result": True}
@@ -6019,11 +6025,7 @@ def manage_file(
             # If the downloaded file came from a non salt server or local
             # source, and we are not skipping checksum verification, then
             # verify that it matches the specified checksum.
-            if (
-                not skip_verify
-                and urllib.parse.urlparse(source).scheme != "salt"
-                and not use_etag
-            ):
+            if check_web_source_hash:
                 dl_sum = get_hash(sfn, source_sum["hash_type"])
                 if dl_sum != source_sum["hsum"]:
                     ret["comment"] = (
@@ -6120,11 +6122,7 @@ def manage_file(
                 return _error(ret, "Source file '{}' not found".format(source))
             # If the downloaded file came from a non salt server source verify
             # that it matches the intended sum value
-            if (
-                not skip_verify
-                and urllib.parse.urlparse(source).scheme != "salt"
-                and not use_etag
-            ):
+            if check_web_source_hash:
                 dl_sum = get_hash(sfn, source_sum["hash_type"])
                 if dl_sum != source_sum["hsum"]:
                     ret["comment"] = (
@@ -6233,11 +6231,7 @@ def manage_file(
                 return _error(ret, "Source file '{}' not found".format(source))
             # If the downloaded file came from a non salt server source verify
             # that it matches the intended sum value
-            if (
-                not skip_verify
-                and urllib.parse.urlparse(source).scheme != "salt"
-                and not use_etag
-            ):
+            if check_web_source_hash:
                 dl_sum = get_hash(sfn, source_sum["hash_type"])
                 if dl_sum != source_sum["hsum"]:
                     ret["comment"] = (

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4462,6 +4462,7 @@ def get_managed(
     defaults,
     skip_verify=False,
     verify_ssl=True,
+    use_etag=False,
     **kwargs
 ):
     """
@@ -4517,6 +4518,15 @@ def get_managed(
         will not attempt to validate the servers certificate. Default is True.
 
         .. versionadded:: 3002
+
+    use_etag
+        If ``True``, remote http/https file sources will attempt to use the
+        ETag header to determine if the remote file needs to be downloaded.
+        This provides a lightweight mechanism for promptly refreshing files
+        changed on a web server without requiring a full hash comparison via
+        the ``source_hash`` parameter.
+
+        .. versionadded:: 3005
 
     CLI Example:
 
@@ -4589,7 +4599,7 @@ def get_managed(
                         )
                     except CommandExecutionError as exc:
                         return "", {}, exc.strerror
-                else:
+                elif not use_etag:
                     msg = (
                         "Unable to verify upstream hash of source file {}, "
                         "please set source_hash or set skip_verify to True".format(
@@ -4602,7 +4612,7 @@ def get_managed(
         # Check if we have the template or remote file cached
         cache_refetch = False
         cached_dest = __salt__["cp.is_cached"](source, saltenv)
-        if cached_dest and (source_hash or skip_verify):
+        if cached_dest and (source_hash or skip_verify or use_etag):
             htype = source_sum.get("hash_type", "sha256")
             cached_sum = get_hash(cached_dest, form=htype)
             if skip_verify:
@@ -4610,7 +4620,9 @@ def get_managed(
                 # but `cached_sum == source_sum['hsum']` is elliptical as prev if
                 sfn = cached_dest
                 source_sum = {"hsum": cached_sum, "hash_type": htype}
-            elif cached_sum != source_sum.get("hsum", __opts__["hash_type"]):
+            elif use_etag or cached_sum != source_sum.get(
+                "hsum", __opts__["hash_type"]
+            ):
                 cache_refetch = True
             else:
                 sfn = cached_dest
@@ -4624,6 +4636,7 @@ def get_managed(
                     saltenv,
                     source_hash=source_sum.get("hsum"),
                     verify_ssl=verify_ssl,
+                    use_etag=use_etag,
                 )
             except Exception as exc:  # pylint: disable=broad-except
                 # A 404 or other error code may raise an exception, catch it
@@ -5812,6 +5825,7 @@ def manage_file(
     setype=None,
     serange=None,
     verify_ssl=True,
+    use_etag=False,
     **kwargs
 ):
     """
@@ -5932,6 +5946,15 @@ def manage_file(
 
         .. versionadded:: 3002
 
+    use_etag
+        If ``True``, remote http/https file sources will attempt to use the
+        ETag header to determine if the remote file needs to be downloaded.
+        This provides a lightweight mechanism for promptly refreshing files
+        changed on a web server without requiring a full hash comparison via
+        the ``source_hash`` parameter.
+
+        .. versionadded:: 3005
+
     CLI Example:
 
     .. code-block:: bash
@@ -5988,13 +6011,19 @@ def manage_file(
             or source_sum.get("hsum", __opts__["hash_type"]) != name_sum
         ):
             if not sfn:
-                sfn = __salt__["cp.cache_file"](source, saltenv, verify_ssl=verify_ssl)
+                sfn = __salt__["cp.cache_file"](
+                    source, saltenv, verify_ssl=verify_ssl, use_etag=use_etag
+                )
             if not sfn:
                 return _error(ret, "Source file '{}' not found".format(source))
             # If the downloaded file came from a non salt server or local
             # source, and we are not skipping checksum verification, then
             # verify that it matches the specified checksum.
-            if not skip_verify and urllib.parse.urlparse(source).scheme != "salt":
+            if (
+                not skip_verify
+                and urllib.parse.urlparse(source).scheme != "salt"
+                and not use_etag
+            ):
                 dl_sum = get_hash(sfn, source_sum["hash_type"])
                 if dl_sum != source_sum["hsum"]:
                     ret["comment"] = (
@@ -6016,9 +6045,9 @@ def manage_file(
                 ret["changes"]["diff"] = "<show_changes=False>"
             else:
                 try:
-                    ret["changes"]["diff"] = get_diff(
-                        real_name, sfn, show_filenames=False
-                    )
+                    file_diff = get_diff(real_name, sfn, show_filenames=False)
+                    if file_diff:
+                        ret["changes"]["diff"] = file_diff
                 except CommandExecutionError as exc:
                     ret["changes"]["diff"] = exc.strerror
 
@@ -6091,7 +6120,11 @@ def manage_file(
                 return _error(ret, "Source file '{}' not found".format(source))
             # If the downloaded file came from a non salt server source verify
             # that it matches the intended sum value
-            if not skip_verify and urllib.parse.urlparse(source).scheme != "salt":
+            if (
+                not skip_verify
+                and urllib.parse.urlparse(source).scheme != "salt"
+                and not use_etag
+            ):
                 dl_sum = get_hash(sfn, source_sum["hash_type"])
                 if dl_sum != source_sum["hsum"]:
                     ret["comment"] = (
@@ -6200,7 +6233,11 @@ def manage_file(
                 return _error(ret, "Source file '{}' not found".format(source))
             # If the downloaded file came from a non salt server source verify
             # that it matches the intended sum value
-            if not skip_verify and urllib.parse.urlparse(source).scheme != "salt":
+            if (
+                not skip_verify
+                and urllib.parse.urlparse(source).scheme != "salt"
+                and not use_etag
+            ):
                 dl_sum = get_hash(sfn, source_sum["hash_type"])
                 if dl_sum != source_sum["hsum"]:
                     ret["comment"] = (

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2136,6 +2136,7 @@ def managed(
     win_inheritance=True,
     win_perms_reset=False,
     verify_ssl=True,
+    use_etag=False,
     **kwargs
 ):
     r"""
@@ -2716,6 +2717,15 @@ def managed(
         will not attempt to validate the servers certificate. Default is True.
 
         .. versionadded:: 3002
+
+    use_etag
+        If ``True``, remote http/https file sources will attempt to use the
+        ETag header to determine if the remote file needs to be downloaded.
+        This provides a lightweight mechanism for promptly refreshing files
+        changed on a web server without requiring a full hash comparison via
+        the ``source_hash`` parameter.
+
+        .. versionadded:: 3005
     """
     if "env" in kwargs:
         # "env" is not supported; Use "saltenv".
@@ -3082,6 +3092,7 @@ def managed(
             defaults,
             skip_verify,
             verify_ssl=verify_ssl,
+            use_etag=use_etag,
             **kwargs
         )
     except Exception as exc:  # pylint: disable=broad-except
@@ -3136,6 +3147,7 @@ def managed(
                 serole=serole,
                 setype=setype,
                 serange=serange,
+                use_etag=use_etag,
                 **kwargs
             )
         except Exception as exc:  # pylint: disable=broad-except
@@ -3214,6 +3226,7 @@ def managed(
                 serole=serole,
                 setype=setype,
                 serange=serange,
+                use_etag=use_etag,
                 **kwargs
             )
         except Exception as exc:  # pylint: disable=broad-except

--- a/tests/pytests/functional/states/test_file.py
+++ b/tests/pytests/functional/states/test_file.py
@@ -16,6 +16,12 @@ class TestRequestHandler(http.server.SimpleHTTPRequestHandler):
     Modified request handler class
     """
 
+    def __init__(self, *args, directory=None, **kwargs):
+        if directory is None:
+            directory = os.getcwd()
+        self.directory = directory
+        super().__init__(*args, **kwargs)
+
     def do_GET(self):
         """
         GET request handling

--- a/tests/pytests/functional/states/test_file.py
+++ b/tests/pytests/functional/states/test_file.py
@@ -99,7 +99,7 @@ def web_root(tmp_path_factory):
     """
     _web_root = tmp_path_factory.mktemp("web_root")
     try:
-        yield _web_root
+        yield str(_web_root)
     finally:
         shutil.rmtree(str(_web_root), ignore_errors=True)
 

--- a/tests/pytests/functional/states/test_file.py
+++ b/tests/pytests/functional/states/test_file.py
@@ -5,6 +5,7 @@ import multiprocessing
 import os
 import shutil
 import socket
+import sys
 from contextlib import closing
 
 import pytest
@@ -20,7 +21,10 @@ class TestRequestHandler(http.server.SimpleHTTPRequestHandler):
         if directory is None:
             directory = os.getcwd()
         self.directory = directory
-        super().__init__(*args, **kwargs)
+        if sys.version_info.minor < 7:
+            super().__init__(*args, **kwargs)
+        else:
+            super().__init__(*args, directory=directory, **kwargs)
 
     def do_GET(self):
         """

--- a/tests/pytests/functional/states/test_file.py
+++ b/tests/pytests/functional/states/test_file.py
@@ -1,0 +1,183 @@
+import functools
+import hashlib
+import http.server
+import multiprocessing
+import os
+import shutil
+import socket
+from contextlib import closing
+
+import pytest
+import salt.utils.files
+
+
+class TestRequestHandler(http.server.SimpleHTTPRequestHandler):
+    """
+    Modified request handler class
+    """
+
+    def do_GET(self):
+        """
+        GET request handling
+        """
+        none_match = self.headers.get("If-None-Match")
+        status_code = 200
+        try:
+            # Retrieve the local file from the web root to serve to clients
+            with salt.utils.files.fopen(
+                os.path.join(self.directory, self.path[1:])
+            ) as reqfp:
+                return_text = reqfp.read().encode("utf-8")
+                # We're using this checksum as the etag to show file changes
+                checksum = hashlib.md5(return_text).hexdigest()
+                if none_match == checksum:
+                    # Status code 304 Not Modified is returned if the file is unchanged
+                    status_code = 304
+        except:  # pylint: disable=bare-except
+            # Something went wrong. We didn't find the requested file
+            status_code = 404
+            return_text = None
+            checksum = None
+
+        self.send_response(status_code)
+
+        # Return the Etag header if we have the checksum
+        if checksum:
+            self.send_header("Etag", checksum)
+            self.end_headers()
+
+        # Return file content
+        if return_text:
+            self.wfile.write(return_text)
+
+
+def serve(port=8000, directory=None):
+    """
+    Function to serve a directory via http.server
+    """
+    handler = functools.partial(TestRequestHandler, directory=directory)
+    s = http.server.HTTPServer(("127.0.0.1", port), handler)
+    s.serve_forever()
+
+
+@pytest.fixture(scope="session")
+def free_port():
+    """
+    Utility fixture to grab a free port for the web server
+    """
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("", 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return s.getsockname()[1]
+
+
+@pytest.fixture(autouse=True, scope="session")
+def server(free_port, web_root):
+    """
+    Web server fixture
+    """
+    p = multiprocessing.Process(target=serve, args=(free_port, web_root))
+    p.start()
+    yield
+    p.terminate()
+
+
+@pytest.fixture(scope="session")
+def web_root(tmp_path_factory):
+    """
+    Temporary directory fixture for the web server root
+    """
+    _web_root = tmp_path_factory.mktemp("web_root")
+    try:
+        yield _web_root
+    finally:
+        shutil.rmtree(str(_web_root), ignore_errors=True)
+
+
+def test_file_managed_web_source_etag_operation(
+    states, free_port, web_root, minion_opts
+):
+    """
+    This functional test checks the operation of the use_etag parameter to the
+    file.managed state. There are four (4) invocations of file.managed with a
+    web source, but only three (3) will trigger a call to the web server as
+    shown below and in comments within.
+
+        127.0.0.1 - - [08/Jan/2022 00:53:11] "GET /foo.txt HTTP/1.1" 200 -
+        127.0.0.1 - - [08/Jan/2022 00:53:11] "GET /foo.txt HTTP/1.1" 304 -
+        127.0.0.1 - - [08/Jan/2022 00:53:12] "GET /foo.txt HTTP/1.1" 200 -
+
+    Checks are documented in the comments.
+    """
+    # Create file in the web root directory to serve
+    states.file.managed(
+        name=os.path.join(web_root, "foo.txt"), contents="this is my file"
+    )
+
+    # File should not be cached yet
+    cached_file = os.path.join(
+        minion_opts["cachedir"],
+        "extrn_files",
+        "base",
+        "localhost:{free_port}".format(free_port=free_port),
+        "foo.txt",
+    )
+    cached_etag = cached_file + ".etag"
+    assert not os.path.exists(cached_file)
+    assert not os.path.exists(cached_etag)
+
+    # Pull the file from the web server
+    #     Web server returns 200 status code with content:
+    #     127.0.0.1 - - [08/Jan/2022 00:53:11] "GET /foo.txt HTTP/1.1" 200 -
+    states.file.managed(
+        name=os.path.join(web_root, "bar.txt"),
+        source="http://localhost:{free_port}/foo.txt".format(free_port=free_port),
+        use_etag=True,
+    )
+
+    # Now the file is cached
+    assert os.path.exists(cached_file)
+    assert os.path.exists(cached_etag)
+
+    # Store the original modified time of the cached file
+    cached_file_mtime = os.path.getmtime(cached_file)
+
+    # Pull the file again. Etag hasn't changed. No download occurs.
+    #     Web server returns 304 status code and no content:
+    #     127.0.0.1 - - [08/Jan/2022 00:53:11] "GET /foo.txt HTTP/1.1" 304 -
+    states.file.managed(
+        name=os.path.join(web_root, "bar.txt"),
+        source="http://localhost:{free_port}/foo.txt".format(free_port=free_port),
+        use_etag=True,
+    )
+
+    # Check that the modified time of the cached file hasn't changed
+    assert cached_file_mtime == os.path.getmtime(cached_file)
+
+    # Change file in the web root directory
+    states.file.managed(
+        name=os.path.join(web_root, "foo.txt"), contents="this is my changed file"
+    )
+
+    # Don't use Etag. Cached file is there, Salt won't try to download.
+    #     No call to the web server will be made.
+    states.file.managed(
+        name=os.path.join(web_root, "bar.txt"),
+        source="http://localhost:{free_port}/foo.txt".format(free_port=free_port),
+        use_etag=False,
+    )
+
+    # Check that the modified time of the cached file hasn't changed
+    assert cached_file_mtime == os.path.getmtime(cached_file)
+
+    # Now use Etag again. Cached file changes
+    #     Web server returns 200 status code with content
+    #     127.0.0.1 - - [08/Jan/2022 00:53:12] "GET /foo.txt HTTP/1.1" 200 -
+    states.file.managed(
+        name=os.path.join(web_root, "bar.txt"),
+        source="http://localhost:{free_port}/foo.txt".format(free_port=free_port),
+        use_etag=True,
+    )
+
+    # The modified time of the cached file now changes
+    assert cached_file_mtime != os.path.getmtime(cached_file)


### PR DESCRIPTION
### What does this PR do?
This PR introduces the ability to use the `Etag` response header to determine if a file hosted by a remote web server has changed since the last time it was retrieved.

### What issues does this PR fix or reference?
Fixes: #61270 

### Previous Behavior
Near as I can tell, remote web sources (http/https) in `file.managed` are currently handled one of two ways:

1. The `source_hash` is provided for a source file. If the hash changes, then the file is downloaded again. If the hash is the same and the file is already cached, then the cached file is used for comparison.
2. The `skip_verify` flag is set, either because the source location doesn't host a hash file, it's not in the "correct" format to be read by Salt, or statically setting the source hash in the SLS file isn't pragmatic. When this flag is set, the remote file is only downloaded if it's not in the cache. As long as it's in the cache, the remote source is not checked again. Removing the cached file is the only way to trigger retrieval of an updated remote file.

### New Behavior
This PR introduces a third option for handling remote web sources:

3. With the `use_etag` option, a quick check with the remote web server is always performed. The last `Etag` response header value is stored with the cached file, and is provided as the value of the `If-None-Match` request header with every "check-in". If the stored Etag value matches the value calculated by the web server, the remote file is not retrieved. A `304` HTTP status code (Not Modified) is sent back to the minion instead. This allows for a "middle ground" where new file versions can be retrieved as soon as they're available on the web server without needing to provide a hash for comparison.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
