### PR TITLE
[3006.x] Merge pull request #63712 from Airtonomy/fix-typo

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -563,7 +563,7 @@ But that advice is backwards for the changelog. We follow the
 our changelog, and use towncrier to generate it for each release. As a
 contributor, all that means is that you need to add a file to the
 ``salt/changelog`` directory, using the ``<issue #>.<type>`` format. For
-instanch, if you fixed issue 123, you would do:
+instance, if you fixed issue 123, you would do:
 
 ::
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `3006.x`:
 - [Merge pull request #63712 from Airtonomy/fix-typo](https://github.com/saltstack/salt/pull/63712)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)