### PR TITLE
Make pillar cache pass extra minion data

### DIFF
--- a/changelog/63208.fixed
+++ b/changelog/63208.fixed
@@ -1,0 +1,1 @@
+Made pillar cache pass extra minion data as well

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -81,6 +81,7 @@ def get_pillar(
             pillar_override=pillar_override,
             pillarenv=pillarenv,
             clean_cache=clean_cache,
+            extra_minion_data=extra_minion_data,
         )
     return ptype(
         opts,
@@ -419,6 +420,7 @@ class PillarCache:
         self.pillar_override = pillar_override
         self.pillarenv = pillarenv
         self.clean_cache = clean_cache
+        self.extra_minion_data = extra_minion_data
 
         if saltenv is None:
             self.saltenv = "base"
@@ -455,6 +457,7 @@ class PillarCache:
             functions=self.functions,
             pillar_override=self.pillar_override,
             pillarenv=self.pillarenv,
+            extra_minion_data=self.extra_minion_data,
         )
         return fresh_pillar.compile_pillar()
 

--- a/tests/pytests/integration/pillar/cache/conftest.py
+++ b/tests/pytests/integration/pillar/cache/conftest.py
@@ -18,6 +18,9 @@ def pillar_salt_master(salt_factories, pillar_state_tree):
         "pillar_roots": {"base": [str(pillar_state_tree)]},
         "open_mode": True,
         "pillar_cache": True,
+        "ext_pillar": [
+            {"extra_minion_data_in_pillar": "*"},
+        ],
     }
     factory = salt_factories.salt_master_daemon(
         "pillar-cache-functional-master", defaults=config_defaults
@@ -30,7 +33,8 @@ def pillar_salt_master(salt_factories, pillar_state_tree):
 def pillar_salt_minion(pillar_salt_master):
     assert pillar_salt_master.is_running()
     factory = pillar_salt_master.salt_minion_daemon(
-        "pillar-cache-functional-minion-1", defaults={"open_mode": True}
+        "pillar-cache-functional-minion-1",
+        defaults={"open_mode": True, "hi": "there", "pass_to_ext_pillars": ["hi"]},
     )
     with factory.started():
         # Sync All

--- a/tests/pytests/integration/pillar/cache/test_pillar_cache.py
+++ b/tests/pytests/integration/pillar/cache/test_pillar_cache.py
@@ -88,7 +88,7 @@ def test_pillar_cache_items(pillar_cache_tree_no_refresh, pillar_salt_call_cli):
     Test pillar cache does not refresh pillar when using pillar.items
     """
     # pillar.items should be empty
-    assert not pillar_salt_call_cli.run("pillar.items").data
+    pillar_before = pillar_salt_call_cli.run("pillar.items").data
     pillar_salt_call_cli.run("saltutil.refresh_pillar", wait=True)
     # pillar.items should contain the new pillar data
     ret = pillar_salt_call_cli.run("pillar.items")
@@ -96,3 +96,16 @@ def test_pillar_cache_items(pillar_cache_tree_no_refresh, pillar_salt_call_cli):
     assert ret.data
     assert "test" in ret.data
     assert "test2" in ret.data
+    assert ret.data != pillar_before
+
+
+def test_pillar_cache_passes_extra_minion_data(pillar_salt_call_cli):
+    """
+    Test that pillar cache does not disable passing of
+    extra_minion_data to external pillars
+    """
+    ret = pillar_salt_call_cli.run("pillar.items")
+    assert ret.returncode == 0
+    assert ret.data
+    assert "hi" in ret.data
+    assert ret.data["hi"] == "there"


### PR DESCRIPTION
### What does this PR do?
Makes pillar cache pass extra minion data to external pillars.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/63208

### Previous Behavior
`extra_minion_data` is ignored

### New Behavior
`extra_minion_data` is passed when the pillar is rendered

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes