### PR TITLE
[3006.x] Fix wayward uses of "RPM" in dpkg module

### DIFF
--- a/salt/modules/dpkg_lowpkg.py
+++ b/salt/modules/dpkg_lowpkg.py
@@ -37,12 +37,12 @@ def bin_pkg_info(path, saltenv="base"):
     """
     .. versionadded:: 2015.8.0
 
-    Parses RPM metadata and returns a dictionary of information about the
+    Parses DEB metadata and returns a dictionary of information about the
     package (name, version, etc.).
 
     path
         Path to the file. Can either be an absolute path to a file on the
-        minion, or a salt fileserver URL (e.g. ``salt://path/to/file.rpm``).
+        minion, or a salt fileserver URL (e.g. ``salt://path/to/file.deb``).
         If a salt fileserver URL is passed, the file will be cached to the
         minion so that it can be examined.
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `3006.x`:
 - [Fix wayward uses of "RPM" in dpkg module](https://github.com/saltstack/salt/pull/63783)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)