### PR TITLE
Call `os._exit()` instead of `sys.exit()` on forked processes.

### DIFF
--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -1090,7 +1090,8 @@ class SignalHandlingProcess(Process):
                     self.pid,
                     os.getpid(),
                 )
-        sys.exit(salt.defaults.exitcodes.EX_OK)
+        # It's OK to call os._exit instead of sys.exit on forked processed
+        os._exit(salt.defaults.exitcodes.EX_OK)
 
     def start(self):
         with default_signals(signal.SIGINT, signal.SIGTERM):


### PR DESCRIPTION
### What does this PR do?
Call `os._exit()` instead of `sys.exit()` on forked processes.
This avoids some tracebacks while python is shutting down.