### PR TITLE
Encode password for ZipFile

### DIFF
--- a/changelog/61422.fixed
+++ b/changelog/61422.fixed
@@ -1,0 +1,1 @@
+Fix issue with archive.unzip where the password was not being encoded for the extract function

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -1093,7 +1093,7 @@ def unzip(
                             source = zfile.read(target)
                             os.symlink(source, os.path.join(dest, target))
                             continue
-                    zfile.extract(target, dest, password)
+                    zfile.extract(target, dest, password.encode())
                     if extract_perms:
                         if not salt.utils.platform.is_windows():
                             perm = zfile.getinfo(target).external_attr >> 16

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -1093,8 +1093,8 @@ def unzip(
                             source = zfile.read(target)
                             os.symlink(source, os.path.join(dest, target))
                             continue
-                    # if password:
-                    #     password = password.encode()
+                    if password:
+                        password = password.encode()
                     zfile.extract(target, dest, password)
                     if extract_perms:
                         if not salt.utils.platform.is_windows():

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -1093,7 +1093,9 @@ def unzip(
                             source = zfile.read(target)
                             os.symlink(source, os.path.join(dest, target))
                             continue
-                    zfile.extract(target, dest, password.encode())
+                    # if password:
+                    #     password = password.encode()
+                    zfile.extract(target, dest, password)
                     if extract_perms:
                         if not salt.utils.platform.is_windows():
                             perm = zfile.getinfo(target).external_attr >> 16

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -1093,8 +1093,12 @@ def unzip(
                             source = zfile.read(target)
                             os.symlink(source, os.path.join(dest, target))
                             continue
+                    # file.extract is expecting the password to be a bytestring
                     if password:
-                        password = password.encode()
+                        if isinstance(password, int):
+                            password = str(password)
+                        if isinstance(password, str):
+                            password = password.encode()
                     zfile.extract(target, dest, password)
                     if extract_perms:
                         if not salt.utils.platform.is_windows():

--- a/tests/pytests/unit/modules/test_archive.py
+++ b/tests/pytests/unit/modules/test_archive.py
@@ -392,6 +392,34 @@ def test_unzip_password():
         mock().extract.assert_called_once_with(expected_file_name, dest, b"spongebob")
 
 
+def test_unzip_password_bytestring():
+    mock = ZipFileMock()
+    target = "/tmp/salt.zip"
+    dest = "/tmp/dest"
+    # This is the file inside target zip file, returned by ZipFileMock.namelist
+    expected_file_name = "salt"
+    with patch("zipfile.ZipFile", mock):
+        ret = archive.unzip(target, dest, password=b"spongebob", extract_perms=False)
+        assert [expected_file_name] == ret
+        # mock needs to be mock() because contextlib.closing appears to actually
+        # call the mock
+        mock().extract.assert_called_once_with(expected_file_name, dest, b"spongebob")
+
+
+def test_unzip_password_integer():
+    mock = ZipFileMock()
+    target = "/tmp/salt.zip"
+    dest = "/tmp/dest"
+    # This is the file inside target zip file, returned by ZipFileMock.namelist
+    expected_file_name = "salt"
+    with patch("zipfile.ZipFile", mock):
+        ret = archive.unzip(target, dest, password=12345, extract_perms=False)
+        assert [expected_file_name] == ret
+        # mock needs to be mock() because contextlib.closing appears to actually
+        # call the mock
+        mock().extract.assert_called_once_with(expected_file_name, dest, b"12345")
+
+
 def test_unzip_raises_exception_if_not_found():
     mock = MagicMock(return_value="salt")
     with patch.dict(archive.__salt__, {"cmd.run": mock}):

--- a/tests/pytests/unit/modules/test_archive.py
+++ b/tests/pytests/unit/modules/test_archive.py
@@ -378,7 +378,6 @@ def test_unzip():
         assert ["salt"] == ret
 
 
-@pytest.mark.xfail
 def test_unzip_password():
     mock = ZipFileMock()
     target = "/tmp/salt.zip"

--- a/tests/pytests/unit/modules/test_archive.py
+++ b/tests/pytests/unit/modules/test_archive.py
@@ -378,6 +378,21 @@ def test_unzip():
         assert ["salt"] == ret
 
 
+@pytest.mark.xfail
+def test_unzip_password():
+    mock = ZipFileMock()
+    target = "/tmp/salt.zip"
+    dest = "/tmp/dest"
+    # This is the file inside target zip file, returned by ZipFileMock.namelist
+    expected_file_name = "salt"
+    with patch("zipfile.ZipFile", mock):
+        ret = archive.unzip(target, dest, password="spongebob", extract_perms=False)
+        assert [expected_file_name] == ret
+        # mock needs to be mock() because contextlib.closing appears to actually
+        # call the mock
+        mock().extract.assert_called_once_with(expected_file_name, dest, b"spongebob")
+
+
 def test_unzip_raises_exception_if_not_found():
     mock = MagicMock(return_value="salt")
     with patch.dict(archive.__salt__, {"cmd.run": mock}):


### PR DESCRIPTION
### What does this PR do?
Encodes the password for the `zipfile.extract` function. This function expects a binary value for the password.

As a side note, if using winrar to create a password-protected zip, you must select legacy encryption when setting the password. Otherwise, zipfile cannot read it.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/61422

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes