### PR TITLE
Bump to pyjwt==2.4.0 due to CVE-2022-29217

### DIFF
--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -657,7 +657,7 @@ pyiface==0.0.11
     # via -r requirements/static/ci/linux.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via
     #   adal
     #   twilio
@@ -791,7 +791,6 @@ six==1.16.0
     #   pyvmomi
     #   responses
     #   transitions
-    #   twilio
     #   vcert
     #   virtualenv
     #   websocket-client
@@ -827,7 +826,7 @@ tornado==6.1
     # via python-telegram-bot
 transitions==0.8.8
     # via junos-eznc
-twilio==6.63.0
+twilio==7.9.2
     # via -r requirements/static/ci/linux.in
 tzlocal==3.0
     # via apscheduler

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -653,7 +653,7 @@ pyiface==0.0.11
     # via -r requirements/static/ci/linux.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via
     #   adal
     #   twilio
@@ -790,7 +790,6 @@ six==1.16.0
     #   pyvmomi
     #   responses
     #   transitions
-    #   twilio
     #   vcert
     #   virtualenv
     #   websocket-client
@@ -812,7 +811,7 @@ tornado==6.1
     # via python-telegram-bot
 transitions==0.8.8
     # via junos-eznc
-twilio==6.63.0
+twilio==7.9.2
     # via -r requirements/static/ci/linux.in
 tzlocal==3.0
     # via apscheduler

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -672,7 +672,7 @@ pyiface==0.0.11
     # via -r requirements/static/ci/linux.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via
     #   adal
     #   twilio
@@ -846,7 +846,6 @@ six==1.16.0
     #   pyvmomi
     #   responses
     #   transitions
-    #   twilio
     #   vcert
     #   virtualenv
     #   websocket-client
@@ -868,7 +867,7 @@ tornado==6.1
     # via python-telegram-bot
 transitions==0.8.1
     # via junos-eznc
-twilio==6.63.0
+twilio==7.9.2
     # via -r requirements/static/ci/linux.in
 typing-extensions==4.2.0
     # via

--- a/requirements/static/ci/py3.5/linux.txt
+++ b/requirements/static/ci/py3.5/linux.txt
@@ -920,7 +920,7 @@ tornado==6.1
     # via python-telegram-bot
 transitions==0.8.1
     # via junos-eznc
-twilio==6.63.0
+twilio==6.63.2
     # via -r requirements/static/ci/linux.in
 typing-extensions==3.10.0.2
     # via

--- a/requirements/static/ci/py3.6/docs.txt
+++ b/requirements/static/ci/py3.6/docs.txt
@@ -682,7 +682,7 @@ pyiface==0.0.11
     # via -r requirements/static/ci/linux.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via
     #   adal
     #   twilio
@@ -816,7 +816,6 @@ six==1.16.0
     #   responses
     #   textfsm
     #   transitions
-    #   twilio
     #   vcert
     #   virtualenv
     #   websocket-client
@@ -854,7 +853,7 @@ tornado==6.1
     # via python-telegram-bot
 transitions==0.8.8
     # via junos-eznc
-twilio==6.63.0
+twilio==7.9.2
     # via -r requirements/static/ci/linux.in
 typing-extensions==3.10.0.0
     # via

--- a/requirements/static/ci/py3.6/lint.txt
+++ b/requirements/static/ci/py3.6/lint.txt
@@ -680,7 +680,7 @@ pyiface==0.0.11
     # via -r requirements/static/ci/linux.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via
     #   adal
     #   twilio
@@ -818,7 +818,6 @@ six==1.16.0
     #   responses
     #   textfsm
     #   transitions
-    #   twilio
     #   vcert
     #   virtualenv
     #   websocket-client
@@ -842,7 +841,7 @@ tornado==6.1
     # via python-telegram-bot
 transitions==0.8.8
     # via junos-eznc
-twilio==6.63.0
+twilio==7.9.2
     # via -r requirements/static/ci/linux.in
 typed-ast==1.4.1
     # via astroid

--- a/requirements/static/ci/py3.6/linux.txt
+++ b/requirements/static/ci/py3.6/linux.txt
@@ -697,7 +697,7 @@ pyiface==0.0.11
     # via -r requirements/static/ci/linux.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via
     #   adal
     #   twilio
@@ -872,7 +872,6 @@ six==1.16.0
     #   responses
     #   textfsm
     #   transitions
-    #   twilio
     #   vcert
     #   virtualenv
     #   websocket-client
@@ -898,7 +897,7 @@ tornado==6.1
     # via python-telegram-bot
 transitions==0.8.1
     # via junos-eznc
-twilio==6.63.0
+twilio==7.9.2
     # via -r requirements/static/ci/linux.in
 typing-extensions==3.10.0.0
     # via

--- a/requirements/static/ci/py3.7/docs.txt
+++ b/requirements/static/ci/py3.7/docs.txt
@@ -700,7 +700,7 @@ pyiface==0.0.11
     # via -r requirements/static/ci/linux.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via
     #   adal
     #   twilio
@@ -841,7 +841,6 @@ six==1.16.0
     #   responses
     #   textfsm
     #   transitions
-    #   twilio
     #   vcert
     #   virtualenv
     #   websocket-client
@@ -883,7 +882,7 @@ tornado==6.1
     # via python-telegram-bot
 transitions==0.8.8
     # via junos-eznc
-twilio==6.63.0
+twilio==7.9.2
     # via -r requirements/static/ci/linux.in
 typing-extensions==3.10.0.0
     # via

--- a/requirements/static/ci/py3.7/lint.txt
+++ b/requirements/static/ci/py3.7/lint.txt
@@ -698,7 +698,7 @@ pyiface==0.0.11
     # via -r requirements/static/ci/linux.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via
     #   adal
     #   twilio
@@ -843,7 +843,6 @@ six==1.16.0
     #   responses
     #   textfsm
     #   transitions
-    #   twilio
     #   vcert
     #   virtualenv
     #   websocket-client
@@ -871,7 +870,7 @@ tornado==6.1
     # via python-telegram-bot
 transitions==0.8.8
     # via junos-eznc
-twilio==6.63.0
+twilio==7.9.2
     # via -r requirements/static/ci/linux.in
 typed-ast==1.4.1
     # via astroid

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -710,7 +710,7 @@ pyiface==0.0.11
     # via -r requirements/static/ci/linux.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via
     #   adal
     #   twilio
@@ -892,7 +892,6 @@ six==1.16.0
     #   responses
     #   textfsm
     #   transitions
-    #   twilio
     #   vcert
     #   virtualenv
     #   websocket-client
@@ -921,7 +920,7 @@ tornado==6.1
     # via python-telegram-bot
 transitions==0.8.1
     # via junos-eznc
-twilio==6.63.0
+twilio==7.9.2
     # via -r requirements/static/ci/linux.in
 typing-extensions==3.10.0.0
     # via

--- a/requirements/static/ci/py3.8/docs.txt
+++ b/requirements/static/ci/py3.8/docs.txt
@@ -692,7 +692,7 @@ pyiface==0.0.11
     # via -r requirements/static/ci/linux.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via
     #   adal
     #   twilio
@@ -834,7 +834,6 @@ six==1.16.0
     #   responses
     #   textfsm
     #   transitions
-    #   twilio
     #   vcert
     #   virtualenv
     #   websocket-client
@@ -876,7 +875,7 @@ tornado==6.1
     # via python-telegram-bot
 transitions==0.8.8
     # via junos-eznc
-twilio==6.63.0
+twilio==7.9.2
     # via -r requirements/static/ci/linux.in
 tzlocal==3.0
     # via apscheduler

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -690,7 +690,7 @@ pyiface==0.0.11
     # via -r requirements/static/ci/linux.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via
     #   adal
     #   twilio
@@ -835,7 +835,6 @@ six==1.16.0
     #   responses
     #   textfsm
     #   transitions
-    #   twilio
     #   vcert
     #   virtualenv
     #   websocket-client
@@ -863,7 +862,7 @@ tornado==6.1
     # via python-telegram-bot
 transitions==0.8.8
     # via junos-eznc
-twilio==6.63.0
+twilio==7.9.2
     # via -r requirements/static/ci/linux.in
 tzlocal==3.0
     # via apscheduler

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -701,7 +701,7 @@ pyiface==0.0.11
     # via -r requirements/static/ci/linux.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via
     #   adal
     #   twilio
@@ -883,7 +883,6 @@ six==1.16.0
     #   responses
     #   textfsm
     #   transitions
-    #   twilio
     #   vcert
     #   virtualenv
     #   websocket-client
@@ -912,7 +911,7 @@ tornado==6.1
     # via python-telegram-bot
 transitions==0.8.1
     # via junos-eznc
-twilio==6.63.0
+twilio==7.9.2
     # via -r requirements/static/ci/linux.in
 typing-extensions==4.2.0
     # via

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -690,7 +690,7 @@ pyiface==0.0.11
     # via -r requirements/static/ci/linux.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via
     #   adal
     #   twilio
@@ -832,7 +832,6 @@ six==1.16.0
     #   responses
     #   textfsm
     #   transitions
-    #   twilio
     #   vcert
     #   virtualenv
     #   websocket-client
@@ -874,7 +873,7 @@ tornado==6.1
     # via python-telegram-bot
 transitions==0.8.8
     # via junos-eznc
-twilio==6.63.0
+twilio==7.9.2
     # via -r requirements/static/ci/linux.in
 tzlocal==3.0
     # via apscheduler

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -688,7 +688,7 @@ pyiface==0.0.11
     # via -r requirements/static/ci/linux.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via
     #   adal
     #   twilio
@@ -833,7 +833,6 @@ six==1.16.0
     #   responses
     #   textfsm
     #   transitions
-    #   twilio
     #   vcert
     #   virtualenv
     #   websocket-client
@@ -861,7 +860,7 @@ tornado==6.1
     # via python-telegram-bot
 transitions==0.8.8
     # via junos-eznc
-twilio==6.63.0
+twilio==7.9.2
     # via -r requirements/static/ci/linux.in
 tzlocal==3.0
     # via apscheduler

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -703,7 +703,7 @@ pyiface==0.0.11
     # via -r requirements/static/ci/linux.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via
     #   adal
     #   twilio
@@ -885,7 +885,6 @@ six==1.16.0
     #   responses
     #   textfsm
     #   transitions
-    #   twilio
     #   vcert
     #   virtualenv
     #   websocket-client
@@ -914,7 +913,7 @@ tornado==6.1
     # via python-telegram-bot
 transitions==0.8.1
     # via junos-eznc
-twilio==6.63.0
+twilio==7.9.2
     # via -r requirements/static/ci/linux.in
 typing-extensions==4.2.0
     # via


### PR DESCRIPTION
Twilio also had to be upgraded because it was locked to the vulnerable pyjwt version.