### PR TITLE
Add Etag support to archive.extracted

### DIFF
--- a/changelog/61763.added
+++ b/changelog/61763.added
@@ -1,0 +1,1 @@
+Add Etag support for archive.extracted web sources

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -55,10 +55,11 @@ def list_(
     verbose=False,
     saltenv="base",
     source_hash=None,
+    use_etag=False,
 ):
     """
     .. versionadded:: 2016.11.0
-    .. versionchanged:: 2016.11.2
+    .. versionchanged:: 2016.11.2,3005
         The rarfile_ Python module is now supported for listing the contents of
         rar archives. This is necessary on minions with older releases of the
         ``rar`` CLI tool, which do not support listing the contents in a
@@ -151,6 +152,15 @@ def list_(
         hash.
 
         .. versionadded:: 2018.3.0
+
+    use_etag
+        If ``True``, remote http/https file sources will attempt to use the
+        ETag header to determine if the remote file needs to be downloaded.
+        This provides a lightweight mechanism for promptly refreshing files
+        changed on a web server without requiring a full hash comparison via
+        the ``source_hash`` parameter.
+
+        .. versionadded:: 3005
 
     .. _tarfile: https://docs.python.org/2/library/tarfile.html
     .. _xz: http://tukaani.org/xz/
@@ -321,7 +331,9 @@ def list_(
                 )
         return dirs, files, []
 
-    cached = __salt__["cp.cache_file"](name, saltenv, source_hash=source_hash)
+    cached = __salt__["cp.cache_file"](
+        name, saltenv, source_hash=source_hash, use_etag=use_etag
+    )
     if not cached:
         raise CommandExecutionError("Failed to cache {}".format(name))
 
@@ -1107,9 +1119,10 @@ def unzip(
     return _trim_files(cleaned_files, trim_output)
 
 
-def is_encrypted(name, clean=False, saltenv="base", source_hash=None):
+def is_encrypted(name, clean=False, saltenv="base", source_hash=None, use_etag=False):
     """
     .. versionadded:: 2016.11.0
+    .. versionchanged:: 3005
 
     Returns ``True`` if the zip archive is password-protected, ``False`` if
     not. If the specified file is not a ZIP archive, an error will be raised.
@@ -1139,6 +1152,15 @@ def is_encrypted(name, clean=False, saltenv="base", source_hash=None):
 
         .. versionadded:: 2018.3.0
 
+    use_etag
+        If ``True``, remote http/https file sources will attempt to use the
+        ETag header to determine if the remote file needs to be downloaded.
+        This provides a lightweight mechanism for promptly refreshing files
+        changed on a web server without requiring a full hash comparison via
+        the ``source_hash`` parameter.
+
+        .. versionadded:: 3005
+
     CLI Examples:
 
     .. code-block:: bash
@@ -1150,7 +1172,9 @@ def is_encrypted(name, clean=False, saltenv="base", source_hash=None):
             salt '*' archive.is_encrypted https://domain.tld/myfile.zip source_hash=f1d2d2f924e986ac86fdf7b36c94bcdf32beec15
             salt '*' archive.is_encrypted ftp://10.1.2.3/foo.zip
     """
-    cached = __salt__["cp.cache_file"](name, saltenv, source_hash=source_hash)
+    cached = __salt__["cp.cache_file"](
+        name, saltenv, source_hash=source_hash, use_etag=use_etag
+    )
     if not cached:
         raise CommandExecutionError("Failed to cache {}".format(name))
 

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -189,11 +189,12 @@ def extracted(
     enforce_toplevel=True,
     enforce_ownership_on=None,
     archive_format=None,
+    use_etag=False,
     **kwargs
 ):
     """
     .. versionadded:: 2014.1.0
-    .. versionchanged:: 2016.11.0
+    .. versionchanged:: 2016.11.0,3005
         This state has been rewritten. Some arguments are new to this release
         and will not be available in the 2016.3 release cycle (and earlier).
         Additionally, the **ZIP Archive Handling** section below applies
@@ -661,6 +662,15 @@ def extracted(
     .. _zipfile: https://docs.python.org/2/library/zipfile.html
     .. _xz: http://tukaani.org/xz/
 
+    use_etag
+        If ``True``, remote http/https file sources will attempt to use the
+        ETag header to determine if the remote file needs to be downloaded.
+        This provides a lightweight mechanism for promptly refreshing files
+        changed on a web server without requiring a full hash comparison via
+        the ``source_hash`` parameter.
+
+        .. versionadded:: 3005
+
     **Examples**
 
     1. tar with lmza (i.e. xz) compression:
@@ -1052,6 +1062,7 @@ def extracted(
                 source_hash_name=source_hash_name,
                 skip_verify=skip_verify,
                 saltenv=__env__,
+                use_etag=use_etag,
             )
         except Exception as exc:  # pylint: disable=broad-except
             msg = "Failed to cache {}: {}".format(
@@ -1085,7 +1096,7 @@ def extracted(
         # implicitly enabled by setting the "options" argument.
         try:
             encrypted_zip = __salt__["archive.is_encrypted"](
-                cached, clean=False, saltenv=__env__
+                cached, clean=False, saltenv=__env__, use_etag=use_etag
             )
         except CommandExecutionError:
             # This would happen if archive_format=zip and the source archive is
@@ -1109,6 +1120,7 @@ def extracted(
             strip_components=strip_components,
             clean=False,
             verbose=True,
+            use_etag=use_etag,
         )
     except CommandExecutionError as exc:
         contents = None

--- a/tests/pytests/functional/states/test_archive.py
+++ b/tests/pytests/functional/states/test_archive.py
@@ -1,0 +1,224 @@
+import functools
+import hashlib
+import http.server
+import multiprocessing
+import os
+import random
+import shutil
+import socket
+import sys
+from contextlib import closing
+
+import pytest
+import salt.utils.files
+
+
+class TestRequestHandler(http.server.SimpleHTTPRequestHandler):
+    """
+    Modified request handler class
+    """
+
+    def __init__(self, *args, directory=None, **kwargs):
+        if directory is None:
+            directory = os.getcwd()
+        self.directory = directory
+        if sys.version_info.minor < 7:
+            super().__init__(*args, **kwargs)
+        else:
+            super().__init__(*args, directory=directory, **kwargs)
+
+    def do_GET(self):
+        """
+        GET request handling
+        """
+        none_match = self.headers.get("If-None-Match")
+        status_code = 200
+        try:
+            # Retrieve the local file from the web root to serve to clients
+            with salt.utils.files.fopen(
+                os.path.join(self.directory, self.path[1:]), "rb"
+            ) as reqfp:
+                return_data = reqfp.read()
+                # We're using this checksum as the etag to show file changes
+                checksum = hashlib.md5(return_data).hexdigest()
+                if none_match == checksum:
+                    # Status code 304 Not Modified is returned if the file is unchanged
+                    status_code = 304
+        except:  # pylint: disable=bare-except
+            # Something went wrong. We didn't find the requested file
+            status_code = 404
+            return_data = None
+            checksum = None
+
+        self.send_response(status_code)
+
+        # Return the Etag header if we have the checksum
+        if checksum:
+            # IMPORTANT: This introduces randomness into the tests. The Etag header key
+            # will be converted to lowercase in the code... but if someone breaks that,
+            # it'll rear it's head here as random failures that are hard to reproduce.
+            # Any alternatives seem overly complex. So... don't break the case insensitivity
+            # in the code.
+            possible_etags = ["Etag", "ETag", "etag", "ETAG"]
+            self.send_header(random.choice(possible_etags), checksum)
+            self.end_headers()
+
+        # Return file content
+        if return_data:
+            self.wfile.write(return_data)
+
+
+def serve(port=8000, directory=None):
+    """
+    Function to serve a directory via http.server
+    """
+    handler = functools.partial(TestRequestHandler, directory=directory)
+    s = http.server.HTTPServer(("127.0.0.1", port), handler)
+    s.serve_forever()
+
+
+@pytest.fixture(scope="module")
+def free_port():
+    """
+    Utility fixture to grab a free port for the web server
+    """
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("", 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return s.getsockname()[1]
+
+
+@pytest.fixture(autouse=True, scope="module")
+def server(free_port, web_root):
+    """
+    Web server fixture
+    """
+    p = multiprocessing.Process(target=serve, args=(free_port, web_root))
+    p.start()
+    yield
+    p.terminate()
+    p.join()
+
+
+@pytest.fixture(scope="module")
+def web_root(tmp_path_factory):
+    """
+    Temporary directory fixture for the web server root
+    """
+    _web_root = tmp_path_factory.mktemp("web_root")
+    try:
+        yield str(_web_root)
+    finally:
+        shutil.rmtree(str(_web_root), ignore_errors=True)
+
+
+def test_archive_extracted_web_source_etag_operation(
+    modules, states, free_port, web_root, minion_opts
+):
+    """
+    This functional test checks the operation of the use_etag parameter to the
+    archive.extracted state. There are four (4) invocations of archive.extracted
+    with a web source, but only three (3) will trigger a call to the web server
+    as shown below and in comments within.
+
+        127.0.0.1 - - [08/Mar/2022 13:07:10] "GET /foo.tar.gz HTTP/1.1" 200 -
+        127.0.0.1 - - [08/Mar/2022 13:07:10] "GET /foo.tar.gz HTTP/1.1" 304 -
+        127.0.0.1 - - [08/Mar/2022 13:07:10] "GET /foo.tar.gz HTTP/1.1" 200 -
+
+    Checks are documented in the comments.
+    """
+    # Create file in the web root directory to serve
+    states.file.managed(
+        name=os.path.join(web_root, "foo", "bar.txt"),
+        contents="this is my file",
+        makedirs=True,
+    )
+    modules.archive.tar(
+        options="czf",
+        tarfile=os.path.join(web_root, "foo.tar.gz"),
+        sources=[os.path.join(web_root, "foo")],
+        cwd=web_root,
+    )
+
+    # File should not be cached yet
+    cached_file = os.path.join(
+        minion_opts["cachedir"],
+        "extrn_files",
+        "base",
+        "localhost:{free_port}".format(free_port=free_port),
+        "foo.tar.gz",
+    )
+    cached_etag = cached_file + ".etag"
+    assert not os.path.exists(cached_file)
+    assert not os.path.exists(cached_etag)
+
+    # Pull the file from the web server
+    #     Web server returns 200 status code with content:
+    #     127.0.0.1 - - [08/Mar/2022 13:07:10] "GET /foo.tar.gz HTTP/1.1" 200 -
+    states.archive.extracted(
+        name=web_root,
+        source="http://localhost:{free_port}/foo.tar.gz".format(free_port=free_port),
+        archive_format="tar",
+        options="z",
+        use_etag=True,
+    )
+
+    # Now the file is cached
+    assert os.path.exists(cached_file)
+    assert os.path.exists(cached_etag)
+
+    # Store the original modified time of the cached file
+    cached_file_mtime = os.path.getmtime(cached_file)
+
+    # Pull the file again. Etag hasn't changed. No download occurs.
+    #     Web server returns 304 status code and no content:
+    #     127.0.0.1 - - [08/Mar/2022 13:07:10] "GET /foo.tar.gz HTTP/1.1" 304 -
+    states.archive.extracted(
+        name=web_root,
+        source="http://localhost:{free_port}/foo.tar.gz".format(free_port=free_port),
+        archive_format="tar",
+        options="z",
+        use_etag=True,
+    )
+
+    # Check that the modified time of the cached file hasn't changed
+    assert cached_file_mtime == os.path.getmtime(cached_file)
+
+    # Change file in the web root directory
+    states.file.managed(
+        name=os.path.join(web_root, "foo", "bar.txt"),
+        contents="this is my changed file",
+    )
+    modules.archive.tar(
+        options="czf",
+        tarfile=os.path.join(web_root, "foo.tar.gz"),
+        sources=[os.path.join(web_root, "foo")],
+        cwd=web_root,
+    )
+
+    # Don't use Etag. Cached file is there, Salt won't try to download.
+    #     No call to the web server will be made.
+    states.archive.extracted(
+        name=web_root,
+        source="http://localhost:{free_port}/foo.tar.gz".format(free_port=free_port),
+        archive_format="tar",
+        options="z",
+        use_etag=False,
+    )
+
+    # Check that the modified time of the cached file hasn't changed
+    assert cached_file_mtime == os.path.getmtime(cached_file)
+
+    # Now use Etag again. Cached file changes
+    #     Web server returns 200 status code with content
+    #     127.0.0.1 - - [08/Mar/2022 13:07:10] "GET /foo.tar.gz HTTP/1.1" 200 -
+    states.archive.extracted(
+        name=web_root,
+        source="http://localhost:{free_port}/foo.tar.gz".format(free_port=free_port),
+        archive_format="tar",
+        options="z",
+        use_etag=True,
+    )
+
+    # The modified time of the cached file now changes
+    assert cached_file_mtime != os.path.getmtime(cached_file)


### PR DESCRIPTION
### What does this PR do?
This PR introduces the ability to use the Etag response header to determine if a file hosted by a remote web server has changed since the last time it was retrieved.

### What issues does this PR fix or reference?
Fixes: #61763 

### Previous/New Behavior
See #61391 for details regarding similar `file.managed` operation.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
