### PR TITLE
[3006.x] Ensure kwargs is passed along to _call_apt when passed into install function.

### DIFF
--- a/changelog/63847.fixed.md
+++ b/changelog/63847.fixed.md
@@ -1,0 +1,1 @@
+Ensure kwargs is passed along to _call_apt when passed into install function.

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -1003,7 +1003,7 @@ def install(
             unhold(pkgs=to_unhold)
 
         for cmd in cmds:
-            out = _call_apt(cmd)
+            out = _call_apt(cmd, **kwargs)
             if out["retcode"] != 0 and out["stderr"]:
                 errors.append(out["stderr"])
 


### PR DESCRIPTION
### What does this PR do?
Ensure kwargs is passed along to _call_apt when passed into install function.

### What issues does this PR fix or reference?
Fixes: #63847 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
