### PR TITLE
[3006.x] fix salt-run exception issue to set exitcode to 1 instead of 0

### DIFF
--- a/changelog/61173.fixed.md
+++ b/changelog/61173.fixed.md
@@ -1,1 +1,1 @@
-fix fixed runner not having a proper exit code when runner modules throw an exception.  
+fixed runner not having a proper exit code when runner modules throw an exception.  

--- a/changelog/61173.fixed.md
+++ b/changelog/61173.fixed.md
@@ -1,0 +1,1 @@
+fix fixed runner not having a proper exit code when runner modules throw an exception.  

--- a/salt/cli/run.py
+++ b/salt/cli/run.py
@@ -38,6 +38,12 @@ class SaltRun(salt.utils.parsers.SaltRunOptionParser):
                     # runners might still use it. For this reason, we
                     # also check ret['data']['retcode'] if
                     # ret['retcode'] is not available.
+                    if (
+                        isinstance(ret, dict)
+                        and "return" in ret
+                        and "retcode" not in ret
+                    ):
+                        ret = ret["return"]
                     if isinstance(ret, dict) and "retcode" in ret:
                         self.exit(ret["retcode"])
                     elif isinstance(ret, dict) and "retcode" in ret.get("data", {}):

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -517,7 +517,7 @@ class AsyncClientMixin(ClientStateMixin):
             instance = cls(opts)
 
         try:
-            return instance.cmd_sync(low, full_return=False)
+            return instance.cmd_sync(low, full_return=full_return)
         except salt.exceptions.EauthAuthenticationError as exc:
             log.error(exc)
 

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -481,17 +481,7 @@ class AsyncClientMixin(ClientStateMixin):
 
     @classmethod
     def _proc_function_remote(
-        cls,
-        *,
-        instance,
-        opts,
-        fun,
-        low,
-        user,
-        tag,
-        jid,
-        daemonize=True,
-        full_return=False
+        cls, *, instance, opts, fun, low, user, tag, jid, daemonize=True
     ):
         """
         Run this method in a multiprocess target to execute the function on the
@@ -517,7 +507,7 @@ class AsyncClientMixin(ClientStateMixin):
             instance = cls(opts)
 
         try:
-            return instance.cmd_sync(low, full_return=full_return)
+            return instance.cmd_sync(low)
         except salt.exceptions.EauthAuthenticationError as exc:
             log.error(exc)
 

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -412,6 +412,7 @@ class SyncClientMixin(ClientStateMixin):
                         traceback.format_exc(),
                     )
                 data["success"] = False
+                data["retcode"] = 1
 
             if self.store_job:
                 try:
@@ -480,7 +481,17 @@ class AsyncClientMixin(ClientStateMixin):
 
     @classmethod
     def _proc_function_remote(
-        cls, *, instance, opts, fun, low, user, tag, jid, daemonize=True
+        cls,
+        *,
+        instance,
+        opts,
+        fun,
+        low,
+        user,
+        tag,
+        jid,
+        daemonize=True,
+        full_return=False
     ):
         """
         Run this method in a multiprocess target to execute the function on the
@@ -506,13 +517,23 @@ class AsyncClientMixin(ClientStateMixin):
             instance = cls(opts)
 
         try:
-            return instance.cmd_sync(low)
+            return instance.cmd_sync(low, full_return=False)
         except salt.exceptions.EauthAuthenticationError as exc:
             log.error(exc)
 
     @classmethod
     def _proc_function(
-        cls, *, instance, opts, fun, low, user, tag, jid, daemonize=True
+        cls,
+        *,
+        instance,
+        opts,
+        fun,
+        low,
+        user,
+        tag,
+        jid,
+        daemonize=True,
+        full_return=False
     ):
         """
         Run this method in a multiprocess target to execute the function
@@ -537,7 +558,7 @@ class AsyncClientMixin(ClientStateMixin):
         low["__user__"] = user
         low["__tag__"] = tag
 
-        return instance.low(fun, low)
+        return instance.low(fun, low, full_return=full_return)
 
     def cmd_async(self, low):
         """

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -289,7 +289,7 @@ class Runner(RunnerClient):
 
                 # otherwise run it in the main process
                 if self.opts.get("eauth"):
-                    ret = self.cmd_sync(low, full_return=True)
+                    ret = self.cmd_sync(low)
                     if isinstance(ret, dict) and set(ret) == {"data", "outputter"}:
                         outputter = ret["outputter"]
                         ret = ret["data"]

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -289,7 +289,7 @@ class Runner(RunnerClient):
 
                 # otherwise run it in the main process
                 if self.opts.get("eauth"):
-                    ret = self.cmd_sync(low)
+                    ret = self.cmd_sync(low, full_return=True)
                     if isinstance(ret, dict) and set(ret) == {"data", "outputter"}:
                         outputter = ret["outputter"]
                         ret = ret["data"]
@@ -306,6 +306,7 @@ class Runner(RunnerClient):
                         tag=async_pub["tag"],
                         jid=async_pub["jid"],
                         daemonize=False,
+                        full_return=True,
                     )
             except salt.exceptions.SaltException as exc:
                 with salt.utils.event.get_event("master", opts=self.opts) as evt:

--- a/tests/pytests/functional/cli/test_salt_run_.py
+++ b/tests/pytests/functional/cli/test_salt_run_.py
@@ -1,10 +1,86 @@
 import logging
+import os
+
+import salt.version
 
 log = logging.getLogger(__name__)
 
 
-def test_exception_exit(salt_run_cli):
+def test_salt_run_exception_exit(salt_run_cli):
+    """
+    test that the exitcode is 1 when an exception is
+    thrown in a salt runner
+    """
     ret = salt_run_cli.run(
         "error.error", "name='Exception'", "message='This is an error.'"
     )
     assert ret.returncode == 1
+
+
+def test_salt_run_non_exception_exit(salt_run_cli):
+    """
+    Test standard exitcode and output when runner works.
+    """
+    ret = salt_run_cli.run("test.stdout_print")
+    assert ret.returncode == 0
+    assert ret.stdout == 'foo\n"bar"\n'
+
+
+def test_versions_report(salt_run_cli):
+    """
+    test salt-run --versions-report
+    """
+    expected = salt.version.versions_information()
+    # sanitize expected of unnnecessary whitespace
+    for _, section in expected.items():
+        for key in section:
+            if isinstance(section[key], str):
+                section[key] = section[key].strip()
+
+    ret = salt_run_cli.run("--versions-report")
+    assert ret.returncode == 0
+    assert ret.stdout
+    ret_lines = ret.stdout.split("\n")
+
+    assert ret_lines
+    # sanitize lines
+    ret_lines = [line.strip() for line in ret_lines]
+
+    for header in expected:
+        assert "{}:".format(header) in ret_lines
+
+    ret_dict = {}
+    expected_keys = set()
+    for line in ret_lines:
+        if not line:
+            continue
+        if line.endswith(":"):
+            assert not expected_keys
+            current_header = line.rstrip(":")
+            assert current_header in expected
+            ret_dict[current_header] = {}
+            expected_keys = set(expected[current_header].keys())
+        else:
+            key, *value_list = line.split(":", 1)
+            assert value_list
+            assert len(value_list) == 1
+            value = value_list[0].strip()
+            if value == "Not Installed":
+                value = None
+            ret_dict[current_header][key] = value
+            assert key in expected_keys
+            expected_keys.remove(key)
+    assert not expected_keys
+    if os.environ.get("ONEDIR_TESTRUN", "0") == "0":
+        # Stop any more testing
+        return
+
+    assert "relenv" in ret_dict["Dependency Versions"]
+    assert "Salt Extensions" in ret_dict
+    assert "salt-analytics-framework" in ret_dict["Salt Extensions"]
+
+
+def test_salt_run_version(salt_run_cli):
+    expected = salt.version.__version__
+    ret = salt_run_cli.run("--version")
+    assert f"cli_salt_run.py {expected}\n" == ret.stdout

--- a/tests/pytests/functional/cli/test_salt_run_.py
+++ b/tests/pytests/functional/cli/test_salt_run_.py
@@ -1,0 +1,10 @@
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def test_exception_exit(salt_run_cli):
+    ret = salt_run_cli.run(
+        "error.error", "name='Exception'", "message='This is an error.'"
+    )
+    assert ret.returncode == 1

--- a/tests/pytests/functional/cli/test_salt_run_.py
+++ b/tests/pytests/functional/cli/test_salt_run_.py
@@ -77,7 +77,6 @@ def test_versions_report(salt_run_cli):
 
     assert "relenv" in ret_dict["Dependency Versions"]
     assert "Salt Extensions" in ret_dict
-    assert "salt-analytics-framework" in ret_dict["Salt Extensions"]
 
 
 def test_salt_run_version(salt_run_cli):


### PR DESCRIPTION
### What does this PR do?

This fix changes the flow of using salt-run to return the full return to the cli command, so that the cli can pick up the retcode of the command run. it also adjusts the exception so that an exception cause during the run will set the retcode to 1. 

### What issues does this PR fix or reference?
Fixes: #61173 

### Previous Behavior
exitcode is 0 if an exception happens in a runner module. 

### New Behavior
exitcode is the retcode. 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated
