### PR TITLE
Removing the deprecated _ext_nodes alias to the master_tops function

### DIFF
--- a/changelog/62917.deprecated
+++ b/changelog/62917.deprecated
@@ -1,0 +1,1 @@
+Removing support for the now deprecated _ext_nodes from salt/master.py.

--- a/salt/master.py
+++ b/salt/master.py
@@ -1199,7 +1199,6 @@ class AESFuncs(TransportMethods):
         "_dir_list",
         "_symlink_list",
         "_file_envs",
-        "_ext_nodes",  # To be removed in 3006 (Sulfur) #60980
     )
 
     def __init__(self, opts, context=None):
@@ -1398,10 +1397,6 @@ class AESFuncs(TransportMethods):
         if load is False:
             return {}
         return self.masterapi._master_tops(load, skip_verify=True)
-
-    # Needed so older minions can request master_tops
-    # To be removed in 3006 (Sulfur) #60980
-    _ext_nodes = _master_tops
 
     def _master_opts(self, load):
         """


### PR DESCRIPTION
### What does this PR do?
Removing the deprecated _ext_nodes alias to the master_tops function

### What issues does this PR fix or reference?
Fixes: #62917 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
