### PR TITLE
Update multimaster_pki.rst

### DIFF
--- a/doc/topics/tutorials/multimaster_pki.rst
+++ b/doc/topics/tutorials/multimaster_pki.rst
@@ -300,10 +300,8 @@ To avoid that, the master can use a pre-created signature of its public-key.
 The signature is saved as a base64 encoded string which the master reads
 once when starting and attaches only that string to auth-replies.
 
-Enabling this also gives paranoid users the possibility, to have the signing
-key-pair on a different system than the actual salt-master and create the public
-keys signature there. Probably on a system with more restrictive firewall rules,
-without internet access, less users, etc.
+This process turns each master into a "signing" master server that helps reduce overhead for auth-requests coming from minions.
+
 
 That signature can be created with
 


### PR DESCRIPTION
Previous verbiage gave the impression that a separate "signing" server can be used to prevent the copying of private keys (ie. master.pem) across the network. The problem is that the process to generate a signature file requires both the master.pem (from the original master) and the master_sign.pem (from the signing master) to be on the same box. This would require either copying the appropriate pem file from one master to another. Unfortunately, there is no current way around copying the pem files if you are trying to implement a separate master signing server. 
This process turns an existing master into a signing server to reduce overhead of auth-requests coming from minions attached to it.

### What does this PR do?
Corrects the inference that a separate signing master server prevents the copying of private keys across the network.


