### PR TITLE
[master] Zabbix_host integer inventory reports changes + interface_diff output

### DIFF
--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -277,7 +277,7 @@ def present(host, groups, interfaces, **kwargs):
         ]
         for param in host_properties_definition:
             if param in kwargs:
-                host_extra_properties[param] = kwargs.pop(param)
+                host_extra_properties[param] = str(kwargs.pop(param))
 
     host_exists = __salt__["zabbix.host_exists"](host, **connection_args)
 

--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -343,8 +343,8 @@ def present(host, groups, interfaces, **kwargs):
                     else:
                         hostintf["details"] = []
             interface_diff = [
-                x for x in interfaces_formated if x not in hostinterfaces_copy
-            ] + [y for y in hostinterfaces_copy if y not in interfaces_formated]
+                x for x in interfaces_formated[0] if x not in hostinterfaces_copy[0]
+            ] + [y for y in hostinterfaces_copy[0] if y not in interfaces_formated[0]]
             if interface_diff:
                 update_interfaces = True
 


### PR DESCRIPTION
### What does this PR do?

1. Fixes interface_diff check. 
Both interfaces_formated and hostinterfaces_copy are lists with dict inside - [ {"key": "value", "key2": "value2" } ]. The previous check just checks, whether both dictionaries are same. If not, interface_diff returns list of 2 full dicts.
```
output = [ {}, {} ]
[ {'type': '1', 'main': '1', 'useip': '1', 'ip': 'x.x.x.x', 'dns': 'dns-name', 'port': '1000', 'details': []}, 
  {'main': '1', 'type': '1', 'useip': '1', 'ip': 'x.x.x.x', 'dns': 'dns-name', 'port': '1000', 'disable_until': '0', 'details': []}
]
```

After the fix, diff returns what keys are different.
```
output = [ "dif_key1", "dif_key2" ]
['disable_until']
```

This doesn't change logic, just helps with debug.

2. Fix inventory_mode always returns changes while using integer

Zabbix API return values as strings, if we define some inventory property with integer, this results in salt always reporting changes. I explicitly converted values to be strings.

eg
```
host:
  zabbix_host.present:
   - inventory_mode: 1
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
