### PR TITLE
Don't try to split domain name

### DIFF
--- a/changelog/60076.fixed
+++ b/changelog/60076.fixed
@@ -1,0 +1,1 @@
+Send un-parsed username to LookupAccountName function

--- a/salt/utils/win_runas.py
+++ b/salt/utils/win_runas.py
@@ -49,6 +49,14 @@ def __virtual__():
     return "win_runas"
 
 
+def get_username(username):
+    if "@" in username:
+        username, _ = username.split("@")
+    if "\\" in username:
+        _, username = username.split("\\")
+    return username
+
+
 def create_env(user_token, inherit, timeout=1):
     """
     CreateEnvironmentBlock might fail when we close a login session and then
@@ -83,6 +91,7 @@ def runas(cmdLine, username, password=None, cwd=None):
     # Validate the domain and sid exist for the username
     try:
         _, domain, _ = win32security.LookupAccountName(None, username)
+        username = get_username(username)
     except pywintypes.error as exc:
         message = win32api.FormatMessage(exc.winerror).rstrip("\n")
         raise CommandExecutionError(message)
@@ -246,6 +255,7 @@ def runas_unpriv(cmd, username, password, cwd=None):
     # Validate the domain and sid exist for the username
     try:
         _, domain, _ = win32security.LookupAccountName(None, username)
+        username = get_username(username)
     except pywintypes.error as exc:
         message = win32api.FormatMessage(exc.winerror).rstrip("\n")
         raise CommandExecutionError(message)

--- a/salt/utils/win_runas.py
+++ b/salt/utils/win_runas.py
@@ -49,16 +49,6 @@ def __virtual__():
     return "win_runas"
 
 
-def split_username(username):
-    # TODO: Is there a windows api for this?
-    domain = "."
-    if "@" in username:
-        username, domain = username.split("@")
-    if "\\" in username:
-        domain, username = username.split("\\")
-    return username, domain
-
-
 def create_env(user_token, inherit, timeout=1):
     """
     CreateEnvironmentBlock might fail when we close a login session and then
@@ -91,9 +81,8 @@ def runas(cmdLine, username, password=None, cwd=None):
     account provided.
     """
     # Validate the domain and sid exist for the username
-    username, domain = split_username(username)
     try:
-        _, domain, _ = win32security.LookupAccountName(domain, username)
+        _, domain, _ = win32security.LookupAccountName(None, username)
     except pywintypes.error as exc:
         message = win32api.FormatMessage(exc.winerror).rstrip("\n")
         raise CommandExecutionError(message)
@@ -255,9 +244,8 @@ def runas_unpriv(cmd, username, password, cwd=None):
     Runas that works for non-privileged users
     """
     # Validate the domain and sid exist for the username
-    username, domain = split_username(username)
     try:
-        _, domain, _ = win32security.LookupAccountName(domain, username)
+        _, domain, _ = win32security.LookupAccountName(None, username)
     except pywintypes.error as exc:
         message = win32api.FormatMessage(exc.winerror).rstrip("\n")
         raise CommandExecutionError(message)

--- a/salt/utils/win_runas.py
+++ b/salt/utils/win_runas.py
@@ -49,12 +49,14 @@ def __virtual__():
     return "win_runas"
 
 
-def get_username(username):
+def split_username(username):
+    domain = "."
+    user_name = username
     if "@" in username:
-        username, _ = username.split("@")
+        user_name, domain = username.split("@")
     if "\\" in username:
-        _, username = username.split("\\")
-    return username
+        domain, user_name = username.split("\\")
+    return user_name, domain
 
 
 def create_env(user_token, inherit, timeout=1):
@@ -91,7 +93,7 @@ def runas(cmdLine, username, password=None, cwd=None):
     # Validate the domain and sid exist for the username
     try:
         _, domain, _ = win32security.LookupAccountName(None, username)
-        username = get_username(username)
+        username, _ = split_username(username)
     except pywintypes.error as exc:
         message = win32api.FormatMessage(exc.winerror).rstrip("\n")
         raise CommandExecutionError(message)
@@ -255,7 +257,7 @@ def runas_unpriv(cmd, username, password, cwd=None):
     # Validate the domain and sid exist for the username
     try:
         _, domain, _ = win32security.LookupAccountName(None, username)
-        username = get_username(username)
+        username, _ = split_username(username)
     except pywintypes.error as exc:
         message = win32api.FormatMessage(exc.winerror).rstrip("\n")
         raise CommandExecutionError(message)

--- a/tests/pytests/unit/utils/test_win_runas.py
+++ b/tests/pytests/unit/utils/test_win_runas.py
@@ -1,0 +1,18 @@
+import pytest
+
+from salt.utils import win_runas
+
+
+@pytest.mark.parametrize(
+    "input_value, expected",
+    [
+        ("test_user", "test_user"),  # Simple system name
+        ("domain\\test_user", "test_user"),  # Sam name
+        ("domain.com\\test_user", "test_user"),  # Sam name with com
+        ("test_user@domain", "test_user"),  # UPN Name
+        ("test_user@domain.com", "test_user"),  # UPN Name with dom
+    ]
+)
+def test_get_username(input_value, expected):
+    result = win_runas.get_username(input_value)
+    assert result == expected

--- a/tests/pytests/unit/utils/test_win_runas.py
+++ b/tests/pytests/unit/utils/test_win_runas.py
@@ -1,18 +1,21 @@
 import pytest
-
 from salt.utils import win_runas
 
 
 @pytest.mark.parametrize(
     "input_value, expected",
     [
-        ("test_user", "test_user"),  # Simple system name
-        ("domain\\test_user", "test_user"),  # Sam name
-        ("domain.com\\test_user", "test_user"),  # Sam name with com
-        ("test_user@domain", "test_user"),  # UPN Name
-        ("test_user@domain.com", "test_user"),  # UPN Name with dom
-    ]
+        ("test_user", ("test_user", ".")),  # Simple system name
+        ("domain\\test_user", ("test_user", "domain")),  # Sam name
+        ("domain.com\\test_user", ("test_user", "domain.com")),  # Sam name with com
+        ("test_user@domain", ("test_user", "domain")),  # UPN Name
+        ("test_user@domain.com", ("test_user", "domain.com")),  # UPN Name with com
+    ],
 )
-def test_get_username(input_value, expected):
-    result = win_runas.get_username(input_value)
+def test_split_username(input_value, expected):
+    """
+    Test that the username is parsed properly from various domain/username
+    combinations
+    """
+    result = win_runas.split_username(input_value)
     assert result == expected


### PR DESCRIPTION
### What does this PR do?
There is no need to split out the domain. The LookupAccountName function works with the following:
- username
- domain\\username
- domain.com\\username
- username@domain
- username@domain.com

According to Microsoft, this is the preferred method
https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-lookupaccountnamea#remarks

### What issues does this PR fix or reference?
Fixes: #60076

### Previous Behavior
Would fail when passed the domain in the domain field if LookupAccountName

### New Behavior
Account is resolved and domain is returned

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes