### PR TITLE
Bug 62940 fix cron inconsistency in _write_cron_lines

### DIFF
--- a/changelog/62940.fixed
+++ b/changelog/62940.fixed
@@ -1,0 +1,1 @@
+Allow root user to modify crontab lines for non-root users (except AIX and Solaris). Align crontab line changes with the file ones and also with listing crontab.

--- a/tests/unit/modules/test_cron.py
+++ b/tests/unit/modules/test_cron.py
@@ -1512,9 +1512,7 @@ class PsTestCase(TestCase, LoaderModuleMockMixin):
 
         with patch.dict(cron.__grains__, {"os_family": "AIX"}), patch.dict(
             cron.__salt__, {"cmd.run_all": MagicMock()}
-        ), patch(
-            "salt.utils.files.fpopen", mock_open()
-        ), patch.dict(
+        ), patch("salt.utils.files.fpopen", mock_open()), patch.dict(
             cron.__salt__, {"file.user_to_uid": MagicMock(return_value=1)}
         ), patch(
             "salt.utils.files.mkstemp", MagicMock(return_value=temp_path)
@@ -1537,9 +1535,7 @@ class PsTestCase(TestCase, LoaderModuleMockMixin):
 
         with patch.dict(cron.__grains__, {"os_family": "AIX"}), patch.dict(
             cron.__salt__, {"cmd.run_all": MagicMock()}
-        ), patch(
-            "salt.utils.files.fpopen", mock_open()
-        ), patch.dict(
+        ), patch("salt.utils.files.fpopen", mock_open()), patch.dict(
             cron.__salt__, {"file.user_to_uid": MagicMock(return_value=1)}
         ), patch(
             "salt.utils.files.mkstemp", MagicMock(return_value=temp_path)

--- a/tests/unit/modules/test_cron.py
+++ b/tests/unit/modules/test_cron.py
@@ -1533,7 +1533,7 @@ class PsTestCase(TestCase, LoaderModuleMockMixin):
         temp_path = "some_temp_path"
         crontab_cmd = "crontab {}".format(temp_path)
 
-        with patch.dict(cron.__grains__, {"os_family": "AIX"}), patch.dict(
+        with patch.dict(cron.__grains__, {"os_family": "Solaris"}), patch.dict(
             cron.__salt__, {"cmd.run_all": MagicMock()}
         ), patch("salt.utils.files.fpopen", mock_open()), patch.dict(
             cron.__salt__, {"file.user_to_uid": MagicMock(return_value=1)}

--- a/tests/unit/modules/test_cron.py
+++ b/tests/unit/modules/test_cron.py
@@ -1421,10 +1421,11 @@ class PsTestCase(TestCase, LoaderModuleMockMixin):
             ret = cron.rm_job("DUMMY_USER", "/bin/echo NOT A DROID", 1, 2, 3, 4, 5)
             self.assertEqual("absent", ret)
 
-    def test_write_cron_lines_root_rh(self):
+    def test_write_cron_lines_euid_match_user_rh(self):
         """
         Assert that _write_cron_lines() is called with the correct cron command and user
-        OS: RedHat. User: root. Expected to run with runas argument.
+        OS: RedHat. EUID match User (either root, root or user, user).
+        Expected to run without runas argument.
         """
         temp_path = "some_temp_path"
         crontab_cmd = "crontab {}".format(temp_path)
@@ -1436,8 +1437,6 @@ class PsTestCase(TestCase, LoaderModuleMockMixin):
             new=MagicMock(return_value=True),
         ), patch(
             "salt.utils.files.fpopen", mock_open()
-        ), patch.dict(
-            cron.__salt__, {"file.user_to_uid": MagicMock(return_value=1)}
         ), patch(
             "salt.utils.files.mkstemp", MagicMock(return_value=temp_path)
         ), patch(
@@ -1445,26 +1444,25 @@ class PsTestCase(TestCase, LoaderModuleMockMixin):
         ):
             cron._write_cron_lines("root", "test 123")
             cron.__salt__["cmd.run_all"].assert_called_with(
-                crontab_cmd, python_shell=False, runas="root"
+                crontab_cmd, python_shell=False
             )
 
-    def test_write_cron_lines_non_root_rh(self):
+    def test_write_cron_lines_root_non_root_rh(self):
         """
         Assert that _write_cron_lines() is called with the correct cron command and user
-        OS: RedHat. User: non-root. Expected to run without runas argument.
+        OS: RedHat. EUID: root. User: non-root.
+        Expected to run without runas argument and with -u non-root argument.
         """
         temp_path = "some_temp_path"
-        crontab_cmd = "crontab {}".format(temp_path)
+        crontab_cmd = "crontab -u {} {}".format("non-root", temp_path)
 
         with patch.dict(cron.__grains__, {"os_family": "RedHat"}), patch.dict(
             cron.__salt__, {"cmd.run_all": MagicMock()}
         ), patch(
             "salt.modules.cron._check_instance_uid_match",
-            new=MagicMock(return_value=False),
+            new=MagicMock(side_effect=[False, True]),
         ), patch(
             "salt.utils.files.fpopen", mock_open()
-        ), patch.dict(
-            cron.__salt__, {"file.user_to_uid": MagicMock(return_value=1)}
         ), patch(
             "salt.utils.files.mkstemp", MagicMock(return_value=temp_path)
         ), patch(
@@ -1475,15 +1473,16 @@ class PsTestCase(TestCase, LoaderModuleMockMixin):
                 crontab_cmd, python_shell=False
             )
 
-    def test_write_cron_lines_non_root_aix(self):
+    def test_write_cron_lines_non_root_euid_doesnt_match_user_rh(self):
         """
         Assert that _write_cron_lines() is called with the correct cron command and user
-        OS: AIX. User: non-root. Expected to run with runas argument.
+        OS: RedHat. EUID: non-root. EUID doesn't match User.
+        Expected to run with runas argument.
         """
         temp_path = "some_temp_path"
         crontab_cmd = "crontab {}".format(temp_path)
 
-        with patch.dict(cron.__grains__, {"os_family": "AIX"}), patch.dict(
+        with patch.dict(cron.__grains__, {"os_family": "RedHat"}), patch.dict(
             cron.__salt__, {"cmd.run_all": MagicMock()}
         ), patch(
             "salt.modules.cron._check_instance_uid_match",
@@ -1502,10 +1501,11 @@ class PsTestCase(TestCase, LoaderModuleMockMixin):
                 crontab_cmd, python_shell=False, runas="non-root"
             )
 
-    def test_write_cron_lines_non_root_solaris(self):
+    def test_write_cron_lines_non_root_aix(self):
         """
         Assert that _write_cron_lines() is called with the correct cron command and user
-        OS: Solaris. User: non-root. Expected to run with runas argument.
+        OS: AIX. User: non-root.
+        Expected to run with runas argument.
         """
         temp_path = "some_temp_path"
         crontab_cmd = "crontab {}".format(temp_path)
@@ -1513,8 +1513,30 @@ class PsTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(cron.__grains__, {"os_family": "AIX"}), patch.dict(
             cron.__salt__, {"cmd.run_all": MagicMock()}
         ), patch(
-            "salt.modules.cron._check_instance_uid_match",
-            new=MagicMock(return_value=False),
+            "salt.utils.files.fpopen", mock_open()
+        ), patch.dict(
+            cron.__salt__, {"file.user_to_uid": MagicMock(return_value=1)}
+        ), patch(
+            "salt.utils.files.mkstemp", MagicMock(return_value=temp_path)
+        ), patch(
+            "os.remove", MagicMock()
+        ):
+            cron._write_cron_lines("non-root", "test 123")
+            cron.__salt__["cmd.run_all"].assert_called_with(
+                crontab_cmd, python_shell=False, runas="non-root"
+            )
+
+    def test_write_cron_lines_non_root_solaris(self):
+        """
+        Assert that _write_cron_lines() is called with the correct cron command and user
+        OS: Solaris. User: non-root.
+        Expected to run with runas argument.
+        """
+        temp_path = "some_temp_path"
+        crontab_cmd = "crontab {}".format(temp_path)
+
+        with patch.dict(cron.__grains__, {"os_family": "AIX"}), patch.dict(
+            cron.__salt__, {"cmd.run_all": MagicMock()}
         ), patch(
             "salt.utils.files.fpopen", mock_open()
         ), patch.dict(


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes: Bug #62940

### Previous Behavior
See the bug report: https://github.com/saltstack/salt/issues/62940

### New Behavior
Allow root user to manipulate users crontab via cron.absent.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
