### PR TITLE
fix small typo

### DIFF
--- a/doc/ref/configuration/logging/index.rst
+++ b/doc/ref/configuration/logging/index.rst
@@ -240,9 +240,9 @@ at the ``debug`` level, and sets a custom module to the ``all`` level:
 
 .. conf_log:: log_fmt_jid
 
-You can determine what log call name to use here by adding `%(module)s` to the 
+You can determine what log call name to use here by adding ``%(module)s`` to the 
 log format. Typically, it is the path of the file which generates the log 
-without the trailing `.py`` and with path separators replaced with `.`
+without the trailing ``.py`` and with path separators replaced with ``.``
 
 
 ``log_fmt_jid``


### PR DESCRIPTION
## What does this PR do?

Missed reviewing the other PR, this one fixes some formatting strings (yay, rST).

### What issues does this PR fix or reference?

Fixes some formatting typos in #62946

### Previous Behavior/Look

![logging_1](https://user-images.githubusercontent.com/189750/197600237-dd271d4f-ecfa-49c6-ab85-b3e30ef42b3a.png) (ignore the orange bit, that was just me actually highlighting text with my cursor)

### New Behavior/Look

![logging_2](https://user-images.githubusercontent.com/189750/197600302-ebb05864-2bb3-4914-8edb-2ab3823cc078.png)

### Merge requirements satisfied?

- [x] Docs 

### Commits signed with GPG?
Yes