### PR TITLE
Fix ipset state when the comment kwarg is set.

### DIFF
--- a/changelog/61122.fixed
+++ b/changelog/61122.fixed
@@ -1,0 +1,1 @@
+Fix ipset state when the comment kwarg is set.

--- a/salt/modules/ipset.py
+++ b/salt/modules/ipset.py
@@ -302,7 +302,6 @@ def new_set(name=None, set_type=None, family="ipv4", comment=False, **kwargs):
         IPv6:
         salt '*' ipset.new_set custom_set list:set family=ipv6
     """
-
     ipset_family = _IPSET_FAMILIES[family]
     if not name:
         return "Error: Set Name needs to be specified"
@@ -483,7 +482,7 @@ def add(name=None, entry=None, family="ipv4", **kwargs):
 
     settype = setinfo["Type"]
 
-    cmd = [_ipset_cmd(), "add", "-exist", name, entry]
+    cmd = [_ipset_cmd(), "add", "-exist", name] + entry.split()
 
     if "timeout" in kwargs:
         if "timeout" not in setinfo["Header"]:
@@ -497,7 +496,7 @@ def add(name=None, entry=None, family="ipv4", **kwargs):
         if "comment" not in setinfo["Header"]:
             return "Error: Set {} not created with comment support".format(name)
         if "comment" not in entry:
-            cmd = '{} comment "{}"'.format(cmd, kwargs["comment"])
+            cmd = cmd + ["comment", f"{kwargs['comment']}"]
 
     if {"skbmark", "skbprio", "skbqueue"} & set(kwargs.keys()):
         if "skbinfo" not in setinfo["Header"]:

--- a/salt/states/ipset.py
+++ b/salt/states/ipset.py
@@ -186,7 +186,7 @@ def present(name, entry=None, family="ipv4", **kwargs):
         if "timeout" in kwargs and "timeout" not in entry_opts:
             entry_opts = "timeout {} {}".format(kwargs["timeout"], entry_opts)
         if "comment" in kwargs and "comment" not in entry_opts:
-            entry_opts = '{} comment "{}"'.format(entry_opts, kwargs["comment"])
+            entry_opts = "{} comment {}".format(entry_opts, kwargs["comment"])
         _entry = " ".join([entry, entry_opts.lstrip()]).strip()
 
         if __salt__["ipset.check"](kwargs["set_name"], _entry, family) is True:
@@ -254,7 +254,7 @@ def absent(name, entry=None, entries=None, family="ipv4", **kwargs):
         if "timeout" in kwargs and "timeout" not in entry_opts:
             entry_opts = "timeout {} {}".format(kwargs["timeout"], entry_opts)
         if "comment" in kwargs and "comment" not in entry_opts:
-            entry_opts = '{} comment "{}"'.format(entry_opts, kwargs["comment"])
+            entry_opts = "{} comment {}".format(entry_opts, kwargs["comment"])
         _entry = " ".join([entry, entry_opts]).strip()
 
         log.debug("_entry %s", _entry)

--- a/tests/pytests/functional/modules/test_ipset.py
+++ b/tests/pytests/functional/modules/test_ipset.py
@@ -3,8 +3,10 @@ import logging
 import pytest
 
 pytestmark = [
-    pytest.mark.windows_whitelisted,
+    pytest.mark.slow_test,
+    pytest.mark.skip_if_binaries_missing("ipset", check_all=False),
 ]
+
 
 log = logging.getLogger(__name__)
 

--- a/tests/pytests/functional/modules/test_ipset.py
+++ b/tests/pytests/functional/modules/test_ipset.py
@@ -1,0 +1,47 @@
+import logging
+
+import pytest
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+]
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def ipset(modules):
+    return modules.ipset
+
+
+@pytest.fixture()
+def setup_set(ipset):
+    set_name = "test_name"
+    kwargs = {"range": "192.168.0.0/16", "comment": "Hello18"}
+    ipset.new_set(name=set_name, set_type="bitmap:ip", family="ipv4", **kwargs)
+    yield set_name
+    ipset.delete_set(set_name)
+
+
+def test_ipset_add(ipset, setup_set):
+    """
+    test ipset.add
+    """
+    # add set first
+    ret = ipset.add(name=setup_set, entry="192.168.0.3 comment Hello18")
+    assert ret == "Success"
+    check_set = ipset.list_sets()
+    assert any([x for x in check_set if x["Name"] == setup_set])
+
+
+def test_ipset_add_comment_kwarg(ipset, setup_set):
+    """
+    test ipset.add when comment is set in kwarg
+    """
+    # add set first
+    kwargs = {"comment": "Hello19"}
+    entry = "192.168.0.3"
+    ret = ipset.add(name=setup_set, entry="192.168.0.3", **kwargs)
+    assert ret == "Success"
+    check_set = ipset.list_sets()
+    assert any([x for x in check_set if x["Name"] == setup_set])

--- a/tests/pytests/functional/states/test_ipset.py
+++ b/tests/pytests/functional/states/test_ipset.py
@@ -8,6 +8,11 @@ pytestmark = [
 
 log = logging.getLogger(__name__)
 
+pytestmark = [
+    pytest.mark.slow_test,
+    pytest.mark.skip_if_binaries_missing("ipset", check_all=False),
+]
+
 
 @pytest.fixture()
 def setup_set(modules):

--- a/tests/pytests/functional/states/test_ipset.py
+++ b/tests/pytests/functional/states/test_ipset.py
@@ -1,0 +1,35 @@
+import logging
+
+import pytest
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+]
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture()
+def setup_set(modules):
+    set_name = "test_name"
+    kwargs = {"range": "192.168.0.0/16", "comment": "Hello18"}
+    modules.ipset.new_set(name=set_name, set_type="bitmap:ip", family="ipv4", **kwargs)
+    yield set_name
+    modules.ipset.delete_set(set_name)
+
+
+def test_ipset_present(states, setup_set):
+    """
+    test ipset.present
+    """
+    # add set first
+    entry = "192.168.0.3"
+    comment = "Hello"
+    ret = states.ipset.present(
+        name="setname_entries", set_name=setup_set, entry=entry, comment=comment
+    )
+    assert ret.result
+    assert (
+        ret.comment
+        == f"entry {entry} comment {comment} added to set {setup_set} for family ipv4\n"
+    )


### PR DESCRIPTION
### What does this PR do?

Fixes ipset.present when using comments as a kwarg.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/61122

### Previous Behavior

```
          ID: setname_entries
    Function: ipset.present
      Result: False
     Comment: Failed to add to entry 192.168.0.3 comment "Hello19" to set setname3 for family ipv4.
              Error: ipset v7.15: Syntax error: cannot parse 192.168.0.3 comment "Hello19": resolving to IPv4 address failed
     Started: 09:05:15.671586
    Duration: 20.856 ms
     Changes:   
```

### New Behavior

```
          ID: setname_entries
    Function: ipset.present
      Result: True
     Comment: entry 192.168.0.3 comment Hello19 added to set setname3 for family ipv4
     Started: 09:05:33.698257
    Duration: 20.674 ms
     Changes:   
              ----------
              locale:
                  setname_entries
```
