### PR TITLE
Try to fix flaky test by setting config mode to apply only

### DIFF
--- a/tests/pytests/functional/modules/test_win_dsc.py
+++ b/tests/pytests/functional/modules/test_win_dsc.py
@@ -15,7 +15,14 @@ pytestmark = [
 
 @pytest.fixture(scope="module")
 def dsc(modules):
-    return modules.dsc
+    # We seem to be hitting an issue where there is a consistency check in
+    # progress during some of the tests. When this happens, the test fails
+    # This should disabled background refreshes
+    # https://github.com/saltstack/salt/issues/62714
+    existing_config_mode = modules.dsc.get_lcm_config()["ConfigurationMode"]
+    modules.dsc.set_lcm_config(config_mode="ApplyOnly")
+    yield modules.dsc
+    modules.dsc.set_lcm_config(config_mode=existing_config_mode)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
### What does this PR do?
An attempt to fix flaky tests here:

```
tests.pytests.functional.modules.test_win_dsc
```
by setting the Config mode to ApplyOnly

### What issues does this PR fix or reference?
Fixes: #62714

### Previous Behavior
The test would intermittently fail

### New Behavior
Test test shouldn't fail anymore

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes