### PR TITLE
[DOCS] Fix incorrect reactor target in documentation

### DIFF
--- a/doc/topics/beacons/index.rst
+++ b/doc/topics/beacons/index.rst
@@ -246,7 +246,7 @@ Add the following to ``/srv/reactor/revert.sls``:
 
     revert-file:
       local.state.apply:
-        - tgt: {{ data['data']['id'] }}
+        - tgt: {{ data['id'] }}
         - arg:
           - maintain_important_file
 
@@ -256,12 +256,6 @@ Add the following to ``/srv/reactor/revert.sls``:
     ``disable_during_state_run: True`` for an inotify beacon whose reaction is
     to modify the watched file, it is important to ensure the state applied is
     also :term:`idempotent <Idempotent>`.
-
-.. note::
-
-    The expression ``{{ data['data']['id'] }}`` :ref:`is correct
-    <beacons-and-reactors>` as it matches the event structure :ref:`shown above
-    <beacon-event-bus>`.
 
 State SLS
 `````````


### PR DESCRIPTION
The documentation has an incorrect reactor target

The current documentation will cause the following error
```
jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'data'
```

### What does this PR do?
Fixes an error in documentation

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/63701