### PR TITLE
ci: add GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,8 +2,14 @@ name: Docs
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   Salt:
+    permissions:
+      contents: read  # for dorny/paths-filter to fetch a list of changed files
+      pull-requests: read  # for dorny/paths-filter to read pull requests
     name: Build Salt Documentation
     runs-on: ubuntu-latest
 
@@ -59,6 +65,9 @@ jobs:
         path: doc/_build/html
 
   Manpages:
+    permissions:
+      contents: read  # for dorny/paths-filter to fetch a list of changed files
+      pull-requests: read  # for dorny/paths-filter to read pull requests
     name: Build Salt man Pages
     runs-on: ubuntu-latest
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,8 +2,14 @@ name: Lint
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   Salt:
+    permissions:
+      contents: read  # for dorny/paths-filter to fetch a list of changed files
+      pull-requests: read  # for dorny/paths-filter to read pull requests
     name: Lint Salt's Source Code
     runs-on: ubuntu-latest
 
@@ -66,6 +72,9 @@ jobs:
         nox --forcecolor -e lint-salt
 
   Tests:
+    permissions:
+      contents: read  # for dorny/paths-filter to fetch a list of changed files
+      pull-requests: read  # for dorny/paths-filter to read pull requests
     name: Lint Salt's Test Suite
     runs-on: ubuntu-latest
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,9 +4,15 @@ on:
   pull_request_target:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
 
   Check-Changed-Files-Docstrings:
+    permissions:
+      contents: read
+      pull-requests: write
     name: Check Docstrings For Changed Files On PR
     runs-on: ubuntu-latest
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,8 +2,14 @@ name: Pre-Commit
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   Pre-Commit:
+    permissions:
+      contents: read  # for dorny/paths-filter to fetch a list of changed files
+      pull-requests: read  # for dorny/paths-filter to read pull requests
     name: Run Pre-Commit Against Salt
 
     runs-on: ubuntu-latest

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -16,8 +16,13 @@ on:
         description: 'Re Tag (Deletes tag and release)'
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   GenerateTagRelease:
+    permissions:
+      contents: write  # for dev-drprasad/delete-tag-and-release to delete tags or releases
     name: Generate Tag and Github Release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,14 @@ on:
         default: true
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   SaltChangelog:
+    permissions:
+      contents: read  # for dorny/paths-filter to fetch a list of changed files
+      pull-requests: read  # for dorny/paths-filter to read pull requests
     name: Build Salt Changelog
     runs-on: ubuntu-latest
 
@@ -75,6 +81,9 @@ jobs:
           rn_changelog
 
   Manpages:
+    permissions:
+      contents: read  # for dorny/paths-filter to fetch a list of changed files
+      pull-requests: read  # for dorny/paths-filter to read pull requests
     name: Build Salt man Pages
     runs-on: ubuntu-latest
 
@@ -134,6 +143,9 @@ jobs:
         path: doc/_build/man
 
   PullRequest:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     needs: [SaltChangelog, Manpages]
     name: Create Pull Request
     runs-on: ubuntu-latest

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -4,8 +4,16 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   label-and-assign:
+    permissions:
+      actions: read  # for dawidd6/action-download-artifact to query and download artifacts
+      contents: read  # for actions/checkout to fetch code
+      issues: write
+      pull-requests: read  # for dawidd6/action-download-artifact to query commit hash
     name: Triage New Issue
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/twine-check.yml
+++ b/.github/workflows/twine-check.yml
@@ -2,6 +2,9 @@ name: Twine Check
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   Twine-Check:
     name: Run 'twine check' Against Salt


### PR DESCRIPTION
### What does this PR do?

This PR adds minimum token permissions for the GITHUB_TOKEN using https://github.com/step-security/secure-workflows.

GitHub recommends defining minimum GITHUB_TOKEN permissions for securing GitHub Actions workflows 
- https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/  
- https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) treats not setting token permissions as a high-risk issue 

This project is part of the top 100 critical projects as per OpenSSF (https://github.com/ossf/wg-securing-critical-projects), so fixing the token permissions to improve security.

Signed-off-by: Varun Sharma <varunsh@stepsecurity.io>

### What issues does this PR fix or reference?
Fixes: N/A

### Previous Behavior
`GITHUB_TOKEN` has all permissions, e.g.
https://github.com/saltstack/salt/runs/7286247590?check_suite_focus=true#step:1:19

### New Behavior
`GITHUB_TOKEN` will have minimum permissions

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
