### PR TITLE
[master] Slack notification: Properly link GitHub jobs, and when failures occur

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2119,13 +2119,13 @@ jobs:
         with:
           payload: |
             {
-              "text": "Nightly Workflow build result: ${{ job.status }}\n${{ github.event.head_commit.url }}",
+              "text": "Nightly Workflow build result: ${{ steps.get-workflow-info.outputs.conclusion }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "GitHub Action build result: ${{ job.status }}\n${{ github.event.head_commit.url }}"
+                    "text": "Nightly Workflow build result: ${{ steps.get-workflow-info.outputs.conclusion }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]


### PR DESCRIPTION
### What does this PR do?

- Provides proper GitHub Actions workflow variable outputs to link back to nightly build jobs
- Provides proper information when failed workflows occur, instead of pulling the wrong variable that may pass "success" even when the workflow has failures