### PR TITLE
Add compare function to freezer module

### DIFF
--- a/changelog/61682.added
+++ b/changelog/61682.added
@@ -1,0 +1,1 @@
+Add a function to the freezer module for comparison of packages and repos in two frozen states

--- a/salt/modules/freezer.py
+++ b/salt/modules/freezer.py
@@ -8,6 +8,7 @@
 import logging
 import os
 
+import salt.utils.dictdiffer
 import salt.utils.json as json
 from salt.exceptions import CommandExecutionError
 from salt.utils.args import clean_kwargs
@@ -292,5 +293,45 @@ def restore(name=None, clean=False, **kwargs):
     if clean and not ret["comment"]:
         for fname in _paths(name):
             os.remove(fname)
+
+    return ret
+
+
+def compare(old, new):
+    """
+    Display the difference between two frozen states. The results are shown as
+    as a dictionary with keys for packages and repositories. Each key may
+    contain a changes dictionary showing items that differ between the two
+    frozen states. Items shown in the "old" changes but not the "new" were
+    removed. Items in "new" but not "old" were added. Items shown in both
+    probably updated/changed versions between freezes.
+
+    old
+        Name of the "old" frozen state. Required.
+
+    new
+        Name of the "new" frozen state. Required.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' freezer.freeze pre_install post_install
+
+    """
+    ret = {}
+
+    if not (status(old) and status(new)):
+        raise CommandExecutionError("Frozen state not found.")
+
+    for ofile, nfile in zip(_paths(old), _paths(new)):
+        with fopen(ofile, "r") as ofp:
+            old_dict = json.load(ofp)
+        with fopen(nfile, "r") as nfp:
+            new_dict = json.load(nfp)
+        if ofile.endswith("-pkgs.yml"):
+            ret["pkgs"] = salt.utils.dictdiffer.deep_diff(old_dict, new_dict)
+        elif ofile.endswith("-reps.yml"):
+            ret["repos"] = salt.utils.dictdiffer.deep_diff(old_dict, new_dict)
 
     return ret

--- a/tests/pytests/functional/modules/test_freezer.py
+++ b/tests/pytests/functional/modules/test_freezer.py
@@ -1,0 +1,87 @@
+import salt.modules.freezer as freezer
+from tests.support.mock import patch
+
+
+def test_compare(states, temp_salt_minion, tmp_path):
+    """
+    Test freezer.compare
+    """
+    # Default options
+    opts = temp_salt_minion.config.copy()
+
+    # Set cachedir
+    cachedir = tmp_path / "__salt_test_freezer_cache_dir/minion"
+    opts["cachedir"] = str(cachedir)
+
+    # Freeze data setup
+    freezedir = cachedir / "freezer"
+    old_pkg_file = str(freezedir / "pre_install-pkgs.yml")
+    old_rep_file = str(freezedir / "pre_install-reps.yml")
+    new_pkg_file = str(freezedir / "post_install-pkgs.yml")
+    new_rep_file = str(freezedir / "post_install-reps.yml")
+
+    old_reps = {
+        "http://deb.debian.org/debian": [
+            {
+                "file": "/etc/apt/sources.list",
+                "comps": ["main"],
+                "disabled": False,
+                "dist": "buster",
+                "type": "deb",
+                "uri": "http://deb.debian.org/debian",
+                "line": "deb http://deb.debian.org/debian buster main",
+                "architectures": [],
+            }
+        ]
+    }
+    new_reps = {
+        "http://deb.debian.org/debian": [
+            {
+                "file": "/etc/apt/sources.list",
+                "comps": ["main"],
+                "disabled": False,
+                "dist": "buster",
+                "type": "deb",
+                "uri": "http://deb.debian.org/debian",
+                "line": "deb http://deb.debian.org/debian buster main",
+                "architectures": [],
+            }
+        ],
+        "http://security.debian.org/debian-security": [
+            {
+                "file": "/etc/apt/sources.list",
+                "comps": ["main"],
+                "disabled": False,
+                "dist": "buster/updates",
+                "type": "deb",
+                "uri": "http://security.debian.org/debian-security",
+                "line": "deb http://security.debian.org/debian-security buster/updates main",
+                "architectures": [],
+            }
+        ],
+    }
+    old_pkgs = {"adduser": "3.118"}
+    new_pkgs = {"adduser": "3.118", "consul": "1.11.1"}
+
+    # Mock up freeze files
+    states.file.serialize(
+        name=old_pkg_file, dataset=old_pkgs, serializer="json", makedirs=True
+    )
+    states.file.serialize(
+        name=new_pkg_file, dataset=new_pkgs, serializer="json", makedirs=True
+    )
+    states.file.serialize(
+        name=old_rep_file, dataset=old_reps, serializer="json", makedirs=True
+    )
+    states.file.serialize(
+        name=new_rep_file, dataset=new_reps, serializer="json", makedirs=True
+    )
+
+    # Compare
+    with patch("salt.modules.freezer.__opts__", opts, create=True):
+        ret = freezer.compare(old="pre_install", new="post_install")
+
+    assert ret["pkgs"]["new"]["consul"] == "1.11.1"
+    assert "old" not in ret["pkgs"]
+    assert len(ret["repos"]["new"]) == 1
+    assert "old" not in ret["repos"]

--- a/tests/pytests/unit/modules/test_freezer.py
+++ b/tests/pytests/unit/modules/test_freezer.py
@@ -1,0 +1,40 @@
+import pytest
+import salt.modules.freezer as freezer
+from salt.exceptions import CommandExecutionError
+
+
+@pytest.fixture()
+def configure_loader_modules():
+    return {freezer: {"__opts__": {"cachedir": ""}}}
+
+
+def test_compare_no_args():
+    """
+    Test freezer.compare with no arguments
+    """
+    with pytest.raises(TypeError):
+        freezer.compare()  # pylint: disable=no-value-for-parameter
+
+
+def test_compare_not_enough_args():
+    """
+    Test freezer.compare without enough arguments
+    """
+    with pytest.raises(TypeError):
+        freezer.compare(None)  # pylint: disable=no-value-for-parameter
+
+
+def test_compare_too_many_args():
+    """
+    Test freezer.compare with too many arguments
+    """
+    with pytest.raises(TypeError):
+        freezer.compare(None, None, None)  # pylint: disable=too-many-function-args
+
+
+def test_compare_no_names():
+    """
+    Test freezer.compare with no real freeze names as arguments
+    """
+    with pytest.raises(CommandExecutionError):
+        freezer.compare(old=None, new=None)


### PR DESCRIPTION
### What does this PR do?
This PR adds a `compare` function to the `freezer` module, which can display the diff between two named frozen states.

### What issues does this PR fix or reference?
Fixes: #61681

### Previous Behavior
No clean way to diff frozen states natively.

### New Behavior
The `freezer.compare` function shows output similar to that found in the changes dictionary for state output. This can be used to quickly determine changes between packages and repos in two frozen states.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
