### PR TITLE
Allow symlink to be created if source is missing on Windows

### DIFF
--- a/changelog/61544.fixed
+++ b/changelog/61544.fixed
@@ -1,0 +1,1 @@
+Allow symlink to be created even if source is missing on Windows

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -1244,9 +1244,6 @@ def symlink(src, link, force=False):
         msg = "Existing path is not a symlink: {}".format(link)
         raise CommandExecutionError(msg)
 
-    if not os.path.exists(src):
-        raise CommandExecutionError("Source path does not exist: {}".format(src))
-
     if not os.path.isabs(link):
         raise SaltInvocationError("Link path must be absolute: {}".format(link))
 

--- a/tests/pytests/functional/modules/file/test_symlink.py
+++ b/tests/pytests/functional/modules/file/test_symlink.py
@@ -36,6 +36,19 @@ def test_symlink(file, source):
         target.unlink()
 
 
+def test_symlink_missing_src(file, source):
+    """
+    Test symlink when src is missing should still create the link
+    """
+    target = source.parent / "symlink.lnk"
+    missing_source = source.parent / "missing.txt"
+    try:
+        file.symlink(str(missing_source), str(target))
+        assert salt.utils.path.islink(str(target))
+    finally:
+        target.unlink()
+
+
 def test_symlink_exists_same(file, source):
     """
     Test symlink with an existing symlink to the correct file


### PR DESCRIPTION
### What does this PR do?
Allows the symlink to be created even if the source is missing. This is in line with behavior on Linux.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/61544

### Previous Behavior
CommandExecutionError if source was missing

### New Behavior
Symlink is created

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes