### PR TITLE
pkg repo commands fail if there are duplicate keys in yum.conf

### DIFF
--- a/changelog/59090.fixed
+++ b/changelog/59090.fixed
@@ -1,0 +1,1 @@
+Allow for multiple configuration entries with keyword strict_config=False

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -366,7 +366,7 @@ def _get_yum_config(**kwargs):
         "reposdir": ["/etc/yum/repos.d", "/etc/yum.repos.d"],
     }
 
-    strict_parser = kwargs.get("strict_config", False)
+    strict_parser = kwargs.get("strict_config", True)
     if HAS_YUM:
         try:
             yb = yum.YumBase()
@@ -2771,7 +2771,7 @@ def list_repos(basedir=None, **kwargs):
     Lists all repos in <basedir> (default: all dirs in `reposdir` yum option).
 
     Strict parsing of configuration files is the default, this can be disabled
-    using the  ``strict_config`` keyword argument
+    using the  ``strict_config`` keyword argument set to False
 
     CLI Example:
 
@@ -2840,7 +2840,7 @@ def del_repo(repo, basedir=None, **kwargs):  # pylint: disable=W0613
     configuration, the file itself will be deleted.
 
     Strict parsing of configuration files is the default, this can be disabled
-    using the  ``strict_config`` keyword argument
+    using the  ``strict_config`` keyword argument set to False
 
     CLI Examples:
 
@@ -2927,7 +2927,7 @@ def mod_repo(repo, basedir=None, **kwargs):
     baseurl can only be deleted if a mirrorlist is specified (or vice versa).
 
     Strict parsing of configuration files is the default, this can be disabled
-    using the  ``strict_config`` keyword argument
+    using the  ``strict_config`` keyword argument set to False
 
     CLI Examples:
 
@@ -3087,7 +3087,7 @@ def _parse_repo_file(filename, **kwargs):
     """
     Turn a single repo file into a dict
     """
-    strict_parser = kwargs.get("strict_config", False)
+    strict_parser = kwargs.get("strict_config", True)
     parsed = configparser.ConfigParser(strict=strict_parser)
     config = {}
 

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -346,7 +346,7 @@ def _get_options(**kwargs):
     return ret
 
 
-def _get_yum_config(**kwargs):
+def _get_yum_config(strict_parser=True):
     """
     Returns a dict representing the yum config options and values.
 
@@ -366,7 +366,6 @@ def _get_yum_config(**kwargs):
         "reposdir": ["/etc/yum/repos.d", "/etc/yum.repos.d"],
     }
 
-    strict_parser = kwargs.get("strict_config", True)
     if HAS_YUM:
         try:
             yb = yum.YumBase()
@@ -420,11 +419,11 @@ def _get_yum_config(**kwargs):
     return conf
 
 
-def _get_yum_config_value(name, **kwargs):
+def _get_yum_config_value(name, strict_config=True):
     """
     Look for a specific config variable and return its value
     """
-    conf = _get_yum_config(**kwargs)
+    conf = _get_yum_config(strict_config)
     if name in conf.keys():
         return conf.get(name)
     return None
@@ -447,7 +446,8 @@ def _normalize_basedir(basedir=None, **kwargs):
 
     # nothing specified, so use the reposdir option as the default
     if not basedir:
-        basedir = _get_yum_config_value("reposdir", **kwargs)
+        strict_config = kwargs.get("strict_config", True)
+        basedir = _get_yum_config_value("reposdir", strict_config)
 
     if not isinstance(basedir, list) or not basedir:
         raise SaltInvocationError("Could not determine any repo directories")
@@ -2976,7 +2976,6 @@ def mod_repo(repo, basedir=None, **kwargs):
     repos = {}
     basedirs = _normalize_basedir(basedir, **kwargs)
     repos = list_repos(basedirs, **kwargs)
-
     repofile = ""
     header = ""
     filerepos = {}

--- a/tests/pytests/functional/modules/test_pkg.py
+++ b/tests/pytests/functional/modules/test_pkg.py
@@ -1,4 +1,4 @@
-## import configparser
+import configparser
 import logging
 import os
 import time
@@ -487,50 +487,53 @@ def test_pkg_latest_version(grains, modules, states, test_pkg):
     assert pkg_latest in cmd_pkg
 
 
-## @pytest.mark.destructive_test
-## @pytest.mark.requires_salt_modules("pkg.list_repos")
-## @pytest.mark.slow_test
-## def test_list_repos_duplicate_entries(grains, modules):
-##     """
-##     test duplicate entries in /etc/yum.conf
-##
-##     This is a destructive test as it installs and then removes a package
-##     """
-##     if grains["os_family"] != "RedHat":
-##         pytest.skip("Only runs on RedHat.")
-##
-##     # write valid config with duplicates entries
-##     cfg_file = "/etc/yum.conf"
-##     with salt.utils.files.fpopen(cfg_file, "w", mode=0o644) as fp_:
-##         fp_.write("[main]\n")
-##         fp_.write("gpgcheck=1\n")
-##         fp_.write("installonly_limit=3\n")
-##         fp_.write("clean_requirements_on_remove=True\n")
-##         fp_.write("best=True\n")
-##         fp_.write("skip_if_unavailable=False\n")
-##         fp_.write("http_caching=True\n")
-##         fp_.write("http_caching=True\n")
-##
-##     ret = modules.pkg.list_repos(strict_config=False)
-##     assert ret != []
-##     assert isinstance(ret, dict) is True
-##
-##     # test explicitly strict_config
-##     expected = "While reading from '/etc/yum.conf' [line  8]: option 'http_caching' in section 'main' already exists"
-##     with pytest.raises(configparser.DuplicateOptionError) as exc_info:
-##         result = modules.pkg.list_repos(strict_config=True)
-##     assert "{}".format(exc_info.value) == expected
-##
-##     # test implicitly strict_config
-##     with pytest.raises(configparser.DuplicateOptionError) as exc_info:
-##         result = modules.pkg.list_repos()
-##     assert "{}".format(exc_info.value) == expected
-##
-##     # leave yum.com in reasonable state
-##     with salt.utils.files.fpopen(cfg_file, "w", mode=0o644) as fp_:
-##         fp_.write("[main]\n")
-##         fp_.write("gpgcheck=1\n")
-##         fp_.write("installonly_limit=3\n")
-##         fp_.write("clean_requirements_on_remove=True\n")
-##         fp_.write("best=True\n")
-##         fp_.write("skip_if_unavailable=False\n")
+@pytest.mark.destructive_test
+@pytest.mark.requires_salt_modules("pkg.list_repos")
+@pytest.mark.slow_test
+def test_list_repos_duplicate_entries(grains, modules):
+    """
+    test duplicate entries in /etc/yum.conf
+
+    This is a destructive test as it installs and then removes a package
+    """
+    if grains["os_family"] != "RedHat":
+        pytest.skip("Only runs on RedHat.")
+
+    if grains["os"] == "Amazon":
+        pytest.skip("Only runs on RedHat, Amazon /etc/yum.conf differs.")
+
+    # write valid config with duplicates entries
+    cfg_file = "/etc/yum.conf"
+    with salt.utils.files.fpopen(cfg_file, "w", mode=0o644) as fp_:
+        fp_.write("[main]\n")
+        fp_.write("gpgcheck=1\n")
+        fp_.write("installonly_limit=3\n")
+        fp_.write("clean_requirements_on_remove=True\n")
+        fp_.write("best=True\n")
+        fp_.write("skip_if_unavailable=False\n")
+        fp_.write("http_caching=True\n")
+        fp_.write("http_caching=True\n")
+
+    ret = modules.pkg.list_repos(strict_config=False)
+    assert ret != []
+    assert isinstance(ret, dict) is True
+
+    # test explicitly strict_config
+    expected = "While reading from '/etc/yum.conf' [line  8]: option 'http_caching' in section 'main' already exists"
+    with pytest.raises(configparser.DuplicateOptionError) as exc_info:
+        result = modules.pkg.list_repos(strict_config=True)
+    assert "{}".format(exc_info.value) == expected
+
+    # test implicitly strict_config
+    with pytest.raises(configparser.DuplicateOptionError) as exc_info:
+        result = modules.pkg.list_repos()
+    assert "{}".format(exc_info.value) == expected
+
+    # leave yum.com in reasonable state
+    with salt.utils.files.fpopen(cfg_file, "w", mode=0o644) as fp_:
+        fp_.write("[main]\n")
+        fp_.write("gpgcheck=1\n")
+        fp_.write("installonly_limit=3\n")
+        fp_.write("clean_requirements_on_remove=True\n")
+        fp_.write("best=True\n")
+        fp_.write("skip_if_unavailable=False\n")

--- a/tests/pytests/functional/modules/test_pkg.py
+++ b/tests/pytests/functional/modules/test_pkg.py
@@ -18,10 +18,17 @@ def ctx():
 
 
 @pytest.fixture
-def default_rhel_yum_conf():
+@requires_system_grains
+def default_rhel_yum_conf(grains):
     try:
         yield
     finally:
+        if grains["os_family"] != "RedHat":
+            pytest.skip("Only runs on RedHat.")
+
+        if grains["os"] == "Amazon":
+            pytest.skip("Only runs on RedHat, Amazon /etc/yum.conf differs.")
+
         # ensure yum.com in reasonable state
         cfg_file = "/etc/yum.conf"
         with salt.utils.files.fpopen(cfg_file, "w", mode=0o644) as fp_:

--- a/tests/pytests/functional/modules/test_pkg.py
+++ b/tests/pytests/functional/modules/test_pkg.py
@@ -534,4 +534,3 @@ def test_list_repos_duplicate_entries(grains, modules):
         fp_.write("clean_requirements_on_remove=True\n")
         fp_.write("best=True\n")
         fp_.write("skip_if_unavailable=False\n")
-        fp_.write("http_caching=True\n")

--- a/tests/pytests/functional/modules/test_pkg.py
+++ b/tests/pytests/functional/modules/test_pkg.py
@@ -525,3 +525,13 @@ def test_list_repos_duplicate_entries(grains, modules):
     with pytest.raises(configparser.DuplicateOptionError) as exc_info:
         result = modules.pkg.list_repos()
     assert "{}".format(exc_info.value) == expected
+
+    # leave yum.com in reasonable state
+    with salt.utils.files.fpopen(cfg_file, "w", mode=0o644) as fp_:
+        fp_.write("[main]\n")
+        fp_.write("gpgcheck=1\n")
+        fp_.write("installonly_limit=3\n")
+        fp_.write("clean_requirements_on_remove=True\n")
+        fp_.write("best=True\n")
+        fp_.write("skip_if_unavailable=False\n")
+        fp_.write("http_caching=True\n")

--- a/tests/pytests/functional/modules/test_pkg.py
+++ b/tests/pytests/functional/modules/test_pkg.py
@@ -21,8 +21,12 @@ def ctx():
 
 @pytest.fixture
 def preserve_rhel_yum_conf():
+
     # save off current yum.conf
     cfg_file = "/etc/yum.conf"
+    if not os.path.exists(cfg_file):
+        pytest.skip("Only runs on RedHat.")
+
     tmp_dir = str(tempfile.gettempdir())
     tmp_file = os.path.join(tmp_dir, "yum.conf")
     shutil.copy2(cfg_file, tmp_file)

--- a/tests/pytests/functional/modules/test_pkg.py
+++ b/tests/pytests/functional/modules/test_pkg.py
@@ -1,4 +1,4 @@
-import configparser
+## import configparser
 import logging
 import os
 import time
@@ -487,50 +487,50 @@ def test_pkg_latest_version(grains, modules, states, test_pkg):
     assert pkg_latest in cmd_pkg
 
 
-@pytest.mark.destructive_test
-@pytest.mark.requires_salt_modules("pkg.list_repos")
-@pytest.mark.slow_test
-def test_list_repos_duplicate_entries(grains, modules):
-    """
-    test duplicate entries in /etc/yum.conf
-
-    This is a destructive test as it installs and then removes a package
-    """
-    if grains["os_family"] != "RedHat":
-        pytest.skip("Only runs on RedHat.")
-
-    # write valid config with duplicates entries
-    cfg_file = "/etc/yum.conf"
-    with salt.utils.files.fpopen(cfg_file, "w", mode=0o644) as fp_:
-        fp_.write("[main]\n")
-        fp_.write("gpgcheck=1\n")
-        fp_.write("installonly_limit=3\n")
-        fp_.write("clean_requirements_on_remove=True\n")
-        fp_.write("best=True\n")
-        fp_.write("skip_if_unavailable=False\n")
-        fp_.write("http_caching=True\n")
-        fp_.write("http_caching=True\n")
-
-    ret = modules.pkg.list_repos(strict_config=False)
-    assert ret != []
-    assert isinstance(ret, dict) is True
-
-    # test explicitly strict_config
-    expected = "While reading from '/etc/yum.conf' [line  8]: option 'http_caching' in section 'main' already exists"
-    with pytest.raises(configparser.DuplicateOptionError) as exc_info:
-        result = modules.pkg.list_repos(strict_config=True)
-    assert "{}".format(exc_info.value) == expected
-
-    # test implicitly strict_config
-    with pytest.raises(configparser.DuplicateOptionError) as exc_info:
-        result = modules.pkg.list_repos()
-    assert "{}".format(exc_info.value) == expected
-
-    # leave yum.com in reasonable state
-    with salt.utils.files.fpopen(cfg_file, "w", mode=0o644) as fp_:
-        fp_.write("[main]\n")
-        fp_.write("gpgcheck=1\n")
-        fp_.write("installonly_limit=3\n")
-        fp_.write("clean_requirements_on_remove=True\n")
-        fp_.write("best=True\n")
-        fp_.write("skip_if_unavailable=False\n")
+## @pytest.mark.destructive_test
+## @pytest.mark.requires_salt_modules("pkg.list_repos")
+## @pytest.mark.slow_test
+## def test_list_repos_duplicate_entries(grains, modules):
+##     """
+##     test duplicate entries in /etc/yum.conf
+##
+##     This is a destructive test as it installs and then removes a package
+##     """
+##     if grains["os_family"] != "RedHat":
+##         pytest.skip("Only runs on RedHat.")
+##
+##     # write valid config with duplicates entries
+##     cfg_file = "/etc/yum.conf"
+##     with salt.utils.files.fpopen(cfg_file, "w", mode=0o644) as fp_:
+##         fp_.write("[main]\n")
+##         fp_.write("gpgcheck=1\n")
+##         fp_.write("installonly_limit=3\n")
+##         fp_.write("clean_requirements_on_remove=True\n")
+##         fp_.write("best=True\n")
+##         fp_.write("skip_if_unavailable=False\n")
+##         fp_.write("http_caching=True\n")
+##         fp_.write("http_caching=True\n")
+##
+##     ret = modules.pkg.list_repos(strict_config=False)
+##     assert ret != []
+##     assert isinstance(ret, dict) is True
+##
+##     # test explicitly strict_config
+##     expected = "While reading from '/etc/yum.conf' [line  8]: option 'http_caching' in section 'main' already exists"
+##     with pytest.raises(configparser.DuplicateOptionError) as exc_info:
+##         result = modules.pkg.list_repos(strict_config=True)
+##     assert "{}".format(exc_info.value) == expected
+##
+##     # test implicitly strict_config
+##     with pytest.raises(configparser.DuplicateOptionError) as exc_info:
+##         result = modules.pkg.list_repos()
+##     assert "{}".format(exc_info.value) == expected
+##
+##     # leave yum.com in reasonable state
+##     with salt.utils.files.fpopen(cfg_file, "w", mode=0o644) as fp_:
+##         fp_.write("[main]\n")
+##         fp_.write("gpgcheck=1\n")
+##         fp_.write("installonly_limit=3\n")
+##         fp_.write("clean_requirements_on_remove=True\n")
+##         fp_.write("best=True\n")
+##         fp_.write("skip_if_unavailable=False\n")

--- a/tests/pytests/functional/states/test_pkg.py
+++ b/tests/pytests/functional/states/test_pkg.py
@@ -623,6 +623,7 @@ def test_pkg_015_installed_held(grains, modules, states, PKG_TARGETS):
         refresh=False,
     )
     assert ret.result is True
+    print(f"DGM ensure pkg is installed target '{target}', result '{ret}'")
 
     # Then we check that the package is now held
     ret = states.pkg.installed(
@@ -630,6 +631,7 @@ def test_pkg_015_installed_held(grains, modules, states, PKG_TARGETS):
         hold=True,
         refresh=False,
     )
+    print(f"DGM ensure pkg is installed and hold target '{target}', result '{ret}'")
 
     if versionlock_pkg and "-versionlock is not installed" in str(ret):
         pytest.skip("{}  `{}` is installed".format(ret, versionlock_pkg))

--- a/tests/pytests/functional/states/test_pkg.py
+++ b/tests/pytests/functional/states/test_pkg.py
@@ -623,7 +623,7 @@ def test_pkg_015_installed_held(grains, modules, states, PKG_TARGETS):
         refresh=False,
     )
     assert ret.result is True
-    print(f"DGM ensure pkg is installed target '{target}', result '{ret}'")
+    print("DGM ensure pkg is installed target '{}', result '{}'".format(target, ret))
 
     # Then we check that the package is now held
     ret = states.pkg.installed(
@@ -631,7 +631,15 @@ def test_pkg_015_installed_held(grains, modules, states, PKG_TARGETS):
         hold=True,
         refresh=False,
     )
-    print(f"DGM ensure pkg is installed and hold target '{target}', result '{ret}'")
+    print(
+        "DGM ensure pkg is installed and hold target '{}', result '{}'".format(
+            target, ret
+        )
+    )
+    ## DGM
+    assert versionlock_pkg is True
+    assert str(ret) == "-versionlock is not installed"
+    assert ret.result is True
 
     if versionlock_pkg and "-versionlock is not installed" in str(ret):
         pytest.skip("{}  `{}` is installed".format(ret, versionlock_pkg))

--- a/tests/pytests/functional/states/test_pkg.py
+++ b/tests/pytests/functional/states/test_pkg.py
@@ -94,7 +94,7 @@ def PKG_DOT_TARGETS(grains):
         elif grains["osmajorrelease"] == 7:
             _PKG_DOT_TARGETS = ["tomcat-el-2.2-api"]
         elif grains["osmajorrelease"] == 8:
-            _PKG_DOT_TARGETS = ["vid.stab"]
+            _PKG_DOT_TARGETS = ["aspnetcore-runtime-6.0"]
     return _PKG_DOT_TARGETS
 
 

--- a/tests/pytests/functional/states/test_pkg.py
+++ b/tests/pytests/functional/states/test_pkg.py
@@ -623,7 +623,6 @@ def test_pkg_015_installed_held(grains, modules, states, PKG_TARGETS):
         refresh=False,
     )
     assert ret.result is True
-    print("DGM ensure pkg is installed target '{}', result '{}'".format(target, ret))
 
     # Then we check that the package is now held
     ret = states.pkg.installed(
@@ -631,15 +630,6 @@ def test_pkg_015_installed_held(grains, modules, states, PKG_TARGETS):
         hold=True,
         refresh=False,
     )
-    print(
-        "DGM ensure pkg is installed and hold target '{}', result '{}'".format(
-            target, ret
-        )
-    )
-    ## DGM
-    assert versionlock_pkg is True
-    assert str(ret) == "-versionlock is not installed"
-    assert ret.result is True
 
     if versionlock_pkg and "-versionlock is not installed" in str(ret):
         pytest.skip("{}  `{}` is installed".format(ret, versionlock_pkg))

--- a/tests/pytests/integration/cli/test_batch.py
+++ b/tests/pytests/integration/cli/test_batch.py
@@ -2,13 +2,8 @@
     :codeauthor: Nicole Thomas <nicole@saltstack.com>
 """
 
-# DGM
-import logging
-
 import pytest
 import salt.utils.platform
-
-log = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.windows_whitelisted,


### PR DESCRIPTION
### What does this PR do?
Relaxes strict configuration rules for yum.conf and other configuration files, e.g. dnf.conf, if use of keyword strict_config=False is used. Azure has an issue which sometimes leaves duplicate configuration lines in configuration files like yuim.conf.  This allows Azure Cloud users to work around the issue.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/59090

### Previous Behavior
Commands such as pkg.list_repos would fail due to duplicate entries in yum.conf

### New Behavior
Commands such as pkg.list_repos no longer fail due to duplicate entries in yum.conf, with keyword strict_config=False, which relaxes strict configuration rules.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
