### PR TITLE
Use str() method instead of repo_line for SourceEntry

### DIFF
--- a/changelog/62546.fixed
+++ b/changelog/62546.fixed
@@ -1,0 +1,1 @@
+Use str() method instead of repo_line for when python3-apt is installed or not in aptpkg.py.

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -182,6 +182,9 @@ if not HAS_APT:
                 self.file = str(pathlib.Path(os.sep, "etc", "apt", "sources.list"))
             self._parse_sources(line)
 
+        def str(self):
+            return self.repo_line()
+
         def repo_line(self):
             """
             Return the repo line for the sources file
@@ -2946,7 +2949,7 @@ def mod_repo(repo, saltenv="base", aptkey=True, **kwargs):
 
     if mod_source.uri != repo_uri:
         mod_source.uri = repo_uri
-        mod_source.line = mod_source.repo_line()
+        mod_source.line = mod_source.str()
 
     sources.save()
     # on changes, explicitly refresh

--- a/tests/pytests/functional/states/pkgrepo/test_debian.py
+++ b/tests/pytests/functional/states/pkgrepo/test_debian.py
@@ -537,6 +537,37 @@ def test_repo_present_absent_no_trailing_slash_uri(pkgrepo, trailing_slash_repo_
     assert ret.result
 
 
+@pytest.mark.requires_salt_states("pkgrepo.managed", "pkgrepo.absent")
+def test_repo_present_absent_no_trailing_slash_uri_add_slash(
+    pkgrepo, trailing_slash_repo_file
+):
+    """
+    test adding a repo without a trailing slash, and then running it
+    again with a trailing slash.
+    """
+    # without the trailing slash
+    repo_content = "deb http://www.deb-multimedia.org stable main"
+    # initial creation
+    ret = pkgrepo.managed(
+        name=repo_content, file=trailing_slash_repo_file, refresh=False, clean_file=True
+    )
+    with salt.utils.files.fopen(trailing_slash_repo_file, "r") as fp:
+        file_content = fp.read()
+    assert file_content.strip() == "deb http://www.deb-multimedia.org stable main"
+    assert ret.changes
+    # now add a trailing slash in the name
+    repo_content = "deb http://www.deb-multimedia.org/ stable main"
+    ret = pkgrepo.managed(
+        name=repo_content, file=trailing_slash_repo_file, refresh=False
+    )
+    with salt.utils.files.fopen(trailing_slash_repo_file, "r") as fp:
+        file_content = fp.read()
+    assert file_content.strip() == "deb http://www.deb-multimedia.org/ stable main"
+    # absent
+    ret = pkgrepo.absent(name=repo_content)
+    assert ret.result
+
+
 @attr.s(kw_only=True)
 class Repo:
     key_root = attr.ib(default=pathlib.Path("/usr", "share", "keyrings"))


### PR DESCRIPTION
### What does this PR do?
Call str() for both situations when python3-apt is installed and when it is not, if the uri is different.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/62546

### Previous Behavior
When python3-apt is installed:

```
local:
----------
          ID: linode-longview-repo
    Function: pkgrepo.managed
        Name: deb https://apt-longview.linode.com/ bullseye main
      Result: False
     Comment: Failed to configure repo 'deb https://apt-longview.linode.com/ bullseye main': 'SourceEntry' object has no attribute 'repo_line'
     Started: 15:45:37.512521
    Duration: 845.507 ms
     Changes:   

Summary for local
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time: 845.507 ms
```

### New Behavior

```
local:
----------
          ID: linode-longview-repo
    Function: pkgrepo.managed
        Name: deb https://apt-longview.linode.com/ bullseye main
      Result: True
     Comment: Configured package repo 'deb https://apt-longview.linode.com/ bullseye main'
     Started: 15:46:02.685605
    Duration: 1843.596 ms
     Changes:   
              ----------
              repo:
                  deb https://apt-longview.linode.com/ bullseye main

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time:   1.844 s
```