### PR TITLE
[3006.x] Prevent MasterMinon from loading config from /etc/salt/minion.d/*conf

### DIFF
--- a/changelog/64219.fixed.md
+++ b/changelog/64219.fixed.md
@@ -1,0 +1,3 @@
+Fixes issue with MasterMinion class loading configuration from `/etc/salt/minion.d/*.conf.
+
+The MasterMinion class (used for running orchestraions on master and other functionality) was incorrectly loading configuration from `/etc/salt/minion.d/*.conf`, when it should only load configuration from `/etc/salt/master` and `/etc/salt/master.d/*.conf`.

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -2283,6 +2283,8 @@ def minion_config(
     """
     if defaults is None:
         defaults = DEFAULT_MINION_OPTS.copy()
+        if role == "master":
+            defaults["default_include"] = DEFAULT_MASTER_OPTS["default_include"]
 
     if not os.environ.get(env_var, None):
         # No valid setting was given using the configuration variable.

--- a/tests/pytests/functional/masterminion/test_masterminion_conf.py
+++ b/tests/pytests/functional/masterminion/test_masterminion_conf.py
@@ -1,0 +1,41 @@
+"""
+Tests for MasterMinion class
+"""
+
+import logging
+import os
+import pathlib
+
+import pytest
+
+import salt.minion
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def minion_config_overrides(master_opts):
+    """Configure minion to use same root_dir and config path as master."""
+    root_dir = pathlib.Path(master_opts["root_dir"])
+    conf_file = root_dir / "conf" / "minion"
+    yield {"conf_file": str(conf_file), "root_dir": str(root_dir)}
+
+
+@pytest.fixture
+def minion_d_include_value(minion_opts):
+    """Create minion.d/test.conf with 'minion_d_value' config option."""
+    conf_dir = pathlib.Path(minion_opts["conf_file"]).parent
+    minion_include_dir = (conf_dir / minion_opts["default_include"]).parent
+    test_conf = minion_include_dir / "test.conf"
+    os.makedirs(minion_include_dir)
+    with salt.utils.files.fopen(test_conf, "w") as test_conf:
+        test_conf.write("minion_d_value: True")
+
+
+def test_issue_64219_masterminion_no_minion_d_include(
+    master_opts, minion_d_include_value
+):
+    """Create MasterMinion and test it doesn't get config from 'minion.d/*.conf'."""
+
+    mminion = salt.minion.MasterMinion(master_opts)
+    assert "minion_d_value" not in mminion.opts


### PR DESCRIPTION
### What does this PR do?
Stops the MasterMinion loading config from  `/etc/salt/minion.d/*.conf` by ensuring `default_include` is set to `DEFAULT_MASTER_OPTS["default_include"] ` when `minion_config()` is called from `mminion_config()`

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/64219

### Previous Behavior
MasterMinion class would load config from `/etc/salt/minion.d/*.conf`

### New Behavior
MasterMinion class only loads config from `/etc/salt/master` and `/etc/salt/master.d/*.conf`

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No
