### PR TITLE
[3006.x] Fix to cloud.run_profile when show_deploy_args is False

### DIFF
--- a/changelog/61236.fixed.md
+++ b/changelog/61236.fixed.md
@@ -1,0 +1,1 @@
+Check that the return data from the cloud create function is a dictionary before attempting to pull values out.

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1427,7 +1427,8 @@ class Cloud:
                         raise SaltCloudSystemExit("Failed to deploy VM")
                     continue
                 if self.opts.get("show_deploy_args", False) is False:
-                    ret[name].pop("deploy_kwargs", None)
+                    if isinstance(ret[name], dict):
+                        ret[name].pop("deploy_kwargs", None)
             except (SaltCloudSystemExit, SaltCloudConfigError) as exc:
                 if len(names) == 1:
                     raise


### PR DESCRIPTION
### What does this PR do?
Check that the return data from the cloud create function is a dictionary before attempting to pull values out when show_deploy_args is False

### What issues does this PR fix or reference?
Fixes: #61236 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
