### PR TITLE
Make default pki directory configurable

### DIFF
--- a/changelog/3396.added
+++ b/changelog/3396.added
@@ -1,0 +1,5 @@
+Introduce a `LIB_STATE_DIR` syspaths variable which defaults to `CONFIG_DIR`,
+but can be individually customized during installation by specifying
+`--salt-lib-state-dir` during installation. Change the default `pki_dir` to
+`<LIB_STATE_DIR>/pki/master` (for the master) and `<LIB_STATE_DIR>/pki/minion`
+(for the minion).

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -180,9 +180,14 @@ The path to the master's configuration file.
 ``pki_dir``
 -----------
 
-Default: ``/etc/salt/pki/master``
+Default: ``<LIB_STATE_DIR>/pki/master``
 
 The directory to store the pki authentication keys.
+
+``<LIB_STATE_DIR>`` is the pre-configured variable state directory set during
+installation via ``--salt-lib-state-dir``. It defaults to ``/etc/salt``. Systems
+following the Filesystem Hierarchy Standard (FHS) might set it to
+``/var/lib/salt``.
 
 .. code-block:: yaml
 

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -602,9 +602,14 @@ The path to the minion's configuration file.
 ``pki_dir``
 -----------
 
-Default: ``/etc/salt/pki/minion``
+Default: ``<LIB_STATE_DIR>/pki/minion``
 
 The directory used to store the minion's public and private keys.
+
+``<LIB_STATE_DIR>`` is the pre-configured variable state directory set during
+installation via ``--salt-lib-state-dir``. It defaults to ``/etc/salt``. Systems
+following the Filesystem Hierarchy Standard (FHS) might set it to
+``/var/lib/salt``.
 
 .. code-block:: yaml
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -999,7 +999,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze(
         "syndic_finger": "",
         "user": salt.utils.user.get_user(),
         "root_dir": salt.syspaths.ROOT_DIR,
-        "pki_dir": os.path.join(salt.syspaths.CONFIG_DIR, "pki", "minion"),
+        "pki_dir": os.path.join(salt.syspaths.LIB_STATE_DIR, "pki", "minion"),
         "id": "",
         "id_function": {},
         "cachedir": os.path.join(salt.syspaths.CACHE_DIR, "minion"),
@@ -1294,7 +1294,7 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze(
         "keep_jobs": 24,
         "archive_jobs": False,
         "root_dir": salt.syspaths.ROOT_DIR,
-        "pki_dir": os.path.join(salt.syspaths.CONFIG_DIR, "pki", "master"),
+        "pki_dir": os.path.join(salt.syspaths.LIB_STATE_DIR, "pki", "master"),
         "key_cache": "",
         "cachedir": os.path.join(salt.syspaths.CACHE_DIR, "master"),
         "file_roots": {
@@ -1647,7 +1647,7 @@ DEFAULT_PROXY_MINION_OPTS = immutabletypes.freeze(
         "proxy_always_alive": True,
         "proxy_keep_alive": True,  # by default will try to keep alive the connection
         "proxy_keep_alive_interval": 1,  # frequency of the proxy keepalive in minutes
-        "pki_dir": os.path.join(salt.syspaths.CONFIG_DIR, "pki", "proxy"),
+        "pki_dir": os.path.join(salt.syspaths.LIB_STATE_DIR, "pki", "proxy"),
         "cachedir": os.path.join(salt.syspaths.CACHE_DIR, "proxy"),
         "sock_dir": os.path.join(salt.syspaths.SOCK_DIR, "proxy"),
     }

--- a/salt/syspaths.py
+++ b/salt/syspaths.py
@@ -40,6 +40,7 @@ EXPECTED_VARIABLES = (
     "BASE_PILLAR_ROOTS_DIR",
     "BASE_THORIUM_ROOTS_DIR",
     "BASE_MASTER_ROOTS_DIR",
+    "LIB_STATE_DIR",
     "LOGS_DIR",
     "PIDFILE_DIR",
     "SPM_PARENT_PATH",
@@ -193,6 +194,10 @@ BASE_MASTER_ROOTS_DIR = __generated_syspaths.BASE_MASTER_ROOTS_DIR
 if BASE_MASTER_ROOTS_DIR is None:
     BASE_MASTER_ROOTS_DIR = os.path.join(SRV_ROOT_DIR, "salt-master")
 
+LIB_STATE_DIR = __generated_syspaths.LIB_STATE_DIR
+if LIB_STATE_DIR is None:
+    LIB_STATE_DIR = CONFIG_DIR
+
 LOGS_DIR = __generated_syspaths.LOGS_DIR
 if LOGS_DIR is None:
     LOGS_DIR = os.path.join(ROOT_DIR, "var", "log", "salt")
@@ -236,6 +241,7 @@ __all__ = [
     "BASE_PILLAR_ROOTS_DIR",
     "BASE_MASTER_ROOTS_DIR",
     "BASE_THORIUM_ROOTS_DIR",
+    "LIB_STATE_DIR",
     "LOGS_DIR",
     "PIDFILE_DIR",
     "INSTALL_DIR",

--- a/setup.py
+++ b/setup.py
@@ -268,6 +268,7 @@ class GenerateSaltSyspaths(Command):
                 base_pillar_roots_dir=self.distribution.salt_base_pillar_roots_dir,
                 base_master_roots_dir=self.distribution.salt_base_master_roots_dir,
                 base_thorium_roots_dir=self.distribution.salt_base_thorium_roots_dir,
+                lib_state_dir=self.distribution.salt_lib_state_dir,
                 logs_dir=self.distribution.salt_logs_dir,
                 pidfile_dir=self.distribution.salt_pidfile_dir,
                 spm_parent_path=self.distribution.salt_spm_parent_dir,
@@ -665,6 +666,7 @@ BASE_FILE_ROOTS_DIR = {base_file_roots_dir!r}
 BASE_PILLAR_ROOTS_DIR = {base_pillar_roots_dir!r}
 BASE_MASTER_ROOTS_DIR = {base_master_roots_dir!r}
 BASE_THORIUM_ROOTS_DIR = {base_thorium_roots_dir!r}
+LIB_STATE_DIR = {lib_state_dir!r}
 LOGS_DIR = {logs_dir!r}
 PIDFILE_DIR = {pidfile_dir!r}
 SPM_PARENT_PATH = {spm_parent_path!r}
@@ -860,6 +862,11 @@ class SaltDistribution(distutils.dist.Distribution):
             ("salt-sock-dir=", None, "Salt's pre-configured socket directory"),
             ("salt-srv-root-dir=", None, "Salt's pre-configured service directory"),
             (
+                "salt-lib-state-dir=",
+                None,
+                "Salt's pre-configured variable state directory (used for storing pki data)",
+            ),
+            (
                 "salt-base-file-roots-dir=",
                 None,
                 "Salt's pre-configured file roots directory",
@@ -912,6 +919,7 @@ class SaltDistribution(distutils.dist.Distribution):
         self.salt_base_thorium_roots_dir = None
         self.salt_base_pillar_roots_dir = None
         self.salt_base_master_roots_dir = None
+        self.salt_lib_state_dir = None
         self.salt_logs_dir = None
         self.salt_pidfile_dir = None
         self.salt_spm_parent_dir = None


### PR DESCRIPTION
The files in `/etc/salt/pki` are not configuration files in the sense of the FHS ("local file used to control the operation of a program"). Debian wants to change the default location to `/var/lib/salt/pki` (to properly follow FHS and to allow setting StateDirectory in the salt master systemd configuration).

Therefore introduce a `LIB_STATE_DIR` syspaths variable which defaults to `CONFIG_DIR`, but can be individually customized.

This merge proposal is a follow-up of merge proposal #46277 since that MR was closed.

fixes #3396
Bug-Debian: https://bugs.debian.org/698898