### PR TITLE
Updated renderer docs to mention GPG as a text and data renderer

### DIFF
--- a/doc/ref/renderers/index.rst
+++ b/doc/ref/renderers/index.rst
@@ -19,8 +19,8 @@ Two Kinds of Renderers
 ----------------------
 
 Renderers fall into one of two categories, based on what they output: text or
-data. The one exception to this would be the :mod:`pure python
-<salt.renderers.py>` renderer, which can be used in either capacity.
+data. Some exceptions to this would be the :mod:`pure python
+<salt.renderers.py>` and :mod:`gpg <salt.renderers.gpg>` renderers which could be used in either capacity.
 
 Text Renderers
 **************
@@ -59,7 +59,7 @@ following are all data renderers:
 - :mod:`stateconf <salt.renderers.stateconf>`
 - :mod:`yamlex <salt.renderers.yamlex>`
 - :mod:`yaml <salt.renderers.yaml>`
-
+- :mod:`gpg <salt.renderers.gpg>`
 
 Overriding the Default Renderer
 -------------------------------


### PR DESCRIPTION
### What does this PR do?
Modifies [renderers index page ](https://docs.saltproject.io/en/master/ref/renderers/) by listing gpg renderer as both, text and data renderer
### What issues does this PR fix or reference?
Fixes #58276

### Commits signed with GPG?
No
