### PR TITLE
Disable the setuptools user warning "Setuptools is replacing distutils."

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -69,6 +69,14 @@ warnings.filterwarnings(
     append=True,
 )
 
+# Filter the setuptools UserWarning until we stop relying on distutils
+warnings.filterwarnings(
+    "ignore",
+    message="Setuptools is replacing distutils.",
+    category=UserWarning,
+    module="_distutils_hack",
+)
+
 
 def __define_global_system_encoding_variable__():
     import sys

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,8 @@ The setup script for salt
 """
 
 # pylint: disable=file-perms,resource-leakage
+import setuptools  # isort:skip
+
 import contextlib
 import distutils.dist
 import glob


### PR DESCRIPTION
### What does this PR do?
See title.
Once we stop relying on distutils, this filter can be removed.

### Refs
https://jira.eng.vmware.com/browse/VRAE-30141
https://github.com/saltstack/salt/issues/60476
