### PR TITLE
[3006.x] Fix 63981 - Support verify_ssl in pkg.install

### DIFF
--- a/changelog/63981.fixed.md
+++ b/changelog/63981.fixed.md
@@ -1,0 +1,1 @@
+Issue #63981: Allow users to pass verify_ssl to pkg.install/pkg.installed on Windows

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -1298,7 +1298,7 @@ def _repo_process_pkg_sls(filename, short_path_name, ret, successful_verbose):
         successful_verbose[short_path_name] = []
 
 
-def _get_source_sum(source_hash, file_path, saltenv):
+def _get_source_sum(source_hash, file_path, saltenv, **kwargs):
     """
     Extract the hash sum, whether it is in a remote hash file, or just a string.
     """
@@ -1314,7 +1314,9 @@ def _get_source_sum(source_hash, file_path, saltenv):
     if source_hash_scheme in schemes:
         # The source_hash is a file on a server
         try:
-            cached_hash_file = __salt__["cp.cache_file"](source_hash, saltenv)
+            cached_hash_file = __salt__["cp.cache_file"](
+                source_hash, saltenv, verify_ssl=kwargs.get("verify_ssl", True)
+            )
         except MinionError as exc:
             log.exception("Failed to cache %s", source_hash, exc_info=exc)
             raise
@@ -1667,7 +1669,11 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
                 cached_file = __salt__["cp.is_cached"](cache_file, saltenv)
                 if not cached_file:
                     try:
-                        cached_file = __salt__["cp.cache_file"](cache_file, saltenv)
+                        cached_file = __salt__["cp.cache_file"](
+                            cache_file,
+                            saltenv,
+                            verify_ssl=kwargs.get("verify_ssl", True),
+                        )
                     except MinionError as exc:
                         msg = "Failed to cache {}".format(cache_file)
                         log.exception(msg, exc_info=exc)
@@ -1678,7 +1684,11 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
                     "cp.hash_file"
                 ](cached_file):
                     try:
-                        cached_file = __salt__["cp.cache_file"](cache_file, saltenv)
+                        cached_file = __salt__["cp.cache_file"](
+                            cache_file,
+                            saltenv,
+                            verify_ssl=kwargs.get("verify_ssl", True),
+                        )
                     except MinionError as exc:
                         msg = "Failed to cache {}".format(cache_file)
                         log.exception(msg, exc_info=exc)
@@ -1695,7 +1705,9 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
             if not cached_pkg:
                 # It's not cached. Cache it, mate.
                 try:
-                    cached_pkg = __salt__["cp.cache_file"](installer, saltenv)
+                    cached_pkg = __salt__["cp.cache_file"](
+                        installer, saltenv, verify_ssl=kwargs.get("verify_ssl", True)
+                    )
                 except MinionError as exc:
                     msg = "Failed to cache {}".format(installer)
                     log.exception(msg, exc_info=exc)
@@ -1716,7 +1728,11 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
                     "cp.hash_file"
                 ](cached_pkg):
                     try:
-                        cached_pkg = __salt__["cp.cache_file"](installer, saltenv)
+                        cached_pkg = __salt__["cp.cache_file"](
+                            installer,
+                            saltenv,
+                            verify_ssl=kwargs.get("verify_ssl", True),
+                        )
                     except MinionError as exc:
                         msg = "Failed to cache {}".format(installer)
                         log.exception(msg, exc_info=exc)
@@ -1738,7 +1754,7 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
         # Compare the hash sums
         source_hash = pkginfo[version_num].get("source_hash", False)
         if source_hash:
-            source_sum = _get_source_sum(source_hash, cached_pkg, saltenv)
+            source_sum = _get_source_sum(source_hash, cached_pkg, saltenv, **kwargs)
             log.debug(
                 "pkg.install: Source %s hash: %s",
                 source_sum["hash_type"],
@@ -2108,7 +2124,11 @@ def remove(name=None, pkgs=None, **kwargs):
                 if not cached_pkg:
                     # It's not cached. Cache it, mate.
                     try:
-                        cached_pkg = __salt__["cp.cache_file"](uninstaller, saltenv)
+                        cached_pkg = __salt__["cp.cache_file"](
+                            uninstaller,
+                            saltenv,
+                            verify_ssl=kwargs.get("verify_ssl", True),
+                        )
                     except MinionError as exc:
                         msg = "Failed to cache {}".format(uninstaller)
                         log.exception(msg, exc_info=exc)
@@ -2128,7 +2148,11 @@ def remove(name=None, pkgs=None, **kwargs):
                         "cp.hash_file"
                     ](cached_pkg):
                         try:
-                            cached_pkg = __salt__["cp.cache_file"](uninstaller, saltenv)
+                            cached_pkg = __salt__["cp.cache_file"](
+                                uninstaller,
+                                saltenv,
+                                verify_ssl=kwargs.get("verify_ssl", True),
+                            )
                         except MinionError as exc:
                             msg = "Failed to cache {}".format(uninstaller)
                             log.exception(msg, exc_info=exc)

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -760,7 +760,7 @@ def _find_install_targets(
             err = "Unable to cache {0}: {1}"
             try:
                 cached_path = __salt__["cp.cache_file"](
-                    version_string, saltenv=kwargs["saltenv"]
+                    version_string, saltenv=kwargs["saltenv"], **kwargs
                 )
             except CommandExecutionError as exc:
                 problems.append(err.format(version_string, exc))


### PR DESCRIPTION
### What does this PR do?
Allows the user to pass `verify_ssl` to the `pkg.install` and `pkg.installed` modules. The argument will be forwarded on the `cp.cache_file` function.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/63981

### Previous Behavior
No way to force it not to verify ssl

### New Behavior
Now the user can ignore certificate errors

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes