### PR TITLE
Fix 61010 - master pillar_cache caching _errors

### DIFF
--- a/changelog/61010.fixed
+++ b/changelog/61010.fixed
@@ -1,0 +1,1 @@
+Stop caching `_errors` when pillars are loaded and `pillar_cache: True`.

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -456,7 +456,11 @@ class PillarCache:
             pillar_override=self.pillar_override,
             pillarenv=self.pillarenv,
         )
-        return fresh_pillar.compile_pillar()
+        pillars = fresh_pillar.compile_pillar()
+        # Could .pop instead, but LBYL is slightly faster
+        if "_errors" in pillars:
+            del pillars["_errors"]
+        return pillars
 
     def clear_pillar(self):
         """

--- a/tests/pytests/unit/pillar/test_pillar.py
+++ b/tests/pytests/unit/pillar/test_pillar.py
@@ -125,7 +125,6 @@ def test_pillar_envs_path_substitution(env, temp_salt_minion, tmp_path):
     assert pillar.opts["pillar_roots"] == expected
 
 
-@pytest.mark.xfail
 def test_issue_61010_do_not_cache_pillar_errors(temp_salt_minion):
     expected_cache_data = {"some": "totally cool pillar data"}
     with patch("salt.pillar.Pillar", autospec=True) as fake_pillar:


### PR DESCRIPTION
### What does this PR do?

What it says on the tin.


### What issues does this PR fix or reference?

Fixes #61010

### Previous Behavior

When rendering pillars, if any of the pillar renders produced `_errors` we
would store that in the pillar cache (see 61010). Since errors aren't actually
pillar data it doesn't make any sense to store them.

### New Behavior

Now we filter out the `_errors` from returned pillar data, and no longer cache
it.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
~- [ ] Docs~
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?

Yes
