### PR TITLE
[master] MacOS fixes ~/Library/LaunchAgent directory resolution.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ Versions are `MAJOR.PATCH`.
 
 ### Fixed
 
+- Darwin: Fix for resolving home directory when controlling services on MacOS - see [#64354](https://github.com/saltstack/salt/issues/64354).
+
+
+## 3006.1 (2023-05-05)
+
+
+### Fixed
+
 - Check that the return data from the cloud create function is a dictionary before attempting to pull values out. [#61236](https://github.com/saltstack/salt/issues/61236)
 - Ensure NamedLoaderContext's have their value() used if passing to other modules [#62477](https://github.com/saltstack/salt/issues/62477)
 - add documentation note about reactor state ids. [#63589](https://github.com/saltstack/salt/issues/63589)

--- a/salt/utils/mac_utils.py
+++ b/salt/utils/mac_utils.py
@@ -406,6 +406,17 @@ def _available_services(refresh=False):
         "/System/Library/LaunchDaemons",
     }
 
+    # MickMake notes: If your home directory is elsewhere; for
+    # example if you have an external disk that replaces /Users,
+    # but not mounted there, then the following method will pull
+    # in the current user's Library path.
+    # Use either os.path.expanduser('~') OR Path.home()
+    # Not sure which is better, but either works.
+    agent_path = os.path.expanduser('~') + "/Library/LaunchAgents"
+    if os.path.isdir(agent_path.format(user))
+        launchd_paths.update(os.path.expanduser('~') + "/Library/LaunchAgents")
+    # log.error("mmDEBUG: " + agent_path)
+
     agent_path = "/Users/{}/Library/LaunchAgents"
     launchd_paths.update(
         {


### PR DESCRIPTION
### What does this PR do?
This fixes the MacOS issue of home directories not actually being mounted on /Users.
Usually happens when you have a second drive that you have moved all users over to.
In my case, my home directory is /Volumes/home/mick, which barfs the current directory logic.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/64354

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No - It's a very simple change.

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.