### PR TITLE
[3006.x] Add check for leftover old file locations when installing the packages

### DIFF
--- a/pkg/tests/support/helpers.py
+++ b/pkg/tests/support/helpers.py
@@ -591,6 +591,10 @@ class SaltPkgInstall:
         else:
             log.info("Installing packages:\n%s", pprint.pformat(self.pkgs))
             ret = self.proc.run(self.pkg_mngr, "install", "-y", *self.pkgs)
+        if not (platform.is_darwin() or platform.is_windows()):
+            # Make sure we don't have any trailing references to old package file locations
+            assert "No such file or directory" not in ret.stdout
+            assert "/saltstack/salt/run" not in ret.stdout
         log.info(ret)
         self._check_retcode(ret)
 


### PR DESCRIPTION
### What does this PR do?
Port the check from https://github.com/saltstack/salt/pull/63842 to 3006.x

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/63821

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes