### PR TITLE
(Fix #63636) terraform roster to use explicit priv value if defined in state

### DIFF
--- a/changelog/63636.fixed
+++ b/changelog/63636.fixed
@@ -1,0 +1,1 @@
+Explicit "priv" attribute in terraform state is now correctly used instead of overriden with default / fallback values.

--- a/salt/roster/terraform.py
+++ b/salt/roster/terraform.py
@@ -124,7 +124,9 @@ def _add_ssh_key(ret):
     """
     Setups the salt-ssh minion to be accessed with salt-ssh default key
     """
-    priv = None
+    priv = ret.get("priv", None)
+    if priv and os.path.isfile(priv):
+        return  # Use roster_entry explicitly defined "priv"
     if __opts__.get("ssh_use_home_key") and os.path.isfile(
         os.path.expanduser("~/.ssh/id_rsa")
     ):

--- a/tests/pytests/unit/roster/terraform.data/ssh/salt-ssh-custom.rsa
+++ b/tests/pytests/unit/roster/terraform.data/ssh/salt-ssh-custom.rsa
@@ -1,0 +1,1 @@
+FAKE-SSH-KEY

--- a/tests/pytests/unit/roster/terraform.data/terraform-new-specific-priv.tfstate
+++ b/tests/pytests/unit/roster/terraform.data/terraform-new-specific-priv.tfstate
@@ -1,0 +1,59 @@
+{
+    "version": 4,
+    "terraform_version": "1.2.3",
+    "serial": 1,
+    "lineage": "86545604-7463-4aa5-e9e8-a2a221de98d2",
+    "outputs": {},
+    "resources": [
+        {
+            "mode": "managed",
+            "name": "example",
+            "type": "salt_host",
+            "provider": "provider.libvrt",
+            "instances": [
+                {
+                    "schema_version": 1,
+                    "attributes": {
+                        "host": "192.168.122.106",
+                        "id": "web0",
+                        "passwd": "linux",
+                        "salt_id": "web0",
+                        "timeout": "22",
+                        "user": "root"
+                    }
+                },
+                {
+                    "schema_version": 1,
+                    "attributes": {
+                        "host": "192.168.122.107",
+                        "id": "web1",
+                        "passwd": "linux",
+                        "salt_id": "web1",
+                        "timeout": "22",
+                        "user": "root",
+                        "priv": "tests/pytests/unit/roster/terraform.data/ssh/salt-ssh-custom.rsa"
+                    }
+                }
+            ]
+        },
+        {
+            "mode": "managed",
+            "name": "example",
+            "type": "non_salt_host",
+            "provider": "provider.libvrt",
+            "instances": [
+                {
+                    "schema_version": 1,
+                    "attributes": {
+                        "host": "192.168.122.106",
+                        "id": "web0",
+                        "passwd": "linux",
+                        "salt_id": "web0",
+                        "timeout": "22",
+                        "user": "root"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/tests/pytests/unit/roster/test_terraform.py
+++ b/tests/pytests/unit/roster/test_terraform.py
@@ -21,6 +21,12 @@ def roster_file_new():
 
 
 @pytest.fixture
+def roster_file_priv():
+    """ Fixture containing a specified "priv" argument. """
+    return pathlib.Path(__file__).parent / "terraform.data" / "terraform-new-specific-priv.tfstate"
+
+
+@pytest.fixture
 def pki_dir():
     return pathlib.Path(__file__).parent / "terraform.data"
 
@@ -151,6 +157,33 @@ def test_defaults_new_matching(pki_dir, roster_file_new):
 
     with patch.dict(terraform.__opts__, {"roster_file": str(roster_file_new)}):
         ret = terraform.targets("*1")
+        assert expected_result == ret
+
+
+def test_specified_priv(pki_dir, roster_file_priv):
+    """
+    Test the output of a fixture tfstate file which contains libvirt
+    resources using matching
+    """
+    expected_result = {
+        "web0": {
+            "host": "192.168.122.106",
+            "user": "root",
+            "passwd": "linux",
+            "timeout": 22,
+            "priv": str(pki_dir / "ssh" / "salt-ssh.rsa"),
+        },
+        "web1": {
+            "host": "192.168.122.107",
+            "user": "root",
+            "passwd": "linux",
+            "timeout": 22,
+            "priv": "tests/pytests/unit/roster/terraform.data/ssh/salt-ssh-custom.rsa",
+        },
+    }
+
+    with patch.dict(terraform.__opts__, {"roster_file": str(roster_file_priv)}):
+        ret = terraform.targets("*")
         assert expected_result == ret
 
 


### PR DESCRIPTION
### What does this PR do?

Fixes terraform roster from overriding explicit `priv` attributes with default behaviour.

*This PR does not include test cases yet as I'm not sure how to do this for Salt.*

### What issues does this PR fix or reference?

Fixes: #63636

### Previous Behavior

Explicit `priv` values from terraform state was overriden with default values.

### New Behavior

If an explicit value for `priv` is defined, the default value determination is skipped.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes
