### PR TITLE
hetzner cloud show_instance function should be an action

### DIFF
--- a/changelog/61392.fixed
+++ b/changelog/61392.fixed
@@ -1,0 +1,1 @@
+show_instance of hetzner cloud provider should enforce an action like the other ones

--- a/salt/cloud/clouds/hetzner.py
+++ b/salt/cloud/clouds/hetzner.py
@@ -222,7 +222,7 @@ def wait_until(name, state, timeout=300):
 def show_instance(name, call=None):
     if call != "action":
         raise SaltCloudSystemExit(
-            "The show_instance action must be called with -a or --action."
+            "The show_instance function must be called with -a or --action."
         )
 
     try:

--- a/salt/cloud/clouds/hetzner.py
+++ b/salt/cloud/clouds/hetzner.py
@@ -209,20 +209,20 @@ def wait_until(name, state, timeout=300):
     Wait until a specific state has been reached on  a node
     """
     start_time = time.time()
-    node = show_instance(name, call="function")
+    node = show_instance(name, call="action")
     while True:
         if node["state"] == state:
             return True
         time.sleep(1)
         if time.time() - start_time > timeout:
             return False
-        node = show_instance(name, call="function")
+        node = show_instance(name, call="action")
 
 
 def show_instance(name, call=None):
-    if call == "action":
+    if call != "action":
         raise SaltCloudSystemExit(
-            "The show_instance function must be called with -f or --function"
+            "The show_instance action must be called with -a or --action."
         )
 
     try:
@@ -500,7 +500,7 @@ def destroy(name, call=None):
         transport=__opts__["transport"],
     )
 
-    node = show_instance(name, call="function")
+    node = show_instance(name, call="action")
     if node["state"] == "running":
         stop(name, call="action", wait=False)
         if not wait_until(name, "off"):
@@ -565,7 +565,7 @@ def resize(name, kwargs, call=None):
         transport=__opts__["transport"],
     )
 
-    node = show_instance(name, call="function")
+    node = show_instance(name, call="action")
     if node["state"] == "running":
         stop(name, call="action", wait=False)
         if not wait_until(name, "off"):

--- a/tests/pytests/unit/cloud/clouds/test_hetzner.py
+++ b/tests/pytests/unit/cloud/clouds/test_hetzner.py
@@ -238,7 +238,7 @@ def test_show_instance():
         "salt.cloud.clouds.hetzner._connect_client", return_value=MagicMock()
     ) as connect:
         with pytest.raises(SaltCloudSystemExit):
-            hetzner.show_instance("myvm", "action")
+            hetzner.show_instance("myvm")
 
         mock = MagicMock()
         mock.id = 123456
@@ -249,10 +249,10 @@ def test_show_instance():
         mock.labels = "abc"
         connect.return_value.servers.get_all.return_value = [mock]
 
-        nodes = hetzner.show_instance(mock.name)
+        nodes = hetzner.show_instance(mock.name, "action")
         assert nodes["id"] == mock.id
 
-        nodes = hetzner.show_instance("not-existing")
+        nodes = hetzner.show_instance("not-existing", "action")
         assert nodes == {}
 
 


### PR DESCRIPTION
### What does this PR do?
This PR should change the show_instance function of the hetzner cloud provider to ensure the call as an action like the other cloud providers do.

### What issues does this PR fix or reference?
Fixes: #61392 

### Previous Behavior
The function raised an error when called as action with an error message that it had to be called as function

### New Behavior
The function can only be called as an action

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
