### PR TITLE
fix compile_template_str not cleaning up temp files. 

### DIFF
--- a/changelog/63724.fixed.md
+++ b/changelog/63724.fixed.md
@@ -1,0 +1,1 @@
+have salt.template.compile_template_str cleanup its temp files.

--- a/salt/template.py
+++ b/salt/template.py
@@ -149,7 +149,9 @@ def compile_template_str(template, renderers, default, blacklist, whitelist):
     fn_ = salt.utils.files.mkstemp()
     with salt.utils.files.fopen(fn_, "wb") as ofile:
         ofile.write(SLS_ENCODER(template)[0])
-    return compile_template(fn_, renderers, default, blacklist, whitelist)
+    ret = compile_template(fn_, renderers, default, blacklist, whitelist)
+    os.unlink(fn_)
+    return ret
 
 
 def template_shebang(template, renderers, default, blacklist, whitelist, input_data):

--- a/tests/pytests/unit/test_template.py
+++ b/tests/pytests/unit/test_template.py
@@ -1,0 +1,19 @@
+import salt.state
+from salt import template
+from salt.config import minion_config
+from tests.support.mock import MagicMock, patch
+
+
+def test_compile_template_str_mkstemp_cleanup():
+    with patch("os.unlink", MagicMock()) as unlinked:
+        _config = minion_config(None)
+        _config["file_client"] = "local"
+        _state = salt.state.State(_config)
+        assert template.compile_template_str(
+            "{'val':'test'}",
+            _state.rend,
+            _state.opts["renderer"],
+            _state.opts["renderer_blacklist"],
+            _state.opts["renderer_whitelist"],
+        ) == {"val": "test"}
+        unlinked.assert_called_once()


### PR DESCRIPTION
### What does this PR do?
fixes #63724 but not just for file_tree but also for state.template_str which also was not cleaning up it's temp files. 

### What issues does this PR fix or reference?
Fixes: #63724 

### Previous Behavior
temp files were being left in the /tmp filesystem

### New Behavior
temp files are cleaned up after use. 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated
