### PR TITLE
Speed up salt-ssh minions by setting ulimit nofile

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -129,6 +129,7 @@ SSH_SH_SHIM = "\n".join(
         for s in r'''/bin/sh << 'EOF'
 set -e
 set -u
+ulimit -n 8192
 DEBUG="{{DEBUG}}"
 if [ -n "$DEBUG" ]
     then set -x


### PR DESCRIPTION
Some systems could be very slow with close_fds=True in subprocess.Popen, it is related to nofile settings which could be set to very high values.

This change add simple "ulimit -n 8192" to SSH_SH_SHIM and should speed up salt-ssh minion subprocess executions. In my case total execution time changed from 62s to 10s.