### PR TITLE
test_pkg: Do not run refresh_db on every pkg test

### DIFF
--- a/tests/pytests/functional/modules/test_pkg.py
+++ b/tests/pytests/functional/modules/test_pkg.py
@@ -38,7 +38,7 @@ def preserve_rhel_yum_conf():
     os.remove(tmp_file)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def refresh_db(ctx, grains, modules):
     if "refresh" not in ctx:
         modules.pkg.refresh_db()
@@ -72,7 +72,7 @@ def test_pkg(grains):
 
 @pytest.mark.requires_salt_modules("pkg.list_pkgs")
 @pytest.mark.slow_test
-def test_list(modules):
+def test_list(modules, refresh_db):
     """
     verify that packages are installed
     """
@@ -108,7 +108,7 @@ def test_version_cmp(grains, modules):
 @pytest.mark.requires_salt_modules("pkg.mod_repo", "pkg.del_repo", "pkg.get_repo")
 @pytest.mark.slow_test
 @pytest.mark.requires_network
-def test_mod_del_repo(grains, modules):
+def test_mod_del_repo(grains, modules, refresh_db):
     """
     test modifying and deleting a software repository
     """
@@ -158,7 +158,7 @@ def test_mod_del_repo(grains, modules):
 
 
 @pytest.mark.slow_test
-def test_mod_del_repo_multiline_values(modules):
+def test_mod_del_repo_multiline_values(modules, refresh_db):
     """
     test modifying and deleting a software repository defined with multiline values
     """
@@ -234,7 +234,7 @@ def test_which(modules):
 @pytest.mark.requires_salt_modules("pkg.version", "pkg.install", "pkg.remove")
 @pytest.mark.slow_test
 @pytest.mark.requires_network
-def test_install_remove(modules, test_pkg):
+def test_install_remove(modules, test_pkg, refresh_db):
     """
     successfully install and uninstall a package
     """
@@ -275,7 +275,7 @@ def test_install_remove(modules, test_pkg):
 @pytest.mark.slow_test
 @pytest.mark.requires_network
 @pytest.mark.requires_salt_states("pkg.installed")
-def test_hold_unhold(grains, modules, states, test_pkg):
+def test_hold_unhold(grains, modules, states, test_pkg, refresh_db):
     """
     test holding and unholding a package
     """
@@ -321,7 +321,7 @@ def test_hold_unhold(grains, modules, states, test_pkg):
 @pytest.mark.requires_salt_modules("pkg.refresh_db")
 @pytest.mark.slow_test
 @pytest.mark.requires_network
-def test_refresh_db(grains, tmp_path, minion_opts):
+def test_refresh_db(grains, tmp_path, minion_opts, refresh_db):
     """
     test refreshing the package database
     """
@@ -348,7 +348,7 @@ def test_refresh_db(grains, tmp_path, minion_opts):
 
 @pytest.mark.requires_salt_modules("pkg.info_installed")
 @pytest.mark.slow_test
-def test_pkg_info(grains, modules, test_pkg):
+def test_pkg_info(grains, modules, test_pkg, refresh_db):
     """
     Test returning useful information on Ubuntu systems.
     """
@@ -384,7 +384,7 @@ def test_pkg_info(grains, modules, test_pkg):
 )
 @pytest.mark.slow_test
 @pytest.mark.requires_network
-def test_pkg_upgrade_has_pending_upgrades(grains, modules, test_pkg):
+def test_pkg_upgrade_has_pending_upgrades(grains, modules, test_pkg, refresh_db):
     """
     Test running a system upgrade when there are packages that need upgrading
     """
@@ -463,7 +463,7 @@ def test_pkg_upgrade_has_pending_upgrades(grains, modules, test_pkg):
 @pytest.mark.requires_salt_modules("pkg.remove", "pkg.latest_version")
 @pytest.mark.slow_test
 @pytest.mark.requires_salt_states("pkg.removed")
-def test_pkg_latest_version(grains, modules, states, test_pkg):
+def test_pkg_latest_version(grains, modules, states, test_pkg, refresh_db):
     """
     Check that pkg.latest_version returns the latest version of the uninstalled package.
     The package is not installed. Only the package version is checked.


### PR DESCRIPTION
The fixture `refresh_db` calls `pkg.refresh_db` which runs `apt-get update` on Debian based systems. This requires root permission, Internet access, and makes the tests slow.

Not every test case in `test_pkg.py` needs to run `refresh_db`. So remove `autouse=True` from the `refresh_db` fixture and add it explicitly to most test cases. Following (fast executing) test cases will not use the `refresh_db` fixture any more:

 * test_version_cmp
 * test_owner
 * test_which

Even after this change, `test_version_cmp` takes 18 seconds to execute.