### PR TITLE
Use registry to detect VC Redist installation

### DIFF
--- a/pkg/windows/nsis/build_pkg.ps1
+++ b/pkg/windows/nsis/build_pkg.ps1
@@ -119,15 +119,6 @@ if ( Test-Path -Path "$NSIS_BIN" ) {
     exit 1
 }
 
-Write-Host "Getting Estimated Installation Size: " -NoNewLine
-$estimated_size = [math]::Round(((Get-ChildItem "$BUILDENV_DIR" -Recurse -Force | Measure-Object -Sum Length).Sum / 1kb))
-if ( $estimated_size -gt 0 ) {
-    Write-Result "Success" -ForegroundColor Green
-} else {
-    Write-Result "Failed" -ForegroundColor Red
-    exit 1
-}
-
 #-------------------------------------------------------------------------------
 # Copy the icon file to the build_env directory
 #-------------------------------------------------------------------------------
@@ -139,6 +130,82 @@ if ( Test-Path -Path "$INSTALLER_DIR\salt.ico" ) {
 } else {
     Write-Result "Failed" -ForegroundColor Red
     Write-Host "Failed to find salt.ico in build_env directory"
+    exit 1
+}
+
+#-------------------------------------------------------------------------------
+# Remove compiled files
+#-------------------------------------------------------------------------------
+# We have to do this again because we use the Relenv Python to get the build
+# architecture. This recreates some of the pycache files that were removed
+# in the prep_salt script
+Write-Host "Removing __pycache__ directories: " -NoNewline
+$found = Get-ChildItem -Path "$BUILDENV_DIR" -Filter "__pycache__" -Recurse
+$found | ForEach-Object {
+    Remove-Item -Path "$($_.FullName)" -Recurse -Force
+    if ( Test-Path -Path "$($_.FullName)" ) {
+        Write-Result "Failed" -ForegroundColor Red
+        Write-Host "Failed to remove: $($_.FullName)"
+        exit 1
+    }
+}
+Write-Result "Success" -ForegroundColor Green
+
+# If we try to remove *.pyc with the same Get-ChildItem that we used to remove
+# __pycache__ directories, it won't be able to find them because they are no
+# longer present
+# This probably won't find any *.pyc files, but just in case
+$remove = "*.pyc",
+"*.chm"
+$remove | ForEach-Object {
+    Write-Host "Removing unneeded $_ files: " -NoNewline
+    $found = Get-ChildItem -Path "$BUILDENV_DIR" -Filter $_ -Recurse
+    $found | ForEach-Object {
+        Remove-Item -Path "$($_.FullName)" -Recurse -Force
+        if ( Test-Path -Path "$($_.FullName)" ) {
+            Write-Result "Failed" -ForegroundColor Red
+            Write-Host "Failed to remove: $($_.FullName)"
+            exit 1
+        }
+    }
+    Write-Result "Success" -ForegroundColor Green
+}
+
+#-------------------------------------------------------------------------------
+# Set timestamps on Files
+#-------------------------------------------------------------------------------
+
+# We're doing this again in this script because we use python above to get the
+# build architecture and that adds back some __pycache__ and *.pyc files
+Write-Host "Getting commit time stamp: " -NoNewline
+[DateTime]$origin = "1970-01-01 00:00:00"
+$hash_time = $(git show -s --format=%at)
+$time_stamp = $origin.AddSeconds($hash_time)
+if ( $hash_time ) {
+    Write-Result "Success" -ForegroundColor Green
+} else {
+    Write-Result "Failed" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "Setting time stamp on all files: " -NoNewline
+$found = Get-ChildItem -Path $BUILDENV_DIR -Recurse
+$found | ForEach-Object {
+    $_.CreationTime = $time_stamp
+    $_.LastAccessTime = $time_stamp
+    $_.LastWriteTime = $time_stamp
+}
+Write-Result "Success" -ForegroundColor Green
+
+#-------------------------------------------------------------------------------
+# Get the estimated size of the installation
+#-------------------------------------------------------------------------------
+Write-Host "Getting Estimated Installation Size: " -NoNewLine
+$estimated_size = [math]::Round(((Get-ChildItem "$BUILDENV_DIR" -Recurse -Force | Measure-Object -Sum Length).Sum / 1kb))
+if ( $estimated_size -gt 0 ) {
+    Write-Result "Success" -ForegroundColor Green
+} else {
+    Write-Result "Failed" -ForegroundColor Red
     exit 1
 }
 

--- a/pkg/windows/nsis/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/nsis/installer/Salt-Minion-Setup.nsi
@@ -607,50 +607,44 @@ SectionEnd
 Section -install_vcredist_2013
 
     Var /GLOBAL VcRedistName
-    Var /GLOBAL VcRedistGuid
-    Var /GLOBAL NeedVcRedist
-
-    # GUIDs can be found by installing them and then running the following
-    # command:
-    # wmic product where "Name like '%2013%minimum runtime%'" get Name, Version, IdentifyingNumber
-    !define VCREDIST_X86_NAME "vcredist_x86_2013"
-    !define VCREDIST_X86_GUID "{8122DAB1-ED4D-3676-BB0A-CA368196543E}"
-    !define VCREDIST_X64_NAME "vcredist_x64_2013"
-    !define VCREDIST_X64_GUID "{53CF6934-A98D-3D84-9146-FC4EDF3D5641}"
+    Var /GLOBAL VcRedistReg
 
     # Only install 64bit VCRedist on 64bit machines
     # Use RunningX64 here to get the Architecture for the system running the
     # installer.
     ${If} ${RunningX64}
-        StrCpy $VcRedistName ${VCREDIST_X64_NAME}
-        StrCpy $VcRedistGuid ${VCREDIST_X64_GUID}
+        StrCpy $VcRedistName "vcredist_x64_2013"
+        StrCpy $VcRedistReg "SOFTWARE\WOW6432Node\Microsoft\VisualStudio\12.0\VC\Runtimes\x64"
     ${Else}
-        StrCpy $VcRedistName ${VCREDIST_X86_NAME}
-        StrCpy $VcRedistGuid ${VCREDIST_X86_GUID}
+        StrCpy $VcRedistName "vcredist_x86_2013"
+        StrCpy $VcRedistReg "SOFTWARE\Microsoft\VisualStudio\12.0\VC\Runtimes\x86"
     ${EndIf}
 
     # Detecting VCRedist Installation
-    !define INSTALLSTATE_DEFAULT "5"
-
-    StrCpy $NeedVcRedist "False"
     detailPrint "Checking for $VcRedistName..."
-    System::Call "msi::MsiQueryProductStateA(t '$VcRedistGuid') i.r0"
-    StrCmp $0 ${INSTALLSTATE_DEFAULT} +2 0
-    StrCpy $NeedVcRedist "True"
-
+    ReadRegDword $0 HKLM $VcRedistReg "Installed"
+    StrCmp $0 "1" +2 0
     Call InstallVCRedist
 
 SectionEnd
 
 
 Function InstallVCRedist
-    # Check to see if it's already installed
-    ${If} $NeedVcRedist == "True"
-        detailPrint "System requires $VcRedistName"
-        MessageBox MB_ICONQUESTION|MB_YESNO|MB_DEFBUTTON2 \
-            "$VcRedistName is currently not installed. Would you like to \
-            install?" \
-            /SD IDYES IDNO endVCRedist
+    detailPrint "System requires $VcRedistName"
+    MessageBox MB_ICONQUESTION|MB_YESNO|MB_DEFBUTTON2 \
+        "$VcRedistName is currently not installed. Would you like to \
+        install?" \
+        /SD IDYES IDYES InstallVcRedist
+
+    detailPrint "$VcRedistName not installed"
+    detailPrint ">>>Installation aborted by user<<<"
+    MessageBox MB_ICONEXCLAMATION \
+        "$VcRedistName not installed. Aborted by user.$\n$\n\
+        Installer will now close." \
+        /SD IDOK
+    Quit
+
+    InstallVcRedist:
 
         # If an output variable is specified ($0 in the case below), ExecWait
         # sets the variable with the exit code (and only sets the error flag if
@@ -666,12 +660,15 @@ Function InstallVCRedist
         detailPrint "An error occurred during installation of $VcRedistName"
         MessageBox MB_OK|MB_ICONEXCLAMATION \
             "$VcRedistName failed to install. Try installing the package \
-            manually." \
+            manually.$\n$\n\
+            The installer will now close." \
             /SD IDOK
+            Quit
 
         CheckVcRedistErrorCode:
         # Check for Reboot Error Code (3010)
         ${If} $0 == 3010
+            detailPrint "$VcRedistName installed but requires a restart to complete."
             detailPrint "Reboot and run Salt install again"
             MessageBox MB_OK|MB_ICONINFORMATION \
                 "$VcRedistName installed but requires a restart to complete." \
@@ -682,14 +679,12 @@ Function InstallVCRedist
             detailPrint "An error occurred during installation of $VcRedistName"
             detailPrint "Error: $0"
             MessageBox MB_OK|MB_ICONEXCLAMATION \
-                "$VcRedistName failed with ErrorCode: $0. Try installing the \
-                package manually." \
+                "$VcRedistName failed to install. Try installing the package \
+                mnually.$\n\
+                ErrorCode: $0$\n\
+                The installer will now close." \
                 /SD IDOK
         ${EndIf}
-
-        endVCRedist:
-
-    ${EndIf}
 
 FunctionEnd
 


### PR DESCRIPTION
### What does this PR do?
The installer was using the `MsiQueryProductStateA` function to detect the presence of VC redist. Though it works when run from a CLI, it was returning a `-2` instead of a `5`, which was causing the installer to think VC Redist wasn't installed.

This PR will just use the registry to detect the presence of VC Redist.

Also moves the size estimation to after removing all the .pyc and __pycache__ stuff.

### What issues does this PR fix or reference?
Fixes: 3006.0rc2 blocker

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes