### PR TITLE
Don't expect ``lsof`` to be available

### DIFF
--- a/changelog/62303.fixed
+++ b/changelog/62303.fixed
@@ -1,0 +1,1 @@
+Don't expect ``lsof`` to be installed when trying check which minions are connected.

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -11,6 +11,7 @@ import os
 import platform
 import random
 import re
+import shutil
 import socket
 import subprocess
 import types
@@ -1996,6 +1997,9 @@ def _linux_remotes_on(port, which_end):
 
     """
     remotes = set()
+    lsof_binary = shutil.which("lsof")
+    if lsof_binary is None:
+        return remotes
 
     try:
         data = subprocess.check_output(


### PR DESCRIPTION
### What does this PR do?
Addresses this traceback seen on macOS tiamat builds

```
ERROR    salt._logging.impl:impl.py:1069 [SaltMaster(id='master-13R2FM')] An un-handled exception was caught by Salt's global exception handler:
FileNotFoundError: [Errno 2] No such file or directory: 'lsof'
Traceback (most recent call last):
  File "env PYTHONUTF8=1 LANG=POSIX /var/folders/c6/10qfzy9x1qx7zhyc97t_yv_40000gn/T/tmpp7crdd9w/bin/salt", line 91, in <module>
  File "env PYTHONUTF8=1 LANG=POSIX /var/folders/c6/10qfzy9x1qx7zhyc97t_yv_40000gn/T/tmpp7crdd9w/bin/salt", line 86, in redirect
  File "salt/scripts.py", line 530, in salt_main
    client.run()
  File "salt/cli/salt.py", line 194, in run
    for full_ret in cmd_func(**kwargs):
  File "salt/client/__init__.py", line 832, in cmd_cli
    for fn_ret in self.get_cli_event_returns(
  File "salt/client/__init__.py", line 1671, in get_cli_event_returns
    connected_minions = salt.utils.minions.CkMinions(
  File "salt/utils/minions.py", line 637, in connected_ids
    addrs = salt.utils.network.local_port_tcp(int(self.opts["publish_port"]))
  File "salt/utils/network.py", line 1613, in local_port_tcp
    ret = _remotes_on(port, "local_port")
  File "salt/utils/network.py", line 1667, in _remotes_on
    return _linux_remotes_on(port, which_end)
  File "salt/utils/network.py", line 2001, in _linux_remotes_on
    data = subprocess.check_output(
  File "subprocess.py", line 424, in check_output
  File "subprocess.py", line 505, in run
  File "salt/utils/pyinstaller/rthooks/_overrides.py", line 65, in __init__
    super().__init__(*args, **kwargs)
  File "subprocess.py", line 951, in __init__
  File "subprocess.py", line 1821, in _execute_child
FileNotFoundError: [Errno 2] No such file or directory: 'lsof'
FAILED
```