### PR TITLE
Fix use of pip uninstall without '-y', else hang on prompt y/n

### DIFF
--- a/pkg/tests/integration/test_pip.py
+++ b/pkg/tests/integration/test_pip.py
@@ -24,7 +24,7 @@ def wipe_pydeps(pypath, install_salt):
     finally:
         for dep in ["pep8", "PyGithub"]:
             subprocess.run(
-                install_salt.binary_paths["pip"] + ["uninstall", dep],
+                install_salt.binary_paths["pip"] + ["uninstall", "-y", dep],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 check=False,
@@ -66,7 +66,7 @@ def test_pip_non_root(install_salt, test_account, pypath):
     check_path = pypath / "pep8"
     # Lets make sure pep8 is not currently installed
     subprocess.run(
-        install_salt.binary_paths["pip"] + ["uninstall", "pep8"],
+        install_salt.binary_paths["pip"] + ["uninstall", "-y", "pep8"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         check=False,


### PR DESCRIPTION
### What does this PR do?
Adds 'y' to use of pip uninstall so it does not want input, that is, the removal (Y/N) prompt

### What issues does this PR fix or reference?
Fixes: No

### Previous Behavior
The pkg/tests/integration/test_pip.py would hang on treadown in wipe_deps for the pip uninstall of pep8, etc.

### New Behavior
Tests work successfully and pip uninstall does not seek prompted input for Y/N

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
