### PR TITLE
[freeze] Ensure the status of the service is captured when emitatstartup is False

### DIFF
--- a/changelog/62675.fixed
+++ b/changelog/62675.fixed
@@ -1,0 +1,1 @@
+Ensure the status of the service is captured when the beacon function is called, even when the event is not being emitted.

--- a/salt/beacons/service.py
+++ b/salt/beacons/service.py
@@ -142,9 +142,9 @@ def beacon(config):
             )
         if "onchangeonly" in service_config and service_config["onchangeonly"] is True:
             if service not in LAST_STATUS:
+                LAST_STATUS[service] = ret_dict[service]
                 if not service_config["emitatstartup"]:
                     continue
-                LAST_STATUS[service] = ret_dict[service]
                 if service_config["delay"] > 0:
                     LAST_STATUS[service]["time"] = currtime
                 else:

--- a/tests/pytests/unit/beacons/test_service.py
+++ b/tests/pytests/unit/beacons/test_service.py
@@ -68,14 +68,15 @@ def test_service_running():
 
         assert ret == (True, "Valid beacon configuration")
 
-        ret = service_beacon.beacon(config)
-        assert ret == [
-            {
-                "service_name": "salt-master",
-                "tag": "salt-master",
-                "salt-master": {"running": True},
-            }
-        ]
+        with patch.dict(service_beacon.LAST_STATUS, {}):
+            ret = service_beacon.beacon(config)
+            assert ret == [
+                {
+                    "service_name": "salt-master",
+                    "tag": "salt-master",
+                    "salt-master": {"running": True},
+                }
+            ]
 
         # When onchangeonly is True and emitatstartup is False ,
         # we should not see a return when the beacon is run.
@@ -91,8 +92,13 @@ def test_service_running():
 
         assert ret == (True, "Valid beacon configuration")
 
-        ret = service_beacon.beacon(config)
-        assert ret == []
+        # The return is empty because the beacon did not run
+        # but the LAST_STATUS should contain the last status
+        # for the service.
+        with patch.dict(service_beacon.LAST_STATUS, {}):
+            ret = service_beacon.beacon(config)
+            assert "salt-master" in service_beacon.LAST_STATUS
+            assert ret == []
 
         # When onchangeonly is True and emitatstartup is
         # the default value True, we should see a return
@@ -103,14 +109,15 @@ def test_service_running():
 
         assert ret == (True, "Valid beacon configuration")
 
-        ret = service_beacon.beacon(config)
-        assert ret == [
-            {
-                "service_name": "salt-master",
-                "tag": "salt-master",
-                "salt-master": {"running": True},
-            }
-        ]
+        with patch.dict(service_beacon.LAST_STATUS, {}):
+            ret = service_beacon.beacon(config)
+            assert ret == [
+                {
+                    "service_name": "salt-master",
+                    "tag": "salt-master",
+                    "salt-master": {"running": True},
+                }
+            ]
 
         # LAST_STATUS has service name and status has not changed
         config = [{"services": {"salt-master": {"onchangeonly": True}}}]
@@ -145,6 +152,29 @@ def test_service_running():
                     "salt-master": {"running": True},
                 }
             ]
+
+        # When onchangeonly is True and emitatstartup is True,
+        # we should see a return when the beacon is run.
+        config = [
+            {"services": {"salt-master": {"emitatstartup": True, "onchangeonly": True}}}
+        ]
+
+        ret = service_beacon.validate(config)
+
+        assert ret == (True, "Valid beacon configuration")
+
+        with patch.dict(service_beacon.LAST_STATUS, {}):
+            ret = service_beacon.beacon(config)
+            assert ret == [
+                {
+                    "salt-master": {"running": True},
+                    "service_name": "salt-master",
+                    "tag": "salt-master",
+                }
+            ]
+
+            ret = service_beacon.beacon(config)
+            assert ret == []
 
 
 def test_service_not_running():


### PR DESCRIPTION
### What does this PR do?
Ensure the status of the service is captured when the beacon function is called, even when the event is not being emitted.

### What issues does this PR fix or reference?
Fixes: #62675 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
