### PR TITLE
Bump to `future==0.18.3` due to https://github.com/advisories/GHSA-v3c5-jqr6-7qm8

### DIFF
--- a/requirements/static/ci/py3.6/cloud.txt
+++ b/requirements/static/ci/py3.6/cloud.txt
@@ -428,7 +428,7 @@ frozenlist==1.2.0
     # via
     #   aiohttp
     #   aiosignal
-future==0.18.2
+future==0.18.3
     # via textfsm
 genshi==0.7.5
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.6/docs.txt
+++ b/requirements/static/ci/py3.6/docs.txt
@@ -432,7 +432,7 @@ frozenlist==1.2.0
     # via
     #   aiohttp
     #   aiosignal
-future==0.18.2
+future==0.18.3
     # via textfsm
 genshi==0.7.5
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.6/lint.txt
+++ b/requirements/static/ci/py3.6/lint.txt
@@ -428,7 +428,7 @@ frozenlist==1.2.0
     # via
     #   aiohttp
     #   aiosignal
-future==0.18.2
+future==0.18.3
     # via textfsm
 genshi==0.7.5
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.6/linux.txt
+++ b/requirements/static/ci/py3.6/linux.txt
@@ -440,7 +440,7 @@ frozenlist==1.2.0
     # via
     #   aiohttp
     #   aiosignal
-future==0.17.1
+future==0.18.3
     # via textfsm
 genshi==0.7.5
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -432,7 +432,7 @@ frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
-future==0.18.2
+future==0.18.3
     # via
     #   napalm
     #   textfsm

--- a/requirements/static/ci/py3.7/docs.txt
+++ b/requirements/static/ci/py3.7/docs.txt
@@ -434,7 +434,7 @@ frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
-future==0.18.2
+future==0.18.3
     # via
     #   napalm
     #   textfsm

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -430,7 +430,7 @@ frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
-future==0.17.1
+future==0.18.3
     # via
     #   napalm
     #   textfsm

--- a/requirements/static/ci/py3.7/lint.txt
+++ b/requirements/static/ci/py3.7/lint.txt
@@ -430,7 +430,7 @@ frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
-future==0.18.2
+future==0.18.3
     # via
     #   napalm
     #   textfsm

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -444,7 +444,7 @@ frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
-future==0.17.1
+future==0.18.3
     # via
     #   napalm
     #   textfsm

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -430,7 +430,7 @@ frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
-future==0.18.2
+future==0.18.3
     # via
     #   napalm
     #   textfsm

--- a/requirements/static/ci/py3.8/docs.txt
+++ b/requirements/static/ci/py3.8/docs.txt
@@ -432,7 +432,7 @@ frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
-future==0.18.2
+future==0.18.3
     # via
     #   napalm
     #   textfsm

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -428,7 +428,7 @@ frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
-future==0.17.1
+future==0.18.3
     # via
     #   napalm
     #   textfsm

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -428,7 +428,7 @@ frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
-future==0.18.2
+future==0.18.3
     # via
     #   napalm
     #   textfsm

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -442,7 +442,7 @@ frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
-future==0.17.1
+future==0.18.3
     # via
     #   napalm
     #   textfsm

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -430,7 +430,7 @@ frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
-future==0.18.2
+future==0.18.3
     # via
     #   napalm
     #   textfsm

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -430,7 +430,7 @@ frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
-future==0.17.1
+future==0.18.3
     # via
     #   napalm
     #   textfsm

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -430,7 +430,7 @@ frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
-future==0.18.2
+future==0.18.3
     # via
     #   napalm
     #   textfsm

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -428,7 +428,7 @@ frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
-future==0.17.1
+future==0.18.3
     # via
     #   napalm
     #   textfsm

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -426,7 +426,7 @@ frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
-future==0.18.2
+future==0.18.3
     # via
     #   napalm
     #   textfsm

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -444,7 +444,7 @@ frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
-future==0.17.1
+future==0.18.3
     # via
     #   napalm
     #   textfsm


### PR DESCRIPTION
### What does this PR do?
Bump to `future==0.18.3` due to https://github.com/advisories/GHSA-v3c5-jqr6-7qm8
