### PR TITLE
prepare removed

### DIFF
--- a/salt/states/rsync.py
+++ b/salt/states/rsync.py
@@ -93,7 +93,6 @@ def synchronized(
     passwordfile=None,
     exclude=None,
     excludefrom=None,
-    prepare=False,
     dryrun=False,
     additional_opts=None,
 ):
@@ -105,9 +104,6 @@ def synchronized(
 
     source
         Source directory.
-
-    prepare
-        Create destination directory if it does not exists.
 
     delete
         Delete extraneous files from the destination dirs (True or False)
@@ -141,12 +137,10 @@ def synchronized(
 
     ret = {"name": name, "changes": {}, "result": True, "comment": ""}
 
-    if not os.path.exists(name) and not force and not prepare:
+    if not os.path.exists(name) and not force:
         ret["result"] = False
         ret["comment"] = "Destination directory {dest} was not found.".format(dest=name)
     else:
-        if not os.path.exists(name) and prepare:
-            os.makedirs(name)
 
         if __opts__["test"]:
             dryrun = True


### PR DESCRIPTION
### What does this PR do?
Just removing an error in rsync salt state. 

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
Remove this section if not relevant
let's say we are using the following state:
```
rsync-data:
  rsync.synchronized:
    - name: {{ pillar['rsync-target-dir'] }}
    - source: {{ pillar['rsync-source-dir'] }}
    - prepare: True
    - additional_opts:
      - -a
      - -e ssh -o StrictHostKeyChecking=no -p {{ pillar['rsync-ssh-port'] | default(22, true) }}
```
pillar:
```
rsync-target-dir: root@192.168.56.21:/home/vagrant/target-files
rsync-source-dir: /home/vagrant/src-files
rsync-ssh-port: 22
```
This results to create some junk directory in `/` of the minion. Namely '/root@192.168.56.21/`. This is an undesirable behavior since we intended to create directories in remote host and not in local. 

### New Behavior
Remove this section if not relevant
Will not create parent dirs. Instead they can be created using additional_opts.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
