### PR TITLE
[master] corrected misleading comment

### DIFF
--- a/salt/utils/find.py
+++ b/salt/utils/find.py
@@ -25,7 +25,7 @@ The default action is 'print=path'.
 
 file-glob:
     *                = match zero or more chars
-    ?                = match any char
+    ?                = match zero or single char
     [abc]            = match a, b, or c
     [!abc] or [^abc] = match anything except a, b, and c
     [x-y]            = match chars x through y


### PR DESCRIPTION
`?` is used to match a given char defined left to it either zero or single time. Even implementation line talks the same: 
https://github.com/rakyll/salt/blob/develop/salt/utils/find.py#L229
```
class NameOption(Option):
    '''
    Match files with a case-sensitive glob filename pattern.
    Note: this is the 'basename' portion of a pathname.
    The option name is 'name', e.g. {'name' : '*.txt'}.
    '''
    def __init__(self, key, value):
        self.regex = re.compile(value.replace('.', '\\.')
                                     .replace('?', '.?')
                                     .replace('*', '.*') + '$')

    def match(self, dirname, filename, fstat):
        return self.regex.match(filename)

``` 

We can able to see `?` is getting replaced by `.?` and `.?` will match any character either zero and single time.

So I just corrected the commented line so it wont mislead the interpretation.