### PR TITLE
Fix run.py for non-spawning platforms

### DIFF
--- a/run.py
+++ b/run.py
@@ -87,6 +87,5 @@ def redirect(argv):
 
 
 if __name__ == "__main__":
-    if sys.platform.startswith("win"):
-        multiprocessing.freeze_support()
+    multiprocessing.freeze_support()
     redirect(sys.argv)


### PR DESCRIPTION
### What does this PR do?
Makes a change to `run.py` that addresses a stacktrace occurring in Tiamat builds for non-spawning platforms. Removes the gate around `multiprocessing.freeze_support()` which is a no-op on forking platforms.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/62138

### Previous Behavior
Stacktrace when starting minion. Multiple stacktraces starting master.

### New Behavior
No more stacktraces.

### Commits signed with GPG?
Yes