### PR TITLE
doc: gitfs_remotes provide additional ordering information

### DIFF
--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -259,10 +259,12 @@ And each repository contains some files:
         edit/vim.sls
         edit/vimrc
         nginx/init.sls
+        shell/init.sls
 
     second.git:
         edit/dev_vimrc
         haproxy/init.sls
+        shell.sls
 
     third:
         haproxy/haproxy.conf
@@ -278,6 +280,12 @@ is executed. For example:
   the :strong:`https://github.com/example/second.git` git repo.
 * A request for the file :strong:`salt://haproxy/haproxy.conf` will be served from the
   :strong:`file:///root/third` repo.
+
+Also a requested state file overrules a directories with an `init.sls`-file.
+For example:
+
+* A request for :strong:`state.apply shell` will be served from the
+  :strong:`https://github.com/example/second.git` git repo. 
 
 .. note::
 

--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -281,7 +281,7 @@ is executed. For example:
 * A request for the file :strong:`salt://haproxy/haproxy.conf` will be served from the
   :strong:`file:///root/third` repo.
 
-Also a requested state file overrules a directories with an `init.sls`-file.
+Also a requested state file overrules a directory with an `init.sls`-file.
 For example:
 
 * A request for :strong:`state.apply shell` will be served from the


### PR DESCRIPTION
### What does this PR do?

The user should be informed that a state in a file will overrule a state
in an directory for gitfs_remotes because the remotes are merged
together to one structure.

An extra example should illustrate that it.

### What issues does this PR fix or reference?

Documentation update based on how gitfs_remotes overwrites states (files and folders).

### Commits signed with GPG?

No