### PR TITLE
[3006.x] Fix salt user login shell path in Debian packages

### DIFF
--- a/changelog/64377.fixed.md
+++ b/changelog/64377.fixed.md
@@ -1,0 +1,1 @@
+Fix salt user login shell path in Debian packages

--- a/pkg/debian/salt-common.preinst
+++ b/pkg/debian/salt-common.preinst
@@ -4,6 +4,7 @@ case "$1" in
     [ -z "$SALT_USER" ] && SALT_USER=salt
     [ -z "$SALT_NAME" ] && SALT_NAME="Salt"
     [ -z "$SALT_GROUP" ] && SALT_GROUP=salt
+    [ -z "$SALT_SHELL" ] && SALT_SHELL=/usr/sbin/nologin
 
     # create user to avoid running server as root
     # 1. create group if not existing
@@ -19,7 +20,7 @@ case "$1" in
       echo -n "Adding system user $SALT_USER.."
       useradd --system \
               --no-create-home \
-              -s /sbin/nologin \
+              -s $SALT_SHELL \
               -g $SALT_GROUP \
               $SALT_USER 2>/dev/null || true
       echo "..done"
@@ -27,6 +28,7 @@ case "$1" in
     # 4. adjust passwd entry
     usermod -c "$SALT_NAME" \
             -d $SALT_HOME   \
+            -s $SALT_SHELL  \
             -g $SALT_GROUP  \
              $SALT_USER
     # 5. adjust file and directory permissions

--- a/pkg/tests/integration/test_salt_user.py
+++ b/pkg/tests/integration/test_salt_user.py
@@ -57,6 +57,24 @@ def test_salt_user_group(install_salt):
     assert in_group is True
 
 
+def test_salt_user_shell(install_salt):
+    """
+    Test the salt user's login shell
+    """
+    proc = subprocess.run(
+        ["getent", "passwd", "salt"], check=False, capture_output=True
+    )
+    assert proc.returncode == 0
+    shell = ""
+    shell_exists = False
+    try:
+        shell = proc.stdout.decode().split(":")[6].strip()
+        shell_exists = pathlib.Path(shell).exists()
+    except:
+        pass
+    assert shell_exists is True
+
+
 def test_salt_cloud_dirs(install_salt):
     """
     Test the correct user is running the Salt Master


### PR DESCRIPTION
There are cases where /sbin/nologin doesn't exist on Debian servers. This will set /usr/sbin/nologin on new installs and update it on existing installs during the next upgrade as well.

### What does this PR do?

### What issues does this PR fix or reference?
Fixes: #64377

### Previous Behavior
In cases where /sbin/nologin doesn't exist on Debian servers, running ```salt-master -l debug``` will fail because the login shell is not available.

### New Behavior
The "salt" user login shell will be set to /usr/sbin/nologin which is the Debian default.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes