### PR TITLE
Fix get_policy KeyError on some policies

### DIFF
--- a/changelog/61860.fixed
+++ b/changelog/61860.fixed
@@ -1,0 +1,1 @@
+win_lgpo: Fixed intermittent KeyError when getting policy setting using lgpo.get_policy

--- a/salt/modules/win_lgpo.py
+++ b/salt/modules/win_lgpo.py
@@ -9705,7 +9705,7 @@ def _get_policy_adm_setting(
                         full_name
                     ] = policy_item
             # go back and remove any "unpathed" policies that need a full path
-            for path_needed in unpathed_dict[policy_namespace]:
+            for path_needed in unpathed_dict.get(policy_namespace, {}):
                 # remove the item with the same full name and re-add it w/a path'd version
                 full_path_list = hierarchy[policy_namespace][
                     unpathed_dict[policy_namespace][path_needed]

--- a/tests/pytests/functional/modules/win_lgpo/test_get_policy.py
+++ b/tests/pytests/functional/modules/win_lgpo/test_get_policy.py
@@ -1,0 +1,53 @@
+import pytest
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+    pytest.mark.skip_unless_on_windows,
+]
+
+
+@pytest.fixture(scope="module")
+def lgpo(modules):
+    return modules.lgpo
+
+
+def test_hierarchical_return(lgpo):
+    result = lgpo.get_policy(
+        policy_name="Calculator",
+        policy_class="Machine",
+        hierarchical_return=True,
+    )
+    result = result["Administrative Templates"]
+    result = result["Windows Components"]
+    result = result["Microsoft User Experience Virtualization"]
+    result = result["Applications"]
+    result = result["Calculator"]
+    assert result in ("Enabled", "Disabled", "Not Configured")
+
+
+def test_return_value_only_false(lgpo):
+    result = lgpo.get_policy(
+        policy_name="Calculator",
+        policy_class="Machine",
+        return_value_only=False,
+    )
+    assert result[
+        r"Windows Components\Microsoft User Experience Virtualization\Applications\Calculator"
+    ] in ("Enabled", "Disabled", "Not Configured")
+
+
+def test_return_full_policy_names_false(lgpo):
+    result = lgpo.get_policy(
+        policy_name="Calculator",
+        policy_class="Machine",
+        return_full_policy_names=False,
+        return_value_only=False,
+    )
+    assert result["Calculator"] in ("Enabled", "Disabled", "Not Configured")
+
+
+def test_61860_calculator(lgpo):
+    result = lgpo.get_policy(policy_name="Calculator", policy_class="Machine")
+    # Any of the following are valid settings. We're only making sure it doesn't
+    # throw a stacktrace
+    assert result in ("Enabled", "Disabled", "Not Configured")


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where some policies would throw a KeyError when getting the policy setting using the get_policy function. It was getting a key name from an empty dict. We will use a get statement instead.

### What issues does this PR fix or reference?
Fixes: #61860

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes