### PR TITLE
Fix vt.Terminal failing test: test_log_sanitize

### DIFF
--- a/tests/pytests/unit/utils/test_vt.py
+++ b/tests/pytests/unit/utils/test_vt.py
@@ -3,7 +3,6 @@ import os
 import signal
 
 import pytest
-
 import salt.utils.vt as vt
 
 

--- a/tests/pytests/unit/utils/test_vt.py
+++ b/tests/pytests/unit/utils/test_vt.py
@@ -1,7 +1,9 @@
+import logging
 import os
 import signal
 
 import pytest
+
 import salt.utils.vt as vt
 
 
@@ -42,10 +44,13 @@ def test_log_sanitize(test_cmd, caplog):
         cmd,
         log_stdout=True,
         log_stderr=True,
+        log_stdout_level="debug",
+        log_stderr_level="debug",
         log_sanitize=password,
         stream_stdout=False,
         stream_stderr=False,
     )
-    ret = term.recv()
+    with caplog.at_level(logging.DEBUG):
+        ret = term.recv()
     assert password not in caplog.text
     assert "******" in caplog.text


### PR DESCRIPTION
Fixes failing test added in a09b4f445052be66f0ac53fd01fa02bfa5b82ea6

We can't assume tests are run at debug level, so this ensures the test
passes regardless of what logging level is currently set by capturing
the output in caplog at DEBUG which stream_stdout/stream_stderr uses by
default.

Signed-off-by: Joe Groocock <jgroocock@cloudflare.com>

---

This fails without this patch for us:
```python
tests/pytests/unit/utils/test_vt.py:30 (test_log_sanitize[echo])
****** !=
test_cmd = 'echo'
caplog = <_pytest.logging.LogCaptureFixture object at 0x7fc94f04d0d0>
    @pytest.mark.parametrize("test_cmd", ["echo", "ls"])
    @pytest.mark.skip_on_windows()
    def test_log_sanitize(test_cmd, caplog):
        """
        test when log_sanitize is passed in
        we do not see the password in either
        standard out or standard error logs
        """
        password = "123456"
        cmd = [test_cmd, password]
        term = vt.Terminal(
            cmd,
            log_stdout=True,
            log_stderr=True,
            log_sanitize=password,
            stream_stdout=False,
            stream_stderr=False,
        )
        ret = term.recv()
        assert password not in caplog.text
>       assert "******" in caplog.text
E       AssertionError: assert '******' in ''
E        +  where '' = <_pytest.logging.LogCaptureFixture object at 0x7fc94f04d0d0>.text
salt/tests/pytests/unit/utils/test_vt.py:51: AssertionError
```

@Ch3LL 