### PR TITLE
[master] Fix 63991: Add option to use a fresh connection for mysql cache

### DIFF
--- a/changelog/63991.fixed.md
+++ b/changelog/63991.fixed.md
@@ -1,0 +1,1 @@
+Added option to use a fresh connection for mysql cache

--- a/tests/pytests/unit/cache/test_mysql_cache.py
+++ b/tests/pytests/unit/cache/test_mysql_cache.py
@@ -170,6 +170,7 @@ def test_init_client():
             assert (
                 mysql_cache.__context__["mysql_kwargs"]["max_allowed_packet"] == 100000
             )
+            assert not mysql_cache.__context__["mysql_fresh_connection"]
 
     with patch.dict(
         mysql_cache.__opts__,
@@ -177,6 +178,7 @@ def test_init_client():
             "mysql.max_allowed_packet": 100000,
             "mysql.db": "salt_mysql_db",
             "mysql.host": "mysql-host",
+            "mysql.fresh_connection": True,
         },
     ):
         with patch.object(mysql_cache, "_create_table") as mock_create_table:
@@ -193,6 +195,7 @@ def test_init_client():
             assert (
                 mysql_cache.__context__["mysql_kwargs"]["max_allowed_packet"] == 100000
             )
+            assert mysql_cache.__context__["mysql_fresh_connection"]
 
 
 def test_create_table():


### PR DESCRIPTION
### What does this PR do?

Adds a fresh connection variable for mysql_cache and fixes some other small issues that we've encountered in production at scale.

### What issues does this PR fix or reference?
Fixes: #63991 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
