### PR TITLE
Fix parallel state run time output

### DIFF
--- a/changelog/61999.fixed
+++ b/changelog/61999.fixed
@@ -1,0 +1,1 @@
+When states are running in parallel, ensure that the total run time produced by the highstate outputter takes that into account.

--- a/salt/state.py
+++ b/salt/state.py
@@ -2020,6 +2020,7 @@ class State:
         # duration in milliseconds.microseconds
         duration = (delta.seconds * 1000000 + delta.microseconds) / 1000.0
         ret["duration"] = duration
+        ret["__parallel__"] = True
 
         troot = os.path.join(self.opts["cachedir"], self.jid)
         tfile = os.path.join(troot, salt.utils.hashutils.sha1_digest(tag))

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -9,7 +9,6 @@ This is a base library used by a number of AWS services.
 """
 
 import binascii
-import copy
 import hashlib
 import hmac
 import logging
@@ -187,9 +186,9 @@ def assumed_creds(prov_dict, role_arn, location=None):
     # current time in epoch seconds
     now = time.mktime(datetime.utcnow().timetuple())
 
-    for key, creds in copy.deepcopy(__AssumeCache__.items()):
+    for key, creds in __AssumeCache__.items():
         if (creds["Expiration"] - now) <= 120:
-            del __AssumeCache__[key]
+            __AssumeCache__[key].delete()
 
     if role_arn in __AssumeCache__:
         c = __AssumeCache__[role_arn]

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -9,6 +9,7 @@ This is a base library used by a number of AWS services.
 """
 
 import binascii
+import copy
 import hashlib
 import hmac
 import logging
@@ -186,9 +187,9 @@ def assumed_creds(prov_dict, role_arn, location=None):
     # current time in epoch seconds
     now = time.mktime(datetime.utcnow().timetuple())
 
-    for key, creds in __AssumeCache__.items():
+    for key, creds in copy.deepcopy(__AssumeCache__.items()):
         if (creds["Expiration"] - now) <= 120:
-            __AssumeCache__.delete(key)
+            del __AssumeCache__[key]
 
     if role_arn in __AssumeCache__:
         c = __AssumeCache__[role_arn]

--- a/tests/pytests/functional/modules/state/requisites/test_require.py
+++ b/tests/pytests/functional/modules/state/requisites/test_require.py
@@ -596,7 +596,7 @@ def test_parallel_state_with_requires(state, state_tree):
     """
     with pytest.helpers.temp_file("requisite.sls", sls_contents, state_tree):
         start_time = time.time()
-        state.sls(
+        ret = state.sls(
             "requisite",
             __pub_jid="1",  # Because these run in parallel we need a fake JID)
         )
@@ -606,6 +606,10 @@ def test_parallel_state_with_requires(state, state_tree):
         # they'll run in parallel so we should be below 30 seconds
         # confirm that the total runtime is below 30s
         assert (end_time - start_time) < 30
+
+        for item in range(1, 10):
+            _id = "cmd_|-blah-{}_|-sleep 2_|-run".format(item)
+            assert "__parallel__" in ret[_id]
 
 
 def test_issue_59922_conflict_in_name_and_id_for_require_in(state, state_tree):

--- a/tests/pytests/functional/modules/state/requisites/test_require.py
+++ b/tests/pytests/functional/modules/state/requisites/test_require.py
@@ -571,6 +571,7 @@ def test_issue_38683_require_order_failhard_combination(state, state_tree):
 
 
 @pytest.mark.slow_test
+@pytest.mark.skip_on_windows
 def test_parallel_state_with_requires(state, state_tree):
     """
     This is a test case for https://github.com/saltstack/salt/issues/49273

--- a/tests/pytests/unit/output/test_highstate.py
+++ b/tests/pytests/unit/output/test_highstate.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 import sys
 
 import pytest
@@ -6,6 +7,8 @@ import salt.config
 import salt.output.highstate as highstate
 from tests.support.mock import patch
 from tests.support.unit import skipIf
+
+log = logging.getLogger(__name__)
 
 
 @pytest.fixture
@@ -593,3 +596,150 @@ def test__compress_ids_multiple_module_functions():
     assert "Succeeded: 2 (changed=1)" in actual_output
     assert "Failed:    0" in actual_output
     assert "Total states run:     2" in actual_output
+
+
+def test_parallel_summary_output():
+    data = {
+        "local": {
+            "test_|-barrier_|-barrier_|-nop": {
+                "name": "barrier",
+                "changes": {},
+                "result": True,
+                "comment": "Success!",
+                "__sls__": "test.49273",
+                "__run_num__": 0,
+                "start_time": "15:11:31.459770",
+                "duration": 0.698,
+                "__id__": "barrier",
+            },
+            "cmd_|-blah-1_|-sleep 10_|-run": {
+                "name": "sleep 10",
+                "result": True,
+                "changes": {"pid": 524313, "retcode": 0, "stdout": "", "stderr": ""},
+                "comment": 'Command "sleep 10" run',
+                "__sls__": "test.49273",
+                "__run_num__": 1,
+                "start_time": "15:11:31.496410",
+                "duration": 10007.711,
+                "__id__": "blah-1",
+                "__parallel__": True,
+            },
+            "cmd_|-blah-2_|-sleep 10_|-run": {
+                "name": "sleep 10",
+                "result": True,
+                "changes": {"pid": 524315, "retcode": 0, "stdout": "", "stderr": ""},
+                "comment": 'Command "sleep 10" run',
+                "__sls__": "test.49273",
+                "__run_num__": 2,
+                "start_time": "15:11:31.537001",
+                "duration": 10007.264,
+                "__id__": "blah-2",
+                "__parallel__": True,
+            },
+            "cmd_|-blah-3_|-sleep 10_|-run": {
+                "name": "sleep 10",
+                "result": True,
+                "changes": {"pid": 524317, "retcode": 0, "stdout": "", "stderr": ""},
+                "comment": 'Command "sleep 10" run',
+                "__sls__": "test.49273",
+                "__run_num__": 3,
+                "start_time": "15:11:31.577076",
+                "duration": 10008.646,
+                "__id__": "blah-3",
+                "__parallel__": True,
+            },
+            "test_|-barrier2_|-barrier2_|-nop": {
+                "name": "barrier2",
+                "changes": {},
+                "result": True,
+                "comment": "Success!",
+                "__sls__": "test.49273",
+                "__run_num__": 4,
+                "start_time": "15:11:41.619874",
+                "duration": 0.762,
+                "__id__": "barrier2",
+            },
+        }
+    }
+
+    actual_output = highstate.output(data)
+
+    assert "Succeeded: 5 (changed=3)" in actual_output
+    assert "Failed:    0" in actual_output
+    assert "Total states run:     5" in actual_output
+
+    # The three main states were run in parallel and slept for
+    # 10 seconds each so the total run time should around 10 seconds
+    assert "Total run time:  10.010 s" in actual_output
+
+
+def test_summary_output():
+    data = {
+        "local": {
+            "test_|-barrier_|-barrier_|-nop": {
+                "name": "barrier",
+                "changes": {},
+                "result": True,
+                "comment": "Success!",
+                "__sls__": "test.49273",
+                "__run_num__": 0,
+                "start_time": "15:11:31.459770",
+                "duration": 0.698,
+                "__id__": "barrier",
+            },
+            "cmd_|-blah-1_|-sleep 10_|-run": {
+                "name": "sleep 10",
+                "result": True,
+                "changes": {"pid": 524313, "retcode": 0, "stdout": "", "stderr": ""},
+                "comment": 'Command "sleep 10" run',
+                "__sls__": "test.49273",
+                "__run_num__": 1,
+                "start_time": "15:11:31.496410",
+                "duration": 10007.711,
+                "__id__": "blah-1",
+            },
+            "cmd_|-blah-2_|-sleep 10_|-run": {
+                "name": "sleep 10",
+                "result": True,
+                "changes": {"pid": 524315, "retcode": 0, "stdout": "", "stderr": ""},
+                "comment": 'Command "sleep 10" run',
+                "__sls__": "test.49273",
+                "__run_num__": 2,
+                "start_time": "15:11:31.537001",
+                "duration": 10007.264,
+                "__id__": "blah-2",
+            },
+            "cmd_|-blah-3_|-sleep 10_|-run": {
+                "name": "sleep 10",
+                "result": True,
+                "changes": {"pid": 524317, "retcode": 0, "stdout": "", "stderr": ""},
+                "comment": 'Command "sleep 10" run',
+                "__sls__": "test.49273",
+                "__run_num__": 3,
+                "start_time": "15:11:31.577076",
+                "duration": 10008.646,
+                "__id__": "blah-3",
+            },
+            "test_|-barrier2_|-barrier2_|-nop": {
+                "name": "barrier2",
+                "changes": {},
+                "result": True,
+                "comment": "Success!",
+                "__sls__": "test.49273",
+                "__run_num__": 4,
+                "start_time": "15:11:41.619874",
+                "duration": 0.762,
+                "__id__": "barrier2",
+            },
+        }
+    }
+
+    actual_output = highstate.output(data)
+
+    assert "Succeeded: 5 (changed=3)" in actual_output
+    assert "Failed:    0" in actual_output
+    assert "Total states run:     5" in actual_output
+
+    # The three main states were not run in parallel and slept for
+    # 10 seconds each so the total run time should around 30 seconds
+    assert "Total run time:  30.025 s" in actual_output


### PR DESCRIPTION
### What does this PR do?
When states are running in parallel, ensure that the total run time produced by the highstate outputter takes that into account.

### What issues does this PR fix or reference?
Fixes: #61999 

### Previous Behavior
When running states in parallel the total run time was incorrect, combining the runtime for all sates.

### New Behavior
When running states in parallel, we calculate the run time for states that were not run in parallel as normal and add the duration of the longest running parallel state run.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
