### PR TITLE
Fix wayward uses of "RPM" in dpkg module

### DIFF
--- a/salt/modules/dpkg_lowpkg.py
+++ b/salt/modules/dpkg_lowpkg.py
@@ -37,12 +37,12 @@ def bin_pkg_info(path, saltenv="base"):
     """
     .. versionadded:: 2015.8.0
 
-    Parses RPM metadata and returns a dictionary of information about the
+    Parses DEB metadata and returns a dictionary of information about the
     package (name, version, etc.).
 
     path
         Path to the file. Can either be an absolute path to a file on the
-        minion, or a salt fileserver URL (e.g. ``salt://path/to/file.rpm``).
+        minion, or a salt fileserver URL (e.g. ``salt://path/to/file.deb``).
         If a salt fileserver URL is passed, the file will be cached to the
         minion so that it can be examined.
 


### PR DESCRIPTION
It looks like this function was added in commit 52ef17fa99b03 based on (then) `salt/modules/rpm.py`, and the documentation was never fully updated to reflect that it was now for .deb's, not RPMs.

### What does this PR do?

Fixes documentation issue.

### What issues does this PR fix or reference?
Fixes: minor doc error, no issue filed

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [N/A] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [N/A] Tests written/updated

### Commits signed with GPG?
**No**

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
