### PR TITLE
Fix #61848: Pin Jinja2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-Jinja2
+Jinja2<3.1
 msgpack-python > 0.3
 PyYAML
 MarkupSafe


### PR DESCRIPTION
Fixes:

salt-master[18967]:   File "/usr/local/lib/python3.8/dist-packages/salt/utils/jinja.py", line 28, in <module>
salt-master[18967]:     from jinja2 import BaseLoader, Markup, TemplateNotFound, nodes
salt-master[18967]: ImportError: cannot import name 'Markup' from 'jinja2' (/usr/local/lib/python3.8/dist-packages/jinja2/__init__.py)

### What does this PR do?

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
