### PR TITLE
Don't rely on `importlib.metadata`, it's still not ready for our usage.

### DIFF
--- a/salt/_compat.py
+++ b/salt/_compat.py
@@ -11,23 +11,18 @@ if sys.version_info >= (3, 9, 5):
 else:
     import salt.ext.ipaddress as ipaddress
 
-if sys.version_info >= (3, 10):
-    # Python 3.10 will include a fix in importlib.metadata which allows us to
-    # get the distribution of a loaded entry-point
-    import importlib.metadata  # pylint: disable=no-member,no-name-in-module
-else:
-    # importlib_metadata before version 3.3.0 does not include the functionality we need.
-    try:
-        import importlib_metadata
+# importlib_metadata before version 3.3.0 does not include the functionality we need.
+try:
+    import importlib_metadata
 
-        importlib_metadata_version = [
-            int(part)
-            for part in importlib_metadata.version("importlib_metadata").split(".")
-            if part.isdigit()
-        ]
-        if tuple(importlib_metadata_version) < (3, 3, 0):
-            # Use the vendored importlib_metadata
-            import salt.ext.importlib_metadata as importlib_metadata
-    except ImportError:
+    importlib_metadata_version = [
+        int(part)
+        for part in importlib_metadata.version("importlib_metadata").split(".")
+        if part.isdigit()
+    ]
+    if tuple(importlib_metadata_version) < (3, 3, 0):
         # Use the vendored importlib_metadata
         import salt.ext.importlib_metadata as importlib_metadata
+except ImportError:
+    # Use the vendored importlib_metadata
+    import salt.ext.importlib_metadata as importlib_metadata

--- a/salt/utils/entrypoints.py
+++ b/salt/utils/entrypoints.py
@@ -1,23 +1,9 @@
 import functools
 import logging
-import sys
 import time
 import types
 
-if sys.version_info >= (3, 10):
-    # Python 3.10 will include a fix in importlib.metadata which allows us to
-    # get the distribution of a loaded entry-point
-    import importlib.metadata  # pylint: disable=no-member,no-name-in-module
-
-    USE_IMPORTLIB_METADATA_STDLIB = True
-else:
-    USE_IMPORTLIB_METADATA_STDLIB = False
-    try:
-        from salt._compat import importlib_metadata
-
-        USE_IMPORTLIB_METADATA = True
-    except ImportError:
-        USE_IMPORTLIB_METADATA = False
+from salt._compat import importlib_metadata
 
 log = logging.getLogger(__name__)
 
@@ -50,14 +36,7 @@ def timed_lru_cache(timeout_seconds, *, maxsize=256, typed=False):
 @timed_lru_cache(timeout_seconds=0.5)
 def iter_entry_points(group, name=None):
     entry_points_listing = []
-    if USE_IMPORTLIB_METADATA_STDLIB:
-        log.debug("Using importlib.metadata to load entry points")
-        entry_points = importlib.metadata.entry_points()
-    elif USE_IMPORTLIB_METADATA:
-        log.debug("Using importlib_metadata to load entry points")
-        entry_points = importlib_metadata.entry_points()
-    else:
-        return entry_points_listing
+    entry_points = importlib_metadata.entry_points()
 
     for entry_point_group, entry_points_list in entry_points.items():
         if entry_point_group != group:


### PR DESCRIPTION
```
[root@36c42c7ecd24 code]# [ERROR   ] 'PathDistribution' object has no attribute '_normalized_name'
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/salt/utils/parsers.py", line 210, in parse_args
    mixin_after_parsed_func(self)
  File "/usr/lib/python3.10/site-packages/salt/utils/parsers.py", line 887, in __setup_extended_logging
    log.setup_extended_logging(self.config)
  File "/usr/lib/python3.10/site-packages/salt/log/setup.py", line 414, in setup_extended_logging
    providers = salt.loader.log_handlers(opts)
  File "/usr/lib/python3.10/site-packages/salt/loader/__init__.py", line 686, in log_handlers
    _module_dirs(
  File "/usr/lib/python3.10/site-packages/salt/loader/__init__.py", line 148, in _module_dirs
    for entry_point in entrypoints.iter_entry_points("salt.loader"):
  File "/usr/lib/python3.10/site-packages/salt/utils/entrypoints.py", line 43, in _wrapped
    return f(*args, **kwargs)
  File "/usr/lib/python3.10/site-packages/salt/utils/entrypoints.py", line 55, in iter_entry_points
    entry_points = importlib.metadata.entry_points()
  File "/usr/lib64/python3.10/importlib/metadata/__init__.py", line 980, in entry_points
    return SelectableGroups.load(eps).select(**params)
  File "/usr/lib64/python3.10/importlib/metadata/__init__.py", line 429, in load
    ordered = sorted(eps, key=by_group)
  File "/usr/lib64/python3.10/importlib/metadata/__init__.py", line 977, in <genexpr>
    eps = itertools.chain.from_iterable(
  File "/usr/lib64/python3.10/importlib/metadata/_itertools.py", line 16, in unique_everseen
    k = key(element)
AttributeError: 'PathDistribution' object has no attribute '_normalized_name'
```
