### PR TITLE
Remove toc link to http tutorial in netapi page

### DIFF
--- a/doc/topics/netapi/index.rst
+++ b/doc/topics/netapi/index.rst
@@ -55,6 +55,5 @@ the :command:`salt` command.
 
 .. toctree::
 
-    ../tutorials/http
     writing
 


### PR DESCRIPTION
### What does this PR do?
Removes toc link to ../tutorials/http in `doc/topics/netapi/index.rst`. The http modules tutorial is not relevant to the netapi modules overview and I suspect that this toc link was added by mistake in this massive docs restructuring commit - https://github.com/saltstack/salt/commit/b192a9ba38fd11a6ed8a455bdbb66d2ce4ad468b#diff-a86315fccac33271b7c901b5613a36d8a5bed253fe86731799bc20bd1803d085


### Merge requirements satisfied?
- [X] Docs

