### PR TITLE
Fix access to opts and sls vars in pyobjects renderer

### DIFF
--- a/changelog/62336.fixed
+++ b/changelog/62336.fixed
@@ -1,0 +1,1 @@
+Fix pyobjects renderer access to opts and sls

--- a/salt/renderers/pyobjects.py
+++ b/salt/renderers/pyobjects.py
@@ -210,6 +210,24 @@ The following pairs of lines are functionally equivalent:
     value = __salt__['config.get']('foo:bar:baz', 'qux')
 
 
+Opts dictionary and SLS name
+----------------------------
+
+Pyobjects provides variable access to the minion options dictionary and the SLS
+name that the code resides in. These variables are the same as the `opts` and
+`sls` variables available in the Jinja renderer.
+
+The following lines show how to access that information.
+
+.. code-block:: python
+   :linenos:
+
+    #!pyobjects
+
+    test_mode = __opts__["test"]
+    sls_name = __sls__
+
+
 Map Data
 --------
 
@@ -400,6 +418,8 @@ def render(template, saltenv="base", sls="", salt_data=True, **kwargs):
                 "__salt__": __salt__,
                 "__pillar__": __pillar__,
                 "__grains__": __grains__,
+                "__opts__": __opts__,
+                "__sls__": sls,
             }
         )
     except NameError:

--- a/tests/pytests/unit/utils/test_pyobjects.py
+++ b/tests/pytests/unit/utils/test_pyobjects.py
@@ -1,0 +1,75 @@
+import logging
+
+import pytest
+import salt.config
+import salt.renderers.pyobjects as pyobjects
+from salt.utils.odict import OrderedDict
+from tests.support.mock import MagicMock
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def cache_dir(tmp_path):
+    cachedir = tmp_path / "cachedir"
+    cachedir.mkdir()
+    return cachedir
+
+
+@pytest.fixture
+def minion_config(cache_dir):
+    opts = salt.config.DEFAULT_MINION_OPTS.copy()
+    opts["cachedir"] = str(cache_dir)
+    opts["file_client"] = "local"
+    opts["id"] = "testminion"
+    return opts
+
+
+@pytest.fixture()
+def configure_loader_modules(minion_config):
+    pillar = MagicMock(return_value={})
+    return {
+        pyobjects: {
+            "__opts__": minion_config,
+            "__pillar__": pillar,
+            "__salt__": {
+                "config.get": MagicMock(),
+                "grains.get": MagicMock(),
+                "mine.get": MagicMock(),
+                "pillar.get": MagicMock(),
+            },
+        },
+    }
+
+
+@pytest.fixture
+def pyobjects_template():
+    class Template:
+        def readlines():  # pylint: disable=no-method-argument
+            return [
+                "#!pyobjects",
+                "state_id = __sls__ + '_' + __opts__['id']",
+                "File.directory(state_id, name='/tmp', mode='1777', owner='root', group='root')",
+            ]
+
+    return Template
+
+
+@pytest.mark.slow_test
+def test_opts_and_sls_access(pyobjects_template):
+    ret = pyobjects.render(pyobjects_template, sls="pyobj.runtest")
+    assert ret == OrderedDict(
+        [
+            (
+                "pyobj.runtest_testminion",
+                {
+                    "file.directory": [
+                        {"group": "root"},
+                        {"mode": "1777"},
+                        {"name": "/tmp"},
+                        {"owner": "root"},
+                    ]
+                },
+            ),
+        ]
+    )


### PR DESCRIPTION
### What does this PR do?
This PR adds access to the minion options dictionary and SLS name of the state file being run in the pyobjects renderer.

### What issues does this PR fix or reference?
Fixes: 62336

### Previous Behavior
No access to `__opts__` or `__sls__`

### New Behavior
Access to `__opts__` and `__sls__`

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
