### PR TITLE
remove boto dependency from boto3mod

### DIFF
--- a/changelog/62672.fixed
+++ b/changelog/62672.fixed
@@ -1,0 +1,1 @@
+Fix depenency on legacy boto module in boto3 modules

--- a/salt/utils/boto3mod.py
+++ b/salt/utils/boto3mod.py
@@ -40,8 +40,8 @@ try:
     # pylint: disable=import-error
     import boto3
     import boto3.session
-    import boto.exception
     import botocore  # pylint: disable=W0611
+    import botocore.exceptions
 
     # pylint: enable=import-error
     logging.getLogger("boto3").setLevel(logging.CRITICAL)
@@ -201,7 +201,7 @@ def get_connection(
         conn = session.client(module)
         if conn is None:
             raise SaltInvocationError('Region "{}" is not valid.'.format(region))
-    except boto.exception.NoAuthHandlerFound:
+    except botocore.exceptions.NoCredentialsError:
         raise SaltInvocationError(
             "No authentication credentials found when "
             "attempting to make boto {} connection to "

--- a/salt/utils/boto3mod.py
+++ b/salt/utils/boto3mod.py
@@ -38,7 +38,6 @@ from salt.exceptions import SaltInvocationError
 # pylint: disable=import-error
 try:
     # pylint: disable=import-error
-    import boto
     import boto3
     import boto3.session
     import boto.exception


### PR DESCRIPTION
### What does this PR do?
Removes the Boto dependency from Boto3mod

### What issues does this PR fix or reference?
Fixes: [62672](https://github.com/saltstack/salt/issues/62672)

### Previous Behavior
Boto3 commands are unusable unless the four year old module is installed

### New Behavior
Will work correctly

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
