### PR TITLE
Add file.comment ignore_missing

### DIFF
--- a/changelog/61662.fixed
+++ b/changelog/61662.fixed
@@ -1,0 +1,1 @@
+Fix file.comment incorrectly reports changes in test mode

--- a/changelog/62044.added
+++ b/changelog/62044.added
@@ -1,0 +1,1 @@
+Add ignore_missing parameter to file.comment state

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -6062,7 +6062,7 @@ def comment(name, regex, char="#", backup=".bak", ignore_missing=False):
     # remove (?i)-like flags, ^ and $
     unanchor_regex = re.sub(r"^(\(\?[iLmsux]\))?\^?(.*?)\$?$", r"\2", regex)
 
-    uncomment_regex = "[^{}]?".format(char) + unanchor_regex
+    uncomment_regex = "^(?!.*{}).*".format(char) + unanchor_regex
     comment_regex = char + unanchor_regex
 
     # Make sure the pattern appears in the file before continuing

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -6062,7 +6062,7 @@ def comment(name, regex, char="#", backup=".bak", ignore_missing=False):
     # remove (?i)-like flags, ^ and $
     unanchor_regex = re.sub(r"^(\(\?[iLmsux]\))?\^?(.*?)\$?$", r"\2", regex)
 
-    uncomment_regex = "[^{}]".format(char) + unanchor_regex
+    uncomment_regex = "[^{}]?".format(char) + unanchor_regex
     comment_regex = char + unanchor_regex
 
     # Make sure the pattern appears in the file before continuing

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -6004,8 +6004,11 @@ def blockreplace(
     return ret
 
 
-def comment(name, regex, char="#", backup=".bak"):
+def comment(name, regex, char="#", backup=".bak", ignore_missing=False):
     """
+    .. versionadded:: 0.9.5
+    .. versionchanged:: 3005
+
     Comment out specified lines in a file.
 
     name
@@ -6030,6 +6033,12 @@ def comment(name, regex, char="#", backup=".bak"):
             after the first invocation.
 
         Set to False/None to not keep a backup.
+    ignore_missing
+        Ignore a failure to find the regex in the file. This is useful for
+        scenarios where a line must only be commented if it is found in the
+        file.
+
+        .. versionadded:: 3005
 
     Usage:
 
@@ -6039,7 +6048,6 @@ def comment(name, regex, char="#", backup=".bak"):
           file.comment:
             - regex: ^bind 127.0.0.1
 
-    .. versionadded:: 0.9.5
     """
     name = os.path.expanduser(name)
 
@@ -6062,6 +6070,10 @@ def comment(name, regex, char="#", backup=".bak"):
             ret["comment"] = "Pattern already commented"
             ret["result"] = True
             return ret
+        elif ignore_missing:
+            ret["comment"] = "Pattern not found and ignore_missing set to True"
+            ret["result"] = True
+            return ret
         else:
             return _error(ret, "{}: Pattern not found".format(unanchor_regex))
 
@@ -6070,6 +6082,7 @@ def comment(name, regex, char="#", backup=".bak"):
         ret["comment"] = "File {} is set to be updated".format(name)
         ret["result"] = None
         return ret
+
     with salt.utils.files.fopen(name, "rb") as fp_:
         slines = fp_.read()
         slines = slines.decode(__salt_system_encoding__)

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -6062,10 +6062,11 @@ def comment(name, regex, char="#", backup=".bak", ignore_missing=False):
     # remove (?i)-like flags, ^ and $
     unanchor_regex = re.sub(r"^(\(\?[iLmsux]\))?\^?(.*?)\$?$", r"\2", regex)
 
+    uncomment_regex = "[^{}]".format(char) + unanchor_regex
     comment_regex = char + unanchor_regex
 
     # Make sure the pattern appears in the file before continuing
-    if not __salt__["file.search"](name, regex, multiline=True):
+    if not __salt__["file.search"](name, uncomment_regex, multiline=True):
         if __salt__["file.search"](name, comment_regex, multiline=True):
             ret["comment"] = "Pattern already commented"
             ret["result"] = True
@@ -6097,7 +6098,7 @@ def comment(name, regex, char="#", backup=".bak", ignore_missing=False):
         nlines = nlines.splitlines(True)
 
     # Check the result
-    ret["result"] = __salt__["file.search"](name, unanchor_regex, multiline=True)
+    ret["result"] = __salt__["file.search"](name, comment_regex, multiline=True)
 
     if slines != nlines:
         if not __utils__["files.is_text"](name):

--- a/tests/pytests/unit/states/file/test_comment.py
+++ b/tests/pytests/unit/states/file/test_comment.py
@@ -65,11 +65,19 @@ def test_comment():
         with patch.object(os.path, "isabs", mock_t):
             with patch.dict(
                 filestate.__salt__,
-                {"file.search": MagicMock(side_effect=[False, True, False, False])},
+                {
+                    "file.search": MagicMock(
+                        side_effect=[False, True, False, False, False, False]
+                    )
+                },
             ):
                 comt = "Pattern already commented"
                 ret.update({"comment": comt, "result": True})
                 assert filestate.comment(name, regex) == ret
+
+                comt = "Pattern not found and ignore_missing set to True"
+                ret.update({"comment": comt, "result": True})
+                assert filestate.comment(name, regex, ignore_missing=True) == ret
 
                 comt = "{}: Pattern not found".format(regex)
                 ret.update({"comment": comt, "result": False})

--- a/tests/pytests/unit/states/file/test_comment.py
+++ b/tests/pytests/unit/states/file/test_comment.py
@@ -86,7 +86,9 @@ def test_comment():
             with patch.dict(
                 filestate.__salt__,
                 {
-                    "file.search": MagicMock(side_effect=[True, True, True]),
+                    "file.search": MagicMock(
+                        side_effect=[True, True, True, False, True]
+                    ),
                     "file.comment": mock_t,
                     "file.comment_line": mock_t,
                 },
@@ -105,6 +107,11 @@ def test_comment():
                         comt = "Commented lines successfully"
                         ret.update({"comment": comt, "result": True, "changes": {}})
                         assert filestate.comment(name, regex) == ret
+
+                with patch.dict(filestate.__opts__, {"test": True}):
+                    comt = "Pattern already commented"
+                    ret.update({"comment": comt, "result": True, "changes": {}})
+                    assert filestate.comment(name, regex) == ret
 
 
 # 'uncomment' function tests: 1


### PR DESCRIPTION
### What does this PR do?
This PR adds the ability to ignore missing regex matches in a file when using the `file.comment` state. This allows for a "comment only if a match is found" workflow and prevents unnecessary state failures or requisite use. This PR also fixes a small bug where changes would be reported in test mode when the line has already been commented.

### What issues does this PR fix or reference?
Fixes: #62044
Fixes: #61662

### Previous Behavior
See relevant issues for details.

### New Behavior
The `ignore_missing` parameter allows the state to succeed if the line to be commented is not found. Additionally, changes are no longer reported in test mode when the line is already commented.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
