### PR TITLE
Fix #62092: Catch zmq.error.ZMQError to set HWM for zmq >= 3

### DIFF
--- a/changelog/62092.fixed
+++ b/changelog/62092.fixed
@@ -1,0 +1,3 @@
+Fix #62092: Catch zmq.error.ZMQError to set HWM for zmq >= 3.
+
+Run ``git show 0be0941`` for more info.

--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -723,7 +723,7 @@ class PublishServer(salt.transport.base.DaemonizedPublishServer):
         try:
             pub_sock.setsockopt(zmq.HWM, self.opts.get("pub_hwm", 1000))
         # in zmq >= 3.0, there are separate send and receive HWM settings
-        except AttributeError:
+        except (AttributeError, zmq.error.ZMQError):
             # Set the High Water Marks. For more information on HWM, see:
             # http://api.zeromq.org/4-1:zmq-setsockopt
             pub_sock.setsockopt(zmq.SNDHWM, self.opts.get("pub_hwm", 1000))


### PR DESCRIPTION
It looks like before release 23.0.0, when trying to access zmq.HWM it
was raising ``AttributeError``, which is now wrapped under pyzmq's own
``zmq.error.ZMQError``.
Simply caching that, should then set the HWM correctly for zmq >= 3
and therefore fix #62092.
