### PR TITLE
[3006.x] Only collect `pkg` tests from `pkg/`

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2107,13 +2107,13 @@ jobs:
         with:
           payload: |
             {
-              "text": "Nightly Workflow build result for the ${{ github.ref_name }} branch: ${{ steps.get-workflow-info.outputs.conclusion }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "text": "Nightly Workflow build result for the `${{ github.ref_name }}` branch(attempt: ${{ github.run_attempt }}): `${{ steps.get-workflow-info.outputs.conclusion }}`\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Nightly Workflow build result for the ${{ github.ref_name }} branch: ${{ steps.get-workflow-info.outputs.conclusion }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\nThis is attempt #${{ github.run_attempt }}"
+                    "text": "Nightly Workflow build result for the `${{ github.ref_name }}` branch(attempt: ${{ github.run_attempt }})\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]

--- a/.github/workflows/templates/nightly.yml.jinja
+++ b/.github/workflows/templates/nightly.yml.jinja
@@ -127,13 +127,13 @@ concurrency:
         with:
           payload: |
             {
-              "text": "Nightly Workflow build result for the ${{ github.ref_name }} branch: ${{ steps.get-workflow-info.outputs.conclusion }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "text": "Nightly Workflow build result for the `${{ github.ref_name }}` branch(attempt: ${{ github.run_attempt }}): `${{ steps.get-workflow-info.outputs.conclusion }}`\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Nightly Workflow build result for the ${{ github.ref_name }} branch: ${{ steps.get-workflow-info.outputs.conclusion }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\nThis is attempt #${{ github.run_attempt }}"
+                    "text": "Nightly Workflow build result for the `${{ github.ref_name }}` branch(attempt: ${{ github.run_attempt }})\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]

--- a/noxfile.py
+++ b/noxfile.py
@@ -1743,18 +1743,18 @@ def test_pkgs_onedir(session):
     chunks = {
         "install": ["pkg/tests/"],
         "upgrade": [
-            "pkg/tests/upgrade/test_salt_upgrade.py::test_salt_upgrade",
             "--upgrade",
             "--no-uninstall",
+            "pkg/tests/upgrade/",
         ],
         "upgrade-classic": [
-            "pkg/tests/upgrade/test_salt_upgrade.py::test_salt_upgrade",
             "--upgrade",
             "--no-uninstall",
+            "pkg/tests/upgrade/",
         ],
         "download-pkgs": [
             "--download-pkgs",
-            "pkg/tests/download/test_pkg_download.py",
+            "pkg/tests/download/",
         ],
     }
 
@@ -1802,6 +1802,8 @@ def test_pkgs_onedir(session):
     pytest_args = (
         cmd_args[:]
         + [
+            "-c",
+            str(REPO_ROOT / "pkg-tests-pytest.ini"),
             f"--junitxml=artifacts/xml-unittests-output/{junit_report_filename}.xml",
             f"--log-file=artifacts/logs/{runtests_log_filename}.log",
         ]
@@ -1813,6 +1815,8 @@ def test_pkgs_onedir(session):
         pytest_args = (
             cmd_args[:]
             + [
+                "-c",
+                str(REPO_ROOT / "pkg-tests-pytest.ini"),
                 "--no-install",
                 f"--junitxml=artifacts/xml-unittests-output/{junit_report_filename}.xml",
                 f"--log-file=artifacts/logs/{runtests_log_filename}.log",

--- a/pkg-tests-pytest.ini
+++ b/pkg-tests-pytest.ini
@@ -1,0 +1,10 @@
+[pytest]
+log_date_format=%H:%M:%S
+log_cli_format=%(asctime)s,%(msecs)03.0f [%(name)-5s:%(lineno)-4d][%(levelname)-8s][%(processName)s(%(process)s)] %(message)s
+log_file_format=%(asctime)s,%(msecs)03d [%(name)-17s:%(lineno)-4d][%(levelname)-8s][%(processName)s(%(process)d)] %(message)s
+norecursedirs=templates tests/
+testpaths=pkg/tests
+python_files=test_*.py
+python_classes=Test*
+python_functions = test_*
+junit_family=xunit2

--- a/pkg/tests/conftest.py
+++ b/pkg/tests/conftest.py
@@ -44,6 +44,21 @@ def grains(sminion):
     return sminion.opts["grains"].copy()
 
 
+@pytest.fixture(scope="module", autouse=True)
+def _system_up_to_date(
+    grains,
+    shell,
+):
+    if grains["os_family"] == "Debian":
+        ret = shell.run("apt", "update")
+        assert ret.returncode == 0
+        ret = shell.run("apt", "upgrade", "-y")
+        assert ret.returncode == 0
+    elif grains["os_family"] == "Redhat":
+        ret = shell.run("yum", "update", "-y")
+        assert ret.returncode == 0
+
+
 def pytest_addoption(parser):
     """
     register argparse-style options and ini-style config values.

--- a/pkg/tests/upgrade/test_salt_upgrade.py
+++ b/pkg/tests/upgrade/test_salt_upgrade.py
@@ -19,6 +19,7 @@ def test_salt_upgrade(salt_call_cli, salt_minion, install_salt):
     assert install.returncode == 0
     use_lib = salt_call_cli.run("--local", "github.get_repo_info", repo)
     assert "Authentication information could" in use_lib.stderr
+
     # upgrade Salt from previous version and test
     install_salt.install(upgrade=True)
     ret = salt_call_cli.run("test.ping")


### PR DESCRIPTION
### What does this PR do?
This will fix nightly builds on master, but doesn't hurt to also be going into 3006.x