### PR TITLE
Fix various spelling mistakes in release notes

### DIFF
--- a/doc/topics/releases/2014.7.6.rst
+++ b/doc/topics/releases/2014.7.6.rst
@@ -97,7 +97,7 @@ Changelog for v2014.7.5..v2014.7.6
 
   * 2d9aa2bb97 Avoid shadowing variables in lxc module
 
-  * 792e1021f2 Allow to override profile options in lxc.cloud_init_interface
+  * 792e1021f2 Allow overriding profile options in lxc.cloud_init_interface
 
   * 42bd64b9b3 Return changes on successful lxc.create from salt-cloud
 
@@ -325,9 +325,9 @@ Changelog for v2014.7.5..v2014.7.6
 * **PR** `#23551`_: (`dr4Ke`_) grains.append unit tests, related to `#23474`_
   @ *2015-05-11 21:54:25 UTC*
 
-  * **PR** `#23474`_: (`dr4Ke`_) Fix grains.append in nested dictionnary grains `#23411`_ (refs: `#23551`_)
+  * **PR** `#23474`_: (`dr4Ke`_) Fix grains.append in nested dictionary grains `#23411`_ (refs: `#23551`_)
 
-  * **PR** `#23440`_: (`dr4Ke`_) fix grains.append in nested dictionnary grains `#23411`_ (refs: `#23474`_)
+  * **PR** `#23440`_: (`dr4Ke`_) fix grains.append in nested dictionary grains `#23411`_ (refs: `#23474`_)
 
   * 6ec87ce9f5 Merge pull request `#23551`_ from dr4Ke/grains.append_unit_tests
 
@@ -341,18 +341,18 @@ Changelog for v2014.7.5..v2014.7.6
 
 * **ISSUE** `#23411`_: (`dr4Ke`_) grains.append should work at any level of a grain (refs: `#23440`_, `#23474`_)
 
-* **PR** `#23474`_: (`dr4Ke`_) Fix grains.append in nested dictionnary grains `#23411`_ (refs: `#23551`_)
+* **PR** `#23474`_: (`dr4Ke`_) Fix grains.append in nested dictionary grains `#23411`_ (refs: `#23551`_)
   @ *2015-05-11 18:00:21 UTC*
 
-  * **PR** `#23440`_: (`dr4Ke`_) fix grains.append in nested dictionnary grains `#23411`_ (refs: `#23474`_)
+  * **PR** `#23440`_: (`dr4Ke`_) fix grains.append in nested dictionary grains `#23411`_ (refs: `#23474`_)
 
   * e96c5c5bf3 Merge pull request `#23474`_ from dr4Ke/fix_grains.append_nested
 
-  * a01a5bb51e grains.get, parameter delimititer, versionadded: 2014.7.6
+  * a01a5bb51e grains.get, parameter delimiter, versionadded: 2014.7.6
 
   * b39f50475d remove debugging output
 
-  * b6e15e295c fix grains.append in nested dictionnary grains `#23411`_
+  * b6e15e295c fix grains.append in nested dictionary grains `#23411`_
 
 * **PR** `#23537`_: (`t0rrant`_) Update changelog
   @ *2015-05-11 17:02:16 UTC*
@@ -565,12 +565,12 @@ Changelog for v2014.7.5..v2014.7.6
 
 * **ISSUE** `#22742`_: (`hvnsweeting`_) salt-master says: "This master address: 'salt' was previously resolvable but now fails to resolve!" (refs: `#23344`_)
 
-* **PR** `#23344`_: (`cachedout`_) Explicitely set file_client on master
+* **PR** `#23344`_: (`cachedout`_) Explicitly set file_client on master
   @ *2015-05-04 23:21:48 UTC*
 
   * 02658b1e60 Merge pull request `#23344`_ from cachedout/issue_22742
 
-  * 5adc96ce7f Explicitely set file_client on master
+  * 5adc96ce7f Explicitly set file_client on master
 
 * **PR** `#23318`_: (`cellscape`_) Honor seed argument in LXC container initializaton
   @ *2015-05-04 20:58:12 UTC*
@@ -865,7 +865,7 @@ Changelog for v2014.7.5..v2014.7.6
 * **PR** `#23113`_: (`rallytime`_) Revert "Backport `#22895`_ to 2014.7"
   @ *2015-04-28 03:27:29 UTC*
 
-  * **PR** `#22895`_: (`aletourneau`_) pam_tally counter was not reset to 0 after a succesfull login (refs: `#23113`_, `#22925`_, #saltstack/salt`#22925`_)
+  * **PR** `#22895`_: (`aletourneau`_) pam_tally counter was not reset to 0 after a successful login (refs: `#23113`_, `#22925`_, #saltstack/salt`#22925`_)
 
   * dfe2066b25 Merge pull request `#23113`_ from saltstack/revert-22925-bp-22895
 
@@ -1047,7 +1047,7 @@ Changelog for v2014.7.5..v2014.7.6
 * **PR** `#22925`_: (`rallytime`_) Backport `#22895`_ to 2014.7
   @ *2015-04-22 02:30:26 UTC*
 
-  * **PR** `#22895`_: (`aletourneau`_) pam_tally counter was not reset to 0 after a succesfull login (refs: `#23113`_, `#22925`_, #saltstack/salt`#22925`_)
+  * **PR** `#22895`_: (`aletourneau`_) pam_tally counter was not reset to 0 after a successful login (refs: `#23113`_, `#22925`_, #saltstack/salt`#22925`_)
 
   * 6890752dd3 Merge pull request `#22925`_ from rallytime/bp-22895
 
@@ -1057,7 +1057,7 @@ Changelog for v2014.7.5..v2014.7.6
 
   * 5ebf159554 Cleaned up pull request
 
-  * a08ac478f6 pam_tally counter was not reset to 0 after a succesfull login
+  * a08ac478f6 pam_tally counter was not reset to 0 after a successful login
 
 * **ISSUE** `#22790`_: (`whiteinge`_) jobs.list_jobs runner tracebacks on 'missing' argument (refs: `#22914`_)
 

--- a/doc/topics/releases/2015.5.1.rst
+++ b/doc/topics/releases/2015.5.1.rst
@@ -182,7 +182,7 @@ Changelog for v2015.5.0..v2015.5.1
 
   * 9d87fd335c add proper marker for format argument
 
-  * 197688ef0c Added exception handler to trap the RuntimeError raised when Depends.enforce_dependency() class method fires unsuccessfully. There appears to be no synchronization within the Depends decorator class wrt the class global dependency_dict which results in incomplete population of any loader instantiation occuring at the time of one of these exceptions.
+  * 197688ef0c Added exception handler to trap the RuntimeError raised when Depends.enforce_dependency() class method fires unsuccessfully. There appears to be no synchronization within the Depends decorator class wrt the class global dependency_dict which results in incomplete population of any loader instantiation occurring at the time of one of these exceptions.
 
 * **ISSUE** `#19852`_: (`TaiSHiNet`_) DigitalOcean APIv2 can't delete machines when there is only 1 page (refs: `#23955`_)
 
@@ -556,7 +556,7 @@ Changelog for v2015.5.0..v2015.5.1
 
   * 558798df1f Fix net_io_counters deprecation issue
 
-  * 8140f92ba8 Override unecessary pylint errors
+  * 8140f92ba8 Override unnecessary pylint errors
 
   * 7d02ad4f06 Fix some of the mock names for the new API
 
@@ -568,7 +568,7 @@ Changelog for v2015.5.0..v2015.5.1
 
   * e48982ff9c Fix version checking in psutil_compat
 
-  * 93ee411fd5 Create compatability psutil. psutil 3.0 drops 1.0 API, but we still support old psutil versions.
+  * 93ee411fd5 Create compatibility psutil. psutil 3.0 drops 1.0 API, but we still support old psutil versions.
 
 * **PR** `#23782`_: (`terminalmage`_) Replace "command -v" with "which" and get rid of spurious log messages
   @ *2015-05-16 04:03:10 UTC*
@@ -608,7 +608,7 @@ Changelog for v2015.5.0..v2015.5.1
 
       * 2d9aa2bb97 Avoid shadowing variables in lxc module
 
-      * 792e1021f2 Allow to override profile options in lxc.cloud_init_interface
+      * 792e1021f2 Allow overriding profile options in lxc.cloud_init_interface
 
       * 42bd64b9b3 Return changes on successful lxc.create from salt-cloud
 
@@ -837,12 +837,12 @@ Changelog for v2015.5.0..v2015.5.1
 
   * ecff2181e4 fix lvs_service
 
-* **PR** `#23686`_: (`jfindlay`_) remove superflous return statement
+* **PR** `#23686`_: (`jfindlay`_) remove superfluous return statement
   @ *2015-05-14 14:20:18 UTC*
 
   * 39973d4095 Merge pull request `#23686`_ from jfindlay/fix_lvs_server
 
-  * 5aaeb73532 remove superflous return statement
+  * 5aaeb73532 remove superfluous return statement
 
 * **PR** `#23690`_: (`rallytime`_) Backport `#23424`_ to 2015.5
   @ *2015-05-13 23:04:36 UTC*
@@ -962,11 +962,11 @@ Changelog for v2015.5.0..v2015.5.1
 
     * e96c5c5bf3 Merge pull request `#23474`_ from dr4Ke/fix_grains.append_nested
 
-      * a01a5bb51e grains.get, parameter delimititer, versionadded: 2014.7.6
+      * a01a5bb51e grains.get, parameter delimiter, versionadded: 2014.7.6
 
       * b39f50475d remove debugging output
 
-      * b6e15e295c fix grains.append in nested dictionnary grains `#23411`_
+      * b6e15e295c fix grains.append in nested dictionary grains `#23411`_
 
     * ab7e1aed8e Merge pull request `#23537`_ from t0rrant/patch-1
 
@@ -983,7 +983,7 @@ Changelog for v2015.5.0..v2015.5.1
 
   * 73cfda751a Remove unused import
 
-  * 52b68d695a Use the zip_longest from six module for python 3 compatiblity
+  * 52b68d695a Use the zip_longest from six module for python 3 compatibility
 
   * 18d5ff9a8e Fix salt.state.file._unify_sources_and_hashes when sources is used without sources_hashes
 
@@ -1559,7 +1559,7 @@ Changelog for v2015.5.0..v2015.5.1
 
     * 02658b1e60 Merge pull request `#23344`_ from cachedout/issue_22742
 
-      * 5adc96ce7f Explicitely set file_client on master
+      * 5adc96ce7f Explicitly set file_client on master
 
     * ba7605d1cb Merge pull request `#23318`_ from cellscape/honor-seed-argument
 

--- a/doc/topics/releases/2015.5.11.rst
+++ b/doc/topics/releases/2015.5.11.rst
@@ -265,7 +265,7 @@ Changelog for v2015.5.10..v2015.5.11
 
   * **PR** `#32421`_: (`terminalmage`_) Ignore Raspbian in service.py __virtual__
 
-* **ISSUE** `#1409`_: (`twinshadow`_) module/network.py: Interfaces do not list multiple addesses
+* **ISSUE** `#1409`_: (`twinshadow`_) module/network.py: Interfaces do not list multiple addresses
 
 * **ISSUE** `saltstack/salt#28262`_: (`palica`_) FreeBSD pkgng provider raising error for minion (refs: `#32376`_)
 
@@ -440,9 +440,9 @@ Changelog for v2015.5.10..v2015.5.11
 
   * d18b4be80b remove whitespace end of line 186:q
 
-  * d2b89c85ad fix formating
+  * d2b89c85ad fix formatting
 
-  * 103cee9e29 cleaned up formating
+  * 103cee9e29 cleaned up formatting
 
   * 7a4d7f0bff added whitespace
 

--- a/doc/topics/releases/2015.5.2.rst
+++ b/doc/topics/releases/2015.5.2.rst
@@ -121,7 +121,7 @@ Changelog for v2015.5.1..v2015.5.2
 
   * 02bfb254d6 Merge pull request `#24281`_ from steverweber/ipmi_docfix
 
-  * dd36f2c555 yaml formating
+  * dd36f2c555 yaml formatting
 
   * f6deef3047 include api_kg kwarg in ipmi state
 
@@ -255,7 +255,7 @@ Changelog for v2015.5.1..v2015.5.2
 
   * 608da5ef5d modules/lxc: merge resolution
 
-  * 27c4689a24 modules/lxc: more consistent comparsion
+  * 27c4689a24 modules/lxc: more consistent comparison
 
   * 07c365a23b lxc: merge conflict spotted
 
@@ -1026,7 +1026,7 @@ Changelog for v2015.5.1..v2015.5.2
 
   * 1dc67e5678 lxc: versionadded
 
-  * fcad7cb804 lxc: states improvments
+  * fcad7cb804 lxc: states improvements
 
   * 644bd729f7 lxc: more consistence for profiles
 

--- a/doc/topics/releases/2015.5.3.rst
+++ b/doc/topics/releases/2015.5.3.rst
@@ -71,7 +71,7 @@ Changelog for v2015.5.2..v2015.5.3
 
   * 564dffd14a depend on win libs rather than mocking them
 
-  * 9b9aeb8628 resolved all erors.
+  * 9b9aeb8628 resolved all errors.
 
   * aaf89354c0 adding win_groupadd unit test case.
 
@@ -230,7 +230,7 @@ Changelog for v2015.5.2..v2015.5.3
 
   * a3c1063a37 fix deprecated pymongo usage causing errors in latest pymongo
 
-* **ISSUE** `#24862`_: (`dkatsanikakis`_) gpg.import_key returns error after succesfully completed (refs: `#24994`_, `#24966`_)
+* **ISSUE** `#24862`_: (`dkatsanikakis`_) gpg.import_key returns error after successfully completed (refs: `#24994`_, `#24966`_)
 
 * **PR** `#24994`_: (`garethgreenaway`_) Another Fix to gpg.py in 2015.5
   @ *2015-06-27 22:28:15 UTC*
@@ -282,7 +282,7 @@ Changelog for v2015.5.2..v2015.5.3
 
   * 6b544227ab Only warn about digital ocean deprecation if digital ocean is configured
 
-* **ISSUE** `#24862`_: (`dkatsanikakis`_) gpg.import_key returns error after succesfully completed (refs: `#24994`_, `#24966`_)
+* **ISSUE** `#24862`_: (`dkatsanikakis`_) gpg.import_key returns error after successfully completed (refs: `#24994`_, `#24966`_)
 
 * **PR** `#24966`_: (`garethgreenaway`_) Fixes to gpg.py in 2015.5
   @ *2015-06-25 19:58:49 UTC*
@@ -592,11 +592,11 @@ Changelog for v2015.5.2..v2015.5.3
 * **PR** `#24791`_: (`rallytime`_) Back-port `#24749`_ to 2015.5
   @ *2015-06-18 17:43:15 UTC*
 
-  * **PR** `#24749`_: (`obestwalter`_) add windows specfic default for multiprocessing (refs: `#24791`_)
+  * **PR** `#24749`_: (`obestwalter`_) add windows specific default for multiprocessing (refs: `#24791`_)
 
   * 7073a9f850 Merge pull request `#24791`_ from rallytime/bp-24749
 
-  * be43b2b394 add windows specfic default for multiprocessing
+  * be43b2b394 add windows specific default for multiprocessing
 
 * **PR** `#24792`_: (`rallytime`_) Back-port `#24757`_ to 2015.5
   @ *2015-06-18 15:58:35 UTC*
@@ -1042,7 +1042,7 @@ Changelog for v2015.5.2..v2015.5.3
 
 * **ISSUE** `#24480`_: (`kiorky`_) [CRITICAL] [2015.5] tls breaks tzinfo (refs: `#24551`_)
 
-* **PR** `#24551`_: (`joejulian`_) 2015.5 dont pollute environment
+* **PR** `#24551`_: (`joejulian`_) 2015.5 don't pollute environment
   @ *2015-06-11 02:13:06 UTC*
 
   * 20ada1f8a1 Merge pull request `#24551`_ from joejulian/2015.5_dont_pollute_environment
@@ -1364,13 +1364,13 @@ Changelog for v2015.5.2..v2015.5.3
 * **PR** `#24456`_: (`rallytime`_) Back-port `#24441`_ to 2015.5
   @ *2015-06-05 22:32:25 UTC*
 
-  * **PR** `#24441`_: (`arthurlogilab`_) [doc] Alignement fix on external_auth documentation (refs: `#24456`_)
+  * **PR** `#24441`_: (`arthurlogilab`_) [doc] Alignment fix on external_auth documentation (refs: `#24456`_)
 
   * ced558a6e6 Merge pull request `#24456`_ from rallytime/bp-24441
 
   * 70028553c1 yaml indentations should be 2 spaces
 
-  * 21b51abf25 [doc] Alignement fix on external_auth documentation
+  * 21b51abf25 [doc] Alignment fix on external_auth documentation
 
 * **ISSUE** `#24397`_: (`kiorky`_) on debian: states.apt should use virtualname as it shadows system apt module (refs: `#24398`_, `#24400`_, `#24399`_)
 

--- a/doc/topics/releases/2015.5.4.rst
+++ b/doc/topics/releases/2015.5.4.rst
@@ -99,12 +99,12 @@ Changelog for v2015.5.3..v2015.5.4
 
   * a1f90fa070 Only call convert_to_arn when action name is provided
 
-* **PR** `#26288`_: (`bbinet`_) allow to delete grains which value is False
+* **PR** `#26288`_: (`bbinet`_) allow deleting grains which value is False
   @ *2015-08-13 18:24:36 UTC*
 
   * c81dc0b62f Merge pull request `#26288`_ from bbinet/grains-absent-fix
 
-  * f46722aaeb allow to delete grains which value is False
+  * f46722aaeb allow deleting grains which value is False
 
 * **ISSUE** `#24882`_: (`nmadhok`_) salt.states.openstack_config.present and salt.states.openstack_config.absent make changes when test=True (refs: `#26263`_)
 
@@ -366,7 +366,7 @@ Changelog for v2015.5.3..v2015.5.4
 
   * 08eaca4fe4 lint fixes.
 
-  * 7046b84ac8 Fixing a bug where cp.get_file_str would not work if using http(s) URLs with authentication.  The salt.utils.http library in 2015.5 defaults to using urllib instead of requests and there was no authenitication support added.  This PR adds authentication support. `#24106`_
+  * 7046b84ac8 Fixing a bug where cp.get_file_str would not work if using http(s) URLs with authentication.  The salt.utils.http library in 2015.5 defaults to using urllib instead of requests and there was no authentication support added.  This PR adds authentication support. `#24106`_
 
 * **ISSUE** `#26141`_: (`nmadhok`_) salt-cloud VMware driver fails with error in parsing configuration file (refs: `#26140`_)
 
@@ -926,7 +926,7 @@ Changelog for v2015.5.3..v2015.5.4
 
   * d7f448d501 Needed popen.wait().
 
-  * 25f8042e41 Checking for scp existance. Using command -v should be POSIX
+  * 25f8042e41 Checking for scp existence. Using command -v should be POSIX
 
   * 6b2100a30b New exitcode for SCP not found Re: https://github.com/saltstack/salt/issues/25478 and https://github.com/saltstack/salt/issues/25026
 
@@ -1019,7 +1019,7 @@ Changelog for v2015.5.3..v2015.5.4
 
   * 067ea788e9 Add salt:// to key_url options to docs for pkgrepo.managed
 
-* **ISSUE** `#22699`_: (`arthurlogilab`_) salt-cloud fails on KeyError when given a nonexistant action (refs: `#25807`_)
+* **ISSUE** `#22699`_: (`arthurlogilab`_) salt-cloud fails on KeyError when given a nonexistent action (refs: `#25807`_)
 
 * **PR** `#25807`_: (`rallytime`_) Provide helpful error when using actions with a mapfile
   @ *2015-07-29 15:30:15 UTC*
@@ -1473,7 +1473,7 @@ Changelog for v2015.5.3..v2015.5.4
 
   * 8a1765fc6f Add version_cmp function to yumpkg.py
 
-  * 457e72e273 Fix refernces to __salt__['version_cmp']
+  * 457e72e273 Fix references to __salt__['version_cmp']
 
   * a19fa2296a Avoid using single-letter variable
 
@@ -1936,11 +1936,11 @@ Changelog for v2015.5.3..v2015.5.4
 * **PR** `#25392`_: (`rallytime`_) Back-port `#25256`_ to 2015.5
   @ *2015-07-14 03:25:13 UTC*
 
-  * **PR** `#25256`_: (`yanatan16`_) Dont assume source_hash exists (refs: `#25392`_)
+  * **PR** `#25256`_: (`yanatan16`_) Don't assume source_hash exists (refs: `#25392`_)
 
   * 008e3295c6 Merge pull request `#25392`_ from rallytime/bp-25256
 
-  * 6b2da4d582 Dont assume source_hash exists
+  * 6b2da4d582 Don't assume source_hash exists
 
 * **PR** `#25398`_: (`twangboy`_) Fix date
   @ *2015-07-14 03:21:17 UTC*
@@ -2042,7 +2042,7 @@ Changelog for v2015.5.3..v2015.5.4
 
   * e13a9fd74e Fix documentation for file.blockreplace
 
-* **ISSUE** `#19288`_: (`oba11`_) AssociatePublicIpAddress doesnt work with salt-cloud 2014.7.0 (refs: `#25326`_, `#20972`_)
+* **ISSUE** `#19288`_: (`oba11`_) AssociatePublicIpAddress doesn't work with salt-cloud 2014.7.0 (refs: `#25326`_, `#20972`_)
 
 * **PR** `#25326`_: (`rallytime`_) Back-port `#20972`_ to 2015.5
   @ *2015-07-10 18:49:44 UTC*

--- a/doc/topics/releases/2015.5.5.rst
+++ b/doc/topics/releases/2015.5.5.rst
@@ -95,12 +95,12 @@ Changelog for v2015.5.4..v2015.5.5
 
   * cbe330e78b add dateutil dependency reporting
 
-* **PR** `#26494`_: (`cachedout`_) Remove unecessary debug statements
+* **PR** `#26494`_: (`cachedout`_) Remove unnecessary debug statements
   @ *2015-08-19 20:46:00 UTC*
 
   * 4fff53b842 Merge pull request `#26494`_ from cachedout/remove_debug_statements
 
-  * d717a43dcc Remove unecessary debug statements
+  * d717a43dcc Remove unnecessary debug statements
 
 * **PR** `#26465`_: (`rallytime`_) Back-port `#26457`_ to 2015.5
   @ *2015-08-19 16:08:16 UTC*
@@ -234,7 +234,7 @@ Changelog for v2015.5.4..v2015.5.5
 
   * 87151736c5 Merge pull request `#26371`_ from bastiaanb/fix/issue-26161-salt-initscripts-dont-set-lockfile
 
-  * ec8d4b0470 test wether RETVAL is 0 with -eq rather than =.
+  * ec8d4b0470 test whether RETVAL is 0 with -eq rather than =.
 
   * a83a5de41e fix issue `#26161`_: on RedHat family systems touch /var/lock/subsys/$SERVICE to ensure the daemon will be stopped on shutdown.
 

--- a/doc/topics/releases/2015.5.6.rst
+++ b/doc/topics/releases/2015.5.6.rst
@@ -112,12 +112,12 @@ Changelog for v2015.5.5..v2015.5.6
 
 * **ISSUE** `#27447`_: (`junster1`_) Fix mysql table size for salt_events (refs: `#27472`_)
 
-* **PR** `#27472`_: (`cachedout`_) Change recommeded schema for data field in mysql event table
+* **PR** `#27472`_: (`cachedout`_) Change recommended schema for data field in mysql event table
   @ *2015-09-29 15:49:37 UTC*
 
   * 68d784c3dd Merge pull request `#27472`_ from cachedout/fix_27447
 
-  * 5e745ad6da Change recommeded schema for data field in mysql event table
+  * 5e745ad6da Change recommended schema for data field in mysql event table
 
 * **PR** `#27468`_: (`cachedout`_) Fix 27351
   @ *2015-09-29 15:35:29 UTC*
@@ -192,7 +192,7 @@ Changelog for v2015.5.5..v2015.5.6
 
   * ed6207a438 Merge pull request `#27419`_ from rallytime/fix-9856
 
-  * 551396564a Ammend error log to include multiple tips for troubleshooting.
+  * 551396564a Amend error log to include multiple tips for troubleshooting.
 
 * **ISSUE** `#16753`_: (`johtso`_) Duplicate selector in top file gives unhelpful traceback (refs: `#27426`_)
 
@@ -212,7 +212,7 @@ Changelog for v2015.5.5..v2015.5.6
 
   * 39a4ae5a6c Remove hdd: 19 refs from SL docs - no longer available from SoftLayer.
 
-  * de2f9234d3 Use correct default for bandwith
+  * de2f9234d3 Use correct default for bandwidth
 
   * 42d8127f79 Don't set the optional_products default to a boolean, and then try to loop.
 

--- a/doc/topics/releases/2015.5.7.rst
+++ b/doc/topics/releases/2015.5.7.rst
@@ -511,7 +511,7 @@ Changelog for v2015.5.6..v2015.5.7
 
   * b1f4a2bdf4 i think i changed the wrong header, updated to fix
 
-  * 846b3aece1 I found you can not run the cp.push commands until after enabling the feature in the conf, so I wanted to update the docs so others who try these commands wont bump into the same issue I had.
+  * 846b3aece1 I found you can not run the cp.push commands until after enabling the feature in the conf, so I wanted to update the docs so others who try these commands won't bump into the same issue I had.
 
 * **ISSUE** `#28248`_: (`0xf10e`_) conventions/formula.rst: "Gather external data" suggests unavailable jinja functionality (refs: `#28280`_)
 
@@ -983,7 +983,7 @@ Changelog for v2015.5.6..v2015.5.7
 
   * 579f2646ba .. versionadded:: 2015.5.6
 
-  * cbaf46e066 python <2.7 compability (pylint issue)
+  * cbaf46e066 python <2.7 compatibility (pylint issue)
 
   * ecde499478 s/bin/b to avoid confusion with bin()
 

--- a/doc/topics/releases/2015.5.9.rst
+++ b/doc/topics/releases/2015.5.9.rst
@@ -69,7 +69,7 @@ Changelog for v2015.5.8..v2015.5.9
 * **PR** `#30127`_: (`jsutton`_) Updating documentation and example minion config for random_master/master_shuffle.
   @ *2016-01-04 19:30:50 UTC*
 
-  * 1a5d585d91 Merge pull request `#30127`_ from jsutton/clarify-documenation-for-random_master
+  * 1a5d585d91 Merge pull request `#30127`_ from jsutton/clarify-documentation-for-random_master
 
   * 01dbf385ef Adding random_master to reference and updating master_shuffle. Adding master_shuffle to the minion example config file as it is needed for multi-master PKI.
 

--- a/doc/topics/releases/2015.8.1.rst
+++ b/doc/topics/releases/2015.8.1.rst
@@ -205,7 +205,7 @@ Changelog for v2015.8.0..v2015.8.1
 
     * 68d784c3dd Merge pull request `#27472`_ from cachedout/fix_27447
 
-      * 5e745ad6da Change recommeded schema for data field in mysql event table
+      * 5e745ad6da Change recommended schema for data field in mysql event table
 
     * ee6e0ed057 Merge pull request `#27468`_ from cachedout/fix_27351
 
@@ -241,7 +241,7 @@ Changelog for v2015.8.0..v2015.8.1
 
     * ed6207a438 Merge pull request `#27419`_ from rallytime/fix-9856
 
-      * 551396564a Ammend error log to include multiple tips for troubleshooting.
+      * 551396564a Amend error log to include multiple tips for troubleshooting.
 
     * 73fa89edf7 Merge pull request `#27426`_ from rallytime/fix-16753
 
@@ -251,7 +251,7 @@ Changelog for v2015.8.0..v2015.8.1
 
       * 39a4ae5a6c Remove hdd: 19 refs from SL docs - no longer available from SoftLayer.
 
-      * de2f9234d3 Use correct default for bandwith
+      * de2f9234d3 Use correct default for bandwidth
 
       * 42d8127f79 Don't set the optional_products default to a boolean, and then try to loop.
 
@@ -675,7 +675,7 @@ Changelog for v2015.8.0..v2015.8.1
 
   * ed18384108 Merge pull request `#7`_ from jtand/cloud-logging-eight
 
-    * a6c1d0b408 Fixed a bug where logging_command wasnt set as a key in a couple spots
+    * a6c1d0b408 Fixed a bug where logging_command wasn't set as a key in a couple spots
 
   * 8bb7cb7ff4 Use correct indexes
 
@@ -1562,12 +1562,12 @@ Changelog for v2015.8.0..v2015.8.1
 
   * 7e35b13022 Turned multiprocessing on
 
-* **PR** `#27086`_: (`techhat`_) Document develoment of SPM loader modules
+* **PR** `#27086`_: (`techhat`_) Document development of SPM loader modules
   @ *2015-09-13 04:52:55 UTC*
 
   * c78d833540 Merge pull request `#27086`_ from techhat/spmdevdocs
 
-  * ee0c8955dd Document develoment of SPM loader modules
+  * ee0c8955dd Document development of SPM loader modules
 
 * **ISSUE** `#23125`_: (`bemeyert`_) Elasticsearch as master_job_cache throws critical (refs: `#26941`_)
 

--- a/doc/topics/releases/2015.8.11.rst
+++ b/doc/topics/releases/2015.8.11.rst
@@ -456,7 +456,7 @@ Changelog for v2015.8.10..v2015.8.11
 
   * **PR** `#33599`_: (`lomeroe`_) Fix s3 large file download (refs: `#33681`_)
 
-* **ISSUE** `#34213`_: (`terminalmage`_) gitfs w/pygit2 - corner case, traceback with short hexidecimal environment names (refs: `#34218`_)
+* **ISSUE** `#34213`_: (`terminalmage`_) gitfs w/pygit2 - corner case, traceback with short hexadecimal environment names (refs: `#34218`_)
 
 * **ISSUE** `#34212`_: (`terminalmage`_) gitfs: commit SHAs no longer available as fileserver environments (refs: `#34218`_)
 
@@ -1087,7 +1087,7 @@ Changelog for v2015.8.10..v2015.8.11
 
   * 6b6febb211 unit tests for rpm.checksum() and zypper.download()
 
-* **ISSUE** `#33319`_: (`ghost`_) Salt interpets jinja syntax in contents pillar (refs: `#33513`_)
+* **ISSUE** `#33319`_: (`ghost`_) Salt interprets jinja syntax in contents pillar (refs: `#33513`_)
 
 * **PR** `#33513`_: (`rallytime`_) Add a section to the jinja docs about escaping jinja
   @ *2016-05-26 14:24:58 UTC*
@@ -1150,14 +1150,14 @@ Changelog for v2015.8.10..v2015.8.11
 
   * 68d8050cb8 Fix diskusage beacon
 
-* **PR** `#33465`_: (`meaksh`_) jobs.exit_success allow to check if a job has executed and exit successfully
+* **PR** `#33465`_: (`meaksh`_) jobs.exit_success allow checking if a job has executed and exit successfully
   @ *2016-05-25 16:52:53 UTC*
 
   * 3bfb6bf719 Merge pull request `#33465`_ from meaksh/check-if-job-returns-successfully-2015.8
 
   * 9deb70fd8e jobs.exit_success() now works parsing the results of jobs.lookup_id()
 
-  * 7ba40c4f31 jobs.exit_success allow to check if a job has executed and exit successfully
+  * 7ba40c4f31 jobs.exit_success allow checking if a job has executed and exit successfully
 
   * **PR** `saltstack/salt-jenkins#175`_: (`justinta`_) Adding back shade to setup states (refs: `#33487`_)
 
@@ -1292,7 +1292,7 @@ Changelog for v2015.8.10..v2015.8.11
 
   * **PR** `#33421`_: (`abednarik`_) Documentation update in file.serialize.
 
-  * **PR** `#33398`_: (`lvg01`_) Fix LVM parameter devices as a pure list. Comma seperated lists are c…
+  * **PR** `#33398`_: (`lvg01`_) Fix LVM parameter devices as a pure list. Comma separated lists are c…
 
   * **PR** `#33406`_: (`rallytime`_) Back-port `#33387`_ to 2015.8
 

--- a/doc/topics/releases/2015.8.12.rst
+++ b/doc/topics/releases/2015.8.12.rst
@@ -292,7 +292,7 @@ Changelog for v2015.8.11..v2015.8.12
 
   * 8a5b47b5d7 Collect all error data from the wfuncs call
 
-  * 11864c31b7 supress a stack trace to show clean ssh error
+  * 11864c31b7 suppress a stack trace to show clean ssh error
 
   * 9fbfa282fa wow this solves an issue!
 
@@ -465,7 +465,7 @@ Changelog for v2015.8.11..v2015.8.12
 
   * e1fcb8311d Put pkg.latest_version in try/except structure Move refreshed or refresh to different spot (just for code tidyness)
 
-  * e0b6261659 changed name of varibale 'refreshed' to 'was_refreshed'
+  * e0b6261659 changed name of variable 'refreshed' to 'was_refreshed'
 
   * 340110b4b4 Move check for rtag to outermost-nesting in function
 
@@ -748,7 +748,7 @@ Changelog for v2015.8.11..v2015.8.12
 
   * 9c803d05a5 Add output_file option to master config docs
 
-* **ISSUE** `saltstack/salt#32276`_: (`javicacheiro`_) pkg.installed using sources from master fails with file not found after first succesful run (refs: `#34689`_)
+* **ISSUE** `saltstack/salt#32276`_: (`javicacheiro`_) pkg.installed using sources from master fails with file not found after first successful run (refs: `#34689`_)
 
 * **PR** `#34689`_: (`Azidburn`_) fix second run problems with pkg.installed using sources
   @ *2016-07-15 21:19:39 UTC*

--- a/doc/topics/releases/2015.8.2.rst
+++ b/doc/topics/releases/2015.8.2.rst
@@ -849,65 +849,65 @@ Changelog for v2015.8.1..v2015.8.2
 
   * ec924e8410 Merge pull request `#28560`_ from bdrung/2015.8
 
-  * 89dcb66310 Fix the wrong "allow to do" phrase
+  * 89dcb66310 Fix "allow one to do" phrase
 
-  * 859b6b46a6 Fix typo an nonexistant -> nonexistent
+  * 859b6b46a6 Fix typo of nonexistent
 
-  * 66921cc61e Fix typo an succesfully -> successfully
+  * 66921cc61e Fix typo of successfully
 
-  * c1e3ef7c8d Fix typo an explicitely -> explicitly
+  * c1e3ef7c8d Fix typo of explicitly
 
-  * 029a95398c Fix typo an superflous -> superfluous
+  * 029a95398c Fix typo of superfluous
 
-  * 026c215933 Fix typo an unecessary -> unnecessary
+  * 026c215933 Fix typo of unnecessary
 
-  * 5f7fc5f94b Fix typo an edditable -> editable
+  * 5f7fc5f94b Fix typo of editable
 
-  * 0b768944c2 Fix typo an deamon -> daemon
+  * 0b768944c2 Fix typo of daemon
 
-  * 5af49881d7 Fix typo an completly -> completely
+  * 5af49881d7 Fix typo of completely
 
   * 14d2a16f74 Fix typos of compatibility
 
-  * 46a5a9b073 Fix typo an suppored -> supported
+  * 46a5a9b073 Fix typo of supported
 
-  * abc490a78e Fix typo an usefull -> useful
+  * abc490a78e Fix typo of useful
 
-  * ddd412180c Fix typo an targetting -> targeting
+  * ddd412180c Fix typo of targeting
 
-  * 610a6a77ae Fix typo an verison -> version
+  * 610a6a77ae Fix typo of version
 
-  * e0a5d46a1e Fix typo an seperated -> separated
+  * e0a5d46a1e Fix typo of separated
 
-  * 7f11cfd5e1 Fix typo an helpfull -> helpful
+  * 7f11cfd5e1 Fix typo of helpful
 
   * 2e9b520d84 Fix typos of omitted
 
-  * 3029f64481 Fix typo an compatbility -> compatibility
+  * 3029f64481 Fix typo of compatibility
 
-  * 470e82f17f Fix typo an dictionnary -> dictionary
+  * 470e82f17f Fix typo of dictionary
 
-  * 5843c7aa24 Fix typo an optionnal -> optional
+  * 5843c7aa24 Fix typo of optional
 
-  * 730d0f95e7 Fix typo an transfered -> transferred
+  * 730d0f95e7 Fix typo of transferred
 
-  * c7e7884de2 Fix typo an recieved -> received
+  * c7e7884de2 Fix typo of received
 
-  * 50eea287f3 Fix typo an managment -> management
+  * 50eea287f3 Fix typo of management
 
   * cb01da81c6 Fix typos of parameter
 
-  * 45fcc7d339 Fix typo an dont -> don't
+  * 45fcc7d339 Fix typo of don't
 
-  * 3624935d32 Fix typo an other -> another
+  * 3624935d32 Fix typo of another
 
-  * d16afe2607 Fix typo sofwares -> software
+  * d16afe2607 Fix typo of software
 
-  * b9b7cbe525 Fix typo sofware -> software
+  * b9b7cbe525 Fix typo of software
 
   * 8edd2c1add Fix typos of dependency
 
-  * 3a5e2e3437 Fix typo documention -> documentation
+  * 3a5e2e3437 Fix typo of documentation
 
 * **ISSUE** `#28528`_: (`schlagify`_) timezone.system error:  CommandExecutionError: Failed to parse timedatectl output, this is likely a bug (refs: `#28550`_)
 
@@ -1130,7 +1130,7 @@ Changelog for v2015.8.1..v2015.8.2
 
       * b1f4a2bdf4 i think i changed the wrong header, updated to fix
 
-      * 846b3aece1 I found you can not run the cp.push commands until after enabling the feature in the conf, so I wanted to update the docs so others who try these commands wont bump into the same issue I had.
+      * 846b3aece1 I found you can not run the cp.push commands until after enabling the feature in the conf, so I wanted to update the docs so others who try these commands won't bump into the same issue I had.
 
     * e3eff9b909 Merge pull request `#28280`_ from 0xf10e/patch-1
 
@@ -3057,7 +3057,7 @@ Changelog for v2015.8.1..v2015.8.2
 
     * 579f2646ba .. versionadded:: 2015.5.6
 
-    * cbaf46e066 python <2.7 compability (pylint issue)
+    * cbaf46e066 python <2.7 compatibility (pylint issue)
 
     * ecde499478 s/bin/b to avoid confusion with bin()
 

--- a/doc/topics/releases/2015.8.3.rst
+++ b/doc/topics/releases/2015.8.3.rst
@@ -299,7 +299,7 @@ Changelog for v2015.8.2..v2015.8.3
 
   * 15f83e180d Add more preset colors
 
-  * 44339f3dc1 Impement color setter with transition
+  * 44339f3dc1 Implement color setter with transition
 
   * 0f4d5b9eac Implement effects method
 

--- a/doc/topics/releases/2015.8.4.rst
+++ b/doc/topics/releases/2015.8.4.rst
@@ -743,14 +743,14 @@ Changelog for v2015.8.3..v2015.8.4
 
   * a7c2ad5505 Fix issue where pyVmomi 6.0.0 raises SSL Error for systems using Python2.7+
 
-* **PR** `#30354`_: (`anlutro`_) Make sure all ignore_missing SLSes are catched
+* **PR** `#30354`_: (`anlutro`_) Make sure all ignore_missing SLSes are caught
   @ *2016-01-14 16:24:19 UTC*
 
   * **PR** `#19429`_: (`ryan-lane`_) Add new ignore_missing option to pillar top (refs: `#30354`_)
 
   * 7ee61f0d62 Merge pull request `#30354`_ from alprs/fix-pillar_ignore_missing
 
-  * 2f662bbc8d make sure *all* ignore_missing slses are catched
+  * 2f662bbc8d make sure *all* ignore_missing slses are caught
 
 * **PR** `#30356`_: (`nmadhok`_) Adding code author
   @ *2016-01-14 16:23:08 UTC*
@@ -1048,7 +1048,7 @@ Changelog for v2015.8.3..v2015.8.4
 
   * 0877b33026 Fixed some linting issues
 
-  * 8ec36497a1 Added note about systemd and uncleanshutdown. Also fixed line lenght of comments to max 80 characters as per PEP0008
+  * 8ec36497a1 Added note about systemd and uncleanshutdown. Also fixed line length of comments to max 80 characters as per PEP0008
 
   * a50428d02c On an unclean shutdown, if oncleanshutdown is given a path, an keyy:value of shutdown:unclean is added to the returned data. The documentation states that the key should be 'uncleanshutdown' and that the value should either be True or False. This is fixed in the code
 
@@ -1292,7 +1292,7 @@ Changelog for v2015.8.3..v2015.8.4
 
       * 56544a77f6 Update user home event when createhome is set to False
 
-    * 1a5d585d91 Merge pull request `#30127`_ from jsutton/clarify-documenation-for-random_master
+    * 1a5d585d91 Merge pull request `#30127`_ from jsutton/clarify-documentation-for-random_master
 
       * 01dbf385ef Adding random_master to reference and updating master_shuffle. Adding master_shuffle to the minion example config file as it is needed for multi-master PKI.
 
@@ -1630,12 +1630,12 @@ Changelog for v2015.8.3..v2015.8.4
 
   * 0bb83e51aa Updated Cloud msic section.
 
-* **PR** `#30029`_: (`terminalmage`_) git.latest: Fix handling of nonexistant branches
+* **PR** `#30029`_: (`terminalmage`_) git.latest: Fix handling of nonexistent branches
   @ *2015-12-28 19:39:29 UTC*
 
-  * a5f7d9c2fc Merge pull request `#30029`_ from terminalmage/git.latest-nonexistant-branch
+  * a5f7d9c2fc Merge pull request `#30029`_ from terminalmage/git.latest-nonexistent-branch
 
-  * 0b95894c9f git.latest: Fix handling of nonexistant branches
+  * 0b95894c9f git.latest: Fix handling of nonexistent branches
 
 * **PR** `#30016`_: (`anlutro`_) Properly normalize locales in locale.gen_locale
   @ *2015-12-28 15:33:48 UTC*
@@ -1845,7 +1845,7 @@ Changelog for v2015.8.3..v2015.8.4
 
   * 3b7f5540ec Add vSphere module to doc ref module tree
 
-* **ISSUE** `#29751`_: (`ether42`_) mod_hostname behavior is systemd dependant (refs: `#29767`_)
+* **ISSUE** `#29751`_: (`ether42`_) mod_hostname behavior is systemd dependent (refs: `#29767`_)
 
 * **PR** `#29767`_: (`abednarik`_) Hosts file update in mod_hostname.
   @ *2015-12-17 18:31:18 UTC*
@@ -2037,7 +2037,7 @@ Changelog for v2015.8.3..v2015.8.4
 
   * 7c50533d3f Merge pull request `#29683`_ from rallytime/vsan_fixes
 
-  * afc003079e Catch more specifc error to pass the error message through elegantly.
+  * afc003079e Catch more specific error to pass the error message through elegantly.
 
 * **PR** `#29687`_: (`basepi`_) [2015.8] Merge forward from 2015.5 to 2015.8
   @ *2015-12-15 18:38:46 UTC*
@@ -2220,9 +2220,9 @@ Changelog for v2015.8.3..v2015.8.4
 
   * b96d8ff1d9 Minor update to release notes for missing fix
 
-  * e72354aac4 Fix typo specfic -> specific
+  * e72354aac4 Fix typo of specific
 
-  * 5708355762 Fix typo comparsion -> comparison
+  * 5708355762 Fix typo of comparison
 
 * **PR** `#29540`_: (`basepi`_) [2015.8] Merge forward from 2015.5 to 2015.8
   @ *2015-12-08 21:27:01 UTC*
@@ -2556,7 +2556,7 @@ Changelog for v2015.8.3..v2015.8.4
 
   * 8fe39d0ef8 Merge pull request `#29400`_ from twangboy/fix_19332
 
-  * 7bdddaca53 Fixed grammer
+  * 7bdddaca53 Fixed grammar
 
   * d965d00a09 Fix `#19332`_
 

--- a/doc/topics/releases/2015.8.8.rst
+++ b/doc/topics/releases/2015.8.8.rst
@@ -102,7 +102,7 @@ Changelog for v2015.8.7..v2015.8.8
 
   * d661081016 Lint.
 
-  * 59e0a6f923 Dont add this file
+  * 59e0a6f923 Don't add this file
 
   * c68b968403 Old-style proxymodules need to be setup earlier in minion init. Also include more correct comments in config.py
 
@@ -369,7 +369,7 @@ Changelog for v2015.8.7..v2015.8.8
 
 * **ISSUE** `#31293`_: (`deuscapturus`_) Git Pillars lose HEAD reference over time (refs: `#31836`_)
 
-* **ISSUE** `#29239`_: (`timwsuqld`_) Occasionaly git_pillar pull fails causing incorrect results of highstate (when running highstate for multiple minions) (refs: `#31836`_)
+* **ISSUE** `#29239`_: (`timwsuqld`_) Occasionally git_pillar pull fails causing incorrect results of highstate (when running highstate for multiple minions) (refs: `#31836`_)
 
 * **PR** `#31836`_: (`terminalmage`_) Fix git_pillar race condition
   @ *2016-03-14 15:48:28 UTC*
@@ -562,7 +562,7 @@ Changelog for v2015.8.7..v2015.8.8
 
   * ec90294442 Merge pull request `#31733`_ from jacobhammons/cloud-docs
 
-  * 209c641a41 Made udpates as suggested by @rallytime
+  * 209c641a41 Made updates as suggested by @rallytime
 
   * 26d4991cb3 moved previous intro to new quick start topic (topics/cloud/qs.rst) added new intro that explains the salt cloud configuration files added an inheritance and minion startup state example to topics/cloud/config.rst
 
@@ -604,12 +604,12 @@ Changelog for v2015.8.7..v2015.8.8
 
   * 1349bdd2e8 fix influxdb user functionality for version 0.9+
 
-* **PR** `#31743`_: (`Talkless`_) Fix parentheses missmatch in documentation
+* **PR** `#31743`_: (`Talkless`_) Fix parentheses mismatch in documentation
   @ *2016-03-08 18:01:23 UTC*
 
   * c0868307df Merge pull request `#31743`_ from Talkless/patch-1
 
-  * 26ff46dbc6 Fix parenthesis missmatch in documentation
+  * 26ff46dbc6 Fix parenthesis mismatch in documentation
 
 * **PR** `#31162`_: (`isbm`_) Remove MD5 digest from everywhere and default to SHA256
   @ *2016-03-07 19:11:36 UTC*
@@ -652,7 +652,7 @@ Changelog for v2015.8.7..v2015.8.8
 
   * f0d931f4d0 Use hash_type configuration for the Cloud
 
-  * 95cb59dec7 Set defalt hash as SHA1 in config and explain why.
+  * 95cb59dec7 Set default hash as SHA1 in config and explain why.
 
   * 8f9543c292 Set config hash_type to SHA1
 
@@ -1528,7 +1528,7 @@ Changelog for v2015.8.7..v2015.8.8
 
   * 274e6467be do not change kwargs in refresh while checking a value
 
-  * 644b14c273 simplify checking the refresh paramater
+  * 644b14c273 simplify checking the refresh parameter
 
   * db0e0de2fd add refresh option to more functions
 
@@ -1554,7 +1554,7 @@ Changelog for v2015.8.7..v2015.8.8
 
 * **ISSUE** `#28004`_: (`warden`_) dockerng.image_present should allow public repository pulling by default (refs: `#31354`_)
 
-* **PR** `#31354`_: (`ticosax`_) [dockerng] Dont require auth for all registries
+* **PR** `#31354`_: (`ticosax`_) [dockerng] Don't require auth for all registries
   @ *2016-02-20 05:45:10 UTC*
 
   * 174ee10fc2 Merge pull request `#31354`_ from ticosax/dont-require-auth-for-all-registries
@@ -1805,7 +1805,7 @@ Changelog for v2015.8.7..v2015.8.8
 
   * 29e3dd091d Merge pull request `#31271`_ from rallytime/bp-30689
 
-  * 3dae79d516 fix nested grains always show update due to __grains__.get() not supporting the ":" seperator
+  * 3dae79d516 fix nested grains always show update due to __grains__.get() not supporting the ":" separator
 
 * **ISSUE** `#30461`_: (`jfindlay`_) update documentation on bootstrap-supported platforms (refs: `#31255`_)
 
@@ -1998,7 +1998,7 @@ Changelog for v2015.8.7..v2015.8.8
 
   * 47ecb7a150 include all ips in public_ips or private_ips
 
-  * b2e8202f5d dont exit on a missing server
+  * b2e8202f5d don't exit on a missing server
 
   * 8ad1ee6db4 clean up references to access_ip extra network
 
@@ -2543,49 +2543,49 @@ Changelog for v2015.8.7..v2015.8.8
 
   * 4372851ad9 Merge pull request `#30895`_ from bdrung/2015.8
 
-  * 708f2ff8ea Fix typo reponse -> response
+  * 708f2ff8ea Fix typo of response
 
-  * 72c4eab6d7 Fix typo propogate -> propagate
+  * 72c4eab6d7 Fix typo of propagate
 
-  * 4912e365cb Fix typo directores -> directories
+  * 4912e365cb Fix typo of directories
 
-  * 74c8aba03e Fix typo exeption -> exception
+  * 74c8aba03e Fix typo of exception
 
   * 4692d84b07 Fix typos of improvement
 
-  * 213fc2d858 Fix typo occuring -> occurring
+  * 213fc2d858 Fix typo of occurring
 
-  * fe6124003b Fix typo nonexistant -> nonexistent
+  * fe6124003b Fix typo of nonexistent
 
-  * 56ce7479b1 Fix typo catched -> caught
+  * 56ce7479b1 Fix typo of caught
 
-  * 821e690e65 Fix typo develoment -> development
+  * 821e690e65 Fix typo of development
 
-  * b51279e086 Fix typo overide -> override
+  * b51279e086 Fix typo of override
 
-  * 4f2f04ea7d Fix typo relevent -> relevant
+  * 4f2f04ea7d Fix typo of relevant
 
-  * fe8be562c5 Fix typo existance -> existence
+  * fe8be562c5 Fix typo of existence
 
-  * 4a2f4de1a8 Fix typo accross -> across
+  * 4a2f4de1a8 Fix typo of across
 
-  * 9ae50c993e Fix typo Lenth -> Length
+  * 9ae50c993e Fix typo of Length
 
-  * 20e79981e1 Fix typo preferrably -> preferably
+  * 20e79981e1 Fix typo of preferably
 
-  * f8d9f608dd Fix typo addres -> address
+  * f8d9f608dd Fix typo of address
 
-  * a7f12a13f0 Fix typo keywork -> keyword
+  * a7f12a13f0 Fix typo of keyword
 
-  * bf92c3663b Fix typo formating -> formatting
+  * bf92c3663b Fix typo of formatting
 
-  * ca4450d881 Fix typo wont -> won't
+  * ca4450d881 Fix typo of won't
 
-  * cd72b12161 Fix typo thats -> that's
+  * cd72b12161 Fix typo of that's
 
-  * 6db9724ec7 Fix typo doesnt -> doesn't
+  * 6db9724ec7 Fix typo of doesn't
 
-  * 58d46a7e98 Fix typo certficate -> certificate
+  * 58d46a7e98 Fix typo of certificate
 
 * **ISSUE** `#30887`_: (`anlutro`_) salt-ssh fails on import msgpack - 2015.8 (refs: `#30889`_)
 
@@ -3209,7 +3209,7 @@ Changelog for v2015.8.7..v2015.8.8
 
   * 57b7e6cc93 Add glance state to list of state modules
 
-* **ISSUE** `#19288`_: (`oba11`_) AssociatePublicIpAddress doesnt work with salt-cloud 2014.7.0 (refs: `#20972`_, `#30591`_)
+* **ISSUE** `#19288`_: (`oba11`_) AssociatePublicIpAddress doesn't work with salt-cloud 2014.7.0 (refs: `#20972`_, `#30591`_)
 
 * **PR** `#30618`_: (`rallytime`_) Back-port `#30591`_ to 2015.8
   @ *2016-01-25 23:55:20 UTC*

--- a/doc/topics/releases/2015.8.9.rst
+++ b/doc/topics/releases/2015.8.9.rst
@@ -124,7 +124,7 @@ Changelog for v2015.8.8.2..v2015.8.9
 
   * **PR** `#33224`_: (`rallytime`_) Make note of files that begin with '_' in master.d or minion.d dirs
 
-* **ISSUE** `#31975`_: (`rajvidhimar`_) Docstrings not reflected in the salt documenation. (refs: `#33150`_)
+* **ISSUE** `#31975`_: (`rajvidhimar`_) Docstrings not reflected in the salt documentation. (refs: `#33150`_)
 
   * **PR** `#33150`_: (`rallytime`_) Gate jnpr imports in salt.proxy.junos.py
 
@@ -204,7 +204,7 @@ Changelog for v2015.8.8.2..v2015.8.9
 
   * **PR** `#33142`_: (`cachedout`_) Hash fileclients by opts
 
-* **ISSUE** `#22142`_: (`multani`_) State `acl.present` doesn't allow to set "default" ACLs (refs: `#31769`_)
+* **ISSUE** `#22142`_: (`multani`_) State `acl.present` doesn't allow setting "default" ACLs (refs: `#31769`_)
 
   * **PR** `#33139`_: (`rallytime`_) Back-port `#31769`_ to 2015.8
 
@@ -687,7 +687,7 @@ Changelog for v2015.8.8.2..v2015.8.9
 
 * **ISSUE** `#32229`_: (`seanjnkns`_) 2015.8.8.2: pkg.installed fails to update packages with epoch (refs: `#32563`_)
 
-  * **PR** `#32563`_: (`terminalmage`_) yumpkg: Ignore epoch in version comparison for explict versions without an epoch
+  * **PR** `#32563`_: (`terminalmage`_) yumpkg: Ignore epoch in version comparison for explicit versions without an epoch
 
   * **PR** `#32640`_: (`nmadhok`_) [2015.8] - Fixing critical bug to remove only the specified Host instead of the entire Host cluster
 
@@ -912,12 +912,12 @@ Changelog for v2015.8.8.2..v2015.8.9
 
 * **ISSUE** `#31632`_: (`zieba88`_) salt-cloud map parallel provisioning -P option failed on 2015.8.5 (refs: `#32425`_)
 
-* **PR** `#32425`_: (`cachedout`_) Fix salt-cloud paralell provisioning
+* **PR** `#32425`_: (`cachedout`_) Fix salt-cloud parallel provisioning
   @ *2016-04-07 21:52:06 UTC*
 
   * c07e02bacb Merge pull request `#32425`_ from cachedout/issue_31632
 
-  * 127c0829ee Fix salt-cloud paralell provisioning
+  * 127c0829ee Fix salt-cloud parallel provisioning
 
 * **PR** `#32323`_: (`mcalmer`_) fix sorting by latest version when called with an attribute
   @ *2016-04-07 06:24:35 UTC*
@@ -1138,37 +1138,37 @@ Changelog for v2015.8.8.2..v2015.8.9
 
   * f16e332b3a Merge pull request `#32326`_ from bdrung/fix-typos
 
-  * a7db152333 Fix typo dont -> don't
+  * a7db152333 Fix typo of don't
 
-  * d4c037301b Fix typo missmatch -> mismatch
+  * d4c037301b Fix typo of mismatch
 
-  * 70dba70ff0 Fix typo additonal -> addition
+  * 70dba70ff0 Fix typo of addition
 
-  * 68c60903aa Fix typo mutliple -> multiple
+  * 68c60903aa Fix typo of multiple
 
-  * 0f2c779b90 Fix typo fucntion -> function
+  * 0f2c779b90 Fix typo of function
 
-  * 0c9e4c8c80 Fix typo avilable -> available
+  * 0c9e4c8c80 Fix typo of available
 
-  * 920abe2ec7 Fix typo formated -> formatted
+  * 920abe2ec7 Fix typo of formatted
 
-  * e56dd4bb23 Fix typo ommitted -> omitted
+  * e56dd4bb23 Fix typo of omitted
 
-  * f99e6f1f13 Fix typo ouptut -> output
+  * f99e6f1f13 Fix typo of output
 
-  * d3804094f2 Fix typo wether -> whether
+  * d3804094f2 Fix typo of whether
 
-  * 538fb6fae2 Fix typo perfomed -> performed
+  * 538fb6fae2 Fix typo of performed
 
-  * db7af998ee Fix typo santized -> sanitized
+  * db7af998ee Fix typo of sanitized
 
-  * d7af01da2b Fix typo coresponding -> corresponding
+  * d7af01da2b Fix typo of corresponding
 
-  * 301e78b5be Fix typo vaules -> values
+  * 301e78b5be Fix typo of values
 
   * 8cada9573f Fix typos of retrieve
 
-  * b484d6f9c9 Fix typo directorys -> directories
+  * b484d6f9c9 Fix typo of directories
 
 * **PR** `#32300`_: (`twangboy`_) Add documentation to disable winrepo/winrepo_ng
   @ *2016-04-01 21:23:09 UTC*
@@ -1338,7 +1338,7 @@ Changelog for v2015.8.8.2..v2015.8.9
 
   * bf59f06733 Merge pull request `#32217`_ from jacobhammons/dot8
 
-  * 596444e2b4 2015.8.8.2 release notes Adds banner notifiying user when they are viewing release notes for an old release
+  * 596444e2b4 2015.8.8.2 release notes Adds banner notifying user when they are viewing release notes for an old release
 
 * **ISSUE** `#31844`_: (`Talkless`_) slspath is not documented (refs: `#32197`_)
 
@@ -1544,9 +1544,9 @@ Changelog for v2015.8.8.2..v2015.8.9
 
       * d18b4be80b remove whitespace end of line 186:q
 
-      * d2b89c85ad fix formating
+      * d2b89c85ad fix formatting
 
-      * 103cee9e29 cleaned up formating
+      * 103cee9e29 cleaned up formatting
 
       * 7a4d7f0bff added whitespace
 

--- a/doc/topics/releases/2016.11.2.rst
+++ b/doc/topics/releases/2016.11.2.rst
@@ -185,9 +185,9 @@ Changelog for v2016.11.1..v2016.11.2
 
     * fd2ee7db30 Add some simple unit tests for salt.config.api_config function
 
-    * 3d2fefc83b Make sure the pidfile and log_file values are overriden by api opts
+    * 3d2fefc83b Make sure the pidfile and log_file values are overridden by api opts
 
-    * 1f6b540e46 Make sure the pidfile and log_file values are overriden by api opts
+    * 1f6b540e46 Make sure the pidfile and log_file values are overridden by api opts
 
     * 04d307f917 salt-api no longer forces the default timeout
 
@@ -427,7 +427,7 @@ Changelog for v2016.11.1..v2016.11.2
 
     * 7b657ca4ae add the ability to use keystone v2 and v3
 
-    * 5646ae1b34 add ability to use keystoneauth to authenitcate in nova driver
+    * 5646ae1b34 add ability to use keystoneauth to authenticate in nova driver
 
   * 383768d838 Merge pull request `#38650`_ from rallytime/remove-ubuntu-ppa-docs
 
@@ -572,7 +572,7 @@ Changelog for v2016.11.1..v2016.11.2
 
   * 26fae54f5b network.ifacestartswith throws exception on Solaris-like platforms
 
-* **ISSUE** `#37027`_: (`sjorge`_) Solaris FQDN/UQDN and documentation/consistancy (refs: `#38615`_)
+* **ISSUE** `#37027`_: (`sjorge`_) Solaris FQDN/UQDN and documentation/consistency (refs: `#38615`_)
 
 * **PR** `#38615`_: (`sjorge`_) add note related to issue `#37027`_
   @ *2017-01-06 16:38:34 UTC*
@@ -778,7 +778,7 @@ Changelog for v2016.11.1..v2016.11.2
 
   * 68d5475c1f Fixing Snapper unit tests for SUBVOLUME support
 
-  * e9919a913f Removing posible double '/' from the file paths
+  * e9919a913f Removing possible double '/' from the file paths
 
   * 8b4f87f226 Updating and fixing the documentation
 
@@ -1208,14 +1208,14 @@ Changelog for v2016.11.1..v2016.11.2
 
   * 6b9060c38f [2016.3] Bump latest release version to 2016.11.1 (`#38256`_)
 
-* **ISSUE** `#38231`_: (`tjuup`_) Typo: salt-key deleteed (refs: `#38232`_)
+* **ISSUE** `#38231`_: (`tjuup`_) Typo: salt-key deleted (refs: `#38232`_)
 
-* **PR** `#38232`_: (`rallytime`_) Strip final 'e' in key cmd to correct "deleteed" misspelling
+* **PR** `#38232`_: (`rallytime`_) Strip final 'e' in key cmd to correct "deleted" misspelling
   @ *2016-12-15 10:38:49 UTC*
 
   * 0af343e71f Merge pull request `#38232`_ from rallytime/fix-38231
 
-  * 26e1ee3650 Strip final 'e' in key cmd to correct "deleteed" misspelling
+  * 26e1ee3650 Strip final 'e' in key cmd to correct "deleted" misspelling
 
 * **ISSUE** `#38200`_: (`sebw`_) selinux.mode doesn't return any output and doesn't persist (refs: `#38236`_)
 

--- a/doc/topics/releases/2016.11.3.rst
+++ b/doc/topics/releases/2016.11.3.rst
@@ -361,7 +361,7 @@ Changelog for v2016.11.2..v2016.11.3
 
   * 52440416ca Merge pull request `#39221`_ from lvg01/fix-bug-39220
 
-    * e8a41d6341 Removes to early content stripping (stripping is allready done when needed with ident:true), fixes `#39220`_
+    * e8a41d6341 Removes to early content stripping (stripping is already done when needed with ident:true), fixes `#39220`_
 
     * a4b169e0bd Fixed wrong logic, fixes `#39220`_
 
@@ -447,7 +447,7 @@ Changelog for v2016.11.2..v2016.11.3
 
       * 624f25b78d Fix for `#38697`_
 
-* **ISSUE** `#39269`_: (`alexharrington`_) Remount forced with lizardfs fuse filesystem due to device missmatch (refs: `#39276`_)
+* **ISSUE** `#39269`_: (`alexharrington`_) Remount forced with lizardfs fuse filesystem due to device mismatch (refs: `#39276`_)
 
 * **ISSUE** `#39106`_: (`carsten-AEI`_) CVMFS fuse mount gets remounted every time (refs: `#39276`_)
 
@@ -678,7 +678,7 @@ Changelog for v2016.11.2..v2016.11.3
 
       * 97521b3468 Second attempt to fix prepending of root_dir to paths
 
-    * 6ffeda3ee5 Clarify ipv6 option for minion and inteface for master, closes `#39118`_ (`#39131`_)
+    * 6ffeda3ee5 Clarify ipv6 option for minion and interface for master, closes `#39118`_ (`#39131`_)
 
     * 646b9ea4e5 Don't abort pillar.get with merge=True if default is None (`#39116`_)
 
@@ -1117,7 +1117,7 @@ Changelog for v2016.11.2..v2016.11.3
 
       * fbc4d2a2c4 reactor: ensure glob_ref is a string
 
-      * 2e443d79a3 cp.cache_file: add note re: return for nonexistant salt:// path
+      * 2e443d79a3 cp.cache_file: add note re: return for nonexistent salt:// path
 
     * e9ebec4d80 Merge pull request `#38890`_ from cro/vmware_reset_vm_20163
 

--- a/doc/topics/releases/2016.11.4.rst
+++ b/doc/topics/releases/2016.11.4.rst
@@ -873,7 +873,7 @@ Changelog for v2016.11.3..v2016.11.4
 
   * d68067f1d7 Merge remote-tracking branch 'main/2016.11' into pip-cache-fixes
 
-  * 4f23a23ca8 Fixed the `test_install_download_cache_argument_in_resulting_command` to accomodate introduced cache directory argument fixes and renamed it to `test_install_download_cache_dir_arguments_in_resulting_command`.
+  * 4f23a23ca8 Fixed the `test_install_download_cache_argument_in_resulting_command` to accommodate introduced cache directory argument fixes and renamed it to `test_install_download_cache_dir_arguments_in_resulting_command`.
 
   * 9d0f94eeba Fixed unnecessary API changes introduced with suggested changes.
 
@@ -1387,7 +1387,7 @@ Changelog for v2016.11.3..v2016.11.4
 
   * 116201f345 Merge pull request `#40059`_ from terminalmage/fix-virtualenv-traceback
 
-    * e3cfd29d6b Fix traceback when virtualenv.managed is invoked with nonexistant user
+    * e3cfd29d6b Fix traceback when virtualenv.managed is invoked with nonexistent user
 
   * a01b52b9a3 Merge pull request `#40090`_ from rallytime/bp-40056
 
@@ -1423,9 +1423,9 @@ Changelog for v2016.11.3..v2016.11.4
 
   * 8dcffc7751 Merge pull request `#40018`_ from meaksh/2016.3-handling-timeouts-for-manage.up-runner
 
-    * 9f5c3b7dcd Allows to set custom timeouts for 'manage.up' and 'manage.status'
+    * 9f5c3b7dcd Allows one to set custom timeouts for 'manage.up' and 'manage.status'
 
-    * 2102d9c75c Allows to set 'timeout' and 'gather_job_timeout' via kwargs
+    * 2102d9c75c Allows one to set 'timeout' and 'gather_job_timeout' via kwargs
 
   * 22fc5299a2 Merge pull request `#40038`_ from velom/fix-pip-freeze-parsing
 
@@ -1453,9 +1453,9 @@ Changelog for v2016.11.3..v2016.11.4
 
   * e73a1d0e54 Merge pull request `#40072`_ from meaksh/2016.11-handling-timeouts-for-manage.up-runner
 
-  * 40246d3723 Allows to set custom timeouts for 'manage.up' and 'manage.status'
+  * 40246d3723 Allows one to set custom timeouts for 'manage.up' and 'manage.status'
 
-  * ad232fdc01 Allows to set 'timeout' and 'gather_job_timeout' via kwargs
+  * ad232fdc01 Allows one to set 'timeout' and 'gather_job_timeout' via kwargs
 
 * **PR** `#40045`_: (`terminalmage`_) Fix error when chhome is invoked by user.present state in Windows
   @ *2017-03-15 19:00:41 UTC*
@@ -1499,7 +1499,7 @@ Changelog for v2016.11.3..v2016.11.4
 
   * 0c61d064ad Merge pull request `#39980`_ from vutny/cmd-run-state-bg
 
-    * a81dc9dfc1 [2016.3] Allow to use `bg` kwarg for `cmd.run` state function
+    * a81dc9dfc1 [2016.3] Allow using `bg` kwarg for `cmd.run` state function
 
   * b042484455 Merge pull request `#39994`_ from rallytime/ulimits-dockerng-version
 
@@ -1817,14 +1817,14 @@ Changelog for v2016.11.3..v2016.11.4
 
   * 6539dbdbca Do not use name resolving for --notrim check
 
-* **ISSUE** `#38231`_: (`tjuup`_) Typo: salt-key deleteed (refs: `#39799`_)
+* **ISSUE** `#38231`_: (`tjuup`_) Typo: salt-key deleted (refs: `#39799`_)
 
-* **PR** `#39799`_: (`Ch3LL`_) Fix deleteed message when key is deleted
+* **PR** `#39799`_: (`Ch3LL`_) Fix deleted message when key is deleted
   @ *2017-03-03 05:17:43 UTC*
 
   * d0440e2a2a Merge pull request `#39799`_ from Ch3LL/fix_salt_key_msg
 
-  * 8346682cf7 Fix deleteed message when key is deleted
+  * 8346682cf7 Fix deleted message when key is deleted
 
 * **ISSUE** `#38962`_: (`gstachowiak`_) Broken /jobs in salt-api in salt 2016.11.1 (Carbon) (refs: `#39472`_)
 
@@ -2038,12 +2038,12 @@ Changelog for v2016.11.3..v2016.11.4
 
 * **ISSUE** `#38836`_: (`toanctruong`_) file.managed with S3 Source errors out with obscure message (refs: `#39609`_, `#39589`_)
 
-* **PR** `#39609`_: (`gtmanfred`_) intialize the Client stuff in FSClient
+* **PR** `#39609`_: (`gtmanfred`_) initialize the Client stuff in FSClient
   @ *2017-02-24 18:50:55 UTC*
 
   * 0bc6027e68 Merge pull request `#39609`_ from gtmanfred/2016.11
 
-  * 0820620ef8 intialize the Client stuff in FSClient
+  * 0820620ef8 initialize the Client stuff in FSClient
 
 * **PR** `#39615`_: (`skizunov`_) Bonjour/Avahi beacons: Make sure TXT record length is valid
   @ *2017-02-24 18:47:05 UTC*

--- a/doc/topics/releases/2016.11.6.rst
+++ b/doc/topics/releases/2016.11.6.rst
@@ -466,7 +466,7 @@ Changelog for v2016.11.5..v2016.11.6
 
   * 1592687294 Document aptpkg architectures parameter
 
-* **ISSUE** `#41478`_: (`jf`_) security / information leak with consul pillar when subsitution values are not present (refs: `#41530`_)
+* **ISSUE** `#41478`_: (`jf`_) security / information leak with consul pillar when substitution values are not present (refs: `#41530`_)
 
 * **PR** `#41530`_: (`gtmanfred`_) Set default for consul_pillar to None
   @ *2017-06-08 18:13:15 UTC*
@@ -533,14 +533,14 @@ Changelog for v2016.11.5..v2016.11.6
 
   * 53bca96328 Update __init__.py
 
-* **PR** `#41552`_: (`Enquier`_) Adding logic so that update_floatingip can dissassociate floatingip's
+* **PR** `#41552`_: (`Enquier`_) Adding logic so that update_floatingip can disassociate floatingip's
   @ *2017-06-06 18:25:56 UTC*
 
   * 846ca54688 Merge pull request `#41552`_ from Enquier/neutron-floatingip-remove
 
   * aeed51c1e3 Adding port=None default and documentation
 
-  * fcce05e1e4 Adding logic so that update_floatingip can dissassociate floatingip's Previously update_floatingip would cause an error if port is set to None.
+  * fcce05e1e4 Adding logic so that update_floatingip can disassociate floatingip's Previously update_floatingip would cause an error if port is set to None.
 
 * **PR** `#41569`_: (`gtmanfred`_) Check all entries in result
   @ *2017-06-06 18:18:17 UTC*
@@ -581,7 +581,7 @@ Changelog for v2016.11.5..v2016.11.6
 
   * ef8e3ef569 Update win_pki.py
 
-* **PR** `#41557`_: (`dmurphy18`_) Add symbolic link for salt-proxy service similar to other serivce files
+* **PR** `#41557`_: (`dmurphy18`_) Add symbolic link for salt-proxy service similar to other service files
   @ *2017-06-06 17:13:52 UTC*
 
   * 3335fcbc7d Merge pull request `#41557`_ from dmurphy18/fix-proxy-service
@@ -826,7 +826,7 @@ Changelog for v2016.11.5..v2016.11.6
 
   * 66ab1e5184 Re-adding neutron dependency check
 
-  * cce07eefc2 Updating Neutron module to suport KeystoneAuth
+  * cce07eefc2 Updating Neutron module to support KeystoneAuth
 
 * **ISSUE** `#34460`_: (`Ch3LL`_) Receive an error when using salt-api to call a runner (refs: `#41409`_)
 
@@ -1022,7 +1022,7 @@ Changelog for v2016.11.5..v2016.11.6
 * **PR** `#41319`_: (`lomeroe`_) backport `#41307`_ to 2016.11, properly pack version numbers into single
   @ *2017-05-19 18:25:00 UTC*
 
-  * **PR** `#41307`_: (`lomeroe`_) properly pack/unpack the verison numbers into a number (refs: `#41319`_)
+  * **PR** `#41307`_: (`lomeroe`_) properly pack/unpack the version numbers into a number (refs: `#41319`_)
 
   * 140b0427e1 Merge pull request `#41319`_ from lomeroe/bp_41307
 

--- a/doc/topics/releases/2016.11.8.rst
+++ b/doc/topics/releases/2016.11.8.rst
@@ -97,7 +97,7 @@ Changelog for v2016.11.7..v2016.11.8
 
   * c15bcbe1cc Merge remote-tracking branch 'upstream/2016.11' into fix-apache-config-multi-entity
 
-  * 4164047951 Fix apache.config with multiple statement At this moment when you post more than one statement in config only last is used. Also file is rewrited multiple times until last statement is written. Example: salt '*' apache.config /etc/httpd/conf.d/ports.conf config="[{'Listen': '8080'}, {'Proxy': "Something"}]" Ends only with    Proxy Something and ignore Listen 8080, This patch fix this issue.
+  * 4164047951 Fix apache.config with multiple statement At this moment when you post more than one statement in config only last is used. Also file is rewrote multiple times until last statement is written. Example: salt '*' apache.config /etc/httpd/conf.d/ports.conf config="[{'Listen': '8080'}, {'Proxy': "Something"}]" Ends only with    Proxy Something and ignore Listen 8080, This patch fix this issue.
 
 * **ISSUE** `#42279`_: (`dafyddj`_) win_lgpo matches multiple policies due to startswith() (refs: `#43154`_, `#43116`_)
 
@@ -972,12 +972,12 @@ Changelog for v2016.11.7..v2016.11.8
 
   * 8c048403d7 Detect Server OS with a desktop release name
 
-* **PR** `#42356`_: (`meaksh`_) Allow to check whether a function is available on the AliasesLoader wrapper
+* **PR** `#42356`_: (`meaksh`_) Allow checking whether a function is available on the AliasesLoader wrapper
   @ *2017-07-19 16:56:41 UTC*
 
   * 0a72e56f6b Merge pull request `#42356`_ from meaksh/2016.11-AliasesLoader-wrapper-fix
 
-  * 915d94219e Allow to check whether a function is available on the AliasesLoader wrapper
+  * 915d94219e Allow checking whether a function is available on the AliasesLoader wrapper
 
 * **PR** `#42368`_: (`twangboy`_) Remove build and dist directories before install (2016.11)
   @ *2017-07-19 16:47:28 UTC*
@@ -1578,7 +1578,7 @@ Changelog for v2016.11.7..v2016.11.8
 
   * 7f6961378e test and lint fixes
 
-  * 8ee48432f4 Suppress output of crypt context and be more specifc with whitespace vs. serial
+  * 8ee48432f4 Suppress output of crypt context and be more specific with whitespace vs. serial
 
   * 61f817d172 Match serials based on output position (fix for non-English languages)
 

--- a/doc/topics/releases/2016.11.9.rst
+++ b/doc/topics/releases/2016.11.9.rst
@@ -485,7 +485,7 @@ Changelog for v2016.11.8..v2016.11.9
 
   * 998d714ee7 Merge pull request `#44517`_ from whytewolf/publish_port_doc_missing
 
-  * 4b5855283a missed one place where i didnt chanbge master_port from my copy to publish_port
+  * 4b5855283a missed one place where i didn't chanbge master_port from my copy to publish_port
 
   * e4610baea5 update doc to have publish port
 
@@ -690,7 +690,7 @@ Changelog for v2016.11.8..v2016.11.9
 
   * cab54e34b5 Merge pull request `#44173`_ from twangboy/win_system_docs
 
-  * 8e111b413d Fix some of the wording and grammer errors
+  * 8e111b413d Fix some of the wording and grammar errors
 
   * a12bc5ae41 Use google style docstrings
 
@@ -1135,12 +1135,12 @@ Changelog for v2016.11.8..v2016.11.9
 
 * **ISSUE** `#40311`_: (`cralston0`_) --hide-timeout used with --output json --static produces unparseable JSON (refs: `#43772`_)
 
-* **PR** `#43772`_: (`gtmanfred`_) dont print Minion not responding with quiet
+* **PR** `#43772`_: (`gtmanfred`_) don't print Minion not responding with quiet
   @ *2017-09-27 15:39:18 UTC*
 
   * 1a8cc60bb4 Merge pull request `#43772`_ from gtmanfred/2016.11
 
-  * 0194c60960 dont print Minion not responding with quiet
+  * 0194c60960 don't print Minion not responding with quiet
 
 * **PR** `#43747`_: (`rallytime`_) Add GPG Verification section to Contributing Docs
   @ *2017-09-26 21:25:37 UTC*

--- a/doc/topics/releases/2016.3.1.rst
+++ b/doc/topics/releases/2016.3.1.rst
@@ -193,7 +193,7 @@ Changelog for v2016.3.0..v2016.3.1
 
   * **PR** `#33861`_: (`cachedout`_) Set master and cloud to log level warning
 
-  * **PR** `#33821`_: (`cachedout`_) Restore deafault log level to warning (refs: `#33861`_)
+  * **PR** `#33821`_: (`cachedout`_) Restore default log level to warning (refs: `#33861`_)
 
 * **PR** `#33698`_: (`opdude`_) Vsphere fixes
   @ *2016-06-08 14:12:17 UTC*
@@ -262,12 +262,12 @@ Changelog for v2016.3.0..v2016.3.1
 
 * **ISSUE** `#33818`_: (`saltuser`_) 2016.3.0 minion default log level INFO (refs: `#33821`_, `#33861`_)
 
-* **PR** `#33821`_: (`cachedout`_) Restore deafault log level to warning (refs: `#33861`_)
+* **PR** `#33821`_: (`cachedout`_) Restore default log level to warning (refs: `#33861`_)
   @ *2016-06-07 16:51:46 UTC*
 
   * 3f6d06a060 Merge pull request `#33821`_ from cachedout/issue_33818
 
-  * 52f1f77a38 Restore deafault log level to warning
+  * 52f1f77a38 Restore default log level to warning
 
 * **ISSUE** `#33578`_: (`ohauer`_) 2016.3.0 FreeBSD Failed to load grains defined in grain file disks.disks in function <function disks at 0x80cff9320>, error: (refs: `#33604`_, `#33767`_)
 
@@ -635,7 +635,7 @@ Changelog for v2016.3.0..v2016.3.1
 
   * c738a0de76 fix a KeyError if group is provided but not user
 
-* **ISSUE** `#33543`_: (`arthurlogilab`_) Thorium documentation is incorrectly formated and appears partially on docs.saltproject.io (refs: `#33550`_)
+* **ISSUE** `#33543`_: (`arthurlogilab`_) Thorium documentation is incorrectly formatted and appears partially on docs.saltproject.io (refs: `#33550`_)
 
 * **PR** `#33550`_: (`jacobhammons`_) Fixes display of thorium docs
   @ *2016-05-26 17:57:05 UTC*
@@ -726,7 +726,7 @@ Changelog for v2016.3.0..v2016.3.1
 
     * 9deb70fd8e jobs.exit_success() now works parsing the results of jobs.lookup_id()
 
-    * 7ba40c4f31 jobs.exit_success allow to check if a job has executed and exit successfully
+    * 7ba40c4f31 jobs.exit_success allow checking if a job has executed and exit successfully
 
   * 70eb7b66f3 Merge pull request `#33487`_ from jtand/glance_doc_fixes
 

--- a/doc/topics/releases/2016.3.2.rst
+++ b/doc/topics/releases/2016.3.2.rst
@@ -185,7 +185,7 @@ Changelog for v2016.3.1..v2016.3.2
 
     * fb223e1bd4 Invalidate the target cache very quickly (`#34862`_)
 
-    * 1ca1367289 Fail git.latest states with uncommitted changes when force_reset=False (`#34869`_)
+    * 1ca1367289 Fail git.latest states with uncomitted changes when force_reset=False (`#34869`_)
 
     * 4f4381e5b9 Merge pull request `#34859`_ from cachedout/fix_wheel_test
 
@@ -410,7 +410,7 @@ Changelog for v2016.3.1..v2016.3.2
 
 * **ISSUE** `saltstack/salt#34630`_: (`bdrung`_) Spelling errors (refs: `#34756`_, `#34722`_)
 
-* **ISSUE** `saltstack/salt#33923`_: (`pavankumar2203`_) Salt module certutil install doesnt work (refs: `#34756`_)
+* **ISSUE** `saltstack/salt#33923`_: (`pavankumar2203`_) Salt module certutil install doesn't work (refs: `#34756`_)
 
   * **PR** `#34756`_: (`jacobhammons`_) Rebuild man pages
 
@@ -1830,7 +1830,7 @@ Changelog for v2016.3.1..v2016.3.2
 
   * 2cf787d4ba 2016.3.0 known issues update
 
-  * **PR** `#33908`_: (`ticosax`_) [boto_lambda] handle ommitted Permissions parameter
+  * **PR** `#33908`_: (`ticosax`_) [boto_lambda] handle omitted Permissions parameter
 
 * **ISSUE** `#33575`_: (`anlutro`_) File states seem slower in 2016.3, especially on first cache retrieval (refs: `#33896`_)
 

--- a/doc/topics/releases/2016.3.3.rst
+++ b/doc/topics/releases/2016.3.3.rst
@@ -508,7 +508,7 @@ Changelog for v2016.3.2..v2016.3.3
 
     * 8a5b47b5d7 Collect all error data from the wfuncs call
 
-    * 11864c31b7 supress a stack trace to show clean ssh error
+    * 11864c31b7 suppress a stack trace to show clean ssh error
 
     * 9fbfa282fa wow this solves an issue!
 
@@ -709,7 +709,7 @@ Changelog for v2016.3.2..v2016.3.3
 
   * f0961e741e Merge with 2016.3
 
-* **ISSUE** `#35234`_: (`Sylvain303`_) Bug: module disk.wipe dont wipe the filesystem information (refs: `#35253`_)
+* **ISSUE** `#35234`_: (`Sylvain303`_) Bug: module disk.wipe don't wipe the filesystem information (refs: `#35253`_)
 
 * **PR** `#35259`_: (`cachedout`_) Fixup 35253
   @ *2016-08-06 21:59:48 UTC*
@@ -722,7 +722,7 @@ Changelog for v2016.3.2..v2016.3.3
 
   * 6714e8f386 Fix mock call in disk wipe test
 
-* **ISSUE** `#35234`_: (`Sylvain303`_) Bug: module disk.wipe dont wipe the filesystem information (refs: `#35253`_)
+* **ISSUE** `#35234`_: (`Sylvain303`_) Bug: module disk.wipe don't wipe the filesystem information (refs: `#35253`_)
 
 * **PR** `#35253`_: (`abednarik`_) Fix disk.wipe missing option. (refs: `#35259`_)
   @ *2016-08-06 21:55:01 UTC*
@@ -827,7 +827,7 @@ Changelog for v2016.3.2..v2016.3.3
 
     * e1fcb8311d Put pkg.latest_version in try/except structure Move refreshed or refresh to different spot (just for code tidyness)
 
-    * e0b6261659 changed name of varibale 'refreshed' to 'was_refreshed'
+    * e0b6261659 changed name of variable 'refreshed' to 'was_refreshed'
 
     * 340110b4b4 Move check for rtag to outermost-nesting in function
 
@@ -863,7 +863,7 @@ Changelog for v2016.3.2..v2016.3.3
 
   * 77b1f43b0d Merge pull request `#35110`_ from hu-dabao/master-check-lighter
 
-  * 3a3b66e27d dont return job status back to master for master_alive and master_failback schedules
+  * 3a3b66e27d don't return job status back to master for master_alive and master_failback schedules
 
 * **PR** `#35104`_: (`rallytime`_) [2016.3] Merge forward from 2015.8 to 2016.3
   @ *2016-08-01 18:56:43 UTC*

--- a/doc/topics/releases/2016.3.4.rst
+++ b/doc/topics/releases/2016.3.4.rst
@@ -2530,7 +2530,7 @@ Changelog for v2016.3.3..v2016.3.4
 
   * eda2ae0add Merge pull request `#35781`_ from thatch45/ssh_deploy_more
 
-    * 2558dcc100 follow up on the re-deploy if there is a checksum missmatch
+    * 2558dcc100 follow up on the re-deploy if there is a checksum mismatch
 
   * 165237412c Merge pull request `#35815`_ from gtmanfred/2015.8
 

--- a/doc/topics/releases/2016.3.5.rst
+++ b/doc/topics/releases/2016.3.5.rst
@@ -179,9 +179,9 @@ Changelog for v2016.3.4..v2016.3.5
 
   * fd2ee7db30 Add some simple unit tests for salt.config.api_config function
 
-  * 3d2fefc83b Make sure the pidfile and log_file values are overriden by api opts
+  * 3d2fefc83b Make sure the pidfile and log_file values are overridden by api opts
 
-  * 1f6b540e46 Make sure the pidfile and log_file values are overriden by api opts
+  * 1f6b540e46 Make sure the pidfile and log_file values are overridden by api opts
 
   * 04d307f917 salt-api no longer forces the default timeout
 
@@ -294,7 +294,7 @@ Changelog for v2016.3.4..v2016.3.5
 
   * 7b657ca4ae add the ability to use keystone v2 and v3
 
-  * 5646ae1b34 add ability to use keystoneauth to authenitcate in nova driver
+  * 5646ae1b34 add ability to use keystoneauth to authenticate in nova driver
 
 * **ISSUE** `#38648`_: (`ericuldall`_) No release file error from PPA on Ubuntu (refs: `#38650`_)
 
@@ -1110,7 +1110,7 @@ Changelog for v2016.3.4..v2016.3.5
 
   * **PR** `#37826`_: (`rallytime`_) Update branch refs to more relevant branch
 
-  * **PR** `#37822`_: (`laleocen`_) add documenation for multiline encryption using nacl (refs: `#37826`_)
+  * **PR** `#37822`_: (`laleocen`_) add documentation for multiline encryption using nacl (refs: `#37826`_)
 
 * **ISSUE** `#19269`_: (`markuskramerIgitt`_) Undocumented  feature `names:` of `file.directory` (refs: `#37823`_)
 

--- a/doc/topics/releases/2016.3.6.rst
+++ b/doc/topics/releases/2016.3.6.rst
@@ -159,12 +159,12 @@ Changelog for v2016.3.5..v2016.3.6
 
   * af1545deed Use the first address if cannot connect to any
 
-* **PR** `#40059`_: (`terminalmage`_) Fix traceback when virtualenv.managed is invoked with nonexistant user
+* **PR** `#40059`_: (`terminalmage`_) Fix traceback when virtualenv.managed is invoked with nonexistent user
   @ *2017-03-16 20:46:43 UTC*
 
   * 116201f345 Merge pull request `#40059`_ from terminalmage/fix-virtualenv-traceback
 
-  * e3cfd29d6b Fix traceback when virtualenv.managed is invoked with nonexistant user
+  * e3cfd29d6b Fix traceback when virtualenv.managed is invoked with nonexistent user
 
 * **PR** `#40090`_: (`rallytime`_) Back-port `#40056`_ to 2016.3
   @ *2017-03-16 19:42:58 UTC*
@@ -194,9 +194,9 @@ Changelog for v2016.3.5..v2016.3.6
 
   * 8dcffc7751 Merge pull request `#40018`_ from meaksh/2016.3-handling-timeouts-for-manage.up-runner
 
-  * 9f5c3b7dcd Allows to set custom timeouts for 'manage.up' and 'manage.status'
+  * 9f5c3b7dcd Allows one to set custom timeouts for 'manage.up' and 'manage.status'
 
-  * 2102d9c75c Allows to set 'timeout' and 'gather_job_timeout' via kwargs
+  * 2102d9c75c Allows one to set 'timeout' and 'gather_job_timeout' via kwargs
 
 * **PR** `#40038`_: (`velom`_) correctly parse "pkg_name===version" from pip freeze
   @ *2017-03-15 19:30:03 UTC*
@@ -239,12 +239,12 @@ Changelog for v2016.3.5..v2016.3.6
 
   * 5d84b40bfd Attempt to fix failing grains tests in 2016.3
 
-* **PR** `#39980`_: (`vutny`_) [2016.3] Allow to use `bg` kwarg for `cmd.run` state function
+* **PR** `#39980`_: (`vutny`_) [2016.3] Allow using `bg` kwarg for `cmd.run` state function
   @ *2017-03-14 17:16:14 UTC*
 
   * 0c61d064ad Merge pull request `#39980`_ from vutny/cmd-run-state-bg
 
-  * a81dc9dfc1 [2016.3] Allow to use `bg` kwarg for `cmd.run` state function
+  * a81dc9dfc1 [2016.3] Allow using `bg` kwarg for `cmd.run` state function
 
 * **ISSUE** `#39942`_: (`Foxlik`_) Web Documentation not in sync with release 2016.11.3 (refs: `#39994`_)
 
@@ -744,7 +744,7 @@ Changelog for v2016.3.5..v2016.3.6
 
   * 52440416ca Merge pull request `#39221`_ from lvg01/fix-bug-39220
 
-  * e8a41d6341 Removes to early content stripping (stripping is allready done when needed with ident:true), fixes `#39220`_
+  * e8a41d6341 Removes to early content stripping (stripping is already done when needed with ident:true), fixes `#39220`_
 
   * a4b169e0bd Fixed wrong logic, fixes `#39220`_
 
@@ -889,7 +889,7 @@ Changelog for v2016.3.5..v2016.3.6
 
 * **ISSUE** `#39118`_: (`bobrik`_) Minion ipv6 option is not documented (refs: `#39289`_, `#39131`_)
 
-  * **PR** `#39131`_: (`bobrik`_) Clarify ipv6 option for minion and inteface for master, closes `#39118`_
+  * **PR** `#39131`_: (`bobrik`_) Clarify ipv6 option for minion and interface for master, closes `#39118`_
 
   * **PR** `#39116`_: (`terminalmage`_) Don't abort pillar.get with merge=True if default is None
 
@@ -1090,14 +1090,14 @@ Changelog for v2016.3.5..v2016.3.6
 
 * **ISSUE** `#36121`_: (`Ashald`_) TemplateNotFound/Unable to cache file (refs: `#38875`_)
 
-* **PR** `#38875`_: (`terminalmage`_) Reactor: fix traceback when salt:// path is nonexistant
+* **PR** `#38875`_: (`terminalmage`_) Reactor: fix traceback when salt:// path is nonexistent
   @ *2017-01-24 15:23:39 UTC*
 
   * b5df104fc2 Merge pull request `#38875`_ from terminalmage/issue36121
 
   * fbc4d2a2c4 reactor: ensure glob_ref is a string
 
-  * 2e443d79a3 cp.cache_file: add note re: return for nonexistant salt:// path
+  * 2e443d79a3 cp.cache_file: add note re: return for nonexistent salt:// path
 
 * **ISSUE** `#37413`_: (`Snarfingcode666`_) Salt-cloud vmware missing reboot command (refs: `#38887`_, `#38890`_)
 

--- a/doc/topics/releases/2017.7.2.rst
+++ b/doc/topics/releases/2017.7.2.rst
@@ -947,7 +947,7 @@ Changelog for v2017.7.1..v2017.7.2
 
     * 1cc86592ed Update return data before calling returners
 
-* **ISSUE** `#42842`_: (`Giandom`_) retreive kwargs passed with slack engine (refs: `#42884`_)
+* **ISSUE** `#42842`_: (`Giandom`_) retrieve kwargs passed with slack engine (refs: `#42884`_)
 
 * **PR** `#42884`_: (`Giandom`_) Convert to dict type the pillar string value passed from slack
   @ *2017-08-16 22:30:43 UTC*
@@ -1236,12 +1236,12 @@ Changelog for v2017.7.1..v2017.7.2
 
 * **ISSUE** `saltstack/salt-jenkins#480`_: (`rallytime`_) [2017.7] PY3 Debian 8 has several vmware unit tests failing (refs: `#42857`_)
 
-* **PR** `#42857`_: (`gtmanfred`_) use older name if _create_unverified_context is unvailable
+* **PR** `#42857`_: (`gtmanfred`_) use older name if _create_unverified_context is unavailable
   @ *2017-08-11 13:37:59 UTC*
 
   * 3d05d89e09 Merge pull request `#42857`_ from gtmanfred/vmware
 
-  * c1f673eca4 use older name if _create_unverified_context is unvailable
+  * c1f673eca4 use older name if _create_unverified_context is unavailable
 
 * **PR** `#42866`_: (`twangboy`_) Change to GitPython version 2.1.1
   @ *2017-08-11 13:23:52 UTC*
@@ -1999,7 +1999,7 @@ Changelog for v2017.7.1..v2017.7.2
 
     * 0a72e56f6b Merge pull request `#42356`_ from meaksh/2016.11-AliasesLoader-wrapper-fix
 
-      * 915d94219e Allow to check whether a function is available on the AliasesLoader wrapper
+      * 915d94219e Allow checking whether a function is available on the AliasesLoader wrapper
 
     * 10eb7b7a79 Merge pull request `#42368`_ from twangboy/win_fix_build_2016.11
 

--- a/doc/topics/releases/2017.7.3.rst
+++ b/doc/topics/releases/2017.7.3.rst
@@ -131,7 +131,7 @@ Changelog for v2017.7.2..v2017.7.3
 * **PR** `#45664`_: (`rallytime`_) Back-port `#45452`_ to 2017.7.3
   @ *2018-01-24 15:33:13 UTC*
 
-  * **PR** `#45452`_: (`adelcast`_) opkg.py: make owner fuction return value, instead of iterator (refs: `#45664`_)
+  * **PR** `#45452`_: (`adelcast`_) opkg.py: make owner function return value, instead of iterator (refs: `#45664`_)
 
   * 0717f7a578 Merge pull request `#45664`_ from rallytime/bp-45452
 
@@ -447,7 +447,7 @@ Changelog for v2017.7.2..v2017.7.3
 
   * 9a15ec3430 Updating versionadded string.  Fixing typo.
 
-  * edfc3dc078 Adding in documention for `auth_events` configuration option
+  * edfc3dc078 Adding in documentation for `auth_events` configuration option
 
   * 3ee4eabffd Fixing small typo
 
@@ -1076,7 +1076,7 @@ Changelog for v2017.7.2..v2017.7.3
 
   * 4b60b1ec84 Merge remote branch 'refs/remotes/upstream/2017.7' into 2017.7_replace_with_newer_2016.11_win_pkg
 
-  * b46f818a57 Raise a PR to fix 2016 issues commited here, fixed issues with merge.
+  * b46f818a57 Raise a PR to fix 2016 issues committed here, fixed issues with merge.
 
   * 32ef1e12ae Merge branch '2017.7' into 2017.7_replace_with_newer_2016.11_win_pkg
 
@@ -1409,7 +1409,7 @@ Changelog for v2017.7.2..v2017.7.3
 
     * 998d714ee7 Merge pull request `#44517`_ from whytewolf/publish_port_doc_missing
 
-      * 4b5855283a missed one place where i didnt chanbge master_port from my copy to publish_port
+      * 4b5855283a missed one place where i didn't chanbge master_port from my copy to publish_port
 
       * e4610baea5 update doc to have publish port
 
@@ -1627,9 +1627,9 @@ Changelog for v2017.7.2..v2017.7.3
 
   * 3bb385b44e removing debugging logging
 
-  * 7f0ff5a8b0 When passing IDs on the command line convert them all the strings for later comparision.
+  * 7f0ff5a8b0 When passing IDs on the command line convert them all the strings for later comparison.
 
-  * 99e436add4 When looking for job ids to remove based on the tag_name the comparision was comparing an INT to a STR, so the correct job id was not being returned.
+  * 99e436add4 When looking for job ids to remove based on the tag_name the comparison was comparing an INT to a STR, so the correct job id was not being returned.
 
 * **ISSUE** `#44136`_: (`dupsatou`_) KeyError: 'runas' after updating to latest salt in yum repo. (refs: `#44695`_)
 
@@ -1785,7 +1785,7 @@ Changelog for v2017.7.2..v2017.7.3
 
     * 88ef9f18fc ignore lint error on import
 
-    * 25427d845e convert key iterator to list as python 3 wont index an iterator
+    * 25427d845e convert key iterator to list as python 3 won't index an iterator
 
   * bce50154e5 Merge branch '2017.7' into improve-net-load
 
@@ -1846,14 +1846,14 @@ Changelog for v2017.7.2..v2017.7.3
 
                   * c6733ac1ee pop None
 
-* **PR** `#44616`_: (`Ch3LL`_) Add Non Base Environement salt:// source integration test
+* **PR** `#44616`_: (`Ch3LL`_) Add Non Base Environment salt:// source integration test
   @ *2017-11-22 16:13:54 UTC*
 
   * d6ccf4bb30 Merge pull request `#44616`_ from Ch3LL/nonbase_test
 
   * 80b71652e3 Merge branch '2017.7' into nonbase_test
 
-  * c9ba33432e Add Non Base Environement salt:// source integration test
+  * c9ba33432e Add Non Base Environment salt:// source integration test
 
 * **PR** `#44617`_: (`Ch3LL`_) Add ssh thin_dir integration test
   @ *2017-11-22 16:12:51 UTC*
@@ -1982,7 +1982,7 @@ Changelog for v2017.7.2..v2017.7.3
 
   * ce1882943d Use salt.utils.files.mkstemp() instead
 
-  * 6689bd3b2d Dont use dangerous os.tmpnam
+  * 6689bd3b2d Don't use dangerous os.tmpnam
 
   * 2d6176b0bc Fx2 proxy minion: clean return, like all the other modules
 
@@ -2249,7 +2249,7 @@ Changelog for v2017.7.2..v2017.7.3
 
   * cab54e34b5 Merge pull request `#44173`_ from twangboy/win_system_docs
 
-    * 8e111b413d Fix some of the wording and grammer errors
+    * 8e111b413d Fix some of the wording and grammar errors
 
     * a12bc5ae41 Use google style docstrings
 
@@ -2818,9 +2818,9 @@ Changelog for v2017.7.2..v2017.7.3
 * **PR** `#44133`_: (`cachedout`_) Fix typos in parallel states docs
   @ *2017-10-17 15:24:19 UTC*
 
-  * 6252f82f58 Merge pull request `#44133`_ from cachedout/fix_paralell_docs
+  * 6252f82f58 Merge pull request `#44133`_ from cachedout/fix_parallel_docs
 
-  * 8d1c1e21f0 Fix typos in paralell states docs
+  * 8d1c1e21f0 Fix typos in parallel states docs
 
 * **PR** `#44135`_: (`timfreund`_) Insert missing verb in gitfs walkthrough
   @ *2017-10-17 14:32:13 UTC*
@@ -3387,7 +3387,7 @@ Changelog for v2017.7.2..v2017.7.3
 
     * 1a8cc60bb4 Merge pull request `#43772`_ from gtmanfred/2016.11
 
-      * 0194c60960 dont print Minion not responding with quiet
+      * 0194c60960 don't print Minion not responding with quiet
 
     * 9dee896fb9 Merge pull request `#43747`_ from rallytime/gpg-verification
 
@@ -4413,7 +4413,7 @@ Changelog for v2017.7.2..v2017.7.3
     * c15bcbe1cc Merge remote-tracking branch 'upstream/2016.11' into fix-apache-config-multi-entity
 
     * 4164047951 Fix apache.config with multiple statement At this moment when you post more than
-      one statement in config only last is used. Also file is rewrited multiple times until last
+      one statement in config only last is used. Also file is rewritten multiple times until last
       statement is written. Example: salt '*' apache.config /etc/httpd/conf.d/ports.conf
       config="[{'Listen': '8080'}, {'Proxy': "Something"}]" Ends only with Proxy Something and
       ignore Listen 8080, This patch fix this issue.

--- a/doc/topics/releases/2017.7.5.rst
+++ b/doc/topics/releases/2017.7.5.rst
@@ -879,7 +879,7 @@ Changelog for v2017.7.4..v2017.7.5
 * **PR** `#45932`_: (`The-Loeki`_) Fix cmd run_all bg error
   @ *2018-02-16 14:53:15 UTC*
 
-  * **PR** `#39980`_: (`vutny`_) [2016.3] Allow to use `bg` kwarg for `cmd.run` state function (refs: `#45932`_)
+  * **PR** `#39980`_: (`vutny`_) [2016.3] Allow using `bg` kwarg for `cmd.run` state function (refs: `#45932`_)
 
   * 5e0e2a30e2 Merge pull request `#45932`_ from The-Loeki/fix_cmd_run_all_bg
 

--- a/doc/topics/releases/2017.7.6.rst
+++ b/doc/topics/releases/2017.7.6.rst
@@ -282,14 +282,14 @@ Changelog for v2017.7.5..v2017.7.6
 
 * **ISSUE** `#45790`_: (`bdarnell`_) Test with Tornado 5.0b1 (refs: `#47106`_, `#47433`_)
 
-* **PR** `#47433`_: (`s0undt3ch`_) Add missing requirements files not commited in `#47106`_
+* **PR** `#47433`_: (`s0undt3ch`_) Add missing requirements files not committed in `#47106`_
   @ *2018-05-02 20:57:14 UTC*
 
   * **PR** `#47106`_: (`DmitryKuzmenko`_) Tornado50 compatibility fixes (refs: `#47433`_)
 
   * ed69821d19 Merge pull request `#47433`_ from s0undt3ch/2017.7
 
-  * 5abadf25d6 Add missing requirements files not commited in `#47106`_
+  * 5abadf25d6 Add missing requirements files not committed in `#47106`_
 
 * **ISSUE** `#47424`_: (`bcharron`_) "salt-cloud -m" fails with nova driver: "There was a query error: u'state'" (refs: `#47429`_)
 
@@ -495,7 +495,7 @@ Changelog for v2017.7.5..v2017.7.6
 
   * 65c3ba7ff1 Remove useless documentation
 
-  * 5d67cb27de Remove unncessary commented line
+  * 5d67cb27de Remove unnecessary commented line
 
 * **PR** `#47347`_: (`dwoz`_) Proper fix for mysql tests
   @ *2018-04-27 17:27:53 UTC*
@@ -563,7 +563,7 @@ Changelog for v2017.7.5..v2017.7.6
 
   * 85451f48d4 Fix python 3 support for inet_pton function
 
-* **PR** `#47339`_: (`dwoz`_) Use salt.utils.fopen for line ending consistancy
+* **PR** `#47339`_: (`dwoz`_) Use salt.utils.fopen for line ending consistency
   @ *2018-04-26 22:39:56 UTC*
 
   * e4779f3246 Merge pull request `#47339`_ from dwoz/ssh_key_test_fix
@@ -572,7 +572,7 @@ Changelog for v2017.7.5..v2017.7.6
 
   * b2ae5889b7 Close the temporary file handle
 
-  * 9f7f83a975 Use salt.utils.fopen for line ending consistancy
+  * 9f7f83a975 Use salt.utils.fopen for line ending consistency
 
 * **PR** `#47335`_: (`dwoz`_) Remove un-needed string-escape
   @ *2018-04-26 21:49:27 UTC*
@@ -718,7 +718,7 @@ Changelog for v2017.7.5..v2017.7.6
 
   * **PR** `#47207`_: (`benediktwerner`_) Fix pip_state with pip3 if no changes occourred (refs: `#47220`_)
 
-  * **PR** `#47102`_: (`gtmanfred`_) dont allow using no_use_wheel for pip 10.0.0 or newer (refs: `#47220`_)
+  * **PR** `#47102`_: (`gtmanfred`_) don't allow using no_use_wheel for pip 10.0.0 or newer (refs: `#47220`_)
 
   * 4e2e1f0719 Merge pull request `#47220`_ from benediktwerner/fix-pip-2017.7
 
@@ -900,7 +900,7 @@ Changelog for v2017.7.5..v2017.7.6
 
   * bd0c23396c fix pip.req import error in pip 10.0.0
 
-* **PR** `#47102`_: (`gtmanfred`_) dont allow using no_use_wheel for pip 10.0.0 or newer (refs: `#47220`_)
+* **PR** `#47102`_: (`gtmanfred`_) don't allow using no_use_wheel for pip 10.0.0 or newer (refs: `#47220`_)
   @ *2018-04-17 20:44:58 UTC*
 
   * eb5ac51a48 Merge pull request `#47102`_ from gtmanfred/2017.7
@@ -911,7 +911,7 @@ Changelog for v2017.7.5..v2017.7.6
 
   * 4c07a3d1e9 fix other tests
 
-  * b71e3d8a04 dont allow using no_use_wheel for pip 10.0.0 or newer
+  * b71e3d8a04 don't allow using no_use_wheel for pip 10.0.0 or newer
 
 * **PR** `#47037`_: (`twangboy`_) Fix build_env scripts
   @ *2018-04-17 18:54:17 UTC*
@@ -1259,7 +1259,7 @@ Changelog for v2017.7.5..v2017.7.6
 
   * 058bbed221 Merge pull request `#46799`_ from garethgreenaway/46762_prereq_shenanigans_tests
 
-  * 13875e78cf Fixing documention string for test.
+  * 13875e78cf Fixing documentation string for test.
 
   * 3d288c44d4 Fixing test documentation
 
@@ -1399,7 +1399,7 @@ Changelog for v2017.7.5..v2017.7.6
 
   * 2bee383e9d correct create list item value names if the valuePrefix attribute does not exist on the list item, the value is the value name, other wise, the valuename a number with the valuePrefix prepended to it
 
-* **ISSUE** `#46347`_: (`twangboy`_) Buid 449: unit.modules.test_inspect_collector (refs: `#46675`_)
+* **ISSUE** `#46347`_: (`twangboy`_) Build 449: unit.modules.test_inspect_collector (refs: `#46675`_)
 
 * **PR** `#46675`_: (`dwoz`_) Skip test when git symlinks are not configured
   @ *2018-04-03 12:19:19 UTC*
@@ -1570,11 +1570,11 @@ Changelog for v2017.7.5..v2017.7.6
 * **PR** `#46732`_: (`rallytime`_) Back-port `#46032`_ to 2017.7
   @ *2018-03-28 13:43:17 UTC*
 
-  * **PR** `#46032`_: (`DmitryKuzmenko`_) Workaroung python bug in traceback.format_exc() (refs: `#46732`_)
+  * **PR** `#46032`_: (`DmitryKuzmenko`_) Workaround python bug in traceback.format_exc() (refs: `#46732`_)
 
   * 1222bdbc00 Merge pull request `#46732`_ from rallytime/bp-46032
 
-  * bf0b962dc0 Workaroung python bug in traceback.format_exc()
+  * bf0b962dc0 Workaround python bug in traceback.format_exc()
 
 * **ISSUE** `#28142`_: (`zmalone`_) Deprecate or update the copr repo (refs: `#46749`_)
 
@@ -1829,7 +1829,7 @@ Changelog for v2017.7.5..v2017.7.6
 
   * f038e3c452 Merge pull request `#46571`_ from garethgreenaway/46552_onfail_and_require
 
-  * 152c43c843 Accounting for a case when multiple onfails are used along with requires.  Previously if you have multiple states using 'onfail' and two of those states using a 'require' against the first one state, the last two will run even if the 'onfail' isn't met because the 'require' is met because the first state returns true even though it didn't excute.  This change adds an additional hidden variable that is used when checking requisities to determine if the state actually ran.
+  * 152c43c843 Accounting for a case when multiple onfails are used along with requires.  Previously if you have multiple states using 'onfail' and two of those states using a 'require' against the first one state, the last two will run even if the 'onfail' isn't met because the 'require' is met because the first state returns true even though it didn't execute.  This change adds an additional hidden variable that is used when checking requisities to determine if the state actually ran.
 
 * **ISSUE** `#46512`_: (`blarghmatey`_) git.pull failing when run from the salt scheduler (refs: `#46520`_)
 
@@ -1917,11 +1917,11 @@ Changelog for v2017.7.5..v2017.7.6
 * **PR** `#46511`_: (`rallytime`_) Back-port `#45769`_ to 2017.7
   @ *2018-03-13 17:08:52 UTC*
 
-  * **PR** `#45769`_: (`Quarky9`_) Surpress boto WARNING during SQS msg decode in sqs_engine (refs: `#46511`_)
+  * **PR** `#45769`_: (`Quarky9`_) Suppress boto WARNING during SQS msg decode in sqs_engine (refs: `#46511`_)
 
   * 5cc11129f1 Merge pull request `#46511`_ from rallytime/bp-45769
 
-  * a8ffceda53 Surpress boto WARNING during decode, reference: https://github.com/boto/boto/issues/2965
+  * a8ffceda53 Suppress boto WARNING during decode, reference: https://github.com/boto/boto/issues/2965
 
 .. _`#20581`: https://github.com/saltstack/salt/issues/20581
 .. _`#20639`: https://github.com/saltstack/salt/issues/20639

--- a/doc/topics/releases/2017.7.8.rst
+++ b/doc/topics/releases/2017.7.8.rst
@@ -405,7 +405,7 @@ Changelog for v2017.7.7..v2017.7.8
 
   * 8a1285239a Merge pull request `#48426`_ from garethgreenaway/46689_fixing_pkg_held_when_package_is_installed
 
-  * 9b0f5dd212 Fixing identation, removing some unnecessary conditionals.
+  * 9b0f5dd212 Fixing indentation, removing some unnecessary conditionals.
 
   * 727964ab55 One last cleanup.
 
@@ -601,7 +601,7 @@ Changelog for v2017.7.7..v2017.7.8
 
   * 83e4bba916 Merge pull request `#48635`_ from nbraud/acme
 
-  * 3673bae9de modules/acme: explicitely ignore the `perms` return value
+  * 3673bae9de modules/acme: explicitly ignore the `perms` return value
 
   * 1800a231e8 Fixup some schema expectations
 
@@ -787,9 +787,9 @@ Changelog for v2017.7.7..v2017.7.8
 
   * 1b6e6388f8 Merge pull request `#48588`_ from garethgreenaway/48415_event_send_multi_master
 
-  * fab25af1a9 Adding some quick documention about why we are setting ret=True following the channel.send.
+  * fab25af1a9 Adding some quick documentation about why we are setting ret=True following the channel.send.
 
-  * bf78f4b188 If the channel send is sucessful and does not raise an exception, we set ret to True, in case a previous exception from a previous channel send to another master has sent it to False.
+  * bf78f4b188 If the channel send is successful and does not raise an exception, we set ret to True, in case a previous exception from a previous channel send to another master has sent it to False.
 
   * 8d1551c5fb When using Salt multi-master, if we encouter a salt master that has not accepted the minion key yet we should not exit right away, rather continue on and try the next salt master available in the list.
 
@@ -1262,11 +1262,11 @@ Changelog for v2017.7.7..v2017.7.8
 * **PR** `#48293`_: (`rallytime`_) Back-port `#47453`_ to 2017.7
   @ *2018-06-25 19:06:42 UTC*
 
-  * **PR** `#47453`_: (`dqminh`_) dont reset system locale when running rabbitmqctl commands (refs: `#48293`_)
+  * **PR** `#47453`_: (`dqminh`_) don't reset system locale when running rabbitmqctl commands (refs: `#48293`_)
 
   * 06a927b2aa Merge pull request `#48293`_ from rallytime/bp-47453
 
-  * e96ab6778e dont reset system locale when running rabbitmqctl commands
+  * e96ab6778e don't reset system locale when running rabbitmqctl commands
 
 * **PR** `#48219`_: (`zer0def`_) Fix: LXC legacy configuration key warnings falsely report errors during state change
   @ *2018-06-25 13:46:07 UTC*
@@ -1293,7 +1293,7 @@ Changelog for v2017.7.7..v2017.7.8
 
   * 83d7d286c4 Merge pull request `#48080`_ from lusche/2017.7
 
-  * 917dc985fc `#47984`_ remove the line completly
+  * 917dc985fc `#47984`_ remove the line completely
 
   * ba12ee947b Merge branch '2017.7' of https://github.com/saltstack/salt into 2017.7
 
@@ -1902,12 +1902,12 @@ Changelog for v2017.7.7..v2017.7.8
 
   * 4475ba19b8 Prevent zypper from parsing repo configuration from not .repo files
 
-* **PR** `#47781`_: (`rallytime`_) Update cloud test profile and docs to use new Linode size lables
+* **PR** `#47781`_: (`rallytime`_) Update cloud test profile and docs to use new Linode size labels
   @ *2018-05-23 13:09:13 UTC*
 
   * 0e87559ee3 Merge pull request `#47781`_ from rallytime/update-linode-sizes
 
-  * a90c1b760e Update cloud test profile and docs to use new Linode size lables
+  * a90c1b760e Update cloud test profile and docs to use new Linode size labels
 
 * **PR** `#47748`_: (`rallytime`_) [2017.7] Merge forward from 2017.7.6 to 2017.7
   @ *2018-05-22 20:53:02 UTC*
@@ -2258,12 +2258,12 @@ Changelog for v2017.7.7..v2017.7.8
 
   * d22ed7dffa added handling for the aws error ConflictingDomainExists
 
-* **PR** `#47444`_: (`terminalmage`_) Skip trying to render a template for a nonexistant SLS file
+* **PR** `#47444`_: (`terminalmage`_) Skip trying to render a template for a nonexistent SLS file
   @ *2018-05-07 13:48:24 UTC*
 
   * 7f53be6e92 Merge pull request `#47444`_ from terminalmage/render_state-spurious-error
 
-  * a1e9fe00fd Skip trying to render a template for a nonexistant SLS file
+  * a1e9fe00fd Skip trying to render a template for a nonexistent SLS file
 
 * **PR** `#47478`_: (`terminalmage`_) Rename pip state test modules to match naming convention
   @ *2018-05-07 13:13:13 UTC*

--- a/doc/topics/releases/2017.7.9.rst
+++ b/doc/topics/releases/2017.7.9.rst
@@ -11,6 +11,6 @@ Salt Cloud Features
 GCE Driver
 ----------
 The GCE salt cloud driver can now be used with GCE instance credentials by
-setting the configuration paramaters ``service_account_private_key`` and
+setting the configuration parameters ``service_account_private_key`` and
 ``service_account_private_email`` to an empty string.
 

--- a/doc/topics/releases/2018.3.1.rst
+++ b/doc/topics/releases/2018.3.1.rst
@@ -73,7 +73,7 @@ Changes to Automatically Updating the Roster File
 
 In ``2018.3.0`` salt-ssh was configured to automatically update the flat roster
 file if a minion was not found for salt-ssh. This was decided to be
-undesireable as a default.  The ``--skip-roster`` flag has been removed and
+undesirable as a default.  The ``--skip-roster`` flag has been removed and
 replaced  with ``--update-roster``, which will enable salt-ssh to add minions
 to the flat roster file.  This behavior can also be enabled by setting
 ``ssh_update_roster: True`` in the master config file.
@@ -504,7 +504,7 @@ Changelog for v2018.3.0..v2018.3.1
 
     * ed69821d19 Merge pull request `#47433`_ from s0undt3ch/2017.7
 
-      * 5abadf25d6 Add missing requirements files not commited in `#47106`_
+      * 5abadf25d6 Add missing requirements files not committed in `#47106`_
 
 * **ISSUE** `#47443`_: (`skylerberg`_) Input validation does not raise SaltInvocationError in win_dsc.py (refs: `#47505`_)
 
@@ -796,7 +796,7 @@ Changelog for v2018.3.0..v2018.3.1
 
       * 65c3ba7ff1 Remove useless documentation
 
-      * 5d67cb27de Remove unncessary commented line
+      * 5d67cb27de Remove unnecessary commented line
 
             * 8de3d41adb fixed vpc_peering_connection_name option
 
@@ -941,7 +941,7 @@ Changelog for v2018.3.0..v2018.3.1
 
       * b2ae5889b7 Close the temporary file handle
 
-      * 9f7f83a975 Use salt.utils.fopen for line ending consistancy
+      * 9f7f83a975 Use salt.utils.fopen for line ending consistency
 
     * b221860151 Merge pull request `#47335`_ from dwoz/pip_test_fix
 
@@ -1263,12 +1263,12 @@ Changelog for v2018.3.0..v2018.3.1
 
   * 9075070573 make sure not to send invalid information
 
-* **ISSUE** `#46977`_: (`gtmanfred`_) [2018.3.0] Backwards compatibilty breaking change in 2018.3.0 (refs: `#47038`_)
+* **ISSUE** `#46977`_: (`gtmanfred`_) [2018.3.0] Backwards compatibility breaking change in 2018.3.0 (refs: `#47038`_)
 
 * **PR** `#47038`_: (`garethgreenaway`_) [2018.3] fix to fileclient.py
   @ *2018-04-25 14:57:04 UTC*
 
-  * 205701dcbe Merge pull request `#47038`_ from garethgreenaway/46977_fixing_fileclient_forward_compatibilty
+  * 205701dcbe Merge pull request `#47038`_ from garethgreenaway/46977_fixing_fileclient_forward_compatibility
 
   * ba01d2133a Updating version.py to include Magnesium.
 
@@ -1401,7 +1401,7 @@ Changelog for v2018.3.0..v2018.3.1
 
   * 2ed4b38b02 Merge pull request `#47142`_ from garethgreenaway/47047_passing_pillar_to_slack_aliases
 
-  * 6f183e1d80 Initial commmit for unit/engines/test_slack_engine
+  * 6f183e1d80 Initial commit for unit/engines/test_slack_engine
 
   * a2840fc230 Only include the rest of the cmdline if the cmd is an alias.
 
@@ -1524,7 +1524,7 @@ Changelog for v2018.3.0..v2018.3.1
 
       * 4c07a3d1e9 fix other tests
 
-      * b71e3d8a04 dont allow using no_use_wheel for pip 10.0.0 or newer
+      * b71e3d8a04 don't allow using no_use_wheel for pip 10.0.0 or newer
 
     * c1dc42e67e Merge pull request `#47037`_ from twangboy/fix_dev_scripts
 
@@ -1760,7 +1760,7 @@ Changelog for v2018.3.0..v2018.3.1
 
   * a52137ee36 Merge pull request `#47109`_ from garethgreenaway/46943_slack_engine_fixes
 
-  * 02baa76595 Fixing a bug that occured when a comment was added to a message sent to Slack by Salt.  Also making `slack_engine:groups_pillar` optional.
+  * 02baa76595 Fixing a bug that occurred when a comment was added to a message sent to Slack by Salt.  Also making `slack_engine:groups_pillar` optional.
 
 * **PR** `#47045`_: (`tankywoo`_) Fix ba7d00f5 for gentoo pkg.installed method
   @ *2018-04-17 13:55:45 UTC*
@@ -1918,18 +1918,18 @@ Changelog for v2018.3.0..v2018.3.1
 
   * c33de7c82d Merge pull request `#47009`_ from garethgreenaway/46947_slack_documentation_update_catch_non_dicts
 
-  * f0fadbb4ce Fixing indention for slack documention.  Updating try..except to ensure we catch when groups aren't dicts.
+  * f0fadbb4ce Fixing indention for slack documentation.  Updating try..except to ensure we catch when groups aren't dicts.
 
 * **PR** `#47023`_: (`rallytime`_) Back-port `#46997`_ to 2018.3
   @ *2018-04-12 15:05:24 UTC*
 
-  * **PR** `#46997`_: (`LukeCarrier`_) Fix respository (=> repository) typo in sls_build (refs: `#47023`_)
+  * **PR** `#46997`_: (`LukeCarrier`_) Fix repository (=> repository) typo in sls_build (refs: `#47023`_)
 
   * **PR** `#44638`_: (`terminalmage`_) Many improvements to docker network and container states (refs: `#46997`_)
 
   * 68d17c71f1 Merge pull request `#47023`_ from rallytime/bp-46997
 
-  * c2c60f4ffc Fix respository (=> repository) typo in sls_build
+  * c2c60f4ffc Fix repository (=> repository) typo in sls_build
 
 * **PR** `#47026`_: (`rallytime`_) [2018.3] Merge forward from 2017.7 to 2018.3
   @ *2018-04-12 14:39:41 UTC*
@@ -2144,7 +2144,7 @@ Changelog for v2018.3.0..v2018.3.1
 
   * dceda5eb88 Moving all jinja filter tests into support/jinja_filters.py.  Updaitng integration/ssh/test_jinja_filters.py to use those tests.  Adding integration/modules/test_state_jinja_filters.py to also use the common jinja filter tests.
 
-  * 07d7e3ca01 Adding a new integration test and corresponding state files to test availabilty of jinja filters when using salt-ssh.
+  * 07d7e3ca01 Adding a new integration test and corresponding state files to test availability of jinja filters when using salt-ssh.
 
 * **ISSUE** `#46880`_: (`liquidgecka`_) rabbitmq_policy broken in 2018.3.0 (refs: `#46973`_)
 
@@ -2273,7 +2273,7 @@ Changelog for v2018.3.0..v2018.3.1
 
     * 058bbed221 Merge pull request `#46799`_ from garethgreenaway/46762_prereq_shenanigans_tests
 
-      * 13875e78cf Fixing documention string for test.
+      * 13875e78cf Fixing documentation string for test.
 
       * 3d288c44d4 Fixing test documentation
 
@@ -2661,7 +2661,7 @@ Changelog for v2018.3.0..v2018.3.1
 
     * 1222bdbc00 Merge pull request `#46732`_ from rallytime/bp-46032
 
-      * bf0b962dc0 Workaroung python bug in traceback.format_exc()
+      * bf0b962dc0 Workaround python bug in traceback.format_exc()
 
     * 50fe1e9480 Merge pull request `#46749`_ from vutny/doc-deprecate-copr
 
@@ -2863,7 +2863,7 @@ Changelog for v2018.3.0..v2018.3.1
 
     * f038e3c452 Merge pull request `#46571`_ from garethgreenaway/46552_onfail_and_require
 
-      * 152c43c843 Accounting for a case when multiple onfails are used along with requires.  Previously if you have multiple states using 'onfail' and two of those states using a 'require' against the first one state, the last two will run even if the 'onfail' isn't met because the 'require' is met because the first state returns true even though it didn't excute.  This change adds an additional hidden variable that is used when checking requisities to determine if the state actually ran.
+      * 152c43c843 Accounting for a case when multiple onfails are used along with requires.  Previously if you have multiple states using 'onfail' and two of those states using a 'require' against the first one state, the last two will run even if the 'onfail' isn't met because the 'require' is met because the first state returns true even though it didn't execute.  This change adds an additional hidden variable that is used when checking requisities to determine if the state actually ran.
 
     * 2677330e19 Merge pull request `#46520`_ from gtmanfred/2017.7
 
@@ -2937,7 +2937,7 @@ Changelog for v2018.3.0..v2018.3.1
 
   * f15f92318d Add tests for salt.utils.win_reg
 
-  * f7112b19a2 Submit `#46527`_ agains 2018.3
+  * f7112b19a2 Submit `#46527`_ against 2018.3
 
 * **ISSUE** `#46334`_: (`sjorge`_) [2018.3.0rc1] Stacktrace on call to nacl.dec (refs: `#46426`_)
 
@@ -3032,7 +3032,7 @@ Changelog for v2018.3.0..v2018.3.1
 
     * 5cc11129f1 Merge pull request `#46511`_ from rallytime/bp-45769
 
-      * a8ffceda53 Surpress boto WARNING during decode, reference: https://github.com/boto/boto/issues/2965
+      * a8ffceda53 Suppress boto WARNING during decode, reference: https://github.com/boto/boto/issues/2965
 
     * 0e90c8ca6f Merge pull request `#46493`_ from terminalmage/issue46207
 
@@ -3559,7 +3559,7 @@ Changelog for v2018.3.0..v2018.3.1
 
   * **PR** `#45932`_: (`The-Loeki`_) Fix cmd run_all bg error (refs: `#46172`_)
 
-  * **PR** `#39980`_: (`vutny`_) [2016.3] Allow to use `bg` kwarg for `cmd.run` state function (refs: `#46172`_, `#45932`_)
+  * **PR** `#39980`_: (`vutny`_) [2016.3] Allow using `bg` kwarg for `cmd.run` state function (refs: `#46172`_, `#45932`_)
 
   * 20d869c228 Merge pull request `#46172`_ from The-Loeki/fix_cmd_run_all_bg_oxygen
 

--- a/doc/topics/releases/2018.3.3.rst
+++ b/doc/topics/releases/2018.3.3.rst
@@ -1202,7 +1202,7 @@ Changelog for v2018.3.2..v2018.3.3
 
   * abd7f1312d Merge pull request `#48928`_ from Ch3LL/mac_runas
 
-  * 3d6455dbcd remove unecessary comment in setup
+  * 3d6455dbcd remove unnecessary comment in setup
 
   * 8e30db0217 move destructivetest to testname
 
@@ -1312,12 +1312,12 @@ Changelog for v2018.3.2..v2018.3.3
 
 * **ISSUE** `#37512`_: (`ChristianBeer`_) What's the precedence if multiple master configurations are specified? (refs: `#48888`_)
 
-* **PR** `#48888`_: (`terminalmage`_) Explictly document the configuration override priority
+* **PR** `#48888`_: (`terminalmage`_) Explicitly document the configuration override priority
   @ *2018-08-02 16:57:18 UTC*
 
   * ec8e07e8ce Merge pull request `#48888`_ from terminalmage/issue37512
 
-  * 7dce7cde14 Explictly document the configuration override priority
+  * 7dce7cde14 Explicitly document the configuration override priority
 
 * **PR** `#48871`_: (`dwoz`_) Remove unicode key pairs from environ after test
   @ *2018-08-01 22:33:41 UTC*
@@ -1354,7 +1354,7 @@ Changelog for v2018.3.2..v2018.3.3
 
     * 8a1285239a Merge pull request `#48426`_ from garethgreenaway/46689_fixing_pkg_held_when_package_is_installed
 
-      * 9b0f5dd212 Fixing identation, removing some unnecessary conditionals.
+      * 9b0f5dd212 Fixing indentation, removing some unnecessary conditionals.
 
       * 727964ab55 One last cleanup.
 
@@ -1524,7 +1524,7 @@ Changelog for v2018.3.2..v2018.3.3
 
   * 95329acb1e Fileserver transfers bytes
 
-  * aa34a80997 Always trasfer bytes from fileserver roots
+  * aa34a80997 Always transfer bytes from fileserver roots
 
 * **PR** `#48822`_: (`Ch3LL`_) Fix salt-ssh state.sls_id TypeError key must be a string
   @ *2018-07-30 20:29:29 UTC*
@@ -1702,7 +1702,7 @@ Changelog for v2018.3.2..v2018.3.3
 
     * 83e4bba916 Merge pull request `#48635`_ from nbraud/acme
 
-      * 3673bae9de modules/acme: explicitely ignore the `perms` return value
+      * 3673bae9de modules/acme: explicitly ignore the `perms` return value
 
       * 1800a231e8 Fixup some schema expectations
 
@@ -1814,9 +1814,9 @@ Changelog for v2018.3.2..v2018.3.3
 
     * 1b6e6388f8 Merge pull request `#48588`_ from garethgreenaway/48415_event_send_multi_master
 
-      * fab25af1a9 Adding some quick documention about why we are setting ret=True following the channel.send.
+      * fab25af1a9 Adding some quick documentation about why we are setting ret=True following the channel.send.
 
-      * bf78f4b188 If the channel send is sucessful and does not raise an exception, we set ret to True, in case a previous exception from a previous channel send to another master has sent it to False.
+      * bf78f4b188 If the channel send is successful and does not raise an exception, we set ret to True, in case a previous exception from a previous channel send to another master has sent it to False.
 
       * 8d1551c5fb When using Salt multi-master, if we encouter a salt master that has not accepted the minion key yet we should not exit right away, rather continue on and try the next salt master available in the list.
 
@@ -2618,7 +2618,7 @@ Changelog for v2018.3.2..v2018.3.3
 
   * 06a927b2aa Merge pull request `#48293`_ from rallytime/bp-47453
 
-    * e96ab6778e dont reset system locale when running rabbitmqctl commands
+    * e96ab6778e don't reset system locale when running rabbitmqctl commands
 
 * **ISSUE** `#45939`_: (`andygabby`_) user.present with hash_password: True detects change on every state.apply/highstate (refs: `#47147`_)
 
@@ -2654,7 +2654,7 @@ Changelog for v2018.3.2..v2018.3.3
 
     * 83d7d286c4 Merge pull request `#48080`_ from lusche/2017.7
 
-      * 917dc985fc `#47984`_ remove the line completly
+      * 917dc985fc `#47984`_ remove the line completely
 
       * ba12ee947b Merge branch '2017.7' of https://github.com/saltstack/salt into 2017.7
 
@@ -3168,7 +3168,7 @@ Changelog for v2018.3.2..v2018.3.3
 
   * a040643a82 Accounting for certain situations when the query result is not a string, but actually a dictionary.
 
-* **ISSUE** `#48113`_: (`gaetanquentin`_) state file.line has error and  erase file content completly, while with mode  test=true it is ok (refs: `#48156`_)
+* **ISSUE** `#48113`_: (`gaetanquentin`_) state file.line has error and  erase file content completely, while with mode  test=true it is ok (refs: `#48156`_)
 
 * **PR** `#48156`_: (`garethgreenaway`_) [2018.3] Unicode fixes for file.line
   @ *2018-06-17 19:34:08 UTC*
@@ -4011,7 +4011,7 @@ Changelog for v2018.3.2..v2018.3.3
 
     * 0e87559ee3 Merge pull request `#47781`_ from rallytime/update-linode-sizes
 
-      * a90c1b760e Update cloud test profile and docs to use new Linode size lables
+      * a90c1b760e Update cloud test profile and docs to use new Linode size labels
 
     * 3ddc56cb9b Merge pull request `#47748`_ from rallytime/merge-2017.7
 
@@ -4577,7 +4577,7 @@ Changelog for v2018.3.2..v2018.3.3
 
   * 7f53be6e92 Merge pull request `#47444`_ from terminalmage/render_state-spurious-error
 
-    * a1e9fe00fd Skip trying to render a template for a nonexistant SLS file
+    * a1e9fe00fd Skip trying to render a template for a nonexistent SLS file
 
   * 50b9c4d79d Merge pull request `#47478`_ from terminalmage/rename-pip-state-test
 

--- a/doc/topics/releases/2018.3.4.rst
+++ b/doc/topics/releases/2018.3.4.rst
@@ -1494,7 +1494,7 @@ Changelog for v2018.3.3..v2018.3.4
 
   * 60b4622 Merge pull request `#50366`_ from jdsieci/2018.3-fix-issue50254
 
-  * a9b9fa2 Fixed pylint warnigs
+  * a9b9fa2 Fixed pylint warnings
 
   * 342786b Issue `#50254`_ fixed
 
@@ -1849,7 +1849,7 @@ Changelog for v2018.3.3..v2018.3.4
   * 77e8dcc On later versions of elementary, the os_family is being populated as elementary.
     In order for the aptpkg module to function, we need to override is to be Debian.
 
-* **ISSUE** `#50311`_: (`marek-obuchowicz`_) pkg.installed state fails even though it suceeded (refs: `#50590`_, `#50333`_)
+* **ISSUE** `#50311`_: (`marek-obuchowicz`_) pkg.installed state fails even though it succeeded (refs: `#50590`_, `#50333`_)
 
 * **ISSUE** `#46689`_: (`mxork`_) pkg.installed: hold: True not applied to a package which is already installed. (refs: `#48426`_)
 
@@ -2471,7 +2471,7 @@ Changelog for v2018.3.3..v2018.3.4
 
     * f28a4fa Merge pull request `#50211`_ from channias/fix-spm-modules-install
 
-      * 9b203d5 Fix broken install of additionnal modules in SPM packages
+      * 9b203d5 Fix broken install of additional modules in SPM packages
 
     * 6b4e07b Merge pull request `#50212`_ from dwoz/test_no_fail
 
@@ -3205,7 +3205,7 @@ Changelog for v2018.3.3..v2018.3.4
 
   * eee82d3 Merge pull request `#49875`_ from dwoz/win_spm_tests
 
-  * e76a751 Use os.path.split for more consistancy
+  * e76a751 Use os.path.split for more consistency
 
   * bc54d15 Fix wart in spm on windows
 
@@ -3266,7 +3266,7 @@ Changelog for v2018.3.3..v2018.3.4
 
     * 9ef9206 Actually catch the exception when we fail
 
-            * 19072f0 Use os.path.split for more consistancy
+            * 19072f0 Use os.path.split for more consistency
 
             * 6c22459 Merge remote-tracking branch 'origin/shelltests' into shelltests
 
@@ -3404,13 +3404,13 @@ Changelog for v2018.3.3..v2018.3.4
 * **PR** `#49846`_: (`rallytime`_) Back-port `#49650`_ and `#49827`_ to 2018.3
   @ *2018-10-01 20:05:24 UTC*
 
-  * **PR** `#49827`_: (`dgmorrisjr`_) fixing mis-spelling of lattrs in file.py, referncing `#49204`_  (refs: `#49846`_)
+  * **PR** `#49827`_: (`dgmorrisjr`_) fixing mis-spelling of lattrs in file.py, referencing `#49204`_  (refs: `#49846`_)
 
   * **PR** `#49650`_: (`Yxnt`_) fix aliyun cloud typeerror (refs: `#49846`_)
 
   * 93d064a Merge pull request `#49846`_ from rallytime/bp-49650
 
-  * fb7fed7 referncing `#49204`_, fixing mis-spelling of lattrs on line 4514 per request from @gtmanfred
+  * fb7fed7 referencing `#49204`_, fixing mis-spelling of lattrs on line 4514 per request from @gtmanfred
 
   * ec9fa92 use stringutils instead of hard code
 
@@ -3431,7 +3431,7 @@ Changelog for v2018.3.3..v2018.3.4
 
   * 44ee2ec Updating default for retry_dns_count
 
-  * 75f64a6 Removing unneccesary code.
+  * 75f64a6 Removing unnecessary code.
 
   * e66dc18 Updating the resolve_dns function in minion.py to include a new minion configuration option which will control how many attempts will be made when the master hostname is unable to be resolved before giving up.
 
@@ -3691,7 +3691,7 @@ Changelog for v2018.3.3..v2018.3.4
 
   * d40c034 Fix index error when running on Python 3
 
-* **PR** `#49720`_: (`cstarke`_) Seperate prlctl and prlsrvctl checks into each requiring function
+* **PR** `#49720`_: (`cstarke`_) Separate prlctl and prlsrvctl checks into each requiring function
   @ *2018-09-21 13:32:46 UTC*
 
   * e7bbb83 Merge pull request `#49720`_ from cstarke/2018.3
@@ -3704,7 +3704,7 @@ Changelog for v2018.3.3..v2018.3.4
 
   * 9034c4e Add import for CommandExecutionError
 
-  * 752b6f8 Seperate prlctl and prlsrvctl checks into each requiring function
+  * 752b6f8 Separate prlctl and prlsrvctl checks into each requiring function
 
 * **PR** `#49615`_: (`terminalmage`_) ping_interval: use service.restart instead of signaling
   @ *2018-09-21 13:26:41 UTC*

--- a/doc/topics/releases/2019.2.1.rst
+++ b/doc/topics/releases/2019.2.1.rst
@@ -201,7 +201,7 @@ Changelog for v2019.2.0..v2019.2.1
 
   * 94c03e5 Merge pull request `#54338`_ from dwoz/logging_fixup
 
-  * a3e227e Log server closes completely durring shutdown
+  * a3e227e Log server closes completely during shutdown
 
 * **PR** `#54327`_: (`garethgreenaway`_) [2019.2.1] Catch the AccessDenied exception and continue when running under Py3.
   @ *2019-08-29 16:59:34 UTC*
@@ -265,7 +265,7 @@ Changelog for v2019.2.0..v2019.2.1
 
   * 659c805 Change noise log to debug
 
-  * 0660b1a Clean up typoes
+  * 0660b1a Clean up typos
 
   * 9f1fe42 Call os.fork less to avoid race conditions
 
@@ -404,7 +404,7 @@ Changelog for v2019.2.0..v2019.2.1
 
   * b3c70c3 Merge pull request `#54264`_ from dwoz/jinja_units
 
-  * 10a6d53 Fix unit utils jinja when run on thier own
+  * 10a6d53 Fix unit utils jinja when run on their own
 
 * **PR** `#54266`_: (`Akm0d`_) Fix incorrect types on failing cloud tests
   @ *2019-08-21 17:14:40 UTC*
@@ -1019,12 +1019,12 @@ Changelog for v2019.2.0..v2019.2.1
 
   * ceaba05 Skip get time test
 
-* **PR** `#54038`_: (`Ch3LL`_) Pyton3 digitial ocean test fix: to_str on key
+* **PR** `#54038`_: (`Ch3LL`_) Pyton3 digital ocean test fix: to_str on key
   @ *2019-07-29 16:54:19 UTC*
 
   * 4aed833 Merge pull request `#54038`_ from Ch3LL/do_py3_fix
 
-  * f7346db Pyton3 digitial ocean test fix: to_str on key
+  * f7346db Pyton3 digital ocean test fix: to_str on key
 
       * 05cd93f fixs integration terminate error
 
@@ -1050,7 +1050,7 @@ Changelog for v2019.2.0..v2019.2.1
 
   * cc1cda1 Merge pull request `#53953`_ from Ch3LL/improve_git_test
 
-  * 347ea1e Use Sigkill and add time.sleep befor check
+  * 347ea1e Use Sigkill and add time.sleep before check
 
   * 637bf95 Merge branch '2019.2.1' into improve_git_test
 
@@ -1611,11 +1611,11 @@ Changelog for v2019.2.0..v2019.2.1
 
   * 353f9d4 Fixing the beacons.reset function.  Once the reset has taken place in beacons/__init__.py we need to fire an event back to complete the loop and ensure that everything worked as expected.
 
-  * ee3cbc7 fix to how the depends decorator works.  Only run the dependancy commands for the module we're checking.
+  * ee3cbc7 fix to how the depends decorator works.  Only run the dependency commands for the module we're checking.
 
   * 8440176 Fixing a log issue that pops up after test_gen_thin_compression_fallback_py3 on "OS X, need to ensure that salt.utils.thin.os.close is mocked.
 
-  * 9767ddd Format for the sqlite3 databse used for the assistive information changed in Mojave, additional columns added.
+  * 9767ddd Format for the sqlite3 database used for the assistive information changed in Mojave, additional columns added.
 
   * 9c8a7e6 Fixing a bug when the roots fileserver and the location is a symlink to another location.  This fix ensures that when fsroot is referenced we are using the real path and not the symlink path.
 
@@ -2161,7 +2161,7 @@ Changelog for v2019.2.0..v2019.2.1
 
             * 78aeb61 Dropping the version check for InstallationError down to anything 1.0 or greater.  Removing the test that simulates versions of pip below 1.0.
 
-            * 4ec90c2 Adding an jinja if statement to only the python parameter if the result from get_python_executable is a valid value.  Maintaining backwards compatibilty to run tests without Nox.
+            * 4ec90c2 Adding an jinja if statement to only the python parameter if the result from get_python_executable is a valid value.  Maintaining backwards compatibility to run tests without Nox.
 
 * **PR** `#53192`_: (`twangboy`_) Skip `test_gen_hash` test on Windows
   @ *2019-05-23 05:33:13 UTC*
@@ -2407,7 +2407,7 @@ Changelog for v2019.2.0..v2019.2.1
 
   * 6375944 Add ubuntu1804 to pr tests
 
-  * 8fdb04d SIGKILL is not alwasy available use a local variable
+  * 8fdb04d SIGKILL is not always available use a local variable
 
   * 4d6b8da Fix linter
 
@@ -2441,9 +2441,9 @@ Changelog for v2019.2.0..v2019.2.1
 
   * 52ca668 Skip tests when no libcloud
 
-  * 2cf4b98 Add centos-6-py2 and debain 8,9 py2 and 3 to PR tests
+  * 2cf4b98 Add centos-6-py2 and Debian 8,9 py2 and 3 to PR tests
 
-  * 522599d Dont fail just because some random process died
+  * 522599d Don't fail just because some random process died
 
   * 34cef86 Ignore super not called
 
@@ -2469,7 +2469,7 @@ Changelog for v2019.2.0..v2019.2.1
 
   * f4ae97f Upgrade etcd to > 0.4.2
 
-  * 381f5fe Limit and reduce the ammount of log records sent over the wire
+  * 381f5fe Limit and reduce the amount of log records sent over the wire
 
   * 0c94b5d More entries to ignore
 
@@ -2551,7 +2551,7 @@ Changelog for v2019.2.0..v2019.2.1
 
   * f86a44e Use the real python executable path when running within a virtualenv
 
-  * 3d407e8 Add a helper to return the path to the real pytohn executable
+  * 3d407e8 Add a helper to return the path to the real python executable
 
   * ea9d246 We must also provide `venv_bin` when running within a virtualenv
 
@@ -2567,7 +2567,7 @@ Changelog for v2019.2.0..v2019.2.1
 
   * 870b899 Remove unused argument
 
-  * 1656cb4 Disable re-runing failed tests for now
+  * 1656cb4 Disable re-running failed tests for now
 
   * 6db4141 Also ignore multiprocessing coverage files
 
@@ -3228,7 +3228,7 @@ Changelog for v2019.2.0..v2019.2.1
 
     * 1bdaf29 Ensure exceptions in service future are handled
 
-    * c7ad732 Use six.reraise for py3 compatability
+    * c7ad732 Use six.reraise for py3 compatibility
 
     * 29999b0 Close message service on subscriber close
 
@@ -3499,7 +3499,7 @@ Changelog for v2019.2.0..v2019.2.1
 
   * c9ec8b1 Ensure exceptions in service future are handled
 
-  * 25f5a90 Use six.reraise for py3 compatability
+  * 25f5a90 Use six.reraise for py3 compatibility
 
   * 6d80789 Fix ipc unit tests
 
@@ -3710,7 +3710,7 @@ Changelog for v2019.2.0..v2019.2.1
 
     * ae0e18f Merge branch '2018.3' into zone-clarification
 
-    * e8c8dba Added in an explaination of the --zone flag approved in `#52251`_
+    * e8c8dba Added in an explanation of the --zone flag approved in `#52251`_
 
       * 4908ed3 Merge branch '2017.7' into merge-2018.3
 
@@ -4521,7 +4521,7 @@ Changelog for v2019.2.0..v2019.2.1
 
   * e75fc1c Merge pull request `#51747`_ from ymasson/fix_mysql_grants
 
-    * f614dd7 Fix escaping for special charaters
+    * f614dd7 Fix escaping for special characters
 
   * b1f7e85 Merge pull request `#51387`_ from chrillux/make-binarydata-output-possible
 
@@ -4641,7 +4641,7 @@ Changelog for v2019.2.0..v2019.2.1
 
         * 40cb4db Merge branch '2017.7' into multi_master
 
-        * 2dc5171 Hanlde multi_master failover when daemonized
+        * 2dc5171 Handle multi_master failover when daemonized
 
       * 8df083c Merge pull request `#51608`_ from dwoz/wait_minions_2017.7
 
@@ -4784,9 +4784,9 @@ Changelog for v2019.2.0..v2019.2.1
 
       * d879d18 fix broken network.py
 
-      * 76770f3 ss commmand replace to netstat command
+      * 76770f3 ss command replace to netstat command
 
-      * 241707e ss commmand replace to netstat command
+      * 241707e ss command replace to netstat command
 
             * deeefc7 Merge branch '2018.3' into 51266_schedule_enable_disable_break_save
 
@@ -4948,7 +4948,7 @@ Changelog for v2019.2.0..v2019.2.1
 
           * 5eec144 Add `.coveragerc`
 
-          * aa108d5 Run tests from tox, wether runtests or pytest
+          * aa108d5 Run tests from tox, whether runtests or pytest
 
           * 80a3826 Update TODO
 
@@ -5244,7 +5244,7 @@ Changelog for v2019.2.0..v2019.2.1
 
     * 3f17776 Actually, remove python-ldap. It needs system deps. Have salt-jenkins do it.
 
-    * afcb6bd Fix the `ldap` pacakge name in requirements/tests.txt
+    * afcb6bd Fix the `ldap` package name in requirements/tests.txt
 
     * 588cb87 Merge pull request `#51454`_ from terminalmage/fix-deprecation-warning
 
@@ -5348,7 +5348,7 @@ Changelog for v2019.2.0..v2019.2.1
 
       * 1d4b9f5 Add `.coveragerc`
 
-      * 78c6d68 Run tests from tox, wether runtests or pytest
+      * 78c6d68 Run tests from tox, whether runtests or pytest
 
       * c02757d gitfs: Fix use of deprecated pygit2 function
 
@@ -5364,7 +5364,7 @@ Changelog for v2019.2.0..v2019.2.1
 
               * ad17ac5 Fix mocks to reflect changes to git.latest state
 
-              * c817213 Don't try to run git.config_get_regexp from nonexistant cwd
+              * c817213 Don't try to run git.config_get_regexp from nonexistent cwd
 
               * f8c3e44 git.latest: add auth to merge/reset calls when LFS used with SSH auth
 
@@ -5624,7 +5624,7 @@ Changelog for v2019.2.0..v2019.2.1
 
       * 6a9daa7 Merge branch '2018.3' into 51208_file_manage_escaped_double_quotes
 
-      * 0bf468c Fixing lint.  Using a constant intead of looking for the condition in the string.
+      * 0bf468c Fixing lint.  Using a constant instead of looking for the condition in the string.
 
       * a233dbc Ensuring we can handle a string that contains single quote + an escaped double quote.
 
@@ -5709,7 +5709,7 @@ Changelog for v2019.2.0..v2019.2.1
 
   * 6d62156 Add `.coveragerc`
 
-  * 6bb56ce Run tests from tox, wether runtests or pytest
+  * 6bb56ce Run tests from tox, whether runtests or pytest
 
 * **PR** `#51307`_: (`s0undt3ch`_) Add 2019.2 codecov config
   @ *2019-01-24 13:34:25 UTC*

--- a/doc/topics/releases/2019.2.2.rst
+++ b/doc/topics/releases/2019.2.2.rst
@@ -98,7 +98,7 @@ Changelog for v2019.2.1..v2019.2.2
 
   * 9e3914a Merge pull request `#54826`_ from dwoz/issue_54755
 
-  * 0bad9cb Handle locals and globals separatly
+  * 0bad9cb Handle locals and globals separately
 
   * bcbe9a2 Only purge pip when needed
 


### PR DESCRIPTION
There are various spelling mistakes in the git commit messages in the release notes.

Fix those spelling mistakes. Since each commit is either referenced by the commit has or pull request, fixing those spelling mistakes has no negative effect on finding those commit.