### PR TITLE
[3006.x] Upgrade Requirements Due to Security Issues

### DIFF
--- a/changelog/63882.security.md
+++ b/changelog/63882.security.md
@@ -4,3 +4,6 @@ Upgrade Requirements Due to Security Issues.
   * https://github.com/advisories/GHSA-x4qr-2fvf-3mr5
   * https://github.com/advisories/GHSA-w7pp-m8wf-vj6r
 * Upgrade to `pyopenssl==23.0.0` due to the cryptography upgrade.
+* Update to `markdown-it-py==2.2.0` due to:
+  * https://github.com/advisories/GHSA-jrwr-5x3p-hvc3
+  * https://github.com/advisories/GHSA-vrjv-mxr7-vjf8

--- a/changelog/63882.security.md
+++ b/changelog/63882.security.md
@@ -3,3 +3,4 @@ Upgrade Requirements Due to Security Issues.
 * Upgrade to `cryptography>=39.0.1` due to:
   * https://github.com/advisories/GHSA-x4qr-2fvf-3mr5
   * https://github.com/advisories/GHSA-w7pp-m8wf-vj6r
+* Upgrade to `pyopenssl==23.0.0` due to the cryptography upgrade.

--- a/changelog/63882.security.md
+++ b/changelog/63882.security.md
@@ -1,0 +1,5 @@
+Upgrade Requirements Due to Security Issues.
+
+* Upgrade to `cryptography>=39.0.1` due to:
+  * https://github.com/advisories/GHSA-x4qr-2fvf-3mr5
+  * https://github.com/advisories/GHSA-w7pp-m8wf-vj6r

--- a/requirements/darwin.txt
+++ b/requirements/darwin.txt
@@ -5,7 +5,7 @@
 apache-libcloud>=2.4.0
 backports.ssl_match_hostname>=3.7.0.1; python_version < '3.7'
 cherrypy>=17.4.1
-cryptography>=2.6.1
+cryptography>=39.0.1
 gitpython>=3.1.30; python_version >= '3.7'
 idna>=2.8
 linode-python>=1.1.1

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -671,7 +671,7 @@ pyjwt==2.4.0
     # via adal
 pynacl==1.4.0
     # via paramiko
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -821,7 +821,6 @@ six==1.16.0
     #   paramiko
     #   profitbricks
     #   pynacl
-    #   pyopenssl
     #   pypsexec
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -385,8 +385,9 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.2
     # via
+    #   -r requirements/static/pkg/linux.in
     #   adal
     #   azure-cosmosdb-table
     #   azure-keyvault
@@ -807,7 +808,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -386,7 +386,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.2
     # via
     #   -r requirements/darwin.txt
     #   adal
@@ -800,7 +800,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -672,7 +672,7 @@ pyjwt==2.4.0
     # via adal
 pynacl==1.3.0
     # via paramiko
-pyopenssl==19.0.0
+pyopenssl==23.0.0
     # via
     #   -r requirements/darwin.txt
     #   etcd3-py
@@ -813,7 +813,6 @@ six==1.16.0
     #   ncclient
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-dateutil
     #   pyvmomi
     #   responses

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -78,7 +78,7 @@ looseversion==1.0.2
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   -r requirements/base.txt
-markdown-it-py==2.1.0
+markdown-it-py==2.2.0
     # via
     #   mdit-py-plugins
     #   myst-docutils

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -669,7 +669,7 @@ pyjwt==2.4.0
     # via adal
 pynacl==1.3.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   etcd3-py
@@ -811,7 +811,6 @@ six==1.16.0
     #   ncclient
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-dateutil
     #   pyvmomi
     #   responses

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -384,7 +384,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.2
     # via
     #   adal
     #   azure-cosmosdb-table
@@ -796,7 +796,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -390,8 +390,9 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.4.7
+cryptography==39.0.2
     # via
+    #   -r requirements/static/pkg/linux.in
     #   adal
     #   ansible-core
     #   azure-cosmosdb-table

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -675,7 +675,7 @@ pymysql==1.0.2 ; python_version > "3.5"
     # via -r requirements/static/ci/linux.in
 pynacl==1.4.0
     # via paramiko
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -794,7 +794,6 @@ six==1.16.0
     #   ncclient
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -398,8 +398,9 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.2
     # via
+    #   -r requirements/static/pkg/linux.in
     #   adal
     #   ansible-core
     #   azure-cosmosdb-table
@@ -833,7 +834,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -689,7 +689,7 @@ pymysql==1.0.2 ; python_version > "3.5"
     # via -r requirements/static/ci/linux.in
 pynacl==1.3.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -848,7 +848,6 @@ six==1.16.0
     #   ncclient
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -71,7 +71,7 @@ colorama==0.4.1
     # via pytest
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.4.7
+cryptography==39.0.2
     # via
     #   -r requirements/windows.txt
     #   etcd3-py

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -239,7 +239,7 @@ pymssql==2.2.7
     # via -r requirements/windows.txt
 pymysql==1.0.2
     # via -r requirements/windows.txt
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via
     #   -r requirements/windows.txt
     #   etcd3-py
@@ -364,7 +364,6 @@ six==1.15.0
     #   jsonschema
     #   kubernetes
     #   mock
-    #   pyopenssl
     #   python-dateutil
     #   pyvmomi
     #   pywinrm

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -713,7 +713,7 @@ pyjwt==2.4.0
     # via adal
 pynacl==1.4.0
     # via paramiko
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -870,7 +870,6 @@ six==1.16.0
     #   paramiko
     #   profitbricks
     #   pynacl
-    #   pyopenssl
     #   pypsexec
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -392,8 +392,9 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.2
     # via
+    #   -r requirements/static/pkg/linux.in
     #   adal
     #   azure-cosmosdb-table
     #   azure-keyvault
@@ -856,7 +857,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet

--- a/requirements/static/ci/py3.7/docs.txt
+++ b/requirements/static/ci/py3.7/docs.txt
@@ -82,7 +82,7 @@ looseversion==1.0.2
     # via
     #   -c requirements/static/ci/py3.7/linux.txt
     #   -r requirements/base.txt
-markdown-it-py==2.1.0
+markdown-it-py==2.2.0
     # via
     #   mdit-py-plugins
     #   myst-docutils

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -705,7 +705,7 @@ pyjwt==2.4.0
     # via adal
 pynacl==1.3.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   etcd3-py
@@ -854,7 +854,6 @@ six==1.16.0
     #   ncclient
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-dateutil
     #   pyvmomi
     #   responses

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -391,7 +391,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.2
     # via
     #   adal
     #   azure-cosmosdb-table
@@ -839,7 +839,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet

--- a/requirements/static/ci/py3.7/lint.txt
+++ b/requirements/static/ci/py3.7/lint.txt
@@ -399,8 +399,9 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.4.7
+cryptography==39.0.2
     # via
+    #   -r requirements/static/pkg/linux.in
     #   adal
     #   ansible-core
     #   azure-cosmosdb-table

--- a/requirements/static/ci/py3.7/lint.txt
+++ b/requirements/static/ci/py3.7/lint.txt
@@ -718,7 +718,7 @@ pymysql==1.0.2 ; python_version > "3.5"
     # via -r requirements/static/ci/linux.in
 pynacl==1.4.0
     # via paramiko
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -844,7 +844,6 @@ six==1.16.0
     #   ncclient
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -405,8 +405,9 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.2
     # via
+    #   -r requirements/static/pkg/linux.in
     #   adal
     #   ansible-core
     #   azure-cosmosdb-table
@@ -878,7 +879,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -725,7 +725,7 @@ pymysql==1.0.2 ; python_version > "3.5"
     # via -r requirements/static/ci/linux.in
 pynacl==1.3.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -893,7 +893,6 @@ six==1.16.0
     #   ncclient
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -77,7 +77,7 @@ colorama==0.4.1
     # via pytest
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.4.7
+cryptography==39.0.2
     # via
     #   -r requirements/windows.txt
     #   etcd3-py

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -252,7 +252,7 @@ pymssql==2.2.1
     # via -r requirements/windows.txt
 pymysql==1.0.2
     # via -r requirements/windows.txt
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via
     #   -r requirements/windows.txt
     #   etcd3-py
@@ -378,7 +378,6 @@ six==1.15.0
     #   jsonschema
     #   kubernetes
     #   mock
-    #   pyopenssl
     #   python-dateutil
     #   pyvmomi
     #   pywinrm

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -390,8 +390,9 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.2
     # via
+    #   -r requirements/static/pkg/linux.in
     #   adal
     #   azure-cosmosdb-table
     #   azure-keyvault
@@ -845,7 +846,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -702,7 +702,7 @@ pyjwt==2.4.0
     # via adal
 pynacl==1.4.0
     # via paramiko
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -859,7 +859,6 @@ six==1.16.0
     #   paramiko
     #   profitbricks
     #   pynacl
-    #   pyopenssl
     #   pypsexec
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.8/docs.txt
+++ b/requirements/static/ci/py3.8/docs.txt
@@ -78,7 +78,7 @@ looseversion==1.0.2
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   -r requirements/base.txt
-markdown-it-py==2.1.0
+markdown-it-py==2.2.0
     # via
     #   mdit-py-plugins
     #   myst-docutils

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -695,7 +695,7 @@ pyjwt==2.4.0
     # via adal
 pynacl==1.3.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   etcd3-py
@@ -844,7 +844,6 @@ six==1.16.0
     #   ncclient
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-dateutil
     #   pyvmomi
     #   responses

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -389,7 +389,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.2
     # via
     #   adal
     #   azure-cosmosdb-table
@@ -829,7 +829,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -709,7 +709,7 @@ pymysql==1.0.2 ; python_version > "3.5"
     # via -r requirements/static/ci/linux.in
 pynacl==1.4.0
     # via paramiko
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -835,7 +835,6 @@ six==1.16.0
     #   ncclient
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -397,8 +397,9 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.4.7
+cryptography==39.0.2
     # via
+    #   -r requirements/static/pkg/linux.in
     #   adal
     #   ansible-core
     #   azure-cosmosdb-table

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -403,8 +403,9 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.2
     # via
+    #   -r requirements/static/pkg/linux.in
     #   adal
     #   ansible-core
     #   azure-cosmosdb-table
@@ -866,7 +867,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -715,7 +715,7 @@ pymysql==1.0.2 ; python_version > "3.5"
     # via -r requirements/static/ci/linux.in
 pynacl==1.3.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -881,7 +881,6 @@ six==1.16.0
     #   ncclient
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -73,7 +73,7 @@ colorama==0.4.1
     # via pytest
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.4.7
+cryptography==39.0.2
     # via
     #   -r requirements/windows.txt
     #   etcd3-py

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -240,7 +240,7 @@ pymssql==2.2.1
     # via -r requirements/windows.txt
 pymysql==1.0.2
     # via -r requirements/windows.txt
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via
     #   -r requirements/windows.txt
     #   etcd3-py
@@ -366,7 +366,6 @@ six==1.15.0
     #   jsonschema
     #   kubernetes
     #   mock
-    #   pyopenssl
     #   python-dateutil
     #   pyvmomi
     #   pywinrm

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -705,7 +705,7 @@ pyjwt==2.4.0
     # via adal
 pynacl==1.4.0
     # via paramiko
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -862,7 +862,6 @@ six==1.16.0
     #   paramiko
     #   profitbricks
     #   pynacl
-    #   pyopenssl
     #   pypsexec
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -390,8 +390,9 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.2
     # via
+    #   -r requirements/static/pkg/linux.in
     #   adal
     #   azure-cosmosdb-table
     #   azure-keyvault
@@ -848,7 +849,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -391,7 +391,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.2
     # via
     #   -r requirements/darwin.txt
     #   adal
@@ -836,7 +836,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -701,7 +701,7 @@ pyjwt==2.4.0
     # via adal
 pynacl==1.3.0
     # via paramiko
-pyopenssl==19.0.0
+pyopenssl==23.0.0
     # via
     #   -r requirements/darwin.txt
     #   etcd3-py
@@ -849,7 +849,6 @@ six==1.16.0
     #   ncclient
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-dateutil
     #   pyvmomi
     #   responses

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -82,7 +82,7 @@ looseversion==1.0.2
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   -r requirements/base.txt
-markdown-it-py==2.1.0
+markdown-it-py==2.2.0
     # via
     #   mdit-py-plugins
     #   myst-docutils

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -698,7 +698,7 @@ pyjwt==2.4.0
     # via adal
 pynacl==1.3.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   etcd3-py
@@ -847,7 +847,6 @@ six==1.16.0
     #   ncclient
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-dateutil
     #   pyvmomi
     #   responses

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -389,7 +389,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.2
     # via
     #   adal
     #   azure-cosmosdb-table
@@ -832,7 +832,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -395,8 +395,9 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.4.7
+cryptography==39.0.2
     # via
+    #   -r requirements/static/pkg/linux.in
     #   adal
     #   ansible-core
     #   azure-cosmosdb-table

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -710,7 +710,7 @@ pymysql==1.0.2 ; python_version > "3.5"
     # via -r requirements/static/ci/linux.in
 pynacl==1.4.0
     # via paramiko
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -836,7 +836,6 @@ six==1.16.0
     #   ncclient
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -720,7 +720,7 @@ pymysql==1.0.2 ; python_version > "3.5"
     # via -r requirements/static/ci/linux.in
 pynacl==1.3.0
     # via paramiko
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
@@ -886,7 +886,6 @@ six==1.16.0
     #   ncclient
     #   paramiko
     #   pynacl
-    #   pyopenssl
     #   python-consul
     #   python-dateutil
     #   pyvmomi

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -405,8 +405,9 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==3.3.2
+cryptography==39.0.2
     # via
+    #   -r requirements/static/pkg/linux.in
     #   adal
     #   ansible-core
     #   azure-cosmosdb-table
@@ -871,7 +872,6 @@ six==1.16.0
     #   bcrypt
     #   cassandra-driver
     #   cheroot
-    #   cryptography
     #   etcd3-py
     #   genshi
     #   geomet

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -73,7 +73,7 @@ colorama==0.4.1
     # via pytest
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.4.7
+cryptography==39.0.2
     # via
     #   -r requirements/windows.txt
     #   etcd3-py

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -241,7 +241,7 @@ pymssql==2.2.1
     # via -r requirements/windows.txt
 pymysql==1.0.2
     # via -r requirements/windows.txt
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via
     #   -r requirements/windows.txt
     #   etcd3-py
@@ -367,7 +367,6 @@ six==1.15.0
     #   jsonschema
     #   kubernetes
     #   mock
-    #   pyopenssl
     #   python-dateutil
     #   pyvmomi
     #   pywinrm

--- a/requirements/static/pkg/linux.in
+++ b/requirements/static/pkg/linux.in
@@ -10,3 +10,4 @@ rpm-vercmp
 setproctitle>=1.2.3
 timelib>=0.2.5
 importlib-metadata>=3.3.0
+cryptography>=39.0.1

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -84,7 +84,7 @@ pycparser==2.21
     #   cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pyopenssl==19.0.0
+pyopenssl==23.0.0
     # via -r requirements/darwin.txt
 python-dateutil==2.8.0
     # via -r requirements/darwin.txt
@@ -106,7 +106,6 @@ setproctitle==1.3.2
 six==1.16.0
     # via
     #   cheroot
-    #   pyopenssl
     #   python-dateutil
 smmap==3.0.2
     # via gitdb

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -18,7 +18,7 @@ cherrypy==18.6.1
     # via -r requirements/darwin.txt
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.3.2
+cryptography==39.0.2
     # via
     #   -r requirements/darwin.txt
     #   pyopenssl
@@ -106,7 +106,6 @@ setproctitle==1.3.2
 six==1.16.0
     # via
     #   cheroot
-    #   cryptography
     #   pyopenssl
     #   python-dateutil
 smmap==3.0.2

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.3.2
+cryptography==39.0.2
     # via pyopenssl
 distro==1.5.0
     # via
@@ -88,7 +88,6 @@ setproctitle==1.3.2
 six==1.16.0
     # via
     #   cheroot
-    #   cryptography
     #   more-itertools
     #   pyopenssl
     #   python-dateutil

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -69,7 +69,7 @@ pycparser==2.21 ; python_version >= "3.9"
     #   cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via -r requirements/static/pkg/freebsd.in
 python-dateutil==2.8.1
     # via -r requirements/static/pkg/freebsd.in
@@ -89,7 +89,6 @@ six==1.16.0
     # via
     #   cheroot
     #   more-itertools
-    #   pyopenssl
     #   python-dateutil
 tempora==4.1.1
     # via portend

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -16,8 +16,10 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.3.2
-    # via pyopenssl
+cryptography==39.0.2
+    # via
+    #   -r requirements/static/pkg/linux.in
+    #   pyopenssl
 distro==1.5.0
     # via -r requirements/base.txt
 idna==2.8
@@ -88,7 +90,6 @@ setproctitle==1.3.2
 six==1.16.0
     # via
     #   cheroot
-    #   cryptography
     #   more-itertools
     #   pyopenssl
     #   python-dateutil

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -69,7 +69,7 @@ pycparser==2.21 ; python_version >= "3.9"
     #   cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via -r requirements/static/pkg/linux.in
 python-dateutil==2.8.1
     # via -r requirements/static/pkg/linux.in
@@ -91,7 +91,6 @@ six==1.16.0
     # via
     #   cheroot
     #   more-itertools
-    #   pyopenssl
     #   python-dateutil
 tempora==4.1.1
     # via portend

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -93,7 +93,7 @@ pymssql==2.2.7
     # via -r requirements/windows.txt
 pymysql==1.0.2
     # via -r requirements/windows.txt
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via -r requirements/windows.txt
 python-dateutil==2.8.1
     # via -r requirements/windows.txt
@@ -120,7 +120,6 @@ setproctitle==1.3.2
 six==1.15.0
     # via
     #   cheroot
-    #   pyopenssl
     #   python-dateutil
 smmap==4.0.0
     # via gitdb

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -23,7 +23,7 @@ clr-loader==0.2.4
     # via pythonnet
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.4.7
+cryptography==39.0.2
     # via
     #   -r requirements/windows.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.7/freebsd.txt
+++ b/requirements/static/pkg/py3.7/freebsd.txt
@@ -67,7 +67,7 @@ pycparser==2.17
     # via cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via -r requirements/static/pkg/freebsd.in
 python-dateutil==2.8.1
     # via -r requirements/static/pkg/freebsd.in
@@ -87,7 +87,6 @@ six==1.16.0
     # via
     #   cheroot
     #   more-itertools
-    #   pyopenssl
     #   python-dateutil
 tempora==4.1.1
     # via portend

--- a/requirements/static/pkg/py3.7/freebsd.txt
+++ b/requirements/static/pkg/py3.7/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.3.2
+cryptography==39.0.2
     # via pyopenssl
 distro==1.5.0
     # via
@@ -86,7 +86,6 @@ setproctitle==1.3.2
 six==1.16.0
     # via
     #   cheroot
-    #   cryptography
     #   more-itertools
     #   pyopenssl
     #   python-dateutil

--- a/requirements/static/pkg/py3.7/linux.txt
+++ b/requirements/static/pkg/py3.7/linux.txt
@@ -67,7 +67,7 @@ pycparser==2.17
     # via cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via -r requirements/static/pkg/linux.in
 python-dateutil==2.8.1
     # via -r requirements/static/pkg/linux.in
@@ -89,7 +89,6 @@ six==1.16.0
     # via
     #   cheroot
     #   more-itertools
-    #   pyopenssl
     #   python-dateutil
 tempora==4.1.1
     # via portend

--- a/requirements/static/pkg/py3.7/linux.txt
+++ b/requirements/static/pkg/py3.7/linux.txt
@@ -16,8 +16,10 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.3.2
-    # via pyopenssl
+cryptography==39.0.2
+    # via
+    #   -r requirements/static/pkg/linux.in
+    #   pyopenssl
 distro==1.5.0
     # via -r requirements/base.txt
 idna==2.8
@@ -86,7 +88,6 @@ setproctitle==1.3.2
 six==1.16.0
     # via
     #   cheroot
-    #   cryptography
     #   more-itertools
     #   pyopenssl
     #   python-dateutil

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -95,7 +95,7 @@ pymssql==2.2.1
     # via -r requirements/windows.txt
 pymysql==1.0.2
     # via -r requirements/windows.txt
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via -r requirements/windows.txt
 python-dateutil==2.8.1
     # via -r requirements/windows.txt
@@ -123,7 +123,6 @@ setproctitle==1.3.2
 six==1.15.0
     # via
     #   cheroot
-    #   pyopenssl
     #   python-dateutil
 smmap==4.0.0
     # via gitdb

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -23,7 +23,7 @@ clr-loader==0.2.4
     # via pythonnet
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.4.7
+cryptography==39.0.2
     # via
     #   -r requirements/windows.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -67,7 +67,7 @@ pycparser==2.17
     # via cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via -r requirements/static/pkg/freebsd.in
 python-dateutil==2.8.1
     # via -r requirements/static/pkg/freebsd.in
@@ -87,7 +87,6 @@ six==1.16.0
     # via
     #   cheroot
     #   more-itertools
-    #   pyopenssl
     #   python-dateutil
 tempora==4.1.1
     # via portend

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.3.2
+cryptography==39.0.2
     # via pyopenssl
 distro==1.5.0
     # via
@@ -86,7 +86,6 @@ setproctitle==1.3.2
 six==1.16.0
     # via
     #   cheroot
-    #   cryptography
     #   more-itertools
     #   pyopenssl
     #   python-dateutil

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -67,7 +67,7 @@ pycparser==2.17
     # via cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via -r requirements/static/pkg/linux.in
 python-dateutil==2.8.1
     # via -r requirements/static/pkg/linux.in
@@ -89,7 +89,6 @@ six==1.16.0
     # via
     #   cheroot
     #   more-itertools
-    #   pyopenssl
     #   python-dateutil
 tempora==4.1.1
     # via portend

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -16,8 +16,10 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.3.2
-    # via pyopenssl
+cryptography==39.0.2
+    # via
+    #   -r requirements/static/pkg/linux.in
+    #   pyopenssl
 distro==1.5.0
     # via -r requirements/base.txt
 idna==2.8
@@ -86,7 +88,6 @@ setproctitle==1.3.2
 six==1.16.0
     # via
     #   cheroot
-    #   cryptography
     #   more-itertools
     #   pyopenssl
     #   python-dateutil

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -93,7 +93,7 @@ pymssql==2.2.1
     # via -r requirements/windows.txt
 pymysql==1.0.2
     # via -r requirements/windows.txt
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via -r requirements/windows.txt
 python-dateutil==2.8.1
     # via -r requirements/windows.txt
@@ -121,7 +121,6 @@ setproctitle==1.3.2
 six==1.15.0
     # via
     #   cheroot
-    #   pyopenssl
     #   python-dateutil
 smmap==4.0.0
     # via gitdb

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -23,7 +23,7 @@ clr-loader==0.2.4
     # via pythonnet
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.4.7
+cryptography==39.0.2
     # via
     #   -r requirements/windows.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -84,7 +84,7 @@ pycparser==2.21
     #   cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pyopenssl==19.0.0
+pyopenssl==23.0.0
     # via -r requirements/darwin.txt
 python-dateutil==2.8.0
     # via -r requirements/darwin.txt
@@ -106,7 +106,6 @@ setproctitle==1.3.2
 six==1.16.0
     # via
     #   cheroot
-    #   pyopenssl
     #   python-dateutil
 smmap==3.0.2
     # via gitdb

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -18,7 +18,7 @@ cherrypy==18.6.1
     # via -r requirements/darwin.txt
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.3.2
+cryptography==39.0.2
     # via
     #   -r requirements/darwin.txt
     #   pyopenssl
@@ -106,7 +106,6 @@ setproctitle==1.3.2
 six==1.16.0
     # via
     #   cheroot
-    #   cryptography
     #   pyopenssl
     #   python-dateutil
 smmap==3.0.2

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.3.2
+cryptography==39.0.2
     # via pyopenssl
 distro==1.5.0
     # via
@@ -88,7 +88,6 @@ setproctitle==1.3.2
 six==1.16.0
     # via
     #   cheroot
-    #   cryptography
     #   more-itertools
     #   pyopenssl
     #   python-dateutil

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -69,7 +69,7 @@ pycparser==2.21 ; python_version >= "3.9"
     #   cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via -r requirements/static/pkg/freebsd.in
 python-dateutil==2.8.1
     # via -r requirements/static/pkg/freebsd.in
@@ -89,7 +89,6 @@ six==1.16.0
     # via
     #   cheroot
     #   more-itertools
-    #   pyopenssl
     #   python-dateutil
 tempora==4.1.1
     # via portend

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -16,8 +16,10 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.3.2
-    # via pyopenssl
+cryptography==39.0.2
+    # via
+    #   -r requirements/static/pkg/linux.in
+    #   pyopenssl
 distro==1.5.0
     # via -r requirements/base.txt
 idna==2.8
@@ -88,7 +90,6 @@ setproctitle==1.3.2
 six==1.16.0
     # via
     #   cheroot
-    #   cryptography
     #   more-itertools
     #   pyopenssl
     #   python-dateutil

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -69,7 +69,7 @@ pycparser==2.21 ; python_version >= "3.9"
     #   cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pyopenssl==19.1.0
+pyopenssl==23.0.0
     # via -r requirements/static/pkg/linux.in
 python-dateutil==2.8.1
     # via -r requirements/static/pkg/linux.in
@@ -91,7 +91,6 @@ six==1.16.0
     # via
     #   cheroot
     #   more-itertools
-    #   pyopenssl
     #   python-dateutil
 tempora==4.1.1
     # via portend

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -93,7 +93,7 @@ pymssql==2.2.1
     # via -r requirements/windows.txt
 pymysql==1.0.2
     # via -r requirements/windows.txt
-pyopenssl==20.0.1
+pyopenssl==23.0.0
     # via -r requirements/windows.txt
 python-dateutil==2.8.1
     # via -r requirements/windows.txt
@@ -121,7 +121,6 @@ setproctitle==1.3.2
 six==1.15.0
     # via
     #   cheroot
-    #   pyopenssl
     #   python-dateutil
 smmap==4.0.0
     # via gitdb

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -23,7 +23,7 @@ clr-loader==0.2.4
     # via pythonnet
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==3.4.7
+cryptography==39.0.2
     # via
     #   -r requirements/windows.txt
     #   pyopenssl

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -10,7 +10,7 @@ backports.ssl-match-hostname>=3.7.0.1; python_version < '3.7'
 certifi>=2022.12.07
 cffi>=1.14.5
 cherrypy>=18.6.1
-cryptography>=3.4.7
+cryptography>=39.0.1
 gitpython>=3.1.30; python_version >= '3.7'
 ioloop>=0.1a0
 lxml>=4.6.3

--- a/tests/pytests/functional/states/test_x509_v2.py
+++ b/tests/pytests/functional/states/test_x509_v2.py
@@ -1205,7 +1205,7 @@ def test_certificate_managed_chain_change(
     if cert_args["encoding"].startswith("pkcs7"):
         cert = cert[0]
     elif cert_args["encoding"] == "pkcs12":
-        if CRYPTOGRAPHY_VERSION[0] == 36:
+        if CRYPTOGRAPHY_VERSION[0] >= 36:
             # it seems (serial number) parsing of pkcs12 certificates is broken (?) in that release
             return
         cert = cert.cert.certificate
@@ -2456,7 +2456,7 @@ def test_certificate_managed_should_not_fail_with_removed_args(
     cert_args["days_valid"] = 30
     cert_args["days_remaining"] = 7
     cert_args["private_key"] = rsa_privkey
-    with pytest.deprecated_call():
+    with pytest.warns(DeprecationWarning):
         ret = x509.certificate_managed(**cert_args, **arg)
     assert ret.result is True
     cert = _get_cert(cert_args["name"])
@@ -2469,7 +2469,7 @@ def test_certificate_managed_warns_about_algorithm_renaming(
     cert_args["days_valid"] = 30
     cert_args["days_remaining"] = 7
     cert_args["private_key"] = rsa_privkey
-    with pytest.deprecated_call():
+    with pytest.warns(DeprecationWarning):
         ret = x509.certificate_managed(**cert_args, algorithm="sha512")
     assert ret.result is True
     cert = _get_cert(cert_args["name"])
@@ -2483,7 +2483,7 @@ def test_certificate_managed_warns_about_long_name_attributes(
     cert_args["days_remaining"] = 7
     cert_args["commonName"] = "success"
     cert_args["private_key"] = rsa_privkey
-    with pytest.deprecated_call():
+    with pytest.warns(DeprecationWarning):
         ret = x509.certificate_managed(**cert_args)
     assert ret.result is True
     cert = _get_cert(cert_args["name"])
@@ -2495,7 +2495,7 @@ def test_certificate_managed_warns_about_long_extensions(x509, cert_args, rsa_pr
     cert_args["days_valid"] = 30
     cert_args["days_remaining"] = 7
     cert_args["private_key"] = rsa_privkey
-    with pytest.deprecated_call():
+    with pytest.warns(DeprecationWarning):
         ret = x509.certificate_managed(**cert_args)
     assert ret.result is True
     cert = _get_cert(cert_args["name"])
@@ -2508,7 +2508,7 @@ def test_certificate_managed_warns_about_long_extensions(x509, cert_args, rsa_pr
 
 @pytest.mark.parametrize("arg", [{"version": 1}, {"text": True}])
 def test_csr_managed_should_not_fail_with_removed_args(x509, arg, csr_args):
-    with pytest.deprecated_call():
+    with pytest.warns(DeprecationWarning):
         ret = x509.csr_managed(**csr_args, **arg)
     assert ret.result is True
     csr = _get_csr(csr_args["name"])
@@ -2516,7 +2516,7 @@ def test_csr_managed_should_not_fail_with_removed_args(x509, arg, csr_args):
 
 
 def test_csr_managed_warns_about_algorithm_renaming(x509, csr_args):
-    with pytest.deprecated_call():
+    with pytest.warns(DeprecationWarning):
         ret = x509.csr_managed(**csr_args, algorithm="sha512")
     assert ret.result is True
     csr = _get_csr(csr_args["name"])
@@ -2525,7 +2525,7 @@ def test_csr_managed_warns_about_algorithm_renaming(x509, csr_args):
 
 def test_csr_managed_warns_about_long_name_attributes(x509, csr_args):
     csr_args.pop("CN", None)
-    with pytest.deprecated_call():
+    with pytest.warns(DeprecationWarning):
         ret = x509.csr_managed(**csr_args, commonName="deprecated_yo")
     assert ret.result is True
     csr = _get_csr(csr_args["name"])
@@ -2534,7 +2534,7 @@ def test_csr_managed_warns_about_long_name_attributes(x509, csr_args):
 
 def test_csr_managed_warns_about_long_extensions(x509, csr_args):
     csr_args["X509v3 Basic Constraints"] = "critical CA:FALSE"
-    with pytest.deprecated_call():
+    with pytest.warns(DeprecationWarning):
         ret = x509.csr_managed(**csr_args)
     assert ret.result is True
     csr = _get_csr(csr_args["name"])
@@ -2549,7 +2549,7 @@ def test_csr_managed_warns_about_long_extensions(x509, csr_args):
 def test_crl_managed_should_not_fail_with_removed_args(x509, arg, crl_args):
     crl_args["days_remaining"] = 3
     crl_args["days_valid"] = 7
-    with pytest.deprecated_call():
+    with pytest.warns(DeprecationWarning):
         ret = x509.crl_managed(**crl_args, **arg)
     assert ret.result is True
     crl = _get_crl(crl_args["name"])
@@ -2564,7 +2564,7 @@ def test_crl_managed_should_recognize_old_style_revoked(x509, crl_args, crl_revo
     crl_args["revoked"] = revoked
     crl_args["days_remaining"] = 3
     crl_args["days_valid"] = 7
-    with pytest.deprecated_call():
+    with pytest.warns(DeprecationWarning):
         ret = x509.crl_managed(**crl_args)
     assert ret.result is True
     crl = _get_crl(crl_args["name"])
@@ -2587,7 +2587,7 @@ def test_crl_managed_should_recognize_old_style_revoked_for_change_detection(
     crl_args["revoked"] = revoked
     crl_args["days_remaining"] = 3
     crl_args["days_valid"] = 7
-    with pytest.deprecated_call():
+    with pytest.warns(DeprecationWarning):
         ret = x509.crl_managed(**crl_args)
     assert ret.result is True
     assert not ret.changes
@@ -2598,7 +2598,7 @@ def test_crl_managed_should_recognize_old_style_reason(x509, crl_args):
     crl_args["revoked"] = revoked
     crl_args["days_remaining"] = 3
     crl_args["days_valid"] = 7
-    with pytest.deprecated_call():
+    with pytest.warns(DeprecationWarning):
         ret = x509.crl_managed(**crl_args)
     assert ret.result is True
     crl = _get_crl(crl_args["name"])
@@ -2614,14 +2614,14 @@ def test_crl_managed_should_recognize_old_style_reason(x509, crl_args):
     "arg", [{"cipher": "aes_256_cbc"}, {"verbose": True}, {"text": True}]
 )
 def test_private_key_managed_should_not_fail_with_removed_args(x509, arg, pk_args):
-    with pytest.deprecated_call():
+    with pytest.warns(DeprecationWarning):
         ret = x509.private_key_managed(**pk_args, **arg)
     assert ret.result is True
     assert _get_privkey(pk_args["name"])
 
 
 def test_private_key_managed_warns_about_bits_renaming(x509, pk_args):
-    with pytest.deprecated_call():
+    with pytest.warns(DeprecationWarning):
         ret = x509.private_key_managed(**pk_args, bits=3072)
     assert ret.result is True
     pk = _get_privkey(pk_args["name"])

--- a/tools/pkg/build.py
+++ b/tools/pkg/build.py
@@ -253,12 +253,18 @@ def onedir_dependencies(
 
     create(dest, arch=arch, version=python_version)
 
+    install_args = ["-v"]
     if platform == "windows":
         python_bin = dest / "Scripts" / "python"
-        no_binary = []
     else:
         python_bin = dest / "bin" / "python3"
-        no_binary = ["--no-binary=:all:"]
+        install_args.extend(
+            [
+                "--use-pep517",
+                "--no-cache-dir",
+                "--no-binary=:all:",
+            ]
+        )
 
     version_info = ctx.run(
         str(python_bin),
@@ -285,9 +291,9 @@ def onedir_dependencies(
         "-m",
         "pip",
         "install",
+        *install_args,
         "-r",
         str(requirements_file),
-        *no_binary,
     )
 
 


### PR DESCRIPTION
### What does this PR do?
Upgrade Requirements Due to Security Issues.

* Upgrade to `cryptography>=39.0.1` due to:
  * https://github.com/advisories/GHSA-x4qr-2fvf-3mr5
  * https://github.com/advisories/GHSA-w7pp-m8wf-vj6r
* Upgrade to `pyopenssl==23.0.0` due to the cryptography upgrade.  
* Update to `markdown-it-py==2.2.0` due to:
  * https://github.com/advisories/GHSA-jrwr-5x3p-hvc3
  * https://github.com/advisories/GHSA-vrjv-mxr7-vjf8
  
Closes #63761 
Closes #63762
Closes #63763
Closes #63764