### PR TITLE
[master] fix: slack bolt engine name is slack_bolt

### DIFF
--- a/salt/engines/slack_bolt_engine.py
+++ b/salt/engines/slack_bolt_engine.py
@@ -234,7 +234,7 @@ class SlackClient:
 
         self.msg_queue = collections.deque()
 
-        trigger_pattern = "(^{}.*)".format(trigger_string)
+        trigger_pattern = f"(^{trigger_string}.*)"
 
         # Register message_trigger when we see messages that start
         # with the trigger string
@@ -843,7 +843,7 @@ class SlackClient:
         results = {}
         for jid in outstanding_jids:
             # results[jid] = runner.cmd('jobs.lookup_jid', [jid])
-            if self.master_minion.returners["{}.get_jid".format(source)](jid):
+            if self.master_minion.returners[f"{source}.get_jid"](jid):
                 job_result = runner.cmd("jobs.list_job", [jid])
                 jid_result = job_result.get("Result", {})
                 jid_function = job_result.get("Function", {})
@@ -954,7 +954,7 @@ class SlackClient:
                     )
                     ts = time.time()
                     st = datetime.datetime.fromtimestamp(ts).strftime("%Y%m%d%H%M%S%f")
-                    filename = "salt-results-{}.yaml".format(st)
+                    filename = f"salt-results-{st}.yaml"
                     resp = self.app.client.files_upload(
                         channels=channel,
                         filename=filename,
@@ -1075,4 +1075,4 @@ def start(
         )
         client.run_commands_from_slack_async(message_generator, fire_all, tag, control)
     except Exception:  # pylint: disable=broad-except
-        raise Exception("{}".format(traceback.format_exc()))
+        raise Exception(f"{traceback.format_exc()}")

--- a/salt/engines/slack_bolt_engine.py
+++ b/salt/engines/slack_bolt_engine.py
@@ -111,7 +111,7 @@ the desired command.
 .. code-block:: text
 
     engines:
-      - slack:
+      - slack_bolt:
           app_token: "xapp-x-xxxxxxxxxxx-xxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
           bot_token: 'xoxb-xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx'
           control: True
@@ -149,7 +149,7 @@ must be quoted, or else PyYAML will fail to load the configuration.
 .. code-block:: text
 
     engines:
-      - slack:
+      - slack_bolt:
           groups_pillar: slack_engine_pillar
           app_token: "xapp-x-xxxxxxxxxxx-xxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
           bot_token: 'xoxb-xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx'


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes: The new slack bolt module docs appear to be referencing the old engine name.

### Previous Behavior
The bolt engine is not actually started.

### New Behavior
The bolt engine is started.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
