### PR TITLE
Remove signedby argument. Specify in the name

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2159,7 +2159,7 @@ def _parse_repo_keys_output(cmd_ret):
                     "capability": items[11],
                     "date_creation": items[5],
                     "date_expiration": items[6],
-                    "keyid": items[4],
+                    "keyid": str(items[4]),
                     "validity": items[1],
                 }
             )
@@ -2742,10 +2742,7 @@ def mod_repo(repo, saltenv="base", aptkey=True, **kwargs):
     full_comp_list = {comp.strip() for comp in repo_comps}
     no_proxy = __salt__["config.option"]("no_proxy")
 
-    if "signedby" in kwargs:
-        kwargs["signedby"] = pathlib.Path(kwargs["signedby"])
-    else:
-        kwargs["signedby"] = pathlib.Path(repo_signedby) if repo_signedby else ""
+    kwargs["signedby"] = pathlib.Path(repo_signedby) if repo_signedby else ""
 
     if "keyid" in kwargs:
         keyid = kwargs.pop("keyid", None)

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -115,36 +115,6 @@ Using ``aptkey: False`` with ``keyserver`` and ``keyid``:
         - keyserver: keyserver.ubuntu.com
         - keyid: 0E08A149DE57BFBE
         - aptkey: False
-
-You can also use the ``signedby`` option as an argument to the state.
-This option is only supported if you do NOT have python3-apt installed.
-Python3-apt does not currently support the ``signed-by`` option in repo
-definitions. You can set ``signed-by`` in the name of the repo, but
-NOT in the ``signedby`` argument of the state if python3-apt is installed.
-
-.. code-block:: yaml
-
-    deb [arch=amd64] https://repo.saltproject.io/py3/ubuntu/18.04/amd64/latest bionic main:
-      pkgrepo.managed:
-        - file: /etc/apt/sources.list.d/salt.list
-        - signedby: /etc/apt/keyrings/salt-archive-keyring.gpg
-        - keyserver: keyserver.ubuntu.com
-        - keyid: 0E08A149DE57BFBE
-        - aptkey: False
-
-If you have the ``signed-by`` option set in your pkgrepo.managed name
-and the ``signedby`` arg set in the state, the ``signedby`` arg
-will override what is set in the name.
-
-.. code-block:: yaml
-
-    deb [arch=amd64 signed-by=/etc/apt/keyrings/salt-archive-keyring.gpg] https://repo.saltproject.io/py3/ubuntu/18.04/amd64/latest bionic main:
-      pkgrepo.managed:
-        - file: /etc/apt/sources.list.d/salt.list
-        - signedby: /etc/apt/keyrings/salt-archive-keyring-override.gpg
-        - keyserver: keyserver.ubuntu.com
-        - keyid: 0E08A149DE57BFBE
-        - aptkey: False
 """
 
 
@@ -374,10 +344,6 @@ def managed(name, ppa=None, copr=None, aptkey=True, **kwargs):
     aptkey: Use the binary apt-key. If the command ``apt-key`` is not found
        in the path, aptkey will be False, regardless of what is passed into
        this argument.
-
-    signedby:
-        On apt-based systems, ``signedby`` is the the path to the key file
-        the repository will use. This is required if apt-key is False.
     """
     if not salt.utils.path.which("apt-key"):
         aptkey = False

--- a/tests/pytests/functional/states/pkgrepo/test_debian.py
+++ b/tests/pytests/functional/states/pkgrepo/test_debian.py
@@ -705,7 +705,9 @@ def test_adding_repo_file_signedby_alt_file(pkgrepo, states, repo):
     assert repo.repo_content in ret.comment
 
     key_file = repo.key_file.parent / "salt-alt-key.gpg"
-    repo_content="deb [arch=amd64 signed-by={}] https://repo.saltproject.io/py3/debian/10/amd64/latest buster main".format(str(key_file))
+    repo_content = "deb [arch=amd64 signed-by={}] https://repo.saltproject.io/py3/debian/10/amd64/latest buster main".format(
+        str(key_file)
+    )
     ret = states.pkgrepo.managed(
         name=repo_content,
         file=str(repo.repo_file),

--- a/tests/pytests/functional/states/pkgrepo/test_debian.py
+++ b/tests/pytests/functional/states/pkgrepo/test_debian.py
@@ -644,6 +644,7 @@ def test_adding_repo_file_signedby(pkgrepo, states, repo):
         file_content = fp.read()
         assert file_content.strip() == repo.repo_content
     assert repo.key_file.is_file()
+    assert repo.repo_content in ret.comment
 
 
 def test_adding_repo_file_signedby_keyserver(pkgrepo, states, repo):

--- a/tests/pytests/unit/modules/test_aptpkg.py
+++ b/tests/pytests/unit/modules/test_aptpkg.py
@@ -16,6 +16,7 @@ import textwrap
 import pytest
 import salt.modules.aptpkg as aptpkg
 import salt.modules.pkg_resource as pkg_resource
+import salt.utils.path
 from salt.exceptions import (
     CommandExecutionError,
     CommandNotFoundError,
@@ -763,14 +764,20 @@ def test_mod_repo_match():
                                 "deb http://cdn-aws.deb.debian.org/debian"
                                 " stretch main"
                             )
-                            if HAS_APT:
-                                repo = aptpkg.mod_repo(source_line_no_slash, enabled=False)
+                            if salt.utils.path.which("apt-key"):
+                                repo = aptpkg.mod_repo(
+                                    source_line_no_slash, enabled=False
+                                )
                                 assert repo[source_line_no_slash]["uri"] == source_uri
                             else:
                                 with pytest.raises(Exception) as err:
-                                    repo = aptpkg.mod_repo(source_line_no_slash, enabled=False)
-                                assert "missing 'signedby' option when apt-key is missing" in str(err.value)
-
+                                    repo = aptpkg.mod_repo(
+                                        source_line_no_slash, enabled=False
+                                    )
+                                assert (
+                                    "missing 'signedby' option when apt-key is missing"
+                                    in str(err.value)
+                                )
 
 
 @patch("salt.utils.path.os_walk", MagicMock(return_value=[("test", "test", "test")]))

--- a/tests/pytests/unit/modules/test_aptpkg.py
+++ b/tests/pytests/unit/modules/test_aptpkg.py
@@ -763,8 +763,14 @@ def test_mod_repo_match():
                                 "deb http://cdn-aws.deb.debian.org/debian"
                                 " stretch main"
                             )
-                            repo = aptpkg.mod_repo(source_line_no_slash, enabled=False)
-                            assert repo[source_line_no_slash]["uri"] == source_uri
+                            if HAS_APT:
+                                repo = aptpkg.mod_repo(source_line_no_slash, enabled=False)
+                                assert repo[source_line_no_slash]["uri"] == source_uri
+                            else:
+                                with pytest.raises(Exception) as err:
+                                    repo = aptpkg.mod_repo(source_line_no_slash, enabled=False)
+                                assert "missing 'signedby' option when apt-key is missing" in str(err.value)
+
 
 
 @patch("salt.utils.path.os_walk", MagicMock(return_value=[("test", "test", "test")]))


### PR DESCRIPTION
### What does this PR do?
Removes the signedby kwarg in the pkgrepo state. The signedby argument is not able to be supported when python3-apt is installed and when it is not. It's also lead to more confusion than is helpful. The signedby argument is set in the name and we do not need a separate kwarg for it. This will keep things more simple and remove unexpected behavior when a user is migrating from using the python3-apt library to not using it.

This kwarg was never included in a released version so this does not require a deprecation or changelog.
