### PR TITLE
Rename `salt/serializers/toml.py` to `salt/serializers/tomlmod.py`

### DIFF
--- a/doc/ref/serializers/all/index.rst
+++ b/doc/ref/serializers/all/index.rst
@@ -15,6 +15,6 @@ serializer modules
     msgpack
     plist
     python
-    toml
+    tomlmod
     yaml
     yamlex

--- a/doc/ref/serializers/all/salt.serializers.tomlmod.rst
+++ b/doc/ref/serializers/all/salt.serializers.tomlmod.rst
@@ -1,5 +1,5 @@
 salt.serializers.toml
 =====================
 
-.. automodule:: salt.serializers.toml
+.. automodule:: salt.serializers.tomlmod
     :members:

--- a/salt/renderers/tomlmod.py
+++ b/salt/renderers/tomlmod.py
@@ -1,7 +1,7 @@
 import logging
 import warnings
 
-import salt.serializers.toml
+import salt.serializers.tomlmod
 import salt.utils.url
 
 log = logging.getLogger(__name__)
@@ -11,7 +11,7 @@ __virtualname__ = "toml"
 
 
 def __virtual__():
-    if salt.serializers.toml.HAS_TOML is False:
+    if salt.serializers.tomlmod.HAS_TOML is False:
         return (False, "The 'toml' library is missing")
     return __virtualname__
 
@@ -24,7 +24,7 @@ def render(sls_data, saltenv="base", sls="", **kws):
     :rtype: A Python data structure
     """
     with warnings.catch_warnings(record=True) as warn_list:
-        data = salt.serializers.toml.deserialize(sls_data) or {}
+        data = salt.serializers.tomlmod.deserialize(sls_data) or {}
 
         for item in warn_list:
             log.warning(

--- a/salt/serializers/tomlmod.py
+++ b/salt/serializers/tomlmod.py
@@ -1,11 +1,14 @@
 """
-    salt.serializers.toml
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    salt.serializers.tomlmod
+    ~~~~~~~~~~~~~~~~~~~~~~~~
 
     Implements TOML serializer.
 
     It's just a wrapper around the python toml module.
 """
+
+import logging
 
 from salt.serializers import DeserializationError, SerializationError
 
@@ -17,7 +20,17 @@ except ImportError:
     HAS_TOML = False
 
 
+__virtualname__ = "toml"
+
 __all__ = ["deserialize", "serialize", "HAS_TOML"]
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    if HAS_TOML is False:
+        return (False, "The 'toml' library is missing")
+    return __virtualname__
 
 
 def deserialize(stream_or_string, **options):

--- a/tests/pytests/integration/renderers/test_toml.py
+++ b/tests/pytests/integration/renderers/test_toml.py
@@ -1,10 +1,10 @@
 import pytest
 
-import salt.serializers.toml
+import salt.serializers.tomlmod
 
 
 @pytest.mark.skipif(
-    salt.serializers.toml.HAS_TOML is False, reason="The 'toml' library is missing"
+    salt.serializers.tomlmod.HAS_TOML is False, reason="The 'toml' library is missing"
 )
 def test_toml_renderer(salt_call_cli, tmp_path, base_env_state_tree_root_dir):
     config_file_path = tmp_path / "config.toml"

--- a/tests/pytests/unit/renderers/test_toml.py
+++ b/tests/pytests/unit/renderers/test_toml.py
@@ -1,11 +1,11 @@
 import pytest
 
 import salt.renderers.tomlmod
-import salt.serializers.toml
+import salt.serializers.tomlmod
 
 
 @pytest.mark.skipif(
-    salt.serializers.toml.HAS_TOML is False, reason="The 'toml' library is missing"
+    salt.serializers.tomlmod.HAS_TOML is False, reason="The 'toml' library is missing"
 )
 def test_toml_render_string():
     data = """[[user-sshkey."ssh_auth.present"]]

--- a/tests/pytests/unit/serializers/test_serializers.py
+++ b/tests/pytests/unit/serializers/test_serializers.py
@@ -9,7 +9,7 @@ import salt.serializers.json as json
 import salt.serializers.msgpack as msgpack
 import salt.serializers.plist as plist
 import salt.serializers.python as python
-import salt.serializers.toml as toml
+import salt.serializers.tomlmod as tomlmod
 import salt.serializers.yaml as yaml
 import salt.serializers.yamlex as yamlex
 from salt.serializers import SerializationError
@@ -359,13 +359,13 @@ def test_configparser():
     assert deserialized == data, deserialized
 
 
-@pytest.mark.skipif(toml.HAS_TOML is False, reason=SKIP_MESSAGE.format("toml"))
+@pytest.mark.skipif(tomlmod.HAS_TOML is False, reason=SKIP_MESSAGE.format("toml"))
 def test_serialize_toml():
     data = {"foo": "bar"}
-    serialized = toml.serialize(data)
+    serialized = tomlmod.serialize(data)
     assert serialized == 'foo = "bar"\n', serialized
 
-    deserialized = toml.deserialize(serialized)
+    deserialized = tomlmod.deserialize(serialized)
     assert deserialized == data, deserialized
 
 


### PR DESCRIPTION
### What does this PR do?
See title.

### What issues does this PR fix or reference?

To avoid importing our `toml` code when we actually want the `toml` library.