### PR TITLE
GitFS: Introduce a repo lock when using "__env__" in git remotes configuration to avoid race conditions

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -172,8 +172,6 @@ class Maintenance(salt.utils.process.SignalHandlingProcess):
         self.event = salt.utils.event.get_master_event(
             self.opts, self.opts["sock_dir"], listen=False
         )
-        # Init any values needed by the git ext pillar
-        self.git_pillar = salt.daemons.masterapi.init_git_pillar(self.opts)
 
         if self.opts["maintenance_niceness"] and not salt.utils.platform.is_windows():
             log.info(
@@ -299,8 +297,10 @@ class Maintenance(salt.utils.process.SignalHandlingProcess):
         """
         Update git pillar
         """
+        # Init any values needed by the git ext pillar
+        git_pillar = salt.daemons.masterapi.init_git_pillar(self.opts)
         try:
-            for pillar in self.git_pillar:
+            for pillar in git_pillar:
                 pillar.fetch_remotes()
         except Exception as exc:  # pylint: disable=broad-except
             log.error("Exception caught while updating git_pillar", exc_info=True)

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -485,13 +485,13 @@ class GitProvider:
                 break
             except (OSError, GitLockError) as exc:
                 log.debug(
-                    "Repo lock is present for remote: '{}', sleeping 0.5 seconds before trying again.".format(
-                        self.id
-                    )
+                    "Repo lock is present for remote: '%s', sleeping 0.5 seconds before trying again.",
+                    self.id,
                 )
                 time.sleep(0.5)
                 continue
 
+    # pylint: disable=W1701
     def __del__(self):
         try:
             self.clear_lock(lock_type="repo")
@@ -904,13 +904,13 @@ class GitProvider:
                                 "cache, the lock may have been obtained "
                                 "by another master."
                             )
-                    if not lock_type == "repo":
+                    if lock_type != "repo":
                         log.warning(msg)
                     if failhard:
                         raise
                     return
                 elif pid and pid_exists(pid):
-                    if not lock_type == "repo":
+                    if lock_type != "repo":
                         log.warning(
                             "Process %d has a %s %s lock (%s)",
                             pid,

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -904,18 +904,20 @@ class GitProvider:
                                 "cache, the lock may have been obtained "
                                 "by another master."
                             )
-                    log.warning(msg)
+                    if not lock_type == "repo":
+                        log.warning(msg)
                     if failhard:
                         raise
                     return
                 elif pid and pid_exists(pid):
-                    log.warning(
-                        "Process %d has a %s %s lock (%s)",
-                        pid,
-                        self.role,
-                        lock_type,
-                        lock_file,
-                    )
+                    if not lock_type == "repo":
+                        log.warning(
+                            "Process %d has a %s %s lock (%s)",
+                            pid,
+                            self.role,
+                            lock_type,
+                            lock_file,
+                        )
                     if failhard:
                         raise
                     return

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -931,9 +931,9 @@ class GitProvider:
                             lock_type,
                             lock_file,
                         )
-                    success, fail = self.clear_lock()
+                    success, fail = self.clear_lock(lock_type=lock_type)
                     if success:
-                        return self._lock(lock_type="update", failhard=failhard)
+                        return self._lock(lock_type=lock_type, failhard=failhard)
                     elif failhard:
                         raise
                     return


### PR DESCRIPTION
### What does this PR do?

This PR provides an alternative solution to what https://github.com/saltstack/salt/pull/61477 proposes.

---

This PR fixes a race condition that produces wrong results and leaks between different saltenv/pillarenv when using `__env__` in your gitfs remotes configuration and perform many requests for different envs at the same time.

### Previous Behavior
Given that you have a git pillar configuration as follows in your Salt master:

```yaml
gitfs_provider: pygit2

ext_pillar:
  - git:
    - __env__ file:///test_repo.git
```

My `test_repo.git` repository contains few branches: "prod" / "dev" / "test", each one of them with `top.sls` file and providing a custom pillar with a different value on each branch.

Once my salt master is started, and multiple pillar requests are generated for different pillarenvs at the same time, then wrong results/leak happens:
2022-02-04 17:38:45,080 [salt.utils.gitfs :888 ][WARNING ][32372] Process 32378 has a git_pillar checkout lock (/var/cache/salt/master/git_pillar/76f8d8390124f6fd664b35a371ec52d407b6b94745a9458eb9c4be5976a9d6da/.git/checkout.lk)

```console
# for i in {1..10}; do salt \* -lquiet pillar.get mycustompillar pillarenv=prod & done; for i in {1..10}; do salt \* -lquiet pillar.get mycustompillar pillarenv=dev & done
test_minion:
    prod
test_minion:
test_minion:
    dev
test_minion:
    prod
test_minion:
test_minion:
    prod
test_minion:
    dev
test_minion:
test_minion:
test_minion:
    prod
test_minion:
    prod
test_minion:
    prod
test_minion:
    prod
test_minion:
    dev
test_minion:
    prod
test_minion:
    dev
test_minion:
    dev
test_minion:
test_minion:
test_minion:
    dev
```

We were expecting 10 x "prod" + 10 x "dev"  as the result for this test, but as you see above this is not the case, we got some empty results with no errors. Some other times we get more "dev" than "prod" in the results, which indicates a leak is produced. 

Depending on the load and also in the content of your git repo, we might see warning messages like:

```
2022-02-04 17:38:45,080 [salt.utils.gitfs :888 ][WARNING ][32372] Process 32378 has a git_pillar checkout lock (/var/cache/salt/master/git_pillar/76f8d8390124f6fd664b35a371ec52d407b6b94745a9458eb9c4be5976a9d6da/.git/checkout.lk)
```

or even ERROR messages because the requested pillar SLS is not found (as the content of the underlying cachedir was changed between the `top.sls` was read and the other referenced SLS were processed by other git pillar instance)

This situation/leak is produced because we have an unique cachedir for the each `__env__` git remote, where Salt is checking out to the corresponding branch for every request. This constant switching of branches in the repo cachedir, caused by the different master workers competing for the same filesystem resource, makes this race condition to occur.


### New Behavior
This PR introduces a "repo" lock for those git remotes that are configured with `__env__` that prevents multiple git pillar instances to be consuming the same resource at the same time. The repo lock is cleared as soon as the instance is done.

In case "salt-master" is restarted but a `repo.lk` file was not cleaned, Salt will clean those up during starting, as the other lock when dealing with GitFS providers. 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
