### PR TITLE
[FREEZE] Upgrade to `cryptography==39.0.1`

### DIFF
--- a/changelog/63757.changed
+++ b/changelog/63757.changed
@@ -1,0 +1,3 @@
+Fix pre-commit by changing the pyzmq requirements:
+
+* It's now `pyzmq>=20.0.0` on all platforms, and `<=22.0.3` just for windows.

--- a/changelog/63757.changed
+++ b/changelog/63757.changed
@@ -1,3 +1,4 @@
-Fix pre-commit by changing the pyzmq requirements:
+Additional required package upgrades
 
 * It's now `pyzmq>=20.0.0` on all platforms, and `<=22.0.3` just for windows.
+* Upgrade to `pyopenssl==23.0.0` due to the cryptography upgrade.

--- a/changelog/63757.security
+++ b/changelog/63757.security
@@ -1,0 +1,7 @@
+Upgrade to `cryptography==39.0.1`
+
+Due to:
+  * https://github.com/advisories/GHSA-x4qr-2fvf-3mr5
+  * https://github.com/advisories/GHSA-w7pp-m8wf-vj6r
+
+There is no security upgrade available for Py3.5

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -665,7 +665,7 @@ pyjwt==2.4.0
     # via adal
 pynacl==1.4.0
     # via paramiko
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -812,7 +812,6 @@ six==1.16.0
     #   paramiko
     #   profitbricks
     #   pynacl
-    #   pyopenssl
     #   pypsexec
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -383,7 +383,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.1
     # via
     #   adal
     #   azure-cosmosdb-table
@@ -799,7 +799,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -746,7 +746,7 @@ pyyaml==5.4.1
     #   junos-eznc
     #   kubernetes
     #   yamlordereddictloader
-pyzmq==23.2.0 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -386,7 +386,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.1
     # via
     #   -r requirements/darwin.txt
     #   adal

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -667,7 +667,7 @@ pyjwt==2.4.0
     # via adal
 pynacl==1.3.0
     # via paramiko
-pyopenssl==19.0.0
+pyopenssl==23.0.0
     # via
     #   -r requirements/darwin.txt
     #   etcd3-py
@@ -792,7 +792,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet
@@ -807,7 +806,6 @@ six==1.16.0
     #   packaging
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-dateutil
     #   pyvmomi
     #   responses

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -745,7 +745,7 @@ pyyaml==5.4.1
     #   kubernetes
     #   yamllint
     #   yamlordereddictloader
-pyzmq==23.2.0 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -390,7 +390,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.1
     # via
     #   adal
     #   ansible-core
@@ -775,7 +775,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -669,7 +669,7 @@ pymysql==1.0.2 ; python_version > "3.5"
     # via -r requirements/static/ci/linux.in
 pynacl==1.4.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -788,7 +788,6 @@ six==1.16.0
     #   ncclient
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -719,7 +719,7 @@ pyyaml==5.4.1
     #   kubernetes
     #   yamllint
     #   yamlordereddictloader
-pyzmq==23.2.0 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via -r requirements/zeromq.txt
 redis-py-cluster==2.1.3
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -382,7 +382,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.1
     # via
     #   adal
     #   azure-cosmosdb-table

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -662,7 +662,7 @@ pyjwt==2.4.0
     # via adal
 pynacl==1.3.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   etcd3-py
@@ -786,7 +786,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet
@@ -803,7 +802,6 @@ six==1.16.0
     #   packaging
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-dateutil
     #   pyvmomi
     #   responses

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -740,7 +740,7 @@ pyyaml==5.4.1
     #   kubernetes
     #   yamllint
     #   yamlordereddictloader
-pyzmq==23.2.0 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -388,7 +388,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.4.7
+cryptography==39.0.1
     # via
     #   adal
     #   ansible-core

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -669,7 +669,7 @@ pymysql==1.0.2 ; python_version > "3.5"
     # via -r requirements/static/ci/linux.in
 pynacl==1.4.0
     # via paramiko
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -788,7 +788,6 @@ six==1.16.0
     #   ncclient
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -718,7 +718,7 @@ pyyaml==5.4.1
     #   kubernetes
     #   yamllint
     #   yamlordereddictloader
-pyzmq==23.2.0 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via -r requirements/zeromq.txt
 redis-py-cluster==2.1.3
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -684,7 +684,7 @@ pymysql==1.0.2 ; python_version > "3.5"
     # via -r requirements/static/ci/linux.in
 pynacl==1.3.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -828,7 +828,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet
@@ -844,7 +843,6 @@ six==1.16.0
     #   packaging
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -396,7 +396,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.1
     # via
     #   adal
     #   ansible-core

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -771,7 +771,7 @@ pyyaml==5.4.1
     #   kubernetes
     #   yamllint
     #   yamlordereddictloader
-pyzmq==23.2.0 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -72,8 +72,8 @@ clustershell==1.8.3
 colorama==0.4.1
     # via pytest
 contextvars==2.4
-    # via -r requirements/static/pkg/py3.10/windows.txt
-cryptography==3.4.7
+    # via -r requirements/base.txt
+cryptography==39.0.1
     # via
     #   -r requirements/static/pkg/py3.10/windows.txt
     #   moto

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -263,7 +263,7 @@ pygit2==1.5.0 ; python_version >= "3.7"
     # via -r requirements/static/ci/windows.in
 pymysql==1.0.2
     # via -r requirements/static/pkg/py3.10/windows.txt
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via -r requirements/static/pkg/py3.10/windows.txt
 pyparsing==2.4.5
     # via packaging

--- a/requirements/static/ci/py3.5/linux.txt
+++ b/requirements/static/ci/py3.5/linux.txt
@@ -394,7 +394,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.0
+cryptography==3.2.1
     # via
     #   adal
     #   ansible-core

--- a/requirements/static/ci/py3.5/linux.txt
+++ b/requirements/static/ci/py3.5/linux.txt
@@ -717,7 +717,7 @@ pymysql==0.9.3 ; python_version <= "3.5"
     # via -r requirements/static/ci/linux.in
 pynacl==1.3.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==20.0.0
     # via -r requirements/static/pkg/linux.in
 pyparsing==2.4.5
     # via

--- a/requirements/static/ci/py3.5/linux.txt
+++ b/requirements/static/ci/py3.5/linux.txt
@@ -803,7 +803,7 @@ pyyaml==5.3.1
     #   moto
     #   yamllint
     #   yamlordereddictloader
-pyzmq==18.0.1 ; python_version < "3.9"
+pyzmq==19.0.2 ; python_version < "3.6"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.6/cloud.txt
+++ b/requirements/static/ci/py3.6/cloud.txt
@@ -687,7 +687,7 @@ pyjwt==2.4.0
     # via adal
 pynacl==1.4.0
     # via paramiko
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -834,7 +834,6 @@ six==1.16.0
     #   paramiko
     #   profitbricks
     #   pynacl
-    #   pyopenssl
     #   pypsexec
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.6/cloud.txt
+++ b/requirements/static/ci/py3.6/cloud.txt
@@ -387,7 +387,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.1
     # via
     #   adal
     #   azure-cosmosdb-table
@@ -821,7 +821,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet

--- a/requirements/static/ci/py3.6/cloud.txt
+++ b/requirements/static/ci/py3.6/cloud.txt
@@ -768,7 +768,7 @@ pyyaml==5.4.1
     #   junos-eznc
     #   kubernetes
     #   yamlordereddictloader
-pyzmq==21.0.2 ; python_version < "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.6/docs.txt
+++ b/requirements/static/ci/py3.6/docs.txt
@@ -396,7 +396,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.4.7
+cryptography==39.0.1
     # via
     #   adal
     #   ansible-core

--- a/requirements/static/ci/py3.6/docs.txt
+++ b/requirements/static/ci/py3.6/docs.txt
@@ -691,7 +691,7 @@ pymysql==1.0.2 ; python_version > "3.5"
     # via -r requirements/static/ci/linux.in
 pynacl==1.4.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -810,7 +810,6 @@ six==1.16.0
     #   ncclient
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.6/docs.txt
+++ b/requirements/static/ci/py3.6/docs.txt
@@ -741,7 +741,7 @@ pyyaml==5.4.1
     #   kubernetes
     #   yamllint
     #   yamlordereddictloader
-pyzmq==18.0.1 ; python_version < "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via -r requirements/zeromq.txt
 redis-py-cluster==2.1.3
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.6/lint.txt
+++ b/requirements/static/ci/py3.6/lint.txt
@@ -394,7 +394,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.4.7
+cryptography==39.0.1
     # via
     #   adal
     #   ansible-core

--- a/requirements/static/ci/py3.6/lint.txt
+++ b/requirements/static/ci/py3.6/lint.txt
@@ -693,7 +693,7 @@ pymysql==1.0.2 ; python_version > "3.5"
     # via -r requirements/static/ci/linux.in
 pynacl==1.4.0
     # via paramiko
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -812,7 +812,6 @@ six==1.16.0
     #   ncclient
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.6/lint.txt
+++ b/requirements/static/ci/py3.6/lint.txt
@@ -742,7 +742,7 @@ pyyaml==5.4.1
     #   kubernetes
     #   yamllint
     #   yamlordereddictloader
-pyzmq==21.0.2 ; python_version < "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via -r requirements/zeromq.txt
 redis-py-cluster==2.1.3
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.6/linux.txt
+++ b/requirements/static/ci/py3.6/linux.txt
@@ -400,7 +400,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.1
     # via
     #   adal
     #   ansible-core

--- a/requirements/static/ci/py3.6/linux.txt
+++ b/requirements/static/ci/py3.6/linux.txt
@@ -706,7 +706,7 @@ pymysql==1.0.2 ; python_version > "3.5"
     # via -r requirements/static/ci/linux.in
 pynacl==1.3.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -850,7 +850,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet
@@ -866,7 +865,6 @@ six==1.16.0
     #   packaging
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.6/linux.txt
+++ b/requirements/static/ci/py3.6/linux.txt
@@ -793,7 +793,7 @@ pyyaml==5.4.1
     #   kubernetes
     #   yamllint
     #   yamlordereddictloader
-pyzmq==18.0.1 ; python_version < "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -390,7 +390,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.1
     # via
     #   adal
     #   azure-cosmosdb-table
@@ -847,7 +847,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -706,7 +706,7 @@ pyjwt==2.4.0
     # via adal
 pynacl==1.4.0
     # via paramiko
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -860,7 +860,6 @@ six==1.16.0
     #   paramiko
     #   profitbricks
     #   pynacl
-    #   pyopenssl
     #   pypsexec
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -790,7 +790,7 @@ pyyaml==5.4.1
     #   kubernetes
     #   napalm
     #   yamlordereddictloader
-pyzmq==21.0.2 ; python_version < "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.7/docs.txt
+++ b/requirements/static/ci/py3.7/docs.txt
@@ -399,7 +399,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.4.7
+cryptography==39.0.1
     # via
     #   adal
     #   ansible-core

--- a/requirements/static/ci/py3.7/docs.txt
+++ b/requirements/static/ci/py3.7/docs.txt
@@ -709,7 +709,7 @@ pymysql==1.0.2 ; python_version > "3.5"
     # via -r requirements/static/ci/linux.in
 pynacl==1.4.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -835,7 +835,6 @@ six==1.16.0
     #   ncclient
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.7/docs.txt
+++ b/requirements/static/ci/py3.7/docs.txt
@@ -762,7 +762,7 @@ pyyaml==5.4.1
     #   napalm
     #   yamllint
     #   yamlordereddictloader
-pyzmq==18.0.1 ; python_version < "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via -r requirements/zeromq.txt
 redis-py-cluster==2.1.3
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -389,7 +389,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.1
     # via
     #   adal
     #   azure-cosmosdb-table

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -699,7 +699,7 @@ pyjwt==2.4.0
     # via adal
 pynacl==1.3.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   etcd3-py
@@ -830,7 +830,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet
@@ -847,7 +846,6 @@ six==1.16.0
     #   packaging
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-dateutil
     #   pyvmomi
     #   responses

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -780,7 +780,7 @@ pyyaml==5.4.1
     #   napalm
     #   yamllint
     #   yamlordereddictloader
-pyzmq==18.0.1 ; python_version < "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.7/lint.txt
+++ b/requirements/static/ci/py3.7/lint.txt
@@ -397,7 +397,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.4.7
+cryptography==39.0.1
     # via
     #   adal
     #   ansible-core

--- a/requirements/static/ci/py3.7/lint.txt
+++ b/requirements/static/ci/py3.7/lint.txt
@@ -711,7 +711,7 @@ pymysql==1.0.2 ; python_version > "3.5"
     # via -r requirements/static/ci/linux.in
 pynacl==1.4.0
     # via paramiko
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -837,7 +837,6 @@ six==1.16.0
     #   ncclient
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.7/lint.txt
+++ b/requirements/static/ci/py3.7/lint.txt
@@ -763,7 +763,7 @@ pyyaml==5.4.1
     #   napalm
     #   yamllint
     #   yamlordereddictloader
-pyzmq==21.0.2 ; python_version < "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via -r requirements/zeromq.txt
 redis-py-cluster==2.1.3
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -403,7 +403,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.1
     # via
     #   adal
     #   ansible-core

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -719,7 +719,7 @@ pymysql==1.0.2 ; python_version > "3.5"
     # via -r requirements/static/ci/linux.in
 pynacl==1.3.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -870,7 +870,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet
@@ -886,7 +885,6 @@ six==1.16.0
     #   packaging
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -809,7 +809,7 @@ pyyaml==5.4.1
     #   napalm
     #   yamllint
     #   yamlordereddictloader
-pyzmq==18.0.1 ; python_version < "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -248,7 +248,7 @@ pymssql==2.2.1
     # via -r requirements/windows.txt
 pymysql==1.0.2
     # via -r requirements/windows.txt
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via
     #   -r requirements/windows.txt
     #   etcd3-py
@@ -372,7 +372,6 @@ six==1.16.0
     #   kubernetes
     #   mock
     #   packaging
-    #   pyopenssl
     #   python-dateutil
     #   pyvmomi
     #   pywinrm

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -74,7 +74,7 @@ colorama==0.4.1
     # via pytest
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.4.7
+cryptography==39.0.1
     # via
     #   -r requirements/windows.txt
     #   etcd3-py

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -325,7 +325,7 @@ pyyaml==5.4.1
     #   clustershell
     #   kubernetes
     #   yamllint
-pyzmq==22.0.3 ; python_version < "3.9" and sys_platform == "win32"
+pyzmq==22.0.3 ; sys_platform == "win32"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -696,7 +696,7 @@ pyjwt==2.4.0
     # via adal
 pynacl==1.4.0
     # via paramiko
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -850,7 +850,6 @@ six==1.16.0
     #   paramiko
     #   profitbricks
     #   pynacl
-    #   pyopenssl
     #   pypsexec
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -388,7 +388,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.1
     # via
     #   adal
     #   azure-cosmosdb-table
@@ -837,7 +837,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -780,7 +780,7 @@ pyyaml==5.4.1
     #   kubernetes
     #   napalm
     #   yamlordereddictloader
-pyzmq==21.0.2 ; python_version < "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.8/docs.txt
+++ b/requirements/static/ci/py3.8/docs.txt
@@ -701,7 +701,7 @@ pymysql==1.0.2 ; python_version > "3.5"
     # via -r requirements/static/ci/linux.in
 pynacl==1.4.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -827,7 +827,6 @@ six==1.16.0
     #   ncclient
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.8/docs.txt
+++ b/requirements/static/ci/py3.8/docs.txt
@@ -397,7 +397,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.1
     # via
     #   adal
     #   ansible-core
@@ -814,7 +814,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet

--- a/requirements/static/ci/py3.8/docs.txt
+++ b/requirements/static/ci/py3.8/docs.txt
@@ -754,7 +754,7 @@ pyyaml==5.4.1
     #   napalm
     #   yamllint
     #   yamlordereddictloader
-pyzmq==19.0.0 ; python_version < "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via -r requirements/zeromq.txt
 redis-py-cluster==2.1.3
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -387,7 +387,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.1
     # via
     #   adal
     #   azure-cosmosdb-table

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -690,7 +690,7 @@ pyjwt==2.4.0
     # via adal
 pynacl==1.3.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   etcd3-py
@@ -821,7 +821,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet
@@ -838,7 +837,6 @@ six==1.16.0
     #   packaging
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-dateutil
     #   pyvmomi
     #   responses

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -771,7 +771,7 @@ pyyaml==5.4.1
     #   napalm
     #   yamllint
     #   yamlordereddictloader
-pyzmq==19.0.0 ; python_version < "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -395,7 +395,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.4.7
+cryptography==39.0.1
     # via
     #   adal
     #   ansible-core

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -703,7 +703,7 @@ pymysql==1.0.2 ; python_version > "3.5"
     # via -r requirements/static/ci/linux.in
 pynacl==1.4.0
     # via paramiko
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -829,7 +829,6 @@ six==1.16.0
     #   ncclient
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -755,7 +755,7 @@ pyyaml==5.4.1
     #   napalm
     #   yamllint
     #   yamlordereddictloader
-pyzmq==21.0.2 ; python_version < "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via -r requirements/zeromq.txt
 redis-py-cluster==2.1.3
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -401,7 +401,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.1
     # via
     #   adal
     #   ansible-core

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -710,7 +710,7 @@ pymysql==1.0.2 ; python_version > "3.5"
     # via -r requirements/static/ci/linux.in
 pynacl==1.3.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -861,7 +861,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet
@@ -877,7 +876,6 @@ six==1.16.0
     #   packaging
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -800,7 +800,7 @@ pyyaml==5.4.1
     #   napalm
     #   yamllint
     #   yamlordereddictloader
-pyzmq==19.0.0 ; python_version < "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -239,7 +239,7 @@ pymssql==2.2.1
     # via -r requirements/windows.txt
 pymysql==1.0.2
     # via -r requirements/windows.txt
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via
     #   -r requirements/windows.txt
     #   etcd3-py
@@ -363,7 +363,6 @@ six==1.15.0
     #   kubernetes
     #   mock
     #   packaging
-    #   pyopenssl
     #   python-dateutil
     #   pyvmomi
     #   pywinrm

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -72,7 +72,7 @@ colorama==0.4.1
     # via pytest
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.4.7
+cryptography==39.0.1
     # via
     #   -r requirements/windows.txt
     #   etcd3-py

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -316,7 +316,7 @@ pyyaml==5.4.1
     #   clustershell
     #   kubernetes
     #   yamllint
-pyzmq==22.0.3 ; python_version < "3.9" and sys_platform == "win32"
+pyzmq==22.0.3 ; sys_platform == "win32"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -699,7 +699,7 @@ pyjwt==2.4.0
     # via adal
 pynacl==1.4.0
     # via paramiko
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -853,7 +853,6 @@ six==1.16.0
     #   paramiko
     #   profitbricks
     #   pynacl
-    #   pyopenssl
     #   pypsexec
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -388,7 +388,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.1
     # via
     #   adal
     #   azure-cosmosdb-table
@@ -840,7 +840,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -783,7 +783,7 @@ pyyaml==5.4.1
     #   kubernetes
     #   napalm
     #   yamlordereddictloader
-pyzmq==23.2.0 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -391,7 +391,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.1
     # via
     #   -r requirements/darwin.txt
     #   adal

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -698,7 +698,7 @@ pyjwt==2.4.0
     # via adal
 pynacl==1.3.0
     # via paramiko
-pyopenssl==19.0.0
+pyopenssl==23.0.0
     # via
     #   -r requirements/darwin.txt
     #   etcd3-py
@@ -830,7 +830,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet
@@ -845,7 +844,6 @@ six==1.16.0
     #   packaging
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-dateutil
     #   pyvmomi
     #   responses

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -779,7 +779,7 @@ pyyaml==5.4.1
     #   napalm
     #   yamllint
     #   yamlordereddictloader
-pyzmq==23.2.0 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -702,7 +702,7 @@ pymysql==1.0.2 ; python_version > "3.5"
     # via -r requirements/static/ci/linux.in
 pynacl==1.4.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -828,7 +828,6 @@ six==1.16.0
     #   ncclient
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -395,7 +395,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.1
     # via
     #   adal
     #   ansible-core
@@ -815,7 +815,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -755,7 +755,7 @@ pyyaml==5.4.1
     #   napalm
     #   yamllint
     #   yamlordereddictloader
-pyzmq==23.2.0 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via -r requirements/zeromq.txt
 redis-py-cluster==2.1.3
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -387,7 +387,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.1
     # via
     #   adal
     #   azure-cosmosdb-table

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -693,7 +693,7 @@ pyjwt==2.4.0
     # via adal
 pynacl==1.3.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   etcd3-py
@@ -824,7 +824,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet
@@ -841,7 +840,6 @@ six==1.16.0
     #   packaging
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-dateutil
     #   pyvmomi
     #   responses

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -774,7 +774,7 @@ pyyaml==5.4.1
     #   napalm
     #   yamllint
     #   yamlordereddictloader
-pyzmq==23.2.0 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -393,7 +393,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.4.7
+cryptography==39.0.1
     # via
     #   adal
     #   ansible-core

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -704,7 +704,7 @@ pymysql==1.0.2 ; python_version > "3.5"
     # via -r requirements/static/ci/linux.in
 pynacl==1.4.0
     # via paramiko
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -830,7 +830,6 @@ six==1.16.0
     #   ncclient
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -756,7 +756,7 @@ pyyaml==5.4.1
     #   napalm
     #   yamllint
     #   yamlordereddictloader
-pyzmq==23.2.0 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via -r requirements/zeromq.txt
 redis-py-cluster==2.1.3
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -403,7 +403,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.1
     # via
     #   adal
     #   ansible-core

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -715,7 +715,7 @@ pymysql==1.0.2 ; python_version > "3.5"
     # via -r requirements/static/ci/linux.in
 pynacl==1.3.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -866,7 +866,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet
@@ -882,7 +881,6 @@ six==1.16.0
     #   packaging
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -805,7 +805,7 @@ pyyaml==5.4.1
     #   napalm
     #   yamllint
     #   yamlordereddictloader
-pyzmq==23.2.0 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -72,7 +72,7 @@ colorama==0.4.1
     # via pytest
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.4.7
+cryptography==39.0.1
     # via
     #   -r requirements/windows.txt
     #   etcd3-py

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -240,7 +240,7 @@ pymssql==2.2.1
     # via -r requirements/windows.txt
 pymysql==1.0.2
     # via -r requirements/windows.txt
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via
     #   -r requirements/windows.txt
     #   etcd3-py
@@ -364,7 +364,6 @@ six==1.15.0
     #   kubernetes
     #   mock
     #   packaging
-    #   pyopenssl
     #   python-dateutil
     #   pyvmomi
     #   pywinrm

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -317,7 +317,7 @@ pyyaml==5.4.1
     #   clustershell
     #   kubernetes
     #   yamllint
-pyzmq==23.2.0 ; python_version >= "3.9"
+pyzmq==22.0.3 ; sys_platform == "win32"
     # via
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -18,7 +18,7 @@ cherrypy==18.6.1
     # via -r requirements/darwin.txt
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.3.2
+cryptography==39.0.1
     # via
     #   -r requirements/darwin.txt
     #   pyopenssl
@@ -100,7 +100,6 @@ setproctitle==1.1.10
 six==1.16.0
     # via
     #   cheroot
-    #   cryptography
     #   pyopenssl
     #   python-dateutil
 smmap==3.0.2

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -78,7 +78,7 @@ pycparser==2.21
     #   cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pyopenssl==19.0.0
+pyopenssl==23.0.0
     # via -r requirements/darwin.txt
 python-dateutil==2.8.0
     # via -r requirements/darwin.txt
@@ -100,7 +100,6 @@ setproctitle==1.1.10
 six==1.16.0
     # via
     #   cheroot
-    #   pyopenssl
     #   python-dateutil
 smmap==3.0.2
     # via gitdb

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -88,7 +88,7 @@ pytz==2022.1
     # via tempora
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==23.2.0 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -63,7 +63,7 @@ pycparser==2.21 ; python_version >= "3.9"
     #   cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via -r requirements/static/pkg/freebsd.in
 python-dateutil==2.8.1
     # via -r requirements/static/pkg/freebsd.in
@@ -83,7 +83,6 @@ six==1.16.0
     # via
     #   cheroot
     #   more-itertools
-    #   pyopenssl
     #   python-dateutil
 tempora==4.1.1
     # via portend

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.3.2
+cryptography==39.0.1
     # via pyopenssl
 distro==1.5.0
     # via
@@ -82,7 +82,6 @@ setproctitle==1.1.10
 six==1.16.0
     # via
     #   cheroot
-    #   cryptography
     #   more-itertools
     #   pyopenssl
     #   python-dateutil

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -73,7 +73,7 @@ pytz==2022.1
     # via tempora
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==23.2.0 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.3.2
+cryptography==39.0.1
     # via pyopenssl
 distro==1.5.0
     # via -r requirements/base.txt
@@ -84,7 +84,6 @@ setproctitle==1.2.2 ; python_version >= "3.10"
 six==1.16.0
     # via
     #   cheroot
-    #   cryptography
     #   more-itertools
     #   pyopenssl
     #   python-dateutil

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -63,7 +63,7 @@ pycparser==2.21 ; python_version >= "3.9"
     #   cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via -r requirements/static/pkg/linux.in
 python-dateutil==2.8.1
     # via -r requirements/static/pkg/linux.in
@@ -85,7 +85,6 @@ six==1.16.0
     # via
     #   cheroot
     #   more-itertools
-    #   pyopenssl
     #   python-dateutil
 tempora==4.1.1
     # via portend

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -73,7 +73,7 @@ pytz==2022.1
     # via tempora
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==23.2.0 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -20,7 +20,7 @@ cherrypy==18.6.1
     # via -r requirements/windows.txt
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.4.7
+cryptography==39.0.1
     # via
     #   -r requirements/windows.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -85,7 +85,7 @@ pycurl==7.43.0.5
     # via -r requirements/windows.txt
 pymysql==1.0.2
     # via -r requirements/windows.txt
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via -r requirements/windows.txt
 python-dateutil==2.8.1
     # via -r requirements/windows.txt

--- a/requirements/static/pkg/py3.5/linux.txt
+++ b/requirements/static/pkg/py3.5/linux.txt
@@ -18,7 +18,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.0
+cryptography==3.2.1
     # via pyopenssl
 distro==1.5.0
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.5/linux.txt
+++ b/requirements/static/pkg/py3.5/linux.txt
@@ -62,7 +62,7 @@ pycparser==2.17
     # via cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pyopenssl==19.1.0
+pyopenssl==20.0.0
     # via -r requirements/static/pkg/linux.in
 python-dateutil==2.8.1
     # via -r requirements/static/pkg/linux.in

--- a/requirements/static/pkg/py3.5/linux.txt
+++ b/requirements/static/pkg/py3.5/linux.txt
@@ -72,7 +72,7 @@ pytz==2022.1
     # via tempora
 pyyaml==5.3.1
     # via -r requirements/base.txt
-pyzmq==18.0.1 ; python_version < "3.9"
+pyzmq==19.0.2 ; python_version < "3.6"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.6/linux.txt
+++ b/requirements/static/pkg/py3.6/linux.txt
@@ -18,7 +18,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.3.2
+cryptography==39.0.1
     # via pyopenssl
 distro==1.5.0
     # via -r requirements/base.txt
@@ -86,7 +86,6 @@ setproctitle==1.1.10 ; python_version < "3.10"
 six==1.16.0
     # via
     #   cheroot
-    #   cryptography
     #   more-itertools
     #   pyopenssl
     #   python-dateutil

--- a/requirements/static/pkg/py3.6/linux.txt
+++ b/requirements/static/pkg/py3.6/linux.txt
@@ -65,7 +65,7 @@ pycparser==2.17
     # via cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via -r requirements/static/pkg/linux.in
 python-dateutil==2.8.1
     # via -r requirements/static/pkg/linux.in
@@ -87,7 +87,6 @@ six==1.16.0
     # via
     #   cheroot
     #   more-itertools
-    #   pyopenssl
     #   python-dateutil
 tempora==4.1.1
     # via portend

--- a/requirements/static/pkg/py3.6/linux.txt
+++ b/requirements/static/pkg/py3.6/linux.txt
@@ -75,7 +75,7 @@ pytz==2022.1
     # via tempora
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==18.0.1 ; python_version < "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.7/freebsd.txt
+++ b/requirements/static/pkg/py3.7/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.3.2
+cryptography==39.0.1
     # via pyopenssl
 distro==1.5.0
     # via
@@ -82,7 +82,6 @@ setproctitle==1.1.10
 six==1.16.0
     # via
     #   cheroot
-    #   cryptography
     #   more-itertools
     #   pyopenssl
     #   python-dateutil

--- a/requirements/static/pkg/py3.7/freebsd.txt
+++ b/requirements/static/pkg/py3.7/freebsd.txt
@@ -63,7 +63,7 @@ pycparser==2.17
     # via cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via -r requirements/static/pkg/freebsd.in
 python-dateutil==2.8.1
     # via -r requirements/static/pkg/freebsd.in
@@ -83,7 +83,6 @@ six==1.16.0
     # via
     #   cheroot
     #   more-itertools
-    #   pyopenssl
     #   python-dateutil
 tempora==4.1.1
     # via portend

--- a/requirements/static/pkg/py3.7/freebsd.txt
+++ b/requirements/static/pkg/py3.7/freebsd.txt
@@ -73,7 +73,7 @@ pytz==2022.1
     # via tempora
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==18.0.1 ; python_version < "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.7/linux.txt
+++ b/requirements/static/pkg/py3.7/linux.txt
@@ -61,7 +61,7 @@ pycparser==2.17
     # via cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via -r requirements/static/pkg/linux.in
 python-dateutil==2.8.1
     # via -r requirements/static/pkg/linux.in
@@ -83,7 +83,6 @@ six==1.16.0
     # via
     #   cheroot
     #   more-itertools
-    #   pyopenssl
     #   python-dateutil
 tempora==4.1.1
     # via portend

--- a/requirements/static/pkg/py3.7/linux.txt
+++ b/requirements/static/pkg/py3.7/linux.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.3.2
+cryptography==39.0.1
     # via pyopenssl
 distro==1.5.0
     # via -r requirements/base.txt
@@ -82,7 +82,6 @@ setproctitle==1.1.10 ; python_version < "3.10"
 six==1.16.0
     # via
     #   cheroot
-    #   cryptography
     #   more-itertools
     #   pyopenssl
     #   python-dateutil

--- a/requirements/static/pkg/py3.7/linux.txt
+++ b/requirements/static/pkg/py3.7/linux.txt
@@ -71,7 +71,7 @@ pytz==2022.1
     # via tempora
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==18.0.1 ; python_version < "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -20,7 +20,7 @@ cherrypy==18.6.1
     # via -r requirements/windows.txt
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.4.7
+cryptography==39.0.1
     # via
     #   -r requirements/windows.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -91,7 +91,7 @@ pymssql==2.2.1
     # via -r requirements/windows.txt
 pymysql==1.0.2
     # via -r requirements/windows.txt
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via -r requirements/windows.txt
 python-dateutil==2.8.1
     # via -r requirements/windows.txt
@@ -119,7 +119,6 @@ setproctitle==1.1.10
 six==1.16.0
     # via
     #   cheroot
-    #   pyopenssl
     #   python-dateutil
 smmap==3.0.4
     # via gitdb

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -108,7 +108,7 @@ pywin32==303
     #   wmi
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==22.0.3 ; python_version < "3.9" and sys_platform == "win32"
+pyzmq==22.0.3 ; sys_platform == "win32"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.3.2
+cryptography==39.0.1
     # via pyopenssl
 distro==1.5.0
     # via
@@ -82,7 +82,6 @@ setproctitle==1.1.10
 six==1.16.0
     # via
     #   cheroot
-    #   cryptography
     #   more-itertools
     #   pyopenssl
     #   python-dateutil

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -63,7 +63,7 @@ pycparser==2.17
     # via cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via -r requirements/static/pkg/freebsd.in
 python-dateutil==2.8.1
     # via -r requirements/static/pkg/freebsd.in
@@ -83,7 +83,6 @@ six==1.16.0
     # via
     #   cheroot
     #   more-itertools
-    #   pyopenssl
     #   python-dateutil
 tempora==4.1.1
     # via portend

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -73,7 +73,7 @@ pytz==2022.1
     # via tempora
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==19.0.0 ; python_version < "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -61,7 +61,7 @@ pycparser==2.17
     # via cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via -r requirements/static/pkg/linux.in
 python-dateutil==2.8.1
     # via -r requirements/static/pkg/linux.in
@@ -83,7 +83,6 @@ six==1.16.0
     # via
     #   cheroot
     #   more-itertools
-    #   pyopenssl
     #   python-dateutil
 tempora==4.1.1
     # via portend

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.3.2
+cryptography==39.0.1
     # via pyopenssl
 distro==1.5.0
     # via -r requirements/base.txt
@@ -82,7 +82,6 @@ setproctitle==1.1.10 ; python_version < "3.10"
 six==1.16.0
     # via
     #   cheroot
-    #   cryptography
     #   more-itertools
     #   pyopenssl
     #   python-dateutil

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -71,7 +71,7 @@ pytz==2022.1
     # via tempora
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==19.0.0 ; python_version < "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -20,7 +20,7 @@ cherrypy==18.6.1
     # via -r requirements/windows.txt
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.4.7
+cryptography==39.0.1
     # via
     #   -r requirements/windows.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -91,7 +91,7 @@ pymssql==2.2.1
     # via -r requirements/windows.txt
 pymysql==1.0.2
     # via -r requirements/windows.txt
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via -r requirements/windows.txt
 python-dateutil==2.8.1
     # via -r requirements/windows.txt
@@ -119,7 +119,6 @@ setproctitle==1.1.10
 six==1.15.0
     # via
     #   cheroot
-    #   pyopenssl
     #   python-dateutil
 smmap==4.0.0
     # via gitdb

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -108,7 +108,7 @@ pywin32==303
     #   wmi
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==22.0.3 ; python_version < "3.9" and sys_platform == "win32"
+pyzmq==22.0.3 ; sys_platform == "win32"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -80,7 +80,7 @@ pycparser==2.21
     #   cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pyopenssl==19.0.0
+pyopenssl==23.0.0
     # via -r requirements/darwin.txt
 python-dateutil==2.8.0
     # via -r requirements/darwin.txt
@@ -102,7 +102,6 @@ setproctitle==1.1.10
 six==1.16.0
     # via
     #   cheroot
-    #   pyopenssl
     #   python-dateutil
 smmap==3.0.2
     # via gitdb

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -18,7 +18,7 @@ cherrypy==18.6.1
     # via -r requirements/darwin.txt
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.3.2
+cryptography==39.0.1
     # via
     #   -r requirements/darwin.txt
     #   pyopenssl
@@ -102,7 +102,6 @@ setproctitle==1.1.10
 six==1.16.0
     # via
     #   cheroot
-    #   cryptography
     #   pyopenssl
     #   python-dateutil
 smmap==3.0.2

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -90,7 +90,7 @@ pytz==2022.1
     # via tempora
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==23.2.0 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -65,7 +65,7 @@ pycparser==2.21 ; python_version >= "3.9"
     #   cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via -r requirements/static/pkg/freebsd.in
 python-dateutil==2.8.1
     # via -r requirements/static/pkg/freebsd.in
@@ -85,7 +85,6 @@ six==1.16.0
     # via
     #   cheroot
     #   more-itertools
-    #   pyopenssl
     #   python-dateutil
 tempora==4.1.1
     # via portend

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.3.2
+cryptography==39.0.1
     # via pyopenssl
 distro==1.5.0
     # via
@@ -84,7 +84,6 @@ setproctitle==1.1.10
 six==1.16.0
     # via
     #   cheroot
-    #   cryptography
     #   more-itertools
     #   pyopenssl
     #   python-dateutil

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -75,7 +75,7 @@ pytz==2022.1
     # via tempora
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==23.2.0 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -63,7 +63,7 @@ pycparser==2.21 ; python_version >= "3.9"
     #   cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via -r requirements/static/pkg/linux.in
 python-dateutil==2.8.1
     # via -r requirements/static/pkg/linux.in
@@ -85,7 +85,6 @@ six==1.16.0
     # via
     #   cheroot
     #   more-itertools
-    #   pyopenssl
     #   python-dateutil
 tempora==4.1.1
     # via portend

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.3.2
+cryptography==39.0.1
     # via pyopenssl
 distro==1.5.0
     # via -r requirements/base.txt
@@ -84,7 +84,6 @@ setproctitle==1.1.10 ; python_version < "3.10"
 six==1.16.0
     # via
     #   cheroot
-    #   cryptography
     #   more-itertools
     #   pyopenssl
     #   python-dateutil

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -73,7 +73,7 @@ pytz==2022.1
     # via tempora
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==23.2.0 ; python_version >= "3.9"
+pyzmq==23.2.0 ; python_version >= "3.6"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via -r requirements/base.txt

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -20,7 +20,7 @@ cherrypy==18.6.1
     # via -r requirements/windows.txt
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.4.7
+cryptography==39.0.1
     # via
     #   -r requirements/windows.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -91,7 +91,7 @@ pymssql==2.2.1
     # via -r requirements/windows.txt
 pymysql==1.0.2
     # via -r requirements/windows.txt
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via -r requirements/windows.txt
 python-dateutil==2.8.1
     # via -r requirements/windows.txt
@@ -119,7 +119,6 @@ setproctitle==1.1.10
 six==1.15.0
     # via
     #   cheroot
-    #   pyopenssl
     #   python-dateutil
 smmap==4.0.0
     # via gitdb

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -108,7 +108,7 @@ pywin32==303
     #   wmi
 pyyaml==5.4.1
     # via -r requirements/base.txt
-pyzmq==23.2.0 ; python_version >= "3.9"
+pyzmq==22.0.3 ; sys_platform == "win32"
     # via -r requirements/zeromq.txt
 requests==2.25.1
     # via

--- a/requirements/zeromq.txt
+++ b/requirements/zeromq.txt
@@ -1,10 +1,8 @@
 -r base.txt
 -r crypto.txt
 
-pyzmq<=20.0.0 ; python_version < "3.6"
-pyzmq>=17.0.0 ; python_version < "3.9"
-pyzmq>19.0.2 ; python_version >= "3.9"
-
+pyzmq<20.0.0; python_version < "3.6"
+pyzmq>=20.0.0; python_version >= "3.6"
 # We can't use 23+ on Windows until they fix this:
 # https://github.com/zeromq/pyzmq/issues/1472
-pyzmq>=20.0.0, <=22.0.3 ; python_version < "3.9" and sys_platform == 'win32'
+pyzmq>=20.0.0,<=22.0.3 ; sys_platform == "win32"

--- a/salt/utils/cache.py
+++ b/salt/utils/cache.py
@@ -203,14 +203,14 @@ class CacheCli:
         """
         published the given minions to the ConCache
         """
-        self.cupd_out.send(salt.payload.dumps(minions))
+        self.cupd_out.send(salt.payload.dumps(minions))  # pylint: disable=missing-kwoa
 
     def get_cached(self):
         """
         queries the ConCache for a list of currently connected minions
         """
         msg = salt.payload.dumps("minions")
-        self.creq_out.send(msg)
+        self.creq_out.send(msg)  # pylint: disable=missing-kwoa
         min_list = salt.payload.loads(self.creq_out.recv())
         return min_list
 

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -568,7 +568,7 @@ class CacheTimer(Thread):
         count = 0
         log.debug("ConCache-Timer started")
         while not self.stopped.wait(1):
-            socket.send(salt.payload.dumps(count))
+            socket.send(salt.payload.dumps(count))  # pylint: disable=missing-kwoa
 
             count += 1
             if count >= 60:
@@ -733,7 +733,7 @@ class ConnectedCache(Process):
                     if msg == "minions":
                         # Send reply back to client
                         reply = salt.payload.dumps(self.minions)
-                        creq_in.send(reply)
+                        creq_in.send(reply)  # pylint: disable=missing-kwoa
 
             # check for next cache-update from workers
             if socks.get(cupd_in) == zmq.POLLIN:

--- a/tests/pytests/functional/test_payload.py
+++ b/tests/pytests/functional/test_payload.py
@@ -57,7 +57,7 @@ class EchoServer:
                         msg_deserialized["load"]["sleep"],
                     )
                     time.sleep(msg_deserialized["load"]["sleep"])
-                socket.send(message)
+                socket.send(message)  # pylint: disable=missing-kwoa
             except zmq.ZMQError as exc:
                 if exc.errno == errno.EAGAIN:
                     continue


### PR DESCRIPTION
### What does this PR do?
Upgrade to `cryptography==39.0.1`
Due to:
  * https://github.com/advisories/GHSA-x4qr-2fvf-3mr5
  * https://github.com/advisories/GHSA-w7pp-m8wf-vj6r

FYI, We can't upgrade for Py3.5