### PR TITLE
add securejsondata in grafana datasource state/module

### DIFF
--- a/changelog/63196.added
+++ b/changelog/63196.added
@@ -1,0 +1,1 @@
+add SecureJsonData argument in grafana4_datasource state and module


### PR DESCRIPTION
### What does this PR do?

This PR allows to add the SecureJsonData argument in the API Call that is made to Grafana.
We also had to add a force_recreate_secure_json_data option to avoid recreating the datasource at each run (see comment in the code)

### What issues does this PR fix or reference?
Fixes: #63196

### Merge requirements satisfied?

- [X] Docs
- [X] Changelog
- [ ] Tests written/updated

We didn't write tests but are using it in our production environment.

### Commits signed with GPG?

Yes