### PR TITLE
fopen: Workaround bad buffering for binary mode

### DIFF
--- a/salt/utils/files.py
+++ b/salt/utils/files.py
@@ -382,6 +382,11 @@ def fopen(*args, **kwargs):
     if not binary and not kwargs.get("newline", None):
         kwargs["newline"] = ""
 
+    # Workaround callers with bad buffering setting for binary files
+    if kwargs.get("buffering", -1) == 1 and 'b' in kwargs.get("mode", ""):
+        log.debug("Bad buffering specified for '%s'", args[0], stack_info=True)
+        del(kwargs["buffering"])
+
     f_handle = open(*args, **kwargs)  # pylint: disable=resource-leakage
 
     if is_fcntl_available():


### PR DESCRIPTION
### What does this PR do?
A lot of code assumes Python 2.x behavior for buffering, in which 1 is a special value meaning line buffered.

Python 3 makes this value unusable, so fallback to the default buffering size, and report these calls to be fixed.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/57584

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No