### PR TITLE
add LastDeploymentChangeTime to updates info

### DIFF
--- a/salt/utils/win_update.py
+++ b/salt/utils/win_update.py
@@ -179,6 +179,7 @@ class Updates:
                 "KBs": ["KB" + item for item in update.KBArticleIDs],
                 "Categories": [item.Name for item in update.Categories],
                 "SupportUrl": update.SupportUrl,
+                "LastDeploymentChangeTime": str(update.LastDeploymentChangeTime),
             }
 
         return results


### PR DESCRIPTION
### What does this PR do?

Adds the field `IUpdate::LastDeploymentChangeTime` to the `IUpdate` json object (ref: https://docs.microsoft.com/en-us/windows/win32/api/wuapi/nf-wuapi-iupdate-get_lastdeploymentchangetime).

### What issues does this PR fix or reference?

N/A

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

It's a 1-line change...

### Commits signed with GPG?

No.

It's a 1-line change. Please don't make me do this.
