### PR TITLE
[master] sysrc.get: be more quiet

### DIFF
--- a/salt/modules/sysrc.py
+++ b/salt/modules/sysrc.py
@@ -49,7 +49,7 @@ def get(**kwargs):
     else:
         cmd += " -a"
 
-    sysrcs = __salt__["cmd.run"](cmd)
+    sysrcs = __salt__["cmd.run"](cmd, output_loglevel="quiet")
     if "sysrc: unknown variable" in sysrcs:
         # raise CommandExecutionError(sysrcs)
         return None


### PR DESCRIPTION
sysrc.get is frequently used by states like sysrc.absent, where it is expected that the variable will not be present.  So don't write errors to the log file.

### What does this PR do?

Removes noise from the minion's logfile

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
applying a "sysrc.absent" state that didn't need to change anything would print useless error messages to the log file

### New Behavior
No useless error messages are logged.

### Merge requirements satisfied?
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes
