### PR TITLE
Bump to ``pyzmq==23.2.0`` for Python >=3.9

### DIFF
--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -742,7 +742,7 @@ pyyaml==5.4.1
     #   junos-eznc
     #   kubernetes
     #   yamlordereddictloader
-pyzmq==21.0.2 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.9"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -743,7 +743,7 @@ pyyaml==5.4.1
     #   kubernetes
     #   yamllint
     #   yamlordereddictloader
-pyzmq==21.0.2 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.9"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -715,7 +715,7 @@ pyyaml==5.4.1
     #   kubernetes
     #   yamllint
     #   yamlordereddictloader
-pyzmq==21.0.2 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.9"
     # via -r requirements/zeromq.txt
 redis-py-cluster==2.1.3
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -736,7 +736,7 @@ pyyaml==5.4.1
     #   kubernetes
     #   yamllint
     #   yamlordereddictloader
-pyzmq==21.0.2 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.9"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -714,7 +714,7 @@ pyyaml==5.4.1
     #   kubernetes
     #   yamllint
     #   yamlordereddictloader
-pyzmq==21.0.2 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.9"
     # via -r requirements/zeromq.txt
 redis-py-cluster==2.1.3
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -767,7 +767,7 @@ pyyaml==5.4.1
     #   kubernetes
     #   yamllint
     #   yamlordereddictloader
-pyzmq==21.0.2 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.9"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -321,7 +321,7 @@ pyyaml==5.4.1
     #   clustershell
     #   kubernetes
     #   moto
-pyzmq==20.0.0 ; python_version >= "3.9"
+pyzmq==23.2.0
     # via
     #   -r requirements/static/pkg/py3.10/windows.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -779,7 +779,7 @@ pyyaml==5.4.1
     #   kubernetes
     #   napalm
     #   yamlordereddictloader
-pyzmq==21.0.2 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.9"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -777,7 +777,7 @@ pyyaml==5.4.1
     #   napalm
     #   yamllint
     #   yamlordereddictloader
-pyzmq==21.0.2 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.9"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -751,7 +751,7 @@ pyyaml==5.4.1
     #   napalm
     #   yamllint
     #   yamlordereddictloader
-pyzmq==21.0.2 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.9"
     # via -r requirements/zeromq.txt
 redis-py-cluster==2.1.3
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -770,7 +770,7 @@ pyyaml==5.4.1
     #   napalm
     #   yamllint
     #   yamlordereddictloader
-pyzmq==21.0.2 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.9"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -752,7 +752,7 @@ pyyaml==5.4.1
     #   napalm
     #   yamllint
     #   yamlordereddictloader
-pyzmq==21.0.2 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.9"
     # via -r requirements/zeromq.txt
 redis-py-cluster==2.1.3
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -801,7 +801,7 @@ pyyaml==5.4.1
     #   napalm
     #   yamllint
     #   yamlordereddictloader
-pyzmq==21.0.2 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.9"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -315,7 +315,7 @@ pyyaml==5.4.1
     #   clustershell
     #   kubernetes
     #   yamllint
-pyzmq==20.0.0 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.9"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -86,7 +86,7 @@ pytz==2022.1
     # via tempora
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==21.0.2 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.9"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -69,7 +69,7 @@ pytz==2022.1
     # via tempora
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==21.0.2 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.9"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -69,7 +69,7 @@ pytz==2022.1
     # via tempora
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==21.0.2 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.9"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -102,7 +102,7 @@ pywin32==303
     #   wmi
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==20.0.0 ; python_version >= "3.9"
+pyzmq==23.2.0
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -88,7 +88,7 @@ pytz==2022.1
     # via tempora
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==21.0.2 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.9"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -71,7 +71,7 @@ pytz==2022.1
     # via tempora
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==21.0.2 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.9"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -69,7 +69,7 @@ pytz==2022.1
     # via tempora
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==21.0.2 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.9"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -106,7 +106,7 @@ pywin32==303
     #   wmi
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==20.0.0 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.9"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via

--- a/salt/log_handlers/logstash_mod.py
+++ b/salt/log_handlers/logstash_mod.py
@@ -167,6 +167,7 @@ from salt._logging import LOG_LEVELS
 
 try:
     import zmq
+    import zmq.error
 except ImportError:
     pass
 
@@ -434,7 +435,7 @@ class ZMQLogstashHander(logging.Handler):
                 # Above the defined high water mark(unsent messages), start
                 # dropping them
                 self._publisher.setsockopt(zmq.HWM, self._zmq_hwm)
-            except AttributeError:
+            except (AttributeError, zmq.error.ZMQError):
                 # In ZMQ >= 3.0, there are separate send and receive HWM
                 # settings
                 self._publisher.setsockopt(zmq.SNDHWM, self._zmq_hwm)


### PR DESCRIPTION
### What does this PR do?
See title.

This way we can use wheel packages on Py3.10 instead of having it build
from source.

It will enable us to build, at least, the Arch Linux golden image used in the CI pipelines.