### PR TITLE
Add information about logging for non-Python users [DOCS ONLY]

### DIFF
--- a/doc/ref/configuration/logging/index.rst
+++ b/doc/ref/configuration/logging/index.rst
@@ -4,7 +4,7 @@
 Logging
 =======
 
-The salt project tries to get the logging to work for you and help us solve any
+The Salt Project tries to get the logging to work for you and help us solve any
 issues you might find along the way.
 
 If you want to get some more information on the nitty-gritty of salt's logging
@@ -239,6 +239,11 @@ at the ``debug`` level, and sets a custom module to the ``all`` level:
     'salt.loader.saltmaster.ext.module.custom_module': 'all'
 
 .. conf_log:: log_fmt_jid
+
+You can determine what log call name to use here by adding `%(module)s` to the 
+log format. Typically, it is the path of the file which generates the log 
+without the trailing `.py`` and with path separators replaced with `.`
+
 
 ``log_fmt_jid``
 -------------------


### PR DESCRIPTION
### What does this PR do?
A community member requested we add a note to the log_granular_levels module on the logging topic explaining which log call names are available. OrangeDog provided an explanation for people who don't come from a Python background and then the person who opened the ticket suggested adding the note to the docs. This PR implements that community member's suggestion. See https://github.com/saltstack/salt/issues/60027


### What issues does this PR fix or reference?
Resolves: https://github.com/saltstack/salt/issues/60027


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes?