### PR TITLE
[DOCS] Add missing commas in node list for modules.pcs

### DIFF
--- a/salt/modules/pcs.py
+++ b/salt/modules/pcs.py
@@ -183,7 +183,7 @@ def auth(nodes, pcsuser="hacluster", pcspasswd="hacluster", extra_args=None):
 
     .. code-block:: bash
 
-        salt '*' pcs.auth nodes='[ node1.example.org node2.example.org ]' pcsuser=hacluster pcspasswd=hoonetorg extra_args=[ '--force' ]
+        salt '*' pcs.auth nodes='[ node1.example.org, node2.example.org ]' pcsuser=hacluster pcspasswd=hoonetorg extra_args=[ '--force' ]
     """
     if __use_new_commands():
         cmd = ["pcs", "host", "auth"]
@@ -215,7 +215,7 @@ def is_auth(nodes, pcsuser="hacluster", pcspasswd="hacluster"):
 
     .. code-block:: bash
 
-        salt '*' pcs.is_auth nodes='[node1.example.org node2.example.org]' pcsuser=hacluster pcspasswd=hoonetorg
+        salt '*' pcs.is_auth nodes='[node1.example.org, node2.example.org]' pcsuser=hacluster pcspasswd=hoonetorg
     """
     if __use_new_commands():
         cmd = ["pcs", "host", "auth", "-u", pcsuser, "-p", pcspasswd]
@@ -244,7 +244,7 @@ def cluster_setup(nodes, pcsclustername="pcscluster", extra_args=None):
 
     .. code-block:: bash
 
-        salt '*' pcs.cluster_setup nodes='[ node1.example.org node2.example.org ]' pcsclustername=pcscluster
+        salt '*' pcs.cluster_setup nodes='[ node1.example.org, node2.example.org ]' pcsclustername=pcscluster
     """
     cmd = ["pcs", "cluster", "setup"]
 


### PR DESCRIPTION
### What does this PR do?
The examples nodes lists in pcs.auth, pcs.is_auth, and pcs.cluster_setup do not use commas to separate the list of nodes, making the module think it's a list with a single item.

### What issues does this PR fix or reference?
Fixes: #62414 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [N/A] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [N/A] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
