### PR TITLE
Add debug logging to win_pkg.remove

### DIFF
--- a/changelog/63866.added.md
+++ b/changelog/63866.added.md
@@ -1,0 +1,1 @@
+Added debug log messages displaying the command being run when removing packages on Windows

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -2154,6 +2154,8 @@ def remove(name=None, pkgs=None, **kwargs):
             # Uninstall the software
             changed.append(pkgname)
             # Check Use Scheduler Option
+            log.debug("PKG : cmd: %s /s /c %s", cmd_shell, arguments)
+            log.debug("PKG : pwd: %s", cache_path)
             if pkginfo[target].get("use_scheduler", False):
                 # Create Scheduled Task
                 __salt__["task.create_task"](
@@ -2184,6 +2186,7 @@ def remove(name=None, pkgs=None, **kwargs):
                     python_shell=False,
                     redirect_stderr=True,
                 )
+                log.debug("PKG : retcode: %s", result["retcode"])
                 if not result["retcode"]:
                     ret[pkgname] = {"uninstall status": "success"}
                     changed.append(pkgname)


### PR DESCRIPTION
### What does this PR do?
Adds a debug message to display the actual command that is being run when removing packages using the Windows package manager.
### What issues does this PR fix or reference?
Fixes: #63866

### Previous Behavior

Nothing relevant was logged

### New Behavior
Displays a debug message similar this:
```
[DEBUG   ] PKG : cmd: C:\Windows\system32\cmd.exe /s /c "msiexec" /X "C:\ProgramData\Salt Project\Salt\var\cache\salt\mi
nion\extrn_files\base\the.earth.li\~sgtatham\putty\0.78\w64\putty-64bit-0.78-installer.msi" /qn
[DEBUG   ] PKG : pwd: C:\ProgramData\Salt Project\Salt\var\cache\salt\minion\extrn_files\base\the.earth.li\~sgtatham\put
ty\0.78\w64
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes