### PR TITLE
Add ipc_write_buffer to master/minion config docs

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -1008,6 +1008,23 @@ is set to ``tcp`` by default on Windows.
 
     ipc_mode: ipc
 
+.. conf_master:: ipc_write_buffer
+
+``ipc_write_buffer``
+-----------------------
+
+Default: ``0``
+
+The maximum size of a message sent via the IPC transport module can be limited
+dynamically or by sharing an integer value lower than the total memory size. When
+the value ``dynamic`` is set, salt will use 2.5% of the total memory as
+``ipc_write_buffer`` value (rounded to an integer). A value of ``0`` disables
+this option.
+
+.. code-block:: yaml
+
+    ipc_write_buffer: 10485760
+
 .. conf_master:: tcp_master_pub_port
 
 ``tcp_master_pub_port``

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -177,7 +177,7 @@ The type of the :conf_minion:`master` variable. Can be ``str``, ``failover``,
 
     master_type: str
 
-If this option is ``str`` (default), multiple hot masters are configured.    
+If this option is ``str`` (default), multiple hot masters are configured.
 Minions can connect to multiple masters simultaneously (all master are "hot").
 
 .. code-block:: yaml
@@ -1493,6 +1493,23 @@ process communications. ``ipc_mode`` is set to ``tcp`` on such systems.
 .. code-block:: yaml
 
     ipc_mode: ipc
+
+.. conf_minion:: ipc_write_buffer
+
+``ipc_write_buffer``
+-----------------------
+
+Default: ``0``
+
+The maximum size of a message sent via the IPC transport module can be limited
+dynamically or by sharing an integer value lower than the total memory size. When
+the value ``dynamic`` is set, salt will use 2.5% of the total memory as
+``ipc_write_buffer`` value (rounded to an integer). A value of ``0`` disables
+this option.
+
+.. code-block:: yaml
+
+    ipc_write_buffer: 10485760
 
 .. conf_minion:: tcp_pub_port
 


### PR DESCRIPTION
This option was introduced in 2016 [1] and typing enforced in 2022 [2]. However, documentation was not added in the master and minion configuration docs. This change adds the mentioned documentation.

1. https://github.com/saltstack/salt/pull/34683
2. https://github.com/saltstack/salt/commit/ea35cb527e715b9930f621f1820a2c764ff23925

Fixes: https://github.com/saltstack/salt/issues/62842

### Commits signed with GPG?
Yes