### PR TITLE
[3006.x] Populate user data / name within runners and for runner events on the event bus

### DIFF
--- a/changelog/63148.fixed.md
+++ b/changelog/63148.fixed.md
@@ -1,0 +1,1 @@
+User responsible for the runner is now correctly reported in the events on the event bus for the runner.

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -246,6 +246,8 @@ class SyncClientMixin(ClientStateMixin):
             self.functions[fun], arglist, pub_data
         )
         low = {"fun": fun, "arg": args, "kwarg": kwargs}
+        if "user" in pub_data:
+            low["__user__"] = pub_data["user"]
         return self.low(fun, low, print_event=print_event, full_return=full_return)
 
     @property

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -1730,9 +1730,11 @@ def runner(
         arg = []
     if kwarg is None:
         kwarg = {}
+    pub_data = {}
     jid = kwargs.pop("__orchestration_jid__", jid)
     saltenv = kwargs.pop("__env__", saltenv)
     kwargs = salt.utils.args.clean_kwargs(**kwargs)
+    pub_data["user"] = kwargs.pop("__pub_user", "UNKNOWN")
     if kwargs:
         kwarg.update(kwargs)
 

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -1764,6 +1764,7 @@ def runner(
     return rclient.cmd(
         name,
         arg=arg,
+        pub_data=pub_data,
         kwarg=kwarg,
         print_event=False,
         full_return=full_return,

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -1733,8 +1733,8 @@ def runner(
     pub_data = {}
     jid = kwargs.pop("__orchestration_jid__", jid)
     saltenv = kwargs.pop("__env__", saltenv)
-    kwargs = salt.utils.args.clean_kwargs(**kwargs)
     pub_data["user"] = kwargs.pop("__pub_user", "UNKNOWN")
+    kwargs = salt.utils.args.clean_kwargs(**kwargs)
     if kwargs:
         kwarg.update(kwargs)
 
@@ -1762,7 +1762,11 @@ def runner(
         )
 
     return rclient.cmd(
-        name, arg=arg, kwarg=kwarg, print_event=False, full_return=full_return
+        name,
+        arg=arg,
+        kwarg=kwarg,
+        print_event=False,
+        full_return=full_return,
     )
 
 

--- a/salt/runners/state.py
+++ b/salt/runners/state.py
@@ -101,6 +101,16 @@ def orchestrate(
        salt-run state.orchestrate webserver pillar_enc=gpg pillar="$(cat somefile.json)"
 
     """
+
+    try:
+        orig_user = __opts__["user"]
+        __opts__["user"] = __user__
+        log.debug(
+            f"changed opts user from original '{orig_user}' to global user '{__user__}'"
+        )
+    except NameError:
+        log.debug("unable to find global user __user__")
+
     if pillar is not None and not isinstance(pillar, dict):
         raise SaltInvocationError("Pillar data must be formatted as a dictionary")
     __opts__["file_client"] = "local"

--- a/salt/state.py
+++ b/salt/state.py
@@ -2302,6 +2302,7 @@ class State:
             "__running__": immutabletypes.freeze(running) if running else {},
             "__instance_id__": self.instance_id,
             "__lowstate__": immutabletypes.freeze(chunks) if chunks else {},
+            "__user__": self.opts.get("user", "UNKNOWN"),
         }
 
         if "__env__" in low:

--- a/salt/state.py
+++ b/salt/state.py
@@ -2293,6 +2293,7 @@ class State:
             initial_ret={"full": state_func_name},
             expected_extra_kws=STATE_INTERNAL_KEYWORDS,
         )
+
         inject_globals = {
             # Pass a copy of the running dictionary, the low state chunks and
             # the current state dictionaries.

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -125,7 +125,7 @@ def state(
     subset=None,
     orchestration_jid=None,
     failhard=None,
-    **kwargs
+    **kwargs,
 ):
     """
     Invoke a state run on a given target
@@ -454,7 +454,7 @@ def function(
     batch=None,
     subset=None,
     failhard=None,
-    **kwargs
+    **kwargs,
 ):  # pylint: disable=unused-argument
     """
     Execute a single module function on a remote minion via salt or salt-ssh
@@ -780,6 +780,14 @@ def runner(name, **kwargs):
         log.debug("Unable to fire args event due to missing __orchestration_jid__")
         jid = None
 
+    try:
+        kwargs["__pub_user"] = __user__
+        log.debug(
+            f"added __pub_user to kwargs using dunder user '{__user__}', kwargs '{kwargs}'"
+        )
+    except NameError:
+        log.warning("unable to find user for fire args event due to missing __user__")
+
     if __opts__.get("test", False):
         ret = {
             "name": name,
@@ -899,7 +907,7 @@ def parallel_runners(name, runners, **kwargs):  # pylint: disable=unused-argumen
             __orchestration_jid__=jid,
             __env__=__env__,
             full_return=True,
-            **(runner_config.get("kwarg", {}))
+            **(runner_config.get("kwarg", {})),
         )
 
     try:


### PR DESCRIPTION
### What does this PR do?
Populates the user correctly through out runners and reported as such on the events on the event bus.
First noticed in orchestration runners in https://github.com/saltstack/salt/issues/63148 found this problem runs much deeper. saltutil.runner when called from the salt cli will properly propagate the user, as will the runner orchestrate.

Re-working of PR https://github.com/saltstack/salt/pull/64030 but specifically against 3006.x branch for a cleaner PR.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/63148

### Previous Behavior
The user responsible for the runner was reported as 'UNKNOWN' in the events on the event bus.

### New Behavior
The user responsible for the runner is now correctly reported in the events on the event bus.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
