### PR TITLE
Fix pkgrepo.managed PPA handling for newer Ubuntu versions

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -1956,9 +1956,11 @@ def get_repo(repo, **kwargs):
             if HAS_SOFTWAREPROPERTIES:
                 try:
                     if hasattr(softwareproperties.ppa, "PPAShortcutHandler"):
-                        repo = softwareproperties.ppa.PPAShortcutHandler(repo).expand(
-                            dist
-                        )[0]
+                        handler = softwareproperties.ppa.PPAShortcutHandler(repo)
+                        if hasattr(handler, "expand"):
+                            repo = handler.expand(dist)[0]
+                        else:
+                            repo = handler.SourceEntry().line
                     else:
                         repo = softwareproperties.ppa.expand_ppa_line(repo, dist)[0]
                 except NameError as name_error:
@@ -2040,7 +2042,11 @@ def del_repo(repo, **kwargs):
                 repo = LP_SRC_FORMAT.format(owner_name, ppa_name, dist)
         else:
             if hasattr(softwareproperties.ppa, "PPAShortcutHandler"):
-                repo = softwareproperties.ppa.PPAShortcutHandler(repo).expand(dist)[0]
+                handler = softwareproperties.ppa.PPAShortcutHandler(repo)
+                if hasattr(handler, "expand"):
+                    repo = handler.expand(dist)[0]
+                else:
+                    repo = handler.SourceEntry().line
             else:
                 repo = softwareproperties.ppa.expand_ppa_line(repo, dist)[0]
 
@@ -3030,9 +3036,11 @@ def _expand_repo_def(os_name, lsb_distrib_codename=None, **kwargs):
         else:
             if HAS_SOFTWAREPROPERTIES:
                 if hasattr(softwareproperties.ppa, "PPAShortcutHandler"):
-                    repo = softwareproperties.ppa.PPAShortcutHandler(repo).expand(dist)[
-                        0
-                    ]
+                    handler = softwareproperties.ppa.PPAShortcutHandler(repo)
+                    if hasattr(handler, "expand"):
+                        repo = handler.expand(dist)[0]
+                    else:
+                        repo = handler.SourceEntry().line
                 else:
                     repo = softwareproperties.ppa.expand_ppa_line(repo, dist)[0]
             else:


### PR DESCRIPTION
### What does this PR do?

Fixed PPA handling in newer Ubuntu versions with patch provided in https://github.com/saltstack/salt/issues/59065#issuecomment-1118112165

### What issues does this PR fix or reference?
Fixes: #59065 

### Previous Behavior
It would fail to manage PPA repos

### New Behavior
It now handles PPA repos

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
