### PR TITLE
Close publish channel after each connection attempt

### DIFF
--- a/changelog/62489.fixed
+++ b/changelog/62489.fixed
@@ -1,0 +1,1 @@
+Fixes an issue where the minion could not connect to a master after 2 failed attempts

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -820,11 +820,11 @@ class MinionBase:
                     self.connected = True
                     raise salt.ext.tornado.gen.Return((opts["master"], pub_channel))
                 except SaltClientError:
+                    if pub_channel:
+                        pub_channel.close()
                     if attempts == tries:
                         # Exhausted all attempts. Return exception.
                         self.connected = False
-                        if pub_channel:
-                            pub_channel.close()
                         raise
 
     def _discover_masters(self):


### PR DESCRIPTION
### What does this PR do?
Closes the pub channel after each connection attempt. This keeps the auth from going stale.

The default config for `master_tries` on Windows is `-1`. This was causing the connection loop to never close the pub channel and initiate a new connection. The connection was only being closed if the number of tries matched the `master_tries` setting. On Windows this never happens because it is `-1` by default. If the master is not started when the minion starts, then the auth would get stale and the connection would never succeed after a certain amount of time... approximately 3 attempts.

### What issues does this PR fix or reference?
Fixes: #62489

### Previous Behavior
Minion could not connect to the master after 3 failed attempts.

### New Behavior
Minion can connect to the master

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes