### PR TITLE
[3006.x] Change default GPG keyserver from pgp.mit.edu to keys.openpgp.org

### DIFF
--- a/changelog/63806.fixed.md
+++ b/changelog/63806.fixed.md
@@ -1,0 +1,1 @@
+Change default GPG keyserver from pgp.mit.edu to keys.openpgp.org.

--- a/salt/modules/gpg.py
+++ b/salt/modules/gpg.py
@@ -66,6 +66,8 @@ VERIFY_TRUST_LEVELS = {
     "4": "Ultimate",
 }
 
+_DEFAULT_KEY_SERVER = "keys.openpgp.org"
+
 try:
     import gnupg
 
@@ -216,7 +218,7 @@ def search_keys(text, keyserver=None, user=None):
         Text to search the keyserver for, e.g. email address, keyID or fingerprint.
 
     keyserver
-        Keyserver to use for searching for GPG keys, defaults to pgp.mit.edu.
+        Keyserver to use for searching for GPG keys, defaults to keys.openpgp.org.
 
     user
         Which user's keychain to access, defaults to user Salt is running as.
@@ -235,7 +237,7 @@ def search_keys(text, keyserver=None, user=None):
 
     """
     if not keyserver:
-        keyserver = "pgp.mit.edu"
+        keyserver = _DEFAULT_KEY_SERVER
 
     _keys = []
     for _key in _search_keys(text, keyserver, user):
@@ -881,7 +883,7 @@ def receive_keys(keyserver=None, keys=None, user=None, gnupghome=None):
     Receive key(s) from keyserver and add them to keychain
 
     keyserver
-        Keyserver to use for searching for GPG keys, defaults to pgp.mit.edu
+        Keyserver to use for searching for GPG keys, defaults to keys.openpgp.org
 
     keys
         The keyID(s) to retrieve from the keyserver.  Can be specified as a comma
@@ -911,7 +913,7 @@ def receive_keys(keyserver=None, keys=None, user=None, gnupghome=None):
     gpg = _create_gpg(user, gnupghome)
 
     if not keyserver:
-        keyserver = "pgp.mit.edu"
+        keyserver = _DEFAULT_KEY_SERVER
 
     if isinstance(keys, str):
         keys = keys.split(",")

--- a/tests/pytests/unit/modules/test_gpg.py
+++ b/tests/pytests/unit/modules/test_gpg.py
@@ -15,7 +15,7 @@ import psutil
 import pytest
 
 import salt.modules.gpg as gpg
-from tests.support.mock import MagicMock, patch
+from tests.support.mock import MagicMock, call, patch
 
 pytest.importorskip("gnupg")
 
@@ -879,12 +879,26 @@ def test_search_keys(gpghome):
         }
     ]
 
+    mock_search_keys = MagicMock(return_value=_search_result)
     mock_opt = MagicMock(return_value="root")
     with patch.dict(gpg.__salt__, {"user.info": MagicMock(return_value=_user_mock)}):
         with patch.dict(gpg.__salt__, {"config.option": mock_opt}):
-            with patch.object(gpg, "_search_keys", return_value=_search_result):
+            with patch.object(gpg, "_search_keys", mock_search_keys):
                 ret = gpg.search_keys("person@example.com")
                 assert ret == _expected_result
+
+                assert (
+                    call("person@example.com", "keys.openpgp.org", None)
+                    in mock_search_keys.mock_calls
+                )
+
+                ret = gpg.search_keys("person@example.com", "keyserver.ubuntu.com")
+                assert ret == _expected_result
+
+                assert (
+                    call("person@example.com", "keyserver.ubuntu.com", None)
+                    in mock_search_keys.mock_calls
+                )
 
 
 def test_gpg_import_pub_key(gpghome):


### PR DESCRIPTION
### What does this PR do?
Change default GPG keyserver from pgp.mit.edu to keys.openpgp.org.

### What issues does this PR fix or reference?
Fixes: #63806 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
