### PR TITLE
Import StrictVersion and LooseVersion from setuptools.distutils.verison or setuptools._distutils.version

### DIFF
--- a/changelog/63350.fixed
+++ b/changelog/63350.fixed
@@ -1,0 +1,1 @@
+Import StrictVersion and LooseVersion from setuptools.distutils.verison or setuptools._distutils.version, if first not available

--- a/salt/utils/pkg/win.py
+++ b/salt/utils/pkg/win.py
@@ -80,9 +80,13 @@ except ImportError:
             LooseVersion,  # pylint: disable=blacklisted-module
         )
     except ImportError:
-        from setuptools._distutils.version import (
-            LooseVersion,  # pylint: disable=blacklisted-module
-        )
+        try:
+            from setuptools._distutils.version import (
+                LooseVersion,  # pylint: disable=blacklisted-module
+            )
+        except ImportError:
+            # pylint: disable=blacklisted-module
+            from distutils.version import LooseVersion
 
 # pylint: disable=too-many-instance-attributes
 

--- a/salt/utils/pkg/win.py
+++ b/salt/utils/pkg/win.py
@@ -72,21 +72,7 @@ try:
 except ImportError:
     from collections import OrderedDict
 
-try:
-    from salt.utils.versions import LooseVersion
-except ImportError:
-    try:
-        from setuptools.distutils.version import (
-            LooseVersion,  # pylint: disable=blacklisted-module
-        )
-    except ImportError:
-        try:
-            from setuptools._distutils.version import (
-                LooseVersion,  # pylint: disable=blacklisted-module
-            )
-        except ImportError:
-            # pylint: disable=blacklisted-module
-            from distutils.version import LooseVersion
+from salt.utils.versions import LooseVersion
 
 # pylint: disable=too-many-instance-attributes
 

--- a/salt/utils/pkg/win.py
+++ b/salt/utils/pkg/win.py
@@ -75,9 +75,14 @@ except ImportError:
 try:
     from salt.utils.versions import LooseVersion
 except ImportError:
-    from setuptools._distutils.version import (
-        LooseVersion,  # pylint: disable=blacklisted-module
-    )
+    try:
+        from setuptools.distutils.version import (
+            LooseVersion,  # pylint: disable=blacklisted-module
+        )
+    except ImportError:
+        from setuptools._distutils.version import (
+            LooseVersion,  # pylint: disable=blacklisted-module
+        )
 
 # pylint: disable=too-many-instance-attributes
 

--- a/salt/utils/versions.py
+++ b/salt/utils/versions.py
@@ -18,16 +18,37 @@ import numbers
 import sys
 import warnings
 
-from setuptools._distutils.version import LooseVersion as _LooseVersion
-from setuptools._distutils.version import StrictVersion as _StrictVersion
+log = logging.getLogger(__name__)
+
+try:
+    from setuptools.distutils.version import LooseVersion as _LooseVersion
+except ImportError:
+    log.debug(
+        "unable to import LooseVersion from setuptools.distutils.version, will attempt setuptools._distutils.version"
+    )
+    try:
+        from setuptools._distutils.version import LooseVersion as _LooseVersion
+    except:
+        log.debug("unable to import LooseVersion from setuptools._distutils.version")
+        raise ImportError()
+
+try:
+    from setuptools.distutils.version import StrictVersion as _StrictVersion
+except ImportError:
+    log.debug(
+        "unable to import StrictVersion from setuptools.distutils.version, will attempt setuptools._distutils.version"
+    )
+    try:
+        from setuptools._distutils.version import StrictVersion as _StrictVersion
+    except:
+        log.debug("unable to import StrictVersion from setuptools._distutils.version")
+        raise ImportError()
+
 
 # pylint: enable=blacklisted-module
 import salt.version
 
 # pylint: disable=blacklisted-module
-
-
-log = logging.getLogger(__name__)
 
 
 class StrictVersion(_StrictVersion):

--- a/salt/utils/versions.py
+++ b/salt/utils/versions.py
@@ -22,26 +22,16 @@ log = logging.getLogger(__name__)
 
 try:
     from setuptools.distutils.version import LooseVersion as _LooseVersion
-except ImportError:
-    log.debug(
-        "unable to import LooseVersion from setuptools.distutils.version, will attempt setuptools._distutils.version"
-    )
-    try:
-        from setuptools._distutils.version import LooseVersion as _LooseVersion
-    except:
-        log.debug("unable to import LooseVersion from setuptools._distutils.version")
-        raise ImportError()
-
-try:
     from setuptools.distutils.version import StrictVersion as _StrictVersion
 except ImportError:
     log.debug(
-        "unable to import StrictVersion from setuptools.distutils.version, will attempt setuptools._distutils.version"
+        "unable to import from setuptools.distutils.version, will attempt setuptools._distutils.version"
     )
     try:
+        from setuptools._distutils.version import LooseVersion as _LooseVersion
         from setuptools._distutils.version import StrictVersion as _StrictVersion
     except:
-        log.debug("unable to import StrictVersion from setuptools._distutils.version")
+        log.debug("unable to import from setuptools._distutils.version")
         raise ImportError()
 
 

--- a/salt/utils/versions.py
+++ b/salt/utils/versions.py
@@ -18,33 +18,24 @@ import numbers
 import sys
 import warnings
 
-log = logging.getLogger(__name__)
-
+# pylint: disable=blacklisted-module
 try:
     from setuptools.distutils.version import LooseVersion as _LooseVersion
     from setuptools.distutils.version import StrictVersion as _StrictVersion
 except ImportError:
-    log.debug(
-        "unable to import from setuptools.distutils.version, will attempt setuptools._distutils.version"
-    )
     try:
         from setuptools._distutils.version import LooseVersion as _LooseVersion
         from setuptools._distutils.version import StrictVersion as _StrictVersion
     except ImportError:
-        log.debug("unable to import from setuptools._distutils.version")
-        try:
-            # pylint: disable=blacklisted-module
-            from distutils.version import LooseVersion as _LooseVersion
-            from distutils.version import StrictVersion as _StrictVersion
-        except ImportError:
-            log.debug("unable to import from distutils.version")
-            raise ImportError()
+        from distutils.version import LooseVersion as _LooseVersion
+        from distutils.version import StrictVersion as _StrictVersion
 
 
 # pylint: enable=blacklisted-module
 import salt.version
 
 # pylint: disable=blacklisted-module
+log = logging.getLogger(__name__)
 
 
 class StrictVersion(_StrictVersion):

--- a/salt/utils/versions.py
+++ b/salt/utils/versions.py
@@ -30,9 +30,15 @@ except ImportError:
     try:
         from setuptools._distutils.version import LooseVersion as _LooseVersion
         from setuptools._distutils.version import StrictVersion as _StrictVersion
-    except:
+    except ImportError:
         log.debug("unable to import from setuptools._distutils.version")
-        raise ImportError()
+        try:
+            # pylint: disable=blacklisted-module
+            from distutils.version import LooseVersion as _LooseVersion
+            from distutils.version import StrictVersion as _StrictVersion
+        except ImportError:
+            log.debug("unable to import from distutils.version")
+            raise ImportError()
 
 
 # pylint: enable=blacklisted-module


### PR DESCRIPTION
### What does this PR do?
Import StrictVersion and LooseVersion from setuptools.distutils.verison or setuptools._distutils.version if the first attempt to import fails, thus allow for old and newer versions of setuptools.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/63350

### Previous Behavior
Test would fail on Debian 10, due to ImportError, since setuptools._distutils is not available in setuptools v40.8.0 which is current for Debian 10

### New Behavior
Works with new and old versions of setuptools, and tests pass.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
