### PR TITLE
Update regex to allow for Debian family architectures and tarballs  when determining version of Salt

### DIFF
--- a/pkg/tests/conftest.py
+++ b/pkg/tests/conftest.py
@@ -29,7 +29,7 @@ def version():
     _version = ""
     for artifact in ARTIFACTS_DIR.glob("**/*.*"):
         _version = re.search(
-            r"([0-9].*)(\-[0-9].fc|\-[0-9].el|\+ds|\-[0-9].am|(\-[0-9]-[a-z]*-[a-z]*[0-9_]*.|\-[0-9]*.*)(tar.gz|zip|exe|pkg|rpm))",
+            r"([0-9].*)(\-[0-9].fc|\-[0-9].el|\+ds|\_all|\_any|\_amd64|\_arm64|\-[0-9].am|(\-[0-9]-[a-z]*-[a-z]*[0-9_]*.|\-[0-9]*.*)(tar.gz|tar.xz|zip|exe|pkg|rpm|deb))",
             artifact.name,
         )
         if _version:
@@ -37,8 +37,8 @@ def version():
                 _version.groups()[0]
                 .replace("_", "-")
                 .replace("~", "")
-                .replace("-py3-x86-64", "")
             )
+            _version = _version.split("-")[0]
             break
     return _version
 


### PR DESCRIPTION
### What does this PR do?
This update the pytest fixture which detemines to version of Salt being tested to allow for Debian packages, their specific architectures supported, and also expands to allow for tarballs with xz compression.  It also eliminates the tarballs naming 'xxxxxx-onedir-yyyyyy' of '-onedir' or '-py3' in version determination.

For example:
salt-3005.1+1998.g09350372e5-onedir-windows-amd64.zip
salt-3005.1+1998.g09350372e5-onedir-darwin-x86_64.tar.xz
salt-3005.1+1998.g09350372e5-py3-x86_64-unsigned.pkg
salt-3005.1+1998.g09350372e5-onedir-linux-aarch64.tar.xz
salt-ssh_3005.1+1998.g09350372e5_all.deb

### What issues does this PR fix or reference?
Fixes: none

### Previous Behavior
Failed to determine version from Debian or tarballs correctly.

### New Behavior
Correct Salt version is now determined for Debian or tarballs.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
