### PR TITLE
Fix helpers arch support for upgrade tests

### DIFF
--- a/pkg/tests/support/helpers.py
+++ b/pkg/tests/support/helpers.py
@@ -476,7 +476,105 @@ class SaltPkgInstall:
     def _install_pkgs(self, upgrade=False):
         if upgrade:
             log.info("Installing packages:\n%s", pprint.pformat(self.pkgs))
-            ret = self.proc.run(self.pkg_mngr, "upgrade", "-y", *self.pkgs)
+            upgrade_location = "/tmp/testing/pkg/artifacts"
+            if self.distro_id in ("ubuntu", "debian"):
+                # --allow-downgrades and yum's downgrade is a workaround since
+                # dpkg/yum is seeing 3005 version as a greater version than our nightly builds.
+                # Also this helps work around the situation when the Salt
+                # branch has not been updated with code so the versions might
+                # be the same and you can still install and test the new
+                # package.
+                ## DGM ret = self.proc.run(
+                ## DGM     self.pkg_mngr, "upgrade", "-y", "--allow-downgrades", *self.pkgs
+                ## DGM )
+                # due to apt perferring released builds vs nightly builds,
+                # need to give preference to the nightly build
+
+                # get first package
+                dgm_pkg_version_name = self.pkgs[0]
+                log.debug(
+                    f"DGM _install_pkgs attempt self.pkgs '{self.pkgs}', dgm_pkg_version_name '{dgm_pkg_version_name}'"
+                )
+                dgm_pkg_version_list = dgm_pkg_version_name.split("_")
+                log.debug(
+                    f"DGM _install_pkgs attempt dgm_pkg_version_list '{dgm_pkg_version_list}'"
+                )
+                if len(dgm_pkg_version_list) < 3:
+                    log.debug(
+                        f"DGM Unable to retrieve package version from package name '{dgm_pkg_version_name}', length '{len(dgm_pkg_version_list)}'"
+                    )
+                    log.error("Unable to retrieve package version from package name")
+                    return False
+
+                dgm_pkg_version = dgm_pkg_version_list[1]
+                log.debug(
+                    f"DGM _install_pkgs attempt dgm_pkg_version '{dgm_pkg_version}'"
+                )
+                with open(
+                    pathlib.Path("/etc", "apt", "/etc/apt/preferences.d", "salt.pref"),
+                    "w",
+                ) as fp:
+                    fp.write(
+                        "Package: salt-*\n"
+                        f"Pin: version {dgm_pkg_version}\n"
+                        "Pin-Priority: 1001\n"
+                    )
+                log.debug(
+                    f"DGM _install_pkgs attempt upgrade to version '{dgm_pkg_version}'"
+                )
+
+                root_url = "salt/py3/"
+                if self.classic:
+                    root_url = "py3/"
+                ## only classic 3005 has arm64 support
+                if platform.is_aarch64() and self.classic:
+                    arch = "arm64"
+                else:
+                    arch = "amd64"
+                ret = self.proc.run("mkdir", "-p", "/etc/apt/keyrings")
+                log.debug(
+                    f"DGM _install_pkgs arch '{arch}', version '{dgm_pkg_version}', salt-archive-keyring-2023.gpg"
+                )
+                self._check_retcode(ret)
+                ret = self.proc.run(
+                    "cp",
+                    "-a",
+                    f"{upgrade_location}/salt-archive-keyring-2023.gpg",
+                    "/etc/apt/keyrings/",
+                )
+                self._check_retcode(ret)
+                with open(
+                    pathlib.Path("/etc", "apt", "sources.list.d", "salt.list"), "w"
+                ) as fp:
+                    fp.write(
+                        f"deb [signed-by=/etc/apt/keyrings/salt-archive-keyring-2023.gpg arch={arch}] "
+                        f"file://{upgrade_location} {self.distro_codename} main"
+                    )
+                ret = self.proc.run(self.pkg_mngr, "update")
+                self._check_retcode(ret)
+
+                log.debug("DGM _install_pkgs attempt upgrade now")
+                ret = self.proc.run(
+                    self.pkg_mngr, "upgrade", "-y", "--allow-downgrades", *self.pkgs
+                )
+                log.debug(
+                    f"DGM _install_pkgs upgrade result ret.returncode '{ret.returncode}', stdout '{ret.stdout}'"
+                )
+                self._check_retcode(ret)
+            else:
+                ret = self.proc.run(self.pkg_mngr, "upgrade", "-y", *self.pkgs)
+                if (
+                    ret.returncode != 0
+                    or "does not update installed package" in ret.stdout
+                    or "cannot update it" in ret.stderr
+                ):
+                    log.info(
+                        "The new packages version is not returning as new. Attempting to downgrade"
+                    )
+                    ret = self.proc.run(self.pkg_mngr, "downgrade", "-y", *self.pkgs)
+                    if ret.returncode != 0:
+                        log.error("Could not install the packages")
+                        return False
         else:
             log.info("Installing packages:\n%s", pprint.pformat(self.pkgs))
             ret = self.proc.run(self.pkg_mngr, "install", "-y", *self.pkgs)
@@ -565,15 +663,21 @@ class SaltPkgInstall:
             self._check_retcode(ret)
             ret = self.proc.run(self.pkg_mngr, "install", "apt-transport-https", "-y")
             self._check_retcode(ret)
-            if platform.is_aarch64():
+            ## only classic 3005 has arm64 support
+            if platform.is_aarch64() and root_url.startswith("py3"):
                 arch = "arm64"
             else:
                 arch = "amd64"
+            ret = self.proc.run("mkdir", "-p", "/etc/apt/keyrings")
+            log.debug(
+                f"DGM install_previous arch '{arch}', major version '{major_ver}'"
+            )
+            self._check_retcode(ret)
             ret = self.proc.run(
                 "curl",
                 "-fsSL",
                 "-o",
-                "/usr/share/keyrings/salt-archive-keyring.gpg",
+                "/etc/apt/keyrings/salt-archive-keyring.gpg",
                 f"https://repo.saltproject.io/{root_url}{distro_name}/{self.distro_version}/{arch}/{major_ver}/salt-archive-keyring.gpg",
             )
             self._check_retcode(ret)
@@ -581,7 +685,7 @@ class SaltPkgInstall:
                 pathlib.Path("/etc", "apt", "sources.list.d", "salt.list"), "w"
             ) as fp:
                 fp.write(
-                    f"deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch={arch}] "
+                    f"deb [signed-by=/etc/apt/keyrings/salt-archive-keyring.gpg arch={arch}] "
                     f"https://repo.saltproject.io/{root_url}{distro_name}/{self.distro_version}/{arch}/{major_ver} {self.distro_codename} main"
                 )
             ret = self.proc.run(self.pkg_mngr, "update")
@@ -606,6 +710,7 @@ class SaltPkgInstall:
             pkg_path = pathlib.Path(r"C:\TEMP", win_pkg)
             pkg_path.parent.mkdir(exist_ok=True)
             ret = requests.get(win_pkg_url)
+
             with open(pkg_path, "wb") as fp:
                 fp.write(ret.content)
             ret = self.proc.run(pkg_path, "/start-minion=0", "/S")

--- a/pkg/tests/support/helpers.py
+++ b/pkg/tests/support/helpers.py
@@ -532,16 +532,20 @@ class SaltPkgInstall:
             gpg_key = "SALTSTACK-GPG-KEY.pub"
             if self.distro_version == "9":
                 gpg_key = "SALTSTACK-GPG-KEY2.pub"
+            if platform.is_aarch64():
+                arch = "aarch64"
+            else:
+                arch = "x86_64"
             ret = self.proc.run(
                 "rpm",
                 "--import",
-                f"https://repo.saltproject.io/{root_url}{distro_name}/{self.distro_version}/x86_64/{major_ver}/{gpg_key}",
+                f"https://repo.saltproject.io/{root_url}{distro_name}/{self.distro_version}/{arch}/{major_ver}/{gpg_key}",
             )
             self._check_retcode(ret)
             ret = self.proc.run(
                 "curl",
                 "-fsSL",
-                f"https://repo.saltproject.io/{root_url}{distro_name}/{self.distro_version}/x86_64/{major_ver}.repo",
+                f"https://repo.saltproject.io/{root_url}{distro_name}/{self.distro_version}/{arch}/{major_ver}.repo",
                 "-o",
                 f"/etc/yum.repos.d/salt-{distro_name}.repo",
             )
@@ -561,20 +565,24 @@ class SaltPkgInstall:
             self._check_retcode(ret)
             ret = self.proc.run(self.pkg_mngr, "install", "apt-transport-https", "-y")
             self._check_retcode(ret)
+            if platform.is_aarch64():
+                arch = "arm64"
+            else:
+                arch = "amd64"
             ret = self.proc.run(
                 "curl",
                 "-fsSL",
                 "-o",
                 "/usr/share/keyrings/salt-archive-keyring.gpg",
-                f"https://repo.saltproject.io/{root_url}{distro_name}/{self.distro_version}/amd64/{major_ver}/salt-archive-keyring.gpg",
+                f"https://repo.saltproject.io/{root_url}{distro_name}/{self.distro_version}/{arch}/{major_ver}/salt-archive-keyring.gpg",
             )
             self._check_retcode(ret)
             with open(
                 pathlib.Path("/etc", "apt", "sources.list.d", "salt.list"), "w"
             ) as fp:
                 fp.write(
-                    "deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch=amd64] "
-                    f"https://repo.saltproject.io/{root_url}{distro_name}/{self.distro_version}/amd64/{major_ver} {self.distro_codename} main"
+                    f"deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch={arch}] "
+                    f"https://repo.saltproject.io/{root_url}{distro_name}/{self.distro_version}/{arch}/{major_ver} {self.distro_codename} main"
                 )
             ret = self.proc.run(self.pkg_mngr, "update")
             self._check_retcode(ret)

--- a/pkg/tests/support/helpers.py
+++ b/pkg/tests/support/helpers.py
@@ -572,8 +572,7 @@ class SaltPkgInstall:
                 arch = "arm64"
             else:
                 arch = "amd64"
-            ret = self.proc.run("mkdir", "-p", "/etc/apt/keyrings")
-            self._check_retcode(ret)
+            pathlib.PATH("/etc/apt/keyrings").mkdir(parents=True, exist_ok=True)
             ret = self.proc.run(
                 "curl",
                 "-fsSL",

--- a/pkg/tests/support/helpers.py
+++ b/pkg/tests/support/helpers.py
@@ -572,7 +572,7 @@ class SaltPkgInstall:
                 arch = "arm64"
             else:
                 arch = "amd64"
-            pathlib.PATH("/etc/apt/keyrings").mkdir(parents=True, exist_ok=True)
+            pathlib.Path("/etc/apt/keyrings").mkdir(parents=True, exist_ok=True)
             ret = self.proc.run(
                 "curl",
                 "-fsSL",

--- a/pkg/tests/support/helpers.py
+++ b/pkg/tests/support/helpers.py
@@ -476,105 +476,7 @@ class SaltPkgInstall:
     def _install_pkgs(self, upgrade=False):
         if upgrade:
             log.info("Installing packages:\n%s", pprint.pformat(self.pkgs))
-            upgrade_location = "/tmp/testing/pkg/artifacts"
-            if self.distro_id in ("ubuntu", "debian"):
-                # --allow-downgrades and yum's downgrade is a workaround since
-                # dpkg/yum is seeing 3005 version as a greater version than our nightly builds.
-                # Also this helps work around the situation when the Salt
-                # branch has not been updated with code so the versions might
-                # be the same and you can still install and test the new
-                # package.
-                ## DGM ret = self.proc.run(
-                ## DGM     self.pkg_mngr, "upgrade", "-y", "--allow-downgrades", *self.pkgs
-                ## DGM )
-                # due to apt perferring released builds vs nightly builds,
-                # need to give preference to the nightly build
-
-                # get first package
-                dgm_pkg_version_name = self.pkgs[0]
-                log.debug(
-                    f"DGM _install_pkgs attempt self.pkgs '{self.pkgs}', dgm_pkg_version_name '{dgm_pkg_version_name}'"
-                )
-                dgm_pkg_version_list = dgm_pkg_version_name.split("_")
-                log.debug(
-                    f"DGM _install_pkgs attempt dgm_pkg_version_list '{dgm_pkg_version_list}'"
-                )
-                if len(dgm_pkg_version_list) < 3:
-                    log.debug(
-                        f"DGM Unable to retrieve package version from package name '{dgm_pkg_version_name}', length '{len(dgm_pkg_version_list)}'"
-                    )
-                    log.error("Unable to retrieve package version from package name")
-                    return False
-
-                dgm_pkg_version = dgm_pkg_version_list[1]
-                log.debug(
-                    f"DGM _install_pkgs attempt dgm_pkg_version '{dgm_pkg_version}'"
-                )
-                with open(
-                    pathlib.Path("/etc", "apt", "/etc/apt/preferences.d", "salt.pref"),
-                    "w",
-                ) as fp:
-                    fp.write(
-                        "Package: salt-*\n"
-                        f"Pin: version {dgm_pkg_version}\n"
-                        "Pin-Priority: 1001\n"
-                    )
-                log.debug(
-                    f"DGM _install_pkgs attempt upgrade to version '{dgm_pkg_version}'"
-                )
-
-                root_url = "salt/py3/"
-                if self.classic:
-                    root_url = "py3/"
-                ## only classic 3005 has arm64 support
-                if platform.is_aarch64() and self.classic:
-                    arch = "arm64"
-                else:
-                    arch = "amd64"
-                ret = self.proc.run("mkdir", "-p", "/etc/apt/keyrings")
-                log.debug(
-                    f"DGM _install_pkgs arch '{arch}', version '{dgm_pkg_version}', salt-archive-keyring-2023.gpg"
-                )
-                self._check_retcode(ret)
-                ret = self.proc.run(
-                    "cp",
-                    "-a",
-                    f"{upgrade_location}/salt-archive-keyring-2023.gpg",
-                    "/etc/apt/keyrings/",
-                )
-                self._check_retcode(ret)
-                with open(
-                    pathlib.Path("/etc", "apt", "sources.list.d", "salt.list"), "w"
-                ) as fp:
-                    fp.write(
-                        f"deb [signed-by=/etc/apt/keyrings/salt-archive-keyring-2023.gpg arch={arch}] "
-                        f"file://{upgrade_location} {self.distro_codename} main"
-                    )
-                ret = self.proc.run(self.pkg_mngr, "update")
-                self._check_retcode(ret)
-
-                log.debug("DGM _install_pkgs attempt upgrade now")
-                ret = self.proc.run(
-                    self.pkg_mngr, "upgrade", "-y", "--allow-downgrades", *self.pkgs
-                )
-                log.debug(
-                    f"DGM _install_pkgs upgrade result ret.returncode '{ret.returncode}', stdout '{ret.stdout}'"
-                )
-                self._check_retcode(ret)
-            else:
-                ret = self.proc.run(self.pkg_mngr, "upgrade", "-y", *self.pkgs)
-                if (
-                    ret.returncode != 0
-                    or "does not update installed package" in ret.stdout
-                    or "cannot update it" in ret.stderr
-                ):
-                    log.info(
-                        "The new packages version is not returning as new. Attempting to downgrade"
-                    )
-                    ret = self.proc.run(self.pkg_mngr, "downgrade", "-y", *self.pkgs)
-                    if ret.returncode != 0:
-                        log.error("Could not install the packages")
-                        return False
+            ret = self.proc.run(self.pkg_mngr, "upgrade", "-y", *self.pkgs)
         else:
             log.info("Installing packages:\n%s", pprint.pformat(self.pkgs))
             ret = self.proc.run(self.pkg_mngr, "install", "-y", *self.pkgs)
@@ -664,14 +566,13 @@ class SaltPkgInstall:
             ret = self.proc.run(self.pkg_mngr, "install", "apt-transport-https", "-y")
             self._check_retcode(ret)
             ## only classic 3005 has arm64 support
-            if platform.is_aarch64() and root_url.startswith("py3"):
+            if self.major >= "3006" and platform.is_aarch64():
+                arch = "arm64"
+            elif platform.is_aarch64() and self.classic:
                 arch = "arm64"
             else:
                 arch = "amd64"
             ret = self.proc.run("mkdir", "-p", "/etc/apt/keyrings")
-            log.debug(
-                f"DGM install_previous arch '{arch}', major version '{major_ver}'"
-            )
             self._check_retcode(ret)
             ret = self.proc.run(
                 "curl",

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -476,7 +476,11 @@ def matrix(ctx: Context, distro_slug: str):
     _matrix = []
     for transport in ("zeromq", "tcp"):
         if transport == "tcp":
-            if distro_slug not in ("centosstream-9", "ubuntu-22.04-arm64"):
+            if distro_slug not in (
+                "centosstream-9",
+                "ubuntu-22.04",
+                "ubuntu-22.04-arm64",
+            ):
                 # Only run TCP transport tests on these distributions
                 continue
         for chunk in ("unit", "functional", "integration", "scenarios"):
@@ -506,7 +510,11 @@ def transport_matrix(ctx: Context, distro_slug: str):
     _matrix = []
     for transport in ("zeromq", "tcp"):
         if transport == "tcp":
-            if distro_slug not in ("centosstream-9", "ubuntu-22.04-arm64"):
+            if distro_slug not in (
+                "centosstream-9",
+                "ubuntu-22.04",
+                "ubuntu-22.04-arm64",
+            ):
                 # Only run TCP transport tests on these distributions
                 continue
         _matrix.append({"transport": transport})


### PR DESCRIPTION
### What does this PR do?
Fix helpers arch support for upgrade tests, previously url's for installing previous were hard-coded to use Intel, x86_64 and amd64.  The fix checks if AARCH64 and sets the architecture to use appropriately

### What issues does this PR fix or reference?
Fixes: n/a

### New Behavior
Now test upgrade on ARM64

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
