### PR TITLE
Add back ssm.exe to salt onedir tarball

### DIFF
--- a/pkg/windows/prep_salt.ps1
+++ b/pkg/windows/prep_salt.ps1
@@ -153,7 +153,8 @@ if ( $PKG ) {
     }
 }
 
-if ( $PKG ) {
+# Make sure ssm.exe is present. This is needed for VMtools
+if ( ! (Test-Path -Path "$BUILD_DIR\ssm.exe") ) {
     Write-Host "Copying SSM to Root: " -NoNewline
     Invoke-WebRequest -Uri "$SALT_DEP_URL/ssm-2.24-103-gdee49fc.exe" -OutFile "$BUILD_DIR\ssm.exe"
     if ( Test-Path -Path "$BUILD_DIR\ssm.exe" ) {

--- a/tools/pkg.py
+++ b/tools/pkg.py
@@ -223,7 +223,7 @@ def set_salt_version(
 )
 def pre_archive_cleanup(ctx: Context, cleanup_path: str, pkg: bool = False):
     """
-    Clean the provided path of paths that shouyld not be included in the archive.
+    Clean the provided path of paths that should not be included in the archive.
 
     For example:
 


### PR DESCRIPTION
### What does this PR do?
Adds back ssm.exe to the salt tarball for Windows. It is needed for vmtools

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
