### PR TITLE
Add dig.cname function

### DIFF
--- a/changelog/61991.added
+++ b/changelog/61991.added
@@ -1,0 +1,1 @@
+Add CNAME record support to the dig exec module

--- a/salt/modules/dig.py
+++ b/salt/modules/dig.py
@@ -137,7 +137,7 @@ def CNAME(host, nameserver=None):
 
     .. code-block:: bash
 
-        salt ns1 dig.CNAME www.google.com
+        salt ns1 dig.CNAME mail.google.com
     """
     dig = ["dig", "+short", str(host), "CNAME"]
 

--- a/salt/modules/dig.py
+++ b/salt/modules/dig.py
@@ -129,6 +129,33 @@ def AAAA(host, nameserver=None):
     return [x for x in cmd["stdout"].split("\n") if check_ip(x)]
 
 
+def CNAME(host, nameserver=None):
+    """
+    Return the CNAME record for ``host``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt ns1 dig.CNAME www.google.com
+    """
+    dig = ["dig", "+short", str(host), "CNAME"]
+
+    if nameserver is not None:
+        dig.append("@{}".format(nameserver))
+
+    cmd = __salt__["cmd.run_all"](dig, python_shell=False)
+    # In this case, 0 is not the same as False
+    if cmd["retcode"] != 0:
+        log.warning(
+            "dig returned exit code '%s'.",
+            cmd["retcode"],
+        )
+        return []
+
+    return cmd["stdout"]
+
+
 def NS(domain, resolve=True, nameserver=None):
     """
     Return a list of IPs of the nameservers for ``domain``
@@ -291,6 +318,7 @@ def TXT(host, nameserver=None):
 # Let lowercase work, since that is the convention for Salt functions
 a = A
 aaaa = AAAA
+cname = CNAME
 ns = NS
 spf = SPF
 mx = MX

--- a/salt/modules/dig.py
+++ b/salt/modules/dig.py
@@ -133,6 +133,8 @@ def CNAME(host, nameserver=None):
     """
     Return the CNAME record for ``host``.
 
+    .. versionadded:: 3005
+
     CLI Example:
 
     .. code-block:: bash

--- a/tests/pytests/unit/modules/test_dig.py
+++ b/tests/pytests/unit/modules/test_dig.py
@@ -1,0 +1,41 @@
+import pytest
+import salt.modules.cmdmod as cmdmod
+import salt.modules.dig as dig
+from tests.support.mock import MagicMock, patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {
+        dig: {
+            "__salt__": {
+                "cmd.run_all": cmdmod.run_all,
+            },
+        }
+    }
+
+
+def test_dig_cname_found():
+    dig_mock = MagicMock(
+        return_value={
+            "pid": 2018,
+            "retcode": 0,
+            "stderr": "",
+            "stdout": "bellanotte1986.github.io.",
+        }
+    )
+    with patch.dict(dig.__salt__, {"cmd.run_all": dig_mock}):
+        assert dig.CNAME("www.eitr.tech") == "bellanotte1986.github.io."
+
+
+def test_dig_cname_none_found():
+    dig_mock = MagicMock(
+        return_value={
+            "pid": 2022,
+            "retcode": 0,
+            "stderr": "",
+            "stdout": "",
+        }
+    )
+    with patch.dict(dig.__salt__, {"cmd.run_all": dig_mock}):
+        assert dig.CNAME("www.google.com") == ""


### PR DESCRIPTION
### What does this PR do?
This PR adds a function to the `dig` execution module which supports returning CNAME records for a given host.

### What issues does this PR fix or reference?
Fixes: #61991

### New Behavior
New function to support CNAME record queries via dig.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
