### PR TITLE
Enforce config types

### DIFF
--- a/changelog/57873.fixed
+++ b/changelog/57873.fixed
@@ -1,0 +1,1 @@
+Config options are enforced according to config type

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1879,7 +1879,7 @@ def _validate_opts(opts):
                                         key,
                                         val,
                                         type(val).__name__,
-                                        VALID_OPTS[key].__name__
+                                        VALID_OPTS[key].__name__,
                                     )
                                 )
                 except (TypeError, ValueError):
@@ -1918,7 +1918,7 @@ def _validate_opts(opts):
                             key,
                             val,
                             type(val).__name__,
-                            format_multi_opt(VALID_OPTS[key])
+                            format_multi_opt(VALID_OPTS[key]),
                         )
                     )
 

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -118,7 +118,7 @@ VALID_OPTS = immutabletypes.freeze(
         # specify 'default' or 'ip_only'. If 'ip_only' is specified, then the
         # master address will not be split into IP and PORT.
         "master_uri_format": str,
-        # The following optiosn refer to the Minion only, and they specify
+        # The following options refer to the Minion only, and they specify
         # the details of the source address / port to be used when connecting to
         # the Master. This is useful when dealing withmachines where due to firewall
         # rules you are restricted to use a certain IP/port combination only.
@@ -157,7 +157,7 @@ VALID_OPTS = immutabletypes.freeze(
         # Instead of computing the signature for each auth-reply, use a pre-calculated signature.
         # The master_pubkey_signature must also be set for this.
         "master_use_pubkey_signature": bool,
-        # Enable master stats eveents to be fired, these events will contain information about
+        # Enable master stats events to be fired, these events will contain information about
         # what commands the master is processing and what the rates are of the executions
         "master_stats": bool,
         "master_stats_event_iter": int,
@@ -646,7 +646,7 @@ VALID_OPTS = immutabletypes.freeze(
         "fileserver_followsymlinks": bool,
         "fileserver_ignoresymlinks": bool,
         "fileserver_verify_config": bool,
-        # Optionally apply '*' permissioins to any user. By default '*' is a fallback case that is
+        # Optionally apply '*' permissions to any user. By default '*' is a fallback case that is
         # applied only if the user didn't matched by other matchers.
         "permissive_acl": bool,
         # Optionally enables keeping the calculated user's auth list in the token file.
@@ -872,7 +872,7 @@ VALID_OPTS = immutabletypes.freeze(
         "no_proxy": list,
         # Minion de-dup jid cache max size
         "minion_jid_queue_hwm": int,
-        # Minion data cache driver (one of satl.cache.* modules)
+        # Minion data cache driver (one of salt.cache.* modules)
         "cache": str,
         # Enables a fast in-memory cache booster and sets the expiration time.
         "memcache_expire_seconds": int,
@@ -1834,7 +1834,12 @@ def _validate_opts(opts):
                         # VALID_OPTS[key] is not iterable and not None
                         pass
 
-            if isinstance(val, VALID_OPTS[key]):
+            # int(True) evaluates to 1, int(False) evaluates to 0
+            # We want to make sure True and False are only valid for bool
+            if val is True or val is False:
+                if VALID_OPTS[key] is bool:
+                    continue
+            elif isinstance(val, VALID_OPTS[key]):
                 continue
 
             # We don't know what data type sdb will return at run-time so we
@@ -1842,33 +1847,74 @@ def _validate_opts(opts):
             if isinstance(val, str) and val.startswith("sdb://"):
                 continue
 
+            # Non-failing types that don't convert properly
+            nf_types = {
+                str: [list, tuple, dict],
+                list: [dict, str],
+                tuple: [dict, str],
+                bool: [list, tuple, str, int, float, dict, type(None)],
+                int: [bool, float],
+                float: [bool],
+            }
+
+            # Is this a single type (not a tuple of types)?
             if hasattr(VALID_OPTS[key], "__call__"):
+                # This config option has a single defined type
                 try:
+                    # This will try to evaluate the specified value type
                     VALID_OPTS[key](val)
-                    if isinstance(val, (list, dict)):
-                        # We'll only get here if VALID_OPTS[key] is str or
-                        # bool, and the passed value is a list/dict. Attempting
-                        # to run int() or float() on a list/dict will raise an
-                        # exception, but running str() or bool() on it will
-                        # pass despite not being the correct type.
-                        errors.append(
-                            err.format(
-                                key, val, type(val).__name__, VALID_OPTS[key].__name__
-                            )
-                        )
+
+                    # Since it evaluated properly, let's make sure it's valid
+                    # Some value types don't evaluate properly. For example,
+                    # running list on a string: `list("test")` will return
+                    # a list of individual characters:`['t', 'e', 's', 't']` and
+                    # therefore won't fail on evaluation
+                    for nf_type in nf_types:
+                        if VALID_OPTS[key] is nf_type:
+                            # Is it one of the non-failing types that we don't
+                            # want for this type
+                            if isinstance(val, tuple(nf_types[nf_type])):
+                                errors.append(
+                                    err.format(
+                                        key, val, type(val).__name__, VALID_OPTS[key].__name__
+                                    )
+                                )
                 except (TypeError, ValueError):
                     errors.append(
                         err.format(
                             key, val, type(val).__name__, VALID_OPTS[key].__name__
                         )
                     )
-                continue
+            else:
+                # This config option has multiple defined types (tuple of types)
+                if type(val) in VALID_OPTS[key]:
+                    continue
 
-            errors.append(
-                err.format(
-                    key, val, type(val).__name__, format_multi_opt(VALID_OPTS[key])
-                )
-            )
+                valid = []
+                for nf_type in nf_types:
+                    try:
+                        nf_type(val)
+
+                        if nf_type in VALID_OPTS[key]:
+                            nf = nf_types[nf_type]
+                            for item in VALID_OPTS[key]:
+                                if item in nf:
+                                    nf.remove(item)
+                            if isinstance(val, tuple(nf)):
+                                # Running str on any of the above types will succeed,
+                                # however, it will change the value in such a way
+                                # that it is invalid.
+                                valid.append(False)
+                            else:
+                                valid.append(True)
+                    except (TypeError, ValueError):
+                        valid.append(False)
+                if True not in valid:
+                    errors.append(
+                        err.format(
+                            key, val, type(val).__name__, format_multi_opt(VALID_OPTS[key])
+                        )
+                    )
 
     # Convert list to comma-delimited string for 'return' config option
     if isinstance(opts.get("return"), list):

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1876,7 +1876,10 @@ def _validate_opts(opts):
                             if isinstance(val, tuple(nf_types[nf_type])):
                                 errors.append(
                                     err.format(
-                                        key, val, type(val).__name__, VALID_OPTS[key].__name__
+                                        key,
+                                        val,
+                                        type(val).__name__,
+                                        VALID_OPTS[key].__name__
                                     )
                                 )
                 except (TypeError, ValueError):
@@ -1912,7 +1915,10 @@ def _validate_opts(opts):
                 if True not in valid:
                     errors.append(
                         err.format(
-                            key, val, type(val).__name__, format_multi_opt(VALID_OPTS[key])
+                            key,
+                            val,
+                            type(val).__name__,
+                            format_multi_opt(VALID_OPTS[key])
                         )
                     )
 

--- a/tests/filename_map.yml
+++ b/tests/filename_map.yml
@@ -193,6 +193,7 @@ salt/(client/ssh/.+|cli/ssh\.py):
 
 salt/config/*:
   - unit.test_config
+  - pytests.unit.config.test__validate_opts
 
 salt/loader/*:
   - integration.loader.test_ext_grains

--- a/tests/pytests/unit/config/test__validate_opts.py
+++ b/tests/pytests/unit/config/test__validate_opts.py
@@ -20,8 +20,8 @@ import salt.config
 )
 def test_list_types(option_value, expected):
     """
-    List type config options return True when the value is a list. All other
-    types return False
+    List and tuple type config options return True when the value is a list. All
+    other types return False
     modules_dirs is a list type config option
     """
     result = salt.config._validate_opts({"module_dirs": option_value})
@@ -43,8 +43,8 @@ def test_list_types(option_value, expected):
 )
 def test_str_types(option_value, expected):
     """
-    Str type config options return True when the value is a str. All other types
-    return False
+    Str, bool, int, float, and none type config options return True when the
+    value is a str. All other types return False
     user is a str type config option
     """
     result = salt.config._validate_opts({"user": option_value})
@@ -135,8 +135,8 @@ def test_int_types(option_value, expected):
 )
 def test_float_types(option_value, expected):
     """
-    Float type config options return True when the value is a float. All other
-    types return False
+    Float and int type config options return True when the value is a float. All
+    other types return False
     ssh_timeout is a float type config option
     """
     result = salt.config._validate_opts({"ssh_timeout": option_value})
@@ -158,8 +158,9 @@ def test_float_types(option_value, expected):
 )
 def test_none_str_types(option_value, expected):
     """
-    Some config settings have two types, None and str which should evaluate as
-    True. All others should return False.
+    Some config settings have two types, None and str. In that case str, bool,
+    int, float, and None type options should evaluate as True. All others should
+    return False.
     saltenv is a None, str type config option
     """
     result = salt.config._validate_opts({"saltenv": option_value})
@@ -181,7 +182,7 @@ def test_none_str_types(option_value, expected):
 )
 def test_none_int_types(option_value, expected):
     """
-    Some config settings have two types, None and int which should evaluate as
+    Some config settings have two types, None and int, which should evaluate as
     True. All others should return False.
     retry_dns_count is a None, int type config option
     """
@@ -227,8 +228,9 @@ def test_none_bool_types(option_value, expected):
 )
 def test_str_list_types(option_value, expected):
     """
-    Some config settings have two types, str and list which should evaluate as
-    True. All others should return False.
+    Some config settings have two types, str and list. In that case, list,
+    tuple, str, bool, int, float, and None should evaluate as True. All others
+    should return False.
     master is a str, list type config option
     """
     result = salt.config._validate_opts({"master": option_value})
@@ -250,8 +252,9 @@ def test_str_list_types(option_value, expected):
 )
 def test_str_int_types(option_value, expected):
     """
-    Some config settings have two types, str and int which should evaluate as
-    True. All others should return False.
+    Some config settings have two types, str and int. In that case, str, bool,
+    int, float, and None should evaluate as True. All others should return
+    False.
     master_port is a str, int type config option
     """
     result = salt.config._validate_opts({"master_port": option_value})
@@ -273,8 +276,9 @@ def test_str_int_types(option_value, expected):
 )
 def test_str_dict_types(option_value, expected):
     """
-    Some config settings have two types, str and dict which should evaluate as
-    True. All others should return False.
+    Some config settings have two types, str and dict. In that case, dict, str,
+    bool, int, float, and None should evaluate as True. All others should return
+    False.
     id_function is a str, dict type config option
     """
     result = salt.config._validate_opts({"id_function": option_value})
@@ -296,8 +300,9 @@ def test_str_dict_types(option_value, expected):
 )
 def test_str_tuple_types(option_value, expected):
     """
-    Some config settings have two types, str and tuple which should evaluate as
-    True. All others should return False.
+    Some config settings have two types, str and tuple. In that case, list,
+    tuple, str, bool, int, float, and None should evaluate as True. All others
+    should return False.
     log_fmt_logfile is a str, tuple type config option
     """
     result = salt.config._validate_opts({"log_fmt_logfile": option_value})
@@ -319,8 +324,9 @@ def test_str_tuple_types(option_value, expected):
 )
 def test_str_bool_types(option_value, expected):
     """
-    Some config settings have two types, str and bool which should evaluate as
-    True. All others should return False.
+    Some config settings have two types, str and bool. In that case, str, bool,
+    int, float, and None should evaluate as True. All others should return
+    False.
     update_url is a str, bool type config option
     """
     result = salt.config._validate_opts({"update_url": option_value})
@@ -365,8 +371,8 @@ def test_dict_bool_types(option_value, expected):
 )
 def test_dict_list_types(option_value, expected):
     """
-    Some config settings have two types, dict and list which should evaluate as
-    True. All others should return False.
+    Some config settings have two types, dict and list. In that case, list,
+    tuple, and dict should evaluate as True. All others should return False.
     nodegroups is a dict, list type config option
     """
     result = salt.config._validate_opts({"nodegroups": option_value})

--- a/tests/pytests/unit/config/test__validate_opts.py
+++ b/tests/pytests/unit/config/test__validate_opts.py
@@ -1,0 +1,396 @@
+"""
+Test config option type enforcement
+"""
+import pytest
+import salt.config
+
+
+@pytest.mark.parametrize(
+    "option_value,expected",
+    [
+        ([1, 2, 3], True),  # list
+        ((1, 2, 3), True),  # tuple
+        ({"key": "value"}, False),  # dict
+        ("str", False),  # str
+        (True, False),  # bool
+        (1, False),  # int
+        (0.123, False),  # float
+        (None, False),  # None
+    ]
+)
+def test_list_types(option_value, expected):
+    """
+    List type config options return True when the value is a list. All other
+    types return False
+    modules_dirs is a list type config option
+    """
+    result = salt.config._validate_opts({"module_dirs": option_value})
+    assert result is expected
+
+
+@pytest.mark.parametrize(
+    "option_value,expected",
+    [
+        ([1, 2, 3], False),  # list
+        ((1, 2, 3), False),  # tuple
+        ({"key": "value"}, False),  # dict
+        ("str", True),  # str
+        (True, True),  # bool
+        (1, True),  # int
+        (0.123, True),  # float
+        (None, True),  # None
+    ]
+)
+def test_str_types(option_value, expected):
+    """
+    Str type config options return True when the value is a str. All other types
+    return False
+    user is a str type config option
+    """
+    result = salt.config._validate_opts({"user": option_value})
+    assert result is expected
+
+
+@pytest.mark.parametrize(
+    "option_value,expected",
+    [
+        ([1, 2, 3], False),  # list
+        ((1, 2, 3), False),  # tuple
+        ({"key": "value"}, True),  # dict
+        ("str", False),  # str
+        (True, False),  # bool
+        (1, False),  # int
+        (0.123, False),  # float
+        (None, False),  # None
+    ]
+)
+def test_dict_types(option_value, expected):
+    """
+    Dict type config options return True when the value is a dict. All other
+    types return False
+    file_roots is a dict type config option
+    """
+    result = salt.config._validate_opts({"file_roots": option_value})
+    assert result is expected
+
+
+@pytest.mark.parametrize(
+    "option_value,expected",
+    [
+        ([1, 2, 3], False),  # list
+        ((1, 2, 3), False),  # tuple
+        ({"key": "value"}, False),  # dict
+        ("str", False),  # str
+        (True, True),  # bool
+        (1, False),  # int
+        (0.123, False),  # float
+        (None, False),  # None
+    ]
+)
+def test_bool_types(option_value, expected):
+    """
+    Bool type config options return True when the value is a bool. All other
+    types return False
+    local is a bool type config option
+    """
+    result = salt.config._validate_opts({"local": option_value})
+    assert result is expected
+
+
+@pytest.mark.parametrize(
+    "option_value,expected",
+    [
+        ([1, 2, 3], False),  # list
+        ((1, 2, 3), False),  # tuple
+        ({"key": "value"}, False),  # dict
+        ("str", False),  # str
+        (True, False),  # bool
+        (1, True),  # int
+        (0.123, False),  # float
+        (None, False),  # None
+    ]
+)
+def test_int_types(option_value, expected):
+    """
+    Int type config options return True when the value is an int. All other
+    types return False
+    publish_port is an int type config option
+    """
+    result = salt.config._validate_opts({"publish_port": option_value})
+    assert result is expected
+
+
+@pytest.mark.parametrize(
+    "option_value,expected",
+    [
+        ([1, 2, 3], False),  # list
+        ((1, 2, 3), False),  # tuple
+        ({"key": "value"}, False),  # dict
+        ("str", False),  # str
+        (True, False),  # bool
+        (1, True),  # int
+        (0.123, True),  # float
+        (None, False),  # None
+    ]
+)
+def test_float_types(option_value, expected):
+    """
+    Float type config options return True when the value is a float. All other
+    types return False
+    ssh_timeout is a float type config option
+    """
+    result = salt.config._validate_opts({"ssh_timeout": option_value})
+    assert result is expected
+
+
+@pytest.mark.parametrize(
+    "option_value,expected",
+    [
+        ([1, 2, 3], False),  # list
+        ((1, 2, 3), False),  # tuple
+        ({"key": "value"}, False),  # dict
+        ("str", True),  # str
+        (True, True),  # bool
+        (1, True),  # int
+        (0.123, True),  # float
+        (None, True),  # None
+    ]
+)
+def test_none_str_types(option_value, expected):
+    """
+    Some config settings have two types, None and str which should evaluate as
+    True. All others should return False.
+    saltenv is a None, str type config option
+    """
+    result = salt.config._validate_opts({"saltenv": option_value})
+    assert result is expected
+
+
+@pytest.mark.parametrize(
+    "option_value,expected",
+    [
+        ([1, 2, 3], False),  # list
+        ((1, 2, 3), False),  # tuple
+        ({"key": "value"}, False),  # dict
+        ("str", False),  # str
+        (True, False),  # bool
+        (1, True),  # int
+        (0.123, False),  # float
+        (None, True),  # None
+    ]
+)
+def test_none_int_types(option_value, expected):
+    """
+    Some config settings have two types, None and int which should evaluate as
+    True. All others should return False.
+    retry_dns_count is a None, int type config option
+    """
+    result = salt.config._validate_opts({"retry_dns_count": option_value})
+    assert result is expected
+
+
+@pytest.mark.parametrize(
+    "option_value,expected",
+    [
+        ([1, 2, 3], False),  # list
+        ((1, 2, 3), False),  # tuple
+        ({"key": "value"}, False),  # dict
+        ("str", False),  # str
+        (True, True),  # bool
+        (1, False),  # int
+        (0.123, False),  # float
+        (None, True),  # None
+    ]
+)
+def test_none_bool_types(option_value, expected):
+    """
+    Some config settings have two types, None and bool which should evaluate as
+    True. All others should return False.
+    ipv6 is a None, bool type config option
+    """
+    result = salt.config._validate_opts({"ipv6": option_value})
+    assert result is expected
+
+
+@pytest.mark.parametrize(
+    "option_value,expected",
+    [
+        ([1, 2, 3], True),  # list
+        ((1, 2, 3), True),  # tuple
+        ({"key": "value"}, False),  # dict
+        ("str", True),  # str
+        (True, True),  # bool
+        (1, True),  # int
+        (0.123, True),  # float
+        (None, True),  # None
+    ]
+)
+def test_str_list_types(option_value, expected):
+    """
+    Some config settings have two types, str and list which should evaluate as
+    True. All others should return False.
+    master is a str, list type config option
+    """
+    result = salt.config._validate_opts({"master": option_value})
+    assert result is expected
+
+
+@pytest.mark.parametrize(
+    "option_value,expected",
+    [
+        ([1, 2, 3], False),  # list
+        ((1, 2, 3), False),  # tuple
+        ({"key": "value"}, False),  # dict
+        ("str", True),  # str
+        (True, True),  # bool
+        (1, True),  # int
+        (0.123, True),  # float
+        (None, True),  # None
+    ]
+)
+def test_str_int_types(option_value, expected):
+    """
+    Some config settings have two types, str and int which should evaluate as
+    True. All others should return False.
+    master_port is a str, int type config option
+    """
+    result = salt.config._validate_opts({"master_port": option_value})
+    assert result is expected
+
+
+@pytest.mark.parametrize(
+    "option_value,expected",
+    [
+        ([1, 2, 3], False),  # list
+        ((1, 2, 3), False),  # tuple
+        ({"key": "value"}, True),  # dict
+        ("str", True),  # str
+        (True, True),  # bool
+        (1, True),  # int
+        (0.123, True),  # float
+        (None, True),  # None
+    ]
+)
+def test_str_dict_types(option_value, expected):
+    """
+    Some config settings have two types, str and dict which should evaluate as
+    True. All others should return False.
+    id_function is a str, dict type config option
+    """
+    result = salt.config._validate_opts({"id_function": option_value})
+    assert result is expected
+
+
+@pytest.mark.parametrize(
+    "option_value,expected",
+    [
+        ([1, 2, 3], True),  # list
+        ((1, 2, 3), True),  # tuple
+        ({"key": "value"}, False),  # dict
+        ("str", True),  # str
+        (True, True),  # bool
+        (1, True),  # int
+        (0.123, True),  # float
+        (None, True),  # None
+    ]
+)
+def test_str_tuple_types(option_value, expected):
+    """
+    Some config settings have two types, str and tuple which should evaluate as
+    True. All others should return False.
+    log_fmt_logfile is a str, tuple type config option
+    """
+    result = salt.config._validate_opts({"log_fmt_logfile": option_value})
+    assert result is expected
+
+
+@pytest.mark.parametrize(
+    "option_value,expected",
+    [
+        ([1, 2, 3], False),  # list
+        ((1, 2, 3), False),  # tuple
+        ({"key": "value"}, False),  # dict
+        ("str", True),  # str
+        (True, True),  # bool
+        (1, True),  # int
+        (0.123, True),  # float
+        (None, True),  # None
+    ]
+)
+def test_str_bool_types(option_value, expected):
+    """
+    Some config settings have two types, str and bool which should evaluate as
+    True. All others should return False.
+    update_url is a str, bool type config option
+    """
+    result = salt.config._validate_opts({"update_url": option_value})
+    assert result is expected
+
+
+@pytest.mark.parametrize(
+    "option_value,expected",
+    [
+        ([1, 2, 3], False),  # list
+        ((1, 2, 3), False),  # tuple
+        ({"key": "value"}, True),  # dict
+        ("str", False),  # str
+        (True, True),  # bool
+        (1, False),  # int
+        (0.123, False),  # float
+        (None, False),  # None
+    ]
+)
+def test_dict_bool_types(option_value, expected):
+    """
+    Some config settings have two types, dict and bool which should evaluate as
+    True. All others should return False.
+    token_expire_user_override is a dict, bool type config option
+    """
+    result = salt.config._validate_opts({"token_expire_user_override": option_value})
+    assert result is expected
+
+
+@pytest.mark.parametrize(
+    "option_value,expected",
+    [
+        ([1, 2, 3], True),  # list
+        ((1, 2, 3), True),  # tuple
+        ({"key": "value"}, True),  # dict
+        ("str", False),  # str
+        (True, False),  # bool
+        (1, False),  # int
+        (0.123, False),  # float
+        (None, False),  # None
+    ]
+)
+def test_dict_list_types(option_value, expected):
+    """
+    Some config settings have two types, dict and list which should evaluate as
+    True. All others should return False.
+    nodegroups is a dict, list type config option
+    """
+    result = salt.config._validate_opts({"nodegroups": option_value})
+    assert result is expected
+
+
+@pytest.mark.parametrize(
+    "option_value,expected",
+    [
+        ([1, 2, 3], False),  # list
+        ((1, 2, 3), False),  # tuple
+        ({"key": "value"}, True),  # dict
+        ("str", False),  # str
+        (True, True),  # bool
+        (1, False),  # int
+        (0.123, False),  # float
+        (None, True),  # None
+    ]
+)
+def test_dict_bool_none_types(option_value, expected):
+    """
+    Some config settings have three types, dict, bool, and None which should
+    evaluate as True. All others should return False.
+    ssl is a dict, bool type config option
+    """
+    result = salt.config._validate_opts({"ssl": option_value})
+    assert result is expected

--- a/tests/pytests/unit/config/test__validate_opts.py
+++ b/tests/pytests/unit/config/test__validate_opts.py
@@ -16,7 +16,7 @@ import salt.config
         (1, False),  # int
         (0.123, False),  # float
         (None, False),  # None
-    ]
+    ],
 )
 def test_list_types(option_value, expected):
     """
@@ -39,7 +39,7 @@ def test_list_types(option_value, expected):
         (1, True),  # int
         (0.123, True),  # float
         (None, True),  # None
-    ]
+    ],
 )
 def test_str_types(option_value, expected):
     """
@@ -62,7 +62,7 @@ def test_str_types(option_value, expected):
         (1, False),  # int
         (0.123, False),  # float
         (None, False),  # None
-    ]
+    ],
 )
 def test_dict_types(option_value, expected):
     """
@@ -85,7 +85,7 @@ def test_dict_types(option_value, expected):
         (1, False),  # int
         (0.123, False),  # float
         (None, False),  # None
-    ]
+    ],
 )
 def test_bool_types(option_value, expected):
     """
@@ -108,7 +108,7 @@ def test_bool_types(option_value, expected):
         (1, True),  # int
         (0.123, False),  # float
         (None, False),  # None
-    ]
+    ],
 )
 def test_int_types(option_value, expected):
     """
@@ -131,7 +131,7 @@ def test_int_types(option_value, expected):
         (1, True),  # int
         (0.123, True),  # float
         (None, False),  # None
-    ]
+    ],
 )
 def test_float_types(option_value, expected):
     """
@@ -154,7 +154,7 @@ def test_float_types(option_value, expected):
         (1, True),  # int
         (0.123, True),  # float
         (None, True),  # None
-    ]
+    ],
 )
 def test_none_str_types(option_value, expected):
     """
@@ -177,7 +177,7 @@ def test_none_str_types(option_value, expected):
         (1, True),  # int
         (0.123, False),  # float
         (None, True),  # None
-    ]
+    ],
 )
 def test_none_int_types(option_value, expected):
     """
@@ -200,7 +200,7 @@ def test_none_int_types(option_value, expected):
         (1, False),  # int
         (0.123, False),  # float
         (None, True),  # None
-    ]
+    ],
 )
 def test_none_bool_types(option_value, expected):
     """
@@ -223,7 +223,7 @@ def test_none_bool_types(option_value, expected):
         (1, True),  # int
         (0.123, True),  # float
         (None, True),  # None
-    ]
+    ],
 )
 def test_str_list_types(option_value, expected):
     """
@@ -246,7 +246,7 @@ def test_str_list_types(option_value, expected):
         (1, True),  # int
         (0.123, True),  # float
         (None, True),  # None
-    ]
+    ],
 )
 def test_str_int_types(option_value, expected):
     """
@@ -269,7 +269,7 @@ def test_str_int_types(option_value, expected):
         (1, True),  # int
         (0.123, True),  # float
         (None, True),  # None
-    ]
+    ],
 )
 def test_str_dict_types(option_value, expected):
     """
@@ -292,7 +292,7 @@ def test_str_dict_types(option_value, expected):
         (1, True),  # int
         (0.123, True),  # float
         (None, True),  # None
-    ]
+    ],
 )
 def test_str_tuple_types(option_value, expected):
     """
@@ -315,7 +315,7 @@ def test_str_tuple_types(option_value, expected):
         (1, True),  # int
         (0.123, True),  # float
         (None, True),  # None
-    ]
+    ],
 )
 def test_str_bool_types(option_value, expected):
     """
@@ -338,7 +338,7 @@ def test_str_bool_types(option_value, expected):
         (1, False),  # int
         (0.123, False),  # float
         (None, False),  # None
-    ]
+    ],
 )
 def test_dict_bool_types(option_value, expected):
     """
@@ -361,7 +361,7 @@ def test_dict_bool_types(option_value, expected):
         (1, False),  # int
         (0.123, False),  # float
         (None, False),  # None
-    ]
+    ],
 )
 def test_dict_list_types(option_value, expected):
     """
@@ -384,7 +384,7 @@ def test_dict_list_types(option_value, expected):
         (1, False),  # int
         (0.123, False),  # float
         (None, True),  # None
-    ]
+    ],
 )
 def test_dict_bool_none_types(option_value, expected):
     """

--- a/tests/pytests/unit/test_config.py
+++ b/tests/pytests/unit/test_config.py
@@ -20,3 +20,10 @@ def test_call_id_function(tmp_path):
     }
     ret = salt.config.call_id_function(opts)
     assert ret == "meh"
+
+
+def test__validate_opts_list():
+    opts = {
+        "module_dirs": ["valid type list"]
+    }
+    assert salt.config._validate_opts(opts)

--- a/tests/pytests/unit/test_config.py
+++ b/tests/pytests/unit/test_config.py
@@ -20,10 +20,3 @@ def test_call_id_function(tmp_path):
     }
     ret = salt.config.call_id_function(opts)
     assert ret == "meh"
-
-
-def test__validate_opts_list():
-    opts = {
-        "module_dirs": ["valid type list"]
-    }
-    assert salt.config._validate_opts(opts)


### PR DESCRIPTION
### What does this PR do?
Enforces config types as specified in the VALID_OPTS dictionary.

### What issues does this PR fix or reference?
Fixes: #57873

### Previous Behavior
Config types were not enforced in all cases. This allowed for a config type that was supposed to be a list that was passed a string would end up with something like `['s', 't', 'r', 'i', 'n', 'g']`

### New Behavior
Does not allow config types where they cannot be cleanly converted to the expected type

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes