### PR TITLE
Allow passing metadata during service registration.

### DIFF
--- a/changelog/61792.fixed
+++ b/changelog/61792.fixed
@@ -1,0 +1,1 @@
+Allow passing metadata during Consul service registration.

--- a/salt/modules/consul.py
+++ b/salt/modules/consul.py
@@ -987,6 +987,8 @@ def agent_service_register(consul_url=None, token=None, **kwargs):
     :param id: Unique ID to identify the service, if not
                provided the value of the name parameter is used.
     :param tags: Identifying tags for service, string or list.
+    :param metadata: Arbitrary KV metadata linked to service
+                     instance.
     :param script: If script is provided, the check type is
                    a script, and Consul will evaluate that script
                    based on the interval parameter.
@@ -1042,6 +1044,11 @@ def agent_service_register(consul_url=None, token=None, **kwargs):
 
     if "enabletagoverride" in lc_kwargs:
         data["EnableTagOverride"] = lc_kwargs["enabletagoverride"]
+
+    if "metadata" in lc_kwargs:
+        _metadata = lc_kwargs["metadata"]
+        if isinstance(_metadata, dict):
+            data["Meta"] = _metadata
 
     if "check" in lc_kwargs:
         dd = dict()


### PR DESCRIPTION
### What does this PR do?
Allow passing metadata during service registration

e.g.

```
consul.agent_service_register:
  module.run:
    - consul_url: "http://localhost:8500"
    - token: foo
    - kwargs:
        name: prometheus-node-exporter
        id: prometheus-node-exporter
        port: 9100
        tags: ["metrics"]
        metadata:
          appid: "prometheus"
        check:
          interval: 5m
          timeout: 10s
          http: "http://localhost:9100/metrics"
          name: "Node Exporter HTTP checks"
```

### What issues does this PR fix or reference?
Fixes #61792

### Previous Behavior
Unable to pass metadata at service registration

### New Behavior
Allows passing metadata at service registration

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
