### PR TITLE
Remove enable_slsvars_fixes feature flag and enable behavior by default

### DIFF
--- a/changelog/61697.removed
+++ b/changelog/61697.removed
@@ -1,0 +1,5 @@
+Remove the feature flag feature.enable_slsvars_fixes and enable the fixes for `sls_path`, `tpl_file`, and `tpldir` by default.
+Enabling this behavior by default will fix the following:
+  - tpldir: If your directory name and your SLS file name are the same tpldir used to return a ., now it returns the correct directory name.
+  - slspath,slsdotpath,slscolonpath,sls_path: If an init.sls file is accessed by its explicit name path.to.init instead of path.to, init shows up as a directory for in various sls context parameters, now it will only show as a file.
+  - tplfile: When using tplfile in a SLS file in the root directory of file roots it returns empty. Now it returns the filename.

--- a/doc/ref/states/vars.rst
+++ b/doc/ref/states/vars.rst
@@ -4,17 +4,9 @@ SLS Template Variable Reference
 
 
 .. warning::
-   In the 3002 release ``sls_path``, ``tplfile``, and ``tpldir`` have had some significant
+   In the 3005 release ``sls_path``, ``tplfile``, and ``tpldir`` have had some significant
    improvements which have the potential to break states that rely on old and
-   broken functionality. These fixes can be enabled by setting the
-   ``enable_slsvars_fixes`` feature flag to ``True`` in your minion's config file.
-   This functionality will become the default in the 3005 release.
-
-   .. code-block:: yaml
-
-       features:
-         enable_slsvars_fixes: True
-
+   broken functionality.
 
 
 The template engines available to sls files and file templates come loaded

--- a/tests/pytests/functional/conftest.py
+++ b/tests/pytests/functional/conftest.py
@@ -61,7 +61,6 @@ def minion_opts(
         {
             "file_client": "local",
             "file_roots": {"base": [str(state_tree)], "prod": [str(state_tree_prod)]},
-            "features": {"enable_slsvars_fixes": True},
         }
     )
     factory = salt_factories.salt_minion_daemon(


### PR DESCRIPTION
### What does this PR do?
Remove the feature flag `feature.enable_slsvars_fixes` and enable the fixes for `sls_path`, `tpl_file`, and `tpldir` by default.
Enabling this behavior by default will fix the following:
  - tpldir: If your directory name and your SLS file name are the same tpldir used to return a ., now it returns the correct directory name.
  - slspath,slsdotpath,slscolonpath,sls_path: If an init.sls file is accessed by its explicit name path.to.init instead of path.to, init shows up as a directory for in various sls context parameters, now it will only show as a file.
  - tplfile: When using tplfile in a SLS file in the root directory of file roots it returns empty. Now it returns the filename.


### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/61697

