### PR TITLE
Fix osmajorrelease on Ubuntu and Pop!_OS

### DIFF
--- a/changelog/58010.changed
+++ b/changelog/58010.changed
@@ -1,0 +1,1 @@
+On Ubuntu and Pop!_OS the `osmajorrelease` returns a float in the form YY.MM (e.g. 20.04) instead of just an int of the year now.

--- a/changelog/61618.fixed
+++ b/changelog/61618.fixed
@@ -1,0 +1,4 @@
+Some Linux distributions (like AlmaLinux, Astra Linux, Debian, Mendel, Linux
+Mint, Pop!_OS, Rocky Linux) report different `oscodename`, `osfullname`,
+`osfinger` grains if lsb-release is installed or not. They have been changed to
+only derive these OS grains from `/etc/os-release`.

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1683,6 +1683,11 @@ def id_():
     return {"id": __opts__.get("id", "")}
 
 
+# Pattern for os-release PRETTY_NAME containing "name version (codename)"
+_PRETTY_NAME_RE = re.compile(r"[^\d]+ (?P<version>\d[\d.+\-a-z]*) \((?P<codename>.+)\)")
+# Pattern for os-release VERSION containing "version (codename)"
+_VERSION_RE = re.compile(r"\d[\d.+\-a-z]* \((?P<codename>.+)\)")
+
 _REPLACE_LINUX_RE = re.compile(r"\W(?:gnu/)?linux", re.IGNORECASE)
 
 # This maps (at most) the first ten characters (no spaces, lowercased) of
@@ -1729,14 +1734,31 @@ _OS_NAME_MAP = {
     "mendel": "Mendel",
 }
 
+# This dictionary maps the pair of os-release ID and NAME to the 'os' grain
+# that Salt traditionally uses, and is used by the os_data() function to
+# create the "os" grain.
+#
+# Add entries to this dictionary to retain historic values of the "os" grain.
+_ID_AND_NAME_TO_OS_NAME_MAP = {
+    ("astra", "Astra Linux (Orel)"): "AstraLinuxCE",
+    ("astra", "Astra Linux (Smolensk)"): "AstraLinuxSE",
+    ("pop", "Pop!_OS"): "Pop",
+}
 
-def _derive_os_grain(osfullname):
+
+def _derive_os_grain(osfullname, os_id=None):
     """
     Derive the 'os' grain from the 'osfullname' grain
+
+    For deriving the 'os' grain from the os-release data,
+    pass NAME as 'osfullname' and ID as 'os_id'.
 
     The 'os' grain that Salt traditionally uses is a shortened
     version of the 'osfullname' grain.
     """
+    if (os_id, osfullname) in _ID_AND_NAME_TO_OS_NAME_MAP:
+        return _ID_AND_NAME_TO_OS_NAME_MAP[(os_id, osfullname)]
+
     distroname = _REPLACE_LINUX_RE.sub("", osfullname).strip()
     # return the first ten characters with no spaces, lowercased
     shortname = distroname.replace(" ", "").lower()[:10]
@@ -1817,6 +1839,25 @@ _OS_FAMILY_MAP = {
     "Mendel": "Debian",
     "OSMC": "Debian",
 }
+
+
+# Map the 'family_id' (from os-release) to the 'os_family' grain. If your
+# system is having trouble with detection, please make sure that the
+# 'family_id' is determined correctly first (in case multiple ID_LIKE entries
+# are specified).
+_OS_FAMILY_ID_MAP = {
+    # Red Hat Enterprise Linux (RHEL) is based on Fedora
+    # and Fedora is the successor of Red Hat Linux (RHL).
+    "fedora": "RedHat",
+}
+
+
+def _prettify_os_family(family_id):
+    if family_id in _OS_FAMILY_ID_MAP:
+        return _OS_FAMILY_ID_MAP[family_id]
+    # Fall back to use the os_id with an capital starting letter.
+    return family_id.capitalize()
+
 
 # Matches any possible format:
 #     DISTRIB_ID="Ubuntu"
@@ -2018,6 +2059,91 @@ def _linux_lsb_distrib_data():
     return grains, has_error
 
 
+def _family_id(os_id, id_like):
+    """
+    Return the family ID which is the oldest distribution ancestor.
+    """
+    if not id_like:
+        # If ID_LIKE is not specified, the distribution has no derivative.
+        return os_id
+
+    ids_like = [os_id] + id_like.split()
+
+    # Linux Mint 20.3 does not declare to be a derivative of Debian.
+    if "debian" in ids_like or "ubuntu" in ids_like:
+        return "debian"
+
+    # The IDs are ordered from closest to farthest.
+    return ids_like[-1]
+
+
+def _os_release_quirks_for_oscodename(os_release):
+    """
+    Apply quirks for 'oscodename' grain for faulty os-release files
+
+    Some distributions do not (fully) follow the os-release
+    specification. This function bundles all required quirks
+    for the 'oscodename' grain. To be on the safe side, only
+    apply the quirks for allow-listed distributions. Better
+    not set the codename instead of setting it wrong.
+    """
+    if os_release["ID"] in ("astra",):
+        # Astra Linux has no version codename, but Salt used
+        # to report the variant ID as oscodename.
+        return os_release.get("VARIANT_ID")
+    if os_release["ID"] in ("almalinux", "rocky"):
+        # VERSION_CODENAME is not set, but the codename is
+        # mentioned in PRETTY_NAME and VERSION.
+        match = _VERSION_RE.match(os_release.get("VERSION", ""))
+        if match:
+            return match.group("codename")
+    return None
+
+
+def _os_release_quirks_for_osrelease(os_release):
+    """
+    Apply quirks for 'osrelease' grain for faulty os-release files
+
+    Some distributions do not (fully) follow the os-release
+    specification. This function bundles all required quirks
+    for the 'osrelease' grain. To be on the safe side, only
+    apply the quirks for allow-listed distributions. Better
+    not set the release instead of setting it wrong.
+    """
+    if os_release["ID"] in ("mendel",):
+        # Mendel sets VERSION_CODENAME but not VERSION_ID.
+        # Only PRETTY_NAME mentions the version number.
+        match = _PRETTY_NAME_RE.match(os_release["PRETTY_NAME"])
+        if match:
+            return match.group("version")
+    return None
+
+
+def _os_release_to_grains(os_release):
+    """
+    Transform the given os-release data to grains.
+
+    The os-release file is a freedesktop.org standard:
+    https://www.freedesktop.org/software/systemd/man/os-release.html
+
+    The keys NAME, ID, and PRETTY_NAME are expected to exist. All
+    other keys are optional.
+    """
+    family_id = _family_id(os_release["ID"], os_release.get("ID_LIKE"))
+    grains = {
+        "os": _derive_os_grain(os_release["NAME"], os_release["ID"]),
+        "os_family": _prettify_os_family(family_id),
+        "oscodename": os_release.get("VERSION_CODENAME")
+        or _os_release_quirks_for_oscodename(os_release),
+        "osfullname": os_release["NAME"].strip(),
+        "osrelease": os_release.get("VERSION_ID")
+        or _os_release_quirks_for_osrelease(os_release),
+    }
+
+    # oscodename and osrelease could be empty or None. Remove those.
+    return {key: value for key, value in grains.items() if key}
+
+
 def _linux_distribution_data():
     """
     Determine distribution information like OS name and version.
@@ -2031,9 +2157,53 @@ def _linux_distribution_data():
 
     This function might also return lsb_distrib_* grains
     from _linux_lsb_distrib_data().
+
+    Most Linux distributions should ship a os-release file
+    and this file should be the sole source for deriving the
+    OS grains. To not cause regressions, only switch the
+    distribution that has been tested.
     """
     grains, lsb_has_error = _linux_lsb_distrib_data()
 
+    log.trace("Getting OS name, release, and codename from freedesktop_os_release")
+    try:
+        os_release = _freedesktop_os_release()
+        grains.update(_os_release_to_grains(os_release))
+
+        # To prevent regressions, only let distributions solely
+        # use os-release after testing.
+        if os_release["ID"] in (
+            "almalinux",
+            "astra",
+            "debian",
+            "linuxmint",
+            "mendel",
+            "pop",
+            "rocky",
+            "ubuntu",
+        ):
+            # Solely use os-release data. See description of the function.
+            return grains
+
+    except OSError:
+        os_release = {}
+
+    # Warning: The remaining code is legacy code. Please solely rely
+    # on os-release data. See description of the function.
+    if "osrelease" in grains:
+        # Let the legacy code define osrelease to avoid discrepancies.
+        del grains["osrelease"]
+    return _legacy_linux_distribution_data(grains, os_release, lsb_has_error)
+
+
+def _legacy_linux_distribution_data(grains, os_release, lsb_has_error):
+    """
+    Legacy heuristics to determine distribution information.
+
+    Most Linux distributions should ship a os-release file
+    and this file should be the sole source for deriving the
+    OS grains. See _linux_distribution_data.
+    """
     if lsb_has_error:
         if grains.get("lsb_distrib_description", "").lower().startswith("antergos"):
             # Antergos incorrectly configures their /etc/lsb-release,
@@ -2042,10 +2212,6 @@ def _linux_distribution_data():
             grains["osfullname"] = "Antergos Linux"
         elif "lsb_distrib_id" not in grains:
             log.trace("Failed to get lsb_distrib_id, trying to parse os-release")
-            try:
-                os_release = _freedesktop_os_release()
-            except OSError:
-                os_release = {}
             if os_release:
                 if "NAME" in os_release:
                     grains["lsb_distrib_id"] = os_release["NAME"].strip()
@@ -2054,13 +2220,7 @@ def _linux_distribution_data():
                 if "VERSION_CODENAME" in os_release:
                     grains["lsb_distrib_codename"] = os_release["VERSION_CODENAME"]
                 elif "PRETTY_NAME" in os_release:
-                    codename = os_release["PRETTY_NAME"]
-                    # https://github.com/saltstack/salt/issues/44108
-                    if os_release["ID"] == "debian":
-                        codename_match = re.search(r"\((\w+)\)$", codename)
-                        if codename_match:
-                            codename = codename_match.group(1)
-                    grains["lsb_distrib_codename"] = codename
+                    grains["lsb_distrib_codename"] = os_release["PRETTY_NAME"]
                 if "CPE_NAME" in os_release:
                     cpe = _parse_cpe_name(os_release["CPE_NAME"])
                     if not cpe:

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2404,8 +2404,14 @@ def _osrelease_data(os, osfullname, osrelease):
             continue
         osrelease_info[idx] = int(value)
     grains["osrelease_info"] = tuple(osrelease_info)
+    os_major_release = None
     try:
-        grains["osmajorrelease"] = int(grains["osrelease_info"][0])
+        if os in ("Ubuntu", "Pop"):
+            os_major_release = osrelease
+            grains["osmajorrelease"] = float(os_major_release)
+        else:
+            os_major_release = grains["osrelease_info"][0]
+            grains["osmajorrelease"] = int(os_major_release)
     except (IndexError, TypeError, ValueError):
         log.debug(
             "Unable to derive osmajorrelease from osrelease_info '%s'. "
@@ -2417,10 +2423,8 @@ def _osrelease_data(os, osfullname, osrelease):
         os_name = os
     else:
         os_name = osfullname
-    grains["osfinger"] = "{}-{}".format(
-        os_name,
-        osrelease if os in ("Ubuntu", "Pop") else grains["osrelease_info"][0],
-    )
+    if os_major_release:
+        grains["osfinger"] = "{}-{}".format(os_name, os_major_release)
 
     return grains
 

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -1017,7 +1017,7 @@ def test_rocky_8_os_grains():
     expectation = {
         "os": "Rocky",
         "os_family": "RedHat",
-        "oscodename": "Rocky Linux 8.5 (Green Obsidian)",
+        "oscodename": "Green Obsidian",
         "osfullname": "Rocky Linux",
         "osrelease": "8.5",
         "osrelease_info": (8, 5),
@@ -1052,8 +1052,22 @@ def test_osmc_os_grains():
 @pytest.mark.skip_unless_on_linux
 def test_mendel_os_grains():
     """
-    Test if OS grains are parsed correctly in Mendel Linux
+    Test if OS grains are parsed correctly in Mendel Linux 5.3 Eagle (Nov 2021)
     """
+    # From https://coral.ai/software/
+    # downloaded enterprise-eagle-flashcard-20211117215217.zip
+    # -> flashcard_arm64.img -> rootfs.img -> /etc/os-release
+    _os_release_data = {
+        "PRETTY_NAME": "Mendel GNU/Linux 5 (Eagle)",
+        "NAME": "Mendel GNU/Linux",
+        "ID": "mendel",
+        "ID_LIKE": "debian",
+        "HOME_URL": "https://coral.ai/",
+        "SUPPORT_URL": "https://coral.ai/",
+        "BUG_REPORT_URL": "https://coral.ai/",
+        "VERSION_CODENAME": "eagle",
+    }
+    # Note: "lsb_release -a" falsely reports the version to be 10.0
     _os_release_map = {
         "_linux_distribution": ("Mendel", "10.0", "eagle"),
     }
@@ -1062,13 +1076,13 @@ def test_mendel_os_grains():
         "os": "Mendel",
         "os_family": "Debian",
         "oscodename": "eagle",
-        "osfullname": "Mendel",
-        "osrelease": "10.0",
-        "osrelease_info": (10, 0),
-        "osmajorrelease": 10,
-        "osfinger": "Mendel-10",
+        "osfullname": "Mendel GNU/Linux",
+        "osrelease": "5",
+        "osrelease_info": (5,),
+        "osmajorrelease": 5,
+        "osfinger": "Mendel GNU/Linux-5",
     }
-    _run_os_grains_tests(None, _os_release_map, expectation)
+    _run_os_grains_tests(_os_release_data, _os_release_map, expectation)
 
 
 @pytest.mark.skip_unless_on_linux
@@ -1100,7 +1114,7 @@ def test_almalinux_8_os_grains():
     expectation = {
         "os": "AlmaLinux",
         "os_family": "RedHat",
-        "oscodename": "AlmaLinux 8.5 (Arctic Sphynx)",
+        "oscodename": "Arctic Sphynx",
         "osfullname": "AlmaLinux",
         "osrelease": "8.5",
         "osrelease_info": (8, 5),
@@ -1258,20 +1272,37 @@ def test_pop_focal_os_grains():
     """
     Test if OS grains are parsed correctly in Pop!_OS 20.04 "Focal Fossa"
     """
+    # /etc/pop-os/os-release data taken from
+    # pop-default-settings 4.0.6~1642047816~20.04~932caee
+    _os_release_data = {
+        "NAME": "Pop!_OS",
+        "VERSION": "20.04 LTS",
+        "ID": "pop",
+        "ID_LIKE": "ubuntu debian",
+        "PRETTY_NAME": "Pop!_OS 20.04 LTS",
+        "VERSION_ID": "20.04",
+        "HOME_URL": "https://pop.system76.com",
+        "SUPPORT_URL": "https://support.system76.com",
+        "BUG_REPORT_URL": "https://github.com/pop-os/pop/issues",
+        "PRIVACY_POLICY_URL": "https://system76.com/privacy",
+        "VERSION_CODENAME": "focal",
+        "UBUNTU_CODENAME": "focal",
+        "LOGO": "distributor-logo-pop-os",
+    }
     _os_release_map = {
-        "_linux_distribution": ("Pop", "20.04", "focal"),
+        "_linux_distribution": ("pop", "20.04", "focal"),
     }
     expectation = {
         "os": "Pop",
         "os_family": "Debian",
         "oscodename": "focal",
-        "osfullname": "Pop",
+        "osfullname": "Pop!_OS",
         "osrelease": "20.04",
         "osrelease_info": (20, 4),
         "osmajorrelease": 20,
-        "osfinger": "Pop-20.04",
+        "osfinger": "Pop!_OS-20.04",
     }
-    _run_os_grains_tests(None, _os_release_map, expectation)
+    _run_os_grains_tests(_os_release_data, _os_release_map, expectation)
 
 
 @pytest.mark.skip_unless_on_linux
@@ -1279,20 +1310,37 @@ def test_pop_impish_os_grains():
     """
     Test if OS grains are parsed correctly in Pop!_OS 21.10 "Impish Indri"
     """
+    # /etc/pop-os/os-release data taken from
+    # pop-default-settings 5.1.0~1640204937~21.10~3f0be51
+    _os_release_data = {
+        "NAME": "Pop!_OS",
+        "VERSION": "21.10",
+        "ID": "pop",
+        "ID_LIKE": "ubuntu debian",
+        "PRETTY_NAME": "Pop!_OS 21.10",
+        "VERSION_ID": "21.10",
+        "HOME_URL": "https://pop.system76.com",
+        "SUPPORT_URL": "https://support.system76.com",
+        "BUG_REPORT_URL": "https://github.com/pop-os/pop/issues",
+        "PRIVACY_POLICY_URL": "https://system76.com/privacy",
+        "VERSION_CODENAME": "impish",
+        "UBUNTU_CODENAME": "impish",
+        "LOGO": "distributor-logo-pop-os",
+    }
     _os_release_map = {
-        "_linux_distribution": ("Pop", "21.10", "impish"),
+        "_linux_distribution": ("pop", "21.10", "impish"),
     }
     expectation = {
         "os": "Pop",
         "os_family": "Debian",
         "oscodename": "impish",
-        "osfullname": "Pop",
+        "osfullname": "Pop!_OS",
         "osrelease": "21.10",
         "osrelease_info": (21, 10),
         "osmajorrelease": 21,
-        "osfinger": "Pop-21.10",
+        "osfinger": "Pop!_OS-21.10",
     }
-    _run_os_grains_tests(None, _os_release_map, expectation)
+    _run_os_grains_tests(_os_release_data, _os_release_map, expectation)
 
 
 @pytest.mark.skip_unless_on_linux
@@ -1300,20 +1348,37 @@ def test_astralinuxce_os_grains():
     """
     Test that OS grains are parsed correctly for Astra Linux Orel
     """
+    # os-release data taken from astra-version 8.1.24+v2.12.43.6
+    # found in pool on installer ISO downloaded from
+    # https://mirrors.edge.kernel.org/astra/stable/orel/iso/orel-current.iso
+    _os_release_data = {
+        "PRETTY_NAME": "Astra Linux (Orel 2.12.43)",
+        "NAME": "Astra Linux (Orel)",
+        "ID": "astra",
+        "ID_LIKE": "debian",
+        "ANSI_COLOR": "1;31",
+        "HOME_URL": "http://astralinux.ru",
+        "SUPPORT_URL": "http://astralinux.ru/support",
+        "VARIANT_ID": "orel",
+        "VARIANT": "Orel",
+        "LOGO": "astra",
+        "VERSION_ID": "2.12.43",
+        "VERSION_CODENAME": "orel",
+    }
     _os_release_map = {
-        "_linux_distribution": ("AstraLinuxCE", "2.12.40", "orel"),
+        "_linux_distribution": ("astra", "2.12.43", "orel"),
     }
     expectation = {
         "os": "AstraLinuxCE",
         "os_family": "Debian",
         "oscodename": "orel",
-        "osfullname": "AstraLinuxCE",
-        "osrelease": "2.12.40",
-        "osrelease_info": (2, 12, 40),
+        "osfullname": "Astra Linux (Orel)",
+        "osrelease": "2.12.43",
+        "osrelease_info": (2, 12, 43),
         "osmajorrelease": 2,
-        "osfinger": "AstraLinuxCE-2",
+        "osfinger": "Astra Linux (Orel)-2",
     }
-    _run_os_grains_tests(None, _os_release_map, expectation)
+    _run_os_grains_tests(_os_release_data, _os_release_map, expectation)
 
 
 @pytest.mark.skip_unless_on_linux
@@ -1321,20 +1386,34 @@ def test_astralinuxse_os_grains():
     """
     Test that OS grains are parsed correctly for Astra Linux Smolensk
     """
+    # /etc/os-release data taken from base-files 7.2astra2
+    # from Docker image crbrka/astra16se:latest
+    _os_release_data = {
+        "PRETTY_NAME": "Astra Linux (Smolensk 1.6)",
+        "NAME": "Astra Linux (Smolensk)",
+        "ID": "astra",
+        "ID_LIKE": "debian",
+        "ANSI_COLOR": "1;31",
+        "HOME_URL": "http://astralinux.ru",
+        "SUPPORT_URL": "http://astralinux.ru/support",
+        "VARIANT_ID": "smolensk",
+        "VARIANT": "Smolensk",
+        "VERSION_ID": "1.6",
+    }
     _os_release_map = {
-        "_linux_distribution": ("AstraLinuxSE", "1.6", "smolensk"),
+        "_linux_distribution": ("astra", "1.6", "smolensk"),
     }
     expectation = {
         "os": "AstraLinuxSE",
         "os_family": "Debian",
         "oscodename": "smolensk",
-        "osfullname": "AstraLinuxSE",
+        "osfullname": "Astra Linux (Smolensk)",
         "osrelease": "1.6",
         "osrelease_info": (1, 6),
         "osmajorrelease": 1,
-        "osfinger": "AstraLinuxSE-1",
+        "osfinger": "Astra Linux (Smolensk)-1",
     }
-    _run_os_grains_tests(None, _os_release_map, expectation)
+    _run_os_grains_tests(_os_release_data, _os_release_map, expectation)
 
 
 @pytest.mark.skip_unless_on_windows

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -592,7 +592,10 @@ def _run_os_grains_tests(os_release_data, os_release_map, expectation):
     # - Skip all the /etc/*-release stuff (not pertinent)
     # - Mock _linux_distribution to give us the OS name that we want
     # - Mock the osarch
-    distro_mock = MagicMock(return_value=os_release_map["_linux_distribution"])
+    _linux_distribution = os_release_map.get(
+        "_linux_distribution", ("id", "version", "codename")
+    )
+    distro_mock = MagicMock(return_value=_linux_distribution)
     with patch.object(
         salt.utils.platform, "is_proxy", MagicMock(return_value=False)
     ), patch.object(
@@ -641,7 +644,6 @@ def _run_os_grains_tests(os_release_data, os_release_map, expectation):
 
 
 def _run_suse_os_grains_tests(os_release_data, os_release_map, expectation):
-    os_release_map["_linux_distribution"] = ("SUSE test", "version", "arch")
     expectation["os"] = "SUSE"
     expectation["os_family"] = "Suse"
     _run_os_grains_tests(os_release_data, os_release_map, expectation)
@@ -815,9 +817,6 @@ def test_debian_9_os_grains():
         "SUPPORT_URL": "https://www.debian.org/support",
         "BUG_REPORT_URL": "https://bugs.debian.org/",
     }
-    _os_release_map = {
-        "_linux_distribution": ("debian", "9.3", ""),
-    }
     expectation = {
         "os": "Debian",
         "os_family": "Debian",
@@ -828,7 +827,7 @@ def test_debian_9_os_grains():
         "osmajorrelease": 9,
         "osfinger": "Debian-9",
     }
-    _run_os_grains_tests(_os_release_data, _os_release_map, expectation)
+    _run_os_grains_tests(_os_release_data, {}, expectation)
 
 
 @pytest.mark.skip_unless_on_linux
@@ -848,9 +847,6 @@ def test_debian_10_os_grains():
         "SUPPORT_URL": "https://www.debian.org/support",
         "BUG_REPORT_URL": "https://bugs.debian.org/",
     }
-    _os_release_map = {
-        "_linux_distribution": ("debian", "10", "buster"),
-    }
     expectation = {
         "os": "Debian",
         "os_family": "Debian",
@@ -861,7 +857,7 @@ def test_debian_10_os_grains():
         "osmajorrelease": 10,
         "osfinger": "Debian-10",
     }
-    _run_os_grains_tests(_os_release_data, _os_release_map, expectation)
+    _run_os_grains_tests(_os_release_data, {}, expectation)
 
 
 @pytest.mark.skip_unless_on_linux
@@ -881,9 +877,6 @@ def test_debian_11_os_grains():
         "SUPPORT_URL": "https://www.debian.org/support",
         "BUG_REPORT_URL": "https://bugs.debian.org/",
     }
-    _os_release_map = {
-        "_linux_distribution": ("debian", "11", "bullseye"),
-    }
     expectation = {
         "os": "Debian",
         "os_family": "Debian",
@@ -894,7 +887,7 @@ def test_debian_11_os_grains():
         "osmajorrelease": 11,
         "osfinger": "Debian-11",
     }
-    _run_os_grains_tests(_os_release_data, _os_release_map, expectation)
+    _run_os_grains_tests(_os_release_data, {}, expectation)
 
 
 @pytest.mark.skip_unless_on_linux
@@ -1010,10 +1003,6 @@ def test_rocky_8_os_grains():
         "ROCKY_SUPPORT_PRODUCT": "Rocky Linux",
         "ROCKY_SUPPORT_PRODUCT_VERSION": "8",
     }
-    _os_release_map = {
-        "_linux_distribution": ("rocky", "8.5", "Green Obsidian"),
-    }
-
     expectation = {
         "os": "Rocky",
         "os_family": "RedHat",
@@ -1024,7 +1013,7 @@ def test_rocky_8_os_grains():
         "osmajorrelease": 8,
         "osfinger": "Rocky Linux-8",
     }
-    _run_os_grains_tests(_os_release_data, _os_release_map, expectation)
+    _run_os_grains_tests(_os_release_data, {}, expectation)
 
 
 @pytest.mark.skip_unless_on_linux
@@ -1067,11 +1056,6 @@ def test_mendel_os_grains():
         "BUG_REPORT_URL": "https://coral.ai/",
         "VERSION_CODENAME": "eagle",
     }
-    # Note: "lsb_release -a" falsely reports the version to be 10.0
-    _os_release_map = {
-        "_linux_distribution": ("Mendel", "10.0", "eagle"),
-    }
-
     expectation = {
         "os": "Mendel",
         "os_family": "Debian",
@@ -1082,7 +1066,7 @@ def test_mendel_os_grains():
         "osmajorrelease": 5,
         "osfinger": "Mendel GNU/Linux-5",
     }
-    _run_os_grains_tests(_os_release_data, _os_release_map, expectation)
+    _run_os_grains_tests(_os_release_data, {}, expectation)
 
 
 @pytest.mark.skip_unless_on_linux
@@ -1107,10 +1091,6 @@ def test_almalinux_8_os_grains():
         "ALMALINUX_MANTISBT_PROJECT": "AlmaLinux-8",
         "ALMALINUX_MANTISBT_PROJECT_VERSION": "8.5",
     }
-    _os_release_map = {
-        "_linux_distribution": ("almaLinux", "8.5", "Arctic Sphynx"),
-    }
-
     expectation = {
         "os": "AlmaLinux",
         "os_family": "RedHat",
@@ -1121,7 +1101,7 @@ def test_almalinux_8_os_grains():
         "osmajorrelease": 8,
         "osfinger": "AlmaLinux-8",
     }
-    _run_os_grains_tests(_os_release_data, _os_release_map, expectation)
+    _run_os_grains_tests(_os_release_data, {}, expectation)
 
 
 @pytest.mark.skip_unless_on_linux
@@ -1179,9 +1159,6 @@ def test_ubuntu_focal_os_grains():
         "VERSION_CODENAME": "focal",
         "UBUNTU_CODENAME": "focal",
     }
-    _os_release_map = {
-        "_linux_distribution": ("ubuntu", "20.04", "focal"),
-    }
     expectation = {
         "os": "Ubuntu",
         "os_family": "Debian",
@@ -1192,7 +1169,7 @@ def test_ubuntu_focal_os_grains():
         "osmajorrelease": 20,
         "osfinger": "Ubuntu-20.04",
     }
-    _run_os_grains_tests(_os_release_data, _os_release_map, expectation)
+    _run_os_grains_tests(_os_release_data, {}, expectation)
 
 
 @pytest.mark.skip_unless_on_linux
@@ -1215,9 +1192,6 @@ def test_ubuntu_impish_os_grains():
         "PRIVACY_POLICY_URL": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
         "UBUNTU_CODENAME": "impish",
     }
-    _os_release_map = {
-        "_linux_distribution": ("ubuntu", "21.10", "impish"),
-    }
     expectation = {
         "os": "Ubuntu",
         "os_family": "Debian",
@@ -1228,7 +1202,7 @@ def test_ubuntu_impish_os_grains():
         "osmajorrelease": 21,
         "osfinger": "Ubuntu-21.10",
     }
-    _run_os_grains_tests(_os_release_data, _os_release_map, expectation)
+    _run_os_grains_tests(_os_release_data, {}, expectation)
 
 
 @pytest.mark.skip_unless_on_linux
@@ -1251,9 +1225,6 @@ def test_linux_mint_una_os_grains():
         "VERSION_CODENAME": "una",
         "UBUNTU_CODENAME": "focal",
     }
-    _os_release_map = {
-        "_linux_distribution": ("linuxmint", "20.03", "una"),
-    }
     expectation = {
         "os": "Mint",
         "os_family": "Debian",
@@ -1264,7 +1235,7 @@ def test_linux_mint_una_os_grains():
         "osmajorrelease": 20,
         "osfinger": "Linux Mint-20",
     }
-    _run_os_grains_tests(_os_release_data, _os_release_map, expectation)
+    _run_os_grains_tests(_os_release_data, {}, expectation)
 
 
 @pytest.mark.skip_unless_on_linux
@@ -1289,9 +1260,6 @@ def test_pop_focal_os_grains():
         "UBUNTU_CODENAME": "focal",
         "LOGO": "distributor-logo-pop-os",
     }
-    _os_release_map = {
-        "_linux_distribution": ("pop", "20.04", "focal"),
-    }
     expectation = {
         "os": "Pop",
         "os_family": "Debian",
@@ -1302,7 +1270,7 @@ def test_pop_focal_os_grains():
         "osmajorrelease": 20,
         "osfinger": "Pop!_OS-20.04",
     }
-    _run_os_grains_tests(_os_release_data, _os_release_map, expectation)
+    _run_os_grains_tests(_os_release_data, {}, expectation)
 
 
 @pytest.mark.skip_unless_on_linux
@@ -1327,9 +1295,6 @@ def test_pop_impish_os_grains():
         "UBUNTU_CODENAME": "impish",
         "LOGO": "distributor-logo-pop-os",
     }
-    _os_release_map = {
-        "_linux_distribution": ("pop", "21.10", "impish"),
-    }
     expectation = {
         "os": "Pop",
         "os_family": "Debian",
@@ -1340,7 +1305,7 @@ def test_pop_impish_os_grains():
         "osmajorrelease": 21,
         "osfinger": "Pop!_OS-21.10",
     }
-    _run_os_grains_tests(_os_release_data, _os_release_map, expectation)
+    _run_os_grains_tests(_os_release_data, {}, expectation)
 
 
 @pytest.mark.skip_unless_on_linux
@@ -1365,9 +1330,6 @@ def test_astralinuxce_os_grains():
         "VERSION_ID": "2.12.43",
         "VERSION_CODENAME": "orel",
     }
-    _os_release_map = {
-        "_linux_distribution": ("astra", "2.12.43", "orel"),
-    }
     expectation = {
         "os": "AstraLinuxCE",
         "os_family": "Debian",
@@ -1378,7 +1340,7 @@ def test_astralinuxce_os_grains():
         "osmajorrelease": 2,
         "osfinger": "Astra Linux (Orel)-2",
     }
-    _run_os_grains_tests(_os_release_data, _os_release_map, expectation)
+    _run_os_grains_tests(_os_release_data, {}, expectation)
 
 
 @pytest.mark.skip_unless_on_linux
@@ -1400,9 +1362,6 @@ def test_astralinuxse_os_grains():
         "VARIANT": "Smolensk",
         "VERSION_ID": "1.6",
     }
-    _os_release_map = {
-        "_linux_distribution": ("astra", "1.6", "smolensk"),
-    }
     expectation = {
         "os": "AstraLinuxSE",
         "os_family": "Debian",
@@ -1413,7 +1372,7 @@ def test_astralinuxse_os_grains():
         "osmajorrelease": 1,
         "osfinger": "Astra Linux (Smolensk)-1",
     }
-    _run_os_grains_tests(_os_release_data, _os_release_map, expectation)
+    _run_os_grains_tests(_os_release_data, {}, expectation)
 
 
 @pytest.mark.skip_unless_on_windows

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -3276,6 +3276,7 @@ def test_linux_proc_files_with_non_utf8_chars():
     _salt_utils_files_fopen = salt.utils.files.fopen
 
     empty_mock = MagicMock(return_value={})
+    os_release_mock = {"NAME": "Linux", "ID": "linux", "PRETTY_NAME": "Linux"}
 
     with tempfile.TemporaryDirectory() as tempdir:
 
@@ -3300,7 +3301,7 @@ def test_linux_proc_files_with_non_utf8_chars():
         ), patch.object(
             core, "_parse_lsb_release", return_value=empty_mock
         ), patch.object(
-            core, "_freedesktop_os_release", return_value=empty_mock
+            core, "_freedesktop_os_release", return_value=os_release_mock
         ), patch.object(
             core, "_hw_data", return_value=empty_mock
         ), patch.object(

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -1166,7 +1166,7 @@ def test_ubuntu_focal_os_grains():
         "osfullname": "Ubuntu",
         "osrelease": "20.04",
         "osrelease_info": (20, 4),
-        "osmajorrelease": 20,
+        "osmajorrelease": 20.04,
         "osfinger": "Ubuntu-20.04",
     }
     _run_os_grains_tests(_os_release_data, {}, expectation)
@@ -1199,7 +1199,7 @@ def test_ubuntu_impish_os_grains():
         "osfullname": "Ubuntu",
         "osrelease": "21.10",
         "osrelease_info": (21, 10),
-        "osmajorrelease": 21,
+        "osmajorrelease": 21.10,
         "osfinger": "Ubuntu-21.10",
     }
     _run_os_grains_tests(_os_release_data, {}, expectation)
@@ -1267,7 +1267,7 @@ def test_pop_focal_os_grains():
         "osfullname": "Pop!_OS",
         "osrelease": "20.04",
         "osrelease_info": (20, 4),
-        "osmajorrelease": 20,
+        "osmajorrelease": 20.04,
         "osfinger": "Pop!_OS-20.04",
     }
     _run_os_grains_tests(_os_release_data, {}, expectation)
@@ -1302,7 +1302,7 @@ def test_pop_impish_os_grains():
         "osfullname": "Pop!_OS",
         "osrelease": "21.10",
         "osrelease_info": (21, 10),
-        "osmajorrelease": 21,
+        "osmajorrelease": 21.10,
         "osfinger": "Pop!_OS-21.10",
     }
     _run_os_grains_tests(_os_release_data, {}, expectation)


### PR DESCRIPTION
Ubuntu/Pop!_OS publish major releases every six month and the version uses YY.MM (e.g. 20.04). So just using the year part of the release is wrong and cannot be used for differentiating between 20.04 and 20.10.

So change `osmajorrelease` on Ubuntu and Pop!_OS to return a float in the form `YY.MM` (e.g. 20.04) instead of just an int of the year.

Fixes https://github.com/saltstack/salt/issues/58010

This merge request contains the commits from the merge request https://github.com/saltstack/salt/pull/61597, https://github.com/saltstack/salt/pull/61589, https://github.com/saltstack/salt/pull/61619, and https://github.com/saltstack/salt/pull/61626. So I recommend to review and merge those first.