### PR TITLE
[master] remove get event transport arg

### DIFF
--- a/changelog/64461.removed.md
+++ b/changelog/64461.removed.md
@@ -1,0 +1,1 @@
+Removed 'transport' arg from salt.utils.event.get_event

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -105,7 +105,6 @@ TAGS = {
 def get_event(
     node,
     sock_dir=None,
-    transport=None,
     opts=None,
     listen=True,
     io_loop=None,
@@ -120,13 +119,6 @@ def get_event(
                            set_event_handler() API. Otherwise, operation
                            will be synchronous.
     """
-    if transport:
-        salt.utils.versions.warn_until(
-            "Chlorine",
-            "The 'transport' kwarg has been deprecated and it will be removed "
-            "in the Chlorine release, as such, its usage is no longer required.",
-        )
-
     sock_dir = sock_dir or opts["sock_dir"]
     # TODO: AIO core is separate from transport
     if node == "master":


### PR DESCRIPTION
### What does this PR do?
Remove transport arg from salt.utils.event.get_even

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/64461

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html

### Commits signed with GPG?
Yes
