### PR TITLE
loader: Add `__opts__` to pack if not already present

### DIFF
--- a/changelog/63013.fixed
+++ b/changelog/63013.fixed
@@ -1,0 +1,3 @@
+The `__opts__` dunder dictionary is now added to the loader's `pack` if not
+already present, which makes it accessible via the
+`salt.loader.context.NamedLoaderContext` class.

--- a/doc/topics/development/modules/developing.rst
+++ b/doc/topics/development/modules/developing.rst
@@ -155,6 +155,11 @@ The following dunder dictionaries are always defined, but may be empty
 __opts__
 --------
 
+..versionchanged:: 3006.0
+
+    The ``__opts__`` dictionary can now be accessed via
+    :py:mod:`~salt.loader.context``.
+
 Defined in: All modules
 
 The ``__opts__`` dictionary contains all of the options passed in the

--- a/salt/loader/lazy.py
+++ b/salt/loader/lazy.py
@@ -590,6 +590,10 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             if key == "logger":
                 continue
             mod_opts[key] = val
+
+        if "__opts__" not in self.pack:
+            self.pack["__opts__"] = mod_opts
+
         return mod_opts
 
     def _iter_files(self, mod_name):

--- a/tests/pytests/unit/loader/test_context.py
+++ b/tests/pytests/unit/loader/test_context.py
@@ -45,3 +45,12 @@ def test_named_loader_context_deepcopy():
     assert coppied.name == named_context.name
     assert id(coppied.loader_context) == id(named_context.loader_context)
     assert id(coppied.default) != id(named_context.default)
+
+
+def test_named_loader_context_opts():
+    loader_context = salt.loader.context.LoaderContext()
+    opts = loader_context.named_context("__opts__")
+    loader = salt.loader.lazy.LazyLoader(["/foo"], opts={"foo": "bar"})
+    with salt.loader.context.loader_context(loader):
+        assert "foo" in opts
+        assert opts["foo"] == "bar"

--- a/tests/pytests/unit/loader/test_lazy.py
+++ b/tests/pytests/unit/loader/test_lazy.py
@@ -119,3 +119,23 @@ def test_missing_loader_from_salt_internal_loaders():
         salt.loader._module_dirs(
             {"extension_modules": "/tmp/foo"}, "missingmodules", "module"
         )
+
+
+def test_loader_pack_always_has_opts(loader_dir):
+    loader = salt.loader.lazy.LazyLoader([loader_dir], opts={"foo": "bar"})
+    assert "__opts__" in loader.pack
+    assert "foo" in loader.pack["__opts__"]
+    assert loader.pack["__opts__"]["foo"] == "bar"
+
+
+def test_loader_pack_opts_not_overwritten(loader_dir):
+    opts = {"foo": "bar"}
+    loader = salt.loader.lazy.LazyLoader(
+        [loader_dir],
+        opts={"foo": "bar"},
+        pack={"__opts__": {"baz": "bif"}},
+    )
+    assert "__opts__" in loader.pack
+    assert "foo" not in loader.pack["__opts__"]
+    assert "baz" in loader.pack["__opts__"]
+    assert loader.pack["__opts__"]["baz"] == "bif"


### PR DESCRIPTION
### What does this PR do?

Adds the `__opts__` dunder dictionary to the loader's `pack` if not already present, which makes it accessible via the `salt.loader.context.NamedLoaderContext` class.

### What issues does this PR fix or reference?

See https://github.com/saltstack/salt/pull/62932#issuecomment-1298016582 for context.

### Previous Behavior

Accessing `__opts__` via `salt.loader.context.NamedLoaderContext` raised a `KeyError: '__opts__'` exception.

### New Behavior

Accessing `__opts__` via `salt.loader.context.NamedLoaderContext` is now possible, and returns (a proxy for) the options dict that is passed to the `LazyLoader` constructor.

### Merge requirements satisfied?

- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?

no