### PR TITLE
fix 62553 by checking for master_type before deciding to connect

### DIFF
--- a/changelog/62553.fixed
+++ b/changelog/62553.fixed
@@ -1,0 +1,1 @@
+fixes #62553 by checking for disabled master_type before starting master connection and skipping it if set.

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1131,7 +1131,8 @@ class MinionManager(MinionBase):
                     minion.setup_beacons(before_connect=True)
                 if minion.opts.get("scheduler_before_connect", False):
                     minion.setup_scheduler(before_connect=True)
-                yield minion.connect_master(failed=failed)
+                if minion.opts.get("master_type", "str") != "disable":
+                    yield minion.connect_master(failed=failed)
                 minion.tune_in(start=False)
                 self.minions.append(minion)
                 break


### PR DESCRIPTION
### What does this PR do?

fix #62553 by checking for master_type before deciding to run connection code. 

### What issues does this PR fix or reference?
Fixes: #62553

### Previous Behavior
error messages thrown if `master_type: disable` is set.

### New Behavior
masterless minion doens't even try connecting to master if `master_type: disable` is set.

### Merge requirements satisfied?
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No
