### PR TITLE
[3006.x] Fix Slack notifications on nightly builds and link

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2103,13 +2103,13 @@ jobs:
         with:
           payload: |
             {
-              "text": "Nightly Workflow build result: ${{ job.status }}\n${{ github.event.head_commit.url }}",
+              "text": "Nightly Workflow build result for the ${{ github.ref_name }} branch: ${{ steps.get-workflow-info.outputs.conclusion }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "GitHub Action build result: ${{ job.status }}\n${{ github.event.head_commit.url }}"
+                    "text": "Nightly Workflow build result for the ${{ github.ref_name }} branch: ${{ steps.get-workflow-info.outputs.conclusion }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]

--- a/.github/workflows/templates/nightly.yml.jinja
+++ b/.github/workflows/templates/nightly.yml.jinja
@@ -127,13 +127,13 @@ concurrency:
         with:
           payload: |
             {
-              "text": "Nightly Workflow build result: ${{ job.status }}\n${{ github.event.head_commit.url }}",
+              "text": "Nightly Workflow build result for the ${{ github.ref_name }} branch: ${{ steps.get-workflow-info.outputs.conclusion }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "GitHub Action build result: ${{ job.status }}\n${{ github.event.head_commit.url }}"
+                    "text": "Nightly Workflow build result for the ${{ github.ref_name }} branch: ${{ steps.get-workflow-info.outputs.conclusion }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]


### PR DESCRIPTION
### What does this PR do?

- Provides proper GitHub Actions workflow variable outputs to link back to nightly build jobs
- Provides proper information when failed workflows occur, instead of pulling the wrong variable that may pass "success" even when the workflow has failures
- Adding a branch reference in the message