### PR TITLE
Fix setting state_aggregate option on the minion

### DIFF
--- a/changelog/61478.fixed
+++ b/changelog/61478.fixed
@@ -1,0 +1,1 @@
+Fix state_aggregate minion option not respected

--- a/salt/state.py
+++ b/salt/state.py
@@ -3534,8 +3534,8 @@ class BaseHighState:
             opts["env_order"] = mopts.get("env_order", opts.get("env_order", []))
             opts["default_top"] = mopts.get("default_top", opts.get("default_top"))
             opts["state_events"] = mopts.get("state_events")
-            opts["state_aggregate"] = mopts.get(
-                "state_aggregate", opts.get("state_aggregate", False)
+            opts["state_aggregate"] = (
+                opts.get("state_aggregate") or mopts.get("state_aggregate") or False
             )
             opts["jinja_env"] = mopts.get("jinja_env", {})
             opts["jinja_sls_env"] = mopts.get("jinja_sls_env", {})

--- a/tests/pytests/unit/state/test_state_options.py
+++ b/tests/pytests/unit/state/test_state_options.py
@@ -1,0 +1,68 @@
+import itertools
+
+import pytest
+import salt.config
+import salt.state
+
+
+@pytest.fixture
+def master_opts():
+    """
+    Return a subset of master options to the minion
+    """
+    opts = salt.config.DEFAULT_MASTER_OPTS.copy()
+    mopts = {}
+    mopts["file_roots"] = opts["file_roots"]
+    mopts["top_file_merging_strategy"] = opts["top_file_merging_strategy"]
+    mopts["env_order"] = opts["env_order"]
+    mopts["default_top"] = opts["default_top"]
+    mopts["renderer"] = opts["renderer"]
+    mopts["failhard"] = opts["failhard"]
+    mopts["state_top"] = opts["state_top"]
+    mopts["state_top_saltenv"] = opts["state_top_saltenv"]
+    mopts["nodegroups"] = opts["nodegroups"]
+    mopts["state_auto_order"] = opts["state_auto_order"]
+    mopts["state_events"] = opts["state_events"]
+    mopts["state_aggregate"] = opts["state_aggregate"]
+    mopts["jinja_env"] = opts["jinja_env"]
+    mopts["jinja_sls_env"] = opts["jinja_sls_env"]
+    mopts["jinja_lstrip_blocks"] = opts["jinja_lstrip_blocks"]
+    mopts["jinja_trim_blocks"] = opts["jinja_trim_blocks"]
+    return mopts
+
+
+class MockBaseHighStateClient:
+    def __init__(self, opts):
+        self.opts = opts
+
+    def master_opts(self):
+        return self.opts
+
+
+def test_state_aggregate_option_behavior(master_opts):
+    """
+    Ensure state_aggregate can be overridden on the minion
+    """
+    minion_opts = salt.config.DEFAULT_MINION_OPTS.copy()
+    possible = [None, True, False, ["pkg"]]
+    expected_result = [
+        True,
+        False,
+        ["pkg"],
+        True,
+        True,
+        ["pkg"],
+        False,
+        True,
+        ["pkg"],
+        ["pkg"],
+        True,
+        ["pkg"],
+    ]
+
+    for idx, combo in enumerate(itertools.permutations(possible, 2)):
+        master_opts["state_aggregate"], minion_opts["state_aggregate"] = combo
+        state_obj = salt.state.BaseHighState
+        state_obj.client = MockBaseHighStateClient(master_opts)
+        return_result = state_obj(minion_opts)._BaseHighState__gen_opts(minion_opts)
+        assert expected_result[idx] == return_result["state_aggregate"]


### PR DESCRIPTION
### What does this PR do?
Addresses issue where the `state_aggregate` minion option is not respected and always favors the master option whether or not it's actively set on the master.

### What issues does this PR fix or reference?
Fixes: #61478

### Previous Behavior
See issue for details.

### New Behavior
See issue for details.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
