### PR TITLE
Fix file.comment state picks up comments after config in line

### DIFF
--- a/changelog/62121.fixed
+++ b/changelog/62121.fixed
@@ -1,0 +1,1 @@
+Fix broken file.comment functionality introduced in #62045

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -6062,7 +6062,7 @@ def comment(name, regex, char="#", backup=".bak", ignore_missing=False):
     # remove (?i)-like flags, ^ and $
     unanchor_regex = re.sub(r"^(\(\?[iLmsux]\))?\^?(.*?)\$?$", r"\2", regex)
 
-    uncomment_regex = "^(?!.*{}).*".format(char) + unanchor_regex
+    uncomment_regex = r"^(?!\s*{}).*".format(char) + unanchor_regex
     comment_regex = char + unanchor_regex
 
     # Make sure the pattern appears in the file before continuing

--- a/tests/pytests/functional/states/file/test_comment.py
+++ b/tests/pytests/functional/states/file/test_comment.py
@@ -1,0 +1,54 @@
+"""
+Tests for file.comment state function
+"""
+import re
+
+import pytest
+import salt.utils.files
+from tests.support.helpers import dedent
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+]
+
+
+@pytest.fixture(scope="module")
+def file(states):
+    return states.file
+
+
+@pytest.fixture(scope="function")
+def source():
+    with pytest.helpers.temp_file(
+        name="file.txt",
+        contents=dedent(
+            """
+            things = stuff
+            port = 5432                             # (change requires restart)
+            # commented = something
+            moar = things
+            """
+        ),
+    ) as source:
+        yield source
+
+
+def test_issue_62121(file, source):
+    """
+    Test file.comment when the comment character is
+    later in the line, after the text
+    """
+    regex = r"^port\s*=.+"
+    reg_cmp = re.compile(regex, re.MULTILINE)
+    cmt_regex = r"^#port\s*=.+"
+    cmt_cmp = re.compile(cmt_regex, re.MULTILINE)
+
+    with salt.utils.files.fopen(source) as _fp:
+        assert reg_cmp.findall(_fp.read())
+
+    file.comment(name=str(source), regex=regex)
+
+    with salt.utils.files.fopen(source) as _fp:
+        assert not reg_cmp.findall(_fp.read())
+        _fp.seek(0)
+        assert cmt_cmp.findall(_fp.read())

--- a/tests/pytests/functional/states/file/test_comment.py
+++ b/tests/pytests/functional/states/file/test_comment.py
@@ -43,12 +43,12 @@ def test_issue_62121(file, source):
     cmt_regex = r"^#port\s*=.+"
     cmt_cmp = re.compile(cmt_regex, re.MULTILINE)
 
-    with salt.utils.files.fopen(source) as _fp:
+    with salt.utils.files.fopen(str(source)) as _fp:
         assert reg_cmp.findall(_fp.read())
 
     file.comment(name=str(source), regex=regex)
 
-    with salt.utils.files.fopen(source) as _fp:
+    with salt.utils.files.fopen(str(source)) as _fp:
         assert not reg_cmp.findall(_fp.read())
         _fp.seek(0)
         assert cmt_cmp.findall(_fp.read())


### PR DESCRIPTION
### What does this PR do?
See issue referenced below and comment in #62045 for details.

### What issues does this PR fix or reference?
Fixes: #62121

### Previous Behavior
Uncommented lines with a comment later in the line would not be commented as expected.

### New Behavior
Comments are inserted as expected when the line has a later comment after the config.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
