### PR TITLE
Fix 59705 - yumpkg mod versions

### DIFF
--- a/changelog/59705.fixed
+++ b/changelog/59705.fixed
@@ -1,0 +1,1 @@
+Changed yumpkg module to normalize versions to strings when they were ambiguously floats (example version=3005.0).

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -101,7 +101,7 @@ def parse_targets(
     if __grains__["os"] == "MacOS" and sources:
         log.warning('Parameter "sources" ignored on MacOS hosts.')
 
-    version = kwargs.get("version")
+    version = str(kwargs["version"]) if "version" in kwargs else None
 
     if pkgs and sources:
         log.error('Only one of "pkgs" and "sources" can be used.')

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -101,7 +101,7 @@ def parse_targets(
     if __grains__["os"] == "MacOS" and sources:
         log.warning('Parameter "sources" ignored on MacOS hosts.')
 
-    version = str(kwargs["version"]) if "version" in kwargs else None
+    version = kwargs.get("version")
 
     if pkgs and sources:
         log.error('Only one of "pkgs" and "sources" can be used.')

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1448,6 +1448,8 @@ def install(
                 'version': '<new-version>',
                 'arch': '<new-arch>'}}}
     """
+    if "version" in kwargs:
+        kwargs["version"] = str(kwargs["version"])
     options = _get_options(**kwargs)
 
     if salt.utils.data.is_true(refresh):

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1464,8 +1464,6 @@ def install(
     if pkg_params is None or len(pkg_params) == 0:
         return {}
 
-    version_num = kwargs.get("version")
-
     diff_attr = kwargs.get("diff_attr")
     old = (
         list_pkgs(versions_as_list=False, attr=diff_attr)

--- a/tests/pytests/unit/modules/test_yumpkg.py
+++ b/tests/pytests/unit/modules/test_yumpkg.py
@@ -2103,6 +2103,9 @@ def test_59705_version_as_accidental_float_should_become_text(
     patch_list_pkgs = patch.object(
         yumpkg, "list_pkgs", return_value={"foo": ["foo-42"]}
     )
+    patch_list_downloaded = patch(
+        "salt.module.yumpkg.list_downloaded", autospec=True, return_value={}
+    )
     patch_systemd = patch("salt.utils.systemd.has_scope", MagicMock(return_value=False))
     with patch_list_pkgs, patch_systemd, patch_yum_salt:
         yumpkg.install("foo", version=new)

--- a/tests/pytests/unit/modules/test_yumpkg.py
+++ b/tests/pytests/unit/modules/test_yumpkg.py
@@ -2072,7 +2072,6 @@ def yum_and_dnf(request):
         yield request.param["cmd"]
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize(
     "new,full_pkg_string",
     (

--- a/tests/pytests/unit/modules/test_yumpkg.py
+++ b/tests/pytests/unit/modules/test_yumpkg.py
@@ -2072,12 +2072,11 @@ def yum_and_dnf(request):
         yield request.param["cmd"]
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize(
     "new,full_pkg_string",
     (
         (42, "foo-42"),
-        # ("99:1.2.3", "foo-1.2.3"),
+        ("99:1.2.3", "foo-1.2.3"),
     ),
 )
 def test_59705_version_as_accidental_float_should_become_text(


### PR DESCRIPTION
### What does this PR do?

Fixes #59705 - changes yumpkg.install to force version specifier to be a string
instead of an ambiguous float.

### Previous Behavior

When calling `pkg.install version=1.2` or other version that *could* be a
float, yumpkg would treat it as a float and catch on fire a little bit. 

### New Behavior

Now it will not - `version=3005.0` will be treated the same as
`version="3005.0"`, as one would expect from version numbers.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- ~[ ] Docs~
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?

Yes
