### PR TITLE
Remove un-needed 'scripts' property in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1131,45 +1131,6 @@ class SaltDistribution(distutils.dist.Distribution):
         return install_requires
 
     @property
-    def _property_scripts(self):
-        # Scripts common to all scenarios
-        scripts = ["scripts/salt-call"]
-        if self.ssh_packaging or PACKAGED_FOR_SALT_SSH:
-            scripts.append("scripts/salt-ssh")
-            if IS_WINDOWS_PLATFORM and not os.environ.get("SALT_BUILD_ALL_BINS"):
-                return scripts
-            scripts.extend(["scripts/salt-cloud", "scripts/spm"])
-            return scripts
-
-        if IS_WINDOWS_PLATFORM and not os.environ.get("SALT_BUILD_ALL_BINS"):
-            scripts.extend(
-                [
-                    "scripts/salt-cp",
-                    "scripts/salt-minion",
-                ]
-            )
-            return scripts
-
-        # *nix, so, we need all scripts
-        scripts.extend(
-            [
-                "scripts/salt",
-                "scripts/salt-api",
-                "scripts/salt-cloud",
-                "scripts/salt-cp",
-                "scripts/salt-key",
-                "scripts/salt-master",
-                "scripts/salt-minion",
-                "scripts/salt-proxy",
-                "scripts/salt-run",
-                "scripts/salt-ssh",
-                "scripts/salt-syndic",
-                "scripts/spm",
-            ]
-        )
-        return scripts
-
-    @property
     def _property_entry_points(self):
         entrypoints = {
             "pyinstaller40": [


### PR DESCRIPTION
### What does this PR do?

Looks like this is adding erroneous lines in the installed package's `RECORD` file.

```
salt-3005.1.data/scripts/salt,sha256=knSVh4-RpAO87XkBIoGTeJP_pz653TI4bF5a8N_lTno,170
salt-3005.1.data/scripts/salt-api,sha256=5qOIARcNEs2VO7lttCQeT3FNE_KgNhtNDGJEb35bXqc,106
salt-3005.1.data/scripts/salt-call,sha256=A4Gr3vRXZEriO2Phe6ukd-YrtCf0LwDECjqI7NQkTac,189
salt-3005.1.data/scripts/salt-cloud,sha256=qwmxEYNsvthdmPPREhm4RN-SxKGr9szzVfrUc2dXE8k,172
salt-3005.1.data/scripts/salt-cp,sha256=xszMe3Tmwt4wu5C9niqllcDB3os3OSoZGdCzyaSvDgI,166
salt-3005.1.data/scripts/salt-key,sha256=1wXEvyV283EfROg9DxAVVYuaV_gCBpQGX8SBfZASExc,140
salt-3005.1.data/scripts/salt-master,sha256=XDM_yA9XBp1C98xipC5_D-X56rleitEGevIS4nLZq_s,735
salt-3005.1.data/scripts/salt-minion,sha256=Gn1ufUvZSfQktMT90Q6IBrxF46iuSUcvZxIosVgjROw,949
salt-3005.1.data/scripts/salt-run,sha256=R0rJwQkgNsFP-WTv9INCiSnY7OGPMo6dB5-pzHfb-88,130
salt-3005.1.data/scripts/salt-ssh,sha256=ZKgGqfhiHC6bzF2G3fK4lRyjNtUku8IdXVOinIoIxUg,123
salt-3005.1.data/scripts/salt-syndic,sha256=78Tq84faK9yEXofrvHeQf7Sw_vbL4gUQOrvd-9RlYns,154
salt-3005.1.data/scripts/spm,sha256=51Ct_tgEtNvf1BtL6g-3kqokgKVtRFl90dkiDi45j5o,196

```