### PR TITLE
pillarstack match list item

### DIFF
--- a/salt/pillar/stack.py
+++ b/salt/pillar/stack.py
@@ -403,7 +403,12 @@ def ext_pillar(minion_id, pillar, *args, **kwargs):
                     t, traverse.keys()
                 )
             )
-        cfgs = matchs.get(traverse[t](matcher, None), [])
+        traverse_out = traverse[t](matcher, None)
+        if isinstance(traverse_out, list):
+          list_match = [ key for key in matchs.keys() if key in traverse_out ]
+          cfgs = [ matchs.get(match) for match in list_match ]
+        else:
+          cfgs = matchs.get(traverse_out, [])
         if not isinstance(cfgs, list):
             cfgs = [cfgs]
         stack_config_files += cfgs


### PR DESCRIPTION
### What does this PR do?

In pillarstack you can match a minion by grains.
For example:

``` yaml
ext_pillar:
  - stack:
      grains:host:
        minion1:
          - /path/to/stack1.cfg
          - /path/to/stack2.cfg
```

### Previous Behavior

If the matching grain is a list, the pillar stack file wouldn't assigned to the minion.
In the following case, the pillar stack file would be ignored by the minion:

``` yaml
ext_pillar:
  - stack:
      grains:ipv4:
        127.0.0.1:
          - /path/to/stack1.cfg
          - /path/to/stack2.cfg
```

### New Behavior

After the PR all minions with a ipv4 address of 127.0.0.1 would match and get the pillar stack file.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

