### PR TITLE
[FIX]: Fix for Issue 63695

### DIFF
--- a/changelog/63695.fixed
+++ b/changelog/63695.fixed
@@ -1,0 +1,1 @@
+When copying ssh_pre_flight script to target host, ensure the destination directory exists prior to copy.

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1009,7 +1009,7 @@ class Single:
         """
         script = os.path.join(tempfile.gettempdir(), self.ssh_pre_file)
 
-        self.shell.send(self.ssh_pre_flight, script)
+        self.shell.send(self.ssh_pre_flight, script, makedirs=True)
 
         return self.execute_script(script, script_args=self.ssh_pre_flight_args)
 


### PR DESCRIPTION
### What does this PR do?
This addresses [Issue
63695](https://github.com/saltstack/salt/issues/63695) by ensuring the destination tempdir on the target host is created before copying the ssh_pre_flight script to that target host.

### What issues does this PR fix or reference?
Fixes: [63695](https://github.com/saltstack/salt/issues/63695)

### Previous Behavior
salt-ssh from Mac to Mac or Linux would fail to execute ssh_preflight_hook due to locally determined tempdir not existing on target.

### New Behavior
Locally determined tempdir is created on the target prior to copying the script.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [-] Docs - Don't think any doc changes are needed.
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated - TBD

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
