### PR TITLE
[3006.x] Stop using the deprecated `salt.transport.client` imports.

### DIFF
--- a/changelog/64186.fixed.md
+++ b/changelog/64186.fixed.md
@@ -1,0 +1,1 @@
+Stop using the deprecated `salt.transport.client` imports.

--- a/salt/metaproxy/deltaproxy.py
+++ b/salt/metaproxy/deltaproxy.py
@@ -347,7 +347,7 @@ def post_master_init(self, master):
                 if self.deltaproxy_opts[minion_id] and self.deltaproxy_objs[minion_id]:
                     self.deltaproxy_objs[
                         minion_id
-                    ].req_channel = salt.transport.client.AsyncReqChannel.factory(
+                    ].req_channel = salt.channel.client.AsyncReqChannel.factory(
                         sub_proxy_data["proxy_opts"], io_loop=self.io_loop
                     )
     else:
@@ -366,7 +366,7 @@ def post_master_init(self, master):
                 if self.deltaproxy_opts[minion_id] and self.deltaproxy_objs[minion_id]:
                     self.deltaproxy_objs[
                         minion_id
-                    ].req_channel = salt.transport.client.AsyncReqChannel.factory(
+                    ].req_channel = salt.channel.client.AsyncReqChannel.factory(
                         sub_proxy_data["proxy_opts"], io_loop=self.io_loop
                     )
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1363,7 +1363,7 @@ class Minion(MinionBase):
         )
 
         # a long-running req channel
-        self.req_channel = salt.transport.client.AsyncReqChannel.factory(
+        self.req_channel = salt.channel.client.AsyncReqChannel.factory(
             self.opts, io_loop=self.io_loop
         )
 
@@ -2817,10 +2817,8 @@ class Minion(MinionBase):
                             self.opts["master"],
                         )
 
-                        self.req_channel = (
-                            salt.transport.client.AsyncReqChannel.factory(
-                                self.opts, io_loop=self.io_loop
-                            )
+                        self.req_channel = salt.channel.client.AsyncReqChannel.factory(
+                            self.opts, io_loop=self.io_loop
                         )
 
                         # put the current schedule into the new loaders

--- a/salt/transport/client.py
+++ b/salt/transport/client.py
@@ -13,8 +13,6 @@ from salt.utils.versions import warn_until
 
 log = logging.getLogger(__name__)
 
-# XXX: Add depreication warnings to start using salt.channel.client
-
 
 class ReqChannel:
     """

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -13,7 +13,6 @@ import salt.ext.tornado.concurrent
 import salt.ext.tornado.gen
 import salt.ext.tornado.ioloop
 import salt.ext.tornado.netutil
-import salt.transport.client
 import salt.transport.frame
 import salt.utils.msgpack
 from salt.ext.tornado.ioloop import IOLoop

--- a/salt/transport/local.py
+++ b/salt/transport/local.py
@@ -1,7 +1,7 @@
 import logging
 
 import salt.utils.files
-from salt.transport.client import ReqChannel
+from salt.channel.client import ReqChannel
 
 log = logging.getLogger(__name__)
 

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -25,10 +25,8 @@ import salt.ext.tornado.tcpclient
 import salt.ext.tornado.tcpserver
 import salt.master
 import salt.payload
-import salt.transport.client
 import salt.transport.frame
 import salt.transport.ipc
-import salt.transport.server
 import salt.utils.asynchronous
 import salt.utils.files
 import salt.utils.msgpack

--- a/tests/pytests/functional/transport/server/test_req_channel.py
+++ b/tests/pytests/functional/transport/server/test_req_channel.py
@@ -11,8 +11,6 @@ import salt.config
 import salt.exceptions
 import salt.ext.tornado.gen
 import salt.master
-import salt.transport.client
-import salt.transport.server
 import salt.utils.platform
 import salt.utils.process
 import salt.utils.stringutils


### PR DESCRIPTION
### What does this PR do?
See title

### What issues does this PR fix or reference?
Fixes #64186