### PR TITLE
macOS: Fix 'productname' grain trailing null

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -3230,7 +3230,9 @@ def _hw_data(osdata):
         sysctl = salt.utils.path.which("sysctl")
         hwdata = {"productname": "hw.model"}
         for key, oid in hwdata.items():
-            value = __salt__["cmd.run"]("{} -b {}".format(sysctl, oid))
+            value = __salt__["cmd.run"]("{} -n {}".format(sysctl, oid))
+            if isinstance(value, str):
+                value = value.strip()
             if not value.endswith(" is invalid"):
                 grains[key] = _clean_value(key, value)
     elif osdata["kernel"] == "SunOS" and osdata["cpuarch"].startswith("sparc"):


### PR DESCRIPTION
### What does this PR do?

Changes the output flag where `salt.grains.core` invokes `sysctl` on macOS from outputting a trailing null (`\0`) to a trailing newline (`\n`), which is then removed with `str.strip()`.

### What issues does this PR fix or reference?

Fixes: #57454

### Previous Behavior

On macOS, the `productname` core grain had a trailing null character (`\0`) due to the use of the `-b` flag.

The `-b` and `-n` flags are documented in `sysctl(8)` as:

```
     -b      Force the value of the variable(s) to be output in raw, binary format.  No names are printed and no terminating newlines are output.  This is mostly useful with a single variable.
     -n      Show only variable values, not their names.  This option is useful for setting shell variables.  For instance, to save the pagesize in variable psize, use:

                   set psize=`sysctl -n hw.pagesize`
```

The difference in flags can be seen when using `sysctl` and `tr` on the command line

Examples are of my 2021 14" Macbook Pro, with a `hw.model` value of `MacBookPro18,4`. 

`sysctl -b` outputs a null-terminated string. `tr '\0' '?'` replaces the null with `?`.

```shell
# replace null "\0" with "?"
$ sysctl -b hw.model | tr '\0' '?'
MacBookPro18,4?
```

`sysctl -n` outputs a newline-terminated string. `tr '\n' '^'` replaces `\n` with `^`.

```shell
# replace newline "\n" with "^"
$ sysctl -n hw.model | tr '\n' '^'
MacBookPro18,4^
```

### Merge requirements satisfied?

- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Not yet

### Notes

This PR is a Work in Progress. It was easier to fix the bug than it is to write the tests :)

The challenge I have is that there are no existing tests for `salt.grains.core` for macOS. There are _similar_ tests for various Linux and BSD OS's, which I may be able to use to create good tests for macOS core grains.

Advice welcome! I'll be asking on Salt community Slack for help. 