### PR TITLE
[master] Remove requirement for Proxmox image property

### DIFF
--- a/changelog/64197.fixed.md
+++ b/changelog/64197.fixed.md
@@ -1,0 +1,1 @@
+Remove required but unused "image" parameter for proxmox cloud profiles

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -3371,6 +3371,7 @@ def is_profile_configured(opts, provider, profile_name, vm_=None):
         "softlayer",
         "oneandone",
         "profitbricks",
+        "proxmox",
     ]
 
     # Most drivers need a size, but some do not.


### PR DESCRIPTION
### What does this PR do?

The image parameter is currently required for creating Proxmox VMs, but it doesn't exist in the Proxmox API. Removing it.

### Commits signed with GPG?
No