### PR TITLE
Handle CRLF when generating fingerprint

### DIFF
--- a/changelog/63742.fixed.md
+++ b/changelog/63742.fixed.md
@@ -1,0 +1,1 @@
+Fixed an issue with generating fingerprints for public keys with different line endings

--- a/salt/utils/crypt.py
+++ b/salt/utils/crypt.py
@@ -143,6 +143,10 @@ def pem_finger(path=None, key=None, sum_type="sha256"):
 
         with salt.utils.files.fopen(path, "rb") as fp_:
             key = b"".join([x for x in fp_.readlines() if x.strip()][1:-1])
+            # We should never have \r\n in a key file. This will cause the
+            # finger to be different even though the only difference is the line
+            # endings.
+            key = key.replace(b"\r\n", b"\n")
 
     pre = getattr(hashlib, sum_type)(key).hexdigest()
     finger = ""

--- a/salt/utils/crypt.py
+++ b/salt/utils/crypt.py
@@ -148,6 +148,9 @@ def pem_finger(path=None, key=None, sum_type="sha256"):
             # endings.
             key = key.replace(b"\r\n", b"\n")
 
+    if not isinstance(key, bytes):
+        key = key.encode("utf-8")
+
     pre = getattr(hashlib, sum_type)(key).hexdigest()
     finger = ""
     for ind, _ in enumerate(pre):

--- a/tests/pytests/unit/utils/test_crypt.py
+++ b/tests/pytests/unit/utils/test_crypt.py
@@ -6,11 +6,6 @@ import pytest
 import salt.utils.crypt
 from tests.support.mock import patch
 
-pytestmark = [
-    pytest.mark.windows_whitelisted,
-]
-
-
 try:
     import M2Crypto  # pylint: disable=unused-import
 

--- a/tests/pytests/unit/utils/test_crypt.py
+++ b/tests/pytests/unit/utils/test_crypt.py
@@ -1,10 +1,15 @@
 """
 Unit tests for salt.utils.crypt.py
 """
-
+import pytest
 
 import salt.utils.crypt
 from tests.support.mock import patch
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+]
+
 
 try:
     import M2Crypto  # pylint: disable=unused-import
@@ -29,8 +34,23 @@ except ImportError:
     HAS_CRYPTO = False
 
 
+@pytest.fixture
+def pub_key_data():
+    return [
+        "-----BEGIN PUBLIC KEY-----",
+        "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyc9ehbU4J2uzPZZCEw8K",
+        "5URYcKSUh0h/c6m9PR2kRFbXkHcSnpkWX+LCuFKQ5iF2+0rVn9pO/94rL5zAQ6DU",
+        "lucqk9EvamSk+TjHh3Ps/HdSxxVbkLk3nglVJrDgENxnAz+Kp+OSNfI2uhhzJiu1",
+        "Dhn86Wb46eu7EFYeJ+7z9+29UXuCiMIUL5sRx3Xy37gpiD4Z+JVtoBNx1MKJ4MqB",
+        "24ZXsvtEyrCmuLwhKCiQqvNx91CkyIL+sfMoHDSf7sLwl1CuCEgny7EV7bJpoNzN",
+        "ZFKggcJCopfzLWDijF5A5OOvvvFrr/rYjW79LkGviWTzJrBPNgoD01zWIlzJfLdh",
+        "ywIDAQAB",
+        "-----END PUBLIC KEY-----",
+    ]
+
+
 def test_random():
-    # make sure the right liberty is used for random
+    # make sure the right library is used for random
     if HAS_M2CRYPTO:
         assert None is salt.utils.crypt.Random
     elif HAS_CYPTODOME:
@@ -40,7 +60,7 @@ def test_random():
 
 
 def test_reinit_crypto():
-    # make sure reinit cryptot does not crash
+    # make sure reinit crypto does not crash
     salt.utils.crypt.reinit_crypto()
 
     # make sure reinit does not crash when no crypt is found
@@ -49,3 +69,23 @@ def test_reinit_crypto():
             with patch("salt.utils.crypt.HAS_CRYPTO", False):
                 with patch("salt.utils.crypt.Random", None):
                     salt.utils.crypt.reinit_crypto()
+
+
+def test_pem_finger_lf(tmp_path, pub_key_data):
+    key_file = tmp_path / "master_lf.pub"
+    key_file.write_bytes("\n".join(pub_key_data).encode("utf-8"))
+    finger = salt.utils.crypt.pem_finger(path=str(key_file))
+    assert (
+        finger
+        == "9b:42:66:92:8a:d1:b9:27:42:e0:6d:f3:12:c9:74:74:b0:e0:0e:42:83:87:62:ad:95:49:9d:6f:8e:d0:ed:35"
+    )
+
+
+def test_pem_finger_crlf(tmp_path, pub_key_data):
+    key_file = tmp_path / "master_crlf.pub"
+    key_file.write_bytes("\r\n".join(pub_key_data).encode("utf-8"))
+    finger = salt.utils.crypt.pem_finger(path=str(key_file))
+    assert (
+        finger
+        == "9b:42:66:92:8a:d1:b9:27:42:e0:6d:f3:12:c9:74:74:b0:e0:0e:42:83:87:62:ad:95:49:9d:6f:8e:d0:ed:35"
+    )

--- a/tests/pytests/unit/utils/test_crypt.py
+++ b/tests/pytests/unit/utils/test_crypt.py
@@ -66,9 +66,10 @@ def test_reinit_crypto():
                     salt.utils.crypt.reinit_crypto()
 
 
-def test_pem_finger_lf(tmp_path, pub_key_data):
-    key_file = tmp_path / "master_lf.pub"
-    key_file.write_bytes("\n".join(pub_key_data).encode("utf-8"))
+@pytest.mark.parametrize("line_ending", ["\n", "\r\n"])
+def test_pem_finger_file_line_endings(tmp_path, pub_key_data, line_ending):
+    key_file = tmp_path / "master_crlf.pub"
+    key_file.write_bytes(line_ending.join(pub_key_data).encode("utf-8"))
     finger = salt.utils.crypt.pem_finger(path=str(key_file))
     assert (
         finger
@@ -76,11 +77,19 @@ def test_pem_finger_lf(tmp_path, pub_key_data):
     )
 
 
-def test_pem_finger_crlf(tmp_path, pub_key_data):
-    key_file = tmp_path / "master_crlf.pub"
-    key_file.write_bytes("\r\n".join(pub_key_data).encode("utf-8"))
-    finger = salt.utils.crypt.pem_finger(path=str(key_file))
+@pytest.mark.parametrize("key", [b"123abc", "123abc"])
+def test_pem_finger_key(key):
+    finger = salt.utils.crypt.pem_finger(key=key)
     assert (
         finger
-        == "9b:42:66:92:8a:d1:b9:27:42:e0:6d:f3:12:c9:74:74:b0:e0:0e:42:83:87:62:ad:95:49:9d:6f:8e:d0:ed:35"
+        == "dd:13:0a:84:9d:7b:29:e5:54:1b:05:d2:f7:f8:6a:4a:cd:4f:1e:c5:98:c1:c9:43:87:83:f5:6b:c4:f0:ff:80"
+    )
+
+
+def test_pem_finger_sha512():
+    finger = salt.utils.crypt.pem_finger(key="123abc", sum_type="sha512")
+    assert (
+        finger
+        == "7b:6a:d7:9b:34:6f:b6:95:12:75:34:39:48:e1:3c:1b:4e:bc:a8:2a:54:52:a6:c5:d1:56:84:37:7f:09:6c:a9:"
+        "27:50:6a:23:a8:47:e6:e0:46:06:13:99:63:1b:16:fc:28:20:c8:b0:e0:2d:0e:a8:7a:a5:a2:03:a7:7c:2a:7e"
     )


### PR DESCRIPTION
### What does this PR do?
Handles .pub files that have ``CRLF`` line endings. They are converted to ``LF`` line endings so that the fingerprint is consistent.

### What issues does this PR fix or reference?
Fixes: #63742 

### Previous Behavior
Fingerprints generated from files with CRLF line endings did not match fingerprints from files with LF line endings. Even when the content is the same.

### New Behavior
Fingerprints now match.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes