### PR TITLE
Fix the virtual grain's detection of parallels

### DIFF
--- a/changelog/63181.fixed.md
+++ b/changelog/63181.fixed.md
@@ -1,0 +1,1 @@
+Fixed issue with the core virtual grain not detecting some Parallels virtual machines

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -973,7 +973,8 @@ def _virtual(osdata):
             elif ": Microsoft" in output and "Virtual Machine" in output:
                 grains["virtual"] = "VirtualPC"
             # Manufacturer: Parallels Software International Inc.
-            elif "Parallels Software" in output:
+            # Manufacturer: Parallels International GmbH.
+            elif "Manufacturer: Parallels" in output:
                 grains["virtual"] = "Parallels"
             elif "Manufacturer: Google" in output:
                 grains["virtual"] = "kvm"


### PR DESCRIPTION
### What does this PR do?
dmidecode returns "Parallels International GmbH." instead of "Parallels Software International Inc." for the manufacture on some Parallels virtual machines. I'm not entirely sure why/when the new value is returned, but this change broadens the match to include both variations.

### What issues does this PR fix or reference?
Fixes: #63181

### Previous Behavior
`salt-call grains.get virtual` would return `physical` on some Parallels VM's.

### New Behavior
`salt-call grains.get virtual` returns `Parallels` on all Parallels VM's.

### Merge requirements satisfied?
I did not add a test for this, since there doesn't appear to be any tests for the dmidecode path at all.

### Commits signed with GPG?
Yes
