### PR TITLE
[3006.x] Test failure: Skip cassandra_cql tests when driver isn't loaded

### DIFF
--- a/tests/pytests/unit/modules/test_cassandra_cql.py
+++ b/tests/pytests/unit/modules/test_cassandra_cql.py
@@ -15,6 +15,11 @@ from tests.support.mock import MagicMock, patch
 log = logging.getLogger(__name__)
 
 
+pytestmark = pytest.mark.skipif(
+    not cassandra_cql.HAS_DRIVER, reason="Cassandra CQL driver not loaded"
+)
+
+
 @pytest.fixture
 def configure_loader_modules():
     return {cassandra_cql: {}}


### PR DESCRIPTION
Prevents the following failures when the `cassandra` package isn't installed:

    FAILED tests/pytests/unit/modules/test_cassandra_cql.py::test_cql_query - NameError: name 'dict_factory' is not defined
    FAILED tests/pytests/unit/modules/test_cassandra_cql.py::test_cql_query_with_prepare - NameError: name 'dict_factory' is not defined
    FAILED tests/pytests/unit/modules/test_cassandra_cql.py::test_valid_asynchronous_args - NameError: name 'dict_factory' is not defined
    FAILED tests/pytests/unit/modules/test_cassandra_cql.py::test_valid_async_args - NameError: name 'dict_factory' is not defined