### PR TITLE
Removes support for old-style Windows Group Policy names

### DIFF
--- a/changelog/61696.fixed
+++ b/changelog/61696.fixed
@@ -1,1 +1,0 @@
-Deprecated old style Windows Group Policy names

--- a/changelog/61696.fixed
+++ b/changelog/61696.fixed
@@ -1,0 +1,1 @@
+Deprecated old style Windows Group Policy names

--- a/changelog/61696.removed
+++ b/changelog/61696.removed
@@ -1,0 +1,2 @@
+Removed support for old-style Windows Group Policy names
+Recommended policy names will be displayed in comments

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -6916,7 +6916,7 @@ def _checkAllAdmxPolicies(
 
                             if etree.QName(child_item).localname == "boolean":
                                 # https://msdn.microsoft.com/en-us/library/dn605978(v=vs.85).aspx
-                                if child_item:
+                                if child_item is not None:
                                     if (
                                         TRUE_VALUE_XPATH(child_item)
                                         and this_element_name not in configured_elements
@@ -9313,7 +9313,7 @@ def _get_policy_adm_setting(
                     )
                     if etree.QName(child_item).localname == "boolean":
                         # https://msdn.microsoft.com/en-us/library/dn605978(v=vs.85).aspx
-                        if child_item:
+                        if child_item is not None:
                             if (
                                 TRUE_VALUE_XPATH(child_item)
                                 and this_element_name not in configured_elements

--- a/salt/states/win_lgpo.py
+++ b/salt/states/win_lgpo.py
@@ -387,7 +387,7 @@ def set_(
     }
 
     current_policy = {}
-    deprecation_comments = []
+    comments = []
     for p_class, p_data in pol_data.items():
         if p_data["requested_policy"]:
             for p_name, _ in p_data["requested_policy"].items():
@@ -416,41 +416,19 @@ def set_(
                             valid_names.extend(element["element_aliases"])
                         for e_name in p_data["requested_policy"][p_name]:
                             if e_name not in valid_names:
-                                new_e_name = e_name.split(":")[-1].strip()
-                                # If we find an invalid name, test the new
-                                # format. If found, replace the old with the
-                                # new
-                                if new_e_name in valid_names:
-                                    msg = (
-                                        "The LGPO module changed the way "
-                                        "it gets policy element names.\n"
-                                        '"{}" is no longer valid.\n'
-                                        'Please use "{}" instead.'
-                                        "".format(e_name, new_e_name)
-                                    )
-                                    salt.utils.versions.warn_until("Phosphorus", msg)
-                                    pol_data[p_class]["requested_policy"][p_name][
-                                        new_e_name
-                                    ] = pol_data[p_class]["requested_policy"][
-                                        p_name
-                                    ].pop(
-                                        e_name
-                                    )
-                                    deprecation_comments.append(msg)
-                                else:
-                                    msg = "Invalid element name: {}".format(e_name)
-                                    ret["comment"] = "\n".join(
-                                        [ret["comment"], msg]
-                                    ).strip()
-                                    ret["result"] = False
+                                msg = "Invalid element name: {}".format(e_name)
+                                ret["comment"] = "\n".join(
+                                    [ret["comment"], msg]
+                                ).strip()
+                                ret["result"] = False
                 else:
                     ret["comment"] = "\n".join(
                         [ret["comment"], lookup["message"]]
                     ).strip()
                     ret["result"] = False
     if not ret["result"]:
-        deprecation_comments.append(ret["comment"])
-        ret["comment"] = "\n".join(deprecation_comments).strip()
+        comments.append(ret["comment"])
+        ret["comment"] = "\n".join(comments).strip()
         return ret
 
     log.debug("pol_data == %s", pol_data)
@@ -544,8 +522,8 @@ def set_(
             ret["result"] = None
         else:
             msg = "All specified policies are properly configured"
-        deprecation_comments.append(msg)
-        ret["comment"] = "\n".join(deprecation_comments).strip()
+        comments.append(msg)
+        ret["comment"] = "\n".join(comments).strip()
     else:
         if policy_changes:
             _ret = __salt__["lgpo.set"](
@@ -588,11 +566,11 @@ def set_(
                     )
                 )
                 ret["result"] = False
-            deprecation_comments.append(msg)
-            ret["comment"] = "\n".join(deprecation_comments).strip()
+            comments.append(msg)
+            ret["comment"] = "\n".join(comments).strip()
         else:
             msg = "All specified policies are properly configured"
-            deprecation_comments.append(msg)
-            ret["comment"] = "\n".join(deprecation_comments).strip()
+            comments.append(msg)
+            ret["comment"] = "\n".join(comments).strip()
 
     return ret

--- a/tests/pytests/functional/modules/win_lgpo/test_audit_settings_module.py
+++ b/tests/pytests/functional/modules/win_lgpo/test_audit_settings_module.py
@@ -42,7 +42,9 @@ def clean_adv_audit():
     win_dir = os.environ.get("WINDIR")
     audit_csv_files = [
         r"{}\security\audit\audit.csv".format(win_dir),
-        r"{}\System32\GroupPolicy\Machine\Microsoft\Windows NT\Audit\audit.csv".format(win_dir),
+        r"{}\System32\GroupPolicy\Machine\Microsoft\Windows NT\Audit\audit.csv".format(
+            win_dir
+        ),
     ]
     for audit_file in audit_csv_files:
         if os.path.exists(audit_file):
@@ -80,7 +82,9 @@ def test_auditing(lgpo, setting, enable_legacy_auditing, clean_adv_audit):
         ("Audit Account Management", "Failure"),
     ],
 )
-def test_auditing_case_names(lgpo, setting_name, setting, enable_legacy_auditing, clean_adv_audit):
+def test_auditing_case_names(
+    lgpo, setting_name, setting, enable_legacy_auditing, clean_adv_audit
+):
     """
     Helper function to set an audit setting and assert that it was successful
     """
@@ -90,7 +94,9 @@ def test_auditing_case_names(lgpo, setting_name, setting, enable_legacy_auditing
 
 
 @pytest.mark.parametrize("setting", ["Enabled", "Disabled"])
-def test_enable_legacy_audit_policy(lgpo, setting, legacy_auditing_not_defined, clean_adv_audit):
+def test_enable_legacy_audit_policy(
+    lgpo, setting, legacy_auditing_not_defined, clean_adv_audit
+):
     lgpo.set_computer_policy("SceNoApplyLegacyAuditPolicy", setting)
     result = lgpo.get_policy("SceNoApplyLegacyAuditPolicy", "machine")
     assert result == setting

--- a/tests/pytests/functional/modules/win_lgpo/test_audit_settings_module.py
+++ b/tests/pytests/functional/modules/win_lgpo/test_audit_settings_module.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 pytestmark = [
@@ -32,6 +34,23 @@ def enable_legacy_auditing(lgpo):
 
 
 @pytest.fixture(scope="module")
+def clean_adv_audit():
+    # An `audit.csv` file will cause these tests to fail. Delete the `audit.csv`
+    # files from the following locations:
+    # - C:\Windows\security\audit
+    # - C:\Windows\System32\GroupPolicy\Machine\Microsoft\Windows NT\Audit
+    win_dir = os.environ.get("WINDIR")
+    audit_csv_files = [
+        r"{}\security\audit\audit.csv".format(win_dir),
+        r"{}\System32\GroupPolicy\Machine\Microsoft\Windows NT\Audit\audit.csv".format(win_dir),
+    ]
+    for audit_file in audit_csv_files:
+        if os.path.exists(audit_file):
+            os.remove(audit_file)
+    yield
+
+
+@pytest.fixture(scope="module")
 def legacy_auditing_not_defined(lgpo):
     try:
         lgpo.set_computer_policy("SceNoApplyLegacyAuditPolicy", "Not Defined")
@@ -45,7 +64,7 @@ def legacy_auditing_not_defined(lgpo):
 @pytest.mark.parametrize(
     "setting", ["No auditing", "Success", "Failure", "Success, Failure"]
 )
-def test_auditing(lgpo, setting, enable_legacy_auditing):
+def test_auditing(lgpo, setting, enable_legacy_auditing, clean_adv_audit):
     """
     Helper function to set an audit setting and assert that it was successful
     """
@@ -61,7 +80,7 @@ def test_auditing(lgpo, setting, enable_legacy_auditing):
         ("Audit Account Management", "Failure"),
     ],
 )
-def test_auditing_case_names(lgpo, setting_name, setting, enable_legacy_auditing):
+def test_auditing_case_names(lgpo, setting_name, setting, enable_legacy_auditing, clean_adv_audit):
     """
     Helper function to set an audit setting and assert that it was successful
     """
@@ -71,7 +90,7 @@ def test_auditing_case_names(lgpo, setting_name, setting, enable_legacy_auditing
 
 
 @pytest.mark.parametrize("setting", ["Enabled", "Disabled"])
-def test_enable_legacy_audit_policy(lgpo, setting, legacy_auditing_not_defined):
+def test_enable_legacy_audit_policy(lgpo, setting, legacy_auditing_not_defined, clean_adv_audit):
     lgpo.set_computer_policy("SceNoApplyLegacyAuditPolicy", setting)
     result = lgpo.get_policy("SceNoApplyLegacyAuditPolicy", "machine")
     assert result == setting

--- a/tests/pytests/functional/states/win_lgpo/test_audit_settings_state.py
+++ b/tests/pytests/functional/states/win_lgpo/test_audit_settings_state.py
@@ -76,7 +76,9 @@ def clean_adv_audit():
     win_dir = os.environ.get("WINDIR")
     audit_csv_files = [
         r"{}\security\audit\audit.csv".format(win_dir),
-        r"{}\System32\GroupPolicy\Machine\Microsoft\Windows NT\Audit\audit.csv".format(win_dir),
+        r"{}\System32\GroupPolicy\Machine\Microsoft\Windows NT\Audit\audit.csv".format(
+            win_dir
+        ),
     ]
     for audit_file in audit_csv_files:
         if os.path.exists(audit_file):

--- a/tests/pytests/unit/states/test_win_lgpo.py
+++ b/tests/pytests/unit/states/test_win_lgpo.py
@@ -180,54 +180,6 @@ def test_current_element_naming_style(policy_clear):
 @pytest.mark.skip_unless_on_windows
 @pytest.mark.destructive_test
 @pytest.mark.slow_test
-def test_old_element_naming_style(policy_clear):
-    """
-    Ensure that the old naming style is converted to new and a warning is
-    returned
-    """
-    computer_policy = {
-        "Point and Print Restrictions": {
-            "Users can only point and print to these servers": True,
-            "Enter fully qualified server names separated by semicolons": (
-                "fakeserver1;fakeserver2"
-            ),
-            "Users can only point and print to machines in their forest": True,
-            # Here's the old one
-            "Security Prompts: When installing drivers for a new connection": (
-                "Show warning and elevation prompt"
-            ),
-            "When updating drivers for an existing connection": "Show warning only",
-        }
-    }
-
-    with patch.dict(win_lgpo.__opts__, {"test": False}):
-        result = win_lgpo.set_(name="test_state", computer_policy=computer_policy)
-    expected = {
-        "Point and Print Restrictions": {
-            "Enter fully qualified server names separated by semicolons": (
-                "fakeserver1;fakeserver2"
-            ),
-            "When installing drivers for a new connection": (
-                "Show warning and elevation prompt"
-            ),
-            "Users can only point and print to machines in their forest": True,
-            "Users can only point and print to these servers": True,
-            "When updating drivers for an existing connection": "Show warning only",
-        }
-    }
-    assert result["changes"]["new"]["Computer Configuration"] == expected
-    expected = (
-        'The LGPO module changed the way it gets policy element names.\n"Security'
-        ' Prompts: When installing drivers for a new connection" is no longer'
-        ' valid.\nPlease use "When installing drivers for a new connection"'
-        " instead.\nThe following policies changed:\nPoint and Print Restrictions"
-    )
-    assert result["comment"] == expected
-
-
-@pytest.mark.skip_unless_on_windows
-@pytest.mark.destructive_test
-@pytest.mark.slow_test
 def test_invalid_elements():
     computer_policy = {
         "Point and Print Restrictions": {
@@ -278,44 +230,6 @@ def test_current_element_naming_style_true(policy_set):
     expected = {
         "changes": {},
         "comment": "All specified policies are properly configured",
-    }
-    assert result["changes"] == expected["changes"]
-    assert result["result"]
-    assert result["comment"] == expected["comment"]
-
-
-@pytest.mark.skip_unless_on_windows
-@pytest.mark.destructive_test
-@pytest.mark.slow_test
-def test_old_element_naming_style_true(policy_set):
-    """
-    Test old naming style with test=True. Should not make changes but return a
-    warning
-    """
-    computer_policy = {
-        "Point and Print Restrictions": {
-            "Users can only point and print to these servers": True,
-            "Enter fully qualified server names separated by semicolons": (
-                "fakeserver1;fakeserver2"
-            ),
-            "Users can only point and print to machines in their forest": True,
-            # Here's the old one
-            "Security Prompts: When installing drivers for a new connection": (
-                "Show warning and elevation prompt"
-            ),
-            "When updating drivers for an existing connection": "Show warning only",
-        }
-    }
-    with patch.dict(win_lgpo.__opts__, {"test": True}):
-        result = win_lgpo.set_(name="test_state", computer_policy=computer_policy)
-    expected = {
-        "changes": {},
-        "comment": (
-            'The LGPO module changed the way it gets policy element names.\n"Security'
-            ' Prompts: When installing drivers for a new connection" is no longer'
-            ' valid.\nPlease use "When installing drivers for a new connection"'
-            " instead.\nAll specified policies are properly configured"
-        ),
     }
     assert result["changes"] == expected["changes"]
     assert result["result"]


### PR DESCRIPTION
### What does this PR do?
Removes support for old-style Windows Group Policy names.

### What issues does this PR fix or reference?
Fixes: #61696 

### Previous Behavior
Displayed a deprecation warning

### New Behavior
Removes the warning and throws an error on old-style policy names

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes