### PR TITLE
fix yamllint config failure on older versions.

### DIFF
--- a/salt/modules/yaml.py
+++ b/salt/modules/yaml.py
@@ -4,20 +4,38 @@ Yaml helper module for troubleshooting yaml
 
 .. versionadded:: 3005
 
-:depends:   yamllint
+:depends:   yamllint >= 1.20.0
 
 
 """
 
 import logging
 
+import salt.utils.versions
+
 log = logging.getLogger(__name__)
 
 __virtualname__ = "yaml"
 
 
+try:
+    import salt.utils.yamllint
+
+    HAS_LINT = True
+except ImportError:
+    HAS_LINT = False
+
+
 def __virtual__():
-    return __virtualname__
+    if HAS_LINT:
+        version = salt.utils.yamllint.version()
+        version_cmp = salt.utils.versions.version_cmp(version, "1.20.0")
+        if version_cmp >= 0:
+            return __virtualname__
+        else:
+            return (False, "yamllint below 1.20.0, please pip install a newer version")
+    else:
+        return (False, "yamllint not installd")
 
 
 def lint(source, saltenv=None, pre_render=None, **kwargs):
@@ -53,4 +71,4 @@ def lint(source, saltenv=None, pre_render=None, **kwargs):
         yaml_out = __salt__["slsutil.renderer"](
             path=source, default_renderer=pre_render, **kwargs
         )
-    return __utils__["yamllint.lint"](yaml_out)
+    return salt.utils.yamllint.lint(yaml_out)

--- a/salt/utils/yamllint.py
+++ b/salt/utils/yamllint.py
@@ -6,6 +6,7 @@ HAS_YAMLLINT = True
 try:
     from yamllint import linter
     from yamllint.config import YamlLintConfig
+    import yamllint
 except ImportError:
     HAS_YAMLLINT = False
 
@@ -19,6 +20,13 @@ def __virtual__():
         return __virtualname__
     else:
         return (False, "YAMLLint Not installed")
+
+
+def version():
+    """
+    report version of yamllint installed for version comparison
+    """
+    return yamllint.__version__
 
 
 def lint(
@@ -44,7 +52,6 @@ def lint(
           empty-values: {forbid-in-block-mappings: false, forbid-in-flow-mappings: true}
           trailing-spaces: disable
           key-ordering: disable
-          truthy: {level: warning, check-keys: false }
         """
         conf = YamlLintConfig(yamlconf)
 

--- a/tests/pytests/functional/modules/test_yaml.py
+++ b/tests/pytests/functional/modules/test_yaml.py
@@ -54,3 +54,7 @@ def test_lint_pre_render():
         "problems": [],
         "source": "key: value\n",
     }
+
+
+def test_yamllint_virtual():
+    assert salt.modules.yaml.__virtual__() == "yaml"

--- a/tests/pytests/functional/utils/yamllint/test_yamllint.py
+++ b/tests/pytests/functional/utils/yamllint/test_yamllint.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import salt.utils.versions as versions
 import salt.utils.yamllint as yamllint
 
 
@@ -47,4 +48,4 @@ def test_config():
 
 
 def test_version():
-    assert yamllint.version() == "1.26.3"
+    assert versions.version_cmp(yamllint.version(), "1.26.3") >= 0

--- a/tests/pytests/functional/utils/yamllint/test_yamllint.py
+++ b/tests/pytests/functional/utils/yamllint/test_yamllint.py
@@ -44,3 +44,7 @@ def test_config():
             }
         ],
     }
+
+
+def test_version():
+    assert yamllint.version() == "1.26.3"


### PR DESCRIPTION
### What does this PR do?
* adds version comp stuff so older versions of yamllint don't break.
* removes __utils__ call and changes to import
* adds version information to utils module. 
* checks version in module.

### What issues does this PR fix or reference?
Fixes: #62238 

### Previous Behavior
packaged yamllint from ubuntu 20.04 caused issues. 

### New Behavior
yamllint 1.20.0 and above don't cause issues and should work just fine. 

### Merge requirements satisfied?
- [X] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
No