### PR TITLE
Add pythonw.exe back to the package

### DIFF
--- a/pkg/common/env-cleanup-rules.yml
+++ b/pkg/common/env-cleanup-rules.yml
@@ -258,7 +258,6 @@ pkg:
       - *ci_windows_file_patterns
       - "**/Scripts/py.exe"
       - "**/Scripts/pyw.exe"
-      - "**/Scripts/pythonw.exe"
       - "**/Scripts/venvlauncher.exe"
       - "**/Scripts/venvwlauncher.exe"
       - "**/Scripts/wheel*"

--- a/pkg/windows/prep_salt.ps1
+++ b/pkg/windows/prep_salt.ps1
@@ -193,7 +193,6 @@ if ( $PKG ) {
     $binaries = @(
         "py.exe",
         "pyw.exe",
-        "pythonw.exe",
         "venvlauncher.exe",
         "venvwlauncher.exe"
     )


### PR DESCRIPTION
### What does this PR do?
Adds `pythonw.exe` back to the Windows packages. This is needed to spin up a master for testing without a `salt-master.exe` binary.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes