### PR TITLE
[3006.x] Fix deleting from `utils/aws.py::__AssumeCache__` while iterating over it

### DIFF
--- a/changelog/61049.fixed.md
+++ b/changelog/61049.fixed.md
@@ -1,0 +1,1 @@
+Do not update the credentials dictionary in `utils/aws.py` while iterating over it, and use the correct delete functionality

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -8,6 +8,7 @@ This is a base library used by a number of AWS services.
 :depends: requests
 """
 
+import copy
 import hashlib
 import hmac
 import logging
@@ -230,9 +231,9 @@ def assumed_creds(prov_dict, role_arn, location=None):
     # current time in epoch seconds
     now = time.mktime(datetime.utcnow().timetuple())
 
-    for key, creds in __AssumeCache__.items():
+    for key, creds in copy.deepcopy(__AssumeCache__).items():
         if (creds["Expiration"] - now) <= 120:
-            __AssumeCache__[key].delete()
+            del __AssumeCache__[key]
 
     if role_arn in __AssumeCache__:
         c = __AssumeCache__[role_arn]

--- a/tests/pytests/unit/utils/test_aws.py
+++ b/tests/pytests/unit/utils/test_aws.py
@@ -6,10 +6,12 @@
 """
 
 import io
+import time
+from datetime import datetime, timedelta
 
 import requests
 
-from salt.utils.aws import get_metadata
+import salt.utils.aws as aws
 from tests.support.mock import MagicMock, patch
 
 
@@ -19,7 +21,7 @@ def test_get_metadata_imdsv1():
     response.reason = "OK"
     response.raw = io.BytesIO(b"""test""")
     with patch("requests.get", return_value=response):
-        result = get_metadata("/")
+        result = aws.get_metadata("/")
         assert result.text == "test"
 
 
@@ -48,5 +50,76 @@ def test_get_metadata_imdsv2():
     with patch("requests.get", MagicMock(side_effect=handle_get_mock)), patch(
         "requests.put", return_value=put_response
     ):
-        result = get_metadata("/")
+        result = aws.get_metadata("/")
         assert result.text == "test"
+
+
+def test_assumed_creds_not_updating_dictionary_while_iterating():
+    mock_cache = {
+        "expired": {
+            "Expiration": time.mktime(datetime.utcnow().timetuple()),
+        },
+        "not_expired_1": {
+            "Expiration": time.mktime(
+                (datetime.utcnow() + timedelta(days=1)).timetuple()
+            ),
+            "AccessKeyId": "mock_AccessKeyId",
+            "SecretAccessKey": "mock_SecretAccessKey",
+            "SessionToken": "mock_SessionToken",
+        },
+        "not_expired_2": {
+            "Expiration": time.mktime(
+                (datetime.utcnow() + timedelta(seconds=300)).timetuple()
+            ),
+        },
+    }
+    with patch.dict(aws.__AssumeCache__, mock_cache):
+        ret = aws.assumed_creds({}, "not_expired_1")
+        assert "expired" not in aws.__AssumeCache__
+        assert ret == ("mock_AccessKeyId", "mock_SecretAccessKey", "mock_SessionToken")
+
+
+def test_assumed_creds_deletes_expired_key():
+    mock_cache = {
+        "expired": {
+            "Expiration": time.mktime(datetime.utcnow().timetuple()),
+        },
+        "not_expired_1": {
+            "Expiration": time.mktime(
+                (datetime.utcnow() + timedelta(days=1)).timetuple()
+            ),
+            "AccessKeyId": "mock_AccessKeyId",
+            "SecretAccessKey": "mock_SecretAccessKey",
+            "SessionToken": "mock_SessionToken",
+        },
+        "not_expired_2": {
+            "Expiration": time.mktime(
+                (datetime.utcnow() + timedelta(seconds=300)).timetuple()
+            ),
+        },
+    }
+    creds_dict = {
+        "AccessKeyId": "mock_AccessKeyId",
+        "SecretAccessKey": "mock_SecretAccessKey",
+        "SessionToken": "mock_SessionToken",
+    }
+    response_mock = MagicMock()
+    response_mock.status_code = 200
+    response_mock.json.return_value = {
+        "AssumeRoleResponse": {
+            "AssumeRoleResult": {
+                "Credentials": creds_dict,
+            },
+        },
+    }
+    with patch.dict(aws.__AssumeCache__, mock_cache):
+        with patch.object(aws, "sig4", return_value=({}, "fakeurl.com")):
+            with patch("requests.request", return_value=response_mock):
+                ret = aws.assumed_creds({}, "expired")
+                assert "expired" in aws.__AssumeCache__
+                assert aws.__AssumeCache__["expired"] == creds_dict
+                assert ret == (
+                    "mock_AccessKeyId",
+                    "mock_SecretAccessKey",
+                    "mock_SessionToken",
+                )


### PR DESCRIPTION
### What does this PR do?
Fixes use of invalid delete method for a dictionary and avoids deleting on the dictionary we iterate over. 

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/61049

### Previous Behavior
Invalid `.delete()` method for a dictionary, and attempting to delete from the dictionary we are iterating over.

### New Behavior
Use of `del` to delete from a dictionary, and don't delete from the dictionary we are iterating over, but a copy of it.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes