### PR TITLE
Fix version part of osfinger on Pop!_OS

### DIFF
--- a/changelog/61619.fixed
+++ b/changelog/61619.fixed
@@ -1,0 +1,1 @@
+Pop!_OS uses the full version (YY.MM) in the osfinger grain now, not just the year. This allows differentiating for example between 20.04 and 20.10.

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2258,7 +2258,7 @@ def _osrelease_data(os, osfullname, osrelease):
         os_name = osfullname
     grains["osfinger"] = "{}-{}".format(
         os_name,
-        osrelease if os_name in ("Ubuntu",) else grains["osrelease_info"][0],
+        osrelease if os in ("Ubuntu", "Pop") else grains["osrelease_info"][0],
     )
 
     return grains

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -1249,22 +1249,22 @@ def test_pop_focal_os_grains():
 
 
 @pytest.mark.skip_unless_on_linux
-def test_pop_groovy_os_grains():
+def test_pop_impish_os_grains():
     """
-    Test if OS grains are parsed correctly in Pop!_OS 20.10 "Groovy Gorilla"
+    Test if OS grains are parsed correctly in Pop!_OS 21.10 "Impish Indri"
     """
     _os_release_map = {
-        "_linux_distribution": ("Pop", "20.10", "groovy"),
+        "_linux_distribution": ("Pop", "21.10", "impish"),
     }
     expectation = {
         "os": "Pop",
         "os_family": "Debian",
-        "oscodename": "groovy",
+        "oscodename": "impish",
         "osfullname": "Pop",
-        "osrelease": "20.10",
-        "osrelease_info": (20, 10),
-        "osmajorrelease": 20,
-        "osfinger": "Pop-20",
+        "osrelease": "21.10",
+        "osrelease_info": (21, 10),
+        "osmajorrelease": 21,
+        "osfinger": "Pop-21",
     }
     _run_os_grains_tests(None, _os_release_map, expectation)
 

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -1243,7 +1243,7 @@ def test_pop_focal_os_grains():
         "osrelease": "20.04",
         "osrelease_info": (20, 4),
         "osmajorrelease": 20,
-        "osfinger": "Pop-20",
+        "osfinger": "Pop-20.04",
     }
     _run_os_grains_tests(None, _os_release_map, expectation)
 
@@ -1264,7 +1264,7 @@ def test_pop_impish_os_grains():
         "osrelease": "21.10",
         "osrelease_info": (21, 10),
         "osmajorrelease": 21,
-        "osfinger": "Pop-21",
+        "osfinger": "Pop-21.10",
     }
     _run_os_grains_tests(None, _os_release_map, expectation)
 


### PR DESCRIPTION
Pop!_OS uses the same version scheme than Ubuntu (YY.MM) and releases every six month in April and October. Using only the year from the version in the `osfinger` does not allow differentiating between 20.04 and 20.10. Both has the `osfinger` set to `Pop-20`.

So include the full version in the `osfinger` grain.

This merge request is the third in the series after merge request https://github.com/saltstack/salt/pull/61597 and https://github.com/saltstack/salt/pull/61589.