### PR TITLE
3004 has been released.

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -75,7 +75,7 @@ class SaltVersionsInfo(type):
     SODIUM        = SaltVersion("Sodium"       , info=3001,       released=True)
     MAGNESIUM     = SaltVersion("Magnesium"    , info=3002,       released=True)
     ALUMINIUM     = SaltVersion("Aluminium"    , info=3003,       released=True)
-    SILICON       = SaltVersion("Silicon"      , info=3004)
+    SILICON       = SaltVersion("Silicon"      , info=3004,       released=True)
     PHOSPHORUS    = SaltVersion("Phosphorus"   , info=3005)
     SULFUR        = SaltVersion("Sulfur"       , info=3006)
     CHLORINE      = SaltVersion("Chlorine"     , info=3007)


### PR DESCRIPTION
### What does this PR do?

Marks 3004 as having been released in `salt/version.py`
