### PR TITLE
Lock pre-commit version, bump isort pre-commit hook to 5.12.0

### DIFF
--- a/.github/workflows/pre-commit-action.yml
+++ b/.github/workflows/pre-commit-action.yml
@@ -8,6 +8,8 @@ on:
         type: string
         description: JSON string containing information about changed files
 
+env:
+  PRE_COMMIT_VERSION: "2.21.0"
 
 jobs:
   Pre-Commit:
@@ -34,8 +36,7 @@ jobs:
           PIP_INDEX_URL: https://pypi-proxy.saltstack.net/root/local/+simple/
           PIP_EXTRA_INDEX_URL: https://pypi.org/simple
         run: |
-          python -m pip install --upgrade pip
-          pip install pre-commit
+          pip install wheel pre-commit==${PRE_COMMIT_VERSION}
           pre-commit install --install-hooks
 
       - name: Check ALL Files On Branch

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1082,7 +1082,7 @@ repos:
         args: [--silent, -E, fix_asserts, -E, fix_docstrings]
 
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         additional_dependencies: ['toml']


### PR DESCRIPTION
### What does this PR do?
See title

### What issues does this PR fix or reference?
Refs https://github.com/PyCQA/isort/issues/2077