### PR TITLE
[master] Fix for issue 29835

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1805,7 +1805,11 @@ class Minion(MinionBase):
 
     @classmethod
     def _target(cls, minion_instance, opts, data, connected):
-        if not minion_instance:
+        # Quick fix for https://github.com/saltstack/salt/issues/29835
+        # added 'or not hasattr(minion_instance, "functions")'
+        # Allows masterless minion to run highsate on startup when
+        # master_type set to disabled
+        if not minion_instance or not hasattr(minion_instance, "functions"):
             minion_instance = cls(opts, load_grains=False)
             minion_instance.connected = connected
             if not hasattr(minion_instance, "functions"):


### PR DESCRIPTION
Quick fix for https://github.com/saltstack/salt/issues/29835,  added 'or not hasattr(minion_instance, "functions")' to allow a masterless minion to run highsate on startup when master_type set to disabled

### What does this PR do?
quick fix to generate a minion_instance object with proper data (functions, returners and executors).

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/29835

### Previous Behavior
Minion in masterless setup does not run highstate on startup, described in 
https://github.com/saltstack/salt/issues/29835

### New Behavior
Minion in masterless setup executes highstate on startup

