### PR TITLE
Add salt daemons tests

### DIFF
--- a/tests/pytests/scenarios/daemons/conftest.py
+++ b/tests/pytests/scenarios/daemons/conftest.py
@@ -1,0 +1,33 @@
+import pytest
+from saltfactories.utils import random_string
+
+
+@pytest.fixture(scope="package")
+def salt_master_factory(request, salt_factories):
+    config_defaults = {
+        "open_mode": True,
+        "transport": request.config.getoption("--transport"),
+    }
+    config_overrides = {
+        "interface": "127.0.0.1",
+    }
+
+    return salt_factories.salt_master_daemon(
+        random_string("master-daemonized-"),
+        defaults=config_defaults,
+        overrides=config_overrides,
+        extra_cli_arguments_after_first_start_failure=["--log-level=debug"],
+    )
+
+
+@pytest.fixture(scope="package")
+def salt_minion_factory(salt_master_factory):
+    config_defaults = {
+        "transport": salt_master_factory.config["transport"],
+    }
+
+    return salt_master_factory.salt_minion_daemon(
+        random_string("minion-daemonized-"),
+        defaults=config_defaults,
+        extra_cli_arguments_after_first_start_failure=["--log-level=debug"],
+    )

--- a/tests/pytests/scenarios/daemons/test_salt_as_daemons.py
+++ b/tests/pytests/scenarios/daemons/test_salt_as_daemons.py
@@ -1,0 +1,58 @@
+import subprocess
+
+import pytest
+from pytestshellutils.exceptions import FactoryNotStarted
+
+pytestmark = [
+    pytest.mark.destructive_test,
+]
+
+
+def test_salt_master_as_daemon(salt_master_factory):
+    for cli_option in ("-d", "--daemon"):
+        try:
+            with salt_master_factory.started(
+                cli_option, start_timeout=120, max_start_attempts=1
+            ):
+                pass
+        except FactoryNotStarted:
+            pass
+        finally:
+            # We are going to kill the possible child processes based on the entire cmdline
+            # We know this is unique to these processes because of the unique name of the config files, for example
+            cmdline = salt_master_factory.cmdline(cli_option)
+            pkill_proc = subprocess.Popen(
+                ["pkill", "-f", " ".join(cmdline)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            ).communicate()
+            assert pkill_proc[1] == b""
+
+        assert salt_master_factory.impl._terminal_result.stdout == ""
+        assert salt_master_factory.impl._terminal_result.stderr == ""
+        assert salt_master_factory.impl._terminal_result.returncode == 0
+
+
+def test_salt_minion_as_daemon(salt_minion_factory):
+    for cli_option in ("-d", "--daemon"):
+        try:
+            with salt_minion_factory.started(
+                cli_option, start_timeout=120, max_start_attempts=1
+            ):
+                pass
+        except FactoryNotStarted:
+            pass
+        finally:
+            # We are going to kill the possible child processes based on the entire cmdline
+            # We know this is unique to these processes because of the unique name of the config files, for example
+            cmdline = salt_minion_factory.cmdline(cli_option)
+            pkill_proc = subprocess.Popen(
+                ["pkill", "-f", " ".join(cmdline)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            ).communicate()
+            assert pkill_proc[1] == b""
+
+        assert salt_minion_factory.impl._terminal_result.stdout == ""
+        assert salt_minion_factory.impl._terminal_result.stderr == ""
+        assert salt_minion_factory.impl._terminal_result.returncode == 0

--- a/tests/pytests/scenarios/daemons/test_salt_as_daemons.py
+++ b/tests/pytests/scenarios/daemons/test_salt_as_daemons.py
@@ -1,4 +1,5 @@
 import subprocess
+import time
 
 import pytest
 from pytestshellutils.exceptions import FactoryNotStarted
@@ -9,6 +10,7 @@ pytestmark = [
 
 
 def test_salt_master_as_daemon(salt_master_factory):
+    max_grep_tries = 5
     for cli_option in ("-d", "--daemon"):
         try:
             with salt_master_factory.started(
@@ -18,6 +20,10 @@ def test_salt_master_as_daemon(salt_master_factory):
         except FactoryNotStarted:
             pass
         finally:
+            assert salt_master_factory.impl._terminal_result.stdout == ""
+            assert salt_master_factory.impl._terminal_result.stderr == ""
+            assert salt_master_factory.impl._terminal_result.returncode == 0
+
             # We are going to kill the possible child processes based on the entire cmdline
             # We know this is unique to these processes because of the unique name of the config files, for example
             cmdline = salt_master_factory.cmdline(cli_option)
@@ -27,13 +33,21 @@ def test_salt_master_as_daemon(salt_master_factory):
                 stderr=subprocess.PIPE,
             ).communicate()
             assert pkill_proc[1] == b""
-
-        assert salt_master_factory.impl._terminal_result.stdout == ""
-        assert salt_master_factory.impl._terminal_result.stderr == ""
-        assert salt_master_factory.impl._terminal_result.returncode == 0
+            for _ in range(max_grep_tries):
+                pgrep_proc = subprocess.Popen(
+                    ["pgrep", "-f", " ".join(cmdline)],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                ).communicate()
+                if pgrep_proc[0] == b"" and pgrep_proc[1] == b"":
+                    break
+                time.sleep(1)
+            else:
+                pytest.skip("Skipping this test because processes didn't kill in time.")
 
 
 def test_salt_minion_as_daemon(salt_minion_factory):
+    max_grep_tries = 5
     for cli_option in ("-d", "--daemon"):
         try:
             with salt_minion_factory.started(
@@ -43,6 +57,10 @@ def test_salt_minion_as_daemon(salt_minion_factory):
         except FactoryNotStarted:
             pass
         finally:
+            assert salt_minion_factory.impl._terminal_result.stdout == ""
+            assert salt_minion_factory.impl._terminal_result.stderr == ""
+            assert salt_minion_factory.impl._terminal_result.returncode == 0
+
             # We are going to kill the possible child processes based on the entire cmdline
             # We know this is unique to these processes because of the unique name of the config files, for example
             cmdline = salt_minion_factory.cmdline(cli_option)
@@ -52,7 +70,14 @@ def test_salt_minion_as_daemon(salt_minion_factory):
                 stderr=subprocess.PIPE,
             ).communicate()
             assert pkill_proc[1] == b""
-
-        assert salt_minion_factory.impl._terminal_result.stdout == ""
-        assert salt_minion_factory.impl._terminal_result.stderr == ""
-        assert salt_minion_factory.impl._terminal_result.returncode == 0
+            for _ in range(max_grep_tries):
+                pgrep_proc = subprocess.Popen(
+                    ["pgrep", "-f", " ".join(cmdline)],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                ).communicate()
+                if pgrep_proc[0] == b"" and pgrep_proc[1] == b"":
+                    break
+                time.sleep(1)
+            else:
+                pytest.skip("Skipping this test because processes didn't kill in time.")


### PR DESCRIPTION
### What does this PR do?
Adds tests to ensure `-d` and `--daemon` work correctly as cli options to `salt-minion` and `salt-master`.

These tests are marked as destructive because there is the explicit (but warranted) killing of processes.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/61101

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes