### PR TITLE
chore(pty.py): Fix link to broken cpython mirror

### DIFF
--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -14,7 +14,7 @@
     get us into.
 
     .. __: http://code.activestate.com/recipes/440554/
-    .. __: https://github.com/python-mirror/python/blob/3.3/Lib/pty.py
+    .. __: https://github.com/python/cpython/blob/3.3/Lib/pty.py
     .. __: https://github.com/pexpect/pexpect
 
 """


### PR DESCRIPTION
### What does this PR do?
Fix an internal link 

### What issues does this PR fix or reference?
Link to https://github.com/saltstack/salt/blob/bb610f761e107de111fa8b4c92c60c77ff7a920e/salt/utils/vt.py breaking

### Previous Behavior

404 not found: https://github.com/python/python/blob/3.3/Lib/pty.py

### New Behavior

200 Found: https://github.com/python/cpython/blob/3.3/Lib/pty.py

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes