### PR TITLE
Make legacy and modern syntax detection work for module.wait

### DIFF
--- a/changelog/62988.fixed
+++ b/changelog/62988.fixed
@@ -1,0 +1,1 @@
+Fixed bug where module.wait states were detected as running legacy module.run syntax

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -376,8 +376,10 @@ def run(**kwargs):
     legacy_run = False
 
     keys = list(kwargs)
-    if "name" in keys:
-        keys.remove("name")
+    ignored_kwargs = ["name", "__reqs__", "sfun"]
+    for item in ignored_kwargs:
+        if item in keys:
+            keys.remove(item)
 
     # The rest of the keys should be function names for new-style syntax
     for name in keys:

--- a/tests/pytests/functional/states/test_module.py
+++ b/tests/pytests/functional/states/test_module.py
@@ -82,7 +82,66 @@ def test_issue_58763_b(tmp_path, modules, state_tree, caplog):
                 mods="issue-58763",
             )
             assert len(ret.raw) == 1
-            print(ret)
             for k in ret.raw:
                 assert ret.raw[k]["result"] is True
             assert "Detected legacy module.run syntax: test.ping" in caplog.messages
+
+
+@pytest.mark.slow_test
+def test_issue_62988_a(tmp_path, modules, state_tree, caplog):
+
+    venv_dir = tmp_path / "issue-2028-pip-installed"
+
+    sls_contents = dedent(
+        """
+    test_foo:
+      test.succeed_with_changes
+
+    run_new:
+      module.wait:
+        - test.random_hash:
+          - size: 10
+          - hash_type: md5
+        - watch:
+          - test: test_foo
+    """
+    )
+    with pytest.helpers.temp_file("issue-62988.sls", sls_contents, state_tree):
+        with caplog.at_level(logging.DEBUG):
+            ret = modules.state.sls(
+                mods="issue-62988",
+            )
+            assert len(ret.raw) == 2
+            for k in ret.raw:
+                assert ret.raw[k]["result"] is True
+            assert "Using new style module.run syntax: run_new" in caplog.messages
+
+
+@pytest.mark.slow_test
+def test_issue_62988_b(tmp_path, modules, state_tree, caplog):
+
+    venv_dir = tmp_path / "issue-2028-pip-installed"
+
+    sls_contents = dedent(
+        """
+    test_foo:
+      test.succeed_with_changes:
+        - watch_in:
+          - module: run_new
+
+    run_new:
+      module.wait:
+        - test.random_hash:
+          - size: 10
+          - hash_type: md5
+    """
+    )
+    with pytest.helpers.temp_file("issue-62988.sls", sls_contents, state_tree):
+        with caplog.at_level(logging.DEBUG):
+            ret = modules.state.sls(
+                mods="issue-62988",
+            )
+            assert len(ret.raw) == 2
+            for k in ret.raw:
+                assert ret.raw[k]["result"] is True
+            assert "Using new style module.run syntax: run_new" in caplog.messages


### PR DESCRIPTION
### What does this PR do?
This PR fixes `module.run` syntax detection when using `module.wait`. It also adds test cases for `module.wait` use-case.

### What issues does this PR fix or reference?
Fixes: #62988 

### Previous Behavior
`module.run` syntax detection did not work for `module.wait` because of additional `kwargs` passed. This led to all `module.wait` syntaxes to be treated as legacy and states to fail if modern style was being used

### New Behavior
`sfun` and `__reqs__` has been added to list of items ignored in `kwargs` when deciding if `module.run` syntax is legacy or modern.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No