### PR TITLE
Fix __pillar__ access in modules in pillar render

### DIFF
--- a/changelog/63398.fixed.md
+++ b/changelog/63398.fixed.md
@@ -1,0 +1,1 @@
+Fix __pillar__ access in execution modules during pillar render with ext_pillar_first

--- a/tests/pytests/unit/pillar/test_pillar.py
+++ b/tests/pytests/unit/pillar/test_pillar.py
@@ -7,6 +7,7 @@ import salt.loader
 import salt.pillar
 import salt.utils.cache
 from salt.utils.odict import OrderedDict
+from tests.support.mock import patch
 
 
 @pytest.mark.parametrize(
@@ -157,3 +158,27 @@ def test_pillar_get_cache_disk(temp_salt_minion, caplog):
             in caplog.messages
         )
         assert fresh_pillar == {}
+
+
+def test_ext_pillar_dunder_in_modules_in_pillar(temp_salt_minion):
+    """
+    Test that ext_pillar is available in __pillar__ inside execution modules
+    during pillar render when using ext_pillar_first=true
+    """
+    opts = temp_salt_minion.config.copy()
+    opts["ext_pillar_first"] = True
+
+    grains = salt.loader.grains(opts)
+    pillar = salt.pillar.Pillar(opts, grains, temp_salt_minion.id, "base")
+    # Pillar should be empty to start with
+    assert pillar.functions.pack["__pillar__"] == {}
+
+    ext_value = {"ext": "some ext value"}
+    pil_value = {"pillar": "some pillar value"}
+    with patch.object(pillar, "ext_pillar", return_value=(ext_value, [])):
+        with patch.object(pillar, "render_pillar", return_value=(pil_value, [])):
+            compiled = pillar.compile_pillar()
+            assert compiled == dict(**ext_value, **pil_value)
+
+    # Loader should pack the opts pillar dict from the ext_pillar() call
+    assert pillar.functions.pack["__pillar__"] == ext_value


### PR DESCRIPTION
Historically the \_\_pillar\_\_ dunder has never been available or worked in extension modules during pillar render, due to what I can only assume is a bug/oversight in the overly-complex mess of branches and logic in the pillar rendering code. Functionally there is very little reason this shouldn't work, and it even appears like it may have worked at some point, or at least was intended to work by the fact that the ext_pillar data was stuffed right back into opts before attempting to render the remainder of the pillar.

The missing piece to the puzzle here was that the partially-rendered ext_pillar data wasn't available in the opts dict packed into the salt.loader.minion_mods() call when it was generated, and the fact that the functions weren't reloaded after the pillar dict was updated. This commit fixes both of those things.

Ensure the minion_mods are *always* reloaded with the updated opts dict containing the partial pillar data when rendering pillar with ext_pillar_first enabled.

Signed-off-by: Joe Groocock <jgroocock@cloudflare.com>


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
