### PR TITLE
Deprecated napalm_mod.py, netmiko_conn and pyeapi_conn functions not to be called from the CLI

### DIFF
--- a/changelog/61566.deprecated
+++ b/changelog/61566.deprecated
@@ -1,2 +1,1 @@
 Deprecated netmiko_conn and pyeapi_conn in napalm_mod.py as these function should not be called from the CLI
-

--- a/changelog/61566.deprecated
+++ b/changelog/61566.deprecated
@@ -1,0 +1,2 @@
+Deprecated netmiko_conn and pyeapi_conn in napalm_mod.py as these function should not be called from the CLI
+

--- a/salt/modules/napalm_mod.py
+++ b/salt/modules/napalm_mod.py
@@ -766,8 +766,8 @@ def netmiko_conn(**kwargs):
     salt.utils.versions.warn_until(
         "Chlorine",
         "This 'napalm_mod.netmiko_conn' function as been deprecated and "
-        "its functionality removed, as such, it has been made an internal "
-        "function since it is not suitable for CLI usage",
+        "will be removed in the {version} release, as such, it has been "
+        "made an internal function since it is not suitable for CLI usage",
     )
     return _netmiko_conn(**kwargs)
 
@@ -1163,8 +1163,8 @@ def pyeapi_conn(**kwargs):
     salt.utils.versions.warn_until(
         "Chlorine",
         "This 'napalm_mod.pyeapi_conn' function as been deprecated and "
-        "its functionality removed, as such, it has been made an internal "
-        "function since it is not suitable for CLI usage",
+        "will be removed in the {version} release, as such, it has been "
+        "made an internal function since it is not suitable for CLI usage",
     )
     return _pyeapi_conn(**kwargs)
 

--- a/salt/modules/napalm_mod.py
+++ b/salt/modules/napalm_mod.py
@@ -161,6 +161,57 @@ def _junos_prep_fun(napalm_device):
     return {"result": True}
 
 
+@proxy_napalm_wrap
+def _netmiko_conn(**kwargs):
+    """
+    .. versionadded:: 2019.2.0
+
+    Return the connection object with the network device, over Netmiko, passing
+    the authentication details from the existing NAPALM connection.
+
+    .. warning::
+
+        This function is not suitable for CLI usage, more rather to be used
+        in various Salt modules.
+
+    USAGE Example:
+
+    .. code-block:: python
+
+        conn = __salt__['napalm.netmiko_conn']()
+        res = conn.send_command('show interfaces')
+        conn.disconnect()
+    """
+    netmiko_kwargs = netmiko_args()
+    kwargs.update(netmiko_kwargs)
+    return __salt__["netmiko.get_connection"](**kwargs)
+
+
+@proxy_napalm_wrap
+def _pyeapi_conn(**kwargs):
+    """
+    .. versionadded:: 2019.2.0
+
+    Return the connection object with the Arista switch, over ``pyeapi``,
+    passing the authentication details from the existing NAPALM connection.
+
+    .. warning::
+        This function is not suitable for CLI usage, more rather to be used in
+        various Salt modules, to reusing the established connection, as in
+        opposite to opening a new connection for each task.
+
+    Usage example:
+
+    .. code-block:: python
+
+        conn = __salt__['napalm.pyeapi_conn']()
+        res1 = conn.run_commands('show version')
+        res2 = conn.get_config(as_string=True)
+    """
+    pyeapi_kwargs = pyeapi_nxos_api_args(**kwargs)
+    return __salt__["pyeapi.get_connection"](**pyeapi_kwargs)
+
+
 # ----------------------------------------------------------------------------------------------------------------------
 # callable functions
 # ----------------------------------------------------------------------------------------------------------------------
@@ -614,7 +665,7 @@ def netmiko_commands(*commands, **kwargs):
 
         salt '*' napalm.netmiko_commands 'show version' 'show interfaces'
     """
-    conn = netmiko_conn(**kwargs)
+    conn = _netmiko_conn(**kwargs)
     ret = []
     for cmd in commands:
         ret.append(conn.send_command(cmd))
@@ -712,9 +763,13 @@ def netmiko_conn(**kwargs):
         res = conn.send_command('show interfaces')
         conn.disconnect()
     """
-    netmiko_kwargs = netmiko_args()
-    kwargs.update(netmiko_kwargs)
-    return __salt__["netmiko.get_connection"](**kwargs)
+    salt.utils.versions.warn_until(
+        "Chlorine",
+        "This 'napalm_mod.netmiko_conn' function as been deprecated and "
+        "its functionality removed, as such, it has been made an internal "
+        "function since it is not suitable for CLI usage",
+    )
+    return _netmiko_conn(**kwargs)
 
 
 @proxy_napalm_wrap
@@ -1105,8 +1160,13 @@ def pyeapi_conn(**kwargs):
         res1 = conn.run_commands('show version')
         res2 = conn.get_config(as_string=True)
     """
-    pyeapi_kwargs = pyeapi_nxos_api_args(**kwargs)
-    return __salt__["pyeapi.get_connection"](**pyeapi_kwargs)
+    salt.utils.versions.warn_until(
+        "Chlorine",
+        "This 'napalm_mod.pyeapi_conn' function as been deprecated and "
+        "its functionality removed, as such, it has been made an internal "
+        "function since it is not suitable for CLI usage",
+    )
+    return _pyeapi_conn(**kwargs)
 
 
 @proxy_napalm_wrap


### PR DESCRIPTION
### What does this PR do?
Deprecated netmiko_conn and pyeapi_conn in napalm_mod.py as these function should not be called from the CLI after conversation with @s0undt3ch whereby all public functions should be callable from the CLI.  Moves these functions to internal with an external function named similarly, and marked as deprecated to be removed in the Chlorine release.  Want to get this into Phosphorous so removed by Chlorine timeframe

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/61566

### Previous Behavior
Interfaces publicly available

### New Behavior
Interfaces publicly available, but marked deprecated and to be removed by Chlorine

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
