### PR TITLE
Add typing_extensions to salt-ssh thin tarball

### DIFF
--- a/changelog/59942.fixed
+++ b/changelog/59942.fixed
@@ -1,0 +1,1 @@
+Add typing_extensions to thin tarball. Fixes salt-ssh for targets with python<=3.8

--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -33,6 +33,7 @@ import yaml
 has_immutables = False
 try:
     import immutables
+    import typing_extensions  # Needed by immutables for <py3.8
 
     has_immutables = True
 except ImportError:
@@ -435,6 +436,7 @@ def get_tops(extra_mods="", so_mods=""):
     mods.append(contextvars)
     if has_immutables:
         mods.append(immutables)
+        mods.append(typing_extensions)
     for mod in mods:
         if mod:
             log.debug('Adding module to the tops: "%s"', mod.__name__)

--- a/tests/unit/utils/test_thin.py
+++ b/tests/unit/utils/test_thin.py
@@ -446,6 +446,11 @@ class SSHThinTestCase(TestCase):
         "salt.utils.thin.immutables",
         type("immutables", (), {"__file__": "/site-packages/immutables"}),
     )
+    @patch_if(
+        salt.utils.thin.has_immutables,
+        "salt.utils.thin.typing_extensions",
+        type("typing_extensions", (), {"__file__": "/site-packages/typing_extensions"}),
+    )
     @patch("salt.utils.thin.log", MagicMock())
     def test_get_tops(self):
         """
@@ -469,7 +474,7 @@ class SSHThinTestCase(TestCase):
             "contextvars",
         ]
         if salt.utils.thin.has_immutables:
-            base_tops.extend(["immutables"])
+            base_tops.extend(["immutables", "typing_extensions"])
         tops = []
         for top in thin.get_tops(extra_mods="foo,bar"):
             if top.find("/") != -1:
@@ -541,6 +546,11 @@ class SSHThinTestCase(TestCase):
         "salt.utils.thin.immutables",
         type("immutables", (), {"__file__": "/site-packages/immutables"}),
     )
+    @patch_if(
+        salt.utils.thin.has_immutables,
+        "salt.utils.thin.typing_extensions",
+        type("typing_extensions", (), {"__file__": "/site-packages/typing_extensions"}),
+    )
     @patch("salt.utils.thin.log", MagicMock())
     def test_get_tops_extra_mods(self):
         """
@@ -566,7 +576,7 @@ class SSHThinTestCase(TestCase):
             "bar.py",
         ]
         if salt.utils.thin.has_immutables:
-            base_tops.extend(["immutables"])
+            base_tops.extend(["immutables", "typing_extensions"])
         libs = salt.utils.thin.find_site_modules("contextvars")
         foo = {"__file__": os.sep + os.path.join("custom", "foo", "__init__.py")}
         bar = {"__file__": os.sep + os.path.join("custom", "bar")}
@@ -646,6 +656,11 @@ class SSHThinTestCase(TestCase):
         "salt.utils.thin.immutables",
         type("immutables", (), {"__file__": "/site-packages/immutables"}),
     )
+    @patch_if(
+        salt.utils.thin.has_immutables,
+        "salt.utils.thin.typing_extensions",
+        type("typing_extensions", (), {"__file__": "/site-packages/typing_extensions"}),
+    )
     @patch("salt.utils.thin.log", MagicMock())
     def test_get_tops_so_mods(self):
         """
@@ -671,7 +686,7 @@ class SSHThinTestCase(TestCase):
             "bar.so",
         ]
         if salt.utils.thin.has_immutables:
-            base_tops.extend(["immutables"])
+            base_tops.extend(["immutables", "typing_extensions"])
         libs = salt.utils.thin.find_site_modules("contextvars")
         with patch("salt.utils.thin.find_site_modules", MagicMock(side_effect=[libs])):
             with patch(


### PR DESCRIPTION
### What does this PR do?

When one uses `salt-ssh` 3003+ on python3.6-running targets (who are numerous, see RHEL, CentOS, RockyLinux, etc..., as OS vendors are supporting python3.6 and fixing security issues themselves even if upstream py36 is End Of Life), salt-ssh will include a backport of python3.7's `contextvars` module in the salt thin tarball.

However, the `contextvars` backport makes uses of the `immutables` module.

This module went through a typing refactor (see https://github.com/MagicStack/immutables/pull/62) which landed in its v0.16 release on August 2021.

However, that typing refactor added a new dependency, `typing_extensions`, but only on pre-3.8 deployments (see https://github.com/MagicStack/immutables/blob/master/immutables/_protocols.py#L13).

This third-order dependency (!) is nowhere to be found on the salt ssh thin tarball, which leads to several issues (#59942) as that import error triggers a cascade of exceptions.

This PR aims to fix that issue by adding `typing_extensions` to the thin tarball.

*Note: First-time Salt contributor here, don't hesistate to walk me through stuff if you think I missed something in my reading of the Contributor's Guide !*

### What issues does this PR fix or reference?
Fixes: #59942

### New Behavior
salt-ssh will add `typing_extensions` to the thin tarball in the cases where `immutables` is imported (i.e. target is running python 3.6)

### Merge requirements satisfied?
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes