### PR TITLE
[3006.x] Update 3006 packaging to reduce permissions given to salt user for running salt-master

### DIFF
--- a/changelog/64193.fixed.md
+++ b/changelog/64193.fixed.md
@@ -1,0 +1,6 @@
+Fixes permissions created by the Debian and RPM packages for the salt user.
+
+The salt user created by the Debian and RPM packages to run the salt-master process, was previously given ownership of various directories in a way which compromised the benefits of running the salt-master process as a non-root user.
+
+This fix sets the salt user to only have write access to those files and
+directories required for the salt-master process to run.

--- a/pkg/common/salt-common.logrotate
+++ b/pkg/common/salt-common.logrotate
@@ -4,6 +4,7 @@
 	rotate 7
 	compress
 	notifempty
+	create 0640 salt salt
 }
 
 /var/log/salt/minion {

--- a/pkg/common/salt-common.logrotate
+++ b/pkg/common/salt-common.logrotate
@@ -21,6 +21,7 @@
 	rotate 7
 	compress
 	notifempty
+	create 0640 salt salt
 }
 
 /var/log/salt/api {

--- a/pkg/common/salt-common.logrotate
+++ b/pkg/common/salt-common.logrotate
@@ -29,6 +29,7 @@
 	rotate 7
 	compress
 	notifempty
+	create 0640 salt salt
 }
 
 /var/log/salt/syndic {

--- a/pkg/debian/salt-api.postinst
+++ b/pkg/debian/salt-api.postinst
@@ -1,0 +1,9 @@
+case "$1" in
+  configure)
+    if [ ! -e "/var/log/salt/api" ]; then
+      touch /var/log/salt/api
+      chmod 640 /var/log/salt/api
+    fi
+    chown salt:salt /var/log/salt/api
+  ;;
+esac

--- a/pkg/debian/salt-api.postinst
+++ b/pkg/debian/salt-api.postinst
@@ -5,5 +5,6 @@ case "$1" in
       chmod 640 /var/log/salt/api
     fi
     chown salt:salt /var/log/salt/api
+    if command -v systemctl; then systemctl enable salt-api; fi
   ;;
 esac

--- a/pkg/debian/salt-common.install
+++ b/pkg/debian/salt-common.install
@@ -1,5 +1,6 @@
 conf/roster /etc/salt
 conf/cloud /etc/salt
+pkg/common/salt-common.logrotate /etc/logrotate.d/salt
 pkg/common/fish-completions/salt-cp.fish /usr/share/fish/vendor_completions.d
 pkg/common/fish-completions/salt-call.fish /usr/share/fish/vendor_completions.d
 pkg/common/fish-completions/salt-syndic.fish /usr/share/fish/vendor_completions.d

--- a/pkg/debian/salt-common.postinst
+++ b/pkg/debian/salt-common.postinst
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+/opt/saltstack/salt/bin/python3 -m compileall -qq /opt/saltstack/salt/lib

--- a/pkg/debian/salt-common.preinst
+++ b/pkg/debian/salt-common.preinst
@@ -31,11 +31,5 @@ case "$1" in
             -s $SALT_SHELL  \
             -g $SALT_GROUP  \
              $SALT_USER
-    # 5. adjust file and directory permissions
-    if ! dpkg-statoverride --list $SALT_HOME >/dev/null
-    then
-        chown -R $SALT_USER:$SALT_GROUP $SALT_HOME
-        chmod u=rwx,g=rwx,o=rx $SALT_HOME
-    fi
   ;;
 esac

--- a/pkg/debian/salt-common.prerm
+++ b/pkg/debian/salt-common.prerm
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+dpkg -L salt-common | perl -ne 's,/([^/]*)\.py$,/__pycache__/\1.*, or next; unlink $_ or die $! foreach glob($_)'
+find /opt/saltstack/salt -type d -name __pycache__ -empty -print0 | xargs --null --no-run-if-empty rmdir

--- a/pkg/debian/salt-master.dirs
+++ b/pkg/debian/salt-master.dirs
@@ -13,3 +13,4 @@
 /var/cache/salt/master/roots
 /var/cache/salt/master/syndics
 /var/cache/salt/master/tokens
+/var/run/salt/master

--- a/pkg/debian/salt-master.postinst
+++ b/pkg/debian/salt-master.postinst
@@ -8,7 +8,7 @@ case "$1" in
       touch /var/log/salt/key
       chmod 640 /var/log/salt/key
     fi
-    chown -R salt:salt /etc/salt/pki/master /etc/salt/master.d /etc/salt/minion.d /var/log/salt/master /var/log/salt/key /var/cache/salt/master /var/run/salt/master
+    chown -R salt:salt /etc/salt/pki/master /etc/salt/master.d /var/log/salt/master /var/log/salt/key /var/cache/salt/master /var/run/salt/master
     if command -v systemctl; then systemctl enable salt-master; fi
   ;;
 esac

--- a/pkg/debian/salt-master.postinst
+++ b/pkg/debian/salt-master.postinst
@@ -1,6 +1,6 @@
 case "$1" in
   configure)
-    chown -R salt:salt /etc/salt /var/log/salt /opt/saltstack/salt/ /var/cache/salt/ /var/run/salt
+    chown -R salt:salt /etc/salt /var/log/salt /var/cache/salt/ /var/run/salt
     if command -v systemctl; then systemctl enable salt-master; fi
   ;;
 esac

--- a/pkg/debian/salt-master.postinst
+++ b/pkg/debian/salt-master.postinst
@@ -1,6 +1,10 @@
 case "$1" in
   configure)
-    chown -R salt:salt /etc/salt /var/log/salt /var/cache/salt/ /var/run/salt
+    if [ ! -e "/var/log/salt/master" ]; then
+      touch /var/log/salt/master
+      chmod 640 /var/log/salt/master
+    fi
+    chown -R salt:salt /etc/salt/pki/master /etc/salt/master.d /etc/salt/minion.d /var/log/salt/master /var/cache/salt/master /var/run/salt/master
     if command -v systemctl; then systemctl enable salt-master; fi
   ;;
 esac

--- a/pkg/debian/salt-master.postinst
+++ b/pkg/debian/salt-master.postinst
@@ -4,7 +4,11 @@ case "$1" in
       touch /var/log/salt/master
       chmod 640 /var/log/salt/master
     fi
-    chown -R salt:salt /etc/salt/pki/master /etc/salt/master.d /etc/salt/minion.d /var/log/salt/master /var/cache/salt/master /var/run/salt/master
+    if [ ! -e "/var/log/salt/key" ]; then
+      touch /var/log/salt/key
+      chmod 640 /var/log/salt/key
+    fi
+    chown -R salt:salt /etc/salt/pki/master /etc/salt/master.d /etc/salt/minion.d /var/log/salt/master /var/log/salt/key /var/cache/salt/master /var/run/salt/master
     if command -v systemctl; then systemctl enable salt-master; fi
   ;;
 esac

--- a/pkg/debian/salt-master.preinst
+++ b/pkg/debian/salt-master.preinst
@@ -4,7 +4,7 @@ case "$1" in
     [ -z "$SALT_USER" ] && SALT_USER=salt
     [ -z "$SALT_NAME" ] && SALT_NAME="Salt"
     [ -z "$SALT_GROUP" ] && SALT_GROUP=salt
-    PY_VER=$(/opt/saltstack/salt/bin/python3 -c "import sys; sys.stdout.write('{}.{}'.format(*sys.version_info)); sys.stdout.flush;")
+    PY_VER=$(/opt/saltstack/salt/bin/python3 -c "import sys; sys.stdout.write('{}.{}'.format(*sys.version_info)); sys.stdout.flush();")
 
     # Reset permissions to fix previous installs
     find ${SALT_HOME} /etc/salt /var/log/salt /var/cache/salt /var/run/salt \

--- a/pkg/debian/salt-master.preinst
+++ b/pkg/debian/salt-master.preinst
@@ -1,0 +1,14 @@
+case "$1" in
+  install|upgrade)
+    [ -z "$SALT_HOME" ] && SALT_HOME=/opt/saltstack/salt
+    [ -z "$SALT_USER" ] && SALT_USER=salt
+    [ -z "$SALT_NAME" ] && SALT_NAME="Salt"
+    [ -z "$SALT_GROUP" ] && SALT_GROUP=salt
+    PY_VER=$(/opt/saltstack/salt/bin/python3 -c "import sys; sys.stdout.write('{}.{}'.format(*sys.version_info)); sys.stdout.flush;")
+
+    # Reset permissions to fix previous installs
+    find ${SALT_HOME} /etc/salt /var/log/salt /var/cache/salt /var/run/salt \
+        \! \( -path /etc/salt/cloud.deploy.d\* -o -path /var/log/salt/cloud -o -path /opt/saltstack/salt/lib/python${PY_VER}/site-packages/salt/cloud/deploy\* \) -a \
+        \( -user ${SALT_USER} -o -group ${SALT_GROUP} \) -exec chown root:root \{\} \;
+  ;;
+esac

--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -486,11 +486,12 @@ ln -s -f /opt/saltstack/salt/salt-api %{_bindir}/salt-api
 
 
 %posttrans cloud
+PY_VER=$(/opt/saltstack/salt/bin/python3 -c "import sys; sys.stdout.write('{}.{}'.format(*sys.version_info)); sys.stdout.flush();")
 if [ ! -e "/var/log/salt/cloud" ]; then
   touch /var/log/salt/cloud
   chmod 640 /var/log/salt/cloud
 fi
-chown -R %{_SALT_USER}:%{_SALT_GROUP} /etc/salt/cloud.deploy.d /var/log/salt/cloud /opt/saltstack/salt/lib/python3.10/site-packages/salt/cloud/deploy
+chown -R %{_SALT_USER}:%{_SALT_GROUP} /etc/salt/cloud.deploy.d /var/log/salt/cloud /opt/saltstack/salt/lib/python${PY_VER}/site-packages/salt/cloud/deploy
 
 
 %posttrans master

--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -490,7 +490,11 @@ if [ ! -e "/var/log/salt/master" ]; then
   touch /var/log/salt/master
   chmod 640 /var/log/salt/master
 fi
-chown -R %{_SALT_USER}:%{_SALT_GROUP} /etc/salt/pki/master /etc/salt/master.d /var/log/salt/master /var/cache/salt/master /var/run/salt/master
+if [ ! -e "/var/log/salt/key" ]; then
+  touch /var/log/salt/key
+  chmod 640 /var/log/salt/key
+fi
+chown -R %{_SALT_USER}:%{_SALT_GROUP} /etc/salt/pki/master /etc/salt/master.d /var/log/salt/master /var/log/salt/key /var/cache/salt/master /var/run/salt/master
 
 
 %posttrans api

--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -194,6 +194,7 @@ cp -R $RPM_BUILD_DIR/build/salt %{buildroot}/opt/saltstack/
 # Add some directories
 install -d -m 0755 %{buildroot}%{_var}/log/salt
 install -d -m 0755 %{buildroot}%{_var}/run/salt
+install -d -m 0755 %{buildroot}%{_var}/run/salt/master
 install -d -m 0755 %{buildroot}%{_var}/cache/salt
 install -Dd -m 0750 %{buildroot}%{_var}/cache/salt/master
 install -Dd -m 0750 %{buildroot}%{_var}/cache/salt/minion
@@ -328,6 +329,7 @@ rm -rf %{buildroot}
 %dir %attr(0750, salt, salt) %{_sysconfdir}/salt/pki/master/minions_denied/
 %dir %attr(0750, salt, salt) %{_sysconfdir}/salt/pki/master/minions_pre/
 %dir %attr(0750, salt, salt) %{_sysconfdir}/salt/pki/master/minions_rejected/
+%dir %attr(0750, salt, salt) %{_var}/run/salt/master/
 %dir %attr(0750, salt, salt) %{_var}/cache/salt/master/
 %dir %attr(0750, salt, salt) %{_var}/cache/salt/master/jobs/
 %dir %attr(0750, salt, salt) %{_var}/cache/salt/master/proc/

--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -411,7 +411,7 @@ usermod -c "%{_SALT_NAME}" \
 
 %pre master
 # Reset permissions to fix previous installs
-PY_VER=$(/opt/saltstack/salt/bin/python3 -c "import sys; sys.stdout.write('{}.{}'.format(*sys.version_info)); sys.stdout.flush;")
+PY_VER=$(/opt/saltstack/salt/bin/python3 -c "import sys; sys.stdout.write('{}.{}'.format(*sys.version_info)); sys.stdout.flush();")
 find /etc/salt /opt/saltstack/salt /var/log/salt /var/cache/salt /var/run/salt \
   \! \( -path /etc/salt/cloud.deploy.d\* -o -path /var/log/salt/cloud -o -path /opt/saltstack/salt/lib/python${PY_VER}/site-packages/salt/cloud/deploy\* \) -a \
   \( -user salt -o -group salt \) -exec chown root:root \{\} \;

--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -428,6 +428,7 @@ chown -R %{_SALT_USER}:%{_SALT_GROUP} %{_SALT_HOME}
 chmod u=rwx,g=rwx,o=rx %{_SALT_HOME}
 ln -s -f /opt/saltstack/salt/spm %{_bindir}/spm
 ln -s -f /opt/saltstack/salt/salt-pip %{_bindir}/salt-pip
+/opt/saltstack/salt/bin/python3 -m compileall -qq /opt/saltstack/salt/lib
 
 
 %post cloud
@@ -452,7 +453,7 @@ if [ $1 -lt 2 ]; then
     /bin/openssl sha256 -r -hmac orboDeJITITejsirpADONivirpUkvarP /opt/saltstack/salt/lib/libcrypto.so.1.1 | cut -d ' ' -f 1 > /opt/saltstack/salt/lib/.libcrypto.so.1.1.hmac || :
   fi
 fi
-chown -R salt:salt /etc/salt /var/log/salt /opt/saltstack/salt/ /var/cache/salt/ /var/run/salt/
+chown -R salt:salt /etc/salt /var/log/salt /var/cache/salt/ /var/run/salt/
 
 %post syndic
 %systemd_post salt-syndic.service
@@ -479,6 +480,10 @@ ln -s -f /opt/saltstack/salt/salt-ssh %{_bindir}/salt-ssh
 %post api
 %systemd_post salt-api.service
 ln -s -f /opt/saltstack/salt/salt-api %{_bindir}/salt-api
+
+%preun
+find /opt/saltstack/salt -type f -name \*\.pyc -print0 | xargs --null --no-run-if-empty rm
+find /opt/saltstack/salt -type d -name __pycache__ -empty -print0 | xargs --null --no-run-if-empty rmdir
 
 %postun master
 %systemd_postun_with_restart salt-master.service

--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -493,6 +493,14 @@ fi
 chown -R %{_SALT_USER}:%{_SALT_GROUP} /etc/salt/pki/master /etc/salt/master.d /var/log/salt/master /var/cache/salt/master /var/run/salt/master
 
 
+%posttrans api
+if [ ! -e "/var/log/salt/api" ]; then
+  touch /var/log/salt/api
+  chmod 640 /var/log/salt/api
+fi
+chown %{_SALT_USER}:%{_SALT_GROUP} /var/log/salt/api
+
+
 %preun
 if [ $1 -eq 0 ]; then
   # Uninstall

--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -409,6 +409,14 @@ usermod -c "%{_SALT_NAME}" \
         -g %{_SALT_GROUP}  \
          %{_SALT_USER}
 
+%pre master
+# Reset permissions to fix previous installs
+PY_VER=$(/opt/saltstack/salt/bin/python3 -c "import sys; sys.stdout.write('{}.{}'.format(*sys.version_info)); sys.stdout.flush;")
+find /etc/salt /opt/saltstack/salt /var/log/salt /var/cache/salt /var/run/salt \
+  \! \( -path /etc/salt/cloud.deploy.d\* -o -path /var/log/salt/cloud -o -path /opt/saltstack/salt/lib/python${PY_VER}/site-packages/salt/cloud/deploy\* \) -a \
+  \( -user salt -o -group salt \) -exec chown root:root \{\} \;
+
+
 # assumes systemd for RHEL 7 & 8 & 9
 %preun master
 # RHEL 9 is giving warning msg if syndic is not installed, supress it

--- a/pkg/tests/conftest.py
+++ b/pkg/tests/conftest.py
@@ -352,11 +352,13 @@ def salt_master(salt_factories, install_salt, state_tree, pillar_tree):
                 config_overrides["api_pidfile"] = salt.config.DEFAULT_API_OPTS.get(
                     "api_pidfile"
                 )
-                # verify files where set with correct owner/group
+                # verify files were set with correct owner/group
                 verify_files = [
-                    pathlib.Path("/var", "log", "salt"),
-                    pathlib.Path("/etc", "salt", "master"),
+                    pathlib.Path("/var", "log", "salt", "master"),
+                    pathlib.Path("/etc", "salt", "pki", "master"),
+                    pathlib.Path("/etc", "salt", "master.d"),
                     pathlib.Path("/var", "cache", "salt", "master"),
+                    pathlib.Path("/var", "run", "salt", "master"),
                 ]
                 for _file in verify_files:
                     assert _file.owner() == "salt"

--- a/pkg/tests/conftest.py
+++ b/pkg/tests/conftest.py
@@ -412,10 +412,17 @@ def salt_master(salt_factories, install_salt, state_tree, pillar_tree):
     factory.after_terminate(pytest.helpers.remove_stale_master_key, factory)
     if test_user:
         # Salt factories calls salt.utils.verify.verify_env
-        # which sets root perms on /var/log/salt since we are running
+        # which sets root perms on /etc/salt/pki/master since we are running
         # the test suite as root, but we want to run Salt master as salt
         # We ensure those permissions where set by the package earlier
-        shutil.chown(pathlib.Path("/var", "log", "salt"), "salt", "salt")
+        subprocess.run(
+            [
+                "chown",
+                "-R",
+                "salt:salt",
+                str(pathlib.Path("/etc", "salt", "pki", "master")),
+            ]
+        )
         # The engines_dirs is created in .nox path. We need to set correct perms
         # for the user running the Salt Master
         subprocess.run(["chown", "-R", "salt:salt", str(CODE_DIR.parent / ".nox")])

--- a/pkg/tests/conftest.py
+++ b/pkg/tests/conftest.py
@@ -354,11 +354,9 @@ def salt_master(salt_factories, install_salt, state_tree, pillar_tree):
                 )
                 # verify files were set with correct owner/group
                 verify_files = [
-                    pathlib.Path("/var", "log", "salt", "master"),
                     pathlib.Path("/etc", "salt", "pki", "master"),
                     pathlib.Path("/etc", "salt", "master.d"),
                     pathlib.Path("/var", "cache", "salt", "master"),
-                    pathlib.Path("/var", "run", "salt", "master"),
                 ]
                 for _file in verify_files:
                     assert _file.owner() == "salt"

--- a/pkg/tests/integration/test_salt_user.py
+++ b/pkg/tests/integration/test_salt_user.py
@@ -27,7 +27,7 @@ def test_salt_user_master(salt_master, install_salt):
 
 def test_salt_user_home(install_salt):
     """
-    Test the correct user is running the Salt Master
+    Test the salt user's home is /opt/saltstack/salt
     """
     proc = subprocess.run(
         ["getent", "passwd", "salt"], check=False, capture_output=True
@@ -43,7 +43,7 @@ def test_salt_user_home(install_salt):
 
 def test_salt_user_group(install_salt):
     """
-    Test the salt user is the salt group
+    Test the salt user is in the salt group
     """
     proc = subprocess.run(["id", "salt"], check=False, capture_output=True)
     assert proc.returncode == 0
@@ -77,7 +77,7 @@ def test_salt_user_shell(install_salt):
 
 def test_salt_cloud_dirs(install_salt):
     """
-    Test the correct user is running the Salt Master
+    Test salt-cloud directories are owned by salt:salt
     """
     paths = [
         "/opt/saltstack/salt/lib/python{}.{}/site-packages/salt/cloud/deploy".format(

--- a/pkg/tests/integration/test_salt_user.py
+++ b/pkg/tests/integration/test_salt_user.py
@@ -40,7 +40,6 @@ def pkg_paths_salt_user():
         "/opt/saltstack/salt/lib/python3.10/site-packages/salt/cloud/deploy",
         "/etc/salt/pki/master",
         "/etc/salt/master.d",
-        "/etc/salt/minion.d",
         "/var/log/salt/master",
         "/var/log/salt/api",
         "/var/log/salt/key",

--- a/pkg/tests/integration/test_salt_user.py
+++ b/pkg/tests/integration/test_salt_user.py
@@ -37,7 +37,9 @@ def pkg_paths_salt_user():
     return [
         "/etc/salt/cloud.deploy.d",
         "/var/log/salt/cloud",
-        "/opt/saltstack/salt/lib/python3.10/site-packages/salt/cloud/deploy",
+        "/opt/saltstack/salt/lib/python{}.{}/site-packages/salt/cloud/deploy".format(
+            *sys.version_info
+        ),
         "/etc/salt/pki/master",
         "/etc/salt/master.d",
         "/var/log/salt/master",

--- a/pkg/tests/integration/test_salt_user.py
+++ b/pkg/tests/integration/test_salt_user.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import subprocess
 import sys
@@ -11,6 +12,41 @@ pytestmark = [
     pytest.mark.skip_on_windows,
     pytest.mark.skip_on_darwin,
 ]
+
+
+@pytest.fixture
+def pkg_paths():
+    """
+    Paths created by package installs
+    """
+    paths = [
+        "/etc/salt",
+        "/var/cache/salt",
+        "/var/log/salt",
+        "/var/run/salt",
+        "/opt/saltstack/salt",
+    ]
+    return paths
+
+
+@pytest.fixture
+def pkg_paths_salt_user():
+    """
+    Paths created by package installs and owned by salt user
+    """
+    paths = [
+        "/etc/salt/cloud.deploy.d",
+        "/var/log/salt/cloud",
+        "/opt/saltstack/salt/lib/python3.10/site-packages/salt/cloud/deploy",
+        "/etc/salt/pki/master",
+        "/etc/salt/master.d",
+        "/etc/salt/minion.d",
+        "/var/log/salt/master",
+        "/var/log/salt/api",
+        "/var/cache/salt/master",
+        "/var/run/salt/master",
+    ]
+    return paths
 
 
 def test_salt_user_master(salt_master, install_salt):
@@ -77,12 +113,12 @@ def test_salt_user_shell(install_salt):
 
 def test_salt_cloud_dirs(install_salt):
     """
-    Test salt-cloud directories are owned by salt:salt
+    Test the correct user is running the Salt Master
     """
+    if platform.is_windows() or platform.is_darwin():
+        pytest.skip("Package does not have user set. Not testing user")
     paths = [
-        "/opt/saltstack/salt/lib/python{}.{}/site-packages/salt/cloud/deploy".format(
-            *sys.version_info
-        ),
+        "/opt/saltstack/salt/lib/python3.10/site-packages/salt/cloud/deploy",
         "/etc/salt/cloud.deploy.d",
     ]
     for name in paths:
@@ -90,3 +126,39 @@ def test_salt_cloud_dirs(install_salt):
         assert path.exists()
         assert path.owner() == "salt"
         assert path.group() == "salt"
+
+
+def test_pkg_paths(install_salt, pkg_paths, pkg_paths_salt_user):
+    """
+    Test package paths ownership
+    """
+    salt_user_subdirs = []
+    for _path in pkg_paths:
+        pkg_path = pathlib.Path(_path)
+        assert pkg_path.exists()
+        for dirpath, sub_dirs, files in os.walk(pkg_path):
+            path = pathlib.Path(dirpath)
+            # Directories owned by salt:salt or their subdirs/files
+            if str(path) in pkg_paths_salt_user or str(path) in salt_user_subdirs:
+                assert path.owner() == "salt"
+                assert path.group() == "salt"
+                salt_user_subdirs.extend(
+                    [str(path.joinpath(sub_dir)) for sub_dir in sub_dirs]
+                )
+                for file in files:
+                    file_path = path.joinpath(file)
+                    assert file_path.owner() == "salt"
+                    assert file_path.group() == "salt"
+            # Directories owned by root:root
+            else:
+                assert path.owner() == "root"
+                assert path.group() == "root"
+                for file in files:
+                    file_path = path.joinpath(file)
+                    # Individual files owned by salt:salt
+                    if str(file_path) in pkg_paths_salt_user:
+                        assert file_path.owner() == "salt"
+                        assert file_path.group() == "salt"
+                    else:
+                        assert file_path.owner() == "root"
+                        assert file_path.group() == "root"

--- a/pkg/tests/integration/test_salt_user.py
+++ b/pkg/tests/integration/test_salt_user.py
@@ -34,7 +34,7 @@ def pkg_paths_salt_user():
     """
     Paths created by package installs and owned by salt user
     """
-    paths = [
+    return [
         "/etc/salt/cloud.deploy.d",
         "/var/log/salt/cloud",
         "/opt/saltstack/salt/lib/python3.10/site-packages/salt/cloud/deploy",
@@ -46,7 +46,6 @@ def pkg_paths_salt_user():
         "/var/cache/salt/master",
         "/var/run/salt/master",
     ]
-    return paths
 
 
 @pytest.fixture

--- a/pkg/tests/integration/test_salt_user.py
+++ b/pkg/tests/integration/test_salt_user.py
@@ -123,23 +123,6 @@ def test_salt_user_shell(install_salt):
     assert shell_exists is True
 
 
-def test_salt_cloud_dirs(install_salt):
-    """
-    Test the correct user is running the Salt Master
-    """
-    if platform.is_windows() or platform.is_darwin():
-        pytest.skip("Package does not have user set. Not testing user")
-    paths = [
-        "/opt/saltstack/salt/lib/python3.10/site-packages/salt/cloud/deploy",
-        "/etc/salt/cloud.deploy.d",
-    ]
-    for name in paths:
-        path = pathlib.Path(name)
-        assert path.exists()
-        assert path.owner() == "salt"
-        assert path.group() == "salt"
-
-
 def test_pkg_paths(
     install_salt, pkg_paths, pkg_paths_salt_user, pkg_paths_salt_user_exclusions
 ):

--- a/pkg/tests/integration/test_salt_user.py
+++ b/pkg/tests/integration/test_salt_user.py
@@ -43,8 +43,20 @@ def pkg_paths_salt_user():
         "/etc/salt/minion.d",
         "/var/log/salt/master",
         "/var/log/salt/api",
+        "/var/log/salt/key",
         "/var/cache/salt/master",
         "/var/run/salt/master",
+    ]
+    return paths
+
+
+@pytest.fixture
+def pkg_paths_salt_user_exclusions():
+    """
+    Exclusions from paths created by package installs and owned by salt user
+    """
+    paths = [
+        "/var/cache/salt/master/.root_key"  # written by salt, salt-run and salt-key as root
     ]
     return paths
 
@@ -128,7 +140,9 @@ def test_salt_cloud_dirs(install_salt):
         assert path.group() == "salt"
 
 
-def test_pkg_paths(install_salt, pkg_paths, pkg_paths_salt_user):
+def test_pkg_paths(
+    install_salt, pkg_paths, pkg_paths_salt_user, pkg_paths_salt_user_exclusions
+):
     """
     Test package paths ownership
     """
@@ -139,7 +153,9 @@ def test_pkg_paths(install_salt, pkg_paths, pkg_paths_salt_user):
         for dirpath, sub_dirs, files in os.walk(pkg_path):
             path = pathlib.Path(dirpath)
             # Directories owned by salt:salt or their subdirs/files
-            if str(path) in pkg_paths_salt_user or str(path) in salt_user_subdirs:
+            if (
+                str(path) in pkg_paths_salt_user or str(path) in salt_user_subdirs
+            ) and str(path) not in pkg_paths_salt_user_exclusions:
                 assert path.owner() == "salt"
                 assert path.group() == "salt"
                 salt_user_subdirs.extend(
@@ -148,7 +164,8 @@ def test_pkg_paths(install_salt, pkg_paths, pkg_paths_salt_user):
                 # Individual files owned by salt user
                 for file in files:
                     file_path = path.joinpath(file)
-                    assert file_path.owner() == "salt"
+                    if str(file_path) not in pkg_paths_salt_user_exclusions:
+                        assert file_path.owner() == "salt"
             # Directories owned by root:root
             else:
                 assert path.owner() == "root"

--- a/pkg/tests/integration/test_salt_user.py
+++ b/pkg/tests/integration/test_salt_user.py
@@ -145,20 +145,19 @@ def test_pkg_paths(install_salt, pkg_paths, pkg_paths_salt_user):
                 salt_user_subdirs.extend(
                     [str(path.joinpath(sub_dir)) for sub_dir in sub_dirs]
                 )
+                # Individual files owned by salt user
                 for file in files:
                     file_path = path.joinpath(file)
                     assert file_path.owner() == "salt"
-                    assert file_path.group() == "salt"
             # Directories owned by root:root
             else:
                 assert path.owner() == "root"
                 assert path.group() == "root"
                 for file in files:
                     file_path = path.joinpath(file)
-                    # Individual files owned by salt:salt
+                    # Individual files owned by salt user
                     if str(file_path) in pkg_paths_salt_user:
                         assert file_path.owner() == "salt"
-                        assert file_path.group() == "salt"
                     else:
                         assert file_path.owner() == "root"
                         assert file_path.group() == "root"


### PR DESCRIPTION
### What does this PR do?

Updates Debian and RPM packages to improve isolation offered by running the `salt-master` processes under the `salt` user.

Implementation of running salt-master as a non-root user by default introduced in https://github.com/saltstack/salt/pull/64037, gives ownership of shared salt directories to the `salt` user to mitigate a number of issues with running the `salt-master` as a non-root user. This PR aims to reduce the scope of those permission grants to increase isolation of the `salt-master` processes running under the `salt` user - see https://github.com/saltstack/salt/issues/64193 for more detail.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/64193

### Previous Behavior
The `salt` user that the `salt-master` process runs as was able to:

* Write to `/opt/saltstack/salt` modifying the salt install, including python, shared libs and python modules used by both the salt master and other salt process (eg `salt-api` and `salt-minion`) which run as root, compromising the isolation offered by running the `salt-master` as a non-root user.
* Read and write configs in `/etc/salt` for other salt daemons (that run as root) compromising the isolation offered by running as a non-root user.
* Reading private data from `/etc/salt/pki/minion` and `/var/cache/salt/minion` again compromising isolation.

### New Behavior

Debian and RPM packages will now:

* Keep ownership of `/opt/saltstack/salt` hierarchy as `root:root` to prevent modification by `salt-master` process
* Bytecompile python packages under `/opt/saltstack/salt/lib/` on install so that performance isn't compromised and the bytecompiled modules are owned by root
* Clean up *.pyc files and \_\_pycache__ dirs under `/opt/saltstack/salt/lib` on uninstall
* Under /etc/salt limit ownership to  /etc/salt/pki/master and /etc/salt/master.d
* Under /var/cache/salt and /var/run/salt only give ownership on master directories
* Under /var/log/salt, ensure /var/log/salt/master exists and give ownership of that. Also update logrotate config to create that with correct ownership and perms and install that on debian packages.

This should ensure that a compromised `salt-master` process cannot:

* Modify the salt installation used by it or other salt-daemons
* Modify the config of other salt daemons or tools
* Read pki or other private data *via the local filesystem* for a `salt-minion` running on the same host

### Merge requirements satisfied?

- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

