### PR TITLE
Fix rpm_lowpkg version comparison logic when using rpm-vercmp

### DIFF
--- a/changelog/63317.fixed.md
+++ b/changelog/63317.fixed.md
@@ -1,0 +1,1 @@
+Fix rpm_lowpkg version comparison logic when using rpm-vercmp and only one version has a release number.

--- a/tests/pytests/unit/modules/test_rpm_lowpkg.py
+++ b/tests/pytests/unit/modules/test_rpm_lowpkg.py
@@ -281,6 +281,8 @@ def test_version_cmp_rpm_all_libraries(rpm_lib):
         assert 0 == rpm.version_cmp("3:2.9.1-6.el7.4", "3:2.9.1-6.el7.4")
         assert -1 == rpm.version_cmp("3:2.9.1-6.el7.4", "3:2.9.1-7.el7.4")
         assert 1 == rpm.version_cmp("3:2.9.1-8.el7.4", "3:2.9.1-7.el7.4")
+        assert 0 == rpm.version_cmp("3.23-6.el9", "3.23")
+        assert 0 == rpm.version_cmp("3.23", "3.23-6.el9")
 
 
 def test_version_cmp_rpm():

--- a/tests/pytests/unit/modules/test_rpm_lowpkg.py
+++ b/tests/pytests/unit/modules/test_rpm_lowpkg.py
@@ -271,18 +271,18 @@ def test_version_cmp_rpm_all_libraries(rpm_lib):
             pytest.skip("The Python RPM lib is not installed, skipping")
 
     with patch_rpm, patch_py_rpm, patch_cmd:
-        assert -1 == rpm.version_cmp("1", "2")
-        assert -1 == rpm.version_cmp("2.9.1-6.el7_2.3", "2.9.1-6.el7.4")
-        assert 1 == rpm.version_cmp("3.2", "3.0")
-        assert 0 == rpm.version_cmp("3.0", "3.0")
-        assert 1 == rpm.version_cmp("1:2.9.1-6.el7_2.3", "2.9.1-6.el7.4")
-        assert -1 == rpm.version_cmp("1:2.9.1-6.el7_2.3", "1:2.9.1-6.el7.4")
-        assert 1 == rpm.version_cmp("2:2.9.1-6.el7_2.3", "1:2.9.1-6.el7.4")
-        assert 0 == rpm.version_cmp("3:2.9.1-6.el7.4", "3:2.9.1-6.el7.4")
-        assert -1 == rpm.version_cmp("3:2.9.1-6.el7.4", "3:2.9.1-7.el7.4")
-        assert 1 == rpm.version_cmp("3:2.9.1-8.el7.4", "3:2.9.1-7.el7.4")
-        assert 0 == rpm.version_cmp("3.23-6.el9", "3.23")
-        assert 0 == rpm.version_cmp("3.23", "3.23-6.el9")
+        assert rpm.version_cmp("1", "2") == -1
+        assert rpm.version_cmp("2.9.1-6.el7_2.3", "2.9.1-6.el7.4") == -1
+        assert rpm.version_cmp("3.2", "3.0") == 1
+        assert rpm.version_cmp("3.0", "3.0") == 0
+        assert rpm.version_cmp("1:2.9.1-6.el7_2.3", "2.9.1-6.el7.4") == 1
+        assert rpm.version_cmp("1:2.9.1-6.el7_2.3", "1:2.9.1-6.el7.4") == -1
+        assert rpm.version_cmp("2:2.9.1-6.el7_2.3", "1:2.9.1-6.el7.4") == 1
+        assert rpm.version_cmp("3:2.9.1-6.el7.4", "3:2.9.1-6.el7.4") == 0
+        assert rpm.version_cmp("3:2.9.1-6.el7.4", "3:2.9.1-7.el7.4") == -1
+        assert rpm.version_cmp("3:2.9.1-8.el7.4", "3:2.9.1-7.el7.4") == 1
+        assert rpm.version_cmp("3.23-6.el9", "3.23") == 0
+        assert rpm.version_cmp("3.23", "3.23-6.el9") == 0
 
 
 def test_version_cmp_rpm():


### PR DESCRIPTION
### What does this PR do?
Fixes the logic when using rpm-vercmp and comparing the versions: `("3.23-6.el9", "3.23")`

This also fixes this logic when using the cli tool `rpmdev-vercmp`. This was found when adding a test.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/63317

### Previous Behavior

```
>>> import salt.modules.rpm_lowpkg
>>> salt.modules.rpm_lowpkg.version_cmp("3.23-6.el9", "3.23")
1
```

### New Behavior
```
>>> import salt.modules.rpm_lowpkg
>>> salt.modules.rpm_lowpkg.version_cmp("3.23-6.el9", "3.23")
0
```
