### PR TITLE
sysutils/py-salt: fix the efi grain on FreeBSD

### DIFF
--- a/changelog/63052.fixed.md
+++ b/changelog/63052.fixed.md
@@ -1,0 +1,1 @@
+fix the efi grain on FreeBSD

--- a/salt/grains/extra.py
+++ b/salt/grains/extra.py
@@ -81,14 +81,25 @@ def __secure_boot(efivars_dir):
 
 def uefi():
     """Populate UEFI grains."""
-    efivars_dir = next(
-        filter(os.path.exists, ["/sys/firmware/efi/efivars", "/sys/firmware/efi/vars"]),
-        None,
-    )
-    grains = {
-        "efi": bool(efivars_dir),
-        "efi-secure-boot": __secure_boot(efivars_dir) if efivars_dir else False,
-    }
+    if salt.utils.platform.is_freebsd():
+        grains = {
+            "efi": os.path.exists("/dev/efi"),
+            # Needs a contributor with a secure boot system to implement this
+            # part.
+            "efi-secure-boot": False,
+        }
+    else:
+        # Works on Linux and Apple ?
+        efivars_dir = next(
+            filter(
+                os.path.exists, ["/sys/firmware/efi/efivars", "/sys/firmware/efi/vars"]
+            ),
+            None,
+        )
+        grains = {
+            "efi": bool(efivars_dir),
+            "efi-secure-boot": __secure_boot(efivars_dir) if efivars_dir else False,
+        }
 
     return grains
 


### PR DESCRIPTION
The logic to detect whether we booted from EFI only worked on Linux and Apple, AFAICT.

### What does this PR do?

Correctly detects EFI on FreeBSD

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
grains.get efi would always return False on FreeBSD

### New Behavior
grains.get efi will return the correct value on FreeBSD

### Merge requirements satisfied?
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes