### PR TITLE
Convert Py 2'isms to Python 3, and add tests for set_filesystems on AIX

### DIFF
--- a/changelog/61509.fixed
+++ b/changelog/61509.fixed
@@ -1,0 +1,1 @@
+Convert Py 2'isms to Python 3, and add tests for set_filesystems on AIX

--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -778,7 +778,7 @@ def set_fstab(
     test=False,
     match_on="auto",
     not_change=False,
-    **kwargs,
+    **kwargs
 ):
     """
     Verify that this mount is represented in the fstab, change the mount
@@ -915,7 +915,7 @@ def set_vfstab(
     test=False,
     match_on="auto",
     not_change=False,
-    **kwargs,
+    **kwargs
 ):
     """
     .. versionadded:: 2016.3.2
@@ -1102,7 +1102,7 @@ def set_automaster(
     config="/etc/auto_salt",
     test=False,
     not_change=False,
-    **kwargs,
+    **kwargs
 ):
     """
     Verify that this mount is represented in the auto_salt, change the mount
@@ -1764,7 +1764,7 @@ def set_filesystems(
     test=False,
     match_on="auto",
     not_change=False,
-    **kwargs,
+    **kwargs
 ):
     """
     .. versionadded:: 2018.3.3

--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -546,7 +546,7 @@ class _FileSystemsEntry:
     def dict_from_cmd_line(cls, ipargs, keys):
         cmdln_dict = ipargs
         if keys:
-            for key, value in keys:
+            for key, value in keys.items():
                 # ignore unknown or local scope keys
                 if key.startswith("__"):
                     continue
@@ -568,6 +568,17 @@ class _FileSystemsEntry:
                 strg_out += "\t{}\t\t= {}".format(k, v) + os.linesep
         strg_out += os.linesep
         return str(strg_out)
+
+    @classmethod
+    def dict_to_list_lines(cls, fsys_dict_entry):
+        entry = fsys_dict_entry
+        list_out = []
+        list_out.append(str(entry["name"] + ":" + os.linesep))
+        for k, v in entry.items():
+            if "name" not in k:
+                list_out.append(str("\t{}\t\t= {}".format(k, v) + os.linesep))
+        list_out.append(str(os.linesep))
+        return list_out
 
     def dict_from_entry(self):
         ret = OrderedDict()
@@ -767,7 +778,7 @@ def set_fstab(
     test=False,
     match_on="auto",
     not_change=False,
-    **kwargs
+    **kwargs,
 ):
     """
     Verify that this mount is represented in the fstab, change the mount
@@ -904,7 +915,7 @@ def set_vfstab(
     test=False,
     match_on="auto",
     not_change=False,
-    **kwargs
+    **kwargs,
 ):
     """
     .. versionadded:: 2016.3.2
@@ -1091,7 +1102,7 @@ def set_automaster(
     config="/etc/auto_salt",
     test=False,
     not_change=False,
-    **kwargs
+    **kwargs,
 ):
     """
     Verify that this mount is represented in the auto_salt, change the mount
@@ -1331,8 +1342,10 @@ def remount(name, device, mkmnt=False, fstype="", opts="defaults", user=None):
         if force_mount:
             # We need to force the mount but first we should unmount
             umount(name, device, user=user)
-        lopts = ",".join(opts)
-        args = "-o {}".format(lopts)
+        args = ""
+        if opts:
+            lopts = ",".join(opts)
+            args = "-o {}".format(lopts)
 
         if fstype:
             # use of fstype on AIX differs from typical Linux use of
@@ -1751,7 +1764,7 @@ def set_filesystems(
     test=False,
     match_on="auto",
     not_change=False,
-    **kwargs
+    **kwargs,
 ):
     """
     .. versionadded:: 2018.3.3
@@ -1890,10 +1903,13 @@ def set_filesystems(
                 # The line was changed, commit it!
                 for fsys_view in view_lines:
                     entry = fsys_view[1]
-                    mystrg = _FileSystemsEntry.dict_to_lines(entry)
-                    ofile.writelines(salt.utils.data.encode(mystrg))
+                    list_strgs = _FileSystemsEntry.dict_to_list_lines(entry)
+                    ofile.writelines(salt.utils.data.encode(list_strgs))
+
         except OSError:
             raise CommandExecutionError("File not writable {}".format(config))
+        except Exception as exc:
+            raise CommandExecutionError("set_filesystems error exception {exc}")
 
     return ret
 
@@ -1937,9 +1953,11 @@ def rm_filesystems(name, device, config="/etc/filesystems"):
             with salt.utils.files.fopen(config, "wb") as ofile:
                 for fsys_view in view_lines:
                     entry = fsys_view[1]
-                    mystrg = _FileSystemsEntry.dict_to_lines(entry)
-                    ofile.writelines(salt.utils.data.encode(mystrg))
+                    list_strgs = _FileSystemsEntry.dict_to_list_lines(entry)
+                    ofile.writelines(salt.utils.data.encode(list_strgs))
         except OSError as exc:
             raise CommandExecutionError("Couldn't write to {}: {}".format(config, exc))
+        except Exception as exc:
+            raise CommandExecutionError("rm_filesystems error exception {exc}")
 
     return modified

--- a/tests/pytests/unit/modules/test_mount.py
+++ b/tests/pytests/unit/modules/test_mount.py
@@ -400,6 +400,9 @@ def test_set_filesystems():
     sys.version_info[0] == 3 and sys.version_info[1] <= 5,
     reason="run on Python 3.6 or greater where OrderedDict is default",
 )
+@pytest.mark.skip_on_windows(
+    reason="Not supported on Windows, does not handle tabs well"
+)
 def test_set_filesystems_with_data(tmp_sub_dir, config_file):
     """
     Tests to verify set_filesystems reads and adjusts file /etc/filesystems correctly

--- a/tests/pytests/unit/modules/test_mount.py
+++ b/tests/pytests/unit/modules/test_mount.py
@@ -2,7 +2,10 @@
     :codeauthor: Rupesh Tare <rupesht@saltstack.com>
 """
 
+import logging
 import os
+import shutil
+import sys
 import textwrap
 
 import pytest
@@ -12,6 +15,8 @@ import salt.utils.path
 from salt.exceptions import CommandExecutionError
 from tests.support.mock import MagicMock, mock_open, patch
 
+log = logging.getLogger(__name__)
+
 
 @pytest.fixture
 def mock_shell_file():
@@ -19,8 +24,56 @@ def mock_shell_file():
 
 
 @pytest.fixture
+def config_initial_file():
+    inital_fsystem = [
+        "/:\n",
+        "\tdev\t\t= /dev/hd4\n",
+        "\tvfs\t\t= jfs2\n",
+        "\tlog\t\t= /dev/hd8\n",
+        "\tmount \t\t= automatic\n",
+        "\tcheck\t\t= false\n",
+        "\ttype\t\t= bootfs\n",
+        "\tvol\t\t= root\n",
+        "\tfree\t\t= true\n",
+        "\n",
+        "/home:\n",
+        "\tdev\t\t= /dev/hd1\n",
+        "\tvfs\t\t= jfs2\n",
+        "\tlog\t\t= /dev/hd8\n",
+        "\tmount\t\t= true\n",
+        "\tcheck\t\t= true\n",
+        "\tvol\t\t= /home\n",
+        "\tfree\t\t= false\n",
+        "\n",
+    ]
+    return inital_fsystem
+
+
+@pytest.fixture
 def configure_loader_modules():
     return {mount: {}}
+
+
+@pytest.fixture
+def tmp_sub_dir(tmp_path):
+    directory = tmp_path / "filesystems-dir"
+    directory.mkdir()
+
+    yield directory
+
+    shutil.rmtree(str(directory))
+
+
+@pytest.fixture
+def config_file(tmp_sub_dir, config_initial_file):
+    filename = str(tmp_sub_dir / "filesystems")
+
+    with salt.utils.files.fopen(filename, "wb") as fp:
+        fp.writelines(salt.utils.data.encode(config_initial_file))
+
+    yield filename
+
+    os.remove(filename)
 
 
 def test_active():
@@ -341,6 +394,54 @@ def test_set_filesystems():
                 pytest.raises(
                     CommandExecutionError, mount.set_filesystems, "A", "B", "C"
                 )
+
+
+@pytest.mark.skipif(
+    sys.version_info[0] == 3 and sys.version_info[1] <= 5,
+    reason="run on Python 3.6 or greater where OrderedDict is default",
+)
+def test_set_filesystems_with_data(tmp_sub_dir, config_file):
+    """
+    Tests to verify set_filesystems reads and adjusts file /etc/filesystems correctly
+    """
+    # Note AIX uses tabs in filesystems files, hence disable warings and errors for tabs and spaces
+    # pylint: disable=W8191
+    # pylint: disable=E8101
+    config_filepath = str(tmp_sub_dir / "filesystems")
+    with patch.dict(mount.__grains__, {"os": "AIX", "kernel": "AIX"}):
+        mount.set_filesystems(
+            "/test_mount", "/dev/hd3", "jsf2", "-", "true", config_filepath
+        )
+        with salt.utils.files.fopen(config_filepath, "r") as fp:
+            fsys_content = fp.read()
+
+        test_fsyst = """/:
+	dev		= /dev/hd4
+	vfs		= jfs2
+	log		= /dev/hd8
+	mount		= automatic
+	check		= false
+	type		= bootfs
+	vol		= root
+	free		= true
+
+/home:
+	dev		= /dev/hd1
+	vfs		= jfs2
+	log		= /dev/hd8
+	mount		= true
+	check		= true
+	vol		= /home
+	free		= false
+
+/test_mount:
+	dev		= /dev/hd3
+	vfstype		= jsf2
+	opts		= -
+	mount		= true
+
+"""
+    assert test_fsyst == fsys_content
 
 
 def test_mount():


### PR DESCRIPTION
### What does this PR do?
Replace Python 2 syntax with Python 3 syntax for AIX set_filesystems and add unit tests

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/61509

### Previous Behavior
Generate ValueError exception
```
  File "/opt/saltstack/salt/run/salt/modules/mount.py", line 1848, in set_filesystems
    entry_ip = _FileSystemsEntry.from_line(entry_args, kwargs)
  File "/opt/saltstack/salt/run/salt/modules/mount.py", line 560, in from_line
    return cls(**cls.dict_from_cmd_line(*args, **kwargs))
  File "/opt/saltstack/salt/run/salt/modules/mount.py", line 549, in dict_from_cmd_line
    for key, value in keys:
ValueError: too many values to unpack (expected 2)
```

### New Behavior
Functions correctly with Python 3

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
