### PR TITLE
Fix saltcheck _get_top_states doesn't pass saltenv to state.show_top

### DIFF
--- a/changelog/62654.fixed
+++ b/changelog/62654.fixed
@@ -1,0 +1,1 @@
+Fix saltcheck _get_top_states doesn't pass saltenv to state.show_top

--- a/salt/modules/saltcheck.py
+++ b/salt/modules/saltcheck.py
@@ -651,7 +651,7 @@ def _get_top_states(saltenv="base"):
     Equivalent to a salt cli: salt web state.show_top
     """
     top_states = []
-    top_states = __salt__["state.show_top"]()[saltenv]
+    top_states = __salt__["state.show_top"](saltenv=saltenv)[saltenv]
     log.debug("saltcheck for saltenv: %s found top states: %s", saltenv, top_states)
     return top_states
 

--- a/tests/pytests/unit/modules/test_saltcheck.py
+++ b/tests/pytests/unit/modules/test_saltcheck.py
@@ -1,0 +1,15 @@
+import pytest
+
+import salt.modules.saltcheck as saltcheck
+from tests.support.mock import MagicMock
+
+
+@pytest.fixture()
+def configure_loader_modules():
+    return {saltcheck: {"__salt__": {"state.show_top": MagicMock()}}}
+
+
+@pytest.mark.parametrize("saltenv", ["base", "dev", "howdy"])
+def test__get_top_states_call_args(saltenv):
+    saltcheck._get_top_states(saltenv=saltenv)
+    saltcheck.__salt__["state.show_top"].assert_called_with(saltenv=saltenv)


### PR DESCRIPTION
### What does this PR do?
See issue for details

### What issues does this PR fix or reference?
Fixes: #62654

### Previous Behavior
saltenv isn't passed to `state.show_top`

### New Behavior
now it is!

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
