### PR TITLE
[master] Log verify TLS bundle path used on vault.make_request calls

### DIFF
--- a/salt/utils/vault.py
+++ b/salt/utils/vault.py
@@ -335,12 +335,19 @@ def make_request(
     namespace = namespace or connection.get("namespace")
     if "verify" in args:
         args["verify"] = args["verify"]
+        log.debug(
+            'TLS bundle path for Vault found in args["verify"]: %s', args["verify"]
+        )
     else:
         try:
             args["verify"] = __opts__.get("vault").get("verify", None)
+            log.debug(
+                "TLS bundle path for Vault found in Salt configuration vault.verify: %s",
+                args["verify"],
+            )
         except (TypeError, AttributeError):
             # Don't worry about setting verify if it doesn't exist
-            pass
+            log.debug("TLS bundle path for Vault hasn't been set or specified")
     url = "{}/{}".format(vault_url, resource)
     headers = {"X-Vault-Token": str(token), "Content-Type": "application/json"}
     if namespace is not None:


### PR DESCRIPTION
It's not always trivial to determine what value is used for vault.verify, so if a job fails with a TLS certificate can't be verified error, the logging will help to determine:

  - if a certificate bundle has been specified or not, in the job or config
  - if so, the path used

It can help to catch cases like minion non restarted, so config not updated, of config unexpectingly propagated by the master to the minion.

### What does this PR do?

Add logging information.
Logging offers new information to help to debug issues with vault.verify

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [x] Docs - Behavior isn't modified
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated - no op as far as tests are concerned

### Commits signed with GPG?
(pending)
