### PR TITLE
Fix renderers not getting the correct salt functions

### DIFF
--- a/changelog/62610.fixed
+++ b/changelog/62610.fixed
@@ -1,0 +1,1 @@
+Renderers now have access to the correct set of salt functions.

--- a/changelog/62620.fixed
+++ b/changelog/62620.fixed
@@ -1,0 +1,1 @@
+Renderers now have access to the correct set of salt functions.

--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -47,7 +47,7 @@ class SSHState(salt.state.State):
         self.states = salt.loader.states(
             self.opts, locals_, self.utils, self.serializers
         )
-        self.rend = salt.loader.render(self.opts, locals_)
+        self.rend = salt.loader.render(self.opts, self.wrapper)
 
     def check_refresh(self, data, ret):
         """

--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -47,7 +47,7 @@ class SSHState(salt.state.State):
         self.states = salt.loader.states(
             self.opts, locals_, self.utils, self.serializers
         )
-        self.rend = salt.loader.render(self.opts, self.wrapper)
+        self.rend = salt.loader.render(self.opts, locals_)
 
     def check_refresh(self, data, ret):
         """

--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -47,7 +47,7 @@ class SSHState(salt.state.State):
         self.states = salt.loader.states(
             self.opts, locals_, self.utils, self.serializers
         )
-        self.rend = salt.loader.render(self.opts, self.functions)
+        self.rend = salt.loader.render(self.opts, locals_)
 
     def check_refresh(self, data, ret):
         """

--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -40,16 +40,14 @@ class SSHState(salt.state.State):
         """
         Load up the modules for remote compilation via ssh
         """
-        self.functions = salt.loader.ssh_wrapper(self.opts, None, context=self.context)
-        if self.wrapper is not None:
-            self.wrapper.wfuncs = self.functions
+        self.functions = self.wrapper
         self.utils = salt.loader.utils(self.opts)
         self.serializers = salt.loader.serializers(self.opts)
         locals_ = salt.loader.minion_mods(self.opts, utils=self.utils)
         self.states = salt.loader.states(
             self.opts, locals_, self.utils, self.serializers
         )
-        self.rend = salt.loader.render(self.opts, self.wrapper)
+        self.rend = salt.loader.render(self.opts, self.functions)
 
     def check_refresh(self, data, ret):
         """

--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -41,7 +41,8 @@ class SSHState(salt.state.State):
         Load up the modules for remote compilation via ssh
         """
         self.functions = salt.loader.ssh_wrapper(self.opts, None, context=self.context)
-        self.wrapper.wfuncs = self.functions
+        if self.wrapper is not None:
+            self.wrapper.wfuncs = self.functions
         self.utils = salt.loader.utils(self.opts)
         self.serializers = salt.loader.serializers(self.opts)
         locals_ = salt.loader.minion_mods(self.opts, utils=self.utils)

--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -41,13 +41,14 @@ class SSHState(salt.state.State):
         Load up the modules for remote compilation via ssh
         """
         self.functions = salt.loader.ssh_wrapper(self.opts, None, context=self.context)
+        self.wrapper.wfuncs = self.functions
         self.utils = salt.loader.utils(self.opts)
         self.serializers = salt.loader.serializers(self.opts)
         locals_ = salt.loader.minion_mods(self.opts, utils=self.utils)
         self.states = salt.loader.states(
             self.opts, locals_, self.utils, self.serializers
         )
-        self.rend = salt.loader.render(self.opts, locals_)
+        self.rend = salt.loader.render(self.opts, self.wrapper)
 
     def check_refresh(self, data, ret):
         """

--- a/tests/pytests/integration/ssh/test_jinja_mods.py
+++ b/tests/pytests/integration/ssh/test_jinja_mods.py
@@ -1,0 +1,50 @@
+import pytest
+from saltfactories.utils.functional import StateResult
+
+pytestmark = [
+    pytest.mark.skip_on_windows(reason="salt-ssh not available on Windows"),
+]
+
+
+@pytest.fixture(scope="module")
+def state_tree(base_env_state_tree_root_dir, salt_ssh_cli):
+    name = "echo"
+    state_file = """
+    ssh_test_echo:
+      test.show_notification:
+        - text: {{{{ salt['test.echo']('hello') }}}}
+        - template: jinja
+    """.format(
+        user=salt_ssh_cli.ssh_user
+    )
+    state_tempfile = pytest.helpers.temp_file(
+        "{}.sls".format(name), state_file, base_env_state_tree_root_dir
+    )
+
+    with state_tempfile:
+        yield name
+
+
+@pytest.mark.slow_test
+def test_echo(salt_ssh_cli, base_env_state_tree_root_dir):
+    """
+    verify salt-ssh can use imported map files in states
+    """
+    name = "echo"
+    echo = "hello"
+    state_file = """
+    ssh_test_echo:
+      test.show_notification:
+        - text: {{{{ salt['test.echo']('{echo}') }}}}
+        - template: jinja
+    """.format(
+        echo=echo
+    )
+    state_tempfile = pytest.helpers.temp_file(
+        "{}.sls".format(name), state_file, base_env_state_tree_root_dir
+    )
+
+    with state_tempfile:
+        ret = salt_ssh_cli.run("state.apply", name)
+        result = StateResult(ret.data)
+        assert result.comment == echo

--- a/tests/pytests/integration/ssh/test_jinja_mods.py
+++ b/tests/pytests/integration/ssh/test_jinja_mods.py
@@ -6,25 +6,6 @@ pytestmark = [
 ]
 
 
-@pytest.fixture(scope="module")
-def state_tree(base_env_state_tree_root_dir, salt_ssh_cli):
-    name = "echo"
-    state_file = """
-    ssh_test_echo:
-      test.show_notification:
-        - text: {{{{ salt['test.echo']('hello') }}}}
-        - template: jinja
-    """.format(
-        user=salt_ssh_cli.ssh_user
-    )
-    state_tempfile = pytest.helpers.temp_file(
-        "{}.sls".format(name), state_file, base_env_state_tree_root_dir
-    )
-
-    with state_tempfile:
-        yield name
-
-
 @pytest.mark.slow_test
 def test_echo(salt_ssh_cli, base_env_state_tree_root_dir):
     """
@@ -36,7 +17,6 @@ def test_echo(salt_ssh_cli, base_env_state_tree_root_dir):
     ssh_test_echo:
       test.show_notification:
         - text: {{{{ salt['test.echo']('{echo}') }}}}
-        - template: jinja
     """.format(
         echo=echo
     )


### PR DESCRIPTION
### What does this PR do?
Gives the renderers access to the correct function sets via the wrapper that is passed in.

**_NOTE: This reverts the fix from https://github.com/saltstack/salt/pull/61634, but this is definitely a bigger issue._**

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/62620 https://github.com/saltstack/salt/issues/62610 et. al.

### Previous Behavior
Jinja variable 'salt.utils.templates.AliasedLoader object' has no attribute 'pkg'

### New Behavior
No error, jinja (and other renderers) now have access to the correct set of functions

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes