### PR TITLE
[3006.x] Fix building package on amazon linux

### DIFF
--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -43,8 +43,12 @@ BuildRequires: python3
 BuildRequires: python3-pip
 BuildRequires: openssl
 BuildRequires: git
+
+# rhel is not defined on all rpm based distros.
+%if %{?rhel:1}%{!?rhel:0}
 %if %{rhel} >= 9
 BuildRequires: libxcrypt-compat
+%endif
 %endif
 
 %description


### PR DESCRIPTION
Fix building package on amazon linux and other distros which wont' have rhel defined.