### PR TITLE
Fix extend+exclude interaction

### DIFF
--- a/changelog/62082.fixed
+++ b/changelog/62082.fixed
@@ -1,0 +1,1 @@
+Ignore extend declarations in sls files that are excluded.

--- a/salt/state.py
+++ b/salt/state.py
@@ -1685,6 +1685,25 @@ class State:
                     else:
                         name = ids[0][0]
 
+                sls_excludes = []
+                # excluded sls are plain list items or dicts with an "sls" key
+                for exclude in high.get("__exclude__", []):
+                    if isinstance(exclude, str):
+                        sls_excludes.append(exclude)
+                    elif exclude.get("sls"):
+                        sls_excludes.append(exclude["sls"])
+
+                if body.get("__sls__") in sls_excludes:
+                    log.debug(
+                        "Cannot extend ID '%s' in '%s:%s' because '%s:%s' is excluded.",
+                        name,
+                        body.get("__env__", "base"),
+                        body.get("__sls__", "base"),
+                        body.get("__env__", "base"),
+                        body.get("__sls__", "base"),
+                    )
+                    continue
+
                 for state, run in body.items():
                     if state.startswith("__"):
                         continue

--- a/tests/pytests/unit/state/test_state_highstate.py
+++ b/tests/pytests/unit/state/test_state_highstate.py
@@ -181,7 +181,7 @@ def test_find_sls_ids_with_exclude(highstate, state_tree_dir):
         with pytest.helpers.temp_file(
             "slsfile1.sls", slsfile1, sls_dir
         ), pytest.helpers.temp_file(
-            "slsfile1.sls", slsfile1, sls_dir
+            "slsfile2.sls", slsfile2, sls_dir
         ), pytest.helpers.temp_file(
             "stateB.sls", stateB, sls_dir
         ), pytest.helpers.temp_file(

--- a/tests/pytests/unit/state/test_state_highstate.py
+++ b/tests/pytests/unit/state/test_state_highstate.py
@@ -3,10 +3,12 @@
 """
 
 import logging
+import textwrap
 
 import pytest  # pylint: disable=unused-import
 
 import salt.state
+from salt.utils.odict import OrderedDict
 
 log = logging.getLogger(__name__)
 
@@ -197,3 +199,151 @@ def test_find_sls_ids_with_exclude(highstate, state_tree_dir):
             high, _ = highstate.render_highstate(matches)
             ret = salt.state.find_sls_ids("issue-47182.stateA.newer", high)
             assert ret == [("somestuff", "cmd")]
+
+
+def test_dont_extend_in_excluded_sls_file(highstate, state_tree_dir):
+    """
+    See https://github.com/saltstack/salt/issues/62082#issuecomment-1245461333
+    """
+    top_sls = textwrap.dedent(
+        """\
+        base:
+          '*':
+            - test1
+            - exclude
+        """
+    )
+    exclude_sls = textwrap.dedent(
+        """\
+       exclude:
+         - sls: test2
+       """
+    )
+    test1_sls = textwrap.dedent(
+        """\
+       include:
+         - test2
+
+       test1:
+         cmd.run:
+           - name: echo test1
+       """
+    )
+    test2_sls = textwrap.dedent(
+        """\
+        extend:
+          test1:
+            cmd.run:
+              - name: echo "override test1 in test2"
+
+        test2-id:
+          cmd.run:
+            - name: echo test2
+        """
+    )
+    sls_dir = str(state_tree_dir)
+    with pytest.helpers.temp_file(
+        "top.sls", top_sls, sls_dir
+    ), pytest.helpers.temp_file(
+        "test1.sls", test1_sls, sls_dir
+    ), pytest.helpers.temp_file(
+        "test2.sls", test2_sls, sls_dir
+    ), pytest.helpers.temp_file(
+        "exclude.sls", exclude_sls, sls_dir
+    ):
+        # manually compile the high data, error checking is not needed in this
+        # test case.
+        top = highstate.get_top()
+        matches = highstate.top_matches(top)
+        high, _ = highstate.render_highstate(matches)
+
+        # high is mutated by call_high and the different "pipeline steps"
+        assert high == OrderedDict(
+            [
+                (
+                    "__extend__",
+                    [
+                        {
+                            "test1": OrderedDict(
+                                [
+                                    ("__sls__", "test2"),
+                                    ("__env__", "base"),
+                                    (
+                                        "cmd",
+                                        [
+                                            OrderedDict(
+                                                [
+                                                    (
+                                                        "name",
+                                                        'echo "override test1 in test2"',
+                                                    )
+                                                ]
+                                            ),
+                                            "run",
+                                        ],
+                                    ),
+                                ]
+                            )
+                        }
+                    ],
+                ),
+                (
+                    "test1",
+                    OrderedDict(
+                        [
+                            (
+                                "cmd",
+                                [
+                                    OrderedDict([("name", "echo test1")]),
+                                    "run",
+                                    {"order": 10001},
+                                ],
+                            ),
+                            ("__sls__", "test1"),
+                            ("__env__", "base"),
+                        ]
+                    ),
+                ),
+                (
+                    "test2-id",
+                    OrderedDict(
+                        [
+                            (
+                                "cmd",
+                                [
+                                    OrderedDict([("name", "echo test2")]),
+                                    "run",
+                                    {"order": 10000},
+                                ],
+                            ),
+                            ("__sls__", "test2"),
+                            ("__env__", "base"),
+                        ]
+                    ),
+                ),
+                ("__exclude__", [OrderedDict([("sls", "test2")])]),
+            ]
+        )
+        highstate.state.call_high(high)
+        # assert that the extend declaration was not applied
+        assert high == OrderedDict(
+            [
+                (
+                    "test1",
+                    OrderedDict(
+                        [
+                            (
+                                "cmd",
+                                [
+                                    OrderedDict([("name", "echo test1")]),
+                                    "run",
+                                    {"order": 10001},
+                                ],
+                            ),
+                            ("__sls__", "test1"),
+                            ("__env__", "base"),
+                        ]
+                    ),
+                )
+            ]
+        )


### PR DESCRIPTION
### What does this PR do?
Exclude declarations that are specified in excluded SLS files are ignored. Users don't expect that exluded SLS files have any effect at all. The PR is a bit rough around the edges, I don't mind cleaning it up a bit but first I'd like to have feedback on the approach I took.

I haven't yet checked if `None` can be in `__exclude__`. If that never happens, I will remove the sentinel object.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/62082

### Previous Behavior
An SLS file that is excluded affects other states if it contains an extend declaration.

### New Behavior
An  SLS file that is excluded does not extend other states.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Always

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
