### PR TITLE
Ensure default opts have valid type defined for ipc buffers

### DIFF
--- a/changelog/62591.fixed
+++ b/changelog/62591.fixed
@@ -1,0 +1,1 @@
+Ensure default values for IPC Buffers are correct type

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -97,9 +97,9 @@ def _gather_buffer_space():
 
 # For the time being this will be a fixed calculation
 # TODO: Allow user configuration
-_DFLT_IPC_WBUFFER = _gather_buffer_space() * 0.5
+_DFLT_IPC_WBUFFER = int(_gather_buffer_space() * 0.5)
 # TODO: Reserved for future use
-_DFLT_IPC_RBUFFER = _gather_buffer_space() * 0.5
+_DFLT_IPC_RBUFFER = int(_gather_buffer_space() * 0.5)
 
 VALID_OPTS = immutabletypes.freeze(
     {

--- a/tests/pytests/functional/test_config.py
+++ b/tests/pytests/functional/test_config.py
@@ -1,0 +1,26 @@
+import logging
+import os
+import tempfile
+
+import pytest
+import salt.config
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+]
+
+log = logging.getLogger(__name__)
+
+
+def test_minion_config_type_check(caplog):
+    msg = "Config option 'ipc_write_buffer' with value"
+    caplog.set_level(logging.WARNING)
+    fd, path = tempfile.mkstemp()
+    try:
+        with os.fdopen(fd, "w") as tmp:
+            tmp.write("ipc_write_buffer: 'dynamic'\n")
+        salt.config.minion_config(path)
+
+        assert msg not in caplog.text
+    finally:
+        os.remove(path)


### PR DESCRIPTION
### What does this PR do?
Ensures the types defined for ipc buffers match their type definition.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/62591

### Previous Behavior
With 3005 type checking was introduced which caught the default values for ipc buffers were floats, when they should have been int.

### New Behavior
The default values for ipc buffers were floats, are now cast to int, their correct tpe.


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
