### PR TITLE
Add ability to ignore symlinks in file.tidied

### DIFF
--- a/changelog/63042.added
+++ b/changelog/63042.added
@@ -1,0 +1,1 @@
+Add ability to ignore symlinks in file.tidied

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1949,10 +1949,11 @@ def tidied(
     time_comparison="atime",
     age_size_logical_operator="OR",
     age_size_only=None,
+    rmlinks=True,
     **kwargs
 ):
     """
-    .. versionchanged:: 3006,3005
+    .. versionchanged:: 3006.0,3005
 
     Remove unwanted files based on specific criteria.
 
@@ -2016,7 +2017,7 @@ def tidied(
         is not old enough will NOT get tidied. A file will need to fulfill BOTH
         conditions in order to be tidied. Accepts ``OR`` or ``AND``.
 
-        .. versionadded:: 3006
+        .. versionadded:: 3006.0
 
     age_size_only
         This parameter can trigger the reduction of age and size conditions
@@ -2027,7 +2028,12 @@ def tidied(
         evaluation down to that specific condition. Path matching and
         exclusions still apply.
 
-        .. versionadded:: 3006
+        .. versionadded:: 3006.0
+
+    rmlinks
+        Whether or not it's allowed to remove symbolic links
+
+        .. versionadded:: 3006.0
 
     .. code-block:: yaml
 
@@ -2111,6 +2117,8 @@ def tidied(
                         mytimestamp = os.lstat(path).st_mtime
                     else:
                         mytimestamp = os.lstat(path).st_atime
+                    if not rmlinks:
+                        deleteme = False
                 else:
                     # Get timestamp of file or directory
                     if time_comparison == "ctime":

--- a/tests/pytests/unit/states/file/test_tidied.py
+++ b/tests/pytests/unit/states/file/test_tidied.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from datetime import datetime, timedelta
+from types import SimpleNamespace
 
 import pytest
 
@@ -578,3 +579,50 @@ def test_tidied_filenotfound(tmp_path):
         "comment": "Nothing to remove from directory {}".format(name),
     }
     assert ret == exp
+
+
+def test_tidied_rmlinks():
+    name = os.sep + "test"
+    if salt.utils.platform.is_windows():
+        name = "c:" + name
+    walker = [
+        (os.path.join("test", "test1"), [], ["file1"]),
+        (os.path.join("test", "test2", "test3"), [], []),
+        (os.path.join("test", "test2"), ["test3"], ["link1"]),
+        ("test", ["test1", "test2"], ["file3"]),
+    ]
+    today_delta = (datetime.today() - timedelta(days=14)) - datetime.utcfromtimestamp(0)
+    mock_lstat = MagicMock(return_value=SimpleNamespace(st_atime=today_delta))
+    remove = MagicMock(name="file.remove")
+    with patch("os.walk", return_value=walker), patch(
+        "os.path.islink", side_effect=[False, True, False, False, False, False]
+    ), patch("os.path.getatime", return_value=today_delta.total_seconds()), patch(
+        "os.lstat", return_value=mock_lstat
+    ), patch(
+        "os.path.getsize", return_value=10
+    ), patch.dict(
+        filestate.__opts__, {"test": False}
+    ), patch.dict(
+        filestate.__salt__, {"file.remove": remove}
+    ), patch(
+        "os.path.isdir", return_value=True
+    ):
+        ret = filestate.tidied(
+            name=name,
+            age=1,
+            size=9,
+            rmlinks=False,
+        )
+    exp = {
+        "name": name,
+        "changes": {
+            "removed": [
+                os.path.join("test", "test1", "file1"),
+                os.path.join("test", "file3"),
+            ]
+        },
+        "result": True,
+        "comment": "Removed 2 files or directories from directory {}".format(name),
+    }
+    assert ret == exp
+    assert remove.call_count == 2


### PR DESCRIPTION
### What does this PR do?
See issue for details

### What issues does this PR fix or reference?
Fixes: #63042

### Previous Behavior
Links could not be excluded from tidying

### New Behavior
Now they can

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
