### PR TITLE
Fix variable reuse causing requisite_in problems

### DIFF
--- a/changelog/62264.fixed
+++ b/changelog/62264.fixed
@@ -1,0 +1,1 @@
+Fix variable reuse causing requisite_in problems

--- a/salt/state.py
+++ b/salt/state.py
@@ -1852,18 +1852,18 @@ class State:
                                     else:
                                         found = False
                                         for _id in iter(high):
-                                            for state in [
-                                                state
-                                                for state in iter(high[_id])
-                                                if not state.startswith("__")
+                                            for st8 in [
+                                                _st8
+                                                for _st8 in iter(high[_id])
+                                                if not _st8.startswith("__")
                                             ]:
-                                                for j in iter(high[_id][state]):
+                                                for j in iter(high[_id][st8]):
                                                     if (
                                                         isinstance(j, dict)
                                                         and "name" in j
                                                     ):
                                                         if j["name"] == ind:
-                                                            ind = {state: _id}
+                                                            ind = {st8: _id}
                                                             found = True
                                         if not found:
                                             continue

--- a/tests/pytests/functional/modules/state/test_state.py
+++ b/tests/pytests/functional/modules/state/test_state.py
@@ -968,3 +968,33 @@ def test_state_sls_lazyloader_allows_recursion(state, state_tree):
         for state_return in ret:
             assert state_return.result is True
             assert "Success!" in state_return.comment
+
+
+def test_issue_62264_requisite_not_found(state, state_tree):
+    """
+    This tests that the proper state module is referenced for _in requisites
+    when no explicit state module is given.
+    Context: https://github.com/saltstack/salt/pull/62264
+    """
+    sls_contents = """
+    stuff:
+      cmd.run:
+        - name: echo hello
+
+    thing_test:
+      cmd.run:
+        - name: echo world
+        - require_in:
+          - /stuff/*
+          - test: service_running
+
+    service_running:
+      test.succeed_without_changes:
+        - require:
+          - cmd: stuff
+    """
+    with pytest.helpers.temp_file("issue-62264.sls", sls_contents, state_tree):
+        ret = state.sls("issue-62264")
+        for state_return in ret:
+            assert state_return.result is True
+            assert "The following requisites were not found" not in state_return.comment


### PR DESCRIPTION
### What does this PR do?
The PR fixes some variable reuse within a loop in a certain section of the code that overwrites a critical variable holding the state name for requisites.

### What issues does this PR fix or reference?
Fixes: #62264

### Previous Behavior
See issue for details.

### New Behavior
Requisites are now using the proper the state module.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
