### PR TITLE
Fix mongo connections

### DIFF
--- a/changelog/63058.fixed
+++ b/changelog/63058.fixed
@@ -1,0 +1,3 @@
+Fix mongo authentication for mongo ext_pillar and mongo returner
+
+This fix also include the ability to use the mongo connection string for mongo ext_pillar

--- a/salt/pillar/mongo.py
+++ b/salt/pillar/mongo.py
@@ -12,19 +12,39 @@ Salt Master Mongo Configuration
 ===============================
 
 The module shares the same base mongo connection variables as
-:py:mod:`salt.returners.mongo_return`. These variables go in your master
+:py:mod:`salt.returners.mongo_future_return`. These variables go in your master
 config file.
 
-   * ``mongo.db`` - The mongo database to connect to. Defaults to ``'salt'``.
-   * ``mongo.host`` - The mongo host to connect to. Supports replica sets by
-     specifying all hosts in the set, comma-delimited. Defaults to ``'salt'``.
-   * ``mongo.port`` - The port that the mongo database is running on. Defaults
-     to ``27017``.
-   * ``mongo.user`` - The username for connecting to mongo. Only required if
-     you are using mongo authentication. Defaults to ``''``.
-   * ``mongo.password`` - The password for connecting to mongo. Only required
-     if you are using mongo authentication. Defaults to ``''``.
+.. code-block:: yaml
 
+    mongo.db: <database name>
+    mongo.host: <server ip address>
+    mongo.user: <MongoDB username>
+    mongo.password: <MongoDB user password>
+    mongo.port: 27017
+
+Or single URI:
+
+.. code-block:: yaml
+
+    mongo.uri: URI
+
+where uri is in the format:
+
+.. code-block:: text
+
+    mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]
+
+Example:
+
+.. code-block:: text
+
+    mongodb://db1.example.net:27017/mydatabase
+    mongodb://db1.example.net:27017,db2.example.net:2500/?replicaSet=test
+    mongodb://db1.example.net:27017,db2.example.net:2500/?replicaSet=test&connectTimeoutMS=300000
+
+More information on URI format can be found in
+https://docs.mongodb.com/manual/reference/connection-string/
 
 Configuring the Mongo ext_pillar
 ================================

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -178,17 +178,15 @@ def _get_conn(ret):
         mdb = conn.get_database()
     else:
         if PYMONGO_VERSION > _LooseVersion("2.3"):
-            conn = pymongo.MongoClient(host, port)
+            conn = pymongo.MongoClient(host, port, username=user, password=password)
         else:
             if uri:
                 raise salt.exceptions.SaltConfigurationError(
                     "pymongo <= 2.3 does not support uri format"
                 )
-            conn = pymongo.Connection(host, port)
+            conn = pymongo.Connection(host, port, username=user, password=password)
 
         mdb = conn[db_]
-        if user and password:
-            mdb.authenticate(user, password)
 
     if indexes:
         if PYMONGO_VERSION > _LooseVersion("2.3"):

--- a/tests/pytests/unit/pillar/test_mongo.py
+++ b/tests/pytests/unit/pillar/test_mongo.py
@@ -1,0 +1,30 @@
+import pytest
+
+import salt.exceptions
+import salt.pillar.mongo as mongo
+from tests.support.mock import patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+
+    return {
+        mongo: {
+            "__opts__": {
+                "mongo.uri": "mongodb://root:pass@localhost27017/salt?authSource=admin"
+            }
+        }
+    }
+
+
+def test_config_exception():
+    opts = {
+        "mongo.host": "localhost",
+        "mongo.port": 27017,
+        "mongo.user": "root",
+        "mongo.password": "pass",
+        "mongo.uri": "mongodb://root:pass@localhost27017/salt?authSource=admin",
+    }
+    with patch.dict(mongo.__opts__, opts):
+        with pytest.raises(salt.exceptions.SaltConfigurationError):
+            mongo.ext_pillar("minion1", {})

--- a/tests/pytests/unit/returners/test_mongo_future_return.py
+++ b/tests/pytests/unit/returners/test_mongo_future_return.py
@@ -1,0 +1,31 @@
+import pytest
+
+import salt.exceptions
+import salt.returners.mongo_future_return as mongo
+from tests.support.mock import patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+
+    return {
+        mongo: {
+            "__opts__": {
+                "mongo.uri": "mongodb://root:pass@localhost27017/salt?authSource=admin"
+            }
+        }
+    }
+
+
+@patch("salt.returners.mongo_future_return.PYMONGO_VERSION", "4.3.2", create=True)
+def test_config_exception():
+    opts = {
+        "mongo.host": "localhost",
+        "mongo.port": 27017,
+        "mongo.user": "root",
+        "mongo.password": "pass",
+        "mongo.uri": "mongodb://root:pass@localhost27017/salt?authSource=admin",
+    }
+    with patch.dict(mongo.__opts__, opts):
+        with pytest.raises(salt.exceptions.SaltConfigurationError):
+            mongo.returner({})


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Add:
- mongo.uri configuration in ext_pillar

Fix:
- remove depr. pymongo authenticate function in mongo ext_pillar and returner

### Previous Behavior

Mongo ext_pillar was not useable, because the pymongo authenticate function is deprecated.

### New Behavior
Now you are able to connect to mongo with uri. And the mongo ext_pillar module is usable.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

Don't know how to write tests for salt - sorry 👎 

### Commits signed with GPG?
No

