### PR TITLE
Add known issue about SSC 8.9.0 dependency

### DIFF
--- a/doc/topics/releases/3005.rst
+++ b/doc/topics/releases/3005.rst
@@ -134,6 +134,19 @@ For example:
         - bin_env: /usr/bin/python3
 
 
+Known issues
+------------
+To make use of Salt 3005 or later on a Salt master connected to SaltStack
+Config, you must use SaltStack Config version 8.9.0 or later.
+
+It is recommended to upgrade SaltStack Config before upgrading your Salt
+masters. However, if a Salt master is upgraded to version 3005 before
+upgrading SaltStack Config, the upgrade can still be completed.
+
+After upgrading SaltStack Config, including the SSC plugin on each Salt master,
+restart the Salt masters.
+
+
 Removed
 -------
 

--- a/doc/topics/releases/3005.rst
+++ b/doc/topics/releases/3005.rst
@@ -139,6 +139,11 @@ Known issues
 To make use of Salt 3005 or later on a Salt master connected to SaltStack
 Config, you must use SaltStack Config version 8.9.0 or later.
 
+The root cause of the issue is a breaking change to
+``AsyncClient._proc_function()``` in Salt, which is the function that the
+raas-master uses to run ``salt-run`` commands. As this is a private API, there's
+no expectation that the API should remain backward-compatible.
+
 It is recommended to upgrade SaltStack Config before upgrading your Salt
 masters. However, if a Salt master is upgraded to version 3005 before
 upgrading SaltStack Config, the upgrade can still be completed.


### PR DESCRIPTION
### What does this PR do?

Adds a note about a known issue about SaltStack Config's compatibility with Salt masters using 3005. Affects any versions of SaltStack Config earlier than 8.9.0.

### What issues does this PR fix or reference?
Resolves VRAE-24139 (internal to VMware)