### PR TITLE
fix: jinja2 DeprecationWarning

### DIFF
--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -706,8 +706,11 @@ def symmetric_difference(lst1, lst2):
 def method_call(obj, f_name, *f_args, **f_kwargs):
     return getattr(obj, f_name, lambda *args, **kwargs: None)(*f_args, **f_kwargs)
 
-
-@jinja2.pass_context
+if jinja2.__version__ < '3.0.0' :
+    contextfunction = jinja2.contextfunction
+else:
+    contextfunction =  jinja2.pass_context
+@contextfunction
 def show_full_context(ctx):
     return salt.utils.data.simple_types_filter(
         {key: value for key, value in ctx.items()}

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -707,7 +707,7 @@ def method_call(obj, f_name, *f_args, **f_kwargs):
     return getattr(obj, f_name, lambda *args, **kwargs: None)(*f_args, **f_kwargs)
 
 
-@jinja2.contextfunction
+@jinja2.pass_context
 def show_full_context(ctx):
     return salt.utils.data.simple_types_filter(
         {key: value for key, value in ctx.items()}


### PR DESCRIPTION
Signed-off-by: jonyhy96 <hy352144278@gmail.com>

### What does this PR do?

Fix a DeprecationWarning for jinja

### What issues does this PR fix or reference?
Fixes: #60745

### Previous Behavior

salt/utils/jinja.py:715: DeprecationWarning: 'contextfunction' is renamed to 'pass_context', the old name will be removed in Jinja 3.1.

### New Behavior
no warning

### Commits signed with GPG?
Yes
