### PR TITLE
[3006.x] Add scripts for setting up multi-minion on Windows

### DIFF
--- a/changelog/64439.added.md
+++ b/changelog/64439.added.md
@@ -1,2 +1,1 @@
-Added documentation on how to run a 2nd minion in a user context on Windows
-Also created a script to automate setting up a 2nd minion
+Added a script to automate setting up a 2nd minion in a user context on Windows

--- a/changelog/64439.added.md
+++ b/changelog/64439.added.md
@@ -1,0 +1,2 @@
+Added documentation on how to run a 2nd minion in a user context on Windows
+Also created a script to automate setting up a 2nd minion

--- a/doc/topics/windows/multi-minion.rst
+++ b/doc/topics/windows/multi-minion.rst
@@ -3,11 +3,10 @@ Multi-Minion Setup on Windows
 =============================
 
 There may be a scenario where having a minion running in the context of the
-current logged in user would be useful. For example, the normal minion running
+current, logged-in user would be useful. For example, the normal minion running
 under the service account would perform machine-wide, administrative tasks. The
-minion runing under the user context could be launched when the user logs in
+minion running under the user context could be launched when the user logs in
 and would be able to perform configuration tasks as if it were the user itself.
-This would be useful for setting user registry settings, for example.
 
 The steps required to do this are as follows:
 
@@ -86,7 +85,7 @@ are present:
 
 The minion will need is own config, separate from the system minion config. This
 config tells the minion where everything is as well as defines the master and
-minion id. Create a minion config file named minion in the conf directory.
+minion id. Create a minion config file named ``minion`` in the conf directory.
 
 .. code-block:: powershell
 

--- a/doc/topics/windows/multi-minion.rst
+++ b/doc/topics/windows/multi-minion.rst
@@ -1,0 +1,165 @@
+=============================
+Multi-Minion Setup on Windows
+=============================
+
+There may be a scenario where having a minion running in the context of the
+current logged in user would be useful. For example, the normal minion running
+under the service account would perform machine-wide, administrative tasks. The
+minion runing under the user context could be launched when the user logs in
+and would be able to perform configuration tasks as if it were the user itself.
+This would be useful for setting user registry settings, for example.
+
+The steps required to do this are as follows:
+
+1. Create new root_dir
+2. Set root_dir permissions
+3. Create directory structure
+4. Write minion config
+
+We will now go through each of these steps in detail.
+
+.. note::
+
+    We have created a powershell script that will configure an additional minion
+    on the system for you. It can be found in the root of the Salt installation.
+    The script is named ``multi-minion.ps1``. You can get help on how to use the
+    script by running the following in a PowerShell prompt:
+
+    ``Get-Help .\multi-minion.ps1 -Detailed``
+
+1. Create new ``root_dir``
+--------------------------
+
+The minion requires a root directory to store config, cache, logs, etc. The user
+must have full permissions to this directory. The easiest way to do this is to
+put the ``root_dir`` in the Local AppData directory (``$env:LocalAppData``).
+
+.. code-block:: powershell
+
+    New-Item -Path "$env:LocalAppData\Salt Project\Salt" -Type Directory
+
+2. Set ``root_dir`` permissions
+-------------------------------
+
+The user running Salt requires full access to the ``root_dir``. If you have
+placed the root_dir in a location that the user does not have access to, you'll
+need to give the user full permissions to that directory.
+
+.. code-block:: powershell
+
+    $RootDir = "<new root_dir location>"
+    $User    = "<user running salt>"
+    $acl = Get-Acl -Path "$RootDir"
+    $access_rule = New-Object System.Security.AccessControl.FileSystemAccessRule($User, "Modify", "Allow")
+    $acl.AddAccessRule($access_rule)
+    Set-Acl -Path "$RootDir" -AclObject $acl
+
+3. Create directory structure
+-----------------------------
+
+Salt expects a certain directory structure to be present to avoid unnecessary
+messages in the logs. This is usually handled by the installer. Since we're
+running our own instance, we need to do it. Make sure the following directories
+are present:
+
+  - root_dir\\conf\\minion.d
+  - root_dir\\conf\\pki
+  - root_dir\\var\\log\\salt
+  - root_dir\\var\\run
+  - root_dir\\var\\cache\\salt\\minion\\extmods\\grains
+  - root_dir\\var\\cache\\salt\\minion\\proc
+
+.. code-block:: powershell
+
+    $RootDir = "<new root_dir location>"
+    $cache_dir = "$RootDir\var\cache\salt\minion"
+    New-Item -Path "$RootDir\conf" -Type Directory
+    New-Item -Path "$RootDir\conf\minion.d" -Type Directory
+    New-Item -Path "$RootDir\conf\pki" -Type Directory
+    New-Item -Path "$RootDir\var\log\salt" -Type Directory
+    New-Item -Path "$RootDir\var\run" -Type Directory
+    New-Item -Path "$cache_dir\extmods\grains" -Type Directory
+    New-Item -Path "$cache_dir\proc" -Type Directory
+
+4. Write minion config
+----------------------
+
+The minion will need is own config, separate from the system minion config. This
+config tells the minion where everything is as well as defines the master and
+minion id. Create a minion config file named minion in the conf directory.
+
+.. code-block:: powershell
+
+    New-Item -Path "$env:LocalAppData\Salt Project\Salt\conf\minion" -Type File
+
+Make sure the config file has at least the following contents:
+
+.. code-block:: yaml
+
+    master: <ip address, dns name, etc>
+    id: <minion id>
+
+    root_dir: <root_dir>
+    log_file: <root_dir>\val\log\salt\minion
+    utils_dirs:
+      - <root_dir>\var\cache\salt\minion\extmods
+    winrepo_dir: <root_dir>\srv\salt\win\repo
+    winrepo_dir_ng: <root_dir>\srv\salt\win\repo-ng
+
+    file_roots:
+      base:
+        - <root_dir>\srv\salt
+        - <root_dir>\srv\spm\salt
+
+    pillar_roots:
+      base:
+        - <root_dir>\srv\pillar
+        - <root_dir>\srv\spm\pillar
+
+    thorium_roots:
+      base:
+        - <root_dir>\srv\thorium
+
+Run the minion
+--------------
+
+Everything is now set up to run the minion. You can start the minion as you
+would normally, but you need to specify the full path to the config file you
+created above.
+
+.. code-block:: powershell
+
+    salt-minion.exe -c <root_dir>\conf
+
+Register the minion as a service
+--------------------------------
+
+You can also register the minion as a service, but you need to understand the
+implications of doing so.
+
+- You will need to have administrator privileges to register this minion service
+- You will need the password to the user account that will be running the minion
+- If the user password changes, you will have to update the service definition
+  to reflect the new password
+- The minion will run all the time under the user context, whether that user is
+  logged in or not
+- This requires great trust from the user as the minion will be able to perform
+  operations under the user's name without the user knowing, whether they are
+  logged in or not
+- If you decide to run the new minion under the Local System account, it might
+  as well just be a normal minion
+- The helper script does not support registering the 2nd minion as a service
+
+To register the minion as a service, use the ``ssm.exe`` binary that came with
+the Salt installation. Run the following commands, replacing ``<service-name>``,
+``<root_dir>``, ``<user_name>``, and ``<password>`` as necessary:
+
+.. code-block:: powershell
+
+    ssm.exe install <service-name> "salt-minion.exe" "-c `"<root_dir>\conf`" -l quiet"
+    ssm.exe set <service-name> Description "Salt Minion <user_name>"
+    ssm.exe set <service-name> Start SERVICE_AUTO_START
+    ssm.exe set <service-name> AppStopMethodConsole 24000
+    ssm.exe set <service-name> AppStopMethodWindow 2000
+    ssm.exe set <service-name> AppRestartDelay 60000
+    ssm.exe set <service-name> ObjectName ".\<user_name>" "<password>"

--- a/doc/topics/windows/multi-minion.rst
+++ b/doc/topics/windows/multi-minion.rst
@@ -1,5 +1,5 @@
 =============================
-Multi-Minion Setup on Windows
+Multi-minion setup on Windows
 =============================
 
 There may be a scenario where having a minion running in the context of the
@@ -14,17 +14,20 @@ The steps required to do this are as follows:
 2. Set root_dir permissions
 3. Create directory structure
 4. Write minion config
-
-We will now go through each of these steps in detail.
+5. Start the minion
+6. Register the minion as a service (optional)
 
 .. note::
 
-    We have created a powershell script that will configure an additional minion
-    on the system for you. It can be found in the root of the Salt installation.
-    The script is named ``multi-minion.ps1``. You can get help on how to use the
-    script by running the following in a PowerShell prompt:
+    The Salt Project has created a powershell script that will configure an
+    additional minion on the system for you. It can be found in the root of the
+    Salt installation. The script is named ``multi-minion.ps1``. You can get
+    help on how to use the script by running the following in a PowerShell
+    prompt:
 
     ``Get-Help .\multi-minion.ps1 -Detailed``
+
+The following guide explains these steps in more detail.
 
 1. Create new ``root_dir``
 --------------------------
@@ -42,7 +45,8 @@ put the ``root_dir`` in the Local AppData directory (``$env:LocalAppData``).
 
 The user running Salt requires full access to the ``root_dir``. If you have
 placed the root_dir in a location that the user does not have access to, you'll
-need to give the user full permissions to that directory.
+need to give the user full permissions to that directory. Replace the
+<placeholder variables> in this example with your own configuration information.
 
 .. code-block:: powershell
 
@@ -57,9 +61,9 @@ need to give the user full permissions to that directory.
 -----------------------------
 
 Salt expects a certain directory structure to be present to avoid unnecessary
-messages in the logs. This is usually handled by the installer. Since we're
-running our own instance, we need to do it. Make sure the following directories
-are present:
+messages in the logs. This is usually handled by the installer. Since you're
+running your own instance, you need to do it. Make sure the following
+directories are present:
 
   - root_dir\\conf\\minion.d
   - root_dir\\conf\\pki
@@ -83,9 +87,10 @@ are present:
 4. Write minion config
 ----------------------
 
-The minion will need is own config, separate from the system minion config. This
-config tells the minion where everything is as well as defines the master and
-minion id. Create a minion config file named ``minion`` in the conf directory.
+The minion will need its own config, separate from the system minion config.
+This config tells the minion where everything is located in the file structure
+and also defines the master and minion id. Create a minion config file named
+``minion`` in the conf directory.
 
 .. code-block:: powershell
 
@@ -119,8 +124,8 @@ Make sure the config file has at least the following contents:
       base:
         - <root_dir>\srv\thorium
 
-Run the minion
---------------
+5. Run the minion
+-----------------
 
 Everything is now set up to run the minion. You can start the minion as you
 would normally, but you need to specify the full path to the config file you
@@ -130,24 +135,26 @@ created above.
 
     salt-minion.exe -c <root_dir>\conf
 
-Register the minion as a service
---------------------------------
+6. Register the minion as a service (optional)
+----------------------------------------------
 
 You can also register the minion as a service, but you need to understand the
 implications of doing so.
 
-- You will need to have administrator privileges to register this minion service
-- You will need the password to the user account that will be running the minion
+- You will need to have administrator privileges to register this minion
+  service.
+- You will need the password to the user account that will be running the
+  minion.
 - If the user password changes, you will have to update the service definition
-  to reflect the new password
-- The minion will run all the time under the user context, whether that user is
-  logged in or not
+  to reflect the new password.
+- The minion runs all the time under the user context, whether that user is
+  logged in or not.
 - This requires great trust from the user as the minion will be able to perform
   operations under the user's name without the user knowing, whether they are
-  logged in or not
+  logged in or not.
 - If you decide to run the new minion under the Local System account, it might
-  as well just be a normal minion
-- The helper script does not support registering the 2nd minion as a service
+  as well just be a normal minion.
+- The helper script does not support registering the second minion as a service.
 
 To register the minion as a service, use the ``ssm.exe`` binary that came with
 the Salt installation. Run the following commands, replacing ``<service-name>``,

--- a/pkg/tests/integration/test_multi_minion.py
+++ b/pkg/tests/integration/test_multi_minion.py
@@ -1,0 +1,127 @@
+import os
+import pathlib
+import subprocess
+
+import psutil
+import pytest
+
+pytestmark = [
+    pytest.mark.skip_unless_on_windows,
+]
+
+
+@pytest.fixture
+def mm_script(install_salt):
+    yield install_salt.ssm_bin.parent / "multi-minion.ps1"
+
+
+@pytest.fixture(scope="function")
+def mm_conf(mm_script):
+    yield pathlib.Path(os.getenv("LocalAppData"), "Salt Project", "Salt", "conf")
+    subprocess.run(
+        ["powershell", "-c", str(mm_script), "-d"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        universal_newlines=True,
+    )
+
+
+def test_script_present(mm_script):
+    """
+    Ensure the multi-minion.ps1 file is present in the root of the installation
+    """
+    assert mm_script.exists()
+
+
+def test_install(mm_script, mm_conf):
+    """
+    Install a 2nd minion with default settings. Should create a minion config
+    file in Local AppData
+    """
+    ret = subprocess.run(
+        ["powershell", "-c", str(mm_script)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        universal_newlines=True,
+    )
+    assert ret.returncode == 0, ret.stderr
+    conf_file = mm_conf / "minion"
+    assert conf_file.exists()
+    assert conf_file.read_text().find("master: salt") > -1
+
+
+def test_install_master(mm_script, mm_conf):
+    """
+    Install a 2nd minion and set the master to spongebob
+    """
+    ret = subprocess.run(
+        ["powershell", "-c", str(mm_script), "-m", "spongebob"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        universal_newlines=True,
+    )
+    assert ret.returncode == 0, ret.stderr
+    conf_file = mm_conf / "minion"
+    assert conf_file.exists()
+    assert conf_file.read_text().find("master: spongebob") > -1
+
+
+def test_install_prefix(mm_script, mm_conf):
+    """
+    Install a 2nd minion and add a prefix to the minion id
+    """
+    ret = subprocess.run(
+        ["powershell", "-c", str(mm_script), "-p", "squarepants"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        universal_newlines=True,
+    )
+    assert ret.returncode == 0, ret.stderr
+    conf_file = mm_conf / "minion"
+    assert conf_file.exists()
+    assert conf_file.read_text().find("id: squarepants") > -1
+
+
+def test_install_log_level(mm_script, mm_conf):
+    """
+    Install a 2nd minion and set the log level in the log file to debug
+    """
+    ret = subprocess.run(
+        ["powershell", "-c", str(mm_script), "-l", "debug"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        universal_newlines=True,
+    )
+    assert ret.returncode == 0, ret.stderr
+    conf_file = mm_conf / "minion"
+    assert conf_file.exists()
+    assert conf_file.read_text().find("log_level_logfile: debug") > -1
+
+
+def test_install_start(mm_script, mm_conf):
+    """
+    Install a 2nd minion and start that minion in a hidden process
+    """
+    ret = subprocess.run(
+        ["powershell", "-c", str(mm_script), "-s"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        universal_newlines=True,
+    )
+    assert ret.returncode == 0, ret.stderr
+    conf_file = mm_conf / "minion"
+    assert conf_file.exists()
+    assert conf_file.read_text().find("master: salt") > -1
+
+    found = False
+    for p in psutil.process_iter(["cmdline", "name"]):
+        if p.info["name"] and p.info["name"] == "salt-minion.exe":
+            if f"{mm_conf}" in p.info["cmdline"]:
+                found = True
+    assert found is True

--- a/pkg/tests/integration/test_multi_minion.py
+++ b/pkg/tests/integration/test_multi_minion.py
@@ -19,7 +19,7 @@ def mm_script(install_salt):
 def mm_conf(mm_script):
     yield pathlib.Path(os.getenv("LocalAppData"), "Salt Project", "Salt", "conf")
     subprocess.run(
-        ["powershell", "-c", str(mm_script), "-d"],
+        ["powershell", str(mm_script).replace(" ", "' '"), "-d"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         check=False,
@@ -40,7 +40,7 @@ def test_install(mm_script, mm_conf):
     file in Local AppData
     """
     ret = subprocess.run(
-        ["powershell", "-c", str(mm_script)],
+        ["powershell", str(mm_script).replace(" ", "' '")],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         check=False,
@@ -57,7 +57,7 @@ def test_install_master(mm_script, mm_conf):
     Install a 2nd minion and set the master to spongebob
     """
     ret = subprocess.run(
-        ["powershell", "-c", str(mm_script), "-m", "spongebob"],
+        ["powershell", str(mm_script).replace(" ", "' '"), "-m", "spongebob"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         check=False,
@@ -74,7 +74,7 @@ def test_install_prefix(mm_script, mm_conf):
     Install a 2nd minion and add a prefix to the minion id
     """
     ret = subprocess.run(
-        ["powershell", "-c", str(mm_script), "-p", "squarepants"],
+        ["powershell", str(mm_script).replace(" ", "' '"), "-p", "squarepants"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         check=False,
@@ -91,7 +91,7 @@ def test_install_log_level(mm_script, mm_conf):
     Install a 2nd minion and set the log level in the log file to debug
     """
     ret = subprocess.run(
-        ["powershell", "-c", str(mm_script), "-l", "debug"],
+        ["powershell", str(mm_script).replace(" ", "' '"), "-l", "debug"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         check=False,
@@ -108,7 +108,7 @@ def test_install_start(mm_script, mm_conf):
     Install a 2nd minion and start that minion in a hidden process
     """
     ret = subprocess.run(
-        ["powershell", "-c", str(mm_script), "-s"],
+        ["powershell", str(mm_script).replace(" ", "' '"), "-s"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         check=False,

--- a/pkg/tests/integration/test_multi_minion.py
+++ b/pkg/tests/integration/test_multi_minion.py
@@ -36,7 +36,7 @@ def test_script_present(mm_script):
 
 def test_install(mm_script, mm_conf):
     """
-    Install a 2nd minion with default settings. Should create a minion config
+    Install a second minion with default settings. Should create a minion config
     file in Local AppData
     """
     ret = subprocess.run(
@@ -54,7 +54,7 @@ def test_install(mm_script, mm_conf):
 
 def test_install_master(mm_script, mm_conf):
     """
-    Install a 2nd minion and set the master to spongebob
+    Install a second minion and set the master to spongebob
     """
     ret = subprocess.run(
         ["powershell", str(mm_script).replace(" ", "' '"), "-m", "spongebob"],
@@ -71,7 +71,7 @@ def test_install_master(mm_script, mm_conf):
 
 def test_install_prefix(mm_script, mm_conf):
     """
-    Install a 2nd minion and add a prefix to the minion id
+    Install a second minion and add a prefix to the minion id
     """
     ret = subprocess.run(
         ["powershell", str(mm_script).replace(" ", "' '"), "-p", "squarepants"],
@@ -88,7 +88,7 @@ def test_install_prefix(mm_script, mm_conf):
 
 def test_install_log_level(mm_script, mm_conf):
     """
-    Install a 2nd minion and set the log level in the log file to debug
+    Install a second minion and set the log level in the log file to debug
     """
     ret = subprocess.run(
         ["powershell", str(mm_script).replace(" ", "' '"), "-l", "debug"],
@@ -105,7 +105,7 @@ def test_install_log_level(mm_script, mm_conf):
 
 def test_install_start(mm_script, mm_conf):
     """
-    Install a 2nd minion and start that minion in a hidden process
+    Install a second minion and start that minion in a hidden process
     """
     ret = subprocess.run(
         ["powershell", str(mm_script).replace(" ", "' '"), "-s"],

--- a/pkg/windows/clean.ps1
+++ b/pkg/windows/clean.ps1
@@ -141,6 +141,33 @@ if ( Test-Path -Path "$RELENV_DIR" ) {
 }
 
 #-------------------------------------------------------------------------------
+# Remove MSI build files
+#-------------------------------------------------------------------------------
+$files = @(
+    "msi/CustomAction01/CustomAction01.CA.dll",
+    "msi/CustomAction01/CustomAction01.dll",
+    "msi/CustomAction01/CustomAction01.pdb",
+    "msi/Product-discovered-files-config.wixobj",
+    "msi/Product-discovered-files-config.wxs",
+    "msi/Product-discovered-files-x64.wixobj",
+    "msi/Product-discovered-files-x64.wxs",
+    "msi/Product.wixobj"
+)
+$files | ForEach-Object {
+    if ( Test-Path -Path "$SCRIPT_DIR\$_" ) {
+        # Use .net, the powershell function is asynchronous
+        Write-Host "Removing $_`: " -NoNewline
+        [System.IO.File]::Delete("$SCRIPT_DIR\$_")
+        if ( ! (Test-Path -Path "$SCRIPT_DIR\$_") ) {
+            Write-Result "Success" -ForegroundColor Green
+        } else {
+            Write-Result "Failed" -ForegroundColor Red
+            exit 1
+        }
+    }
+}
+
+#-------------------------------------------------------------------------------
 # Script Completed
 #-------------------------------------------------------------------------------
 Write-Host $("-" * 80)

--- a/pkg/windows/multi-master.cmd
+++ b/pkg/windows/multi-master.cmd
@@ -1,0 +1,3 @@
+@ echo off
+Set "CurDir=%~dp0"
+PowerShell -ExecutionPolicy RemoteSigned -File "%CurDir%\multi-master.ps1" %*

--- a/pkg/windows/multi-master.cmd
+++ b/pkg/windows/multi-master.cmd
@@ -1,3 +1,0 @@
-@ echo off
-Set "CurDir=%~dp0"
-PowerShell -ExecutionPolicy RemoteSigned -File "%CurDir%\multi-master.ps1" %*

--- a/pkg/windows/multi-minion.cmd
+++ b/pkg/windows/multi-minion.cmd
@@ -1,3 +1,5 @@
+:: This is a helper script for multi-minion.ps1.
+:: See multi-minion.ps1 for documentation
 @ echo off
 Set "CurDir=%~dp0"
 PowerShell -ExecutionPolicy RemoteSigned -File "%CurDir%\multi-minion.ps1" %*

--- a/pkg/windows/multi-minion.cmd
+++ b/pkg/windows/multi-minion.cmd
@@ -1,0 +1,3 @@
+@ echo off
+Set "CurDir=%~dp0"
+PowerShell -ExecutionPolicy RemoteSigned -File "%CurDir%\multi-minion.ps1" %*

--- a/pkg/windows/multi-minion.ps1
+++ b/pkg/windows/multi-minion.ps1
@@ -4,11 +4,11 @@ Script for setting up an additional salt-minion on a machine with Salt installed
 
 .DESCRIPTION
 This script will install an additional minion on a machine that already has a
-Salt installtion using one of the Salt packages. It will set up the directory
+Salt installation using one of the Salt packages. It will set up the directory
 structure required by Salt. It will also lay down a minion config to be used
 by the Salt minion. Additionaly, this script will install and start a Salt
-minion service that uses the root_dir and minion config. You can also pass the
-name of a service account to be used by the service.
+minion service that uses the root_dir specified in the minion config. You can
+also pass the name of a service account to be used by the service.
 
 You can also remove the multiminion setup with this script.
 

--- a/pkg/windows/multi-minion.ps1
+++ b/pkg/windows/multi-minion.ps1
@@ -3,9 +3,9 @@
 Script for setting up an additional salt-minion on a machine with Salt installed
 
 .DESCRIPTION
-This script will configure an additional minion on a machine that already has a
-Salt installation using one of the Salt packages. It will set up the directory
-structure required by Salt. It will also lay down a minion config to be used
+This script configures an additional minion on a machine that already has a Salt
+installation using one of the Salt packages. It sets up the directory structure
+required by Salt. It also lays down a minion config to be used
 by the Salt minion. Additionaly, this script can start the new minion in a
 hidden window.
 
@@ -16,30 +16,30 @@ This script does not need to be run with Administrator privileges
 If a minion that was configured with this script is already running, the script
 will exit.
 
-The following example will set up a minion for the current logged in account. It
+The following example sets up a minion for the current logged in account. It
 configures the minion to connect to the master at 192.168.0.10
 
 .EXAMPLE
 PS>multi-minion.ps1 -Master 192.168.0.10
 PS>multi-minion.ps1 -m 192.168.0.10
 
-The following example will set up a minion for the current logged in account. It
-configures the minion to connect to the master at 192.168.0.10. It will also
-prefix the minion id with `spongebob`
+The following example sets up a minion for the current logged in account. It
+configures the minion to connect to the master at 192.168.0.10. It also prefixes
+the minion id with `spongebob`
 
 .EXAMPLE
 PS>multi-minion.ps1 -Master 192.168.0.10 -Prefix spongebob
 PS>multi-minion.ps1 -m 192.168.0.10 -p spongebob
 
-The following example will set up a minion for the current logged in account. It
-configures the minion to connect to the master at 192.168.0.10. It will also
-start the minion in a hidden window:
+The following example sets up a minion for the current logged in account. It
+configures the minion to connect to the master at 192.168.0.10. It also starts
+the minion in a hidden window:
 
 .EXAMPLE
 PS>multi-minion.ps1 -Master 192.168.0.10 -Start
 PS>multi-minion.ps1 -m 192.168.0.10 -s
 
-The following example will remove a multiminion for the current running account:
+The following example removes a multiminion for the current running account:
 
 .EXAMPLE
 PS>multi-minion.ps1 -Delete
@@ -60,7 +60,7 @@ param(
     [Alias("p")]
     # The prefix to the minion id to differentiate it from the installed system
     # minion. The default is $env:COMPUTERNAME. It might be helpful to use the
-    # minion id of the System minion if you know it
+    # minion id of the system minion if you know it
     [String] $Prefix = "$env:COMPUTERNAME",
 
     [Parameter(Mandatory=$false)]
@@ -82,7 +82,7 @@ param(
         "critical",
         "quiet"
     )]
-    # Start the minion in the background
+    # Set the log level for log file. Default is `warning`
     [String] $LogLevel = "warning",
 
     [Parameter(Mandatory=$false)]

--- a/pkg/windows/multi-minion.ps1
+++ b/pkg/windows/multi-minion.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
 Script for setting up an additional salt-minion on a machine with Salt installed
 

--- a/pkg/windows/multi-minion.ps1
+++ b/pkg/windows/multi-minion.ps1
@@ -1,0 +1,359 @@
+﻿<#
+.SYNOPSIS
+Script for setting up an additional salt-minion on a machine with Salt installed
+
+.DESCRIPTION
+This script will install an additional minion on a machine that already has a
+Salt installtion using one of the Salt packages. It will set up the directory
+structure required by Salt. It will also lay down a minion config to be used
+by the Salt minion. Additionaly, this script will install and start a Salt
+minion service that uses the root_dir and minion config. You can also pass the
+name of a service account to be used by the service.
+
+You can also remove the multiminion setup with this script.
+
+This script should be run with Administrator privileges
+
+The following example will install a service named `salt-minion-mm10` that
+starts with the LOCALSYSTEM account. It is the `-s` parameter that creates the
+service:
+
+.EXAMPLE
+PS>multi-minion.ps1 -Name mm10 -s
+
+The following example will install a service that starts with a user named
+mmuser:
+
+.EXAMPLE
+PS>multi-minion.ps1 -Name mm10 -s -m 192.168.0.10 -u mmuser -p secretword
+
+The following example will set up config for minion that can be run in the
+background under a user account. Notice the command does not have the `-s`
+parameter:
+
+.EXAMPLE
+PS>multi-minion.ps1 -Name mm10 -m 192.168.0.10
+
+The following example will remove a multiminion that has been installed with
+this script:
+
+.EXAMPLE
+PS>multi-minion.ps1 -Name mm10 -d
+
+#>
+
+[CmdletBinding()]
+param(
+
+    [Parameter(Mandatory=$true)]
+    [Alias("n")]
+    # The name used to create the service and root_dir. This is the only
+    # required parameter
+    [String] $Name,
+
+    [Parameter(Mandatory=$false)]
+    [Alias("m")]
+    # The master to connect to. This can be an ip address or an fqdn. Default
+    # is salt
+    [String] $Master = "salt",
+
+    [Parameter(Mandatory=$false)]
+    [Alias("r")]
+    # The root dir to place the minion config and directory structure. The
+    # default is %PROGRAMDATA%\Salt Project\Salt-$Name
+    [String] $RootDir = "$env:ProgramData\Salt Project\Salt-$Name",
+
+    [Parameter(Mandatory=$false)]
+    [Alias("u")]
+    # User account to run the service under. The user account must be present on
+    # the system. The default is to use the LOCALSYSTEM account
+    [String] $User,
+
+    [Parameter(Mandatory=$false)]
+    [Alias("p")]
+    # The password to the user account. Required if User is passed. We should
+    # probably figure out how to make this more secure
+    [String] $Password,
+
+    [Parameter(Mandatory=$false)]
+    [Alias("s")]
+    # Set this switch to install the service. Default is to not install the
+    # service
+    [Switch] $Service,
+
+    [Parameter(Mandatory=$false)]
+    [Alias("d")]
+    # Remove the specified multi-minion. All other parameters are ignored
+    [Switch] $Remove
+)
+
+########################### Script Variables #############################
+$ssm_bin = "$env:ProgramFiles\Salt Project\Salt\ssm.exe"
+$salt_bin = "$env:ProgramFiles\Salt Project\Salt\salt-minion.exe"
+$service_name = "salt-minion-$($Name.ToLower())"
+$default_root_dir = Resolve-Path -Path "$env:ProgramData\Salt Project\Salt"
+$cache_dir = "$RootDir\var\cache\salt\minion"
+
+################################ Remove ##################################
+if ( $Remove ) {
+    Write-Host "######################################################################" -ForegroundColor Cyan
+    Write-Host "Removing multi-minion"
+    Write-Host "Name: $Name"
+    Write-Host "Service Name: $service_name"
+    Write-Host "Root Dir: $RootDir"
+    Write-Host "######################################################################" -ForegroundColor Cyan
+
+    # Stop Service
+    $service_object = Get-Service -Name $service_name -ErrorAction SilentlyContinue
+    if ( $service_object -and ($service_object.Status -ne "Stopped") ) {
+        Write-Host "Stopping service: " -NoNewline
+        Stop-Service -Name $service_name *> $null
+        $service_object.Refresh()
+        if ( $service_object.Status -eq "Stopped" ) {
+            Write-Host "Success" -ForegroundColor Green
+        } else {
+            Write-Host "Failed" -ForegroundColor Red
+            exit 1
+        }
+    }
+
+    # Remove Service
+    $service_object = Get-Service -Name $service_name -ErrorAction SilentlyContinue
+    if ( $service_object ) {
+        Write-Host "Removing service: " -NoNewline
+        & $ssm_bin remove $service_name confirm *> $null
+            $service_object = Get-Service -Name $service_name -ErrorAction SilentlyContinue
+        if ( !$service_object ) {
+            Write-Host "Success" -ForegroundColor Green
+        } else {
+            Write-Host "Failed" -ForegroundColor Red
+            exit 1
+        }
+    }
+
+    # Remove Directory
+    if ( Test-Path -Path $RootDir ) {
+        Write-Host "Removing RootDir: " -NoNewline
+        Remove-Item -Path $RootDir -Force -Recurse
+
+        if ( !(Test-Path -Path $RootDir) ) {
+            Write-Host "Success" -ForegroundColor Green
+        } else {
+            Write-Host "Failed" -ForegroundColor Red
+            exit 1
+        }
+    }
+    # Remind to delete keys from master
+    Write-Host "######################################################################" -ForegroundColor Cyan
+    Write-Host "Multi-Minion installed successfully"
+    Write-Host ">>>>> Don't forget to remove keys from the master <<<<<"
+    Write-Host "######################################################################" -ForegroundColor Cyan
+    exit 0
+}
+
+################################ Install #################################
+# We don't want to share config with the current running minion
+if ( $RootDir.Trim("\") -eq $default_root_dir ) {
+    Write-Host "WARNING: RootDir can't be default Salt rootdir" -ForegroundColor Red
+    exit 1
+}
+
+# Make sure password is set if user is passed
+if ( $User -and !$Password ) {
+    Write-Host "WARNING: You must pass a password when defining a user account" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "######################################################################" -ForegroundColor Cyan
+Write-Host "Installing multi-minion"
+Write-Host "Name: $Name"
+Write-Host "Master: $Master"
+Write-Host "Root Directory: $RootDir"
+Write-Host "Create Service: $Service"
+if ( $Service ) {
+    Write-Host "Service Account: $User"
+    Write-Host "Password: **********"
+    Write-Host "Service Name: $service_name"
+}
+Write-Host "######################################################################" -ForegroundColor Cyan
+
+# Create file_roots Directory Structure
+if ( !( Test-Path -path "$RootDir" ) ) {
+    Write-Host "Creating RootDir: " -NoNewline
+    New-Item -Path "$RootDir" -Type Directory | Out-Null
+    if ( Test-Path -path "$RootDir" ) {
+        Write-Host "Success" -ForegroundColor Green
+    } else {
+        Write-Host "Failed" -ForegroundColor Red
+        exit 1
+    }
+}
+
+# Set permissions
+if ( $User ) {
+    Write-Host "Setting Permissions: " -NoNewline
+    $acl = Get-Acl -Path "$RootDir"
+    $access_rule = New-Object System.Security.AccessControl.FileSystemAccessRule($User, "Modify", "Allow")
+    $acl.AddAccessRule($access_rule)
+    Set-Acl -Path "$RootDir" -AclObject $acl
+
+    $found = $false
+    $acl = Get-Acl -Path "$RootDir"
+    $acl.Access | ForEach-Object {
+        if ( $_.IdentityReference.Value.Contains($User) ) {
+            $found = $true
+        }
+    }
+    if ( $found ) {
+        Write-Host "Success" -ForegroundColor Green
+    } else {
+        Write-Host "Failed" -ForegroundColor Red
+        exit 1
+    }
+}
+
+# Child directories will inherit permissions from the parent
+if ( !( Test-Path -path "$RootDir\conf" ) ) {
+    Write-Host "Creating config dir: " -NoNewline
+    New-Item -Path "$RootDir\conf" -Type Directory | Out-Null
+    if ( Test-Path -path "$RootDir\conf" ) {
+        Write-Host "Success" -ForegroundColor Green
+    } else {
+        Write-Host "Failed" -ForegroundColor Red
+        exit 1
+    }
+}
+if ( !( Test-Path -path "$RootDir\conf\minion.d" ) ) {
+    Write-Host "Creating minion.d dir: " -NoNewline
+    New-Item -Path "$RootDir\conf\minion.d" -Type Directory | Out-Null
+    if ( Test-Path -path "$RootDir\conf\minion.d" ) {
+        Write-Host "Success" -ForegroundColor Green
+    } else {
+        Write-Host "Failed" -ForegroundColor Red
+        exit 1
+    }
+}
+if ( !( Test-Path -path "$RootDir\conf\pki" ) ) {
+    Write-Host "Creating pki dir: " -NoNewline
+    New-Item -Path "$RootDir\conf\pki" -Type Directory | Out-Null
+    if ( Test-Path -path "$RootDir\conf\pki" ) {
+        Write-Host "Success" -ForegroundColor Green
+    } else {
+        Write-Host "Failed" -ForegroundColor Red
+        exit 1
+    }
+}
+if ( !( Test-Path -path "$RootDir\var\log\salt" ) ) {
+    Write-Host "Creating log dir: " -NoNewline
+    New-Item -Path "$RootDir\var\log\salt" -Type Directory | Out-Null
+    if ( Test-Path -path "$RootDir\var\log\salt" ) {
+        Write-Host "Success" -ForegroundColor Green
+    } else {
+        Write-Host "Failed" -ForegroundColor Red
+        exit 1
+    }
+}
+if ( !( Test-Path -path "$RootDir\var\run" ) ) {
+    Write-Host "Creating run dir: " -NoNewline
+    New-Item -Path "$RootDir\var\run" -Type Directory | Out-Null
+    if ( Test-Path -path "$RootDir\var\run" ) {
+        Write-Host "Success" -ForegroundColor Green
+    } else {
+        Write-Host "Failed" -ForegroundColor Red
+        exit 1
+    }
+}
+if ( !( Test-Path -path "$cache_dir\extmods\grains" ) ) {
+    Write-Host "Creating extmods grains dir: " -NoNewline
+    New-Item -Path "$cache_dir\extmods\grains" -Type Directory | Out-Null
+    if ( Test-Path -path "$cache_dir\extmods\grains" ) {
+        Write-Host "Success" -ForegroundColor Green
+    } else {
+        Write-Host "Failed" -ForegroundColor Red
+        exit 1
+    }
+}
+if ( !( Test-Path -path "$cache_dir\proc" ) ) {
+    Write-Host "Creating proc dir: " -NoNewline
+    New-Item -Path "$cache_dir\proc" -Type Directory | Out-Null
+    if ( Test-Path -path "$cache_dir\proc" ) {
+        Write-Host "Success" -ForegroundColor Green
+    } else {
+        Write-Host "Failed" -ForegroundColor Red
+        exit 1
+    }
+}
+
+# Write minion config
+Write-Host "Writing minion config: " -NoNewline
+Add-Content -Force -Path "$RootDir\conf\minion" -Value "master: $Master"
+Add-Content -Force -Path "$RootDir\conf\minion" -Value "id: $Name"
+Add-Content -Force -Path "$RootDir\conf\minion" -Value "root_dir: $RootDir"
+Add-Content -Force -Path "$RootDir\conf\minion" -Value "log_file: $RootDir\var\log\salt\minion"
+Add-Content -Force -Path "$RootDir\conf\minion" -Value "utils_dirs: $RootDir\var\cache\salt\minion\extmods\utils"
+Add-Content -Force -Path "$RootDir\conf\minion" -Value "winrepo_dir: $RootDir\srv\salt\win\repo"
+Add-Content -Force -Path "$RootDir\conf\minion" -Value "winrepo_dir_ng: $RootDir\srv\salt\win\repo-ng"
+
+Add-Content -Force -Path "$RootDir\conf\minion" -Value "file_roots:"
+Add-Content -Force -Path "$RootDir\conf\minion" -Value "  base:"
+Add-Content -Force -Path "$RootDir\conf\minion" -Value "    - $RootDir\srv\salt"
+Add-Content -Force -Path "$RootDir\conf\minion" -Value "    - $RootDir\srv\spm\salt"
+
+Add-Content -Force -Path "$RootDir\conf\minion" -Value "pillar_roots:"
+Add-Content -Force -Path "$RootDir\conf\minion" -Value "  base:"
+Add-Content -Force -Path "$RootDir\conf\minion" -Value "    - $RootDir\srv\pillar"
+Add-Content -Force -Path "$RootDir\conf\minion" -Value "    - $RootDir\srv\spm\pillar"
+
+Add-Content -Force -Path "$RootDir\conf\minion" -Value "thorium_roots:"
+Add-Content -Force -Path "$RootDir\conf\minion" -Value "  base:"
+Add-Content -Force -Path "$RootDir\conf\minion" -Value "    - $RootDir\srv\thorium"
+
+if ( Test-Path -path "$RootDir\conf\minion" ) {
+    Write-Host "Success" -ForegroundColor Green
+} else {
+    Write-Host "Failed" -ForegroundColor Red
+    exit 1
+}
+
+if ( $Service ) {
+    # Register salt-minion service using SSM
+    Write-Host "Registering service $service_name`: " -NoNewline
+    & $ssm_bin install $service_name "$salt_bin" "-c """"$RootDir\conf"""" -l quiet" *> $null
+    & $ssm_bin set $service_name Description "Salt Minion $Name" *> $null
+    & $ssm_bin set $service_name Start SERVICE_AUTO_START *> $null
+    & $ssm_bin set $service_name AppStopMethodConsole 24000 *> $null
+    & $ssm_bin set $service_name AppStopMethodWindow 2000 *> $null
+    & $ssm_bin set $service_name AppRestartDelay 60000 *> $null
+    if ( $User -and $Password ) {
+        & $ssm_bin set $service_name ObjectName ".\$User" "$Password" *> $null
+    }
+
+    $service_object = Get-Service -Name $service_name -ErrorAction SilentlyContinue
+    if ( $service_object ) {
+        Write-Host "Success" -ForegroundColor Green
+    } else {
+        Write-Host "Failed" -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host "Starting service: " -NoNewline
+    Start-Service -Name $service_name
+    $service_object.Refresh()
+    if ( $service_object.Status -eq "Running" ) {
+        Write-Host "Success" -ForegroundColor Green
+    } else {
+        Write-Host "Failed" -ForegroundColor Red
+        exit 1
+    }
+}
+
+Write-Host "######################################################################" -ForegroundColor Cyan
+Write-Host "Multi-Minion installed successfully"
+Write-Host "Root Directory: $RootDir"
+if ( $Service ) {
+    Write-Host "Service Name: $service_name"
+} else {
+    Write-Host "To start the minion, run the following command:"
+    Write-Host "salt-minion -c `"$RootDir\conf`""
+}
+Write-Host "######################################################################" -ForegroundColor Cyan

--- a/pkg/windows/multi-minion.ps1
+++ b/pkg/windows/multi-minion.ps1
@@ -331,7 +331,7 @@ if ( Test-Path -path "$root_dir\conf\minion" ) {
 # Start the minion
 if ( $Start ) {
     Write-Host "Starting minion process: " -NoNewline
-    Start-Process -FilePath "$salt_bin" `
+    Start-Process -FilePath "`"$salt_bin`"" `
                   -ArgumentList "-c","`"$root_dir\conf`"" `
                   -WindowStyle Hidden
     # Verify running minion

--- a/pkg/windows/prep_salt.ps1
+++ b/pkg/windows/prep_salt.ps1
@@ -165,6 +165,25 @@ if ( ! (Test-Path -Path "$BUILD_DIR\ssm.exe") ) {
     }
 }
 
+# Copy the multiminion scripts to the Build directory
+$scripts = @(
+    "multi-minion.cmd",
+    "multi-minion.ps1"
+)
+$scripts | ForEach-Object {
+    if (!(Test-Path -Path "$BUILD_DIR\$_")) {
+        Write-Host "Copying $_ to the Build directory: " -NoNewline
+        Copy-Item -Path "$SCRIPT_DIR\$_" -Destination "$BUILD_DIR\$_"
+        if (Test-Path -Path "$BUILD_DIR\$_") {
+            Write-Result "Success" -ForegroundColor Green
+        } else {
+            Write-Result "Failed" -ForegroundColor Red
+            exit 1
+        }
+    }
+}
+
+# Copy VCRedist 2013 to the prereqs directory
 New-Item -Path $PREREQ_DIR -ItemType Directory | Out-Null
 Write-Host "Copying VCRedist 2013 $ARCH_X to prereqs: " -NoNewline
 $file = "vcredist_$ARCH_X`_2013.exe"
@@ -176,6 +195,7 @@ if ( Test-Path -Path "$PREREQ_DIR\$file" ) {
     exit 1
 }
 
+# Copy Universal C Runtimes to the prereqs directory
 Write-Host "Copying Universal C Runtimes $ARCH_X to prereqs: " -NoNewline
 $file = "ucrt_$ARCH_X.zip"
 Invoke-WebRequest -Uri "$SALT_DEP_URL/$file" -OutFile "$PREREQ_DIR\$file"


### PR DESCRIPTION
### What does this PR do?
This adds a powershell script for setting up a multi-minion environment on Windows. This is a request from the Windows Working Group.

This script allows you to configure additional minions alongside the minion installed by one of the installers. It will lay down the required minion config and directory structure. You can also pass an option to have it set up a service using that config.

There is also an option that allows you to remove a multi-minion config created by this script.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes