### PR TITLE
Skip is_writeable check for log files in /dev/

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -787,7 +787,8 @@ class LogLevelMixIn(six.with_metaclass(MixInMeta, object)):
             )
         )
 
-        if not is_writeable(logfile, check_parent=True):
+        if (not logfile.startswith("file:///dev/") and
+            not is_writeable(logfile, check_parent=True)):
             # Since we're not be able to write to the log file or its parent
             # directory (if the log file does not exit), are we the same user
             # as the one defined in the configuration file?


### PR DESCRIPTION
### What does this PR do?

The [documented way](https://docs.saltproject.io/en/latest/ref/configuration/logging/index.html#std-conf_log-log_file) to write to syslog is to use the config: `log_file: file:///dev/log`.

This breaks in some circumstances when running as non-root, for example, when `log_level: info` is set. In that case, `/dev/log` is not "writeable", so the code falls back to writing to `/root/.salt/master.log`, which is definitely not writeable by the non-root user salt is configured to run as.

Files in `/dev/` are unlikely to be normal files. There are other solutions that might, for example, try and test to see if the file is a socket, but these will be a lot more complicated - they will need to recognise and remove the `file://` prefix, parse the line (the documented format permits e.g. a `/<log-facility>` suffix), and may not be cross-platform compatible. This seems the simplest solution and will fix the issue in the vast majority of cases.


### What issues does this PR fix or reference?

Likely also fixes: #61286

The test to see if the file is writeable was added in #7875

### Previous Behavior

Salt will try and write logs to `/root/.salt/master.log`, which is inaccessible when running as non-root, which means salt-master crashes out with a permissions error.

### New Behavior

There is no check to see if `/dev/log` is writeable or not, so salt-master starts correctly.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
