### PR TITLE
[master] Zabbix host macros support

### DIFF
--- a/salt/modules/zabbix.py
+++ b/salt/modules/zabbix.py
@@ -2821,37 +2821,3 @@ def configuration_import(config_file, rules=None, file_format="xml", **connectio
     except SaltException as exc:
         return {"name": config_file, "result": False, "message": str(exc)}
 
-
-def host_macros_get(hostids, **connection_args):
-    '''
-    Retrieve host macros according to host id.
-    See: https://www.zabbix.com/documentation/current/en/manual/api/reference/host/get
-
-    :param hostids: ID of the host to query
-
-    :return: List of dictonaries, every dict represents one existing macro, False if no convenient host found, no existing macros or on failure.
-
-    CLI Example:
-    .. code-block:: bash
-
-        salt '*' zabbix.host_macros_get 101054
-    '''
-    conn_args = _login(**connection_args)
-    ret = False
-    try:
-        if conn_args:
-            method = 'host.get'
-            params = {"selectMacros": "extend"}
-            if hostids:
-                params.setdefault('hostids', hostids)
-            params = _params_extend(params, **connection_args)
-            ret = _query(method, params, conn_args['url'], conn_args['auth'])
-            return (
-                ret['result'][0]['macros']
-                if ret["result"] and ret['result'][0]['macros']
-                else False
-            )
-        else:
-            raise KeyError
-    except KeyError:
-        return ret

--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -73,7 +73,7 @@ def present(host, groups, interfaces, **kwargs):
                     - alias: some alias
                     - asset_tag: jlm3937
                 - macros:
-                    - $MACRO_NAME: "macro_value"
+                    - MACRO_NAME: "macro_value"
 
 
     """

--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -380,7 +380,7 @@ def present(host, groups, interfaces, **kwargs):
 
         # Check for new macros
         if new_macros is not None:
-            cur_macros = __salt__["zabbix.host_macros_get"](
+            cur_macros = __salt__["zabbix.usermacro_get"](
                 hostids=hostid, **connection_args
             )
 


### PR DESCRIPTION
### What does this PR do?

Add supports for host macros in zabbix_host.present state.

### Previous Behavior

Not possible to add host macros in zabbix_host.present state.

### New Behavior

It's possible to add host macros as a list in zabbix_host.present state.

eg.

```
host:
  zabbix_host.present:
    macros:
     IP: "127.0.0.53"
     PORT: "1050"
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
