### PR TITLE
Set default transport and port settings for Napalm NXOS, if not set

### DIFF
--- a/changelog/59448.fixed
+++ b/changelog/59448.fixed
@@ -1,0 +1,1 @@
+Set default transport and port settings for Napalm NXOS, if not set.

--- a/salt/modules/napalm_mod.py
+++ b/salt/modules/napalm_mod.py
@@ -1015,8 +1015,19 @@ def pyeapi_nxos_api_args(**prev_kwargs):
     kwargs["username"] = napalm_opts["USERNAME"]
     kwargs["password"] = napalm_opts["PASSWORD"]
     kwargs["timeout"] = napalm_opts["TIMEOUT"]
-    kwargs["transport"] = optional_args.get("transport")
-    kwargs["port"] = optional_args.get("port")
+    # kwargs["transport"] = optional_args.get("transport", "https")
+    # kwargs["port"] = optional_args.get("port", 443)
+
+    if "transport" in optional_args and optional_args["transport"]:
+        kwargs["transport"] = optional_args["transport"]
+    else:
+        kwargs["transport"] = "https"
+
+    if "port" in optional_args and optional_args["port"]:
+        kwargs["port"] = optional_args["port"]
+    else:
+        kwargs["port"] = 80 if kwargs["transport"] == "http" else 443
+
     kwargs["verify"] = optional_args.get("verify")
     prev_kwargs.update(kwargs)
     return prev_kwargs

--- a/salt/modules/napalm_mod.py
+++ b/salt/modules/napalm_mod.py
@@ -1015,8 +1015,6 @@ def pyeapi_nxos_api_args(**prev_kwargs):
     kwargs["username"] = napalm_opts["USERNAME"]
     kwargs["password"] = napalm_opts["PASSWORD"]
     kwargs["timeout"] = napalm_opts["TIMEOUT"]
-    # kwargs["transport"] = optional_args.get("transport", "https")
-    # kwargs["port"] = optional_args.get("port", 443)
 
     if "transport" in optional_args and optional_args["transport"]:
         kwargs["transport"] = optional_args["transport"]

--- a/salt/modules/nxos_api.py
+++ b/salt/modules/nxos_api.py
@@ -233,7 +233,7 @@ def rpc(commands, method="cli", **kwargs):
 
     .. code-block:: bash
 
-        salt-call --local nxps_api.rpc 'show version'
+        salt-call --local nxos_api.rpc 'show version'
     """
     nxos_api_kwargs = __salt__["config.get"]("nxos_api", {})
     nxos_api_kwargs.update(**kwargs)

--- a/tests/pytests/unit/modules/napalm/test_mod.py
+++ b/tests/pytests/unit/modules/napalm/test_mod.py
@@ -48,7 +48,6 @@ def test_config_kwargs_empty():
     ):
         test_kwargs = {}
         ret = napalm_mod.pyeapi_nxos_api_args(kwargs=test_kwargs)
-        log.debug(f"DGM test_config post ret '{ret}', test_kwargs '{test_kwargs}'")
         assert ret["transport"] == "https"
         assert ret["port"] == 443
 
@@ -75,7 +74,6 @@ def test_config_kwargs_none():
     ):
         test_kwargs = {}
         ret = napalm_mod.pyeapi_nxos_api_args(kwargs=test_kwargs)
-        log.debug(f"DGM test_config post ret '{ret}', test_kwargs '{test_kwargs}'")
         assert ret["transport"] == "https"
         assert ret["port"] == 443
 
@@ -101,7 +99,6 @@ def test_config_kwargs_http_no_port():
     ):
         test_kwargs = {}
         ret = napalm_mod.pyeapi_nxos_api_args(kwargs=test_kwargs)
-        log.debug(f"DGM test_config post ret '{ret}', test_kwargs '{test_kwargs}'")
         assert ret["transport"] == "http"
         assert ret["port"] == 80
 
@@ -128,7 +125,6 @@ def test_config_kwargs_http_and_port():
     ):
         test_kwargs = {}
         ret = napalm_mod.pyeapi_nxos_api_args(kwargs=test_kwargs)
-        log.debug(f"DGM test_config post ret '{ret}', test_kwargs '{test_kwargs}'")
         assert ret["transport"] == "http"
         assert ret["port"] == 8080
 
@@ -154,7 +150,6 @@ def test_config_kwargs_https_no_port():
     ):
         test_kwargs = {}
         ret = napalm_mod.pyeapi_nxos_api_args(kwargs=test_kwargs)
-        log.debug(f"DGM test_config post ret '{ret}', test_kwargs '{test_kwargs}'")
         assert ret["transport"] == "https"
         assert ret["port"] == 443
 
@@ -181,7 +176,6 @@ def test_config_kwargs_https_and_port():
     ):
         test_kwargs = {}
         ret = napalm_mod.pyeapi_nxos_api_args(kwargs=test_kwargs)
-        log.debug(f"DGM test_config post ret '{ret}', test_kwargs '{test_kwargs}'")
         assert ret["transport"] == "https"
         assert ret["port"] == 5432
 
@@ -208,6 +202,5 @@ def test_config_kwargs_werid_transport_port():
     ):
         test_kwargs = {}
         ret = napalm_mod.pyeapi_nxos_api_args(kwargs=test_kwargs)
-        log.debug(f"DGM test_config post ret '{ret}', test_kwargs '{test_kwargs}'")
         assert ret["transport"] == "nxos_protocol"
         assert ret["port"] == 2080

--- a/tests/pytests/unit/modules/napalm/test_mod.py
+++ b/tests/pytests/unit/modules/napalm/test_mod.py
@@ -1,0 +1,213 @@
+"""
+    :codeauthor: :email:`David Murphy <damurphy@vmware.com>`
+"""
+import logging
+
+import pytest
+import salt.modules.napalm_mod as napalm_mod
+import tests.support.napalm as napalm_test_support
+from tests.support.mock import MagicMock, patch
+
+log = logging.getLogger(__file__)
+
+
+@pytest.fixture
+def configure_loader_modules():
+    module_globals = {
+        "__salt__": {
+            "config.get": MagicMock(
+                return_value={"test": {"driver": "test", "key": "2orgk34kgk34g"}}
+            ),
+            "file.file_exists": napalm_test_support.true,
+            "file.join": napalm_test_support.join,
+            "file.get_managed": napalm_test_support.get_managed_file,
+            "random.hash": napalm_test_support.random_hash,
+        }
+    }
+
+    return {napalm_mod: module_globals}
+
+
+def test_config_kwargs_empty():
+    test_napalm_opts = {
+        "HOSTNAME": None,
+        "USERNAME": None,
+        "DRIVER_NAME": None,
+        "PASSWORD": "",
+        "TIMEOUT": 60,
+        "OPTIONAL_ARGS": {
+            "config_lock": False,
+            "keepalive": 5,
+        },
+        "ALWAYS_ALIVE": True,
+        "PROVIDER": None,
+        "UP": False,
+    }
+    with patch(
+        "salt.utils.napalm.get_device_opts", MagicMock(return_value=test_napalm_opts)
+    ):
+        test_kwargs = {}
+        ret = napalm_mod.pyeapi_nxos_api_args(kwargs=test_kwargs)
+        log.debug(f"DGM test_config post ret '{ret}', test_kwargs '{test_kwargs}'")
+        assert ret["transport"] == "https"
+        assert ret["port"] == 443
+
+
+def test_config_kwargs_none():
+    test_napalm_opts = {
+        "HOSTNAME": None,
+        "USERNAME": None,
+        "DRIVER_NAME": None,
+        "PASSWORD": "",
+        "TIMEOUT": 60,
+        "OPTIONAL_ARGS": {
+            "config_lock": False,
+            "keepalive": 5,
+            "transport": None,
+            "port": None,
+        },
+        "ALWAYS_ALIVE": True,
+        "PROVIDER": None,
+        "UP": False,
+    }
+    with patch(
+        "salt.utils.napalm.get_device_opts", MagicMock(return_value=test_napalm_opts)
+    ):
+        test_kwargs = {}
+        ret = napalm_mod.pyeapi_nxos_api_args(kwargs=test_kwargs)
+        log.debug(f"DGM test_config post ret '{ret}', test_kwargs '{test_kwargs}'")
+        assert ret["transport"] == "https"
+        assert ret["port"] == 443
+
+
+def test_config_kwargs_http_no_port():
+    test_napalm_opts = {
+        "HOSTNAME": None,
+        "USERNAME": None,
+        "DRIVER_NAME": None,
+        "PASSWORD": "",
+        "TIMEOUT": 60,
+        "OPTIONAL_ARGS": {
+            "config_lock": False,
+            "keepalive": 5,
+            "transport": "http",
+        },
+        "ALWAYS_ALIVE": True,
+        "PROVIDER": None,
+        "UP": False,
+    }
+    with patch(
+        "salt.utils.napalm.get_device_opts", MagicMock(return_value=test_napalm_opts)
+    ):
+        test_kwargs = {}
+        ret = napalm_mod.pyeapi_nxos_api_args(kwargs=test_kwargs)
+        log.debug(f"DGM test_config post ret '{ret}', test_kwargs '{test_kwargs}'")
+        assert ret["transport"] == "http"
+        assert ret["port"] == 80
+
+
+def test_config_kwargs_http_and_port():
+    test_napalm_opts = {
+        "HOSTNAME": None,
+        "USERNAME": None,
+        "DRIVER_NAME": None,
+        "PASSWORD": "",
+        "TIMEOUT": 60,
+        "OPTIONAL_ARGS": {
+            "config_lock": False,
+            "keepalive": 5,
+            "transport": "http",
+            "port": 8080,
+        },
+        "ALWAYS_ALIVE": True,
+        "PROVIDER": None,
+        "UP": False,
+    }
+    with patch(
+        "salt.utils.napalm.get_device_opts", MagicMock(return_value=test_napalm_opts)
+    ):
+        test_kwargs = {}
+        ret = napalm_mod.pyeapi_nxos_api_args(kwargs=test_kwargs)
+        log.debug(f"DGM test_config post ret '{ret}', test_kwargs '{test_kwargs}'")
+        assert ret["transport"] == "http"
+        assert ret["port"] == 8080
+
+
+def test_config_kwargs_https_no_port():
+    test_napalm_opts = {
+        "HOSTNAME": None,
+        "USERNAME": None,
+        "DRIVER_NAME": None,
+        "PASSWORD": "",
+        "TIMEOUT": 60,
+        "OPTIONAL_ARGS": {
+            "config_lock": False,
+            "keepalive": 5,
+            "transport": "https",
+        },
+        "ALWAYS_ALIVE": True,
+        "PROVIDER": None,
+        "UP": False,
+    }
+    with patch(
+        "salt.utils.napalm.get_device_opts", MagicMock(return_value=test_napalm_opts)
+    ):
+        test_kwargs = {}
+        ret = napalm_mod.pyeapi_nxos_api_args(kwargs=test_kwargs)
+        log.debug(f"DGM test_config post ret '{ret}', test_kwargs '{test_kwargs}'")
+        assert ret["transport"] == "https"
+        assert ret["port"] == 443
+
+
+def test_config_kwargs_https_and_port():
+    test_napalm_opts = {
+        "HOSTNAME": None,
+        "USERNAME": None,
+        "DRIVER_NAME": None,
+        "PASSWORD": "",
+        "TIMEOUT": 60,
+        "OPTIONAL_ARGS": {
+            "config_lock": False,
+            "keepalive": 5,
+            "transport": "https",
+            "port": 5432,
+        },
+        "ALWAYS_ALIVE": True,
+        "PROVIDER": None,
+        "UP": False,
+    }
+    with patch(
+        "salt.utils.napalm.get_device_opts", MagicMock(return_value=test_napalm_opts)
+    ):
+        test_kwargs = {}
+        ret = napalm_mod.pyeapi_nxos_api_args(kwargs=test_kwargs)
+        log.debug(f"DGM test_config post ret '{ret}', test_kwargs '{test_kwargs}'")
+        assert ret["transport"] == "https"
+        assert ret["port"] == 5432
+
+
+def test_config_kwargs_werid_transport_port():
+    test_napalm_opts = {
+        "HOSTNAME": None,
+        "USERNAME": None,
+        "DRIVER_NAME": None,
+        "PASSWORD": "",
+        "TIMEOUT": 60,
+        "OPTIONAL_ARGS": {
+            "config_lock": False,
+            "keepalive": 5,
+            "transport": "nxos_protocol",
+            "port": 2080,
+        },
+        "ALWAYS_ALIVE": True,
+        "PROVIDER": None,
+        "UP": False,
+    }
+    with patch(
+        "salt.utils.napalm.get_device_opts", MagicMock(return_value=test_napalm_opts)
+    ):
+        test_kwargs = {}
+        ret = napalm_mod.pyeapi_nxos_api_args(kwargs=test_kwargs)
+        log.debug(f"DGM test_config post ret '{ret}', test_kwargs '{test_kwargs}'")
+        assert ret["transport"] == "nxos_protocol"
+        assert ret["port"] == 2080


### PR DESCRIPTION
### What does this PR do?
Sets the default transport and port values for Napalm NXOS if they are not set.  Napalm itself does this, but Salt is not recognizing these defaults values correctly and setting None, without an appropriate default value.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/59448

### Previous Behavior
Would cause a traceback when attempting to use the url 'None://a.b.c.d' rather than 'https' or 'http'.

### New Behavior
Correctly now sets a default transport of 'https' and appropriate port 443.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
