### PR TITLE
[master] fix passing wrong keyword arguments to cp.cache_file in pkg.installed with sources

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -760,7 +760,9 @@ def _find_install_targets(
             err = "Unable to cache {0}: {1}"
             try:
                 cached_path = __salt__["cp.cache_file"](
-                    version_string, saltenv=kwargs["saltenv"], **kwargs
+                    version_string,
+                    saltenv=kwargs["saltenv"],
+                    verify_ssl=kwargs.get("verify_ssl", True),
                 )
             except CommandExecutionError as exc:
                 problems.append(err.format(version_string, exc))


### PR DESCRIPTION
### What does this PR do?

In salt 3006 I started getting `TypeError: salt.loaded.int.module.cp.cache_file() got multiple values for keyword argument 'saltenv'` errors in pkg.installed states.

I tracked it down to commit 88b2dd1020bf33ec4fdbe3e7de102bc27525f875 which modified pkg.py by passing all kwargs to `cp.cache_file`, resulting in duplicated `saltenv` and other invalid keyword arguments.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes
