### PR TITLE
[3006.x] Fix pip install error

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -927,6 +927,9 @@ def _parser():
     parser.add_argument(
         "--next-release", help="Return the next release", action="store_true"
     )
+    # When pip installing we pass in other args to this script.
+    # This allows us to catch those args but not use them
+    parser.add_argument("unknown", nargs=argparse.REMAINDER)
     return parser.parse_args()
 
 


### PR DESCRIPTION
Fixes error when trying to pip install salt:

```
(py-3.10)  ch3ll@megan-precision5550  ~/git/salt  ➦ c3dc2550e3 <B>  pip install .
Processing /home/ch3ll/git/salt
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 2
  ╰─> [2 lines of output]
      usage: setup.py [-h] [--next-release]
      setup.py: error: unrecognized arguments: egg_info
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 2
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.

[notice] A new release of pip available: 22.3.1 -> 23.0.1
[notice] To update, run: python3.10 -m pip install --upgrade pip
```