### PR TITLE
No official packages for Ubuntu 16.04 LTS

### DIFF
--- a/doc/topics/installation/ubuntu.rst
+++ b/doc/topics/installation/ubuntu.rst
@@ -9,8 +9,8 @@ Ubuntu
 Installation from the Official SaltStack Repository
 ===================================================
 
-Packages for Ubuntu 20.04 (Focal), Ubuntu 18.04 (Bionic), and Ubuntu 16
-(Xenial) are available in the SaltStack repository.
+Packages for Ubuntu 20.04 (Focal) and 18.04 (Bionic)
+are available in the SaltStack repository.
 
 Instructions are at https://repo.saltproject.io/#ubuntu.
 


### PR DESCRIPTION
There are no official Salt packages built for Ubuntu 16.04 LTS any more.

### What does this PR do?
Fixes official documentation.

### Merge requirements satisfied?
- [x] Docs

### Commits signed with GPG?
No