### PR TITLE
fix file.managed creating temporary files in cwd

### DIFF
--- a/changelog/63877.fixed.md
+++ b/changelog/63877.fixed.md
@@ -1,0 +1,1 @@
+When check_cmd is used without specifying tmp_dir use use pythons built-in tmpdir lookup mechanic instead of the current working directory for creating temporary files.

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2295,7 +2295,7 @@ def managed(
     show_changes=True,
     create=True,
     contents=None,
-    tmp_dir="",
+    tmp_dir=None,
     tmp_ext="",
     contents_pillar=None,
     contents_grains=None,


### PR DESCRIPTION
tempfile.mkstemp internally calls os.path.abspath on its dir argument, causing "" to be converted to the working directory of the process.

### What does this PR do?
Change default for mkstemp call in state file.managed to prevent creation of temporary files in cwd.

### What issues does this PR fix or reference?
Fixes: #63877 

### Previous Behavior
A file.managed state with check_cmd enabled will create temporary files in the processes working directory

### New Behavior
A file.managed state with check_cmd enabled will create temporary files in the typical temporary folders - following the algorithm specified in pythons tempfile documentation.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
