### PR TITLE
Fix `(pillar|grains).filter_by` with salt-ssh

### DIFF
--- a/changelog/56093.fixed
+++ b/changelog/56093.fixed
@@ -1,0 +1,1 @@
+Fixed pillar.filter_by with salt-ssh

--- a/salt/client/ssh/wrapper/grains.py
+++ b/salt/client/ssh/wrapper/grains.py
@@ -3,15 +3,12 @@ Return/control aspects of the grains data
 """
 
 
-import copy
 import math
-from collections.abc import Mapping
 
 import salt.utils.data
 import salt.utils.dictupdate
 import salt.utils.json
 from salt.defaults import DEFAULT_TARGET_DELIM
-from salt.exceptions import SaltException
 
 # Seed the grains dict so cython will build
 __grains__ = {}

--- a/salt/client/ssh/wrapper/grains.py
+++ b/salt/client/ssh/wrapper/grains.py
@@ -184,7 +184,7 @@ def filter_by(lookup_dict, grain="os_family", merge=None, default="default", bas
         {% set apache = salt['grains.filter_by']({
             'Debian': {'pkg': 'apache2', 'srv': 'apache2'},
             'RedHat': {'pkg': 'httpd', 'srv': 'httpd'},
-        }), default='Debian' %}
+        }, default='Debian') %}
 
         myapache:
           pkg.installed:
@@ -216,26 +216,47 @@ def filter_by(lookup_dict, grain="os_family", merge=None, default="default", bas
         values relevant to systems matching that grain. For example, a key
         could be the grain for an OS and the value could the name of a package
         on that particular OS.
+
+        .. versionchanged:: 2016.11.0
+
+            The dictionary key could be a globbing pattern. The function will
+            return the corresponding ``lookup_dict`` value where grain value
+            matches the pattern. For example:
+
+            .. code-block:: bash
+
+                # this will render 'got some salt' if Minion ID begins from 'salt'
+                salt '*' grains.filter_by '{salt*: got some salt, default: salt is not here}' id
+
     :param grain: The name of a grain to match with the current system's
         grains. For example, the value of the "os_family" grain for the current
         system could be used to pull values from the ``lookup_dict``
         dictionary.
-    :param merge: A dictionary to merge with the ``lookup_dict`` before doing
-        the lookup. This allows Pillar to override the values in the
+
+        .. versionchanged:: 2016.11.0
+
+            The grain value could be a list. The function will return the
+            ``lookup_dict`` value for a first found item in the list matching
+            one of the ``lookup_dict`` keys.
+
+    :param merge: A dictionary to merge with the results of the grain selection
+        from ``lookup_dict``. This allows Pillar to override the values in the
         ``lookup_dict``. This could be useful, for example, to override the
         values for non-standard package names such as when using a different
         Python version from the default Python version provided by the OS
         (e.g., ``python26-mysql`` instead of ``python-mysql``).
-    :param default: default lookup_dict's key used if the grain does not exists
-         or if the grain value has no match on lookup_dict.
 
-         .. versionadded:: 2014.1.0
+    :param default: default lookup_dict's key used if the grain does not exists
+        or if the grain value has no match on lookup_dict. If unspecified
+        the value is "default".
+
+        .. versionadded:: 2014.1.0
 
     :param base: A lookup_dict key to use for a base dictionary. The
         grain-selected ``lookup_dict`` is merged over this and then finally
         the ``merge`` dictionary is merged. This allows common values for
         each case to be collected in the base and overridden by the grain
-        selection dictionary and the merge dictionary. Default is None.
+        selection dictionary and the merge dictionary. Default is unset.
 
         .. versionadded:: 2015.8.11,2016.3.2
 
@@ -245,31 +266,16 @@ def filter_by(lookup_dict, grain="os_family", merge=None, default="default", bas
 
         salt '*' grains.filter_by '{Debian: Debheads rule, RedHat: I love my hat}'
         # this one will render {D: {E: I, G: H}, J: K}
-        salt '*' grains.filter_by '{A: B, C: {D: {E: F,G: H}}}' 'xxx' '{D: {E: I},J: K}' 'C'
+        salt '*' grains.filter_by '{A: B, C: {D: {E: F, G: H}}}' 'xxx' '{D: {E: I}, J: K}' 'C'
+        # next one renders {A: {B: G}, D: J}
+        salt '*' grains.filter_by '{default: {A: {B: C}, D: E}, F: {A: {B: G}}, H: {D: I}}' 'xxx' '{D: J}' 'F' 'default'
+        # next same as above when default='H' instead of 'F' renders {A: {B: C}, D: J}
     """
-    ret = lookup_dict.get(
-        __grains__.get(grain, default), lookup_dict.get(default, None)
+    return salt.utils.data.filter_by(
+        lookup_dict=lookup_dict,
+        lookup=grain,
+        traverse=__grains__.value(),
+        merge=merge,
+        default=default,
+        base=base,
     )
-
-    if base and base in lookup_dict:
-        base_values = lookup_dict[base]
-        if ret is None:
-            ret = base_values
-
-        elif isinstance(base_values, Mapping):
-            if not isinstance(ret, Mapping):
-                raise SaltException(
-                    "filter_by default and look-up values must both be dictionaries."
-                )
-            ret = salt.utils.dictupdate.update(copy.deepcopy(base_values), ret)
-
-    if merge:
-        if not isinstance(merge, Mapping):
-            raise SaltException("filter_by merge argument must be a dictionary.")
-        else:
-            if ret is None:
-                ret = merge
-            else:
-                salt.utils.dictupdate.update(ret, merge)
-
-    return ret

--- a/salt/client/ssh/wrapper/pillar.py
+++ b/salt/client/ssh/wrapper/pillar.py
@@ -141,6 +141,64 @@ def keys(key, delimiter=DEFAULT_TARGET_DELIM):
     return ret.keys()
 
 
+def filter_by(lookup_dict, pillar, merge=None, default="default", base=None):
+    """
+    .. versionadded:: 2017.7.0
+
+    Look up the given pillar in a given dictionary and return the result
+
+    :param lookup_dict: A dictionary, keyed by a pillar, containing a value or
+        values relevant to systems matching that pillar. For example, a key
+        could be a pillar for a role and the value could the name of a package
+        on that particular OS.
+
+        The dictionary key can be a globbing pattern. The function will return
+        the corresponding ``lookup_dict`` value where the pillar value matches
+        the  pattern. For example:
+
+        .. code-block:: bash
+
+            # this will render 'got some salt' if ``role`` begins with 'salt'
+            salt '*' pillar.filter_by '{salt*: got some salt, default: salt is not here}' role
+
+    :param pillar: The name of a pillar to match with the system's pillar. For
+        example, the value of the "role" pillar could be used to pull values
+        from the ``lookup_dict`` dictionary.
+
+        The pillar value can be a list. The function will return the
+        ``lookup_dict`` value for a first found item in the list matching
+        one of the ``lookup_dict`` keys.
+
+    :param merge: A dictionary to merge with the results of the pillar
+        selection from ``lookup_dict``. This allows another dictionary to
+        override the values in the ``lookup_dict``.
+
+    :param default: default lookup_dict's key used if the pillar does not exist
+        or if the pillar value has no match on lookup_dict.  If unspecified
+        the value is "default".
+
+    :param base: A lookup_dict key to use for a base dictionary.  The
+        pillar-selected ``lookup_dict`` is merged over this and then finally
+        the ``merge`` dictionary is merged.  This allows common values for
+        each case to be collected in the base and overridden by the pillar
+        selection dictionary and the merge dictionary.  Default is unset.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pillar.filter_by '{web: Serve it up, db: I query, default: x_x}' role
+    """
+    return salt.utils.data.filter_by(
+        lookup_dict=lookup_dict,
+        lookup=pillar,
+        traverse=__pillar__.value(),
+        merge=merge,
+        default=default,
+        base=base,
+    )
+
+
 # Allow pillar.data to also be used to return pillar data
 items = raw
 data = items

--- a/tests/pytests/integration/ssh/test_grains.py
+++ b/tests/pytests/integration/ssh/test_grains.py
@@ -8,6 +8,71 @@ pytestmark = [
 ]
 
 
+@pytest.fixture(scope="module")
+def grains_filter_by_lookup(salt_ssh_cli):
+    ret = salt_ssh_cli.run("grains.get", "os")
+    assert ret.returncode == 0
+    assert ret.data
+    os = ret.data
+
+    return {
+        "common": {
+            "has_common": True,
+        },
+        "custom_default": {
+            "defaulted": True,
+        },
+        "merge": {
+            "merged": True,
+        },
+        os: {
+            "filtered": True,
+        },
+    }
+
+
+@pytest.fixture(scope="module")
+def grains_filter_by_default():
+    return {
+        "common": {
+            "has_common": True,
+        },
+        "custom_default": {
+            "defaulted": True,
+        },
+        "merge": {
+            "merged": True,
+        },
+    }
+
+
+@pytest.fixture(scope="module")
+def grains_filter_by_states(
+    salt_master, salt_ssh_cli, grains_filter_by_lookup, grains_filter_by_default
+):
+    filter_content = f"{{%- set lookup = {grains_filter_by_lookup} %}}"
+    default_content = f"{{%- set lookup = {grains_filter_by_default} %}}"
+    content = r"""
+{%- set res = salt["grains.filter_by"](lookup, grain="os", merge=lookup["merge"], base="common", default="custom_default") %}
+grains-filter-by:
+  file.managed:
+    - name: {{ salt["temp.file"]() }}
+    - context: {{ res | json }}
+    """
+    try:
+        with salt_master.state_tree.base.temp_file(
+            "grains_filter_by.sls", filter_content + content
+        ):
+            with salt_master.state_tree.base.temp_file(
+                "grains_filter_by_default.sls", default_content + content
+            ):
+                ret = salt_ssh_cli.run("--regen-thin", "test.true")
+                assert ret.returncode == 0
+                yield
+    finally:
+        salt_ssh_cli.run("--regen-thin", "test.true")
+
+
 def test_grains_id(salt_ssh_cli):
     """
     Test salt-ssh grains id work for localhost.
@@ -34,3 +99,73 @@ def test_grains_items(salt_ssh_cli):
     else:
         grain = "Linux"
     assert ret.data["kernel"] == grain
+
+
+def test_grains_filter_by(salt_ssh_cli, grains_filter_by_lookup):
+    """
+    test grains.filter_by with salt-ssh
+    """
+    ret = salt_ssh_cli.run(
+        "grains.filter_by",
+        grains_filter_by_lookup,
+        grain="os",
+        merge=grains_filter_by_lookup["merge"],
+        base="common",
+        default="custom_default",
+    )
+    assert ret.returncode == 0
+    assert ret.data
+    assert "has_common" in ret.data
+    assert "filtered" in ret.data
+    assert "merged" in ret.data
+    assert "defaulted" not in ret.data
+
+
+@pytest.mark.usefixtures("grains_filter_by_states")
+def test_grains_filter_by_jinja(salt_ssh_cli):
+    """
+    test grains.filter_by during template rendering with salt-ssh
+    """
+    ret = salt_ssh_cli.run("state.show_sls", "grains_filter_by")
+    assert ret.returncode == 0
+    assert ret.data
+    rendered = ret.data["grains-filter-by"]["file"][1]["context"]
+
+    assert "has_common" in rendered
+    assert "filtered" in rendered
+    assert "merged" in rendered
+    assert "defaulted" not in rendered
+
+
+def test_grains_filter_by_default(salt_ssh_cli, grains_filter_by_default):
+    """
+    test grains.filter_by with salt-ssh and default parameter
+    """
+    ret = salt_ssh_cli.run(
+        "grains.filter_by",
+        grains_filter_by_default,
+        grain="os",
+        merge=grains_filter_by_default["merge"],
+        base="common",
+        default="custom_default",
+    )
+    assert ret.returncode == 0
+    assert ret.data
+    assert "has_common" in ret.data
+    assert "merged" in ret.data
+    assert "defaulted" in ret.data
+
+
+@pytest.mark.usefixtures("grains_filter_by_states")
+def test_grains_filter_by_default_jinja(salt_ssh_cli, grains_filter_by_default):
+    """
+    test grains.filter_by during template rendering with salt-ssh and default parameter
+    """
+    ret = salt_ssh_cli.run("state.show_sls", "grains_filter_by_default")
+    assert ret.returncode == 0
+    assert ret.data
+    rendered = ret.data["grains-filter-by"]["file"][1]["context"]
+
+    assert "has_common" in rendered
+    assert "merged" in rendered
+    assert "defaulted" in rendered

--- a/tests/pytests/integration/ssh/test_pillar.py
+++ b/tests/pytests/integration/ssh/test_pillar.py
@@ -2,10 +2,11 @@ import pytest
 
 pytestmark = [
     pytest.mark.skip_on_windows(reason="salt-ssh not available on Windows"),
+    pytest.mark.slow_test,
 ]
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="module", autouse=True)
 def pillar_tree(base_env_pillar_tree_root_dir):
     top_file = """
     base:
@@ -33,8 +34,22 @@ def pillar_tree(base_env_pillar_tree_root_dir):
         yield
 
 
-@pytest.mark.slow_test
-def test_pillar_items(salt_ssh_cli, pillar_tree):
+@pytest.fixture()
+def pillar_filter_by_lookup():
+    return {
+        "common": {
+            "has_common": True,
+        },
+        "custom_default": {
+            "defaulted": True,
+        },
+        "merge": {
+            "merged": True,
+        },
+    }
+
+
+def test_pillar_items(salt_ssh_cli):
     """
     test pillar.items with salt-ssh
     """
@@ -48,8 +63,7 @@ def test_pillar_items(salt_ssh_cli, pillar_tree):
     assert pillar_items["knights"] == ["Lancelot", "Galahad", "Bedevere", "Robin"]
 
 
-@pytest.mark.slow_test
-def test_pillar_get(salt_ssh_cli, pillar_tree):
+def test_pillar_get(salt_ssh_cli):
     """
     test pillar.get with salt-ssh
     """
@@ -59,11 +73,50 @@ def test_pillar_get(salt_ssh_cli, pillar_tree):
     assert ret.data == "python"
 
 
-@pytest.mark.slow_test
-def test_pillar_get_doesnotexist(salt_ssh_cli, pillar_tree):
+def test_pillar_get_doesnotexist(salt_ssh_cli):
     """
     test pillar.get when pillar does not exist with salt-ssh
     """
     ret = salt_ssh_cli.run("pillar.get", "doesnotexist")
     assert ret.returncode == 0
     assert ret.data == ""
+
+
+def test_pillar_filter_by(salt_ssh_cli, pillar_filter_by_lookup):
+    """
+    test pillar.filter_by with salt-ssh
+    """
+    pillar_filter_by_lookup["python"] = {"filtered": True}
+    ret = salt_ssh_cli.run(
+        "pillar.filter_by",
+        pillar_filter_by_lookup,
+        pillar="monty",
+        merge=pillar_filter_by_lookup["merge"],
+        base="common",
+        default="custom_default",
+    )
+    assert ret.returncode == 0
+    assert ret.data
+    assert "has_common" in ret.data
+    assert "filtered" in ret.data
+    assert "merged" in ret.data
+    assert "defaulted" not in ret.data
+
+
+def test_pillar_filter_by_default(salt_ssh_cli, pillar_filter_by_lookup):
+    """
+    test pillar.filter_by default param with salt-ssh
+    """
+    ret = salt_ssh_cli.run(
+        "pillar.filter_by",
+        pillar_filter_by_lookup,
+        pillar="monty",
+        merge=pillar_filter_by_lookup["merge"],
+        base="common",
+        default="custom_default",
+    )
+    assert ret.returncode == 0
+    assert ret.data
+    assert "has_common" in ret.data
+    assert "merged" in ret.data
+    assert "defaulted" in ret.data


### PR DESCRIPTION
### What does this PR do?
* Adds `pillar.filter_by` to the salt-ssh wrapper, which makes it work as expected while using salt-ssh (see linked issue)
* Adds some tests for `grains.filter_by` salt-ssh wrapper (tried but failed to reproduce https://github.com/saltstack/salt/issues/46948 / https://github.com/saltstack/salt/issues/50247)
* Syncs `grains.filter_by` salt-ssh wrapper with the current execution module function, which makes use of the utility module. This might fix the above issues, if they are still relevant.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/56093

### Previous Behavior
* `pillar.filter_by` always defaults to the default key using salt-ssh
* `grains.filter_by` does not support nested grains and does not deepcopy the merging dict

### New Behavior
* `pillar.filter_by` works as usual
* `grains.filter_by` works as usual

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes