### PR TITLE
Remove 40 character limit to update Title

### DIFF
--- a/changelog/61533.fixed
+++ b/changelog/61533.fixed
@@ -1,0 +1,1 @@
+win_wua: Titles no longer limited to 40 characters

--- a/salt/states/win_wua.py
+++ b/salt/states/win_wua.py
@@ -185,7 +185,7 @@ def installed(name, updates=None):
         if not salt.utils.data.is_true(post_info[item]["Installed"]):
             ret["changes"]["failed"] = {
                 item: {
-                    "Title": post_info[item]["Title"][:40] + "...",
+                    "Title": post_info[item]["Title"],
                     "KBs": post_info[item]["KBs"],
                 }
             }
@@ -193,7 +193,7 @@ def installed(name, updates=None):
         else:
             ret["changes"]["installed"] = {
                 item: {
-                    "Title": post_info[item]["Title"][:40] + "...",
+                    "Title": post_info[item]["Title"],
                     "NeedsReboot": post_info[item]["NeedsReboot"],
                     "KBs": post_info[item]["KBs"],
                 }
@@ -309,7 +309,7 @@ def removed(name, updates=None):
         if salt.utils.data.is_true(post_info[item]["Installed"]):
             ret["changes"]["failed"] = {
                 item: {
-                    "Title": post_info[item]["Title"][:40] + "...",
+                    "Title": post_info[item]["Title"],
                     "KBs": post_info[item]["KBs"],
                 }
             }
@@ -317,7 +317,7 @@ def removed(name, updates=None):
         else:
             ret["changes"]["removed"] = {
                 item: {
-                    "Title": post_info[item]["Title"][:40] + "...",
+                    "Title": post_info[item]["Title"],
                     "NeedsReboot": post_info[item]["NeedsReboot"],
                     "KBs": post_info[item]["KBs"],
                 }
@@ -494,7 +494,7 @@ def uptodate(
             if not salt.utils.data.is_true(post_info[item]["Installed"]):
                 ret["changes"]["failed"] = {
                     item: {
-                        "Title": post_info[item]["Title"][:40] + "...",
+                        "Title": post_info[item]["Title"],
                         "KBs": post_info[item]["KBs"],
                     }
                 }
@@ -502,7 +502,7 @@ def uptodate(
             else:
                 ret["changes"]["installed"] = {
                     item: {
-                        "Title": post_info[item]["Title"][:40] + "...",
+                        "Title": post_info[item]["Title"],
                         "NeedsReboot": post_info[item]["NeedsReboot"],
                         "KBs": post_info[item]["KBs"],
                     }

--- a/tests/pytests/unit/states/test_win_wua.py
+++ b/tests/pytests/unit/states/test_win_wua.py
@@ -56,7 +56,7 @@ def updates_list():
         "eac02b09-d745-4891-b80f-400e0e5e4b6d": {
             "KBs": ["KB4052623"],
             "Installed": False,
-            "Title": "Blank",
+            "Title": "KB4052623: Really long title that exceeds 40 characters",
         },
         "0689e74b-54d1-4f55-a916-96e3c737db90": {
             "KBs": ["KB890830"],
@@ -172,8 +172,8 @@ def test_uptodate(updates_list):
         "changes": {
             "failed": {
                 "eac02b09-d745-4891-b80f-400e0e5e4b6d": {
-                    "Title": "Blank...",
                     "KBs": ["KB4052623"],
+                    "Title": "KB4052623: Really long title that exceeds 40 characters",
                 }
             }
         },
@@ -195,7 +195,7 @@ def test_uptodate(updates_list):
         "eac02b09-d745-4891-b80f-400e0e5e4b6d": {
             "KBs": ["KB4052623"],
             "Installed": False,
-            "Title": "Blank",
+            "Title": "KB4052623: Really long title that exceeds 40 characters",
         },
         "eac02c07-d744-4892-b80f-312d045e4ccc": {
             "KBs": ["KB4052444"],
@@ -224,7 +224,6 @@ def test_uptodate(updates_list):
     patch_opts = patch.dict(win_wua.__opts__, {"test": False})
 
     with patch_winapi_com, patch_win32, patch_wua, patch_win_wua_update, patch_opts:
-        wua = win_update.WindowsUpdateAgent(online=False)
         result = win_wua.uptodate(name="NA")
         assert result == expected
 
@@ -243,7 +242,7 @@ def test_installed(update_records, update_records_identity):
             ),
             IsDownloaded=False,
             IsInstalled=False,
-            Title="Update 2",
+            Title="KB4052623: Really long title that exceeds 40 characters",
         ),
     }
 
@@ -253,7 +252,7 @@ def test_installed(update_records, update_records_identity):
             "KBs": ["KB4052623"],
             "Installed": True,
             "NeedsReboot": True,
-            "Title": "Update 2",
+            "Title": "KB4052623: Really long title that exceeds 40 characters",
         },
     }
 
@@ -270,7 +269,7 @@ def test_installed(update_records, update_records_identity):
             "KBs": ["KB4052623"],
             "Installed": True,
             "NeedsReboot": True,
-            "Title": "Update 2",
+            "Title": "KB4052623: Really long title that exceeds 40 characters",
         },
         "eac02c07-d744-4892-b80f-312d045e4ccc": {
             "Downloaded": True,
@@ -325,7 +324,7 @@ def test_installed(update_records, update_records_identity):
                     "eac02b09-d745-4891-b80f-400e0e5e4b6d": {
                         "KBs": ["KB4052623"],
                         "NeedsReboot": True,
-                        "Title": "Update 2...",
+                        "Title": "KB4052623: Really long title that exceeds 40 characters",
                     }
                 }
             },
@@ -482,4 +481,172 @@ def test_installed_already_installed(update_records, update_records_identity):
             "result": True,
         }
         result = win_wua.installed(name="KB4062623")
+        assert result == expected
+
+
+@pytest.mark.skip_unless_on_windows
+def test_removed(update_records, update_records_identity):
+    """
+    Test removed function
+    """
+
+    update_search_obj = {
+        update_records(
+            KBArticleIDs=("4052623",),
+            Identity=update_records_identity(
+                UpdateID="eac02b09-d745-4891-b80f-400e0e5e4b6d"
+            ),
+            IsDownloaded=False,
+            IsInstalled=True,
+            Title="KB4052623: Really long title that exceeds 40 characters",
+        ),
+    }
+
+    update_search_dict = {
+        "eac02b09-d745-4891-b80f-400e0e5e4b6d": {
+            "Downloaded": True,
+            "KBs": ["KB4052623"],
+            "Installed": False,
+            "NeedsReboot": True,
+            "Title": "KB4052623: Really long title that exceeds 40 characters",
+        },
+    }
+
+    updates_refresh = {
+        "a0f997b1-1abe-4a46-941f-b37f732f9fbd": {
+            "Downloaded": False,
+            "KBs": ["KB3193497"],
+            "Installed": False,
+            "NeedsReboot": False,
+            "Title": "Update 1",
+        },
+        "eac02b09-d745-4891-b80f-400e0e5e4b6d": {
+            "Downloaded": True,
+            "KBs": ["KB4052623"],
+            "Installed": False,
+            "NeedsReboot": True,
+            "Title": "KB4052623: Really long title that exceeds 40 characters",
+        },
+        "eac02c07-d744-4892-b80f-312d045e4ccc": {
+            "Downloaded": True,
+            "KBs": ["KB4052444"],
+            "Installed": True,
+            "NeedsReboot": False,
+            "Title": "Update 3",
+        },
+    }
+
+    # Mocks the connection to the Windows Update Agent
+    mock_wua = MagicMock()
+    # Mocks the initial search
+    mock_wua.search = MagicMock()
+    # Mocks the number of updates found.
+    mock_wua.search().count.return_value = 1
+    # Mocks the the updates collection object
+    mock_wua.search().updates = update_search_obj
+
+    # This mocks the updates collection in the uninstall variable. This will
+    # get populated as matches are found with the Add method
+    mock_updates = MagicMock()
+    # Needs to return the number of updates that need to be installed
+    # (IsInstalled = False)
+    mock_updates.count.return_value = 1
+    # Returns the updates that need to be installed as a dict
+    mock_updates.list.return_value = update_search_dict
+
+    # This gives us post_info
+    mock_wua.updates = MagicMock()
+    # Mock a refresh of the updates recognized by the machine. This would
+    # occur post uninstall. This is compared with the updates on the machine
+    # to determine if the removal was successful
+    mock_wua.updates().list.return_value = updates_refresh
+
+    patch_winapi_com = patch("salt.utils.winapi.Com", autospec=True)
+    patch_dispatch = patch("win32com.client.Dispatch", autospec=True)
+    patch_wua = patch(
+        "salt.utils.win_update.WindowsUpdateAgent",
+        autospec=True,
+        return_value=mock_wua,
+    )
+    patch_update_collection = patch(
+        "salt.utils.win_update.Updates", autospec=True, return_value=mock_updates
+    )
+    patch_opts = patch.dict(win_wua.__opts__, {"test": False})
+
+    with patch_winapi_com, patch_dispatch, patch_wua, patch_update_collection, patch_opts:
+        expected = {
+            "changes": {
+                "removed": {
+                    "eac02b09-d745-4891-b80f-400e0e5e4b6d": {
+                        "KBs": ["KB4052623"],
+                        "NeedsReboot": True,
+                        "Title": "KB4052623: Really long title that exceeds 40 characters",
+                    }
+                }
+            },
+            "comment": "Updates removed successfully",
+            "name": "KB4062623",
+            "result": True,
+        }
+        result = win_wua.removed(name="KB4062623")
+        assert result == expected
+
+
+@pytest.mark.skip_unless_on_windows
+def test_removed_test_mode(update_records, update_records_identity):
+    """
+    Test removed function in test mode
+    """
+
+    update_search_obj = {
+        update_records(
+            KBArticleIDs=("4052623",),
+            Identity=update_records_identity(
+                UpdateID="eac02b09-d745-4891-b80f-400e0e5e4b6d"
+            ),
+            IsDownloaded=False,
+            IsInstalled=True,
+            Title="KB4052623: Really long title that exceeds 40 characters",
+        ),
+    }
+
+    # Mocks the connection to the Windows Update Agent
+    mock_wua = MagicMock()
+    # Mocks the initial search
+    mock_wua.search = MagicMock()
+    # Mocks the number of updates found.
+    mock_wua.search().count.return_value = 1
+    # Mocks the the updates collection object
+    mock_wua.search().updates = update_search_obj
+
+    # This mocks the updates collection in the install variable. This will
+    # get populated to as matches are found with the Add method
+    mock_updates = MagicMock()
+    # Needs to return the number of updates that need to be installed
+    # (IsInstalled = False)
+    mock_updates.count.return_value = 1
+
+    patch_winapi_com = patch("salt.utils.winapi.Com", autospec=True)
+    patch_dispatch = patch("win32com.client.Dispatch", autospec=True)
+    patch_wua = patch(
+        "salt.utils.win_update.WindowsUpdateAgent",
+        autospec=True,
+        return_value=mock_wua,
+    )
+    patch_update_collection = patch(
+        "salt.utils.win_update.Updates", autospec=True, return_value=mock_updates
+    )
+    patch_opts = patch.dict(win_wua.__opts__, {"test": True})
+
+    with patch_winapi_com, patch_dispatch, patch_wua, patch_update_collection, patch_opts:
+        expected = {
+            "changes": {},
+            "comment": "Updates will be removed:",
+            # I don't know how to mock this part so the list will show up.
+            # It's an update collection object populated using the Add
+            # method. But this works for now
+            "name": "KB4062623",
+            "result": None,
+        }
+        result = win_wua.removed(name="KB4062623")
         assert result == expected


### PR DESCRIPTION
### What does this PR do?
Removes 40 character limit to the Title for Windows updates.

### What issues does this PR fix or reference?
Fixes: #61533 

### Previous Behavior
Title was being trimmed at 40 characters

### New Behavior
The full title is returned

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes