### PR TITLE
switch to test.ping for ssh setup tests

### DIFF
--- a/tests/pytests/integration/ssh/test_ssh_setup.py
+++ b/tests/pytests/integration/ssh/test_ssh_setup.py
@@ -156,24 +156,24 @@ def salt_ssh_cli(
 
 def test_setup(salt_ssh_cli, ssh_container_name, ssh_sub_container_name, ssh_password):
     """
-    Test salt-ssh grains id work for localhost.
+    Test salt-ssh setup works
     """
     # Provide the passwd from the CLI to allow the key deploy
     possible_ids = (ssh_container_name, ssh_sub_container_name)
     ret = salt_ssh_cli.run(
-        "--passwd", ssh_password, "--key-deploy", "grains.get", "id", minion_tgt="*"
+        "--passwd", ssh_password, "--key-deploy", "test.ping", minion_tgt="*"
     )
     assert ret.returncode == 0
     for id in possible_ids:
         assert id in ret.data
-        assert ret.data[id] == id
+        assert ret.data[id] is True
 
     # Run it again without the key deploy
-    ret = salt_ssh_cli.run("grains.get", "id", minion_tgt="*")
+    ret = salt_ssh_cli.run("test.ping", minion_tgt="*")
     assert ret.returncode == 0
     for id in possible_ids:
         assert id in ret.data
-        assert ret.data[id] == id
+        assert ret.data[id] is True
 
     # Run a test.sleep and kill it
     sleep_time = 15


### PR DESCRIPTION
### What does this PR do?
Fixes this failing test: [tests.pytests.integration.ssh.test_ssh_setup.test_setup](https://jenkins.saltproject.io/job/pr-centos-7-x86_64-py3-tcp-pytest/job/master/2737/testReport/tests.pytests.integration.ssh/test_ssh_setup/test_setup/)

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes