### PR TITLE
Don't crash if dmesg contains non-utf8 characters

### DIFF
--- a/changelog/62316.fixed
+++ b/changelog/62316.fixed
@@ -1,0 +1,1 @@
+Fix a crash on startup on FreeBSD when /var/run/dmesg.boot contains non-UTF8 characters.

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -455,7 +455,9 @@ def _bsd_cpudata(osdata):
     if osdata["kernel"] == "FreeBSD" and os.path.isfile("/var/run/dmesg.boot"):
         grains["cpu_flags"] = []
         # TODO: at least it needs to be tested for BSD other then FreeBSD
-        with salt.utils.files.fopen("/var/run/dmesg.boot", "r") as _fp:
+        with salt.utils.files.fopen(
+            "/var/run/dmesg.boot", "r", encoding="utf8", errors='ignore'
+        ) as _fp:
             cpu_here = False
             for line in _fp:
                 if line.startswith("CPU: "):


### PR DESCRIPTION
On FreeBSD Salt scrapes /var/run/dmesg.boot to set the "cpu_flags"
grain.  But it's possible for that file to contain non-UTF-8 characters.
Skipping over such characters is better than crashing.

Signed-off-by: Alan Somers <asomers@gmail.com>

### What does this PR do?

Fixes a crash on startup on FreeBSD systems if non-UTF8 data is present in /var/run/dmesg.boot .  That can happen, for example, if a connected SAS device has a serial number containing non-UTF8 characters.

### Previous Behavior
On such systems, Salt would crash on startup with an error like this:
```
2022-06-30 13:54:03,038 [salt.log.setup   :911 ][ERROR   ][25928] An un-handled exception was caught by salt's global exception handler:
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 470: invalid start byte
Traceback (most recent call last):
  File "/usr/local/bin/salt-call", line 33, in <module>
    sys.exit(load_entry_point('salt==3004', 'console_scripts', 'salt-call')())
  File "/usr/local/lib/python3.8/site-packages/salt/scripts.py", line 432, in salt_call
    client.run()
  File "/usr/local/lib/python3.8/site-packages/salt/cli/call.py", line 45, in run
    caller = salt.cli.caller.Caller.factory(self.config)
  File "/usr/local/lib/python3.8/site-packages/salt/cli/caller.py", line 55, in factory
    return ZeroMQCaller(opts, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/salt/cli/caller.py", line 319, in _init_
    super()._init_(opts)
  File "/usr/local/lib/python3.8/site-packages/salt/cli/caller.py", line 79, in _init_
    self.minion = salt.minion.SMinion(opts)
  File "/usr/local/lib/python3.8/site-packages/salt/minion.py", line 926, in _init_
    opts["grains"] = salt.loader.grains(opts)
  File "/usr/local/lib/python3.8/site-packages/salt/loader/_init_.py", line 909, in grains
    ret = funcs[key]()
  File "/usr/local/lib/python3.8/site-packages/salt/loader/lazy.py", line 149, in _call_
    return self.loader.run(run_func, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/salt/loader/lazy.py", line 1201, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/salt/loader/lazy.py", line 1216, in _run_as
    return _func_or_method(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/salt/grains/core.py", line 2251, in os_data
    grains.update(_bsd_cpudata(grains))
  File "/usr/local/lib/python3.8/site-packages/salt/grains/core.py", line 412, in _bsd_cpudata
    for line in _fp:
  File "/usr/local/lib/python3.8/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 470: invalid start byte
```

### New Behavior
Salt will skip over the illegal bytes in /var/run/dmesg.boot .

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes