### PR TITLE
Bump to `wheel==0.38.4` due to `GHSA-qwmp-2cf2-g9g6`

### DIFF
--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -401,7 +401,7 @@ werkzeug==2.2.2
     # via
     #   moto
     #   pytest-httpserver
-wheel==0.36.2
+wheel==0.38.4
     # via -r requirements/windows.txt
 wmi==1.5.1
     # via -r requirements/windows.txt

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -422,7 +422,7 @@ werkzeug==2.0.3
     # via
     #   moto
     #   pytest-httpserver
-wheel==0.36.2
+wheel==0.38.4
     # via -r requirements/windows.txt
 wmi==1.5.1
     # via -r requirements/windows.txt

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -405,7 +405,7 @@ werkzeug==2.0.3
     # via
     #   moto
     #   pytest-httpserver
-wheel==0.36.2
+wheel==0.38.4
     # via -r requirements/windows.txt
 wmi==1.5.1
     # via -r requirements/windows.txt

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -406,7 +406,7 @@ werkzeug==2.0.3
     # via
     #   moto
     #   pytest-httpserver
-wheel==0.36.2
+wheel==0.38.4
     # via -r requirements/windows.txt
 wmi==1.5.1
     # via -r requirements/windows.txt

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -124,7 +124,7 @@ urllib3==1.26.6
     # via
     #   -r requirements/windows.txt
     #   requests
-wheel==0.36.2
+wheel==0.38.4
     # via -r requirements/windows.txt
 wmi==1.5.1
     # via -r requirements/windows.txt

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -133,7 +133,7 @@ urllib3==1.26.6
     # via
     #   -r requirements/windows.txt
     #   requests
-wheel==0.36.2
+wheel==0.38.4
     # via -r requirements/windows.txt
 wmi==1.5.1
     # via -r requirements/windows.txt

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -127,7 +127,7 @@ urllib3==1.26.6
     # via
     #   -r requirements/windows.txt
     #   requests
-wheel==0.36.2
+wheel==0.38.4
     # via -r requirements/windows.txt
 wmi==1.5.1
     # via -r requirements/windows.txt

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -127,7 +127,7 @@ urllib3==1.26.6
     # via
     #   -r requirements/windows.txt
     #   requests
-wheel==0.36.2
+wheel==0.38.4
     # via -r requirements/windows.txt
 wmi==1.5.1
     # via -r requirements/windows.txt

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -31,6 +31,6 @@ urllib3>=1.26.5
 # windows distribution package.
 #
 # watchdog>=2.1.3
-wheel>=0.36.2
+wheel>=0.38.1
 
 importlib_metadata>=3.3.0; python_version >= '3.6' and python_version < '3.10'


### PR DESCRIPTION
### What does this PR do?
Bump to `wheel==0.38.4` due to https://github.com/advisories/GHSA-qwmp-2cf2-g9g6

### What issues does this PR fix or reference?
Closes https://github.com/saltstack/salt/pull/63371
Closes https://github.com/saltstack/salt/pull/63372
Closes https://github.com/saltstack/salt/pull/63373
Closes https://github.com/saltstack/salt/pull/63374
Closes https://github.com/saltstack/salt/pull/63375
Closes https://github.com/saltstack/salt/pull/63376
Closes https://github.com/saltstack/salt/pull/63377
Closes https://github.com/saltstack/salt/pull/63378
