### PR TITLE
Do not hang on salt-ssh with sudo and sanitize log output

### DIFF
--- a/changelog/62603.fixed
+++ b/changelog/62603.fixed
@@ -1,0 +1,1 @@
+Fix a hang on salt-ssh when using sudo.

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -117,6 +117,7 @@ class Terminal:
         log_stdout_level="debug",
         log_stderr=None,
         log_stderr_level="debug",
+        log_sanitize=None,
         # sys.stdXYZ streaming options
         stream_stdout=None,
         stream_stderr=None,
@@ -221,7 +222,16 @@ class Terminal:
             self.child_fd,
             self.child_fde,
         )
+        if log_sanitize:
+            if not isinstance(log_sanitize, str):
+                raise RuntimeError("'log_sanitize' needs to be a str type")
+            self.log_sanitize = log_sanitize
+        else:
+            self.log_sanitize = None
+
         terminal_command = " ".join(self.args)
+        if self.log_sanitize:
+            terminal_command = terminal_command.replace(self.log_sanitize, ("*" * 6))
         if (
             'decode("base64")' in terminal_command
             or "base64.b64decode(" in terminal_command
@@ -579,6 +589,10 @@ class Terminal:
 
                         if self.stderr_logger:
                             stripped = stderr.rstrip()
+                            if self.log_sanitize:
+                                stripped = stripped.replace(
+                                    self.log_sanitize, ("*" * 6)
+                                )
                             if stripped.startswith(os.linesep):
                                 stripped = stripped[len(os.linesep) :]
                             if stripped:
@@ -612,6 +626,10 @@ class Terminal:
 
                         if self.stdout_logger:
                             stripped = stdout.rstrip()
+                            if self.log_sanitize:
+                                stripped = stripped.replace(
+                                    self.log_sanitize, ("*" * 6)
+                                )
                             if stripped.startswith(os.linesep):
                                 stripped = stripped[len(os.linesep) :]
                             if stripped:

--- a/tests/pytests/unit/client/ssh/test_shell.py
+++ b/tests/pytests/unit/client/ssh/test_shell.py
@@ -3,6 +3,7 @@ import types
 
 import pytest
 import salt.client.ssh.shell as shell
+from tests.support.mock import patch
 
 
 @pytest.fixture
@@ -27,3 +28,26 @@ def test_ssh_shell_key_gen(keys):
         timeout=30,
     )
     assert ret.decode().startswith("ssh-rsa")
+
+
+@pytest.mark.skip_on_windows(reason="Windows does not support salt-ssh")
+@pytest.mark.skip_if_binaries_missing("ssh", "ssh-keygen", check_all=True)
+def test_ssh_shell_exec_cmd(caplog):
+    """
+    Test executing a command and ensuring the password
+    is not in the stdout/stderr logs.
+    """
+    passwd = "12345"
+    opts = {"_ssh_version": (4, 9)}
+    host = ""
+    _shell = shell.Shell(opts=opts, host=host)
+    _shell.passwd = passwd
+    with patch.object(_shell, "_split_cmd", return_value=["echo", passwd]):
+        ret = _shell.exec_cmd("echo {}".format(passwd))
+        assert not any([x for x in ret if passwd in str(x)])
+        assert passwd not in caplog.text
+
+    with patch.object(_shell, "_split_cmd", return_value=["ls", passwd]):
+        ret = _shell.exec_cmd("ls {}".format(passwd))
+        assert not any([x for x in ret if passwd in str(x)])
+        assert passwd not in caplog.text

--- a/tests/pytests/unit/utils/test_vt.py
+++ b/tests/pytests/unit/utils/test_vt.py
@@ -26,3 +26,26 @@ def test_isalive_no_child():
     aliveness = term.isalive()
     assert term.exitstatus == 0
     assert aliveness is False
+
+
+@pytest.mark.parametrize("test_cmd", ["echo", "ls"])
+@pytest.mark.skip_on_windows()
+def test_log_sanitize(test_cmd, caplog):
+    """
+    test when log_sanitize is passed in
+    we do not see the password in either
+    standard out or standard error logs
+    """
+    password = "123456"
+    cmd = [test_cmd, password]
+    term = vt.Terminal(
+        cmd,
+        log_stdout=True,
+        log_stderr=True,
+        log_sanitize=password,
+        stream_stdout=False,
+        stream_stderr=False,
+    )
+    ret = term.recv()
+    assert password not in caplog.text
+    assert "******" in caplog.text


### PR DESCRIPTION
### What does this PR do?
Ensures salt-ssh does not hang when using sudo.
Also sanitizes the ssh logs when using sudo with a password.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/62603

### Previous Behavior
salt-ssh just hangs and does not complete the command

### New Behavior
salt-ssh can run a command and return

