### PR TITLE
modules.mac_brew_pkg: don't use sudo -i

### DIFF
--- a/salt/modules/mac_brew_pkg.py
+++ b/salt/modules/mac_brew_pkg.py
@@ -112,7 +112,7 @@ def _call_brew(*cmd, failhard=True):
     runas = user if user != __opts__["user"] else None
     _cmd = []
     if runas:
-        _cmd = ["sudo -i -n -H -u {} -- ".format(runas)]
+        _cmd = ["sudo -n -H -u {} -- ".format(runas)]
     _cmd = _cmd + [salt.utils.path.which("brew")] + list(cmd)
     _cmd = " ".join(_cmd)
 


### PR DESCRIPTION
### What does this PR do?

sudo -i is used for starting interactive sessions.  It causes sudo to
tell the shell to run a login session, which triggers reading e.g.
~/.bash_profile.

Since that's intended for interactive use cases, it may produce output.
But any output on stdout will be read as brew's json output - breaking
states.pkg.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/62394

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
