### PR TITLE
modify gpg.encrypt example

### DIFF
--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -1249,7 +1249,7 @@ def encrypt(
 
         salt '*' gpg.encrypt filename='/path/to/important.file' recipients=recipient@example.com
 
-        salt '*' gpg.encrypt filename='/path/to/important.file' use_passphrase=True \\
+        salt '*' gpg.encrypt filename='/path/to/important.file' sign=True use_passphrase=True \\
                              recipients=recipient@example.com
 
     """


### PR DESCRIPTION
### What does this PR do?
It modifies an existing example for the gpg.encrypt function  
```diff
-        salt '*' gpg.encrypt filename='/path/to/important.file' use_passphrase=True \\
+        salt '*' gpg.encrypt filename='/path/to/important.file' sign=True use_passphrase=True \\
                              recipients=recipient@example.com
```
A passphrase is not used when encrypting a message -- as a message is encrypted using the recipients public key.
A passphrase is needed when signing a message (if the users private key is encrypted).
And that's how this function works
```python
    if sign and use_passphrase:
        gpg_passphrase = __salt__["pillar.get"]("gpg_passphrase")
        if not gpg_passphrase:
            raise SaltInvocationError("gpg_pass```phrase not available in pillar.")
```

### Commits signed with GPG?
Yes

