### PR TITLE
handle AttributeError: 'dict' object has no attribute 'append'

### DIFF
--- a/salt/beacons/__init__.py
+++ b/salt/beacons/__init__.py
@@ -94,7 +94,11 @@ class Beacon:
                     log.error("Configuration for beacon must be a list.")
                     continue
 
-            b_config[mod].append({"_beacon_name": mod})
+            try:
+                b_config[mod].append({"_beacon_name": mod})
+            except AttributeError:
+                continue
+                
             fun_str = "{}.beacon".format(beacon_name)
             if fun_str in self.beacons:
                 runonce = self._determine_beacon_config(


### PR DESCRIPTION
### What does this PR do?
Fixes beacon processing when the mod object is dict

### What issues does this PR fix or reference?
Fixes issue #59506

### Previous Behavior
  File "/usr/lib/python3.6/site-packages/salt/minion.py", line 2877, in handle_beacons
    beacons = self.process_beacons(self.functions)
  File "/usr/lib/python3.6/site-packages/salt/minion.py", line 516, in process_beacons
    b_conf, self.opts["grains"]
  File "/usr/lib/python3.6/site-packages/salt/beacons/__init__.py", line 75, in process
    b_config[mod].append({"_beacon_name": mod})
AttributeError: 'dict' object has no attribute 'append'


### New Behavior
Exception is handled

### Merge requirements satisfied?
yes, already deployed this change in my production environment

### Commits signed with GPG?
No
