### PR TITLE
Add debug message displaying actual installation command

### DIFF
--- a/changelog/62480.added
+++ b/changelog/62480.added
@@ -1,0 +1,1 @@
+Added debug log messages displaying the command being run when installing packages on Windows

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1768,10 +1768,10 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
 
         # Install the software
         # Check Use Scheduler Option
+        log.debug("PKG : cmd: %s /s /c %s", cmd_shell, arguments)
+        log.debug("PKG : pwd: %s", cache_path)
         if pkginfo[version_num].get("use_scheduler", False):
             # Create Scheduled Task
-            log.debug("PKG : cmd: %s /s /c %s", cmd_shell, arguments)
-            log.debug("PKG : pwd: %s", cache_path)
             __salt__["task.create_task"](
                 name="update-salt-software",
                 user_name="System",
@@ -1829,8 +1829,6 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
                     ret[pkg_name] = {"install status": "failed"}
         else:
             # Launch the command
-            log.debug("PKG : cmd: %s /s /c %s", cmd_shell, arguments)
-            log.debug("PKG : pwd: %s", cache_path)
             result = __salt__["cmd.run_all"](
                 '"{}" /s /c "{}"'.format(cmd_shell, arguments),
                 cache_path,

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1770,6 +1770,8 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
         # Check Use Scheduler Option
         if pkginfo[version_num].get("use_scheduler", False):
             # Create Scheduled Task
+            log.debug("PKG : cmd: %s /s /c %s", cmd_shell, arguments)
+            log.debug("PKG : pwd: %s", cache_path)
             __salt__["task.create_task"](
                 name="update-salt-software",
                 user_name="System",
@@ -1827,6 +1829,8 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
                     ret[pkg_name] = {"install status": "failed"}
         else:
             # Launch the command
+            log.debug("PKG : cmd: %s /s /c %s", cmd_shell, arguments)
+            log.debug("PKG : pwd: %s", cache_path)
             result = __salt__["cmd.run_all"](
                 '"{}" /s /c "{}"'.format(cmd_shell, arguments),
                 cache_path,
@@ -1834,6 +1838,7 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
                 python_shell=False,
                 redirect_stderr=True,
             )
+            log.debug("PKG : retcode: %s", result["retcode"])
             if not result["retcode"]:
                 ret[pkg_name] = {"install status": "success"}
                 changed.append(pkg_name)

--- a/tests/pytests/unit/modules/test_win_pkg.py
+++ b/tests/pytests/unit/modules/test_win_pkg.py
@@ -312,7 +312,9 @@ def test_pkg_install_log_message(caplog):
             "cp.is_cached": MagicMock(return_value="C:\\fake\\path.exe"),
             "cmd.run_all": mock_cmd_run_all,
         },
-    ), caplog.at_level(logging.DEBUG):
+    ), caplog.at_level(
+        logging.DEBUG
+    ):
         win_pkg.install(
             pkgs=["firebox"],
             version="3.03",

--- a/tests/pytests/unit/modules/test_win_pkg.py
+++ b/tests/pytests/unit/modules/test_win_pkg.py
@@ -323,8 +323,8 @@ def test_pkg_install_log_message(caplog):
         assert (
             'PKG : cmd: C:\\WINDOWS\\system32\\cmd.exe /s /c "runme.exe" /s -e '
             "True -test_flag True"
-        ) in caplog.messages
-        assert "PKG : pwd: " in caplog.messages
+        ).lower() in [x.lower() for x in caplog.messages]
+        assert "PKG : pwd: ".lower() in [x.lower() for x in caplog.messages]
         assert "PKG : retcode: 0" in caplog.messages
 
 

--- a/tests/pytests/unit/modules/test_win_pkg.py
+++ b/tests/pytests/unit/modules/test_win_pkg.py
@@ -1,6 +1,8 @@
 """
 Tests for the win_pkg module
 """
+import logging
+
 import pytest
 
 import salt.modules.config as config
@@ -277,6 +279,51 @@ def test_pkg_install_single_pkg():
             extra_install_flags="-e True -test_flag True",
         )
         assert "-e True -test_flag True" in str(mock_cmd_run_all.call_args[0])
+
+
+def test_pkg_install_log_message(caplog):
+    """
+    test pkg.install pkg with extra_install_flags
+    """
+    ret__get_package_info = {
+        "3.03": {
+            "uninstaller": "%program.exe",
+            "reboot": False,
+            "msiexec": False,
+            "installer": "runme.exe",
+            "uninstall_flags": "/S",
+            "locale": "en_US",
+            "install_flags": "/s",
+            "full_name": "Firebox 3.03 (x86 en-US)",
+        }
+    }
+
+    mock_cmd_run_all = MagicMock(return_value={"retcode": 0})
+    with patch.object(
+        salt.utils.data, "is_true", MagicMock(return_value=True)
+    ), patch.object(
+        win_pkg, "_get_package_info", MagicMock(return_value=ret__get_package_info)
+    ), patch.dict(
+        win_pkg.__salt__,
+        {
+            "pkg_resource.parse_targets": MagicMock(
+                return_value=[{"firebox": "3.03"}, None]
+            ),
+            "cp.is_cached": MagicMock(return_value="C:\\fake\\path.exe"),
+            "cmd.run_all": mock_cmd_run_all,
+        },
+    ), caplog.at_level(logging.DEBUG):
+        win_pkg.install(
+            pkgs=["firebox"],
+            version="3.03",
+            extra_install_flags="-e True -test_flag True",
+        )
+        assert (
+            'PKG : cmd: C:\\WINDOWS\\system32\\cmd.exe /s /c "runme.exe" /s -e '
+            "True -test_flag True"
+        ) in caplog.messages
+        assert "PKG : pwd: " in caplog.messages
+        assert "PKG : retcode: 0" in caplog.messages
 
 
 def test_pkg_install_multiple_pkgs():


### PR DESCRIPTION
### What does this PR do?
Adds a debug message to display the actual command that is being run when installing packages using the Windows package manager.

### What issues does this PR fix or reference?
Fixes: #62480 

### Previous Behavior
I was only displaying the message from the `cmd.run` command which only showed the binary being run without the arguments that were passed.

### New Behavior
Displays a debug message similar this:
```
[DEBUG ] PKG : cmd: C:\\WINDOWS\\system32\\cmd.exe /s /c "runme.exe" /s -e True -test True
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes