### PR TITLE
Fix relative jinja includes broken in local mode

### DIFF
--- a/changelog/62117.fixed
+++ b/changelog/62117.fixed
@@ -1,0 +1,1 @@
+Fix broken relative jinja includes in local mode bug introduced in #62043

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -176,7 +176,10 @@ class SaltCacheLoader(BaseLoader):
                 )
                 raise TemplateNotFound(template)
             # local file clients should pass the dot-expanded relative path
-            if environment.globals.get("opts", {}).get("file_client") == "local":
+            # when it's an absolute local filesystem location
+            if environment.globals.get("opts", {}).get(
+                "file_client"
+            ) == "local" and os.path.isabs(base_path):
                 _template = os.path.relpath(_template, base_path)
 
         self.check_cache(_template)


### PR DESCRIPTION
### What does this PR do?
This PR fixes a bug introduced in #62043 . See PR comments and referenced issue for details.

### What issues does this PR fix or reference?
Fixes: #62117 

### Previous Behavior
Relative includes didn't work with `salt-call --local` runs

### New Behavior
Relative includes work as expected

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
