### PR TITLE
[3006.x] Bump to `sqlparse>=0.4.4` due to https://github.com/advisories/GHSA-rrm6-wvj7-cwh2

### DIFF
--- a/requirements/static/ci/common.in
+++ b/requirements/static/ci/common.in
@@ -36,7 +36,7 @@ python-etcd>0.4.2
 pyvmomi
 requests
 rfc3987
-sqlparse>=0.4.2
+sqlparse>=0.4.4
 strict_rfc3339>=0.7
 toml
 vcert~=0.7.0; sys_platform != 'win32'

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -838,7 +838,7 @@ smbprotocol==1.10.1
     #   pypsexec
 smmap==4.0.0
     # via gitdb
-sqlparse==0.4.2
+sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -820,7 +820,7 @@ six==1.16.0
     #   websocket-client
 smmap==3.0.2
     # via gitdb
-sqlparse==0.4.2
+sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -820,7 +820,7 @@ six==1.16.0
     #   websocket-client
 smmap==3.0.4
     # via gitdb
-sqlparse==0.4.2
+sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -808,7 +808,7 @@ slack-sdk==3.19.5
     # via slack-bolt
 smmap==4.0.0
     # via gitdb
-sqlparse==0.4.2
+sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -862,7 +862,7 @@ slack-sdk==3.19.5
     # via slack-bolt
 smmap==3.0.4
     # via gitdb
-sqlparse==0.4.2
+sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -369,7 +369,7 @@ six==1.15.0
     #   websocket-client
 smmap==4.0.0
     # via gitdb
-sqlparse==0.4.2
+sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -888,7 +888,7 @@ smbprotocol==1.10.1
     #   pypsexec
 smmap==4.0.0
     # via gitdb
-sqlparse==0.4.2
+sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -864,7 +864,7 @@ six==1.16.0
     #   websocket-client
 smmap==3.0.4
     # via gitdb
-sqlparse==0.4.2
+sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.7/lint.txt
+++ b/requirements/static/ci/py3.7/lint.txt
@@ -859,7 +859,7 @@ slack-sdk==3.19.5
     # via slack-bolt
 smmap==4.0.0
     # via gitdb
-sqlparse==0.4.2
+sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -908,7 +908,7 @@ slack-sdk==3.19.5
     # via slack-bolt
 smmap==3.0.4
     # via gitdb
-sqlparse==0.4.2
+sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -384,7 +384,7 @@ six==1.15.0
     #   websocket-client
 smmap==4.0.0
     # via gitdb
-sqlparse==0.4.2
+sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -877,7 +877,7 @@ smbprotocol==1.10.1
     #   pypsexec
 smmap==4.0.0
     # via gitdb
-sqlparse==0.4.2
+sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -854,7 +854,7 @@ six==1.16.0
     #   websocket-client
 smmap==3.0.4
     # via gitdb
-sqlparse==0.4.2
+sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -850,7 +850,7 @@ slack-sdk==3.19.5
     # via slack-bolt
 smmap==4.0.0
     # via gitdb
-sqlparse==0.4.2
+sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -896,7 +896,7 @@ slack-sdk==3.19.5
     # via slack-bolt
 smmap==3.0.4
     # via gitdb
-sqlparse==0.4.2
+sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -372,7 +372,7 @@ six==1.15.0
     #   websocket-client
 smmap==4.0.0
     # via gitdb
-sqlparse==0.4.2
+sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -880,7 +880,7 @@ smbprotocol==1.10.1
     #   pypsexec
 smmap==4.0.0
     # via gitdb
-sqlparse==0.4.2
+sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -857,7 +857,7 @@ six==1.16.0
     #   websocket-client
 smmap==3.0.2
     # via gitdb
-sqlparse==0.4.2
+sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -857,7 +857,7 @@ six==1.16.0
     #   websocket-client
 smmap==3.0.4
     # via gitdb
-sqlparse==0.4.2
+sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -851,7 +851,7 @@ slack-sdk==3.19.5
     # via slack-bolt
 smmap==4.0.0
     # via gitdb
-sqlparse==0.4.2
+sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -901,7 +901,7 @@ slack-sdk==3.19.5
     # via slack-bolt
 smmap==3.0.4
     # via gitdb
-sqlparse==0.4.2
+sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -373,7 +373,7 @@ six==1.15.0
     #   websocket-client
 smmap==4.0.0
     # via gitdb
-sqlparse==0.4.2
+sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in


### PR DESCRIPTION
### What does this PR do?
Bump to `sqlparse>=0.4.4` due to https://github.com/advisories/GHSA-rrm6-wvj7-cwh2

### What issues does this PR fix or reference?
Closes https://github.com/saltstack/salt/pull/64135
Closes https://github.com/saltstack/salt/pull/64136
Closes https://github.com/saltstack/salt/pull/64137
Closes https://github.com/saltstack/salt/pull/64138
Closes https://github.com/saltstack/salt/pull/64139
