### PR TITLE
Don't use `patcher.start()`, specially if `patcher.stop()` is not called it breaks unrelated tests

### DIFF
--- a/tests/pytests/unit/modules/test_djangomod.py
+++ b/tests/pytests/unit/modules/test_djangomod.py
@@ -11,9 +11,8 @@ from tests.support.mock import MagicMock, patch
 
 @pytest.fixture
 def configure_loader_modules():
-    patcher = patch("salt.utils.path.which", lambda exe: exe)
-    patcher.start()
-    return {djangomod: {}}
+    with patch("salt.utils.path.which", lambda exe: exe):
+        yield {djangomod: {}}
 
 
 def test_command():


### PR DESCRIPTION
### What does this PR do?
See title

### What issues does this PR fix or reference?
Refs https://github.com/saltstack/salt/commit/7a59410c2d7a29602c7ab0da266a7af46c980f41
https://jenkins.saltproject.io/job/pr-centos-7-x86_64-py3-pytest/job/master/2907/#showFailuresLink