### PR TITLE
Use debug instead of error for logging pusher failure

### DIFF
--- a/changelog/62334.fixed
+++ b/changelog/62334.fixed
@@ -1,0 +1,1 @@
+Issue 62334: Displays a debug log message instead of an error log message when the publisher fails to connect

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -426,8 +426,10 @@ class SaltEvent:
                 try:
                     self.pusher.connect(timeout=timeout)
                     self.cpush = True
+                except salt.ext.tornado.iostream.StreamClosedError as exc:
+                    log.debug("Unable to connect pusher: %s", exc)
                 except Exception as exc:  # pylint: disable=broad-except
-                    log.debug(
+                    log.error(
                         "Unable to connect pusher: %s",
                         exc,
                         exc_info_on_loglevel=logging.DEBUG,

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -427,7 +427,7 @@ class SaltEvent:
                     self.pusher.connect(timeout=timeout)
                     self.cpush = True
                 except Exception as exc:  # pylint: disable=broad-except
-                    log.error(
+                    log.debug(
                         "Unable to connect pusher: %s",
                         exc,
                         exc_info_on_loglevel=logging.DEBUG,

--- a/tests/pytests/unit/utils/event/test_event.py
+++ b/tests/pytests/unit/utils/event/test_event.py
@@ -11,14 +11,11 @@ import salt.utils.event
 import salt.utils.stringutils
 from salt.utils.event import SaltEvent
 from tests.support.events import eventpublisher_process, eventsender_process
-from tests.support.mock import MagicMock, patch, call
+from tests.support.mock import patch
 
 NO_LONG_IPC = False
 if getattr(zmq, "IPC_PATH_MAX_LEN", 103) <= 103:
     NO_LONG_IPC = True
-
-# TODO: Remove me
-NO_LONG_IPC = False
 
 pytestmark = [
     pytest.mark.skipif(
@@ -299,8 +296,12 @@ def test_send_master_event(sock_dir):
 def test_connect_pull_should_debug_log_on_StreamClosedError():
     event = SaltEvent(node=None)
     with patch.object(event, "pusher") as mock_pusher:
-        with patch.object(salt.utils.event.log, "debug", auto_spec=True) as mock_log_debug:
-            mock_pusher.connect.side_effect = salt.ext.tornado.iostream.StreamClosedError
+        with patch.object(
+            salt.utils.event.log, "debug", auto_spec=True
+        ) as mock_log_debug:
+            mock_pusher.connect.side_effect = (
+                salt.ext.tornado.iostream.StreamClosedError
+            )
             event.connect_pull()
             call = mock_log_debug.mock_calls[0]
             assert call.args[0] == "Unable to connect pusher: %s"
@@ -312,11 +313,17 @@ def test_connect_pull_should_debug_log_on_StreamClosedError():
 def test_connect_pull_should_error_log_on_other_errors(error):
     event = SaltEvent(node=None)
     with patch.object(event, "pusher") as mock_pusher:
-        with patch.object(salt.utils.event.log, "debug", auto_spec=True) as mock_log_debug:
-            with patch.object(salt.utils.event.log, "error", auto_spec=True) as mock_log_error:
+        with patch.object(
+            salt.utils.event.log, "debug", auto_spec=True
+        ) as mock_log_debug:
+            with patch.object(
+                salt.utils.event.log, "error", auto_spec=True
+            ) as mock_log_error:
                 mock_pusher.connect.side_effect = error
                 event.connect_pull()
                 mock_log_debug.assert_not_called()
                 call = mock_log_error.mock_calls[0]
                 assert call.args[0] == "Unable to connect pusher: %s"
-                assert not isinstance(call.args[1], salt.ext.tornado.iostream.StreamClosedError)
+                assert not isinstance(
+                    call.args[1], salt.ext.tornado.iostream.StreamClosedError
+                )

--- a/tests/pytests/unit/utils/event/test_event.py
+++ b/tests/pytests/unit/utils/event/test_event.py
@@ -2,19 +2,23 @@ import hashlib
 import time
 
 import pytest
-import zmq
 import zmq.eventloop.ioloop
 
 import salt.config
 import salt.ext.tornado.ioloop
+import salt.ext.tornado.iostream
 import salt.utils.event
 import salt.utils.stringutils
+from salt.utils.event import SaltEvent
 from tests.support.events import eventpublisher_process, eventsender_process
+from tests.support.mock import MagicMock, patch, call
 
 NO_LONG_IPC = False
 if getattr(zmq, "IPC_PATH_MAX_LEN", 103) <= 103:
     NO_LONG_IPC = True
 
+# TODO: Remove me
+NO_LONG_IPC = False
 
 pytestmark = [
     pytest.mark.skipif(
@@ -290,3 +294,29 @@ def test_send_master_event(sock_dir):
                     "pretag": None,
                 },
             )
+
+
+def test_connect_pull_should_debug_log_on_StreamClosedError():
+    event = SaltEvent(node=None)
+    with patch.object(event, "pusher") as mock_pusher:
+        with patch.object(salt.utils.event.log, "debug", auto_spec=True) as mock_log_debug:
+            mock_pusher.connect.side_effect = salt.ext.tornado.iostream.StreamClosedError
+            event.connect_pull()
+            call = mock_log_debug.mock_calls[0]
+            assert call.args[0] == "Unable to connect pusher: %s"
+            assert isinstance(call.args[1], salt.ext.tornado.iostream.StreamClosedError)
+            assert call.args[1].args[0] == "Stream is closed"
+
+
+@pytest.mark.parametrize("error", [Exception, KeyError, IOError])
+def test_connect_pull_should_error_log_on_other_errors(error):
+    event = SaltEvent(node=None)
+    with patch.object(event, "pusher") as mock_pusher:
+        with patch.object(salt.utils.event.log, "debug", auto_spec=True) as mock_log_debug:
+            with patch.object(salt.utils.event.log, "error", auto_spec=True) as mock_log_error:
+                mock_pusher.connect.side_effect = error
+                event.connect_pull()
+                mock_log_debug.assert_not_called()
+                call = mock_log_error.mock_calls[0]
+                assert call.args[0] == "Unable to connect pusher: %s"
+                assert not isinstance(call.args[1], salt.ext.tornado.iostream.StreamClosedError)


### PR DESCRIPTION
### What does this PR do?
Lowers the log level when the pusher fails to connect. This was causing an error to show up when running salt-call commands. This makes them debug-level events instead of errors.

This error started occurring with this PR: https://github.com/saltstack/salt/pull/60782

Prior to that PR the exception was just ignored with a `pass`

### What issues does this PR fix or reference?
Fixes: #62334 

### Previous Behavior
The following error would be displayed when running some salt-call commands:
```
(venv) PS C:\src\salt-winrepo-ng> salt-call --local saltutil.sync_grains
[ERROR   ] Unable to connect pusher: Stream is closed
local:
```

### New Behavior
No more error:
```
(venv) PS C:\src\salt> salt-call --local saltutil.sync_grains
local:
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes