### PR TITLE
Resolve Dockermod incompatibility with docker-py 6.0.0

### DIFF
--- a/changelog/62882.fixed
+++ b/changelog/62882.fixed
@@ -1,0 +1,1 @@
+Fixed dockermod version_info function for docker-py 6.0.0+

--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -344,7 +344,12 @@ def _get_docker_py_versioninfo():
     try:
         return docker.version_info
     except AttributeError:
-        pass
+        # docker 6.0.0+ exposes version from __version__ attribute
+        try:
+            docker_version = docker.__version__.split(".")
+            return tuple(int(n) for n in docker_version)
+        except AttributeError:
+            pass
 
 
 def _get_client(timeout=NOTSET, **kwargs):


### PR DESCRIPTION
### What does this PR do?
Resolve inability for dockermod to fetch the version on docker-py 6.0.0+

### What issues does this PR fix or reference?
Fixes:
  - Change in docker-py to use a `docker.__version__` string instead of `docker.version_info` tuple https://github.com/docker/docker-py/releases/tag/6.0.0

### Previous Behavior
Attempted to retrieve version info from `docker.version_info`

### New Behavior
The same, but on failure will attempt to retrieve version info from `docker.__version__` and convert it to a tuple of ints

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
