### PR TITLE
[3006.x] Fix the debian downgrade problem

### DIFF
--- a/changelog/64117.fixed.md
+++ b/changelog/64117.fixed.md
@@ -1,0 +1,1 @@
+Moved /etc/salt/proxy and /lib/systemd/system/salt-proxy@.service to the salt-minion DEB package

--- a/pkg/debian/salt-common.install
+++ b/pkg/debian/salt-common.install
@@ -1,7 +1,6 @@
 pkg/common/salt-proxy@.service /lib/systemd/system
 conf/roster /etc/salt
 conf/cloud /etc/salt
-conf/proxy /etc/salt
 pkg/common/fish-completions/salt-cp.fish /usr/share/fish/vendor_completions.d
 pkg/common/fish-completions/salt-call.fish /usr/share/fish/vendor_completions.d
 pkg/common/fish-completions/salt-syndic.fish /usr/share/fish/vendor_completions.d

--- a/pkg/debian/salt-common.install
+++ b/pkg/debian/salt-common.install
@@ -1,4 +1,3 @@
-pkg/common/salt-proxy@.service /lib/systemd/system
 conf/roster /etc/salt
 conf/cloud /etc/salt
 pkg/common/fish-completions/salt-cp.fish /usr/share/fish/vendor_completions.d

--- a/pkg/debian/salt-minion.install
+++ b/pkg/debian/salt-minion.install
@@ -1,2 +1,3 @@
 conf/minion /etc/salt
+conf/proxy /etc/salt
 pkg/common/salt-minion.service /lib/systemd/system

--- a/pkg/debian/salt-minion.install
+++ b/pkg/debian/salt-minion.install
@@ -1,3 +1,4 @@
 conf/minion /etc/salt
 conf/proxy /etc/salt
 pkg/common/salt-minion.service /lib/systemd/system
+pkg/common/salt-proxy@.service /lib/systemd/system


### PR DESCRIPTION
### What does this PR do?
Resolves the conflict on `/etc/salt/minion` on some debian downgrades

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/64117

### Previous Behavior
There was a conflict between salt-common>=3006.0 and salt-minion<3006.0

### New Behavior
The conflict is no longer present

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes