### PR TITLE
Document how to use GPG encrypted pillar within another pillar file

### DIFF
--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -189,7 +189,7 @@ data like so:
 
     #!yaml|gpg
 
-    a-secret: |
+    a_secret: |
       -----BEGIN PGP MESSAGE-----
       Version: GnuPG v1
 
@@ -202,6 +202,17 @@ data like so:
       FKlwHiJt5yA8X2dDtfk8/Ph1Jx2TwGS+lGjlZaNqp3R1xuAZzXzZMLyZDe5+i3RJ
       skqmFTbOiA===Eqsm
       -----END PGP MESSAGE-----
+
+If you need to use this value in a decrypted state within another pillar file you can do so as follows:
+
+.. code-block:: yaml
+
+    #!jinja|yaml|gpg
+
+    {% import_yaml "hidden_secret.sls" as hidden_secret %}
+    
+    foo:
+      bar: {{ hidden_secret.a_secret }}
 
 .. _encrypted-cli-pillar-data:
 

--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -210,7 +210,7 @@ If you need to use this value in a decrypted state within another pillar file yo
     #!jinja|yaml|gpg
 
     {% import_yaml "hidden_secret.sls" as hidden_secret %}
-    
+
     foo:
       bar: {{ hidden_secret.a_secret }}
 

--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -205,7 +205,7 @@ data like so:
 
 If you need to use this value in a decrypted state within another pillar file you can do so as follows:
 
-.. code-block:: yaml
+.. code-block:: text
 
     #!jinja|yaml|gpg
 


### PR DESCRIPTION
### What does this PR do?

It adds to the GPG documentation so that it's easy for users to import GPG encrypted data within other pillar files.

The context for this was it took me waaaayyyy to long to find [this](https://github.com/saltstack/salt/issues/36673#issuecomment-355281133) solution to what would seem to be a common problem - especially given the prevalence of salt-stack formulas that rely on pillar data.

My use case was I wanted to define my secrets in one pillar, then have other pillar files use this (ie. database password used by the postgres-formula pillar and also my applications pillar).

### What issues does this PR fix or reference?

References #36673 but doesn't directly fix it.

### Merge requirements satisfied?

- [x] Docs
- [ ] ~~Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html~~ Is this required for documentation updates?
- [ ] ~~Tests written/updated~~ N/A

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
