### PR TITLE
[3006.x] saltutil.cmd: "Authentication error occurred." when master is not running as root

### DIFF
--- a/changelog/64398.fixed.md
+++ b/changelog/64398.fixed.md
@@ -1,0 +1,1 @@
+Allow for multiple user's keys presented when authenticating, for example: root, salt, etc.

--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -322,66 +322,27 @@ class LoadAuth:
         If the effective user id is the same as the passed one, return True on success or False on
         failure.
         """
-        log.warning(f"DGM auth authenticate_key load '{load}', key '{key}'")
         error_msg = 'Authentication failure of type "user" occurred.'
 
         auth_key = load.pop("key", None)
         if auth_key is None:
-            log.warning(
-                f"DGM auth authenticate_key auth_key is none, error_msg '{error_msg}'"
-            )
             log.warning(error_msg)
             return False
 
         if "user" in load:
             auth_user = AuthUser(load["user"])
-            log.warning(f"DGM auth auth_user '{auth_user}', load '{load}'")
             if auth_user.is_sudo():
-                # If someone sudos check to make sure there is no ACL's around their username
-                dgm_user = self.opts.get("user", "root")
-
-                ## dgm_opts_key = key[self.opts.get("user", "root")]
-                ## log.warning(f"DGM auth auth_key, user in load, dgm_user '{dgm_user}', '{auth_key}', dgm_opts_key '{dgm_opts_key}', opts '{self.opts}'")
-                ## if auth_key != key[self.opts.get("user", "root")]:
-                ##     log.warning(f"DGM auth error error_msg '{error_msg}'")
-                ##     log.warning(error_msg)
-                ##     return False
-                ## return auth_user.sudo_name()
-
                 for check_key in key:
-                    dgm_user = self.opts.get("user", "root")
-                    dgm_check_key = key[check_key]
-                    log.warning(
-                        f"DGM auth auth_key, user in load is_sudo, dgm_user '{dgm_user}', '{auth_key}', check_key '{check_key}', dgm_check_key '{dgm_check_key}'"
-                    )
                     if auth_key == key[check_key]:
-                        log.warning(
-                            f"DGM auth user successful auth_user.sudo_name '{auth_user.sudo_name()}'"
-                        )
                         return auth_user.sudo_name()
-
-                log.warning(f"DGM auth error error_msg '{error_msg}'")
-                log.warning(error_msg)
                 return False
             elif (
                 load["user"] == self.opts.get("user", "root") or load["user"] == "root"
             ):
-                ## if auth_key != key[self.opts.get("user", "root")]:
-                ##     log.warning(
-                ##         "Master runs as %r, but user in payload is %r",
-                ##         self.opts.get("user", "root"),
-                ##         load["user"],
-                ##     )
-                ##     log.warning(error_msg)
-                ##     return False
-
                 for check_key in key:
                     dgm_user = self.opts.get("user", "root")
                     dgm_check_key = key[check_key]
                     if auth_key == key[check_key]:
-                        log.warning(
-                            f"DGM auth user successful, auth_key matches check_key dgm_user '{dgm_user}', auth_key '{auth_key}', check_key '{check_key}', dgm_check_key '{dgm_check_key}', key[dgm_user] '{key[dgm_user]}'"
-                        )
                         return True
                 log.warning(
                     "Master runs as %r, but user in payload is %r",
@@ -394,16 +355,12 @@ class LoadAuth:
             elif auth_user.is_running_user():
                 if auth_key != key.get(load["user"]):
                     load_user = load["user"]
-                    log.warning(
-                        f"DGM auth user unsuccessful, auth_user is running useri and not present, load_user '{load_user}', auth_key '{auth_key}', key '{key}' "
-                    )
                     log.warning(error_msg)
                     return False
             elif auth_key == key.get("root"):
                 pass
-            # DGM TBD should we allow for salt ? here, sounds too breakable
-            # but there is nologin for salt, so maybe fine
             elif auth_key == key.get("salt"):
+                # there is nologin for salt
                 pass
             else:
                 if load["user"] in key:
@@ -416,28 +373,10 @@ class LoadAuth:
                     log.warning(error_msg)
                     return False
         else:
-            ## dgm_user = salt.utils.user.get_user()
-            ## dgm_key = key[salt.utils.user.get_user()]
-            ## log.warning(f"DGM authenticate_key, user '{dgm_user}', user key '{dgm_user_key}', auth_key '{auth_key}'")
-            ## if auth_key != key[salt.utils.user.get_user()]:
-            ##     log.warning(f"DGM authenticate_key, user '{dgm_user}', user key '{dgm_user_key}', auth_key '{auth_key}', keys not equal '{error_msg}'")
-            ##     log.warning(error_msg)
-            ##     return False
             for check_key in key:
-                dgm_user = salt.utils.user.get_user()
-                dgm_check_key = key[check_key]
-                log.warning(
-                    f"DGM authenticate_key, user '{dgm_user}', check_key '{check_key}', dgm_check_key '{dgm_check_key}', auth_key '{auth_key}'"
-                )
                 if auth_key == key[check_key]:
-                    log.warning(
-                        f"DGM authenticate_key, user '{dgm_user}', check_key '{check_key}', dgm_check_key '{dgm_check_key}', auth_key '{auth_key}', keys equal"
-                    )
                     return True
 
-            log.warning(
-                f"DGM authenticate_key, user '{dgm_user}', auth_key '{auth_key}', keys not equal '{error_msg}', key '{key}'"
-            )
             log.warning(error_msg)
             return False
 
@@ -504,14 +443,9 @@ class LoadAuth:
         If an error is encountered, return immediately with the relevant error dictionary
         as authentication has failed. Otherwise, return the username and valid auth_list.
         """
-        log.warning(
-            f"DGM check_authentication auth_type '{auth_type}', key '{key}', load '{load}'"
-        )
         auth_list = []
         username = load.get("username", "UNKNOWN")
         ret = {"auth_list": auth_list, "username": username, "error": {}}
-
-        log.warning(f"DGM check_authentication initial ret '{ret}'")
 
         # Authenticate
         if auth_type == "token":
@@ -528,7 +462,6 @@ class LoadAuth:
             ret["username"] = username
             auth_list = self.get_auth_list(load, token=token)
         elif auth_type == "eauth":
-            # DGM TBD needs to check how eauth handles the load and multiple users and their keys
             if not self.authenticate_eauth(load):
                 ret["error"] = {
                     "name": "EauthAuthenticationError",

--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -354,7 +354,6 @@ class LoadAuth:
 
             elif auth_user.is_running_user():
                 if auth_key != key.get(load["user"]):
-                    load_user = load["user"]
                     log.warning(error_msg)
                     return False
             elif auth_key == key.get("root"):

--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -322,36 +322,88 @@ class LoadAuth:
         If the effective user id is the same as the passed one, return True on success or False on
         failure.
         """
+        log.warning(f"DGM auth authenticate_key load '{load}', key '{key}'")
         error_msg = 'Authentication failure of type "user" occurred.'
+
         auth_key = load.pop("key", None)
         if auth_key is None:
+            log.warning(
+                f"DGM auth authenticate_key auth_key is none, error_msg '{error_msg}'"
+            )
             log.warning(error_msg)
             return False
 
         if "user" in load:
             auth_user = AuthUser(load["user"])
+            log.warning(f"DGM auth auth_user '{auth_user}', load '{load}'")
             if auth_user.is_sudo():
                 # If someone sudos check to make sure there is no ACL's around their username
-                if auth_key != key[self.opts.get("user", "root")]:
-                    log.warning(error_msg)
-                    return False
-                return auth_user.sudo_name()
+                dgm_user = self.opts.get("user", "root")
+
+                ## dgm_opts_key = key[self.opts.get("user", "root")]
+                ## log.warning(f"DGM auth auth_key, user in load, dgm_user '{dgm_user}', '{auth_key}', dgm_opts_key '{dgm_opts_key}', opts '{self.opts}'")
+                ## if auth_key != key[self.opts.get("user", "root")]:
+                ##     log.warning(f"DGM auth error error_msg '{error_msg}'")
+                ##     log.warning(error_msg)
+                ##     return False
+                ## return auth_user.sudo_name()
+
+                for check_key in key:
+                    dgm_user = self.opts.get("user", "root")
+                    dgm_check_key = key[check_key]
+                    log.warning(
+                        f"DGM auth auth_key, user in load is_sudo, dgm_user '{dgm_user}', '{auth_key}', check_key '{check_key}', dgm_check_key '{dgm_check_key}'"
+                    )
+                    if auth_key == key[check_key]:
+                        log.warning(
+                            f"DGM auth user successful auth_user.sudo_name '{auth_user.sudo_name()}'"
+                        )
+                        return auth_user.sudo_name()
+
+                log.warning(f"DGM auth error error_msg '{error_msg}'")
+                log.warning(error_msg)
+                return False
             elif (
                 load["user"] == self.opts.get("user", "root") or load["user"] == "root"
             ):
-                if auth_key != key[self.opts.get("user", "root")]:
+                ## if auth_key != key[self.opts.get("user", "root")]:
+                ##     log.warning(
+                ##         "Master runs as %r, but user in payload is %r",
+                ##         self.opts.get("user", "root"),
+                ##         load["user"],
+                ##     )
+                ##     log.warning(error_msg)
+                ##     return False
+
+                for check_key in key:
+                    dgm_user = self.opts.get("user", "root")
+                    dgm_check_key = key[check_key]
+                    if auth_key == key[check_key]:
+                        log.warning(
+                            f"DGM auth user successful, auth_key matches check_key dgm_user '{dgm_user}', auth_key '{auth_key}', check_key '{check_key}', dgm_check_key '{dgm_check_key}', key[dgm_user] '{key[dgm_user]}'"
+                        )
+                        return True
+                log.warning(
+                    "Master runs as %r, but user in payload is %r",
+                    self.opts.get("user", "root"),
+                    load["user"],
+                )
+                log.warning(error_msg)
+                return False
+
+            elif auth_user.is_running_user():
+                if auth_key != key.get(load["user"]):
+                    load_user = load["user"]
                     log.warning(
-                        "Master runs as %r, but user in payload is %r",
-                        self.opts.get("user", "root"),
-                        load["user"],
+                        f"DGM auth user unsuccessful, auth_user is running useri and not present, load_user '{load_user}', auth_key '{auth_key}', key '{key}' "
                     )
                     log.warning(error_msg)
                     return False
-            elif auth_user.is_running_user():
-                if auth_key != key.get(load["user"]):
-                    log.warning(error_msg)
-                    return False
             elif auth_key == key.get("root"):
+                pass
+            # DGM TBD should we allow for salt ? here, sounds too breakable
+            # but there is nologin for salt, so maybe fine
+            elif auth_key == key.get("salt"):
                 pass
             else:
                 if load["user"] in key:
@@ -364,9 +416,31 @@ class LoadAuth:
                     log.warning(error_msg)
                     return False
         else:
-            if auth_key != key[salt.utils.user.get_user()]:
-                log.warning(error_msg)
-                return False
+            ## dgm_user = salt.utils.user.get_user()
+            ## dgm_key = key[salt.utils.user.get_user()]
+            ## log.warning(f"DGM authenticate_key, user '{dgm_user}', user key '{dgm_user_key}', auth_key '{auth_key}'")
+            ## if auth_key != key[salt.utils.user.get_user()]:
+            ##     log.warning(f"DGM authenticate_key, user '{dgm_user}', user key '{dgm_user_key}', auth_key '{auth_key}', keys not equal '{error_msg}'")
+            ##     log.warning(error_msg)
+            ##     return False
+            for check_key in key:
+                dgm_user = salt.utils.user.get_user()
+                dgm_check_key = key[check_key]
+                log.warning(
+                    f"DGM authenticate_key, user '{dgm_user}', check_key '{check_key}', dgm_check_key '{dgm_check_key}', auth_key '{auth_key}'"
+                )
+                if auth_key == key[check_key]:
+                    log.warning(
+                        f"DGM authenticate_key, user '{dgm_user}', check_key '{check_key}', dgm_check_key '{dgm_check_key}', auth_key '{auth_key}', keys equal"
+                    )
+                    return True
+
+            log.warning(
+                f"DGM authenticate_key, user '{dgm_user}', auth_key '{auth_key}', keys not equal '{error_msg}', key '{key}'"
+            )
+            log.warning(error_msg)
+            return False
+
         return True
 
     def get_auth_list(self, load, token=None):
@@ -430,9 +504,14 @@ class LoadAuth:
         If an error is encountered, return immediately with the relevant error dictionary
         as authentication has failed. Otherwise, return the username and valid auth_list.
         """
+        log.warning(
+            f"DGM check_authentication auth_type '{auth_type}', key '{key}', load '{load}'"
+        )
         auth_list = []
         username = load.get("username", "UNKNOWN")
         ret = {"auth_list": auth_list, "username": username, "error": {}}
+
+        log.warning(f"DGM check_authentication initial ret '{ret}'")
 
         # Authenticate
         if auth_type == "token":
@@ -449,6 +528,7 @@ class LoadAuth:
             ret["username"] = username
             auth_list = self.get_auth_list(load, token=token)
         elif auth_type == "eauth":
+            # DGM TBD needs to check how eauth handles the load and multiple users and their keys
             if not self.authenticate_eauth(load):
                 ret["error"] = {
                     "name": "EauthAuthenticationError",

--- a/tests/pytests/unit/daemons/masterapi/test_local_funcs.py
+++ b/tests/pytests/unit/daemons/masterapi/test_local_funcs.py
@@ -2,7 +2,9 @@ import logging
 
 import pytest
 
+import salt.config
 import salt.daemons.masterapi as masterapi
+import salt.utils.platform
 from tests.support.mock import MagicMock, patch
 
 log = logging.getLogger(__name__)
@@ -22,7 +24,8 @@ def check_keys():
 
 @pytest.fixture
 def local_funcs(master_opts):
-    return masterapi.LocalFuncs(master_opts, "test-key")
+    opts = salt.config.master_config(None)
+    return masterapi.LocalFuncs(opts, "test-key")
 
 
 @pytest.fixture

--- a/tests/pytests/unit/daemons/masterapi/test_local_funcs.py
+++ b/tests/pytests/unit/daemons/masterapi/test_local_funcs.py
@@ -2,9 +2,7 @@ import logging
 
 import pytest
 
-import salt.config
 import salt.daemons.masterapi as masterapi
-import salt.utils.platform
 from tests.support.mock import MagicMock, patch
 
 log = logging.getLogger(__name__)
@@ -13,22 +11,23 @@ pytestmark = [
     pytest.mark.slow_test,
 ]
 
-test_check_key = {
-    "test": "mGXdurU1c8lXt5cmpbGq4rWvrOvDXxkwI9gbkP5CBBjpyGWuB8vkgz9r+sjjG0wVDL9/uFuREtk=",
-    "root": "2t5HHv/ek2wIFh8tTX2c3hdt+6V+93xKlcXb7IlGLIszOeCVv2NuH38LyCw9UwQTfUFTeseXhSs=",
-}
+
+@pytest.fixture
+def check_keys():
+    return {
+        "test": "mGXdurU1c8lXt5cmpbGq4rWvrOvDXxkwI9gbkP5CBBjpyGWuB8vkgz9r+sjjG0wVDL9/uFuREtk=",
+        "root": "2t5HHv/ek2wIFh8tTX2c3hdt+6V+93xKlcXb7IlGLIszOeCVv2NuH38LyCw9UwQTfUFTeseXhSs=",
+    }
 
 
 @pytest.fixture
-def local_funcs():
-    opts = salt.config.master_config(None)
-    return masterapi.LocalFuncs(opts, "test-key")
+def local_funcs(master_opts):
+    return masterapi.LocalFuncs(master_opts, "test-key")
 
 
 @pytest.fixture
-def check_local_funcs():
-    opts = salt.config.master_config(None)
-    return masterapi.LocalFuncs(opts, test_check_key)
+def check_local_funcs(master_opts, check_keys):
+    return masterapi.LocalFuncs(master_opts, check_keys)
 
 
 # runner tests

--- a/tests/pytests/unit/daemons/masterapi/test_local_funcs.py
+++ b/tests/pytests/unit/daemons/masterapi/test_local_funcs.py
@@ -1,13 +1,9 @@
-import logging
-
 import pytest
 
 import salt.config
 import salt.daemons.masterapi as masterapi
 import salt.utils.platform
 from tests.support.mock import MagicMock, patch
-
-log = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.slow_test,


### PR DESCRIPTION
### What does this PR do?
Allows for multiple keys presented for authentication rather than just a single key for root, now that we can have the root key and the salt key presented

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/64398

### Previous Behavior
Would return 'Authentication error occurred.'

### New Behavior
Allows for salt key presented, and operations succeed, in addition to the root key.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
