### PR TITLE
[3006.x][BACKPORT] Move the mac_user._kcpassword unit test into the pytests directory.

### DIFF
--- a/tests/pytests/README.md
+++ b/tests/pytests/README.md
@@ -11,4 +11,4 @@ shall be used, neither our [customizations to it](../support/case.py).
 While [PyTest](https://docs.pytest.org) can happily run unittest tests(withough taking advantage of most of PyTest's strengths),
 this new path in the tests directory was created to provide a clear separation between the two approaches to writing tests.
 Some(hopefully all) of the existing unittest tests might get ported to PyTest's style of writing tests, new tests should be added under
-this directory tree, and, in the long run, this directoy shall become the top level tests directoy.
+this directory tree, and, in the long run, this directory shall become the top level tests directory.

--- a/tests/pytests/unit/modules/test_mac_user.py
+++ b/tests/pytests/unit/modules/test_mac_user.py
@@ -420,3 +420,24 @@ def test_list_users():
         mac_user.__salt__, {"cmd.run_all": mock_run}
     ):
         assert mac_user.list_users() == expected
+
+
+def test_kcpassword():
+    hashes = {
+        # Actual hashes from macOS, since reference implementation didn't account for trailing null
+        "0": "4d 89 f9 91 1f 7a 46 5e f7 a8 11 ff",
+        "password": "0d e8 21 50 a5 d3 af 8e a3 de d9 14",
+        "shorterpwd": "0e e1 3d 51 a6 d9 af 9a d4 dd 1f 27",
+        "Squarepants": "2e f8 27 42 a0 d9 ad 8b cd cd 6c 7d",
+        "longerpasswd": "11 e6 3c 44 b7 ce ad 8b d0 ca 68 19 89 b1 65 ae 7e 89 12 b8 51 f8 f0 ff",
+        "ridiculouslyextendedpass": "0f e0 36 4a b1 c9 b1 85 d6 ca 73 04 ec 2a 57 b7 d2 b9 8f c7 c9 7e 0e fa 52 7b 71 e6 f8 b7 a6 ae 47 94 d7 86",
+    }
+    for password, hash in hashes.items():
+        kcpass = mac_user._kcpassword(password)
+        hash = bytes.fromhex(hash)
+
+        # macOS adds a trailing null and pads the rest with random data
+        length = len(password) + 1
+
+        assert kcpass[:length] == hash[:length]
+        assert len(kcpass) == len(hash)


### PR DESCRIPTION
Fix broken Backport 
This will backport the following commits from master to 3006.x:

https://github.com/saltstack/salt/pull/64229
Move the mac_user._kcpassword unit test into the pytests directory.
Also fix a typo in the pytests README.

The automated backport had an error which was not caught, it only backport two file changes and not the 5 it should have.

See https://github.com/saltstack/salt/issues/64294 capaturing the issue

These changes backported by hand correctly.

(cherry picked from commit 7fc547faffadb83e15bba228004dd12d38d2a45f)

### What does this PR do?

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/pull/64293 and https://github.com/saltstack/salt/issues/64226

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
