### PR TITLE
add support for gpgautoimport to refresh_db in the zypperpkg module

### DIFF
--- a/changelog/42039.fixed.md
+++ b/changelog/42039.fixed.md
@@ -1,0 +1,1 @@
+fix autoaccept gpg keys by supporting it in refresh_db module

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -1412,12 +1412,12 @@ def refresh_db(force=None, root=None, **kwargs):
         If set to True, automatically trust and import public GPG key for
         the repository.
 
-        .. versionadded:: 3005
+        .. versionadded:: 3007
 
     repos
         Refresh just the specified repos
 
-        .. versionadded:: 3005
+        .. versionadded:: 3007
 
     root
         operate on a different root directory.

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -1397,7 +1397,7 @@ def mod_repo(repo, **kwargs):
     return repo
 
 
-def refresh_db(force=None, root=None, **kwargs):
+def refresh_db(force=None, root=None, gpgautoimport=False, **kwargs):
     """
     Trigger a repository refresh by calling ``zypper refresh``. Refresh will run
     with ``--force`` if the "force=True" flag is passed on the CLI or
@@ -1447,7 +1447,7 @@ def refresh_db(force=None, root=None, **kwargs):
     repos = kwargs.get("repos", [])
     refresh_opts.extend([repos] if not isinstance(repos, list) else repos)
 
-    if kwargs.get("gpgautoimport", False):
+    if gpgautoimport:
         global_opts.append("--gpg-auto-import-keys")
 
     # We do the actual call to zypper refresh.

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -1374,7 +1374,6 @@ def mod_repo(repo, **kwargs):
         cmd_opt.append(kwargs.get("name"))
 
     if kwargs.get("gpgautoimport") is True:
-        global_cmd_opt.append("--gpg-auto-import-keys")
         call_refresh = True
 
     if cmd_opt:
@@ -1386,8 +1385,8 @@ def mod_repo(repo, **kwargs):
         # when used with "zypper ar --refresh" or "zypper mr --refresh"
         # --gpg-auto-import-keys is not doing anything
         # so we need to specifically refresh here with --gpg-auto-import-keys
-        refresh_opts = global_cmd_opt + ["refresh"] + [repo]
-        __zypper__(root=root).xml.call(*refresh_opts)
+        kwargs.update({"repos": repo})
+        refresh_db(root=root, **kwargs)
     elif not added and not cmd_opt:
         comment = "Specified arguments did not result in modification of repo"
 

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -1412,12 +1412,12 @@ def refresh_db(force=None, root=None, gpgautoimport=False, **kwargs):
         If set to True, automatically trust and import public GPG key for
         the repository.
 
-        .. versionadded:: 3007
+        .. versionadded:: 3007.0
 
     repos
         Refresh just the specified repos
 
-        .. versionadded:: 3007
+        .. versionadded:: 3007.0
 
     root
         operate on a different root directory.

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -1450,6 +1450,8 @@ def refresh_db(force=None, root=None, **kwargs):
     if kwargs.get("gpgautoimport", False):
         global_opts.append("--gpg-auto-import-keys")
 
+    # We do the actual call to zypper refresh.
+    # We ignore retcode 6 which is returned when there are no repositories defined.
     out = __zypper__(root=root).refreshable.call(
         *global_opts, *refresh_opts, success_retcodes=[0, 6]
     )

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -1450,7 +1450,9 @@ def refresh_db(force=None, root=None, **kwargs):
     if kwargs.get("gpgautoimport", False):
         global_opts.append("--gpg-auto-import-keys")
 
-    out = __zypper__(root=root).refreshable.call(*global_opts, *refresh_opts)
+    out = __zypper__(root=root).refreshable.call(
+        *global_opts, *refresh_opts, success_retcodes=[0, 6]
+    )
 
     for line in out.splitlines():
         if not line:

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -560,7 +560,7 @@ def list_upgrades(refresh=True, root=None, **kwargs):
         salt '*' pkg.list_upgrades
     """
     if refresh:
-        refresh_db(root)
+        refresh_db(root, **kwargs)
 
     ret = dict()
     cmd = ["list-updates"]
@@ -674,7 +674,7 @@ def info_available(*names, **kwargs):
 
     # Refresh db before extracting the latest package
     if kwargs.get("refresh", True):
-        refresh_db(root)
+        refresh_db(root, **kwargs)
 
     pkg_info = []
     batch = names[:]
@@ -1620,7 +1620,7 @@ def install(
                 'arch': '<new-arch>'}}}
     """
     if refresh:
-        refresh_db(root)
+        refresh_db(root, **kwargs)
 
     try:
         pkg_params, pkg_type = __salt__["pkg_resource.parse_targets"](
@@ -1905,7 +1905,7 @@ def upgrade(
         cmd_update.insert(0, "--no-gpg-checks")
 
     if refresh:
-        refresh_db(root)
+        refresh_db(root, **kwargs)
 
     if dryrun:
         cmd_update.append("--dry-run")
@@ -2728,7 +2728,7 @@ def search(criteria, refresh=False, **kwargs):
     root = kwargs.get("root", None)
 
     if refresh:
-        refresh_db(root)
+        refresh_db(root, **kwargs)
 
     cmd = ["search"]
     if kwargs.get("match") == "exact":
@@ -2879,7 +2879,7 @@ def download(*packages, **kwargs):
 
     refresh = kwargs.get("refresh", False)
     if refresh:
-        refresh_db(root)
+        refresh_db(root, **kwargs)
 
     pkg_ret = {}
     for dld_result in (
@@ -3031,7 +3031,7 @@ def list_patches(refresh=False, root=None, **kwargs):
         salt '*' pkg.list_patches
     """
     if refresh:
-        refresh_db(root)
+        refresh_db(root, **kwargs)
 
     return _get_patches(root=root)
 
@@ -3125,7 +3125,7 @@ def resolve_capabilities(pkgs, refresh=False, root=None, **kwargs):
         salt '*' pkg.resolve_capabilities resolve_capabilities=True w3m_ssl
     """
     if refresh:
-        refresh_db(root)
+        refresh_db(root, **kwargs)
 
     ret = list()
     for pkg in pkgs:

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -391,6 +391,73 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                 zypper_mock.assert_called_with(
                     ["zypper", "--non-interactive", "refresh", "--force"], **call_kwargs
                 )
+                zypper.refresh_db(gpgautoimport=True)
+                zypper_mock.assert_called_with(
+                    [
+                        "zypper",
+                        "--non-interactive",
+                        "--gpg-auto-import-keys",
+                        "refresh",
+                        "--force",
+                    ],
+                    **call_kwargs
+                )
+                zypper.refresh_db(gpgautoimport=True, force=True)
+                zypper_mock.assert_called_with(
+                    [
+                        "zypper",
+                        "--non-interactive",
+                        "--gpg-auto-import-keys",
+                        "refresh",
+                        "--force",
+                    ],
+                    **call_kwargs
+                )
+                zypper.refresh_db(gpgautoimport=True, force=False)
+                zypper_mock.assert_called_with(
+                    [
+                        "zypper",
+                        "--non-interactive",
+                        "--gpg-auto-import-keys",
+                        "refresh",
+                    ],
+                    **call_kwargs
+                )
+                zypper.refresh_db(
+                    gpgautoimport=True,
+                    refresh=True,
+                    repos="mock-repo-name",
+                    root=None,
+                    url="http://repo.url/some/path",
+                )
+                zypper_mock.assert_called_with(
+                    [
+                        "zypper",
+                        "--non-interactive",
+                        "--gpg-auto-import-keys",
+                        "refresh",
+                        "--force",
+                        "mock-repo-name",
+                    ],
+                    **call_kwargs
+                )
+                zypper.refresh_db(
+                    gpgautoimport=True,
+                    repos="mock-repo-name",
+                    root=None,
+                    url="http://repo.url/some/path",
+                )
+                zypper_mock.assert_called_with(
+                    [
+                        "zypper",
+                        "--non-interactive",
+                        "--gpg-auto-import-keys",
+                        "refresh",
+                        "--force",
+                        "mock-repo-name",
+                    ],
+                    **call_kwargs
+                )
 
     def test_info_installed(self):
         """

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -373,7 +373,12 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
         run_out = {"stderr": "", "stdout": "\n".join(ref_out), "retcode": 0}
 
         zypper_mock = MagicMock(return_value=run_out)
-        call_kwargs = {"output_loglevel": "trace", "python_shell": False, "env": {}}
+        call_kwargs = {
+            "output_loglevel": "trace",
+            "python_shell": False,
+            "env": {},
+            "success_retcodes": [0, 6],
+        }
         with patch.dict(zypper.__salt__, {"cmd.run_all": zypper_mock}):
             with patch.object(salt.utils.pkg, "clear_rtag", Mock()):
                 result = zypper.refresh_db()

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -405,7 +405,7 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                         "refresh",
                         "--force",
                     ],
-                    **call_kwargs
+                    **call_kwargs,
                 )
                 zypper.refresh_db(gpgautoimport=True, force=True)
                 zypper_mock.assert_called_with(
@@ -416,7 +416,7 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                         "refresh",
                         "--force",
                     ],
-                    **call_kwargs
+                    **call_kwargs,
                 )
                 zypper.refresh_db(gpgautoimport=True, force=False)
                 zypper_mock.assert_called_with(
@@ -426,7 +426,7 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                         "--gpg-auto-import-keys",
                         "refresh",
                     ],
-                    **call_kwargs
+                    **call_kwargs,
                 )
                 zypper.refresh_db(
                     gpgautoimport=True,
@@ -444,7 +444,7 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                         "--force",
                         "mock-repo-name",
                     ],
-                    **call_kwargs
+                    **call_kwargs,
                 )
                 zypper.refresh_db(
                     gpgautoimport=True,
@@ -461,7 +461,7 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                         "--force",
                         "mock-repo-name",
                     ],
-                    **call_kwargs
+                    **call_kwargs,
                 )
 
     def test_info_installed(self):
@@ -1896,15 +1896,11 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
         _zpr.nolock.xml.call = MagicMock(return_value=minidom.parseString(xmldoc))
 
         for op in zypper.Wildcard.Z_OP:
-            assert zypper.Wildcard(_zpr)(
-                "libzypp", "{}*.1".format(op)
-            ) == "{}17.2.6-27.9.1".format(op)
+            assert zypper.Wildcard(_zpr)("libzypp", f"{op}*.1") == f"{op}17.2.6-27.9.1"
 
         # Auto-fix feature: moves operator from end to front
         for op in zypper.Wildcard.Z_OP:
