### PR TITLE
Fix added to load_args_and_kwargs

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -339,7 +339,7 @@ def load_args_and_kwargs(func, args, data=None, ignore_invalid=False):
                     # list of positional arguments. This keyword argument is
                     # invalid.
                     invalid_kwargs.append("{}={}".format(key, val))
-            # Add __kwarg__ key-value again since delta proxy passes the 
+            # Add __kwarg__ key-value again since delta proxy passes the
             # key-value as key-value argument to proxy minions.
             arg.update({"__kwarg__": True})
             continue

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -339,6 +339,9 @@ def load_args_and_kwargs(func, args, data=None, ignore_invalid=False):
                     # list of positional arguments. This keyword argument is
                     # invalid.
                     invalid_kwargs.append("{}={}".format(key, val))
+            # Add __kwarg__ key-value again since delta proxy passes the 
+            # key-value as key-value argument to proxy minions.
+            arg.update({"__kwarg__": True})
             continue
 
         else:


### PR DESCRIPTION
Added fix that solves the issue with proxy minions not getting __kwargs__ key-value from deltaproxys.

### What does this PR do?
Solves the issue with __kwargs__ missing on proxy minions.

### What issues does this PR fix or reference?
Fixes: Proxy minions missing __kwargs__

### Previous Behavior
Removed __kwargs__ key-value from the arguments sent to proxy minions.

### New Behavior
Removes the __kwargs__ and adding it back so that proxy minions is getting it as well.

### Replication:
Run `napalm.junos_cli "show version" format=xml`
will not work on multiple proxy minions since it pops the __kwargs__ after the first one.
This fix solves this issue

### Merge requirements satisfied?
- [N/A] Docs
- [N/A] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [N/A] Tests written/updated

