### PR TITLE
[freeze] Remove connection_timeout from Netmiko args 

### DIFF
--- a/changelog/62547.fixed
+++ b/changelog/62547.fixed
@@ -1,0 +1,1 @@
+Remove the connection_timeout from netmiko_connection_args before netmiko_connection_args is added to __context__["netmiko_device"]["args"] which is passed along to the Netmiko library.

--- a/salt/proxy/netmiko_px.py
+++ b/salt/proxy/netmiko_px.py
@@ -270,6 +270,7 @@ def init(opts):
     netmiko_connection_args.pop("proxytype", None)
     netmiko_connection_args.pop("multiprocessing", None)
     netmiko_connection_args.pop("skip_connect_on_init", None)
+    netmiko_connection_args.pop("connection_timeout", None)
 
     __context__["netmiko_device"]["args"] = netmiko_connection_args
 

--- a/tests/pytests/unit/proxy/test_netmiko_px.py
+++ b/tests/pytests/unit/proxy/test_netmiko_px.py
@@ -104,6 +104,24 @@ def test_init_skip_connect_on_init_false(proxy_minion_config):
     assert "connection" in netmiko_device
 
 
+def test_init_connection_timeout(proxy_minion_config):
+    """
+    check that connection_timeout is removed from args
+    before being passed along.
+    """
+
+    proxy_minion_config["connection_timeout"] = 60
+
+    mock_make_con = MagicMock()
+    with patch.object(netmiko_proxy, "make_con", mock_make_con):
+        assert netmiko_proxy.init(proxy_minion_config) is None
+
+    assert "netmiko_device" in netmiko_proxy.__context__
+    netmiko_device = netmiko_proxy.__context__["netmiko_device"]
+    assert "args" in netmiko_device
+    assert "connection_timeout" not in netmiko_device["args"]
+
+
 def test_make_con(proxy_minion_config):
     """
     check netmiko_proxy make_con method


### PR DESCRIPTION
### What does this PR do?
Remove the connection_timeout from netmiko_connection_args before netmiko_connection_args is added to __context__["netmiko_device"]["args"] which is passed along to the Netmiko library.

### What issues does this PR fix or reference?
Fixes: #62547 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
