### PR TITLE
Add necessary options to run salt-ssh as a normal user

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -3093,6 +3093,7 @@ class SaltSSHOptionParser(
     OutputOptionsMixIn,
     SaltfileMixIn,
     HardCrashMixin,
+    CacheDirMixIn,
     NoParseMixin,
     JIDMixin,
     metaclass=OptionParserMeta,

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -3371,6 +3371,11 @@ class SaltSSHOptionParser(
                 "into the default roster file (flat)."
             ),
         )
+        auth_group.add_option(
+            "--pki-dir",
+            dest="pki_dir",
+            help=("Set the directory to load the pki keys."),
+        )
         self.add_option_group(auth_group)
 
         scan_group = optparse.OptionGroup(


### PR DESCRIPTION
### What does this PR do?

This adds the `--cachedir` and `--pki-dir` options necessary for running salt-ssh as a normal user without a config file.

The commits are by @crhan; I had to only make a minor change to fix a merge conflict.

The original PR for this resulted in a merge to the `develop` branch:
https://github.com/saltstack/salt/pull/50802

The changes never got into `master`, though.

### What issues does this PR fix or reference?
Fixes:
https://github.com/saltstack/salt/issues/44073

### Previous Behavior
Errors from salt-ssh when run as a normal user.

### New Behavior
Errors are still present by default, but the user has the option to fix the problem by specifying appropriate `--cachedir` and `--pki-dir` parameters.

Please note that this code was already accepted in:
https://github.com/saltstack/salt/pull/50802

@cachedout, since you approved and merged the original PR, can you please do the same for this one?