### PR TITLE
Fix VoidLinux os grain check in xbpspkg exec module virtual

### DIFF
--- a/changelog/63186.fixed
+++ b/changelog/63186.fixed
@@ -1,0 +1,1 @@
+Disambiguate str vs tuple containment check

--- a/salt/modules/xbpspkg.py
+++ b/salt/modules/xbpspkg.py
@@ -29,7 +29,7 @@ def __virtual__():
     """
     Set the virtual pkg module if the os is Void and xbps-install found
     """
-    if __grains__["os"] in ("Void") and _check_xbps():
+    if __grains__["os"] in ("Void",) and _check_xbps():
         return __virtualname__
     return (False, "Missing dependency: xbps-install")
 

--- a/salt/roster/range.py
+++ b/salt/roster/range.py
@@ -18,18 +18,22 @@ import logging
 log = logging.getLogger(__name__)
 
 # Try to import range from https://github.com/ytoolshed/range
-HAS_RANGE = False
 try:
     import seco.range
 
     HAS_RANGE = True
 except ImportError:
-    log.error("Unable to load range library")
+    HAS_RANGE = False
 # pylint: enable=import-error
+
+__virtualname__ = "range"
 
 
 def __virtual__():
-    return HAS_RANGE
+    if HAS_RANGE:
+        return __virtualname__
+    else:
+        return (False, "Unable to load seco.range library")
 
 
 def targets(tgt, tgt_type="range", **kwargs):


### PR DESCRIPTION
If for an unrelated reason the `os` grain is `None`, an interesting, and very likely error happens here:
```python
16:26:17.769 [salt.loader.lazy ]:1150 [    8] [ERROR   ] Exception raised when processing __virtual__ function for salt.loaded.int.module.xbpspkg. Module will not be loaded: 'in <string>' requires string as left operand, not NoneType
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/salt/loader/lazy.py", line 1133, in _process_virtual
    virtual = self.run(virtual_attr)
  File "/usr/lib/python3/dist-packages/salt/loader/lazy.py", line 1228, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/salt/loader/lazy.py", line 1243, in _run_as
    return _func_or_method(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/salt/modules/xbpspkg.py", line 32, in __virtual__
    if __grains__["os"] in ("Void") and _check_xbps():
TypeError: 'in <string>' requires string as left operand, not NoneType
```