### PR TITLE
Create unique error message when state.find_name returns more than one match

### DIFF
--- a/changelog/63673.changed.md
+++ b/changelog/63673.changed.md
@@ -1,0 +1,1 @@
+Improved the "Cannot extend ID" compiler error to identify the duplicate state IDs when an extend or require_in target matches more than one state's ``name`` parameter, instead of returning the generic "not part of the high state" message.

--- a/salt/state.py
+++ b/salt/state.py
@@ -1799,7 +1799,7 @@ class State:
                 if name not in high or state_type not in high[name]:
                     # Check for a matching 'name' override in high data
                     ids = find_name(name, state_type, high, strict=strict)
-                    if len(ids) != 1:
+                    if len(ids) == 0:
                         errors.append(
                             "Cannot extend ID '{0}' in '{1}:{2}'. It is not "
                             "part of the high state.\n"
@@ -1810,6 +1810,22 @@ class State:
                                 name,
                                 body.get("__env__", "base"),
                                 body.get("__sls__", "base"),
+                            )
+                        )
+                        continue
+                    elif len(ids) > 1:
+                        errors.append(
+                            "Cannot extend ID '{0}' in '{1}:{2}'. It is not "
+                            "unique in the running high state.\n"
+                            "This is likely due to more than one state using "
+                            "the same `name` parameter. Ensure that\nthe "
+                            "state with an ID of '{0}' is unique in "
+                            "environment '{1}' and to SLS '{2}'.\nDuplicate "
+                            "states IDs are: '{3}'".format(
+                                name,
+                                body.get("__env__", "base"),
+                                body.get("__sls__", "base"),
+                                ", ".join(f"{state}: {id}" for id, state in ids),
                             )
                         )
                         continue

--- a/tests/pytests/functional/modules/state/requisites/test_require.py
+++ b/tests/pytests/functional/modules/state/requisites/test_require.py
@@ -361,6 +361,44 @@ def test_requisites_require_ordering_and_errors_5(state, state_tree):
         assert ret.errors == [errmsg]
 
 
+def test_requisites_require_ordering_duplicate_extend_id(state, state_tree):
+    """
+    Regression test for PR #63673.
+
+    When the target of an extend (or a require_in, which desugars to extend)
+    cannot be resolved to a single state because multiple states share the
+    same ``name`` parameter, the compiler should fail with a "not unique"
+    error that names every duplicate, instead of the older generic
+    "not part of the high state" message.
+    """
+    sls_contents = """
+    state_a:
+      test.succeed_without_changes:
+        - name: duplicate-target
+
+    state_b:
+      test.succeed_without_changes:
+        - name: duplicate-target
+
+    trigger:
+      test.succeed_without_changes:
+        - require_in:
+          - test: duplicate-target
+    """
+    errmsg = (
+        "Cannot extend ID 'duplicate-target' in 'base:requisite'. It is not"
+        " unique in the running high state.\nThis is likely due to more than"
+        " one state using the same `name` parameter. Ensure that\nthe state"
+        " with an ID of 'duplicate-target' is unique in environment 'base'"
+        " and to SLS 'requisite'.\nDuplicate states IDs are:"
+        " 'test: state_a, test: state_b'"
+    )
+    with pytest.helpers.temp_file("requisite.sls", sls_contents, state_tree):
+        ret = state.sls("requisite")
+        assert ret.failed
+        assert ret.errors == [errmsg]
+
+
 def test_requisites_require_with_order_first_last(state, state_tree):
     """
     Call sls file containing a state with require_in order first


### PR DESCRIPTION
### What does this PR do?
Updates the error message returned when users try to setup a requisite against an ID that appears multiple times within a highstate.

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
The previous error message was:
```
local:
    Data failed to compile:
----------
    Cannot extend ID 'bob' in 'base:common'. It is not part of the high state.
This is likely due to a missing include statement or an incorrectly typed ID.
Ensure that a state with an ID of 'bob' is available
in environment 'base' and to SLS 'common'
```

### New Behavior
```
local:
    Data failed to compile:
----------
    Cannot extend ID 'bob' in 'base:common'. It is not unique in the running high state.
This is likely due to more than one state using the same `name` parameter. Ensure that
the state with an ID of 'bob' is unique in environment 'base' and to SLS 'common'.
Duplicate states IDs are: 'user: my-test-user, user: another_user'
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
