### PR TITLE
Bump to ``pyjwt==2.4.0`` due to CVE-2022-29217

### DIFF
--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -657,7 +657,7 @@ pycurl==7.44.1 ; python_version >= "3.10"
     # via -r requirements/static/ci/common.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==2.1.0
+pyjwt==2.4.0
     # via adal
 pynacl==1.4.0
     # via paramiko

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -661,7 +661,7 @@ pycurl==7.44.1 ; python_version >= "3.10"
     # via -r requirements/static/ci/common.in
 pygit2==1.5.0 ; python_version >= "3.7"
     # via -r requirements/static/ci/darwin.in
-pyjwt==2.0.0
+pyjwt==2.4.0
     # via adal
 pynacl==1.3.0
     # via paramiko

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -654,7 +654,7 @@ pygit2==1.8.0 ; python_version >= "3.7"
     # via -r requirements/static/ci/freebsd.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==2.0.0
+pyjwt==2.4.0
     # via adal
 pynacl==1.3.0
     # via paramiko

--- a/requirements/static/ci/py3.6/cloud.txt
+++ b/requirements/static/ci/py3.6/cloud.txt
@@ -682,7 +682,7 @@ pycurl==7.44.1 ; python_version <= "3.9"
     # via -r requirements/static/ci/common.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==2.1.0
+pyjwt==2.4.0
     # via adal
 pynacl==1.4.0
     # via paramiko

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -701,7 +701,7 @@ pyeapi==0.8.4
     # via napalm
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==2.1.0
+pyjwt==2.4.0
     # via adal
 pynacl==1.4.0
     # via paramiko

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -694,7 +694,7 @@ pygit2==1.8.0 ; python_version >= "3.7"
     # via -r requirements/static/ci/freebsd.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==2.0.0
+pyjwt==2.4.0
     # via adal
 pynacl==1.3.0
     # via paramiko

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -691,7 +691,7 @@ pyeapi==0.8.4
     # via napalm
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==2.1.0
+pyjwt==2.4.0
     # via adal
 pynacl==1.4.0
     # via paramiko

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -685,7 +685,7 @@ pygit2==1.8.0 ; python_version >= "3.7"
     # via -r requirements/static/ci/freebsd.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==2.0.0
+pyjwt==2.4.0
     # via adal
 pynacl==1.3.0
     # via paramiko

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -691,7 +691,7 @@ pyeapi==0.8.4
     # via napalm
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==2.1.0
+pyjwt==2.4.0
     # via adal
 pynacl==1.4.0
     # via paramiko

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -692,7 +692,7 @@ pyeapi==0.8.3
     # via napalm
 pygit2==1.5.0 ; python_version >= "3.7"
     # via -r requirements/static/ci/darwin.in
-pyjwt==2.0.0
+pyjwt==2.4.0
     # via adal
 pynacl==1.3.0
     # via paramiko

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -685,7 +685,7 @@ pygit2==1.8.0 ; python_version >= "3.7"
     # via -r requirements/static/ci/freebsd.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==2.0.0
+pyjwt==2.4.0
     # via adal
 pynacl==1.3.0
     # via paramiko


### PR DESCRIPTION
### What does this PR do?

Bump to ``pyjwt==2.4.0`` due to CVE-2022-29217

Closes #62102
Closes #62103
Closes #62104
Closes #62105
Closes #62106
Closes #62107