### PR TITLE
fixed test_gpg_sign unit test

### DIFF
--- a/changelog/62974.fixed
+++ b/changelog/62974.fixed
@@ -1,0 +1,1 @@
+Fixed test_gpg_sign unit test

--- a/changelog/62974.fixed
+++ b/changelog/62974.fixed
@@ -1,1 +1,0 @@
-Fixed test_gpg_sign unit test

--- a/tests/pytests/unit/modules/test_gpg.py
+++ b/tests/pytests/unit/modules/test_gpg.py
@@ -874,4 +874,4 @@ def test_gpg_sign(gpghome):
                     use_passphrase=True,
                     gnupghome=str(gpghome.path),
                 )
-                assert '-----BEGIN PGP SIGNATURE-----' in str(gpg_sign_output)
+                assert "-----BEGIN PGP SIGNATURE-----" in str(gpg_sign_output)

--- a/tests/pytests/unit/modules/test_gpg.py
+++ b/tests/pytests/unit/modules/test_gpg.py
@@ -861,7 +861,7 @@ def test_gpg_sign(gpghome):
     user_info = MagicMock(
         return_value={"name": "salt", "home": str(gpghome.path), "uid": 1000}
     )
-    pillar_mock = MagicMock(return_value={"gpg_passphrase": GPG_TEST_KEY_PASSPHRASE})
+    pillar_mock = MagicMock(return_value=GPG_TEST_KEY_PASSPHRASE)
     with patch.dict(gpg.__salt__, {"config.option": config_user}):
         with patch.dict(gpg.__salt__, {"user.info": user_info}):
             with patch.dict(gpg.__salt__, {"pillar.get": pillar_mock}):
@@ -869,12 +869,9 @@ def test_gpg_sign(gpghome):
                 assert ret["res"] is True
                 gpg_text_input = "The quick brown fox jumped over the lazy dog"
                 gpg_sign_output = gpg.sign(
-                    config_user,
-                    GPG_TEST_KEY_ID,
-                    gpg_text_input,
-                    None,
-                    None,
-                    True,
-                    str(gpghome.path),
+                    keyid=GPG_TEST_KEY_ID,
+                    text=gpg_text_input,
+                    use_passphrase=True,
+                    gnupghome=str(gpghome.path),
                 )
-                assert gpg_sign_output is not None
+                assert '-----BEGIN PGP SIGNATURE-----' in str(gpg_sign_output)


### PR DESCRIPTION
### What does this PR do?
It fixes the `test_gpg_sign` unit test

### What issues does this PR fix or reference?
Fixes:
https://github.com/saltstack/salt/issues/62974

### Previous Behavior
It didn't correctly configure a passphrase, sign a message, or check for a signed message. 

### New Behavior
The passphrase is now correctly configured, it signs a message, and validates that a signed message was returned. 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes
