### PR TITLE
virt: don't break if qemu-img is too old to support -U parameter

### DIFF
--- a/changelog/61570.fixed
+++ b/changelog/61570.fixed
@@ -1,0 +1,1 @@
+Don't fail is qemu-img doesn't support -U parameter when extracting disk infos

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -601,6 +601,8 @@ def _get_disks(conn, dom):
                             extra_properties = {"error": stderr}
                     except FileNotFoundError:
                         extra_properties = {"error": "qemu-img not found"}
+                    except ValueError:
+                        extra_properties = {"error": "qemu-img is too old"}
             elif disk_type == "block":
                 qemu_target = source.get("dev", "")
                 # If the qemu_target is a known path, output a volume


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes: #61570

### Previous Behavior

`virt.vm_info` fails if the `qemu-img` installed on the minion is too old to have `-U` parameter

### New Behavior
`virt.vm_info` doesn't fail, but adds an `error` property to the disks stating that qemu-img is too old.

### Merge requirements satisfied?
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes