### PR TITLE
Lazy import

### DIFF
--- a/changelog/63073.fixed
+++ b/changelog/63073.fixed
@@ -1,0 +1,1 @@
+New `salt.utils.lazy.lazy_import` function for lazy loading Python imports.

--- a/changelog/63073.fixed
+++ b/changelog/63073.fixed
@@ -1,3 +1,3 @@
 New `salt.utils.lazy.lazy_import` function for lazy loading Python imports.
 Converted several deferred `import` statements in core code to instead use the
-new function.
+new function, and converted some eager imports to lazy imports.

--- a/changelog/63073.fixed
+++ b/changelog/63073.fixed
@@ -1,1 +1,3 @@
 New `salt.utils.lazy.lazy_import` function for lazy loading Python imports.
+Converted several deferred `import` statements in core code to instead use the
+new function.

--- a/changelog/63335.fixed
+++ b/changelog/63335.fixed
@@ -1,0 +1,1 @@
+Fixed some minor issues with Python `import` statements

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2310,6 +2310,7 @@ def mminion_config(path, overrides, ignore_config_errors=True):
     apply_sdb(opts)
 
     _validate_opts(opts)
+    import salt.loader
     opts["grains"] = salt.loader.grains(opts)
     opts["pillar"] = {}
     return opts

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -28,7 +28,6 @@ import salt.utils.user
 import salt.utils.validate.path
 import salt.utils.versions
 import salt.utils.xdg
-import salt.utils.yaml
 from salt._logging import (
     DFLT_LOG_DATEFMT,
     DFLT_LOG_DATEFMT_LOGFILE,
@@ -53,6 +52,7 @@ _ssl = salt.utils.lazy.lazy_import("ssl")
 _salt_grains_core = salt.utils.lazy.lazy_import("salt.grains.core")
 _salt_loader = salt.utils.lazy.lazy_import("salt.loader")
 _salt_utils_sdb = salt.utils.lazy.lazy_import("salt.utils.sdb")
+_salt_utils_yaml = salt.utils.lazy.lazy_import("salt.utils.yaml")
 
 log = logging.getLogger(__name__)
 
@@ -2003,8 +2003,8 @@ def _read_conf_file(path):
     append_file_suffix_YAMLError = False
     with salt.utils.files.fopen(path, "r") as conf_file:
         try:
-            conf_opts = salt.utils.yaml.safe_load(conf_file) or {}
-        except salt.utils.yaml.YAMLError as err:
+            conf_opts = _salt_utils_yaml.safe_load(conf_file) or {}
+        except _salt_utils_yaml.YAMLError as err:
             message = "Error parsing configuration file: {} - {}".format(path, err)
             log.error(message)
             if path.endswith("_schedule.conf"):

--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -12,7 +12,6 @@ import re
 import time
 import types
 
-import salt.config
 import salt.defaults.events
 import salt.defaults.exitcodes
 import salt.loader.context
@@ -33,6 +32,7 @@ from salt.utils import entrypoints
 
 from .lazy import SALT_BASE_PATH, FilterDictWrapper, LazyLoader
 
+_salt_config = salt.utils.lazy.lazy_import("salt.config")
 _salt_modules_cmdmod = salt.utils.lazy.lazy_import("salt.modules.cmdmod")
 
 log = logging.getLogger(__name__)
@@ -1077,21 +1077,21 @@ def grains(opts, force_refresh=False, proxy=None, context=None, loaded_base_name
     if "conf_file" in opts:
         pre_opts = {}
         pre_opts.update(
-            salt.config.load_config(
+            _salt_config.load_config(
                 opts["conf_file"],
                 "SALT_MINION_CONFIG",
-                salt.config.DEFAULT_MINION_OPTS["conf_file"],
+                _salt_config.DEFAULT_MINION_OPTS["conf_file"],
             )
         )
         default_include = pre_opts.get("default_include", opts["default_include"])
         include = pre_opts.get("include", [])
         pre_opts.update(
-            salt.config.include_config(
+            _salt_config.include_config(
                 default_include, opts["conf_file"], verbose=False
             )
         )
         pre_opts.update(
-            salt.config.include_config(include, opts["conf_file"], verbose=True)
+            _salt_config.include_config(include, opts["conf_file"], verbose=True)
         )
         if "grains" in pre_opts:
             opts["grains"] = pre_opts["grains"]

--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -1060,8 +1060,9 @@ def grains(opts, force_refresh=False, proxy=None, context=None, loaded_base_name
         __grains__ = salt.loader.grains(__opts__)
         print __grains__['id']
     """
-    # Need to re-import salt.config, somehow it got lost when a minion is starting
-    import salt.config
+    # Without this global declaration, the late `import` statement below causes
+    # `salt` to become a function-local variable.
+    global salt
 
     # if we have no grains, lets try loading from disk (TODO: move to decorator?)
     cfn = os.path.join(opts["cachedir"], "grains.cache.p")

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -123,7 +123,6 @@ def resolve_dns(opts, fallback=True):
         "use_master_when_local", False
     ):
         check_dns = False
-    import salt.utils.network
 
     if check_dns is True:
         try:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -914,9 +914,11 @@ class SMinion(MinionBase):
     """
 
     def __init__(self, opts, context=None):
-        # Late setup of the opts grains, so we can log from the grains module
-        import salt.loader
+        # Without this global declaration, the late `import` statement below
+        # causes `salt` to become a function-local variable.
+        global salt
 
+        # Late setup of the opts grains, so we can log from the grains module
         opts["grains"] = salt.loader.grains(opts)
         super().__init__(opts)
 

--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -12,9 +12,11 @@ from collections import namedtuple
 
 import salt.utils.data
 import salt.utils.jid
+import salt.utils.lazy
 import salt.utils.versions
-import salt.utils.yaml
 from salt.exceptions import SaltInvocationError
+
+_salt_utils_yaml = salt.utils.lazy.lazy_import("salt.utils.yaml")
 
 log = logging.getLogger(__name__)
 
@@ -174,14 +176,14 @@ def yamlify_arg(arg):
         if "#" in arg:
             # Only yamlify if it parses into a non-string type, to prevent
             # loss of content due to # as comment character
-            parsed_arg = salt.utils.yaml.safe_load(arg)
+            parsed_arg = _salt_utils_yaml.safe_load(arg)
             if isinstance(parsed_arg, str) or parsed_arg is None:
                 return arg
             return parsed_arg
         if arg == "None":
             arg = None
         else:
-            arg = salt.utils.yaml.safe_load(arg)
+            arg = _salt_utils_yaml.safe_load(arg)
 
         if isinstance(arg, dict):
             # dicts must be wrapped in curly braces

--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -170,9 +170,6 @@ def yamlify_arg(arg):
             return arg
 
     try:
-        # Explicit late import to avoid circular import. DO NOT MOVE THIS.
-        import salt.utils.yaml
-
         original_arg = arg
         if "#" in arg:
             # Only yamlify if it parses into a non-string type, to prevent
@@ -360,9 +357,6 @@ def test_mode(**kwargs):
     "Test" in any variation on capitalization (i.e. "TEST", "Test", "TeSt",
     etc) contains a True value (as determined by salt.utils.data.is_true).
     """
-    # Once is_true is moved, remove this import and fix the ref below
-    import salt.utils
-
     for arg, value in kwargs.items():
         try:
             if arg.lower() == "test" and salt.utils.data.is_true(value):

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -15,12 +15,15 @@ import re
 from collections.abc import Mapping, MutableMapping, Sequence
 
 import salt.utils.dictupdate
+import salt.utils.lazy
 import salt.utils.stringutils
 import salt.utils.yaml
 from salt.defaults import DEFAULT_TARGET_DELIM
 from salt.exceptions import SaltException
 from salt.utils.decorators.jinja import jinja_filter
 from salt.utils.odict import OrderedDict
+
+_salt_utils_args = salt.utils.lazy.lazy_import("salt.utils.args")
 
 try:
     import jmespath
@@ -852,12 +855,9 @@ def traverse_dict_and_list(data, key, default=None, delimiter=DEFAULT_TARGET_DEL
             try:
                 ptr = ptr[each]
             except KeyError:
-                # Late import to avoid circular import
-                import salt.utils.args
-
                 # YAML-load the current key (catches integer/float dict keys)
                 try:
-                    loaded_key = salt.utils.args.yamlify_arg(each)
+                    loaded_key = _salt_utils_args.yamlify_arg(each)
                 except Exception:  # pylint: disable=broad-except
                     return default
                 if loaded_key == each:

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -17,13 +17,13 @@ from collections.abc import Mapping, MutableMapping, Sequence
 import salt.utils.dictupdate
 import salt.utils.lazy
 import salt.utils.stringutils
-import salt.utils.yaml
 from salt.defaults import DEFAULT_TARGET_DELIM
 from salt.exceptions import SaltException
 from salt.utils.decorators.jinja import jinja_filter
 from salt.utils.odict import OrderedDict
 
 _salt_utils_args = salt.utils.lazy.lazy_import("salt.utils.args")
+_salt_utils_yaml = salt.utils.lazy.lazy_import("salt.utils.yaml")
 
 try:
     import jmespath
@@ -1043,8 +1043,8 @@ def repack_dictlist(data, strict=False, recurse=False, key_cb=None, val_cb=None)
     """
     if isinstance(data, str):
         try:
-            data = salt.utils.yaml.safe_load(data)
-        except salt.utils.yaml.parser.ParserError as err:
+            data = _salt_utils_yaml.safe_load(data)
+        except _salt_utils_yaml.parser.ParserError as err:
             log.error(err)
             return {}
 

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -12,13 +12,15 @@ import time
 from collections import defaultdict
 from functools import wraps
 
-import salt.utils.args
+import salt.utils.lazy
 import salt.utils.versions
 from salt.exceptions import (
     CommandExecutionError,
     SaltConfigurationError,
     SaltInvocationError,
 )
+
+_salt_utils_args = salt.utils.lazy.lazy_import("salt.utils.args")
 
 IS_WINDOWS = False
 if getattr(sys, "getwindowsversion", False):
@@ -119,9 +121,9 @@ class Depends:
         full_name = "{}.{}".format(mod_name, func_name)
         log.trace("Running '%s' for '%s'", dependency, full_name)
         if IS_WINDOWS:
-            args = salt.utils.args.shlex_split(dependency, posix=False)
+            args = _salt_utils_args.shlex_split(dependency, posix=False)
         else:
-            args = salt.utils.args.shlex_split(dependency)
+            args = _salt_utils_args.shlex_split(dependency)
         log.trace("Command after shlex_split: %s", args)
         proc = subprocess.Popen(
             args, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
@@ -256,7 +258,7 @@ def timing(function):
     @wraps(function)
     def wrapped(*args, **kwargs):
         start_time = time.time()
-        ret = function(*args, **salt.utils.args.clean_kwargs(**kwargs))
+        ret = function(*args, **_salt_utils_args.clean_kwargs(**kwargs))
         end_time = time.time()
         if function.__module__.startswith("salt.loaded.int."):
             mod_name = function.__module__[16:]
@@ -334,7 +336,7 @@ class _DeprecationDecorator:
         :return:
         """
         _args = list()
-        _kwargs = salt.utils.args.clean_kwargs(**kwargs)
+        _kwargs = _salt_utils_args.clean_kwargs(**kwargs)
 
         return _args, _kwargs
 

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -13,7 +13,6 @@ from collections import defaultdict
 from functools import wraps
 
 import salt.utils.args
-import salt.utils.data
 import salt.utils.versions
 from salt.exceptions import (
     CommandExecutionError,

--- a/salt/utils/lazy.py
+++ b/salt/utils/lazy.py
@@ -3,7 +3,9 @@ Lazily-evaluated data structures, primarily used by Salt's loader
 """
 
 
+import importlib.util
 import logging
+import sys
 from collections.abc import MutableMapping
 
 import salt.exceptions
@@ -116,3 +118,123 @@ class LazyDict(MutableMapping):
         if not self.loaded:
             self._load_all()
         return iter(self._dict)
+
+
+class _LazyModuleLoader(importlib.util.LazyLoader):  # pylint: disable=abstract-method
+    _known = {"__file__", "__loader__", "__name__", "__path__", "__spec__"}
+
+    class _LazyModule(importlib.util._LazyModule):
+        def __getattribute__(self, attr):
+            # Avoid triggering load for attributes whose value is already known.
+            # This makes it possible to lazy load a module without eagerly
+            # loading its parent module.
+            if attr in _LazyModuleLoader._known:
+                grandself = super(importlib.util._LazyModule, self)
+                return grandself.__getattribute__(attr)
+            # If the parent module is a lazy module, load it first in case it
+            # mutates this module during its load.
+            parent_name = self.__name__.rpartition(".")[0]
+            if parent_name:
+                parent_mod = importlib.import_module(parent_name)
+                if isinstance(parent_mod, _LazyModuleLoader._LazyModule):
+                    # There is no risk of infinite recursion if the parent
+                    # module accesses an attribute of this module during its
+                    # load because the parent's module type is changed to
+                    # types.ModuleType before it loads.
+                    vars(parent_mod)
+            # If the parent module accessed an attribute of this module while it
+            # was loading, then this __getattribute__ method was called a second
+            # time and returned before the first call reached this point.  In
+            # that case, the second call will have already completed the load so
+            # a plain getattr() should suffice.
+            if not isinstance(self, _LazyModuleLoader._LazyModule):
+                return getattr(self, attr)
+            return super().__getattribute__(attr)
+
+    def exec_module(self, module):
+        super().exec_module(module)
+        module.__class__ = self._LazyModule
+
+
+def lazy_import(name):
+    """Python ``import`` with loading delayed until first attribute access.
+
+    This function is meant to be a drop-in replacement for the Python ``import``
+    statement.  In other words, the following:
+
+    .. code-block:: python
+
+        import salt.utils.lazy
+        _baz = salt.utils.lazy.lazy_import("foo.bar.baz")
+
+    behaves the same as:
+
+    .. code-block:: python
+
+        import foo.bar.baz as _baz
+
+    except the actual read of ``foo/__init__.py``, ``foo/bar/__init__.py``, and
+    ``foo/bar/baz.py``—and the execution of their contents—does not happen until
+    an attribute of ``_baz`` is read or deleted (assuming the modules are not
+    already loaded).
+
+    Lazily importing modules is useful for breaking circular imports or for
+    improving startup speed.
+
+    If the module is not a top-level module (in other words, if ``name``
+    contains a period), the module's parent module is also imported lazily.
+
+    Relative imports are not supported.
+
+    Advantages of this function over a delayed ``import`` statement (an
+    ``import`` statement inside a function instead of at the top of the ``.py``
+    file):
+
+    * This function immediately checks whether the module can be loaded without
+      loading it, so an ``ImportError`` exception will be raised right away if
+      the module is missing.
+    * The statement ``import foo.bar`` anywhere in a function makes ``foo`` a
+      function-local variable unless ``global foo`` is added to the function.
+      This will cause references to ``foo`` to raise an "UnboundLocalError:
+      local variable 'foo' referenced before assignment" exception unless the
+      ``import`` statement is guaranteed to execute before any reference to
+      ``foo``.
+
+    Disadvantages vs. an ordinary ``import`` statement at the top of the file:
+
+    * Added latency when the lazily imported module is first used.
+    * Any exception raised during module load will surface when the lazily
+      imported module is first used, not during program startup.
+
+    This function is a copy of
+    <https://docs.python.org/3.11/library/importlib.html#implementing-lazy-imports>
+    with the following changes:
+
+    * This version checks if the module has already been imported.
+    * This version supports lazy loading of parent modules (the example given in
+      the Python documentation always eagerly loads any parent modules).
+    * When importing a module like ``parent.child``, the ``child`` attribute of
+      the ``parent`` module is set to the ``parent.child`` module object (like
+      the ``import`` statement does).
+
+    """
+    try:
+        return sys.modules[name]
+    except KeyError:
+        pass
+    parent_name, _, child_name = name.rpartition(".")
+    # Lazy import the parent module before creating the child module to prevent
+    # importlib.util.find_spec() from eagerly importing the parent.
+    parent_module = lazy_import(parent_name) if parent_name else None
+    spec = importlib.util.find_spec(name)
+    loader = _LazyModuleLoader(spec.loader)
+    spec.loader = loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    loader.exec_module(module)
+    if parent_module is not None:
+        # Setting an attribute on a lazy module will not cause the module to
+        # load -- only getting or deleting an attribute does that.  This
+        # attribute will be preserved when the parent is eventually loaded.
+        setattr(parent_module, child_name, module)
+    return module

--- a/tests/pytests/unit/utils/_lazy_test_module/__init__.py
+++ b/tests/pytests/unit/utils/_lazy_test_module/__init__.py
@@ -1,0 +1,1 @@
+evaluation_counts = {}

--- a/tests/pytests/unit/utils/_lazy_test_module/pkg/__init__.py
+++ b/tests/pytests/unit/utils/_lazy_test_module/pkg/__init__.py
@@ -1,0 +1,9 @@
+import tests.pytests.unit.utils._lazy_test_module as m
+import tests.pytests.unit.utils._lazy_test_module.pkg.sub as child
+
+m.evaluation_counts.setdefault(__name__, 0)
+m.evaluation_counts[__name__] += 1
+
+name = __name__
+if not child.mutated_from_parent:  # Trigger the lazy module's __getattribute__.
+    child.mutated_from_parent = True

--- a/tests/pytests/unit/utils/_lazy_test_module/pkg/sub.py
+++ b/tests/pytests/unit/utils/_lazy_test_module/pkg/sub.py
@@ -1,0 +1,6 @@
+import tests.pytests.unit.utils._lazy_test_module as m
+
+m.evaluation_counts.setdefault(__name__, 0)
+m.evaluation_counts[__name__] += 1
+
+mutated_from_parent = False

--- a/tests/pytests/unit/utils/test_lazy.py
+++ b/tests/pytests/unit/utils/test_lazy.py
@@ -1,0 +1,91 @@
+import importlib
+import importlib.machinery
+import os.path
+import sys
+
+import pytest
+
+import salt.utils.lazy
+import tests.pytests.unit.utils._lazy_test_module as m
+
+
+def test_lazy_import(subtests):
+    pkg_name = f"{m.__name__}.pkg"
+    sub_name = f"{pkg_name}.sub"
+
+    with subtests.test("initial state"):
+        assert m.evaluation_counts == {}
+
+    with subtests.test("lazy import"):
+        sub_mod = salt.utils.lazy.lazy_import(sub_name)
+
+    with subtests.test("updates sys.modules"):
+        assert sub_name in sys.modules
+        assert sys.modules[sub_name] is sub_mod
+
+    with subtests.test("parent module is created"):
+        assert pkg_name in sys.modules
+        pkg_mod = salt.utils.lazy.lazy_import(pkg_name)
+        assert sys.modules[pkg_name] is pkg_mod
+
+    with subtests.test("nothing loaded yet"):
+        assert m.evaluation_counts == {}
+
+    with subtests.test("idempotent"):
+        assert salt.utils.lazy.lazy_import(sub_name) is sub_mod
+        assert m.evaluation_counts == {}
+
+    with subtests.test("normal import returns the same module without loading"):
+        sub_mod2 = importlib.import_module(sub_name)
+        assert sub_mod2 is sub_mod
+        assert sys.modules[sub_name] is sub_mod
+        assert m.evaluation_counts == {}
+
+    with subtests.test("attributes that don't trigger load"):
+        pkgdir = os.path.join(os.path.dirname(m.__file__), "pkg")
+        want_known_attrs = {
+            pkg_mod: {
+                "__file__": os.path.join(pkgdir, "__init__.py"),
+                "__loader__": object,
+                "__name__": pkg_name,
+                "__path__": list,
+                "__spec__": importlib.machinery.ModuleSpec,
+            },
+            sub_mod: {
+                "__file__": os.path.join(pkgdir, "sub.py"),
+                "__loader__": object,
+                "__name__": sub_name,
+                "__path__": AttributeError,
+                "__spec__": importlib.machinery.ModuleSpec,
+            },
+        }
+        for mod, wants in want_known_attrs.items():
+            with subtests.test(mod=mod):
+                with subtests.test("complete coverage"):
+                    for attr in salt.utils.lazy._LazyModuleLoader._known:
+                        with subtests.test(attr=attr):
+                            assert attr in wants
+                for attr, want in wants.items():
+                    with subtests.test(attr=attr):
+                        if isinstance(want, type) and issubclass(want, Exception):
+                            with pytest.raises(want):
+                                getattr(mod, attr)
+                        else:
+                            got = getattr(mod, attr)
+                            if isinstance(want, type):
+                                assert isinstance(got, want)
+                            else:
+                                assert got == want
+                        assert m.evaluation_counts == {}
+
+    with subtests.test("loading submodule loads parent"):
+        assert sub_mod.mutated_from_parent
+        assert m.evaluation_counts == {pkg_name: 1, sub_name: 1}
+
+    with subtests.test("loading does not affect sys.modules"):
+        assert sys.modules[pkg_name] is pkg_mod
+        assert sys.modules[sub_name] is sub_mod
+
+    with subtests.test("still idempotent after load"):
+        assert salt.utils.lazy.lazy_import(pkg_name) is pkg_mod
+        assert salt.utils.lazy.lazy_import(sub_name) is sub_mod

--- a/tests/unit/test_module_names.py
+++ b/tests/unit/test_module_names.py
@@ -18,6 +18,7 @@ EXCLUDED_DIRS = [
     os.path.join("tests", "kitchen", "tests"),
     os.path.join("tests", "perf"),
     os.path.join("tests", "pkg"),
+    os.path.join("tests", "pytests", "unit", "utils", "_lazy_test_module"),
     os.path.join("tests", "support"),
     os.path.join("tests", "unit", "files"),
     os.path.join("tests", "unit", "modules", "inspectlib"),


### PR DESCRIPTION
### What does this PR do?

  * Defines a new `lazy_import` function that acts like Python's `import` statement but defers module load until a module attribute is read or deleted.  This function is unrelated to and independent of (not a wrapper around) the `salt.loader.*` stuff.
  * Converts some of the existing deferred `import` statements (`import` statements inside a function that are evaluated when the function is called) to lazy imports.
  * Converts some eager imports to lazy imports to avoid circular imports with planned features (https://github.com/saltstack/salt/pull/62932)

The new `lazy_import` function is a copy of https://docs.python.org/3/library/importlib.html#implementing-lazy-imports except:
  * This version checks if the module has already been imported.
  * This version supports lazy loading of parent modules (the example given in the Python documentation always eagerly loads any parent modules).
  * When importing `parent.child`, the `child` attribute of the `parent` module is set to the `parent.child` module object (like the `import` statement does).

### What issues does this PR fix or reference?

See https://github.com/saltstack/salt/pull/62932#issuecomment-1318063856 for context.

### Behavior Changes

No behavior changes are expected.  The new `salt.utils.lazy.lazy_import` function is meant to be a drop-in replacement of the Python `import` statement.  In other words, this:

```python
import salt.utils.lazy
_baz = salt.utils.lazy.lazy_import("foo.bar.baz")
```

behaves the same as:

```python
import foo.bar.baz as _baz
```

except:
  * The actual read of `foo/__init__.py`, `foo/bar/__init__.py`, and `foo/bar/baz.py`—and the execution of their contents—does not happen until an attribute of `_baz` is read or deleted (assuming the modules are not already loaded).
  * Relative imports are not (yet) supported.

### Merge requirements satisfied?

- [x] Docs (only docstrings because this only changes internals)
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?

No
