### PR TITLE
Fix sources.list multi-arch definition

### DIFF
--- a/changelog/62247.fixed
+++ b/changelog/62247.fixed
@@ -1,0 +1,1 @@
+Fix arch parsing issue in apt source files

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -278,7 +278,7 @@ if not HAS_APT:
             opts_count = []
             opts_line = ""
             if architectures:
-                architectures = "arch={}".format(" ".join(architectures))
+                architectures = "arch={}".format(",".join(architectures))
                 opts_count.append(architectures)
             if signedby:
                 signedby = "signed-by={}".format(signedby)

--- a/tests/pytests/functional/states/pkgrepo/test_debian.py
+++ b/tests/pytests/functional/states/pkgrepo/test_debian.py
@@ -53,7 +53,7 @@ def test_adding_repo_file(pkgrepo, tmp_path):
 
 
 @pytest.mark.requires_salt_states("pkgrepo.managed")
-def test_adding_repo_file_arch(pkgrepo, tmp_path):
+def test_adding_repo_file_arch(pkgrepo, tmp_path, subtests):
     """
     test adding a repo file using pkgrepo.managed
     and setting architecture
@@ -67,6 +67,17 @@ def test_adding_repo_file_arch(pkgrepo, tmp_path):
             file_content.strip()
             == "deb [arch=amd64] http://www.deb-multimedia.org stable main"
         )
+    with subtests.test("With multiple archs"):
+        repo_content = (
+            "deb [arch=amd64,i386  ] http://www.deb-multimedia.org stable main"
+        )
+        pkgrepo.managed(name=repo_content, file=repo_file, clean_file=True)
+        with salt.utils.files.fopen(repo_file, "r") as fp:
+            file_content = fp.read()
+            assert (
+                file_content.strip()
+                == "deb [arch=amd64,i386] http://www.deb-multimedia.org stable main"
+            )
 
 
 @pytest.mark.requires_salt_states("pkgrepo.managed")


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug in multi-arch sources.list generation

### What issues does this PR fix or reference?
Currently, multi-arch definition are generated using space as separator
Multi-arch definition should be comma separated

ex: deb [arch=amd64,i386] http://uk.archive.ubuntu.com/ubuntu/ quantal main universe

https://wiki.debian.org/Multiarch/HOWTO


### Commits signed with GPG?
No

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs N/A
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

