### PR TITLE
[master] Don't report failure on task manager installs

### DIFF
--- a/changelog/63767.fixed.md
+++ b/changelog/63767.fixed.md
@@ -1,0 +1,1 @@
+pkg.installed no longer reports failure when installing packages that are installed via the task manager


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where ``pkg.installed`` was reporting failure on packages that use the task manager. This is seen mainly when upgrading Salt itself, as it uses the task manager to upgrade itself.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/63767

### Previous Behavior
The state would fail, though the task that launches the minion installer started successfully.

### New Behavior
The state now completes successfully.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes