### PR TITLE
[#61650] Strip spaces from ssh config parameters

### DIFF
--- a/changelog/61650.fixed
+++ b/changelog/61650.fixed
@@ -1,0 +1,1 @@
+Fix ssh config roster to correctly parse the ssh config files that contain spaces.

--- a/salt/roster/sshconfig.py
+++ b/salt/roster/sshconfig.py
@@ -64,7 +64,7 @@ def parse_ssh_config(lines):
             for field in _ROSTER_FIELDS:
                 match = re.match(field.pattern, line)
                 if match:
-                    target[field.target_field] = match.group(1)
+                    target[field.target_field] = match.group(1).strip()
         for hostname in hostnames:
             targets[hostname] = target
 

--- a/tests/pytests/unit/roster/test_ssh_config.py
+++ b/tests/pytests/unit/roster/test_ssh_config.py
@@ -68,7 +68,7 @@ def mock_fp():
         IdentityFile ~/.ssh/id_rsa_abc
 
     Host def*
-        IdentityFile ~/.ssh/id_rsa_def
+        IdentityFile  ~/.ssh/id_rsa_def
 
     Host abc.asdfgfdhgjkl.com
         HostName 123.123.123.123
@@ -77,7 +77,7 @@ def mock_fp():
         HostName 123.123.123.124
 
     Host def.asdfgfdhgjkl.com
-        HostName 234.234.234.234
+        HostName      234.234.234.234
     """
     )
 


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes: #61650 

### Previous Behavior
Previously it would pass the parameters from ssh config file as-is, with spaces/tabs in front of them.

### New Behavior
The values of parameters are now stripped.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No
