### PR TITLE
Mark test that uses ensure_deps with requires_network

### DIFF
--- a/tests/pytests/functional/cache/test_redis_cache.py
+++ b/tests/pytests/functional/cache/test_redis_cache.py
@@ -21,6 +21,7 @@ def ensure_deps(states):
     ), "unable to pip install requirements {}".format(installation_result.comment)
 
 
+@pytest.mark.requires_network
 def test_redis_cluster_cache_should_import_correctly(redis_cluster_cache):
     import rediscluster.exceptions
 


### PR DESCRIPTION
The test fixture `ensure_deps` requires Internet access to download the pip modules.