### PR TITLE
Add win_shortcut execution and state modules

### DIFF
--- a/changelog/53706.added
+++ b/changelog/53706.added
@@ -1,0 +1,1 @@
+Added win_shortcut execution and state module that does not prepend the current working directory to paths. Use shortcut.create and shortcut.present instead of file.shortcut.

--- a/changelog/53706.fixed
+++ b/changelog/53706.fixed
@@ -1,0 +1,1 @@
+Fixes issue with current directory being prepended to all paths

--- a/changelog/53706.fixed
+++ b/changelog/53706.fixed
@@ -1,1 +1,0 @@
-Fixes issue with current directory being prepended to all paths

--- a/changelog/61170.added
+++ b/changelog/61170.added
@@ -1,0 +1,1 @@
+Added new shortcut execution and state module to better handle UNC shortcuts and to test more thoroughly

--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -526,6 +526,7 @@ execution modules
     win_servermanager
     win_service
     win_shadow
+    win_shortcut
     win_smtp_server
     win_snmp
     win_status

--- a/doc/ref/modules/all/salt.modules.win_shortcut.rst
+++ b/doc/ref/modules/all/salt.modules.win_shortcut.rst
@@ -1,0 +1,5 @@
+salt.modules.win_shortcut
+=========================
+
+.. automodule:: salt.modules.win_shortcut
+    :members:

--- a/doc/ref/states/all/index.rst
+++ b/doc/ref/states/all/index.rst
@@ -335,6 +335,7 @@ state modules
     win_pki
     win_powercfg
     win_servermanager
+    win_shortcut
     win_smtp_server
     win_snmp
     win_system

--- a/doc/ref/states/all/salt.states.win_shortcut.rst
+++ b/doc/ref/states/all/salt.states.win_shortcut.rst
@@ -1,0 +1,5 @@
+salt.states.win_shortcut
+========================
+
+.. automodule:: salt.states.win_shortcut
+    :members:

--- a/salt/modules/win_shortcut.py
+++ b/salt/modules/win_shortcut.py
@@ -1,3 +1,9 @@
+"""
+Execution module for creating shortcuts on Windows. Handles file shortcuts
+(`.lnk`) and url shortcuts (`.url`). Allows for the configuration of icons and
+hot keys on file shortcuts. Changing the icon and hot keys are unsupported for
+url shortcuts.
+"""
 # https://docs.microsoft.com/en-us/troubleshoot/windows-client/admin-development/create-desktop-shortcut-with-wsh
 # https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/f5y78918(v=vs.84)
 import logging
@@ -49,6 +55,23 @@ def __virtual__():
 
 
 def get(path):
+    """
+    Gets the properties for a shortcut
+
+    Args:
+        path (str): The path to the shortcut
+
+    Returns:
+        dict: A dictionary containing all available properties for the specified
+            shortcut
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt * shortcut.get path="C:\path\to\shortcut.lnk"
+    ..
+    """
     if not os.path.exists(path):
         raise CommandExecutionError("Shortcut not found: {}".format(path))
 
@@ -110,6 +133,56 @@ def _set_info(
     window_style="Normal",
     working_dir="",
 ):
+    """
+    The main worker function for creating and modifying shortcuts. the `create`
+    and `modify` functions are wrappers around this function.
+
+    Args:
+
+        path (str): The full path to the shortcut
+
+        target (str): The full path to the target
+
+        arguments (str, optional): Any arguments to be passed to the target
+
+        description (str, optional): The description for the shortcut. This is
+            shown in the ``Comment`` field of the dialog box. Default is an
+            empty string
+
+        hot_key (str, optional): A combination of hot Keys to trigger this
+            shortcut. This is something like ``Ctrl+Alt+D``. This is shown in
+            the ``Shortcut key`` field in the dialog box. Default is an empty
+            string. Available options are:
+
+            - Ctrl
+            - Alt
+            - Shift
+            - Ext
+
+        icon_index (int, optional): The index for the icon to use in files that
+            contain multiple icons. Default is 0
+
+        icon_location (str, optional): The full path to a file containing icons.
+            This is shown in the ``Change Icon`` dialog box by clicking the
+            ``Change Icon`` button. If no file is specified and a binary is
+            passed as the target, Windows will attempt to get the icon from the
+            binary file. Default is an empty string
+
+        window_style (str, optional): The window style the program should start
+            in. This is shown in the ``Run`` field of the dialog box. Default is
+            ``Normal``. Valid options are:
+
+            - Normal
+            - Minimized
+            - Maximized
+
+        working_dir (str, optional): The full path to the working directory for
+            the program to run in. This is shown in the ``Start in`` field of
+            the dialog box.
+
+    Returns:
+        bool: True if successful
+    """
     path = salt.utils.path.expand(path)
 
     # This will load the existing shortcut if it already exists
@@ -154,6 +227,63 @@ def modify(
     window_style="Normal",
     working_dir="",
 ):
+    """
+    Modify an existing shortcut. This can be a file shortcut (``.lnk``) or a
+    url shortcut (``.url``).
+
+    Args:
+
+        path (str): The full path to the shortcut
+
+        target (str): The full path to the target
+
+        arguments (str, optional): Any arguments to be passed to the target
+
+        description (str, optional): The description for the shortcut. This is
+            shown in the ``Comment`` field of the dialog box. Default is an
+            empty string
+
+        hot_key (str, optional): A combination of hot Keys to trigger this
+            shortcut. This is something like ``Ctrl+Alt+D``. This is shown in
+            the ``Shortcut key`` field in the dialog box. Default is an empty
+            string. Available options are:
+
+            - Ctrl
+            - Alt
+            - Shift
+            - Ext
+
+        icon_index (int, optional): The index for the icon to use in files that
+            contain multiple icons. Default is 0
+
+        icon_location (str, optional): The full path to a file containing icons.
+            This is shown in the ``Change Icon`` dialog box by clicking the
+            ``Change Icon`` button. If no file is specified and a binary is
+            passed as the target, Windows will attempt to get the icon from the
+            binary file. Default is an empty string
+
+        window_style (str, optional): The window style the program should start
+            in. This is shown in the ``Run`` field of the dialog box. Default is
+            ``Normal``. Valid options are:
+
+            - Normal
+            - Minimized
+            - Maximized
+
+        working_dir (str, optional): The full path to the working directory for
+            the program to run in. This is shown in the ``Start in`` field of
+            the dialog box.
+
+    Returns:
+        bool: True if successful
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        # Modify an existing shortcut. Set it to target notepad.exe
+        salt * shortcut.modify "C:\path\to\shortcut.lnk" "C:\Windows\notepad.exe"
+    """
     if not os.path.exists(path):
         raise CommandExecutionError("Shortcut not found: {}".format(path))
 
@@ -185,6 +315,105 @@ def create(
     make_dirs=False,
     user=None,
 ):
+    """
+    Create a new shortcut. This can be a file shortcut (``.lnk``) or a url
+    shortcut (``.url``).
+
+    Args:
+
+        path (str): The full path to the shortcut
+
+        target (str): The full path to the target
+
+        arguments (str, optional): Any arguments to be passed to the target
+
+        description (str, optional): The description for the shortcut. This is
+            shown in the ``Comment`` field of the dialog box. Default is an
+            empty string
+
+        hot_key (str, optional): A combination of hot Keys to trigger this
+            shortcut. This is something like ``Ctrl+Alt+D``. This is shown in
+            the ``Shortcut key`` field in the dialog box. Default is an empty
+            string. Available options are:
+
+            - Ctrl
+            - Alt
+            - Shift
+            - Ext
+
+        icon_index (int, optional): The index for the icon to use in files that
+            contain multiple icons. Default is 0
+
+        icon_location (str, optional): The full path to a file containing icons.
+            This is shown in the ``Change Icon`` dialog box by clicking the
+            ``Change Icon`` button. If no file is specified and a binary is
+            passed as the target, Windows will attempt to get the icon from the
+            binary file. Default is an empty string
+
+        window_style (str, optional): The window style the program should start
+            in. This is shown in the ``Run`` field of the dialog box. Default is
+            ``Normal``. Valid options are:
+
+            - Normal
+            - Minimized
+            - Maximized
+
+        working_dir (str, optional): The full path to the working directory for
+            the program to run in. This is shown in the ``Start in`` field of
+            the dialog box.
+
+        backup (bool, optional): If there is already a shortcut with the same
+            name, set this value to ``True`` to backup the existing shortcut and
+            continue creating the new shortcut. Default is ``False``
+
+        force (bool, optional): If there is already a shortcut with the same
+            name and you aren't backing up the shortcut, set this value to
+            ``True`` to remove the existing shortcut and create a new with these
+            settings. Default is ``False``
+
+        make_dirs (bool, optional): If the parent directory structure does not
+            exist for the new shortcut, create it. Default is ``False``
+
+        user (str, optional): The user to be the owner of any directories
+            created by setting ``make_dirs`` to ``True``. If no value is passed
+            Salt will use the user account that it is running under. Default is
+            an empty string.
+
+    Returns:
+        bool: True if successful
+
+    Raises:
+        CommandExecutionError: If the path is not a ``.lnk`` or ``.url`` file
+            extension.
+        CommandExecutionError: If there is an existing shortcut with the same
+            name and ``backup`` and ``force`` are both ``False``
+        CommandExecutionError: If the parent directory is not created and
+            ``make_dirs`` is ``False``
+        CommandExecutionError: If there was an error creating the parent
+            directories
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        # Create a shortcut and set the ``Shortcut key`` (``hot_key``)
+        salt * shortcut.create "C:\path\to\shortcut.lnk" "C:\Windows\notepad.exe" hot_key="Ctrl+Alt+N"
+
+        # Create a shortcut and change the icon to the 3rd one in the icon file
+        salt * shortcut.create "C:\path\to\shortcut.lnk" "C:\Windows\notepad.exe" icon_location="C:\path\to\icon.ico" icon_index=2
+
+        # Create a shortcut and change the startup mode to full screen
+        salt * shortcut.create "C:\path\to\shortcut.lnk" "C:\Windows\notepad.exe" window_style="Maximized"
+
+        # Create a shortcut and change the icon
+        salt * shortcut.create "C:\path\to\shortcut.lnk" "C:\Windows\notepad.exe" icon_location="C:\path\to\icon.ico"
+
+        # Create a shortcut and force it to overwrite an existing shortcut
+        salt * shortcut.create "C:\path\to\shortcut.lnk" "C:\Windows\notepad.exe" force=True
+
+        # Create a shortcut and create any parent directories if they are missing
+        salt * shortcut.create "C:\path\to\shortcut.lnk" "C:\Windows\notepad.exe" make_dirs=True
+    """
     if not path.endswith((".lnk", ".url")):
         _, ext = os.path.splitext(path)
         raise CommandExecutionError("Invalid file extension: {}".format(ext))

--- a/salt/modules/win_shortcut.py
+++ b/salt/modules/win_shortcut.py
@@ -13,7 +13,6 @@ import time
 import salt.utils.path
 import salt.utils.platform
 import salt.utils.winapi
-
 from salt.exceptions import CommandExecutionError
 
 HAS_WIN32 = False
@@ -55,7 +54,7 @@ def __virtual__():
 
 
 def get(path):
-    """
+    r"""
     Gets the properties for a shortcut
 
     Args:
@@ -133,7 +132,7 @@ def _set_info(
     window_style="Normal",
     working_dir="",
 ):
-    """
+    r"""
     The main worker function for creating and modifying shortcuts. the `create`
     and `modify` functions are wrappers around this function.
 
@@ -227,7 +226,7 @@ def modify(
     window_style="Normal",
     working_dir="",
 ):
-    """
+    r"""
     Modify an existing shortcut. This can be a file shortcut (``.lnk``) or a
     url shortcut (``.url``).
 
@@ -315,7 +314,7 @@ def create(
     make_dirs=False,
     user=None,
 ):
-    """
+    r"""
     Create a new shortcut. This can be a file shortcut (``.lnk``) or a url
     shortcut (``.url``).
 
@@ -420,16 +419,16 @@ def create(
 
     if os.path.exists(path):
         if backup:
-            log.debug("Backing up: {}".format(path))
+            log.debug("Backing up: %s", path)
             file, ext = os.path.splitext(path)
             ext = ext.strip(".")
             backup_path = "{}-{}.{}".format(file, time.time_ns(), ext)
             os.rename(path, backup_path)
         elif force:
-            log.debug("Removing: {}".format(path))
+            log.debug("Removing: %s", path)
             os.remove(path)
         else:
-            log.debug("Shortcut exists: {}".format(path))
+            log.debug("Shortcut exists: %s", path)
             raise CommandExecutionError("Found existing shortcut")
 
     if not os.path.isdir(os.path.dirname(path)):

--- a/salt/modules/win_shortcut.py
+++ b/salt/modules/win_shortcut.py
@@ -1,5 +1,4 @@
 """
-.. versionadded:: 3005
 Execution module for creating shortcuts on Windows. Handles file shortcuts
 (`.lnk`) and url shortcuts (`.url`). Allows for the configuration of icons and
 hot keys on file shortcuts. Changing the icon and hot keys are unsupported for
@@ -73,7 +72,6 @@ def get(path):
     .. code-block:: bash
 
         salt * shortcut.get path="C:\path\to\shortcut.lnk"
-    ..
     """
     if not os.path.exists(path):
         raise CommandExecutionError("Shortcut not found: {}".format(path))

--- a/salt/modules/win_shortcut.py
+++ b/salt/modules/win_shortcut.py
@@ -1,0 +1,243 @@
+# https://docs.microsoft.com/en-us/troubleshoot/windows-client/admin-development/create-desktop-shortcut-with-wsh
+# https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/windows-scripting/f5y78918(v=vs.84)
+import logging
+import os
+import time
+
+import salt.utils.path
+import salt.utils.platform
+import salt.utils.winapi
+
+from salt.exceptions import CommandExecutionError
+
+HAS_WIN32 = False
+if salt.utils.platform.is_windows():
+    import win32com.client
+
+    HAS_WIN32 = True
+
+# Set up logging
+log = logging.getLogger(__name__)
+
+# Define the module's virtual name
+__virtualname__ = "shortcut"
+
+
+WINDOW_STYLE = {
+    1: "Normal",
+    3: "Maximized",
+    7: "Minimized",
+    "Normal": 1,
+    "Maximized": 3,
+    "Minimized": 7,
+}
+
+
+def __virtual__():
+    """
+    Make sure we're on Windows
+    """
+    # Verify Windows
+    if not salt.utils.platform.is_windows():
+        log.debug("Shortcut module only available on Windows systems")
+        return False, "Shortcut module only available on Windows systems"
+    if not HAS_WIN32:
+        log.debug("Shortcut module requires pywin32")
+        return False, "Shortcut module requires pywin32"
+
+    return __virtualname__
+
+
+def get(path):
+    if not os.path.exists(path):
+        raise CommandExecutionError("Shortcut not found: {}".format(path))
+
+    # This will load the existing shortcut
+    with salt.utils.winapi.Com():
+        shell = win32com.client.Dispatch("WScript.Shell")
+        shortcut = shell.CreateShortcut(path)
+
+        arguments = ""
+        description = ""
+        hot_key = ""
+        icon_location = ""
+        icon_index = 0
+        window_style = ""
+        working_dir = ""
+
+        path = salt.utils.path.expand(shortcut.FullName)
+        # A shortcut can have either a .lnk or a .url exension. We only want to
+        # expand the target if it is a .lnk
+        if path.endswith(".lnk"):
+            target = salt.utils.path.expand(shortcut.TargetPath)
+            if shortcut.Arguments:
+                arguments = shortcut.Arguments
+            if shortcut.Description:
+                description = shortcut.Description
+            if shortcut.Hotkey:
+                hot_key = shortcut.Hotkey
+            if shortcut.IconLocation:
+                icon_location, icon_index = shortcut.IconLocation.split(",")
+                icon_location = salt.utils.path.expand(icon_location)
+            if shortcut.WindowStyle:
+                window_style = WINDOW_STYLE[shortcut.WindowStyle]
+            if shortcut.WorkingDirectory:
+                working_dir = salt.utils.path.expand(shortcut.WorkingDirectory)
+        else:
+            target = shortcut.TargetPath
+
+        return {
+            "arguments": arguments,
+            "description": description,
+            "hot_key": hot_key,
+            "icon_index": int(icon_index),
+            "icon_location": icon_location,
+            "path": path,
+            "target": target,
+            "window_style": window_style,
+            "working_dir": working_dir,
+        }
+
+
+def _set_info(
+    path,
+    target,
+    arguments="",
+    description="",
+    hot_key="",
+    icon_index=0,
+    icon_location="",
+    window_style="Normal",
+    working_dir="",
+):
+    path = salt.utils.path.expand(path)
+
+    # This will load the existing shortcut if it already exists
+    # If it is a new shortcut, it won't be created until it is saved
+    with salt.utils.winapi.Com():
+        shell = win32com.client.Dispatch("WScript.Shell")
+        shortcut = shell.CreateShortcut(path)
+
+        # A shortcut can have either a .lnk or a .url exension. We only want to
+        # expand the target if it is a .lnk
+        if path.endswith(".lnk"):
+            target = salt.utils.path.expand(target)
+
+            # These settings only apply to lnk shortcuts
+            if arguments:
+                shortcut.Arguments = arguments
+            if description:
+                shortcut.Description = description
+            if hot_key:
+                shortcut.Hotkey = hot_key
+            if icon_location:
+                shortcut.IconLocation = ",".join([icon_location, str(icon_index)])
+            if window_style:
+                shortcut.WindowStyle = WINDOW_STYLE[window_style]
+            if working_dir:
+                shortcut.WorkingDirectory = working_dir
+
+        shortcut.TargetPath = target
+
+        shortcut.Save()
+    return True
+
+
+def modify(
+    path,
+    target,
+    arguments="",
+    description="",
+    hot_key="",
+    icon_index=0,
+    icon_location="",
+    window_style="Normal",
+    working_dir="",
+):
+    if not os.path.exists(path):
+        raise CommandExecutionError("Shortcut not found: {}".format(path))
+
+    return _set_info(
+        path=path,
+        arguments=arguments,
+        description=description,
+        hot_key=hot_key,
+        icon_index=icon_index,
+        icon_location=icon_location,
+        target=target,
+        window_style=window_style,
+        working_dir=working_dir,
+    )
+
+
+def create(
+    path,
+    target,
+    arguments="",
+    description="",
+    hot_key="",
+    icon_index=0,
+    icon_location="",
+    window_style="Normal",
+    working_dir="",
+    backup=False,
+    force=False,
+    make_dirs=False,
+    user=None,
+):
+    if not path.endswith((".lnk", ".url")):
+        _, ext = os.path.splitext(path)
+        raise CommandExecutionError("Invalid file extension: {}".format(ext))
+
+    if os.path.exists(path):
+        if backup:
+            log.debug("Backing up: {}".format(path))
+            file, ext = os.path.splitext(path)
+            ext = ext.strip(".")
+            backup_path = "{}-{}.{}".format(file, time.time_ns(), ext)
+            os.rename(path, backup_path)
+        elif force:
+            log.debug("Removing: {}".format(path))
+            os.remove(path)
+        else:
+            log.debug("Shortcut exists: {}".format(path))
+            raise CommandExecutionError("Found existing shortcut")
+
+    if not os.path.isdir(os.path.dirname(path)):
+        if make_dirs:
+
+            # Get user from opts if not defined
+            if not user:
+                user = __opts__["user"]
+
+            # Make sure the user exists in Windows
+            # Salt default is 'SYSTEM' for Windows
+            if not __salt__["user.info"](user):
+                # User not found, use the account salt is running under
+                # If username not found, use System
+                user = __salt__["user.current"]()
+                if not user:
+                    user = "SYSTEM"
+
+            try:
+                __salt__["file.makedirs"](path=path, owner=user)
+            except CommandExecutionError as exc:
+                raise CommandExecutionError(
+                    "Error creating parent directory: {}".format(exc.message)
+                )
+        else:
+            raise CommandExecutionError(
+                "Parent directory not present: {}".format(os.path.dirname(path))
+            )
+
+    return _set_info(
+        path=path,
+        arguments=arguments,
+        description=description,
+        hot_key=hot_key,
+        icon_index=icon_index,
+        icon_location=icon_location,
+        target=target,
+        window_style=window_style,
+        working_dir=working_dir,
+    )

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -8484,6 +8484,10 @@ def shortcut(
         The default mode for new files and directories corresponds umask of salt
         process. For existing files and directories it's not enforced.
     """
+    salt.utils.versions.warn_until(
+        version="Argon",
+        message="This function is being deprecated in favor of 'shortcut.present'",
+    )
     user = _test_owner(kwargs, user=user)
     ret = {"name": name, "changes": {}, "result": True, "comment": ""}
     if not salt.utils.platform.is_windows():

--- a/salt/states/win_shortcut.py
+++ b/salt/states/win_shortcut.py
@@ -1,3 +1,9 @@
+"""
+State module for creating shortcuts on Windows. Handles file shortcuts (`.lnk`)
+and url shortcuts (`.url`). Allows for the configuration of icons and hot keys
+on file shortcuts. Changing the icon and hot keys are unsupported for url
+shortcuts.
+"""
 import salt.utils.data
 import salt.utils.path
 import salt.utils.platform
@@ -32,7 +38,127 @@ def present(
     backup=False,
     force=False,
     make_dirs=False,
+    user=None,
 ):
+    """
+    Create a new shortcut. This can be a file shortcut (``.lnk``) or a url
+    shortcut (``.url``).
+
+    Args:
+
+        name (str): The full path to the shortcut
+
+        target (str): The full path to the target
+
+        arguments (str, optional): Any arguments to be passed to the target
+
+        description (str, optional): The description for the shortcut. This is
+            shown in the ``Comment`` field of the dialog box. Default is an
+            empty string
+
+        hot_key (str, optional): A combination of hot Keys to trigger this
+            shortcut. This is something like ``Ctrl+Alt+D``. This is shown in
+            the ``Shortcut key`` field in the dialog box. Default is an empty
+            string. Available options are:
+
+            - Ctrl
+            - Alt
+            - Shift
+            - Ext
+
+        icon_index (int, optional): The index for the icon to use in files that
+            contain multiple icons. Default is 0
+
+        icon_location (str, optional): The full path to a file containing icons.
+            This is shown in the ``Change Icon`` dialog box by clicking the
+            ``Change Icon`` button. If no file is specified and a binary is
+            passed as the target, Windows will attempt to get the icon from the
+            binary file. Default is an empty string
+
+        window_style (str, optional): The window style the program should start
+            in. This is shown in the ``Run`` field of the dialog box. Default is
+            ``Normal``. Valid options are:
+
+            - Normal
+            - Minimized
+            - Maximized
+
+        working_dir (str, optional): The full path to the working directory for
+            the program to run in. This is shown in the ``Start in`` field of
+            the dialog box.
+
+        backup (bool, optional): If there is already a shortcut with the same
+            name, set this value to ``True`` to backup the existing shortcut and
+            continue creating the new shortcut. Default is ``False``
+
+        force (bool, optional): If there is already a shortcut with the same
+            name and you aren't backing up the shortcut, set this value to
+            ``True`` to remove the existing shortcut and create a new with these
+            settings. Default is ``False``
+
+        make_dirs (bool, optional): If the parent directory structure does not
+            exist for the new shortcut, create it. Default is ``False``
+
+        user (str, optional): The user to be the owner of any directories
+            created by setting ``make_dirs`` to ``True``. If no value is passed
+            Salt will use the user account that it is running under. Default is
+            an empty string.
+
+    Returns:
+        dict: A dictionary containing the changes, comments, and result of the
+            state
+
+    Example:
+
+    .. code-block:: yaml
+
+        KB123456:
+          wusa.installed:
+            - source: salt://kb123456.msu
+
+        # Create a shortcut and set the ``Shortcut key`` (``hot_key``)
+        new_shortcut:
+          shortcut.present:
+            - name: C:\path\to\shortcut.lnk
+            - target: C:\Windows\notepad.exe
+            - hot_key: Ctrl+Alt+N
+
+        # Create a shortcut and change the icon to the 3rd one in the icon file
+        new_shortcut:
+          shortcut.present:
+            - name: C:\path\to\shortcut.lnk
+            - target: C:\Windows\notepad.exe
+            - icon_location: C:\path\to\icon.ico
+            - icon_index: 2
+
+        # Create a shortcut and change the startup mode to full screen
+        new_shortcut:
+          shortcut.present:
+            - name: C:\path\to\shortcut.lnk
+            - target: C:\Windows\notepad.exe
+            - window_style: Maximized
+
+        # Create a shortcut and change the icon
+        new_shortcut:
+          shortcut.present:
+            - name: C:\path\to\shortcut.lnk
+            - target: C:\Windows\notepad.exe
+            - icon_location: C:\path\to\icon.ico
+
+        # Create a shortcut and force it to overwrite an existing shortcut
+        new_shortcut:
+          shortcut.present:
+            - name: C:\path\to\shortcut.lnk
+            - target: C:\Windows\notepad.exe
+            - force: True
+
+        # Create a shortcut and create any parent directories if they are missing
+        new_shortcut:
+          shortcut.present:
+            - name: C:\path\to\shortcut.lnk
+            - target: C:\Windows\notepad.exe
+            - make_dirs: True
+    """
     ret = {"name": name, "changes": {}, "result": True, "comment": []}
 
     proposed = {
@@ -81,6 +207,7 @@ def present(
             backup=backup,
             force=force,
             make_dirs=make_dirs,
+            user=user,
         )
     except CommandExecutionError as exc:
         ret["comment"] = ["Failed to create the shortcut: {}".format(name)]

--- a/salt/states/win_shortcut.py
+++ b/salt/states/win_shortcut.py
@@ -3,6 +3,8 @@ State module for creating shortcuts on Windows. Handles file shortcuts (`.lnk`)
 and url shortcuts (`.url`). Allows for the configuration of icons and hot keys
 on file shortcuts. Changing the icon and hot keys are unsupported for url
 shortcuts.
+
+.. versionadded:: 3005
 """
 import salt.utils.data
 import salt.utils.path

--- a/salt/states/win_shortcut.py
+++ b/salt/states/win_shortcut.py
@@ -40,7 +40,7 @@ def present(
     make_dirs=False,
     user=None,
 ):
-    """
+    r"""
     Create a new shortcut. This can be a file shortcut (``.lnk``) or a url
     shortcut (``.url``).
 

--- a/salt/states/win_shortcut.py
+++ b/salt/states/win_shortcut.py
@@ -1,0 +1,112 @@
+import salt.utils.data
+import salt.utils.path
+import salt.utils.platform
+from salt.exceptions import CommandExecutionError
+
+# Define the module's virtual name
+__virtualname__ = "shortcut"
+
+
+def __virtual__():
+    """
+    Only works on Windows systems
+    """
+    if not salt.utils.platform.is_windows():
+        return False, "Shortcut state only available on Windows systems."
+    if not __salt__.get("shortcut.create", None):
+        return False, "Shortcut state requires the shortcut module."
+
+    return __virtualname__
+
+
+def present(
+    name,
+    arguments="",
+    description="",
+    hot_key="",
+    icon_location="",
+    icon_index=0,
+    target="",
+    window_style="Normal",
+    working_dir="",
+    backup=False,
+    force=False,
+    make_dirs=False,
+):
+    ret = {"name": name, "changes": {}, "result": True, "comment": []}
+
+    proposed = {
+        "arguments": arguments,
+        "description": description,
+        "hot_key": hot_key,
+        "icon_location": salt.utils.path.expand(icon_location),
+        "icon_index": icon_index,
+        "path": salt.utils.path.expand(name),
+        "target": salt.utils.path.expand(target),
+        "window_style": window_style,
+        "working_dir": salt.utils.path.expand(working_dir),
+    }
+
+    try:
+        old = __salt__["shortcut.get"](name)
+        changes = salt.utils.data.compare_dicts(old, proposed)
+        if not changes:
+            ret["comment"] = "Shortcut already present and configured"
+            return ret
+
+    except CommandExecutionError:
+        changes = {}
+
+    if __opts__["test"]:
+        if changes:
+            ret["comment"] = "Shortcut will be modified: {}".format(name)
+            ret["changes"] = changes
+        else:
+            ret["comment"] = "Shortcut will be created: {}".format(name)
+
+        ret["result"] = None
+        return ret
+
+    try:
+        __salt__["shortcut.create"](
+            arguments=arguments,
+            description=description,
+            hot_key=hot_key,
+            icon_location=icon_location,
+            icon_index=icon_index,
+            path=name,
+            target=target,
+            window_style=window_style,
+            working_dir=working_dir,
+            backup=backup,
+            force=force,
+            make_dirs=make_dirs,
+        )
+    except CommandExecutionError as exc:
+        ret["comment"] = ["Failed to create the shortcut: {}".format(name)]
+        ret["comment"].append(exc.message)
+        ret["result"] = False
+        return ret
+
+    try:
+        new = __salt__["shortcut.get"](name)
+    except CommandExecutionError as exc:
+        ret["comment"] = ["Failed to create the shortcut: {}".format(name)]
+        ret["comment"].append(exc.message)
+        ret["result"] = False
+        return ret
+
+    verify_changes = salt.utils.data.compare_dicts(new, proposed)
+    if verify_changes:
+        ret["comment"] = "Failed to make the following changes:"
+        ret["changes"]["failed"] = verify_changes
+        ret["result"] = False
+        return ret
+
+    if changes:
+        ret["comment"] = "Shortcut modified: {}".format(name)
+        ret["changes"] = changes
+    else:
+        ret["comment"] = "Shortcut created: {}".format(name)
+
+    return ret

--- a/salt/utils/path.py
+++ b/salt/utils/path.py
@@ -367,3 +367,20 @@ def os_walk(top, *args, **kwargs):
     top_query = salt.utils.stringutils.to_str(top)
     for item in os.walk(top_query, *args, **kwargs):
         yield salt.utils.data.decode(item, preserve_tuples=True)
+
+
+def expand(path):
+    """
+    Expands all user and environment variables
+    .. versionadded: Sulfur
+
+    Args:
+
+        path (str): A path to a file or directory
+
+    Returns:
+        str: A fully expanded, real path
+    """
+    path = os.path.expanduser(path)  # expand ~ to home directory
+    path = os.path.expandvars(path)  # expand any other environment vars
+    return os.path.realpath(path)  # fix path format

--- a/salt/utils/path.py
+++ b/salt/utils/path.py
@@ -372,7 +372,7 @@ def os_walk(top, *args, **kwargs):
 def expand(path):
     """
     Expands all user and environment variables
-    .. versionadded: Sulfur
+    .. versionadded:: 3006
 
     Args:
 

--- a/salt/utils/path.py
+++ b/salt/utils/path.py
@@ -372,7 +372,7 @@ def os_walk(top, *args, **kwargs):
 def expand(path):
     """
     Expands all user and environment variables
-    .. versionadded:: 3006
+    .. versionadded:: 3005
 
     Args:
 

--- a/tests/pytests/functional/modules/test_win_shortcut.py
+++ b/tests/pytests/functional/modules/test_win_shortcut.py
@@ -2,17 +2,24 @@
 Tests for win_shortcut execution module
 """
 import os
-import pythoncom
 import shutil
 import subprocess
-from win32com.shell import shell
 
 import pytest
 from salt.exceptions import CommandExecutionError
 
+try:
+    import pythoncom
+    from win32com.shell import shell
+
+    HAS_WIN32 = True
+except ImportError:
+    HAS_WIN32 = False
+
 pytestmark = [
     pytest.mark.windows_whitelisted,
     pytest.mark.skip_unless_on_windows,
+    pytest.mark.skipif(not HAS_WIN32, reason="Requires Win32 libraries"),
 ]
 
 
@@ -90,11 +97,11 @@ def tmp_share():
         "-command",
         '"Remove-SmbShare -Name {} -Force" | Out-Null'.format(share_name),
     ]
-    subprocess.run(create_cmd)
+    subprocess.run(create_cmd, check=True)
 
     yield share_name
 
-    subprocess.run(remove_cmd)
+    subprocess.run(remove_cmd, check=True)
 
 
 def test_get_missing(shortcut, tmp_dir):

--- a/tests/pytests/functional/modules/test_win_shortcut.py
+++ b/tests/pytests/functional/modules/test_win_shortcut.py
@@ -1,0 +1,368 @@
+"""
+Tests for win_shortcut execution module
+"""
+import os
+import pythoncom
+import shutil
+import subprocess
+from win32com.shell import shell
+
+import pytest
+from salt.exceptions import CommandExecutionError
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+    pytest.mark.skip_unless_on_windows,
+]
+
+
+@pytest.fixture(scope="module")
+def shortcut(modules):
+    return modules.shortcut
+
+
+@pytest.fixture(scope="function")
+def tmp_dir(tmp_path_factory):
+    test_dir = tmp_path_factory.mktemp("test_dir")
+    yield test_dir
+    if test_dir.exists():
+        shutil.rmtree(str(test_dir))
+
+
+@pytest.fixture(scope="function")
+def tmp_lnk(tmp_path_factory):
+    tmp_dir = tmp_path_factory.mktemp("test_dir")
+    tmp_lnk = tmp_dir / "test.lnk"
+    # https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nn-shobjidl_core-ishelllinkw
+    # http://timgolden.me.uk/python/win32_how_do_i/create-a-shortcut.html
+    shortcut = pythoncom.CoCreateInstance(
+        shell.CLSID_ShellLink,
+        None,
+        pythoncom.CLSCTX_INPROC_SERVER,
+        shell.IID_IShellLink,
+    )
+    program = r"C:\Windows\notepad.exe"
+    shortcut.SetArguments("some args")
+    shortcut.SetDescription("Test description")
+    shortcut.SetIconLocation(program, 0)
+    shortcut.SetHotkey(1601)
+    shortcut.SetPath(program)
+    shortcut.SetShowCmd(1)
+    shortcut.SetWorkingDirectory(os.path.dirname(program))
+
+    persist_file = shortcut.QueryInterface(pythoncom.IID_IPersistFile)
+    persist_file.Save(str(tmp_lnk), 0)
+
+    yield tmp_lnk
+
+    if tmp_dir.exists():
+        shutil.rmtree(str(tmp_dir))
+
+
+@pytest.fixture(scope="function")
+def tmp_url(shortcut, tmp_path_factory):
+    tmp_dir = tmp_path_factory.mktemp("test_dir")
+    tmp_url = tmp_dir / "test.url"
+    shortcut.create(
+        path=str(tmp_url),
+        target="http://www.google.com",
+        window_style="",
+    )
+    yield tmp_url
+
+    if tmp_dir.exists():
+        shutil.rmtree(str(tmp_dir))
+
+
+@pytest.fixture(scope="function")
+def tmp_share():
+    share_dir = r"C:\Windows\Temp"
+    share_name = "TmpShare"
+    create_cmd = [
+        "powershell",
+        "-command",
+        '"New-SmbShare -Name {} -Path {}" | Out-Null'.format(
+            share_name, str(share_dir)
+        ),
+    ]
+    remove_cmd = [
+        "powershell",
+        "-command",
+        '"Remove-SmbShare -Name {} -Force" | Out-Null'.format(share_name),
+    ]
+    subprocess.run(create_cmd)
+
+    yield share_name
+
+    subprocess.run(remove_cmd)
+
+
+def test_get_missing(shortcut, tmp_dir):
+    """
+    Make sure that a CommandExecutionError is raised if the shortcut does NOT
+    exist
+    """
+    fake_shortcut = tmp_dir / "fake.lnk"
+    with pytest.raises(CommandExecutionError):
+        shortcut.get(path=str(fake_shortcut))
+
+
+def test_get_lnk(shortcut, tmp_lnk):
+    expected = {
+        "arguments": "some args",
+        "description": "Test description",
+        "hot_key": "Alt+Ctrl+A",
+        "icon_index": 0,
+        "icon_location": r"C:\Windows\notepad.exe",
+        "path": str(tmp_lnk),
+        "target": r"C:\Windows\notepad.exe",
+        "window_style": "Normal",
+        "working_dir": r"C:\Windows",
+    }
+    assert shortcut.get(path=str(tmp_lnk)) == expected
+
+
+def test_get_url(shortcut, tmp_url):
+    expected = {
+        "arguments": "",
+        "description": "",
+        "hot_key": "",
+        "icon_index": 0,
+        "icon_location": "",
+        "path": str(tmp_url),
+        "target": "http://www.google.com/",
+        "window_style": "",
+        "working_dir": "",
+    }
+    assert shortcut.get(path=str(tmp_url)) == expected
+
+
+def test_modify_missing(shortcut, tmp_dir):
+    """
+    Make sure that a CommandExecutionError is raised if the shortcut does NOT
+    exist
+    """
+    fake_shortcut = tmp_dir / "fake.lnk"
+    with pytest.raises(CommandExecutionError):
+        shortcut.modify(path=str(fake_shortcut), target=r"C:\fake\path.lnk")
+
+
+def test_modify_lnk(shortcut, tmp_lnk):
+    expected = {
+        "arguments": "different args",
+        "description": "different description",
+        "hot_key": "Ctrl+Shift+B",
+        "icon_index": 1,
+        "icon_location": r"C:\Windows\System32\calc.exe",
+        "path": str(tmp_lnk),
+        "target": r"C:\Windows\System32\calc.exe",
+        "window_style": "Minimized",
+        "working_dir": r"C:\Windows\System32",
+    }
+    shortcut.modify(
+        path=str(tmp_lnk),
+        arguments="different args",
+        description="different description",
+        hot_key="Ctrl+Shift+B",
+        icon_index=1,
+        icon_location=r"C:\Windows\System32\calc.exe",
+        target=r"C:\Windows\System32\calc.exe",
+        window_style="Minimized",
+        working_dir=r"C:\Windows\System32",
+    )
+    result = shortcut.get(path=str(tmp_lnk))
+    assert result == expected
+
+
+def test_modify_url(shortcut, tmp_url):
+    expected = {
+        "arguments": "",
+        "description": "",
+        "hot_key": "",
+        "icon_index": 0,
+        "icon_location": "",
+        "path": str(tmp_url),
+        "target": "http://www.python.org/",
+        "window_style": "",
+        "working_dir": "",
+    }
+    shortcut.modify(
+        path=str(tmp_url),
+        target=r"www.python.org",
+    )
+    result = shortcut.get(path=str(tmp_url))
+    assert result == expected
+
+
+def test_create_existing(shortcut, tmp_lnk):
+    with pytest.raises(CommandExecutionError):
+        shortcut.create(path=str(tmp_lnk), target=r"C:\fake\path.lnk")
+
+
+def test_create_lnk(shortcut, tmp_dir):
+    test_link = str(os.path.join(str(tmp_dir / "test_link.lnk")))
+    shortcut.create(
+        path=test_link,
+        arguments="create args",
+        description="create description",
+        hot_key="Alt+Ctrl+C",
+        icon_index=0,
+        icon_location=r"C:\Windows\notepad.exe",
+        target=r"C:\Windows\notepad.exe",
+        window_style="Normal",
+        working_dir=r"C:\Windows",
+    )
+
+    expected = {
+        "arguments": "create args",
+        "description": "create description",
+        "hot_key": "Alt+Ctrl+C",
+        "icon_index": 0,
+        "icon_location": r"C:\Windows\notepad.exe",
+        "path": test_link,
+        "target": r"C:\Windows\notepad.exe",
+        "window_style": "Normal",
+        "working_dir": r"C:\Windows",
+    }
+    result = shortcut.get(path=test_link)
+    assert result == expected
+
+
+def test_create_lnk_dfs_issue_61170(shortcut, tmp_dir, tmp_share):
+    test_link = str(os.path.join(str(tmp_dir / "test_link.lnk")))
+    shortcut.create(
+        path=test_link,
+        arguments="create args",
+        description="create description",
+        hot_key="Alt+Ctrl+C",
+        icon_index=0,
+        icon_location=r"C:\Windows\notepad.exe",
+        target=r"\\localhost\{}".format(tmp_share),
+        window_style="Normal",
+        working_dir=r"C:\Windows",
+    )
+
+    expected = {
+        "arguments": "create args",
+        "description": "create description",
+        "hot_key": "Alt+Ctrl+C",
+        "icon_index": 0,
+        "icon_location": r"C:\Windows\notepad.exe",
+        "path": test_link,
+        "target": r"\\localhost\{}".format(tmp_share),
+        "window_style": "Normal",
+        "working_dir": r"C:\Windows",
+    }
+    result = shortcut.get(path=test_link)
+    assert result == expected
+
+
+def test_create_url(shortcut, tmp_dir):
+    test_link = str(os.path.join(str(tmp_dir / "test_link.url")))
+    shortcut.create(
+        path=test_link,
+        target="www.google.com",
+    )
+
+    expected = {
+        "arguments": "",
+        "description": "",
+        "hot_key": "",
+        "icon_index": 0,
+        "icon_location": "",
+        "path": test_link,
+        "target": "http://www.google.com/",
+        "window_style": "",
+        "working_dir": "",
+    }
+    result = shortcut.get(path=test_link)
+    assert result == expected
+
+
+def test_create_force(shortcut, tmp_lnk):
+    shortcut.create(
+        path=str(tmp_lnk),
+        arguments="create args",
+        description="create description",
+        hot_key="Alt+Ctrl+C",
+        icon_index=0,
+        icon_location=r"C:\Windows\notepad.exe",
+        target=r"C:\Windows\notepad.exe",
+        window_style="Normal",
+        working_dir=r"C:\Windows",
+        force=True,
+    )
+
+    expected = {
+        "arguments": "create args",
+        "description": "create description",
+        "hot_key": "Alt+Ctrl+C",
+        "icon_index": 0,
+        "icon_location": r"C:\Windows\notepad.exe",
+        "path": str(tmp_lnk),
+        "target": r"C:\Windows\notepad.exe",
+        "window_style": "Normal",
+        "working_dir": r"C:\Windows",
+    }
+    result = shortcut.get(path=str(tmp_lnk))
+    assert result == expected
+
+
+def test_create_backup(shortcut, tmp_lnk):
+    shortcut.create(
+        path=str(tmp_lnk),
+        arguments="create args",
+        description="create description",
+        hot_key="Alt+Ctrl+C",
+        icon_index=0,
+        icon_location=r"C:\Windows\notepad.exe",
+        target=r"C:\Windows\notepad.exe",
+        window_style="Normal",
+        working_dir=r"C:\Windows",
+        backup=True,
+    )
+
+    expected = {
+        "arguments": "create args",
+        "description": "create description",
+        "hot_key": "Alt+Ctrl+C",
+        "icon_index": 0,
+        "icon_location": r"C:\Windows\notepad.exe",
+        "path": str(tmp_lnk),
+        "target": r"C:\Windows\notepad.exe",
+        "window_style": "Normal",
+        "working_dir": r"C:\Windows",
+    }
+    result = shortcut.get(path=str(tmp_lnk))
+    assert result == expected
+    assert len(list(tmp_lnk.parent.glob("{}-*.lnk".format(tmp_lnk.stem)))) == 1
+
+
+def test_create_make_dirs(shortcut, tmp_dir):
+    file_shortcut = tmp_dir / "subdir" / "test.lnk"
+    shortcut.create(
+        path=str(file_shortcut),
+        arguments="create args",
+        description="create description",
+        hot_key="Alt+Ctrl+C",
+        icon_index=0,
+        icon_location=r"C:\Windows\notepad.exe",
+        target=r"C:\Windows\notepad.exe",
+        window_style="Normal",
+        working_dir=r"C:\Windows",
+        make_dirs=True,
+    )
+
+    expected = {
+        "arguments": "create args",
+        "description": "create description",
+        "hot_key": "Alt+Ctrl+C",
+        "icon_index": 0,
+        "icon_location": r"C:\Windows\notepad.exe",
+        "path": str(file_shortcut),
+        "target": r"C:\Windows\notepad.exe",
+        "window_style": "Normal",
+        "working_dir": r"C:\Windows",
+    }
+    result = shortcut.get(path=str(file_shortcut))
+    assert result == expected

--- a/tests/pytests/functional/states/test_win_shortcut.py
+++ b/tests/pytests/functional/states/test_win_shortcut.py
@@ -1,13 +1,20 @@
 import os
-import pythoncom
 import shutil
-from win32com.shell import shell
 
 import pytest
+
+try:
+    import pythoncom
+    from win32com.shell import shell
+
+    HAS_WIN32 = True
+except ImportError:
+    HAS_WIN32 = False
 
 pytestmark = [
     pytest.mark.windows_whitelisted,
     pytest.mark.skip_unless_on_windows,
+    pytest.mark.skipif(not HAS_WIN32, reason="Requires Win32 libraries"),
 ]
 
 
@@ -75,7 +82,7 @@ def test_present(shortcut, shortcut_mod, tmp_dir):
     assert ret.name == str(file_shortcut)
     assert ret.changes == {}
     assert "Shortcut created" in ret.comment
-    assert ret.result == True
+    assert ret.result is True
 
     expected = {
         "arguments": "present arguments",
@@ -110,7 +117,7 @@ def test_present_existing_same(shortcut, tmp_shortcut):
     assert ret.name == str(file_shortcut)
     assert ret.changes == {}
     assert "Shortcut already present and configured" in ret.comment
-    assert ret.result == True
+    assert ret.result is True
 
 
 def test_present_existing(shortcut, tmp_shortcut):
@@ -131,7 +138,7 @@ def test_present_existing(shortcut, tmp_shortcut):
     assert ret.name == str(file_shortcut)
     assert ret.changes == {}
     assert "Found existing shortcut" in ret.comment
-    assert ret.result == False
+    assert ret.result is False
 
 
 def test_present_existing_force(shortcut, shortcut_mod, tmp_shortcut):
@@ -160,7 +167,7 @@ def test_present_existing_force(shortcut, shortcut_mod, tmp_shortcut):
     assert ret.name == str(file_shortcut)
     assert ret.changes == changes
     assert "Shortcut modified" in ret.comment
-    assert ret.result == True
+    assert ret.result is True
 
     expected = {
         "arguments": "present arguments",
@@ -202,7 +209,7 @@ def test_present_existing_backup(shortcut, shortcut_mod, tmp_shortcut):
     assert ret.name == str(file_shortcut)
     assert ret.changes == changes
     assert "Shortcut modified" in ret.comment
-    assert ret.result == True
+    assert ret.result is True
 
     expected = {
         "arguments": "present arguments",
@@ -235,7 +242,7 @@ def test_present_existing_subdir(shortcut, tmp_dir):
     assert ret.name == str(file_shortcut)
     assert ret.changes == {}
     assert "Failed to create the shortcut" in ret.comment
-    assert ret.result == False
+    assert ret.result is False
 
 
 def test_present_existing_subdir_make_dirs(shortcut, shortcut_mod, tmp_dir):
@@ -255,7 +262,7 @@ def test_present_existing_subdir_make_dirs(shortcut, shortcut_mod, tmp_dir):
     assert ret.name == str(file_shortcut)
     assert ret.changes == {}
     assert "Shortcut created" in ret.comment
-    assert ret.result == True
+    assert ret.result is True
 
     expected = {
         "arguments": "present arguments",
@@ -289,7 +296,7 @@ def test_present_test_true(shortcut, tmp_dir):
     assert ret.name == str(file_shortcut)
     assert ret.changes == {}
     assert "Shortcut will be created" in ret.comment
-    assert ret.result == None
+    assert ret.result is None
 
 
 def test_present_existing_test_true(shortcut, tmp_shortcut):
@@ -315,4 +322,4 @@ def test_present_existing_test_true(shortcut, tmp_shortcut):
     assert ret.name == str(file_shortcut)
     assert ret.changes == changes
     assert "Shortcut will be modified" in ret.comment
-    assert ret.result == None
+    assert ret.result is None

--- a/tests/pytests/functional/states/test_win_shortcut.py
+++ b/tests/pytests/functional/states/test_win_shortcut.py
@@ -1,0 +1,318 @@
+import os
+import pythoncom
+import shutil
+from win32com.shell import shell
+
+import pytest
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+    pytest.mark.skip_unless_on_windows,
+]
+
+
+@pytest.fixture(scope="module")
+def shortcut(states):
+    return states.shortcut
+
+
+@pytest.fixture(scope="module")
+def shortcut_mod(modules):
+    return modules.shortcut
+
+
+@pytest.fixture(scope="function")
+def tmp_dir(tmp_path_factory):
+    test_dir = tmp_path_factory.mktemp("test_dir")
+    yield test_dir
+    if test_dir.exists():
+        shutil.rmtree(str(test_dir))
+
+
+@pytest.fixture(scope="function")
+def tmp_shortcut(tmp_path_factory):
+    tmp_dir = tmp_path_factory.mktemp("test_dir")
+    tmp_shortcut = tmp_dir / "test.lnk"
+    # https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nn-shobjidl_core-ishelllinkw
+    # http://timgolden.me.uk/python/win32_how_do_i/create-a-shortcut.html
+    short_cut = pythoncom.CoCreateInstance(
+        shell.CLSID_ShellLink,
+        None,
+        pythoncom.CLSCTX_INPROC_SERVER,
+        shell.IID_IShellLink,
+    )
+    program = r"C:\Windows\notepad.exe"
+    short_cut.SetArguments("existing arguments")
+    short_cut.SetDescription("existing description")
+    short_cut.SetIconLocation(program, 0)
+    short_cut.SetHotkey(1601)
+    short_cut.SetPath(program)
+    short_cut.SetShowCmd(1)
+    short_cut.SetWorkingDirectory(os.path.dirname(program))
+
+    persist_file = short_cut.QueryInterface(pythoncom.IID_IPersistFile)
+    persist_file.Save(str(tmp_shortcut), 0)
+
+    yield tmp_shortcut
+
+    if tmp_dir.exists():
+        shutil.rmtree(str(tmp_dir))
+
+
+def test_present(shortcut, shortcut_mod, tmp_dir):
+    file_shortcut = tmp_dir / "test.lnk"
+    ret = shortcut.present(
+        name=str(file_shortcut),
+        arguments="present arguments",
+        description="present description",
+        hot_key="Ctrl+Shift+D",
+        icon_location=r"C:\Windows\notepad.exe",
+        icon_index=0,
+        target=r"C:\Windows\notepad.exe",
+        window_style="Maximized",
+        working_dir=r"C:\Windows",
+    )
+    assert ret.name == str(file_shortcut)
+    assert ret.changes == {}
+    assert "Shortcut created" in ret.comment
+    assert ret.result == True
+
+    expected = {
+        "arguments": "present arguments",
+        "description": "present description",
+        "hot_key": "Ctrl+Shift+D",
+        "icon_index": 0,
+        "icon_location": r"C:\Windows\notepad.exe",
+        "path": str(file_shortcut),
+        "target": r"C:\Windows\notepad.exe",
+        "window_style": "Maximized",
+        "working_dir": r"C:\Windows",
+    }
+    results = shortcut_mod.get(path=str(file_shortcut))
+    assert results == expected
+
+
+def test_present_existing_same(shortcut, tmp_shortcut):
+    file_shortcut = str(tmp_shortcut)
+
+    ret = shortcut.present(
+        name=str(file_shortcut),
+        arguments="existing arguments",
+        description="existing description",
+        hot_key="Alt+Ctrl+A",
+        icon_location=r"C:\Windows\notepad.exe",
+        icon_index=0,
+        target=r"C:\Windows\notepad.exe",
+        window_style="Normal",
+        working_dir=r"C:\Windows",
+    )
+
+    assert ret.name == str(file_shortcut)
+    assert ret.changes == {}
+    assert "Shortcut already present and configured" in ret.comment
+    assert ret.result == True
+
+
+def test_present_existing(shortcut, tmp_shortcut):
+    file_shortcut = str(tmp_shortcut)
+
+    ret = shortcut.present(
+        name=str(file_shortcut),
+        arguments="present arguments",
+        description="present description",
+        hot_key="Ctrl+Shift+D",
+        icon_location=r"C:\Windows\notepad.exe",
+        icon_index=0,
+        target=r"C:\Windows\notepad.exe",
+        window_style="Maximized",
+        working_dir=r"C:\Windows",
+    )
+
+    assert ret.name == str(file_shortcut)
+    assert ret.changes == {}
+    assert "Found existing shortcut" in ret.comment
+    assert ret.result == False
+
+
+def test_present_existing_force(shortcut, shortcut_mod, tmp_shortcut):
+    file_shortcut = str(tmp_shortcut)
+
+    ret = shortcut.present(
+        name=str(file_shortcut),
+        arguments="present arguments",
+        description="present description",
+        hot_key="Ctrl+Shift+D",
+        icon_location=r"C:\Windows\notepad.exe",
+        icon_index=0,
+        target=r"C:\Windows\notepad.exe",
+        window_style="Maximized",
+        working_dir=r"C:\Windows",
+        force=True,
+    )
+
+    changes = {
+        "arguments": {"new": "present arguments", "old": "existing arguments"},
+        "description": {"new": "present description", "old": "existing description"},
+        "hot_key": {"new": "Ctrl+Shift+D", "old": "Alt+Ctrl+A"},
+        "window_style": {"new": "Maximized", "old": "Normal"},
+    }
+
+    assert ret.name == str(file_shortcut)
+    assert ret.changes == changes
+    assert "Shortcut modified" in ret.comment
+    assert ret.result == True
+
+    expected = {
+        "arguments": "present arguments",
+        "description": "present description",
+        "hot_key": "Ctrl+Shift+D",
+        "icon_index": 0,
+        "icon_location": r"C:\Windows\notepad.exe",
+        "path": str(file_shortcut),
+        "target": r"C:\Windows\notepad.exe",
+        "window_style": "Maximized",
+        "working_dir": r"C:\Windows",
+    }
+    results = shortcut_mod.get(path=str(file_shortcut))
+    assert results == expected
+
+
+def test_present_existing_backup(shortcut, shortcut_mod, tmp_shortcut):
+    file_shortcut = str(tmp_shortcut)
+
+    ret = shortcut.present(
+        name=str(file_shortcut),
+        arguments="present arguments",
+        description="present description",
+        hot_key="Ctrl+Shift+D",
+        icon_location=r"C:\Windows\notepad.exe",
+        icon_index=0,
+        target=r"C:\Windows\notepad.exe",
+        window_style="Maximized",
+        working_dir=r"C:\Windows",
+        backup=True,
+    )
+
+    changes = {
+        "arguments": {"new": "present arguments", "old": "existing arguments"},
+        "description": {"new": "present description", "old": "existing description"},
+        "hot_key": {"new": "Ctrl+Shift+D", "old": "Alt+Ctrl+A"},
+        "window_style": {"new": "Maximized", "old": "Normal"},
+    }
+    assert ret.name == str(file_shortcut)
+    assert ret.changes == changes
+    assert "Shortcut modified" in ret.comment
+    assert ret.result == True
+
+    expected = {
+        "arguments": "present arguments",
+        "description": "present description",
+        "hot_key": "Ctrl+Shift+D",
+        "icon_index": 0,
+        "icon_location": r"C:\Windows\notepad.exe",
+        "path": str(file_shortcut),
+        "target": r"C:\Windows\notepad.exe",
+        "window_style": "Maximized",
+        "working_dir": r"C:\Windows",
+    }
+    results = shortcut_mod.get(path=str(file_shortcut))
+    assert results == expected
+
+
+def test_present_existing_subdir(shortcut, tmp_dir):
+    file_shortcut = tmp_dir / "subdir" / "test.lnk"
+    ret = shortcut.present(
+        name=str(file_shortcut),
+        arguments="present arguments",
+        description="present description",
+        hot_key="Ctrl+Shift+D",
+        icon_location=r"C:\Windows\notepad.exe",
+        icon_index=0,
+        target=r"C:\Windows\notepad.exe",
+        window_style="Maximized",
+        working_dir=r"C:\Windows",
+    )
+    assert ret.name == str(file_shortcut)
+    assert ret.changes == {}
+    assert "Failed to create the shortcut" in ret.comment
+    assert ret.result == False
+
+
+def test_present_existing_subdir_make_dirs(shortcut, shortcut_mod, tmp_dir):
+    file_shortcut = tmp_dir / "subdir" / "test.lnk"
+    ret = shortcut.present(
+        name=str(file_shortcut),
+        arguments="present arguments",
+        description="present description",
+        hot_key="Ctrl+Shift+D",
+        icon_location=r"C:\Windows\notepad.exe",
+        icon_index=0,
+        target=r"C:\Windows\notepad.exe",
+        window_style="Maximized",
+        working_dir=r"C:\Windows",
+        make_dirs=True,
+    )
+    assert ret.name == str(file_shortcut)
+    assert ret.changes == {}
+    assert "Shortcut created" in ret.comment
+    assert ret.result == True
+
+    expected = {
+        "arguments": "present arguments",
+        "description": "present description",
+        "hot_key": "Ctrl+Shift+D",
+        "icon_index": 0,
+        "icon_location": r"C:\Windows\notepad.exe",
+        "path": str(file_shortcut),
+        "target": r"C:\Windows\notepad.exe",
+        "window_style": "Maximized",
+        "working_dir": r"C:\Windows",
+    }
+    results = shortcut_mod.get(path=str(file_shortcut))
+    assert results == expected
+
+
+def test_present_test_true(shortcut, tmp_dir):
+    file_shortcut = tmp_dir / "test.lnk"
+    ret = shortcut.present(
+        name=str(file_shortcut),
+        arguments="present arguments",
+        description="present description",
+        hot_key="Ctrl+Shift+D",
+        icon_location=r"C:\Windows\notepad.exe",
+        icon_index=0,
+        target=r"C:\Windows\notepad.exe",
+        window_style="Maximized",
+        working_dir=r"C:\Windows",
+        test=True,
+    )
+    assert ret.name == str(file_shortcut)
+    assert ret.changes == {}
+    assert "Shortcut will be created" in ret.comment
+    assert ret.result == None
+
+
+def test_present_existing_test_true(shortcut, tmp_shortcut):
+    file_shortcut = tmp_shortcut
+    ret = shortcut.present(
+        name=str(file_shortcut),
+        arguments="present arguments",
+        description="present description",
+        hot_key="Ctrl+Shift+D",
+        icon_location=r"C:\Windows\notepad.exe",
+        icon_index=0,
+        target=r"C:\Windows\notepad.exe",
+        window_style="Maximized",
+        working_dir=r"C:\Windows",
+        test=True,
+    )
+    changes = {
+        "arguments": {"new": "present arguments", "old": "existing arguments"},
+        "description": {"new": "present description", "old": "existing description"},
+        "hot_key": {"new": "Ctrl+Shift+D", "old": "Alt+Ctrl+A"},
+        "window_style": {"new": "Maximized", "old": "Normal"},
+    }
+    assert ret.name == str(file_shortcut)
+    assert ret.changes == changes
+    assert "Shortcut will be modified" in ret.comment
+    assert ret.result == None


### PR DESCRIPTION
### What does this PR do?
Adds an execution module and a state module for working with shortcuts on Windows.

Splits out the `file.shortcut` code into it's own execution module and state module
Adds future deprecation for the `file.shortcut` state function to be removed in Argon
Adds functional tests for the two new modules

### What issues does this PR fix or reference?
Fixes: #61170
Fixes: #53706

### Previous Behavior
All code for creating shortcuts resided in the `file.shortcut` state module. No execution module.

### New Behavior
Abstracts the execution logic from the state logic by breaking them apart. Allows for the more salty `shortcut.present` state name for creating a new shortcut.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes