### PR TITLE
fix(modules/archive): fix regression introduced re: `common_prefix`

### DIFF
--- a/changelog/61968.fixed
+++ b/changelog/61968.fixed
@@ -1,0 +1,1 @@
+Ensure that `common_prefix` matching only occurs if a directory name is identified (in the `archive.list` execution module function, which affects the `archive.extracted` state).

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -429,7 +429,7 @@ def list_(
             # the common_prefix logic handles scenarios where the TLD
             # isn't listed as an archive member on its own
             common_prefix = os.path.commonprefix(ret["dirs"])
-            if common_prefix:
+            if "/" in common_prefix:
                 common_prefix = common_prefix.split("/")[0] + "/"
                 if common_prefix not in top_level_dirs:
                     top_level_dirs.append(common_prefix)


### PR DESCRIPTION
### What does this PR do?

Fix regression introduced in 3bab5bdd3f2cb1767bd8264374d665baed5f5049 (#61896).

Situation described in #61967.  As mentioned there, I've added this fix to the formulas' group Docker Hub images and now the failing CI is passing again:

* https://gitlab.com/myii/prometheus-formula/-/pipelines/519496855

In terms of the relevant tests in `salt/tests/pytests/functional/modules/test_archive.py`:

Test | Before #61896 | After #61896 | After this PR
--- | :-: | :-: | :-:
`test_tar_list_no_explicit_top_level_directory_member` | Fail | Pass | Pass
`test_tar_list_with_similar_top_level_dirs` | Pass | Fail | Pass

### What issues does this PR fix or reference?
Fixes: #61967.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes