### PR TITLE
Fix flaky test by increasing timeout

### DIFF
--- a/tests/pytests/unit/transport/test_zeromq.py
+++ b/tests/pytests/unit/transport/test_zeromq.py
@@ -456,7 +456,7 @@ def test_serverside_exception(temp_salt_minion, temp_salt_master):
     with MockSaltMinionMaster(temp_salt_minion, temp_salt_master) as minion_master:
         with patch.object(minion_master.mock, "_handle_payload_hook") as _mock:
             _mock.side_effect = salt.ext.tornado.gen.Return(({}, {"fun": "madeup-fun"}))
-            ret = minion_master.channel.send({}, timeout=2, tries=1)
+            ret = minion_master.channel.send({}, timeout=5, tries=1)
             assert ret == "Server-side exception handling payload"
 
 


### PR DESCRIPTION
### What does this PR do?
The following test fails intermittently on Windows:
tests/pytests/unit/transport/test_zeromq.py::test_serverside_exception

This increases the timeout allowing the test to pass. Before this timeout, the test would fail 2 out of 3 times. After increasing the timeout, the test does not fail locally.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes