### PR TITLE
Fix issue with Salt not starting on Windows Server 2016/Windows 10

### DIFF
--- a/salt/utils/win_network.py
+++ b/salt/utils/win_network.py
@@ -23,7 +23,6 @@ depending on the version of Windows this is run on. Once support for Windows
 import platform
 
 import salt.utils.win_reg
-
 from salt._compat import ipaddress
 
 IS_WINDOWS = platform.system() == "Windows"
@@ -38,7 +37,7 @@ if IS_WINDOWS:
     net_release = salt.utils.win_reg.read_value(
         hive="HKLM",
         key=r"SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full",
-        vname="Release"
+        vname="Release",
     )
     # If the registry key is not found, or the value is less than 461808, we
     # need to use WMI
@@ -50,6 +49,7 @@ if IS_WINDOWS:
         # This is supported by all versions of Windows, but the database we're
         # using hasn't really been optimized, so it is much slower
         import wmi
+
         import salt.utils.winapi
     else:
         # This uses .NET to get network settings and is faster than WMI

--- a/salt/utils/win_network.py
+++ b/salt/utils/win_network.py
@@ -22,20 +22,37 @@ depending on the version of Windows this is run on. Once support for Windows
 
 import platform
 
+import salt.utils.win_reg
+
 from salt._compat import ipaddress
-from salt.utils.versions import Version
 
 IS_WINDOWS = platform.system() == "Windows"
 
 __virtualname__ = "win_network"
 
 if IS_WINDOWS:
-    USE_WMI = Version(platform.version()) < Version("6.2")
+    # pythonnet 3.0.1 requires .NET 4.7.2 (461808). This isn't installed by
+    # default until Windows Server 2019 / Windows 10 1809 (10.1.17763). But, it
+    # can be installed on older versions of Windows. So, instead of checking
+    # platform here, let's check the version of .NET
+    net_release = salt.utils.win_reg.read_value(
+        hive="HKLM",
+        key=r"SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full",
+        vname="Release"
+    )
+    # If the registry key is not found, or the value is less than 461808, we
+    # need to use WMI
+    if not net_release["success"] or net_release["vdata"] < 461808:
+        USE_WMI = True
+    else:
+        USE_WMI = False
     if USE_WMI:
+        # This is supported by all versions of Windows, but the database we're
+        # using hasn't really been optimized, so it is much slower
         import wmi
-
         import salt.utils.winapi
     else:
+        # This uses .NET to get network settings and is faster than WMI
         import clr
         from System.Net import NetworkInformation
 


### PR DESCRIPTION
### What does this PR do?
The recent update to pythonnet==3.0.1 broke Salt on older Windows operating systems ( < 10.1.17763 ). https://github.com/saltstack/salt/pull/63355

Pythonnet 3.0.1 has .NET 4.7.2 as the minimum requirement. This version of .NET (or newer) didn't come installed by default until Windows version 10.1.17763. However, .NET 4.7.2 can be installed on older operating systems. So, instead of checking for the version of Windows, this will now check for .NET 4.7.2 or greater. If not present, then we will fall back to using WMI to gather network information, which is slower.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes