### PR TITLE
Update `py` renderer documentation with information on user-provideded context

### DIFF
--- a/salt/renderers/py.py
+++ b/salt/renderers/py.py
@@ -46,8 +46,23 @@ execution functions, grains, pillar, etc. They are:
   ``/srv/salt/foo/bar/baz.sls``, then ``__sls__`` in that file will be
   ``foo.bar.baz``.
 
-When writing a reactor SLS file the global context ``data`` (same as context ``{{ data }}``
-for states written with Jinja + YAML) is available. The following YAML + Jinja state declaration:
+When used in a scenario where additional user-provided context data is supplied
+(such as with :mod:`file.managed <salt.states.file.managed>`), the additional
+data will typically be injected into the script as one or more global
+variables:
+
+.. code-block:: jinja
+    /etc/http/conf/http.conf:
+      file.managed:
+        - source: salt://apache/generate_http_conf.py
+        - template: py
+        - context:
+            # Will be injected as the global variable "site_name".
+            site_name: {{ site_name }}
+
+When writing a reactor SLS file the global context ``data`` (same as context
+``{{ data }}`` for states written with Jinja + YAML) is available. The
+following YAML + Jinja state declaration:
 
 .. code-block:: jinja
 

--- a/salt/renderers/py.py
+++ b/salt/renderers/py.py
@@ -52,6 +52,7 @@ data will typically be injected into the script as one or more global
 variables:
 
 .. code-block:: jinja
+
     /etc/http/conf/http.conf:
       file.managed:
         - source: salt://apache/generate_http_conf.py


### PR DESCRIPTION
### What does this PR do?
Updates the `py` renderer's documentation to include information on how user-provided context data is typically presented.

### Merge requirements satisfied?
- [x] Docs

### Commits signed with GPG?
No
