### PR TITLE
Fixing pkg state changes

### DIFF
--- a/changelog/60995.fixed
+++ b/changelog/60995.fixed
@@ -1,0 +1,1 @@
+Fixing changes dict in pkg state to be consistent when installing and test=True.

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1800,7 +1800,7 @@ def installed(
         )
 
     comment = []
-    changes = {"installed": {}}
+    changes = {}
     if __opts__["test"]:
         if targets:
             if sources:
@@ -1808,9 +1808,7 @@ def installed(
             else:
                 _targets = [_get_desired_pkg(x, targets) for x in targets]
             summary = ", ".join(targets)
-            changes["installed"].update(
-                {x: {"new": "installed", "old": ""} for x in targets}
-            )
+            changes.update({x: {"new": "installed", "old": ""} for x in targets})
             comment.append(
                 "The following packages would be installed/updated: {}".format(summary)
             )
@@ -1819,9 +1817,7 @@ def installed(
                 "The following packages would have their selection status "
                 "changed from 'purge' to 'install': {}".format(", ".join(to_unpurge))
             )
-            changes["installed"].update(
-                {x: {"new": "installed", "old": ""} for x in to_unpurge}
-            )
+            changes.update({x: {"new": "installed", "old": ""} for x in to_unpurge})
         if to_reinstall:
             # Add a comment for each package in to_reinstall with its
             # pkg.verify output
@@ -1834,7 +1830,7 @@ def installed(
                         reinstall_targets.append(
                             _get_desired_pkg(reinstall_pkg, to_reinstall)
                         )
-                    changes["installed"].update(
+                    changes.update(
                         {x: {"new": "installed", "old": ""} for x in reinstall_targets}
                     )
                 msg = "The following packages would be reinstalled: "
@@ -1850,7 +1846,7 @@ def installed(
                         "Package '{}' would be reinstalled because the "
                         "following files have been altered:".format(pkgstr)
                     )
-                    changes["installed"].update({reinstall_pkg: {}})
+                    changes.update({reinstall_pkg: {}})
                     comment.append(_nested_output(altered_files[reinstall_pkg]))
         ret = {
             "name": name,
@@ -1902,7 +1898,7 @@ def installed(
             refresh = False
 
         if isinstance(pkg_ret, dict):
-            changes["installed"].update(pkg_ret)
+            changes.update(pkg_ret)
         elif isinstance(pkg_ret, str):
             comment.append(pkg_ret)
             # Code below will be looking for a dictionary. If this is a string
@@ -1959,7 +1955,7 @@ def installed(
 
     # Analyze pkg.install results for packages in targets
     if sources:
-        modified = [x for x in changes["installed"] if x in targets]
+        modified = [x for x in changes if x in targets]
         not_modified = [
             x for x in desired if x not in targets and x not in to_reinstall
         ]
@@ -1981,11 +1977,6 @@ def installed(
         modified = [x for x in _ok if x in targets]
         not_modified = [x for x in _ok if x not in targets and x not in to_reinstall]
         failed = [x for x in failed if x in targets]
-
-    # If there was nothing unpurged, just set the changes dict to the contents
-    # of changes['installed'].
-    if not changes.get("purge_desired"):
-        changes = changes["installed"]
 
     if modified:
         if sources:

--- a/tests/pytests/unit/states/test_pkg.py
+++ b/tests/pytests/unit/states/test_pkg.py
@@ -544,7 +544,7 @@ def test_installed_with_changes_test_true(list_pkgs):
         },
     ):
 
-        expected = {"installed": {"dummy": {"new": "installed", "old": ""}}}
+        expected = {"dummy": {"new": "installed", "old": ""}}
         # Run state with test=true
         with patch.dict(pkg.__opts__, {"test": True}):
             ret = pkg.installed("dummy", test=True)


### PR DESCRIPTION
### What does this PR do?
Fixing changes dict in pkg state to be consistent when installing and test=True.

### What issues does this PR fix or reference?
Fixes: N/A

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
