### PR TITLE
Fixing slack engine when calling runners

### DIFF
--- a/changelog/52400.fixed
+++ b/changelog/52400.fixed
@@ -1,0 +1,1 @@
+Swapping out args and kwargs for arg and kwarg respectively in the Slack engine when the command passed is a runner.

--- a/salt/engines/slack.py
+++ b/salt/engines/slack.py
@@ -948,7 +948,7 @@ class SlackClient:
             log.debug("Command %s will run via runner_functions", cmd)
             # pylint is tripping
             # pylint: disable=missing-whitespace-after-comma
-            job_id_dict = runner.asynchronous(cmd, {"args": args, "kwargs": kwargs})
+            job_id_dict = runner.asynchronous(cmd, {"arg": args, "kwarg": kwargs})
             job_id = job_id_dict["jid"]
 
         # Default to trying to run as a client module.


### PR DESCRIPTION
### What does this PR do?
swapping out args and kwargs for arg and kwarg respectively in the Slack engine when the command passed is a runner.

### What issues does this PR fix or reference?
Fixes: #52400

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
