### PR TITLE
fixes cmdmod ignoreing saltenv set in configfile.

### DIFF
--- a/changelog/61507.fixed
+++ b/changelog/61507.fixed
@@ -1,0 +1,1 @@
+Fix cmdmod not respecting config for saltenv

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -127,13 +127,13 @@ def _chroot_pids(chroot):
     return pids
 
 
-def _render_cmd(
-    cmd, cwd, template, saltenv="base", pillarenv=None, pillar_override=None
-):
+def _render_cmd(cmd, cwd, template, saltenv=None, pillarenv=None, pillar_override=None):
     """
     If template is a valid template engine, process the cmd and cwd through
     that engine.
     """
+    if saltenv is None:
+        saltenv = __opts__.get("saltenv", "base")
     if not template:
         return (cmd, cwd)
 
@@ -274,7 +274,7 @@ def _run(
     with_communicate=True,
     reset_system_locale=True,
     ignore_retcode=False,
-    saltenv="base",
+    saltenv=None,
     pillarenv=None,
     pillar_override=None,
     use_vt=False,
@@ -898,7 +898,7 @@ def _run_quiet(
     umask=None,
     timeout=None,
     reset_system_locale=True,
-    saltenv="base",
+    saltenv=None,
     pillarenv=None,
     pillar_override=None,
     success_retcodes=None,
@@ -945,7 +945,7 @@ def _run_all_quiet(
     umask=None,
     timeout=None,
     reset_system_locale=True,
-    saltenv="base",
+    saltenv=None,
     pillarenv=None,
     pillar_override=None,
     output_encoding=None,
@@ -1007,7 +1007,7 @@ def run(
     timeout=None,
     reset_system_locale=True,
     ignore_retcode=False,
-    saltenv="base",
+    saltenv=None,
     use_vt=False,
     bg=False,
     password=None,
@@ -1325,7 +1325,7 @@ def shell(
     timeout=None,
     reset_system_locale=True,
     ignore_retcode=False,
-    saltenv="base",
+    saltenv=None,
     use_vt=False,
     bg=False,
     password=None,
@@ -1585,7 +1585,7 @@ def run_stdout(
     timeout=None,
     reset_system_locale=True,
     ignore_retcode=False,
-    saltenv="base",
+    saltenv=None,
     use_vt=False,
     password=None,
     prepend_path=None,
@@ -1819,7 +1819,7 @@ def run_stderr(
     timeout=None,
     reset_system_locale=True,
     ignore_retcode=False,
-    saltenv="base",
+    saltenv=None,
     use_vt=False,
     password=None,
     prepend_path=None,
@@ -2053,7 +2053,7 @@ def run_all(
     timeout=None,
     reset_system_locale=True,
     ignore_retcode=False,
-    saltenv="base",
+    saltenv=None,
     use_vt=False,
     redirect_stderr=False,
     password=None,
@@ -2333,7 +2333,7 @@ def retcode(
     timeout=None,
     reset_system_locale=True,
     ignore_retcode=False,
-    saltenv="base",
+    saltenv=None,
     use_vt=False,
     password=None,
     success_retcodes=None,
@@ -2551,7 +2551,7 @@ def _retcode_quiet(
     timeout=None,
     reset_system_locale=True,
     ignore_retcode=False,
-    saltenv="base",
+    saltenv=None,
     use_vt=False,
     password=None,
     success_retcodes=None,
@@ -2609,7 +2609,7 @@ def script(
     hide_output=False,
     timeout=None,
     reset_system_locale=True,
-    saltenv="base",
+    saltenv=None,
     use_vt=False,
     bg=False,
     password=None,
@@ -2792,6 +2792,8 @@ def script(
 
         salt '*' cmd.script salt://scripts/runme.sh stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     """
+    if saltenv is None:
+        saltenv = __opts__.get("saltenv", "base")
     python_shell = _python_shell_default(python_shell, kwargs.get("__pub_jid", ""))
 
     def _cleanup_tempfile(path):
@@ -2911,7 +2913,7 @@ def script_retcode(
     umask=None,
     timeout=None,
     reset_system_locale=True,
-    saltenv="base",
+    saltenv=None,
     output_encoding=None,
     output_loglevel="debug",
     log_callback=None,
@@ -3264,7 +3266,7 @@ def run_chroot(
     timeout=None,
     reset_system_locale=True,
     ignore_retcode=False,
-    saltenv="base",
+    saltenv=None,
     use_vt=False,
     bg=False,
     success_retcodes=None,
@@ -3802,7 +3804,7 @@ def powershell(
     timeout=None,
     reset_system_locale=True,
     ignore_retcode=False,
-    saltenv="base",
+    saltenv=None,
     use_vt=False,
     password=None,
     depth=None,
@@ -4090,7 +4092,7 @@ def powershell_all(
     timeout=None,
     reset_system_locale=True,
     ignore_retcode=False,
-    saltenv="base",
+    saltenv=None,
     use_vt=False,
     password=None,
     depth=None,
@@ -4462,7 +4464,7 @@ def run_bg(
     log_callback=None,
     reset_system_locale=True,
     ignore_retcode=False,
-    saltenv="base",
+    saltenv=None,
     password=None,
     prepend_path=None,
     success_retcodes=None,

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -133,7 +133,11 @@ def _render_cmd(cmd, cwd, template, saltenv=None, pillarenv=None, pillar_overrid
     that engine.
     """
     if saltenv is None:
-        saltenv = __opts__.get("saltenv", "base")
+        try:
+            saltenv = __opts__.get("saltenv", "base")
+        except NameError:
+            saltenv = "base"
+
     if not template:
         return (cmd, cwd)
 
@@ -2793,7 +2797,10 @@ def script(
         salt '*' cmd.script salt://scripts/runme.sh stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     """
     if saltenv is None:
-        saltenv = __opts__.get("saltenv", "base")
+        try:
+            saltenv = __opts__.get("saltenv", "base")
+        except NameError:
+            saltenv = "base"
     python_shell = _python_shell_default(python_shell, kwargs.get("__pub_jid", ""))
 
     def _cleanup_tempfile(path):

--- a/tests/integration/modules/test_cmdmod.py
+++ b/tests/integration/modules/test_cmdmod.py
@@ -217,7 +217,7 @@ class CMDModuleTest(ModuleCase):
         """
         args = "saltines crackers biscuits=yes"
         script = "salt://script.py"
-        ret = self.run_function("cmd.script", [script, args])
+        ret = self.run_function("cmd.script", [script, args], saltenv="base")
         self.assertEqual(ret["stdout"], args)
 
     @pytest.mark.slow_test
@@ -227,7 +227,7 @@ class CMDModuleTest(ModuleCase):
         """
         args = "saltines crackers biscuits=yes"
         script = "salt://script.py?saltenv=base"
-        ret = self.run_function("cmd.script", [script, args])
+        ret = self.run_function("cmd.script", [script, args], saltenv="base")
         self.assertEqual(ret["stdout"], args)
 
     @pytest.mark.slow_test
@@ -236,7 +236,7 @@ class CMDModuleTest(ModuleCase):
         cmd.script_retcode
         """
         script = "salt://script.py"
-        ret = self.run_function("cmd.script_retcode", [script])
+        ret = self.run_function("cmd.script_retcode", [script], saltenv="base")
         self.assertEqual(ret, 0)
 
     @pytest.mark.slow_test
@@ -247,7 +247,9 @@ class CMDModuleTest(ModuleCase):
         tmp_cwd = tempfile.mkdtemp(dir=RUNTIME_VARS.TMP)
         args = "saltines crackers biscuits=yes"
         script = "salt://script.py"
-        ret = self.run_function("cmd.script", [script, args], cwd=tmp_cwd)
+        ret = self.run_function(
+            "cmd.script", [script, args], cwd=tmp_cwd, saltenv="base"
+        )
         self.assertEqual(ret["stdout"], args)
 
     @pytest.mark.slow_test
@@ -262,7 +264,9 @@ class CMDModuleTest(ModuleCase):
 
         args = "saltines crackers biscuits=yes"
         script = "salt://script.py"
-        ret = self.run_function("cmd.script", [script, args], cwd=tmp_cwd)
+        ret = self.run_function(
+            "cmd.script", [script, args], cwd=tmp_cwd, saltenv="base"
+        )
         self.assertEqual(ret["stdout"], args)
 
     @pytest.mark.destructive_test
@@ -595,7 +599,9 @@ class CMDModuleTest(ModuleCase):
             " -ErrorAction Stop".format(val)
         )
         script = "salt://issue-56195/test.ps1"
-        ret = self.run_function("cmd.script", [script], args=args, shell="powershell")
+        ret = self.run_function(
+            "cmd.script", [script], args=args, shell="powershell", saltenv="base"
+        )
         self.assertEqual(ret["stdout"], val)
 
     @pytest.mark.slow_test
@@ -612,5 +618,7 @@ class CMDModuleTest(ModuleCase):
             " -ErrorAction Stop".format(val)
         )
         script = "salt://issue-56195/test.ps1"
-        ret = self.run_function("cmd.script", [script], args=args, shell="pwsh")
+        ret = self.run_function(
+            "cmd.script", [script], args=args, shell="pwsh", saltenv="base"
+        )
         self.assertEqual(ret["stdout"], val)

--- a/tests/pytests/unit/modules/test_cmdmod.py
+++ b/tests/pytests/unit/modules/test_cmdmod.py
@@ -728,17 +728,19 @@ def test_cmd_script_saltenv_from_config():
             },
         ):
             with patch("salt.modules.cmdmod._run") as mock_run:
-                with patch("shutil.copyfile") as mock_shutil:
-                    with patch("os.chmod") as mock_os_chmod:
-                        with patch("os.chown") as mock_os_chown:
-                            cmdmod.script("test")
-                            assert mock_cp_cache_file.call_count == 1
-                            mock_cp_cache_file.assert_called_with("test", "base")
-
-                            assert mock_run.call_count == 1
-                            assert mock_run.call_args[1]["saltenv"] == "base"
-                            cmdmod.script("test", template="jinja")
-                            assert mock_cp_get_template.call_count == 1
-                            assert mock_cp_get_template.call_args[0][3] == "base"
-                            assert mock_run.call_count == 2
-                            assert mock_run.call_args[1]["saltenv"] == "base"
+                with patch(
+                    "salt.utils.platform.is_windows", MagicMock(return_value=False)
+                ):
+                    with patch("shutil.copyfile", MagicMock()):
+                        with patch("os.chmod", MagicMock()):
+                            with patch("os.chown", MagicMock()):
+                                cmdmod.script("test")
+                                assert mock_cp_cache_file.call_count == 1
+                                mock_cp_cache_file.assert_called_with("test", "base")
+                                assert mock_run.call_count == 1
+                                assert mock_run.call_args[1]["saltenv"] == "base"
+                                cmdmod.script("test", template="jinja")
+                                assert mock_cp_get_template.call_count == 1
+                                assert mock_cp_get_template.call_args[0][3] == "base"
+                                assert mock_run.call_count == 2
+                                assert mock_run.call_args[1]["saltenv"] == "base"

--- a/tests/pytests/unit/modules/test_cmdmod.py
+++ b/tests/pytests/unit/modules/test_cmdmod.py
@@ -28,7 +28,8 @@ MOCK_SHELL_FILE = "# List of acceptable shells\n\n/bin/bash\n"
 
 @pytest.fixture
 def configure_loader_modules():
-    return {cmdmod: {}}
+    opts = salt.config.DEFAULT_MINION_OPTS.copy()
+    return {cmdmod: {"__opts__": opts}}
 
 
 @pytest.fixture(scope="module")
@@ -51,6 +52,20 @@ def test_render_cmd_no_template():
     Tests return when template=None
     """
     assert cmdmod._render_cmd("foo", "bar", None) == ("foo", "bar")
+
+
+def test_render_cmd_saltenv_from_config():
+    mock_template = MagicMock()
+    with patch.dict(cmdmod.__opts__, {"saltenv": "base"}):
+        with patch.dict(
+            "salt.utils.templates.TEMPLATE_REGISTRY", {"test": mock_template}
+        ):
+            cmdmod._render_cmd("test", "test", "test")
+            assert mock_template.call_count == 2
+            assert mock_template.call_args[1]["saltenv"] == "base"
+            cmdmod._render_cmd("test", "test", "test", saltenv="fake")
+            assert mock_template.call_count == 4
+            assert mock_template.call_args[1]["saltenv"] == "fake"
 
 
 def test_render_cmd_unavailable_engine():
@@ -644,7 +659,7 @@ def test_run_chroot_runas():
         python_shell=True,
         reset_system_locale=True,
         rstrip=True,
-        saltenv="base",
+        saltenv=None,
         shell="/bin/sh",
         stdin=None,
         success_retcodes=None,
@@ -693,3 +708,37 @@ def test_log_cmd_non_str_tuple_list():
             return self.cmd
 
     assert cmdmod._log_cmd(cmd("foo bar")) == "foo"
+
+
+def test_cmd_script_saltenv_from_config():
+    mock_cp_get_template = MagicMock()
+    mock_cp_cache_file = MagicMock()
+    mock_run = MagicMock()
+    mock_shutil = MagicMock()
+    mock_os_chmod = MagicMock()
+    mock_os_chown = MagicMock()
+    with patch.dict(cmdmod.__opts__, {"saltenv": "base"}):
+        with patch.dict(
+            cmdmod.__salt__,
+            {
+                "cp.cache_file": mock_cp_cache_file,
+                "cp.get_template": mock_cp_get_template,
+                "file.user_to_uid": MagicMock(),
+                "file.remove": MagicMock(),
+            },
+        ):
+            with patch("salt.modules.cmdmod._run") as mock_run:
+                with patch("shutil.copyfile") as mock_shutil:
+                    with patch("os.chmod") as mock_os_chmod:
+                        with patch("os.chown") as mock_os_chown:
+                            cmdmod.script("test")
+                            assert mock_cp_cache_file.call_count == 1
+                            mock_cp_cache_file.assert_called_with("test", "base")
+
+                            assert mock_run.call_count == 1
+                            assert mock_run.call_args[1]["saltenv"] == "base"
+                            cmdmod.script("test", template="jinja")
+                            assert mock_cp_get_template.call_count == 1
+                            assert mock_cp_get_template.call_args[0][3] == "base"
+                            assert mock_run.call_count == 2
+                            assert mock_run.call_args[1]["saltenv"] == "base"

--- a/tests/pytests/unit/modules/test_cmdmod.py
+++ b/tests/pytests/unit/modules/test_cmdmod.py
@@ -726,22 +726,19 @@ def test_cmd_script_saltenv_from_config():
             },
         ):
             with patch("salt.modules.cmdmod._run") as mock_run:
-                with patch(
-                    "salt.utils.platform.is_windows", MagicMock(return_value=False)
-                ):
-                    with patch("shutil.copyfile", MagicMock()):
-                        with patch("os.chmod", MagicMock()):
-                            with patch("os.chown", MagicMock()):
-                                cmdmod.script("test")
-                                assert mock_cp_cache_file.call_count == 1
-                                mock_cp_cache_file.assert_called_with("test", "base")
-                                assert mock_run.call_count == 1
-                                assert mock_run.call_args[1]["saltenv"] == "base"
-                                cmdmod.script("test", template="jinja")
-                                assert mock_cp_get_template.call_count == 1
-                                assert mock_cp_get_template.call_args[0][3] == "base"
-                                assert mock_run.call_count == 2
-                                assert mock_run.call_args[1]["saltenv"] == "base"
+                with patch("shutil.copyfile", MagicMock()):
+                    with patch("os.chmod", MagicMock()):
+                        with patch("os.chown", MagicMock()):
+                            cmdmod.script("test")
+                            assert mock_cp_cache_file.call_count == 1
+                            mock_cp_cache_file.assert_called_with("test", "base")
+                            assert mock_run.call_count == 1
+                            assert mock_run.call_args[1]["saltenv"] == "base"
+                            cmdmod.script("test", template="jinja")
+                            assert mock_cp_get_template.call_count == 1
+                            assert mock_cp_get_template.call_args[0][3] == "base"
+                            assert mock_run.call_count == 2
+                            assert mock_run.call_args[1]["saltenv"] == "base"
 
 
 @pytest.mark.skip_unless_on_windows
@@ -760,17 +757,14 @@ def test_cmd_script_saltenv_from_config_windows():
             },
         ):
             with patch("salt.modules.cmdmod._run") as mock_run:
-                with patch(
-                    "salt.utils.platform.is_windows", MagicMock(return_value=False)
-                ):
-                    with patch("shutil.copyfile", MagicMock()):
-                        cmdmod.script("test")
-                        assert mock_cp_cache_file.call_count == 1
-                        mock_cp_cache_file.assert_called_with("test", "base")
-                        assert mock_run.call_count == 1
-                        assert mock_run.call_args[1]["saltenv"] == "base"
-                        cmdmod.script("test", template="jinja")
-                        assert mock_cp_get_template.call_count == 1
-                        assert mock_cp_get_template.call_args[0][3] == "base"
-                        assert mock_run.call_count == 2
-                        assert mock_run.call_args[1]["saltenv"] == "base"
+                with patch("shutil.copyfile", MagicMock()):
+                    cmdmod.script("test")
+                    assert mock_cp_cache_file.call_count == 1
+                    mock_cp_cache_file.assert_called_with("test", "base")
+                    assert mock_run.call_count == 1
+                    assert mock_run.call_args[1]["saltenv"] == "base"
+                    cmdmod.script("test", template="jinja")
+                    assert mock_cp_get_template.call_count == 1
+                    assert mock_cp_get_template.call_args[0][3] == "base"
+                    assert mock_run.call_count == 2
+                    assert mock_run.call_args[1]["saltenv"] == "base"


### PR DESCRIPTION
### What does this PR do?

bug fix for cmdmod not respecting saltenv set in config file. 

### What issues does this PR fix or reference?
Fixes: #61507

### Previous Behavior
cmdmod ignores saltenv when it is set in the config file.

### New Behavior
now it will pull the relevant data when it needs to. 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No