### PR TITLE
Bump the release name to Argon to remove the deprecated functions in salt/modules/nxos.py

### DIFF
--- a/salt/modules/nxos.py
+++ b/salt/modules/nxos.py
@@ -219,9 +219,7 @@ def cmd(command, *args, **kwargs):
         salt '*' nxos.cmd show_run
         salt '*' nxos.cmd check_password username=admin password='$5$lkjsdfoi$blahblahblah' encrypted=True
     """
-    warn_until(
-        "Phosphorus", "'nxos.cmd COMMAND' is deprecated in favor of 'nxos.COMMAND'"
-    )
+    warn_until("Argon", "'nxos.cmd COMMAND' is deprecated in favor of 'nxos.COMMAND'")
 
     for k in list(kwargs):
         if k.startswith("__pub_"):
@@ -385,7 +383,7 @@ def show(commands, raw_text=True, **kwargs):
         salt 'regular-minion' nxos.show 'show interfaces' host=sw01.example.com username=test password=test
     """
     warn_until(
-        "Phosphorus",
+        "Argon",
         "'nxos.show commands' is deprecated in favor of 'nxos.sendline commands'",
     )
 
@@ -452,9 +450,7 @@ def system_info(**kwargs):
 
         salt '*' nxos.system_info
     """
-    warn_until(
-        "Phosphorus", "'nxos.system_info' is deprecated in favor of 'nxos.grains'"
-    )
+    warn_until("Argon", "'nxos.system_info' is deprecated in favor of 'nxos.grains'")
     return salt.utils.nxos.system_info(show_ver(**kwargs))["nxos"]
 
 
@@ -481,7 +477,7 @@ def add_config(lines, **kwargs):
         For more than one config added per command, lines should be a list.
     """
     warn_until(
-        "Phosphorus",
+        "Argon",
         "'nxos.add_config lines' is deprecated in favor of 'nxos.config commands'",
     )
 


### PR DESCRIPTION
See explanation in this issue
https://github.com/saltstack/salt/issues/61692#issuecomment-1049067726