### PR TITLE
Fix nt_hash use in pdbedit.create (convert to string)

### DIFF
--- a/changelog/62670.fixed
+++ b/changelog/62670.fixed
@@ -1,0 +1,1 @@
+Fixed pdbedit.create trying to use a bytes-like hash as string.

--- a/salt/modules/pdbedit.py
+++ b/salt/modules/pdbedit.py
@@ -203,7 +203,7 @@ def create(login, password, password_hashed=False, machine_account=False):
         password_hash = password.upper()
         password = ""  # wipe password
     else:
-        password_hash = generate_nt_hash(password)
+        password_hash = generate_nt_hash(password).decode("ascii")
 
     # create user
     if login not in list_users(False):


### PR DESCRIPTION
### What does this PR do?
Fixes nt_hash use in pdbedit.create (by converting the bytes-like hash to string).

### What issues does this PR fix or reference?
Fixes: #62670

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
