### PR TITLE
State pkg.purged doesn't purge removed packages on at least Debian 8 to 11

### DIFF
--- a/changelog/42306.fixed
+++ b/changelog/42306.fixed
@@ -1,0 +1,1 @@
+Fixes state pkg.purged to purge removed packages on Debian family systems

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -2902,16 +2902,24 @@ def _uninstall(
         name, version, pkgs, normalize, ignore_epoch=ignore_epoch, **kwargs
     )
     if isinstance(targets, dict) and "result" in targets:
-        return targets
+        if action == "purge":
+            # found nothing, reset state return obj to empty list and check for removed to be purged
+            targets = []
+        else:
+            return targets
     elif not isinstance(targets, list):
-        return {
-            "name": name,
-            "changes": {},
-            "result": False,
-            "comment": "An error was encountered while checking targets: {}".format(
-                targets
-            ),
-        }
+        if action == "purge":
+            # found nothing, reset state return obj to empty list and check for removed to be purged
+            targets = []
+        else:
+            return {
+                "name": name,
+                "changes": {},
+                "result": False,
+                "comment": "An error was encountered while checking targets: {}".format(
+                    targets
+                ),
+            }
     if action == "purge":
         old_removed = __salt__["pkg.list_pkgs"](
             versions_as_list=True, removed=True, **kwargs

--- a/tests/pytests/functional/states/test_pkg.py
+++ b/tests/pytests/functional/states/test_pkg.py
@@ -993,3 +993,41 @@ def test_pkg_cap_006_uptodate(PKG_CAP_TARGETS, modules, states):
     finally:
         ret = states.pkg.removed(name=realpkg)
         assert ret.result is True
+
+
+@pytest.mark.requires_salt_modules(
+    "pkg.version", "pkg.latest_version", "pkg.remove", "pkg.purge", "pkg.list_pkgs"
+)
+@pytest.mark.requires_salt_states("pkg.installed", "pkg.removed", "pkg.purged")
+def test_pkg_purged_with_removed_pkg(grains, PKG_TARGETS, states, modules):
+    """
+    This is a destructive test as it installs and then removes a package, then purges a removed package
+    """
+    if grains["os_family"] != "Debian":
+        pytest.skip("Only runs on Debian.")
+
+    target = PKG_TARGETS[0]
+
+    ret = states.pkg.installed(
+        name=target,
+        version="<9999999",
+        refresh=False,
+    )
+    assert ret.result is True
+
+    # The version that was installed should be the latest available
+    version = modules.pkg.version(target)
+    assert version
+
+    # Clean up
+    ret = states.pkg.removed(name=target)
+    assert ret.result is True
+
+    ret = states.pkg.purged(name=target)
+    assert ret.result is True
+    assert ret.name == target
+    assert ret.comment == "All targeted packages were purged."
+    assert ret.changes == {
+        "installed": {},
+        "removed": {target: {"new": "", "old": version}},
+    }


### PR DESCRIPTION
### What does this PR do? 
Fixes state pkg.purged to purge removed packages on Debian family systems

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/42306

### Previous Behavior
Packages which had been removed but still on the system are not purged by state pkg.purged

### New Behavior
Packages which had been removed but still on the system are now purged by state pkg.purged.
Note execution module pkg.purge will purge removed packages, for example:
```
root@tdeb11:/usr/lib/python3/dist-packages# dpkg -l | grep figlet
rc  figlet                                2.2.5-3+b1                       amd64        Make large character ASCII banners out of ordinary text
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
