### PR TITLE
Fix regex cache exception in sweep function

### DIFF
--- a/changelog/59437.fixed.md
+++ b/changelog/59437.fixed.md
@@ -1,0 +1,1 @@
+Fix regex cache exception during sort in sweep function

--- a/salt/utils/cache.py
+++ b/salt/utils/cache.py
@@ -271,7 +271,7 @@ class CacheRegex:
             self.timestamp = time.time()
         else:
             paterns = list(self.cache.values())
-            paterns.sort()
+            paterns.sort(key=lambda x: x[0])
             for idx in range(self.clear_size):
                 del self.cache[paterns[idx][2]]
 

--- a/tests/pytests/unit/utils/test_cache.py
+++ b/tests/pytests/unit/utils/test_cache.py
@@ -47,6 +47,28 @@ def test_ttl():
         cd["foo"]  # pylint: disable=pointless-statement
 
 
+def test_cache_regex_sweep_with_equal_usage_counts():
+    """
+    CacheRegex must be able to sweep and remove the outdated or least frequently
+    """
+    regex_cache = cache.CacheRegex(size=2, keep_fraction=0.5)
+
+    # Populate the cache and make two patterns share the same frequency
+    regex_cache.get("pattern1")
+    regex_cache.get("pattern2")
+    regex_cache.get("pattern1")
+    regex_cache.get("pattern2")
+
+    # Add a third pattern without triggering a sweep yet
+    regex_cache.get("pattern3")
+
+    # Adding a fourth pattern triggers a sweep internally
+    compiled = regex_cache.get("pattern4")
+
+    assert compiled is not None
+    assert "pattern4" in regex_cache.cache
+
+
 @pytest.fixture
 def cache_dir(minion_opts):
     return pathlib.Path(minion_opts["cachedir"])


### PR DESCRIPTION
### What does this PR do?
Use lambda function to properly sort patterns using usage counter and avoid exception: TypeError: '<' not supported between instances of '_sre.SRE_Pattern' and '_sre.SRE_Pattern'

### What issues does this PR fix or reference?
Fixes: #59437

### Previous Behavior
```
salt -b 1 '*' cmd.run 'true'
 
Traceback (most recent call last):
 File "/usr/bin/salt", line 10, in <module>
  salt_main()
 File "/usr/lib/python3.6/site-packages/salt/scripts.py", line 516, in salt_main
  client.run()
 File "/usr/lib/python3.6/site-packages/salt/cli/salt.py", line 66, in run
  self._run_batch()
 File "/usr/lib/python3.6/site-packages/salt/cli/salt.py", line 284, in _run_batch
  for res in batch.run():
 File "/usr/lib/python3.6/site-packages/salt/cli/batch.py", line 210, in run
  part = next(queue)
 File "/usr/lib/python3.6/site-packages/salt/client/__init__.py", line 922, in cmd_iter_no_block                                               
  **kwargs):
 File "/usr/lib/python3.6/site-packages/salt/client/__init__.py", line 1107, in get_iter_returns                                               
  for raw in ret_iter:
 File "/usr/lib/python3.6/site-packages/salt/client/__init__.py", line 1041, in get_returns_no_block                                             
  no_block=True, auto_reconnect=self.auto_reconnect)
 File "/usr/lib/python3.6/site-packages/salt/utils/event.py", line 651, in get_event
  ret = self._get_event(wait, tag, match_func, no_block)
 File "/usr/lib/python3.6/site-packages/salt/utils/event.py", line 564, in _get_event
  if not match_func(ret['tag'], tag):
 File "/usr/lib/python3.6/site-packages/salt/utils/event.py", line 516, in _match_tag_regex
  return self.cache_regex.get(search_tag).search(event_tag) is not None
 File "/usr/lib/python3.6/site-packages/salt/utils/cache.py", line 265, in get
  self.sweep()
 File "/usr/lib/python3.6/site-packages/salt/utils/cache.py", line 250, in sweep
  paterns.sort()
TypeError: '<' not supported between instances of '_sre.SRE_Pattern' and '_sre.SRE_Pattern'
```

### New Behavior
No exception

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No