### PR TITLE
Fix AttributeError: module 'salt.config' has no attribute '_DFLT_LOG_FMT_JID'

### DIFF
--- a/tests/pytests/integration/_logging/test_jid_logging.py
+++ b/tests/pytests/integration/_logging/test_jid_logging.py
@@ -1,6 +1,6 @@
 import logging
 
-import salt.config
+from salt._logging import DFLT_LOG_FMT_JID
 from tests.support.helpers import PRE_PYTEST_SKIP
 
 # Using the PRE_PYTEST_SKIP decorator since this test still fails on some platforms.
@@ -12,7 +12,7 @@ def test_jid_in_logs(caplog, salt_call_cli):
     """
     Test JID in log_format
     """
-    jid_formatted_str = salt.config._DFLT_LOG_FMT_JID.split("%")[0]
+    jid_formatted_str = DFLT_LOG_FMT_JID.split("%")[0]
     formatter = logging.Formatter(fmt="%(jid)s %(message)s")
     with caplog.at_level(logging.DEBUG):
         previous_formatter = caplog.handler.formatter


### PR DESCRIPTION
```
$ python3 -m pytest -ra tests/pytests/integration/_logging/test_jid_logging.py
_______________________________ test_jid_in_logs _______________________________

    @PRE_PYTEST_SKIP
    def test_jid_in_logs(caplog, salt_call_cli):
        """
        Test JID in log_format
        """
>       jid_formatted_str = salt.config._DFLT_LOG_FMT_JID.split("%")[0]
E       AttributeError: module 'salt.config' has no attribute '_DFLT_LOG_FMT_JID'

tests/pytests/integration/_logging/test_jid_logging.py:15: AttributeError
```

Commit a9d5e75b528b711412b8fa30eb61c54413a254e9 changed the private variable to a public one.