### PR TITLE
Move spm to master package

### DIFF
--- a/pkg/debian/salt-common.links
+++ b/pkg/debian/salt-common.links
@@ -1,3 +1,2 @@
-opt/saltstack/salt/spm /usr/bin/spm
 opt/saltstack/salt/salt-pip /usr/bin/salt-pip
 opt/saltstack/salt/salt-call /usr/bin/salt-call

--- a/pkg/debian/salt-master.links
+++ b/pkg/debian/salt-master.links
@@ -3,3 +3,4 @@ opt/saltstack/salt/salt usr/bin/salt
 opt/saltstack/salt/salt-cp usr/bin/salt-cp
 opt/saltstack/salt/salt-key usr/bin/salt-key
 opt/saltstack/salt/salt-run usr/bin/salt-run
+opt/saltstack/salt/spm usr/bin/spm

--- a/tools/changelog.py
+++ b/tools/changelog.py
@@ -196,7 +196,7 @@ def update_deb(ctx: Context, salt_version: str, draft: bool = False):
         wfp.write(f"salt ({salt_version}) stable; urgency=medium\n\n")
         wfp.write(formated)
         wfp.write(
-            f"\n -- Salt Project Packaging <saltproject-packaging@vmware.com> {date}\n\n"
+            f"\n -- Salt Project Packaging <saltproject-packaging@vmware.com>  {date}\n\n"
         )
         with open("pkg/debian/changelog") as rfp:
             wfp.write(rfp.read())


### PR DESCRIPTION
### What does this PR do?

- Fixes small wart in Debian package's changelog syntax 
- Moves spm to Debian master package.
