### PR TITLE
Remove onedir test skip - test_install

### DIFF
--- a/changelog/63629.fixed.md
+++ b/changelog/63629.fixed.md
@@ -1,0 +1,10 @@
+Re-enable `tests/pytests/scenarios/setup/test_install.py` under onedir CI and
+fix the latent failures it surfaced: `setup.py`'s
+``SaltDistribution._property_data_files`` now applies the missing-man-page
+handler to every build mode (previously the SSH and Windows-non-SSH branches
+returned early and would fail downstream when ``doc/man/salt-call.1`` was
+absent in dev installs); ``test_salt_install_args`` now compares the constants
+generated in ``salt/_syspaths.py`` by executing the module rather than
+substring-matching its source, which spuriously failed on Windows where
+``repr()`` escapes backslashes; and the obsolete ``pycurl==7.43.0.5`` Windows
+wheel workaround is dropped (modern pycurl ships wheels).

--- a/setup.py
+++ b/setup.py
@@ -949,43 +949,35 @@ class SaltDistribution(distutils.dist.Distribution):
         ]
         if self.ssh_packaging or PACKAGED_FOR_SALT_SSH:
             data_files[0][1].append("doc/man/salt-ssh.1")
-            if IS_WINDOWS_PLATFORM and not os.environ.get("SALT_BUILD_ALL_BINS"):
-                return data_files
-            data_files[0][1].append("doc/man/salt-cloud.1")
-
-            return data_files
-
-        if IS_WINDOWS_PLATFORM and not os.environ.get("SALT_BUILD_ALL_BINS"):
+            if not (IS_WINDOWS_PLATFORM and not os.environ.get("SALT_BUILD_ALL_BINS")):
+                data_files[0][1].append("doc/man/salt-cloud.1")
+        elif IS_WINDOWS_PLATFORM and not os.environ.get("SALT_BUILD_ALL_BINS"):
             data_files[0][1].extend(
                 [
                     "doc/man/salt-cp.1",
                     "doc/man/salt-minion.1",
                 ]
             )
-            return data_files
+        else:
+            # *nix, so, we need all man pages
+            data_files[0][1].extend(
+                [
+                    "doc/man/salt-api.1",
+                    "doc/man/salt-cloud.1",
+                    "doc/man/salt-cp.1",
+                    "doc/man/salt-key.1",
+                    "doc/man/salt-master.1",
+                    "doc/man/salt-minion.1",
+                    "doc/man/salt-proxy.1",
+                    "doc/man/salt-run.1",
+                    "doc/man/spm.1",
+                    "doc/man/salt.1",
+                    "doc/man/salt-ssh.1",
+                    "doc/man/salt-syndic.1",
+                ]
+            )
 
-        # *nix, so, we need all man pages
-        data_files[0][1].extend(
-            [
-                "doc/man/salt-api.1",
-                "doc/man/salt-cloud.1",
-                "doc/man/salt-cp.1",
-                "doc/man/salt-key.1",
-                "doc/man/salt-master.1",
-                "doc/man/salt-minion.1",
-                "doc/man/salt-proxy.1",
-                "doc/man/salt-run.1",
-                "doc/man/spm.1",
-                "doc/man/salt.1",
-                "doc/man/salt-ssh.1",
-                "doc/man/salt-syndic.1",
-            ]
-        )
-        missing = []
-        for file in data_files[0][1]:
-            if os.path.exists(file):
-                continue
-            missing.append(file)
+        missing = [f for f in data_files[0][1] if not os.path.exists(f)]
         if missing:
             # Only treat missing man pages as fatal error if we're in a packaging build
             # (indicated by SALT_ON_SALTSTACK env var). For development/test installs,
@@ -994,17 +986,16 @@ class SaltDistribution(distutils.dist.Distribution):
                 sys.stderr.write(MISSING_MAN_MSG.format(", ".join(missing)))
                 sys.stderr.flush()
                 sys.exit(1)
-            else:
-                # Development/test install - remove missing man pages from data_files
-                log.warn(
-                    "Skipping installation of man pages (missing: %s). "
-                    "Run 'tools docs man' to generate them.",
-                    ", ".join(missing),
-                )
-                data_files[0] = (
-                    data_files[0][0],
-                    [f for f in data_files[0][1] if f not in missing],
-                )
+            # Development/test install - remove missing man pages from data_files
+            log.warn(
+                "Skipping installation of man pages (missing: %s). "
+                "Run 'tools docs man' to generate them.",
+                ", ".join(missing),
+            )
+            data_files[0] = (
+                data_files[0][0],
+                [f for f in data_files[0][1] if f not in missing],
+            )
         return data_files
 
     @property

--- a/tests/pytests/scenarios/setup/test_install.py
+++ b/tests/pytests/scenarios/setup/test_install.py
@@ -23,7 +23,6 @@ log = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.core_test,
     pytest.mark.windows_whitelisted,
-    pytest.mark.skip_initial_onedir_failure,
     pytest.mark.skip_if_binaries_missing(*KNOWN_BINARY_NAMES, check_all=False),
 ]
 

--- a/tests/pytests/scenarios/setup/test_install.py
+++ b/tests/pytests/scenarios/setup/test_install.py
@@ -7,11 +7,11 @@ import logging
 import os
 import pathlib
 import re
+import runpy
 import sys
 
 import pytest
 
-import salt.utils.files
 import salt.utils.path
 import salt.utils.platform
 import salt.version
@@ -87,11 +87,6 @@ def test_wheel(virtualenv, cache_dir, use_static_requirements, src_dir):
 
         # Because bdist_wheel supports pep517, we don't have to pre-install Salt's
         # dependencies before installing the wheel package
-        if not use_static_requirements and salt.utils.platform.is_windows():
-            # However, on windows, the latest pycurl release, 7.43.0.6 at the time of writing,
-            # does not have wheel files uploaded, so, we force pycurl==7.43.0.5 to be
-            # pre-installed before installing salt
-            venv.install("pycurl==7.43.0.5")
         venv.install(str(salt_generated_package))
 
         # Let's ensure the version is correct
@@ -308,13 +303,6 @@ def test_sdist(virtualenv, cache_dir, use_static_requirements, src_dir):
         for package in packages:
             package.unlink()
 
-        if salt.utils.platform.is_windows() and not use_static_requirements:
-            # Like mentioned above, install pycurl==7.43.0.5
-            # However, on windows, the latest pycurl release, 7.43.0.6 at the time of writing,
-            # does not have wheel files uploaded, so, we force pycurl==7.43.0.5 to be
-            # pre-installed before installing salt
-            venv.install("pycurl==7.43.0.5")
-
         venv.run(
             venv.venv_python,
             "setup.py",
@@ -416,13 +404,6 @@ def test_setup_install(virtualenv, cache_dir, use_static_requirements, src_dir):
         for package in packages:
             package.unlink()
 
-        if salt.utils.platform.is_windows() and not use_static_requirements:
-            # Like mentioned above, install pycurl==7.43.0.5
-            # However, on windows, the latest pycurl release, 7.43.0.6 at the time of writing,
-            # does not have wheel files uploaded, so, we force pycurl==7.43.0.5 to be
-            # pre-installed before installing salt
-            venv.install("pycurl==7.43.0.5")
-
         venv.run(
             venv.venv_python,
             "setup.py",
@@ -504,8 +485,11 @@ def test_salt_install_args(
         assert ret.returncode == 0
         syspath = pathlib.Path(src_dir, "build", "lib", "salt", "_syspaths.py")
         assert syspath.exists()
-        with salt.utils.files.fopen(syspath) as fp:
-            data = fp.read()
-        assert str(cache_dir) in data
-        assert str(config_dir) in data
+        # _syspaths.py is generated Python source; values are written as
+        # repr() which escapes backslashes on Windows. Execute the module
+        # and compare the resulting constants rather than substring-matching
+        # the raw file text.
+        syspaths_ns = runpy.run_path(str(syspath))
+        assert syspaths_ns["CACHE_DIR"] == str(cache_dir)
+        assert syspaths_ns["CONFIG_DIR"] == str(config_dir)
         venv.run(venv.venv_python, "setup.py", "clean", cwd=src_dir)


### PR DESCRIPTION
### What does this PR do?

Removes `pytest.mark.skip_initial_onedir_failure` from
`tests/pytests/scenarios/setup/test_install.py` so the test runs again under
onedir CI, and fixes the three latent failures that surfaced when it was
un-skipped:

- `setup.py`: `SaltDistribution._property_data_files` was structured so the
  SSH-packaging and Windows-non-SSH branches `return` before reaching the
  missing-man-page handler. The refactor moves the four build modes into an
  `if/elif/else`, then runs the existing missing-page check once at the end.
  Positive-path `data_files` contents are unchanged for every mode; the only
  new behavior is that missing pages (e.g. `doc/man/salt-call.1` in dev
  installs) are now handled gracefully on every path instead of crashing the
  SSH or Windows-non-SSH branch.
- `tests/.../test_install.py::test_salt_install_args`: the assertion read
  `salt/_syspaths.py` as text and `assert str(cache_dir) in data`. On Windows
  the values are written via `repr()`, which doubles backslashes, so the
  substring never matched. Switched to `runpy.run_path(...)` and compared the
  resulting `CACHE_DIR` / `CONFIG_DIR` constants directly.
- Dropped the stale `pycurl==7.43.0.5` Windows pre-install workaround in
  `test_wheel`, `test_sdist`, and `test_setup_install`. Pycurl has shipped
  Windows wheels for years; the pin is obsolete and was itself the source of
  occasional flakes.

### What issues does this PR fix or reference?
Fixes the lingering onedir skip for `test_install`.

### Previous Behavior

`test_install` was permanently skipped under onedir CI via
`skip_initial_onedir_failure`. The underlying failures (missing `salt-call.1`,
Windows path-escaping in `_syspaths.py`, obsolete pycurl pin) were never
addressed.

### New Behavior

`test_install` runs under onedir CI; the three underlying bugs are fixed.

### Merge requirements satisfied?
- [x] Tests written/updated
- [x] Changelog (`changelog/63629.fixed.md`)
- [ ] Docs — n/a
