### PR TITLE
[3006.x] Add support for test=True to file.cached

### DIFF
--- a/changelog/63785.fixed.md
+++ b/changelog/63785.fixed.md
@@ -1,0 +1,1 @@
+Added support for ``test=True`` to the ``file.cached`` state module

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -8937,6 +8937,25 @@ def cached(
     else:
         source_sum = {}
 
+    if __opts__["test"]:
+        local_copy = __salt__["cp.is_cached"](name, saltenv=saltenv)
+        if local_copy:
+            if source_sum:
+                hash = __salt__["file.get_hash"](local_copy, __opts__["hash_type"])
+                if hash == source_sum["hsum"]:
+                    ret["comment"] = "File already cached: {}".format(name)
+                else:
+                    ret[
+                        "comment"
+                    ] = "Hashes don't match.\nFile will be cached: {}".format(name)
+            else:
+                ret["comment"] = "No hash found. File will be cached: {}".format(name)
+        else:
+            ret["comment"] = "File will be cached: {}".format(name)
+        ret["changes"] = {}
+        ret["result"] = None
+        return ret
+
     if parsed.scheme in salt.utils.files.LOCAL_PROTOS:
         # Source is a local file path
         full_path = os.path.realpath(os.path.expanduser(parsed.path))

--- a/tests/pytests/functional/states/file/test_cached.py
+++ b/tests/pytests/functional/states/file/test_cached.py
@@ -1,0 +1,96 @@
+import secrets
+
+import pytest
+
+import salt.states.file as file
+from tests.support.mock import MagicMock, patch
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+]
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {
+        file: {"__opts__": {"test": False}},
+    }
+
+
+def test_cached_test_true():
+    name = "salt://test/file.exe"
+    source_hash = secrets.token_hex(nbytes=32)
+    expected = {
+        "changes": {},
+        "comment": "File will be cached: {}".format(name),
+        "name": name,
+        "result": None,
+    }
+    salt = {
+        "cp.is_cached": MagicMock(return_value=""),
+        "file.get_source_sum": MagicMock(return_value={"hsum": source_hash}),
+    }
+    opts = {"test": True}
+    with patch.dict(file.__salt__, salt), patch.dict(file.__opts__, opts):
+        result = file.cached(name=name, source_hash=source_hash)
+    assert result == expected
+
+
+def test_cached_present_test_true():
+    name = "salt://test/file.exe"
+    source_hash = secrets.token_hex(nbytes=32)
+    expected = {
+        "changes": {},
+        "comment": "File already cached: {}".format(name),
+        "name": name,
+        "result": None,
+    }
+    salt = {
+        "cp.is_cached": MagicMock(return_value="path/to/file"),
+        "file.get_hash": MagicMock(return_value=source_hash),
+        "file.get_source_sum": MagicMock(return_value={"hsum": source_hash}),
+    }
+    opts = {"test": True, "hash_type": "sha256"}
+    with patch.dict(file.__salt__, salt), patch.dict(file.__opts__, opts):
+        result = file.cached(name=name, source_hash=source_hash)
+    assert result == expected
+
+
+def test_cached_present_different_hash_test_true():
+    name = "salt://test/file.exe"
+    source_hash = secrets.token_hex(nbytes=32)
+    existing_hash = secrets.token_hex(nbytes=32)
+    expected = {
+        "changes": {},
+        "comment": "Hashes don't match.\nFile will be cached: {}".format(name),
+        "name": name,
+        "result": None,
+    }
+    salt = {
+        "cp.is_cached": MagicMock(return_value="path/to/file"),
+        "file.get_hash": MagicMock(return_value=existing_hash),
+        "file.get_source_sum": MagicMock(return_value={"hsum": source_hash}),
+    }
+    opts = {"test": True, "hash_type": "sha256"}
+    with patch.dict(file.__salt__, salt), patch.dict(file.__opts__, opts):
+        result = file.cached(name=name, source_hash=source_hash)
+    assert result == expected
+
+
+def test_cached_present_no_source_hash_test_true():
+    name = "salt://test/file.exe"
+    existing_hash = secrets.token_hex(nbytes=32)
+    expected = {
+        "changes": {},
+        "comment": "No hash found. File will be cached: {}".format(name),
+        "name": name,
+        "result": None,
+    }
+    salt = {
+        "cp.is_cached": MagicMock(return_value="path/to/file"),
+        "file.get_hash": MagicMock(return_value=existing_hash),
+    }
+    opts = {"test": True, "hash_type": "sha256"}
+    with patch.dict(file.__salt__, salt), patch.dict(file.__opts__, opts):
+        result = file.cached(name=name)
+    assert result == expected


### PR DESCRIPTION
### What does this PR do?
Adds support for ``test=True`` to the ``file.cached`` execution module.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/63785

### Previous Behavior
``test=True`` was essentially ignored.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes