### PR TITLE
fixed gpg.decrypt function

### DIFF
--- a/changelog/62977.fixed
+++ b/changelog/62977.fixed
@@ -1,0 +1,1 @@
+Fixed gpg_passphrase issue with gpg decrypt/encrypt functions

--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -1227,30 +1227,21 @@ def encrypt(
         result = gpg.encrypt(
             text,
             recipients,
-            passphrase=gpg_passphrase,
             sign=sign,
+            passphrase=gpg_passphrase,
             always_trust=always_trust,
             output=output,
         )
     elif filename:
         with salt.utils.files.flopen(filename, "rb") as _fp:
-            if output:
-                result = gpg.encrypt_file(
-                    _fp,
-                    recipients,
-                    passphrase=gpg_passphrase,
-                    sign=sign,
-                    always_trust=always_trust,
-                    output=output,
-                )
-            else:
-                result = gpg.encrypt_file(
-                    _fp,
-                    recipients,
-                    passphrase=gpg_passphrase,
-                    sign=sign,
-                    always_trust=always_trust,
-                )
+            result = gpg.encrypt_file(
+                _fp,
+                recipients,
+                sign=sign,
+                passphrase=gpg_passphrase,
+                always_trust=always_trust,
+                output=output,
+            )
     else:
         raise SaltInvocationError("filename or text must be passed.")
 

--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -1229,8 +1229,8 @@ def encrypt(
             recipients,
             passphrase=gpg_passphrase,
             sign=sign,
-            output=output,
-           always_trust=always_trust,
+            always_trust=always_trust,
+            output=output,            
         )
     elif filename:
         with salt.utils.files.flopen(filename, "rb") as _fp:

--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -1194,6 +1194,8 @@ def encrypt(
     always_trust
         Skip key validation and assume that used keys are fully trusted.
 
+        .. versionadded:: 3006.0
+
     gnupghome
         Specify the location where GPG keyring and related files are stored.
 

--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -1224,7 +1224,14 @@ def encrypt(
         gpg_passphrase = None
 
     if text:
-        result = gpg.encrypt(text, recipients, passphrase=gpg_passphrase, sign=sign, output=output, always_trust=always_trust)
+        result = gpg.encrypt(
+            text,
+            recipients,
+            passphrase=gpg_passphrase,
+            sign=sign,
+            output=output,
+           always_trust=always_trust,
+        )
     elif filename:
         with salt.utils.files.flopen(filename, "rb") as _fp:
             if output:
@@ -1232,12 +1239,17 @@ def encrypt(
                     _fp,
                     recipients,
                     passphrase=gpg_passphrase,
-                    output=output,
                     sign=sign,
+                    always_trust=always_trust,
+                    output=output,
                 )
             else:
                 result = gpg.encrypt_file(
-                    _fp, recipients, passphrase=gpg_passphrase, sign=sign, always_trust=always_trust
+                    _fp,
+                    recipients,
+                    passphrase=gpg_passphrase,
+                    sign=sign,
+                    always_trust=always_trust,
                 )
     else:
         raise SaltInvocationError("filename or text must be passed.")

--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -1230,7 +1230,7 @@ def encrypt(
             passphrase=gpg_passphrase,
             sign=sign,
             always_trust=always_trust,
-            output=output,            
+            output=output,
         )
     elif filename:
         with salt.utils.files.flopen(filename, "rb") as _fp:

--- a/tests/pytests/unit/modules/test_gpg.py
+++ b/tests/pytests/unit/modules/test_gpg.py
@@ -865,8 +865,8 @@ def test_gpg_sign(gpghome):
     with patch.dict(gpg.__salt__, {"config.option": config_user}):
         with patch.dict(gpg.__salt__, {"user.info": user_info}):
             with patch.dict(gpg.__salt__, {"pillar.get": pillar_mock}):
-                import_ret = gpg.import_key(None, str(gpghome.priv), "salt", str(gpghome.path))
-                assert import_ret["res"] is True
+                key = gpg.import_key(None, str(gpghome.priv), "salt", str(gpghome.path))
+                assert key["res"] is True
                 gpg_text_input = "The quick brown fox jumped over the lazy dog"
                 ret = gpg.sign(
                     keyid=GPG_TEST_KEY_ID,
@@ -885,8 +885,8 @@ def test_gpg_encrypt_message(gpghome):
     )
     with patch.dict(gpg.__salt__, {"config.option": config_user}):
         with patch.dict(gpg.__salt__, {"user.info": user_info}):
-            import_ret = gpg.import_key(None, str(gpghome.priv), "salt", str(gpghome.path))
-            assert import_ret["res"] is True
+            key = gpg.import_key(None, str(gpghome.priv), "salt", str(gpghome.path))
+            assert key["res"] is True
             gpg_text_input = "The quick brown fox jumped over the lazy dog"
             ret = gpg.encrypt(
                 recipients=GPG_TEST_KEY_ID,
@@ -908,8 +908,8 @@ def test_gpg_encrypt_and_sign_message_with_gpg_passphrase_in_pillar(gpghome):
     with patch.dict(gpg.__salt__, {"config.option": config_user}):
         with patch.dict(gpg.__salt__, {"user.info": user_info}):
             with patch.dict(gpg.__salt__, {"pillar.get": pillar_mock}):
-                import_ret = gpg.import_key(None, str(gpghome.priv), "salt", str(gpghome.path))
-                assert import_ret["res"] is True
+                key = gpg.import_key(None, str(gpghome.priv), "salt", str(gpghome.path))
+                assert key["res"] is True
                 gpg_text_input = "The quick brown fox jumped over the lazy dog"
                 ret = gpg.encrypt(
                     recipients=GPG_TEST_KEY_ID,
@@ -950,8 +950,8 @@ def test_gpg_decrypt_message_with_gpg_passphrase_in_pillar(gpghome):
     with patch.dict(gpg.__salt__, {"config.option": config_user}):
         with patch.dict(gpg.__salt__, {"user.info": user_info}):
             with patch.dict(gpg.__salt__, {"pillar.get": pillar_mock}):
-                import_ret = gpg.import_key(None, str(gpghome.priv), "salt", str(gpghome.path))
-                assert import_ret["res"] is True
+                key = gpg.import_key(None, str(gpghome.priv), "salt", str(gpghome.path))
+                assert key["res"] is True
                 ret = gpg.decrypt(
                     text=gpg_encrypted_message,
                     use_passphrase=True,


### PR DESCRIPTION
### What does this PR do?
 `gpg.decrypt` now works when `use_passphrase=True`

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/62806

### Previous Behavior
 `gpg.decrypt` did not function correctly when `use_passphrase=True` was passed

### New Behavior
 `gpg.decrypt` now functions correctly when `use_passphrase=True` was passed

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes
