### PR TITLE
[master] set the osfullname grain on *BSD

### DIFF
--- a/changelog/64189.fixed.md
+++ b/changelog/64189.fixed.md
@@ -1,0 +1,1 @@
+Fix runtime error on OpenBSD by adding support for the osfullname grain

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2780,11 +2780,13 @@ def os_data():
             # freebsd-version was introduced in 10.0.
             # derive osrelease from kernelversion prior to that
             grains["osrelease"] = grains["kernelrelease"].split("-")[0]
+        grains["osfullname"] = "{} {}".format(grains["kernel"], grains["osrelease"])
         grains.update(_bsd_cpudata(grains))
     elif grains["kernel"] in ("OpenBSD", "NetBSD"):
         grains["os_family"] = grains["os"] = grains["kernel"]
         grains.update(_bsd_cpudata(grains))
         grains["osrelease"] = grains["kernelrelease"].split("-")[0]
+        grains["osfullname"] = "{} {}".format(grains["kernel"], grains["osrelease"])
         if grains["kernel"] == "NetBSD":
             grains.update(_netbsd_gpu_data())
     else:

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -3309,7 +3309,7 @@ def test_bsd_osfullname():
             os_grains = core.os_data()
 
     assert "osfullname" in os_grains
-    assert os_grains.get("osfullname") == "FreeBSD"
+    assert os_grains.get("osfullname") == "FreeBSD 10.3"
 
 
 def test_saltversioninfo():


### PR DESCRIPTION
### What does this PR do?
Fixes a runtime error because osfullname was not set on *BSD

### Previous Behavior
Traceback (most recent call last):
  File "/usr/local/bin/salt-master", line 33, in <module>
    sys.exit(load_entry_point('salt==3006.0', 'console_scripts', 'salt-master')())
  File "/usr/local/lib/python3.10/site-packages/salt/scripts.py", line 89, in salt_master
    master.start()
  File "/usr/local/lib/python3.10/site-packages/salt/cli/daemons.py", line 204, in start
    self.master.start()
  File "/usr/local/lib/python3.10/site-packages/salt/master.py", line 723, in start
    chan = salt.channel.server.PubServerChannel.factory(opts)
  File "/usr/local/lib/python3.10/site-packages/salt/channel/server.py", line 721, in factory
    return cls(opts, transport, presence_events=presence_events)
  File "/usr/local/lib/python3.10/site-packages/salt/channel/server.py", line 727, in __init__
    self.aes_funcs = salt.master.AESFuncs(self.opts)
  File "/usr/local/lib/python3.10/site-packages/salt/master.py", line 1233, in __init__
    self.mminion = salt.minion.MasterMinion(
  File "/usr/local/lib/python3.10/site-packages/salt/minion.py", line 974, in __init__
    self.opts = salt.config.mminion_config(
  File "/usr/local/lib/python3.10/site-packages/salt/config/__init__.py", line 2328, in mminion_config
    opts["grains"] = salt.loader.grains(opts)
  File "/usr/local/lib/python3.10/site-packages/salt/loader/__init__.py", line 1116, in grains
    ret = funcs[key]()
  File "/usr/local/lib/python3.10/site-packages/salt/loader/lazy.py", line 149, in __call__
    return self.loader.run(run_func, *args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/salt/loader/lazy.py", line 1232, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/salt/loader/lazy.py", line 1247, in _run_as
    return _func_or_method(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/salt/grains/core.py", line 2682, in os_data
    _osrelease_data(grains["os"], grains["osfullame"], grains["osrelease"])
KeyError: 'osfullame'

### New Behavior
working as expected
