### PR TITLE
Cleanup PAexec on disconnect

### DIFF
--- a/changelog/62152.fixed
+++ b/changelog/62152.fixed
@@ -1,0 +1,1 @@
+Make sure lingering PAexec-*.exe files in the Windows directory are cleaned up

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -901,6 +901,7 @@ class Client:
         return self._client.connect()
 
     def disconnect(self):
+        self._client.cleanup()  # This removes the lingering PAExec binary
         return self._client.disconnect()
 
     def create_service(self):

--- a/tests/pytests/unit/utils/test_cloud.py
+++ b/tests/pytests/unit/utils/test_cloud.py
@@ -210,6 +210,8 @@ def test_run_psexec_command_cleanup_lingering_paexec():
     pytest.importorskip("pypsexec.client", reason="Requires PyPsExec")
     mock_psexec = patch("salt.utils.cloud.PsExecClient", autospec=True)
     mock_scmr = patch("salt.utils.cloud.ScmrService", autospec=True)
+    # We're mocking 'remove_service' because all we care about is the cleanup
+    # command
     mock_rm_svc = patch("salt.utils.cloud.Client.remove_service", autospec=True)
     with mock_psexec as mock_client, mock_scmr, mock_rm_svc:
         mock_client.return_value.session = MagicMock(username="Gary")

--- a/tests/pytests/unit/utils/test_cloud.py
+++ b/tests/pytests/unit/utils/test_cloud.py
@@ -206,6 +206,29 @@ def test_deploy_windows_custom_port():
         mock.assert_called_once_with("test", "Administrator", None, 1234)
 
 
+def test_run_psexec_command_cleanup_lingering_paexec():
+    pytest.importorskip("pypsexec.client", reason="Requires PyPsExec")
+    mock_psexec = patch("salt.utils.cloud.PsExecClient", autospec=True)
+    mock_scmr = patch("salt.utils.cloud.ScmrService", autospec=True)
+    mock_rm_svc = patch("salt.utils.cloud.Client.remove_service", autospec=True)
+    with mock_psexec as mock_client, mock_scmr, mock_rm_svc:
+        mock_client.return_value.session = MagicMock(username="Gary")
+        mock_client.return_value.connection = MagicMock(server_name="Krabbs")
+        mock_client.return_value.run_executable.return_value = (
+            "Sandy",
+            "MermaidMan",
+            "BarnicleBoy",
+        )
+        cloud.run_psexec_command(
+            "spongebob",
+            "squarepants",
+            "patrick",
+            "squidward",
+            "plankton",
+        )
+        mock_client.return_value.cleanup.assert_called_once()
+
+
 @pytest.mark.skip_unless_on_windows(reason="Only applicable for Windows.")
 def test_deploy_windows_programdata():
     """

--- a/tests/pytests/unit/utils/test_cloud.py
+++ b/tests/pytests/unit/utils/test_cloud.py
@@ -213,7 +213,7 @@ def test_run_psexec_command_cleanup_lingering_paexec():
     # We're mocking 'remove_service' because all we care about is the cleanup
     # command
     mock_rm_svc = patch("salt.utils.cloud.Client.remove_service", autospec=True)
-    with mock_psexec as mock_client, mock_scmr, mock_rm_svc:
+    with mock_scmr, mock_rm_svc, mock_psexec as mock_client:
         mock_client.return_value.session = MagicMock(username="Gary")
         mock_client.return_value.connection = MagicMock(server_name="Krabbs")
         mock_client.return_value.run_executable.return_value = (


### PR DESCRIPTION
### What does this PR do?
Attempts to use the cleanup() function of the pypsexec client to clean up binaries on disconnect.

Wayne and I verified that the `cleanup()` function does in fact clean up any lingering PAexe-*.exe files in the Windows directory.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/62152

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes