### PR TITLE
[freeze] Bump gitpython and wheel

### DIFF
--- a/requirements/darwin.txt
+++ b/requirements/darwin.txt
@@ -6,8 +6,8 @@ apache-libcloud>=2.4.0
 backports.ssl_match_hostname>=3.7.0.1; python_version < '3.7'
 cherrypy>=17.4.1
 cryptography>=2.6.1
-gitpython>3.1.20 ; python_version >= "3.7"
 gitpython>=2.1.15 ; python_version <= "3.6"
+gitpython>=3.1.30 ; python_version >= "3.7"
 idna>=2.8
 linode-python>=1.1.1
 mako>=1.0.7

--- a/requirements/static/ci/common.in
+++ b/requirements/static/ci/common.in
@@ -16,8 +16,8 @@ croniter>=0.3.0,!=0.3.22"; sys_platform != 'win32'
 dnspython
 docker
 etcd3-py==0.1.6 ; python_version >= '3.6'
-gitpython>3.1.20 ; python_version >= "3.7"
 gitpython>=2.1.15 ; python_version <= "3.6"
+gitpython>=3.1.30 ; python_version >= "3.7"
 jmespath
 jsonschema
 junos-eznc==2.4.0; sys_platform != 'win32' and python_version <= '3.9'

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -426,7 +426,7 @@ geomet==0.2.1.post1
     # via cassandra-driver
 gitdb==4.0.7
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via -r requirements/static/ci/common.in
 google-auth==2.1.0
     # via kubernetes

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -428,7 +428,7 @@ geomet==0.1.2
     # via cassandra-driver
 gitdb==4.0.5
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via
     #   -r requirements/darwin.txt
     #   -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -347,6 +347,8 @@ botocore==1.21.27
     #   boto3
     #   moto
     #   s3transfer
+cached-property==1.5.2
+    # via pygit2
 cachetools==4.2.2
     # via
     #   google-auth
@@ -428,7 +430,7 @@ geomet==0.2.1.post1
     # via cassandra-driver
 gitdb==4.0.7
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via -r requirements/static/ci/common.in
 google-auth==2.0.1
     # via kubernetes

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -347,8 +347,6 @@ botocore==1.21.27
     #   boto3
     #   moto
     #   s3transfer
-cached-property==1.5.2
-    # via pygit2
 cachetools==4.2.2
     # via
     #   google-auth

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -342,6 +342,8 @@ botocore==1.20.67
     #   boto3
     #   moto
     #   s3transfer
+cached-property==1.5.2
+    # via pygit2
 cachetools==3.1.0
     # via google-auth
 cassandra-driver==3.24.0
@@ -424,7 +426,7 @@ geomet==0.2.1.post1
     # via cassandra-driver
 gitdb==4.0.5
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via -r requirements/static/ci/common.in
 google-auth==1.6.3
     # via kubernetes

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -342,8 +342,6 @@ botocore==1.20.67
     #   boto3
     #   moto
     #   s3transfer
-cached-property==1.5.2
-    # via pygit2
 cachetools==3.1.0
     # via google-auth
 cassandra-driver==3.24.0

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -345,6 +345,8 @@ botocore==1.21.27
     #   boto3
     #   moto
     #   s3transfer
+cached-property==1.5.2
+    # via pygit2
 cachetools==4.2.2
     # via
     #   google-auth
@@ -424,7 +426,7 @@ geomet==0.2.1.post1
     # via cassandra-driver
 gitdb==4.0.7
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via -r requirements/static/ci/common.in
 google-auth==2.0.1
     # via kubernetes

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -345,8 +345,6 @@ botocore==1.21.27
     #   boto3
     #   moto
     #   s3transfer
-cached-property==1.5.2
-    # via pygit2
 cachetools==4.2.2
     # via
     #   google-auth

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -353,6 +353,8 @@ botocore==1.20.67
     #   boto3
     #   moto
     #   s3transfer
+cached-property==1.5.2
+    # via pygit2
 cachetools==4.2.2
     # via
     #   google-auth
@@ -438,7 +440,7 @@ geomet==0.1.2
     # via cassandra-driver
 gitdb==4.0.5
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via -r requirements/static/ci/common.in
 google-auth==1.6.3
     # via kubernetes

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -353,8 +353,6 @@ botocore==1.20.67
     #   boto3
     #   moto
     #   s3transfer
-cached-property==1.5.2
-    # via pygit2
 cachetools==4.2.2
     # via
     #   google-auth

--- a/requirements/static/ci/py3.5/linux.txt
+++ b/requirements/static/ci/py3.5/linux.txt
@@ -442,9 +442,9 @@ genshi==0.7.5
     # via -r requirements/static/ci/common.in
 geomet==0.1.2
     # via cassandra-driver
-gitdb==4.0.5
+gitdb==4.0.7
     # via gitpython
-gitpython==3.1.12 ; python_version <= "3.6"
+gitpython==3.1.14 ; python_version <= "3.6"
     # via -r requirements/static/ci/common.in
 google-auth==1.6.3
     # via kubernetes
@@ -897,7 +897,7 @@ six==1.16.0
     #   vcert
     #   virtualenv
     #   websocket-client
-smmap==3.0.4
+smmap==4.0.0
     # via gitdb
 sqlparse==0.4.2
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -438,7 +438,7 @@ geomet==0.2.1.post1
     # via cassandra-driver
 gitdb==4.0.7
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via -r requirements/static/ci/common.in
 google-auth==2.1.0
     # via kubernetes

--- a/requirements/static/ci/py3.7/docs.txt
+++ b/requirements/static/ci/py3.7/docs.txt
@@ -442,7 +442,7 @@ geomet==0.2.1.post1
     # via cassandra-driver
 gitdb==4.0.7
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via -r requirements/static/ci/common.in
 google-auth==2.0.1
     # via kubernetes

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -344,6 +344,8 @@ botocore==1.20.67
     #   boto3
     #   moto
     #   s3transfer
+cached-property==1.5.2
+    # via pygit2
 cachetools==3.1.0
     # via google-auth
 cassandra-driver==3.24.0
@@ -436,7 +438,7 @@ geomet==0.2.1.post1
     # via cassandra-driver
 gitdb==4.0.5
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via -r requirements/static/ci/common.in
 google-auth==1.6.3
     # via kubernetes

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -344,8 +344,6 @@ botocore==1.20.67
     #   boto3
     #   moto
     #   s3transfer
-cached-property==1.5.2
-    # via pygit2
 cachetools==3.1.0
     # via google-auth
 cassandra-driver==3.24.0

--- a/requirements/static/ci/py3.7/lint.txt
+++ b/requirements/static/ci/py3.7/lint.txt
@@ -438,7 +438,7 @@ geomet==0.2.1.post1
     # via cassandra-driver
 gitdb==4.0.7
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via -r requirements/static/ci/common.in
 google-auth==2.0.1
     # via kubernetes

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -450,7 +450,7 @@ geomet==0.1.2
     # via cassandra-driver
 gitdb==4.0.5
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via -r requirements/static/ci/common.in
 google-auth==1.6.3
     # via kubernetes

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -113,7 +113,7 @@ geomet==0.1.2
     # via cassandra-driver
 gitdb==4.0.5
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt
@@ -423,7 +423,7 @@ werkzeug==2.0.3
     # via
     #   moto
     #   pytest-httpserver
-wheel==0.36.2
+wheel==0.38.4
     # via -r requirements/windows.txt
 wmi==1.5.1
     # via -r requirements/windows.txt

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -436,7 +436,7 @@ geomet==0.2.1.post1
     # via cassandra-driver
 gitdb==4.0.7
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via -r requirements/static/ci/common.in
 google-auth==2.1.0
     # via kubernetes

--- a/requirements/static/ci/py3.8/docs.txt
+++ b/requirements/static/ci/py3.8/docs.txt
@@ -440,7 +440,7 @@ geomet==0.2.1.post1
     # via cassandra-driver
 gitdb==4.0.7
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via -r requirements/static/ci/common.in
 google-auth==2.0.1
     # via kubernetes

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -342,8 +342,6 @@ botocore==1.20.67
     #   boto3
     #   moto
     #   s3transfer
-cached-property==1.5.2
-    # via pygit2
 cachetools==3.1.0
     # via google-auth
 cassandra-driver==3.24.0

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -342,6 +342,8 @@ botocore==1.20.67
     #   boto3
     #   moto
     #   s3transfer
+cached-property==1.5.2
+    # via pygit2
 cachetools==3.1.0
     # via google-auth
 cassandra-driver==3.24.0
@@ -434,7 +436,7 @@ geomet==0.2.1.post1
     # via cassandra-driver
 gitdb==4.0.5
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via -r requirements/static/ci/common.in
 google-auth==1.6.3
     # via kubernetes

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -436,7 +436,7 @@ geomet==0.2.1.post1
     # via cassandra-driver
 gitdb==4.0.7
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via -r requirements/static/ci/common.in
 google-auth==2.0.1
     # via kubernetes

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -448,7 +448,7 @@ geomet==0.1.2
     # via cassandra-driver
 gitdb==4.0.5
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via -r requirements/static/ci/common.in
 google-auth==1.6.3
     # via kubernetes

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -111,7 +111,7 @@ geomet==0.1.2
     # via cassandra-driver
 gitdb==4.0.7
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt
@@ -409,7 +409,7 @@ werkzeug==2.0.3
     # via
     #   moto
     #   pytest-httpserver
-wheel==0.36.2
+wheel==0.38.4
     # via -r requirements/windows.txt
 wmi==1.5.1
     # via -r requirements/windows.txt

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -436,7 +436,7 @@ geomet==0.2.1.post1
     # via cassandra-driver
 gitdb==4.0.7
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via -r requirements/static/ci/common.in
 google-auth==2.1.0
     # via kubernetes

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -438,7 +438,7 @@ geomet==0.1.2
     # via cassandra-driver
 gitdb==4.0.5
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via
     #   -r requirements/darwin.txt
     #   -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -347,6 +347,8 @@ botocore==1.21.27
     #   boto3
     #   moto
     #   s3transfer
+cached-property==1.5.2
+    # via pygit2
 cachetools==4.2.2
     # via
     #   google-auth
@@ -438,7 +440,7 @@ geomet==0.2.1.post1
     # via cassandra-driver
 gitdb==4.0.7
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via -r requirements/static/ci/common.in
 google-auth==2.0.1
     # via kubernetes

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -347,8 +347,6 @@ botocore==1.21.27
     #   boto3
     #   moto
     #   s3transfer
-cached-property==1.5.2
-    # via pygit2
 cachetools==4.2.2
     # via
     #   google-auth

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -342,8 +342,6 @@ botocore==1.20.67
     #   boto3
     #   moto
     #   s3transfer
-cached-property==1.5.2
-    # via pygit2
 cachetools==3.1.0
     # via google-auth
 cassandra-driver==3.24.0

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -342,6 +342,8 @@ botocore==1.20.67
     #   boto3
     #   moto
     #   s3transfer
+cached-property==1.5.2
+    # via pygit2
 cachetools==3.1.0
     # via google-auth
 cassandra-driver==3.24.0
@@ -434,7 +436,7 @@ geomet==0.2.1.post1
     # via cassandra-driver
 gitdb==4.0.5
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via -r requirements/static/ci/common.in
 google-auth==1.6.3
     # via kubernetes

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -345,6 +345,8 @@ botocore==1.21.27
     #   boto3
     #   moto
     #   s3transfer
+cached-property==1.5.2
+    # via pygit2
 cachetools==4.2.2
     # via
     #   google-auth
@@ -434,7 +436,7 @@ geomet==0.2.1.post1
     # via cassandra-driver
 gitdb==4.0.7
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via -r requirements/static/ci/common.in
 google-auth==2.0.1
     # via kubernetes

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -345,8 +345,6 @@ botocore==1.21.27
     #   boto3
     #   moto
     #   s3transfer
-cached-property==1.5.2
-    # via pygit2
 cachetools==4.2.2
     # via
     #   google-auth

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -450,7 +450,7 @@ geomet==0.1.2
     # via cassandra-driver
 gitdb==4.0.5
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via -r requirements/static/ci/common.in
 google-auth==1.6.3
     # via kubernetes

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -111,7 +111,7 @@ geomet==0.1.2
     # via cassandra-driver
 gitdb==4.0.7
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt
@@ -410,7 +410,7 @@ werkzeug==2.0.3
     # via
     #   moto
     #   pytest-httpserver
-wheel==0.36.2
+wheel==0.38.4
     # via -r requirements/windows.txt
 wmi==1.5.1
     # via -r requirements/windows.txt

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -26,7 +26,7 @@ distro==1.5.0
     # via -r requirements/base.txt
 gitdb==4.0.5
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via -r requirements/darwin.txt
 idna==2.8
     # via

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -28,7 +28,7 @@ distro==1.5.0
     # via -r requirements/base.txt
 gitdb==4.0.5
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via -r requirements/windows.txt
 idna==2.8
     # via requests
@@ -135,7 +135,7 @@ urllib3==1.26.6
     # via
     #   -r requirements/windows.txt
     #   requests
-wheel==0.36.2
+wheel==0.38.4
     # via -r requirements/windows.txt
 wmi==1.5.1
     # via -r requirements/windows.txt

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -28,7 +28,7 @@ distro==1.5.0
     # via -r requirements/base.txt
 gitdb==4.0.7
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via -r requirements/windows.txt
 idna==2.8
     # via requests
@@ -131,7 +131,7 @@ urllib3==1.26.6
     # via
     #   -r requirements/windows.txt
     #   requests
-wheel==0.36.2
+wheel==0.38.4
     # via -r requirements/windows.txt
 wmi==1.5.1
     # via -r requirements/windows.txt

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -26,7 +26,7 @@ distro==1.5.0
     # via -r requirements/base.txt
 gitdb==4.0.5
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via -r requirements/darwin.txt
 idna==2.8
     # via

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -28,7 +28,7 @@ distro==1.5.0
     # via -r requirements/base.txt
 gitdb==4.0.7
     # via gitpython
-gitpython==3.1.29 ; python_version >= "3.7"
+gitpython==3.1.30 ; python_version >= "3.7"
     # via -r requirements/windows.txt
 idna==2.8
     # via requests
@@ -131,7 +131,7 @@ urllib3==1.26.6
     # via
     #   -r requirements/windows.txt
     #   requests
-wheel==0.36.2
+wheel==0.38.4
     # via -r requirements/windows.txt
 wmi==1.5.1
     # via -r requirements/windows.txt

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -12,8 +12,8 @@ certifi<=2021.10.8  ; python_version <= "3.5"
 cffi>=1.14.5
 cherrypy>=18.6.1
 cryptography>=3.4.7
-gitpython>3.1.20 ; python_version >= "3.7"
 gitpython>=2.1.15 ; python_version <= "3.6"
+gitpython>=3.1.30 ; python_version >= "3.7"
 ioloop>=0.1a0
 libnacl>=1.8.0
 lxml>=4.6.3
@@ -34,6 +34,6 @@ urllib3>=1.26.5
 # windows distribution package.
 #
 # watchdog>=2.1.3
-wheel>=0.36.2
+wheel>=0.38.1
 
 importlib_metadata>=3.3.0; python_version >= '3.6' and python_version < '3.10'

--- a/tests/pytests/integration/cli/test_salt_call.py
+++ b/tests/pytests/integration/cli/test_salt_call.py
@@ -243,39 +243,6 @@ def test_pillar_items_masterless(salt_minion, salt_call_cli):
         assert ret.data["monty"] == "python"
 
 
-def test_masterless_highstate(salt_minion, salt_call_cli, tmp_path):
-    """
-    test state.highstate in masterless mode
-    """
-    top_sls = """
-    base:
-      '*':
-        - core
-        """
-
-    testfile = tmp_path / "testfile"
-    core_state = """
-    {}:
-      file:
-        - managed
-        - source: salt://testfile
-        - makedirs: true
-        """.format(
-        testfile
-    )
-
-    expected_id = str(testfile)
-
-    with salt_minion.state_tree.base.temp_file(
-        "top.sls", top_sls
-    ), salt_minion.state_tree.base.temp_file("core.sls", core_state):
-        ret = salt_call_cli.run("--local", "state.highstate")
-        assert ret.returncode == 0
-        state_run_dict = next(iter(ret.data.values()))
-        assert state_run_dict["result"] is True
-        assert state_run_dict["__id__"] == expected_id
-
-
 @pytest.mark.skip_on_windows
 def test_syslog_file_not_found(salt_minion, salt_call_cli, tmp_path):
     """
@@ -443,3 +410,36 @@ def test_local_salt_call_no_function_no_retcode(salt_call_cli):
         a = state_run_dict["test.recho"]
         b = expected
         assert state_run_dict["test.recho"] == expected
+
+
+def test_masterless_highstate(salt_minion, salt_call_cli, tmp_path):
+    """
+    test state.highstate in masterless mode
+    """
+    top_sls = """
+    base:
+      '*':
+        - core
+        """
+
+    testfile = tmp_path / "testfile"
+    core_state = """
+    {}:
+      file:
+        - managed
+        - source: salt://testfile
+        - makedirs: true
+        """.format(
+        testfile
+    )
+
+    expected_id = str(testfile)
+
+    with salt_minion.state_tree.base.temp_file(
+        "top.sls", top_sls
+    ), salt_minion.state_tree.base.temp_file("core.sls", core_state):
+        ret = salt_call_cli.run("--local", "state.highstate")
+        assert ret.returncode == 0
+        state_run_dict = next(iter(ret.data.values()))
+        assert state_run_dict["result"] is True
+        assert state_run_dict["__id__"] == expected_id


### PR DESCRIPTION
### What does this PR do?
Bump to gitpython==3.1.30 because of https://github.com/advisories/GHSA-hcpj-qp55-gfph.  
Bump to wheel==0.38.4 due to GHSA-qwmp-2cf2-g9g6

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
