### PR TITLE
Display Packages marked NoRemove

### DIFF
--- a/changelog/56864.fixed
+++ b/changelog/56864.fixed
@@ -1,0 +1,1 @@
+Display packages that are marked NoRemove in pkg.list_pkgs for Windows platforms

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -561,12 +561,15 @@ def _get_reg_software(include_components=True, include_updates=True):
             vname="NoRemove",
             use_32bit_registry=use_32bit_registry,
         ):
-            if __utils__["reg.read_value"](
-                hive=hive,
-                key="{}\\{}".format(key, sub_key),
-                vname="NoRemove",
-                use_32bit_registry=use_32bit_registry,
-            )["vdata"] > 0:
+            if (
+                __utils__["reg.read_value"](
+                    hive=hive,
+                    key="{}\\{}".format(key, sub_key),
+                    vname="NoRemove",
+                    use_32bit_registry=use_32bit_registry,
+                )["vdata"]
+                > 0
+            ):
                 return False
         if not __utils__["reg.value_exists"](
             hive=hive,

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -543,13 +543,31 @@ def _get_reg_software(include_components=True, include_updates=True):
 
     def skip_uninstall_string(hive, key, sub_key, use_32bit_registry):
         """
-        'UninstallString' must be present, because it stores the command line
+        `UninstallString` must be present, because it stores the command line
         that gets executed by Add/Remove programs, when the user tries to
-        uninstall a program.
+        uninstall a program. Skip those, unless `NoRemove` contains a non-zero
+        value in which case there is no `UninstallString` value.
+
+        We want to display these in case we're trying to install software that
+        will set the `NoRemove` option.
 
         Returns:
             bool: True if the package needs to be skipped, otherwise False
         """
+        # https://docs.microsoft.com/en-us/windows/win32/msi/arpnoremove
+        if __utils__["reg.value_exists"](
+            hive=hive,
+            key="{}\\{}".format(key, sub_key),
+            vname="NoRemove",
+            use_32bit_registry=use_32bit_registry,
+        ):
+            if __utils__["reg.read_value"](
+                hive=hive,
+                key="{}\\{}".format(key, sub_key),
+                vname="NoRemove",
+                use_32bit_registry=use_32bit_registry,
+            )["vdata"] > 0:
+                return False
         if not __utils__["reg.value_exists"](
             hive=hive,
             key="{}\\{}".format(key, sub_key),

--- a/tests/pytests/unit/modules/test_win_pkg.py
+++ b/tests/pytests/unit/modules/test_win_pkg.py
@@ -1,8 +1,6 @@
 """
 Tests for the win_pkg module
 """
-import time
-
 import pytest
 import salt.modules.config as config
 import salt.modules.pkg_resource as pkg_resource
@@ -80,7 +78,9 @@ def test_pkg__get_reg_software_noremove():
     key = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{}".format(search)
     win_reg.set_value(hive="HKLM", key=key, vname="DisplayName", vdata=search)
     win_reg.set_value(hive="HKLM", key=key, vname="DisplayVersion", vdata="1.0.0")
-    win_reg.set_value(hive="HKLM", key=key, vname="NoRemove", vtype="REG_DWORD", vdata="1")
+    win_reg.set_value(
+        hive="HKLM", key=key, vname="NoRemove", vtype="REG_DWORD", vdata="1"
+    )
     try:
         result = win_pkg._get_reg_software()
         assert isinstance(result, dict)

--- a/tests/pytests/unit/modules/test_win_pkg.py
+++ b/tests/pytests/unit/modules/test_win_pkg.py
@@ -1,6 +1,7 @@
 """
 Tests for the win_pkg module
 """
+import time
 
 import pytest
 import salt.modules.config as config
@@ -72,6 +73,44 @@ def test_pkg__get_reg_software():
         if search in key:
             found_python = True
     assert found_python
+
+
+def test_pkg__get_reg_software_noremove():
+    search = "test_pkg_noremove"
+    key = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{}".format(search)
+    win_reg.set_value(hive="HKLM", key=key, vname="DisplayName", vdata=search)
+    win_reg.set_value(hive="HKLM", key=key, vname="DisplayVersion", vdata="1.0.0")
+    win_reg.set_value(hive="HKLM", key=key, vname="NoRemove", vtype="REG_DWORD", vdata="1")
+    try:
+        result = win_pkg._get_reg_software()
+        assert isinstance(result, dict)
+        found = False
+        search = "test_pkg"
+        for item in result:
+            if search in item:
+                found = True
+        assert found is True
+    finally:
+        win_reg.delete_key_recursive(hive="HKLM", key=key)
+        assert not win_reg.key_exists(hive="HKLM", key=key)
+
+
+def test_pkg__get_reg_software_noremove_not_present():
+    search = "test_pkg_noremove_not_present"
+    key = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{}".format(search)
+    win_reg.set_value(hive="HKLM", key=key, vname="DisplayName", vdata=search)
+    win_reg.set_value(hive="HKLM", key=key, vname="DisplayVersion", vdata="1.0.0")
+    try:
+        result = win_pkg._get_reg_software()
+        assert isinstance(result, dict)
+        found = False
+        for item in result:
+            if search in item:
+                found = True
+        assert found is False
+    finally:
+        win_reg.delete_key_recursive(hive="HKLM", key=key)
+        assert not win_reg.key_exists(hive="HKLM", key=key)
 
 
 def test_pkg_install_not_found():


### PR DESCRIPTION
### What does this PR do?
Displays packages marked `NoRemove` in `pkg.list_pkgs` so that they can be managed with Salt. They can be updated, but not removed.

### What issues does this PR fix or reference?
Fixes: #56864

### Previous Behavior
Packages marked `NoRemove` were not displayed in `pkg.list_pkgs`

### New Behavior
Packages marked `NoRemove` are now displayed

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes