### PR TITLE
[master] Fix 64256: Add flags to create local users and groups

### DIFF
--- a/changelog/64256.added.md
+++ b/changelog/64256.added.md
@@ -1,0 +1,1 @@
+Added flags to create local users and groups

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -106,7 +106,7 @@ def _which(cmd):
     """
     _cmd = salt.utils.path.which(cmd)
     if not _cmd:
-        raise CommandExecutionError("Command '{}' cannot be found".format(cmd))
+        raise CommandExecutionError(f"Command '{cmd}' cannot be found")
     return _cmd
 
 
@@ -157,6 +157,7 @@ def add(
     nologinit=False,
     root=None,
     usergroup=None,
+    local=False,
 ):
     """
     Add a user to the minion
@@ -215,13 +216,18 @@ def add(
     usergroup
         Create and add the user to a new primary group of the same name
 
+    local (Only on systems with luseradd available)
+        Specifically add the user locally rather than possibly through remote providers (e.g. LDAP)
+
+        .. versionadded:: 3007.0
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' user.add name <uid> <gid> <groups> <home> <shell>
     """
-    cmd = [_which("useradd")]
+    cmd = [_which("luseradd" if local else "useradd")]
 
     if shell:
         cmd.extend(["-s", shell])
@@ -230,9 +236,10 @@ def add(
     if gid not in (None, ""):
         cmd.extend(["-g", gid])
     elif usergroup:
-        cmd.append("-U")
-        if __grains__["kernel"] != "Linux":
-            log.warning("'usergroup' is only supported on GNU/Linux hosts.")
+        if not local:
+            cmd.append("-U")
+            if __grains__["kernel"] != "Linux":
+                log.warning("'usergroup' is only supported on GNU/Linux hosts.")
     elif groups is not None and name in groups:
         defs_file = "/etc/login.defs"
         if __grains__["kernel"] != "OpenBSD":
@@ -269,14 +276,15 @@ def add(
                 # /etc/usermgmt.conf not present: defaults will be used
                 pass
 
-    # Setting usergroup to False adds the -N command argument. If
+    # Setting usergroup to False adds a command argument. If
     # usergroup is None, no arguments are added to allow useradd to go
     # with the defaults defined for the OS.
     if usergroup is False:
-        cmd.append("-N")
+        cmd.append("-n" if local else "-N")
 
     if createhome:
-        cmd.append("-m")
+        if not local:
+            cmd.append("-m")
     elif __grains__["kernel"] != "NetBSD" and __grains__["kernel"] != "OpenBSD":
         cmd.append("-M")
 
@@ -302,7 +310,7 @@ def add(
 
     cmd.append(name)
 
-    if root is not None and __grains__["kernel"] != "AIX":
+    if root is not None and not local and __grains__["kernel"] != "AIX":
         cmd.extend(("-R", root))
 
     ret = __salt__["cmd.run_all"](cmd, python_shell=False)
@@ -333,7 +341,7 @@ def add(
     return True
 
 
-def delete(name, remove=False, force=False, root=None):
+def delete(name, remove=False, force=False, root=None, local=False):
     """
     Remove a user from the minion
 
@@ -349,23 +357,34 @@ def delete(name, remove=False, force=False, root=None):
     root
         Directory to chroot into
 
+    local (Only on systems with luserdel available):
+        Ensure the user account is removed locally ignoring global
+        account management (default is False).
+
+        .. versionadded:: 3007.0
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' user.delete name remove=True force=True
     """
-    cmd = [_which("userdel")]
+    cmd = [_which("luserdel" if local else "userdel")]
 
     if remove:
         cmd.append("-r")
 
-    if force and __grains__["kernel"] != "OpenBSD" and __grains__["kernel"] != "AIX":
+    if (
+        force
+        and __grains__["kernel"] != "OpenBSD"
+        and __grains__["kernel"] != "AIX"
+        and not local
+    ):
         cmd.append("-f")
 
     cmd.append(name)
 
-    if root is not None and __grains__["kernel"] != "AIX":
+    if root is not None and __grains__["kernel"] != "AIX" and not local:
         cmd.extend(("-R", root))
 
     ret = __salt__["cmd.run_all"](cmd, python_shell=False)
@@ -429,7 +448,7 @@ def _chattrib(name, key, value, param, persist=False, root=None):
     """
     pre_info = info(name, root=root)
     if not pre_info:
-        raise CommandExecutionError("User '{}' does not exist".format(name))
+        raise CommandExecutionError(f"User '{name}' does not exist")
 
     if value == pre_info[key]:
         return True
@@ -911,7 +930,7 @@ def rename(name, new_name, root=None):
         salt '*' user.rename name new_name
     """
     if info(new_name, root=root):
-        raise CommandExecutionError("User '{}' already exists".format(new_name))
+        raise CommandExecutionError(f"User '{new_name}' already exists")
 
     return _chattrib(name, "name", new_name, "-l", root=root)
 

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -47,6 +47,15 @@ def _group_changes(cur, wanted, remove=False):
     return False
 
 
+def _get_root_args(local):
+    """
+    Retrieve args to use for user.info calls depending on platform and the local flag
+    """
+    if not local or salt.utils.platform.is_windows():
+        return {}
+    return {"root": "/"}
+
+
 def _changes(
     name,
     uid=None,
@@ -79,6 +88,7 @@ def _changes(
     allow_uid_change=False,
     allow_gid_change=False,
     password_lock=None,
+    local=False,
 ):
     """
     Return a dict of the changes required for a user if the user is present,
@@ -94,7 +104,7 @@ def _changes(
     if "shadow.info" in __salt__:
         lshad = __salt__["shadow.info"](name)
 
-    lusr = __salt__["user.info"](name)
+    lusr = __salt__["user.info"](name, **_get_root_args(local))
     if not lusr:
         return False
 
@@ -274,6 +284,7 @@ def present(
     allow_uid_change=False,
     allow_gid_change=False,
     password_lock=None,
+    local=False,
 ):
     """
     Ensure that the named user is present with the specified properties
@@ -449,6 +460,12 @@ def present(
         Date that account expires, represented in days since epoch (January 1,
         1970).
 
+    local (Only on systems with luseradd available):
+        Create the user account locally ignoring global account management
+        (default is False).
+
+        .. versionadded:: 3007.0
+
     The below parameters apply to windows only:
 
     win_homedrive (Windows Only)
@@ -530,14 +547,14 @@ def present(
         "name": name,
         "changes": {},
         "result": True,
-        "comment": "User {} is present and up to date".format(name),
+        "comment": f"User {name} is present and up to date",
     }
 
     # the comma is used to separate field in GECOS, thus resulting into
     # salt adding the end of fullname each time this function is called
     for gecos_field in [fullname, roomnumber, workphone]:
         if isinstance(gecos_field, str) and "," in gecos_field:
-            ret["comment"] = "Unsupported char ',' in {}".format(gecos_field)
+            ret["comment"] = f"Unsupported char ',' in {gecos_field}"
             ret["result"] = False
             return ret
 
@@ -614,6 +631,7 @@ def present(
             allow_uid_change,
             allow_gid_change,
             password_lock=password_lock,
+            local=local,
         )
     except CommandExecutionError as exc:
         ret["result"] = False
@@ -629,14 +647,14 @@ def present(
                     val = "XXX-REDACTED-XXX"
                 elif key == "group" and not remove_groups:
                     key = "ensure groups"
-                ret["comment"] += "{}: {}\n".format(key, val)
+                ret["comment"] += f"{key}: {val}\n"
             return ret
         # The user is present
         if "shadow.info" in __salt__:
             lshad = __salt__["shadow.info"](name)
         if __grains__["kernel"] in ("OpenBSD", "FreeBSD"):
             lcpre = __salt__["user.get_loginclass"](name)
-        pre = __salt__["user.info"](name)
+        pre = __salt__["user.info"](name, **_get_root_args(local))
 
         # Make changes
 
@@ -727,11 +745,9 @@ def present(
         # NOTE: list(changes) required here to avoid modifying dictionary
         # during iteration.
         for key in [
-            x
-            for x in list(changes)
-            if x != "groups" and "user.ch{}".format(x) in __salt__
+            x for x in list(changes) if x != "groups" and f"user.ch{x}" in __salt__
         ]:
-            __salt__["user.ch{}".format(key)](name, changes.pop(key))
+            __salt__[f"user.ch{key}"](name, changes.pop(key))
 
         # Do group changes last
         if "groups" in changes:
@@ -742,7 +758,7 @@ def present(
                 "Unhandled changes: {}".format(", ".join(changes))
             )
 
-        post = __salt__["user.info"](name)
+        post = __salt__["user.info"](name, **_get_root_args(local))
         spost = {}
         if "shadow.info" in __salt__ and lshad["passwd"] != password:
             spost = __salt__["shadow.info"](name)
@@ -762,7 +778,7 @@ def present(
         if __grains__["kernel"] in ("OpenBSD", "FreeBSD") and lcpost != lcpre:
             ret["changes"]["loginclass"] = lcpost
         if ret["changes"]:
-            ret["comment"] = "Updated user {}".format(name)
+            ret["comment"] = f"Updated user {name}"
         changes = _changes(
             name,
             uid,
@@ -795,6 +811,7 @@ def present(
             allow_uid_change=True,
             allow_gid_change=True,
             password_lock=password_lock,
+            local=local,
         )
         # allow_uid_change and allow_gid_change passed as True to avoid race
         # conditions where a uid/gid is modified outside of Salt. If an
@@ -802,7 +819,7 @@ def present(
         # first time we ran _changes().
 
         if changes:
-            ret["comment"] = "These values could not be changed: {}".format(changes)
+            ret["comment"] = f"These values could not be changed: {changes}"
             ret["result"] = False
         return ret
 
@@ -810,7 +827,7 @@ def present(
         # The user is not present, make it!
         if __opts__["test"]:
             ret["result"] = None
-            ret["comment"] = "User {} set to be added".format(name)
+            ret["comment"] = f"User {name} set to be added"
             return ret
         if groups and present_optgroups:
             groups.extend(present_optgroups)
@@ -837,6 +854,7 @@ def present(
                 "createhome": createhome,
                 "nologinit": nologinit,
                 "loginclass": loginclass,
+                "local": local,
                 "usergroup": usergroup,
             }
         else:
@@ -853,8 +871,8 @@ def present(
             }
         result = __salt__["user.add"](**params)
         if result is True:
-            ret["comment"] = "New user {} created".format(name)
-            ret["changes"] = __salt__["user.info"](name)
+            ret["comment"] = f"New user {name} created"
+            ret["changes"] = __salt__["user.info"](name, **_get_root_args(local))
             if not createhome:
                 # pwd incorrectly reports presence of home
                 ret["changes"]["home"] = ""
@@ -880,7 +898,7 @@ def present(
                     if spost["passwd"] != "":
                         ret[
                             "comment"
-                        ] = "User {} created but failed to empty password".format(name)
+                        ] = f"User {name} created but failed to empty password"
                         ret["result"] = False
                     ret["changes"]["password"] = ""
                 if date is not None:
@@ -987,12 +1005,12 @@ def present(
             if isinstance(result, str):
                 ret["comment"] = result
             else:
-                ret["comment"] = "Failed to create new user {}".format(name)
+                ret["comment"] = f"Failed to create new user {name}"
             ret["result"] = False
     return ret
 
 
-def absent(name, purge=False, force=False):
+def absent(name, purge=False, force=False, local=False):
     """
     Ensure that the named user is absent
 
@@ -1007,30 +1025,40 @@ def absent(name, purge=False, force=False):
         If the user is logged in, the absent state will fail. Set the force
         option to True to remove the user even if they are logged in. Not
         supported in FreeBSD and Solaris, Default is ``False``.
+
+    local (Only on systems with luserdel available):
+        Ensure the user account is removed locally ignoring global account management
+        (default is False).
+
+        .. versionadded:: 3007.0
     """
     ret = {"name": name, "changes": {}, "result": True, "comment": ""}
 
-    lusr = __salt__["user.info"](name)
+    lusr = __salt__["user.info"](name, **_get_root_args(local))
     if lusr:
         # The user is present, make it not present
         if __opts__["test"]:
             ret["result"] = None
-            ret["comment"] = "User {} set for removal".format(name)
+            ret["comment"] = f"User {name} set for removal"
             return ret
         beforegroups = set(salt.utils.user.get_group_list(name))
-        ret["result"] = __salt__["user.delete"](name, purge, force)
+        if salt.utils.platform.is_windows():
+            del_args = {}
+        else:
+            del_args = {"local": local}
+        ret["result"] = __salt__["user.delete"](name, purge, force, **del_args)
         aftergroups = {g for g in beforegroups if __salt__["group.info"](g)}
         if ret["result"]:
             ret["changes"] = {}
             for g in beforegroups - aftergroups:
-                ret["changes"]["{} group".format(g)] = "removed"
+                ret["changes"][f"{g} group"] = "removed"
             ret["changes"][name] = "removed"
-            ret["comment"] = "Removed user {}".format(name)
+            ret["comment"] = f"Removed user {name}"
         else:
             ret["result"] = False
-            ret["comment"] = "Failed to remove user {}".format(name)
+            ret["comment"] = f"Failed to remove user {name}"
         return ret
 
-    ret["comment"] = "User {} is not present".format(name)
+    ret["comment"] = f"User {name} is not present"
 
     return ret

--- a/tests/pytests/unit/modules/test_useradd.py
+++ b/tests/pytests/unit/modules/test_useradd.py
@@ -26,8 +26,9 @@ def test_add():
     mock = MagicMock(return_value={"retcode": 0})
     with patch(
         "salt.utils.path.which", MagicMock(return_value="/sbin/useradd")
-    ), patch.dict(useradd.__salt__, {"cmd.run_all": mock}):
+    ) as which_mock, patch.dict(useradd.__salt__, {"cmd.run_all": mock}):
         assert useradd.add("Salt") is True
+        which_mock.assert_called_once_with("useradd")
     mock.assert_called_once_with(["/sbin/useradd", "-m", "Salt"], python_shell=False)
 
     # command found and unsuccessful run
@@ -48,13 +49,33 @@ def test_add():
     mock.assert_not_called()
 
 
+def test_add_local():
+    mock = MagicMock(return_value={"retcode": 0})
+    with patch(
+        "salt.utils.path.which", MagicMock(return_value="/sbin/luseradd")
+    ) as which_mock, patch.dict(useradd.__salt__, {"cmd.run_all": mock}):
+        assert useradd.add("Salt", local=True) is True
+        which_mock.assert_called_once_with("luseradd")
+    mock.assert_called_once_with(["/sbin/luseradd", "Salt"], python_shell=False)
+
+
+def test_add_local_with_params():
+    mock = MagicMock(return_value={"retcode": 0})
+    with patch(
+        "salt.utils.path.which", MagicMock(return_value="/sbin/luseradd")
+    ), patch.dict(useradd.__salt__, {"cmd.run_all": mock}):
+        assert useradd.add("Salt", local=True, usergroup=False, root="ignored") is True
+    mock.assert_called_once_with(["/sbin/luseradd", "-n", "Salt"], python_shell=False)
+
+
 def test_delete():
     # command found and successful run
     mock = MagicMock(return_value={"retcode": 0})
     with patch(
         "salt.utils.path.which", MagicMock(return_value="/sbin/userdel")
-    ), patch.dict(useradd.__salt__, {"cmd.run_all": mock}):
+    ) as which_mock, patch.dict(useradd.__salt__, {"cmd.run_all": mock}):
         assert useradd.delete("Salt") is True
+        which_mock.assert_called_once_with("userdel")
     mock.assert_called_once_with(["/sbin/userdel", "Salt"], python_shell=False)
 
     # command found and unsuccessful run
@@ -73,6 +94,28 @@ def test_delete():
         with pytest.raises(CommandExecutionError):
             useradd.delete("Salt")
     mock.assert_not_called()
+
+
+def test_delete_local():
+    # command found and successful run
+    mock = MagicMock(return_value={"retcode": 0})
+    with patch(
+        "salt.utils.path.which", MagicMock(return_value="/sbin/luserdel")
+    ) as which_mock, patch.dict(useradd.__salt__, {"cmd.run_all": mock}):
+        assert useradd.delete("Salt", local=True) is True
+        which_mock.assert_called_once_with("luserdel")
+    mock.assert_called_once_with(["/sbin/luserdel", "Salt"], python_shell=False)
+
+
+def test_delete_local_with_params():
+    # command found and successful run
+    mock = MagicMock(return_value={"retcode": 0})
+    with patch(
+        "salt.utils.path.which", MagicMock(return_value="/sbin/luserdel")
+    ) as which_mock, patch.dict(useradd.__salt__, {"cmd.run_all": mock}):
+        assert useradd.delete("Salt", local=True, force=True, root="ignored") is True
+        which_mock.assert_called_once_with("luserdel")
+    mock.assert_called_once_with(["/sbin/luserdel", "Salt"], python_shell=False)
 
 
 def test_chgroups():

--- a/tests/pytests/unit/states/test_group.py
+++ b/tests/pytests/unit/states/test_group.py
@@ -1,7 +1,8 @@
 import pytest
 
 import salt.states.group as group
-from tests.support.mock import MagicMock, patch
+import salt.utils.platform
+from tests.support.mock import MagicMock, call, patch
 
 __context__ = {}
 
@@ -42,6 +43,43 @@ def test_present_with_non_unique_gid():
         }
 
 
+def test_present_with_local():
+    group_add_mock = MagicMock(return_value=True)
+    group_info_mock = MagicMock(return_value={"things": "stuff"})
+    with patch(
+        "salt.states.group._changes", MagicMock(side_effect=[False, {}, False])
+    ) as changes_mock, patch.dict(
+        group.__salt__,
+        {
+            "group.getent": MagicMock(
+                side_effect=[[{"name": "salt", "gid": 1}], [{"name": "salt", "gid": 1}]]
+            )
+        },
+    ), patch.dict(
+        group.__salt__, {"group.add": group_add_mock}
+    ), patch.dict(
+        group.__salt__, {"group.chgid": MagicMock(return_value=True)}
+    ), patch.dict(
+        group.__salt__, {"group.info": group_info_mock}
+    ):
+        ret = group.present("salt", gid=1, non_unique=True, local=True)
+        assert ret["result"]
+        assert changes_mock.call_args_list == [
+            call("salt", 1, None, None, None, local=True),
+            call("salt", 1, None, None, None, local=True),
+        ]
+        if salt.utils.platform.is_windows():
+            group_info_mock.assert_called_once_with("salt")
+            group_add_mock.assert_called_once_with(
+                "salt", gid=1, system=False, non_unique=True
+            )
+        else:
+            group_info_mock.assert_called_once_with("salt", root="/")
+            group_add_mock.assert_called_once_with(
+                "salt", gid=1, system=False, local=True, non_unique=True
+            )
+
+
 def test_present_with_existing_group_and_non_unique_gid():
     with patch(
         "salt.states.group._changes",
@@ -76,3 +114,24 @@ def test_present_with_existing_group_and_non_unique_gid():
             "name": "salt",
             "result": False,
         }
+
+
+def test_absent_with_local():
+    group_delete_mock = MagicMock(return_value=True)
+    group_info_mock = MagicMock(return_value={"things": "stuff"})
+    with patch.dict(group.__salt__, {"group.delete": group_delete_mock}), patch.dict(
+        group.__salt__, {"group.info": group_info_mock}
+    ):
+        ret = group.absent("salt", local=True)
+        assert ret == {
+            "changes": {"salt": ""},
+            "comment": "Removed group salt",
+            "name": "salt",
+            "result": True,
+        }
+        if salt.utils.platform.is_windows():
+            group_info_mock.assert_called_once_with("salt")
+            group_delete_mock.assert_called_once_with("salt")
+        else:
+            group_info_mock.assert_called_once_with("salt", root="/")
+            group_delete_mock.assert_called_once_with("salt", local=True)


### PR DESCRIPTION
### What does this PR do?
Adds a `local` flag for user/group creation to force users and groups to be created locally instead of in a remotely managed account management system (e.g. LDAP).

### What issues does this PR fix or reference?
Fixes: #64256

### New Behavior
If the `local` flag is specified as truthy, the `luseradd`, `lgroupadd`, etc commands will be used instead. If these do not exist on the system, this will fail.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No
