### PR TITLE
Improves error information to the user if zypper returns with an error code

### DIFF
--- a/changelog/56016.fixed
+++ b/changelog/56016.fixed
@@ -1,0 +1,1 @@
+Included stdout in error message for Zypper calls in zypperpkg module.

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -294,7 +294,8 @@ class _Zypper:
                     self.__call_result["stderr"]
                     and self.__call_result["stderr"].strip()
                     or ""
-                ) or (
+                )
+                msg += (
                     self.__call_result["stdout"]
                     and self.__call_result["stdout"].strip()
                     or ""


### PR DESCRIPTION
### What does this PR do?

For the zypperpkg module, improves error information to the user if zypper returns with an error code. 
There's a previous PR on this regard with a different approach: https://github.com/saltstack/salt/pull/62346
This PR improves the previous one.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/56016

### Previous Behavior
If zypper returns with an error code and there is no output on standard error, uses standard output to give more information to the user.

### New Behavior
If zypper returns with an error code adds standard output to standard error to give more information to the user.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
