### PR TITLE
Recognize OSMC as Debian-based

### DIFF
--- a/changelog/62198.fixed
+++ b/changelog/62198.fixed
@@ -1,0 +1,1 @@
+Recognize OSMC as Debian-based

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1734,6 +1734,7 @@ _OS_FAMILY_MAP = {
     "AstraLinuxSE": "Debian",
     "Alinux": "RedHat",
     "Mendel": "Debian",
+    "OSMC": "Debian",
 }
 
 # Matches any possible format:

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -934,6 +934,28 @@ def test_rocky_8_os_grains(os_release_dir):
 
 
 @pytest.mark.skip_unless_on_linux
+def test_osmc_os_grains(os_release_dir):
+    """
+    Test if OS grains are parsed correctly in OSMC
+    """
+    _os_release_map = {
+        "_linux_distribution": ("OSMC", "2022.03-1", "Open Source Media Center"),
+    }
+
+    expectation = {
+        "os": "OSMC",
+        "os_family": "Debian",
+        "oscodename": "Open Source Media Center",
+        "osfullname": "OSMC",
+        "osrelease": "2022.03-1",
+        "osrelease_info": (2022, "03-1"),
+        "osmajorrelease": 2022,
+        "osfinger": "OSMC-2022",
+    }
+    _run_os_grains_tests(os_release_dir, None, _os_release_map, expectation)
+
+
+@pytest.mark.skip_unless_on_linux
 def test_mendel_os_grains(os_release_dir):
     """
     Test if OS grains are parsed correctly in Mendel Linux


### PR DESCRIPTION
### What does this PR do?

This changes recognizes [OSMC](https://osmc.tv/) as Debian based.

### What issues does this PR fix or reference?
Fixes: #62198

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No, sorry