### PR TITLE
Fix salt-ssh support for sudo with a password

### DIFF
--- a/changelog/8882.fixed
+++ b/changelog/8882.fixed
@@ -1,0 +1,1 @@
+Fix salt-ssh using sudo with a password

--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -21,6 +21,11 @@ SSH_PASSWORD_PROMPT_RE = re.compile(r"(?:.*)[Pp]assword(?: for .*)?:\s*$", re.M)
 KEY_VALID_RE = re.compile(r".*\(yes\/no\).*")
 SSH_PRIVATE_KEY_PASSWORD_PROMPT_RE = re.compile(r"Enter passphrase for key", re.M)
 
+# sudo prompt is used to recognize sudo prompting for a password and should
+# therefore be fairly recognizable and unique
+SUDO_PROMPT = r"[salt:sudo:d11bd4221135c33324a6bdc09674146fbfdf519989847491e34a689369bbce23]passwd:"
+SUDO_PROMPT_RE = re.compile(SUDO_PROMPT, re.M)
+
 # Keep these in sync with ./__init__.py
 RSTR = "_edbc7885e4f9aac9b83b35999b68d015148caf467b78fa39c05f669c0ff89878"
 RSTR_RE = re.compile(r"(?:^|\r?\n)" + RSTR + r"(?:\r?\n|$)")
@@ -433,6 +438,12 @@ class Shell:
                             "flag:\n{}".format(stdout)
                         )
                         return ret_stdout, "", 254
+                elif buff and SUDO_PROMPT_RE.search(buff):
+                    if not self.passwd:
+                        return "", "Sudo password is required but not provided", 254
+                    else:
+                        term.sendline(self.passwd)
+                        continue
                 elif buff and buff.endswith("_||ext_mods||_"):
                     mods_raw = (
                         salt.utils.json.dumps(self.mods, separators=(",", ":"))

--- a/tests/pytests/unit/client/test_ssh.py
+++ b/tests/pytests/unit/client/test_ssh.py
@@ -1,0 +1,144 @@
+import pytest
+import salt.client.ssh
+from tests.support.helpers import dedent
+
+
+@pytest.mark.slow_test
+@pytest.mark.skip_on_windows(reason="Windows does not support salt-ssh")
+@pytest.mark.skip_if_binaries_missing("ssh", check_all=True)
+def test_ssh_single__cmd_str(temp_salt_master):
+    opts = temp_salt_master.config.copy()
+    argv = []
+    id_ = "minion"
+    host = "minion"
+
+    single = salt.client.ssh.Single(opts, argv, id_, host, sudo=False)
+    cmd = single._cmd_str()
+    expected = dedent(
+        """
+        SUDO=""
+        if [ -n "" ]
+        then SUDO=" "
+        fi
+        SUDO_USER=""
+        if [ "$SUDO" ] && [ "$SUDO_USER" ]
+        then SUDO="$SUDO -u $SUDO_USER"
+        fi
+        """
+    )
+
+    assert expected in cmd
+
+
+@pytest.mark.slow_test
+@pytest.mark.skip_on_windows(reason="Windows does not support salt-ssh")
+@pytest.mark.skip_if_binaries_missing("ssh", check_all=True)
+def test_ssh_single__cmd_str_sudo(temp_salt_master):
+    opts = temp_salt_master.config.copy()
+    argv = []
+    id_ = "minion"
+    host = "minion"
+
+    single = salt.client.ssh.Single(opts, argv, id_, host, sudo=True)
+    cmd = single._cmd_str()
+    expected = dedent(
+        """
+        SUDO=""
+        if [ -n "sudo" ]
+        then SUDO="sudo "
+        fi
+        SUDO_USER=""
+        if [ "$SUDO" ] && [ "$SUDO_USER" ]
+        then SUDO="$SUDO -u $SUDO_USER"
+        fi
+        """
+    )
+
+    assert expected in cmd
+
+
+@pytest.mark.slow_test
+@pytest.mark.skip_on_windows(reason="Windows does not support salt-ssh")
+@pytest.mark.skip_if_binaries_missing("ssh", check_all=True)
+def test_ssh_single__cmd_str_sudo_user(temp_salt_master):
+    opts = temp_salt_master.config.copy()
+    argv = []
+    id_ = "minion"
+    host = "minion"
+    user = "wayne"
+
+    single = salt.client.ssh.Single(opts, argv, id_, host, sudo=True, sudo_user=user)
+    cmd = single._cmd_str()
+    expected = dedent(
+        """
+        SUDO=""
+        if [ -n "sudo" ]
+        then SUDO="sudo "
+        fi
+        SUDO_USER="wayne"
+        if [ "$SUDO" ] && [ "$SUDO_USER" ]
+        then SUDO="$SUDO -u $SUDO_USER"
+        fi
+        """
+    )
+
+    assert expected in cmd
+
+
+@pytest.mark.slow_test
+@pytest.mark.skip_on_windows(reason="Windows does not support salt-ssh")
+@pytest.mark.skip_if_binaries_missing("ssh", check_all=True)
+def test_ssh_single__cmd_str_sudo_passwd(temp_salt_master):
+    opts = temp_salt_master.config.copy()
+    argv = []
+    id_ = "minion"
+    host = "minion"
+    passwd = "salty"
+
+    single = salt.client.ssh.Single(opts, argv, id_, host, sudo=True, passwd=passwd)
+    cmd = single._cmd_str()
+    expected = dedent(
+        """
+        SUDO=""
+        if [ -n "sudo -p '[salt:sudo:d11bd4221135c33324a6bdc09674146fbfdf519989847491e34a689369bbce23]passwd:'" ]
+        then SUDO="sudo -p '[salt:sudo:d11bd4221135c33324a6bdc09674146fbfdf519989847491e34a689369bbce23]passwd:' "
+        fi
+        SUDO_USER=""
+        if [ "$SUDO" ] && [ "$SUDO_USER" ]
+        then SUDO="$SUDO -u $SUDO_USER"
+        fi
+        """
+    )
+
+    assert expected in cmd
+
+
+@pytest.mark.slow_test
+@pytest.mark.skip_on_windows(reason="Windows does not support salt-ssh")
+@pytest.mark.skip_if_binaries_missing("ssh", check_all=True)
+def test_ssh_single__cmd_str_sudo_passwd_user(temp_salt_master):
+    opts = temp_salt_master.config.copy()
+    argv = []
+    id_ = "minion"
+    host = "minion"
+    user = "wayne"
+    passwd = "salty"
+
+    single = salt.client.ssh.Single(
+        opts, argv, id_, host, sudo=True, passwd=passwd, sudo_user=user
+    )
+    cmd = single._cmd_str()
+    expected = dedent(
+        """
+        SUDO=""
+        if [ -n "sudo -p '[salt:sudo:d11bd4221135c33324a6bdc09674146fbfdf519989847491e34a689369bbce23]passwd:'" ]
+        then SUDO="sudo -p '[salt:sudo:d11bd4221135c33324a6bdc09674146fbfdf519989847491e34a689369bbce23]passwd:' "
+        fi
+        SUDO_USER="wayne"
+        if [ "$SUDO" ] && [ "$SUDO_USER" ]
+        then SUDO="$SUDO -u $SUDO_USER"
+        fi
+        """
+    )
+
+    assert expected in cmd


### PR DESCRIPTION
### What does this PR do?
This PR ports the work by @MovingEarth in #48435 to the master branch and introduces some tests around building the salt-ssh command required for the functionality.

### What issues does this PR fix or reference?
Fixes: #8882 
Fixes: #60403 

### Previous Behavior
salt-ssh could not be used without having root ssh or password-less sudo

### New Behavior
The provided password for login to a system can now be used for sudo escalation

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
