### PR TITLE
Remove under development notice from 3005 release notes (freeze branch)

### DIFF
--- a/doc/topics/releases/3005.rst
+++ b/doc/topics/releases/3005.rst
@@ -4,8 +4,6 @@
 Salt 3005 release notes - Codename Phosphorus
 =============================================
 
-Salt 3005 is currently under development.
-
 
 Python 3.5 and 3.6 deprecation
 ------------------------------


### PR DESCRIPTION
### What does this PR do?
This PR removes the under development notice from 3005 release notes.

### What issues does this PR fix or reference?
Relates to: https://github.com/saltstack/salt/issues/62543
