### PR TITLE
Add function `primary_group()` to `modules/pw_user.py` and `get_group_name()` to `utils/user.py`

### DIFF
--- a/changelog/63899.added.md
+++ b/changelog/63899.added.md
@@ -1,0 +1,2 @@
+Added function to get a users primary group to `modules/py_user.py`
+and one to get the group name to a given group id to `utils/users.py`.

--- a/changelog/63899.added.md
+++ b/changelog/63899.added.md
@@ -1,2 +1,2 @@
-Added function to get a users primary group to `modules/py_user.py`
-and one to get the group name to a given group id to `utils/users.py`.
+Added function to get a users primary group to `modules/pw_user.py`
+and one to get the group name to a given group id to `utils/user.py`.

--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -506,6 +506,20 @@ def list_users():
     return sorted(user.pw_name for user in pwd.getpwall())
 
 
+def primary_group(name):
+    """
+    Return the primary group of the named user
+
+    name
+        User to get the information
+    CLI Example:
+    .. code-block:: bash
+        salt '*' user.primary_group saltadmin
+    """
+    primary_gid = salt.utils.user.get_default_group(name)
+    return salt.utils.user.get_group_name(primary_gid)
+
+
 def rename(name, new_name):
     """
     Change the username for a named user

--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -516,8 +516,7 @@ def primary_group(name):
     .. code-block:: bash
         salt '*' user.primary_group saltadmin
     """
-    primary_gid = salt.utils.user.get_default_group(name)
-    return salt.utils.user.get_group_name(primary_gid)
+    return salt.utils.user.get_default_group(name)
 
 
 def rename(name, new_name):

--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -510,10 +510,15 @@ def primary_group(name):
     """
     Return the primary group of the named user
 
+    .. versionadded:: 3009.0
+
     name
         User to get the information
+
     CLI Example:
+
     .. code-block:: bash
+
         salt '*' user.primary_group saltadmin
     """
     return salt.utils.user.get_default_group(name)

--- a/salt/utils/user.py
+++ b/salt/utils/user.py
@@ -348,7 +348,7 @@ def get_group_name(gid):
     if no group with this id exists.
     """
     try:
-        return(grp.getgrgid(gid).gr_name)
+        return grp.getgrgid(gid).gr_name
     except KeyError:
         log.warning("No group with Group ID %d found", gid)
         return None

--- a/salt/utils/user.py
+++ b/salt/utils/user.py
@@ -342,6 +342,18 @@ def get_group_list(user, include_default=True):
     return sorted(ugroups)
 
 
+def get_group_name(gid):
+    """
+    Returns the name of the group with given group id or None
+    if no group with this id exists.
+    """
+    try:
+        return(grp.getgrgid(gid).gr_name)
+    except KeyError:
+        log.warning("No group with Group ID %d found", gid)
+        return None
+
+
 def get_group_dict(user=None, include_default=True):
     """
     Returns a dict of all of the system groups as keys, and group ids

--- a/tests/pytests/unit/modules/test_pw_user.py
+++ b/tests/pytests/unit/modules/test_pw_user.py
@@ -339,6 +339,25 @@ def test_list_users():
         assert pw_user.list_users() == [mock_user]
 
 
+def test_primary_group():
+    """
+    Return the primary group of the named user
+    """
+    with patch("salt.utils.user.get_default_group", MagicMock(return_value="wheel")):
+        assert pw_user.primary_group("root") == "wheel"
+
+
+def test_primary_group_nonexistent():
+    """
+    primary_group raises KeyError for a user that does not exist
+    """
+    with patch(
+        "salt.utils.user.get_default_group", MagicMock(side_effect=KeyError("nouser"))
+    ):
+        with pytest.raises(KeyError):
+            pw_user.primary_group("nouser")
+
+
 def test_rename():
     """
     Change the username for a named user

--- a/tests/pytests/unit/utils/test_user.py
+++ b/tests/pytests/unit/utils/test_user.py
@@ -11,6 +11,24 @@ import grp
 import salt.utils.user
 
 
+def test_get_group_name():
+    """
+    get_group_name returns the group name for a known gid.
+    """
+    with patch(
+        "grp.getgrgid", MagicMock(return_value=SimpleNamespace(gr_name="wheel"))
+    ):
+        assert salt.utils.user.get_group_name(0) == "wheel"
+
+
+def test_get_group_name_unknown_gid():
+    """
+    get_group_name returns None when the gid does not exist.
+    """
+    with patch("grp.getgrgid", MagicMock(side_effect=KeyError(9999))):
+        assert salt.utils.user.get_group_name(9999) is None
+
+
 def test_get_group_list():
     getpwname = SimpleNamespace(pw_gid=1000)
     getgrgid = MagicMock(side_effect=[SimpleNamespace(gr_name="remote")])


### PR DESCRIPTION
### What does this PR do?
Adds the missing function `primary_group(name)` to `modules/pw_user.py` so one can use `salt['user.primary_group'](username)` on FreeBSD, too.
As functions from `salt.utils.user` are used anyway I've also added a function to get the name to a given group ID there, `salt.utils.user.get_group_name(gid)` (as I misunderstood `utils.user.get_default_group()` and thought it would return a group id instead of the primary/default group's name).

### What issues does this PR fix or reference?
Fixes: None

### Previous Behavior
```
kvm-master:~# salt -C "*" user.primary_group root
deb11-kvm-minion:
    root
alpine317-kvm-minion:
    root
[...]
obsd72-kvm-minion:
    wheel
fbsd13-kvm-minion:
    'user.primary_group' is not available.
```
### New Behavior
```
kvm-master:~# salt -C "G@os:FreeBSD" user.primary_group root
fbsd13-kvm-minion:
    wheel
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
