### PR TITLE
[3006.x] Fixing EC2 Windows Cloud Tests

### DIFF
--- a/requirements/static/ci/cloud.in
+++ b/requirements/static/ci/cloud.in
@@ -4,3 +4,5 @@ netaddr
 profitbricks
 pypsexec
 pywinrm
+pyspnego==0.8.0
+smbprotocol==1.10.1

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -396,6 +396,7 @@ cryptography==39.0.2
     #   moto
     #   paramiko
     #   pyopenssl
+    #   pyspnego
     #   requests-ntlm
     #   smbprotocol
     #   vcert
@@ -618,9 +619,7 @@ netaddr==0.7.19
     #   -r requirements/static/ci/cloud.in
     #   junos-eznc
 ntlm-auth==1.3.0
-    # via
-    #   requests-ntlm
-    #   smbprotocol
+    # via requests-ntlm
 oauthlib==3.2.2
     # via requests-oauthlib
 oscrypto==1.2.1
@@ -657,7 +656,6 @@ pyasn1==0.4.8
     # via
     #   pyasn1-modules
     #   rsa
-    #   smbprotocol
 pycparser==2.21 ; python_version >= "3.9"
     # via
     #   -r requirements/static/ci/common.in
@@ -685,6 +683,10 @@ pyrsistent==0.18.0
     # via jsonschema
 pyserial==3.5
     # via junos-eznc
+pyspnego==0.8.0
+    # via
+    #   -r requirements/static/ci/cloud.in
+    #   smbprotocol
 pytest-custom-exit-code==0.3.0
     # via -r requirements/pytest.txt
 pytest-helpers-namespace==2021.4.29
@@ -826,13 +828,14 @@ six==1.16.0
     #   pyvmomi
     #   pywinrm
     #   responses
-    #   smbprotocol
     #   transitions
     #   vcert
     #   virtualenv
     #   websocket-client
-smbprotocol==0.1.1
-    # via pypsexec
+smbprotocol==1.10.1
+    # via
+    #   -r requirements/static/ci/cloud.in
+    #   pypsexec
 smmap==4.0.0
     # via gitdb
 sqlparse==0.4.2

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -403,6 +403,7 @@ cryptography==39.0.2
     #   moto
     #   paramiko
     #   pyopenssl
+    #   pyspnego
     #   requests-ntlm
     #   smbprotocol
     #   vcert
@@ -657,9 +658,7 @@ ntc-templates==2.3.2
     #   junos-eznc
     #   netmiko
 ntlm-auth==1.3.0
-    # via
-    #   requests-ntlm
-    #   smbprotocol
+    # via requests-ntlm
 oauthlib==3.2.2
     # via requests-oauthlib
 oscrypto==1.2.1
@@ -700,7 +699,6 @@ pyasn1==0.4.8
     # via
     #   pyasn1-modules
     #   rsa
-    #   smbprotocol
 pycparser==2.19
     # via cffi
 pycryptodomex==3.10.1
@@ -729,6 +727,10 @@ pyserial==3.5
     # via
     #   junos-eznc
     #   netmiko
+pyspnego==0.8.0
+    # via
+    #   -r requirements/static/ci/cloud.in
+    #   smbprotocol
 pytest-custom-exit-code==0.3.0
     # via -r requirements/pytest.txt
 pytest-helpers-namespace==2021.4.29
@@ -875,14 +877,15 @@ six==1.16.0
     #   pyvmomi
     #   pywinrm
     #   responses
-    #   smbprotocol
     #   textfsm
     #   transitions
     #   vcert
     #   virtualenv
     #   websocket-client
-smbprotocol==0.1.1
-    # via pypsexec
+smbprotocol==1.10.1
+    # via
+    #   -r requirements/static/ci/cloud.in
+    #   pypsexec
 smmap==4.0.0
     # via gitdb
 sqlparse==0.4.2

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -401,6 +401,7 @@ cryptography==39.0.2
     #   moto
     #   paramiko
     #   pyopenssl
+    #   pyspnego
     #   requests-ntlm
     #   smbprotocol
     #   vcert
@@ -646,9 +647,7 @@ ntc-templates==2.3.2
     #   junos-eznc
     #   netmiko
 ntlm-auth==1.3.0
-    # via
-    #   requests-ntlm
-    #   smbprotocol
+    # via requests-ntlm
 oauthlib==3.2.2
     # via requests-oauthlib
 oscrypto==1.2.1
@@ -689,7 +688,6 @@ pyasn1==0.4.8
     # via
     #   pyasn1-modules
     #   rsa
-    #   smbprotocol
 pycparser==2.19
     # via cffi
 pycryptodomex==3.10.1
@@ -718,6 +716,10 @@ pyserial==3.5
     # via
     #   junos-eznc
     #   netmiko
+pyspnego==0.8.0
+    # via
+    #   -r requirements/static/ci/cloud.in
+    #   smbprotocol
 pytest-custom-exit-code==0.3.0
     # via -r requirements/pytest.txt
 pytest-helpers-namespace==2021.4.29
@@ -864,14 +866,15 @@ six==1.16.0
     #   pyvmomi
     #   pywinrm
     #   responses
-    #   smbprotocol
     #   textfsm
     #   transitions
     #   vcert
     #   virtualenv
     #   websocket-client
-smbprotocol==0.1.1
-    # via pypsexec
+smbprotocol==1.10.1
+    # via
+    #   -r requirements/static/ci/cloud.in
+    #   pypsexec
 smmap==4.0.0
     # via gitdb
 sqlparse==0.4.2

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -401,6 +401,7 @@ cryptography==39.0.2
     #   moto
     #   paramiko
     #   pyopenssl
+    #   pyspnego
     #   requests-ntlm
     #   smbprotocol
     #   vcert
@@ -646,9 +647,7 @@ ntc-templates==2.3.2
     #   junos-eznc
     #   netmiko
 ntlm-auth==1.3.0
-    # via
-    #   requests-ntlm
-    #   smbprotocol
+    # via requests-ntlm
 oauthlib==3.2.2
     # via requests-oauthlib
 oscrypto==1.2.1
@@ -689,7 +688,6 @@ pyasn1==0.4.8
     # via
     #   pyasn1-modules
     #   rsa
-    #   smbprotocol
 pycparser==2.21 ; python_version >= "3.9"
     # via
     #   -r requirements/static/ci/common.in
@@ -721,6 +719,10 @@ pyserial==3.5
     # via
     #   junos-eznc
     #   netmiko
+pyspnego==0.8.0
+    # via
+    #   -r requirements/static/ci/cloud.in
+    #   smbprotocol
 pytest-custom-exit-code==0.3.0
     # via -r requirements/pytest.txt
 pytest-helpers-namespace==2021.4.29
@@ -867,14 +869,15 @@ six==1.16.0
     #   pyvmomi
     #   pywinrm
     #   responses
-    #   smbprotocol
     #   textfsm
     #   transitions
     #   vcert
     #   virtualenv
     #   websocket-client
-smbprotocol==0.1.1
-    # via pypsexec
+smbprotocol==1.10.1
+    # via
+    #   -r requirements/static/ci/cloud.in
+    #   pypsexec
 smmap==4.0.0
     # via gitdb
 sqlparse==0.4.2


### PR DESCRIPTION
### What does this PR do?
MD4 is disabled in later versions of openssl, but NTLM authentication needs it.  Lock pyspnego to 0.8.0, which has added support for MD4, and smbprotocol to 1.10.1 which takes advantage of the support in this version of pyspnego.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
