### PR TITLE
[master] Allow unsigned but trusted apt repositories

### DIFF
--- a/changelog/64130.fixed.md
+++ b/changelog/64130.fixed.md
@@ -1,0 +1,1 @@
+Allow unsigned but trusted apt repositories

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2941,10 +2941,6 @@ def mod_repo(repo, saltenv="base", aptkey=True, **kwargs):
         if key in _MODIFY_OK and hasattr(mod_source, key):
             setattr(mod_source, key, kwargs[key])
 
-    if mod_source.uri != repo_uri:
-        mod_source.uri = repo_uri
-        mod_source.line = str(mod_source)
-
     sources.save()
     # on changes, explicitly refresh
     if refresh:

--- a/tests/pytests/functional/modules/test_aptpkg.py
+++ b/tests/pytests/functional/modules/test_aptpkg.py
@@ -255,6 +255,17 @@ def test_mod_repo(revert_repo_file):
     assert "#{}".format(msg) in ret["stdout"]
 
 
+def test_mod_repo_unsigned_trusted(tmp_path):
+    """
+    Test aptpkg.mod_repo for a trusted but unsigned repo.
+    """
+    repo = "deb [trusted=yes] http://apt.local/ stable main"
+    with patch.dict(aptpkg.__salt__, {"config.option": Mock()}):
+        with patch.object(aptpkg.SourcesList, 'save', lambda *x: None):
+            ret = aptpkg.mod_repo(repo=repo, file=str(tmp_path/'test.list'), aptkey=False, refresh=False)
+    assert repo.strip() == ret[repo]['line'].strip()
+
+
 @pytest.mark.destructive_test
 def test_mod_repo_no_file(tmp_path, revert_repo_file):
     """

--- a/tests/pytests/functional/states/test_pkgrepo.py
+++ b/tests/pytests/functional/states/test_pkgrepo.py
@@ -39,3 +39,17 @@ def test_adding_repo_file_arch(states, tmp_path):
             file_content.strip()
             == "deb [arch=amd64] http://www.deb-multimedia.org stable main"
         )
+
+
+@pytest.mark.skipif(
+    not any([x for x in ["ubuntu", "debian"] if x in platform.platform()]),
+    reason="Test only for debian based platforms",
+)
+def test_unsigned_trusted_repo(states, tmp_path):
+    repo_file = str(tmp_path / "stable-binary.list")
+    repo_content = "deb [trusted=yes] http://apt.local/ stable main"
+    ret = states.pkgrepo.managed(name=repo_content, file=repo_file, clean_file=True,
+                                 aptkey=False)
+    with salt.utils.files.fopen(repo_file, 'r') as fp:
+        file_content = fp.read()
+        assert file_content.strip() == repo_content


### PR DESCRIPTION
### What does this PR do?
In newer salt apt repositories managed by https://docs.saltproject.io/en/latest/ref/states/all/salt.states.pkgrepo.html#salt.states.pkgrepo.managed *must* have either a signedby or a valid key. However, for locally hosted repositories, the `trusted=yes` option should also suffice.

I made the parsing of repo options a bit smarter, taking the man page of sources.list as a reference. Then I adapted `modules.aptpkg.mod_repo` to accept `trusted=yes` for unsigned repositories.

### What issues does this PR fix or reference?
Fixes: #64130

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs (N/A?)
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated (I think?)

I'm not sure changes to docs are very relevant to this, but I'm very happy to be corrected :)
I *think* I managed with the tests. I only found the testing docs when opening this PR. Nox is currently running locally, so I might have to come back with some corrections.

### Commits signed with GPG?
Yes (but github doesn't like them, never managed to figure out why)

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
