### PR TITLE
Switch to the github repository container registry and our own container mirrors

### DIFF
--- a/tests/pytests/functional/cache/test_consul.py
+++ b/tests/pytests/functional/cache/test_consul.py
@@ -41,7 +41,7 @@ def consul_container(salt_factories):
 
     container = salt_factories.get_container(
         random_string("consul-server-"),
-        image_name="consul:latest",
+        image_name="ghcr.io/saltstack/salt-ci-containers/consul:latest",
         container_run_kwargs={"ports": {"8500/tcp": None}},
         pull_before_start=True,
         skip_on_pull_failure=True,

--- a/tests/pytests/functional/states/rabbitmq/conftest.py
+++ b/tests/pytests/functional/states/rabbitmq/conftest.py
@@ -73,7 +73,9 @@ def rabbitmq_container(salt_factories, rabbitmq_image):
     )
     container = salt_factories.get_container(
         rabbitmq_image.container_id,
-        "{}:{}".format(combo.rabbitmq_name, combo.rabbitmq_version),
+        "ghcr.io/saltstack/salt-ci-containers/{}:{}".format(
+            combo.rabbitmq_name, combo.rabbitmq_version
+        ),
         container_run_kwargs={
             "ports": {"5672/tcp": None},
         },

--- a/tests/pytests/functional/states/test_zookeeper.py
+++ b/tests/pytests/functional/states/test_zookeeper.py
@@ -59,7 +59,7 @@ def minion_config_overrides(zookeeper_port):
 def zookeeper_container(salt_factories):
     container = salt_factories.get_container(
         random_string("zookeeper-"),
-        "zookeeper",
+        "ghcr.io/saltstack/salt-ci-containers/zookeeper",
         container_run_kwargs={
             "ports": {
                 "2181/tcp": None,

--- a/tests/pytests/integration/modules/test_virt.py
+++ b/tests/pytests/integration/modules/test_virt.py
@@ -43,7 +43,7 @@ def virt_minion_0(
     factory = salt_master.salt_minion_daemon(
         virt_minion_0_id,
         name=virt_minion_0_id,
-        image="quay.io/saltstack/virt-minion",
+        image="ghcr.io/saltstack/salt-ci-containers/virt-minion",
         factory_class=SaltVirtMinionContainerFactory,
         defaults=config_defaults,
         overrides=config_overrides,
@@ -79,7 +79,7 @@ def virt_minion_1(
     factory = salt_master.salt_minion_daemon(
         virt_minion_1_id,
         name=virt_minion_1_id,
-        image="quay.io/saltstack/virt-minion",
+        image="ghcr.io/saltstack/salt-ci-containers/virt-minion",
         factory_class=SaltVirtMinionContainerFactory,
         defaults=config_defaults,
         overrides=config_overrides,

--- a/tests/pytests/integration/sdb/test_vault.py
+++ b/tests/pytests/integration/sdb/test_vault.py
@@ -47,7 +47,7 @@ def vault_container_version(request, salt_factories, vault_port, patched_environ
     }
     factory = salt_factories.get_container(
         "vault",
-        "vault:{}".format(vault_version),
+        "ghcr.io/saltstack/salt-ci-containers/vault:{}".format(vault_version),
         check_ports=[vault_port],
         container_run_kwargs={
             "ports": {"8200/tcp": vault_port},

--- a/tests/pytests/scenarios/compat/test_with_versions.py
+++ b/tests/pytests/scenarios/compat/test_with_versions.py
@@ -4,7 +4,6 @@
 
     Test current salt master with older salt minions
 """
-import io
 import logging
 import pathlib
 
@@ -28,59 +27,20 @@ pytestmark = [
 ]
 
 
-DOCKERFILE = """
-FROM {from_container}
-ENV LANG=en_US.UTF8
-
-ENV VIRTUAL_ENV={virtualenv_path}
-
-RUN virtualenv --python=python3 $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-RUN pip install salt=={salt_version}
-
-CMD . $VIRTUAL_ENV/bin/activate
-"""
-
-
 def _get_test_versions_ids(value):
     return "SaltMinion~={}".format(value)
 
 
 @pytest.fixture(
-    params=("3002.7", "3003.3", "3004"), ids=_get_test_versions_ids, scope="module"
+    params=("3002", "3003", "3004"), ids=_get_test_versions_ids, scope="module"
 )
 def compat_salt_version(request):
     return request.param
 
 
 @pytest.fixture(scope="module")
-def container_virtualenv_path():
-    return "/tmp/venv"
-
-
-@pytest.fixture(scope="module")
 def minion_image_name(compat_salt_version):
     return "salt-{}".format(compat_salt_version)
-
-
-@pytest.fixture(scope="module")
-def minion_image(
-    docker_client, compat_salt_version, container_virtualenv_path, minion_image_name
-):
-    dockerfile_contents = DOCKERFILE.format(
-        from_container="saltstack/ci-centos-7",
-        salt_version=compat_salt_version,
-        virtualenv_path=container_virtualenv_path,
-    )
-    log.debug("GENERATED Dockerfile:\n%s", dockerfile_contents)
-    dockerfile_fh = io.BytesIO(dockerfile_contents.encode("utf-8"))
-    _, logs = docker_client.images.build(
-        fileobj=dockerfile_fh,
-        tag=minion_image_name,
-        pull=True,
-    )
-    log.warning("Image %s built. Logs:\n%s", minion_image_name, list(logs))
-    return minion_image_name
 
 
 @pytest.fixture(scope="function")
@@ -103,7 +63,7 @@ def salt_minion(
     salt_master,
     docker_client,
     artifacts_path,
-    minion_image,
+    compat_salt_version,
     host_docker_network_ip_address,
 ):
     config_overrides = {
@@ -120,13 +80,20 @@ def salt_minion(
         extra_cli_arguments_after_first_start_failure=["--log-level=debug"],
         # SaltMinion kwargs
         name=minion_id,
-        image=minion_image,
+        image="ghcr.io/saltstack/salt-ci-containers/salt:{}".format(
+            compat_salt_version
+        ),
         docker_client=docker_client,
         start_timeout=120,
         pull_before_start=False,
         skip_if_docker_client_not_connectable=True,
         container_run_kwargs={
-            "volumes": {str(artifacts_path): {"bind": "/artifacts", "mode": "z"}}
+            "volumes": {
+                str(artifacts_path): {
+                    "bind": "/artifacts",
+                    "mode": "z",
+                },
+            }
         },
     )
     factory.after_terminate(
@@ -138,7 +105,7 @@ def salt_minion(
 
 @pytest.fixture(scope="function")
 def package_name():
-    return "comps-extras"
+    return "figlet"
 
 
 @pytest.fixture

--- a/tests/support/pytest/etcd.py
+++ b/tests/support/pytest/etcd.py
@@ -30,8 +30,8 @@ def etcd_version(request):
 @pytest.fixture(scope="module")
 def etcd_container_image_name(etcd_version):
     if etcd_version == EtcdVersion.v2:
-        return "elcolio/etcd"
-    return "bitnami/etcd:3"
+        return "ghcr.io/saltstack/salt-ci-containers/etcd:2"
+    return "ghcr.io/saltstack/salt-ci-containers/etcd:3"
 
 
 @pytest.fixture(scope="module")

--- a/tests/support/pytest/mysql.py
+++ b/tests/support/pytest/mysql.py
@@ -166,7 +166,9 @@ def mysql_container(salt_factories, mysql_combo):
 
     container = salt_factories.get_container(
         mysql_combo.container_id,
-        "{}:{}".format(mysql_combo.mysql_name, mysql_combo.mysql_version),
+        "ghcr.io/saltstack/salt-ci-containers/{}:{}".format(
+            mysql_combo.mysql_name, mysql_combo.mysql_version
+        ),
         pull_before_start=True,
         skip_on_pull_failure=True,
         skip_if_docker_client_not_connectable=True,


### PR DESCRIPTION
### What does this PR do?
See title.

The github container repository is not throttled like docker hub is these days.
On top of that, we'll have a common registry for every container used throughout the test suite.