### PR TITLE
Fix CODEOWNERS format; Add Outside Collaborators

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,13 +12,13 @@
 *                                   @saltstack/team-core
 
 # Team Boto
-salt/*/*boto*                       @saltstack/team-core @ryan-lane
+salt/*/*boto*                       @saltstack/team-core
 
 # Team Cloud
-salt/cloud/*                        @saltstack/team-core @nicholasmhughes @verhulstm @pcn
-salt/utils/openstack/*              @saltstack/team-core @nicholasmhughes @verhulstm @pcn
-salt/utils/aws.py                   @saltstack/team-core @nicholasmhughes @verhulstm @pcn
-salt/*/*cloud*                      @saltstack/team-core @nicholasmhughes @verhulstm @pcn
+salt/cloud/*                        @saltstack/team-core
+salt/utils/openstack/*              @saltstack/team-core
+salt/utils/aws.py                   @saltstack/team-core
+salt/*/*cloud*                      @saltstack/team-core
 
 # Team NetAPI
 salt/cli/api.py                     @saltstack/team-core
@@ -33,22 +33,22 @@ salt/cli/spm.py                     @saltstack/team-core
 salt/spm/*                          @saltstack/team-core
 
 # Team SSH
-salt/cli/ssh.py                     @saltstack/team-core @meaksh @isbm
-salt/client/ssh/*                   @saltstack/team-core @meaksh @isbm
-salt/roster/*                       @saltstack/team-core @meaksh @isbm
-salt/runners/ssh.py                 @saltstack/team-core @meaksh @isbm
-salt/*/thin.py                      @saltstack/team-core @meaksh @isbm
+salt/cli/ssh.py                     @saltstack/team-core
+salt/client/ssh/*                   @saltstack/team-core
+salt/roster/*                       @saltstack/team-core
+salt/runners/ssh.py                 @saltstack/team-core
+salt/*/thin.py                      @saltstack/team-core
 
 # Team State
 salt/state.py                       @saltstack/team-core
 
 # Team SUSE
-salt/*/*btrfs*                      @saltstack/team-core @aplanas @meaksh @agraul @vzhestkov
-salt/*/*kubernetes*                 @saltstack/team-core @aplanas @meaksh @agraul @vzhestkov
-salt/*/*pkg*                        @saltstack/team-core @aplanas @meaksh @agraul @vzhestkov
-salt/*/*snapper*                    @saltstack/team-core @aplanas @meaksh @agraul @vzhestkov
-salt/*/*xfs*                        @saltstack/team-core @aplanas @meaksh @agraul @vzhestkov
-salt/*/*zypper*                     @saltstack/team-core @aplanas @meaksh @agraul @vzhestkov
+salt/*/*btrfs*                      @saltstack/team-core
+salt/*/*kubernetes*                 @saltstack/team-core
+salt/*/*pkg*                        @saltstack/team-core
+salt/*/*snapper*                    @saltstack/team-core
+salt/*/*xfs*                        @saltstack/team-core
+salt/*/*zypper*                     @saltstack/team-core
 
 # Team Transport
 salt/transport/*                    @saltstack/team-core
@@ -60,4 +60,4 @@ salt/modules/reg.py                 @saltstack/team-core
 salt/states/reg.py                  @saltstack/team-core
 tests/*/*win*                       @saltstack/team-core
 tests/*/test_reg.py                 @saltstack/team-core
-tests/pytests/*                     @s0undt3ch
+tests/pytests/*                     @saltstack/team-core @s0undt3ch

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,55 +12,52 @@
 *                                   @saltstack/team-core
 
 # Team Boto
-salt/*/*boto*                       @saltstack/team-boto @saltstack/team-core
+salt/*/*boto*                       @saltstack/team-core @ryan-lane
 
 # Team Cloud
-salt/cloud/*                        @saltstack/team-cloud @saltstack/team-core
-salt/utils/openstack/*              @saltstack/team-cloud @saltstack/team-core
-salt/utils/aws.py                   @saltstack/team-cloud @saltstack/team-core
-salt/*/*cloud*                      @saltstack/team-cloud @saltstack/team-core
+salt/cloud/*                        @saltstack/team-core @nicholasmhughes @verhulstm @pcn
+salt/utils/openstack/*              @saltstack/team-core @nicholasmhughes @verhulstm @pcn
+salt/utils/aws.py                   @saltstack/team-core @nicholasmhughes @verhulstm @pcn
+salt/*/*cloud*                      @saltstack/team-core @nicholasmhughes @verhulstm @pcn
 
 # Team NetAPI
-salt/cli/api.py                     @saltstack/team-netapi @saltstack/team-core
-salt/client/netapi.py               @saltstack/team-netapi @saltstack/team-core
-salt/netapi/*                       @saltstack/team-netapi @saltstack/team-core
+salt/cli/api.py                     @saltstack/team-core
+salt/client/netapi.py               @saltstack/team-core
+salt/netapi/*                       @saltstack/team-core
 
 # Team Network
-salt/proxy/*                        @saltstack/team-proxy @saltstack/team-core
+salt/proxy/*                        @saltstack/team-core
 
 # Team SPM
-salt/cli/spm.py                     @saltstack/team-spm @saltstack/team-core
-salt/spm/*                          @saltstack/team-spm @saltstack/team-core
+salt/cli/spm.py                     @saltstack/team-core
+salt/spm/*                          @saltstack/team-core
 
 # Team SSH
-salt/cli/ssh.py                     @saltstack/team-ssh @saltstack/team-core
-salt/client/ssh/*                   @saltstack/team-ssh @saltstack/team-core
-salt/roster/*                       @saltstack/team-ssh @saltstack/team-core
-salt/runners/ssh.py                 @saltstack/team-ssh @saltstack/team-core
-salt/*/thin.py                      @saltstack/team-ssh @saltstack/team-core
+salt/cli/ssh.py                     @saltstack/team-core @meaksh @isbm
+salt/client/ssh/*                   @saltstack/team-core @meaksh @isbm
+salt/roster/*                       @saltstack/team-core @meaksh @isbm
+salt/runners/ssh.py                 @saltstack/team-core @meaksh @isbm
+salt/*/thin.py                      @saltstack/team-core @meaksh @isbm
 
 # Team State
-salt/state.py                       @saltstack/team-state @saltstack/team-core
+salt/state.py                       @saltstack/team-core
 
 # Team SUSE
-salt/*/*btrfs*                      @saltstack/team-suse @saltstack/team-core
-salt/*/*kubernetes*                 @saltstack/team-suse @saltstack/team-core
-salt/*/*pkg*                        @saltstack/team-suse @saltstack/team-core
-salt/*/*snapper*                    @saltstack/team-suse @saltstack/team-core
-salt/*/*xfs*                        @saltstack/team-suse @saltstack/team-core
-salt/*/*zypper*                     @saltstack/team-suse @saltstack/team-core
+salt/*/*btrfs*                      @saltstack/team-core @aplanas @meaksh @agraul @vzhestkov
+salt/*/*kubernetes*                 @saltstack/team-core @aplanas @meaksh @agraul @vzhestkov
+salt/*/*pkg*                        @saltstack/team-core @aplanas @meaksh @agraul @vzhestkov
+salt/*/*snapper*                    @saltstack/team-core @aplanas @meaksh @agraul @vzhestkov
+salt/*/*xfs*                        @saltstack/team-core @aplanas @meaksh @agraul @vzhestkov
+salt/*/*zypper*                     @saltstack/team-core @aplanas @meaksh @agraul @vzhestkov
 
 # Team Transport
-salt/transport/*                    @saltstack/team-transport @saltstack/team-core
-salt/utils/zeromq.py                @saltstack/team-transport @saltstack/team-core
+salt/transport/*                    @saltstack/team-core
+salt/utils/zeromq.py                @saltstack/team-core
 
 # Team Windows
-salt/*/*win*                        @saltstack/team-windows @saltstack/team-core
-salt/modules/reg.py                 @saltstack/team-windows @saltstack/team-core
-salt/states/reg.py                  @saltstack/team-windows @saltstack/team-core
-tests/*/*win*                       @saltstack/team-windows @saltstack/team-core
-tests/*/test_reg.py                 @saltstack/team-windows @saltstack/team-core
-tests/pytests/*                     @saltstack/team-code @s0undt3ch
-
-# Jenkins Integration
-.ci/*                               @saltstack/saltstack-sre-team @saltstack/team-core
+salt/*/*win*                        @saltstack/team-core
+salt/modules/reg.py                 @saltstack/team-core
+salt/states/reg.py                  @saltstack/team-core
+tests/*/*win*                       @saltstack/team-core
+tests/*/test_reg.py                 @saltstack/team-core
+tests/pytests/*                     @s0undt3ch


### PR DESCRIPTION
### What does this PR do?

> Related: https://github.com/github/docs/issues/18984

Fixes `CODEOWNERS` file.

- [Info on `CODEOWNERS`](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
- Main problem: Most of the teams listed did not have at least `write` permissions (level required to be included) when it came to this repository, or the team didn't exist.

Problems fixed:
- Following teams don't have proper permissions for repo, and are being excluded
  - `@saltstack/team-boto`
  - `@saltstack/team-cloud`
  - `@saltstack/team-spm`
  - `@salstack/team-ssh`
  - `@saltstack/team-state`
  - `@saltstack/team-suse` (this group is also empty due to conversion of members to Outside Collaborators)
  - `@saltstack/team-transport`
- Following teams do not exist
  - `@saltstack/team-netapi`
  - `@saltstack/team-proxy`
  - `@saltstack/team-code`
- Outside Collaborators were originally added, but are now all removed due to inability for CODEOWNERS to work with members without **Write** access to the repo:
  - @ryan-lane 
  - @verhulstm 
  - @pcn 
  - @nicholasmhughes 
  - @meaksh 
  - @isbm 
  - @agraul 
  - @vzhestkov 
  - @aplanas 
- Removed `.ci/*` as it no longer exists in repo

### Previous Behavior

Broken `CODEOWNERS` file :cry: 

### New Behavior

Functional `CODEOWNERS` file :smile: 

### Commits signed with GPG?
No