### PR TITLE
Fix wua states to return all changes, failures, and supersedences

### DIFF
--- a/changelog/61479.fixed
+++ b/changelog/61479.fixed
@@ -1,0 +1,1 @@
+Fixed wua.installed and wua.uptodate to return all changes, failures, and supersedences

--- a/salt/states/win_wua.py
+++ b/salt/states/win_wua.py
@@ -95,7 +95,11 @@ def installed(name, updates=None):
        more than one update being installed.
 
     Returns:
-        dict: A dictionary containing the results of the update
+        dict: A dictionary containing the results of the update. There are three
+              keys under changes. `installed` is a list of updates that were
+              successfully installed. `failed` is a list of updates that failed
+              to install. `superseded` is a list of updates that were not
+              installed because they were superseded by another update.
 
     CLI Example:
 
@@ -250,7 +254,10 @@ def removed(name, updates=None):
        more than one update being removed.
 
     Returns:
-        dict: A dictionary containing the results of the removal
+        dict: A dictionary containing the results of the removal. There are
+              three keys under changes. `removed` is a list of updates that
+              were successfully removed. `failed` is a list of updates that
+              failed to be removed.
 
     CLI Example:
 
@@ -424,7 +431,11 @@ def uptodate(
 
 
     Returns:
-        dict: A dictionary containing the results of the update
+        dict: A dictionary containing the results of the update. There are three
+              keys under changes. `installed` is a list of updates that were
+              successfully installed. `failed` is a list of updates that failed
+              to install. `superseded` is a list of updates that were not
+              installed because they were superseded by another update.
 
     CLI Example:
 

--- a/tests/pytests/unit/states/test_win_wua.py
+++ b/tests/pytests/unit/states/test_win_wua.py
@@ -173,27 +173,26 @@ def test_uptodate(updates_list):
             "failed": {
                 "a0f997b1-1abe-4a46-941f-b37f732f9fbd": {
                     "KBs": ["KB3193497"],
-                    "Title": "Blank"
+                    "Title": "Blank",
                 },
                 "afda9e11-44a0-4602-9e9b-423af11ecaed": {
                     "KBs": ["KB4541329"],
-                    "Title": "Blank"
+                    "Title": "Blank",
                 },
                 "eac02b09-d745-4891-b80f-400e0e5e4b6d": {
                     "KBs": ["KB4052623"],
                     "Title": "KB4052623: Really long title that exceeds 40 characters",
-                }
+                },
             },
             "superseded": {
                 "eac02c07-d744-4892-b80f-312d045e4ccc": {
                     "KBs": ["KB4052444"],
-                    "Title": "Superseded Update"
+                    "Title": "Superseded Update",
                 }
-            }
+            },
         },
         "result": False,
-        "comment": "Some updates failed to install\n"
-                   "Some updates were superseded"
+        "comment": "Some updates failed to install\nSome updates were superseded",
     }
 
     updates_not_installed = {

--- a/tests/pytests/unit/states/test_win_wua.py
+++ b/tests/pytests/unit/states/test_win_wua.py
@@ -39,7 +39,7 @@ def updates_list():
             "Title": "Blank",
         },
         "d931e99c-4dda-4d39-9905-0f6a73f7195f": {
-            "KBs": ["KB3193497"],
+            "KBs": ["KB3193498"],
             "Installed": False,
             "Title": "Blank",
         },
@@ -171,14 +171,29 @@ def test_uptodate(updates_list):
         "name": "NA",
         "changes": {
             "failed": {
+                "a0f997b1-1abe-4a46-941f-b37f732f9fbd": {
+                    "KBs": ["KB3193497"],
+                    "Title": "Blank"
+                },
+                "afda9e11-44a0-4602-9e9b-423af11ecaed": {
+                    "KBs": ["KB4541329"],
+                    "Title": "Blank"
+                },
                 "eac02b09-d745-4891-b80f-400e0e5e4b6d": {
                     "KBs": ["KB4052623"],
                     "Title": "KB4052623: Really long title that exceeds 40 characters",
                 }
+            },
+            "superseded": {
+                "eac02c07-d744-4892-b80f-312d045e4ccc": {
+                    "KBs": ["KB4052444"],
+                    "Title": "Superseded Update"
+                }
             }
         },
         "result": False,
-        "comment": "Updates failed",
+        "comment": "Some updates failed to install\n"
+                   "Some updates were superseded"
     }
 
     updates_not_installed = {
@@ -200,27 +215,32 @@ def test_uptodate(updates_list):
         "eac02c07-d744-4892-b80f-312d045e4ccc": {
             "KBs": ["KB4052444"],
             "Installed": False,
-            "Title": "Blank",
+            "Title": "Superseded Update",
         },
     }
-    fake_wua = MagicMock()
+
     fake_updates = MagicMock()
     fake_updates.list.return_value = updates_not_installed
 
+    patch_win_wua_update = patch(
+        "salt.utils.win_update.Updates",
+        autospec=True,
+        return_value=fake_updates,
+    )
+
     fake_wua_updates = MagicMock()
     fake_wua_updates.list.return_value = updates_list
-    fake_wua.updates.return_value = fake_wua_updates
 
-    patch_winapi_com = patch("salt.utils.winapi.Com", autospec=True)
-    patch_win32 = patch("win32com.client.Dispatch", autospec=True)
+    fake_wua = MagicMock()
+    fake_wua.updates.return_value = fake_wua_updates
     patch_wua = patch(
         "salt.utils.win_update.WindowsUpdateAgent",
         autospec=True,
         return_value=fake_wua,
     )
-    patch_win_wua_update = patch(
-        "salt.utils.win_update.Updates", autospec=True, return_value=fake_updates
-    )
+
+    patch_winapi_com = patch("salt.utils.winapi.Com", autospec=True)
+    patch_win32 = patch("win32com.client.Dispatch", autospec=True)
     patch_opts = patch.dict(win_wua.__opts__, {"test": False})
 
     with patch_winapi_com, patch_win32, patch_wua, patch_win_wua_update, patch_opts:


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with the win_wua states that were only returning a single item changed or failed.

### What issues does this PR fix or reference?
Fixes: #61479 

### Previous Behavior
It was only returning the last one added to the dictionary for changes or failures

### New Behavior
Now it adds all items properly to the changes and failures entry
Also adds supersedence for updates that are superseded by an installed update.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes