### PR TITLE
Add dir_mode to file.copy state

### DIFF
--- a/changelog/62426.fixed
+++ b/changelog/62426.fixed
@@ -1,0 +1,1 @@
+Added directory mode for file.copy with makedirs


### PR DESCRIPTION
### What does this PR do?
Adds a dir_mode argument to `file.copy` state. Also defaults this dir_mode to mode + execute bits set instead of the file mode, which seems like a poor default.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/62426

### Previous Behavior
Created parent directories had the same permissions as the file.

### New Behavior
Created parent directories by default have the execute bit set. The directory mode is configurable.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes