### PR TITLE
Allow cp functions to derive saltenv from config

### DIFF
--- a/changelog/61562.added
+++ b/changelog/61562.added
@@ -1,0 +1,1 @@
+Allow cp functions to derive saltenv from config if not explicitly set

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -232,9 +232,12 @@ def _render_filenames(path, dest, saltenv, template, **kw):
 
 
 def get_file(
-    path, dest, saltenv="base", makedirs=False, template=None, gzip=None, **kwargs
+    path, dest, saltenv=None, makedirs=False, template=None, gzip=None, **kwargs
 ):
     """
+    .. versionchanged:: 3005
+        ``saltenv`` will use value from config if not explicitly set
+
     .. versionchanged:: 2018.3.0
         ``dest`` can now be a directory
 
@@ -279,6 +282,9 @@ def get_file(
         It may be necessary to quote the URL when using the querystring method,
         depending on the shell being used to run the command.
     """
+    if not saltenv:
+        saltenv = __opts__["saltenv"] or "base"
+
     (path, dest) = _render_filenames(path, dest, saltenv, template, **kwargs)
 
     path, senv = salt.utils.url.split_env(path)
@@ -304,10 +310,11 @@ def envs():
     return _client().envs()
 
 
-def get_template(
-    path, dest, template="jinja", saltenv="base", makedirs=False, **kwargs
-):
+def get_template(path, dest, template="jinja", saltenv=None, makedirs=False, **kwargs):
     """
+    .. versionchanged:: 3005
+        ``saltenv`` will use value from config if not explicitly set
+
     Render a file as a template before setting it down.
     Warning, order is not the same as in fileclient.cp for
     non breaking old API.
@@ -318,6 +325,9 @@ def get_template(
 
         salt '*' cp.get_template salt://path/to/template /minion/dest
     """
+    if not saltenv:
+        saltenv = __opts__["saltenv"] or "base"
+
     if "salt" not in kwargs:
         kwargs["salt"] = __salt__
     if "pillar" not in kwargs:
@@ -329,8 +339,11 @@ def get_template(
     return _client().get_template(path, dest, template, makedirs, saltenv, **kwargs)
 
 
-def get_dir(path, dest, saltenv="base", template=None, gzip=None, **kwargs):
+def get_dir(path, dest, saltenv=None, template=None, gzip=None, **kwargs):
     """
+    .. versionchanged:: 3005
+        ``saltenv`` will use value from config if not explicitly set
+
     Used to recursively copy a directory from the salt master
 
     CLI Example:
@@ -341,13 +354,19 @@ def get_dir(path, dest, saltenv="base", template=None, gzip=None, **kwargs):
 
     get_dir supports the same template and gzip arguments as get_file.
     """
+    if not saltenv:
+        saltenv = __opts__["saltenv"] or "base"
+
     (path, dest) = _render_filenames(path, dest, saltenv, template, **kwargs)
 
     return _client().get_dir(path, dest, saltenv, gzip)
 
 
-def get_url(path, dest="", saltenv="base", makedirs=False, source_hash=None):
+def get_url(path, dest="", saltenv=None, makedirs=False, source_hash=None):
     """
+    .. versionchanged:: 3005
+        ``saltenv`` will use value from config if not explicitly set
+
     .. versionchanged:: 2018.3.0
         ``dest`` can now be a directory
 
@@ -376,7 +395,7 @@ def get_url(path, dest="", saltenv="base", makedirs=False, source_hash=None):
             and ``file://`` URLs. The files fetched by ``http://`` and
             ``https://`` will not be cached.
 
-    saltenv : base
+    saltenv
         Salt fileserver environment from which to retrieve the file. Ignored if
         ``path`` is not a ``salt://`` URL.
 
@@ -394,6 +413,9 @@ def get_url(path, dest="", saltenv="base", makedirs=False, source_hash=None):
         salt '*' cp.get_url salt://my/file /tmp/this_file_is_mine
         salt '*' cp.get_url http://www.slashdot.org /tmp/index.html
     """
+    if not saltenv:
+        saltenv = __opts__["saltenv"] or "base"
+
     if isinstance(dest, str):
         result = _client().get_url(
             path, dest, makedirs, saltenv, source_hash=source_hash
@@ -413,8 +435,11 @@ def get_url(path, dest="", saltenv="base", makedirs=False, source_hash=None):
     return result
 
 
-def get_file_str(path, saltenv="base"):
+def get_file_str(path, saltenv=None):
     """
+    .. versionchanged:: 3005
+        ``saltenv`` will use value from config if not explicitly set
+
     Download a file from a URL to the Minion cache directory and return the
     contents of that file
 
@@ -426,6 +451,9 @@ def get_file_str(path, saltenv="base"):
 
         salt '*' cp.get_file_str salt://my/file
     """
+    if not saltenv:
+        saltenv = __opts__["saltenv"] or "base"
+
     fn_ = cache_file(path, saltenv)
     if isinstance(fn_, str):
         try:
@@ -436,8 +464,11 @@ def get_file_str(path, saltenv="base"):
     return fn_
 
 
-def cache_file(path, saltenv="base", source_hash=None, verify_ssl=True, use_etag=False):
+def cache_file(path, saltenv=None, source_hash=None, verify_ssl=True, use_etag=False):
     """
+    .. versionchanged:: 3005
+        ``saltenv`` will use value from config if not explicitly set
+
     Used to cache a single file on the Minion
 
     Returns the location of the new cached file on the Minion
@@ -487,6 +518,9 @@ def cache_file(path, saltenv="base", source_hash=None, verify_ssl=True, use_etag
         It may be necessary to quote the URL when using the querystring method,
         depending on the shell being used to run the command.
     """
+    if not saltenv:
+        saltenv = __opts__["saltenv"] or "base"
+
     path = salt.utils.data.decode(path)
     saltenv = salt.utils.data.decode(saltenv)
 
@@ -528,9 +562,12 @@ def cache_file(path, saltenv="base", source_hash=None, verify_ssl=True, use_etag
     return result
 
 
-def cache_dest(url, saltenv="base"):
+def cache_dest(url, saltenv=None):
     """
     .. versionadded:: 3000
+
+    .. versionchanged:: 3005
+        ``saltenv`` will use value from config if not explicitly set
 
     Returns the expected cache path for the file, if cached using
     :py:func:`cp.cache_file <salt.modules.cp.cache_file>`.
@@ -548,11 +585,16 @@ def cache_dest(url, saltenv="base"):
         salt '*' cp.cache_dest salt://my/file
         salt '*' cp.cache_dest salt://my/file saltenv=dev
     """
+    if not saltenv:
+        saltenv = __opts__["saltenv"] or "base"
     return _client().cache_dest(url, saltenv)
 
 
-def cache_files(paths, saltenv="base"):
+def cache_files(paths, saltenv=None):
     """
+    .. versionchanged:: 3005
+        ``saltenv`` will use value from config if not explicitly set
+
     Used to gather many files from the Master, the gathered files will be
     saved in the minion cachedir reflective to the paths retrieved from the
     Master
@@ -587,13 +629,18 @@ def cache_files(paths, saltenv="base"):
         It may be necessary to quote the URL when using the querystring method,
         depending on the shell being used to run the command.
     """
+    if not saltenv:
+        saltenv = __opts__["saltenv"] or "base"
     return _client().cache_files(paths, saltenv)
 
 
 def cache_dir(
-    path, saltenv="base", include_empty=False, include_pat=None, exclude_pat=None
+    path, saltenv=None, include_empty=False, include_pat=None, exclude_pat=None
 ):
     """
+    .. versionchanged:: 3005
+        ``saltenv`` will use value from config if not explicitly set
+
     Download and cache everything under a directory from the master
 
 
@@ -623,11 +670,16 @@ def cache_dir(
         salt '*' cp.cache_dir salt://path/to/dir
         salt '*' cp.cache_dir salt://path/to/dir include_pat='E@*.py$'
     """
+    if not saltenv:
+        saltenv = __opts__["saltenv"] or "base"
     return _client().cache_dir(path, saltenv, include_empty, include_pat, exclude_pat)
 
 
-def cache_master(saltenv="base"):
+def cache_master(saltenv=None):
     """
+    .. versionchanged:: 3005
+        ``saltenv`` will use value from config if not explicitly set
+
     Retrieve all of the files on the master and cache them locally
 
     CLI Example:
@@ -636,6 +688,8 @@ def cache_master(saltenv="base"):
 
         salt '*' cp.cache_master
     """
+    if not saltenv:
+        saltenv = __opts__["saltenv"] or "base"
     return _client().cache_master(saltenv)
 
 
@@ -666,8 +720,11 @@ def cache_local_file(path):
     return _client().cache_local_file(path)
 
 
-def list_states(saltenv="base"):
+def list_states(saltenv=None):
     """
+    .. versionchanged:: 3005
+        ``saltenv`` will use value from config if not explicitly set
+
     List all of the available state modules in an environment
 
     CLI Example:
@@ -676,11 +733,16 @@ def list_states(saltenv="base"):
 
         salt '*' cp.list_states
     """
+    if not saltenv:
+        saltenv = __opts__["saltenv"] or "base"
     return _client().list_states(saltenv)
 
 
-def list_master(saltenv="base", prefix=""):
+def list_master(saltenv=None, prefix=""):
     """
+    .. versionchanged:: 3005
+        ``saltenv`` will use value from config if not explicitly set
+
     List all of the files stored on the master
 
     CLI Example:
@@ -689,11 +751,16 @@ def list_master(saltenv="base", prefix=""):
 
         salt '*' cp.list_master
     """
+    if not saltenv:
+        saltenv = __opts__["saltenv"] or "base"
     return _client().file_list(saltenv, prefix)
 
 
-def list_master_dirs(saltenv="base", prefix=""):
+def list_master_dirs(saltenv=None, prefix=""):
     """
+    .. versionchanged:: 3005
+        ``saltenv`` will use value from config if not explicitly set
+
     List all of the directories stored on the master
 
     CLI Example:
@@ -702,11 +769,16 @@ def list_master_dirs(saltenv="base", prefix=""):
 
         salt '*' cp.list_master_dirs
     """
+    if not saltenv:
+        saltenv = __opts__["saltenv"] or "base"
     return _client().dir_list(saltenv, prefix)
 
 
-def list_master_symlinks(saltenv="base", prefix=""):
+def list_master_symlinks(saltenv=None, prefix=""):
     """
+    .. versionchanged:: 3005
+        ``saltenv`` will use value from config if not explicitly set
+
     List all of the symlinks stored on the master
 
     CLI Example:
@@ -715,11 +787,16 @@ def list_master_symlinks(saltenv="base", prefix=""):
 
         salt '*' cp.list_master_symlinks
     """
+    if not saltenv:
+        saltenv = __opts__["saltenv"] or "base"
     return _client().symlink_list(saltenv, prefix)
 
 
-def list_minion(saltenv="base"):
+def list_minion(saltenv=None):
     """
+    .. versionchanged:: 3005
+        ``saltenv`` will use value from config if not explicitly set
+
     List all of the files cached on the minion
 
     CLI Example:
@@ -728,11 +805,16 @@ def list_minion(saltenv="base"):
 
         salt '*' cp.list_minion
     """
+    if not saltenv:
+        saltenv = __opts__["saltenv"] or "base"
     return _client().file_local_list(saltenv)
 
 
-def is_cached(path, saltenv="base"):
+def is_cached(path, saltenv=None):
     """
+    .. versionchanged:: 3005
+        ``saltenv`` will use value from config if not explicitly set
+
     Returns the full path to a file if it is cached locally on the minion
     otherwise returns a blank string
 
@@ -742,11 +824,21 @@ def is_cached(path, saltenv="base"):
 
         salt '*' cp.is_cached salt://path/to/file
     """
+    if not saltenv:
+        saltenv = __opts__["saltenv"] or "base"
+
+    path, senv = salt.utils.url.split_env(path)
+    if senv:
+        saltenv = senv
+
     return _client().is_cached(path, saltenv)
 
 
-def hash_file(path, saltenv="base"):
+def hash_file(path, saltenv=None):
     """
+    .. versionchanged:: 3005
+        ``saltenv`` will use value from config if not explicitly set
+
     Return the hash of a file, to get the hash of a file on the
     salt master file server prepend the path with salt://<file on server>
     otherwise, prepend the file with / for a local file.
@@ -757,6 +849,9 @@ def hash_file(path, saltenv="base"):
 
         salt '*' cp.hash_file salt://path/to/file
     """
+    if not saltenv:
+        saltenv = __opts__["saltenv"] or "base"
+
     path, senv = salt.utils.url.split_env(path)
     if senv:
         saltenv = senv
@@ -764,8 +859,11 @@ def hash_file(path, saltenv="base"):
     return _client().hash_file(path, saltenv)
 
 
-def stat_file(path, saltenv="base", octal=True):
+def stat_file(path, saltenv=None, octal=True):
     """
+    .. versionchanged:: 3005
+        ``saltenv`` will use value from config if not explicitly set
+
     Return the permissions of a file, to get the permissions of a file on the
     salt master file server prepend the path with salt://<file on server>
     otherwise, prepend the file with / for a local file.
@@ -776,6 +874,9 @@ def stat_file(path, saltenv="base", octal=True):
 
         salt '*' cp.stat_file salt://path/to/file
     """
+    if not saltenv:
+        saltenv = __opts__["saltenv"] or "base"
+
     path, senv = salt.utils.url.split_env(path)
     if senv:
         saltenv = senv

--- a/tests/pytests/unit/modules/test_cp.py
+++ b/tests/pytests/unit/modules/test_cp.py
@@ -15,7 +15,7 @@ from tests.support.mock import MagicMock, Mock, mock_open, patch
 
 @pytest.fixture()
 def configure_loader_modules():
-    return {cp: {}}
+    return {cp: {"__opts__": {"saltenv": None}}}
 
 
 def test__render_filenames_undefined_template():
@@ -69,6 +69,10 @@ def test__render_filenames_success():
     with patch.dict(templates.TEMPLATE_REGISTRY, {"jinja": mock_jinja}):
         with patch("salt.utils.files.fopen", mock_open(read_data=file_data)):
             assert cp._render_filenames(path, dest, saltenv, template) == ret
+            # saltenv=None should default to "base" when not set in config
+            assert (
+                cp._render_filenames(path, dest, saltenv=None, template=template) == ret
+            )
 
 
 def test_get_file_not_found():


### PR DESCRIPTION
### What does this PR do?
This PR allows the `cp` module functions to derive `saltenv` from config if not explicitly set as a keyword argument to the function. See issue for details.

### What issues does this PR fix or reference?
Fixes: #61562

### Previous Behavior
On minions with a `saltenv` set:
```
# /etc/salt/minion.d/saltenv.conf

saltenv: dev
```

The `cp` functions would not detect that `saltenv` and default to "base":
```bash
# returns files from the base env (if configured on the master)

salt-call cp.list_master
```

This often leads to user confusion or surprise because they expect the minion to be "in" a given environment.

### New Behavior
The `cp` functions will now detect the `saltenv` from the configuration files and use that unless explicitly set:
```bash
# returns files from the dev env (if configured as previously shown)

salt-call cp.list_master

# the saltenv can still be overridden

salt-call cp.list_master saltenv=prod
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
