### PR TITLE
Add atomic file operation for symlink changes

### DIFF
--- a/changelog/62768.added
+++ b/changelog/62768.added
@@ -1,0 +1,1 @@
+Add atomic file operation for symlink changes

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -14,6 +14,7 @@ import os
 import os.path
 import stat
 import sys
+import tempfile
 
 import salt.utils.path
 import salt.utils.platform
@@ -1368,7 +1369,7 @@ def remove(path, force=False):
     return True
 
 
-def symlink(src, link, force=False):
+def symlink(src, link, force=False, atomic=False):
     """
     Create a symbolic link to a file
 
@@ -1389,9 +1390,13 @@ def symlink(src, link, force=False):
             Overwrite an existing symlink with the same name
             .. versionadded:: 3005
 
+        atomic (bool):
+            Use atomic file operations to create the symlink
+            .. versionadded:: 3006.0
+
     Returns:
 
-        bool: True if successful, otherwise False
+        bool: ``True`` if successful, otherwise raises ``CommandExecutionError``
 
     CLI Example:
 
@@ -1406,6 +1411,9 @@ def symlink(src, link, force=False):
             "Symlinks are only supported on Windows Vista or later."
         )
 
+    if not os.path.isabs(link):
+        raise SaltInvocationError("Link path must be absolute: {}".format(link))
+
     if os.path.islink(link):
         try:
             if os.path.normpath(salt.utils.path.readlink(link)) == os.path.normpath(
@@ -1416,18 +1424,13 @@ def symlink(src, link, force=False):
         except OSError:
             pass
 
-        if force:
-            os.unlink(link)
-        else:
+        if not force and not atomic:
             msg = "Found existing symlink: {}".format(link)
             raise CommandExecutionError(msg)
 
-    if os.path.exists(link):
+    if os.path.exists(link) and not force and not atomic:
         msg = "Existing path is not a symlink: {}".format(link)
         raise CommandExecutionError(msg)
-
-    if not os.path.isabs(link):
-        raise SaltInvocationError("Link path must be absolute: {}".format(link))
 
     # ensure paths are using the right slashes
     src = os.path.normpath(src)
@@ -1439,6 +1442,30 @@ def symlink(src, link, force=False):
     desired_access = win32security.TOKEN_QUERY | win32security.TOKEN_ADJUST_PRIVILEGES
     th = win32security.OpenProcessToken(win32api.GetCurrentProcess(), desired_access)
     salt.platform.win.elevate_token(th)
+
+    if (os.path.islink(link) or os.path.exists(link)) and force and not atomic:
+        os.unlink(link)
+    elif atomic:
+        link_dir = os.path.dirname(link)
+        retry = 0
+        while retry < 5:
+            temp_link = tempfile.mktemp(dir=link_dir)
+            try:
+                win32file.CreateSymbolicLink(temp_link, src, int(is_dir))
+                break
+            except win32file.error:
+                retry += 1
+        try:
+            os.replace(temp_link, link)
+            win32file.MoveFileEx(
+                temp_link,
+                link,
+                win32file.MOVEFILE_REPLACE_EXISTING | win32file.MOVEFILE_WRITE_THROUGH,
+            )
+            return True
+        except OSError:
+            os.remove(temp_link)
+            raise CommandExecutionError("Could not create '{}'".format(link))
 
     try:
         win32file.CreateSymbolicLink(link, src, int(is_dir))

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -1456,14 +1456,13 @@ def symlink(src, link, force=False, atomic=False):
             except win32file.error:
                 retry += 1
         try:
-            os.replace(temp_link, link)
             win32file.MoveFileEx(
                 temp_link,
                 link,
                 win32file.MOVEFILE_REPLACE_EXISTING | win32file.MOVEFILE_WRITE_THROUGH,
             )
             return True
-        except OSError:
+        except win32file.error:
             os.remove(temp_link)
             raise CommandExecutionError("Could not create '{}'".format(link))
 

--- a/tests/pytests/functional/modules/file/test_symlink.py
+++ b/tests/pytests/functional/modules/file/test_symlink.py
@@ -120,3 +120,18 @@ def test_symlink_target_relative_path(file, source):
     with pytest.raises(SaltInvocationError) as exc:
         file.symlink(str(source), str(target))
     assert "Link path must be absolute" in exc.value.message
+
+
+def test_symlink_exists_different_atomic(file, source):
+    """
+    Test symlink with an existing symlink to a different file with atomic=True
+    Should replace the existing symlink with a new one to the correct location
+    """
+    dif_source = source.parent / "dif_source.txt"
+    target = source.parent / "symlink.lnk"
+    target.symlink_to(dif_source)
+    try:
+        file.symlink(str(source), str(target), atomic=True)
+        assert salt.utils.path.readlink(str(target)) == str(source)
+    finally:
+        target.unlink()


### PR DESCRIPTION
### What does this PR do?
Introduces the `atomic` parameter to the `file.symlink` execution and states modules

### What issues does this PR fix or reference?
Fixes: #62768

### Previous Behavior
Narrow gap between link removal and creation during link changes and force mode

### New Behavior
Move operation is atomic when enabled

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
