### PR TITLE
pkg: update mac brew pkg to use combined cask/formula commands

### DIFF
--- a/tests/pytests/unit/modules/test_mac_brew_pkg.py
+++ b/tests/pytests/unit/modules/test_mac_brew_pkg.py
@@ -36,14 +36,15 @@ def custom_call_brew(*cmd, failhard=True):
     if cmd == ("info", "--json=v2", "--installed"):
         result = {
             "stdout": textwrap.dedent(
-                """\
+                """
                 {
-                  "casks": [
-                    {
-                      "appcast": null,
-                      "artifacts": [
-                        [
-                          "Day-3.0/Day-O.app"
+                    "casks": [
+                        {
+                        "token": "saltstack",
+                        "full_token": "smillerdev/saltstack/saltstack",
+                        "tap": "smillerdev/saltstack",
+                        "name": [
+                            "saltstack"
                         ],
                         {
                           "signal": {},
@@ -224,135 +225,299 @@ def custom_call_brew(*cmd, failhard=True):
                           "poured_from_bottle": true,
                           "runtime_dependencies": [
                             {
-                              "full_name": "oniguruma",
-                              "version": "6.9.6"
-                            }
-                          ],
-                          "used_options": [],
-                          "version": "1.6"
-                        }
-                      ],
-                      "keg_only": false,
-                      "license": "MIT",
-                      "linked_keg": "1.6",
-                      "name": "jq",
-                      "oldname": null,
-                      "optional_dependencies": [],
-                      "options": [],
-                      "outdated": false,
-                      "pinned": false,
-                      "recommended_dependencies": [],
-                      "requirements": [],
-                      "revision": 0,
-                      "urls": {
-                        "stable": {
-                          "revision": null,
-                          "tag": null,
-                          "url": "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-1.6.tar.gz"
-                        }
-                      },
-                      "uses_from_macos": [],
-                      "version_scheme": 0,
-                      "versioned_formulae": [],
-                      "versions": {
-                        "bottle": true,
-                        "head": "HEAD",
-                        "stable": "1.6"
-                      }
-                    },
-                    {
-                      "aliases": [],
-                      "bottle": {
-                        "stable": {
-                          "cellar": ":any",
-                          "files": {
-                            "arm64_big_sur": {
-                              "sha256": "c84206005787304416ed81094bd3a0cdd2ae8eb62649db5a3a44fa14b276d09f",
-                              "url": "https://homebrew.bintray.com/bottles/xz-5.2.5.arm64_big_sur.bottle.tar.gz"
+                            "pkgutil": "com.saltstack.salt",
+                            "signal": {}
                             },
-                            "big_sur": {
-                              "sha256": "4fbd4a9e3eb49c27e83bd125b0e76d386c0e12ae1139d4dc9e31841fb8880a35",
-                              "url": "https://homebrew.bintray.com/bottles/xz-5.2.5.big_sur.bottle.tar.gz"
-                            },
-                            "catalina": {
-                              "sha256": "2dcc8e0121c934d1e34ffdb37fcd70f0f7b5c2f4755f2f7cbcf360e9e54cb43b",
-                              "url": "https://homebrew.bintray.com/bottles/xz-5.2.5.catalina.bottle.tar.gz"
-                            },
-                            "high_sierra": {
-                              "sha256": "1491b2b20c40c3cb0b990f520768d7e876e4ab4a7dc1da9994d0150da34ba5c6",
-                              "url": "https://homebrew.bintray.com/bottles/xz-5.2.5.high_sierra.bottle.tar.gz"
-                            },
-                            "mojave": {
-                              "sha256": "44483961b5d2b535b0ece1936c9d40b4bc7d9c7281646cca0fb476291ab9d4dc",
-                              "url": "https://homebrew.bintray.com/bottles/xz-5.2.5.mojave.bottle.tar.gz"
-                            }
-                          },
-                          "prefix": "/usr/local",
-                          "rebuild": 0,
-                          "root_url": "https://homebrew.bintray.com/bottles"
-                        }
-                      },
-                      "bottle_disabled": false,
-                      "build_dependencies": [],
-                      "caveats": null,
-                      "conflicts_with": [],
-                      "dependencies": [],
-                      "deprecated": false,
-                      "deprecation_date": null,
-                      "deprecation_reason": null,
-                      "desc": "General-purpose data compression with high compression ratio",
-                      "disable_date": null,
-                      "disable_reason": null,
-                      "disabled": false,
-                      "full_name": "xz",
-                      "homepage": "https://tukaani.org/xz/",
-                      "installed": [
+                            "salt-3004.2-py3-x86_64.pkg (Pkg)"
+                        ],
+                        "caveats": null,
+                        "depends_on": {},
+                        "conflicts_with": {
+                            "cask": [
+                            "saltstack-3001",
+                            "saltstack-3000"
+                            ]
+                        },
+                        "container": null,
+                        "auto_updates": null
+                        },
                         {
-                          "built_as_bottle": true,
-                          "installed_as_dependency": true,
-                          "installed_on_request": false,
-                          "poured_from_bottle": true,
-                          "runtime_dependencies": [],
-                          "used_options": [],
-                          "version": "5.2.5"
+                        "token": "visual-studio-code",
+                        "full_token": "visual-studio-code",
+                        "tap": "homebrew/cask",
+                        "name": [
+                            "Microsoft Visual Studio Code",
+                            "VS Code"
+                        ],
+                        "desc": "Open-source code editor",
+                        "homepage": "https://code.visualstudio.com/",
+                        "url": "https://update.code.visualstudio.com/1.70.0/darwin/stable",
+                        "appcast": null,
+                        "version": "1.70.0",
+                        "versions": {},
+                        "installed": "1.67.1",
+                        "outdated": false,
+                        "sha256": "ed6b3f9368ca3dd792fc18e74e3d4a4070cf36df4efd1d81db8c96df8c647dde",
+                        "artifacts": [
+                            [
+                            "Visual Studio Code.app"
+                            ],
+                            [
+                            "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"
+                            ],
+                            {
+                            "trash": [
+                                "~/.vscode",
+                                "~/Library/Application Support/Code",
+                                "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.microsoft.vscode.sfl*",
+                                "~/Library/Caches/com.microsoft.VSCode.ShipIt",
+                                "~/Library/Caches/com.microsoft.VSCode",
+                                "~/Library/Preferences/ByHost/com.microsoft.VSCode.ShipIt.*.plist",
+                                "~/Library/Preferences/com.microsoft.VSCode.helper.plist",
+                                "~/Library/Preferences/com.microsoft.VSCode.plist",
+                                "~/Library/Saved Application State/com.microsoft.VSCode.savedState"
+                            ],
+                            "signal": {}
+                            }
+                        ],
+                        "caveats": null,
+                        "depends_on": {},
+                        "conflicts_with": null,
+                        "container": null,
+                        "auto_updates": true
                         }
-                      ],
-                      "keg_only": false,
-                      "license": "GPL-2.0",
-                      "linked_keg": "5.2.5",
-                      "name": "xz",
-                      "oldname": null,
-                      "optional_dependencies": [],
-                      "options": [],
-                      "outdated": false,
-                      "pinned": false,
-                      "recommended_dependencies": [],
-                      "requirements": [],
-                      "revision": 0,
-                      "urls": {
-                        "stable": {
-                          "revision": null,
-                          "tag": null,
-                          "url": "https://downloads.sourceforge.net/project/lzmautils/xz-5.2.5.tar.gz"
+                    ],
+                    "formulae": [
+                        {
+                        "name": "salt",
+                        "full_name": "salt",
+                        "tap": "homebrew/core",
+                        "oldname": "saltstack",
+                        "aliases": [
+                            "saltstack"
+                        ],
+                        "versioned_formulae": [],
+                        "desc": "Dynamic infrastructure communication bus",
+                        "license": "Apache-2.0",
+                        "homepage": "https://saltproject.io/",
+                        "versions": {
+                            "stable": "3004.2",
+                            "head": "HEAD",
+                            "bottle": true
+                        },
+                        "urls": {
+                            "stable": {
+                            "url": "https://files.pythonhosted.org/packages/78/47/0acfc5d43fcf4b01c3f650ce884525dd2330b8827364e4509819f7e925d3/salt-3004.2.tar.gz",
+                            "tag": null,
+                            "revision": null
+                            }
+                        },
+                        "revision": 1,
+                        "version_scheme": 0,
+                        "bottle": {
+                            "stable": {
+                            "rebuild": 0,
+                            "root_url": "https://ghcr.io/v2/homebrew/core",
+                            "files": {
+                                "arm64_monterey": {
+                                "cellar": ":any",
+                                "url": "https://ghcr.io/v2/homebrew/core/salt/blobs/sha256:e62a03420f4859b5d7370b7b4800b73b7b198f97a6ebae2a04d9e77e340a32dd",
+                                "sha256": "e62a03420f4859b5d7370b7b4800b73b7b198f97a6ebae2a04d9e77e340a32dd"
+                                },
+                                "arm64_big_sur": {
+                                "cellar": ":any",
+                                "url": "https://ghcr.io/v2/homebrew/core/salt/blobs/sha256:76308937ea092c4dfc0c661c228cca5c1114d2413ef50be71257d6dc4ee213ac",
+                                "sha256": "76308937ea092c4dfc0c661c228cca5c1114d2413ef50be71257d6dc4ee213ac"
+                                },
+                                "monterey": {
+                                "cellar": ":any",
+                                "url": "https://ghcr.io/v2/homebrew/core/salt/blobs/sha256:cd8258f57d8bd3b0d47ff3aae83ad0180784fcf312a647b33175e51b3a2de34a",
+                                "sha256": "cd8258f57d8bd3b0d47ff3aae83ad0180784fcf312a647b33175e51b3a2de34a"
+                                },
+                                "big_sur": {
+                                "cellar": ":any",
+                                "url": "https://ghcr.io/v2/homebrew/core/salt/blobs/sha256:1aee80b0ed6be7c2cda3fecba7ca5e7aea559945d96bafeb5fabea208c5b7a37",
+                                "sha256": "1aee80b0ed6be7c2cda3fecba7ca5e7aea559945d96bafeb5fabea208c5b7a37"
+                                },
+                                "catalina": {
+                                "cellar": ":any",
+                                "url": "https://ghcr.io/v2/homebrew/core/salt/blobs/sha256:9f81d609b9fbac2571099386ffaf3af3608b96fc03a411b04398051138513a76",
+                                "sha256": "9f81d609b9fbac2571099386ffaf3af3608b96fc03a411b04398051138513a76"
+                                },
+                                "x86_64_linux": {
+                                "cellar": ":any_skip_relocation",
+                                "url": "https://ghcr.io/v2/homebrew/core/salt/blobs/sha256:24c490917bab507a7bcf60a0b53669182eb75369416da07b71b3eb983767c2de",
+                                "sha256": "24c490917bab507a7bcf60a0b53669182eb75369416da07b71b3eb983767c2de"
+                                }
+                            }
+                            }
+                        },
+                        "keg_only": false,
+                        "keg_only_reason": null,
+                        "options": [],
+                        "build_dependencies": [
+                            "swig"
+                        ],
+                        "dependencies": [
+                            "libgit2",
+                            "libyaml",
+                            "openssl@1.1",
+                            "python@3.10",
+                            "six",
+                            "zeromq"
+                        ],
+                        "recommended_dependencies": [],
+                        "optional_dependencies": [],
+                        "uses_from_macos": [
+                            "libffi"
+                        ],
+                        "requirements": [],
+                        "conflicts_with": [],
+                        "caveats": "Sample configuration files have been placed in $(brew --prefix)/etc/saltstack.\\nSaltstack will not use these by default.\\n\\nHomebrew's installation does not include PyObjC.\\n",
+                        "installed": [
+                            {
+                                "version": "3004.2",
+                                "used_options": [],
+                                "built_as_bottle": true,
+                                "poured_from_bottle": true,
+                                "runtime_dependencies": [],
+                                "installed_as_dependency": false,
+                                "installed_on_request": true
+                            }
+                        ],
+                        "linked_keg": null,
+                        "pinned": false,
+                        "outdated": false,
+                        "deprecated": false,
+                        "deprecation_date": null,
+                        "deprecation_reason": null,
+                        "disabled": false,
+                        "disable_date": null,
+                        "disable_reason": null
+                        },
+                        {
+                        "name": "jq",
+                        "full_name": "jq",
+                        "tap": "homebrew/core",
+                        "oldname": null,
+                        "aliases": [],
+                        "versioned_formulae": [],
+                        "desc": "Lightweight and flexible command-line JSON processor",
+                        "license": "MIT",
+                        "homepage": "https://stedolan.github.io/jq/",
+                        "versions": {
+                            "stable": "1.6",
+                            "head": "HEAD",
+                            "bottle": true
+                        },
+                        "urls": {
+                            "stable": {
+                            "url": "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-1.6.tar.gz",
+                            "tag": null,
+                            "revision": null
+                            }
+                        },
+                        "revision": 0,
+                        "version_scheme": 0,
+                        "bottle": {
+                            "stable": {
+                            "rebuild": 1,
+                            "root_url": "https://ghcr.io/v2/homebrew/core",
+                            "files": {
+                                "arm64_monterey": {
+                                "cellar": ":any",
+                                "url": "https://ghcr.io/v2/homebrew/core/jq/blobs/sha256:f70e1ae8df182b242ca004492cc0a664e2a8195e2e46f30546fe78e265d5eb87",
+                                "sha256": "f70e1ae8df182b242ca004492cc0a664e2a8195e2e46f30546fe78e265d5eb87"
+                                },
+                                "arm64_big_sur": {
+                                "cellar": ":any",
+                                "url": "https://ghcr.io/v2/homebrew/core/jq/blobs/sha256:674b3ae41c399f1e8e44c271b0e6909babff9fcd2e04a2127d25e2407ea4dd33",
+                                "sha256": "674b3ae41c399f1e8e44c271b0e6909babff9fcd2e04a2127d25e2407ea4dd33"
+                                },
+                                "monterey": {
+                                "cellar": ":any",
+                                "url": "https://ghcr.io/v2/homebrew/core/jq/blobs/sha256:7fee6ea327062b37d34ef5346a84810a1752cc7146fff1223fab76c9b45686e0",
+                                "sha256": "7fee6ea327062b37d34ef5346a84810a1752cc7146fff1223fab76c9b45686e0"
+                                },
+                                "big_sur": {
+                                "cellar": ":any",
+                                "url": "https://ghcr.io/v2/homebrew/core/jq/blobs/sha256:bf0f8577632af7b878b6425476f5b1ab9c3bf66d65affb0c455048a173a0b6bf",
+                                "sha256": "bf0f8577632af7b878b6425476f5b1ab9c3bf66d65affb0c455048a173a0b6bf"
+                                },
+                                "catalina": {
+                                "cellar": ":any",
+                                "url": "https://ghcr.io/v2/homebrew/core/jq/blobs/sha256:820a3c85fcbb63088b160c7edf125d7e55fc2c5c1d51569304499c9cc4b89ce8",
+                                "sha256": "820a3c85fcbb63088b160c7edf125d7e55fc2c5c1d51569304499c9cc4b89ce8"
+                                },
+                                "mojave": {
+                                "cellar": ":any",
+                                "url": "https://ghcr.io/v2/homebrew/core/jq/blobs/sha256:71f0e76c5b22e5088426c971d5e795fe67abee7af6c2c4ae0cf4c0eb98ed21ff",
+                                "sha256": "71f0e76c5b22e5088426c971d5e795fe67abee7af6c2c4ae0cf4c0eb98ed21ff"
+                                },
+                                "high_sierra": {
+                                "cellar": ":any",
+                                "url": "https://ghcr.io/v2/homebrew/core/jq/blobs/sha256:dffcffa4ea13e8f0f2b45c5121e529077e135ae9a47254c32182231662ee9b72",
+                                "sha256": "dffcffa4ea13e8f0f2b45c5121e529077e135ae9a47254c32182231662ee9b72"
+                                },
+                                "sierra": {
+                                "cellar": ":any",
+                                "url": "https://ghcr.io/v2/homebrew/core/jq/blobs/sha256:bb4d19dc026c2d72c53eed78eaa0ab982e9fcad2cd2acc6d13e7a12ff658e877",
+                                "sha256": "bb4d19dc026c2d72c53eed78eaa0ab982e9fcad2cd2acc6d13e7a12ff658e877"
+                                },
+                                "x86_64_linux": {
+                                "cellar": ":any_skip_relocation",
+                                "url": "https://ghcr.io/v2/homebrew/core/jq/blobs/sha256:2beea2c2c372ccf1081e9a5233fc3020470803254284aeecc071249d76b62338",
+                                "sha256": "2beea2c2c372ccf1081e9a5233fc3020470803254284aeecc071249d76b62338"
+                                }
+                            }
+                            }
+                        },
+                        "keg_only": false,
+                        "keg_only_reason": null,
+                        "options": [],
+                        "build_dependencies": [],
+                        "dependencies": [
+                            "oniguruma"
+                        ],
+                        "recommended_dependencies": [],
+                        "optional_dependencies": [],
+                        "uses_from_macos": [],
+                        "requirements": [],
+                        "conflicts_with": [],
+                        "caveats": null,
+                        "installed": [
+                            {
+                                "version": "1.6",
+                                "used_options": [],
+                                "built_as_bottle": true,
+                                "poured_from_bottle": true,
+                                "runtime_dependencies": [
+                                    {
+                                    "full_name": "oniguruma",
+                                    "version": "6.9.2"
+                                    }
+                                ],
+                                "installed_as_dependency": false,
+                                "installed_on_request": true
+                            }
+                        ],
+                        "linked_keg": "1.6",
+                        "pinned": false,
+                        "outdated": false,
+                        "deprecated": false,
+                        "deprecation_date": null,
+                        "deprecation_reason": null,
+                        "disabled": false,
+                        "disable_date": null,
+                        "disable_reason": null
                         }
-                      },
-                      "uses_from_macos": [],
-                      "version_scheme": 0,
-                      "versioned_formulae": [],
-                      "versions": {
-                        "bottle": true,
-                        "head": null,
-                        "stable": "5.2.5"
-                      }
-                    }
-                  ]
+                    ]
                 }
                 """
             ),
             "stderr": "",
             "retcode": 0,
         }
-
     return result
 
 
@@ -477,7 +642,6 @@ def test_list_pkgs_homebrew_cask_pakages():
         "custom/tap/iterm2": "3.4.3",
         "iterm2": "3.4.3",
         "jq": "1.6",
-        "xz": "5.2.5",
     }
 
     with patch("salt.modules.mac_brew_pkg._call_brew", custom_call_brew), patch.dict(
@@ -495,12 +659,6 @@ def test_list_pkgs_no_context():
     Tests removed implementation
     """
 
-    expected_pkgs = {
-        "zsh": "5.7.1",
-        "homebrew/cask/macvim": "8.1.151",
-        "homebrew/cask-fonts/font-firacode-nerd-font": "2.0.0",
-    }
-
     with patch("salt.modules.mac_brew_pkg._call_brew", custom_call_brew), patch.dict(
         mac_brew.__salt__,
         {
@@ -508,11 +666,11 @@ def test_list_pkgs_no_context():
             "pkg_resource.sort_pkglist": MagicMock(),
         },
     ), patch.object(mac_brew, "_list_pkgs_from_context") as list_pkgs_context_mock:
-        pkgs = mac_brew.list_pkgs(versions_as_list=True, use_context=False)
+        mac_brew.list_pkgs(versions_as_list=True, use_context=False)
         list_pkgs_context_mock.assert_not_called()
         list_pkgs_context_mock.reset_mock()
 
-        pkgs = mac_brew.list_pkgs(versions_as_list=True, use_context=False)
+        mac_brew.list_pkgs(versions_as_list=True, use_context=False)
         list_pkgs_context_mock.assert_not_called()
         list_pkgs_context_mock.reset_mock()
 
@@ -597,6 +755,50 @@ def test_install():
     mock_params = MagicMock(return_value=[None, None])
     with patch.dict(mac_brew.__salt__, {"pkg_resource.parse_targets": mock_params}):
         assert mac_brew.install("name=foo") == {}
+
+
+# 'list_upgrades' function tests: 1
+# Only tested a few basics
+# Full functionality should be tested in integration phase
+
+
+def test_list_upgrades():
+    """
+    Tests if pkg.list_upgrades list all items
+    """
+    expected_pkgs = {
+        "visual-studio-code": "1.70.0",
+        "firefox": "103.0.1",
+        "salt": "3004.2",
+    }
+
+    with patch("salt.modules.mac_brew_pkg._call_brew", custom_call_brew), patch.dict(
+        mac_brew.__salt__,
+        {
+            "pkg_resource.add_pkg": custom_add_pkg,
+            "pkg_resource.sort_pkglist": MagicMock(),
+        },
+    ):
+        assert mac_brew.list_upgrades(refresh=False) == expected_pkgs
+
+
+# 'upgrade_available' function tests: 1
+# Only tested a few basics
+# Full functionality should be tested in integration phase
+
+
+def test_upgrade_available():
+    """
+    Tests if pkg.upgrade_available returns the correct info
+    """
+    with patch("salt.modules.mac_brew_pkg._call_brew", custom_call_brew), patch.dict(
+        mac_brew.__salt__,
+        {
+            "pkg_resource.add_pkg": custom_add_pkg,
+            "pkg_resource.sort_pkglist": MagicMock(),
+        },
+    ):
+        assert mac_brew.upgrade_available("salt", refresh=False)
 
 
 # "hold" function tests: 2


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes: improves interaction with Homebrew package manager

### Previous Behavior
Specific to macOS and no usage of shared commands for cask and formula

### New Behavior
Allow Homebrew anywhere and optimize commands

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
