### PR TITLE
[freeze] Fixing deltaproxy regression

### DIFF
--- a/changelog/62708.fixed
+++ b/changelog/62708.fixed
@@ -1,0 +1,1 @@
+The sub proxies controlled by Deltaproxy need to have their own req_channel otherwise there are timeout exceptions when the __master_req_channel_payload is fired and reacted on.

--- a/salt/metaproxy/deltaproxy.py
+++ b/salt/metaproxy/deltaproxy.py
@@ -372,6 +372,11 @@ def post_master_init(self, master):
         )
         _proxy_minion.subprocess_list = self.subprocess_list
 
+        # a long-running req channel
+        _proxy_minion.req_channel = salt.transport.client.AsyncReqChannel.factory(
+            proxyopts, io_loop=self.io_loop
+        )
+
         # And load the modules
         (
             _proxy_minion.functions,

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2694,10 +2694,10 @@ class Minion(MinionBase):
                 notify=data.get("notify", False),
             )
         elif tag.startswith("__master_req_channel_payload"):
-            yield self.req_channel.send(
+            yield _minion.req_channel.send(
                 data,
-                timeout=self._return_retry_timer(),
-                tries=self.opts["return_retry_tries"],
+                timeout=_minion._return_retry_timer(),
+                tries=_minion.opts["return_retry_tries"],
             )
         elif tag.startswith("pillar_refresh"):
             yield _minion.pillar_refresh(

--- a/tests/pytests/conftest.py
+++ b/tests/pytests/conftest.py
@@ -605,6 +605,8 @@ def delta_proxy_minion_ids():
     return [
         "dummy_proxy_one",
         "dummy_proxy_two",
+        "dummy_proxy_three",
+        "dummy_proxy_four",
     ]
 
 

--- a/tests/pytests/functional/modules/test_network.py
+++ b/tests/pytests/functional/modules/test_network.py
@@ -11,7 +11,7 @@ pytestmark = [
 
 @pytest.fixture(scope="module")
 def url(modules):
-    return "ec2.amazon.com"
+    return "rewrite.amazon.com"
 
 
 @pytest.fixture(scope="module")

--- a/tests/pytests/functional/modules/test_network.py
+++ b/tests/pytests/functional/modules/test_network.py
@@ -11,7 +11,7 @@ pytestmark = [
 
 @pytest.fixture(scope="module")
 def url(modules):
-    return "google-public-dns-a.google.com"
+    return "www.amazon.com"
 
 
 @pytest.fixture(scope="module")

--- a/tests/pytests/functional/modules/test_network.py
+++ b/tests/pytests/functional/modules/test_network.py
@@ -11,7 +11,7 @@ pytestmark = [
 
 @pytest.fixture(scope="module")
 def url(modules):
-    return "www.amazon.com"
+    return "ec2.amazon.com"
 
 
 @pytest.fixture(scope="module")

--- a/tests/pytests/integration/proxy/conftest.py
+++ b/tests/pytests/integration/proxy/conftest.py
@@ -16,7 +16,13 @@ def deltaproxy_pillar_tree(salt_master, salt_delta_proxy_factory):
     """
     Create the pillar files for controlproxy and two dummy proxy minions
     """
-    proxy_one, proxy_two = pytest.helpers.proxy.delta_proxy_minion_ids()
+    (
+        proxy_one,
+        proxy_two,
+        proxy_three,
+        proxy_four,
+    ) = pytest.helpers.proxy.delta_proxy_minion_ids()
+
     top_file = """
     base:
       {control}:
@@ -25,10 +31,16 @@ def deltaproxy_pillar_tree(salt_master, salt_delta_proxy_factory):
         - {one}
       {two}:
         - {two}
+      {three}:
+        - {three}
+      {four}:
+        - {four}
     """.format(
         control=salt_delta_proxy_factory.id,
         one=proxy_one,
         two=proxy_two,
+        three=proxy_three,
+        four=proxy_four,
     )
     controlproxy_pillar_file = """
     proxy:
@@ -36,16 +48,16 @@ def deltaproxy_pillar_tree(salt_master, salt_delta_proxy_factory):
         ids:
           - {}
           - {}
+          - {}
+          - {}
     """.format(
-        proxy_one, proxy_two
+        proxy_one,
+        proxy_two,
+        proxy_three,
+        proxy_four,
     )
 
-    dummy_proxy_one_pillar_file = """
-    proxy:
-      proxytype: dummy
-    """
-
-    dummy_proxy_two_pillar_file = """
+    dummy_proxy_pillar_file = """
     proxy:
       proxytype: dummy
     """
@@ -55,12 +67,18 @@ def deltaproxy_pillar_tree(salt_master, salt_delta_proxy_factory):
         "controlproxy.sls", controlproxy_pillar_file
     )
     dummy_proxy_one_tempfile = salt_master.pillar_tree.base.temp_file(
-        "{}.sls".format(proxy_one), dummy_proxy_one_pillar_file
+        "{}.sls".format(proxy_one), dummy_proxy_pillar_file
     )
     dummy_proxy_two_tempfile = salt_master.pillar_tree.base.temp_file(
-        "{}.sls".format(proxy_two), dummy_proxy_two_pillar_file
+        "{}.sls".format(proxy_two), dummy_proxy_pillar_file
     )
-    with top_tempfile, controlproxy_tempfile, dummy_proxy_one_tempfile, dummy_proxy_two_tempfile:
+    dummy_proxy_three_tempfile = salt_master.pillar_tree.base.temp_file(
+        "{}.sls".format(proxy_three), dummy_proxy_pillar_file
+    )
+    dummy_proxy_four_tempfile = salt_master.pillar_tree.base.temp_file(
+        "{}.sls".format(proxy_four), dummy_proxy_pillar_file
+    )
+    with top_tempfile, controlproxy_tempfile, dummy_proxy_one_tempfile, dummy_proxy_two_tempfile, dummy_proxy_three_tempfile, dummy_proxy_four_tempfile:
         yield
 
 

--- a/tests/pytests/integration/proxy/test_deltaproxy.py
+++ b/tests/pytests/integration/proxy/test_deltaproxy.py
@@ -25,12 +25,26 @@ def proxy_id(request, salt_delta_proxy, skip_on_tcp_transport):
     return request.param
 
 
-def test_can_it_ping(salt_cli, proxy_id):
+@pytest.fixture
+def proxy_ids(request, salt_delta_proxy, skip_on_tcp_transport):
+    return pytest.helpers.proxy.delta_proxy_minion_ids()
+
+
+def test_can_it_ping(salt_cli, proxy_id, proxy_ids):
     """
     Ensure the proxy can ping
     """
     ret = salt_cli.run("test.ping", minion_tgt=proxy_id)
     assert ret.data is True
+
+
+def test_can_it_ping_all(salt_cli, proxy_ids):
+    """
+    Ensure the proxy can ping (all proxy minions)
+    """
+    ret = salt_cli.run("-L", "test.ping", minion_tgt=",".join(proxy_ids))
+    for _id in proxy_ids:
+        assert ret.data[_id] is True
 
 
 def test_list_pkgs(salt_cli, proxy_id):


### PR DESCRIPTION
### What does this PR do?
The sub proxies controlled by Deltaproxy need to have their own req_channel otherwise there are timeout exceptions when the __master_req_channel_payload is fired and reacted on.  Updating existing test to test additional sub proxy minions, adding an additional test to target all controlled sub proxies.

### What issues does this PR fix or reference?
Fixes: #62708 


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
