### PR TITLE
Remove dead minion data cache logic from salt-ssh

### DIFF
--- a/changelog/63039.fixed
+++ b/changelog/63039.fixed
@@ -1,0 +1,1 @@
+Removed dead minion data cache code from salt-ssh


### PR DESCRIPTION
### What does this PR do?
Removes dead code from `salt.client.ssh.Single.run_wfunc` related to a configuration (https://github.com/saltstack/salt/commit/0944019c614fe6c0d3fe709b147e349af334455a) that was abandoned in 2014 (https://github.com/saltstack/salt/commit/4fb8f82eb6cdf95418efe67376beaa34bd584c2a).

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/63039

### Previous Behavior
works hard

### New Behavior
works a bit more efficiently

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes