### PR TITLE
Fix problem with runas failing to execute powershell scripts 

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2870,7 +2870,11 @@ def script(
         os.chown(path, __salt__["file.user_to_uid"](runas), -1)
 
     if salt.utils.platform.is_windows():
-        cmd_path = _cmd_quote(path, (shell.lower() != "powershell"))
+        if shell.lower() != "powershell":
+            cmd_path = _cmd_quote(path, escape=False)
+        else:    
+            # not great but better than not working at all.
+            cmd_path = "&\"" + path.replace('"', '`"') + "\""
     else:
         cmd_path = _cmd_quote(path)
 

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -2869,8 +2869,8 @@ def script(
         os.chmod(path, 320)
         os.chown(path, __salt__["file.user_to_uid"](runas), -1)
 
-    if salt.utils.platform.is_windows() and shell.lower() != "powershell":
-        cmd_path = _cmd_quote(path, escape=False)
+    if salt.utils.platform.is_windows():
+        cmd_path = _cmd_quote(path, (shell.lower() != "powershell"))
     else:
         cmd_path = _cmd_quote(path)
 


### PR DESCRIPTION
### What does this PR do?
Fixes the problem when specifying `runas` when running a powershell script.

The issue was that the code that trying to escape characters by calling `win_functions.escape_argument`. However that function is for escaping characters for the `cmd` shell, and in this case we are using `powershell` to execute a script, and so powershell needs to know how to run the script. This is solved by prefixing the string with a `&`, and surrounding it in quotes.

### What issues does this PR fix or reference?
Fixes: #61166

### Previous Behavior
The output would appear something like this:
```
^C:\ProgramData\Salt Project\Salt\var\cache\salt\minion\tmpg02cql8w\__salt.tmp.j_yi8_ho.ps1^ : The term
                  '^C:\ProgramData\Salt Project\Salt\var\cache\salt\minion\tmpg02cql8w\__salt.tmp.j_yi8_ho.ps1^' is not recognized as
                  the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was
```

### New Behavior
Script runs.
