### PR TITLE
fileclient: Save one round-trip by skipping unused stat

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -1169,15 +1169,7 @@ class RemoteClient(Client):
         if senv:
             saltenv = senv
 
-        if not salt.utils.platform.is_windows():
-            hash_server, stat_server = self.hash_and_stat_file(path, saltenv)
-            try:
-                mode_server = stat_server[0]
-            except (IndexError, TypeError):
-                mode_server = None
-        else:
-            hash_server = self.hash_file(path, saltenv)
-            mode_server = None
+        hash_server = self.hash_file(path, saltenv)
 
         # Check if file exists on server, before creating files and
         # directories
@@ -1218,16 +1210,7 @@ class RemoteClient(Client):
         )
 
         if dest2check and os.path.isfile(dest2check):
-            if not salt.utils.platform.is_windows():
-                hash_local, stat_local = self.hash_and_stat_file(dest2check, saltenv)
-                try:
-                    mode_local = stat_local[0]
-                except (IndexError, TypeError):
-                    mode_local = None
-            else:
-                hash_local = self.hash_file(dest2check, saltenv)
-                mode_local = None
-
+            hash_local = self.hash_file(dest2check, saltenv)
             if hash_local == hash_server:
                 return dest2check
 


### PR DESCRIPTION
get_file() requests both the hash and mode(stat) of a file from the
master before verifying the local cache. The stat appears to be unused
resulting in a wasted round-trip to the master, which can be costly in
high-latency environments.

The stat request was added in 73a156d28cafd45dcc6c2aac9f1ac3ad905695e3
and the usage of the stat values removed again shortly after in
6e34c2b5e5e849302af7ccd00509929c3809c658 but the stat call remained.

Signed-off-by: Joe Groocock <jgroocock@cloudflare.com>

### What does this PR do?
Make salt slightly less slow. See above

### What issues does this PR fix or reference?
Fixes: N/A

### Previous Behavior
Unused stat call to the master

### New Behavior
Identical, but we don't do the busy work in between

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
