### PR TITLE
Remove SaltMessageServer.shutdown and LoadBalancerWorker.stop in tcp transport

### DIFF
--- a/changelog/61698.removed
+++ b/changelog/61698.removed
@@ -1,0 +1,2 @@
+Remove SaltMessageServer.shutdown in favor of close.
+Remove LoadBalancerWorker.stop in favor of close.

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -434,18 +434,6 @@ class SaltMessageServer(salt.ext.tornado.tcpserver.TCPServer):
         except ValueError:
             log.trace("Message server client was not in list to remove")
 
-    def shutdown(self):
-        """
-        Shutdown the whole server
-        """
-        salt.utils.versions.warn_until(
-            "Phosphorus",
-            "Please stop calling {0}.{1}.shutdown() and instead call {0}.{1}.close()".format(
-                __name__, self.__class__.__name__
-            ),
-        )
-        self.close()
-
     def close(self):
         """
         Close the server
@@ -480,15 +468,6 @@ if USE_LOAD_BALANCER:
             self._stop = threading.Event()
             self.thread = threading.Thread(target=self.socket_queue_thread)
             self.thread.start()
-
-        def stop(self):
-            salt.utils.versions.warn_until(
-                "Phosphorus",
-                "Please stop calling {0}.{1}.stop() and instead call {0}.{1}.close()".format(
-                    __name__, self.__class__.__name__
-                ),
-            )
-            self.close()
 
         def close(self):
             self._stop.set()


### PR DESCRIPTION
### What does this PR do?
Remove SaltMessageServer.shutdown and LoadBalancerWorker.stop in tcp transport in favor of close.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/61698