### PR TITLE
[master] Fix aptpkg.latest_version calls apt-cache too much

### DIFF
--- a/changelog/63982.fixed.md
+++ b/changelog/63982.fixed.md
@@ -1,0 +1,1 @@
+Fix aptpkg.latest_version performance, reducing number of times to 'shell out'

--- a/tests/pytests/unit/modules/test_aptpkg.py
+++ b/tests/pytests/unit/modules/test_aptpkg.py
@@ -1362,3 +1362,39 @@ def test_sourceslist_architectures(repo_line):
                     assert source.architectures == ["amd64", "armel"]
                 else:
                     assert source.architectures == ["amd64"]
+
+
+def test_latest_version_calls_aptcache_once_per_run():
+    """
+    Performance Test - don't call apt-cache once for each pkg, call once and parse output
+    """
+    mock_list_pkgs = MagicMock(return_value={"sudo": "1.8.27-1+deb10u5"})
+    apt_cache_ret = {
+        "stdout": textwrap.dedent(
+            """sudo:
+              Installed: 1.8.27-1+deb10u5
+              Candidate: 1.8.27-1+deb10u5
+              Version table:
+             *** 1.8.27-1+deb10u5 500
+                    500 http://security.debian.org/debian-security buster/updates/main amd64 Packages
+                    100 /var/lib/dpkg/status
+                 1.8.27-1+deb10u3 500
+                    500 http://deb.debian.org/debian buster/main amd64 Packages
+            unzip:
+              Installed: (none)
+              Candidate: 6.0-23+deb10u3
+              Version table:
+                 6.0-23+deb10u3 500
+                    500 http://security.debian.org/debian-security buster/updates/main amd64 Packages
+                 6.0-23+deb10u2 500
+                    500 http://deb.debian.org/debian buster/main amd64 Packages
+            """
+        )
+    }
+    mock_apt_cache = MagicMock(return_value=apt_cache_ret)
+    with patch("salt.modules.aptpkg._call_apt", mock_apt_cache), patch(
+        "salt.modules.aptpkg.list_pkgs", mock_list_pkgs
+    ):
+        ret = aptpkg.latest_version("sudo", "unzip", refresh=False)
+    mock_apt_cache.assert_called_once()
+    assert ret == {"sudo": "6.0-23+deb10u3", "unzip": ""}


### PR DESCRIPTION
### What does this PR do?
See issue for details.

### What issues does this PR fix or reference?
Fixes: #63982

### Previous Behavior
```bash
time salt-call pkg.latest_version $(paste -sd" " all_pkgs)
...
real    0m9.154s
user    0m6.935s
sys     0m2.196s
```

### New Behavior
```bash
time salt-call pkg.latest_version $(paste -sd" " all_pkgs)
...
real    0m1.297s
user    0m1.035s
sys     0m0.172s
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
