### PR TITLE
Fix Python 2 syntax used in status commands, notably status.netdev

### DIFF
--- a/changelog/60909.fixed
+++ b/changelog/60909.fixed
@@ -1,0 +1,1 @@
+Fixed Python 2 syntax for Python 3, allow for view objects returned by dictionary keys() function

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -7,6 +7,7 @@ import collections
 import copy
 import datetime
 import fnmatch
+import itertools
 import logging
 import os
 import re
@@ -1369,7 +1370,9 @@ def netdev():
         """
         ret = {}
         ##NOTE: we cannot use hwaddr_interfaces here, so we grab both ip4 and ip6
-        for dev in __grains__["ip4_interfaces"].keys() + __grains__["ip6_interfaces"]:
+        for dev in itertools.chain(
+            __grains__["ip4_interfaces"].keys(), __grains__["ip6_interfaces"].keys()
+        ):
             # fetch device info
             netstat_ipv4 = __salt__["cmd.run"](
                 "netstat -i -I {dev} -n -f inet".format(dev=dev)
@@ -1410,15 +1413,15 @@ def netdev():
         ret = {}
         fields = []
         procn = None
-        for dev in (
-            __grains__["ip4_interfaces"].keys() + __grains__["ip6_interfaces"].keys()
+        for dev in itertools.chain(
+            __grains__["ip4_interfaces"].keys(), __grains__["ip6_interfaces"].keys()
         ):
             # fetch device info
-            # root@la68pp002_pub:/opt/salt/lib/python2.7/site-packages/salt/modules# netstat -i -n -I en0 -f inet6
+            # root@la68pp002_pub:# netstat -i -n -I en0 -f inet
             # Name  Mtu   Network     Address            Ipkts Ierrs    Opkts Oerrs  Coll
             # en0   1500  link#3      e2.eb.32.42.84.c 10029668     0   446490     0     0
             # en0   1500  172.29.128  172.29.149.95    10029668     0   446490     0     0
-            # root@la68pp002_pub:/opt/salt/lib/python2.7/site-packages/salt/modules# netstat -i -n -I en0 -f inet6
+            # root@la68pp002_pub:# netstat -i -n -I en0 -f inet6
             # Name  Mtu   Network     Address            Ipkts Ierrs    Opkts Oerrs  Coll
             # en0   1500  link#3      e2.eb.32.42.84.c 10029731     0   446499     0     0
 

--- a/tests/pytests/unit/modules/test_aix_status.py
+++ b/tests/pytests/unit/modules/test_aix_status.py
@@ -1,0 +1,170 @@
+import logging
+
+import salt.modules.status as status
+from tests.support.mock import MagicMock, patch
+
+try:
+    import pytest
+except ImportError:
+    pytest = None
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def configure_loader_modules():
+
+    return {
+        status: {
+            "__grains__": {
+                "ip4_interfaces": {
+                    "en0": ["129.40.94.58"],
+                    "en1": ["172.24.94.58"],
+                    "lo0": ["127.0.0.1"],
+                },
+                "ip6_interfaces": {"en0": [], "en1": [], "lo0": ["1"]},
+                "kernel": "AIX",
+                "osarch": "PowerPC_POWER8",
+                "os": "AIX",
+                "os_family": "AIX",
+                "osmajorrelease": 7,
+            },
+        },
+    }
+
+
+def test_netdev():
+    """
+    Test status.netdev for AIX
+
+    :return:
+    """
+    # Output from netstat -i -n -I <en0|en1|lo0> -f inet
+    netstat_inet4_en0 = """Name   Mtu   Network     Address                 Ipkts     Ierrs        Opkts     Oerrs  Coll
+en0    1500  link#2      fa.41.f5.e9.bd.20  1523125     0   759364     0     0
+en0    1500  129.40.94.5 129.40.94.58      1523125     0   759364     0     0
+"""
+
+    netstat_inet4_en1 = """Name   Mtu   Network     Address                 Ipkts     Ierrs        Opkts     Oerrs  Coll
+en1    1500  link#3      fa.41.f5.e9.bd.21     1089     0      402     0     0
+en1    1500  172.24.94.5 172.24.94.58         1089     0      402     0     0
+"""
+
+    netstat_inet4_lo0 = """Name   Mtu   Network     Address                 Ipkts     Ierrs        Opkts     Oerrs  Coll
+lo0    16896 link#1                          25568     0    25568     0     0
+lo0    16896 127         127.0.0.1           25568     0    25568     0     0
+"""
+
+    # Output from netstat -i -n -I <en0|en1|lo0> -f inet6
+    netstat_inet6_en0 = """Name   Mtu   Network     Address                 Ipkts     Ierrs        Opkts     Oerrs  Coll
+en0    1500  link#2      fa.41.f5.e9.bd.20  1523160     0   759397     0     0
+"""
+
+    netstat_inet6_en1 = """Name   Mtu   Network     Address                 Ipkts     Ierrs        Opkts     Oerrs  Coll
+en1    1500  link#3      fa.41.f5.e9.bd.21     1089     0      402     0     0
+"""
+
+    netstat_inet6_lo0 = """Name   Mtu   Network     Address                 Ipkts     Ierrs        Opkts     Oerrs  Coll
+lo0    16896 link#1                          25611     0    25611     0     0
+lo0    16896 ::1%1                           25611     0    25611     0     0
+"""
+
+    # allow en0, en1 and lo0 for ipv4 and ipv6
+    netstats_out = MagicMock(
+        side_effect=[
+            netstat_inet4_en0,
+            netstat_inet6_en0,
+            netstat_inet4_en1,
+            netstat_inet6_en1,
+            netstat_inet4_lo0,
+            netstat_inet6_lo0,
+            netstat_inet4_en0,
+            netstat_inet6_en0,
+            netstat_inet4_en1,
+            netstat_inet6_en1,
+            netstat_inet4_lo0,
+            netstat_inet6_lo0,
+        ]
+    )
+
+    with patch.dict(
+        status.__grains__,
+        {
+            "osarch": "PowerPC_POWER8",
+            "ip4_interfaces": {
+                "en0": ["129.40.94.58"],
+                "en1": ["172.24.94.58"],
+                "lo0": ["127.0.0.1"],
+            },
+            "ip6_interfaces": {
+                "en0": [],
+                "en1": [],
+                "lo0": ["::1"],
+            },
+            "kernel": "AIX",
+        },
+    ), patch.dict(status.__salt__, {"cmd.run": netstats_out}):
+        netdev_out = status.netdev()
+        assert netstats_out.call_count == 12
+        netstats_out.assert_any_call("netstat -i -n -I en0 -f inet")
+        netstats_out.assert_any_call("netstat -i -n -I en1 -f inet")
+        netstats_out.assert_any_call("netstat -i -n -I lo0 -f inet")
+        netstats_out.assert_any_call("netstat -i -n -I en0 -f inet6")
+        netstats_out.assert_any_call("netstat -i -n -I en1 -f inet6")
+        netstats_out.assert_called_with("netstat -i -n -I lo0 -f inet6")
+        expected = {
+            "en0": [
+                {
+                    "ipv4": {
+                        "Mtu": "1500",
+                        "Network": "129.40.94.5",
+                        "Address": "129.40.94.58",
+                        "Ipkts": "1523125",
+                        "Ierrs": "0",
+                        "Opkts": "759364",
+                        "Oerrs": "0",
+                        "Coll": "0",
+                    }
+                }
+            ],
+            "en1": [
+                {
+                    "ipv4": {
+                        "Mtu": "1500",
+                        "Network": "172.24.94.5",
+                        "Address": "172.24.94.58",
+                        "Ipkts": "1089",
+                        "Ierrs": "0",
+                        "Opkts": "402",
+                        "Oerrs": "0",
+                        "Coll": "0",
+                    }
+                }
+            ],
+            "lo0": [
+                {
+                    "ipv4": {
+                        "Mtu": "16896",
+                        "Network": "127",
+                        "Address": "127.0.0.1",
+                        "Ipkts": "25568",
+                        "Ierrs": "0",
+                        "Opkts": "25568",
+                        "Oerrs": "0",
+                        "Coll": "0",
+                    }
+                },
+                {
+                    "ipv6": {
+                        "Mtu": "16896",
+                        "Network": "::1%1",
+                        "Address": "25611",
+                        "Ipkts": "0",
+                        "Ierrs": "25611",
+                        "Opkts": "0",
+                        "Oerrs": "0",
+                    }
+                },
+            ],
+        }
+        assert netdev_out == expected

--- a/tests/pytests/unit/modules/test_aix_status.py
+++ b/tests/pytests/unit/modules/test_aix_status.py
@@ -1,13 +1,9 @@
 import logging
 import sys
 
+import pytest
 import salt.modules.status as status
 from tests.support.mock import MagicMock, patch
-
-try:
-    import pytest
-except ImportError:
-    pytest = None
 
 log = logging.getLogger(__name__)
 

--- a/tests/pytests/unit/modules/test_aix_status.py
+++ b/tests/pytests/unit/modules/test_aix_status.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 import salt.modules.status as status
 from tests.support.mock import MagicMock, patch
@@ -33,6 +34,10 @@ def configure_loader_modules():
     }
 
 
+@pytest.mark.skipif(
+    sys.version_info[0] == 3 and sys.version_info[1] <= 5,
+    reason="run on Python 3.6 or greater where OrderedDict is default",
+)
 def test_netdev():
     """
     Test status.netdev for AIX
@@ -111,7 +116,7 @@ lo0    16896 ::1%1                           25611     0    25611     0     0
         netstats_out.assert_any_call("netstat -i -n -I lo0 -f inet")
         netstats_out.assert_any_call("netstat -i -n -I en0 -f inet6")
         netstats_out.assert_any_call("netstat -i -n -I en1 -f inet6")
-        netstats_out.assert_called_with("netstat -i -n -I lo0 -f inet6")
+        netstats_out.assert_any_call("netstat -i -n -I lo0 -f inet6")
         expected = {
             "en0": [
                 {


### PR DESCRIPTION
### What does this PR do?
Fixes Python 2 syntax that was used and had not been converted to Python 3.
In Python 2 a dictionary.keys() function returns a list which could be joined with another list using '+'.
In Python 3 a distionary.keys() function returns a view object which cannot be added to another view object with a '+', hence using itertools.chain functionality to iterate over two view objects.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/60909

### Previous Behavior
Would cause TypeError due to unsupported behavior
```
  File "/opt/saltstack/salt/run/salt/modules/status.py", line 1413, in aix_netdev
    __grains__["ip4_interfaces"].keys() + __grains__["ip6_interfaces"].keys()
TypeError: unsupported operand type(s) for +: 'dict_keys' and 'dict_keys'
```

### New Behavior
Using itertools.chain functionality to iterate over two view objects returned from the dictionary keys() function

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
