### PR TITLE
Correct returned result to False when an error exception occurs for pip.installed

### DIFF
--- a/changelog/61117.fixed
+++ b/changelog/61117.fixed
@@ -1,0 +1,1 @@
+Correct returned result to False when an error exception occurs for pip.installed

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -731,7 +731,7 @@ def installed(
     try:
         cur_version = __salt__["pip.version"](bin_env)
     except (CommandNotFoundError, CommandExecutionError) as err:
-        ret["result"] = None
+        ret["result"] = False
         ret["comment"] = "Error installing '{}': {}".format(name, err)
         return ret
     # Check that the pip binary supports the 'use_wheel' option

--- a/tests/pytests/functional/states/test_pip_state.py
+++ b/tests/pytests/functional/states/test_pip_state.py
@@ -135,7 +135,7 @@ pep8-pip:
         ):
             ret = modules.state.sls("pip-installed-errors")
             for state_return in ret:
-                assert not state_return.result
+                assert state_return.result is False
                 assert "Error installing 'pep8':" in state_return.comment
 
             # We now create the missing virtualenv


### PR DESCRIPTION
### What does this PR do?
When a Command Error exception occurs the returned "result" is set to False

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/61117

### Previous Behavior
The returned "result" was set to None, resulting in the state having succeeded but with an Error declared.

### New Behavior
The state is now reported correctly as Failed when the Command Error is reported.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
