### PR TITLE
Bump to `certifi>=2022.12.7`

### DIFF
--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -6,7 +6,7 @@
 #
 apache-libcloud==2.5.0
     # via -r requirements/darwin.txt
-certifi==2022.5.18.1
+certifi==2022.12.7
     # via requests
 cffi==1.14.6
     # via cryptography

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/static/pkg/py3.10/freebsd.txt requirements/base.txt requirements/static/pkg/freebsd.in requirements/zeromq.txt
 #
-certifi==2022.5.18.1
+certifi==2022.12.7
     # via requests
 cffi==1.14.6
     # via cryptography

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/static/pkg/py3.10/linux.txt requirements/base.txt requirements/static/pkg/linux.in requirements/zeromq.txt
 #
-certifi==2022.5.18.1
+certifi==2022.12.7
     # via requests
 cffi==1.14.6
     # via cryptography

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/static/pkg/py3.10/windows.txt requirements/static/pkg/windows.in requirements/windows.txt
 #
-certifi==2022.5.18.1
+certifi==2022.12.7
     # via
     #   -r requirements/windows.txt
     #   requests

--- a/requirements/static/pkg/py3.6/linux.txt
+++ b/requirements/static/pkg/py3.6/linux.txt
@@ -6,7 +6,7 @@
 #
 backports.ssl-match-hostname==3.7.0.1 ; python_version < "3.7"
     # via -r requirements/static/pkg/linux.in
-certifi==2022.5.18.1
+certifi==2022.12.7
     # via requests
 cffi==1.14.6
     # via cryptography

--- a/requirements/static/pkg/py3.7/freebsd.txt
+++ b/requirements/static/pkg/py3.7/freebsd.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/static/pkg/py3.7/freebsd.txt requirements/base.txt requirements/static/pkg/freebsd.in requirements/zeromq.txt
 #
-certifi==2022.5.18.1
+certifi==2022.12.7
     # via requests
 cffi==1.14.6
     # via cryptography

--- a/requirements/static/pkg/py3.7/linux.txt
+++ b/requirements/static/pkg/py3.7/linux.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/static/pkg/py3.7/linux.txt requirements/base.txt requirements/static/pkg/linux.in requirements/zeromq.txt
 #
-certifi==2022.5.18.1
+certifi==2022.12.7
     # via requests
 cffi==1.14.6
     # via cryptography

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/static/pkg/py3.7/windows.txt requirements/static/pkg/windows.in requirements/windows.txt
 #
-certifi==2022.5.18.1
+certifi==2022.12.7
     # via
     #   -r requirements/windows.txt
     #   requests

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/static/pkg/py3.8/freebsd.txt requirements/base.txt requirements/static/pkg/freebsd.in requirements/zeromq.txt
 #
-certifi==2022.5.18.1
+certifi==2022.12.7
     # via requests
 cffi==1.14.6
     # via cryptography

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/static/pkg/py3.8/linux.txt requirements/base.txt requirements/static/pkg/linux.in requirements/zeromq.txt
 #
-certifi==2022.5.18.1
+certifi==2022.12.7
     # via requests
 cffi==1.14.6
     # via cryptography

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/static/pkg/py3.8/windows.txt requirements/static/pkg/windows.in requirements/windows.txt
 #
-certifi==2022.5.18.1
+certifi==2022.12.7
     # via
     #   -r requirements/windows.txt
     #   requests

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -6,7 +6,7 @@
 #
 apache-libcloud==2.5.0
     # via -r requirements/darwin.txt
-certifi==2022.5.18.1
+certifi==2022.12.7
     # via requests
 cffi==1.14.6
     # via cryptography

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/static/pkg/py3.9/freebsd.txt requirements/base.txt requirements/static/pkg/freebsd.in requirements/zeromq.txt
 #
-certifi==2022.5.18.1
+certifi==2022.12.7
     # via requests
 cffi==1.14.6
     # via cryptography

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/static/pkg/py3.9/linux.txt requirements/base.txt requirements/static/pkg/linux.in requirements/zeromq.txt
 #
-certifi==2022.5.18.1
+certifi==2022.12.7
     # via requests
 cffi==1.14.6
     # via cryptography

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/static/pkg/py3.9/windows.txt requirements/static/pkg/windows.in requirements/windows.txt
 #
-certifi==2022.5.18.1
+certifi==2022.12.7
     # via
     #   -r requirements/windows.txt
     #   requests

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -7,7 +7,7 @@ wmi>=1.5.1
 pythonnet>=2.5.2
 
 backports.ssl-match-hostname>=3.7.0.1; python_version < '3.7'
-certifi>=2020.12.5
+certifi>=2022.12.07
 cffi>=1.14.5
 cherrypy>=18.6.1
 cryptography>=3.4.7


### PR DESCRIPTION
### What does this PR do?
Bump to `certifi>=2022.12.7`

Follow up to https://github.com/saltstack/salt/pull/63284

See https://github.com/advisories/GHSA-43fp-rhv2-5gv8 for additional context.