### PR TITLE
Change Tiamat to onedir in release notes

### DIFF
--- a/doc/topics/releases/3005.rst
+++ b/doc/topics/releases/3005.rst
@@ -153,6 +153,24 @@ For example:
         - bin_env: /usr/bin/python3
 
 
+Known issues
+------------
+To make use of Salt 3005 or later on a Salt master connected to SaltStack
+Config, you must use SaltStack Config version 8.9.0 or later.
+
+The root cause of the issue is a breaking change to
+``AsyncClient._proc_function()``` in Salt, which is the function that the
+raas-master uses to run ``salt-run`` commands. As this is a private API, there's
+no expectation that the API should remain backward-compatible.
+
+It is recommended to upgrade SaltStack Config before upgrading your Salt
+masters. However, if a Salt master is upgraded to version 3005 before
+upgrading SaltStack Config, the upgrade can still be completed.
+
+After upgrading SaltStack Config, including the SSC plugin on each Salt master,
+restart the Salt masters.
+
+
 Removed
 -------
 

--- a/doc/topics/releases/3005.rst
+++ b/doc/topics/releases/3005.rst
@@ -7,14 +7,14 @@ Salt 3005 release notes - Codename Phosphorus
 Salt 3005 is currently under development.
 
 
-Python 3.5 and 3.6 Deprecation
+Python 3.5 and 3.6 deprecation
 ------------------------------
 
 This will be the last release we will support Python versions 3.5 and 3.6.
 In Salt release 3006, we will only support Python versions 3.7 and higher.
 Going forward, our policy will be to align with Python's supported versions.
 
-OS Support End of Life
+OS support end of life
 ----------------------
 Debian and Raspbian 9 are now EOL, therefore we will no longer be building
 packages for these platforms.
@@ -29,73 +29,83 @@ https://saltproject.io/salt-project-announces-the-open-sourcing-of-several-salts
 New packages available
 ----------------------
 
-With the release of Salt 3005, we are pleased to announce the
-new packages using Tiamat and pyinstaller are now out of beta
-and ready for production. These new packages are self-contained
-binaries of Salt, which includes the version of Python needed by Salt
-and the required dependencies of Salt. The Tiamat packages allow users
-to use Salt without Python being installed on the box.
+With the release of Salt 3005, we are pleased to announce the new onedir
+packages using pyinstaller are now out of beta and ready for production. These
+new packages make the installation process easier. Onedir packages install Salt
+with one directory that includes all the executables Salt needs to run
+effectively, including the version of Python and the required dependencies that
+Salt needs. These packages make it easier to use Salt out of the box without
+installing Python first.
 
-Any new OS platforms we support going forward from version 3005 will only
-include Tiamat packages. For this release, this includes Redhat 9 and Ubuntu 22.04.
+Going forward, any new OS platforms supported by the Salt Project from version
+3005 can only be installed using onedir packages. For this release, this
+includes Redhat 9, Ubuntu 22.04, and Photon OS 3. The Salt Project will phase
+out the old ("classic") Salt package builds for currently supported operating
+systems by 3007. See
+`Upgrade to onedir <https://docs.saltproject.io/salt/install-guide/en/latest/topics/upgrade-to-onedir.html>`_
+for more information.
 
-On the day of the Phosphorus release, the instructions on how to install the
-new Tiamat packages will be available on https://repo.saltproject.io for each
-platform. If you want to test out the packages today you can install them
-from https://repo.saltproject.io/salt-dev/py3/ using the correct directory
+On the day of the Phosphorus release, the onedir packages will be available on
+https://repo.saltproject.io for each platform. The instructions for installing
+onedir packages and the classic packages will be available on the new
+`Salt Install Guide <https://docs.saltproject.io/salt/install-guide/en/latest/>`_.
+
+If you want to test out the packages today, you can install them from
+https://repo.saltproject.io/salt-dev/py3/ using the correct directory
 for your platform. If you find any issues with the packages, please open an
 issue on this repo: https://gitlab.com/saltstack/open/salt-pkg
 
 
-Non-Tiamat packaging support
-----------------------------
-The non-Tiamat packaging system previously used for Salt will also be provided
-for platforms supported in previous Salt versions. The non-Tiamat packaging will
-only be avilable for two more releases. Please see the :ref:`release-3006` notes for more
-details on the availablility of Non-Tiamat packaging for the 3006 release.
-The 3007 release and those going forward will only provide the Tiamat packages.
+Classic, non-onedir packaging support
+-------------------------------------
+The classic, non-onedir packaging system previously used for Salt will also be
+provided for platforms supported in previous Salt versions. The classic
+packaging will only be available for two more releases. See the
+:ref:`release-3006` notes for more details on the availability of classic
+packaging for the 3006 release. The 3007 release and those going forward will
+only provide the onedir packages.
 
 Platform package support
 ------------------------
 
-+--------------+---------------------+---------------------+
-|     OS       | New Tiamat Packages | Non-Tiamat Packages |
-+==============+=====================+=====================+
-| RHEL 7       |         yes         |        yes          |
-+--------------+---------------------+---------------------+
-| RHEL 8       |         yes         |        yes          |
-+--------------+---------------------+---------------------+
-| RHEL 9       |         yes         |        no           |
-+--------------+---------------------+---------------------+
-| Ubuntu 18.04 |         yes         |        yes          |
-+--------------+---------------------+---------------------+
-| Ubuntu 20.04 |         yes         |        yes          |
-+--------------+---------------------+---------------------+
-| Ubuntu 22.04 |         yes         |        no           |
-+--------------+---------------------+---------------------+
-| Debian 10    |         yes         |        yes          |
-+--------------+---------------------+---------------------+
-| Debian 11    |         yes         |        yes          |
-+--------------+---------------------+---------------------+
-| Raspbian 10  |         no          |        yes          |
-+--------------+---------------------+---------------------+
-| Raspbian 11  |         no          |        yes          |
-+--------------+---------------------+---------------------+
-| Fedora 35    |         yes         |        yes          |
-+--------------+---------------------+---------------------+
-| Fedora 36    |         yes         |        yes          |
-+--------------+---------------------+---------------------+
-| MacOS        |         yes         |        yes          |
-+--------------+---------------------+---------------------+
-| Windows      |         yes         |        yes          |
-+--------------+---------------------+---------------------+
++--------------+---------------------+------------------------------+
+|     OS       | New onedir packages | Classic, non-onedir packages |
++==============+=====================+==============================+
+| RHEL 7       |         yes         |        yes                   |
++--------------+---------------------+------------------------------+
+| RHEL 8       |         yes         |        yes                   |
++--------------+---------------------+------------------------------+
+| RHEL 9       |         yes         |        no                    |
++--------------+---------------------+------------------------------+
+| Ubuntu 18.04 |         yes         |        yes                   |
++--------------+---------------------+------------------------------+
+| Ubuntu 20.04 |         yes         |        yes                   |
++--------------+---------------------+------------------------------+
+| Ubuntu 22.04 |         yes         |        no                    |
++--------------+---------------------+------------------------------+
+| Debian 10    |         yes         |        yes                   |
++--------------+---------------------+------------------------------+
+| Debian 11    |         yes         |        yes                   |
++--------------+---------------------+------------------------------+
+| Raspbian 10  |         no          |        yes                   |
++--------------+---------------------+------------------------------+
+| Raspbian 11  |         no          |        yes                   |
++--------------+---------------------+------------------------------+
+| Fedora 35    |         yes         |        yes                   |
++--------------+---------------------+------------------------------+
+| Fedora 36    |         yes         |        yes                   |
++--------------+---------------------+------------------------------+
+| MacOS        |         yes         |        yes                   |
++--------------+---------------------+------------------------------+
+| Windows      |         yes         |        yes                   |
++--------------+---------------------+------------------------------+
 
 
 Repo paths
 ----------
 
 +----------+-----------------------------------------------+-----------------------------------------+
-|     OS   | Tiamat Path                                   | Non-Tiamat Path                         |
+|     OS   | Onedir path                                   | Classic, Non-onedir path                |
 +==========+===============================================+=========================================+
 | RHEL     | https://repo.saltproject.io/salt/py3/redhat/  | https://repo.saltproject.io/py3/redhat/ |
 +----------+-----------------------------------------------+-----------------------------------------+
@@ -112,22 +122,24 @@ Repo paths
 | Windows  | https://repo.saltproject.io/salt/py3/windows/ |  https://repo.saltproject.io/windows/   |
 +----------+-----------------------------------------------+-----------------------------------------+
 
-Note that the Tiamat paths above will not be available until the day of the Phosphorus release.
+Note that the onedir paths above will not be available until the day of the
+Phosphorus release.
 
 
-How do I migrate to the Tiamat packages?
+How do I migrate to the onedir packages?
 ----------------------------------------
-The migration path from the non-Tiamat packages to the Tiamat packages will include:
+The migration path from the classic, non-onedir packages to the onedir packages
+will include:
 
-* Repo File: You need to update your repo file to point to the new repo paths for your platform. After the repo
-  file is updated, upgrade your Salt packages.
-* Pip packages: You need to ensure any 3rd party pip packages are installed in the correct Tiamat path.
-  This can be accomplished in two ways:
+* Repo File: You need to update your repo file to point to the new repo paths
+  for your platform. After the repo file is updated, upgrade your Salt packages.
+* Pip packages: You need to ensure any 3rd party pip packages are installed in
+  the correct onedir path. This can be accomplished in two ways:
 
   * ``salt-pip install <package name>``
   * Using the ``pip.installed`` Salt state.
 
-To install python packages into the system python environment, user's must now provide the ``pip_bin`` or ``bin_env`` to the pip state module.
+To install python packages into the system python environment, users must now provide the ``pip_bin`` or ``bin_env`` to the pip state module.
 
 For example:
 
@@ -139,24 +151,6 @@ For example:
     lib-bar:
       pip.installed:
         - bin_env: /usr/bin/python3
-
-
-Known issues
-------------
-To make use of Salt 3005 or later on a Salt master connected to SaltStack
-Config, you must use SaltStack Config version 8.9.0 or later.
-
-The root cause of the issue is a breaking change to
-``AsyncClient._proc_function()``` in Salt, which is the function that the
-raas-master uses to run ``salt-run`` commands. As this is a private API, there's
-no expectation that the API should remain backward-compatible.
-
-It is recommended to upgrade SaltStack Config before upgrading your Salt
-masters. However, if a Salt master is upgraded to version 3005 before
-upgrading SaltStack Config, the upgrade can still be completed.
-
-After upgrading SaltStack Config, including the SSC plugin on each Salt master,
-restart the Salt masters.
 
 
 Removed
@@ -436,8 +430,8 @@ Added
 - Add Etag support for archive.extracted web sources (#61763)
 - Add regex exclusions, full path matching, symlink following, and mtime/ctime comparison to file.tidied (#61823)
 - Add better handling for unit abbreviations and large values to salt.utils.stringutils.human_to_bytes (#61831)
-- Provide PyInstaller hooks that provide some runtime adjustments when Salt is running from a Tiamat(PyInstaller) bundled package. (#61864)
-- Add configurable tiamat pip pypath location (#61937)
+- Provide PyInstaller hooks that provide some runtime adjustments when Salt is running from a onedir (PyInstaller) bundled package. (#61864)
+- Add configurable onedir pip pypath location (#61937)
 - Add CNAME record support to the dig exec module (#61991)
 - Added support for changed user object in Zabbix 5.4+
   Added compatibility with Zabbix 4.0+ for `zabbix.user_getmedia` method

--- a/doc/topics/releases/3006.rst
+++ b/doc/topics/releases/3006.rst
@@ -7,24 +7,28 @@ Salt 3006 release notes - Codename Sulfur
 Salt 3006 is currently under development.
 
 
-Non-Tiamat packaging support
-----------------------------
-The non-Tiamat packaging system previously used for Salt will only be provided
-for platforms that support Python 3.7 and above. If a platform is using
-Python 3.5 or 3.6, only Tiamat packages will be available for that platform.
+Classic, non-onedir packaging support
+-------------------------------------
+The classic, non-onedir packaging system previously used for Salt will only be
+provided for platforms that support Python 3.7 and above. If a platform is using
+Python 3.5 or 3.6, only onedir packages will be available for that platform.
 This policy change will require users to update their repo files to point to
-the new repo path to use the new Tiamat packages. The full installation instructions
-can be found at https://repo.saltproject.io. This change impacts various OS platforms, including:
+the new repo path to use the new onedir packages. The full installation
+instructions can be found at
+https://docs.saltproject.io/salt/install-guide/en/latest/index.html . See also
+`Upgrade to onedir <https://docs.saltproject.io/salt/install-guide/en/latest/topics/upgrade-to-onedir.html>`_ .
+
+This change impacts various OS platforms, including:
 
 * Ubuntu 18.04
 * CentOS 7
 * CentOS 8
 
 
-These platforms will only have Tiamat packages avalable.
+These platforms will only have onedir packages available.
 
-This is the last release we will provide non-Tiamat packaging. The 3007 release and
-those going forward will only provide the Tiamat packages.
+This is the last release we will provide classic, non-onedir packaging. The 3007
+release and those going forward will only provide the onedir packages.
 
 Dropping support for Python 3.5 and 3.6
 ---------------------------------------
@@ -36,33 +40,33 @@ supported versions.
 Platform package support
 ------------------------
 
-+--------------+---------------------+---------------------+
-|     OS       | New Tiamat Packages | Non-Tiamat Packages |
-+==============+=====================+=====================+
-| RHEL 7       |         yes         |        no           |
-+--------------+---------------------+---------------------+
-| RHEL 8       |         yes         |        no           |
-+--------------+---------------------+---------------------+
-| RHEL 9       |         yes         |        no           |
-+--------------+---------------------+---------------------+
-| Ubuntu 18.04 |         yes         |        no           |
-+--------------+---------------------+---------------------+
-| Ubuntu 20.04 |         yes         |        yes          |
-+--------------+---------------------+---------------------+
-| Ubuntu 22.04 |         yes         |        no           |
-+--------------+---------------------+---------------------+
-| Debian 10    |         yes         |        yes          |
-+--------------+---------------------+---------------------+
-| Debian 11    |         yes         |        yes          |
-+--------------+---------------------+---------------------+
-| Fedora 35    |         yes         |        yes          |
-+--------------+---------------------+---------------------+
-| Fedora 36    |         yes         |        yes          |
-+--------------+---------------------+---------------------+
-| MacOS        |         yes         |        yes          |
-+--------------+---------------------+---------------------+
-| Windows      |         yes         |        yes          |
-+--------------+---------------------+---------------------+
++--------------+---------------------+------------------------------+
+|     OS       | New onedir packages | Classic, Non-onedir packages |
++==============+=====================+==============================+
+| RHEL 7       |         yes         |        no                    |
++--------------+---------------------+------------------------------+
+| RHEL 8       |         yes         |        no                    |
++--------------+---------------------+------------------------------+
+| RHEL 9       |         yes         |        no                    |
++--------------+---------------------+------------------------------+
+| Ubuntu 18.04 |         yes         |        no                    |
++--------------+---------------------+------------------------------+
+| Ubuntu 20.04 |         yes         |        yes                   |
++--------------+---------------------+------------------------------+
+| Ubuntu 22.04 |         yes         |        no                    |
++--------------+---------------------+------------------------------+
+| Debian 10    |         yes         |        yes                   |
++--------------+---------------------+------------------------------+
+| Debian 11    |         yes         |        yes                   |
++--------------+---------------------+------------------------------+
+| Fedora 35    |         yes         |        yes                   |
++--------------+---------------------+------------------------------+
+| Fedora 36    |         yes         |        yes                   |
++--------------+---------------------+------------------------------+
+| MacOS        |         yes         |        yes                   |
++--------------+---------------------+------------------------------+
+| Windows      |         yes         |        yes                   |
++--------------+---------------------+------------------------------+
 
 
 Repo paths
@@ -84,35 +88,39 @@ Repo paths
 | Windows  | https://repo.saltproject.io/salt/py3/windows/ |  https://repo.saltproject.io/windows/   |
 +----------+-----------------------------------------------+-----------------------------------------+
 
-Note that the Tiamat paths above will not be available until the day of the Phosphorus release.
+Note that the onedir paths above will not be available until the day of the Phosphorus release.
 
 
-My OS only provides Tiamat packages. What do I do?
+My OS only provides onedir packages. What do I do?
 --------------------------------------------------
-If you are using a platform that no longer provides the non-Tiamat packages as shown
-in the previous tables, you will need to update your repo files to point to the new Tiamat packages.
-The new repo paths are provided in the previous tables, but the full instructions will be included
-at https://repo.saltproject.io.
+If you are using a platform that no longer provides the classic, non-onedir
+packages as shown in the previous tables, you will need to update your repo
+files to point to the new onedir packages. The new repo paths are provided in
+the previous tables, but the full instructions will be included
+at https://docs.saltproject.io/salt/install-guide/en/latest/index.html .
 
 
 My OS uses an unsupported version of Python. What do I do?
 ----------------------------------------------------------
-If your OS is using an unsupported version of Python, you will need to use the Tiamat packages.
+If your OS is using an unsupported version of Python, you will need to use the
+onedir packages.
 
 
-How do I migrate to the Tiamat packages?
+How do I migrate to the onedir packages?
 ----------------------------------------
-The migration path from the non-Tiamat packages to the Tiamat packages will include:
+The migration path from the classic, non-onedir packages to the onedir packages
+will include:
 
-* Repo File: You need to update your repo file to point to the new repo paths for your platform. After the repo
-  file is updated, upgrade your Salt packages.
-* Pip packages: You need to ensure any 3rd party pip packages are installed in the correct Tiamat path.
-  This can be accomplished in two ways:
+* Repo File: You need to update your repo file to point to the new repo paths
+  for your platform. After the repo file is updated, upgrade your Salt packages.
+* Pip packages: You need to ensure any 3rd party pip packages are installed in
+  the correct onedir path. This can be accomplished in two ways:
 
   * ``salt-pip install <package name>``
   * Using the ``pip.installed`` Salt state.
 
-To install python packages into the system python environment, user's must now provide the ``pip_bin`` or ``bin_env`` to the pip state module.
+To install python packages into the system python environment, user's must now
+provide the ``pip_bin`` or ``bin_env`` to the pip state module.
 
 For example:
 


### PR DESCRIPTION
### What does this PR do?

This MR changes all references to the Tiamat packaging system to "onedir" instead.
If you're a community member, first off: hi! 👋 

You might be wondering why this change was made. The simple explanation is that we're changing references to Tiamat to "onedir" because it's a more accurate. The goal of providing a onedir package are to make the installation process easier by making it so that all of Salt's dependencies are included in one directory. We want our documentation to use a name that describes the goal of the installation process, not the underlying tool it is using.

The change in question was to rename the wording around the new onedir packages that are being built for 3005 using the Tiamat tool.  The core team discussed this topic at length and decided that it was more accurate and descriptive to refer to these packages as onedir rather than refering them to tiamat.  This gives us a clear distinction between the new onedir packages and the classic packages by focusing on the concept these are built in rather than the tool used to build them.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated