### PR TITLE
Adjust Debian/Ubuntu package use of name 'ifenslave-2.6' to 'ifenslave'

### DIFF
--- a/changelog/60876.fixed
+++ b/changelog/60876.fixed
@@ -1,0 +1,1 @@
+Adjust Debian/Ubuntu package use of name 'ifenslave-2.6' to 'ifenslave'

--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1649,8 +1649,8 @@ def build_bond(iface, **settings):
     # Load kernel module
     __salt__["kmod.load"]("bonding")
 
-    # install ifenslave-2.6
-    __salt__["pkg.install"]("ifenslave-2.6")
+    # install ifenslave
+    __salt__["pkg.install"]("ifenslave")
 
     return _read_file(path)
 

--- a/tests/pytests/functional/modules/test_pkg.py
+++ b/tests/pytests/functional/modules/test_pkg.py
@@ -42,6 +42,8 @@ def test_pkg(grains):
             _pkg = "snoopy"
         else:
             _pkg = "units"
+    elif grains["os_family"] == "Debian":
+        _pkg = "ifenslave"
     return _pkg
 
 


### PR DESCRIPTION
### What does this PR do?
Changes the name of the package from 'ifenslave-2.6' to 'ifenslave'

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/60876

### Previous Behavior
On Bullseye (Debian 11), there is no ifenslave-2.6 package, so bonding on Debian / Ubuntu fails

### New Behavior
On Bullseye and Debian 10 and 9, use  ifenslave package, and bonding on Debian / Ubuntu succeeds

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
