### PR TITLE
Fix TypeError with rbenv when using build_env pillar

### DIFF
--- a/changelog/31022.fixed.md
+++ b/changelog/31022.fixed.md
@@ -1,0 +1,1 @@
+Fix a TypeError bug when trying to pass build_env flags to rbenv build via pillar data.

--- a/salt/modules/rbenv.py
+++ b/salt/modules/rbenv.py
@@ -240,11 +240,8 @@ def install_ruby(ruby, runas=None):
     elif __salt__["config.option"]("rbenv.build_env"):
         env_list.append(__salt__["config.option"]("rbenv.build_env"))
 
-    if env_list:
-        env = " ".join(env_list)
-
     ret = {}
-    ret = _rbenv_exec(["install", ruby], env=env, runas=runas, ret=ret)
+    ret = _rbenv_exec(["install", ruby], env=env_list, runas=runas, ret=ret)
     if ret is not False and ret["retcode"] == 0:
         rehash(runas=runas)
         return ret["stderr"]

--- a/tests/pytests/unit/modules/test_rbenv.py
+++ b/tests/pytests/unit/modules/test_rbenv.py
@@ -71,6 +71,28 @@ def test_install_ruby():
                 with patch.object(rbenv, "uninstall_ruby", return_value=None):
                     assert not rbenv.install_ruby("ruby")
 
+def test_install_ruby_build_env():
+    """
+    Test for install a ruby implementation using rbenv:build_env.
+    """
+    with patch.dict(rbenv.__grains__, {'os': 'FreeBSD'}):
+        dict_config_ret = {'RUBY_CFLAGS': '-O3'}
+        with patch.dict(rbenv.__salt__, {'config.get': MagicMock(return_value=dict_config_ret)}):
+            with patch.object(
+                rbenv,
+                '_rbenv_exec',
+                return_value={'retcode': 0, 'stderr': 'stderr'},
+            ):
+                with patch.object(rbenv, 'rehash', return_value=None):
+                    assert rbenv.install_ruby("ruby") == "stderr"
+
+            with patch.object(
+                rbenv,
+                '_rbenv_exec',
+                return_value={'retcode': 1, 'stderr': 'stderr'},
+            ):
+                with patch.object(rbenv, 'uninstall_ruby', return_value=None):
+                    assert not rbenv.install_ruby("ruby")
 
 def test_uninstall_ruby():
     """


### PR DESCRIPTION
### What does this PR do?
Fixes a TypeError bug when trying to pass `build_env` flags to `rbenv` build via pillar data.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/31022

### Previous Behavior

The following pillar data and state (for example) will result in Salt failing:
```
rbenv:
  build_env:
    RUBY_CONFIGURE_OPTS: --with-jemalloc
```
```
ruby-3.2.0:
  rbenv.installed:
    - default: True
```

The error produced will resemble:
```
    Function: rbenv.installed
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python3/dist-packages/salt/state.py", line 2276, in call
                  ret = self.states[cdata["full"]](
                File "/usr/lib/python3/dist-packages/salt/loader/lazy.py", line 149, in __call__
                  return self.loader.run(run_func, *args, **kwargs)
                File "/usr/lib/python3/dist-packages/salt/loader/lazy.py", line 1228, in run
                  return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
                File "/usr/lib/python3/dist-packages/salt/loader/lazy.py", line 1243, in _run_as
                  return _func_or_method(*args, **kwargs)
                File "/usr/lib/python3/dist-packages/salt/loader/lazy.py", line 1276, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python3/dist-packages/salt/states/rbenv.py", line 144, in installed
                  return _check_and_install_ruby(ret, name, default, user=user)
                File "/usr/lib/python3/dist-packages/salt/states/rbenv.py", line 90, in _check_and_install_ruby
                  if __salt__["rbenv.install_ruby"](ruby, runas=user):
                File "/usr/lib/python3/dist-packages/salt/loader/lazy.py", line 149, in __call__
                  return self.loader.run(run_func, *args, **kwargs)
                File "/usr/lib/python3/dist-packages/salt/loader/lazy.py", line 1228, in run
                  return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
                File "/usr/lib/python3/dist-packages/salt/loader/lazy.py", line 1243, in _run_as
                  return _func_or_method(*args, **kwargs)
                File "/usr/lib/python3/dist-packages/salt/modules/rbenv.py", line 244, in install_ruby
                  env = " ".join(env_list)
              TypeError: sequence item 0: expected str instance, dict found
```

### New Behavior
Salt will successfully apply the state

```
    Function: rbenv.installed
      Result: True
     Comment: Successfully installed ruby
     Started: 23:23:21.323946
    Duration: 481384.017 ms
     Changes:   
              ----------
              3.2.0:
                  Installed
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No
