### PR TITLE
Fix master scheduler with `when` parameter

### DIFF
--- a/changelog/62858.fixed
+++ b/changelog/62858.fixed
@@ -1,0 +1,1 @@
+Fixed master job scheduler using when

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -1064,7 +1064,9 @@ class Schedule:
                         return
                     when_ = self.opts["pillar"]["whens"][i]
                 elif (
-                    "whens" in self.opts["grains"] and i in self.opts["grains"]["whens"]
+                    "grains" in self.opts
+                    and "whens" in self.opts["grains"]
+                    and i in self.opts["grains"]["whens"]
                 ):
                     if not isinstance(self.opts["grains"]["whens"], dict):
                         data[

--- a/tests/pytests/unit/utils/scheduler/test_eval.py
+++ b/tests/pytests/unit/utils/scheduler/test_eval.py
@@ -68,7 +68,8 @@ def _check_last_run(schedule, job_name, runtime=None):
 
 
 @pytest.mark.slow_test
-def test_eval(schedule):
+@pytest.mark.parametrize("master", [False, True])
+def test_eval(schedule, master):
     """
     verify that scheduled job runs
     """
@@ -82,6 +83,10 @@ def test_eval(schedule):
 
     # Add the job to the scheduler
     schedule.opts.update(job)
+
+    # The master does not have grains
+    if master:
+        schedule.opts.pop("grains", None)
 
     # Evaluate 1 second before the run time
     schedule.eval(now=run_time1)


### PR DESCRIPTION
### What does this PR do?
Make the scheduler check if "grains" is set in opts.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/62858

### Previous Behavior
```
Exception 'grains' occurred in scheduled job
```

### New Behavior
Runs the scheduled job.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes
