### PR TITLE
64015 Port `get_all_groups` within `boto_asg.get_config` to boto3

### DIFF
--- a/changelog/64015.fixed
+++ b/changelog/64015.fixed
@@ -1,0 +1,1 @@
+Transition get_all_groups calls to boto3


### PR DESCRIPTION
Replace calls to `get_all_groups` within `get_config` with a `boto3` equivalent implementation. This change is being made to address the breakage highlighted in issue #64015.

Note that this port doesn't touch any of the other uses of `boto` which still appear to be functioning correctly. These should probably be tackled as a matter of priority though.

### What does this PR do?

### What issues does this PR fix or reference?
Fixes: [64015](https://github.com/saltstack/salt/issues/64015)

### Previous Behavior
Module was broken as a result of changed `get_all_groups` behaviour.

### New Behavior
No longer broken, and compatible with previous implementation (expected key names are translated to preserve previous contract).

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

I don't have the time to write a brand new set of tests for `boto_asg.py` - perhaps this PR could serve as the starting point for someone who does?

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.