### PR TITLE
[DOCS-ONLY] Add warning banner to ESXi modules

### DIFF
--- a/salt/grains/esxi.py
+++ b/salt/grains/esxi.py
@@ -2,13 +2,14 @@
 Generate baseline proxy minion grains for ESXi hosts.
 
 .. Warning::
-    This module will be deprecated in a future release of Salt. VMware strongly 
-    recommends using the 
+    This module will be deprecated in a future release of Salt. VMware strongly
+    recommends using the
     `VMware Salt extensions <https://docs.saltproject.io/salt/extensions/salt-ext-modules-vmware/en/latest/all.html>`_
     instead of the ESXi module. Because the Salt extensions are newer and
-    actively supported by VMware, they are more compatible with current versions 
-    of ESXi and they work well with the latest features in the VMware product 
+    actively supported by VMware, they are more compatible with current versions
+    of ESXi and they work well with the latest features in the VMware product
     line.
+
 
 """
 

--- a/salt/grains/esxi.py
+++ b/salt/grains/esxi.py
@@ -1,7 +1,14 @@
 """
 Generate baseline proxy minion grains for ESXi hosts.
 
-.. versionadded:: 2015.8.4
+.. Warning::
+    This module will be deprecated in a future release of Salt. VMware strongly 
+    recommends using the 
+    `VMware Salt extensions <https://docs.saltproject.io/salt/extensions/salt-ext-modules-vmware/en/latest/all.html>`_
+    instead of the ESXi module. Because the Salt extensions are newer and
+    actively supported by VMware, they are more compatible with current versions 
+    of ESXi and they work well with the latest features in the VMware product 
+    line.
 
 """
 

--- a/salt/modules/esxi.py
+++ b/salt/modules/esxi.py
@@ -2,7 +2,14 @@
 Glues the VMware vSphere Execution Module to the VMware ESXi Proxy Minions to the
 :mod:`esxi proxymodule <salt.proxy.esxi>`.
 
-.. versionadded:: 2015.8.4
+.. Warning::
+    This module will be deprecated in a future release of Salt. VMware strongly 
+    recommends using the 
+    `VMware Salt extensions <https://docs.saltproject.io/salt/extensions/salt-ext-modules-vmware/en/latest/all.html>`_
+    instead of the ESXi module. Because the Salt extensions are newer and
+    actively supported by VMware, they are more compatible with current versions 
+    of ESXi and they work well with the latest features in the VMware product 
+    line.
 
 Depends: :mod:`vSphere Remote Execution Module (salt.modules.vsphere)
 <salt.modules.vsphere>`

--- a/salt/modules/esxi.py
+++ b/salt/modules/esxi.py
@@ -3,13 +3,14 @@ Glues the VMware vSphere Execution Module to the VMware ESXi Proxy Minions to th
 :mod:`esxi proxymodule <salt.proxy.esxi>`.
 
 .. Warning::
-    This module will be deprecated in a future release of Salt. VMware strongly 
-    recommends using the 
+    This module will be deprecated in a future release of Salt. VMware strongly
+    recommends using the
     `VMware Salt extensions <https://docs.saltproject.io/salt/extensions/salt-ext-modules-vmware/en/latest/all.html>`_
     instead of the ESXi module. Because the Salt extensions are newer and
-    actively supported by VMware, they are more compatible with current versions 
-    of ESXi and they work well with the latest features in the VMware product 
+    actively supported by VMware, they are more compatible with current versions
+    of ESXi and they work well with the latest features in the VMware product
     line.
+
 
 Depends: :mod:`vSphere Remote Execution Module (salt.modules.vsphere)
 <salt.modules.vsphere>`

--- a/salt/proxy/esxi.py
+++ b/salt/proxy/esxi.py
@@ -2,13 +2,14 @@
 Proxy Minion interface module for managing VMware ESXi hosts.
 
 .. Warning::
-    This module will be deprecated in a future release of Salt. VMware strongly 
-    recommends using the 
+    This module will be deprecated in a future release of Salt. VMware strongly
+    recommends using the
     `VMware Salt extensions <https://docs.saltproject.io/salt/extensions/salt-ext-modules-vmware/en/latest/all.html>`_
     instead of the ESXi module. Because the Salt extensions are newer and
-    actively supported by VMware, they are more compatible with current versions 
-    of ESXi and they work well with the latest features in the VMware product 
+    actively supported by VMware, they are more compatible with current versions
+    of ESXi and they work well with the latest features in the VMware product
     line.
+
 
 **Special Note: SaltStack thanks** `Adobe Corporation <http://adobe.com/>`_
 **for their support in creating this Proxy Minion integration.**

--- a/salt/proxy/esxi.py
+++ b/salt/proxy/esxi.py
@@ -1,7 +1,14 @@
 """
 Proxy Minion interface module for managing VMware ESXi hosts.
 
-.. versionadded:: 2015.8.4
+.. Warning::
+    This module will be deprecated in a future release of Salt. VMware strongly 
+    recommends using the 
+    `VMware Salt extensions <https://docs.saltproject.io/salt/extensions/salt-ext-modules-vmware/en/latest/all.html>`_
+    instead of the ESXi module. Because the Salt extensions are newer and
+    actively supported by VMware, they are more compatible with current versions 
+    of ESXi and they work well with the latest features in the VMware product 
+    line.
 
 **Special Note: SaltStack thanks** `Adobe Corporation <http://adobe.com/>`_
 **for their support in creating this Proxy Minion integration.**

--- a/salt/states/esxi.py
+++ b/salt/states/esxi.py
@@ -1,7 +1,14 @@
 """
 Manage VMware ESXi Hosts.
 
-.. versionadded:: 2015.8.4
+.. Warning::
+    This module will be deprecated in a future release of Salt. VMware strongly 
+    recommends using the 
+    `VMware Salt extensions <https://docs.saltproject.io/salt/extensions/salt-ext-modules-vmware/en/latest/all.html>`_
+    instead of the ESXi module. Because the Salt extensions are newer and
+    actively supported by VMware, they are more compatible with current versions 
+    of ESXi and they work well with the latest features in the VMware product 
+    line.
 
 Dependencies
 ============

--- a/salt/states/esxi.py
+++ b/salt/states/esxi.py
@@ -2,13 +2,14 @@
 Manage VMware ESXi Hosts.
 
 .. Warning::
-    This module will be deprecated in a future release of Salt. VMware strongly 
-    recommends using the 
+    This module will be deprecated in a future release of Salt. VMware strongly
+    recommends using the
     `VMware Salt extensions <https://docs.saltproject.io/salt/extensions/salt-ext-modules-vmware/en/latest/all.html>`_
     instead of the ESXi module. Because the Salt extensions are newer and
-    actively supported by VMware, they are more compatible with current versions 
-    of ESXi and they work well with the latest features in the VMware product 
+    actively supported by VMware, they are more compatible with current versions
+    of ESXi and they work well with the latest features in the VMware product
     line.
+
 
 Dependencies
 ============


### PR DESCRIPTION
### What does this PR do?
This PR adds a warning banner at the top of the Salt ESXi modules re-directing users to the new VMware Salt extensions.

A couple of notes:

- This request came from the product managers at VMware based on customer confusion, so it is high priority.
- I know that we would prefer to instead deprecate the ESXi modules, but we can't yet deprecate them until we have verified that there is complete feature parity with the old modules.


### What issues does this PR fix or reference?
Relates to: https://github.com/saltstack/salt/issues/62526

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [n/a] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ n/a] Tests written/updated

### Commits signed with GPG?
Yes?

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
