### PR TITLE
[3006.x] Fixes to state check_cmd

### DIFF
--- a/changelog/63948.fixed.md
+++ b/changelog/63948.fixed.md
@@ -1,1 +1,1 @@
-Hhandle the scenario when the check_cmd requisite is used with a state function when the state has a local check_cmd function but that function isn't used by that function.
+Handle the scenario when the check_cmd requisite is used with a state function when the state has a local check_cmd function but that function isn't used by that function.

--- a/changelog/63948.fixed.md
+++ b/changelog/63948.fixed.md
@@ -1,0 +1,1 @@
+Hhandle the scenario when the check_cmd requisite is used with a state function when the state has a local check_cmd function but that function isn't used by that function.

--- a/salt/state.py
+++ b/salt/state.py
@@ -16,6 +16,7 @@ import copy
 import datetime
 import fnmatch
 import importlib
+import inspect
 import logging
 import os
 import random
@@ -2374,11 +2375,17 @@ class State:
                                 *cdata["args"], **cdata["kwargs"]
                             )
                 self.states.inject_globals = {}
-            if (
-                "check_cmd" in low
-                and "{0[state]}.mod_run_check_cmd".format(low) not in self.states
-            ):
-                ret.update(self._run_check_cmd(low))
+            if "check_cmd" in low:
+                state_check_cmd = "{0[state]}.mod_run_check_cmd".format(low)
+                state_func = "{0[state]}.{0[fun]}".format(low)
+                state_func_sig = inspect.signature(self.states[state_func])
+                if state_check_cmd not in self.states:
+                    ret.update(self._run_check_cmd(low))
+                else:
+                    if "check_cmd" in state_func_sig.parameters:
+                        ret.update(self.states[state_check_cmd](low))
+                    else:
+                        ret.update(self._run_check_cmd(low))
         except Exception as exc:  # pylint: disable=broad-except
             log.debug(
                 "An exception occurred in this state: %s",

--- a/salt/state.py
+++ b/salt/state.py
@@ -2382,9 +2382,7 @@ class State:
                 if state_check_cmd not in self.states:
                     ret.update(self._run_check_cmd(low))
                 else:
-                    if "check_cmd" in state_func_sig.parameters:
-                        ret.update(self.states[state_check_cmd](low))
-                    else:
+                    if "check_cmd" not in state_func_sig.parameters:
                         ret.update(self._run_check_cmd(low))
         except Exception as exc:  # pylint: disable=broad-except
             log.debug(

--- a/tests/pytests/functional/states/file/test_append.py
+++ b/tests/pytests/functional/states/file/test_append.py
@@ -138,3 +138,25 @@ def test_issue_1896_file_append_source(file, tmp_path, state_tree):
         testfile_contents = testfile.read_text()
 
         assert testfile_contents == FIRST_IF_CONTENTS + SECOND_IF_CONTENTS
+
+
+def test_file_append_check_cmd(modules, state_tree, tmp_path):
+    """
+    Test that check_cmd works for file.append
+    and those states do not run.
+    """
+    sls_contents = f"""
+append_in_file:
+  file.append:
+    - name: /tmp/test
+    - text: "appended text"
+    - check_cmd:
+      - "djasjahj"
+    """
+    with pytest.helpers.temp_file(
+        "file-append-check-cmd.sls", sls_contents, state_tree
+    ):
+        ret = modules.state.sls("file-append-check-cmd")
+        for state_run in ret:
+            assert state_run.result is False
+            assert state_run.comment == "check_cmd determined the state failed"

--- a/tests/pytests/functional/states/file/test_replace.py
+++ b/tests/pytests/functional/states/file/test_replace.py
@@ -376,3 +376,27 @@ def test_file_replace_prerequired_issues_55775(modules, state_tree, tmp_path):
             assert state_run.result is True
 
     assert managed_file.exists()
+
+
+def test_file_replace_check_cmd(modules, state_tree, tmp_path):
+    """
+    Test that check_cmd works for file.replace
+    and those states do not run.
+    """
+    sls_contents = f"""
+replace_in_file:
+  file.replace:
+    - name: /tmp/test
+    - pattern: hi
+    - repl: "replacement text"
+    - append_if_not_found: True
+    - check_cmd:
+      - "djasjahj"
+    """
+    with pytest.helpers.temp_file(
+        "file-replace-check-cmd.sls", sls_contents, state_tree
+    ):
+        ret = modules.state.sls("file-replace-check-cmd")
+        for state_run in ret:
+            assert state_run.result is False
+            assert state_run.comment == "check_cmd determined the state failed"


### PR DESCRIPTION
### What does this PR do?
Need to handle the scenario when the check_cmd requisite is used with a state function when the state has a local check_cmd function but that function isn't used by that function.

### What issues does this PR fix or reference?
Fixes: #63948 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
