### PR TITLE
Use Salt Bundle in dockermod

### DIFF
--- a/changelog/62109.added
+++ b/changelog/62109.added
@@ -1,0 +1,1 @@
+Use the Salt Bundle to handle calls inside a container with dockermod if the call is performing with the Salt Bundle on the host

--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -6719,7 +6719,7 @@ def _gen_venv_tar(cachedir, venv_dest_dir, venv_name):
         try:
             with __utils__["files.fopen"](venv_hash_file, "r") as fh:
                 venv_hash_src = fh.readline().strip()
-        except:  # pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             # It makes no sense what caused the exception
             # Just calculate the hash different way
             for cmd in ("rpm -qi venv-salt-minion", "dpkg -s venv-salt-minion"):
@@ -6737,11 +6737,10 @@ def _gen_venv_tar(cachedir, venv_dest_dir, venv_name):
         try:
             with __utils__["files.fopen"](venv_hash, "r") as fh:
                 venv_hash_dest = fh.readline().strip()
-        except:  # pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             # It makes no sense what caused the exception
             # Set the hash to impossible value to force new tarball creation
             venv_hash_dest = "UNKNOWN"
-            pass
         if venv_hash_src == venv_hash_dest and os.path.isfile(venv_tar):
             return venv_tar
         try:


### PR DESCRIPTION
### What does this PR do?

Implements the Salt Bundle (SUSE project with the idea similar to Tiamat) usage for a calls inside the containers with `dockermod`.

### Previous Behavior
Passing salt thin into the container to handle salt calls inside.

### New Behavior
If the call is performed with Salt inside Salt Bundle it will use the Salt Bundle instead of salt-thin and Python shipped with it instead of platform python.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
