### PR TITLE
Run sync_roster when saltutil.sync_all is called

### DIFF
--- a/changelog/53914.fixed
+++ b/changelog/53914.fixed
@@ -1,0 +1,1 @@
+Include sync_roster when sync_all is called.

--- a/salt/runners/saltutil.py
+++ b/salt/runners/saltutil.py
@@ -146,6 +146,11 @@ def sync_all(saltenv="base", extmod_whitelist=None, extmod_blacklist=None):
         extmod_whitelist=extmod_whitelist,
         extmod_blacklist=extmod_blacklist,
     )
+    ret["roster"] = sync_roster(
+        saltenv=saltenv,
+        extmod_whitelist=extmod_whitelist,
+        extmod_blacklist=extmod_blacklist,
+    )
     return ret
 
 

--- a/tests/pytests/integration/runners/test_saltutil.py
+++ b/tests/pytests/integration/runners/test_saltutil.py
@@ -76,7 +76,7 @@ def test_sync(
     """
     Ensure modules are synced when various sync functions are called
     """
-    module_name = "hello"
+    module_name = "hello_sync_{}".format(module_type)
     module_contents = """
 def __virtual__():
     return "hello"
@@ -102,7 +102,7 @@ def _write_module_dir_and_file(module_type, salt_minion, salt_master):
     """
     Write out dummy module to appropriate module location
     """
-    module_name = "hello"
+    module_name = "hello_sync_all"
     module_contents = """
 def __virtual__():
     return "hello"

--- a/tests/pytests/integration/runners/test_saltutil.py
+++ b/tests/pytests/integration/runners/test_saltutil.py
@@ -1,0 +1,142 @@
+from contextlib import ExitStack
+
+import pytest
+
+pytestmark = [
+    pytest.mark.slow_test,
+]
+
+
+def get_module_types():
+    module_types = [
+        "clouds",
+        "modules",
+        "states",
+        "grains",
+        "renderers",
+        "returners",
+        "output",
+        "proxy",
+        "runners",
+        "wheel",
+        "engines",
+        "thorium",
+        "queues",
+        "pillar",
+        "utils",
+        "sdb",
+        "cache",
+        "fileserver",
+        "tops",
+        "tokens",
+        "serializers",
+        "executors",
+        "roster",
+    ]
+    return module_types
+
+
+@pytest.fixture(params=get_module_types())
+def module_type(request):
+    yield request.param
+
+
+@pytest.fixture
+def module_sync_functions():
+    yield {
+        "clouds": "clouds",
+        "modules": "modules",
+        "states": "states",
+        "grains": "grains",
+        "renderers": "renderers",
+        "returners": "returners",
+        "output": "output",
+        "proxy": "proxymodules",
+        "runners": "runners",
+        "wheel": "wheel",
+        "engines": "engines",
+        "thorium": "thorium",
+        "queues": "queues",
+        "pillar": "pillar",
+        "utils": "utils",
+        "sdb": "sdb",
+        "cache": "cache",
+        "fileserver": "fileserver",
+        "tops": "tops",
+        "tokens": "eauth_tokens",
+        "serializers": "serializers",
+        "executors": "executors",
+        "roster": "roster",
+    }
+
+
+def test_sync(
+    module_type, module_sync_functions, salt_run_cli, salt_minion, salt_master
+):
+    """
+    Ensure modules are synced when various sync functions are called
+    """
+    module_name = "hello"
+    module_contents = """
+def __virtual__():
+    return "hello"
+
+def world():
+    return "world"
+"""
+
+    test_moduledir = salt_master.state_tree.base.paths[0] / "_{}".format(module_type)
+    test_moduledir.mkdir(parents=True, exist_ok=True)
+    module_tempfile = salt_master.state_tree.base.temp_file(
+        "_{}/{}.py".format(module_type, module_name), module_contents
+    )
+
+    with module_tempfile, test_moduledir:
+        salt_cmd = "saltutil.sync_{}".format(module_sync_functions[module_type])
+        ret = salt_run_cli.run(salt_cmd)
+        assert ret.returncode == 0
+        assert "{}.hello".format(module_type) in ret.stdout
+
+
+def _write_module_dir_and_file(module_type, salt_minion, salt_master):
+    """
+    Write out dummy module to appropriate module location
+    """
+    module_name = "hello"
+    module_contents = """
+def __virtual__():
+    return "hello"
+
+def world():
+    return "world"
+"""
+
+    test_moduledir = salt_master.state_tree.base.paths[0] / "_{}".format(module_type)
+    test_moduledir.mkdir(parents=True, exist_ok=True)
+
+    module_tempfile = salt_master.state_tree.base.temp_file(
+        "_{}/{}.py".format(module_type, module_name), module_contents
+    )
+
+    return module_tempfile
+
+
+def test_sync_all(salt_run_cli, salt_minion, salt_master):
+    """
+    Ensure all modules are synced when sync_all function is called
+    """
+
+    with ExitStack() as stack:
+        files = [
+            stack.enter_context(
+                _write_module_dir_and_file(_module_type, salt_minion, salt_master)
+            )
+            for _module_type in get_module_types()
+        ]
+
+        salt_cmd = "saltutil.sync_all"
+        ret = salt_run_cli.run(salt_cmd)
+
+        assert ret.returncode == 0
+        for module_type in get_module_types():
+            assert "{}.hello".format(module_type) in ret.stdout

--- a/tests/pytests/unit/runners/test_saltutil.py
+++ b/tests/pytests/unit/runners/test_saltutil.py
@@ -5,6 +5,69 @@ import salt.runners.saltutil as saltutil
 from tests.support.mock import MagicMock, patch
 
 
+def get_module_types():
+    module_types = [
+        "clouds",
+        "modules",
+        "states",
+        "grains",
+        "renderers",
+        "returners",
+        "output",
+        "proxy",
+        "runners",
+        "wheel",
+        "engines",
+        "thorium",
+        "queues",
+        "pillar",
+        "utils",
+        "sdb",
+        "cache",
+        "fileserver",
+        "tops",
+        "tokens",
+        "serializers",
+        "executors",
+        "roster",
+    ]
+    return module_types
+
+
+@pytest.fixture(params=get_module_types())
+def module_type(request):
+    yield request.param
+
+
+@pytest.fixture
+def module_sync_functions():
+    yield {
+        "clouds": "clouds",
+        "modules": "modules",
+        "states": "states",
+        "grains": "grains",
+        "renderers": "renderers",
+        "returners": "returners",
+        "output": "output",
+        "proxy": "proxymodules",
+        "runners": "runners",
+        "wheel": "wheel",
+        "engines": "engines",
+        "thorium": "thorium",
+        "queues": "queues",
+        "pillar": "pillar",
+        "utils": "utils",
+        "sdb": "sdb",
+        "cache": "cache",
+        "fileserver": "fileserver",
+        "tops": "tops",
+        "tokens": "eauth_tokens",
+        "serializers": "serializers",
+        "executors": "executors",
+        "roster": "roster",
+    }
+
+
 @pytest.fixture
 def configure_loader_modules():
     opts = salt.config.DEFAULT_MASTER_OPTS.copy()
@@ -13,8 +76,11 @@ def configure_loader_modules():
 
 
 def test_sync_all():
+    """
+    Test saltutil.sync_all
+    """
     sync_out = MagicMock(return_value=[[], True])
-    roster_keys = [
+    module_types = [
         "clouds",
         "modules",
         "states",
@@ -41,277 +107,24 @@ def test_sync_all():
     ]
     with patch("salt.utils.extmods.sync", sync_out):
         ret = saltutil.sync_all()
-        for key in roster_keys:
+        for key in module_types:
             assert key in ret
 
 
-def test_sync_modules():
+def test_sync(module_type, module_sync_functions):
+    """
+    Test saltutil.sync functions
+    """
     sync_out = MagicMock(return_value=[[], True])
     with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
         ret = saltutil.sync_modules()
-        assert ret == []
-
-        extmods_sync.assert_called_with(
-            {}, "modules", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
-        )
-
-
-def test_sync_states():
-    sync_out = MagicMock(return_value=[[], True])
-    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
-        ret = saltutil.sync_states()
-        assert ret == []
-
-        extmods_sync.assert_called_with(
-            {}, "states", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
-        )
-
-
-def test_sync_grains():
-    sync_out = MagicMock(return_value=[[], True])
-    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
-        ret = saltutil.sync_grains()
-        assert ret == []
-
-        extmods_sync.assert_called_with(
-            {}, "grains", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
-        )
-
-
-def test_sync_renderers():
-    sync_out = MagicMock(return_value=[[], True])
-    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
-        ret = saltutil.sync_renderers()
+        func = "sync_{}".format(module_sync_functions[module_type])
+        ret = getattr(saltutil, func)()
         assert ret == []
 
         extmods_sync.assert_called_with(
             {},
-            "renderers",
-            extmod_blacklist=None,
-            extmod_whitelist=None,
-            saltenv="base",
-        )
-
-
-def test_sync_returners():
-    sync_out = MagicMock(return_value=[[], True])
-    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
-        ret = saltutil.sync_returners()
-        assert ret == []
-
-        extmods_sync.assert_called_with(
-            {},
-            "returners",
-            extmod_blacklist=None,
-            extmod_whitelist=None,
-            saltenv="base",
-        )
-
-
-def test_sync_output():
-    sync_out = MagicMock(return_value=[[], True])
-    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
-        ret = saltutil.sync_output()
-        assert ret == []
-
-        extmods_sync.assert_called_with(
-            {}, "output", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
-        )
-
-
-def test_sync_proxymodules():
-    sync_out = MagicMock(return_value=[[], True])
-    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
-        ret = saltutil.sync_proxymodules()
-        assert ret == []
-
-        extmods_sync.assert_called_with(
-            {}, "proxy", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
-        )
-
-
-def test_sync_runners():
-    sync_out = MagicMock(return_value=[[], True])
-    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
-        ret = saltutil.sync_runners()
-        assert ret == []
-
-        extmods_sync.assert_called_with(
-            {}, "runners", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
-        )
-
-
-def test_sync_wheel():
-    sync_out = MagicMock(return_value=[[], True])
-    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
-        ret = saltutil.sync_wheel()
-        assert ret == []
-
-        extmods_sync.assert_called_with(
-            {}, "wheel", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
-        )
-
-
-def test_sync_engines():
-    sync_out = MagicMock(return_value=[[], True])
-    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
-        ret = saltutil.sync_engines()
-        assert ret == []
-
-        extmods_sync.assert_called_with(
-            {}, "engines", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
-        )
-
-
-def test_sync_thorium():
-    sync_out = MagicMock(return_value=[[], True])
-    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
-        ret = saltutil.sync_thorium()
-        assert ret == []
-
-        extmods_sync.assert_called_with(
-            {}, "thorium", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
-        )
-
-
-def test_sync_queues():
-    sync_out = MagicMock(return_value=[[], True])
-    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
-        ret = saltutil.sync_queues()
-        assert ret == []
-
-        extmods_sync.assert_called_with(
-            {}, "queues", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
-        )
-
-
-def test_sync_pillar():
-    sync_out = MagicMock(return_value=[[], True])
-    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
-        ret = saltutil.sync_pillar()
-        assert ret == []
-
-        extmods_sync.assert_called_with(
-            {}, "pillar", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
-        )
-
-
-def test_sync_utils():
-    sync_out = MagicMock(return_value=[[], True])
-    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
-        ret = saltutil.sync_utils()
-        assert ret == []
-
-        extmods_sync.assert_called_with(
-            {}, "utils", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
-        )
-
-
-def test_sync_sdb():
-    sync_out = MagicMock(return_value=[[], True])
-    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
-        ret = saltutil.sync_sdb()
-        assert ret == []
-
-        extmods_sync.assert_called_with(
-            {}, "sdb", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
-        )
-
-
-def test_sync_tops():
-    sync_out = MagicMock(return_value=[[], True])
-    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
-        ret = saltutil.sync_tops()
-        assert ret == []
-
-        extmods_sync.assert_called_with(
-            {}, "tops", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
-        )
-
-
-def test_sync_cache():
-    sync_out = MagicMock(return_value=[[], True])
-    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
-        ret = saltutil.sync_cache()
-        assert ret == []
-
-        extmods_sync.assert_called_with(
-            {}, "cache", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
-        )
-
-
-def test_sync_fileserver():
-    sync_out = MagicMock(return_value=[[], True])
-    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
-        ret = saltutil.sync_fileserver()
-        assert ret == []
-
-        extmods_sync.assert_called_with(
-            {},
-            "fileserver",
-            extmod_blacklist=None,
-            extmod_whitelist=None,
-            saltenv="base",
-        )
-
-
-def test_sync_clouds():
-    sync_out = MagicMock(return_value=[[], True])
-    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
-        ret = saltutil.sync_clouds()
-        assert ret == []
-
-        extmods_sync.assert_called_with(
-            {}, "clouds", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
-        )
-
-
-def test_sync_roster():
-    sync_out = MagicMock(return_value=[[], True])
-    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
-        ret = saltutil.sync_roster()
-        assert ret == []
-
-        extmods_sync.assert_called_with(
-            {}, "roster", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
-        )
-
-
-def test_sync_eauth_tokens():
-    sync_out = MagicMock(return_value=[[], True])
-    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
-        ret = saltutil.sync_eauth_tokens()
-        assert ret == []
-
-        extmods_sync.assert_called_with(
-            {}, "tokens", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
-        )
-
-
-def test_sync_serializers():
-    sync_out = MagicMock(return_value=[[], True])
-    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
-        ret = saltutil.sync_serializers()
-        assert ret == []
-
-        extmods_sync.assert_called_with(
-            {},
-            "serializers",
-            extmod_blacklist=None,
-            extmod_whitelist=None,
-            saltenv="base",
-        )
-
-
-def test_sync_executors():
-    sync_out = MagicMock(return_value=[[], True])
-    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
-        ret = saltutil.sync_executors()
-        assert ret == []
-
-        extmods_sync.assert_called_with(
-            {},
-            "executors",
+            "{}".format(module_type),
             extmod_blacklist=None,
             extmod_whitelist=None,
             saltenv="base",

--- a/tests/pytests/unit/runners/test_saltutil.py
+++ b/tests/pytests/unit/runners/test_saltutil.py
@@ -1,0 +1,318 @@
+import pytest
+
+import salt.config
+import salt.runners.saltutil as saltutil
+from tests.support.mock import MagicMock, patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+    opts = salt.config.DEFAULT_MASTER_OPTS.copy()
+
+    return {saltutil: {"opts": opts}}
+
+
+def test_sync_all():
+    sync_out = MagicMock(return_value=[[], True])
+    roster_keys = [
+        "clouds",
+        "modules",
+        "states",
+        "grains",
+        "renderers",
+        "returners",
+        "output",
+        "proxymodules",
+        "runners",
+        "wheel",
+        "engines",
+        "thorium",
+        "queues",
+        "pillar",
+        "utils",
+        "sdb",
+        "cache",
+        "fileserver",
+        "tops",
+        "tokens",
+        "serializers",
+        "executors",
+        "roster",
+    ]
+    with patch("salt.utils.extmods.sync", sync_out):
+        ret = saltutil.sync_all()
+        for key in roster_keys:
+            assert key in ret
+
+
+def test_sync_modules():
+    sync_out = MagicMock(return_value=[[], True])
+    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
+        ret = saltutil.sync_modules()
+        assert ret == []
+
+        extmods_sync.assert_called_with(
+            {}, "modules", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
+        )
+
+
+def test_sync_states():
+    sync_out = MagicMock(return_value=[[], True])
+    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
+        ret = saltutil.sync_states()
+        assert ret == []
+
+        extmods_sync.assert_called_with(
+            {}, "states", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
+        )
+
+
+def test_sync_grains():
+    sync_out = MagicMock(return_value=[[], True])
+    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
+        ret = saltutil.sync_grains()
+        assert ret == []
+
+        extmods_sync.assert_called_with(
+            {}, "grains", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
+        )
+
+
+def test_sync_renderers():
+    sync_out = MagicMock(return_value=[[], True])
+    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
+        ret = saltutil.sync_renderers()
+        assert ret == []
+
+        extmods_sync.assert_called_with(
+            {},
+            "renderers",
+            extmod_blacklist=None,
+            extmod_whitelist=None,
+            saltenv="base",
+        )
+
+
+def test_sync_returners():
+    sync_out = MagicMock(return_value=[[], True])
+    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
+        ret = saltutil.sync_returners()
+        assert ret == []
+
+        extmods_sync.assert_called_with(
+            {},
+            "returners",
+            extmod_blacklist=None,
+            extmod_whitelist=None,
+            saltenv="base",
+        )
+
+
+def test_sync_output():
+    sync_out = MagicMock(return_value=[[], True])
+    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
+        ret = saltutil.sync_output()
+        assert ret == []
+
+        extmods_sync.assert_called_with(
+            {}, "output", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
+        )
+
+
+def test_sync_proxymodules():
+    sync_out = MagicMock(return_value=[[], True])
+    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
+        ret = saltutil.sync_proxymodules()
+        assert ret == []
+
+        extmods_sync.assert_called_with(
+            {}, "proxy", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
+        )
+
+
+def test_sync_runners():
+    sync_out = MagicMock(return_value=[[], True])
+    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
+        ret = saltutil.sync_runners()
+        assert ret == []
+
+        extmods_sync.assert_called_with(
+            {}, "runners", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
+        )
+
+
+def test_sync_wheel():
+    sync_out = MagicMock(return_value=[[], True])
+    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
+        ret = saltutil.sync_wheel()
+        assert ret == []
+
+        extmods_sync.assert_called_with(
+            {}, "wheel", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
+        )
+
+
+def test_sync_engines():
+    sync_out = MagicMock(return_value=[[], True])
+    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
+        ret = saltutil.sync_engines()
+        assert ret == []
+
+        extmods_sync.assert_called_with(
+            {}, "engines", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
+        )
+
+
+def test_sync_thorium():
+    sync_out = MagicMock(return_value=[[], True])
+    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
+        ret = saltutil.sync_thorium()
+        assert ret == []
+
+        extmods_sync.assert_called_with(
+            {}, "thorium", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
+        )
+
+
+def test_sync_queues():
+    sync_out = MagicMock(return_value=[[], True])
+    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
+        ret = saltutil.sync_queues()
+        assert ret == []
+
+        extmods_sync.assert_called_with(
+            {}, "queues", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
+        )
+
+
+def test_sync_pillar():
+    sync_out = MagicMock(return_value=[[], True])
+    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
+        ret = saltutil.sync_pillar()
+        assert ret == []
+
+        extmods_sync.assert_called_with(
+            {}, "pillar", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
+        )
+
+
+def test_sync_utils():
+    sync_out = MagicMock(return_value=[[], True])
+    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
+        ret = saltutil.sync_utils()
+        assert ret == []
+
+        extmods_sync.assert_called_with(
+            {}, "utils", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
+        )
+
+
+def test_sync_sdb():
+    sync_out = MagicMock(return_value=[[], True])
+    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
+        ret = saltutil.sync_sdb()
+        assert ret == []
+
+        extmods_sync.assert_called_with(
+            {}, "sdb", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
+        )
+
+
+def test_sync_tops():
+    sync_out = MagicMock(return_value=[[], True])
+    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
+        ret = saltutil.sync_tops()
+        assert ret == []
+
+        extmods_sync.assert_called_with(
+            {}, "tops", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
+        )
+
+
+def test_sync_cache():
+    sync_out = MagicMock(return_value=[[], True])
+    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
+        ret = saltutil.sync_cache()
+        assert ret == []
+
+        extmods_sync.assert_called_with(
+            {}, "cache", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
+        )
+
+
+def test_sync_fileserver():
+    sync_out = MagicMock(return_value=[[], True])
+    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
+        ret = saltutil.sync_fileserver()
+        assert ret == []
+
+        extmods_sync.assert_called_with(
+            {},
+            "fileserver",
+            extmod_blacklist=None,
+            extmod_whitelist=None,
+            saltenv="base",
+        )
+
+
+def test_sync_clouds():
+    sync_out = MagicMock(return_value=[[], True])
+    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
+        ret = saltutil.sync_clouds()
+        assert ret == []
+
+        extmods_sync.assert_called_with(
+            {}, "clouds", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
+        )
+
+
+def test_sync_roster():
+    sync_out = MagicMock(return_value=[[], True])
+    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
+        ret = saltutil.sync_roster()
+        assert ret == []
+
+        extmods_sync.assert_called_with(
+            {}, "roster", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
+        )
+
+
+def test_sync_eauth_tokens():
+    sync_out = MagicMock(return_value=[[], True])
+    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
+        ret = saltutil.sync_eauth_tokens()
+        assert ret == []
+
+        extmods_sync.assert_called_with(
+            {}, "tokens", extmod_blacklist=None, extmod_whitelist=None, saltenv="base"
+        )
+
+
+def test_sync_serializers():
+    sync_out = MagicMock(return_value=[[], True])
+    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
+        ret = saltutil.sync_serializers()
+        assert ret == []
+
+        extmods_sync.assert_called_with(
+            {},
+            "serializers",
+            extmod_blacklist=None,
+            extmod_whitelist=None,
+            saltenv="base",
+        )
+
+
+def test_sync_executors():
+    sync_out = MagicMock(return_value=[[], True])
+    with patch("salt.utils.extmods.sync", sync_out) as extmods_sync:
+        ret = saltutil.sync_executors()
+        assert ret == []
+
+        extmods_sync.assert_called_with(
+            {},
+            "executors",
+            extmod_blacklist=None,
+            extmod_whitelist=None,
+            saltenv="base",
+        )


### PR DESCRIPTION
### What does this PR do?
When saltutil.sync_all is called also call sync_roster.  Adding some very basic unit tests.

### What issues does this PR fix or reference?
Fixes: #53914 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
