### PR TITLE
[FEATURE REQUEST] manage grafana org users removal

### DIFF
--- a/changelog/63198.added
+++ b/changelog/63198.added
@@ -1,0 +1,1 @@
+New Feature: manage users removal for Grafana Organizations


### PR DESCRIPTION
### What does this PR do?

This PR allows to delete users present in the Grafana organization but not in the `users` argument of the state.

### What issues does this PR fix or reference?
Fixes: #63198

### Previous Behavior

The user was not deleted.

### New Behavior

The user is deleted if the `clean_users` option is set to `True`.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

We didn't write tests but are using it in our production environment.

### Commits signed with GPG?
Yes