### PR TITLE
dig.X functionality added for PTR lookups by IP, with unit test

### DIFF
--- a/salt/modules/dig.py
+++ b/salt/modules/dig.py
@@ -99,6 +99,35 @@ def A(host, nameserver=None):
     return [x for x in cmd["stdout"].split("\n") if check_ip(x)]
 
 
+def X(host, nameserver=None):
+    """
+    Return the PTR record for ``host``.
+
+    Always returns a list.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt ns1 dig.X 1.2.3.4
+    """
+    dig = ["dig", "+short", "-x", str(host)]
+
+    if nameserver is not None:
+        dig.append("@{}".format(nameserver))
+
+    cmd = __salt__["cmd.run_all"](dig, python_shell=False)
+    # In this case, 0 is not the same as False
+    if cmd["retcode"] != 0:
+        log.warning(
+            "dig returned exit code '%s'. Returning empty list as fallback.",
+            cmd["retcode"],
+        )
+        return []
+
+    return [i for i in cmd["stdout"].split("\n")]
+
+
 def AAAA(host, nameserver=None):
     """
     Return the AAAA record for ``host``.
@@ -319,6 +348,7 @@ def TXT(host, nameserver=None):
 
 # Let lowercase work, since that is the convention for Salt functions
 a = A
+x = X
 aaaa = AAAA
 cname = CNAME
 ns = NS

--- a/tests/unit/modules/test_dig.py
+++ b/tests/unit/modules/test_dig.py
@@ -96,6 +96,23 @@ class DigTestCase(TestCase, LoaderModuleMockMixin):
                 ],
             )
 
+    def test_x(self):
+        dig_mock = MagicMock(
+            return_value={
+                "pid": 3657,
+                "retcode": 0,
+                "stderr": "",
+                "stdout": ("dns.google."),
+            }
+        )
+        with patch.dict(dig.__salt__, {"cmd.run_all": dig_mock}):
+            self.assertEqual(
+                dig.X("8.8.8.8"),
+                [
+                    "dns.google.",
+                ],
+            )
+
     def test_aaaa(self):
         dig_mock = MagicMock(
             return_value={


### PR DESCRIPTION
### What does this PR do?
Adding "dig.X" functionality to dig execution module
### What issues does this PR fix or reference?
Fixes:
https://github.com/saltstack/salt/issues/62275
### Previous Behavior
Remove this section if not relevant
dig.X: module errors out due to function not existing

### New Behavior
dig.X now can resolve IPs to their PTR records

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No
New to this, hadn't configured that yet. I'll read into it and figure it out next.

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
