### PR TITLE
[master] Fix 'unable to unmount' failure to return False result instead of None

### DIFF
--- a/changelog/64420.fixed.md
+++ b/changelog/64420.fixed.md
@@ -1,0 +1,1 @@
+Fix 'unable to unmount' failure to return False result instead of None

--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -626,7 +626,7 @@ def mounted(
                     active = __salt__["mount.active"](extended=True)
                     if comp_real_name in active:
                         ret["comment"] = "Unable to unmount"
-                        ret["result"] = None
+                        ret["result"] = False
                         return ret
                     update_mount_cache = True
             else:

--- a/tests/pytests/unit/states/test_mount.py
+++ b/tests/pytests/unit/states/test_mount.py
@@ -94,7 +94,7 @@ def test_mounted():
                 ret.update(
                     {
                         "comment": comt,
-                        "result": None,
+                        "result": False,
                         "changes": {"umount": umount1},
                     }
                 )
@@ -115,7 +115,7 @@ def test_mounted():
                     "os.path.exists", MagicMock(return_value=False)
                 ):
                     comt = "{} does not exist and would not be created".format(name)
-                    ret.update({"comment": comt, "changes": {}})
+                    ret.update({"comment": comt, "changes": {}, "result": None})
                     assert mount.mounted(name, device, fstype) == ret
 
                 with patch.dict(mount.__opts__, {"test": False}):


### PR DESCRIPTION
### What does this PR do?
See issue for details.

### What issues does this PR fix or reference?
Fixes: #64420

### Previous Behavior
`None` was returned in some scenarios even though an unmount could not be performed

### New Behavior
Failures gonna fail

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
