### PR TITLE
Stop websockets from disconnecting immediately

### DIFF
--- a/changelog/59183.fixed
+++ b/changelog/59183.fixed
@@ -1,0 +1,1 @@
+Fixed saltnado websockets disconnecting immediately

--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -332,13 +332,6 @@ class EventListener:
         """
         Get an event (asynchronous of course) return a future that will get it later
         """
-        # if the request finished, no reason to allow event fetching, since we
-        # can't send back to the client
-        if request._finished:
-            future = Future()
-            future.set_exception(TimeoutException())
-            return future
-
         future = Future()
         if callback is not None:
 

--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -361,6 +361,9 @@ class EventListener:
             return
         if not future.done():
             future.set_exception(TimeoutException())
+        # We need to remove it from the map even if we didn't explicitly time it out
+        # Otherwise, we get a memory leak in the tag_map
+        if future in self.tag_map[(tag, matcher)] and future.done():
             self.tag_map[(tag, matcher)].remove(future)
         if len(self.tag_map[(tag, matcher)]) == 0:
             del self.tag_map[(tag, matcher)]

--- a/tests/pytests/functional/netapi/rest_tornado/test_event_listener.py
+++ b/tests/pytests/functional/netapi/rest_tornado/test_event_listener.py
@@ -13,7 +13,7 @@ class Request:
     __slots__ = ("_finished",)
 
     def __init__(self):
-        self._finished = False
+        self._finished = True
 
 
 @pytest.fixture

--- a/tests/pytests/integration/netapi/rest_tornado/test_minions_api_handler.py
+++ b/tests/pytests/integration/netapi/rest_tornado/test_minions_api_handler.py
@@ -98,3 +98,16 @@ async def test_post_with_incorrect_client(http_client):
             body=salt.utils.json.dumps(low),
         )
     assert exc.value.code == 400
+
+
+@pytest.mark.slow_test
+async def test_mem_leak_in_event_listener(http_client, salt_minion, app):
+    for i in range(10):
+        await http_client.fetch(
+            "/minions/{}".format(salt_minion.id),
+            method="GET",
+            follow_redirects=False,
+        )
+    assert len(app.event_listener.tag_map) == 0
+    assert len(app.event_listener.timeout_map) == 0
+    assert len(app.event_listener.request_map) == 0


### PR DESCRIPTION
## What does this PR do?
Removes a check introduced [here](https://github.com/saltstack/salt/pull/24965) that was part of a patch to solve a memory leak (see the issue [here](https://github.com/saltstack/salt/issues/24846).  The regression test shows that there is no leak even after removing the previous patch.

Also, after a patch from about 5 years ago (I believe [this one](https://github.com/saltstack/salt/pull/45874/files)), the tag_map wasn't being properly cleaned up and was growing to be massive if a lot of calls to the API happened.  That has been resolved.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/59183

### Previous Behavior
Websockets closed immediately, and the tag map leaked memory.

### New Behavior
The connection remains open, and we have a properly cleaned tag map.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes