### PR TITLE
Fix an issue with whitespace in the element alias

### DIFF
--- a/changelog/62058.fixed
+++ b/changelog/62058.fixed
@@ -1,0 +1,1 @@
+Fixed issue with some LGPO policies having whitespace at the beginning or end of the element alias

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -5956,9 +5956,9 @@ def _getAdmlPresentationRefId(adml_data, ref_id):
                 "multiTextBox",
             ]:
                 if result.text:
-                    return result.text.rstrip().rstrip(":")
+                    return result.text.rstrip().rstrip(":").strip()
                 else:
-                    return alternate_label.rstrip(":")
+                    return alternate_label.rstrip(":").strip()
     return None
 
 

--- a/tests/pytests/functional/modules/win_lgpo/test_get_policy_info.py
+++ b/tests/pytests/functional/modules/win_lgpo/test_get_policy_info.py
@@ -1,0 +1,34 @@
+"""
+Unit tests for the LGPO module
+"""
+
+import platform
+
+import pytest
+from packaging import version
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+    pytest.mark.skip_unless_on_windows,
+]
+
+
+@pytest.fixture(scope="module")
+def lgpo(modules):
+    return modules.lgpo
+
+
+# The "Allow Online Tips" policy only became available in version 10.0.16299
+@pytest.mark.skipif(
+    version.parse(platform.version()) < version.parse("10.0.16299"),
+    reason="Policy only available on 10.0.16299 or later",
+)
+def test_62058_whitespace(lgpo):
+    result = lgpo.get_policy_info("Allow Online Tips", "machine")
+    for element in result["policy_elements"]:
+        if "element_aliases" in element:
+            assert (
+                "Allow Settings to retrieve online tips." in element["element_aliases"]
+            )
+            return
+    assert False


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with whitespace in element aliases

The specific example is the "Allow Online Tips" policy that contains
a newline and 10 spaces before the text of the policy.

### What issues does this PR fix or reference?
Fixes: #62058 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes