### PR TITLE
Fix listing minions on OpenBSD

### DIFF
--- a/changelog/61966.fixed
+++ b/changelog/61966.fixed
@@ -1,0 +1,1 @@
+Fixed listing minions on OpenBSD

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1918,11 +1918,11 @@ def _openbsd_remotes_on(port, which_end):
         data = subprocess.check_output(
             ["netstat", "-nf", "inet"]
         )  # pylint: disable=minimum-python-version
-    except subprocess.CalledProcessError:
-        log.error("Failed netstat")
+    except subprocess.CalledProcessError as exc:
+        log.error('Failed "netstat" with returncode = %s', exc.returncode)
         raise
 
-    lines = data.split("\n")
+    lines = salt.utils.stringutils.to_str(data).split("\n")
     for line in lines:
         if "ESTABLISHED" not in line:
             continue


### PR DESCRIPTION
### What does this PR do?
`_openbsd_remotes_on` is currently broken since it treats bytes as strings. This is described in the issue and is most noticeable using ``salt-run manage.list_state``, which crashes.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/61966

### Previous Behavior
See issue

### New Behavior
Works as intended

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes
