### PR TITLE
fix: Update setproctitle dependency

### DIFF
--- a/changelog/62576.fixed
+++ b/changelog/62576.fixed
@@ -1,0 +1,1 @@
+Update setproctitle version for Darwin

--- a/changelog/62576.fixed
+++ b/changelog/62576.fixed
@@ -1,1 +1,1 @@
-Update setproctitle version for Darwin
+Update setproctitle version for all platforms

--- a/requirements/darwin.txt
+++ b/requirements/darwin.txt
@@ -15,7 +15,8 @@ pycparser>=2.21
 pyopenssl>=19.0.0
 python-dateutil>=2.8.0
 python-gnupg>=0.4.4
-setproctitle>=1.1.10
+setproctitle>=1.1.10; python_version < '3.10'
+setproctitle>=1.2.3; python_version >= '3.10'
 timelib>=0.2.5
 vultr>=1.0.1
 

--- a/requirements/darwin.txt
+++ b/requirements/darwin.txt
@@ -15,8 +15,8 @@ pycparser>=2.21
 pyopenssl>=19.0.0
 python-dateutil>=2.8.0
 python-gnupg>=0.4.4
-setproctitle>=1.1.10; python_version < '3.10'
-setproctitle>=1.2.3; python_version >= '3.10'
+setproctitle>=1.1.10 ; python_version < '3.10'
+setproctitle>=1.2.3 ; python_version >= '3.10'
 timelib>=0.2.5
 vultr>=1.0.1
 

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -794,7 +794,7 @@ scp==0.14.1
     # via junos-eznc
 semantic-version==2.9.0
     # via etcd3-py
-setproctitle==1.2.2 ; python_version >= "3.10"
+setproctitle==1.2.3 ; python_version >= "3.10"
     # via -r requirements/static/pkg/linux.in
 six==1.16.0
     # via

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -785,7 +785,7 @@ scp==0.13.2
     # via junos-eznc
 semantic-version==2.9.0
     # via etcd3-py
-setproctitle==1.1.10
+setproctitle==1.3.2 ; python_version >= "3.10"
     # via -r requirements/darwin.txt
 six==1.16.0
     # via

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -766,7 +766,7 @@ scp==0.13.6
     # via junos-eznc
 semantic-version==2.9.0
     # via etcd3-py
-setproctitle==1.2.2 ; python_version >= "3.10"
+setproctitle==1.2.3 ; python_version >= "3.10"
     # via -r requirements/static/pkg/linux.in
 six==1.16.0
     # via

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -781,7 +781,7 @@ scp==0.13.2
     # via junos-eznc
 semantic-version==2.9.0
     # via etcd3-py
-setproctitle==1.1.10
+setproctitle==1.2.3 ; python_version >= "3.10"
     # via -r requirements/static/pkg/freebsd.in
 six==1.16.0
     # via

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -766,7 +766,7 @@ scp==0.13.6
     # via junos-eznc
 semantic-version==2.9.0
     # via etcd3-py
-setproctitle==1.2.2 ; python_version >= "3.10"
+setproctitle==1.2.3 ; python_version >= "3.10"
     # via -r requirements/static/pkg/linux.in
 six==1.16.0
     # via

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -822,7 +822,7 @@ scp==0.13.2
     # via junos-eznc
 semantic-version==2.9.0
     # via etcd3-py
-setproctitle==1.2.2 ; python_version >= "3.10"
+setproctitle==1.2.3 ; python_version >= "3.10"
     # via -r requirements/static/pkg/linux.in
 six==1.16.0
     # via

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -351,7 +351,7 @@ s3transfer==0.3.3
     # via boto3
 sed==0.3.1
     # via -r requirements/static/ci/windows.in
-setproctitle==1.1.10
+setproctitle==1.2.3; python_version >= "3.10"
     # via -r requirements/static/pkg/py3.10/windows.txt
 six==1.15.0
     # via

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -825,7 +825,7 @@ scp==0.13.2
     #   netmiko
 semantic-version==2.9.0
     # via etcd3-py
-setproctitle==1.1.10
+setproctitle==1.1.10 ; python_version < "3.10"
     # via -r requirements/static/pkg/freebsd.in
 six==1.16.0
     # via

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -358,7 +358,7 @@ sed==0.3.1
     # via -r requirements/static/ci/windows.in
 semantic-version==2.9.0
     # via etcd3-py
-setproctitle==1.1.10
+setproctitle==1.1.10 ; python_version < "3.10"
     # via -r requirements/windows.txt
 six==1.16.0
     # via

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -816,7 +816,7 @@ scp==0.13.2
     #   netmiko
 semantic-version==2.9.0
     # via etcd3-py
-setproctitle==1.1.10
+setproctitle==1.1.10 ; python_version < "3.10"
     # via -r requirements/static/pkg/freebsd.in
 six==1.16.0
     # via

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -347,7 +347,7 @@ sed==0.3.1
     # via -r requirements/static/ci/windows.in
 semantic-version==2.9.0
     # via etcd3-py
-setproctitle==1.1.10
+setproctitle==1.1.10 ; python_version < "3.10"
     # via -r requirements/windows.txt
 six==1.15.0
     # via

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -823,7 +823,7 @@ scp==0.13.2
     #   netmiko
 semantic-version==2.9.0
     # via etcd3-py
-setproctitle==1.1.10
+setproctitle==1.1.10 ; python_version < "3.10"
     # via -r requirements/darwin.txt
 six==1.16.0
     # via

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -819,7 +819,7 @@ scp==0.13.2
     #   netmiko
 semantic-version==2.9.0
     # via etcd3-py
-setproctitle==1.1.10
+setproctitle==1.1.10 ; python_version < "3.10"
     # via -r requirements/static/pkg/freebsd.in
 six==1.16.0
     # via

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -348,7 +348,7 @@ sed==0.3.1
     # via -r requirements/static/ci/windows.in
 semantic-version==2.9.0
     # via etcd3-py
-setproctitle==1.1.10
+setproctitle==1.1.10 ; python_version < "3.10"
     # via -r requirements/windows.txt
 six==1.15.0
     # via

--- a/requirements/static/pkg/freebsd.in
+++ b/requirements/static/pkg/freebsd.in
@@ -6,7 +6,8 @@ pycparser>=2.21; python_version >= '3.9'
 pyopenssl>=19.0.0
 python-dateutil>=2.8.0
 python-gnupg>=0.4.4
-setproctitle>=1.1.10
+setproctitle>=1.1.10 ; python_version < '3.10'
+setproctitle>=1.2.3 ; python_version >= '3.10'
 timelib>=0.2.5
 distro>=1.3.0
 importlib_metadata>=3.3.0; python_version >= '3.6' and python_version < '3.10'

--- a/requirements/static/pkg/linux.in
+++ b/requirements/static/pkg/linux.in
@@ -7,8 +7,8 @@ pyopenssl>=19.0.0
 python-dateutil>=2.8.0
 python-gnupg>=0.4.4
 rpm-vercmp
-setproctitle>=1.1.10; python_version < '3.10'
-setproctitle>=1.2.2; python_version >= '3.10'
+setproctitle>=1.1.10 ; python_version < '3.10'
+setproctitle>=1.2.3 ; python_version >= '3.10'
 timelib>=0.2.5
 importlib_metadata>=3.3.0; python_version >= '3.6' and python_version < '3.10'
 importlib_metadata==4.6.3; python_version >= '3.10'

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -93,7 +93,7 @@ requests==2.25.1
     #   -r requirements/base.txt
     #   apache-libcloud
     #   vultr
-setproctitle==1.1.10
+setproctitle==1.3.2 ; python_version >= "3.10"
     # via -r requirements/darwin.txt
 six==1.16.0
     # via

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -75,7 +75,7 @@ pyzmq==23.2.0 ; python_version >= "3.9"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via -r requirements/base.txt
-setproctitle==1.1.10
+setproctitle==1.3.2 ; python_version >= "3.10"
     # via -r requirements/static/pkg/freebsd.in
 six==1.16.0
     # via

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -77,7 +77,7 @@ requests==2.25.1
     # via -r requirements/base.txt
 rpm-vercmp==0.1.2
     # via -r requirements/static/pkg/linux.in
-setproctitle==1.2.2 ; python_version >= "3.10"
+setproctitle==1.3.2 ; python_version >= "3.10"
     # via -r requirements/static/pkg/linux.in
 six==1.16.0
     # via

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -108,7 +108,7 @@ requests==2.25.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/windows.txt
-setproctitle==1.1.10
+setproctitle==1.2.3 ; python_version >= "3.10"
     # via -r requirements/windows.txt
 six==1.15.0
     # via

--- a/requirements/static/pkg/py3.7/freebsd.txt
+++ b/requirements/static/pkg/py3.7/freebsd.txt
@@ -75,7 +75,7 @@ pyzmq==18.0.1 ; python_version < "3.9"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via -r requirements/base.txt
-setproctitle==1.1.10
+setproctitle==1.1.10 ; python_version < "3.10"
     # via -r requirements/static/pkg/freebsd.in
 six==1.16.0
     # via

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -112,7 +112,7 @@ requests==2.25.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/windows.txt
-setproctitle==1.1.10
+setproctitle==1.1.10 ; python_version < "3.10"
     # via -r requirements/windows.txt
 six==1.16.0
     # via

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -75,7 +75,7 @@ pyzmq==19.0.0 ; python_version < "3.9"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via -r requirements/base.txt
-setproctitle==1.1.10
+setproctitle==1.1.10 ; python_version < "3.10"
     # via -r requirements/static/pkg/freebsd.in
 six==1.16.0
     # via

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -112,7 +112,7 @@ requests==2.25.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/windows.txt
-setproctitle==1.1.10
+setproctitle==1.1.10 ; python_version < "3.10"
     # via -r requirements/windows.txt
 six==1.15.0
     # via

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -95,7 +95,7 @@ requests==2.25.1
     #   -r requirements/base.txt
     #   apache-libcloud
     #   vultr
-setproctitle==1.1.10
+setproctitle==1.1.10 ; python_version < "3.10"
     # via -r requirements/darwin.txt
 six==1.16.0
     # via

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -77,7 +77,7 @@ pyzmq==23.2.0 ; python_version >= "3.9"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via -r requirements/base.txt
-setproctitle==1.1.10
+setproctitle==1.1.10 ; python_version < "3.10"
     # via -r requirements/static/pkg/freebsd.in
 six==1.16.0
     # via

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -112,7 +112,7 @@ requests==2.25.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/windows.txt
-setproctitle==1.1.10
+setproctitle==1.1.10 ; python_version < "3.10"
     # via -r requirements/windows.txt
 six==1.15.0
     # via

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -25,7 +25,8 @@ pyopenssl>=20.0.1
 python-dateutil>=2.8.1
 python-gnupg>=0.4.7
 requests>=2.25.1
-setproctitle
+setproctitle>=1.1.10 ; python_version < '3.10'
+setproctitle>=1.2.3 ; python_version >= '3.10'
 timelib>=0.2.5
 urllib3>=1.26.5
 # Watchdog pulls in a GPL-3 package, argh, which cannot be shipped on the


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
References: #62392 and #61384

### Previous Behavior

When executing `sudo -E salt-call state.apply` the next error occurs:

```
/opt/homebrew/Cellar/salt/3005/libexec/lib/python3.10/site-packages/_distutils_hack/__init__.py:33: UserWarning: Setuptools is replacing distutils.
  warnings.warn("Setuptools is replacing distutils.")
[ERROR   ] An un-handled exception was caught by Salt's global exception handler:
SystemError: PY_SSIZE_T_CLEAN macro must be defined for '#' formats
Traceback (most recent call last):
  File "/opt/homebrew/bin/salt-call", line 8, in <module>
    sys.exit(salt_call())
  File "/opt/homebrew/Cellar/salt/3005/libexec/lib/python3.10/site-packages/salt/scripts.py", line 441, in salt_call
    client.run()
  File "/opt/homebrew/Cellar/salt/3005/libexec/lib/python3.10/site-packages/salt/cli/call.py", line 18, in run
    self.parse_args()
  File "/opt/homebrew/Cellar/salt/3005/libexec/lib/python3.10/site-packages/salt/utils/parsers.py", line 227, in parse_args
    salt.utils.process.appendproctitle("MainProcess")
  File "/opt/homebrew/Cellar/salt/3005/libexec/lib/python3.10/site-packages/salt/utils/process.py", line 54, in appendproctitle
    current = setproctitle.getproctitle()
SystemError: PY_SSIZE_T_CLEAN macro must be defined for '#' formats
Traceback (most recent call last):
  File "/opt/homebrew/bin/salt-call", line 8, in <module>
    sys.exit(salt_call())
  File "/opt/homebrew/Cellar/salt/3005/libexec/lib/python3.10/site-packages/salt/scripts.py", line 441, in salt_call
    client.run()
  File "/opt/homebrew/Cellar/salt/3005/libexec/lib/python3.10/site-packages/salt/cli/call.py", line 18, in run
    self.parse_args()
  File "/opt/homebrew/Cellar/salt/3005/libexec/lib/python3.10/site-packages/salt/utils/parsers.py", line 227, in parse_args
    salt.utils.process.appendproctitle("MainProcess")
  File "/opt/homebrew/Cellar/salt/3005/libexec/lib/python3.10/site-packages/salt/utils/process.py", line 54, in appendproctitle
    current = setproctitle.getproctitle()
SystemError: PY_SSIZE_T_CLEAN macro must be defined for '#' formats
```

### New Behavior

After updating the `setproctitle` to version `1.2.3`, the command is executed without the previous error.

Reference taken from: https://github.com/saltstack/salt/blob/3012dc42d6da92b93697aa5f3d195876fad0d1d2/requirements/static/pkg/linux.in#L10-L11

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
