### PR TITLE
fix documentation index ordering

### DIFF
--- a/salt/modules/chroot.py
+++ b/salt/modules/chroot.py
@@ -1,4 +1,5 @@
 """
+Module for chroot
 :maintainer:    Alberto Planas <aplanas@suse.com>
 :maturity:      new
 :depends:       None

--- a/salt/modules/devinfo.py
+++ b/salt/modules/devinfo.py
@@ -1,4 +1,5 @@
 """
+Module for devinfo
 :maintainer:    Alberto Planas <aplanas@suse.com>
 :maturity:      new
 :depends:       None

--- a/salt/modules/freezer.py
+++ b/salt/modules/freezer.py
@@ -1,4 +1,5 @@
 """
+Module for freezer
 :maintainer:    Alberto Planas <aplanas@suse.com>
 :maturity:      new
 :depends:       None

--- a/salt/modules/kubeadm.py
+++ b/salt/modules/kubeadm.py
@@ -1,4 +1,5 @@
 """
+Module for kubeadm
 :maintainer:    Alberto Planas <aplanas@suse.com>
 :maturity:      new
 :depends:       None

--- a/salt/modules/rebootmgr.py
+++ b/salt/modules/rebootmgr.py
@@ -1,4 +1,5 @@
 """
+Module for rebootmgr
 :maintainer:    Alberto Planas <aplanas@suse.com>
 :maturity:      new
 :depends:       None

--- a/salt/runners/vault.py
+++ b/salt/runners/vault.py
@@ -1,10 +1,10 @@
 """
+Runner functions supporting the Vault modules. Configuration instructions are
+documented in the execution module docs.
+
 :maintainer:    SaltStack
 :maturity:      new
 :platform:      all
-
-Runner functions supporting the Vault modules. Configuration instructions are
-documented in the execution module docs.
 """
 
 import base64

--- a/salt/states/btrfs.py
+++ b/salt/states/btrfs.py
@@ -1,4 +1,6 @@
 """
+Manage BTRFS file systems.
+
 :maintainer:    Alberto Planas <aplanas@suse.com>
 :maturity:      new
 :depends:       None

--- a/salt/states/zabbix_action.py
+++ b/salt/states/zabbix_action.py
@@ -1,7 +1,7 @@
 """
-.. versionadded:: 2017.7
-
 Management of Zabbix Action object over Zabbix API.
+
+.. versionadded:: 2017.7
 
 :codeauthor: Jakub Sliva <jakub.sliva@ultimum.io>
 """

--- a/salt/states/zabbix_valuemap.py
+++ b/salt/states/zabbix_valuemap.py
@@ -1,7 +1,7 @@
 """
-.. versionadded:: 2017.7
-
 Management of Zabbix Valuemap object over Zabbix API.
+
+.. versionadded:: 2017.7
 
 :codeauthor: Jakub Sliva <jakub.sliva@ultimum.io>
 """

--- a/salt/states/zookeeper.py
+++ b/salt/states/zookeeper.py
@@ -1,4 +1,6 @@
 """
+Zookeeper State
+
 :depends:  kazoo
 :configuration: See :py:mod:`salt.modules.zookeeper` for setup instructions.
 


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes: website documentation indexes

Specifically, if you go to these site indexes, the description currently only says "maintainer"...
https://docs.saltproject.io/en/latest/ref/modules/all/
https://docs.saltproject.io/en/latest/ref/runners/all/
https://docs.saltproject.io/en/latest/ref/states/all/