### PR TITLE
Include specific UID and GID checks in modules.file.check_perms

### DIFF
--- a/changelog/62818.fixed
+++ b/changelog/62818.fixed
@@ -1,0 +1,2 @@
+Include UID and GID checks in modules.file.check_perms as well as comparing
+ownership by username and group name.

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -5099,6 +5099,7 @@ def check_perms(
         ``follow_symlinks`` option added
     """
     name = os.path.expanduser(name)
+    mode = salt.utils.files.normalize_mode(mode)
 
     if not ret:
         ret = {"name": name, "changes": {}, "comment": [], "result": True}
@@ -5107,121 +5108,127 @@ def check_perms(
         orig_comment = ret["comment"]
         ret["comment"] = []
 
-    # Check permissions
-    perms = {}
+    # Check current permissions
     cur = stats(name, follow_symlinks=follow_symlinks)
-    perms["luser"] = cur["user"]
-    perms["lgroup"] = cur["group"]
-    perms["lmode"] = salt.utils.files.normalize_mode(cur["mode"])
+
+    # Record initial stat for return later. Check whether we're receiving IDs
+    # or names so luser == cuser comparison makes sense.
+    perms = {}
+    perms["luser"] = cur["uid"] if isinstance(user, int) else cur["user"]
+    perms["lgroup"] = cur["gid"] if isinstance(group, int) else cur["group"]
+    perms["lmode"] = cur["mode"]
 
     is_dir = os.path.isdir(name)
     is_link = os.path.islink(name)
 
-    # user/group changes if needed, then check if it worked
+    # Check and make user/group/mode changes, then verify they were successful
     if user:
-        if isinstance(user, int):
-            user = uid_to_user(user)
         if (
-            salt.utils.platform.is_windows()
-            and user_to_uid(user) != user_to_uid(perms["luser"])
-        ) or (not salt.utils.platform.is_windows() and user != perms["luser"]):
+            salt.utils.platform.is_windows() and not user_to_uid(user) == cur["uid"]
+        ) or (
+            not salt.utils.platform.is_windows()
+            and not user == cur["user"]
+            and not user == cur["uid"]
+        ):
             perms["cuser"] = user
 
     if group:
-        if isinstance(group, int):
-            group = gid_to_group(group)
         if (
-            salt.utils.platform.is_windows()
-            and group_to_gid(group) != group_to_gid(perms["lgroup"])
-        ) or (not salt.utils.platform.is_windows() and group != perms["lgroup"]):
+            salt.utils.platform.is_windows() and not group_to_gid(group) == cur["gid"]
+        ) or (
+            not salt.utils.platform.is_windows()
+            and not group == cur["group"]
+            and not group == cur["gid"]
+        ):
             perms["cgroup"] = group
 
     if "cuser" in perms or "cgroup" in perms:
         if not __opts__["test"]:
-            if os.path.islink(name) and not follow_symlinks:
+            if is_link and not follow_symlinks:
                 chown_func = lchown
             else:
                 chown_func = chown
             if user is None:
-                user = perms["luser"]
+                user = cur["user"]
             if group is None:
-                group = perms["lgroup"]
+                group = cur["group"]
             try:
-                chown_func(name, user, group)
-                # Python os.chown() does reset the suid and sgid,
-                # that's why setting the right mode again is needed here.
-                set_mode(name, mode)
+                err = chown_func(name, user, group)
+                if err:
+                    ret["result"] = False
+                    ret["comment"].append(err)
+                else:
+                    # Python os.chown() resets the suid and sgid, hence we
+                    # setting the previous mode again. Pending mode changes
+                    # will be applied later.
+                    set_mode(name, cur["mode"])
             except OSError:
                 ret["result"] = False
 
+    # Mode changes if needed
+    if mode is not None:
+        # File is a symlink, ignore the mode setting
+        # if follow_symlinks is False
+        if is_link and not follow_symlinks:
+            pass
+
+        if __opts__["test"] is True:
+            ret["changes"]["mode"] = mode
+        else:
+            if not mode == cur["mode"]:
+                set_mode(name, mode)
+
+    # verify user/group/mode changes
+    post = stats(name, follow_symlinks=follow_symlinks)
     if user:
-        if isinstance(user, int):
-            user = uid_to_user(user)
         if (
-            salt.utils.platform.is_windows()
-            and user_to_uid(user)
-            != user_to_uid(get_user(name, follow_symlinks=follow_symlinks))
-            and user != ""
+            salt.utils.platform.is_windows() and not user_to_uid(user) == post["uid"]
         ) or (
             not salt.utils.platform.is_windows()
-            and user != get_user(name, follow_symlinks=follow_symlinks)
-            and user != ""
+            and not user == post["user"]
+            and not user == post["uid"]
         ):
             if __opts__["test"] is True:
                 ret["changes"]["user"] = user
             else:
                 ret["result"] = False
                 ret["comment"].append("Failed to change user to {}".format(user))
-        elif "cuser" in perms and user != "":
+        elif "cuser" in perms:
             ret["changes"]["user"] = user
 
     if group:
-        if isinstance(group, int):
-            group = gid_to_group(group)
         if (
-            salt.utils.platform.is_windows()
-            and group_to_gid(group)
-            != group_to_gid(get_group(name, follow_symlinks=follow_symlinks))
-            and user != ""
+            salt.utils.platform.is_windows() and not group_to_gid(group) == post["gid"]
         ) or (
             not salt.utils.platform.is_windows()
-            and group != get_group(name, follow_symlinks=follow_symlinks)
-            and user != ""
+            and not group == post["group"]
+            and not group == post["gid"]
         ):
             if __opts__["test"] is True:
                 ret["changes"]["group"] = group
             else:
                 ret["result"] = False
                 ret["comment"].append("Failed to change group to {}".format(group))
-        elif "cgroup" in perms and user != "":
+        elif "cgroup" in perms:
             ret["changes"]["group"] = group
 
-    # Mode changes if needed
     if mode is not None:
         # File is a symlink, ignore the mode setting
         # if follow_symlinks is False
-        if os.path.islink(name) and not follow_symlinks:
+        if is_link and not follow_symlinks:
             pass
+
+        if not mode == post["mode"]:
+            ret["result"] = False
+            ret["comment"].append("Failed to change mode to {}".format(mode))
         else:
-            mode = salt.utils.files.normalize_mode(mode)
-            if mode != perms["lmode"]:
-                if __opts__["test"] is True:
-                    ret["changes"]["mode"] = mode
-                else:
-                    set_mode(name, mode)
-                    if mode != salt.utils.files.normalize_mode(get_mode(name)):
-                        ret["result"] = False
-                        ret["comment"].append(
-                            "Failed to change mode to {}".format(mode)
-                        )
-                    else:
-                        ret["changes"]["mode"] = mode
+            ret["changes"]["mode"] = mode
 
     # Modify attributes of file if needed
     if attrs is not None and not is_dir:
         # File is a symlink, ignore the mode setting
         # if follow_symlinks is False
-        if os.path.islink(name) and not follow_symlinks:
+        if is_link and not follow_symlinks:
             pass
         else:
             diff_attrs = _cmp_attrs(name, attrs)

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -5167,13 +5167,12 @@ def check_perms(
 
     # Mode changes if needed
     if mode is not None:
-        # File is a symlink, ignore the mode setting
-        # if follow_symlinks is False
-        if not (is_link and not follow_symlinks):
-            if __opts__["test"] is True:
-                ret["changes"]["mode"] = mode
-            else:
+        if not __opts__["test"] is True:
+            # File is a symlink, ignore the mode setting
+            # if follow_symlinks is False
+            if not (is_link and not follow_symlinks):
                 if not mode == cur["mode"]:
+                    perms["cmode"] = mode
                     set_mode(name, mode)
 
     # verify user/group/mode changes
@@ -5215,9 +5214,12 @@ def check_perms(
         # if follow_symlinks is False
         if not (is_link and not follow_symlinks):
             if not mode == post["mode"]:
-                ret["result"] = False
-                ret["comment"].append("Failed to change mode to {}".format(mode))
-            else:
+                if __opts__["test"] is True:
+                    ret["changes"]["mode"] = mode
+                else:
+                    ret["result"] = False
+                    ret["comment"].append("Failed to change mode to {}".format(mode))
+            elif "cmode" in perms:
                 ret["changes"]["mode"] = mode
 
     # Modify attributes of file if needed

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -5169,14 +5169,12 @@ def check_perms(
     if mode is not None:
         # File is a symlink, ignore the mode setting
         # if follow_symlinks is False
-        if is_link and not follow_symlinks:
-            pass
-
-        if __opts__["test"] is True:
-            ret["changes"]["mode"] = mode
-        else:
-            if not mode == cur["mode"]:
-                set_mode(name, mode)
+        if not (is_link and not follow_symlinks):
+            if __opts__["test"] is True:
+                ret["changes"]["mode"] = mode
+            else:
+                if not mode == cur["mode"]:
+                    set_mode(name, mode)
 
     # verify user/group/mode changes
     post = stats(name, follow_symlinks=follow_symlinks)
@@ -5215,22 +5213,18 @@ def check_perms(
     if mode is not None:
         # File is a symlink, ignore the mode setting
         # if follow_symlinks is False
-        if is_link and not follow_symlinks:
-            pass
-
-        if not mode == post["mode"]:
-            ret["result"] = False
-            ret["comment"].append("Failed to change mode to {}".format(mode))
-        else:
-            ret["changes"]["mode"] = mode
+        if not (is_link and not follow_symlinks):
+            if not mode == post["mode"]:
+                ret["result"] = False
+                ret["comment"].append("Failed to change mode to {}".format(mode))
+            else:
+                ret["changes"]["mode"] = mode
 
     # Modify attributes of file if needed
     if attrs is not None and not is_dir:
         # File is a symlink, ignore the mode setting
         # if follow_symlinks is False
-        if is_link and not follow_symlinks:
-            pass
-        else:
+        if not (is_link and not follow_symlinks):
             diff_attrs = _cmp_attrs(name, attrs)
             if diff_attrs and any(attr for attr in diff_attrs):
                 changes = {

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -768,7 +768,7 @@ def _check_directory(
                     if (
                         group is not None
                         and not group == stats.get("group")
-                        and not user == stats.get("gid")
+                        and not group == stats.get("gid")
                     ):
                         fchange["group"] = group
                     smode = salt.utils.files.normalize_mode(stats.get("mode"))

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -759,9 +759,17 @@ def _check_directory(
                     fchange = {}
                     path = os.path.join(root, fname)
                     stats = __salt__["file.stats"](path, None, follow_symlinks)
-                    if user is not None and user != stats.get("user"):
+                    if (
+                        user is not None
+                        and not user == stats.get("user")
+                        and not user == stats.get("uid")
+                    ):
                         fchange["user"] = user
-                    if group is not None and group != stats.get("group"):
+                    if (
+                        group is not None
+                        and not group == stats.get("group")
+                        and not user == stats.get("gid")
+                    ):
                         fchange["group"] = group
                     smode = salt.utils.files.normalize_mode(stats.get("mode"))
                     file_mode = salt.utils.files.normalize_mode(file_mode)

--- a/tests/pytests/unit/modules/file/test_file_check.py
+++ b/tests/pytests/unit/modules/file/test_file_check.py
@@ -7,13 +7,19 @@ import pytest
 import salt.modules.file as filemod
 import salt.utils.files
 import salt.utils.platform
+from tests.support.mock import Mock, patch
 
 log = logging.getLogger(__name__)
 
 
 @pytest.fixture
 def configure_loader_modules():
-    return {filemod: {"__context__": {}}}
+    return {
+        filemod: {
+            "__context__": {},
+            "__opts__": {"test": False},
+        }
+    }
 
 
 @pytest.fixture
@@ -143,3 +149,63 @@ def test_check_managed_changes_follow_symlinks(a_link, tfile):
         follow_symlinks=True,
     )
     assert ret == {}
+
+
+@pytest.mark.skip_on_windows(reason="os.symlink is not available on Windows")
+@patch("os.path.exists", Mock(return_value=True))
+def test_check_perms_user_group_name_and_id():
+    filename = "/path/to/fnord"
+
+    tests = [
+        # user/group changes needed by name
+        {
+            "input": {"user": "cuser", "group": "cgroup"},
+            "expected": {"user": "cuser", "group": "cgroup"},
+        },
+        # no changes needed by name
+        {"input": {"user": "luser", "group": "lgroup"}, "expected": {}},
+        # user/group changes needed by id
+        {
+            "input": {"user": 1001, "group": 2001},
+            "expected": {"user": 1001, "group": 2001},
+        },
+        # no user/group changes needed by id
+        {"input": {"user": 3001, "group": 4001}, "expected": {}},
+    ]
+
+    for test in tests:
+        # Consistent initial file stats
+        stat_out = {
+            "user": "luser",
+            "group": "lgroup",
+            "uid": 3001,
+            "gid": 4001,
+            "mode": "123",
+        }
+
+        patch_stats = patch(
+            "salt.modules.file.stats",
+            Mock(return_value=stat_out),
+        )
+
+        # "chown" the file to the permissions we want in test["input"]
+        # pylint: disable=W0640
+        def fake_chown(cmd, *args, **kwargs):
+            for k, v in test["input"].items():
+                stat_out.update({k: v})
+
+        patch_chown = patch(
+            "salt.modules.file.chown",
+            Mock(side_effect=fake_chown),
+        )
+
+        with patch_stats, patch_chown:
+            ret, pre_post = filemod.check_perms(
+                name=filename,
+                ret={},
+                user=test["input"]["user"],
+                group=test["input"]["group"],
+                mode="123",
+                follow_symlinks=False,
+            )
+            assert ret["changes"] == test["expected"]

--- a/tests/pytests/unit/modules/file/test_file_selinux.py
+++ b/tests/pytests/unit/modules/file/test_file_selinux.py
@@ -112,7 +112,7 @@ def test_file_check_perms(tfile3):
             "name": tfile3,
             "result": True,
         },
-        {"luser": "root", "lmode": "0644", "lgroup": "root"},
+        {"cmode": "0664", "luser": "root", "lmode": "0644", "lgroup": "root"},
     )
 
     # Disable lsattr calls


### PR DESCRIPTION
If the same username exists in more than one nsswitch database, it's possible to end up in a situation where users can be associated with more than one UID. 

### What does this PR do?
The PR updates the `file.check_perms` function to check whether the UID and GID values of the file match the function arguments for `user` and `group` should they be IDs.

The PR also attempts to reduce the number of calls to `get_user` and `get_group` which result in repeat calls to stat. Instead use a single "post" `file.stats` call and compare user/group/mode changes using that.

### What issues does this PR fix or reference?
Fixes: #62818

### Previous Behavior
Files owned by a user who can be mapped to two UIDs, but have file permissions for the "wrong" UID will not be updated by `file.check_perms`. This is due to `file.check_perms` only comparing ownership by names, and not also IDs.

Under normal circumstances, if you supply an ID for `user:` in `file.directory`, and that ID either represents a non-existent user, or maps to a username via `file.uid_to_user`, then salt will correctly update file and directory permissions recursively. However if you end up in the unique situation where during a migration period, a username is present in two name databases but with different UIDs, salt will compare the output from stat (which returns the correct username but with the "previous" UIDs) for the file only against a username due to `uid_to_user(name)` being used. This results in the UID owning the file not being updated.

Example where file uid wont get updated even if a uid is supplied to `file.directory`:
```
% cat srv/salt/common.sls
passwd-cache-reset:
  file.absent:
    - name: /etc/passwd.cache

nsswitch-reset:
  file.line:
    - name: /etc/nsswitch.conf
    - mode: replace
    - content: "passwd:         files"
    - match: "^passwd:"

dir-absent:
  file.absent:
    - name: /test

testing-create:
  user.present:
    - name: testing
    - uid: 2000
    - usergroup: true

testfile:
  file.managed:
    - name: /test/testfile
    - makedirs: true
    - user: testing
    - group: testing
    - replace: false
    - require:
      - file: dir-absent
      - user: testing-create

libnss-cache:
  pkg.installed

nsswitch-update:
  file.line:
    - name: /etc/nsswitch.conf
    - mode: replace
    - content: "passwd:         cache files"
    - match: "^passwd:"

/etc/passwd.cache:
  file.managed:
    - contents: |
        testing:x:8000:2000::/home/testing:/bin/sh

file_stats_pre:
  module.run:
    - file.stats:
      - path: /test/testfile
    - require:
      - file: /etc/passwd.cache

dir-by-user-new-id:
  file.directory:
    - name: /test
    - user: 8000
    - recurse:
      - user
    - require:
      - file: /etc/passwd.cache

user_info_post:
  module.run:
    - user.info:
      - name: testing
    - require:
      - file: /etc/passwd.cache

file_stats_post:
  module.run:
    - file.stats:
      - path: /test/testfile
    - require:
      - file: testfile


# salt-call --version
salt-call 3006.0 (Sulfur)

# salt-call state.apply common;
local:
----------
          ID: passwd-cache-reset
    Function: file.absent
        Name: /etc/passwd.cache
      Result: True
     Comment: Removed file /etc/passwd.cache
     Started: 09:32:01.306346
    Duration: 3.933 ms
     Changes:
              ----------
              removed:
                  /etc/passwd.cache
----------
          ID: nsswitch-reset
    Function: file.line
        Name: /etc/nsswitch.conf
      Result: True
     Comment: Changes were made
     Started: 09:32:01.310382
    Duration: 2.674 ms
     Changes:
              ----------
              diff:
                  ---
                  +++
                  @@ -1,4 +1,4 @@
                  -passwd:         cache files
                  +passwd:         files
                   group:          files
                   shadow:         files
                   gshadow:        files
----------
          ID: dir-absent
    Function: file.absent
        Name: /test
      Result: True
     Comment: Removed directory /test
     Started: 09:32:01.313207
    Duration: 0.577 ms
     Changes:
              ----------
              removed:
                  /test
----------
          ID: testing-create
    Function: user.present
        Name: testing
      Result: True
     Comment: User testing is present and up to date
     Started: 09:32:01.314274
    Duration: 11.486 ms
     Changes:
----------
          ID: testfile
    Function: file.managed
        Name: /test/testfile
      Result: True
     Comment: Empty file
     Started: 09:32:01.326149
    Duration: 1.756 ms
     Changes:
              ----------
              group:
                  testing
              new:
                  file /test/testfile created
              user:
                  testing
----------
          ID: libnss-cache
    Function: pkg.installed
      Result: True
     Comment: All specified packages are already installed
     Started: 09:32:02.181527
    Duration: 23.372 ms
     Changes:
----------
          ID: nsswitch-update
    Function: file.line
        Name: /etc/nsswitch.conf
      Result: True
     Comment: Changes were made
     Started: 09:32:02.205086
    Duration: 2.051 ms
     Changes:
              ----------
              diff:
                  ---
                  +++
                  @@ -1,4 +1,4 @@
                  -passwd:         files
                  +passwd:         cache files
                   group:          files
                   shadow:         files
                   gshadow:        files
----------
          ID: /etc/passwd.cache
    Function: file.managed
      Result: True
     Comment: File /etc/passwd.cache updated
     Started: 09:32:02.207244
    Duration: 3.282 ms
     Changes:
              ----------
              diff:
                  New file
----------
          ID: file_stats_pre
    Function: module.run
      Result: True
     Comment: file.stats: Success
     Started: 09:32:02.212124
    Duration: 0.823 ms
     Changes:
              ----------
              file.stats:
                  ----------
                  atime:
                      1664616721.326989
                  ctime:
                      1664616721.326989
                  gid:
                      2000
                  group:
                      testing
                  inode:
                      1318636
                  mode:
                      0644
                  mtime:
                      1664616721.326989
                  size:
                      0
                  target:
                      /test/testfile
                  type:
                      file
                  uid:
                      2000
                  user:
                      testing
----------
          ID: dir-by-user-new-id              <---- note changes are returned
    Function: file.directory
        Name: /test
      Result: True
     Comment: Directory /test updated
     Started: 09:32:02.213108
    Duration: 1.702 ms
     Changes:
              ----------
              /test:
                  ----------
                  user:
                      8000
              /test/testfile:
                  ----------
                  user:
                      8000
----------
          ID: user_info_post
    Function: module.run
      Result: True
     Comment: user.info: Success
     Started: 09:32:02.214970
    Duration: 0.928 ms
     Changes:
              ----------
              user.info:
                  ----------
                  fullname:
                  gid:
                      2000
                  groups:
                      - testing
                  home:
                      /home/testing
                  homephone:
                  name:
                      testing
                  other:
                  passwd:
                      x
                  roomnumber:
                  shell:
                      /bin/sh
                  uid:
                      8000
                  workphone:
----------
          ID: file_stats_post
    Function: module.run
      Result: True
     Comment: file.stats: Success
     Started: 09:32:02.216141
    Duration: 0.717 ms
     Changes:
              ----------
              file.stats:
                  ----------
                  atime:
                      1664616721.326989
                  ctime:
                      1664616721.326989
                  gid:
                      2000
                  group:
                      testing
                  inode:
                      1318636
                  mode:
                      0644
                  mtime:
                      1664616721.326989
                  size:
                      0
                  target:
                      /test/testfile
                  type:
                      file
                  uid:                      <---- but not actually implemented
                      2000
                  user:
                      testing

Summary for local
-------------
Succeeded: 12 (changed=10)
Failed:     0
-------------
Total states run:     12
Total run time:   53.301 ms
```

When using:
```
dir-by-user-new-id:
  file.directory:
    - name: /test
    - user: testing                  <---- username this time
    - recurse:
      - user
    - require:
      - file: /etc/passwd.cache
```
The `file.directory` state returns `changes: {}`, which makes sense as the usernames match even though the uid doesn't.

Previously `file.check_perms` attempted to retrieve usernames via `file.uid_to_user`. An empty check was done on the return value which would signify a username not being present on the system - a hard failure as `os.chown` takes IDs, but no username means no ID. The PR changes this so that username checks are left to the `file.chown` function. The error string returned by `file.chown` is appended to `ret["comments"]` so it can be returned to the user should either the username or group name not be present.

### New Behavior
Salt will check both file username and UID permissions against the supplied `user` and `group` arguments instead of trying to convert IDs to names and then comparing. This resolves an admittedly pretty unique situation.

I should add that I looked into making salt capable of accepting a username, and performing both name and ID checks using that, but those changes are more significant.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
