### PR TITLE
Uses only LVM command's stdout to populate lvm grain

### DIFF
--- a/changelog/61412.fixed
+++ b/changelog/61412.fixed
@@ -1,0 +1,1 @@
+Sets correctly the lvm grain even when lvm's command execution outputs a WARNING

--- a/salt/grains/lvm.py
+++ b/salt/grains/lvm.py
@@ -33,15 +33,15 @@ def _linux_lvm():
     ret = {}
     cmd = salt.utils.path.which("lvm")
     if cmd:
-        vgs = __salt__["cmd.run"]("{} vgs -o vg_name --noheadings".format(cmd))
+        vgs = __salt__["cmd.run_all"]("{} vgs -o vg_name --noheadings".format(cmd))
 
-        for vg in vgs.splitlines():
+        for vg in vgs["stdout"].splitlines():
             vg = vg.strip()
             ret[vg] = []
-            lvs = __salt__["cmd.run"](
+            lvs = __salt__["cmd.run_all"](
                 "{} lvs -o lv_name --noheadings {}".format(cmd, vg)
             )
-            for lv in lvs.splitlines():
+            for lv in lvs["stdout"].splitlines():
                 ret[vg].append(lv.strip())
 
         return {"lvm": ret}

--- a/tests/unit/grains/test_lvm.py
+++ b/tests/unit/grains/test_lvm.py
@@ -24,9 +24,14 @@ class LvmGrainsTestCase(TestCase, LoaderModuleMockMixin):
         Should return a populated dictionary
         """
 
-        vgs_out = "  vg00\n  vg01"
-        lvs_out_vg00 = "  root\n  swap\n  tmp \n  usr \n  var"
-        lvs_out_vg01 = "  opt \n"
+        vgs_out = {"pid": 123, "retcode": 0, "stdout": "  vg00\n  vg01", "stderr": ""}
+        lvs_out_vg00 = {
+            "pid": 456,
+            "retcode": 0,
+            "stdout": "  root\n  swap\n  tmp \n  usr \n  var",
+            "stderr": "",
+        }
+        lvs_out_vg01 = {"pid": 789, "retcode": 0, "stdout": "  opt", "stderr": ""}
         cmd_out = MagicMock(
             autospec=True, side_effect=[vgs_out, lvs_out_vg00, lvs_out_vg01]
         )
@@ -34,7 +39,80 @@ class LvmGrainsTestCase(TestCase, LoaderModuleMockMixin):
         patch_which = patch(
             "salt.utils.path.which", autospec=True, return_value="/usr/sbin/lvm"
         )
-        patch_cmd_lvm = patch.dict(lvm.__salt__, {"cmd.run": cmd_out})
+        patch_cmd_lvm = patch.dict(lvm.__salt__, {"cmd.run_all": cmd_out})
+        with patch_which, patch_cmd_lvm:
+            ret = lvm._linux_lvm()
+
+        assert ret == {
+            "lvm": {"vg00": ["root", "swap", "tmp", "usr", "var"], "vg01": ["opt"]}
+        }, ret
+
+    def test__linux_lvm_with_WARNINGs(self):
+        """
+        Test grains._linux_lvm, with WARNINGs in lvm command output
+        Should return a populated dictionary
+        """
+
+        vgs_out = {
+            "pid": 123,
+            "retcode": 0,
+            "stdout": "  vg00\n  vg01",
+            "stderr": "WARNING: Something wrong is not right",
+        }
+        lvs_out_vg00 = {
+            "pid": 456,
+            "retcode": 0,
+            "stdout": "  root\n  swap\n  tmp \n  usr \n  var",
+            "stderr": "WARNING: Something wrong is not right",
+        }
+        lvs_out_vg01 = {
+            "pid": 789,
+            "retcode": 0,
+            "stdout": "  opt",
+            "stderr": "WARNING: Something wrong is not right",
+        }
+        cmd_out = MagicMock(
+            autospec=True, side_effect=[vgs_out, lvs_out_vg00, lvs_out_vg01]
+        )
+
+        patch_which = patch(
+            "salt.utils.path.which", autospec=True, return_value="/usr/sbin/lvm"
+        )
+        patch_cmd_lvm = patch.dict(lvm.__salt__, {"cmd.run_all": cmd_out})
+        with patch_which, patch_cmd_lvm:
+            ret = lvm._linux_lvm()
+
+        assert ret == {
+            "lvm": {"vg00": ["root", "swap", "tmp", "usr", "var"], "vg01": ["opt"]}
+        }, ret
+
+    def test__linux_lvm_with_non_zero_exit_codes(self):
+        """
+        Test grains._linux_lvm, with non-zero exit codes for lvm command
+        Should return a populated dictionary
+        """
+
+        vgs_out = {
+            "pid": 123,
+            "retcode": 5,
+            "stdout": "  vg00\n  vg01",
+            "stderr": "  Skipping clustered volume vgcluster\n  Skipping volume group vgcluster",
+        }
+        lvs_out_vg00 = {
+            "pid": 456,
+            "retcode": 0,
+            "stdout": "  root\n  swap\n  tmp \n  usr \n  var",
+            "stderr": "",
+        }
+        lvs_out_vg01 = {"pid": 789, "retcode": 0, "stdout": "  opt", "stderr": ""}
+        cmd_out = MagicMock(
+            autospec=True, side_effect=[vgs_out, lvs_out_vg00, lvs_out_vg01]
+        )
+
+        patch_which = patch(
+            "salt.utils.path.which", autospec=True, return_value="/usr/sbin/lvm"
+        )
+        patch_cmd_lvm = patch.dict(lvm.__salt__, {"cmd.run_all": cmd_out})
         with patch_which, patch_cmd_lvm:
             ret = lvm._linux_lvm()
 
@@ -48,37 +126,62 @@ class LvmGrainsTestCase(TestCase, LoaderModuleMockMixin):
         Should return nothing
         """
 
-        vgs_out = "  vg00\n  vg01"
-        lvs_out_vg00 = "  root\n  swap\n  tmp \n  usr \n  var"
-        lvs_out_vg01 = "  opt \n"
+        vgs_out = {"pid": 123, "retcode": 0, "stdout": "  vg00\n  vg01", "stderr": ""}
+        lvs_out_vg00 = {
+            "pid": 456,
+            "retcode": 0,
+            "stdout": "  root\n  swap\n  tmp \n  usr \n  var",
+            "stderr": "",
+        }
+        lvs_out_vg01 = {"pid": 789, "retcode": 0, "stdout": "  opt", "stderr": ""}
         cmd_out = MagicMock(
             autospec=True, side_effect=[vgs_out, lvs_out_vg00, lvs_out_vg01]
         )
 
         patch_which = patch("salt.utils.path.which", autospec=True, return_value="")
-        patch_cmd_lvm = patch.dict(lvm.__salt__, {"cmd.run": cmd_out})
+        patch_cmd_lvm = patch.dict(lvm.__salt__, {"cmd.run_all": cmd_out})
         with patch_which, patch_cmd_lvm:
             ret = lvm._linux_lvm()
 
         assert ret is None, ret
 
-    def test__linux_lvm_no_logical_volumes(self):
+    def test__linux_lvm_no_volume_groups(self):
         """
-        Test grains._linux_lvm, lvm is installed but no volumes
+        Test grains._linux_lvm, lvm is installed but no volume groups created.
         Should return a dictionary only with the header
         """
 
-        vgs_out = ""
+        vgs_out = {"pid": 123, "retcode": 0, "stdout": "", "stderr": ""}
         cmd_out = MagicMock(autospec=True, side_effect=[vgs_out])
 
         patch_which = patch(
             "salt.utils.path.which", autospec=True, return_value="/usr/sbin/lvm"
         )
-        patch_cmd_lvm = patch.dict(lvm.__salt__, {"cmd.run": cmd_out})
+        patch_cmd_lvm = patch.dict(lvm.__salt__, {"cmd.run_all": cmd_out})
         with patch_which, patch_cmd_lvm:
             ret = lvm._linux_lvm()
 
         assert ret == {"lvm": {}}, ret
+
+    def test__linux_lvm_no_logical_volumes(self):
+        """
+        Test grains._linux_lvm, lvm is installed, volume groups created but
+        no logical volumes present.
+        Should return a dictionary only with the header
+        """
+
+        vgs_out = {"pid": 123, "retcode": 0, "stdout": "  vg00\n  vg01", "stderr": ""}
+        lvs_out = {"pid": 456, "retcode": 0, "stdout": "", "stderr": ""}
+        cmd_out = MagicMock(autospec=True, side_effect=[vgs_out, lvs_out, lvs_out])
+
+        patch_which = patch(
+            "salt.utils.path.which", autospec=True, return_value="/usr/sbin/lvm"
+        )
+        patch_cmd_lvm = patch.dict(lvm.__salt__, {"cmd.run_all": cmd_out})
+        with patch_which, patch_cmd_lvm:
+            ret = lvm._linux_lvm()
+
+        assert ret == {"lvm": {"vg00": [], "vg01": []}}, ret
 
     def test__aix_lvm(self):
         """


### PR DESCRIPTION
### What does this PR do?
Changes the `lvm` grain to ignore WARNING and error messages, using only the `stdout` of  `lvm` command execution to populate the grain's dictionary.

### What issues does this PR fix or reference?
Fixes: #61412 

### Previous Behavior
Parses a merged `stdout` and `stderr` to populate `lvm` grain, generating a broke grain when a WARNING (or any other) message is returned by `lvm` command execution.

### New Behavior
Uses only the `stdout` to populate `lvm` grain, ignoring all `stderr` contents.

### Merge requirements satisfied?
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
