### PR TITLE
Switch from outdated redis-py-cluster to redis-py for cache and returner.

### DIFF
--- a/salt/cache/redis_cache.py
+++ b/salt/cache/redis_cache.py
@@ -181,8 +181,7 @@ except ImportError:
     HAS_REDIS = False
 
 try:
-    from redis.cluster import RedisCluster  # pylint: disable=no-name-in-module
-    from redis.cluster import ClusterNode
+    from redis.cluster import RedisCluster, ClusterNode
 
     HAS_REDIS_CLUSTER = True
 except ImportError:
@@ -220,8 +219,11 @@ def __virtual__():
     if not HAS_REDIS:
         return (False, "Please install the python-redis package.")
     if not HAS_REDIS_CLUSTER and _get_redis_cache_opts()["cluster_mode"]:
-        return (False, "Please install the redis python client at least version 4.1.0-rc1 with cluster\n" \
-                       "support added (https://github.com/redis/redis-py/releases/tag/v4.1.0rc1).")
+        return (
+            False,
+            "Please install the redis python client at least version 4.1.0-rc1 with cluster\n" \
+            "support added (https://github.com/redis/redis-py/releases/tag/v4.1.0rc1)."
+        )
 
     return __virtualname__
 

--- a/salt/cache/redis_cache.py
+++ b/salt/cache/redis_cache.py
@@ -181,7 +181,7 @@ except ImportError:
     HAS_REDIS = False
 
 try:
-    from redis.cluster import RedisCluster, ClusterNode
+    from redis.cluster import ClusterNode, RedisCluster
 
     HAS_REDIS_CLUSTER = True
 except ImportError:
@@ -221,7 +221,7 @@ def __virtual__():
     if not HAS_REDIS_CLUSTER and _get_redis_cache_opts()["cluster_mode"]:
         return (
             False,
-            "Please install the redis python client at least version 4.1.0-rc1 with cluster\n" \
+            "Please install the redis python client at least version 4.1.0-rc1 with cluster\n"
             "support added (https://github.com/redis/redis-py/releases/tag/v4.1.0rc1)."
         )
 

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -127,8 +127,7 @@ log = logging.getLogger(__name__)
 
 try:
     # pylint: disable=no-name-in-module
-    from redis.cluster import RedisCluster
-    from redis.cluster import ClusterNode
+    from redis.cluster import RedisCluster, ClusterNode
 
     # pylint: enable=no-name-in-module
 
@@ -155,8 +154,12 @@ def __virtual__():
             "Could not import redis returner; redis python client is not installed.",
         )
     if not HAS_REDIS_CLUSTER and _get_options().get("cluster_mode", False):
-        return (False, "Please install the redis python client at least version 4.1.0-rc1 with cluster\n" \
-                       "support added (https://github.com/redis/redis-py/releases/tag/v4.1.0rc1).")
+        return (
+            False,
+            "Please install the redis python client at least version 4.1.0-rc1 with cluster\n" \
+            "support added (https://github.com/redis/redis-py/releases/tag/v4.1.0rc1)."
+        )
+
     return __virtualname__
 
 
@@ -259,9 +262,7 @@ def save_load(jid, load, minions=None):
         if minions is None:
             ckminions = salt.utils.minions.CkMinions(__opts__)
             # Retrieve the minions list
-            _res = ckminions.check_minions(
-                load["tgt"], load.get("tgt_type", "glob")
-            )
+            _res = ckminions.check_minions(load["tgt"], load.get("tgt_type", "glob"))
             minions = _res["minions"]
         if minions:
             load["Minions"] = sorted(minions)
@@ -327,7 +328,9 @@ def get_jids():
     serv = _get_serv(ret=None)
     ret = {}
     if HAS_REDIS_CLUSTER: 
-        keys = serv.mget_nonatomic(serv.keys("load:*",target_nodes=RedisCluster.ALL_NODES))
+        keys = serv.mget_nonatomic(
+            serv.keys("load:*",target_nodes=RedisCluster.ALL_NODES)
+        )
     else:
         keys = serv.mget(serv.keys("load:*"))
     for s in keys:
@@ -357,8 +360,8 @@ def clean_old_jobs():
     do manually cleaning here.
     """
     serv = _get_serv(ret=None)
-    ret_jids = serv.keys("ret:*",target_nodes=RedisCluster.ALL_NODES)
-    living_jids = set(serv.keys("load:*",target_nodes=RedisCluster.ALL_NODES))
+    ret_jids = serv.keys("ret:*", target_nodes=RedisCluster.ALL_NODES)
+    living_jids = set(serv.keys("load:*", target_nodes=RedisCluster.ALL_NODES))
     to_remove = []
     for ret_key in ret_jids:
         load_key = ret_key.replace("ret:", "load:", 1)

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -127,7 +127,7 @@ log = logging.getLogger(__name__)
 
 try:
     # pylint: disable=no-name-in-module
-    from redis.cluster import RedisCluster, ClusterNode
+    from redis.cluster import ClusterNode, RedisCluster
 
     # pylint: enable=no-name-in-module
 
@@ -156,7 +156,7 @@ def __virtual__():
     if not HAS_REDIS_CLUSTER and _get_options().get("cluster_mode", False):
         return (
             False,
-            "Please install the redis python client at least version 4.1.0-rc1 with cluster\n" \
+            "Please install the redis python client at least version 4.1.0-rc1 with cluster\n"
             "support added (https://github.com/redis/redis-py/releases/tag/v4.1.0rc1)."
         )
 
@@ -327,9 +327,9 @@ def get_jids():
     """
     serv = _get_serv(ret=None)
     ret = {}
-    if HAS_REDIS_CLUSTER: 
+    if HAS_REDIS_CLUSTER:
         keys = serv.mget_nonatomic(
-            serv.keys("load:*",target_nodes=RedisCluster.ALL_NODES)
+            serv.keys("load:*", target_nodes=RedisCluster.ALL_NODES)
         )
     else:
         keys = serv.mget(serv.keys("load:*"))


### PR DESCRIPTION
### What does this PR do?

It switches from the outdated/deprecated redis-py-cluster module to use the cluster functionality implemented into redis-py directly.

### What issues does this PR fix or reference?
Fixes: #61842
Rework of #61843

### Previous Behavior
cluster mode in redis cache and redis returner didn't work.

### New Behavior
redis cache and returner in cluster mode works

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
