### PR TITLE
fix nftables.delete not working when no position arg provided

### DIFF
--- a/salt/modules/nftables.py
+++ b/salt/modules/nftables.py
@@ -928,7 +928,9 @@ def delete(table, chain=None, position=None, rule=None, family='ipv4'):
     # nftables rules can only be deleted using the handle
     # if we don't have it, find it.
     if not position:
-        position = get_rule_handle(table, chain, rule, family)
+        res = get_rule_handle(table, chain, rule, family)
+        if res["result"]:
+            position = res["handle"]
 
     nft_family = _NFTABLES_FAMILIES[family]
     cmd = '{0} delete rule {1} {2} {3} handle {4}'.\


### PR DESCRIPTION
when position not provided, the data structure of position changes when sent out to cmd.run

### What does this PR do?

### What issues does this PR fix or reference?
Fixes: 
Error when calling nftables.delete with full rule (no position)
```
 [ERROR   ] stdout: Error: syntax error, unexpected '{', expecting number
                  delete rule ip filter INPUT handle {result: True, handle: 45}
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

Thoughts? @garethgreenaway  :)

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
