### PR TITLE
Expand environment var from registry

### DIFF
--- a/changelog/61445.fixed
+++ b/changelog/61445.fixed
@@ -1,0 +1,1 @@
+Expand environment variables in the root_dir registry key

--- a/salt/syspaths.py
+++ b/salt/syspaths.py
@@ -110,7 +110,7 @@ def _get_windows_root_dir():
     log.debug("Failed to get ROOT_DIR from registry. %s", root_dir["comment"])
     # Check for C:\salt\conf
     old_root = "\\".join([os.environ["SystemDrive"], "salt", "conf"])
-    dflt_root = os.path.join(os.environ["ProgramData"], "Salt Project", "salt")
+    dflt_root = os.path.join(os.environ["ProgramData"], "Salt Project", "Salt")
     if os.path.isdir(old_root):
         # If the old config location is present use it
         log.debug("ROOT_DIR: %s", os.path.dirname(old_root))

--- a/salt/syspaths.py
+++ b/salt/syspaths.py
@@ -102,7 +102,7 @@ def _get_windows_root_dir():
     if root_dir["success"]:
         # Make sure vdata contains something
         if root_dir["vdata"]:
-            return root_dir["vdata"]
+            return os.path.expandvars(root_dir["vdata"])
 
     # If this key does not exist, then salt was not installed using the
     # new method installer. Could be pip or setup.py or an older version of the

--- a/tests/pytests/unit/test_syspaths.py
+++ b/tests/pytests/unit/test_syspaths.py
@@ -4,10 +4,12 @@ tests.pytests.unit.test_syspaths
 
 Unit tests for salt's syspaths module
 """
+import pytest
 import salt.syspaths
 from tests.support.mock import patch
 
 
+@pytest.mark.skip_unless_on_windows(reason="Test is only applicable to Windows.")
 def test__get_windows_root_dir_expand_reg():
     return_value = {"success": True, "vdata": "%ProgramData%\\Salt Project\\Salt"}
     expected = "C:\\ProgramData\\Salt Project\\Salt"
@@ -19,6 +21,7 @@ def test__get_windows_root_dir_expand_reg():
     assert expected == result
 
 
+@pytest.mark.skip_unless_on_windows(reason="Test is only applicable to Windows.")
 def test__get_windows_root_dir_no_expand_reg():
     return_value = {"success": True, "vdata": "C:\\ProgramData\\Salt Project\\Salt"}
     expected = "C:\\ProgramData\\Salt Project\\Salt"
@@ -30,6 +33,7 @@ def test__get_windows_root_dir_no_expand_reg():
     assert expected == result
 
 
+@pytest.mark.skip_unless_on_windows(reason="Test is only applicable to Windows.")
 def test__get_windows_root_dir_no_reg_old_exists():
     return_value = {"success": False, "comment": "Not found"}
     expected = "C:\\salt"
@@ -41,6 +45,7 @@ def test__get_windows_root_dir_no_reg_old_exists():
     assert expected == result
 
 
+@pytest.mark.skip_unless_on_windows(reason="Test is only applicable to Windows.")
 def test__get_windows_root_dir_no_reg_default():
     return_value = {"success": False, "comment": "Not found"}
     expected = "C:\\ProgramData\\Salt Project\\Salt"

--- a/tests/pytests/unit/test_syspaths.py
+++ b/tests/pytests/unit/test_syspaths.py
@@ -1,0 +1,52 @@
+"""
+tests.pytests.unit.test_syspaths
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Unit tests for salt's syspaths module
+"""
+import salt.syspaths
+from tests.support.mock import patch
+
+
+def test__get_windows_root_dir_expand_reg():
+    return_value = {"success": True, "vdata": "%ProgramData%\\Salt Project\\Salt"}
+    expected = "C:\\ProgramData\\Salt Project\\Salt"
+    with patch(
+        "salt.utils.win_reg.read_value", autospec=True, return_value=return_value
+    ):
+        result = salt.syspaths._get_windows_root_dir()
+
+    assert expected == result
+
+
+def test__get_windows_root_dir_no_expand_reg():
+    return_value = {"success": True, "vdata": "C:\\ProgramData\\Salt Project\\Salt"}
+    expected = "C:\\ProgramData\\Salt Project\\Salt"
+    with patch(
+        "salt.utils.win_reg.read_value", autospec=True, return_value=return_value
+    ):
+        result = salt.syspaths._get_windows_root_dir()
+
+    assert expected == result
+
+
+def test__get_windows_root_dir_no_reg_old_exists():
+    return_value = {"success": False, "comment": "Not found"}
+    expected = "C:\\salt"
+    with patch(
+        "salt.utils.win_reg.read_value", autospec=True, return_value=return_value
+    ), patch("os.path.isdir", return_value=True):
+        result = salt.syspaths._get_windows_root_dir()
+
+    assert expected == result
+
+
+def test__get_windows_root_dir_no_reg_default():
+    return_value = {"success": False, "comment": "Not found"}
+    expected = "C:\\ProgramData\\Salt Project\\Salt"
+    with patch(
+        "salt.utils.win_reg.read_value", autospec=True, return_value=return_value
+    ), patch("os.path.isdir", return_value=False):
+        result = salt.syspaths._get_windows_root_dir()
+
+    assert expected == result


### PR DESCRIPTION
### What does this PR do?
Expands environment variables in the `root_dir` registry key.

### What issues does this PR fix or reference?
Fixes: #61445 

### Previous Behavior
Environment variables not expanded

### New Behavior
Environment variables expanded

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes