### PR TITLE
Made ext_pillar stack YAML error say file path

### DIFF
--- a/salt/pillar/stack.py
+++ b/salt/pillar/stack.py
@@ -455,9 +455,12 @@ def _process_stack_cfg(cfg, stack, minion_id, pillar):
             log.debug("YAML: basedir=%s, path=%s", basedir, path)
             # FileSystemLoader always expects unix-style paths
             unix_path = _to_unix_slashes(os.path.relpath(path, basedir))
-            obj = salt.utils.yaml.safe_load(
-                jenv.get_template(unix_path).render(stack=stack, ymlpath=path)
-            )
+            try:
+                obj = salt.utils.yaml.safe_load(
+                    jenv.get_template(unix_path).render(stack=stack, ymlpath=path)
+                )
+            except Exception as e:
+                raise Exception(f"for '{path}': {e}")
             if not isinstance(obj, dict):
                 log.info(
                     'Ignoring pillar stack template "%s": Can\'t parse '

--- a/salt/pillar/stack.py
+++ b/salt/pillar/stack.py
@@ -379,6 +379,7 @@ import os
 import posixpath
 
 from jinja2 import Environment, FileSystemLoader
+from yaml import YAMLError
 
 import salt.utils.data
 import salt.utils.jinja
@@ -459,8 +460,9 @@ def _process_stack_cfg(cfg, stack, minion_id, pillar):
                 obj = salt.utils.yaml.safe_load(
                     jenv.get_template(unix_path).render(stack=stack, ymlpath=path)
                 )
-            except Exception as e:
-                raise Exception(f"for '{path}': {e}")
+            except YAMLError as e:
+                # YAMLError inherits Exception with no changes, so constructor just the message
+                raise type(e)("for '{path}': {error}".format(path=path, error=e))
             if not isinstance(obj, dict):
                 log.info(
                     'Ignoring pillar stack template "%s": Can\'t parse '

--- a/salt/pillar/stack.py
+++ b/salt/pillar/stack.py
@@ -461,8 +461,7 @@ def _process_stack_cfg(cfg, stack, minion_id, pillar):
                     jenv.get_template(unix_path).render(stack=stack, ymlpath=path)
                 )
             except YAMLError as e:
-                # YAMLError inherits Exception with no changes, so constructor just the message
-                raise type(e)("for '{path}': {error}".format(path=path, error=e))
+                raise YAMLError("for '{path}': {error}".format(path=path, error=e))
             if not isinstance(obj, dict):
                 log.info(
                     'Ignoring pillar stack template "%s": Can\'t parse '


### PR DESCRIPTION
### What does this PR do?
If the `ext_pillar` `stack` module fails to parse the YAML of a pillar file it re-throws the exception but with a file path in the error message.

### What issues does this PR fix or reference?
Fixes #62748

### Previous Behavior
The YAML parse error would be thrown without a file path in the message, making it impossible to know from where the issue came.

### New Behavior
Adds a the file path to an exception which is re-thrown.

Example:

```
[CRITICAL] Pillar render error: Failed to load ext_pillar stack: for '/srv/pillar/base-secret/internet-secret/nohup.out': mapping values are not allowed in this context
  in "<unicode string>", line 70, column 38
local:
    Data failed to compile:
----------
    Pillar failed to render with the following messages:
----------
    Failed to load ext_pillar stack: for '/srv/pillar/base-secret/internet-secret/nohup.out': mapping values are not allowed in this context
  in "<unicode string>", line 70, column 38
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes