### PR TITLE
Add option to have gpg decrypt failures treated as errors

### DIFF
--- a/changelog/61418.added
+++ b/changelog/61418.added
@@ -1,0 +1,1 @@
+`gpg_decrypt_must_succeed` config to prevent gpg renderer from failing silently

--- a/conf/master
+++ b/conf/master
@@ -873,6 +873,10 @@
 #decrypt_pillar_renderers:
 #  - gpg
 
+# If this is `True` and the ciphertext could not be decrypted, then an error is
+# raised.
+#gpg_decrypt_must_succeed: False
+
 # The ext_pillar_first option allows for external pillar sources to populate
 # before file system pillar. This allows for targeting file system pillar from
 # ext_pillar.

--- a/conf/minion
+++ b/conf/minion
@@ -656,6 +656,10 @@
 #  base:
 #    - /srv/pillar
 
+# If this is `True` and the ciphertext could not be decrypted, then an error is
+# raised.
+#gpg_decrypt_must_succeed: False
+
 # Set a hard-limit on the size of the files that can be pushed to the master.
 # It will be interpreted as megabytes. Default: 100
 #file_recv_max_size: 100

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -4124,6 +4124,32 @@ List of renderers which are permitted to be used for pillar decryption.
       - gpg
       - my_custom_renderer
 
+.. conf_master:: gpg_decrypt_must_succeed
+
+``gpg_decrypt_must_succeed``
+----------------------------
+
+.. versionadded:: 3005
+
+Default: ``False``
+
+If this is ``True`` and the ciphertext could not be decrypted, then an error is
+raised.
+
+Sending the ciphertext through basically is *never* desired, for example if a
+state is setting a database password from pillar and gpg rendering fails, then
+the state will update the password to the ciphertext, which by definition is
+not encrypted.
+
+.. warning::
+
+    The value defaults to ``False`` for backwards compatibility.  In the
+    ``Chlorine`` release, this option will default to ``True``.
+
+.. code-block:: yaml
+
+    gpg_decrypt_must_succeed: False
+
 .. conf_master:: pillar_opts
 
 ``pillar_opts``

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -2660,6 +2660,32 @@ List of renderers which are permitted to be used for pillar decryption.
       - gpg
       - my_custom_renderer
 
+.. conf_minion:: gpg_decrypt_must_succeed
+
+``gpg_decrypt_must_succeed``
+----------------------------
+
+.. versionadded:: 3005
+
+Default: ``False``
+
+If this is ``True`` and the ciphertext could not be decrypted, then an error is
+raised.
+
+Sending the ciphertext through basically is *never* desired, for example if a
+state is setting a database password from pillar and gpg rendering fails, then
+the state will update the password to the ciphertext, which by definition is
+not encrypted.
+
+.. warning::
+
+    The value defaults to ``False`` for backwards compatibility.  In the
+    ``Chlorine`` release, this option will default to ``True``.
+
+.. code-block:: yaml
+
+    gpg_decrypt_must_succeed: False
+
 .. conf_minion:: pillarenv
 
 ``pillarenv``

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -255,6 +255,8 @@ VALID_OPTS = immutabletypes.freeze(
         "decrypt_pillar_default": str,
         # List of renderers available for decrypt_pillar
         "decrypt_pillar_renderers": list,
+        # Treat GPG decryption errors as renderer errors
+        "gpg_decrypt_must_succeed": bool,
         # The type of hashing algorithm to use when doing file comparisons
         "hash_type": str,
         # Order of preference for optimized .pyc files (PY3 only)
@@ -1057,6 +1059,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze(
         "decrypt_pillar_delimiter": ":",
         "decrypt_pillar_default": "gpg",
         "decrypt_pillar_renderers": ["gpg"],
+        "gpg_decrypt_must_succeed": False,
         # Update intervals
         "roots_update_interval": DEFAULT_INTERVAL,
         "azurefs_update_interval": DEFAULT_INTERVAL,
@@ -1294,6 +1297,7 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze(
         "decrypt_pillar_delimiter": ":",
         "decrypt_pillar_default": "gpg",
         "decrypt_pillar_renderers": ["gpg"],
+        "gpg_decrypt_must_succeed": False,
         "thoriumenv": None,
         "thorium_top": "top.sls",
         "thorium_interval": 0.5,

--- a/tests/pytests/functional/pillar/test_gpg.py
+++ b/tests/pytests/functional/pillar/test_gpg.py
@@ -3,6 +3,7 @@ import logging
 import pathlib
 import shutil
 import subprocess
+import textwrap
 
 import pytest
 import salt.pillar
@@ -15,196 +16,237 @@ pytestmark = [
 
 log = logging.getLogger(__name__)
 
-TEST_KEY = """\
------BEGIN PGP PRIVATE KEY BLOCK-----
 
-lQOYBFiKrcYBCADAj92+fz20uKxxH0ffMwcryGG9IogkiUi2QrNYilB4hwrY5Qt7
-Sbywlk/mSDMcABxMxS0vegqc5pgglvAnsi9w7j//9nfjiirsyiTYOOD1akTFQr7b
-qT6zuGFA4oYmYHvfBOena485qvlyitYLKYT9h27TDiiH6Jgt4xSRbjeyhTf3/fKD
-JzHA9ii5oeVi1pH/8/4USgXanBdKwO0JKQtci+PF0qe/nkzRswqTIkdgx1oyNUqL
-tYJ0XPOy+UyOC4J4QDIt9PQbAmiur8By4g2lLYWlGOCjs7Fcj3n5meWKzf1pmXoY
-lAnSab8kUZSSkoWQoTO7RbjFypULKCZui45/ABEBAAEAB/wM1wsAMtfYfx/wgxd1
-yJ9HyhrKU80kMotIq/Xth3uKLecJQ2yakfYlCEDXqCTQTymT7OnwaoDeqXmnYqks
-3HLRYvGdjb+8ym/GTkxapqBJfQaM6MB1QTnPHhJOE0zCrlhULK2NulxYihAMFTnk
-kKYviaJYLG+DcH0FQkkS0XihTKcqnsoJiS6iNd5SME3pa0qijR0D5f78fkvNzzEE
-9vgAX1TgQ5PDJGN6nYlW2bWxTcg+FR2cUAQPTiP9wXCH6VyJoQay7KHVr3r/7SsU
-89otfcx5HVDYPrez6xnP6wN0P/mKxCDbkERLDjZjWOmNXg2zn+/t3u02e+ybfAIp
-kTTxBADY/FmPgLpJ2bpcPH141twpHwhKIbENlTB9745Qknr6aLA0QVCkz49/3joO
-Sj+SZ7Jhl6cfbynrfHwX3b1bOFTzBUH2Tsi0HX40PezEFH0apf55FLZuMOBt/lc1
-ET6evpIHF0dcM+BvZa7E7MyTyEq8S7Cc9RoJyfeGbS7MG5FfuwQA4y9QOb/OQglq
-ZffkVItwY52RKWb/b2WQmt+IcVax/j7DmBva765SIfPDvOCMrYhJBI/uYHQ0Zia7
-SnC9+ez55wdYqgHkYojc21CIOnUvsPSj+rOpryoXzmcTuvKeVIyIA0h/mQyWjimR
-ENrikC4+O8GBMY6V4uvS4EFhLfHE9g0D/20lNOKkpAKPenr8iAPWcl0/pijJCGxF
-agnT7O2GQ9Lr5hSjW86agkevbGktu2ja5t/fHq0wpLQ4DVLMrR0/poaprTr307kW
-AlQV3z/C2cMHNysz4ulOgQrudQbhUEz2A8nQxRtIfWunkEugKLr1QiCkE1LJW8Np
-ZLxE6Qp0/KzdQva0HVNhbHQgR1BHIDxlcmlrQHNhbHRzdGFjay5jb20+iQFUBBMB
-CAA+FiEE+AxQ1ELHGEyFTZPYw5x3k9EbHGsFAliKrcYCGwMFCQPCZwAFCwkIBwIG
-FQgJCgsCBBYCAwECHgECF4AACgkQw5x3k9EbHGubUAf+PLdp1oTLVokockZgLyIQ
-wxOd3ofNOgNk4QoAkSMNSbtnYoQFKumRw/yGyPSIoHMsOC/ga98r8TAJEKfx3DLA
-rsD34oMAaYUT+XUd0KoSmlHqBrtDD1+eBASKYsCosHpCiKuQFfLKSxvpEr2YyL8L
-X3Q2TY5zFlGA9Eeq5g+rlb++yRZrruFN28EWtY/pyXFZgIB30ReDwPkM9hrioPZM
-0Qf3+dWZSK1rWViclB51oNy4un9stTiFZptAqz4NTNssU5A4AcNQPwBwnKIYoE58
-Y/Zyv8HzILGykT+qFebqRlRBI/13eHdzgJOL1iPRfjTk5Cvr+vcyIxAklXOP81ja
-B50DmARYiq3GAQgArnzu4SPCCQGNcCNxN4QlMP5TNvRsm5KrPbcO9j8HPfB+DRXs
-6B3mnuR6OJg7YuC0C2A/m2dSHJKkF0f2AwFRpxLjJ2iAFbrZAW/N0vZDx8zO+YAU
-HyLu0V04wdCE5DTLkgfWNR+0uMa8qZ4Kn56Gv7O+OFE7zgTHeZ7psWlxdafeW7u6
-zlC/3DWksNtuNb0vQDNMM4vgXbnORIfXdyh41zvEEnr/rKw8DuJAmo20mcv6Qi51
-PqqyM62ddQOEVfiMs9l4vmwZAjGFNFNInyPXnogL6UPCDmizb6hh8aX/MwG/XFIG
-KMJWbAVGpyBuqljKIt3qLu/s8ouPqkEN+f+nGwARAQABAAf+NA36d/kieGxZpTQ1
-oQHP1Jty+OiXhBwP8SPtF0J7ZxuZh07cs+zDsfBok/y6bsepfuFSaIq84OBQis+B
-kajxkp3cXZPb7l+lQLv5k++7Dd7Ien+ewSE7TQN6HLwYATrM5n5nBcc1M5C6lQGc
-mr0A5yz42TVG2bHsTpi9kBtsaVRSPUHSh8A8T6eOyCrT+/CAJVEEf7JyNyaqH1dy
-LuxI1VF3ySDEtFzuwN8EZQP9Yz/4AVyEQEA7WkNEwSQsBi2bWgWEdG+qjqnL+YKa
-vwe7/aJYPeL1zICnP/Osd/UcpDxR78MbozstbRljML0fTLj7UJ+XDazwv+Kl0193
-2ZK2QQQAwgXvS19MYNkHO7kbNVLt1VE2ll901iC9GFHBpFUam6gmoHXpCarB+ShH
-8x25aoUu4MxHmFxXd+Zq3d6q2yb57doWoPgvqcefpGmigaITnb1jhV2rt65V8deA
-SQazZNqBEBbZNIhfn6ObxHXXvaYaqq/UOEQ7uKyR9WMJT/rmqMEEAOY5h1R1t7AB
-JZ5VnhyAhdsNWw1gTcXB3o8gKz4vjdnPm0F4aVIPfB3BukETDc3sc2tKmCfUF7I7
-oOrh7iRez5F0RIC3KDzXF8qUuWBfPViww45JgftdKsecCIlEEYCoc+3goX0su2bP
-V1MDuHijMGTJCBABDgizNb0oynW5xcrbA/0QnKfpTwi7G3oRcJWv2YebVDRcU+SP
-dOYhq6SnmWPizEIljRG/X7FHJB+W7tzryO3sCDTAYwxFrfMwvJ2PwnAYI4349zYd
-lC28HowUkBYNhwBXc48xCfyhPZtD0aLx/OX1oLZ/vi8gd8TusgGupV/JjkFVO+Nd
-+shN/UEAldwqkkY2iQE8BBgBCAAmFiEE+AxQ1ELHGEyFTZPYw5x3k9EbHGsFAliK
-rcYCGwwFCQPCZwAACgkQw5x3k9EbHGu4wwf/dRFat91BRX1TJfwJl5otoAXpItYM
-6kdWWf1Eb1BicAvXhI078MSH4WXdKkJjJr1fFP8Ynil513H4Mzb0rotMAhb0jLSA
-lSRkMbhMvPxoS2kaYzioaBpp8yXpGiNo7dF+PJXSm/Uwp3AkcFjoVbBOqDWGgxMi
-DvDAstzLZ9dIcmr+OmcRQykKOKXlhEl3HnR5CyuPrA8hdVup4oeVwdkJhfJFKLLb
-3fR26wxJOmIOAt24eAUy721WfQ9txNAmhdy8mY842ODZESw6WatrQjRfuqosDgrk
-jc0cCHsEqJNZ2AB+1uEl3tcH0tyAFJa33F0znSonP17SS1Ff9sgHYBVLUg==
-=06Tz
------END PGP PRIVATE KEY BLOCK-----
-"""
+@pytest.fixture(scope="module")
+def test_key():
+    """
+    Private key for setting up GPG pillar environment.
+    """
+    return textwrap.dedent(
+        """\
+        -----BEGIN PGP PRIVATE KEY BLOCK-----
 
-GPG_PILLAR_YAML = """\
-secrets:
-  vault:
-    foo: |
-      -----BEGIN PGP MESSAGE-----
+        lQOYBFiKrcYBCADAj92+fz20uKxxH0ffMwcryGG9IogkiUi2QrNYilB4hwrY5Qt7
+        Sbywlk/mSDMcABxMxS0vegqc5pgglvAnsi9w7j//9nfjiirsyiTYOOD1akTFQr7b
+        qT6zuGFA4oYmYHvfBOena485qvlyitYLKYT9h27TDiiH6Jgt4xSRbjeyhTf3/fKD
+        JzHA9ii5oeVi1pH/8/4USgXanBdKwO0JKQtci+PF0qe/nkzRswqTIkdgx1oyNUqL
+        tYJ0XPOy+UyOC4J4QDIt9PQbAmiur8By4g2lLYWlGOCjs7Fcj3n5meWKzf1pmXoY
+        lAnSab8kUZSSkoWQoTO7RbjFypULKCZui45/ABEBAAEAB/wM1wsAMtfYfx/wgxd1
+        yJ9HyhrKU80kMotIq/Xth3uKLecJQ2yakfYlCEDXqCTQTymT7OnwaoDeqXmnYqks
+        3HLRYvGdjb+8ym/GTkxapqBJfQaM6MB1QTnPHhJOE0zCrlhULK2NulxYihAMFTnk
+        kKYviaJYLG+DcH0FQkkS0XihTKcqnsoJiS6iNd5SME3pa0qijR0D5f78fkvNzzEE
+        9vgAX1TgQ5PDJGN6nYlW2bWxTcg+FR2cUAQPTiP9wXCH6VyJoQay7KHVr3r/7SsU
+        89otfcx5HVDYPrez6xnP6wN0P/mKxCDbkERLDjZjWOmNXg2zn+/t3u02e+ybfAIp
+        kTTxBADY/FmPgLpJ2bpcPH141twpHwhKIbENlTB9745Qknr6aLA0QVCkz49/3joO
+        Sj+SZ7Jhl6cfbynrfHwX3b1bOFTzBUH2Tsi0HX40PezEFH0apf55FLZuMOBt/lc1
+        ET6evpIHF0dcM+BvZa7E7MyTyEq8S7Cc9RoJyfeGbS7MG5FfuwQA4y9QOb/OQglq
+        ZffkVItwY52RKWb/b2WQmt+IcVax/j7DmBva765SIfPDvOCMrYhJBI/uYHQ0Zia7
+        SnC9+ez55wdYqgHkYojc21CIOnUvsPSj+rOpryoXzmcTuvKeVIyIA0h/mQyWjimR
+        ENrikC4+O8GBMY6V4uvS4EFhLfHE9g0D/20lNOKkpAKPenr8iAPWcl0/pijJCGxF
+        agnT7O2GQ9Lr5hSjW86agkevbGktu2ja5t/fHq0wpLQ4DVLMrR0/poaprTr307kW
+        AlQV3z/C2cMHNysz4ulOgQrudQbhUEz2A8nQxRtIfWunkEugKLr1QiCkE1LJW8Np
+        ZLxE6Qp0/KzdQva0HVNhbHQgR1BHIDxlcmlrQHNhbHRzdGFjay5jb20+iQFUBBMB
+        CAA+FiEE+AxQ1ELHGEyFTZPYw5x3k9EbHGsFAliKrcYCGwMFCQPCZwAFCwkIBwIG
+        FQgJCgsCBBYCAwECHgECF4AACgkQw5x3k9EbHGubUAf+PLdp1oTLVokockZgLyIQ
+        wxOd3ofNOgNk4QoAkSMNSbtnYoQFKumRw/yGyPSIoHMsOC/ga98r8TAJEKfx3DLA
+        rsD34oMAaYUT+XUd0KoSmlHqBrtDD1+eBASKYsCosHpCiKuQFfLKSxvpEr2YyL8L
+        X3Q2TY5zFlGA9Eeq5g+rlb++yRZrruFN28EWtY/pyXFZgIB30ReDwPkM9hrioPZM
+        0Qf3+dWZSK1rWViclB51oNy4un9stTiFZptAqz4NTNssU5A4AcNQPwBwnKIYoE58
+        Y/Zyv8HzILGykT+qFebqRlRBI/13eHdzgJOL1iPRfjTk5Cvr+vcyIxAklXOP81ja
+        B50DmARYiq3GAQgArnzu4SPCCQGNcCNxN4QlMP5TNvRsm5KrPbcO9j8HPfB+DRXs
+        6B3mnuR6OJg7YuC0C2A/m2dSHJKkF0f2AwFRpxLjJ2iAFbrZAW/N0vZDx8zO+YAU
+        HyLu0V04wdCE5DTLkgfWNR+0uMa8qZ4Kn56Gv7O+OFE7zgTHeZ7psWlxdafeW7u6
+        zlC/3DWksNtuNb0vQDNMM4vgXbnORIfXdyh41zvEEnr/rKw8DuJAmo20mcv6Qi51
+        PqqyM62ddQOEVfiMs9l4vmwZAjGFNFNInyPXnogL6UPCDmizb6hh8aX/MwG/XFIG
+        KMJWbAVGpyBuqljKIt3qLu/s8ouPqkEN+f+nGwARAQABAAf+NA36d/kieGxZpTQ1
+        oQHP1Jty+OiXhBwP8SPtF0J7ZxuZh07cs+zDsfBok/y6bsepfuFSaIq84OBQis+B
+        kajxkp3cXZPb7l+lQLv5k++7Dd7Ien+ewSE7TQN6HLwYATrM5n5nBcc1M5C6lQGc
+        mr0A5yz42TVG2bHsTpi9kBtsaVRSPUHSh8A8T6eOyCrT+/CAJVEEf7JyNyaqH1dy
+        LuxI1VF3ySDEtFzuwN8EZQP9Yz/4AVyEQEA7WkNEwSQsBi2bWgWEdG+qjqnL+YKa
+        vwe7/aJYPeL1zICnP/Osd/UcpDxR78MbozstbRljML0fTLj7UJ+XDazwv+Kl0193
+        2ZK2QQQAwgXvS19MYNkHO7kbNVLt1VE2ll901iC9GFHBpFUam6gmoHXpCarB+ShH
+        8x25aoUu4MxHmFxXd+Zq3d6q2yb57doWoPgvqcefpGmigaITnb1jhV2rt65V8deA
+        SQazZNqBEBbZNIhfn6ObxHXXvaYaqq/UOEQ7uKyR9WMJT/rmqMEEAOY5h1R1t7AB
+        JZ5VnhyAhdsNWw1gTcXB3o8gKz4vjdnPm0F4aVIPfB3BukETDc3sc2tKmCfUF7I7
+        oOrh7iRez5F0RIC3KDzXF8qUuWBfPViww45JgftdKsecCIlEEYCoc+3goX0su2bP
+        V1MDuHijMGTJCBABDgizNb0oynW5xcrbA/0QnKfpTwi7G3oRcJWv2YebVDRcU+SP
+        dOYhq6SnmWPizEIljRG/X7FHJB+W7tzryO3sCDTAYwxFrfMwvJ2PwnAYI4349zYd
+        lC28HowUkBYNhwBXc48xCfyhPZtD0aLx/OX1oLZ/vi8gd8TusgGupV/JjkFVO+Nd
+        +shN/UEAldwqkkY2iQE8BBgBCAAmFiEE+AxQ1ELHGEyFTZPYw5x3k9EbHGsFAliK
+        rcYCGwwFCQPCZwAACgkQw5x3k9EbHGu4wwf/dRFat91BRX1TJfwJl5otoAXpItYM
+        6kdWWf1Eb1BicAvXhI078MSH4WXdKkJjJr1fFP8Ynil513H4Mzb0rotMAhb0jLSA
+        lSRkMbhMvPxoS2kaYzioaBpp8yXpGiNo7dF+PJXSm/Uwp3AkcFjoVbBOqDWGgxMi
+        DvDAstzLZ9dIcmr+OmcRQykKOKXlhEl3HnR5CyuPrA8hdVup4oeVwdkJhfJFKLLb
+        3fR26wxJOmIOAt24eAUy721WfQ9txNAmhdy8mY842ODZESw6WatrQjRfuqosDgrk
+        jc0cCHsEqJNZ2AB+1uEl3tcH0tyAFJa33F0znSonP17SS1Ff9sgHYBVLUg==
+        =06Tz
+        -----END PGP PRIVATE KEY BLOCK-----
+        """
+    )
 
-      hQEMAw2B674HRhwSAQgAhTrN8NizwUv/VunVrqa4/X8t6EUulrnhKcSeb8sZS4th
-      W1Qz3K2NjL4lkUHCQHKZVx/VoZY7zsddBIFvvoGGfj8+2wjkEDwFmFjGE4DEsS74
-      ZLRFIFJC1iB/O0AiQ+oU745skQkU6OEKxqavmKMrKo3rvJ8ZCXDC470+i2/Hqrp7
-      +KWGmaDOO422JaSKRm5D9bQZr9oX7KqnrPG9I1+UbJyQSJdsdtquPWmeIpamEVHb
-      VMDNQRjSezZ1yKC4kCWm3YQbBF76qTHzG1VlLF5qOzuGI9VkyvlMaLfMibriqY73
-      zBbPzf6Bkp2+Y9qyzuveYMmwS4sEOuZL/PetqisWe9JGAWD/O+slQ2KRu9hNww06
-      KMDPJRdyj5bRuBVE4hHkkP23KrYr7SuhW2vpe7O/MvWEJ9uDNegpMLhTWruGngJh
-      iFndxegN9w==
-      =bAuo
-      -----END PGP MESSAGE-----
-    bar: this was unencrypted already
-    baz: |
-      -----BEGIN PGP MESSAGE-----
 
-      hQEMAw2B674HRhwSAQf+Ne+IfsP2IcPDrUWct8sTJrga47jQvlPCmO+7zJjOVcqz
-      gLjUKvMajrbI/jorBWxyAbF+5E7WdG9WHHVnuoywsyTB9rbmzuPqYCJCe+ZVyqWf
-      9qgJ+oUjcvYIFmH3h7H68ldqbxaAUkAOQbTRHdr253wwaTIC91ZeX0SCj64HfTg7
-      Izwk383CRWonEktXJpientApQFSUWNeLUWagEr/YPNFA3vzpPF5/Ia9X8/z/6oO2
-      q+D5W5mVsns3i2HHbg2A8Y+pm4TWnH6mTSh/gdxPqssi9qIrzGQ6H1tEoFFOEq1V
-      kJBe0izlfudqMq62XswzuRB4CYT5Iqw1c97T+1RqENJCASG0Wz8AGhinTdlU5iQl
-      JkLKqBxcBz4L70LYWyHhYwYROJWjHgKAywX5T67ftq0wi8APuZl9olnOkwSK+wrY
-      1OZi
-      =7epf
-      -----END PGP MESSAGE-----
-    qux:
-      - foo
-      - bar
-      - |
-        -----BEGIN PGP MESSAGE-----
+@pytest.fixture(scope="module")
+def gpg_pillar_yaml():
+    """
+    Yaml data for testing GPG pillar.
+    """
+    return textwrap.dedent(
+        """\
+        secrets:
+          vault:
+            foo: |
+              -----BEGIN PGP MESSAGE-----
 
-        hQEMAw2B674HRhwSAQgAg1YCmokrweoOI1c9HO0BLamWBaFPTMblOaTo0WJLZoTS
-        ksbQ3OJAMkrkn3BnnM/djJc5C7vNs86ZfSJ+pvE8Sp1Rhtuxh25EKMqGOn/SBedI
-        gR6N5vGUNiIpG5Tf3DuYAMNFDUqw8uY0MyDJI+ZW3o3xrMUABzTH0ew+Piz85FDA
-        YrVgwZfqyL+9OQuu6T66jOIdwQNRX2NPFZqvon8liZUPus5VzD8E5cAL9OPxQ3sF
-        f7/zE91YIXUTimrv3L7eCgU1dSxKhhfvA2bEUi+AskMWFXFuETYVrIhFJAKnkFmE
-        uZx+O9R9hADW3hM5hWHKH9/CRtb0/cC84I9oCWIQPdI+AaPtICxtsD2N8Q98hhhd
-        4M7I0sLZhV+4ZJqzpUsOnSpaGyfh1Zy/1d3ijJi99/l+uVHuvmMllsNmgR+ZTj0=
-        =LrCQ
-        -----END PGP MESSAGE-----
-"""
+              hQEMAw2B674HRhwSAQgAhTrN8NizwUv/VunVrqa4/X8t6EUulrnhKcSeb8sZS4th
+              W1Qz3K2NjL4lkUHCQHKZVx/VoZY7zsddBIFvvoGGfj8+2wjkEDwFmFjGE4DEsS74
+              ZLRFIFJC1iB/O0AiQ+oU745skQkU6OEKxqavmKMrKo3rvJ8ZCXDC470+i2/Hqrp7
+              +KWGmaDOO422JaSKRm5D9bQZr9oX7KqnrPG9I1+UbJyQSJdsdtquPWmeIpamEVHb
+              VMDNQRjSezZ1yKC4kCWm3YQbBF76qTHzG1VlLF5qOzuGI9VkyvlMaLfMibriqY73
+              zBbPzf6Bkp2+Y9qyzuveYMmwS4sEOuZL/PetqisWe9JGAWD/O+slQ2KRu9hNww06
+              KMDPJRdyj5bRuBVE4hHkkP23KrYr7SuhW2vpe7O/MvWEJ9uDNegpMLhTWruGngJh
+              iFndxegN9w==
+              =bAuo
+              -----END PGP MESSAGE-----
+            bar: this was unencrypted already
+            baz: |
+              -----BEGIN PGP MESSAGE-----
 
-GPG_PILLAR_ENCRYPTED = {
-    "secrets": {
-        "vault": {
-            "foo": (
-                "-----BEGIN PGP MESSAGE-----\n"
-                "\n"
-                "hQEMAw2B674HRhwSAQgAhTrN8NizwUv/VunVrqa4/X8t6EUulrnhKcSeb8sZS4th\n"
-                "W1Qz3K2NjL4lkUHCQHKZVx/VoZY7zsddBIFvvoGGfj8+2wjkEDwFmFjGE4DEsS74\n"
-                "ZLRFIFJC1iB/O0AiQ+oU745skQkU6OEKxqavmKMrKo3rvJ8ZCXDC470+i2/Hqrp7\n"
-                "+KWGmaDOO422JaSKRm5D9bQZr9oX7KqnrPG9I1+UbJyQSJdsdtquPWmeIpamEVHb\n"
-                "VMDNQRjSezZ1yKC4kCWm3YQbBF76qTHzG1VlLF5qOzuGI9VkyvlMaLfMibriqY73\n"
-                "zBbPzf6Bkp2+Y9qyzuveYMmwS4sEOuZL/PetqisWe9JGAWD/O+slQ2KRu9hNww06\n"
-                "KMDPJRdyj5bRuBVE4hHkkP23KrYr7SuhW2vpe7O/MvWEJ9uDNegpMLhTWruGngJh\n"
-                "iFndxegN9w==\n"
-                "=bAuo\n"
-                "-----END PGP MESSAGE-----\n"
-            ),
-            "bar": "this was unencrypted already",
-            "baz": (
-                "-----BEGIN PGP MESSAGE-----\n"
-                "\n"
-                "hQEMAw2B674HRhwSAQf+Ne+IfsP2IcPDrUWct8sTJrga47jQvlPCmO+7zJjOVcqz\n"
-                "gLjUKvMajrbI/jorBWxyAbF+5E7WdG9WHHVnuoywsyTB9rbmzuPqYCJCe+ZVyqWf\n"
-                "9qgJ+oUjcvYIFmH3h7H68ldqbxaAUkAOQbTRHdr253wwaTIC91ZeX0SCj64HfTg7\n"
-                "Izwk383CRWonEktXJpientApQFSUWNeLUWagEr/YPNFA3vzpPF5/Ia9X8/z/6oO2\n"
-                "q+D5W5mVsns3i2HHbg2A8Y+pm4TWnH6mTSh/gdxPqssi9qIrzGQ6H1tEoFFOEq1V\n"
-                "kJBe0izlfudqMq62XswzuRB4CYT5Iqw1c97T+1RqENJCASG0Wz8AGhinTdlU5iQl\n"
-                "JkLKqBxcBz4L70LYWyHhYwYROJWjHgKAywX5T67ftq0wi8APuZl9olnOkwSK+wrY\n"
-                "1OZi\n"
-                "=7epf\n"
-                "-----END PGP MESSAGE-----\n"
-            ),
-            "qux": [
-                "foo",
-                "bar",
-                "-----BEGIN PGP MESSAGE-----\n"
-                "\n"
-                "hQEMAw2B674HRhwSAQgAg1YCmokrweoOI1c9HO0BLamWBaFPTMblOaTo0WJLZoTS\n"
-                "ksbQ3OJAMkrkn3BnnM/djJc5C7vNs86ZfSJ+pvE8Sp1Rhtuxh25EKMqGOn/SBedI\n"
-                "gR6N5vGUNiIpG5Tf3DuYAMNFDUqw8uY0MyDJI+ZW3o3xrMUABzTH0ew+Piz85FDA\n"
-                "YrVgwZfqyL+9OQuu6T66jOIdwQNRX2NPFZqvon8liZUPus5VzD8E5cAL9OPxQ3sF\n"
-                "f7/zE91YIXUTimrv3L7eCgU1dSxKhhfvA2bEUi+AskMWFXFuETYVrIhFJAKnkFmE\n"
-                "uZx+O9R9hADW3hM5hWHKH9/CRtb0/cC84I9oCWIQPdI+AaPtICxtsD2N8Q98hhhd\n"
-                "4M7I0sLZhV+4ZJqzpUsOnSpaGyfh1Zy/1d3ijJi99/l+uVHuvmMllsNmgR+ZTj0=\n"
-                "=LrCQ\n"
-                "-----END PGP MESSAGE-----\n",
-            ],
+              hQEMAw2B674HRhwSAQf+Ne+IfsP2IcPDrUWct8sTJrga47jQvlPCmO+7zJjOVcqz
+              gLjUKvMajrbI/jorBWxyAbF+5E7WdG9WHHVnuoywsyTB9rbmzuPqYCJCe+ZVyqWf
+              9qgJ+oUjcvYIFmH3h7H68ldqbxaAUkAOQbTRHdr253wwaTIC91ZeX0SCj64HfTg7
+              Izwk383CRWonEktXJpientApQFSUWNeLUWagEr/YPNFA3vzpPF5/Ia9X8/z/6oO2
+              q+D5W5mVsns3i2HHbg2A8Y+pm4TWnH6mTSh/gdxPqssi9qIrzGQ6H1tEoFFOEq1V
+              kJBe0izlfudqMq62XswzuRB4CYT5Iqw1c97T+1RqENJCASG0Wz8AGhinTdlU5iQl
+              JkLKqBxcBz4L70LYWyHhYwYROJWjHgKAywX5T67ftq0wi8APuZl9olnOkwSK+wrY
+              1OZi
+              =7epf
+              -----END PGP MESSAGE-----
+            qux:
+              - foo
+              - bar
+              - |
+                -----BEGIN PGP MESSAGE-----
+
+                hQEMAw2B674HRhwSAQgAg1YCmokrweoOI1c9HO0BLamWBaFPTMblOaTo0WJLZoTS
+                ksbQ3OJAMkrkn3BnnM/djJc5C7vNs86ZfSJ+pvE8Sp1Rhtuxh25EKMqGOn/SBedI
+                gR6N5vGUNiIpG5Tf3DuYAMNFDUqw8uY0MyDJI+ZW3o3xrMUABzTH0ew+Piz85FDA
+                YrVgwZfqyL+9OQuu6T66jOIdwQNRX2NPFZqvon8liZUPus5VzD8E5cAL9OPxQ3sF
+                f7/zE91YIXUTimrv3L7eCgU1dSxKhhfvA2bEUi+AskMWFXFuETYVrIhFJAKnkFmE
+                uZx+O9R9hADW3hM5hWHKH9/CRtb0/cC84I9oCWIQPdI+AaPtICxtsD2N8Q98hhhd
+                4M7I0sLZhV+4ZJqzpUsOnSpaGyfh1Zy/1d3ijJi99/l+uVHuvmMllsNmgR+ZTj0=
+                =LrCQ
+                -----END PGP MESSAGE-----
+        """
+    )
+
+
+@pytest.fixture(scope="module")
+def gpg_pillar_encrypted():
+    """
+    Pillar data structure with GPG blocks not decrypted.
+    """
+    return {
+        "secrets": {
+            "vault": {
+                "foo": (
+                    "-----BEGIN PGP MESSAGE-----\n"
+                    "\n"
+                    "hQEMAw2B674HRhwSAQgAhTrN8NizwUv/VunVrqa4/X8t6EUulrnhKcSeb8sZS4th\n"
+                    "W1Qz3K2NjL4lkUHCQHKZVx/VoZY7zsddBIFvvoGGfj8+2wjkEDwFmFjGE4DEsS74\n"
+                    "ZLRFIFJC1iB/O0AiQ+oU745skQkU6OEKxqavmKMrKo3rvJ8ZCXDC470+i2/Hqrp7\n"
+                    "+KWGmaDOO422JaSKRm5D9bQZr9oX7KqnrPG9I1+UbJyQSJdsdtquPWmeIpamEVHb\n"
+                    "VMDNQRjSezZ1yKC4kCWm3YQbBF76qTHzG1VlLF5qOzuGI9VkyvlMaLfMibriqY73\n"
+                    "zBbPzf6Bkp2+Y9qyzuveYMmwS4sEOuZL/PetqisWe9JGAWD/O+slQ2KRu9hNww06\n"
+                    "KMDPJRdyj5bRuBVE4hHkkP23KrYr7SuhW2vpe7O/MvWEJ9uDNegpMLhTWruGngJh\n"
+                    "iFndxegN9w==\n"
+                    "=bAuo\n"
+                    "-----END PGP MESSAGE-----\n"
+                ),
+                "bar": "this was unencrypted already",
+                "baz": (
+                    "-----BEGIN PGP MESSAGE-----\n"
+                    "\n"
+                    "hQEMAw2B674HRhwSAQf+Ne+IfsP2IcPDrUWct8sTJrga47jQvlPCmO+7zJjOVcqz\n"
+                    "gLjUKvMajrbI/jorBWxyAbF+5E7WdG9WHHVnuoywsyTB9rbmzuPqYCJCe+ZVyqWf\n"
+                    "9qgJ+oUjcvYIFmH3h7H68ldqbxaAUkAOQbTRHdr253wwaTIC91ZeX0SCj64HfTg7\n"
+                    "Izwk383CRWonEktXJpientApQFSUWNeLUWagEr/YPNFA3vzpPF5/Ia9X8/z/6oO2\n"
+                    "q+D5W5mVsns3i2HHbg2A8Y+pm4TWnH6mTSh/gdxPqssi9qIrzGQ6H1tEoFFOEq1V\n"
+                    "kJBe0izlfudqMq62XswzuRB4CYT5Iqw1c97T+1RqENJCASG0Wz8AGhinTdlU5iQl\n"
+                    "JkLKqBxcBz4L70LYWyHhYwYROJWjHgKAywX5T67ftq0wi8APuZl9olnOkwSK+wrY\n"
+                    "1OZi\n"
+                    "=7epf\n"
+                    "-----END PGP MESSAGE-----\n"
+                ),
+                "qux": [
+                    "foo",
+                    "bar",
+                    "-----BEGIN PGP MESSAGE-----\n"
+                    "\n"
+                    "hQEMAw2B674HRhwSAQgAg1YCmokrweoOI1c9HO0BLamWBaFPTMblOaTo0WJLZoTS\n"
+                    "ksbQ3OJAMkrkn3BnnM/djJc5C7vNs86ZfSJ+pvE8Sp1Rhtuxh25EKMqGOn/SBedI\n"
+                    "gR6N5vGUNiIpG5Tf3DuYAMNFDUqw8uY0MyDJI+ZW3o3xrMUABzTH0ew+Piz85FDA\n"
+                    "YrVgwZfqyL+9OQuu6T66jOIdwQNRX2NPFZqvon8liZUPus5VzD8E5cAL9OPxQ3sF\n"
+                    "f7/zE91YIXUTimrv3L7eCgU1dSxKhhfvA2bEUi+AskMWFXFuETYVrIhFJAKnkFmE\n"
+                    "uZx+O9R9hADW3hM5hWHKH9/CRtb0/cC84I9oCWIQPdI+AaPtICxtsD2N8Q98hhhd\n"
+                    "4M7I0sLZhV+4ZJqzpUsOnSpaGyfh1Zy/1d3ijJi99/l+uVHuvmMllsNmgR+ZTj0=\n"
+                    "=LrCQ\n"
+                    "-----END PGP MESSAGE-----\n",
+                ],
+            },
         },
-    },
-}
+    }
 
-GPG_PILLAR_DECRYPTED = {
-    "secrets": {
-        "vault": {
-            "foo": "supersecret",
-            "bar": "this was unencrypted already",
-            "baz": "rosebud",
-            "qux": ["foo", "bar", "baz"],
+
+@pytest.fixture(scope="module")
+def gpg_pillar_decrypted():
+    """
+    Pillar data structure with GPG blocks decrypted.
+    """
+    return {
+        "secrets": {
+            "vault": {
+                "foo": "supersecret",
+                "bar": "this was unencrypted already",
+                "baz": "rosebud",
+                "qux": ["foo", "bar", "baz"],
+            },
         },
-    },
-}
-
-# Random data pretending to be ciphertext
-GPG_PILLAR_YAML_FAIL = """\
-fail: |
-  -----BEGIN PGP MESSAGE-----
-
-  OzyJmQJJVPxGQqyxwIcAl0wWqdSTHpMXYPLrDoRU8H1xa2DhE5DeUihjm4fHUcHp
-  -----END PGP MESSAGE-----
-"""
-
-GPG_PILLAR_ENCRYPTED_FAIL = {
-    "fail": (
-        "-----BEGIN PGP MESSAGE-----\n"
-        "\n"
-        "OzyJmQJJVPxGQqyxwIcAl0wWqdSTHpMXYPLrDoRU8H1xa2DhE5DeUihjm4fHUcHp\n"
-        "-----END PGP MESSAGE-----\n"
-    ),
-}
+    }
 
 
-@pytest.fixture(scope="package", autouse=True)
-def gpg_homedir(salt_master):
+@pytest.fixture(scope="module")
+def gpg_pillar_yaml_bad():
+    """
+    Random data pretending to be ciphertext.
+    """
+    return textwrap.dedent(
+        """\
+        fail: |
+          -----BEGIN PGP MESSAGE-----
+
+          OzyJmQJJVPxGQqyxwIcAl0wWqdSTHpMXYPLrDoRU8H1xa2DhE5DeUihjm4fHUcHp
+          -----END PGP MESSAGE-----
+        """
+    )
+
+
+@pytest.fixture(scope="module")
+def gpg_pillar_encrypted_bad():
+    """
+    Random data pretending to be ciphertext almost always does not decrypt.
+    """
+    return {
+        "fail": (
+            "-----BEGIN PGP MESSAGE-----\n"
+            "\n"
+            "OzyJmQJJVPxGQqyxwIcAl0wWqdSTHpMXYPLrDoRU8H1xa2DhE5DeUihjm4fHUcHp\n"
+            "-----END PGP MESSAGE-----\n"
+        ),
+    }
+
+
+@pytest.fixture(scope="module", autouse=True)
+def gpg_homedir(salt_master, test_key):
     """
     Setup gpg environment
     """
@@ -237,7 +279,7 @@ def gpg_homedir(salt_master):
             stderr=subprocess.STDOUT,
             check=True,
             universal_newlines=True,
-            input=TEST_KEY,
+            input=test_key,
         )
         ret = ProcessResult(
             exitcode=proc.returncode,
@@ -274,8 +316,8 @@ def gpg_homedir(salt_master):
         shutil.rmtree(str(_gpg_homedir), ignore_errors=True)
 
 
-@pytest.fixture(scope="package")
-def pillar_homedir(pillar_state_tree):
+@pytest.fixture(scope="module")
+def pillar_homedir(pillar_state_tree, gpg_pillar_yaml):
     """
     Setup gpg pillar
     """
@@ -286,14 +328,14 @@ def pillar_homedir(pillar_state_tree):
     """
     with pytest.helpers.temp_file(
         "top.sls", top_file_contents, pillar_state_tree
-    ), pytest.helpers.temp_file("gpg.sls", GPG_PILLAR_YAML, pillar_state_tree):
+    ), pytest.helpers.temp_file("gpg.sls", gpg_pillar_yaml, pillar_state_tree):
         # Need to yield something so that pytest closes the context as a
         # callback after the test rather than immediately
         yield None
 
 
-@pytest.fixture(scope="package")
-def pillar_homedir_bad(pillar_state_tree):
+@pytest.fixture(scope="module")
+def pillar_homedir_bad(pillar_state_tree, gpg_pillar_yaml_bad):
     """
     Setup gpg pillar with bad data
     """
@@ -304,13 +346,15 @@ def pillar_homedir_bad(pillar_state_tree):
     """
     with pytest.helpers.temp_file(
         "top.sls", top_file_contents, pillar_state_tree
-    ), pytest.helpers.temp_file("gpg.sls", GPG_PILLAR_YAML_FAIL, pillar_state_tree):
+    ), pytest.helpers.temp_file("gpg.sls", gpg_pillar_yaml_bad, pillar_state_tree):
         # Need to yield something so that pytest closes the context as a
         # callback after the test rather than immediately
         yield None
 
 
-def test_decrypt_pillar_default_renderer(salt_master, grains, pillar_homedir):
+def test_decrypt_pillar_default_renderer(
+    salt_master, grains, pillar_homedir, gpg_pillar_decrypted
+):
     """
     Test recursive decryption of secrets:vault as well as the fallback to
     default decryption renderer.
@@ -319,11 +363,13 @@ def test_decrypt_pillar_default_renderer(salt_master, grains, pillar_homedir):
     opts["decrypt_pillar"] = ["secrets:vault"]
     pillar_obj = salt.pillar.Pillar(opts, grains, "test", "base")
     ret = pillar_obj.compile_pillar()
-    assert ret == GPG_PILLAR_DECRYPTED
+    assert ret == gpg_pillar_decrypted
 
 
 @pytest.mark.slow_test
-def test_decrypt_pillar_alternate_delimiter(salt_master, grains, pillar_homedir):
+def test_decrypt_pillar_alternate_delimiter(
+    salt_master, grains, pillar_homedir, gpg_pillar_decrypted
+):
     """
     Test recursive decryption of secrets:vault using a pipe instead of a
     colon as the nesting delimiter.
@@ -337,10 +383,12 @@ def test_decrypt_pillar_alternate_delimiter(salt_master, grains, pillar_homedir)
     opts["decrypt_pillar_delimiter"] = "|"
     pillar_obj = salt.pillar.Pillar(opts, grains, "test", "base")
     ret = pillar_obj.compile_pillar()
-    assert ret == GPG_PILLAR_DECRYPTED
+    assert ret == gpg_pillar_decrypted
 
 
-def test_decrypt_pillar_deeper_nesting(salt_master, grains, pillar_homedir):
+def test_decrypt_pillar_deeper_nesting(
+    salt_master, grains, pillar_homedir, gpg_pillar_encrypted, gpg_pillar_decrypted
+):
     """
     Test recursive decryption, only with a more deeply-nested target. This
     should leave the other keys in secrets:vault encrypted.
@@ -352,14 +400,16 @@ def test_decrypt_pillar_deeper_nesting(salt_master, grains, pillar_homedir):
     opts["decrypt_pillar"] = ["secrets:vault:qux"]
     pillar_obj = salt.pillar.Pillar(opts, grains, "test", "base")
     ret = pillar_obj.compile_pillar()
-    expected = copy.deepcopy(GPG_PILLAR_ENCRYPTED)
-    expected["secrets"]["vault"]["qux"][-1] = GPG_PILLAR_DECRYPTED["secrets"]["vault"][
+    expected = copy.deepcopy(gpg_pillar_encrypted)
+    expected["secrets"]["vault"]["qux"][-1] = gpg_pillar_decrypted["secrets"]["vault"][
         "qux"
     ][-1]
     assert ret == expected
 
 
-def test_decrypt_pillar_explicit_renderer(salt_master, grains, pillar_homedir):
+def test_decrypt_pillar_explicit_renderer(
+    salt_master, grains, pillar_homedir, gpg_pillar_decrypted
+):
     """
     Test recursive decryption of secrets:vault, with the renderer
     explicitly defined, overriding the default. Setting the default to a
@@ -378,10 +428,12 @@ def test_decrypt_pillar_explicit_renderer(salt_master, grains, pillar_homedir):
     opts["decrypt_pillar_renderers"] = ["asdf", "gpg"]
     pillar_obj = salt.pillar.Pillar(opts, grains, "test", "base")
     ret = pillar_obj.compile_pillar()
-    assert ret == GPG_PILLAR_DECRYPTED
+    assert ret == gpg_pillar_decrypted
 
 
-def test_decrypt_pillar_missing_renderer(salt_master, grains, pillar_homedir):
+def test_decrypt_pillar_missing_renderer(
+    salt_master, grains, pillar_homedir, gpg_pillar_encrypted
+):
     """
     Test decryption using a missing renderer. It should fail, leaving the
     encrypted keys intact, and add an error to the pillar dictionary.
@@ -398,7 +450,7 @@ def test_decrypt_pillar_missing_renderer(salt_master, grains, pillar_homedir):
     opts["decrypt_pillar_renderers"] = ["asdf"]
     pillar_obj = salt.pillar.Pillar(opts, grains, "test", "base")
     ret = pillar_obj.compile_pillar()
-    expected = copy.deepcopy(GPG_PILLAR_ENCRYPTED)
+    expected = copy.deepcopy(gpg_pillar_encrypted)
     expected["_errors"] = [
         "Failed to decrypt pillar key 'secrets:vault': Decryption renderer 'asdf' is"
         " not available"
@@ -410,7 +462,9 @@ def test_decrypt_pillar_missing_renderer(salt_master, grains, pillar_homedir):
     assert ret["secrets"]["vault"]["qux"] == expected["secrets"]["vault"]["qux"]
 
 
-def test_decrypt_pillar_invalid_renderer(salt_master, grains, pillar_homedir):
+def test_decrypt_pillar_invalid_renderer(
+    salt_master, grains, pillar_homedir, gpg_pillar_encrypted
+):
     """
     Test decryption using a renderer which is not permitted. It should
     fail, leaving the encrypted keys intact, and add an error to the pillar
@@ -429,7 +483,7 @@ def test_decrypt_pillar_invalid_renderer(salt_master, grains, pillar_homedir):
     opts["decrypt_pillar_renderers"] = ["foo", "bar"]
     pillar_obj = salt.pillar.Pillar(opts, grains, "test", "base")
     ret = pillar_obj.compile_pillar()
-    expected = copy.deepcopy(GPG_PILLAR_ENCRYPTED)
+    expected = copy.deepcopy(gpg_pillar_encrypted)
     expected["_errors"] = [
         "Failed to decrypt pillar key 'secrets:vault': 'gpg' is not a valid decryption"
         " renderer. Valid choices are: foo, bar"
@@ -441,7 +495,9 @@ def test_decrypt_pillar_invalid_renderer(salt_master, grains, pillar_homedir):
     assert ret["secrets"]["vault"]["qux"] == expected["secrets"]["vault"]["qux"]
 
 
-def test_gpg_decrypt_must_succeed(salt_master, grains, pillar_homedir_bad):
+def test_gpg_decrypt_must_succeed(
+    salt_master, grains, pillar_homedir_bad, gpg_pillar_encrypted_bad
+):
     """
     Test that gpg rendering fails when ``gpg_decrypt_must_succeed`` is
     ``True`` and decryption fails.
@@ -455,7 +511,7 @@ def test_gpg_decrypt_must_succeed(salt_master, grains, pillar_homedir_bad):
     opts["decrypt_pillar"] = ["fail"]
     pillar_obj = salt.pillar.Pillar(opts, grains, "test", "base")
     ret = pillar_obj.compile_pillar()
-    expected = copy.deepcopy(GPG_PILLAR_ENCRYPTED_FAIL)
+    expected = copy.deepcopy(gpg_pillar_encrypted_bad)
     expected_error = "Failed to decrypt pillar key 'fail': Could not decrypt cipher "
 
     assert "_errors" in ret
@@ -465,7 +521,9 @@ def test_gpg_decrypt_must_succeed(salt_master, grains, pillar_homedir_bad):
     assert ret["fail"] == expected["fail"]
 
 
-def test_gpg_decrypt_may_succeed(salt_master, grains, pillar_homedir_bad):
+def test_gpg_decrypt_may_succeed(
+    salt_master, grains, pillar_homedir_bad, gpg_pillar_encrypted_bad
+):
     """
     Test that gpg rendering does not fail when ``gpg_decrypt_must_succeed`` is
     ``False`` and decryption fails.
@@ -479,7 +537,7 @@ def test_gpg_decrypt_may_succeed(salt_master, grains, pillar_homedir_bad):
     opts["decrypt_pillar"] = ["fail"]
     pillar_obj = salt.pillar.Pillar(opts, grains, "test", "base")
     ret = pillar_obj.compile_pillar()
-    expected = copy.deepcopy(GPG_PILLAR_ENCRYPTED_FAIL)
+    expected = copy.deepcopy(gpg_pillar_encrypted_bad)
 
     assert "_errors" not in ret
     assert "fail" in ret


### PR DESCRIPTION
### What does this PR do?

This is defaulted `false` for compatibility, and is controlled via a `gpg_decrypt_must_succeed` option.


### Previous Behavior

If this is `True`- and the ciphertext couldn't be decrypted- then it's treated as an error rather than just passing the raw ciphertext through.

Sending the ciphertext through basically is *never* desired- the point of the gpg renderer is to decrypt the secret, not send the cipher text through.

### New Behavior

Explicitly error if gpg does not decrypt the ciphertext.

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes