### PR TITLE
Move the table of contents for the "Returners" page to the "Remote Execution" page.

### DIFF
--- a/doc/topics/configuration/index.rst
+++ b/doc/topics/configuration/index.rst
@@ -34,5 +34,4 @@ secure and troubleshoot, and how to perform many other administrative tasks.
     ../channels/index
     ../transports/index
     ../master_tops/index
-    ../../ref/returners/index
     ../../ref/renderers/index

--- a/doc/topics/execution/index.rst
+++ b/doc/topics/execution/index.rst
@@ -26,4 +26,5 @@ and so on.
     ../tutorials/modules
     remote_execution
     ../../ref/modules/index
+    ../../ref/returners/index
     ../../ref/executors/index


### PR DESCRIPTION
### What does this PR do?
This PR moves the table of contents for the "Returners" page from the "Configuration" page to the "Remote Execution" page.

### Motivation
- While there is section in the "Returners" page relating to configuring a global set of returners, this is a very small section. The rest of the page is largely about what returners are in the context of _remote execution_, and how to write a returner.
- The "Remote Execution" page mentions that returners are a key element to remote execution, but never links to them.

### Commits signed with GPG?
No
