### PR TITLE
oVirt 4.4 differs, salt fails to render virtual_subtype

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -913,7 +913,13 @@ def _virtual(osdata):
                 grains["virtual_subtype"] = "Amazon EC2"
                 break
         elif command == "virt-what":
-            for line in output.splitlines():
+            lines = output.splitlines()
+            # If there's any ovirt mention at all ... we know enough
+            if "ovirt" in lines:
+                grains["virtual"] = "kvm"
+                grains["virtual_subtype"] = "ovirt"
+                break
+            for line in lines:
                 if line in ("kvm", "qemu", "uml", "xen"):
                     grains["virtual"] = line
                     break


### PR DESCRIPTION
### What does this PR do?
If fixes an issue on oVirt 4.4 guests

### What issues does this PR fix or reference?
On oVirt 4.4 salt fails to render virtual_subtype because oVirt 4.4 has no 'oVirt Node' in /sys/devices/virtual/dmi/id/product_name, so rely on virt-what instead to get virtual_subtype back.