### PR TITLE
Add ability for file.symlink to not set ownership on existing links

### DIFF
--- a/changelog/63093.added
+++ b/changelog/63093.added
@@ -1,0 +1,1 @@
+Add ability for file.symlink to not set ownership on existing links

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1537,6 +1537,7 @@ def symlink(
     win_inheritance=None,
     atomic=False,
     disallow_copy_and_unlink=False,
+    inherit_user_and_group=False,
     **kwargs
 ):
     """
@@ -1581,11 +1582,13 @@ def symlink(
 
     user
         The user to own the file, this defaults to the user salt is running as
-        on the minion
+        on the minion unless the link already exists and
+        ``inherit_user_and_group`` is set
 
     group
         The group ownership set for the file, this defaults to the group salt
-        is running as on the minion. On Windows, this is ignored
+        is running as on the minion unless the link already exists and
+        ``inherit_user_and_group`` is set. On Windows, this is ignored
 
     mode
         The permissions to set on this file, aka 644, 0775, 4664. Not supported
@@ -1631,6 +1634,15 @@ def symlink(
         unlink" approach, which is required for moving across filesystems.
 
         .. versionadded:: 3006.0
+
+    inherit_user_and_group
+        If set to ``True``, the link already exists, and either ``user`` or
+        ``group`` are not set, this parameter will inform Salt to pull the user
+        and group information from the existing link and use it where ``user``
+        or ``group`` is not set. The ``user`` and ``group`` parameters will
+        override this behavior.
+
+        .. versionadded:: 3006.0
     """
     name = os.path.expanduser(name)
 
@@ -1642,6 +1654,18 @@ def symlink(
     mode = salt.utils.files.normalize_mode(mode)
 
     user = _test_owner(kwargs, user=user)
+
+    if (
+        inherit_user_and_group
+        and (user is None or group is None)
+        and __salt__["file.is_link"](name)
+    ):
+        cur_user, cur_group = _get_symlink_ownership(name)
+        if user is None:
+            user = cur_user
+        if group is None:
+            group = cur_group
+
     if user is None:
         user = __opts__["user"]
 

--- a/tests/pytests/unit/states/file/test_symlink.py
+++ b/tests/pytests/unit/states/file/test_symlink.py
@@ -392,9 +392,36 @@ def test_symlink():
     ), patch(
         "salt.states.file._check_symlink_ownership", return_value=True
     ):
-        group = None
-
         comt = "Created new symlink {} -> {}".format(name, target)
         ret = return_val({"comment": comt, "result": True, "changes": {"new": name}})
         res = filestate.symlink(name, target, user=user, group=user)
+        assert res == ret
+
+    with patch.dict(
+        filestate.__salt__,
+        {
+            "file.is_link": mock_t,
+            "file.get_user": mock_user,
+            "file.get_group": mock_grp,
+            "file.user_to_uid": mock_uid,
+            "file.group_to_gid": mock_gid,
+            "file.readlink": mock_target,
+        },
+    ), patch.dict(filestate.__opts__, {"test": False}), patch.object(
+        os.path, "isdir", MagicMock(side_effect=[True, False])
+    ), patch.object(
+        os.path, "isfile", mock_f
+    ), patch(
+        "salt.utils.win_functions.get_sid_from_name", return_value="test-sid"
+    ), patch(
+        "salt.states.file._set_symlink_ownership", return_value=True
+    ), patch(
+        "salt.states.file._check_symlink_ownership", return_value=True
+    ):
+        if salt.utils.platform.is_windows():
+            comt = "Symlink {} is present and owned by {}".format(name, user)
+        else:
+            comt = "Symlink {} is present and owned by {}:{}".format(name, user, group)
+        ret = return_val({"comment": comt, "result": True, "changes": {}})
+        res = filestate.symlink(name, target, inherit_user_and_group=True)
         assert res == ret

--- a/tests/pytests/unit/states/file/test_symlink.py
+++ b/tests/pytests/unit/states/file/test_symlink.py
@@ -405,7 +405,9 @@ def test_symlink():
             "file.get_group": mock_grp,
             "file.user_to_uid": mock_uid,
             "file.group_to_gid": mock_gid,
+            "file.gid_to_group": MagicMock(return_value=group),
             "file.readlink": mock_target,
+            "user.info": mock_t,
         },
     ), patch.dict(filestate.__opts__, {"test": False}), patch.object(
         os.path, "isdir", MagicMock(side_effect=[True, False])

--- a/tests/pytests/unit/states/file/test_symlink.py
+++ b/tests/pytests/unit/states/file/test_symlink.py
@@ -417,6 +417,8 @@ def test_symlink():
         "salt.states.file._set_symlink_ownership", return_value=True
     ), patch(
         "salt.states.file._check_symlink_ownership", return_value=True
+    ), patch(
+        "salt.states.file._get_symlink_ownership", return_value=(user, group)
     ):
         if salt.utils.platform.is_windows():
             comt = "Symlink {} is present and owned by {}".format(name, user)


### PR DESCRIPTION
### What does this PR do?
See issue for details.

### What issues does this PR fix or reference?
Fixes: #63093

### Previous Behavior
Salt would _always_ set user/group on the link regardless if the user/group parameters were set.

### New Behavior
The added `inherit_user_and_group` parameter allows the existing ownership to be used for existing links when user/group parameters are not used.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
