### PR TITLE
Allow for additional options for xmit hash policy in mode 4 NIC bonding on RedHat / Centos

### DIFF
--- a/changelog/60583.fixed
+++ b/changelog/60583.fixed
@@ -1,0 +1,1 @@
+Allow for additional options for xmit hash policy in mode 4 NIC bonding on Redhat

--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -468,7 +468,19 @@ def _parse_settings_bond_4(opts, iface):
             bond.update({binding: _BOND_DEFAULTS[binding]})
 
     if "hashing-algorithm" in opts:
-        valid = ("layer2", "layer2+3", "layer3+4")
+        if __grains__["os_family"] == "RedHat":
+            # allowing for Amazon 2 based of RHEL/Centos 7
+            if __grains__["osmajorrelease"] < 8:
+                valid = ("layer2", "layer2+3", "layer3+4", "encap2+3", "encap3+4")
+            else:
+                valid = (
+                    "layer2",
+                    "layer2+3",
+                    "layer3+4",
+                    "encap2+3",
+                    "encap3+4",
+                    "vlan+srcmac",
+                )
         if opts["hashing-algorithm"] in valid:
             bond.update({"xmit_hash_policy": opts["hashing-algorithm"]})
         else:

--- a/tests/unit/modules/test_rh_ip.py
+++ b/tests/unit/modules/test_rh_ip.py
@@ -641,7 +641,93 @@ class RhipTestCase(TestCase, LoaderModuleMockMixin):
                     ]
                     assert bonding_opts == expected, bonding_opts
 
-    def test_build_interface_bond_mode_4(self):
+    def test_build_interface_bond_mode_4_xmit(self):
+        """
+        Test that mode 4 bond interfaces are properly built
+        """
+        kwargs = {
+            "test": True,
+            "duplex": "full",
+            "slaves": "eth1 eth2",
+            "miimon": 100,
+            "downdelay": 200,
+        }
+        valid_lacp_rate = ("fast", "slow", "1", "0")
+        valid_ad_select = ("0",)
+
+        for version in range(7, 8):
+            with patch.dict(
+                rh_ip.__grains__,
+                {
+                    "osmajorrelease": version,
+                    "osrelease": str(version),
+                    "os_family": "RedHat",
+                },
+            ):
+                for mode in ("802.3ad", 4, "4"):
+                    kwargs["mode"] = mode
+                    self._validate_miimon_conf(kwargs)
+
+                    for version in range(7, 8):
+                        with patch.dict(rh_ip.__grains__, {"osmajorrelease": version}):
+                            # Using an invalid hashing algorithm should cause an error
+                            # to be raised.
+                            kwargs["hashing-algorithm"] = "layer42"
+                            try:
+                                bonding_opts = self._get_bonding_opts(kwargs)
+                            except AttributeError as exc:
+                                assert "hashing-algorithm" in str(exc)
+                            else:
+                                raise Exception("AttributeError was not raised")
+
+                        hash_alg = "vlan+srcmac"
+                        if version == 7:
+                            # Using an invalid hashing algorithm should cause an error
+                            # to be raised.
+                            kwargs["hashing-algorithm"] = hash_alg
+                            try:
+                                bonding_opts = self._get_bonding_opts(kwargs)
+                            except AttributeError as exc:
+                                assert "hashing-algorithm" in str(exc)
+                            else:
+                                raise Exception("AttributeError was not raised")
+                        else:
+                            # Correct the hashing algorithm and re-run
+                            kwargs["hashing-algorithm"] = hash_alg
+                            bonding_opts = self._get_bonding_opts(kwargs)
+                            expected = [
+                                "ad_select=0",
+                                "downdelay=200",
+                                "lacp_rate=0",
+                                "miimon=100",
+                                "mode=4",
+                                "use_carrier=0",
+                                "xmit_hash_policy={}".format(hash_alg),
+                            ]
+                            assert bonding_opts == expected, bonding_opts
+
+                        for hash_alg in [
+                            "layer2",
+                            "layer2+3",
+                            "layer3+4",
+                            "encap2+3",
+                            "encap3+4",
+                        ]:
+                            # Correct the hashing algorithm and re-run
+                            kwargs["hashing-algorithm"] = hash_alg
+                            bonding_opts = self._get_bonding_opts(kwargs)
+                            expected = [
+                                "ad_select=0",
+                                "downdelay=200",
+                                "lacp_rate=0",
+                                "miimon=100",
+                                "mode=4",
+                                "use_carrier=0",
+                                "xmit_hash_policy={}".format(hash_alg),
+                            ]
+                            assert bonding_opts == expected, bonding_opts
+
+    def test_build_interface_bond_mode_4_lacp(self):
         """
         Test that mode 4 bond interfaces are properly built
         """


### PR DESCRIPTION
### What does this PR do?
Allows for 'encap2+3', 'encap3+4' and 'vlan+srcmac' additional mode 4 bonding options for xmit_hash_policy on RedHat / Centos ssytems

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/60583

### Previous Behavior
These options were not available.

### New Behavior
These options were now available, in addition to 'vlan+srcmac' on Centos 8 and 9

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
