### PR TITLE
test_roots: Set cachedir to writable temporary directory

### DIFF
--- a/tests/pytests/functional/fileserver/test_roots.py
+++ b/tests/pytests/functional/fileserver/test_roots.py
@@ -11,6 +11,7 @@ pytestmark = [
 def configure_loader_modules(base_env_state_tree_root_dir):
     opts = salt.config.DEFAULT_MINION_OPTS.copy()
     print(base_env_state_tree_root_dir)
+    opts["cachedir"] = str(base_env_state_tree_root_dir / ".." / "..")
     opts["file_roots"]["base"] = [str(base_env_state_tree_root_dir)]
     return {roots: {"__opts__": opts}}
 


### PR DESCRIPTION
Running `test_symlink_list` during Debian package build fails because the test case tries to write to `/var/cache`:

```
=================================== FAILURES ===================================
______________________________ test_symlink_list _______________________________

base_env_state_tree_root_dir = PosixPath('/tmp/stsuite/integration-files/state-tree/base')

    def test_symlink_list(base_env_state_tree_root_dir):
        with pytest.helpers.temp_file(
            "target", "data", base_env_state_tree_root_dir
        ) as target:
            link = base_env_state_tree_root_dir / "link"
            link.symlink_to(str(target))
>           ret = roots.symlink_list({"saltenv": "base"})

tests/pytests/functional/fileserver/test_roots.py:25:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

load = {'saltenv': 'base'}

    def symlink_list(load):
        """
        Return a dict of all symlinks based on a given path on the Master
        """
        if "env" in load:
            # "env" is not supported; Use "saltenv".
            load.pop("env")

        ret = {}
        if (
            load["saltenv"] not in __opts__["file_roots"]
            and "__env__" not in __opts__["file_roots"]
        ):
            return ret

        if "prefix" in load:
            prefix = load["prefix"].strip("/")
        else:
            prefix = ""

        symlinks = _file_lists(load, "links")
>       return {key: val for key, val in symlinks.items() if key.startswith(prefix)}
E       AttributeError: 'list' object has no attribute 'items'

salt/fileserver/roots.py:467: AttributeError
---------------------------- Captured stdout setup -----------------------------
/tmp/stsuite/integration-files/state-tree/base
------------------------------ Captured log setup ------------------------------
ERROR    salt.utils.event:event.py:426 Unable to connect pusher: Stream is closed
Traceback (most recent call last):
  File "/<<PKGBUILDDIR>>/salt/utils/event.py", line 423, in connect_pull
    self.pusher.connect(timeout=timeout)
  File "/<<PKGBUILDDIR>>/salt/utils/asynchronous.py", line 125, in wrap
    raise exc_info[1].with_traceback(exc_info[2])
  File "/<<PKGBUILDDIR>>/salt/utils/asynchronous.py", line 131, in _target
    result = io_loop.run_sync(lambda: getattr(self.obj, key)(*args, **kwargs))
  File "/<<PKGBUILDDIR>>/salt/ext/tornado/ioloop.py", line 459, in run_sync
    return future_cell[0].result()
  File "/<<PKGBUILDDIR>>/salt/ext/tornado/concurrent.py", line 249, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 4, in raise_exc_info
  File "/<<PKGBUILDDIR>>/salt/transport/ipc.py", line 342, in _connect
    yield self.stream.connect(sock_addr)
  File "/<<PKGBUILDDIR>>/salt/ext/tornado/gen.py", line 1056, in run
    value = future.result()
  File "/<<PKGBUILDDIR>>/salt/ext/tornado/concurrent.py", line 249, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 4, in raise_exc_info
salt.ext.tornado.iostream.StreamClosedError: Stream is closed
------------------------------ Captured log call -------------------------------
CRITICAL salt.fileserver.roots:roots.py:322 Unable to make cachedir /var/cache/salt/minion/file_lists/roots
```

So set `cachedir` to the temporary directory used by the test (`/tmp/stsuite/integration-files`).