### PR TITLE
macOS: Fix issue when Homebrew casks's tap is null

### DIFF
--- a/changelog/62793.fixed
+++ b/changelog/62793.fixed
@@ -1,0 +1,1 @@
+Fix mac_brew_pkg to work with null taps

--- a/tests/pytests/unit/modules/test_mac_brew_pkg.py
+++ b/tests/pytests/unit/modules/test_mac_brew_pkg.py
@@ -364,14 +364,14 @@ def custom_add_pkg(ret, name, newest_version):
 # '_list_taps' function tests: 1
 
 
-def test_list_taps(TAPS_STRING, TAPS_LIST):
+def test_list_taps(TAPS_STRING, TAPS_LIST, HOMEBREW_BIN):
     """
     Tests the return of the list of taps
     """
     mock_taps = MagicMock(return_value={"stdout": TAPS_STRING, "retcode": 0})
     mock_user = MagicMock(return_value="foo")
     mock_cmd = MagicMock(return_value="")
-    with patch("salt.utils.path.which", MagicMock(return_value="/usr/local/bin/brew")):
+    with patch("salt.utils.path.which", MagicMock(return_value=HOMEBREW_BIN)):
         with patch.dict(
             mac_brew.__salt__,
             {"file.get_user": mock_user, "cmd.run_all": mock_taps, "cmd.run": mock_cmd},
@@ -392,14 +392,14 @@ def test_tap_installed(TAPS_LIST):
         assert mac_brew._tap("homebrew/science")
 
 
-def test_tap_failure():
+def test_tap_failure(HOMEBREW_BIN):
     """
     Tests if the tap installation failed
     """
     mock_failure = MagicMock(return_value={"stdout": "", "stderr": "", "retcode": 1})
     mock_user = MagicMock(return_value="foo")
     mock_cmd = MagicMock(return_value="")
-    with patch("salt.utils.path.which", MagicMock(return_value="/usr/local/bin/brew")):
+    with patch("salt.utils.path.which", MagicMock(return_value=HOMEBREW_BIN)):
         with patch.dict(
             mac_brew.__salt__,
             {
@@ -411,14 +411,14 @@ def test_tap_failure():
             assert not mac_brew._tap("homebrew/test")
 
 
-def test_tap(TAPS_LIST):
+def test_tap(TAPS_LIST, HOMEBREW_BIN):
     """
     Tests adding unofficial GitHub repos to the list of brew taps
     """
     mock_failure = MagicMock(return_value={"retcode": 0})
     mock_user = MagicMock(return_value="foo")
     mock_cmd = MagicMock(return_value="")
-    with patch("salt.utils.path.which", MagicMock(return_value="/usr/local/bin/brew")):
+    with patch("salt.utils.path.which", MagicMock(return_value=HOMEBREW_BIN)):
         with patch.dict(
             mac_brew.__salt__,
             {
@@ -435,13 +435,13 @@ def test_tap(TAPS_LIST):
 # '_homebrew_bin' function tests: 1
 
 
-def test_homebrew_bin():
+def test_homebrew_bin(HOMEBREW_BIN):
     """
     Tests the path to the homebrew binary
     """
     mock_path = MagicMock(return_value="/usr/local")
     with patch.dict(mac_brew.__salt__, {"cmd.run": mock_path}):
-        assert mac_brew._homebrew_bin() == "/usr/local/bin/brew"
+        assert mac_brew._homebrew_bin() == HOMEBREW_BIN
 
 
 # 'list_pkgs' function tests: 2
@@ -574,7 +574,7 @@ def test_refresh_db(HOMEBREW_BIN):
     """
     mock_user = MagicMock(return_value="foo")
     mock_success = MagicMock(return_value={"retcode": 0})
-    with patch("salt.utils.path.which", MagicMock(return_value="/usr/local/bin/brew")):
+    with patch("salt.utils.path.which", MagicMock(return_value=HOMEBREW_BIN)):
         with patch.dict(
             mac_brew.__salt__, {"file.get_user": mock_user, "cmd.run_all": mock_success}
         ), patch(
@@ -604,7 +604,7 @@ def test_install():
 # Full functionality should be tested in integration phase
 
 
-def test_hold():
+def test_hold(HOMEBREW_BIN):
     """
     Tests holding if package is installed
     """
@@ -623,7 +623,7 @@ def test_hold():
     }
 
     mock_params = MagicMock(return_value=({"foo": None}, "repository"))
-    with patch("salt.utils.path.which", MagicMock(return_value="/usr/local/bin/brew")):
+    with patch("salt.utils.path.which", MagicMock(return_value=HOMEBREW_BIN)):
         with patch(
             "salt.modules.mac_brew_pkg.list_pkgs", return_value={"foo": "0.1.5"}
         ), patch.dict(
@@ -638,7 +638,7 @@ def test_hold():
             assert mac_brew.hold("foo") == _expected
 
 
-def test_hold_not_installed():
+def test_hold_not_installed(HOMEBREW_BIN):
     """
     Tests holding if package is not installed
     """
@@ -657,7 +657,7 @@ def test_hold_not_installed():
     }
 
     mock_params = MagicMock(return_value=({"foo": None}, "repository"))
-    with patch("salt.utils.path.which", MagicMock(return_value="/usr/local/bin/brew")):
+    with patch("salt.utils.path.which", MagicMock(return_value=HOMEBREW_BIN)):
         with patch("salt.modules.mac_brew_pkg.list_pkgs", return_value={}), patch.dict(
             mac_brew.__salt__,
             {
@@ -708,7 +708,7 @@ def test_hold_pinned():
 # "unhold" function tests: 2
 # Only tested a few basics
 # Full functionality should be tested in integration phase
-def test_unhold():
+def test_unhold(HOMEBREW_BIN):
     """
     Tests unholding if package is installed
     """
@@ -727,7 +727,7 @@ def test_unhold():
     }
 
     mock_params = MagicMock(return_value=({"foo": None}, "repository"))
-    with patch("salt.utils.path.which", MagicMock(return_value="/usr/local/bin/brew")):
+    with patch("salt.utils.path.which", MagicMock(return_value=HOMEBREW_BIN)):
         with patch(
             "salt.modules.mac_brew_pkg.list_pkgs", return_value={"foo": "0.1.5"}
         ), patch(
@@ -810,7 +810,7 @@ def test_unhold_not_pinned():
         assert mac_brew.unhold("foo") == _expected
 
 
-def test_info_installed():
+def test_info_installed(HOMEBREW_BIN):
     """
     Tests info_installed method
     """
@@ -842,7 +842,7 @@ def test_info_installed():
                     {
                       "token": "visual-studio-code",
                       "full_token": "visual-studio-code",
-                      "tap": "homebrew/cask",
+                      "tap": null,
                       "name": [
                         "MicrosoftVisualStudioCode",
                         "VSCode"
@@ -870,28 +870,29 @@ def test_info_installed():
         "visual-studio-code": {
             "token": "visual-studio-code",
             "full_token": "visual-studio-code",
-            "tap": "null",
+            "tap": None,
             "name": ["MicrosoftVisualStudioCode", "VSCode"],
         },
     }
 
-    with patch("salt.modules.mac_brew_pkg.list_pkgs", return_value={}), patch(
-        "salt.modules.mac_brew_pkg._list_pinned", return_value=["foo"]
-    ), patch.dict(
-        mac_brew.__salt__,
-        {
-            "file.get_user": mock_user,
-            "cmd.run_all": mock_cmd_all,
-            "cmd.run": mock_cmd,
-        },
-    ):
-        assert (
-            mac_brew.info_installed("cdalvaro/tap/salt", "vim", "visual-studio-code")
-            == _expected
-        )
+    with patch("salt.utils.path.which", MagicMock(return_value=HOMEBREW_BIN)):
+        with patch("salt.modules.mac_brew_pkg.list_pkgs", return_value={}), patch(
+            "salt.modules.mac_brew_pkg._list_pinned", return_value=["foo"]
+        ), patch.dict(
+            mac_brew.__salt__,
+            {
+                "file.get_user": mock_user,
+                "cmd.run_all": mock_cmd_all,
+                "cmd.run": mock_cmd,
+            },
+        ):
+            assert (
+                mac_brew.info_installed("cdalvaro/tap/salt", "vim", "visual-studio-code")
+                == _expected
+            )
 
 
-def test_list_upgrades():
+def test_list_upgrades(HOMEBREW_BIN):
     """
     Tests list_upgrades method
     """
@@ -939,14 +940,15 @@ def test_list_upgrades():
         "ksdiff": "2.3.6,123-jan-18-2021",
     }
 
-    with patch("salt.modules.mac_brew_pkg.list_pkgs", return_value={}), patch(
-        "salt.modules.mac_brew_pkg._list_pinned", return_value=["foo"]
-    ), patch.dict(
-        mac_brew.__salt__,
-        {
-            "file.get_user": mock_user,
-            "cmd.run_all": mock_cmd_all,
-            "cmd.run": mock_cmd,
-        },
-    ):
-        assert mac_brew.list_upgrades(refresh=False, include_casks=True) == _expected
+    with patch("salt.utils.path.which", MagicMock(return_value=HOMEBREW_BIN)):
+        with patch("salt.modules.mac_brew_pkg.list_pkgs", return_value={}), patch(
+            "salt.modules.mac_brew_pkg._list_pinned", return_value=["foo"]
+        ), patch.dict(
+            mac_brew.__salt__,
+            {
+                "file.get_user": mock_user,
+                "cmd.run_all": mock_cmd_all,
+                "cmd.run": mock_cmd,
+            },
+        ):
+            assert mac_brew.list_upgrades(refresh=False, include_casks=True) == _expected

--- a/tests/pytests/unit/modules/test_mac_brew_pkg.py
+++ b/tests/pytests/unit/modules/test_mac_brew_pkg.py
@@ -115,6 +115,52 @@ def custom_call_brew(*cmd, failhard=True):
                       "tap": "custom/tap",
                       "url": "https://iterm2.com/downloads/stable/iTerm2-3_4_3.zip",
                       "version": "3.4.3"
+                    },
+                    {
+                      "token": "discord",
+                      "full_token": "discord",
+                      "tap": null,
+                      "name": [
+                        "Discord"
+                      ],
+                      "desc": "Voice and text chat software",
+                      "homepage": "https://discord.com/",
+                      "url": "https://dl.discordapp.net/apps/osx/0.0.268/Discord.dmg",
+                      "appcast": null,
+                      "version": "0.0.268",
+                      "versions": {
+                      },
+                      "installed": "0.0.266",
+                      "outdated": false,
+                      "sha256": "dfe12315b717ed06ac24d3eaacb700618e96cbb449ed63d2afadcdb70ad09c55",
+                      "artifacts": [
+                        {
+                          "app": [
+                            "Discord.app"
+                          ]
+                        },
+                        {
+                          "zap": [
+                            {
+                              "trash": [
+                                "~/Library/Application Support/discord",
+                                "~/Library/Caches/com.hnc.Discord",
+                                "~/Library/Caches/com.hnc.Discord.ShipIt",
+                                "~/Library/Cookies/com.hnc.Discord.binarycookies",
+                                "~/Library/Preferences/com.hnc.Discord.helper.plist",
+                                "~/Library/Preferences/com.hnc.Discord.plist",
+                                "~/Library/Saved Application State/com.hnc.Discord.savedState"
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "caveats": null,
+                      "depends_on": {
+                      },
+                      "conflicts_with": null,
+                      "container": null,
+                      "auto_updates": true
                     }
                   ],
                   "formulae": [
@@ -426,6 +472,8 @@ def test_list_pkgs_homebrew_cask_pakages():
     expected_pkgs = {
         "homebrew/cask/day-o": "3.0.1",
         "day-o": "3.0.1",
+        "homebrew/cask/discord": "0.0.266",
+        "discord": "0.0.266",
         "custom/tap/iterm2": "3.4.3",
         "iterm2": "3.4.3",
         "jq": "1.6",

--- a/tests/pytests/unit/modules/test_mac_brew_pkg.py
+++ b/tests/pytests/unit/modules/test_mac_brew_pkg.py
@@ -809,146 +809,148 @@ def test_unhold_not_pinned():
     ):
         assert mac_brew.unhold("foo") == _expected
 
-    def test_info_installed(self):
-        """
-        Tests info_installed method
-        """
-        mock_user = MagicMock(return_value="foo")
-        mock_cmd = MagicMock(return_value="")
-        mock_cmd_all = MagicMock(
-            return_value={
-                "pid": 12345,
-                "retcode": 0,
-                "stderr": "",
-                "stdout": textwrap.dedent(
-                    """\
+
+def test_info_installed(self):
+    """
+    Tests info_installed method
+    """
+    mock_user = MagicMock(return_value="foo")
+    mock_cmd = MagicMock(return_value="")
+    mock_cmd_all = MagicMock(
+        return_value={
+            "pid": 12345,
+            "retcode": 0,
+            "stderr": "",
+            "stdout": textwrap.dedent(
+                """\
+                {
+                  "formulae": [
                     {
-                      "formulae": [
-                        {
-                          "name": "salt",
-                          "full_name": "cdalvaro/tap/salt",
-                          "tap": "cdalvaro/tap",
-                          "aliases": []
-                        },
-                        {
-                          "name": "vim",
-                          "full_name": "vim",
-                          "tap": "homebrew/core",
-                          "aliases": []
-                        }
-                      ],
-                      "casks": [
-                        {
-                          "token": "visual-studio-code",
-                          "full_token": "visual-studio-code",
-                          "tap": "homebrew/cask",
-                          "name": [
-                            "MicrosoftVisualStudioCode",
-                            "VSCode"
-                          ]
-                        }
+                      "name": "salt",
+                      "full_name": "cdalvaro/tap/salt",
+                      "tap": "cdalvaro/tap",
+                      "aliases": []
+                    },
+                    {
+                      "name": "vim",
+                      "full_name": "vim",
+                      "tap": "homebrew/core",
+                      "aliases": []
+                    }
+                  ],
+                  "casks": [
+                    {
+                      "token": "visual-studio-code",
+                      "full_token": "visual-studio-code",
+                      "tap": "homebrew/cask",
+                      "name": [
+                        "MicrosoftVisualStudioCode",
+                        "VSCode"
                       ]
                     }
-                 """
-                ),
-            }
-        )
-        _expected = {
-            "cdalvaro/tap/salt": {
-                "name": "salt",
-                "full_name": "cdalvaro/tap/salt",
-                "tap": "cdalvaro/tap",
-                "aliases": [],
-            },
-            "vim": {
-                "name": "vim",
-                "full_name": "vim",
-                "tap": "homebrew/core",
-                "aliases": [],
-            },
-            "visual-studio-code": {
-                "token": "visual-studio-code",
-                "full_token": "visual-studio-code",
-                "tap": "homebrew/cask",
-                "name": ["MicrosoftVisualStudioCode", "VSCode"],
-            },
+                  ]
+                }
+             """
+            ),
         }
+    )
+    _expected = {
+        "cdalvaro/tap/salt": {
+            "name": "salt",
+            "full_name": "cdalvaro/tap/salt",
+            "tap": "cdalvaro/tap",
+            "aliases": [],
+        },
+        "vim": {
+            "name": "vim",
+            "full_name": "vim",
+            "tap": "homebrew/core",
+            "aliases": [],
+        },
+        "visual-studio-code": {
+            "token": "visual-studio-code",
+            "full_token": "visual-studio-code",
+            "tap": "null",
+            "name": ["MicrosoftVisualStudioCode", "VSCode"],
+        },
+    }
 
-        with patch("salt.modules.mac_brew_pkg.list_pkgs", return_value={}), patch(
-            "salt.modules.mac_brew_pkg._list_pinned", return_value=["foo"]
-        ), patch.dict(
-            mac_brew.__salt__,
-            {
-                "file.get_user": mock_user,
-                "cmd.run_all": mock_cmd_all,
-                "cmd.run": mock_cmd,
-            },
-        ):
-            self.assertEqual(
-                mac_brew.info_installed(
-                    "cdalvaro/tap/salt", "vim", "visual-studio-code"
-                ),
-                _expected,
-            )
+    with patch("salt.modules.mac_brew_pkg.list_pkgs", return_value={}), patch(
+        "salt.modules.mac_brew_pkg._list_pinned", return_value=["foo"]
+    ), patch.dict(
+        mac_brew.__salt__,
+        {
+            "file.get_user": mock_user,
+            "cmd.run_all": mock_cmd_all,
+            "cmd.run": mock_cmd,
+        },
+    ):
+        self.assertEqual(
+            mac_brew.info_installed(
+                "cdalvaro/tap/salt", "vim", "visual-studio-code"
+            ),
+            _expected,
+        )
 
-    def test_list_upgrades(self):
-        """
-        Tests list_upgrades method
-        """
-        mock_user = MagicMock(return_value="foo")
-        mock_cmd = MagicMock(return_value="")
-        mock_cmd_all = MagicMock(
-            return_value={
-                "pid": 12345,
-                "retcode": 0,
-                "stderr": "",
-                "stdout": textwrap.dedent(
-                    """\
+
+def test_list_upgrades(self):
+    """
+    Tests list_upgrades method
+    """
+    mock_user = MagicMock(return_value="foo")
+    mock_cmd = MagicMock(return_value="")
+    mock_cmd_all = MagicMock(
+        return_value={
+            "pid": 12345,
+            "retcode": 0,
+            "stderr": "",
+            "stdout": textwrap.dedent(
+                """\
+                {
+                  "formulae": [
                     {
-                      "formulae": [
-                        {
-                          "name": "cmake",
-                          "installed_versions": ["3.19.3"],
-                          "current_version": "3.19.4",
-                          "pinned": false,
-                          "pinned_version": null
-                        },
-                        {
-                          "name": "fzf",
-                          "installed_versions": ["0.25.0"],
-                          "current_version": "0.25.1",
-                          "pinned": false,
-                          "pinned_version": null
-                        }
-                      ],
-                      "casks": [
-                        {
-                          "name": "ksdiff",
-                          "installed_versions": "2.2.0,122",
-                          "current_version": "2.3.6,123-jan-18-2021"
-                        }
-                      ]
+                      "name": "cmake",
+                      "installed_versions": ["3.19.3"],
+                      "current_version": "3.19.4",
+                      "pinned": false,
+                      "pinned_version": null
+                    },
+                    {
+                      "name": "fzf",
+                      "installed_versions": ["0.25.0"],
+                      "current_version": "0.25.1",
+                      "pinned": false,
+                      "pinned_version": null
                     }
-                    """
-                ),
-            }
-        )
-        _expected = {
-            "cmake": "3.19.4",
-            "fzf": "0.25.1",
-            "ksdiff": "2.3.6,123-jan-18-2021",
+                  ],
+                  "casks": [
+                    {
+                      "name": "ksdiff",
+                      "installed_versions": "2.2.0,122",
+                      "current_version": "2.3.6,123-jan-18-2021"
+                    }
+                  ]
+                }
+                """
+            ),
         }
+    )
+    _expected = {
+        "cmake": "3.19.4",
+        "fzf": "0.25.1",
+        "ksdiff": "2.3.6,123-jan-18-2021",
+    }
 
-        with patch("salt.modules.mac_brew_pkg.list_pkgs", return_value={}), patch(
-            "salt.modules.mac_brew_pkg._list_pinned", return_value=["foo"]
-        ), patch.dict(
-            mac_brew.__salt__,
-            {
-                "file.get_user": mock_user,
-                "cmd.run_all": mock_cmd_all,
-                "cmd.run": mock_cmd,
-            },
-        ):
-            self.assertEqual(
-                mac_brew.list_upgrades(refresh=False, include_casks=True), _expected
-            )
+    with patch("salt.modules.mac_brew_pkg.list_pkgs", return_value={}), patch(
+        "salt.modules.mac_brew_pkg._list_pinned", return_value=["foo"]
+    ), patch.dict(
+        mac_brew.__salt__,
+        {
+            "file.get_user": mock_user,
+            "cmd.run_all": mock_cmd_all,
+            "cmd.run": mock_cmd,
+        },
+    ):
+        self.assertEqual(
+            mac_brew.list_upgrades(refresh=False, include_casks=True), _expected
+        )

--- a/tests/pytests/unit/modules/test_mac_brew_pkg.py
+++ b/tests/pytests/unit/modules/test_mac_brew_pkg.py
@@ -810,7 +810,7 @@ def test_unhold_not_pinned():
         assert mac_brew.unhold("foo") == _expected
 
 
-def test_info_installed(self):
+def test_info_installed():
     """
     Tests info_installed method
     """
@@ -885,13 +885,10 @@ def test_info_installed(self):
             "cmd.run": mock_cmd,
         },
     ):
-        self.assertEqual(
-            mac_brew.info_installed("cdalvaro/tap/salt", "vim", "visual-studio-code"),
-            _expected,
-        )
+        assert mac_brew.info_installed("cdalvaro/tap/salt", "vim", "visual-studio-code") == _expected
 
 
-def test_list_upgrades(self):
+def test_list_upgrades():
     """
     Tests list_upgrades method
     """
@@ -949,6 +946,4 @@ def test_list_upgrades(self):
             "cmd.run": mock_cmd,
         },
     ):
-        self.assertEqual(
-            mac_brew.list_upgrades(refresh=False, include_casks=True), _expected
-        )
+        assert mac_brew.list_upgrades(refresh=False, include_casks=True) == _expected

--- a/tests/pytests/unit/modules/test_mac_brew_pkg.py
+++ b/tests/pytests/unit/modules/test_mac_brew_pkg.py
@@ -886,9 +886,7 @@ def test_info_installed(self):
         },
     ):
         self.assertEqual(
-            mac_brew.info_installed(
-                "cdalvaro/tap/salt", "vim", "visual-studio-code"
-            ),
+            mac_brew.info_installed("cdalvaro/tap/salt", "vim", "visual-studio-code"),
             _expected,
         )
 

--- a/tests/pytests/unit/modules/test_mac_brew_pkg.py
+++ b/tests/pytests/unit/modules/test_mac_brew_pkg.py
@@ -885,7 +885,10 @@ def test_info_installed():
             "cmd.run": mock_cmd,
         },
     ):
-        assert mac_brew.info_installed("cdalvaro/tap/salt", "vim", "visual-studio-code") == _expected
+        assert (
+            mac_brew.info_installed("cdalvaro/tap/salt", "vim", "visual-studio-code")
+            == _expected
+        )
 
 
 def test_list_upgrades():

--- a/tests/pytests/unit/modules/test_mac_brew_pkg.py
+++ b/tests/pytests/unit/modules/test_mac_brew_pkg.py
@@ -887,7 +887,9 @@ def test_info_installed(HOMEBREW_BIN):
             },
         ):
             assert (
-                mac_brew.info_installed("cdalvaro/tap/salt", "vim", "visual-studio-code")
+                mac_brew.info_installed(
+                    "cdalvaro/tap/salt", "vim", "visual-studio-code"
+                )
                 == _expected
             )
 
@@ -951,4 +953,6 @@ def test_list_upgrades(HOMEBREW_BIN):
                 "cmd.run": mock_cmd,
             },
         ):
-            assert mac_brew.list_upgrades(refresh=False, include_casks=True) == _expected
+            assert (
+                mac_brew.list_upgrades(refresh=False, include_casks=True) == _expected
+            )


### PR DESCRIPTION
This PR fixes an issue when the tap from a Homebrew cask is `null`.

This can happen when the cask source is: `homebrew/cask`. For other official formulae, such as _fonts_, the tap field is filled with `homebrew/cask-fonts`, for example.

We append the `tap` value to the package name when _full name_ and _short name_ of a package are the same. We do this for backward compatibility with formulas that install packages as: `homebre/cask/firefox`.

A typical response from the `brew` interface is:

```shell
brew info --json=v2 --installed | jq '.casks | map(select(.token == "firefox"))'
```

```json
[
  {
    "token": "firefox",
    "full_token": "firefox",
    "tap": null,
    "name": [
      "Mozilla Firefox"
    ],
    "desc": "Web browser",
    "homepage": "https://www.mozilla.org/firefox/",
    "url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/105.0.1/mac/en-US/Firefox%20105.0.1.dmg",
    "appcast": null,
    # More stuffs
  }
]
```

This PR also recovers some tests that were tabulated so they weren't executed.

Related issue: #59439

### Previous Behavior

Before this patch, salt fails to check wether a homebrew cask has been installed with the following error:

```
    Function: pkg.installed
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/opt/homebrew/Cellar/salt/3005_1/libexec/lib/python3.10/site-packages/salt/state.py", line 2276, in call
                  ret = self.states[cdata["full"]](
                File "/opt/homebrew/Cellar/salt/3005_1/libexec/lib/python3.10/site-packages/salt/loader/lazy.py", line 149, in __call__
                  return self.loader.run(run_func, *args, **kwargs)
                File "/opt/homebrew/Cellar/salt/3005_1/libexec/lib/python3.10/site-packages/salt/loader/lazy.py", line 1228, in run
                  return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
                File "/opt/homebrew/Cellar/salt/3005_1/libexec/lib/python3.10/site-packages/salt/loader/lazy.py", line 1243, in _run_as
                  return _func_or_method(*args, **kwargs)
                File "/opt/homebrew/Cellar/salt/3005_1/libexec/lib/python3.10/site-packages/salt/loader/lazy.py", line 1276, in wrapper
                  return f(*args, **kwargs)
                File "/opt/homebrew/Cellar/salt/3005_1/libexec/lib/python3.10/site-packages/salt/states/pkg.py", line 1698, in installed
                  result = _find_install_targets(
                File "/opt/homebrew/Cellar/salt/3005_1/libexec/lib/python3.10/site-packages/salt/states/pkg.py", line 567, in _find_install_targets
                  cur_pkgs = __salt__["pkg.list_pkgs"](versions_as_list=True, **kwargs)
                File "/opt/homebrew/Cellar/salt/3005_1/libexec/lib/python3.10/site-packages/salt/loader/lazy.py", line 149, in __call__
                  return self.loader.run(run_func, *args, **kwargs)
                File "/opt/homebrew/Cellar/salt/3005_1/libexec/lib/python3.10/site-packages/salt/loader/lazy.py", line 1228, in run
                  return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
                File "/opt/homebrew/Cellar/salt/3005_1/libexec/lib/python3.10/site-packages/salt/loader/lazy.py", line 1243, in _run_as
                  return _func_or_method(*args, **kwargs)
                File "/var/cache/salt/minion/extmods/modules/mac_brew_pkg.py", line 188, in list_pkgs
                  names.add("/".join([package["tap"], package["token"]]))
              TypeError: sequence item 0: expected str instance, NoneType found
     Started: 15:27:09.666115
    Duration: 4169.847 ms
     Changes:
```

### New Behavior

With the patch applied, packages are successfully installed.

### Merge requirements satisfied?

- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?

Yes
