### PR TITLE
[master] virt: Error on unexpected parameters and add docs

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1284,6 +1284,24 @@ def _gen_pool_xml(
     """
     Generate the XML string to define a libvirt storage pool
     """
+
+    # Validate settings
+    types_devices = ['fs', 'logical', 'disk', 'iscsi', 'zfs', 'vstorage', 'iscsi-direct']
+    if ptype not in types_devices and source_devices:
+        raise SaltInvocationError(
+            "pool type does not support passing devices"
+        )
+    types_hosts = ['netfs', 'iscsi', 'rbd', 'sheepdog', 'gluster', 'iscsi-direct']
+    if ptype not in types_hosts and source_hosts:
+        raise SaltInvocationError(
+            "pool type does not support passing hosts"
+        )
+    types_name = ['logical', 'rbd', 'sheepdog', 'gluster', 'zfs']
+    if ptype not in types_name and source_name:
+        raise SaltInvocationError(
+            "pool type does not support passing name"
+        )
+
     hosts = [host.split(":") for host in source_hosts or []]
     source = None
     if any(

--- a/salt/states/virt.py
+++ b/salt/states/virt.py
@@ -2102,6 +2102,12 @@ def pool_running(
                 format: cifs
             - autostart: True
 
+    .. warning::
+
+        Many parameters have a default value in `libvirt`, which will work with
+        Salt. However, leaving them out will generally register a change every
+        time you apply the state.
+
     """
     ret = pool_defined(
         name,

--- a/salt/templates/virt/libvirt_pool.jinja
+++ b/salt/templates/virt/libvirt_pool.jinja
@@ -43,17 +43,15 @@
          {% endif %}
     </adapter>
     {% endif %}
-    {% if ptype in ['netfs', 'iscsi', 'rbd', 'sheepdog', 'gluster', 'iscsi-direct'] and source.hosts %}
     {% for host in source.hosts %}
     <host name='{{ host.name }}' {% if host.port %}port='{{ host.port }}'{% endif %}/>
     {% endfor %}
-    {% endif %}
     {% if ptype in ['iscsi', 'rbd', 'iscsi-direct'] and source.auth %}
     <auth type='{{source.auth.type}}' username='{{ source.auth.username }}'>
       <secret {{ source.auth.secret.type }}='{{source.auth.secret.value}}'/>
     </auth>
     {% endif %}
-    {% if ptype in ['logical', 'rbd', 'sheepdog', 'gluster'] and source.name %}
+    {% if source.name %}
     <name>{{ source.name }}</name>
     {% endif %}
     {% if ptype in ['fs', 'netfs', 'logical', 'disk'] and source.format %}


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes:
- virt.pool_running doesn't support source_name with ZFS
- Error when unexpected parameters are included, rather than silently dropping them
- Add a warning about specifying all parameters

### Previous Behavior
- Ignore source_name with ZFS pools
- Silently drop parameters that don't work with a pool type
- No doc about default parameter behavior

### New Behavior
- Support source name with ZFS pools
- Error when unexpected parameters are included
- Include a warning in the docs

### Merge requirements satisfied?

This PR dubiously ready to be merged: I converted some of the Jinja2 checks for pool type compatibility into a check in the Python that the pool type is compatible, but not all of them. If this change seems generally desirable, I can go back and convert more/all, but I didn't want to do that work if the premise of the change is undesirable.

(I think the source_name with ZFS and the warning in the docs are desirable in some form, but a hard error on unexpected parameters seems more debatable -- I vaguely thought there was a state that had a "we have compatibility checks, but you can override them" setup, but I didn't see it when I looked.)

**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
