### PR TITLE
[master] Removed support for RHEL 5

### DIFF
--- a/changelog/62520.removed.md
+++ b/changelog/62520.removed.md
@@ -1,0 +1,1 @@
+Removed RHEL 5 support since long since end-of-lifed

--- a/salt/modules/groupadd.py
+++ b/salt/modules/groupadd.py
@@ -286,19 +286,13 @@ def adduser(name, username, root=None):
     Verifies if a valid username 'bar' as a member of an existing group 'foo',
     if not then adds it.
     """
-    on_redhat_5 = (
-        __grains__.get("os_family") == "RedHat"
-        and __grains__.get("osmajorrelease") == "5"
-    )
     on_suse_11 = (
         __grains__.get("os_family") == "Suse"
         and __grains__.get("osmajorrelease") == "11"
     )
 
     if __grains__["kernel"] == "Linux":
-        if on_redhat_5:
-            cmd = [_which("gpasswd"), "-a", username, name]
-        elif on_suse_11:
+        if on_suse_11:
             cmd = [_which("usermod"), "-A", name, username]
         else:
             cmd = [_which("gpasswd"), "--add", username, name]
@@ -336,10 +330,6 @@ def deluser(name, username, root=None):
     Removes a member user 'bar' from a group 'foo'. If group is not present
     then returns True.
     """
-    on_redhat_5 = (
-        __grains__.get("os_family") == "RedHat"
-        and __grains__.get("osmajorrelease") == "5"
-    )
     on_suse_11 = (
         __grains__.get("os_family") == "Suse"
         and __grains__.get("osmajorrelease") == "11"
@@ -349,9 +339,7 @@ def deluser(name, username, root=None):
     try:
         if username in grp_info["members"]:
             if __grains__["kernel"] == "Linux":
-                if on_redhat_5:
-                    cmd = [_which("gpasswd"), "-d", username, name]
-                elif on_suse_11:
+                if on_suse_11:
                     cmd = [_which("usermod"), "-R", name, username]
                 else:
                     cmd = [_which("gpasswd"), "--del", username, name]
@@ -400,19 +388,13 @@ def members(name, members_list, root=None):
     Replaces a membership list for a local group 'foo'.
         foo:x:1234:user1,user2,user3,...
     """
-    on_redhat_5 = (
-        __grains__.get("os_family") == "RedHat"
-        and __grains__.get("osmajorrelease") == "5"
-    )
     on_suse_11 = (
         __grains__.get("os_family") == "Suse"
         and __grains__.get("osmajorrelease") == "11"
     )
 
     if __grains__["kernel"] == "Linux":
-        if on_redhat_5:
-            cmd = [_which("gpasswd"), "-M", members_list, name]
-        elif on_suse_11:
+        if on_suse_11:
             for old_member in __salt__["group.info"](name).get("members"):
                 __salt__["cmd.run"](
                     "{} -R {} {}".format(_which("groupmod"), old_member, name),

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -258,11 +258,7 @@ def _versionlock_pkg(grains=None):
     elif _yum() == "tdnf":
         raise SaltInvocationError("Cannot proceed, no versionlock for tdnf")
     else:
-        return (
-            "yum-versionlock"
-            if int(grains.get("osmajorrelease")) == 5
-            else "yum-plugin-versionlock"
-        )
+        return "yum-plugin-versionlock"
 
 
 def _check_versionlock():

--- a/tests/pytests/functional/states/test_pkg.py
+++ b/tests/pytests/functional/states/test_pkg.py
@@ -75,10 +75,7 @@ def PKG_32_TARGETS(grains):
     _PKG_32_TARGETS = []
     if grains["os_family"] == "RedHat":
         if grains["os"] == "CentOS":
-            if grains["osmajorrelease"] == 5:
-                _PKG_32_TARGETS = ["xz-devel.i386"]
-            else:
-                _PKG_32_TARGETS.append("xz-devel.i686")
+            _PKG_32_TARGETS.append("xz-devel.i686")
     if not _PKG_32_TARGETS:
         pytest.skip("No 32 bit packages have been specified for testing")
     return _PKG_32_TARGETS
@@ -88,11 +85,7 @@ def PKG_32_TARGETS(grains):
 def PKG_DOT_TARGETS(grains):
     _PKG_DOT_TARGETS = []
     if grains["os_family"] == "RedHat":
-        if grains["osmajorrelease"] == 5:
-            _PKG_DOT_TARGETS = ["python-migrate0.5"]
-        elif grains["osmajorrelease"] == 6:
-            _PKG_DOT_TARGETS = ["tomcat6-el-2.1-api"]
-        elif grains["osmajorrelease"] == 7:
+        if grains["osmajorrelease"] == 7:
             _PKG_DOT_TARGETS = ["tomcat-el-2.2-api"]
         elif grains["osmajorrelease"] == 8:
             _PKG_DOT_TARGETS = ["aspnetcore-runtime-6.0"]
@@ -455,9 +448,10 @@ def test_pkg_011_latest_only_upgrade(
         new_version = modules.pkg.version(target, use_context=False)
         assert new_version == updates[target]
         ret = states.pkg.latest(name=target, refresh=False, only_upgrade=True)
-        assert ret.raw["pkg_|-{0}_|-{0}_|-latest".format(target)][
-            "comment"
-        ] == "Package {} is already up-to-date".format(target)
+        assert (
+            ret.raw["pkg_|-{0}_|-{0}_|-latest".format(target)]["comment"]
+            == f"Package {target} is already up-to-date"
+        )
 
 
 @pytest.mark.usefixtures("WILDCARDS_SUPPORTED")
@@ -605,7 +599,7 @@ def test_pkg_015_installed_held(grains, modules, states, PKG_TARGETS):
             except AssertionError as exc:
                 log.debug("Versionlock package not found:\n%s", exc)
         else:
-            pytest.fail("Could not install versionlock package from {}".format(pkgs))
+            pytest.fail(f"Could not install versionlock package from {pkgs}")
 
     target = PKG_TARGETS[0]
 
@@ -624,7 +618,7 @@ def test_pkg_015_installed_held(grains, modules, states, PKG_TARGETS):
     )
 
     if versionlock_pkg and "-versionlock is not installed" in str(ret):
-        pytest.skip("{}  `{}` is installed".format(ret, versionlock_pkg))
+        pytest.skip(f"{ret}  `{versionlock_pkg}` is installed")
 
     # changes from pkg.hold for Red Hat family are different
     target_changes = {}
@@ -724,7 +718,7 @@ def test_pkg_017_installed_held_equals_false(grains, modules, states, PKG_TARGET
             except AssertionError as exc:
                 log.debug("Versionlock package not found:\n%s", exc)
         else:
-            pytest.fail("Could not install versionlock package from {}".format(pkgs))
+            pytest.fail(f"Could not install versionlock package from {pkgs}")
 
     target = PKG_TARGETS[0]
 
@@ -737,7 +731,7 @@ def test_pkg_017_installed_held_equals_false(grains, modules, states, PKG_TARGET
     assert target_ret.result is True
 
     if versionlock_pkg and "-versionlock is not installed" in str(target_ret):
-        pytest.skip("{}  `{}` is installed".format(target_ret, versionlock_pkg))
+        pytest.skip(f"{target_ret}  `{versionlock_pkg}` is installed")
 
     try:
         tag = "pkg_|-{0}_|-{0}_|-installed".format(target)
@@ -789,7 +783,7 @@ def test_pkg_cap_001_installed(PKG_CAP_TARGETS, modules, states):
             test=True,
         )
         assert (
-            "The following packages would be installed/updated: {}".format(realpkg)
+            f"The following packages would be installed/updated: {realpkg}"
             in ret.comment
         )
         ret = states.pkg.installed(
@@ -887,7 +881,7 @@ def test_pkg_cap_003_installed_multipkg_with_version(
             test=True,
         )
         assert "packages would be installed/updated" in ret.comment
-        assert "{}={}".format(realpkg, realver) in ret.comment
+        assert f"{realpkg}={realver}" in ret.comment
 
         ret = states.pkg.installed(
             name="test_pkg_cap_003_installed_multipkg_with_version-install-capability",
@@ -931,7 +925,7 @@ def test_pkg_cap_004_latest(PKG_CAP_TARGETS, modules, states):
             test=True,
         )
         assert (
-            "The following packages would be installed/upgraded: {}".format(realpkg)
+            f"The following packages would be installed/upgraded: {realpkg}"
             in ret.comment
         )
         ret = states.pkg.latest(name=target, refresh=False, resolve_capabilities=True)
@@ -971,9 +965,7 @@ def test_pkg_cap_005_downloaded(PKG_CAP_TARGETS, modules, states):
         resolve_capabilities=True,
         test=True,
     )
-    assert (
-        "The following packages would be downloaded: {}".format(realpkg) in ret.comment
-    )
+    assert f"The following packages would be downloaded: {realpkg}" in ret.comment
 
     ret = states.pkg.downloaded(name=target, refresh=False, resolve_capabilities=True)
     assert ret.result is True

--- a/tests/pytests/unit/modules/test_groupadd.py
+++ b/tests/pytests/unit/modules/test_groupadd.py
@@ -188,14 +188,6 @@ def test_adduser():
         {
             "grains": {
                 "kernel": "Linux",
-                "os_family": "RedHat",
-                "osmajorrelease": "5",
-            },
-            "cmd": ["/bin/gpasswd", "-a", "root", "test"],
-        },
-        {
-            "grains": {
-                "kernel": "Linux",
                 "os_family": "Suse",
                 "osmajorrelease": "11",
             },
@@ -242,14 +234,6 @@ def test_deluser():
     Tests if specified user gets deleted from the group.
     """
     os_version_list = [
-        {
-            "grains": {
-                "kernel": "Linux",
-                "os_family": "RedHat",
-                "osmajorrelease": "5",
-            },
-            "cmd": ["/bin/gpasswd", "-d", "root", "test"],
-        },
         {
             "grains": {
                 "kernel": "Linux",
@@ -325,14 +309,6 @@ def test_members():
     Tests if members of the group, get replaced with a provided list.
     """
     os_version_list = [
-        {
-            "grains": {
-                "kernel": "Linux",
-                "os_family": "RedHat",
-                "osmajorrelease": "5",
-            },
-            "cmd": ["/bin/gpasswd", "-M", "foo", "test"],
-        },
         {
             "grains": {
                 "kernel": "Linux",

--- a/tests/pytests/unit/modules/test_groupadd.py
+++ b/tests/pytests/unit/modules/test_groupadd.py
@@ -206,18 +206,12 @@ def test_adduser():
         "salt.utils.path.which",
         MagicMock(
             side_effect=[
-                None,
-                "/bin/gpasswd",
                 "/bin/usermod",
                 "/bin/gpasswd",
                 "/bin/usermod",
             ]
         ),
     ):
-        with patch.dict(groupadd.__grains__, os_version_list[0]["grains"]):
-            with pytest.raises(CommandExecutionError):
-                groupadd.adduser("test", "root")
-
         for os_version in os_version_list:
             mock = MagicMock(return_value={"retcode": 0})
             with patch.dict(groupadd.__grains__, os_version["grains"]), patch.dict(
@@ -253,30 +247,12 @@ def test_deluser():
         "salt.utils.path.which",
         MagicMock(
             side_effect=[
-                None,
-                "/bin/gpasswd",
                 "/bin/usermod",
                 "/bin/gpasswd",
                 "/bin/usermod",
             ]
         ),
     ):
-        with patch.dict(groupadd.__grains__, os_version_list[0]["grains"]), patch.dict(
-            groupadd.__salt__,
-            {
-                "group.info": MagicMock(
-                    return_value={
-                        "passwd": "*",
-                        "gid": 0,
-                        "name": "test",
-                        "members": ["root"],
-                    }
-                ),
-            },
-        ):
-            with pytest.raises(CommandExecutionError):
-                groupadd.deluser("test", "root")
-
         for os_version in os_version_list:
             mock_retcode = MagicMock(return_value=0)
             mock_stdout = MagicMock(return_value="test foo")
@@ -328,8 +304,6 @@ def test_members():
         "salt.utils.path.which",
         MagicMock(
             side_effect=[
-                None,
-                "/bin/gpasswd",
                 "/bin/gpasswd",
                 "/bin/groupmod",
                 "/bin/gpasswd",
@@ -339,10 +313,6 @@ def test_members():
             ]
         ),
     ):
-        with patch.dict(groupadd.__grains__, os_version_list[0]["grains"]):
-            with pytest.raises(CommandExecutionError):
-                groupadd.members("test", "foo")
-
         for os_version in os_version_list:
             mock_ret = MagicMock(return_value={"retcode": 0})
             mock_stdout = MagicMock(return_value={"cmd.run_stdout": 1})


### PR DESCRIPTION
### What does this PR do?
Removed remaining support for RHEL 5 which has long since been end-of-lifed

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/62520

### Previous Behavior
Support for RHEL 5 operating system

### New Behavior
Removed support for RHEL 5 operating system

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
