### PR TITLE
Pass context to pillar ext

### DIFF
--- a/changelog/62898.added
+++ b/changelog/62898.added
@@ -1,0 +1,1 @@
+Pass the context to pillar ext modules to make it possible to reuse the values from it.

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -46,6 +46,7 @@ def get_pillar(
     pillarenv=None,
     extra_minion_data=None,
     clean_cache=False,
+    context=None,
 ):
     """
     Return the correct pillar driver based on the file_client option
@@ -81,6 +82,7 @@ def get_pillar(
             pillar_override=pillar_override,
             pillarenv=pillarenv,
             clean_cache=clean_cache,
+            context=context,
         )
     return ptype(
         opts,
@@ -92,6 +94,7 @@ def get_pillar(
         pillar_override=pillar_override,
         pillarenv=pillarenv,
         extra_minion_data=extra_minion_data,
+        context=context,
     )
 
 
@@ -309,6 +312,7 @@ class RemotePillar(RemotePillarMixin):
         pillar_override=None,
         pillarenv=None,
         extra_minion_data=None,
+        context=None,
     ):
         self.opts = opts
         self.opts["saltenv"] = saltenv
@@ -333,6 +337,7 @@ class RemotePillar(RemotePillarMixin):
             merge_lists=True,
         )
         self._closing = False
+        self.context = context
 
     def compile_pillar(self):
         """
@@ -406,6 +411,7 @@ class PillarCache:
         pillarenv=None,
         extra_minion_data=None,
         clean_cache=False,
+        context=None,
     ):
         # Yes, we need all of these because we need to route to the Pillar object
         # if we have no cache. This is another refactor target.
@@ -432,6 +438,8 @@ class PillarCache:
             minion_cache_path=self._minion_cache_path(minion_id),
         )
 
+        self.context = context
+
     def _minion_cache_path(self, minion_id):
         """
         Return the path to the cache file for the minion.
@@ -455,6 +463,7 @@ class PillarCache:
             functions=self.functions,
             pillar_override=self.pillar_override,
             pillarenv=self.pillarenv,
+            context=self.context,
         )
         return fresh_pillar.compile_pillar()
 
@@ -530,6 +539,7 @@ class Pillar:
         pillar_override=None,
         pillarenv=None,
         extra_minion_data=None,
+        context=None,
     ):
         self.minion_id = minion_id
         self.ext = ext
@@ -568,7 +578,9 @@ class Pillar:
         if opts.get("pillar_source_merging_strategy"):
             self.merge_strategy = opts["pillar_source_merging_strategy"]
 
-        self.ext_pillars = salt.loader.pillars(ext_pillar_opts, self.functions)
+        self.ext_pillars = salt.loader.pillars(
+            ext_pillar_opts, self.functions, context=context
+        )
         self.ignored_pillars = {}
         self.pillar_override = pillar_override or {}
         if not isinstance(self.pillar_override, dict):

--- a/tests/pytests/unit/test_master.py
+++ b/tests/pytests/unit/test_master.py
@@ -1,7 +1,7 @@
 import time
 
 import salt.master
-from tests.support.mock import patch
+from tests.support.mock import MagicMock, patch
 
 
 def test_fileserver_duration():
@@ -14,3 +14,90 @@ def test_fileserver_duration():
         update.called_once()
         # Timeout is 1 second
         assert 2 > end - start > 1
+
+
+def test_mworker_pass_context():
+    """
+    Test of passing the __context__ to pillar ext module loader
+    """
+    req_channel_mock = MagicMock()
+    local_client_mock = MagicMock()
+
+    opts = {
+        "req_server_niceness": None,
+        "mworker_niceness": None,
+        "sock_dir": "/tmp",
+        "conf_file": "/tmp/fake_conf",
+        "transport": "zeromq",
+        "fileserver_backend": ["roots"],
+        "file_client": "local",
+        "pillar_cache": False,
+        "state_top": "top.sls",
+        "pillar_roots": {},
+    }
+
+    data = {
+        "id": "MINION_ID",
+        "grains": {},
+        "saltenv": None,
+        "pillarenv": None,
+        "pillar_override": {},
+        "extra_minion_data": {},
+        "ver": "2",
+        "cmd": "_pillar",
+    }
+
+    test_context = {"testing": 123}
+
+    def mworker_bind_mock():
+        mworker.aes_funcs.run_func(data["cmd"], data)
+
+    with patch("salt.client.get_local_client", local_client_mock), patch(
+        "salt.master.ClearFuncs", MagicMock()
+    ), patch("salt.minion.MasterMinion", MagicMock()), patch(
+        "salt.utils.verify.valid_id", return_value=True
+    ), patch(
+        "salt.loader.matchers", MagicMock()
+    ), patch(
+        "salt.loader.render", MagicMock()
+    ), patch(
+        "salt.loader.utils", MagicMock()
+    ), patch(
+        "salt.loader.fileserver", MagicMock()
+    ), patch(
+        "salt.loader.minion_mods", MagicMock()
+    ), patch(
+        "salt.loader.LazyLoader", MagicMock()
+    ) as loadler_pillars_mock:
+        mworker = salt.master.MWorker(opts, {}, {}, [req_channel_mock])
+
+        with patch.object(mworker, "_MWorker__bind", mworker_bind_mock), patch.dict(
+            mworker.context, test_context
+        ):
+            mworker.run()
+            assert (
+                loadler_pillars_mock.call_args_list[0][1].get("pack").get("__context__")
+                == test_context
+            )
+
+        loadler_pillars_mock.reset_mock()
+
+        opts.update(
+            {
+                "pillar_cache": True,
+                "pillar_cache_backend": "file",
+                "pillar_cache_ttl": 1000,
+                "cachedir": "/tmp",
+            }
+        )
+
+        mworker = salt.master.MWorker(opts, {}, {}, [req_channel_mock])
+
+        with patch.object(mworker, "_MWorker__bind", mworker_bind_mock), patch.dict(
+            mworker.context, test_context
+        ), patch("salt.utils.cache.CacheFactory.factory", MagicMock()):
+            mworker.run()
+            assert (
+                loadler_pillars_mock.call_args_list[0][1].get("pack").get("__context__")
+                == test_context
+            )


### PR DESCRIPTION
### What does this PR do?
This change makes it possible to pass the context to pillar ext modules and let them store the values in the context.

### Previous Behavior
The `__context__` passed to the pillar ext modules was always empty.

### New Behavior
It's possibe to store the values to the `__context__` and reuse them.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
