### PR TITLE
add linux_distribution to utils

### DIFF
--- a/changelog/63904.fixed.md
+++ b/changelog/63904.fixed.md
@@ -1,0 +1,1 @@
+add linux_distribution to util to stop dep warning

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -23,8 +23,6 @@ import time
 import uuid
 from errno import EACCES, EPERM
 
-import distro
-
 import salt.exceptions
 
 # Solve the Chicken and egg problem where grains need to run before any
@@ -41,6 +39,7 @@ import salt.utils.pkg.rpm
 import salt.utils.platform
 import salt.utils.stringutils
 from salt.utils.network import _clear_interfaces, _get_interfaces
+from salt.utils.platform import linux_distribution as _linux_distribution
 
 try:
     # pylint: disable=no-name-in-module
@@ -88,15 +87,6 @@ except ImportError:  # Define freedesktop_os_release for Python < 3.10
 
     def _freedesktop_os_release():
         return _parse_os_release("/etc/os-release", "/usr/lib/os-release")
-
-
-# rewrite distro.linux_distribution to allow best=True kwarg in version(), needed to get the minor version numbers in CentOS
-def _linux_distribution():
-    return (
-        distro.id(),
-        distro.version(best=True),
-        distro.codename(),
-    )
 
 
 def __init__(opts):

--- a/salt/utils/platform.py
+++ b/salt/utils/platform.py
@@ -8,9 +8,18 @@ import platform
 import subprocess
 import sys
 
-from distro import linux_distribution
+import distro
 
 from salt.utils.decorators import memoize as real_memoize
+
+
+def linux_distribution(full_distribution_name=True):
+    """
+    Simple function to return information about the OS distribution (id_name, version, codename).
+    """
+    if full_distribution_name:
+        return distro.name(), distro.version(best=True), distro.codename()
+    return distro.id(), distro.version(best=True), distro.codename()
 
 
 @real_memoize

--- a/salt/version.py
+++ b/salt/version.py
@@ -755,7 +755,7 @@ def system_information():
     Report system versions.
     """
     # Late import so that when getting called from setup.py does not break
-    from distro import linux_distribution
+    from salt.utils.platform import linux_distribution
 
     def system_version():
         """

--- a/tests/pytests/unit/test_version.py
+++ b/tests/pytests/unit/test_version.py
@@ -433,7 +433,7 @@ def test_system_version_linux():
     """
 
     with patch(
-        "distro.linux_distribution",
+        "salt.utils.platform.linux_distribution",
         MagicMock(return_value=("Manjaro Linux", "20.0.2", "Lysia")),
     ):
         versions = [item for item in system_information()]
@@ -441,7 +441,7 @@ def test_system_version_linux():
         assert version in versions
 
     with patch(
-        "distro.linux_distribution",
+        "salt.utils.platform.linux_distribution",
         MagicMock(return_value=("Debian GNU/Linux", "9", "stretch")),
     ):
         versions = [item for item in system_information()]
@@ -449,7 +449,7 @@ def test_system_version_linux():
         assert version in versions
 
     with patch(
-        "distro.linux_distribution",
+        "salt.utils.platform.linux_distribution",
         MagicMock(return_value=("Debian GNU/Linux", "10", "buster")),
     ):
         versions = [item for item in system_information()]
@@ -457,7 +457,7 @@ def test_system_version_linux():
         assert version in versions
 
     with patch(
-        "distro.linux_distribution",
+        "salt.utils.platform.linux_distribution",
         MagicMock(return_value=("CentOS Linux", "7", "Core")),
     ):
         versions = [item for item in system_information()]
@@ -465,7 +465,7 @@ def test_system_version_linux():
         assert version in versions
 
     with patch(
-        "distro.linux_distribution",
+        "salt.utils.platform.linux_distribution",
         MagicMock(return_value=("CentOS Linux", "8", "Core")),
     ):
         versions = [item for item in system_information()]
@@ -473,7 +473,7 @@ def test_system_version_linux():
         assert version in versions
 
     with patch(
-        "distro.linux_distribution",
+        "salt.utils.platform.linux_distribution",
         MagicMock(return_value=("OpenSUSE Leap", "15.1", "")),
     ):
         versions = [item for item in system_information()]


### PR DESCRIPTION
### What does this PR do?
add `distro.linux_distribution()` `utils.platform`  to stop dep warrning

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/63904

### Previous Behavior
used the dep function `distro.linux_distribution()`

### New Behavior
Move to `distro.id(), distro.version() and distro.name()`

### Merge requirements satisfied?
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

