### PR TITLE
Fixing iptables state module mod_aggregate

### DIFF
--- a/changelog/53353.fixed
+++ b/changelog/53353.fixed
@@ -1,0 +1,1 @@
+Ensure when we're adding chunks to the rules when running aggregation with the iptables state module we use a copy of the chunk otherwise we end up with a recursive mess.

--- a/salt/states/iptables.py
+++ b/salt/states/iptables.py
@@ -245,6 +245,8 @@ Example rules for IPSec policy:
     output of iptables-save. This may have unintended consequences on legacy
     releases of ``iptables``.
 """
+import copy
+
 from salt.state import STATE_INTERNAL_KEYWORDS as _STATE_INTERNAL_KEYWORDS
 
 
@@ -432,6 +434,8 @@ def append(name, table="filter", family="ipv4", **kwargs):
         ret["comment"] = "\n".join(comments)
         return ret
 
+    if "__agg__" in kwargs:
+        del kwargs["__agg__"]
     for ignore in _STATE_INTERNAL_KEYWORDS:
         if ignore in kwargs:
             del kwargs[ignore]
@@ -892,7 +896,7 @@ def mod_aggregate(low, chunks, running):
                 continue
 
             if chunk not in rules:
-                rules.append(chunk)
+                rules.append(copy.deepcopy(chunk))
                 chunk["__agg__"] = True
 
     if rules:


### PR DESCRIPTION
### What does this PR do?
Ensure when we're adding chunks to the rules when running aggregation we use a copy of the chunk otherwise we end up with a recursive mess. Updating mod_aggregate test to use real data.

### What issues does this PR fix or reference?
Fixes: #53353 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
