### PR TITLE
[master] Allow opt-out of discard on disk format

### DIFF
--- a/changelog/64310.added.md
+++ b/changelog/64310.added.md
@@ -1,0 +1,1 @@
+Added ``discard`` parameter to ``disk.format_`` and ``blockdev.formatted`` to allow opting out of block discard during filesystem creation, preventing sparse inflation of disk images on host filesystems.

--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -481,6 +481,7 @@ def format_(
     lazy_itable_init=None,
     fat=None,
     force=False,
+    discard=True,
 ):
     """
     Format a filesystem onto a device
@@ -519,6 +520,15 @@ def format_(
 
         This option is dangerous, use it with caution.
 
+    discard
+        Attempt to discard blocks at mkfs time (enabled by default). Set to
+        ``False`` to disable block discard, which prevents sparse file
+        inflation when formatting disk images on a host filesystem.
+
+        This option is only supported for ext and xfs filesystems.
+
+        .. versionadded:: 3009.0
+
     CLI Example:
 
     .. code-block:: bash
@@ -534,6 +544,11 @@ def format_(
     if lazy_itable_init is not None:
         if fs_type[:3] == "ext":
             cmd.extend(["-E", f"lazy_itable_init={lazy_itable_init}"])
+    if not discard:
+        if fs_type[:3] == "ext":
+            cmd.extend(["-E", "nodiscard"])
+        elif fs_type == "xfs":
+            cmd.append("-K")
     if fat is not None and fat in (12, 16, 32):
         if fs_type[-3:] == "fat":
             cmd.extend(["-F", fat])

--- a/tests/pytests/unit/modules/test_disk.py
+++ b/tests/pytests/unit/modules/test_disk.py
@@ -384,6 +384,34 @@ def test_format_():
 
 @pytest.mark.skip_on_windows(reason="Skip on Windows")
 @pytest.mark.skip_if_binaries_missing("mkfs")
+def test_format__nodiscard_ext():
+    """
+    unit tests for disk.format_ with discard=False on an ext filesystem
+    """
+    device = "/dev/sdX1"
+    mock = MagicMock(return_value=0)
+    with patch.dict(disk.__salt__, {"cmd.retcode": mock}):
+        disk.format_(device=device, fs_type="ext4", discard=False)
+        mock.assert_any_call(
+            ["mkfs", "-t", "ext4", "-E", "nodiscard", device], ignore_retcode=True
+        )
+
+
+@pytest.mark.skip_on_windows(reason="Skip on Windows")
+@pytest.mark.skip_if_binaries_missing("mkfs")
+def test_format__nodiscard_xfs():
+    """
+    unit tests for disk.format_ with discard=False on an xfs filesystem
+    """
+    device = "/dev/sdX1"
+    mock = MagicMock(return_value=0)
+    with patch.dict(disk.__salt__, {"cmd.retcode": mock}):
+        disk.format_(device=device, fs_type="xfs", discard=False)
+        mock.assert_any_call(["mkfs", "-t", "xfs", "-K", device], ignore_retcode=True)
+
+
+@pytest.mark.skip_on_windows(reason="Skip on Windows")
+@pytest.mark.skip_if_binaries_missing("mkfs")
 def test_format__fat():
     """
     unit tests for disk.format_ with FAT parameter


### PR DESCRIPTION
### What does this PR do?
This allows disk images to be formatted explicitly non-sparsely by enabling callers to disable the automatic discard of blocks during filesystem creation.

This is only supported for ext and xfs filesystems.

### What issues does this PR fix or reference?
Fixes:

Current behavior of formatting disk images results in e.g. a 20GB disk image being reduced to 44MB on the parent filesystem, which shows up as potential free space when other things are looking at the parent's disk usage. If the parent filesystem no longer has blocks to service the disk image's usage, it gets ENOSPC errors when it is not at 100% usage.

### New Behavior
Callers to `disk.format` and `blockdev.formatted` can specify `discard=False` for ext and xfs filesystems to disable their respective mkfs tools from doing a block discard during filesystem creation. This ensures the disk image is still reserving blocks on the parent filesystem for itself if it was created non-sparsely.

### Merge requirements satisfied?
- [X] Docs
- [ ] Changelog
- [X] Tests written/updated

### Commits signed with GPG?
No
