### PR TITLE
[master] Fix missing arg in acme state/module "dns_plugin_propagate_seconds"

### DIFF
--- a/changelog/63700.fixed.md
+++ b/changelog/63700.fixed.md
@@ -1,0 +1,1 @@
+Fix missing arg in acme state/module "dns_plugin_propagate_seconds"

--- a/salt/modules/acme.py
+++ b/salt/modules/acme.py
@@ -132,6 +132,7 @@ def cert(
     http_01_address=None,
     dns_plugin=None,
     dns_plugin_credentials=None,
+    dns_plugin_propagate_seconds=10,
 ):
     """
     Obtain/renew a certificate from an ACME CA, probably Let's Encrypt.
@@ -216,6 +217,7 @@ def cert(
         if dns_plugin == "cloudflare":
             cmd.append("--dns-cloudflare")
             cmd.append("--dns-cloudflare-credentials {}".format(dns_plugin_credentials))
+            cmd.append("--dns-cloudflare-propagation-seconds {}".format(dns_plugin_propagate_seconds))
         else:
             return {
                 "result": False,

--- a/salt/states/acme.py
+++ b/salt/states/acme.py
@@ -61,6 +61,7 @@ def cert(
     http_01_address=None,
     dns_plugin=None,
     dns_plugin_credentials=None,
+    dns_plugin_propagate_seconds=10,
 ):
     """
     Obtain/renew a certificate from an ACME CA, probably Let's Encrypt.
@@ -91,6 +92,7 @@ def cert(
     :param https_01_address: The address the server listens to during http-01 challenge.
     :param dns_plugin: Name of a DNS plugin to use (currently only 'cloudflare')
     :param dns_plugin_credentials: Path to the credentials file if required by the specified DNS plugin
+    :param dns_plugin_propagate_seconds: Number of seconds to wait for DNS propogations before asking ACME servers to verify the DNS record. (default 10)
     """
 
     if certname is None:
@@ -140,6 +142,7 @@ def cert(
                 http_01_address=http_01_address,
                 dns_plugin=dns_plugin,
                 dns_plugin_credentials=dns_plugin_credentials,
+                dns_plugin_propagate_seconds=dns_plugin_propagate_seconds,
             )
             ret["result"] = res["result"]
             ret["comment"].append(res["comment"])


### PR DESCRIPTION
### What does this PR do?
Adds the function arguments, and the cmd append required to make the documented argument 'dns_plugin_propagate_seconds` work
### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/63700

### Previous Behavior
The argument was documented but did not exist in code

### New Behavior
The relevant code was added for both state and module, and documented in state

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
