### PR TITLE
[3006.x] Ensure dunder global NamedLoaderContext obj's value() is used, when passing outside of execution modules

### DIFF
--- a/changelog/62477.fixed.md
+++ b/changelog/62477.fixed.md
@@ -1,1 +1,1 @@
-Issue #62477: Check NamedLoadedContext mapping is not None, before attempting to create a dictory with it
+Check NamedLoadedContext mapping is not None, before attempting to create a dictory with it

--- a/changelog/62477.fixed.md
+++ b/changelog/62477.fixed.md
@@ -1,1 +1,1 @@
-Check NamedLoadedContext mapping is not None, before attempting to create a dictory with it
+Check NamedLoadedContext mapping is not None, before attempting to create a dictionary with it

--- a/changelog/62477.fixed.md
+++ b/changelog/62477.fixed.md
@@ -1,0 +1,1 @@
+Issue #62477: Check NamedLoadedContext mapping is not None, before attempting to create a dictory with it

--- a/changelog/62477.fixed.md
+++ b/changelog/62477.fixed.md
@@ -1,1 +1,1 @@
-Check NamedLoadedContext mapping is not None, before attempting to create a dictionary with it
+Ensure NamedLoaderContext's have their value() used if passing to other modules

--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -834,7 +834,7 @@ def show_highstate(**kwargs):
     opts = salt.utils.state.get_sls_opts(__opts__, **kwargs)
     with salt.client.ssh.state.SSHHighState(
         opts,
-        __pillar__,
+        __pillar__.value(),
         __salt__,
         __context__["fileclient"],
         context=__context__.value(),

--- a/salt/loader/context.py
+++ b/salt/loader/context.py
@@ -32,7 +32,7 @@ def loader_context(loader):
 class NamedLoaderContext(collections.abc.MutableMapping):
     """
     A NamedLoaderContext object is injected by the loader providing access to
-    Salt's 'magic dunders' (__salt__, __utils__, ect).
+    Salt's 'magic dunders' (__salt__, __utils__, etc).
     """
 
     def __init__(self, name, loader_context, default=None):

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -217,7 +217,7 @@ def _gather_pillar(pillarenv, pillar_override):
     """
     pillar = salt.pillar.get_pillar(
         __opts__,
-        __grains__,
+        __grains__.value(),
         __opts__["id"],
         __opts__["saltenv"],
         pillar_override=pillar_override,

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -185,8 +185,8 @@ def _render_filenames(path, dest, saltenv, template, **kw):
         pillarenv = kw.get("pillarenv", __opts__.get("pillarenv"))
         kwargs["pillar"] = _gather_pillar(pillarenv, kw.get("pillar"))
     else:
-        kwargs["pillar"] = __pillar__
-    kwargs["grains"] = __grains__
+        kwargs["pillar"] = __pillar__.value()
+    kwargs["grains"] = __grains__.value()
     kwargs["opts"] = __opts__
     kwargs["saltenv"] = saltenv
 

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -185,8 +185,8 @@ def _render_filenames(path, dest, saltenv, template, **kw):
         pillarenv = kw.get("pillarenv", __opts__.get("pillarenv"))
         kwargs["pillar"] = _gather_pillar(pillarenv, kw.get("pillar"))
     else:
-        kwargs["pillar"] = __pillar__.value()
-    kwargs["grains"] = __grains__.value()
+        kwargs["pillar"] = __pillar__
+    kwargs["grains"] = __grains__
     kwargs["opts"] = __opts__
     kwargs["saltenv"] = saltenv
 

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -41,7 +41,7 @@ def _gather_pillar(pillarenv, pillar_override):
     """
     pillar = salt.pillar.get_pillar(
         __opts__,
-        __grains__,
+        __grains__.value(),
         __opts__["id"],
         __opts__["saltenv"],
         pillar_override=pillar_override,

--- a/salt/payload.py
+++ b/salt/payload.py
@@ -16,7 +16,6 @@ import salt.utils.msgpack
 import salt.utils.stringutils
 from salt.defaults import _Constant
 from salt.exceptions import SaltDeserializationError, SaltReqTimeoutError
-from salt.loader.context import NamedLoaderContext
 from salt.utils.data import CaseInsensitiveDict
 
 try:
@@ -165,11 +164,6 @@ def dumps(msg, use_bin_type=False):
             return tuple(obj)
         elif isinstance(obj, CaseInsensitiveDict):
             return dict(obj)
-        elif isinstance(obj, NamedLoaderContext):
-            if isinstance(obj.value(), dict):
-                return obj.value()
-            else:
-                return {}
         elif isinstance(obj, collections.abc.MutableMapping):
             return dict(obj)
         # Nothing known exceptions found. Let msgpack raise its own.

--- a/salt/payload.py
+++ b/salt/payload.py
@@ -4,6 +4,7 @@ encrypted keys to general payload dynamics and packaging, these happen
 in here
 """
 
+import collections.abc
 import datetime
 import gc
 import logging
@@ -15,6 +16,7 @@ import salt.utils.msgpack
 import salt.utils.stringutils
 from salt.defaults import _Constant
 from salt.exceptions import SaltDeserializationError, SaltReqTimeoutError
+from salt.loader.context import NamedLoaderContext
 from salt.utils.data import CaseInsensitiveDict
 
 try:
@@ -163,9 +165,11 @@ def dumps(msg, use_bin_type=False):
             return tuple(obj)
         elif isinstance(obj, CaseInsensitiveDict):
             return dict(obj)
-        elif isinstance(obj, salt.loader.context.NamedLoaderContext):
+        elif isinstance(obj, NamedLoaderContext):
             if obj.value() is None:
                 return {}
+            return dict(obj)
+        elif isinstance(obj, collections.abc.MutableMapping):
             return dict(obj)
         # Nothing known exceptions found. Let msgpack raise its own.
         return obj

--- a/salt/payload.py
+++ b/salt/payload.py
@@ -4,7 +4,6 @@ encrypted keys to general payload dynamics and packaging, these happen
 in here
 """
 
-import collections.abc
 import datetime
 import gc
 import logging
@@ -164,7 +163,9 @@ def dumps(msg, use_bin_type=False):
             return tuple(obj)
         elif isinstance(obj, CaseInsensitiveDict):
             return dict(obj)
-        elif isinstance(obj, collections.abc.MutableMapping):
+        elif isinstance(obj, salt.loader.context.NamedLoaderContext):
+            if obj.value() is None:
+                return {}
             return dict(obj)
         # Nothing known exceptions found. Let msgpack raise its own.
         return obj

--- a/salt/payload.py
+++ b/salt/payload.py
@@ -166,9 +166,10 @@ def dumps(msg, use_bin_type=False):
         elif isinstance(obj, CaseInsensitiveDict):
             return dict(obj)
         elif isinstance(obj, NamedLoaderContext):
-            if obj.value() is None:
+            if isinstance(obj.value(), dict):
+                return obj.value()
+            else:
                 return {}
-            return dict(obj)
         elif isinstance(obj, collections.abc.MutableMapping):
             return dict(obj)
         # Nothing known exceptions found. Let msgpack raise its own.

--- a/tests/pytests/integration/master/test_payload.py
+++ b/tests/pytests/integration/master/test_payload.py
@@ -1,0 +1,42 @@
+"""
+Tests for payload
+"""
+import logging
+
+import pytest
+
+log = logging.getLogger(__name__)
+
+
+@pytest.mark.slow_test
+@pytest.mark.skip_if_not_root
+@pytest.mark.skip_on_windows
+@pytest.mark.skip_on_darwin
+def test_payload_no_exception(salt_cli, salt_master, salt_minion):
+    """
+    Test to confirm that no exception is thrown with the jinja file
+    when executed on the minion
+    """
+    test_set_hostname = """
+    {%- set host = pillar.get("hostname", "UNKNOWN") %}
+    {%- if host == 'UNKNOWN' %}
+      {{ raise("Unsupported UNKNOWN hostname") }}
+    {%- else %}
+        hostnamectl set-hostname {{ host }}
+    {%- endif %}
+    """
+    with salt_master.state_tree.base.temp_file("set_hostname.j2", test_set_hostname):
+
+        ret = salt_cli.run("test.ping", minion_tgt=salt_minion.id)
+        assert ret.returncode == 0
+        assert ret.data is True
+
+        ret = salt_cli.run(
+            "cmd.script",
+            "salt://set_hostname.j2",
+            "template=jinja",
+            pillar={"hostname": "test"},
+            minion_tgt=salt_minion.id,
+        )
+        log.warning(f"DGM output '{ret}'")
+        ## assert not ret.stdout.startswith("Authentication failure")

--- a/tests/pytests/integration/master/test_payload.py
+++ b/tests/pytests/integration/master/test_payload.py
@@ -1,11 +1,7 @@
 """
 Tests for payload
 """
-import logging
-
 import pytest
-
-log = logging.getLogger(__name__)
 
 
 @pytest.mark.slow_test
@@ -38,5 +34,4 @@ def test_payload_no_exception(salt_cli, salt_master, salt_minion):
             pillar={"hostname": "test"},
             minion_tgt=salt_minion.id,
         )
-        log.warning(f"DGM output '{ret}'")
-        ## assert not ret.stdout.startswith("Authentication failure")
+        assert "AttributeError:" not in ret.stdout


### PR DESCRIPTION
### What does this PR do?
Checks that the NamedLoaderContext object used does not generate a None before attempting to use it to create a dictionary

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/62477

### Previous Behavior
The code would throw an exception due to effectively executing dict(None) from a NamedLoaderContext object.

### New Behavior
Ensure that NamedLoaderContext objects used with dunder globals, typically grains and pillar, have their 'value(). used to pass their contents rather than the NamedLoaderContext object when the value is passed to other modules, for example: pillar, utils, etc.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
