### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1041,10 +1041,10 @@ class SaltDistribution(distutils.dist.Distribution):
         self.author = "Thomas S Hatch"
         self.author_email = "thatch45@gmail.com"
         self.url = "https://saltproject.io"
-        self.project_urls = {
+        self.project_urls.update({
             "Documentation": "https://docs.saltproject.io/en/latest/contents.html",
             "Source": "https://github.com/saltstack/salt",
-        },
+        }),
         self.cmdclass.update(
             {
                 "test": TestCommand,

--- a/setup.py
+++ b/setup.py
@@ -1041,6 +1041,10 @@ class SaltDistribution(distutils.dist.Distribution):
         self.author = "Thomas S Hatch"
         self.author_email = "thatch45@gmail.com"
         self.url = "https://saltproject.io"
+        self.project_urls = {
+            "Documentation": "https://docs.saltproject.io/en/latest/contents.html",
+            "Source": "https://github.com/saltstack/salt",
+        },
         self.cmdclass.update(
             {
                 "test": TestCommand,


### PR DESCRIPTION
### What does this PR do?

Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
