### PR TITLE
Deprecate return layout in the keyboard module

### DIFF
--- a/changelog/62838.deprecated
+++ b/changelog/62838.deprecated
@@ -1,0 +1,1 @@
+The `set_sys` and `get_x` functions in the keyboard module will change in the Argon release to return True instead of the value of `layout`.

--- a/salt/modules/keyboard.py
+++ b/salt/modules/keyboard.py
@@ -7,6 +7,7 @@ systemd, or such as Redhat, Debian and Gentoo.
 import logging
 
 import salt.utils.path
+import salt.utils.versions
 
 log = logging.getLogger(__name__)
 
@@ -77,6 +78,11 @@ def set_sys(layout):
         __salt__["file.sed"](
             "/etc/conf.d/keymaps", "^keymap=.*", "keymap={}".format(layout)
         )
+
+
+    # set_sys_warning_message = "The set_sys function will return True instead of layout in the Argon release"
+    # salt.utils.versions.warn_until("Argon", set_sys_warning_message)
+
     return layout
 
 
@@ -107,4 +113,8 @@ def set_x(layout):
     """
     cmd = "setxkbmap {}".format(layout)
     __salt__["cmd.run"](cmd)
+
+    # set_x_warning_message = "The set_x function will return True instead of layout in the Argon release"
+    # salt.utils.versions.warn_until("Argon", set_x_warning_message)
+
     return layout


### PR DESCRIPTION
Please see: https://github.com/saltstack/salt/pull/62839 for more context. This patch deprecates the return value for the set_sys and set_x methods in the keyboard module, as this will change from 'layout' to 'True' in the Argon release.

### What does this PR do?

### What issues does this PR fix or reference?
Fixes: #62838 

### Previous Behavior
No warning about deprecated return value

### New Behavior
Keyboard module now warns about deprecated return value

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
