### PR TITLE
[3006.x] Add missing changelog files and a test for salt-ssh CLI `fsclient` destroy method

### DIFF
--- a/changelog/64111.fixed.md
+++ b/changelog/64111.fixed.md
@@ -1,0 +1,1 @@
+Disable class level caching of the file client on `SaltCacheLoader` and properly use context managers to take care of initialization and termination of the file client.

--- a/changelog/64113.fixed.md
+++ b/changelog/64113.fixed.md
@@ -1,0 +1,2 @@
+Fixed several file client uses which were not properly terminating it by switching to using it as a context manager
+whenever possible or making sure `.destroy()` was called when using a context manager was not possible.

--- a/changelog/64184.fixed.md
+++ b/changelog/64184.fixed.md
@@ -1,0 +1,1 @@
+ Make sure the `salt-ssh` CLI calls it's `fsclient.destroy()` method when done.

--- a/salt/cli/ssh.py
+++ b/salt/cli/ssh.py
@@ -16,4 +16,7 @@ class SaltSSH(salt.utils.parsers.SaltSSHOptionParser):
         self.parse_args()
 
         ssh = salt.client.ssh.SSH(self.config)
-        ssh.run()
+        try:
+            ssh.run()
+        finally:
+            ssh.fsclient.destroy()

--- a/tests/pytests/unit/cli/test_ssh.py
+++ b/tests/pytests/unit/cli/test_ssh.py
@@ -1,0 +1,16 @@
+from salt.cli.ssh import SaltSSH
+from tests.support.mock import MagicMock, call, patch
+
+
+def test_fsclient_destroy_called(minion_opts):
+    """
+    Test that `salt.client.ssh.SSH.fsclient.destroy()` is called.
+    """
+    ssh_mock = MagicMock()
+    with patch(
+        "salt.utils.parsers.SaltSSHOptionParser.parse_args", return_value=MagicMock()
+    ), patch("salt.client.ssh.SSH", return_value=ssh_mock):
+        parser = SaltSSH()
+        parser.config = minion_opts
+        parser.run()
+    assert ssh_mock.fsclient.mock_calls == [call.destroy()]


### PR DESCRIPTION
### What does this PR do?
Add missing changelog files from #64113 
Make sure the `salt-ssh` CLI calls `fsclient.destroy()` when done.
