### PR TITLE
[3006.x] detect hyphen namd cryptdev devices

### DIFF
--- a/changelog/64082.fixed.md
+++ b/changelog/64082.fixed.md
@@ -1,0 +1,1 @@
+Fix dmsetup device names with hyphen being picked up.

--- a/salt/modules/cryptdev.py
+++ b/salt/modules/cryptdev.py
@@ -113,7 +113,7 @@ def active():
     ret = {}
     # TODO: This command should be extended to collect more information, such as UUID.
     devices = __salt__["cmd.run_stdout"]("dmsetup ls --target crypt")
-    out_regex = re.compile(r"(?P<devname>\w+)\W+\((?P<major>\d+), (?P<minor>\d+)\)")
+    out_regex = re.compile(r"(?P<devname>\S+)\s+\((?P<major>\d+), (?P<minor>\d+)\)")
 
     log.debug(devices)
     for line in devices.split("\n"):

--- a/tests/pytests/unit/modules/test_cryptdev.py
+++ b/tests/pytests/unit/modules/test_cryptdev.py
@@ -1,0 +1,38 @@
+import pytest
+
+import salt.modules.cryptdev as cryptdev
+from tests.support.mock import MagicMock, patch
+
+
+@pytest.fixture
+def configure_loader_modules(minion_opts):
+    return {cryptdev: {"__opts__": minion_opts}}
+
+
+def test_active(caplog):
+    with patch.dict(
+        cryptdev.__salt__,
+        {"cmd.run_stdout": MagicMock(return_value="my-device       (253, 1)\n")},
+    ):
+        assert cryptdev.active() == {
+            "my-device": {
+                "devname": "my-device",
+                "major": "253",
+                "minor": "1",
+            }
+        }
+
+    # debien output when no devices setup.
+    with patch.dict(cryptdev.__salt__, {"cmd.run_stdout": MagicMock(return_value="")}):
+        caplog.clear()
+        assert cryptdev.active() == {}
+        assert "dmsetup output does not match expected format" in caplog.text
+
+    # centos output of dmsetup when no devices setup.
+    with patch.dict(
+        cryptdev.__salt__,
+        {"cmd.run_stdout": MagicMock(return_value="No devices found")},
+    ):
+        caplog.clear()
+        assert cryptdev.active() == {}
+        assert "dmsetup output does not match expected format" in caplog.text


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes: #64082 

### Previous Behavior
cryptdev.active would not detect devices with a hyphen in the name.

### New Behavior
cryptdev.active now detects hyphened named devices

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
No