### PR TITLE
Fix logic for setting keyboard layout

### DIFF
--- a/changelog/62838.fixed
+++ b/changelog/62838.fixed
@@ -1,0 +1,1 @@
+Fix logic for setting keyboard layout.

--- a/tests/pytests/unit/modules/test_keyboard.py
+++ b/tests/pytests/unit/modules/test_keyboard.py
@@ -34,11 +34,11 @@ def test_set_sys():
     """
     Test if it set current system keyboard setting
     """
-    mock = MagicMock(return_value="us")
+    mock = MagicMock(return_value=0)
     with patch.dict(keyboard.__grains__, {"os_family": "RedHat"}):
-        with patch.dict(keyboard.__salt__, {"cmd.run": mock}):
+        with patch.dict(keyboard.__salt__, {"cmd.retcode": mock}):
             with patch.dict(keyboard.__salt__, {"file.sed": MagicMock()}):
-                assert keyboard.set_sys("us") == "us"
+                assert keyboard.set_sys("us") == True
 
 
 # 'get_x' function tests: 1
@@ -60,6 +60,6 @@ def test_set_x():
     """
     Test if it set current X keyboard setting
     """
-    mock = MagicMock(return_value="us")
-    with patch.dict(keyboard.__salt__, {"cmd.run": mock}):
-        assert keyboard.set_x("us") == "us"
+    mock = MagicMock(return_value=0)
+    with patch.dict(keyboard.__salt__, {"cmd.retcode": mock}):
+        assert keyboard.set_x("us") == True

--- a/tests/pytests/unit/states/test_keyboard.py
+++ b/tests/pytests/unit/states/test_keyboard.py
@@ -25,7 +25,7 @@ def test_system():
     ret = {"name": name, "result": True, "comment": "", "changes": {}}
 
     mock = MagicMock(side_effect=[name, "", "", ""])
-    mock_t = MagicMock(side_effect=[True, False])
+    mock_t = MagicMock(side_effect=[True, False, None])
     with patch.dict(
         keyboard.__salt__, {"keyboard.get_sys": mock, "keyboard.set_sys": mock_t}
     ):
@@ -60,7 +60,7 @@ def test_xorg():
     ret = {"name": name, "result": True, "comment": "", "changes": {}}
 
     mock = MagicMock(side_effect=[name, "", "", ""])
-    mock_t = MagicMock(side_effect=[True, False])
+    mock_t = MagicMock(side_effect=[True, False, None])
     with patch.dict(
         keyboard.__salt__, {"keyboard.get_x": mock, "keyboard.set_x": mock_t}
     ):


### PR DESCRIPTION
Currently, when a command fails to set the keyboard layout, salt reports a success. This commit fixes the logic so that the right message is displayed, by checking the command's return code.

Systems running Debian, RedHat and Gentoo will still have the bug; it would be better to fix those, too, but I'm not sure how to get the retcode for those yet because they set the layout with a different command. The x changes have also not been manually tested though those _should_ work. The system changes do fix the issue on my minion.

### What does this PR do?

### What issues does this PR fix or reference?
Fixes: #62838 

### Previous Behavior
When an unavailable keyboard layout was chosen, Salt would report a success but fail to set it.

### New Behavior
When an unavailable keyboard layout is chosen, Salt reports a failure.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
