### PR TITLE
Fixes #62662 [BUG] apt pkgrepo.managed signed-by and test=true is messed up

### DIFF
--- a/changelog/62662.fixed
+++ b/changelog/62662.fixed
@@ -1,0 +1,1 @@
+Fix pkgrepo.managed signed-by in test=true mode

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -3114,7 +3114,10 @@ def expand_repo_def(**kwargs):
                     opts_order[idx] = repo_opts[opt]["full"]
 
             opts = "[" + " ".join(opts_order) + "]"
-            line.insert(1, opts)
+            if line[1].startswith("["):
+                line[1] = opts
+            else:
+                line.insert(1, opts)
             sanitized["line"] = " ".join(line)
 
     return sanitized

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -3103,14 +3103,14 @@ def expand_repo_def(**kwargs):
         if signedby not in sanitized["line"]:
             line = sanitized["line"].split()
             repo_opts = _get_opts(repo)
-            opts_order = [x for x in repo_opts.keys()]
+            opts_order = [opt_type for opt_type, opt_def in repo_opts.items() if opt_def["full"] != ""]
             for opt in repo_opts:
                 if "index" in repo_opts[opt]:
                     idx = repo_opts[opt]["index"]
                     opts_order[idx] = repo_opts[opt]["full"]
 
             opts = "[" + " ".join(opts_order) + "]"
-            line[1] = opts
+            line.insert(1, opts)
             sanitized["line"] = " ".join(line)
 
     return sanitized

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -3103,7 +3103,11 @@ def expand_repo_def(**kwargs):
         if signedby not in sanitized["line"]:
             line = sanitized["line"].split()
             repo_opts = _get_opts(repo)
-            opts_order = [opt_type for opt_type, opt_def in repo_opts.items() if opt_def["full"] != ""]
+            opts_order = [
+                opt_type
+                for opt_type, opt_def in repo_opts.items()
+                if opt_def["full"] != ""
+            ]
             for opt in repo_opts:
                 if "index" in repo_opts[opt]:
                     idx = repo_opts[opt]["index"]

--- a/tests/pytests/functional/states/pkgrepo/test_debian.py
+++ b/tests/pytests/functional/states/pkgrepo/test_debian.py
@@ -593,7 +593,7 @@ class Repo:
     fullname = attr.ib()
     alt_repo = attr.ib(init=False)
     key_file = attr.ib()
-    tmp_path = attr.ib()
+    sources_list_file = attr.ib()
     repo_file = attr.ib()
     repo_content = attr.ib()
     key_url = attr.ib()
@@ -626,7 +626,7 @@ class Repo:
 
     @repo_file.default
     def _default_repo_file(self):
-        return self.tmp_path / "stable-binary.list"
+        return self.sources_list_file
 
     @repo_content.default
     def _default_repo_content(self):
@@ -666,35 +666,43 @@ class Repo:
 
 
 @pytest.fixture
-def repo(request, grains, tmp_path):
+def repo(request, grains, sources_list_file):
     signedby = False
     if "signedby" in request.node.name:
         signedby = True
-    repo = Repo(grains=grains, tmp_path=tmp_path, signedby=signedby)
+    repo = Repo(grains=grains, sources_list_file=sources_list_file, signedby=signedby)
     yield repo
     for key in [repo.key_file, repo.key_file.parent / "salt-alt-key.gpg"]:
         if key.is_file():
             key.unlink()
 
 
-def test_adding_repo_file_signedby(pkgrepo, states, repo):
+def test_adding_repo_file_signedby(pkgrepo, states, repo, subtests):
     """
     Test adding a repo file using pkgrepo.managed
     and setting signedby
     """
-    ret = states.pkgrepo.managed(
-        name=repo.repo_content,
-        file=str(repo.repo_file),
-        clean_file=True,
-        signedby=str(repo.key_file),
-        key_url=repo.key_url,
-        aptkey=False,
-    )
+
+    def _run(test=False):
+        return states.pkgrepo.managed(
+            name=repo.repo_content,
+            file=str(repo.repo_file),
+            clean_file=True,
+            signedby=str(repo.key_file),
+            key_url=repo.key_url,
+            aptkey=False,
+            test=test,
+        )
+
+    ret = _run()
     with salt.utils.files.fopen(str(repo.repo_file), "r") as fp:
         file_content = fp.read()
         assert file_content.strip() == repo.repo_content
     assert repo.key_file.is_file()
     assert repo.repo_content in ret.comment
+    with subtests.test("test=True"):
+        ret = _run(test=True)
+        assert ret.changes == {}
 
 
 def test_adding_repo_file_signedby_keyserver(pkgrepo, states, repo):


### PR DESCRIPTION
### What does this PR do?


### What issues does this PR fix or reference?
Fixes: #62662

### Previous Behavior
`pkgrepo.managed` with `signed-by` option and called with `test=true` has a buggy output

### New Behavior
Issue is fixed

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs N/A
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated
