### PR TITLE
[DOCS-ONLY] Fix broken link in 3006 release notes

### DIFF
--- a/doc/topics/releases/3006.0.rst
+++ b/doc/topics/releases/3006.0.rst
@@ -32,10 +32,10 @@ All salt-api functionality disabled by default
 ----------------------------------------------
 
 All netapi clients, which provide the functionality to ``salt-api``, will now
-be disabled by default. If you use ``salt-api``, you must add the new 
-``netapi_enable_clients`` option to your salt master config. This is a breaking 
-change and the ``salt-api`` will not function without this new configuration 
-option. See :ref:`netapi-introduction` for more information.
+be disabled by default as a security precaution. If you use ``salt-api``, you 
+must add the new ``netapi_enable_clients`` option to your salt master config. 
+This is a breaking change and the ``salt-api`` will not function without this 
+new configuration option. See :ref:`netapi-introduction` for more information.
 
 
 How do I migrate to the onedir packages?

--- a/doc/topics/releases/3006.0.rst
+++ b/doc/topics/releases/3006.0.rst
@@ -31,13 +31,11 @@ for more information.
 All salt-api functionality disabled by default
 ----------------------------------------------
 
-All netapi clients, which provide the functionality to salt-api, will now
-be disabled by default. If you use the salt-api you must add the new
-`netapi_enable_clients` option to your salt master config. This is
-a breaking change and the salt-api will not function without this
-new configuration option.
-See `Netapi module <https://docs.saltproject.io/en/latest/topics/netapi/index.html#introduction-to-netapi-modules>`
-for more information.
+All netapi clients, which provide the functionality to ``salt-api``, will now
+be disabled by default. If you use ``salt-api``, you must add the new 
+`netapi_enable_clients` option to your salt master config. This is a breaking 
+change and the ``salt-api`` will not function without this new configuration 
+option. See :ref:`netapi-introduction` for more information.
 
 
 How do I migrate to the onedir packages?

--- a/doc/topics/releases/3006.0.rst
+++ b/doc/topics/releases/3006.0.rst
@@ -33,7 +33,7 @@ All salt-api functionality disabled by default
 
 All netapi clients, which provide the functionality to ``salt-api``, will now
 be disabled by default. If you use ``salt-api``, you must add the new 
-`netapi_enable_clients` option to your salt master config. This is a breaking 
+``netapi_enable_clients`` option to your salt master config. This is a breaking 
 change and the ``salt-api`` will not function without this new configuration 
 option. See :ref:`netapi-introduction` for more information.
 


### PR DESCRIPTION
### What does this PR do?
I noticed the link to the NetAPI module introduction is broken in the 3006 release notes, so this fixes the problem.


### What issues does this PR fix or reference?
Fixes: Broken link

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [ n/a] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [n/a] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
