### PR TITLE
Remove impacket

### DIFF
--- a/changelog/62101.fixed
+++ b/changelog/62101.fixed
@@ -1,0 +1,1 @@
+Remove leftover usage of impacket

--- a/salt/cloud/clouds/saltify.py
+++ b/salt/cloud/clouds/saltify.py
@@ -29,12 +29,11 @@ log = logging.getLogger(__name__)
 
 try:
     # noinspection PyUnresolvedReferences
-    from impacket.smb3 import SessionError as smb3SessionError
-    from impacket.smbconnection import SessionError as smbSessionError
+    from smbprotocol.exceptions import InternalError as smbSessionError
 
-    HAS_IMPACKET = True
+    HAS_SMB = True
 except ImportError:
-    HAS_IMPACKET = False
+    HAS_SMB = False
 
 try:
     # noinspection PyUnresolvedReferences
@@ -339,8 +338,8 @@ def _verify(vm_):
 
         log.debug("Testing Windows authentication method for %s", vm_["name"])
 
-        if not HAS_IMPACKET:
-            log.error("Impacket library not found")
+        if not HAS_SMB:
+            log.error("smbprotocol library not found")
             return False
 
         # Test Windows connection
@@ -359,7 +358,7 @@ def _verify(vm_):
             log.debug("Testing SMB protocol for %s", vm_["name"])
             if __utils__["smb.get_conn"](**kwargs) is False:
                 return False
-        except (smbSessionError, smb3SessionError) as exc:
+        except (smbSessionError) as exc:
             log.error("Exception: %s", exc)
             return False
 


### PR DESCRIPTION
### What does this PR do?
Remove left over usage of impacket. This dependency is causing issues with the salt-master during init stage if this package is installed on py3.9 for Rhel.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/62101

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
