### PR TITLE
Add Amazon EC2 detection for virtual grains

### DIFF
--- a/changelog/62539.added
+++ b/changelog/62539.added
@@ -1,0 +1,1 @@
+Implementation of Amazon EC2 instance detection and setting `virtual_subtype` grain accordingly including the product if possible to identify.

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1194,6 +1194,19 @@ def _virtual(osdata):
     if grains.get("virtual_subtype") and grains["virtual"] == "physical":
         grains["virtual"] = "virtual"
 
+    # Try to detect if the instance is running on Amazon EC2
+    if grains["virtual"] in ("qemu", "kvm", "xen"):
+        dmidecode = salt.utils.path.which("dmidecode")
+        if dmidecode:
+            ret = __salt__["cmd.run_all"](
+                [dmidecode, "-t", "system"], ignore_retcode=True
+            )
+            output = ret["stdout"]
+            if "Manufacturer: Amazon EC2" in output or re.match(
+                r".*Version: .*amazon.*", output, flags=re.DOTALL
+            ):
+                grains["virtual_subtype"] = "Amazon EC2"
+
     for command in failed_commands:
         log.info(
             "Although '%s' was found in path, the current user "

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1202,9 +1202,14 @@ def _virtual(osdata):
                 [dmidecode, "-t", "system"], ignore_retcode=True
             )
             output = ret["stdout"]
-            if "Manufacturer: Amazon EC2" in output or re.match(
-                r".*Version: .*amazon.*", output, flags=re.DOTALL
-            ):
+            if "Manufacturer: Amazon EC2" in output:
+                grains["virtual_subtype"] = "Amazon EC2"
+                product = re.match(
+                    r".*Product Name: ([^\r\n]*).*", output, flags=re.DOTALL
+                )
+                if product:
+                    grains["virtual_subtype"] = "Amazon EC2 ({})".format(product[1])
+            elif re.match(r".*Version: [^\r\n]+\.amazon.*", output, flags=re.DOTALL):
                 grains["virtual_subtype"] = "Amazon EC2"
 
     for command in failed_commands:

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -870,6 +870,10 @@ def _virtual(osdata):
                 grains["virtual"] = "container"
                 grains["virtual_subtype"] = "LXC"
                 break
+            elif "amazon" in output:
+                grains["virtual"] = "Nitro"
+                grains["virtual_subtype"] = "Amazon EC2"
+                break
         elif command == "virt-what":
             for line in output.splitlines():
                 if line in ("kvm", "qemu", "uml", "xen"):
@@ -1195,7 +1199,7 @@ def _virtual(osdata):
         grains["virtual"] = "virtual"
 
     # Try to detect if the instance is running on Amazon EC2
-    if grains["virtual"] in ("qemu", "kvm", "xen"):
+    if grains["virtual"] in ("qemu", "kvm", "xen", "amazon"):
         dmidecode = salt.utils.path.which("dmidecode")
         if dmidecode:
             ret = __salt__["cmd.run_all"](
@@ -1203,6 +1207,8 @@ def _virtual(osdata):
             )
             output = ret["stdout"]
             if "Manufacturer: Amazon EC2" in output:
+                if grains["virtual"] != "xen":
+                    grains["virtual"] = "Nitro"
                 grains["virtual_subtype"] = "Amazon EC2"
                 product = re.match(
                     r".*Product Name: ([^\r\n]*).*", output, flags=re.DOTALL

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -933,6 +933,7 @@ def _run_quiet(
     success_retcodes=None,
     success_stdout=None,
     success_stderr=None,
+    ignore_retcode=None,
 ):
     """
     Helper for running commands quietly for minion startup
@@ -959,6 +960,7 @@ def _run_quiet(
         success_retcodes=success_retcodes,
         success_stdout=success_stdout,
         success_stderr=success_stderr,
+        ignore_retcode=ignore_retcode,
     )["stdout"]
 
 
@@ -981,6 +983,7 @@ def _run_all_quiet(
     success_retcodes=None,
     success_stdout=None,
     success_stderr=None,
+    ignore_retcode=None,
 ):
 
     """
@@ -1013,6 +1016,7 @@ def _run_all_quiet(
         success_retcodes=success_retcodes,
         success_stdout=success_stdout,
         success_stderr=success_stderr,
+        ignore_retcode=ignore_retcode,
     )
 
 

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -3285,6 +3285,17 @@ def test_virtual_set_virtual_ec2():
         ]
     )
 
+    def _mock_is_file(filename):
+        if filename in (
+            "/proc/1/cgroup",
+            "/proc/cpuinfo",
+            "/sys/devices/virtual/dmi/id/product_name",
+            "/proc/xen/xsd_kva",
+            "/proc/xen/capabilities",
+        ):
+            return False
+        return True
+
     with patch("salt.utils.path.which", which_mock), patch.dict(
         core.__salt__,
         {
@@ -3293,6 +3304,8 @@ def test_virtual_set_virtual_ec2():
             "cmd.retcode": salt.modules.cmdmod.retcode,
             "smbios.get": salt.modules.smbios.get,
         },
+    ), patch("os.path.isfile", _mock_is_file), patch(
+        "os.path.isdir", return_value=False
     ):
 
         virtual_grains = core._virtual(osdata.copy())

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -3224,6 +3224,11 @@ def test_virtual_set_virtual_ec2():
             "/usr/bin/systemd-detect-virt",
             None,
             None,
+            # Check with systemd-detect-virt returning amazon and no dmidecode available
+            None,
+            "/usr/bin/systemd-detect-virt",
+            None,
+            None,
         ]
     )
     cmd_run_all_mock = MagicMock(
@@ -3282,6 +3287,8 @@ def test_virtual_set_virtual_ec2():
             },
             # Check with systemd-detect-virt when no dmidecode available
             {"retcode": 0, "stderr": "", "stdout": "kvm"},
+            # Check with systemd-detect-virt returning amazon and no dmidecode available
+            {"retcode": 0, "stderr": "", "stdout": "amazon"},
         ]
     )
 
@@ -3322,3 +3329,8 @@ def test_virtual_set_virtual_ec2():
 
         assert virtual_grains["virtual"] == "kvm"
         assert "virtual_subtype" not in virtual_grains
+
+        virtual_grains = core._virtual(osdata.copy())
+
+        assert virtual_grains["virtual"] == "Nitro"
+        assert virtual_grains["virtual_subtype"] == "Amazon EC2"

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -3303,7 +3303,7 @@ def test_virtual_set_virtual_ec2():
         virtual_grains = core._virtual(osdata.copy())
 
         assert virtual_grains["virtual"] == "kvm"
-        assert virtual_grains["virtual_subtype"] == "Amazon EC2"
+        assert virtual_grains["virtual_subtype"] == "Amazon EC2 (m5.large)"
 
         virtual_grains = core._virtual(osdata.copy())
 

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -3302,7 +3302,7 @@ def test_virtual_set_virtual_ec2():
 
         virtual_grains = core._virtual(osdata.copy())
 
-        assert virtual_grains["virtual"] == "kvm"
+        assert virtual_grains["virtual"] == "Nitro"
         assert virtual_grains["virtual_subtype"] == "Amazon EC2 (m5.large)"
 
         virtual_grains = core._virtual(osdata.copy())


### PR DESCRIPTION
### What does this PR do?

Adds `virtual_subtype` set to `Amazon EC2` in case if the it detects the instance running in Amazon EC2 environment.

### Previous Behavior
In case of running the minion in Amazon EC2 instance it's defined as xen or kvm, but no any information about Amazon EC2

### New Behavior
Fills `virtual_subtype` with `Amazon EC2` or `Amazon EC2 (PRODUCT)` where `PRODUCT` is the product name used for `kvm` instance. For example `m5.large` or `m5.metal`.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
