### PR TITLE
Bump RabbitMQ versions

### DIFF
--- a/tests/pytests/functional/states/rabbitmq/conftest.py
+++ b/tests/pytests/functional/states/rabbitmq/conftest.py
@@ -34,7 +34,6 @@ def get_test_versions():
     for version in (
         "3.9",
         "3.10",
-        "3.11",
     ):
         test_versions.append(
             RabbitMQImage(name=name, tag=version),

--- a/tests/pytests/functional/states/rabbitmq/conftest.py
+++ b/tests/pytests/functional/states/rabbitmq/conftest.py
@@ -32,8 +32,9 @@ def get_test_versions():
     test_versions = []
     name = "rabbitmq"
     for version in (
-        "3.8",
         "3.9",
+        "3.10",
+        "3.11",
     ):
         test_versions.append(
             RabbitMQImage(name=name, tag=version),


### PR DESCRIPTION
### What does this PR do?
bump the versions of RabbitMQ we are testing again, 3.8 is no longer supported and there is now 3.10 and 3.11.


### What issues does this PR fix or reference?
Fixes: N/A

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
