### PR TITLE
[3006.x] Make ansible roster docs actually parsable and consistent

### DIFF
--- a/salt/roster/ansible.py
+++ b/salt/roster/ansible.py
@@ -7,16 +7,16 @@ Flat inventory files should be in the regular ansible inventory format.
 
     # /tmp/example_roster
     [servers]
-    salt.gtmanfred.com ansible_ssh_user=gtmanfred ansible_ssh_host=127.0.0.1 ansible_ssh_port=22 ansible_ssh_pass='password'
+    salt.gtmanfred.com ansible_ssh_user=gtmanfred ansible_ssh_host=127.0.0.1 ansible_ssh_port=22 ansible_ssh_pass='password' ansible_sudo_pass='password'
 
     [desktop]
-    home ansible_ssh_user=gtmanfred ansible_ssh_host=12.34.56.78 ansible_ssh_port=23 ansible_ssh_pass='password'
+    home ansible_ssh_user=gtmanfred ansible_ssh_host=12.34.56.78 ansible_ssh_port=23 ansible_ssh_pass='password' ansible_sudo_pass='password'
 
     [computers:children]
     desktop
     servers
 
-    [names:vars]
+    [computers:vars]
     http_port=80
 
 then salt-ssh can be used to hit any of them
@@ -47,35 +47,40 @@ There is also the option of specifying a dynamic inventory, and generating it on
     #!/bin/bash
     # filename: /etc/salt/hosts
     echo '{
-      "servers": [
-        "salt.gtmanfred.com"
-      ],
-      "desktop": [
-        "home"
-      ],
-      "computers": {
-        "hosts": [],
-        "children": [
-          "desktop",
-          "servers"
-        ]
-      },
-      "_meta": {
-        "hostvars": {
-          "salt.gtmanfred.com": {
-            "ansible_ssh_user": "gtmanfred",
-            "ansible_ssh_host": "127.0.0.1",
-            "ansible_sudo_pass": "password",
-            "ansible_ssh_port": 22
-          },
-          "home": {
-            "ansible_ssh_user": "gtmanfred",
-            "ansible_ssh_host": "12.34.56.78",
-            "ansible_sudo_pass": "password",
-            "ansible_ssh_port": 23
-          }
+        "servers": [
+            "salt.gtmanfred.com"
+        ],
+        "desktop": [
+            "home"
+        ],
+        "computers": {
+            "hosts": [],
+            "children": [
+                "desktop",
+                "servers"
+            ],
+            "vars": {
+                "http_port": 80
+            }
+        },
+        "_meta": {
+            "hostvars": {
+                "salt.gtmanfred.com": {
+                    "ansible_ssh_user": "gtmanfred",
+                    "ansible_ssh_host": "127.0.0.1",
+                    "ansible_sudo_pass": "password",
+                    "ansible_ssh_pass": "password",
+                    "ansible_ssh_port": 22
+                },
+                "home": {
+                    "ansible_ssh_user": "gtmanfred",
+                    "ansible_ssh_host": "12.34.56.78",
+                    "ansible_sudo_pass": "password",
+                    "ansible_ssh_pass": "password",
+                    "ansible_ssh_port": 23
+                }
+            }
         }
-      }
     }'
 
 This is the format that an inventory script needs to output to work with ansible, and thus here.

--- a/tests/pytests/unit/roster/test_ansible.py
+++ b/tests/pytests/unit/roster/test_ansible.py
@@ -62,6 +62,28 @@ def expected_targets_return():
     }
 
 
+@pytest.fixture
+def expected_docs_targets_return():
+    return {
+        "home": {
+            "passwd": "password",
+            "sudo": "password",
+            "host": "12.34.56.78",
+            "port": 23,
+            "user": "gtmanfred",
+            "minion_opts": {"http_port": 80},
+        },
+        "salt.gtmanfred.com": {
+            "passwd": "password",
+            "sudo": "password",
+            "host": "127.0.0.1",
+            "port": 22,
+            "user": "gtmanfred",
+            "minion_opts": {"http_port": 80},
+        },
+    }
+
+
 @pytest.fixture(scope="module")
 def roster_dir(tmp_path_factory):
     dpath = tmp_path_factory.mktemp("roster")
@@ -136,6 +158,59 @@ def roster_dir(tmp_path_factory):
       children:
         southeast:
     """
+    docs_ini_contents = """
+    [servers]
+    salt.gtmanfred.com ansible_ssh_user=gtmanfred ansible_ssh_host=127.0.0.1 ansible_ssh_port=22 ansible_ssh_pass='password' ansible_sudo_pass='password'
+
+    [desktop]
+    home ansible_ssh_user=gtmanfred ansible_ssh_host=12.34.56.78 ansible_ssh_port=23 ansible_ssh_pass='password' ansible_sudo_pass='password'
+
+    [computers:children]
+    desktop
+    servers
+
+    [computers:vars]
+    http_port=80
+    """
+    docs_script_contents = """
+    #!/bin/bash
+    echo '{
+        "servers": [
+            "salt.gtmanfred.com"
+        ],
+        "desktop": [
+            "home"
+        ],
+        "computers": {
+            "hosts": [],
+            "children": [
+                "desktop",
+                "servers"
+            ],
+            "vars": {
+                "http_port": 80
+            }
+        },
+        "_meta": {
+            "hostvars": {
+                "salt.gtmanfred.com": {
+                    "ansible_ssh_user": "gtmanfred",
+                    "ansible_ssh_host": "127.0.0.1",
+                    "ansible_sudo_pass": "password",
+                    "ansible_ssh_pass": "password",
+                    "ansible_ssh_port": 22
+                },
+                "home": {
+                    "ansible_ssh_user": "gtmanfred",
+                    "ansible_ssh_host": "12.34.56.78",
+                    "ansible_sudo_pass": "password",
+                    "ansible_ssh_pass": "password",
+                    "ansible_ssh_port": 23
+                }
+            }
+        }
+    }'
+    """
     with pytest.helpers.temp_file(
         "roster.py", roster_py_contents, directory=dpath
     ) as py_roster:
@@ -144,11 +219,17 @@ def roster_dir(tmp_path_factory):
             "roster.ini", roster_ini_contents, directory=dpath
         ), pytest.helpers.temp_file(
             "roster.yml", roster_yaml_contents, directory=dpath
+        ), pytest.helpers.temp_file(
+            "roster-docs.ini", docs_ini_contents, directory=dpath
         ):
-            try:
-                yield dpath
-            finally:
-                shutil.rmtree(str(dpath), ignore_errors=True)
+            with pytest.helpers.temp_file(
+                "roster-docs.sh", docs_script_contents, directory=dpath
+            ) as script_roster:
+                script_roster.chmod(0o755)
+                try:
+                    yield dpath
+                finally:
+                    shutil.rmtree(str(dpath), ignore_errors=True)
 
 
 @pytest.mark.parametrize(
@@ -179,3 +260,17 @@ def test_script(roster_opts, roster_dir, expected_targets_return):
     with patch.dict(ansible.__opts__, roster_opts):
         ret = ansible.targets("*")
         assert ret == expected_targets_return
+
+
+def test_docs_ini(roster_opts, roster_dir, expected_docs_targets_return):
+    roster_opts["roster_file"] = str(roster_dir / "roster-docs.ini")
+    with patch.dict(ansible.__opts__, roster_opts):
+        ret = ansible.targets("*")
+        assert ret == expected_docs_targets_return
+
+
+def test_docs_script(roster_opts, roster_dir, expected_docs_targets_return):
+    roster_opts["roster_file"] = str(roster_dir / "roster-docs.sh")
+    with patch.dict(ansible.__opts__, roster_opts):
+        ret = ansible.targets("*")
+        assert ret == expected_docs_targets_return


### PR DESCRIPTION
### What does this PR do?
Some of the ansible roster docs weren't parsable, now they are, and the two examples produce the same output when run through `ansible-inventory`.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/59293

### Previous Behavior
Ansible roster docs not parsable and inconsistent

### New Behavior
Now they are parsable and consistent

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes