### PR TITLE
Netapi docs rework

### DIFF
--- a/doc/topics/netapi/index.rst
+++ b/doc/topics/netapi/index.rst
@@ -31,7 +31,7 @@ Available interfaces:
 
 * local - run execution modules on minions
 * local_subset - run execution modules on a subset of minions
-* runnner - run runner modules on master
+* runner - run runner modules on master
 * ssh - run salt-ssh commands
 * wheel - run wheel modules
 

--- a/doc/topics/netapi/index.rst
+++ b/doc/topics/netapi/index.rst
@@ -50,8 +50,8 @@ the :command:`salt` command.
 
 
 .. autoclass:: salt.netapi.NetapiClient
-    :members: local, local_async, local_subset, ssh, runner, runner_async,
-        wheel, wheel_async
+    :members: run, local, local_async, local_subset, local_batch, ssh, runner,
+        runner_async, wheel, wheel_async
 
 .. toctree::
 

--- a/doc/topics/netapi/index.rst
+++ b/doc/topics/netapi/index.rst
@@ -4,56 +4,76 @@
 ``netapi`` modules
 ==================
 
-Introduction to netapi modules
-==============================
+netapi modules provide API access to Salt functionality over the network.
 
-netapi modules provide API-centric access to Salt. Usually externally-facing
-services such as REST or WebSockets, XMPP, XMLRPC, etc.
+The included :ref:`netapi modules <all-netapi-modules>` support REST (over 
+HTTP and WSGI) and WebSockets.
 
-In general netapi modules bind to a port and start a service. They are
-purposefully open-ended. A single module can be configured to run as well as
-multiple modules simultaneously.
+Modules expose functions from the :py:class:`NetapiClient <salt.netapi.NetapiClient>`
+and give access to the same functionality as the Salt commandline tools 
+(:command:`salt`, :command:`salt-run`, etc).
 
-netapi modules are enabled by adding configuration to your Salt Master config
-file and then starting the :command:`salt-api` daemon. Check the docs for each
-module to see external requirements and configuration settings.
-
-Communication with Salt and Salt satellite projects is done using Salt's own
-:ref:`Python API <python-api>`. A list of available client interfaces is below.
-
-.. admonition:: salt-api
-
-    Prior to Salt's 2014.7.0 release, netapi modules lived in the separate sister
-    projected ``salt-api``. That project has been merged into the main Salt
-    project.
-
-.. seealso:: :ref:`The full list of netapi modules <all-netapi-modules>`
 
 Client interfaces
 =================
 
-Salt's client interfaces expose executing functions by crafting a dictionary of
-values that are mapped to function arguments. This allows calling functions
-simply by creating a data structure. (And this is exactly how much of Salt's
-own internals work!)
+Salt's client interfaces provide the ability to execute functions from
+execution, runnner, and wheel modules.
+
+The client interfaces available via netapi modules are defined in the
+:py:class:`NetapiClient <salt.netapi.NetapiClient>`, which is a
+limited version of the :ref:`Python API <python-api>`.
+
+The client interfaces accept a dictionary with values for the function
+and its arguments.
+
+Available interfaces:
+
+* local - run execution modules on minions
+* local_subset - run execution modules on a subset of minions
+* runnner - run runner modules on master
+* ssh - run salt-ssh commands
+* wheel - run wheel modules
+
+The local, runner, and wheel clients also have async variants to run
+modules asynchronously.
+
+
+Configuration
+=============
 
 The :conf_master:`netapi_enable_clients` list in the master config sets which
-clients are available. It is recommended to only enable the clients required
-to complete the tasks needed to reduce the amount of Salt functionality exposed
-via the netapi. Enabling the local clients will provide the same functionality as 
-the :command:`salt` command.
-
-.. admonition:: :conf_master:`netapi_enable_clients`
-
-    Prior to Salt's 3006.0 release all clients were enabled and it was not possible
-    to disable clients individually.
-
-
-.. autoclass:: salt.netapi.NetapiClient
-    :members: run, local, local_async, local_subset, local_batch, ssh, runner,
-        runner_async, wheel, wheel_async
+client interfaces are available. It is recommended to only enable the client
+interfaces required to complete the tasks needed to reduce the amount of Salt
+functionality exposed via the netapi. See the
+:ref:`netapi_enable clients <netapi-enable-clients>` documentation.
 
 .. toctree::
 
-    writing
+    netapi-enable-clients
 
+Individual netapi modules can be enabled by adding the module configuration
+section to the master config. The required configuration and dependencies are
+documented for each :ref:`module <all-netapi-modules>`.
+
+The :command:`salt-api` daemon manages netapi modules instances and must be
+started to enable the configured netapi modules. It is possible to run
+multiple netapi modules and multiple instances of each module.
+
+.. admonition:: :conf_master:`netapi_enable_clients`
+
+    Prior to Salt's 3006.0 release all client interfaces were enabled and it 
+    was not possible to disable clients individually.
+
+
+Developing modules
+==================
+
+Developing custom netapi modules for new transports or protocols is documented in
+the :ref:`Writing netapi modules <netapi-writing>` and :ref:`NetapiClient <netapi-client>`
+documentation.
+
+.. toctree::
+
+     writing
+     netapiclient

--- a/doc/topics/netapi/netapi-enable-clients.rst
+++ b/doc/topics/netapi/netapi-enable-clients.rst
@@ -1,0 +1,183 @@
+.. _netapi-enable-clients:
+
+=================================
+Enabling netapi client interfaces
+=================================
+
+From Salt's 3006.0 release onwards, all netapi client interfaces are disabled by default.
+
+To enable netapi/:command:`salt-api` functionality, users should follow the process in this
+documentation. If the :conf_master:`netapi_enable_clients` configuration is not added to the
+Salt master configuration, then the netapi/:command:`salt-api` will not function.
+
+.. admonition:: Breaking change in Salt 3006.0 and above
+
+    Users of netapi/:command:`salt-api` upgrading to Salt 3006.0 **must** follow the process in
+    this documentation to enable the required netapi client interfaces. If the
+    :conf_master:`netapi_enable_clients` configuration is not added to the Salt master
+    configuration netapi/:command:`salt-api` will not function
+
+
+Steps to enable netapi client interfaces
+========================================
+
+1. :ref:`netapi-enable-clients-select`
+2. :ref:`netapi-enable-clients-update`
+3. :ref:`netapi-enable-clients-restart`
+4. :ref:`netapi-enable-clients-verify`
+
+
+.. _netapi-enable-clients-select:
+
+Select client interfaces to enable
+----------------------------------
+
+Salt's client interfaces provide the ability to execute functions from execution, runner,
+wheel modules, and via the salt-ssh system.
+
+It is recommended to only enable the client interfaces required to complete the tasks needed
+to reduce the amount of Salt functionality exposed via the netapi. For example, if the
+salt-ssh system is not in use, not enabling the ssh client interface will help protect
+the Salt master from attacks which look to exploit salt-ssh.
+
+The main client interfaces are:
+
+* local - run execution modules on minions
+* local_subset - run execution modules on a subset of minions
+* runner - run runner modules on master
+* ssh - run salt-ssh commands
+* wheel - run wheel modules
+
+The local, runner, and wheel clients also have async variants to run modules asynchronously.
+See :conf_master:`netapi_enable_clients` for the complete list.
+
+Most scenarios will require enabling the local client (and potentially its local_subset and
+local_async variants). The local client is equivalent to the :command:`salt` command line
+tool and is required to run execution modules against minions.
+
+Many deployments may also require the ability to call runner functions on the master (for
+example, where orchestrations are used), but the runner client should only be enabled if
+this is the case.
+
+As there is not a standard netapi client application, existing users will need to assess
+which client interfaces are in use. Where an application or tool is making a request to
+a netapi module, it will usually pass an option indicating which client to use and it
+should be possible to inspect the source of any tools to understand which client interfaces
+should be enabled.
+
+For common command line clients, such as `pepper <https://github.com/saltstack/pepper>`_
+they will normally default to using the local client interface unless passed an
+option to specify a different client interface.
+
+
+.. _netapi-enable-clients-update:
+
+Update Salt master config
+-------------------------
+
+Once it has been established which client interfaces will be required or are currently
+in use, those should be listed in the Salt master config, under the
+:conf_master:`netapi_enable_clients` key.
+
+Example configuration to enable only the local client interfaces:
+
+    netapi_enable_clients:
+      - local
+      - local_async
+      - local_batch
+      - local_subset
+
+
+Example configuration to enable local client functionality and runners:
+
+    netapi_enable_clients:
+      - local
+      - local_async
+      - local_batch
+      - local_subset
+      - runner
+      - runner_async
+
+See :conf_master:`netapi_enable_clients` for the full list of available client interfaces.
+
+
+.. _netapi-enable-clients-restart:
+
+
+Restart salt-master and salt-api
+--------------------------------
+
+Changes to the Salt master configuration require a restart of the :command:`salt-master`
+service. The :command:`salt-api` service should also be restarted.
+
+
+.. _netapi-enable-clients-verify:
+
+Verify required functionality
+-----------------------------
+
+Testing that the required functionality is available can be done using curl.
+It is recommended to also check that client interfaces that are not
+required are not enabled.
+
+.. admonition:: Examples
+
+    Examples will have to be adjusted to set the correct username, password and
+    :ref:`external authentication <acl-eauth>` values for the user's system.
+
+
+Checking that the local client is enabled:
+
+.. code-block:: bash
+
+    curl -sSKi https://localhost:8000/run \
+        -H 'Accept: application/x-yaml' \
+        -d client='local' \
+        -d tgt='*' \
+        -d fun='test.ping' \
+        -d username='saltdev' \
+        -d password='saltdev' \
+        -d eauth='auto'
+
+    HTTP/1.1 200 OK
+    Content-Type: application/x-yaml
+    Server: CherryPy/18.8.0
+    Date: Mon, 23 Jan 2023 14:54:58 GMT
+    Allow: GET, HEAD, POST
+    Access-Control-Allow-Origin: *
+    Access-Control-Expose-Headers: GET, POST
+    Access-Control-Allow-Credentials: true
+    Vary: Accept-Encoding
+    Content-Length: 25
+
+    return:
+      - saltdev1: true
+
+
+Checking that the runner client is **not** enabled:
+
+.. code-block:: bash
+
+    curl -sSKi https://localhost:8000/run \
+        -H 'Accept: application/x-yaml' \
+        -d client='runner' \
+        -d fun='test.arg' \
+        -d arg='test arg' \
+        -d username='saltdev' \
+        -d password='saltdev' \
+        -d eauth='auto'
+
+    HTTP/1.1 400 Bad Request
+    Content-Type: text/html;charset=utf-8
+    Server: CherryPy/18.8.0
+    Date: Mon, 23 Jan 2023 14:59:33 GMT
+    Allow: GET, HEAD, POST
+    Access-Control-Allow-Origin: *
+    Access-Control-Expose-Headers: GET, POST
+    Access-Control-Allow-Credentials: true
+    Content-Length: 750
+    Vary: Accept-Encoding
+    ...
+
+Further examples are available in the
+:ref:`neatpi modules <all-netapi-modules>` documentation.

--- a/doc/topics/netapi/netapiclient.rst
+++ b/doc/topics/netapi/netapiclient.rst
@@ -1,0 +1,13 @@
+.. _netapi-client:
+
+============
+NetapiClient
+============
+
+The :py:class:`NetapiClient` class provides access to
+:ref:`Python API client interfaces <client-interfaces>` when 
+:ref:`developing netapi modules <netapi-writing>`
+
+.. autoclass:: salt.netapi.NetapiClient
+    :members:  local, local_async, local_subset, ssh, runner, runner_async,
+        wheel, wheel_async, run

--- a/doc/topics/netapi/writing.rst
+++ b/doc/topics/netapi/writing.rst
@@ -1,3 +1,5 @@
+.. _netapi-writing:
+
 ======================
 Writing netapi modules
 ======================

--- a/doc/topics/releases/3006.0.rst
+++ b/doc/topics/releases/3006.0.rst
@@ -35,7 +35,8 @@ All netapi clients, which provide the functionality to ``salt-api``, will now
 be disabled by default as a security precaution. If you use ``salt-api``, you 
 must add the new ``netapi_enable_clients`` option to your salt master config. 
 This is a breaking change and the ``salt-api`` will not function without this 
-new configuration option. See :ref:`netapi-introduction` for more information.
+new configuration option. See :ref:`netapi-enable-clients` for more
+information.
 
 
 How do I migrate to the onedir packages?


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes: #63362

* Reworks the netapi modules documentation to make it clearer. Existing docs mixed information required to develop netapi modules into the main netapi modules docs in a way that made it difficult to understand for users just wanting to use netapi/salt-api.

* Add documentation on how to use the netapi_enable_clients config option and the required steps to test that (#63362)

