### PR TITLE
fix #60239 Caught exception in wait_for_fun utils in OpenStack

### DIFF
--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -444,11 +444,9 @@ def _get_ips(node, addr_type="public"):
                 "OS-EXT-IPS:type"
             ):
                 ret.append(addr["addr"])
-            elif addr_type == "public" and __utils__["cloud.is_public_ip"](
-                addr["addr"]
-            ):
+            elif addr_type == "public" and salt.utils.cloud.is_public_ip(addr["addr"]):
                 ret.append(addr["addr"])
-            elif addr_type == "private" and not __utils__["cloud.is_public_ip"](
+            elif addr_type == "private" and not salt.utils.cloud.is_public_ip(
                 addr["addr"]
             ):
                 ret.append(addr["addr"])


### PR DESCRIPTION
A PR that implements the fix from https://github.com/saltstack/salt/issues/60239

After upgrading to 3004.1 we noticed we could not create any nodes anymore on OpenStack. The fix proposed by @sblaisot in https://github.com/saltstack/salt/issues/60239 seems to fix the issue.

![exception_001](https://user-images.githubusercontent.com/1437341/161784864-2d5af2c2-13ff-42aa-a4e4-d810786af9f1.png)

Looking at an earlier commit like https://github.com/saltstack/salt/commit/47ecb7a150f88c77e082cf6541a40388acd8ea93 I don't think this code is thoroughly unit-tested (`tests/unit/cloud/clouds/test_openstack.py` maybe?)
