### PR TITLE
Fix an incompatibility preventing salt-cloud from deploying VMs on Proxmox VE 7

### DIFF
--- a/changelog/62154.fixed
+++ b/changelog/62154.fixed
@@ -1,0 +1,1 @@
+Fixed an incompatibility preventing salt-cloud from deploying VMs on Proxmox VE 7

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -848,7 +848,7 @@ def _import_api():
     full_url = "https://{}:{}/pve-docs/api-viewer/apidoc.js".format(url, port)
     returned_data = requests.get(full_url, verify=verify_ssl)
 
-    re_filter = re.compile("(?<=pveapi =)(.*)(?=^;)", re.DOTALL | re.MULTILINE)
+    re_filter = re.compile(" (?:pveapi|apiSchema) = (.*)^;", re.DOTALL | re.MULTILINE)
     api_json = re_filter.findall(returned_data.text)[0]
     api = salt.utils.json.loads(api_json)
 


### PR DESCRIPTION
### What does this PR do?
Fixes the regex preventing salt-cloud from deploying VMs on Proxmox VE 7.

### What issues does this PR fix or reference?
Fixes: #62154 

### Previous Behavior
Failing with an IndexError

### New Behavior
Succeeds in deploying a VM

### Merge requirements satisfied?
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No