-            assert zypper.Wildcard(_zpr)(
-                "libzypp", "16*{}".format(op)
-            ) == "{}16.2.5-25.1".format(op)
+            assert zypper.Wildcard(_zpr)("libzypp", f"16*{op}") == f"{op}16.2.5-25.1"
 
     def test_wildcard_to_query_unsupported_operators(self):
         """
@@ -1923,7 +1919,7 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
         _zpr.nolock.xml.call = MagicMock(return_value=minidom.parseString(xmldoc))
         with self.assertRaises(CommandExecutionError):
             for op in [">>", "==", "<<", "+"]:
-                zypper.Wildcard(_zpr)("libzypp", "{}*.1".format(op))
+                zypper.Wildcard(_zpr)("libzypp", f"{op}*.1")
 
     @patch("salt.modules.zypperpkg._get_visible_patterns")
     def test__get_installed_patterns(self, get_visible_patterns):

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -1616,17 +1616,22 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
 
         url = self.new_repo_config["url"]
         name = self.new_repo_config["name"]
-        with zypper_patcher:
+        with zypper_patcher, patch.object(zypper, "refresh_db", Mock()) as refreshmock:
             zypper.mod_repo(name, **{"url": url, "gpgautoimport": True})
             self.assertEqual(
                 zypper.__zypper__(root=None).xml.call.call_args_list,
                 [
                     call("ar", url, name),
-                    call("--gpg-auto-import-keys", "refresh", name),
                 ],
             )
             self.assertTrue(
                 zypper.__zypper__(root=None).refreshable.xml.call.call_count == 0
+            )
+            refreshmock.assert_called_once_with(
+                gpgautoimport=True,
+                repos=name,
+                root=None,
+                url="http://repo.url/some/path",
             )
 
     def test_repo_noadd_nomod_ref(self):
@@ -1646,14 +1651,16 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
             "salt.modules.zypperpkg", **self.zypper_patcher_config
         )
 
-        with zypper_patcher:
+        with zypper_patcher, patch.object(zypper, "refresh_db", Mock()) as refreshmock:
             zypper.mod_repo(name, **{"url": url, "gpgautoimport": True})
-            self.assertEqual(
-                zypper.__zypper__(root=None).xml.call.call_args_list,
-                [call("--gpg-auto-import-keys", "refresh", name)],
-            )
             self.assertTrue(
                 zypper.__zypper__(root=None).refreshable.xml.call.call_count == 0
+            )
+            refreshmock.assert_called_once_with(
+                gpgautoimport=True,
+                repos=name,
+                root=None,
+                url="http://repo.url/some/path",
             )
 
     def test_repo_add_mod_ref(self):
@@ -1667,10 +1674,10 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
         zypper_patcher = patch.multiple(
             "salt.modules.zypperpkg", **self.zypper_patcher_config
         )
-
         url = self.new_repo_config["url"]
         name = self.new_repo_config["name"]
-        with zypper_patcher:
+
+        with zypper_patcher, patch.object(zypper, "refresh_db", Mock()) as refreshmock:
             zypper.mod_repo(
                 name, **{"url": url, "refresh": True, "gpgautoimport": True}
             )
@@ -1678,11 +1685,17 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                 zypper.__zypper__(root=None).xml.call.call_args_list,
                 [
                     call("ar", url, name),
-                    call("--gpg-auto-import-keys", "refresh", name),
                 ],
             )
             zypper.__zypper__(root=None).refreshable.xml.call.assert_called_once_with(
-                "--gpg-auto-import-keys", "mr", "--refresh", name
+                "mr", "--refresh", name
+            )
+            refreshmock.assert_called_once_with(
+                gpgautoimport=True,
+                refresh=True,
+                repos=name,
+                root=None,
+                url="http://repo.url/some/path",
             )
 
     def test_repo_noadd_mod_ref(self):
@@ -1702,16 +1715,19 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
             "salt.modules.zypperpkg", **self.zypper_patcher_config
         )
 
-        with zypper_patcher:
+        with zypper_patcher, patch.object(zypper, "refresh_db", Mock()) as refreshmock:
             zypper.mod_repo(
                 name, **{"url": url, "refresh": True, "gpgautoimport": True}
             )
-            self.assertEqual(
-                zypper.__zypper__(root=None).xml.call.call_args_list,
-                [call("--gpg-auto-import-keys", "refresh", name)],
-            )
             zypper.__zypper__(root=None).refreshable.xml.call.assert_called_once_with(
-                "--gpg-auto-import-keys", "mr", "--refresh", name
+                "mr", "--refresh", name
+            )
+            refreshmock.assert_called_once_with(
+                gpgautoimport=True,
+                refresh=True,
+                repos=name,
+                root=None,
+                url="http://repo.url/some/path",
             )
 
     def test_wildcard_to_query_match_all(self):


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/saltstack/salt/issues/42039

### Previous Behavior
When using the zypper pkg module a refresh could never import GPG keys.

### New Behavior
Now an option is available to enable autoimport of GPG keys. The default is still `off`

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
