### PR TITLE
Fix: "AttributeError: module 'salt.utils' has no attribute 'json'" when using vault as local sdb module at the master #61627

### DIFF
--- a/salt/utils/vault.py
+++ b/salt/utils/vault.py
@@ -15,6 +15,7 @@ import time
 import requests
 import salt.crypt
 import salt.exceptions
+import salt.utils.json
 import salt.utils.versions
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
### What does this PR do?
Fix missing json import for salt.utils.vault when running as sdb / runner at the master.

### What issues does this PR fix or reference?
Fixes: #61627

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
