### PR TITLE
Fix run on start

### DIFF
--- a/changelog/61964.fixed.md
+++ b/changelog/61964.fixed.md
@@ -1,0 +1,1 @@
+Fix regression that prevented salt-minion from running interval-based jobs on startup by default.

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -1534,13 +1534,6 @@ class Schedule:
             if "_splay" not in data:
                 data["_splay"] = None
 
-            if (
-                "run_on_start" in data
-                and data["run_on_start"]
-                and "_run_on_start" not in data
-            ):
-                data["_run_on_start"] = True
-
             if not now:
                 now = datetime.datetime.now()
 
@@ -1575,11 +1568,21 @@ class Schedule:
                 )
                 continue
 
+            uses_time_elements = True in [
+                True for item in time_elements if item in data
+            ]
+
+            # _run_on_start is later set to False, on the first run, after
+            # being read. So, only set it when it is not already set.
+            if "_run_on_start" not in data:
+                # default to True for time elements
+                data["_run_on_start"] = data.get("run_on_start", uses_time_elements)
+
             if "run_explicit" in data:
                 _handle_run_explicit(data, loop_interval)
                 run = data["run"]
 
-            if True in [True for item in time_elements if item in data]:
+            if uses_time_elements:
                 _handle_time_elements(data)
             elif "once" in data:
                 _handle_once(data, loop_interval)

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -1032,10 +1032,6 @@ class Schedule:
                 if interval < self.loop_interval:
                     self.loop_interval = interval
 
-                data["_next_scheduled_fire_time"] = now + datetime.timedelta(
-                    seconds=data["_seconds"]
-                )
-
         def _handle_once(data, loop_interval):
             """
             Handle schedule item with once
@@ -1065,7 +1061,6 @@ class Schedule:
                         log.error(data["_error"])
                         return
                 data["_next_fire_time"] = once
-                data["_next_scheduled_fire_time"] = once
                 # If _next_fire_time is less than now, continue
                 if once < now - loop_interval:
                     data["_continue"] = True
@@ -1169,8 +1164,6 @@ class Schedule:
                 if not data["_next_fire_time"]:
                     data["_next_fire_time"] = when
 
-                data["_next_scheduled_fire_time"] = when
-
                 if data["_next_fire_time"] < when and not run and not data["_run"]:
                     data["_next_fire_time"] = when
                     data["_run"] = True
@@ -1195,9 +1188,6 @@ class Schedule:
                 # executed before or already executed in the past.
                 try:
                     data["_next_fire_time"] = croniter.croniter(
-                        data["cron"], now
-                    ).get_next(datetime.datetime)
-                    data["_next_scheduled_fire_time"] = croniter.croniter(
                         data["cron"], now
                     ).get_next(datetime.datetime)
                 except (ValueError, KeyError):

--- a/tests/pytests/unit/utils/scheduler/test_eval.py
+++ b/tests/pytests/unit/utils/scheduler/test_eval.py
@@ -990,9 +990,6 @@ def test_eval_days(schedule):
         "schedule": {job_name: {"function": "test.ping", "days": "2", "dry_run": True}}
     }
 
-    if salt.utils.platform.is_darwin():
-        job["schedule"][job_name]["dry_run"] = True
-
     # Add job to schedule
     schedule.opts.update(job)
 

--- a/tests/pytests/unit/utils/scheduler/test_eval.py
+++ b/tests/pytests/unit/utils/scheduler/test_eval.py
@@ -424,7 +424,7 @@ def test_eval_after(schedule):
 @pytest.mark.slow_test
 def test_eval_enabled(schedule):
     """
-    verify that scheduled job does not run
+    verify that scheduled job runs
     """
 
     job_name = "test_eval_enabled"
@@ -813,7 +813,7 @@ def test_eval_splay_global(schedule):
 @pytest.mark.slow_test
 def test_eval_seconds(schedule):
     """
-    verify that scheduled job run mutiple times with seconds
+    verify that scheduled job run multiple times with seconds
     """
 
     with patch.dict(schedule.opts, {"run_schedule_jobs_in_background": False}):
@@ -872,7 +872,7 @@ def test_eval_seconds(schedule):
 @pytest.mark.slow_test
 def test_eval_minutes(schedule):
     """
-    verify that scheduled job run mutiple times with minutes
+    verify that scheduled job run multiple times with minutes
     """
 
     with patch.dict(schedule.opts, {"run_schedule_jobs_in_background": False}):
@@ -926,7 +926,7 @@ def test_eval_minutes(schedule):
 @pytest.mark.slow_test
 def test_eval_hours(schedule):
     """
-    verify that scheduled job run mutiple times with hours
+    verify that scheduled job run multiple times with hours
     """
 
     with patch.dict(schedule.opts, {"run_schedule_jobs_in_background": False}):
@@ -982,7 +982,7 @@ def test_eval_hours(schedule):
 @pytest.mark.slow_test
 def test_eval_days(schedule):
     """
-    verify that scheduled job run mutiple times with days
+    verify that scheduled job run multiple times with days
     """
 
     job_name = "job_eval_days"

--- a/tests/pytests/unit/utils/scheduler/test_eval.py
+++ b/tests/pytests/unit/utils/scheduler/test_eval.py
@@ -37,9 +37,8 @@ pytestmark = [
 
 def _check_last_run(schedule, job_name, runtime=None):
     """
-    Check that last_run time exists and
-    is not the previous run time if prev_runtime
-    is passed.
+    Check that _last_run time exists; if runtime is passed, check that
+    _last_run matches runtime.
     """
 
     # The number of times to
@@ -741,9 +740,17 @@ def test_eval_splay(schedule):
     schedule.opts.update(job)
 
     with patch("random.randint", MagicMock(return_value=10)):
-        # eval at 2:00pm to prime, simulate minion start up.
+        # eval at 2:00pm to prime, simulate minion start up; will run.
         run_time = dateutil.parser.parse("11/29/2017 2:00pm")
+        init_run_time = run_time
         schedule.eval(now=run_time)
+        assert _check_last_run(schedule, job_name, run_time)
+
+        # eval at 2:00:30pm, will not run.
+        run_time = dateutil.parser.parse("11/29/2017 2:00:30pm")
+        schedule.eval(now=run_time)
+        ret = schedule.job_status(job_name)
+        assert ret["_last_run"] == init_run_time
 
         # eval at 2:00:40pm, will run.
         run_time = dateutil.parser.parse("11/29/2017 2:00:40pm")
@@ -772,9 +779,17 @@ def test_eval_splay_range(schedule):
     schedule.opts.update(job)
 
     with patch("random.randint", MagicMock(return_value=10)):
-        # eval at 2:00pm to prime, simulate minion start up.
+        # eval at 2:00pm to prime, simulate minion start up; will run.
         run_time = dateutil.parser.parse("11/29/2017 2:00pm")
+        init_run_time = run_time
         schedule.eval(now=run_time)
+        assert _check_last_run(schedule, job_name, run_time)
+
+        # eval at 2:00:30pm, will not run.
+        run_time = dateutil.parser.parse("11/29/2017 2:00:30pm")
+        schedule.eval(now=run_time)
+        ret = schedule.job_status(job_name)
+        assert ret["_last_run"] == init_run_time
 
         # eval at 2:00:40pm, will run.
         run_time = dateutil.parser.parse("11/29/2017 2:00:40pm")
@@ -800,9 +815,17 @@ def test_eval_splay_global(schedule):
     schedule.opts.update(job)
 
     with patch("random.randint", MagicMock(return_value=10)):
-        # eval at 2:00pm to prime, simulate minion start up.
+        # eval at 2:00pm to prime, simulate minion start up; will run.
         run_time = dateutil.parser.parse("11/29/2017 2:00pm")
+        init_run_time = run_time
         schedule.eval(now=run_time)
+        assert _check_last_run(schedule, job_name, run_time)
+
+        # eval at 2:00:30pm, will not run.
+        run_time = dateutil.parser.parse("11/29/2017 2:00:30pm")
+        schedule.eval(now=run_time)
+        ret = schedule.job_status(job_name)
+        assert ret["_last_run"] == init_run_time
 
         # eval at 2:00:40pm, will run.
         run_time = dateutil.parser.parse("11/29/2017 2:00:40pm")

--- a/tests/pytests/unit/utils/scheduler/test_schedule.py
+++ b/tests/pytests/unit/utils/scheduler/test_schedule.py
@@ -335,7 +335,16 @@ def test_eval_schedule_time_eval(schedule):
     """
     schedule.opts.update({"pillar": {"schedule": {}}})
     schedule.opts.update(
-        {"schedule": {"testjob": {"function": "test.true", "seconds": 60, "splay": 5}}}
+        {
+            "schedule": {
+                "testjob": {
+                    "function": "test.true",
+                    "seconds": 60,
+                    "splay": 5,
+                    "run_on_start": False,
+                }
+            }
+        }
     )
     now = datetime.datetime.now()
     schedule.eval()

--- a/tests/pytests/unit/utils/scheduler/test_schedule.py
+++ b/tests/pytests/unit/utils/scheduler/test_schedule.py
@@ -391,7 +391,6 @@ def test_handle_func_schedule_minion_blackout(schedule):
     )
     data = {
         "function": "test.true",
-        "_next_scheduled_fire_time": datetime.datetime(2018, 11, 21, 14, 9, 53, 903438),
         "run": True,
         "name": "testjob",
         "seconds": 60,
@@ -416,7 +415,6 @@ def test_handle_func_check_data(schedule):
 
     data = {
         "function": "test.arg",
-        "_next_scheduled_fire_time": datetime.datetime(2018, 11, 21, 14, 9, 53, 903438),
         "run": True,
         "args": ["arg1", "arg2"],
         "kwargs": {"key1": "value1", "key2": "value2"},
@@ -450,7 +448,6 @@ def test_handle_func_check_dicts(schedule):
 
     data = {
         "function": "test.arg",
-        "_next_scheduled_fire_time": datetime.datetime(2018, 11, 21, 14, 9, 53, 903438),
         "run": True,
         "args": ["arg1", "arg2"],
         "kwargs": {"key1": "value1", "key2": "value2"},

--- a/tests/pytests/unit/utils/scheduler/test_skip.py
+++ b/tests/pytests/unit/utils/scheduler/test_skip.py
@@ -81,8 +81,9 @@ def test_skip_during_range(schedule):
     # Add job to schedule
     schedule.opts.update(job)
 
-    # eval at 1:30pm to prime.
+    # eval at 1:30pm to prime; will run.
     run_time = dateutil.parser.parse("11/29/2017 1:30pm")
+    init_run_time = run_time
     schedule.eval(now=run_time)
     ret = schedule.job_status(job_name)
 
@@ -90,7 +91,7 @@ def test_skip_during_range(schedule):
     run_time = dateutil.parser.parse("11/29/2017 2:30pm")
     schedule.eval(now=run_time)
     ret = schedule.job_status(job_name)
-    assert "_last_run" not in ret
+    assert ret["_last_run"] == init_run_time
     assert ret["_skip_reason"] == "in_skip_range"
     assert ret["_skipped_time"] == run_time
 
@@ -114,6 +115,7 @@ def test_skip_during_range_invalid_datestring(schedule):
                 "function": "test.ping",
                 "hours": "1",
                 "_next_fire_time": run_time,
+                "run_on_start": False,
                 "skip_during_range": {"start": "25pm", "end": "3pm"},
             }
         }
@@ -126,6 +128,7 @@ def test_skip_during_range_invalid_datestring(schedule):
                 "function": "test.ping",
                 "hours": "1",
                 "_next_fire_time": run_time,
+                "run_on_start": False,
                 "skip_during_range": {"start": "2pm", "end": "25pm"},
             }
         }
@@ -180,8 +183,9 @@ def test_skip_during_range_global(schedule):
     # Add job to schedule
     schedule.opts.update(job)
 
-    # eval at 1:30pm to prime.
+    # eval at 1:30pm to prime; will run.
     run_time = dateutil.parser.parse("11/29/2017 1:30pm")
+    init_run_time = run_time
     schedule.eval(now=run_time)
     ret = schedule.job_status(job_name)
 
@@ -189,7 +193,7 @@ def test_skip_during_range_global(schedule):
     run_time = dateutil.parser.parse("11/29/2017 2:30pm")
     schedule.eval(now=run_time)
     ret = schedule.job_status(job_name)
-    assert "_last_run" not in ret
+    assert ret["_last_run"] == init_run_time
     assert ret["_skip_reason"] == "in_skip_range"
     assert ret["_skipped_time"] == run_time
 

--- a/tests/pytests/unit/utils/scheduler/test_skip.py
+++ b/tests/pytests/unit/utils/scheduler/test_skip.py
@@ -104,7 +104,7 @@ def test_skip_during_range(schedule):
 
 def test_skip_during_range_invalid_datestring(schedule):
     """
-    verify that scheduled job is not not and returns the right error string
+    verify that scheduled job is not run and returns the right error string
     """
     run_time = dateutil.parser.parse("11/29/2017 2:30pm")
 


### PR DESCRIPTION
### What does this PR do?

1. Updates the default behavior of the `run_on_start` parameter to match the documentation and older salt behavior.
2. Update/extend unit tests accordingly.

### What issues does this PR fix or reference?
Fixes: #61964

### Initial Behavior
Jobs with seconds/minutes/hours/days parameters would run on startup by default.

### Regression from 391424c4e1859:
Such jobs no longer run on startup by default and need to be forced by `run_on_start: True'.

### New Behavior
Such jobs now run on startup by default again.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs (N/A--this fixes the code to match the docs)
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
