### PR TITLE
Allow passing --update=.. args to raid.present

### DIFF
--- a/changelog/63396.fixed
+++ b/changelog/63396.fixed
@@ -1,0 +1,1 @@
+Fix passing --update=.. args to raid.present state function

--- a/salt/states/mdadm_raid.py
+++ b/salt/states/mdadm_raid.py
@@ -138,6 +138,14 @@ def present(name, level, devices, **kwargs):
         do_create = True
         verb = "created"
 
+    # --update isn't valid when creating an array; only during assembly
+    if "update" in kwargs:
+        if do_assemble:
+            if isinstance(kwargs["update"], list):
+                kwargs["update"] = ",".join(kwargs["update"])
+        else:
+            del kwargs["update"]
+
     # If running with test use the test_mode with create or assemble
     if __opts__["test"]:
         if do_assemble:


### PR DESCRIPTION
mdraid complains loudly if you call raid.create with update= kwargs, even though they are entirely valid for raid.assemble. Given that the user can't influence whether the raid will be assembled or created, helpfully strip out invalid --update=.. args when not assembling an array to avoid any nasty surprises when the raid doesn't exist:

    [INFO    ] Executing state udevraid.present for [/dev/md/all]
    [INFO    ] Executing command mdadm in directory '/root'
    [INFO    ] Executing command 'mdadm' in directory '/root'
    [DEBUG   ] stderr: mdadm: No md superblock detected on /dev/mapper/luks-nvme0n1p2.
    [DEBUG   ] retcode: 1
    [INFO    ] Executing command 'mdadm' in directory '/root'
    [DEBUG   ] stderr: mdadm: No md superblock detected on /dev/mapper/luks-nvme1n1p2.
    [DEBUG   ] retcode: 1
    [INFO    ] Executing command 'mdadm' in directory '/root'
    [DEBUG   ] stderr: mdadm: No md superblock detected on /dev/mapper/luks-nvme2n1p2.
    [DEBUG   ] retcode: 1
    [INFO    ] Executing command mdadm in directory '/root'
    [ERROR   ] Command 'mdadm' failed with return code: 2
    [ERROR   ] stdout: mdadm: :option --update not valid in create mode
    [ERROR   ] retcode: 2
    [ERROR   ] Command 'mdadm' failed with return code: 2
    [ERROR   ] output: mdadm: :option --update not valid in create mode
    [INFO    ] Executing command mdadm in directory '/root'
    [INFO    ] Executing command mdadm in directory '/root'
    [INFO    ] Executing command '/bin/udevadm' in directory '/root'
    [INFO    ] Executing command mdadm in directory '/root'
    [ERROR   ] Raid /dev/md/all failed to be created.

Signed-off-by: Joe Groocock <jgroocock@cloudflare.com>

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
