### PR TITLE
Update python to 3.10.9 in MacOS

### DIFF
--- a/pkg/osx/build_python.sh
+++ b/pkg/osx/build_python.sh
@@ -21,16 +21,20 @@
 # The default version to be built
 # TODO: The is not selectable via RELENV yet. This has to match whatever relenv
 # TODO: is building
-PY_VERSION="3.10.7"
+PY_VERSION="3.10.9"
 
 # Valid versions supported by macOS
 PY_VERSIONS=(
+    "3.10.9"
+    "3.10.8"
     "3.10.7"
+    "3.9.16"
     "3.9.15"
     "3.9.14"
     "3.9.13"
     "3.9.12"
     "3.9.11"
+    "3.8.16"
     "3.8.15"
     "3.8.14"
     "3.8.13"


### PR DESCRIPTION
### What does this PR do?
Update python to 3.10.9 for MacOS
This is unimplemented as of yet, until we update relenv to accept python versions as an argument. But this keeps the script updated.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes