### PR TITLE
Update mysql documentation

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -1,16 +1,12 @@
 """
 Module to provide MySQL compatibility to salt.
 
-:depends:   - MySQLdb Python module
-
-.. note::
-
-    On CentOS 5 (and possibly RHEL 5) both MySQL-python and python26-mysqldb
-    need to be installed.
+:depends:   - Python module: MySQLdb, mysqlclient, or PyMYSQL
 
 :configuration: In order to connect to MySQL, certain configuration is required
-    in /etc/salt/minion on the relevant minions. Some sample configs might look
-    like::
+    in either the relevant minion config (/etc/salt/minion), or pillar.
+    
+    Some sample configs might look like::
 
         mysql.host: 'localhost'
         mysql.port: 3306

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -5,7 +5,7 @@ Module to provide MySQL compatibility to salt.
 
 :configuration: In order to connect to MySQL, certain configuration is required
     in either the relevant minion config (/etc/salt/minion), or pillar.
-    
+
     Some sample configs might look like::
 
         mysql.host: 'localhost'


### PR DESCRIPTION
mysqlclient is a fork of MySQLdb, and the code is also written to work with PyMYSQL.
RHEL 5 has not been supported for a long time.
Config can also go in pillar.

Based on recent Slack discussions.