### PR TITLE
Fix archive.extracted top level directory ownership handling

### DIFF
--- a/changelog/38605.fixed
+++ b/changelog/38605.fixed
@@ -1,0 +1,1 @@
+Fix archive.extracted doesn't set user/group ownership correctly

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -425,7 +425,15 @@ def list_(
                 "files": sorted(salt.utils.data.decode_list(files)),
                 "links": sorted(salt.utils.data.decode_list(links)),
             }
-            ret["top_level_dirs"] = [x for x in ret["dirs"] if x.count("/") == 1]
+            top_level_dirs = [x for x in ret["dirs"] if x.count("/") == 1]
+            # the common_prefix logic handles scenarios where the TLD
+            # isn't listed as an archive member on its own
+            common_prefix = os.path.commonprefix(ret["dirs"])
+            if common_prefix:
+                common_prefix = common_prefix.split("/")[0] + "/"
+                if common_prefix not in top_level_dirs:
+                    top_level_dirs.append(common_prefix)
+            ret["top_level_dirs"] = top_level_dirs
             ret["top_level_files"] = [x for x in ret["files"] if x.count("/") == 0]
             ret["top_level_links"] = [x for x in ret["links"] if x.count("/") == 0]
         else:

--- a/tests/pytests/functional/modules/test_archive.py
+++ b/tests/pytests/functional/modules/test_archive.py
@@ -303,3 +303,31 @@ def test_unrar(archive, unicode_filename):
         ret = archive.unrar(str(arch.archive), str(arch.dst))
         assert isinstance(ret, list)
         arch.assert_artifacts_in_ret(ret)
+
+
+@pytest.mark.skip_on_windows
+@pytest.mark.skip_if_binaries_missing("tar")
+def test_tar_unpack_no_explicit_top_level_directory_member(archive, tmp_path):
+    rel_path = pathlib.Path("archive_top/second_level/file.txt")
+    srcfile = tmp_path / rel_path
+    srcfile.parent.mkdir(parents=True, exist_ok=True)
+    srcfile.write_text("hey there")
+    archive.tar(
+        "-cvzf",
+        str(tmp_path / "tld_test.tar.gz"),
+        sources=str(rel_path.parent),
+        cwd=str(tmp_path),
+    )
+
+    expected = {
+        "dirs": ["archive_top/second_level/"],
+        "files": ["archive_top/second_level/file.txt"],
+        "links": [],
+        "top_level_dirs": ["archive_top/"],
+        "top_level_files": [],
+        "top_level_links": [],
+    }
+    ret = archive.list(
+        str(tmp_path / "tld_test.tar.gz"), archive_format="tar", verbose=True
+    )
+    assert ret["top_level_dirs"] == expected["top_level_dirs"]

--- a/tests/pytests/functional/modules/test_archive.py
+++ b/tests/pytests/functional/modules/test_archive.py
@@ -307,9 +307,9 @@ def test_unrar(archive, unicode_filename):
 
 @pytest.mark.skip_on_windows
 @pytest.mark.skip_if_binaries_missing("tar")
-def test_tar_unpack_no_explicit_top_level_directory_member(archive, tmp_path):
+def test_tar_list_no_explicit_top_level_directory_member(archive, tmp_path):
     rel_path = pathlib.Path("archive_top/second_level/file.txt")
-    srcfile = tmp_path / rel_path
+    srcfile = tmp_path / str(rel_path)
     srcfile.parent.mkdir(parents=True, exist_ok=True)
     srcfile.write_text("hey there")
     archive.tar(


### PR DESCRIPTION
### What does this PR do?
This PR fixes a long-standing issue with `archive.extracted` where it would not properly enforce ownership on the extracted directories and files in certain scenarios.

Given the following structure where we have nested directories but no files in the top or shallow levels:

```
$ tree archive_top/
archive_top/
└── second_level
    └── file.txt

1 directory, 1 file
```

You can see that the structure of the `tar` command will produce different tar members in the listing depending on the invocation. The first invocation captures only the second level directory as a member:

```
$ tar czvf test1.tgz archive_top/second_level/
archive_top/second_level/
archive_top/second_level/file.txt
```

While the second invocation below captures the top level directory as a member as well:

```
$ tar czvf test2.tgz archive_top/
archive_top/
archive_top/second_level/
archive_top/second_level/file.txt
```

BOTH invocations will extract the file and directories to achieve the SAME result. However, the `archive.list` call underlying `archive.extracted` would only successfully enforce ownership on a file created in a manner consistent with the second invocation.

### What issues does this PR fix or reference?
Fixes: #38605

### Previous Behavior
`archive.extracted` would not enforce ownership on archives created with the first invocation above. See issue for more details.

### New Behavior
`archive.extracted` now checks for a common directory prefix to use as a top level directory on which to enforce ownership.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
