### PR TITLE
[3006.x] Raise error when cannot add key with aptpkg

### DIFF
--- a/changelog/64253.fixed.md
+++ b/changelog/64253.fixed.md
@@ -1,0 +1,1 @@
+Ensure we return an error when adding the key fails in the pkgrepo state for debian hosts.

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -632,7 +632,7 @@ def install(
     reinstall=False,
     downloadonly=False,
     ignore_epoch=False,
-    **kwargs
+    **kwargs,
 ):
     """
     .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
@@ -2813,13 +2813,17 @@ def mod_repo(repo, saltenv="base", aptkey=True, **kwargs):
                     else:
                         if not aptkey:
                             key_file = kwargs["signedby"]
-                            add_repo_key(
+                            if not add_repo_key(
                                 keyid=key,
                                 keyserver=keyserver,
                                 aptkey=False,
                                 keydir=key_file.parent,
                                 keyfile=key_file,
-                            )
+                            ):
+                                raise CommandExecutionError(
+                                    f"Error: Could not add key: {key}"
+                                )
+
                         else:
                             cmd = [
                                 "apt-key",
@@ -2859,7 +2863,7 @@ def mod_repo(repo, saltenv="base", aptkey=True, **kwargs):
                 func_kwargs["keydir"] = kwargs.get("signedby").parent
 
             if not add_repo_key(path=str(fn_), aptkey=False, **func_kwargs):
-                return False
+                raise CommandExecutionError(f"Error: Could not add key: {str(fn_)}")
         else:
             cmd = ["apt-key", "add", str(fn_)]
             out = __salt__["cmd.run_stdout"](cmd, python_shell=False, **kwargs)

--- a/tests/pytests/functional/states/pkgrepo/test_debian.py
+++ b/tests/pytests/functional/states/pkgrepo/test_debian.py
@@ -10,8 +10,10 @@ import _pytest._version
 import attr
 import pytest
 
+import salt.modules.aptpkg
 import salt.utils.files
 from tests.conftest import CODE_DIR
+from tests.support.mock import MagicMock, patch
 
 PYTEST_GE_7 = getattr(_pytest._version, "version_tuple", (-1, -1)) >= (7, 0)
 
@@ -789,3 +791,56 @@ def test_adding_repo_file_signedby_alt_file(pkgrepo, states, repo):
         assert file_content.endswith("\n")
     assert key_file.is_file()
     assert repo_content in ret.comment
+
+
+def test_adding_repo_file_signedby_fail_key_keyid(
+    pkgrepo, states, repo, subtests, modules
+):
+    """
+    Test adding a repo file using pkgrepo.managed
+    and setting signedby and keyid when adding the key fails
+    an error is returned
+    """
+
+    def _run(test=False):
+        return states.pkgrepo.managed(
+            name=repo.repo_content,
+            file=str(repo.repo_file),
+            clean_file=True,
+            signedby=str(repo.key_file),
+            keyid="10857FFDD3F91EAE577A21D664CBBC8173D76B3F1",
+            keyserver="keyserver.ubuntu.com",
+            aptkey=False,
+            test=test,
+            keydir="/tmp/test",
+        )
+
+    ret = _run()
+    assert "Failed to configure repo" in ret.comment
+    assert "Could not add key" in ret.comment
+
+
+def test_adding_repo_file_signedby_fail_key_keyurl(
+    pkgrepo, states, repo, subtests, modules
+):
+    """
+    Test adding a repo file using pkgrepo.managed
+    and setting signedby and keyurl when adding the key fails
+    an error is returned
+    """
+
+    def _run(test=False):
+        with patch(
+            "salt.utils.path.which", MagicMock(side_effect=[True, True, False, False])
+        ):
+            return states.pkgrepo.managed(
+                name=repo.repo_content,
+                file=str(repo.repo_file),
+                clean_file=True,
+                key_url="https://repo.saltproject.io/salt/py3/ubuntu/20.04/amd64/latest/SALT-PROJECT-GPG-PUBKEY-2023.pub",
+                aptkey=False,
+            )
+
+    ret = _run()
+    assert "Failed to configure repo" in ret.comment
+    assert "Could not add key" in ret.comment


### PR DESCRIPTION
### What does this PR do?
Ensures we properly raise an error when we cannot properly add a key when adding a repo with apt. The pkg state is catching error exceptions and not expecting False to be returned.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/64253

### Previous Behavior
When adding a key alongside a repo if there was a failure it would not include a failure in the return

### New Behavior
When adding a key now it returns an error.

