### PR TITLE
Deprecate cassandra module/returner

### DIFF
--- a/changelog/62327.deprecated
+++ b/changelog/62327.deprecated
@@ -1,0 +1,1 @@
+Deprecated the cassandra module in favor of the cassandra_cql module/returner.

--- a/salt/modules/cassandra_mod.py
+++ b/salt/modules/cassandra_mod.py
@@ -14,6 +14,7 @@ Cassandra NoSQL Database Module
 import logging
 
 import salt.utils.path
+from salt.utils.versions import warn_until_date
 
 log = logging.getLogger(__name__)
 
@@ -25,6 +26,13 @@ try:
     HAS_PYCASSA = True
 except ImportError:
     pass
+
+
+warn_until_date(
+    "20240101",
+    "The cassandra returner is broken and deprecated, and will be removed"
+    " after {date}. Use the cassandra_cql returner instead",
+)
 
 
 def __virtual__():

--- a/salt/modules/cassandra_mod.py
+++ b/salt/modules/cassandra_mod.py
@@ -1,4 +1,10 @@
 """
+
+.. warning::
+
+    The `cassandra` module is deprecated in favor of the `cassandra_cql`
+    module.
+
 Cassandra NoSQL Database Module
 
 :depends:   - pycassa Cassandra Python adapter

--- a/salt/modules/cassandra_mod.py
+++ b/salt/modules/cassandra_mod.py
@@ -34,13 +34,6 @@ except ImportError:
     pass
 
 
-warn_until_date(
-    "20240101",
-    "The cassandra returner is broken and deprecated, and will be removed"
-    " after {date}. Use the cassandra_cql returner instead",
-)
-
-
 def __virtual__():
     """
     Only load if pycassa is available and the system is configured
@@ -50,6 +43,12 @@ def __virtual__():
             False,
             "The cassandra execution module cannot be loaded: pycassa not installed.",
         )
+
+    warn_until_date(
+        "20240101",
+        "The cassandra returner is broken and deprecated, and will be removed"
+        " after {date}. Use the cassandra_cql returner instead",
+    )
 
     if HAS_PYCASSA and salt.utils.path.which("nodetool"):
         return "cassandra"

--- a/salt/returners/cassandra_return.py
+++ b/salt/returners/cassandra_return.py
@@ -22,6 +22,7 @@ Required python modules: pycassa
 import logging
 
 import salt.utils.jid
+from salt.utils.versions import warn_until_date
 
 try:
     import pycassa  # pylint: disable=import-error
@@ -41,6 +42,12 @@ __opts__ = {
 
 # Define the module's virtual name
 __virtualname__ = "cassandra"
+
+warn_until_date(
+    "20240101",
+    "The cassandra returner is broken and deprecated, and will be removed"
+    " after {date}. Use the cassandra_cql returner instead",
+)
 
 
 def __virtual__():

--- a/salt/returners/cassandra_return.py
+++ b/salt/returners/cassandra_return.py
@@ -48,16 +48,15 @@ __opts__ = {
 # Define the module's virtual name
 __virtualname__ = "cassandra"
 
-warn_until_date(
-    "20240101",
-    "The cassandra returner is broken and deprecated, and will be removed"
-    " after {date}. Use the cassandra_cql returner instead",
-)
-
 
 def __virtual__():
     if not HAS_PYCASSA:
         return False, "Could not import cassandra returner; pycassa is not installed."
+    warn_until_date(
+        "20240101",
+        "The cassandra returner is broken and deprecated, and will be removed"
+        " after {date}. Use the cassandra_cql returner instead",
+    )
     return __virtualname__
 
 

--- a/salt/returners/cassandra_return.py
+++ b/salt/returners/cassandra_return.py
@@ -1,4 +1,9 @@
 """
+.. warning::
+
+    The `cassandra` returner is deprecated in favor of the `cassandra_cql`
+    returner.
+
 Return data to a Cassandra ColumnFamily
 
 Here's an example Keyspace / ColumnFamily setup that works with this


### PR DESCRIPTION
### What does this PR do?

Deprecates the entirely broken cassandra module, directing users to cassandra_cql - the underlying library pycassa https://github.com/pycassa/pycassa has been deprecated for about 8 years now.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
~- [ ] Tests written/updated~ N/A

### Commits signed with GPG?
Yes