### PR TITLE
Add pillar support for vault policy assignment

### DIFF
--- a/salt/modules/vault.py
+++ b/salt/modules/vault.py
@@ -126,7 +126,7 @@ Functions to interact with Hashicorp Vault.
 
     policies
         Policies that are assigned to minions when requesting a token. These
-        can either be static, eg ``saltstack/minions``, or templated with grain
+        can either be static, eg ``saltstack/minions``, or templated with grain or pillar
         values, eg ``my-policies/{grains[os]}``. ``{minion}`` is shorthand for
         ``grains[id]``, eg ``saltstack/minion/{minion}``.
 
@@ -136,13 +136,21 @@ Functions to interact with Hashicorp Vault.
             <faq-grain-security>` for important security information. In short,
             everything except ``grains[id]`` is minion-controlled.
 
-        If a template contains a grain which evaluates to a list, it will be
+        If a template contains a grain or pillar which evaluates to a list, it will be
         expanded into multiple policies. For example, given the template
         ``saltstack/by-role/{grains[roles]}``, and a minion having these grains:
 
         .. code-block:: yaml
 
             grains:
+                roles:
+                    - web
+                    - database
+
+        Alternatively policies can be assigned via pillars ``saltstack/by-role/{pillar[roles]}`` 
+        .. code-block:: yaml
+
+            pillar:
                 roles:
                     - web
                     - database

--- a/salt/modules/vault.py
+++ b/salt/modules/vault.py
@@ -147,15 +147,20 @@ Functions to interact with Hashicorp Vault.
                     - web
                     - database
 
-        Alternatively policies can be assigned via pillars ``saltstack/by-role/{pillar[roles]}`` 
+        The minion will have the policies ``saltstack/by-role/web`` and
+        ``saltstack/by-role/database``.
+
+
+        Alternatively policies can be assigned via pillars ``saltstack/by-role/{pillar[roles]}``.
+         
         .. code-block:: yaml
 
-            pillar:
-                roles:
-                    - web
-                    - database
+            # Pillars assigned to Minion 
+            roles:
+                - web
+                - database
 
-        The minion will have the policies ``saltstack/by-role/web`` and
+        The minion will have the same policies as before, but now assigned via pillar ``saltstack/by-role/web`` and
         ``saltstack/by-role/database``.
 
         .. note::

--- a/salt/runners/vault.py
+++ b/salt/runners/vault.py
@@ -202,11 +202,11 @@ def _get_policies(minion_id, config):
     """
     Get the policies that should be applied to a token for minion_id
     """
-    _, grains, _ = salt.utils.minions.get_minion_data(minion_id, __opts__)
+    _, grains, pillar = salt.utils.minions.get_minion_data(minion_id, __opts__)
     policy_patterns = config.get(
         "policies", ["saltstack/minion/{minion}", "saltstack/minions"]
     )
-    mappings = {"minion": minion_id, "grains": grains or {}}
+    mappings = {"minion": minion_id, "grains": grains or {}, "pillar": pillar or {}}
 
     policies = []
     for pattern in policy_patterns:

--- a/tests/unit/runners/test_vault.py
+++ b/tests/unit/runners/test_vault.py
@@ -66,7 +66,10 @@ class VaultTest(TestCase, LoaderModuleMockMixin):
                 "deeply-nested-list:world",
             ],
             # Test cases -> pillar
-            "single-list-pillar:{pillar[roles]}": ["single-list-pillar:web", "single-list-pillar:database"],
+            "single-list-pillar:{pillar[roles]}": [
+                "single-list-pillar:web",
+                "single-list-pillar:database",
+            ],
             "multiple-lists-pillar:{pillar[roles]}+{pillar[aux]}": [
                 "multiple-lists-pillar:web+foo",
                 "multiple-lists-pillar:web+bar",
@@ -84,7 +87,11 @@ class VaultTest(TestCase, LoaderModuleMockMixin):
         }
 
         # The mappings dict is assembled in _get_policies, so emulate here
-        mappings = {"minion": self.grains["id"], "grains": self.grains, "pillar" : self.pillar}
+        mappings = {
+            "minion": self.grains["id"],
+            "grains": self.grains,
+            "pillar": self.pillar,
+        }
         for case, correct_output in cases.items():
             output = vault._expand_pattern_lists(
                 case, **mappings
@@ -148,7 +155,10 @@ class VaultTest(TestCase, LoaderModuleMockMixin):
                 "case-should-be-lowered:up-low-up"
             ],
             # Test cases -> pillar
-            "single-list-pillar:{pillar[roles]}": ["single-list-pillar:web", "single-list-pillar:database"],
+            "single-list-pillar:{pillar[roles]}": [
+                "single-list-pillar:web",
+                "single-list-pillar:database",
+            ],
             "multiple-lists-pillar:{pillar[roles]}+{pillar[aux]}": [
                 "multiple-lists-pillar:web+foo",
                 "multiple-lists-pillar:web+bar",


### PR DESCRIPTION
### What does this PR do?
SALT.MODULES.VAULT:
- Add pillar support for vault policy assignment 

### Previous Behavior
- Assignment of templated vault policies only via grains

### New Behavior
- Assignment of templated vault policies via grains and pillar

### Merge requirements satisfied?
- [ x] Docs
- [ x] Tests written/updated

### Commits signed with GPG?
- no