### PR TITLE
[lxd]: fix container_create not creating devices other than of type disk

### DIFF
--- a/changelog/63996.fixed.md
+++ b/changelog/63996.fixed.md
@@ -1,0 +1,1 @@
+[lxd] Fixed a bug in `container_create` which prevented devices which are not of type `disk` to be correctly created and added to the container when passed via the `devices` parameter.

--- a/salt/modules/lxd.py
+++ b/salt/modules/lxd.py
@@ -688,7 +688,11 @@ def container_create(
     # Add devices if not wait and devices have been given.
     if devices:
         for dn, dargs in devices.items():
-            container_device_add(name, dn, **dargs)
+            if "type" in dargs:
+                # extract 'type' so it won't be overwritten
+                container_device_add(name, dn, device_type=dargs["type"], **dargs)
+            else:
+                container_device_add(name, dn, **dargs)
 
     if _raw:
         return container

--- a/tests/integration/states/test_lxd_container.py
+++ b/tests/integration/states/test_lxd_container.py
@@ -31,10 +31,7 @@ class LxdContainerTestCase(ModuleCase, SaltReturnAssertsMixin):
             "lxd_image.absent",
             name="images:centos/7",
         )
-        self.run_state(
-            "lxd_container.absent",
-            name="test-container",
-        )
+        self.run_state("lxd_container.absent", name="test-container", stop=True)
 
     def test_02__create_container(self):
         ret = self.run_state(
@@ -42,6 +39,14 @@ class LxdContainerTestCase(ModuleCase, SaltReturnAssertsMixin):
             name="test-container",
             running=True,
             source={"type": "image", "alias": "images:centos/7"},
+            devices={
+                "data1": {"type": "disk", "source": "/tmp", "path": "/mnt/data"},
+                "port9000": {
+                    "type": "proxy",
+                    "listen": "tcp:127.0.0.1:9000",
+                    "connect": "tcp:127.0.0.1:9000",
+                },
+            },
         )
         name = "lxd_container_|-test-container_|-test-container_|-present"
         self.assertSaltTrueReturn(ret)
@@ -56,12 +61,50 @@ class LxdContainerTestCase(ModuleCase, SaltReturnAssertsMixin):
             name="test-container",
             running=True,
             source={"type": "image", "alias": "images:centos/7"},
+            devices={
+                "data1": {"type": "disk", "source": "/tmp", "path": "/mnt/data"},
+                "data2": {"type": "disk", "source": "/tmp", "path": "/mnt/data2"},
+                "port9000": {
+                    "type": "proxy",
+                    "listen": "tcp:127.0.0.1:9000",
+                    "connect": "tcp:127.0.0.1:9000",
+                },
+                "port9001": {
+                    "type": "proxy",
+                    "listen": "tcp:127.0.0.1:9001",
+                    "connect": "tcp:127.0.0.1:9001",
+                },
+                "port9002": {
+                    "type": "proxy",
+                    "listen": "tcp:127.0.0.1:9002",
+                    "connect": "tcp:127.0.0.1:9002",
+                },
+            },
         )
         ret = self.run_state(
             "lxd_container.present",
             name="test-container",
             running=True,
             source={"type": "image", "alias": "images:centos/7"},
+            devices={
+                "data1": {"type": "disk", "source": "/tmp", "path": "/mnt/data"},
+                "data2": {"type": "disk", "source": "/tmp", "path": "/mnt/data3"},
+                "port9000": {
+                    "type": "proxy",
+                    "listen": "tcp:127.0.0.1:9000",
+                    "connect": "tcp:127.0.0.1:9000",
+                },
+                "port9001": {
+                    "type": "proxy",
+                    "listen": "tcp:127.0.0.1:9001",
+                    "connect": "tcp:127.0.0.1:9009",
+                },
+                "port9003": {
+                    "type": "proxy",
+                    "listen": "tcp:127.0.0.1:9003",
+                    "connect": "tcp:127.0.0.1:9003",
+                },
+            },
             restart_on_change=True,
             config=[
                 {"key": "boot.autostart", "value": 1},
@@ -74,6 +117,12 @@ class LxdContainerTestCase(ModuleCase, SaltReturnAssertsMixin):
         assert ret[name]["changes"]["config"] == {
             "boot.autostart": 'Added config key "boot.autostart" = "1"',
             "security.privileged": 'Added config key "security.privileged" = "1"',
+        }
+        assert ret[name]["changes"]["devices"] == {
+            "data2": 'Changed device "data2"',
+            "port9001": 'Changed device "port9001"',
+            "port9002": 'Removed device "port9002"',
+            "port9003": 'Added device "port9003"',
         }
 
     def test_08__running_container(self):


### PR DESCRIPTION
### What does this PR do?
Extract the `type` argument into `device_type` so it's not overwritten by `container_device_add`.

### What issues does this PR fix or reference?
Fixes: #63996 

### Previous Behavior
`lxd.container_create` wouldn't create devices with type other than `disk`.

### New Behavior
`lxd.container_create` correctly creates devices with any type.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes