### PR TITLE
Document pip.installed pkgs parameter

### DIFF
--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -428,20 +428,39 @@ def installed(
     name
         The name of the python package to install. You can also specify version
         numbers here using the standard operators ``==, >=, <=``. If
-        ``requirements`` is given, this parameter will be ignored.
+        ``requirements`` or ``pkgs`` is given, this parameter will be ignored.
 
-    Example:
+        Example:
 
-    .. code-block:: yaml
+        .. code-block:: yaml
 
-        django:
-          pip.installed:
-            - name: django >= 1.6, <= 1.7
-            - require:
-              - pkg: python-pip
+            django:
+              pip.installed:
+                - name: django >= 1.6, <= 1.7
+                - require:
+                  - pkg: python-pip
 
-    This will install the latest Django version greater than 1.6 but less
-    than 1.7.
+        Installs the latest Django version greater than 1.6 but less
+        than 1.7.
+
+    pkgs
+        A list of python packages to install. This let you install multiple
+        packages at the same time.
+
+        Example:
+
+        .. code-block:: yaml
+
+            django-and-psycopg2:
+              pip.installed:
+                - pkgs:
+                  - django >= 1.6, <= 1.7
+                  - psycopg2 >= 2.8.4
+                - require:
+                  - pkg: python-pip
+
+        Installs the latest Django version greater than 1.6 but less than 1.7
+        and the latest psycopg2 greater than 2.8.4 at the same time.
 
     requirements
         Path to a pip requirements file. If the path begins with salt://
@@ -860,7 +879,6 @@ def installed(
             pip_list = False
 
         for prefix, state_pkg_name, version_spec in pkgs_details:
-
             if prefix:
                 out = _check_if_installed(
                     prefix,
@@ -1023,7 +1041,6 @@ def installed(
                 ret["changes"]["editable"] = True
             ret["comment"] = " ".join(comments)
         else:
-
             # Check that the packages set to be installed were installed.
             # Create comments reporting success and failures
             pkg_404_comms = []
@@ -1037,7 +1054,6 @@ def installed(
                     already_installed_packages.add(package.lower())
 
             for prefix, state_name in target_pkgs:
-
                 # Case for packages that are not an URL
                 if prefix:
                     pipsearch = salt.utils.data.CaseInsensitiveDict(


### PR DESCRIPTION
### What does this PR do?

[`pip.installed` documentation](https://docs.saltproject.io/en/latest/ref/states/all/salt.states.pip_state.html#salt.states.pip_state.installed) lack documentation for the pkgs parameter to install multiple python modules at the same time.

This PR adds documentation for the `pkgs` parameter of `pip.installed` state.

### What issues does this PR fix or reference?

None

### Previous Behavior

pip.installed pkgs parameter undocumented

### New Behavior

pip.installed pkgs parameter documented

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [x] Docs
- [N/A] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [N/A] Tests written/updated

### Commits signed with GPG?

No
