### PR TITLE
Correct TCP transport documentation regarding master-side filtering

### DIFF
--- a/changelog/63120.fixed
+++ b/changelog/63120.fixed
@@ -1,0 +1,1 @@
+TCP transport documentation now contains proper master/minion-side filtering information

--- a/doc/topics/transports/tcp.rst
+++ b/doc/topics/transports/tcp.rst
@@ -46,7 +46,7 @@ The TCP transport allows for the master/minion communication to be optionally
 wrapped in a TLS connection. Enabling this is simple, the master and minion need
 to be using the tcp connection, then the `ssl` option is enabled. The `ssl`
 option is passed as a dict and corresponds to the options passed to the
-Python `ssl.wrap_socket <https://docs.python.org/3/library/ssl.html#ssl.wrap_socket>`
+Python `ssl.wrap_socket <https://docs.python.org/3/library/ssl.html#ssl.wrap_socket>`_
 function.
 
 A simple setup looks like this, on the Salt Master add the `ssl` option to the
@@ -58,6 +58,7 @@ master configuration file:
       keyfile: <path_to_keyfile>
       certfile: <path_to_certfile>
       ssl_version: PROTOCOL_TLSv1_2
+      ciphers: ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384
 
 The minimal `ssl` option in the minion configuration file looks like this:
 
@@ -75,7 +76,8 @@ Specific options can be sent to the minion also, as defined in the Python
     While setting the ssl_version is not required, we recommend it. Some older
     versions of python do not support the latest TLS protocol and if this is
     the case for your version of python we strongly recommend upgrading your
-    version of Python.
+    version of Python. Ciphers specification might be omitted, but strongly
+    recommended as otherwise all available ciphers will be enabled.
 
 
 Crypto
@@ -90,7 +92,13 @@ the remote end interprets as a one-way send.
 
 .. note::
 
-    As of today we send all publishes to all minions and rely on minion-side filtering.
+    As of Salt `2016.3.0 <https://github.com/saltstack/salt/commit/1a395ed7a3e72eac87e81dfa072be9cf049453d3>`_, publishes using ``list`` targeting are sent only to relevant minions and not broadcasted.
+
+    As of Salt `3005 <https://github.com/saltstack/salt/commit/9db1af7147f7e6176e5f226cfedf1654ca038ec1>`_, publishes using ``pcre`` and ``glob`` targeting are also sent only to relevant minions and not broadcasted. Other targeting types are always sent to all minions and rely on minion-side filtering.
+
+.. note::
+
+   Salt CLI defaults to ``glob`` targeting type, so in order to target specific minions without broadcast, you need to use `-L` option, such as ``salt -L my.minion test.ping``, for masters before 3005.
 
 
 Request Server and Client


### PR DESCRIPTION
### What does this PR do?
Fixes mention about client-side filtering forTCP transport, plus few small changes

### What issues does this PR fix or reference?
Fixes: #63120

### Previous Behavior
- Link towards `ssl.wrap_socket` was not correctly formatted
- Documentation states that TCP transport supports only `minion-side` filtering

### New Behavior
- Link is correct
- Ciphers configuration is mentioned in the example, as that's what you mostly want to do as well
- Note about master-side filtering is corrected, along with links to appropriate commits that introduced that change
- Note about default CLI filtering value is added, so users know what exactly they should be doing

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
