### PR TITLE
Make salt-ssh respect `--wipe` again

### DIFF
--- a/changelog/61083.fixed
+++ b/changelog/61083.fixed
@@ -1,0 +1,1 @@
+Made salt-ssh respect --wipe again

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1205,6 +1205,13 @@ class Single:
                 opts["grains"][grain] = self.target["grains"][grain]
 
         opts["pillar"] = data.get("pillar")
+
+        # Restore --wipe. Note: Since it is also a CLI option, it should not
+        # be read from cache, hence it is restored here. This is currently only
+        # of semantic distinction since data_cache has been disabled, so refresh
+        # above always evaluates to True. TODO: cleanup?
+        opts["ssh_wipe"] = self.opts.get("ssh_wipe", False)
+
         wrapper = salt.client.ssh.wrapper.FunctionWrapper(
             opts,
             self.id,

--- a/tests/pytests/integration/ssh/test_deploy.py
+++ b/tests/pytests/integration/ssh/test_deploy.py
@@ -49,6 +49,21 @@ def test_thin_dir(salt_ssh_cli):
     assert thin_dir.joinpath("running_data").exists()
 
 
+def test_wipe(salt_ssh_cli):
+    """
+    Ensure --wipe is respected by the state module wrapper
+    issue #61083
+    """
+    ret = salt_ssh_cli.run("config.get", "thin_dir")
+    assert ret.returncode == 0
+    thin_dir = pathlib.Path(ret.data)
+    assert thin_dir.exists()
+    # only few modules (state and cp) will actually respect --wipe
+    # (see commit #8a414d53284ec04940540ebd823306ab5119e105)
+    salt_ssh_cli.run("--wipe", "state.apply")
+    assert not thin_dir.exists()
+
+
 def test_set_path(salt_ssh_cli, tmp_path, salt_ssh_roster_file):
     """
     test setting the path env variable


### PR DESCRIPTION
### What does this PR do?
Ensures the opts dict value `ssh_wipe` passed to wrapped functions is in sync with the current client configuration. This fixes the `--wipe` CLI option and avoids some cluttering by `--rand-thin-dir`.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/61083

### Previous Behavior
Thin dir is left behind, regardless of `--wipe`.

### New Behavior
If requested, the thin dir is wiped (since https://github.com/saltstack/salt/pull/16689/commits/8a414d53284ec04940540ebd823306ab5119e105 only for some wrapped modules, namely `cp` and `state` – this should probably be documented).

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes