### PR TITLE
Add "<tiamat> python" subcommand to allow execution or arbitrary scripts via bundled Python runtime

### DIFF
--- a/changelog/62381.added
+++ b/changelog/62381.added
@@ -1,0 +1,1 @@
+Add "<tiamat> python" subcommand to allow execution or arbitrary scripts via bundled Python runtime

--- a/doc/ref/clients/index.rst
+++ b/doc/ref/clients/index.rst
@@ -10,6 +10,14 @@ These entry points are often referred to as ``*Client()`` APIs. Each client
 accesses different parts of Salt, either from the master or from a minion. Each
 client is detailed below.
 
+.. note::
+    For Tiamat-bundled Salt distribution, you need to use the bundled Python runtime
+    as the system Python won't be able to access Salt internals.
+
+    To execute scripts via bundled Python runtime, either run the script with
+    ``/path/to/salt python script.py`` or use ``#!/path/to/salt python`` `shebang <https://en.wikipedia.org/wiki/Shebang_(Unix)>`_
+
+
 .. seealso:: There are many ways to access Salt programmatically.
 
     Salt can be used from CLI scripts as well as via a REST interface.

--- a/run.py
+++ b/run.py
@@ -30,6 +30,7 @@ AVAIL = (
     "ssh",
     "support",
     "syndic",
+    "python",
 )
 
 
@@ -56,6 +57,19 @@ def py_shell():
     shell.interact()
 
 
+def python_runtime():
+    # extract the absolute script path to alter sys.path and specific dunder variables
+    script = pathlib.Path(sys.argv[2]).expanduser().absolute()
+    sys.path.insert(0, str(script.parent))
+    __file__ = str(script)
+
+    # update passed args so they don't start with "<binary> python"
+    sys.argv = sys.argv[2:]
+
+    with open(script) as f:
+        exec(f.read())
+
+
 def redirect(argv):
     """
     Change the args and redirect to another salt script
@@ -69,6 +83,14 @@ def redirect(argv):
     cmd = sys.argv[1]
     if cmd == "shell":
         py_shell()
+        return
+    if cmd == "python":
+        if len(argv) < 3:
+            msg = "Must pass script location to this command"
+            print(msg, file=sys.stderr, flush=True)
+            sys.exit(1)
+
+        python_runtime()
         return
     if tiamatpip.cli.should_redirect_argv(argv):
         tiamatpip.cli.process_pip_argv(argv)

--- a/run.py
+++ b/run.py
@@ -65,9 +65,13 @@ def python_runtime():
 
     # update passed args so they don't start with "<binary> python"
     sys.argv = sys.argv[2:]
-
-    with open(script) as f:
-        exec(f.read())
+    exec_locals = {"__name__": "__main__", "__file__": str(script), "__doc__": None}
+    with open(script, encoding="utf-8") as rfh:
+        try:
+            exec(rfh.read(), exec_locals)
+        except Exception:
+            traceback.print_exc()
+            sys.exit(1)
 
 
 def redirect(argv):

--- a/run.py
+++ b/run.py
@@ -61,7 +61,6 @@ def python_runtime():
     # extract the absolute script path to alter sys.path and specific dunder variables
     script = pathlib.Path(sys.argv[2]).expanduser().absolute()
     sys.path.insert(0, str(script.parent))
-    __file__ = str(script)
 
     # update passed args so they don't start with "<binary> python"
     sys.argv = sys.argv[2:]

--- a/run.py
+++ b/run.py
@@ -59,11 +59,11 @@ def py_shell():
 
 def python_runtime():
     # extract the absolute script path to alter sys.path and specific dunder variables
-    script = pathlib.Path(sys.argv[2]).expanduser().absolute()
+    script = pathlib.Path(sys.argv[2]).expanduser().resolve()
     sys.path.insert(0, str(script.parent))
 
     # update passed args so they don't start with "<binary> python"
-    sys.argv = sys.argv[2:]
+    sys.argv[:] = sys.argv[2:]
     exec_locals = {"__name__": "__main__", "__file__": str(script), "__doc__": None}
     with open(script, encoding="utf-8") as rfh:
         try:


### PR DESCRIPTION
### What does this PR do?
Introduces new `python` subcommand for Tiamat-based Salt packages in order to run scripts and applications with the same Python runtime as Salt.

### What issues does this PR fix or reference?
Fixes: #62381

### Previous Behavior
Users were not able to utilize [Python Client API](https://docs.saltproject.io/en/latest/ref/clients/index.html) as no Python "executable" was exposed

### New Behavior
Users can run external python scripts and applications via `/path/to/salt python script.py` command

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes