### PR TITLE
 Cosmetic fix in the cassandra_cql module

### DIFF
--- a/changelog/62886.fixed
+++ b/changelog/62886.fixed
@@ -1,0 +1,1 @@
+Moving setting the LOAD_BALANCING_POLICY_MAP dictionary into the try except block that determines if the cassandra_cql module should be made available.

--- a/salt/modules/cassandra_cql.py
+++ b/salt/modules/cassandra_cql.py
@@ -136,25 +136,25 @@ try:
 
     # pylint: enable=import-error,no-name-in-module
     HAS_DRIVER = True
+
+    LOAD_BALANCING_POLICY_MAP = {
+        "HostDistance": HostDistance,
+        "LoadBalancingPolicy": LoadBalancingPolicy,
+        "RoundRobinPolicy": RoundRobinPolicy,
+        "DCAwareRoundRobinPolicy": DCAwareRoundRobinPolicy,
+        "WhiteListRoundRobinPolicy": WhiteListRoundRobinPolicy,
+        "TokenAwarePolicy": TokenAwarePolicy,
+        "HostFilterPolicy": HostFilterPolicy,
+        "SimpleConvictionPolicy": SimpleConvictionPolicy,
+        "ExponentialReconnectionPolicy": ExponentialReconnectionPolicy,
+        "RetryPolicy": RetryPolicy,
+        "IdentityTranslator": IdentityTranslator,
+        "NoSpeculativeExecutionPlan": NoSpeculativeExecutionPlan,
+        "NoSpeculativeExecutionPolicy": NoSpeculativeExecutionPolicy,
+    }
+
 except ImportError:
     pass
-
-
-LOAD_BALANCING_POLICY_MAP = {
-    "HostDistance": HostDistance,
-    "LoadBalancingPolicy": LoadBalancingPolicy,
-    "RoundRobinPolicy": RoundRobinPolicy,
-    "DCAwareRoundRobinPolicy": DCAwareRoundRobinPolicy,
-    "WhiteListRoundRobinPolicy": WhiteListRoundRobinPolicy,
-    "TokenAwarePolicy": TokenAwarePolicy,
-    "HostFilterPolicy": HostFilterPolicy,
-    "SimpleConvictionPolicy": SimpleConvictionPolicy,
-    "ExponentialReconnectionPolicy": ExponentialReconnectionPolicy,
-    "RetryPolicy": RetryPolicy,
-    "IdentityTranslator": IdentityTranslator,
-    "NoSpeculativeExecutionPlan": NoSpeculativeExecutionPlan,
-    "NoSpeculativeExecutionPolicy": NoSpeculativeExecutionPolicy,
-}
 
 
 def __virtual__():


### PR DESCRIPTION
### What does this PR do?
Moving setting the LOAD_BALANCING_POLICY_MAP dictionary into the tryexcept block that determines if the cassandra_cql module should be made available.

### What issues does this PR fix or reference?
Fixes: #62886 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
