### PR TITLE
don't call save_load if job data lacks tgt

### DIFF
--- a/salt/utils/job.py
+++ b/salt/utils/job.py
@@ -124,7 +124,10 @@ def store_job(opts, load, event=None, mminion=None):
         log.error(emsg)
         raise KeyError(emsg)
 
-    if job_cache != "local_cache":
+    # don't call save_load if the load doesn't have a tgt
+    # as this is this is most likely data destined only for
+    # the returner
+    if "tgt" in load:
         try:
             mminion.returners[savefstr](load["jid"], load)
         except KeyError as e:


### PR DESCRIPTION
### What does this PR do?
fixes issue with runner jobs not storing jobs in the cache

### What issues does this PR fix or reference?
Fixes: #61729 

### Previous Behavior
Runner jobs lack job data including function name:

```
20220226004548285855:
    ----------
    Error:
        Cannot contact returner or no job with this jid
    Result:
        ----------
        02f3db77ee3b_master:
            ----------
            return:
                ----------
                _stamp:
                    2022-02-26T00:45:48.861710
                fun:
                    runner.jobs.list_jobs
                fun_args:
                jid:
                    20220226004548285855
                return:
                    ----------
                success:
                    True
                user:
                    root
    StartTime:
        2022, Feb 26 00:45:48.285855
```

### New Behavior
Function argument now appears and error condition is missing:
```
20220225164405632844:
    ----------
    Arguments:
    Function:
        runner.jobs.print_job
    Minions:
    Result:
        ----------
       node231-node1_master:
            ----------
            return:
                ----------
                _stamp:
                    2022-02-26T00:44:05.987420
                fun:
                    runner.jobs.print_job
                jid:
                    20220225164405632844
                return:
                    ----------
                    1:
                        ----------
                        Arguments:
                        Function:
                            unknown-function
                        Result:
                            ----------
                        StartTime:
                        Target:
                            unknown-target
                        Target-type:
                        User:
                            root
                success:
                    True
                user:
                    root
    StartTime:
        2022, Feb 25 16:44:05.632844
    Target:
        node-231-node1_master
    Target-type:
    User:
        root
```
### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No
