### PR TITLE
Fix Salt Syndic return events missing fun_args

### DIFF
--- a/changelog/45823.fixed
+++ b/changelog/45823.fixed
@@ -1,0 +1,1 @@
+Fix fun_args missing from syndic returns

--- a/salt/master.py
+++ b/salt/master.py
@@ -1720,7 +1720,7 @@ class AESFuncs(TransportMethods):
             if any(key not in load for key in ("return", "jid", "id")):
                 continue
             # if we have a load, save it
-            if load.get("load"):
+            if load.get("load") and self.opts["master_job_cache"]:
                 fstr = "{}.save_load".format(self.opts["master_job_cache"])
                 self.mminion.returners[fstr](load["jid"], load["load"])
 

--- a/salt/master.py
+++ b/salt/master.py
@@ -1743,8 +1743,8 @@ class AESFuncs(TransportMethods):
                     ret["master_id"] = load["master_id"]
                 if "fun" in load:
                     ret["fun"] = load["fun"]
-                if "arg" in load:
-                    ret["fun_args"] = load["arg"]
+                if "fun_args" in load:
+                    ret["fun_args"] = load["fun_args"]
                 if "out" in load:
                     ret["out"] = load["out"]
                 if "sig" in load:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -3683,7 +3683,7 @@ class SyndicManager(MinionBase):
                 # __'s to make sure it doesn't print out on the master cli
                 jdict["__master_id__"] = master
             ret = {}
-            for key in "return", "retcode", "success":
+            for key in "return", "retcode", "success", "fun_args":
                 if key in data:
                     ret[key] = data[key]
             jdict[data["id"]] = ret

--- a/tests/pytests/unit/test_master.py
+++ b/tests/pytests/unit/test_master.py
@@ -2,6 +2,21 @@ import time
 
 import salt.master
 from tests.support.mock import patch
+import pytest
+
+
+@pytest.fixture
+def encrypted_requests(tmp_path):
+    # To honor the comment on AESFuncs
+    return salt.master.AESFuncs(
+        opts={
+            "cachedir": str(tmp_path / "cache"),
+            "sock_dir": str(tmp_path / "sock_drawer"),
+            "conf_file": str(tmp_path / "config.conf"),
+            "fileserver_backend": "local",
+            "master_job_cache": False,
+        }
+    )
 
 
 def test_fileserver_duration():
@@ -14,3 +29,96 @@ def test_fileserver_duration():
         update.called_once()
         # Timeout is 1 second
         assert 2 > end - start > 1
+
+
+@pytest.mark.parametrize(
+    "expected_return, payload",
+    (
+        (
+            {
+                "jid": "20221107162714826470",
+                "id": "example-minion",
+                "return": {
+                    "pkg_|-linux-install-utils_|-curl_|-installed": {
+                        "name": "curl",
+                        "changes": {},
+                        "result": True,
+                        "comment": "All specified packages are already installed",
+                        "__sls__": "base-linux.base",
+                        "__run_num__": 0,
+                        "start_time": "08:27:17.594038",
+                        "duration": 32.963,
+                        "__id__": "linux-install-utils",
+                    },
+                },
+                "retcode": 0,
+                "success": True,
+                "fun_args": ["base-linux", {"pillar": {"test": "value"}}],
+                "fun": "state.sls",
+                "out": "highstate",
+            },
+            {
+                "cmd": "_syndic_return",
+                "load": [
+                    {
+                        "id": "aws.us-east-1.salt-syndic",
+                        "jid": "20221107162714826470",
+                        "fun": "state.sls",
+                        "arg": None,
+                        "tgt": None,
+                        "tgt_type": None,
+                        "load": {
+                            "arg": [
+                                "base-linux",
+                                {"pillar": {"test": "value"}, "__kwarg__": True},
+                            ],
+                            "cmd": "publish",
+                            "fun": "state.sls",
+                            "jid": "20221107162714826470",
+                            "ret": "",
+                            "tgt": "example-minion",
+                            "user": "sudo_ubuntu",
+                            "kwargs": {
+                                "show_jid": False,
+                                "delimiter": ":",
+                                "show_timeout": True,
+                            },
+                            "tgt_type": "glob",
+                        },
+                        "return": {
+                            "example-minion": {
+                                "return": {
+                                    "pkg_|-linux-install-utils_|-curl_|-installed": {
+                                        "name": "curl",
+                                        "changes": {},
+                                        "result": True,
+                                        "comment": "All specified packages are already installed",
+                                        "__sls__": "base-linux.base",
+                                        "__run_num__": 0,
+                                        "start_time": "08:27:17.594038",
+                                        "duration": 32.963,
+                                        "__id__": "linux-install-utils",
+                                    },
+                                },
+                                "retcode": 0,
+                                "success": True,
+                                "fun_args": [
+                                    "base-linux",
+                                    {"pillar": {"test": "value"}},
+                                ],
+                            }
+                        },
+                        "out": "highstate",
+                    }
+                ],
+                "_stamp": "2022-11-07T16:27:17.965404",
+            },
+        ),
+    ),
+)
+def test_when_syndic_return_processes_load_then_correct_values_should_be_returned(
+    expected_return, payload, encrypted_requests
+):
+    with patch.object(encrypted_requests, "_return", autospec=True) as fake_return:
+        encrypted_requests._syndic_return(payload)
+        fake_return.assert_called_with(expected_return)

--- a/tests/pytests/unit/test_master.py
+++ b/tests/pytests/unit/test_master.py
@@ -1,8 +1,9 @@
 import time
 
+import pytest
+
 import salt.master
 from tests.support.mock import patch
-import pytest
 
 
 @pytest.fixture


### PR DESCRIPTION
This fixes issue #45823 which is the fun_args value missing from the Salt Syndic returns.

### What does this PR do?
This includes the fun_args value from the Syndic return. Currently this is missing resulting in the fun_args value being null.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/45823

### Previous Behavior
fun_args is null in the return

### New Behavior
fun_args is populated with the correct values

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
