### PR TITLE
Fix Debian repo with trailing slash always shows changes

### DIFF
--- a/changelog/58807.fixed
+++ b/changelog/58807.fixed
@@ -1,0 +1,1 @@
+Clean repo uri before checking if it's present, avoiding ghost change.

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -393,6 +393,9 @@ def managed(name, ppa=None, copr=None, **kwargs):
             else salt.utils.data.is_true(enabled)
         )
 
+    elif __grains__["os_family"] == "Debian":
+        repo = salt.utils.pkg.deb.strip_uri(repo)
+
     for kwarg in _STATE_INTERNAL_KEYWORDS:
         kwargs.pop(kwarg, None)
 
@@ -411,9 +414,6 @@ def managed(name, ppa=None, copr=None, **kwargs):
         sanitizedkwargs = __salt__["pkg.expand_repo_def"](repo=repo, **kwargs)
     else:
         sanitizedkwargs = kwargs
-
-    if __grains__["os_family"] == "Debian":
-        repo = salt.utils.pkg.deb.strip_uri(repo)
 
     if pre:
         # 22412: Remove file attribute in case same repo is set up multiple times but with different files
@@ -622,8 +622,13 @@ def absent(name, **kwargs):
         ret["comment"] = "Repo key management is not implemented for this platform"
         return ret
 
+    if __grains__["os_family"] == "Debian":
+        stripname = salt.utils.pkg.deb.strip_uri(name)
+    else:
+        stripname = name
+
     try:
-        repo = __salt__["pkg.get_repo"](name, **kwargs)
+        repo = __salt__["pkg.get_repo"](stripname, **kwargs)
     except CommandExecutionError as exc:
         ret["result"] = False
         ret["comment"] = "Failed to configure repo '{}': {}".format(name, exc)
@@ -644,14 +649,14 @@ def absent(name, **kwargs):
         return ret
 
     try:
-        __salt__["pkg.del_repo"](repo=name, **kwargs)
+        __salt__["pkg.del_repo"](repo=stripname, **kwargs)
     except (CommandExecutionError, SaltInvocationError) as exc:
         ret["result"] = False
         ret["comment"] = exc.strerror
         return ret
 
     repos = __salt__["pkg.list_repos"]()
-    if name not in repos:
+    if stripname not in repos:
         ret["changes"]["repo"] = name
         ret["comment"] = "Removed repo {}".format(name)
 
@@ -659,7 +664,7 @@ def absent(name, **kwargs):
             ret["result"] = True
         else:
             try:
-                removed_keyid = __salt__["pkg.del_repo_key"](name, **kwargs)
+                removed_keyid = __salt__["pkg.del_repo_key"](stripname, **kwargs)
             except (CommandExecutionError, SaltInvocationError) as exc:
                 ret["result"] = False
                 ret["comment"] += ", but failed to remove key: {}".format(exc)

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -393,7 +393,7 @@ def managed(name, ppa=None, copr=None, **kwargs):
             else salt.utils.data.is_true(enabled)
         )
 
-    elif __grains__["os_family"] == "Debian":
+    if __grains__["os_family"] == "Debian":
         repo = salt.utils.pkg.deb.strip_uri(repo)
 
     for kwarg in _STATE_INTERNAL_KEYWORDS:

--- a/tests/pytests/functional/states/pkgrepo/test_debian.py
+++ b/tests/pytests/functional/states/pkgrepo/test_debian.py
@@ -467,28 +467,43 @@ def test_pkgrepo_with_architectures(pkgrepo, grains, sources_list_file, subtests
         assert ret.result is True
 
 
+@pytest.fixture
+def trailing_slash_repo_file(grains):
+    if grains["os_family"] != "Debian":
+        pytest.skip(
+            "Test only applicable to Debian flavors, not '{}'".format(
+                grains["osfinger"]
+            )
+        )
+    repo_file_path = "/etc/apt/sources.list.d/trailing-slash.list"
+    try:
+        yield repo_file_path
+    finally:
+        try:
+            os.unlink(repo_file_path)
+        except OSError:
+            pass
+
+
 @pytest.mark.requires_salt_states("pkgrepo.managed", "pkgrepo.absent")
-def test_repo_present_absent_trailing_slash_uri(pkgrepo):
+def test_repo_present_absent_trailing_slash_uri(pkgrepo, trailing_slash_repo_file):
     """
     test adding a repo with a trailing slash in the uri
     """
-    repo_file = "/etc/apt/sources.list.d/trailing-slash.list"
     repo_content = "deb http://www.deb-multimedia.org/ stable main"
     # initial creation
     ret = pkgrepo.managed(
-        name=repo_content, file=repo_file, refresh=False, clean_file=True
+        name=repo_content, file=trailing_slash_repo_file, refresh=False, clean_file=True
     )
-    with salt.utils.files.fopen(repo_file, "r") as fp:
+    with salt.utils.files.fopen(trailing_slash_repo_file, "r") as fp:
         file_content = fp.read()
     assert file_content.strip() == "deb http://www.deb-multimedia.org stable main"
     assert ret.changes
     # no changes
-    ret = pkgrepo.managed(name=repo_content, file=repo_file, refresh=False)
+    ret = pkgrepo.managed(
+        name=repo_content, file=trailing_slash_repo_file, refresh=False
+    )
     assert not ret.changes
     # absent
     ret = pkgrepo.absent(name=repo_content)
     assert ret.result
-    try:
-        os.unlink(repo_file)
-    except OSError:
-        pass

--- a/tests/pytests/functional/states/pkgrepo/test_debian.py
+++ b/tests/pytests/functional/states/pkgrepo/test_debian.py
@@ -465,3 +465,30 @@ def test_pkgrepo_with_architectures(pkgrepo, grains, sources_list_file, subtests
         assert not ret.changes
         assert "already" in ret.comment
         assert ret.result is True
+
+
+@pytest.mark.requires_salt_states("pkgrepo.managed", "pkgrepo.absent")
+def test_repo_present_absent_trailing_slash_uri(pkgrepo):
+    """
+    test adding a repo with a trailing slash in the uri
+    """
+    repo_file = "/etc/apt/sources.list.d/trailing-slash.list"
+    repo_content = "deb http://www.deb-multimedia.org/ stable main"
+    # initial creation
+    ret = pkgrepo.managed(
+        name=repo_content, file=repo_file, refresh=False, clean_file=True
+    )
+    with salt.utils.files.fopen(repo_file, "r") as fp:
+        file_content = fp.read()
+    assert file_content.strip() == "deb http://www.deb-multimedia.org stable main"
+    assert ret.changes
+    # no changes
+    ret = pkgrepo.managed(name=repo_content, file=repo_file, refresh=False)
+    assert not ret.changes
+    # absent
+    ret = pkgrepo.absent(name=repo_content)
+    assert ret.result
+    try:
+        os.unlink(repo_file)
+    except OSError:
+        pass


### PR DESCRIPTION
### What does this PR do?
The PR builds off the work by @Vaarlion in #59572 and adds tests for the fix.

### What issues does this PR fix or reference?
Fixes: #58807

### Previous Behavior
the code remove the trailing / from the URI after checking that the string in the file was the same as in the state.
So the applied state was never the same as the one checked, and the state would always return a change.

### New Behavior
check if the repo *without the trailing space* is already there first.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
