### PR TITLE
[3006.x] Fix 64169 lint error

### DIFF
--- a/tests/pytests/unit/states/test_pip.py
+++ b/tests/pytests/unit/states/test_pip.py
@@ -67,5 +67,4 @@ def test_issue_64169(caplog):
 
         # Confirm that the state continued to install the package as expected.
         # Only check the 'pkgs' parameter of pip.install
-        mock_install_call_args, mock_install_call_kwargs = mock_pip_install.call_args
-        assert mock_install_call_kwargs["pkgs"] == pkg_to_install
+        assert mock_pip_install.call_args.kwargs["pkgs"] == pkg_to_install


### PR DESCRIPTION
### What does this PR do?
Nightly Tests would fail due to `tests/pytests/unit/states/test_pip.py:70: [E0633(unpacking-non-sequence), test_issue_64169] Attempting to unpack a non-sequence defined at line 589 of mock`

### Commits signed with GPG?
Yes

