### PR TITLE
Use `pytest.mark()` instead of skipping on the test function body

### DIFF
--- a/tests/pytests/functional/modules/test_pip.py
+++ b/tests/pytests/functional/modules/test_pip.py
@@ -8,7 +8,13 @@ from tests.support.helpers import VirtualEnv
 @pytest.mark.parametrize(
     "pip_version",
     (
-        "pip==9.0.3",
+        pytest.param(
+            "pip==9.0.3",
+            marks=pytest.mark.skipif(
+                sys.version_info >= (3, 10),
+                reason="'pip==9.0.3' is not available on Py >= 3.10",
+            ),
+        ),
         "pip<20.0",
         "pip<21.0",
         "pip>=21.0",
@@ -16,8 +22,6 @@ from tests.support.helpers import VirtualEnv
 )
 @pytest.mark.requires_network
 def test_list_available_packages(modules, pip_version, tmp_path):
-    if sys.version_info >= (3, 10) and pip_version == "pip==9.0.3":
-        pytest.skip("{} is not available on Py3.10".format(pip_version))
     with VirtualEnv(venv_dir=tmp_path, pip_requirement=pip_version) as virtualenv:
         virtualenv.install("-U", pip_version)
         package_name = "pep8"


### PR DESCRIPTION
### What does this PR do?
See title