### PR TITLE
Fix cmdmod availability during minion startup on MacOS

### DIFF
--- a/changelog/61816.fixed
+++ b/changelog/61816.fixed
@@ -1,0 +1,1 @@
+Made cmdmod._run[_all]_quiet work during minion startup on MacOS with runas specified (which fixed mac_service)

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -443,12 +443,13 @@ def _run(
         # Ensure environment is correct for a newly logged-in user by running
         # the command under bash as a login shell
         try:
-            user_shell = __salt__["user.info"](runas)["shell"]
+            # Do not rely on populated __salt__ dict (ie avoid __salt__['user.info'])
+            user_shell = [x for x in pwd.getpwall() if x.pw_name == runas][0].pw_shell
             if re.search("bash$", user_shell):
                 cmd = "{shell} -l -c {cmd}".format(
                     shell=user_shell, cmd=_cmd_quote(cmd)
                 )
-        except KeyError:
+        except (AttributeError, IndexError):
             pass
 
         # Ensure the login is simulated correctly (note: su runs sh, not bash,

--- a/tests/pytests/unit/modules/test_cmdmod.py
+++ b/tests/pytests/unit/modules/test_cmdmod.py
@@ -496,19 +496,20 @@ def test_run_all_quiet_does_not_depend_on_salt_dunder():
     """
 
     proc = MagicMock(return_value=MockTimedProc(stdout=b"success", stderr=None))
-    with patch("salt.utils.timed_subprocess.TimedProc", proc):
-        salt_dunder_mock = MagicMock(spec_set=dict)
-        salt_dunder_mock.__getitem__.side_effect = NameError(
-            "__salt__ might not be defined"
-        )
+    with patch("pwd.getpwnam") as getpwnam_mock:
+        with patch("salt.utils.timed_subprocess.TimedProc", proc):
+            salt_dunder_mock = MagicMock(spec_set=dict)
+            salt_dunder_mock.__getitem__.side_effect = NameError(
+                "__salt__ might not be defined"
+            )
 
-        with patch.object(cmdmod, "__salt__", salt_dunder_mock):
-            ret = cmdmod._run_all_quiet("foo")
-            assert ret["stdout"] == "success"
-            assert salt_dunder_mock.__getitem__.call_count == 0
-            ret = cmdmod._run_all_quiet("foo", runas="bar")
-            assert ret["stdout"] == "success"
-            assert salt_dunder_mock.__getitem__.call_count == 0
+            with patch.object(cmdmod, "__salt__", salt_dunder_mock):
+                ret = cmdmod._run_all_quiet("foo")
+                assert ret["stdout"] == "success"
+                assert salt_dunder_mock.__getitem__.call_count == 0
+                ret = cmdmod._run_all_quiet("foo", runas="bar")
+                assert ret["stdout"] == "success"
+                assert salt_dunder_mock.__getitem__.call_count == 0
 
 
 def test_run_cwd_doesnt_exist_issue_7154():


### PR DESCRIPTION
### What does this PR do?
Removes dependency on `__salt__["user.info"]` from `cmdmod._run[_all]_quiet` on MacOS when `runas` parameter is specified.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt/issues/61816

### Previous Behavior
`NameError: name '__salt__' is not defined`

### New Behavior
Works as intended

### Merge requirements satisfied?
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs (not necessary)
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

### Notes
* I considered importing `salt.modules.mac_user as mac_user` and calling it explicitly, but chose to reimplement the required part with a one-liner instead to avoid dependency issues.
* There is a new rough test for salt dunder usage by `cmdmod.run_all_quiet` which unmasks the previous issue and is fixed by this PR. I did my best implementing it, but maybe someone more experienced with Salt unit testing might have some comments.