### PR TITLE
[master] Add ability to return False result in test mode of configurable_test_state

### DIFF
--- a/changelog/64418.added.md
+++ b/changelog/64418.added.md
@@ -1,0 +1,1 @@
+Add ability to return False result in test mode of configurable_test_state

--- a/salt/states/test.py
+++ b/salt/states/test.py
@@ -173,7 +173,14 @@ def fail_with_changes(name, **kwargs):  # pylint: disable=unused-argument
     return ret
 
 
-def configurable_test_state(name, changes=True, result=True, comment="", warnings=None):
+def configurable_test_state(
+    name,
+    changes=True,
+    result=True,
+    comment="",
+    warnings=None,
+    allow_test_mode_failure=False,
+):
     """
     .. versionadded:: 2014.7.0
 
@@ -221,6 +228,13 @@ def configurable_test_state(name, changes=True, result=True, comment="", warning
         Default is None
 
         .. versionadded:: 3000
+
+    allow_test_mode_failure
+        When False, running this state in test mode can only return a True
+        or None result. When set to True and result is set to False, the
+        test mode result will be False. Default is False
+
+        .. versionadded:: 3007.0
     """
     ret = {"name": name, "changes": {}, "result": False, "comment": comment}
     change_data = {
@@ -276,7 +290,11 @@ def configurable_test_state(name, changes=True, result=True, comment="", warning
         )
 
     if __opts__["test"]:
-        ret["result"] = True if changes is False else None
+        if allow_test_mode_failure and result is False:
+            test_result = result
+        else:
+            test_result = True if changes is False else None
+        ret["result"] = test_result
         ret["comment"] = "This is a test" if not comment else comment
 
     return ret

--- a/tests/pytests/unit/states/test_test.py
+++ b/tests/pytests/unit/states/test_test.py
@@ -354,7 +354,6 @@ def test_configurable_test_state_test():
         ret = test.configurable_test_state(mock_name)
         assert ret == mock_ret
 
-    with patch.dict(test.__opts__, {"test": True}):
         mock_ret = {
             "name": mock_name,
             "changes": mock_changes,
@@ -364,7 +363,6 @@ def test_configurable_test_state_test():
         ret = test.configurable_test_state(mock_name, comment=mock_comment)
         assert ret == mock_ret
 
-    with patch.dict(test.__opts__, {"test": True}):
         mock_ret = {
             "name": mock_name,
             "changes": mock_changes,
@@ -376,7 +374,6 @@ def test_configurable_test_state_test():
         )
         assert ret == mock_ret
 
-    with patch.dict(test.__opts__, {"test": True}):
         mock_ret = {
             "name": mock_name,
             "changes": {},
@@ -385,6 +382,30 @@ def test_configurable_test_state_test():
         }
         ret = test.configurable_test_state(
             mock_name, changes=False, comment=mock_comment
+        )
+        assert ret == mock_ret
+
+        # normal test mode operation doesn't allow False result
+        mock_ret = {
+            "name": mock_name,
+            "changes": {},
+            "result": True,
+            "comment": "This is a test",
+        }
+        ret = test.configurable_test_state(
+            mock_name, changes=False, result=False, allow_test_mode_failure=False
+        )
+        assert ret == mock_ret
+
+        # test allow False result in test mode
+        mock_ret = {
+            "name": mock_name,
+            "changes": {},
+            "result": False,
+            "comment": "This is a test",
+        }
+        ret = test.configurable_test_state(
+            mock_name, changes=False, result=False, allow_test_mode_failure=True
         )
         assert ret == mock_ret
 


### PR DESCRIPTION
### What does this PR do?
See issue for details

### What issues does this PR fix or reference?
Fixes: #64418 

### Previous Behavior
The result of `test.configurable_test_state` could only be `None` or `True` in test mode.

### New Behavior
Now a `False` result can be allowed in test mode.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
