### PR TITLE
[3006.x] Fix `pass` renderer failing to retrieve data

### DIFF
--- a/changelog/64309.fixed.md
+++ b/changelog/64309.fixed.md
@@ -1,0 +1,1 @@
+Fixed `pass` renderer failing to retrieve data because of bytes/string type mismatch

--- a/salt/renderers/pass.py
+++ b/salt/renderers/pass.py
@@ -82,6 +82,7 @@ from os.path import expanduser
 from subprocess import PIPE, Popen
 
 import salt.utils.path
+import salt.utils.stringutils
 from salt.exceptions import SaltConfigurationError, SaltRenderError
 
 log = logging.getLogger(__name__)
@@ -167,7 +168,7 @@ def _fetch_secret(pass_path):
         else:
             log.warning(msg)
             return original_pass_path
-    return pass_data.rstrip("\r\n")
+    return salt.utils.stringutils.to_str(pass_data).rstrip("\r\n")
 
 
 def _decrypt_object(obj):

--- a/tests/pytests/unit/renderers/test_pass.py
+++ b/tests/pytests/unit/renderers/test_pass.py
@@ -37,7 +37,7 @@ def test_strict_fetch():
     }
 
     popen_mock = MagicMock(spec=pass_.Popen)
-    popen_mock.return_value.communicate.return_value = ("password123456\n", "")
+    popen_mock.return_value.communicate.return_value = (b"password123456\n", b"")
     popen_mock.return_value.returncode = 0
 
     mocks = {
@@ -60,7 +60,7 @@ def test_strict_fetch_fail():
     }
 
     popen_mock = MagicMock(spec=pass_.Popen)
-    popen_mock.return_value.communicate.return_value = ("", "Secret not found")
+    popen_mock.return_value.communicate.return_value = (b"", b"Secret not found")
     popen_mock.return_value.returncode = 1
 
     mocks = {
@@ -96,7 +96,7 @@ def test_strict_fetch_pass_path_with_spaces():
     }
 
     popen_mock = MagicMock(spec=pass_.Popen)
-    popen_mock.return_value.communicate.return_value = ("password123456\n", "")
+    popen_mock.return_value.communicate.return_value = (b"password123456\n", b"")
     popen_mock.return_value.returncode = 0
 
     mocks = {
@@ -119,7 +119,10 @@ def test_strict_fetch_secret_with_whitespaces():
     }
 
     popen_mock = MagicMock(spec=pass_.Popen)
-    popen_mock.return_value.communicate.return_value = (" \tpassword123456\t \r\n", "")
+    popen_mock.return_value.communicate.return_value = (
+        b" \tpassword123456\t \r\n",
+        b"",
+    )
     popen_mock.return_value.returncode = 0
 
     mocks = {
@@ -146,7 +149,7 @@ def test_env():
     }
 
     popen_mock = MagicMock(spec=pass_.Popen)
-    popen_mock.return_value.communicate.return_value = ("password123456\n", "")
+    popen_mock.return_value.communicate.return_value = (b"password123456\n", b"")
     popen_mock.return_value.returncode = 0
 
     mocks = {


### PR DESCRIPTION
### What does this PR do?
Accounts for the `bytes` type return value of `Popen.communicate()` in the `pass` renderer module and its tests.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/64309

### Previous Behavior
`TypeError: a bytes-like object is required, not 'str'`

### New Behavior
Works as intended

### Merge requirements satisfied?
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes