### PR TITLE
Revert "Pass context to pillar ext"

### DIFF
--- a/changelog/62898.added
+++ b/changelog/62898.added
@@ -1,1 +1,0 @@
-Pass the context to pillar ext modules to make it possible to reuse the values from it.

--- a/salt/master.py
+++ b/salt/master.py
@@ -950,7 +950,6 @@ class MWorker(salt.utils.process.SignalHandlingProcess):
         self.k_mtime = 0
         self.stats = collections.defaultdict(lambda: {"mean": 0, "runs": 0})
         self.stat_clock = time.time()
-        self.context = {}
 
     # We need __setstate__ and __getstate__ to also pickle 'SMaster.secrets'.
     # Otherwise, 'SMaster.secrets' won't be copied over to the spawned process
@@ -1138,7 +1137,7 @@ class MWorker(salt.utils.process.SignalHandlingProcess):
             self.key,
         )
         self.clear_funcs.connect()
-        self.aes_funcs = AESFuncs(self.opts, context=self.context)
+        self.aes_funcs = AESFuncs(self.opts)
         salt.utils.crypt.reinit_crypto()
         self.__bind()
 
@@ -1201,7 +1200,7 @@ class AESFuncs(TransportMethods):
         "_file_envs",
     )
 
-    def __init__(self, opts, context=None):
+    def __init__(self, opts):
         """
         Create a new AESFuncs
 
@@ -1211,7 +1210,6 @@ class AESFuncs(TransportMethods):
         :returns: Instance for handling AES operations
         """
         self.opts = opts
-        self.context = context
         self.event = salt.utils.event.get_master_event(
             self.opts, self.opts["sock_dir"], listen=False
         )
@@ -1599,7 +1597,6 @@ class AESFuncs(TransportMethods):
             pillarenv=load.get("pillarenv"),
             extra_minion_data=load.get("extra_minion_data"),
             clean_cache=load.get("clean_cache"),
-            context=self.context,
         )
         data = pillar.compile_pillar()
         self.fs_.update_opts()

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -46,7 +46,6 @@ def get_pillar(
     pillarenv=None,
     extra_minion_data=None,
     clean_cache=False,
-    context=None,
 ):
     """
     Return the correct pillar driver based on the file_client option
@@ -82,7 +81,6 @@ def get_pillar(
             pillar_override=pillar_override,
             pillarenv=pillarenv,
             clean_cache=clean_cache,
-            context=context,
         )
     return ptype(
         opts,
@@ -94,7 +92,6 @@ def get_pillar(
         pillar_override=pillar_override,
         pillarenv=pillarenv,
         extra_minion_data=extra_minion_data,
-        context=context,
     )
 
 
@@ -312,7 +309,6 @@ class RemotePillar(RemotePillarMixin):
         pillar_override=None,
         pillarenv=None,
         extra_minion_data=None,
-        context=None,
     ):
         self.opts = opts
         self.opts["saltenv"] = saltenv
@@ -337,7 +333,6 @@ class RemotePillar(RemotePillarMixin):
             merge_lists=True,
         )
         self._closing = False
-        self.context = context
 
     def compile_pillar(self):
         """
@@ -411,7 +406,6 @@ class PillarCache:
         pillarenv=None,
         extra_minion_data=None,
         clean_cache=False,
-        context=None,
     ):
         # Yes, we need all of these because we need to route to the Pillar object
         # if we have no cache. This is another refactor target.
@@ -438,8 +432,6 @@ class PillarCache:
             minion_cache_path=self._minion_cache_path(minion_id),
         )
 
-        self.context = context
-
     def _minion_cache_path(self, minion_id):
         """
         Return the path to the cache file for the minion.
@@ -463,7 +455,6 @@ class PillarCache:
             functions=self.functions,
             pillar_override=self.pillar_override,
             pillarenv=self.pillarenv,
-            context=self.context,
         )
         return fresh_pillar.compile_pillar()
 
@@ -539,7 +530,6 @@ class Pillar:
         pillar_override=None,
         pillarenv=None,
         extra_minion_data=None,
-        context=None,
     ):
         self.minion_id = minion_id
         self.ext = ext
@@ -578,9 +568,7 @@ class Pillar:
         if opts.get("pillar_source_merging_strategy"):
             self.merge_strategy = opts["pillar_source_merging_strategy"]
 
-        self.ext_pillars = salt.loader.pillars(
-            ext_pillar_opts, self.functions, context=context
-        )
+        self.ext_pillars = salt.loader.pillars(ext_pillar_opts, self.functions)
         self.ignored_pillars = {}
         self.pillar_override = pillar_override or {}
         if not isinstance(self.pillar_override, dict):

--- a/tests/pytests/unit/test_master.py
+++ b/tests/pytests/unit/test_master.py
@@ -1,7 +1,7 @@
 import time
 
 import salt.master
-from tests.support.mock import MagicMock, patch
+from tests.support.mock import patch
 
 
 def test_fileserver_duration():
@@ -14,90 +14,3 @@ def test_fileserver_duration():
         update.called_once()
         # Timeout is 1 second
         assert 2 > end - start > 1
-
-
-def test_mworker_pass_context():
-    """
-    Test of passing the __context__ to pillar ext module loader
-    """
-    req_channel_mock = MagicMock()
-    local_client_mock = MagicMock()
-
-    opts = {
-        "req_server_niceness": None,
-        "mworker_niceness": None,
-        "sock_dir": "/tmp",
-        "conf_file": "/tmp/fake_conf",
-        "transport": "zeromq",
-        "fileserver_backend": ["roots"],
-        "file_client": "local",
-        "pillar_cache": False,
-        "state_top": "top.sls",
-        "pillar_roots": {},
-    }
-
-    data = {
-        "id": "MINION_ID",
-        "grains": {},
-        "saltenv": None,
-        "pillarenv": None,
-        "pillar_override": {},
-        "extra_minion_data": {},
-        "ver": "2",
-        "cmd": "_pillar",
-    }
-
-    test_context = {"testing": 123}
-
-    def mworker_bind_mock():
-        mworker.aes_funcs.run_func(data["cmd"], data)
-
-    with patch("salt.client.get_local_client", local_client_mock), patch(
-        "salt.master.ClearFuncs", MagicMock()
-    ), patch("salt.minion.MasterMinion", MagicMock()), patch(
-        "salt.utils.verify.valid_id", return_value=True
-    ), patch(
-        "salt.loader.matchers", MagicMock()
-    ), patch(
-        "salt.loader.render", MagicMock()
-    ), patch(
-        "salt.loader.utils", MagicMock()
-    ), patch(
-        "salt.loader.fileserver", MagicMock()
-    ), patch(
-        "salt.loader.minion_mods", MagicMock()
-    ), patch(
-        "salt.loader.LazyLoader", MagicMock()
-    ) as loadler_pillars_mock:
-        mworker = salt.master.MWorker(opts, {}, {}, [req_channel_mock])
-
-        with patch.object(mworker, "_MWorker__bind", mworker_bind_mock), patch.dict(
-            mworker.context, test_context
-        ):
-            mworker.run()
-            assert (
-                loadler_pillars_mock.call_args_list[0][1].get("pack").get("__context__")
-                == test_context
-            )
-
-        loadler_pillars_mock.reset_mock()
-
-        opts.update(
-            {
-                "pillar_cache": True,
-                "pillar_cache_backend": "file",
-                "pillar_cache_ttl": 1000,
-                "cachedir": "/tmp",
-            }
-        )
-
-        mworker = salt.master.MWorker(opts, {}, {}, [req_channel_mock])
-
-        with patch.object(mworker, "_MWorker__bind", mworker_bind_mock), patch.dict(
-            mworker.context, test_context
-        ), patch("salt.utils.cache.CacheFactory.factory", MagicMock()):
-            mworker.run()
-            assert (
-                loadler_pillars_mock.call_args_list[0][1].get("pack").get("__context__")
-                == test_context
-            )


### PR DESCRIPTION
Reverts saltstack/salt#62898

See [here](https://jenkins.saltproject.io/job/pr-centosstream-8-x86_64-py3-pytest/job/master/lastCompletedBuild/testReport/tests.pytests.unit/test_master/test_mworker_pass_context/) for the failing test on master branch runs.