### PR TITLE
BF: Fix msteams.post_card

### DIFF
--- a/salt/modules/msteams.py
+++ b/salt/modules/msteams.py
@@ -71,7 +71,11 @@ def post_card(message, hook_url=None, title=None, theme_color=None):
     payload = {"text": message, "title": title, "themeColor": theme_color}
 
     result = salt.utils.http.query(
-        hook_url, method="POST", data=salt.utils.json.dumps(payload), status=True
+        hook_url, 
+        method="POST", 
+        header_dict={"Content-Type": "application/json"},
+        data=salt.utils.json.dumps(payload),
+        status=True
     )
 
     if result["status"] <= 201:


### PR DESCRIPTION
Microsoft has gotten more strict and now requires the "Content-Type" is set in the header, otherwise you get a 400 error code.

### What does this PR do?

Fixes the `msteams.post_card` function for current Teams API. 

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior

Attempts to post data would always get `400: Bad Request`

### New Behavior

Posting data works.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
