### PR TITLE
[3006.x] Fix incorrect reactor target

### DIFF
--- a/doc/topics/beacons/index.rst
+++ b/doc/topics/beacons/index.rst
@@ -246,7 +246,7 @@ Add the following to ``/srv/reactor/revert.sls``:
 
     revert-file:
       local.state.apply:
-        - tgt: {{ data['data']['id'] }}
+        - tgt: {{ data['id'] }}
         - arg:
           - maintain_important_file
 
@@ -256,12 +256,6 @@ Add the following to ``/srv/reactor/revert.sls``:
     ``disable_during_state_run: True`` for an inotify beacon whose reaction is
     to modify the watched file, it is important to ensure the state applied is
     also :term:`idempotent <Idempotent>`.
-
-.. note::
-
-    The expression ``{{ data['data']['id'] }}`` :ref:`is correct
-    <beacons-and-reactors>` as it matches the event structure :ref:`shown above
-    <beacon-event-bus>`.
 
 State SLS
 `````````


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `3006.x`:
 - [Fix incorrect reactor target](https://github.com/saltstack/salt/pull/63702)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)