### PR TITLE
Allow overriding arbitrary opts with salt-call

### DIFF
--- a/changelog/63397.added
+++ b/changelog/63397.added
@@ -1,0 +1,1 @@
+Allow overriding arbitrary opts with salt-call

--- a/salt/cli/call.py
+++ b/salt/cli/call.py
@@ -1,9 +1,12 @@
+import logging
 import os
 
 import salt.cli.caller
 import salt.defaults.exitcodes
 import salt.utils.parsers
 from salt.config import _expand_glob_path
+
+log = logging.getLogger(__name__)
 
 
 class SaltCall(salt.utils.parsers.SaltCallOptionParser):
@@ -36,6 +39,12 @@ class SaltCall(salt.utils.parsers.SaltCallOptionParser):
             self.config["file_client"] = "local"
         if self.options.master:
             self.config["master"] = self.options.master
+
+        # This must come after all of the above overrides
+        if self.options.opts:
+            ov = salt.utils.args.parse_input(self.options.opts, condition=False)[1]
+            log.debug("Minion option overrides: %s", ov)
+            self.config.update(ov)
 
         caller = salt.cli.caller.Caller.factory(self.config)
 

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2809,6 +2809,18 @@ class SaltCallOptionParser(
 
     def _mixin_setup(self):
         self.add_option(
+            "-o",
+            "--option",
+            default=[],
+            dest="opts",
+            action="append",
+            help=(
+                "Specify one or more minion option overrides. "
+                "Multiple options can be provided by passing "
+                "`-o/--option` multiple times."
+            ),
+        )
+        self.add_option(
             "-g",
             "--grains",
             dest="grains_run",


### PR DESCRIPTION
Any minion option(s) can be overridden (note this is not a merge), and it can be specified multiple times to set multiple different options. The parser will also accept arbitrarily complex/deep data structures in python/json-compatible syntax. For example:

    $ salt-call --local -o foo='["foo","bar"]' -o bar=1234 config.get foo
    local:
        - foo
        - bar
    $ salt-call --local -o foo='["foo","bar"]' -o bar=1234 config.get bar
    local:
        1234

Signed-off-by: Joe Groocock <jgroocock@cloudflare.com>

### What does this PR do?
Read the commit message

### Merge requirements satisfied?
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
