### PR TITLE
[3006.x] remove the hard coded 2 in an error message.

### DIFF
--- a/changelog/64237.fixed.md
+++ b/changelog/64237.fixed.md
@@ -1,0 +1,1 @@
+remove the hard coded python version in error.

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -174,7 +174,7 @@ def _check_pkg_version_format(pkg):
 
     if not HAS_PIP:
         ret["comment"] = (
-            "An importable Python 2 pip module is required but could not be "
+            "An importable Python pip module is required but could not be "
             "found on your system. This usually means that the system's pip "
             "package is not installed properly."
         )


### PR DESCRIPTION
### What does this PR do? 

remove a 2 in an error message

### What issues does this PR fix or reference?
Fixes: #64237 

### Previous Behavior
message included a 2 as part of the python message.

### New Behavior
message now just says python without the 2

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No
