### PR TITLE
Add quiet mode for file.touch state

### DIFF
--- a/changelog/63035.added
+++ b/changelog/63035.added
@@ -1,0 +1,1 @@
+Add quiet mode for file.touch state

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -7253,8 +7253,11 @@ def patch(
                     )
 
 
-def touch(name, atime=None, mtime=None, makedirs=False):
+def touch(name, atime=None, mtime=None, makedirs=False, quiet=False):
     """
+    .. versionadded:: 0.9.5
+    .. versionchanged:: 3006.0
+
     Replicate the 'nix "touch" command to create a new empty
     file or update the atime and mtime of an existing file.
 
@@ -7277,6 +7280,11 @@ def touch(name, atime=None, mtime=None, makedirs=False):
         whether we should create the parent directory/directories in order to
         touch the file
 
+    quiet
+        don't report changes unless a new file was created.
+
+        .. versionadded:: 3006.0
+
     Usage:
 
     .. code-block:: yaml
@@ -7284,7 +7292,6 @@ def touch(name, atime=None, mtime=None, makedirs=False):
         /var/log/httpd/logrotate.empty:
           file.touch
 
-    .. versionadded:: 0.9.5
     """
     name = os.path.expanduser(name)
 
@@ -7319,7 +7326,8 @@ def touch(name, atime=None, mtime=None, makedirs=False):
         ret["comment"] = "Updated times on {} {}".format(
             "directory" if os.path.isdir(name) else "file", name
         )
-        ret["changes"]["touched"] = name
+        if not quiet:
+            ret["changes"]["touched"] = name
 
     return ret
 


### PR DESCRIPTION
### What does this PR do?
See issue for details

### What issues does this PR fix or reference?
Fixes: #63035

### Previous Behavior
file.touch reported changes on every run

### New Behavior
the new `quiet` parameter will allow file.touch to run "clean" when not creating a new file 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
