### PR TITLE
fopen: Workaround bad buffering for binary mode

### DIFF
--- a/changelog/62817.fixed
+++ b/changelog/62817.fixed
@@ -1,0 +1,1 @@
+Prevent annoying RuntimeWarning message about line buffering (buffering=1) not being supported in binary mode

--- a/salt/utils/files.py
+++ b/salt/utils/files.py
@@ -6,6 +6,7 @@ Functions for working with files
 import codecs
 import contextlib
 import errno
+import io
 import logging
 import os
 import re
@@ -383,9 +384,11 @@ def fopen(*args, **kwargs):
         kwargs["newline"] = ""
 
     # Workaround callers with bad buffering setting for binary files
-    if kwargs.get("buffering", -1) == 1 and 'b' in kwargs.get("mode", ""):
-        log.debug("Bad buffering specified for '%s'", args[0], stack_info=True)
-        del(kwargs["buffering"])
+    if kwargs.get("buffering") == 1 and "b" in kwargs.get("mode", ""):
+        log.debug(
+            "Line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used"
+        )
+        kwargs["buffering"] = io.DEFAULT_BUFFER_SIZE
 
     f_handle = open(*args, **kwargs)  # pylint: disable=resource-leakage
 

--- a/salt/utils/files.py
+++ b/salt/utils/files.py
@@ -382,6 +382,11 @@ def fopen(*args, **kwargs):
     if not binary and not kwargs.get("newline", None):
         kwargs["newline"] = ""
 
+    # Workaround callers with bad buffering setting for binary files
+    if kwargs.get("buffering", -1) == 1 and 'b' in kwargs.get("mode", ""):
+        log.debug("Bad buffering specified for '%s'", args[0], stack_info=True)
+        del(kwargs["buffering"])
+
     f_handle = open(*args, **kwargs)  # pylint: disable=resource-leakage
 
     if is_fcntl_available():

--- a/tests/pytests/unit/utils/test_files.py
+++ b/tests/pytests/unit/utils/test_files.py
@@ -4,12 +4,13 @@ Unit Tests for functions located in salt/utils/files.py
 
 
 import copy
+import io
 import os
 
 import pytest
 
 import salt.utils.files
-from tests.support.mock import patch
+from tests.support.mock import MagicMock, patch
 
 
 def test_safe_rm():
@@ -73,6 +74,16 @@ def test_fopen_with_disallowed_fds():
                 "fopen() should have been prevented from opening a file "
                 "using {} as the filename".format(invalid_fn)
             )
+
+
+def test_fopen_binary_line_buffering(tmp_path):
+    tmp_file = os.path.join(tmp_path, "foobar")
+    with patch("builtins.open") as open_mock, patch(
+        "salt.utils.files.is_fcntl_available", MagicMock(return_value=False)
+    ):
+        salt.utils.files.fopen(os.path.join(tmp_path, "foobar"), mode="b", buffering=1)
+        assert open_mock.called
+        assert open_mock.call_args[1]["buffering"] == io.DEFAULT_BUFFER_SIZE
 
 
 def _create_temp_structure(temp_directory, structure):


### PR DESCRIPTION
### What does this PR do?

This PR brings https://github.com/saltstack/salt/pull/62779 to a mergeable state by:

- Fixing issues caused by dropping "buffering" from kwargs: what we do is simply set default buffersize as Python would do in case of showing the runtime warning.
- Adding missing unit tests for this fix.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/57584

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
