### PR TITLE
[WIP] GitFS: Fix race condition and leaks between saltenvs/pillarenvs when using "__env__" in remotes configuration

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -2365,7 +2365,7 @@ class GitBase:
         self.remotes = []
         remotes_to_process = list(remotes)
         while remotes_to_process:
-            remote = remotes_to_process.pop()
+            remote = remotes_to_process.pop(0)
             repo_obj = self.git_providers[self.provider](
                 self.opts,
                 remote,

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -2448,8 +2448,9 @@ class GitBase:
 
                 # Do not add '__env__' as remote since new remotes for
                 # available refs have been already added to be processed
-                if hasattr(repo_obj, "branch") and not repo_obj.branch == "__env__":
-                    self.remotes.append(repo_obj)
+                if hasattr(repo_obj, "branch") and repo_obj.branch == "__env__":
+                    continue
+                self.remotes.append(repo_obj)
 
         # Don't allow collisions in cachedir naming
         cachedir_map = {}

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -2432,7 +2432,7 @@ class GitBase:
                     log.debug("Fetching all refs to resolve '__env__' dynamically")
                     repo_obj.fetch()
                     envs = repo_obj.envs()
-                    log.debug("Adding available envs as new remotes: {}".format(envs))
+                    log.debug("Adding available envs as new remotes: %s", envs)
                     for env in envs:
                         if isinstance(remote, dict):
                             key = next(iter(remote))

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -1215,7 +1215,7 @@ class GitPython(GitProvider):
         """
         tgt_ref = self.get_checkout_target()
 
-        # Fetch references if in case provider is new
+        # Fetch references in case provider is new
         if self.new:
             self.fetch()
 
@@ -1548,7 +1548,7 @@ class Pygit2(GitProvider):
         remote_ref = "refs/remotes/origin/" + tgt_ref
         tag_ref = "refs/tags/" + tgt_ref
 
-        # Fetch references if in case provider is new
+        # Fetch references in case provider is new
         if self.new:
             self.fetch()
 
@@ -2434,7 +2434,6 @@ class GitBase:
                     envs = repo_obj.envs()
                     log.debug("Adding available envs as new remotes: {}".format(envs))
                     for env in envs:
-                        log.debug("__env --> {}".format(env))
                         if isinstance(remote, dict):
                             key = next(iter(remote))
                             _, _url = key.split(None, 1)

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -1211,6 +1211,11 @@ class GitPython(GitProvider):
         GitPython.
         """
         tgt_ref = self.get_checkout_target()
+
+        # Fetch references if in case provider is new
+        if self.new:
+            self.fetch()
+
         try:
             head_sha = self.repo.rev_parse("HEAD").hexsha
         except Exception:  # pylint: disable=broad-except
@@ -1539,6 +1544,10 @@ class Pygit2(GitProvider):
         local_ref = "refs/heads/" + tgt_ref
         remote_ref = "refs/remotes/origin/" + tgt_ref
         tag_ref = "refs/tags/" + tgt_ref
+
+        # Fetch references if in case provider is new
+        if self.new:
+            self.fetch()
 
         try:
             local_head = self.repo.lookup_reference("HEAD")


### PR DESCRIPTION
### What does this PR do?
This PR fixes a race condition that produces wrong results and leaks between different saltenv/pillarenv when using `__env__` in your gitfs configuration and perform many requests for different envs at the same time.

### Previous Behavior
Given that you have a git pillar configuration as follows in your Salt master:

```yaml
gitfs_provider: pygit2

ext_pillar:
  - git:
    - __env__ file:///test_repo.git
```

My `test_repo.git` repository contains few branches: "prod" / "dev" / "test", each one of them with `top.sls` file and providing a custom pillar with a different value on each branch.

Once my salt master is started, I see the generated `remote_map.txt` for my git_pillar and an unique cachedir:

```console
# cat /var/cache/salt/master/git_pillar/remote_map.txt
# git_pillar_remote map as of 18 Jan 2022 16:31:58.955888
76f8d8390124f6fd664b35a371ec52d407b6b94745a9458eb9c4be5976a9d6da = __env__ file:///test_repo.git
```

Now, when multiple pillar requests are done for different pillarenvs at the same time, then wrong results/leak happens:

```console
# for i in {1..10}; do salt \* -lquiet pillar.get mycustompillar pillarenv=prod & done; for i in {1..10}; do salt \* -lquiet pillar.get mycustompillar pillarenv=dev & done
test_minion:
    prod
test_minion:
test_minion:
    dev
test_minion:
    prod
test_minion:
test_minion:
    prod
test_minion:
    dev
test_minion:
test_minion:
test_minion:
    prod
test_minion:
    prod
test_minion:
    prod
test_minion:
    prod
test_minion:
    dev
test_minion:
    prod
test_minion:
    dev
test_minion:
    dev
test_minion:
test_minion:
test_minion:
    dev
```

We were expecting 10 x "prod" + 10 x "dev"  as the result for this test, but as you see above this is not the case, we got some empty results with no errors. Some other times we get more "dev" than "prod" in the results, which indicates a leak is produced. We see no errors mentioned in the logs.

This situation/leak is produced because we have an unique cachedir for this git remote, where Salt is checking out to the respective branch for every request. This constant branch switching on cachedir directory makes this race condition to occur.

### New Behavior

What this PR implements is a mechanism to evaluate the `__env__` and make gitfs backend to create different cachedir for each one different branches / tags available on the defined repository.

For this particular example, after this PR is applied, the `remote_map.txt` looks like:

```console
# cat /var/cache/salt/master/git_pillar/remote_map.txt
# git_pillar_remote map as of 18 Jan 2022 17:14:25.101147
76f8d8390124f6fd664b35a371ec52d407b6b94745a9458eb9c4be5976a9d6da = __env__ file:///test_repo.git
52e35848062a978253396d7d5112d19a78e548ed494d87c786a52462e5630ced = prod file:///test_repo.git
10d0b28737b206e5e3ce8f335782d7bcbaa318e1b0d3a698c52473d7c0802ba9 = dev file:///test_repo.git
93ce7085174fc9a452934d0a957ed50afda91bf0ff0a9b777c31b4c889b9f5d9 = test file:///test_repo.git
```

And race condition has disappear since a different cachedir is used now for each available branch and no switching is needed.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
