### PR TITLE
chore: Remove the security email for vulnerability reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -10,5 +10,5 @@ contact_links:
     url: https://web.libera.chat/#salt
     about: Please ask and answer questions here.
   - name: Security vulnerabilities
-    email: security@saltstack.com
+    url: security@saltstack.com
     about: Please report security vulnerabilities here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,6 +9,3 @@ contact_links:
   - name: Salt on LiberaChat
     url: https://web.libera.chat/#salt
     about: Please ask and answer questions here.
-  - name: Security vulnerabilities
-    url: security@saltstack.com
-    about: Please report security vulnerabilities here.


### PR DESCRIPTION
Issue template chooser menu items require a URL otherwise they are not shown to to the user.
This PR removes the `Please report security vulnerabilities here.` item as it already doesn't appear.

Here, `Please report security vulnerabilities here.` is not visible.
![image](https://user-images.githubusercontent.com/17709306/178939908-bf36757f-8c9c-4bb8-8986-d4cf0cd7339a.png)

