### PR TITLE
Porting #49873 to master - If ipv6 is enabled and it fails, try the lookup again using ipv4.

### DIFF
--- a/changelog/49835.fixed
+++ b/changelog/49835.fixed
@@ -1,0 +1,1 @@
+Fixes a scenario where ipv6 is enabled but the master is configured as an ipv4 IP address.

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -2177,8 +2177,6 @@ def dns_check(addr, port, safe=False, ipv6=None):
             ),
         )
     except OSError:
-        pass
-    except socket.Error:
         socket_error = True
 
     # If ipv6 is set to True, attempt another lookup using the IPv4 family,

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -2163,6 +2163,7 @@ def dns_check(addr, port, safe=False, ipv6=None):
         if ipv6 is False
         else socket.AF_UNSPEC
     )
+    socket_error = False
     try:
         refresh_dns()
         addrinfo = socket.getaddrinfo(addr, port, family, socket.SOCK_STREAM)
@@ -2177,6 +2178,29 @@ def dns_check(addr, port, safe=False, ipv6=None):
         )
     except OSError:
         pass
+    except socket.Error:
+        socket_error = True
+
+    # If ipv6 is set to True, attempt another lookup using the IPv4 family,
+    # just in case we're attempting to lookup an IPv4 IP
+    # as an IPv6 hostname.
+    if socket_error and ipv6:
+        try:
+            refresh_dns()
+            addrinfo = socket.getaddrinfo(
+                addr, port, socket.AF_INET, socket.SOCK_STREAM
+            )
+            ip_addrs = _test_addrs(addrinfo, port)
+        except TypeError:
+            raise SaltSystemExit(
+                code=42,
+                msg=(
+                    "Attempt to resolve address '{}' failed. Invalid or unresolveable"
+                    " address".format(addr)
+                ),
+            )
+        except OSError:
+            error = True
 
     if not ip_addrs:
         err = "DNS lookup or connection check of '{}' failed.".format(addr)

--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -1019,6 +1019,9 @@ def test_minion_grains_refresh_pre_exec_true():
             minion.destroy()
 
 
+@pytest.mark.skip_on_darwin(
+    reason="Skip on MacOS, where this does not raise an exception."
+)
 def test_valid_ipv4_master_address_ipv6_enabled():
     """
     Tests that the lookups fail back to ipv4 when ipv6 fails.

--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -1017,3 +1017,44 @@ def test_minion_grains_refresh_pre_exec_true():
             grainsfunc.assert_called()
         finally:
             minion.destroy()
+
+
+def test_valid_ipv4_master_address_ipv6_enabled():
+    """
+    Tests that the lookups fail back to ipv4 when ipv6 fails.
+    """
+    interfaces = {
+        "bond0.1234": {
+            "hwaddr": "01:01:01:d0:d0:d0",
+            "up": False,
+            "inet": [
+                {
+                    "broadcast": "111.1.111.255",
+                    "netmask": "111.1.0.0",
+                    "label": "bond0",
+                    "address": "111.1.0.1",
+                }
+            ],
+        }
+    }
+    opts = salt.config.DEFAULT_MINION_OPTS.copy()
+    with patch.dict(
+        opts,
+        {
+            "ipv6": True,
+            "master": "127.0.0.1",
+            "master_port": "4555",
+            "retry_dns": False,
+            "source_address": "111.1.0.1",
+            "source_interface_name": "bond0.1234",
+            "source_ret_port": 49017,
+            "source_publish_port": 49018,
+        },
+    ), patch("salt.utils.network.interfaces", MagicMock(return_value=interfaces)):
+        expected = {
+            "source_publish_port": 49018,
+            "master_uri": "tcp://127.0.0.1:4555",
+            "source_ret_port": 49017,
+            "master_ip": "127.0.0.1",
+        }
+        assert salt.minion.resolve_dns(opts) == expected


### PR DESCRIPTION
### What does this PR do?
If ipv6 is enabled and it fails, try the lookup again using ipv4 just in case the master is a ipv4 address.

### What issues does this PR fix or reference?
Fixes: #49835

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
