### PR TITLE
Deprecate Django returner

### DIFF
--- a/changelog/62644.deprecated
+++ b/changelog/62644.deprecated
@@ -1,0 +1,1 @@
+Deprecated defunct Django returner

--- a/salt/returners/django_return.py
+++ b/salt/returners/django_return.py
@@ -32,6 +32,7 @@ import logging
 # Import Salt libraries
 import salt.returners
 import salt.utils.jid
+from salt.utils.versions import warn_until_date
 
 log = logging.getLogger(__name__)
 
@@ -49,6 +50,11 @@ __virtualname__ = "django"
 
 
 def __virtual__():
+    warn_until_date(
+        "20250101",
+        "The django returner is broken and deprecated, and will be removed"
+        " after {date}.",
+    )
     if not HAS_DJANGO:
         return False, "Could not import django returner; django is not installed."
     return True

--- a/salt/returners/django_return.py
+++ b/salt/returners/django_return.py
@@ -1,4 +1,10 @@
 """
+.. deprecated:: 3006
+
+.. warning::
+
+    This module has been deprecated and will be removed after January 2024.
+
 A returner that will inform a Django system that
 returns are available using Django's signal system.
 
@@ -51,7 +57,7 @@ __virtualname__ = "django"
 
 def __virtual__():
     warn_until_date(
-        "20250101",
+        "20240101",
         "The django returner is broken and deprecated, and will be removed"
         " after {date}.",
     )


### PR DESCRIPTION
### What does this PR do?

Deprecates the Django module so we can remove it. TBH we could probably just go
ahead and remove it.

It's likely that the Django returner never worked - it can only fire
signals from within the same process that the Django server is running
in, which *won't* be the process that Salt is running in. Deprecating
and marking for removal.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
