### PR TITLE
Use match_dict in delete_key/reject() in thorium

### DIFF
--- a/salt/thorium/key.py
+++ b/salt/thorium/key.py
@@ -63,12 +63,14 @@ def timeout(name, delete=0, reject=0):
                     remove.add(id_)
                 if reject and (now - __context__[ktr][id_]) > reject:
                     reject_set.add(id_)
-    for id_ in remove:
-        keyapi.delete_key(id_)
-        __reg__["status"]["val"].pop(id_, None)
-        __context__[ktr].pop(id_, None)
-    for id_ in reject_set:
-        keyapi.reject(id_)
-        __reg__["status"]["val"].pop(id_, None)
-        __context__[ktr].pop(id_, None)
+    if remove:
+        keyapi.delete_key(match_dict={"minions": list(remove))
+        for id_ in remove:
+            __reg__["status"]["val"].pop(id_, None)
+            __context__[ktr].pop(id_, None)
+    if reject_set:
+        keyapi.reject(match_dict={"minions": list(reject_set))
+        for id_ in reject_set:
+            __reg__["status"]["val"].pop(id_, None)
+            __context__[ktr].pop(id_, None)
     return ret

--- a/salt/thorium/key.py
+++ b/salt/thorium/key.py
@@ -64,12 +64,12 @@ def timeout(name, delete=0, reject=0):
                 if reject and (now - __context__[ktr][id_]) > reject:
                     reject_set.add(id_)
     if remove:
-        keyapi.delete_key(match_dict={"minions": list(remove))
+        keyapi.delete_key(match_dict={"minions": list(remove)})
         for id_ in remove:
             __reg__["status"]["val"].pop(id_, None)
             __context__[ktr].pop(id_, None)
     if reject_set:
-        keyapi.reject(match_dict={"minions": list(reject_set))
+        keyapi.reject(match_dict={"minions": list(reject_set)})
         for id_ in reject_set:
             __reg__["status"]["val"].pop(id_, None)
             __context__[ktr].pop(id_, None)


### PR DESCRIPTION
Passing singular keys to these functions results in expensive matching and minion enumeration, for a configuration where minions may only live a few hours this can cause unnecessary load on the master.

Fixed #62149

### Previous Behavior
thorium key.timeout would determine the set of keys to be deleted/rejected, then invoke the corresponding key api function for each key. This used glob matching to find the appropriate key, action it, and then evaluate whether the minion cache needed to be removed.

### New Behavior
Pass the full list of keys as a match_dict to the appropriate key api function, this will result in a single evaluation of minions/caches instead of once per a key.

### Merge requirements satisfied?
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No
