### PR TITLE
implement new function removeptf for zypper pkg module

### DIFF
--- a/changelog/63442.added
+++ b/changelog/63442.added
@@ -1,0 +1,1 @@
+implement removeptf in zypper pkg module


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Introduce a new function for zypper pkg module to remove PTF(Product Temporary Fix) packages.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
