### PR TITLE
[3006.x] Fix setup.py called with salt args

### DIFF
--- a/changelog/64114.fixed.md
+++ b/changelog/64114.fixed.md
@@ -1,0 +1,1 @@
+Fix running setup.py when passing in --salt-config-dir and --salt-cache-dir arguments.

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ The setup script for salt
 
 # pylint: disable=file-perms,resource-leakage
 import setuptools  # isort:skip
-
 import distutils.dist
 import glob
 import os
+import subprocess
 import sys
 import warnings
 from datetime import datetime
@@ -170,8 +170,9 @@ if os.path.exists(SALT_VERSION_HARDCODED):
     with open(SALT_VERSION_HARDCODED, encoding="utf-8") as rfh:
         SALT_VERSION = rfh.read().strip()
 else:
-    exec(compile(open(SALT_VERSION_MODULE).read(), SALT_VERSION_MODULE, "exec"))
-    SALT_VERSION = str(__saltstack_version__)  # pylint: disable=undefined-variable
+    SALT_VERSION = (
+        subprocess.check_output([sys.executable, SALT_VERSION_MODULE]).decode().strip()
+    )
 # pylint: enable=W0122
 
 

--- a/tests/pytests/scenarios/setup/test_install.py
+++ b/tests/pytests/scenarios/setup/test_install.py
@@ -3,12 +3,14 @@ Tests for building and installing salt
 """
 import json
 import logging
+import os
 import pathlib
 import re
 import sys
 
 import pytest
 
+import salt.utils.files
 import salt.utils.path
 import salt.utils.platform
 import salt.version
@@ -457,3 +459,38 @@ def test_setup_install(virtualenv, cache_dir, use_static_requirements, src_dir):
         installed_salt_path = installed_salt_path[0] / "salt"
         salt_generated_version_file_path = installed_salt_path / "_version.txt"
         assert salt_generated_version_file_path.is_file()
+
+
+def test_salt_install_args(
+    virtualenv, cache_dir, use_static_requirements, src_dir, tmp_path
+):
+    """
+    test building with `install` command with --salt-*
+    args. For example, --salt-config-dir and --salt-cache-dir.
+    """
+    cache_dir = tmp_path / "cache_dir"
+    config_dir = tmp_path / "config_dir"
+    # Let's create the testing virtualenv
+    with virtualenv as venv:
+        venv.run(venv.venv_python, "setup.py", "clean", cwd=src_dir)
+        env = os.environ.copy()
+        env["GENERATE_SALT_SYSPATHS"] = "True"
+        ret = venv.run(
+            venv.venv_python,
+            "setup.py",
+            "--salt-config-dir",
+            str(config_dir),
+            "--salt-cache-dir",
+            str(cache_dir),
+            "install",
+            cwd=src_dir,
+            env=env,
+        )
+        assert ret.returncode == 0
+        syspath = pathlib.Path(src_dir, "build", "lib", "salt", "_syspaths.py")
+        assert syspath.exists()
+        with salt.utils.files.fopen(syspath) as fp:
+            data = fp.read()
+        assert str(cache_dir) in data
+        assert str(config_dir) in data
+        venv.run(venv.venv_python, "setup.py", "clean", cwd=src_dir)


### PR DESCRIPTION
### What does this PR do?
Fixes running setup.py with `--salt-cache-dir` and `--salt-config-dir`.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/64114

### Previous Behavior

```
(heist-3.8)  ch3ll@megan-precision5550  ~/git/salt  ➦ 179532f902 <B>  GENERATE_SALT_SYSPATHS=True python setup.py --salt-config-dir=/etc/salt --salt-cache-dir=/var/cache/salt develop             
usage: setup.py [-h] [--next-release] ...
setup.py: error: unrecognized arguments: --salt-config-dir=/etc/salt --salt-cache-dir=/var/cache/salt
```

### New Behavior
Builds and no error