### PR TITLE
``clear_funcs`` is not always a valid clear funcs object.

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -965,10 +965,19 @@ class MWorker(salt.utils.process.SignalHandlingProcess):
 
     def _handle_signals(self, signum, sigframe):
         for channel in getattr(self, "req_channels", ()):
-            channel.close()
+            try:
+                channel.close()
+            except Exception:  # pylint: disable=broad-except
+                # Don't stop closing additional channels because an
+                # exception occurred.
+                pass
         clear_funcs = getattr(self, "clear_funcs", None)
         if clear_funcs is not None:
-            clear_funcs.destroy()
+            try:
+                clear_funcs.destroy()
+            except Exception:  # pylint: disable=broad-except
+                # Don't stop signal handling because an exception occurred.
+                pass
         super()._handle_signals(signum, sigframe)
 
     def __bind(self):

--- a/salt/master.py
+++ b/salt/master.py
@@ -966,7 +966,9 @@ class MWorker(salt.utils.process.SignalHandlingProcess):
     def _handle_signals(self, signum, sigframe):
         for channel in getattr(self, "req_channels", ()):
             channel.close()
-        self.clear_funcs.destroy()
+        clear_funcs = getattr(self, "clear_funcs", None)
+        if clear_funcs is not None:
+            clear_funcs.destroy()
         super()._handle_signals(signum, sigframe)
 
     def __bind(self):


### PR DESCRIPTION
```
Process MWorker-1:
Traceback (most recent call last):
  File "/home/vampas/.pyenv/versions/3.7.12/lib/python3.7/multiprocessing/process.py", line 297, in _bootstrap
    self.run()
  File "/home/vampas/projects/SaltStack/pytest/salt-factories/branches/master/.nox/tests-3/lib/python3.7/site-packages/salt/utils/process.py", line 1034, in wrapped_run_func
    return run_func()
  File "/home/vampas/projects/SaltStack/pytest/salt-factories/branches/master/.nox/tests-3/lib/python3.7/site-packages/salt/master.py", line 1136, in run
    self.key,
  File "/home/vampas/projects/SaltStack/pytest/salt-factories/branches/master/.nox/tests-3/lib/python3.7/site-packages/salt/master.py", line 1981, in __init__
    self.masterapi = salt.daemons.masterapi.LocalFuncs(opts, key)
  File "/home/vampas/projects/SaltStack/pytest/salt-factories/branches/master/.nox/tests-3/lib/python3.7/site-packages/salt/daemons/masterapi.py", line 1079, in __init__
    self.local = salt.client.get_local_client(mopts=self.opts)
  File "/home/vampas/projects/SaltStack/pytest/salt-factories/branches/master/.nox/tests-3/lib/python3.7/site-packages/salt/client/__init__.py", line 129, in get_local_client
    listen=listen,
  File "/home/vampas/projects/SaltStack/pytest/salt-factories/branches/master/.nox/tests-3/lib/python3.7/site-packages/salt/client/__init__.py", line 233, in __init__
    self.functions = salt.loader.minion_mods(self.opts, utils=self.utils)
  File "/home/vampas/projects/SaltStack/pytest/salt-factories/branches/master/.nox/tests-3/lib/python3.7/site-packages/salt/loader/__init__.py", line 308, in minion_mods
    pack_self="__salt__",
  File "/home/vampas/projects/SaltStack/pytest/salt-factories/branches/master/.nox/tests-3/lib/python3.7/site-packages/salt/loader/lazy.py", line 314, in __init__
    super().__init__()  # late init the lazy loader
  File "/home/vampas/projects/SaltStack/pytest/salt-factories/branches/master/.nox/tests-3/lib/python3.7/site-packages/salt/utils/lazy.py", line 37, in __init__
    self.clear()
  File "/home/vampas/projects/SaltStack/pytest/salt-factories/branches/master/.nox/tests-3/lib/python3.7/site-packages/salt/loader/lazy.py", line 561, in clear
    self._refresh_file_mapping()
  File "/home/vampas/projects/SaltStack/pytest/salt-factories/branches/master/.nox/tests-3/lib/python3.7/site-packages/salt/loader/lazy.py", line 459, in _refresh_file_mapping
    dirname, basename = os.path.split(filename)
  File "/home/vampas/.pyenv/versions/3.7.12/lib/python3.7/posixpath.py", line 111, in split
    if head and head != sep*len(head):
  File "/home/vampas/projects/SaltStack/pytest/salt-factories/branches/master/.nox/tests-3/lib/python3.7/site-packages/salt/master.py", line 980, in _handle_signals
    self.clear_funcs.destroy()
AttributeError: 'MWorker' object has no attribute 'clear_funcs'
```