### PR TITLE
Add missing MariaDB Grants to mysql module

### DIFF
--- a/changelog/61409.changed
+++ b/changelog/61409.changed
@@ -1,0 +1,3 @@
+Add missing MariaDB Grants to mysql module.
+MariaDB has added some grants in 10.4.x and 10.5.x that are not present here, which results in an error when creating.
+Also improved exception handling in `grant_add` which did not log the original error message and replaced it with a generic error.

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -78,11 +78,11 @@ __grants__ = [
     "ALTER ROUTINE",
     "BACKUP_ADMIN",
     "BINLOG_ADMIN",
-    "BINLOG ADMIN",
-    "BINLOG MONITOR",
-    "BINLOG REPLAY",
+    "BINLOG ADMIN",  # MariaDB since 10.5.2
+    "BINLOG MONITOR",  # MariaDB since 10.5.2
+    "BINLOG REPLAY",  # MariaDB since 10.5.2
     "CONNECTION_ADMIN",
-    "CONNECTION ADMIN",
+    "CONNECTION ADMIN",  # MariaDB since 10.5.2
     "CREATE",
     "CREATE ROLE",
     "CREATE ROUTINE",
@@ -91,12 +91,13 @@ __grants__ = [
     "CREATE USER",
     "CREATE VIEW",
     "DELETE",
+    "DELETE HISTORY",  # MariaDB since 10.3.4
     "DROP",
     "DROP ROLE",
     "ENCRYPTION_KEY_ADMIN",
     "EVENT",
     "EXECUTE",
-    "FEDERATED ADMIN",
+    "FEDERATED ADMIN",  # MariaDB since 10.5.2
     "FILE",
     "GRANT OPTION",
     "GROUP_REPLICATION_ADMIN",
@@ -105,26 +106,26 @@ __grants__ = [
     "LOCK TABLES",
     "PERSIST_RO_VARIABLES_ADMIN",
     "PROCESS",
-    "READ_ONLY ADMIN",
+    "READ_ONLY ADMIN",  # MariaDB since 10.5.2
     "REFERENCES",
     "RELOAD",
-    "REPLICA MONITOR",
+    "REPLICA MONITOR",  # MariaDB since 10.5.9
     "REPLICATION CLIENT",
-    "REPLICATION MASTER ADMIN",
-    "REPLICATION REPLICA",
+    "REPLICATION MASTER ADMIN",  # MariaDB since 10.5.2
+    "REPLICATION REPLICA",  # MariaDB since 10.5.1
     "REPLICATION SLAVE",
     "REPLICATION_SLAVE_ADMIN",
-    "REPLICATION SLAVE ADMIN",
+    "REPLICATION SLAVE ADMIN",  # MariaDB since 10.5.2
     "RESOURCE_GROUP_ADMIN",
     "RESOURCE_GROUP_USER",
     "ROLE_ADMIN",
     "SELECT",
-    "SET USER",
+    "SET USER",  # MariaDB since 10.5.2
     "SET_USER_ID",
     "SHOW DATABASES",
     "SHOW VIEW",
     "SHUTDOWN",
-    "SLAVE MONITOR",
+    "SLAVE MONITOR",  # MariaDB since 10.5.9
     "SUPER",
     "SYSTEM_VARIABLES_ADMIN",
     "TRIGGER",
@@ -2490,8 +2491,9 @@ def grant_exists(
 
     try:
         target = __grant_generate(grant, database, user, host, grant_option, escape)
-    except Exception:  # pylint: disable=broad-except
+    except Exception as exc:  # pylint: disable=broad-except
         log.error("Error during grant generation.")
+        log.error(exc)
         return False
 
     grants = user_grants(user, host, **connection_args)


### PR DESCRIPTION
### What does this PR do?

MariaDB has added some grants in 10.4.x and 10.5.x that are not present here, which results in an error when creating.

Also improved exception handling in `grant_add` which did not log the original error message and replaced it with a generic error.


### What issues does this PR fix or reference?

Fixes: #61409 

### Previous Behavior

Error when trying to add grants that salt is not aware of.
The error message is very unspecific: "Error during grant generation"

### New Behavior

No error for new MariaDB grants, better error message in case of unsupported grants.


### Merge requirements satisfied?

<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated (there are no tests to update for this change)

### Commits signed with GPG?

Yes

