### PR TITLE
Remove uneeded binaries from Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -820,8 +820,6 @@ class SaltDistribution(distutils.dist.Distribution):
         * salt-call
         * salt-cp
         * salt-minion
-        * salt-syndic
-        * spm
 
     When packaged for salt-ssh, the following scripts should be installed:
         * salt-call
@@ -1058,7 +1056,7 @@ class SaltDistribution(distutils.dist.Distribution):
     def _property_data_files(self):
         # Data files common to all scenarios
         data_files = [
-            ("share/man/man1", ["doc/man/salt-call.1", "doc/man/salt-run.1"]),
+            ("share/man/man1", ["doc/man/salt-call.1"]),
             ("share/man/man7", ["doc/man/salt.7"]),
         ]
         if self.ssh_packaging or PACKAGED_FOR_SALT_SSH:
@@ -1072,12 +1070,8 @@ class SaltDistribution(distutils.dist.Distribution):
         if IS_WINDOWS_PLATFORM:
             data_files[0][1].extend(
                 [
-                    "doc/man/salt-api.1",
                     "doc/man/salt-cp.1",
-                    "doc/man/salt-key.1",
                     "doc/man/salt-minion.1",
-                    "doc/man/salt-syndic.1",
-                    "doc/man/spm.1",
                 ]
             )
             return data_files
@@ -1092,6 +1086,7 @@ class SaltDistribution(distutils.dist.Distribution):
                 "doc/man/salt-master.1",
                 "doc/man/salt-minion.1",
                 "doc/man/salt-proxy.1",
+                "doc/man/salt-run.1",
                 "doc/man/spm.1",
                 "doc/man/salt.1",
                 "doc/man/salt-ssh.1",
@@ -1143,7 +1138,7 @@ class SaltDistribution(distutils.dist.Distribution):
     @property
     def _property_scripts(self):
         # Scripts common to all scenarios
-        scripts = ["scripts/salt-call", "scripts/salt-run"]
+        scripts = ["scripts/salt-call"]
         if self.ssh_packaging or PACKAGED_FOR_SALT_SSH:
             scripts.append("scripts/salt-ssh")
             if IS_WINDOWS_PLATFORM:
@@ -1154,12 +1149,8 @@ class SaltDistribution(distutils.dist.Distribution):
         if IS_WINDOWS_PLATFORM:
             scripts.extend(
                 [
-                    "scripts/salt-api",
                     "scripts/salt-cp",
-                    "scripts/salt-key",
                     "scripts/salt-minion",
-                    "scripts/salt-syndic",
-                    "scripts/spm",
                 ]
             )
             return scripts
@@ -1175,6 +1166,7 @@ class SaltDistribution(distutils.dist.Distribution):
                 "scripts/salt-master",
                 "scripts/salt-minion",
                 "scripts/salt-proxy",
+                "scripts/salt-run",
                 "scripts/salt-ssh",
                 "scripts/salt-syndic",
                 "scripts/spm",
@@ -1192,7 +1184,6 @@ class SaltDistribution(distutils.dist.Distribution):
         # console scripts common to all scenarios
         scripts = [
             "salt-call = salt.scripts:salt_call",
-            "salt-run = salt.scripts:salt_run",
         ]
         if self.ssh_packaging or PACKAGED_FOR_SALT_SSH:
             scripts.append("salt-ssh = salt.scripts:salt_ssh")
@@ -1205,12 +1196,8 @@ class SaltDistribution(distutils.dist.Distribution):
         if IS_WINDOWS_PLATFORM:
             scripts.extend(
                 [
-                    "salt-api = salt.scripts:salt_api",
                     "salt-cp = salt.scripts:salt_cp",
-                    "salt-key = salt.scripts:salt_key",
                     "salt-minion = salt.scripts:salt_minion",
-                    "salt-syndic = salt.scripts:salt_syndic",
-                    "spm = salt.scripts:salt_spm",
                 ]
             )
             entrypoints["console_scripts"] = scripts
@@ -1226,6 +1213,7 @@ class SaltDistribution(distutils.dist.Distribution):
                 "salt-key = salt.scripts:salt_key",
                 "salt-master = salt.scripts:salt_master",
                 "salt-minion = salt.scripts:salt_minion",
+                "salt-run = salt.scripts:salt_run",
                 "salt-ssh = salt.scripts:salt_ssh",
                 "salt-syndic = salt.scripts:salt_syndic",
                 "spm = salt.scripts:salt_spm",

--- a/setup.py
+++ b/setup.py
@@ -832,6 +832,9 @@ class SaltDistribution(distutils.dist.Distribution):
             * salt-cloud
             * salt-run
 
+    To build all binaries on Windows set the SALT_BUILD_ALL_BINS environment
+    variable to `1`
+
     Under *nix, all scripts should be installed
     """
 
@@ -1061,13 +1064,13 @@ class SaltDistribution(distutils.dist.Distribution):
         ]
         if self.ssh_packaging or PACKAGED_FOR_SALT_SSH:
             data_files[0][1].append("doc/man/salt-ssh.1")
-            if IS_WINDOWS_PLATFORM:
+            if IS_WINDOWS_PLATFORM and not os.environ.get("SALT_BUILD_ALL_BINS"):
                 return data_files
             data_files[0][1].append("doc/man/salt-cloud.1")
 
             return data_files
 
-        if IS_WINDOWS_PLATFORM:
+        if IS_WINDOWS_PLATFORM and not os.environ.get("SALT_BUILD_ALL_BINS"):
             data_files[0][1].extend(
                 [
                     "doc/man/salt-cp.1",
@@ -1141,12 +1144,12 @@ class SaltDistribution(distutils.dist.Distribution):
         scripts = ["scripts/salt-call"]
         if self.ssh_packaging or PACKAGED_FOR_SALT_SSH:
             scripts.append("scripts/salt-ssh")
-            if IS_WINDOWS_PLATFORM:
+            if IS_WINDOWS_PLATFORM and not os.environ.get("SALT_BUILD_ALL_BINS"):
                 return scripts
             scripts.extend(["scripts/salt-cloud", "scripts/spm"])
             return scripts
 
-        if IS_WINDOWS_PLATFORM:
+        if IS_WINDOWS_PLATFORM and not os.environ.get("SALT_BUILD_ALL_BINS"):
             scripts.extend(
                 [
                     "scripts/salt-cp",
@@ -1187,13 +1190,13 @@ class SaltDistribution(distutils.dist.Distribution):
         ]
         if self.ssh_packaging or PACKAGED_FOR_SALT_SSH:
             scripts.append("salt-ssh = salt.scripts:salt_ssh")
-            if IS_WINDOWS_PLATFORM:
+            if IS_WINDOWS_PLATFORM and not os.environ.get("SALT_BUILD_ALL_BINS"):
                 return {"console_scripts": scripts}
             scripts.append("salt-cloud = salt.scripts:salt_cloud")
             entrypoints["console_scripts"] = scripts
             return entrypoints
 
-        if IS_WINDOWS_PLATFORM:
+        if IS_WINDOWS_PLATFORM and not os.environ.get("SALT_BUILD_ALL_BINS"):
             scripts.extend(
                 [
                     "salt-cp = salt.scripts:salt_cp",


### PR DESCRIPTION
### What does this PR do?
Removes binaries related to master. They're being cleaned up by the build script anyway.

### Previous Behavior
It was building the following binaries:
- salt-api
- salt-key
- salt-syndic
- spm

### New Behavior
Now it only builds the following:
- salt-call
- salt-cp
- salt-minion

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes