### PR TITLE
[master] Bump to `salt-rewrite==2.5.2` and fix `warn_until` calls

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1191,13 +1191,13 @@ repos:
 
   - repo: https://github.com/s0undt3ch/salt-rewrite
     # Automatically rewrite code with known rules
-    rev: 2.4.4
+    rev: 2.5.2
     hooks:
       - id: salt-rewrite
-        alias: rewrite-docstrings
-        name: Salt docstrings auto-fixes
+        alias: rewrite-salt
+        name: Salt code auto-fixes
         files: ^salt/.*\.py$
-        args: [--silent, -F, fix_docstrings]
+        args: [--silent, -F, fix_docstrings, -F, fix_warn_until]
         exclude: >
             (?x)^(
                 salt/ext/.*

--- a/salt/engines/slack.py
+++ b/salt/engines/slack.py
@@ -747,7 +747,7 @@ class SlackClient:
         results = {}
         for jid in outstanding_jids:
             # results[jid] = runner.cmd('jobs.lookup_jid', [jid])
-            if self.master_minion.returners["{}.get_jid".format(source)](jid):
+            if self.master_minion.returners[f"{source}.get_jid"](jid):
                 job_result = runner.cmd("jobs.list_job", [jid])
                 jid_result = job_result.get("Result", {})
                 jid_function = job_result.get("Function", {})
@@ -838,7 +838,7 @@ class SlackClient:
                     channel.send_message(return_prefix)
                     ts = time.time()
                     st = datetime.datetime.fromtimestamp(ts).strftime("%Y%m%d%H%M%S%f")
-                    filename = "salt-results-{}.yaml".format(st)
+                    filename = f"salt-results-{st}.yaml"
                     r = self.sc.api_call(
                         "files.upload",
                         channels=channel.id,
@@ -947,4 +947,4 @@ def start(
         )
         client.run_commands_from_slack_async(message_generator, fire_all, tag, control)
     except Exception:  # pylint: disable=broad-except
-        raise Exception("{}".format(traceback.format_exc()))
+        raise Exception(f"{traceback.format_exc()}")

--- a/salt/engines/slack.py
+++ b/salt/engines/slack.py
@@ -928,7 +928,7 @@ def start(
     """
 
     salt.utils.versions.warn_until(
-        "Argon",
+        3008,
         "This 'slack' engine will be deprecated and "
         "will be replace by the slack_bolt engine. This new "
         "engine will use the new Bolt library from Slack and requires "

--- a/salt/modules/esxcluster.py
+++ b/salt/modules/esxcluster.py
@@ -41,7 +41,7 @@ def _deprecation_message(function):
     @wraps(function)
     def wrapped(*args, **kwargs):
         salt.utils.versions.warn_until(
-            "Argon",
+            3008,
             "The 'esxcluster' functionality in Salt has been deprecated and its "
             "functionality will be removed in version 3008 in favor of the "
             "saltext.vmware Salt Extension. "

--- a/salt/modules/esxdatacenter.py
+++ b/salt/modules/esxdatacenter.py
@@ -41,7 +41,7 @@ def _deprecation_message(function):
     @wraps(function)
     def wrapped(*args, **kwargs):
         salt.utils.versions.warn_until(
-            "Argon",
+            3008,
             "The 'esxdatacenter' functionality in Salt has been deprecated and its "
             "functionality will be removed in version 3008 in favor of the "
             "saltext.vmware Salt Extension. "

--- a/salt/modules/esxi.py
+++ b/salt/modules/esxi.py
@@ -66,7 +66,7 @@ def _deprecation_message(function):
     @wraps(function)
     def wrapped(*args, **kwargs):
         salt.utils.versions.warn_until(
-            "Argon",
+            3008,
             "The 'esxi' functionality in Salt has been deprecated and its "
             "functionality will be removed in version 3008 in favor of the "
             "saltext.vmware Salt Extension. "

--- a/salt/modules/esxvm.py
+++ b/salt/modules/esxvm.py
@@ -43,7 +43,7 @@ def _deprecation_message(function):
     @wraps(function)
     def wrapped(*args, **kwargs):
         salt.utils.versions.warn_until(
-            "Argon",
+            3008,
             "The 'esxvm' functionality in Salt has been deprecated and its "
             "functionality will be removed in version 3008 in favor of the "
             "saltext.vmware Salt Extension. "

--- a/salt/modules/napalm_mod.py
+++ b/salt/modules/napalm_mod.py
@@ -322,7 +322,7 @@ def call(method, *args, **kwargs):
         napalm_device,  # pylint: disable=undefined-variable
         method,
         *args,
-        **clean_kwargs
+        **clean_kwargs,
     )
 
 
@@ -561,7 +561,7 @@ def netmiko_fun(fun, *args, **kwargs):
         salt '*' napalm.netmiko_fun send_command 'show version'
     """
     if "netmiko." not in fun:
-        fun = "netmiko.{fun}".format(fun=fun)
+        fun = f"netmiko.{fun}"
     netmiko_kwargs = netmiko_args()
     kwargs.update(netmiko_kwargs)
     return __salt__[fun](*args, **kwargs)
@@ -1038,14 +1038,14 @@ def junos_call(fun, *args, **kwargs):
     if not prep["result"]:
         return prep
     if "junos." not in fun:
-        mod_fun = "junos.{}".format(fun)
+        mod_fun = f"junos.{fun}"
     else:
         mod_fun = fun
     if mod_fun not in __salt__:
         return {
             "out": None,
             "result": False,
-            "comment": "{} is not a valid function".format(fun),
+            "comment": f"{fun} is not a valid function",
         }
     return __salt__[mod_fun](*args, **kwargs)
 
@@ -1177,7 +1177,7 @@ def pyeapi_config(
     context=None,
     defaults=None,
     saltenv="base",
-    **kwargs
+    **kwargs,
 ):
     """
     .. versionadded:: 2019.2.0
@@ -1235,7 +1235,7 @@ def pyeapi_config(
         context=context,
         defaults=defaults,
         saltenv=saltenv,
-        **pyeapi_kwargs
+        **pyeapi_kwargs,
     )
 
 
@@ -1271,7 +1271,7 @@ def nxos_api_config(
     context=None,
     defaults=None,
     saltenv="base",
-    **kwargs
+    **kwargs,
 ):
     """
      .. versionadded:: 2019.2.0
@@ -1327,7 +1327,7 @@ def nxos_api_config(
         context=context,
         defaults=defaults,
         saltenv=saltenv,
-        **nxos_api_kwargs
+        **nxos_api_kwargs,
     )
 
 
@@ -1915,7 +1915,7 @@ def scp_get(
         local_path=local_path,
         recursive=recursive,
         preserve_times=preserve_times,
-        **kwargs
+        **kwargs,
     )
 
 
@@ -1926,7 +1926,7 @@ def scp_put(
     recursive=False,
     preserve_times=False,
     saltenv="base",
-    **kwargs
+    **kwargs,
 ):
     """
     .. versionadded:: 2019.2.0
@@ -2021,5 +2021,5 @@ def scp_put(
         recursive=recursive,
         preserve_times=preserve_times,
         saltenv=saltenv,
-        **kwargs
+        **kwargs,
     )

--- a/salt/modules/napalm_mod.py
+++ b/salt/modules/napalm_mod.py
@@ -764,7 +764,7 @@ def netmiko_conn(**kwargs):
         conn.disconnect()
     """
     salt.utils.versions.warn_until(
-        "Chlorine",
+        3007,
         "This 'napalm_mod.netmiko_conn' function as been deprecated and "
         "will be removed in the {version} release, as such, it has been "
         "made an internal function since it is not suitable for CLI usage",
@@ -1161,7 +1161,7 @@ def pyeapi_conn(**kwargs):
         res2 = conn.get_config(as_string=True)
     """
     salt.utils.versions.warn_until(
-        "Chlorine",
+        3007,
         "This 'napalm_mod.pyeapi_conn' function as been deprecated and "
         "will be removed in the {version} release, as such, it has been "
         "made an internal function since it is not suitable for CLI usage",

--- a/salt/modules/nxos.py
+++ b/salt/modules/nxos.py
@@ -219,7 +219,7 @@ def cmd(command, *args, **kwargs):
         salt '*' nxos.cmd show_run
         salt '*' nxos.cmd check_password username=admin password='$5$lkjsdfoi$blahblahblah' encrypted=True
     """
-    warn_until("Argon", "'nxos.cmd COMMAND' is deprecated in favor of 'nxos.COMMAND'")
+    warn_until(3008, "'nxos.cmd COMMAND' is deprecated in favor of 'nxos.COMMAND'")
 
     for k in list(kwargs):
         if k.startswith("__pub_"):
@@ -383,7 +383,7 @@ def show(commands, raw_text=True, **kwargs):
         salt 'regular-minion' nxos.show 'show interfaces' host=sw01.example.com username=test password=test
     """
     warn_until(
-        "Argon",
+        3008,
         "'nxos.show commands' is deprecated in favor of 'nxos.sendline commands'",
     )
 
@@ -450,7 +450,7 @@ def system_info(**kwargs):
 
         salt '*' nxos.system_info
     """
-    warn_until("Argon", "'nxos.system_info' is deprecated in favor of 'nxos.grains'")
+    warn_until(3008, "'nxos.system_info' is deprecated in favor of 'nxos.grains'")
     return salt.utils.nxos.system_info(show_ver(**kwargs))["nxos"]
 
 
@@ -477,7 +477,7 @@ def add_config(lines, **kwargs):
         For more than one config added per command, lines should be a list.
     """
     warn_until(
-        "Argon",
+        3008,
         "'nxos.add_config lines' is deprecated in favor of 'nxos.config commands'",
     )
 

--- a/salt/modules/nxos.py
+++ b/salt/modules/nxos.py
@@ -258,7 +258,7 @@ def get_roles(username, **kwargs):
     user = get_user(username)
     if not user:
         return []
-    command = "show user-account {}".format(username)
+    command = f"show user-account {username}"
     info = sendline(command, **kwargs)
     if isinstance(info, list):
         info = info[0]
@@ -278,7 +278,7 @@ def get_user(username, **kwargs):
 
         salt '*' nxos.get_user username=admin
     """
-    command = 'show run | include "^username {} password 5 "'.format(username)
+    command = f'show run | include "^username {username} password 5 "'
     info = sendline(command, **kwargs)
     if isinstance(info, list):
         info = info[0]
@@ -492,7 +492,7 @@ def config(
     context=None,
     defaults=None,
     saltenv="base",
-    **kwargs
+    **kwargs,
 ):
     """
     Configures the Nexus switch with the specified commands.
@@ -562,7 +562,7 @@ def config(
     if config_file:
         file_str = __salt__["cp.get_file_str"](config_file, saltenv=saltenv)
         if file_str is False:
-            raise CommandExecutionError("Source file {} not found".format(config_file))
+            raise CommandExecutionError(f"Source file {config_file} not found")
     elif commands:
         if isinstance(commands, str):
             commands = [commands]
@@ -664,7 +664,7 @@ def remove_user(username, **kwargs):
 
         salt '*' nxos.remove_user username=daniel
     """
-    user_line = "no username {}".format(username)
+    user_line = f"no username {username}"
     kwargs = clean_kwargs(**kwargs)
     return config(user_line, **kwargs)
 
@@ -681,7 +681,7 @@ def replace(old_value, new_value, full_match=False, **kwargs):
         salt '*' nxos.replace 'TESTSTRINGHERE' 'NEWTESTSTRINGHERE'
     """
     if full_match is False:
-        matcher = re.compile("^.*{}.*$".format(re.escape(old_value)), re.MULTILINE)
+        matcher = re.compile(f"^.*{re.escape(old_value)}.*$", re.MULTILINE)
         repl = re.compile(re.escape(old_value))
     else:
         matcher = re.compile(old_value, re.MULTILINE)
@@ -719,7 +719,7 @@ def set_password(
     role=None,
     crypt_salt=None,
     algorithm="sha256",
-    **kwargs
+    **kwargs,
 ):
     """
     Set users password on switch.
@@ -767,9 +767,9 @@ def set_password(
         )
     else:
         hashed_pass = password
-    password_line = "username {} password 5 {}".format(username, hashed_pass)
+    password_line = f"username {username} password 5 {hashed_pass}"
     if role is not None:
-        password_line += " role {}".format(role)
+        password_line += f" role {role}"
     kwargs = clean_kwargs(**kwargs)
     return config(password_line, **kwargs)
 
@@ -793,7 +793,7 @@ def set_role(username, role, **kwargs):
 
         salt '*' nxos.set_role username=daniel role=vdc-admin.
     """
-    role_line = "username {} role {}".format(username, role)
+    role_line = f"username {username} role {role}"
     kwargs = clean_kwargs(**kwargs)
     return config(role_line, **kwargs)
 
@@ -817,7 +817,7 @@ def unset_role(username, role, **kwargs):
 
         salt '*' nxos.unset_role username=daniel role=vdc-admin
     """
-    role_line = "no username {} role {}".format(username, role)
+    role_line = f"no username {username} role {role}"
     kwargs = clean_kwargs(**kwargs)
     return config(role_line, **kwargs)
 

--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -78,7 +78,7 @@ def module_report():
             if hasattr(__salt__, ref):
                 ret["module_attrs"].append(ref)
             for func in __salt__[ref]:
-                full = "{}.{}".format(ref, func)
+                full = f"{ref}.{func}"
                 if hasattr(getattr(__salt__, ref), func):
                     ret["function_attrs"].append(full)
                 if func in __salt__[ref]:
@@ -426,7 +426,7 @@ def provider(module):
     """
     func = ""
     for key in __salt__:
-        if not key.startswith("{}.".format(module)):
+        if not key.startswith(f"{module}."):
             continue
         func = key
         break

--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -692,7 +692,7 @@ def deprecation_warning():
     """
     # This warn should always stay in Salt.
     salt.utils.versions.warn_until(
-        "Oganesson",
+        3108,
         "This is a test deprecation warning by version.",
     )
     salt.utils.versions.warn_until_date(

--- a/salt/modules/vcenter.py
+++ b/salt/modules/vcenter.py
@@ -41,7 +41,7 @@ def _deprecation_message(function):
     @wraps(function)
     def wrapped(*args, **kwargs):
         salt.utils.versions.warn_until(
-            "Argon",
+            3008,
             "The 'vcenter' functionality in Salt has been deprecated and its "
             "functionality will be removed in version 3008 in favor of the "
             "saltext.vmware Salt Extension. "

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -356,7 +356,7 @@ def _get_proxy_connection_details():
     elif proxytype == "esxvm":
         details = __salt__["esxvm.get_details"]()
     else:
-        raise CommandExecutionError("'{}' proxy is not supported".format(proxytype))
+        raise CommandExecutionError(f"'{proxytype}' proxy is not supported")
     proxy_details = [
         details.get("vcenter") if "vcenter" in details else details.get("host"),
         details.get("username"),
@@ -784,7 +784,7 @@ def coredump_network_enable(
         enable_it = 1
     else:
         enable_it = 0
-    cmd = "system coredump network set -e {}".format(enable_it)
+    cmd = f"system coredump network set -e {enable_it}"
 
     ret = {}
     if esxi_hosts:
@@ -1663,7 +1663,7 @@ def upload_ssh_key(
     if certificate_verify is None:
         certificate_verify = True
 
-    url = "{}://{}:{}/host/ssh_root_authorized_keys".format(protocol, host, port)
+    url = f"{protocol}://{host}:{port}/host/ssh_root_authorized_keys"
     ret = {}
     result = None
     try:
@@ -1734,7 +1734,7 @@ def get_ssh_key(
     if certificate_verify is None:
         certificate_verify = True
 
-    url = "{}://{}:{}/host/ssh_root_authorized_keys".format(protocol, host, port)
+    url = f"{protocol}://{host}:{port}/host/ssh_root_authorized_keys"
     ret = {}
     try:
         result = salt.utils.http.query(
@@ -1998,11 +1998,7 @@ def get_service_policy(
         # If we don't have a valid service, return. The service will be invalid for all hosts.
         if service_name not in valid_services:
             ret.update(
-                {
-                    host_name: {
-                        "Error": "{} is not a valid service name.".format(service_name)
-                    }
-                }
+                {host_name: {"Error": f"{service_name} is not a valid service name."}}
             )
             return ret
 
@@ -2030,7 +2026,7 @@ def get_service_policy(
 
         # If we made it this far, something else has gone wrong.
         if ret.get(host_name) is None:
-            msg = "'vsphere.get_service_policy' failed for host {}.".format(host_name)
+            msg = f"'vsphere.get_service_policy' failed for host {host_name}."
             log.debug(msg)
             ret.update({host_name: {"Error": msg}})
 
@@ -2141,11 +2137,7 @@ def get_service_running(
         # If we don't have a valid service, return. The service will be invalid for all hosts.
         if service_name not in valid_services:
             ret.update(
-                {
-                    host_name: {
-                        "Error": "{} is not a valid service name.".format(service_name)
-                    }
-                }
+                {host_name: {"Error": f"{service_name} is not a valid service name."}}
             )
             return ret
 
@@ -2173,7 +2165,7 @@ def get_service_running(
 
         # If we made it this far, something else has gone wrong.
         if ret.get(host_name) is None:
-            msg = "'vsphere.get_service_running' failed for host {}.".format(host_name)
+            msg = f"'vsphere.get_service_running' failed for host {host_name}."
             log.debug(msg)
             ret.update({host_name: {"Error": msg}})
 
@@ -2330,7 +2322,7 @@ def get_vsan_enabled(
 
         # We must have a VSAN Config in place get information about VSAN state.
         if vsan_config is None:
-            msg = "VSAN System Config Manager is unset for host '{}'.".format(host_name)
+            msg = f"VSAN System Config Manager is unset for host '{host_name}'."
             log.debug(msg)
             ret.update({host_name: {"Error": msg}})
         else:
@@ -3237,7 +3229,7 @@ def set_ntp_config(
         try:
             date_time_manager.UpdateDateTimeConfig(config=date_config)
         except vim.fault.HostConfigFault as err:
-            msg = "vsphere.ntp_configure_servers failed: {}".format(err)
+            msg = f"vsphere.ntp_configure_servers failed: {err}"
             log.debug(msg)
             ret.update({host_name: {"Error": msg}})
             continue
@@ -3356,11 +3348,7 @@ def service_start(
         # If we don't have a valid service, return. The service will be invalid for all hosts.
         if service_name not in valid_services:
             ret.update(
-                {
-                    host_name: {
-                        "Error": "{} is not a valid service name.".format(service_name)
-                    }
-                }
+                {host_name: {"Error": f"{service_name} is not a valid service name."}}
             )
             return ret
 
@@ -3499,11 +3487,7 @@ def service_stop(
         # If we don't have a valid service, return. The service will be invalid for all hosts.
         if service_name not in valid_services:
             ret.update(
-                {
-                    host_name: {
-                        "Error": "{} is not a valid service name.".format(service_name)
-                    }
-                }
+                {host_name: {"Error": f"{service_name} is not a valid service name."}}
             )
             return ret
 
@@ -3515,7 +3499,7 @@ def service_stop(
         try:
             service_manager.StopService(id=temp_service_name)
         except vim.fault.HostConfigFault as err:
-            msg = "'vsphere.service_stop' failed for host {}: {}".format(host_name, err)
+            msg = f"'vsphere.service_stop' failed for host {host_name}: {err}"
             log.debug(msg)
             ret.update({host_name: {"Error": msg}})
             continue
@@ -3640,11 +3624,7 @@ def service_restart(
         # If we don't have a valid service, return. The service will be invalid for all hosts.
         if service_name not in valid_services:
             ret.update(
-                {
-                    host_name: {
-                        "Error": "{} is not a valid service name.".format(service_name)
-                    }
-                }
+                {host_name: {"Error": f"{service_name} is not a valid service name."}}
             )
             return ret
 
@@ -3781,11 +3761,7 @@ def set_service_policy(
         # If we don't have a valid service, return. The service will be invalid for all hosts.
         if service_name not in valid_services:
             ret.update(
-                {
-                    host_name: {
-                        "Error": "{} is not a valid service name.".format(service_name)
-                    }
-                }
+                {host_name: {"Error": f"{service_name} is not a valid service name."}}
             )
             return ret
 
@@ -3812,7 +3788,7 @@ def set_service_policy(
                         id=service_key, policy=service_policy
                     )
                 except vim.fault.NotFound:
-                    msg = "The service name '{}' was not found.".format(service_name)
+                    msg = f"The service name '{service_name}' was not found."
                     log.debug(msg)
                     ret.update({host_name: {"Error": msg}})
                     continue
@@ -4057,7 +4033,7 @@ def vmotion_disable(
         try:
             vmotion_system.DeselectVnic()
         except vim.fault.HostConfigFault as err:
-            msg = "vsphere.vmotion_disable failed: {}".format(err)
+            msg = f"vsphere.vmotion_disable failed: {err}"
             log.debug(msg)
             ret.update({host_name: {"Error": msg, "VMotion Disabled": False}})
             continue
@@ -4145,7 +4121,7 @@ def vmotion_enable(
         try:
             vmotion_system.SelectVnic(device)
         except vim.fault.HostConfigFault as err:
-            msg = "vsphere.vmotion_disable failed: {}".format(err)
+            msg = f"vsphere.vmotion_disable failed: {err}"
             log.debug(msg)
             ret.update({host_name: {"Error": msg, "VMotion Enabled": False}})
             continue
@@ -4872,7 +4848,7 @@ def create_dvs(dvs_dict, dvs_name, service_instance=None):
         dvs_refs = salt.utils.vmware.get_dvss(dc_ref, dvs_names=[dvs_name])
         if not dvs_refs:
             raise VMwareObjectRetrievalError(
-                "DVS '{}' wasn't found in datacenter '{}'".format(dvs_name, datacenter)
+                f"DVS '{dvs_name}' wasn't found in datacenter '{datacenter}'"
             )
         dvs_ref = dvs_refs[0]
         salt.utils.vmware.set_dvs_network_resource_management_enabled(
@@ -4925,7 +4901,7 @@ def update_dvs(dvs_dict, dvs, service_instance=None):
     dvs_refs = salt.utils.vmware.get_dvss(dc_ref, dvs_names=[dvs])
     if not dvs_refs:
         raise VMwareObjectRetrievalError(
-            "DVS '{}' wasn't found in datacenter '{}'".format(dvs, datacenter)
+            f"DVS '{dvs}' wasn't found in datacenter '{datacenter}'"
         )
     dvs_ref = dvs_refs[0]
     # Build the config spec from the input
@@ -5156,7 +5132,7 @@ def list_dvportgroups(dvs=None, portgroup_names=None, service_instance=None):
     if dvs:
         dvs_refs = salt.utils.vmware.get_dvss(dc_ref, dvs_names=[dvs])
         if not dvs_refs:
-            raise VMwareObjectRetrievalError("DVS '{}' was not retrieved".format(dvs))
+            raise VMwareObjectRetrievalError(f"DVS '{dvs}' was not retrieved")
         dvs_ref = dvs_refs[0]
     get_all_portgroups = True if not portgroup_names else False
     for pg_ref in salt.utils.vmware.get_dvportgroups(
@@ -5199,7 +5175,7 @@ def list_uplink_dvportgroup(dvs, service_instance=None):
         dc_ref = salt.utils.vmware.get_datacenter(service_instance, datacenter)
     dvs_refs = salt.utils.vmware.get_dvss(dc_ref, dvs_names=[dvs])
     if not dvs_refs:
-        raise VMwareObjectRetrievalError("DVS '{}' was not retrieved".format(dvs))
+        raise VMwareObjectRetrievalError(f"DVS '{dvs}' was not retrieved")
     uplink_pg_ref = salt.utils.vmware.get_uplink_dvportgroup(dvs_refs[0])
     return _get_dvportgroup_dict(uplink_pg_ref)
 
@@ -5434,7 +5410,7 @@ def create_dvportgroup(portgroup_dict, portgroup_name, dvs, service_instance=Non
         dc_ref = salt.utils.vmware.get_datacenter(service_instance, datacenter)
     dvs_refs = salt.utils.vmware.get_dvss(dc_ref, dvs_names=[dvs])
     if not dvs_refs:
-        raise VMwareObjectRetrievalError("DVS '{}' was not retrieved".format(dvs))
+        raise VMwareObjectRetrievalError(f"DVS '{dvs}' was not retrieved")
     # Make the name of the dvportgroup consistent with the parameter
     portgroup_dict["name"] = portgroup_name
     spec = vim.DVPortgroupConfigSpec()
@@ -5490,14 +5466,12 @@ def update_dvportgroup(portgroup_dict, portgroup, dvs, service_instance=True):
         dc_ref = salt.utils.vmware.get_datacenter(service_instance, datacenter)
     dvs_refs = salt.utils.vmware.get_dvss(dc_ref, dvs_names=[dvs])
     if not dvs_refs:
-        raise VMwareObjectRetrievalError("DVS '{}' was not retrieved".format(dvs))
+        raise VMwareObjectRetrievalError(f"DVS '{dvs}' was not retrieved")
     pg_refs = salt.utils.vmware.get_dvportgroups(
         dvs_refs[0], portgroup_names=[portgroup]
     )
     if not pg_refs:
-        raise VMwareObjectRetrievalError(
-            "Portgroup '{}' was not retrieved".format(portgroup)
-        )
+        raise VMwareObjectRetrievalError(f"Portgroup '{portgroup}' was not retrieved")
     pg_props = salt.utils.vmware.get_properties_of_managed_object(
         pg_refs[0], ["config"]
     )
@@ -5556,14 +5530,12 @@ def remove_dvportgroup(portgroup, dvs, service_instance=None):
         dc_ref = salt.utils.vmware.get_datacenter(service_instance, datacenter)
     dvs_refs = salt.utils.vmware.get_dvss(dc_ref, dvs_names=[dvs])
     if not dvs_refs:
-        raise VMwareObjectRetrievalError("DVS '{}' was not retrieved".format(dvs))
+        raise VMwareObjectRetrievalError(f"DVS '{dvs}' was not retrieved")
     pg_refs = salt.utils.vmware.get_dvportgroups(
         dvs_refs[0], portgroup_names=[portgroup]
     )
     if not pg_refs:
-        raise VMwareObjectRetrievalError(
-            "Portgroup '{}' was not retrieved".format(portgroup)
-        )
+        raise VMwareObjectRetrievalError(f"Portgroup '{portgroup}' was not retrieved")
     salt.utils.vmware.remove_dvportgroup(pg_refs[0])
     return True
 
@@ -5834,7 +5806,7 @@ def update_storage_policy(policy, policy_dict, service_instance=None):
     profile_manager = salt.utils.pbm.get_profile_manager(service_instance)
     policies = salt.utils.pbm.get_storage_policies(profile_manager, [policy])
     if not policies:
-        raise VMwareObjectRetrievalError("Policy '{}' was not found".format(policy))
+        raise VMwareObjectRetrievalError(f"Policy '{policy}' was not found")
     policy_ref = policies[0]
     policy_update_spec = pbm.profile.CapabilityBasedProfileUpdateSpec()
     log.trace("Setting policy values in policy_update_spec")
@@ -5877,9 +5849,7 @@ def list_default_storage_policy_of_datastore(datastore, service_instance=None):
         service_instance, target_ref, datastore_names=[datastore]
     )
     if not ds_refs:
-        raise VMwareObjectRetrievalError(
-            "Datastore '{}' was not found".format(datastore)
-        )
+        raise VMwareObjectRetrievalError(f"Datastore '{datastore}' was not found")
     profile_manager = salt.utils.pbm.get_profile_manager(service_instance)
     policy = salt.utils.pbm.get_default_storage_policy_of_datastore(
         profile_manager, ds_refs[0]
@@ -5921,7 +5891,7 @@ def assign_default_storage_policy_to_datastore(
     # Find policy
     policies = salt.utils.pbm.get_storage_policies(profile_manager, [policy])
     if not policies:
-        raise VMwareObjectRetrievalError("Policy '{}' was not found".format(policy))
+        raise VMwareObjectRetrievalError(f"Policy '{policy}' was not found")
     policy_ref = policies[0]
     # Find datastore
     target_ref = _get_proxy_target(service_instance)
@@ -5929,9 +5899,7 @@ def assign_default_storage_policy_to_datastore(
         service_instance, target_ref, datastore_names=[datastore]
     )
     if not ds_refs:
-        raise VMwareObjectRetrievalError(
-            "Datastore '{}' was not found".format(datastore)
-        )
+        raise VMwareObjectRetrievalError(f"Datastore '{datastore}' was not found")
     ds_ref = ds_refs[0]
     salt.utils.pbm.assign_default_storage_policy_to_datastore(
         profile_manager, policy_ref, ds_ref
@@ -6657,7 +6625,7 @@ def create_vmfs_datastore(
         disks = salt.utils.vmware.get_disks(host_ref, disk_ids=[disk_id])
         if not disks:
             raise VMwareObjectRetrievalError(
-                "Disk '{}' was not found in host '{}'".format(disk_id, hostname)
+                f"Disk '{disk_id}' was not found in host '{hostname}'"
             )
     ds_ref = salt.utils.vmware.create_vmfs_datastore(
         host_ref, datastore_name, disks[0], vmfs_major_version
@@ -6696,9 +6664,7 @@ def rename_datastore(datastore_name, new_datastore_name, service_instance=None):
         service_instance, target, datastore_names=[datastore_name]
     )
     if not datastores:
-        raise VMwareObjectRetrievalError(
-            "Datastore '{}' was not found".format(datastore_name)
-        )
+        raise VMwareObjectRetrievalError(f"Datastore '{datastore_name}' was not found")
     ds = datastores[0]
     salt.utils.vmware.rename_datastore(ds, new_datastore_name)
     return True
@@ -6731,12 +6697,10 @@ def remove_datastore(datastore, service_instance=None):
         service_instance, reference=target, datastore_names=[datastore]
     )
     if not datastores:
-        raise VMwareObjectRetrievalError(
-            "Datastore '{}' was not found".format(datastore)
-        )
+        raise VMwareObjectRetrievalError(f"Datastore '{datastore}' was not found")
     if len(datastores) > 1:
         raise VMwareObjectRetrievalError(
-            "Multiple datastores '{}' were found".format(datastore)
+            f"Multiple datastores '{datastore}' were found"
         )
     salt.utils.vmware.remove_datastore(service_instance, datastores[0])
     return True
@@ -6970,9 +6934,7 @@ def assign_license(
     if safety_checks:
         licenses = salt.utils.vmware.get_licenses(service_instance)
         if not [l for l in licenses if l.licenseKey == license_key]:
-            raise VMwareObjectRetrievalError(
-                "License '{}' wasn't found".format(license_name)
-            )
+            raise VMwareObjectRetrievalError(f"License '{license_name}' wasn't found")
     salt.utils.vmware.assign_license(
         service_instance,
         license_key,
@@ -7348,7 +7310,7 @@ def create_diskgroup(
     for id in disk_ids:
         if not [d for d in disks if d.canonicalName == id]:
             raise VMwareObjectRetrievalError(
-                "No disk with id '{}' was found in ESXi host '{}'".format(id, hostname)
+                f"No disk with id '{id}' was found in ESXi host '{hostname}'"
             )
     cache_disk = [d for d in disks if d.canonicalName == cache_disk_id][0]
     capacity_disks = [d for d in disks if d.canonicalName in capacity_disk_ids]
@@ -7597,7 +7559,7 @@ def get_host_cache(service_instance=None):
     return {
         "enabled": True,
         "datastore": {"name": hci.key.name},
-        "swap_size": "{}MiB".format(hci.swapSize),
+        "swap_size": f"{hci.swapSize}MiB",
     }
 
 
@@ -7661,7 +7623,7 @@ def configure_host_cache(
         )
         if not ds_refs:
             raise VMwareObjectRetrievalError(
-                "Datastore '{}' was not found on host '{}'".format(datastore, hostname)
+                f"Datastore '{datastore}' was not found on host '{hostname}'"
             )
         ds_ref = ds_refs[0]
     salt.utils.vmware.configure_host_cache(host_ref, ds_ref, swap_size_MiB)
@@ -7960,7 +7922,7 @@ def _set_syslog_config_helper(
     """
     Helper function for set_syslog_config that sets the config and populates the return dictionary.
     """
-    cmd = "system syslog config set --{} {}".format(syslog_config, config_value)
+    cmd = f"system syslog config set --{syslog_config} {config_value}"
     ret_dict = {}
 
     valid_resets = [
@@ -7975,7 +7937,7 @@ def _set_syslog_config_helper(
         ret_dict.update(
             {
                 "success": False,
-                "message": "'{}' is not a valid config variable.".format(syslog_config),
+                "message": f"'{syslog_config}' is not a valid config variable.",
             }
         )
         return ret_dict
@@ -8218,14 +8180,14 @@ def add_host_to_dvs(
     dvs = salt.utils.vmware._get_dvs(service_instance, dvs_name)
     if not dvs:
         ret["message"].append(
-            "No Distributed Virtual Switch found with name {}".format(dvs_name)
+            f"No Distributed Virtual Switch found with name {dvs_name}"
         )
         ret["success"] = False
 
     target_portgroup = salt.utils.vmware._get_dvs_portgroup(dvs, target_portgroup_name)
     if not target_portgroup:
         ret["message"].append(
-            "No target portgroup found with name {}".format(target_portgroup_name)
+            f"No target portgroup found with name {target_portgroup_name}"
         )
         ret["success"] = False
 
@@ -8234,7 +8196,7 @@ def add_host_to_dvs(
     )
     if not uplink_portgroup:
         ret["message"].append(
-            "No uplink portgroup found with name {}".format(uplink_portgroup_name)
+            f"No uplink portgroup found with name {uplink_portgroup_name}"
         )
         ret["success"] = False
 
@@ -8245,7 +8207,7 @@ def add_host_to_dvs(
     try:
         host_names = _check_hosts(service_instance, host, host_names)
     except CommandExecutionError as e:
-        ret["message"] = "Error retrieving hosts: {}".format(e.msg)
+        ret["message"] = f"Error retrieving hosts: {e.msg}"
         return ret
 
     for host_name in host_names:
@@ -8272,9 +8234,7 @@ def add_host_to_dvs(
         p_nics = salt.utils.vmware._get_pnics(host_ref)
         p_nic = [x for x in p_nics if x.device == vmnic_name]
         if not p_nic:
-            ret[host_name].update(
-                {"message": "Physical nic {} not found".format(vmknic_name)}
-            )
+            ret[host_name].update({"message": f"Physical nic {vmknic_name} not found"})
             ret["success"] = False
             continue
 
@@ -8282,9 +8242,7 @@ def add_host_to_dvs(
         v_nic = [x for x in v_nics if x.device == vmknic_name]
 
         if not v_nic:
-            ret[host_name].update(
-                {"message": "Virtual nic {} not found".format(vmnic_name)}
-            )
+            ret[host_name].update({"message": f"Virtual nic {vmnic_name} not found"})
             ret["success"] = False
             continue
 
@@ -8377,7 +8335,7 @@ def add_host_to_dvs(
         except Exception as e:  # pylint: disable=broad-except
             if hasattr(e, "msg"):
                 ret[host_name].update(
-                    {"message": "Failed to migrate adapters ({})".format(e.msg)}
+                    {"message": f"Failed to migrate adapters ({e.msg})"}
                 )
                 continue
             else:
@@ -8876,7 +8834,7 @@ def _get_scsi_controller_key(bus_number, scsi_ctrls):
     ]
     if not keys:
         raise salt.exceptions.VMwareVmCreationError(
-            "SCSI controller number {} doesn't exist".format(bus_number)
+            f"SCSI controller number {bus_number} doesn't exist"
         )
     return keys[0]
 
@@ -9055,7 +9013,7 @@ def _create_network_backing(network_name, switch_type, parent_ref):
             )
             if not networks:
                 raise salt.exceptions.VMwareObjectRetrievalError(
-                    "The network '{}' could not be retrieved.".format(network_name)
+                    f"The network '{network_name}' could not be retrieved."
                 )
             network_ref = networks[0]
             backing = vim.vm.device.VirtualEthernetCard.NetworkBackingInfo()
@@ -9067,7 +9025,7 @@ def _create_network_backing(network_name, switch_type, parent_ref):
             )
             if not networks:
                 raise salt.exceptions.VMwareObjectRetrievalError(
-                    "The port group '{}' could not be retrieved.".format(network_name)
+                    f"The port group '{network_name}' could not be retrieved."
                 )
             network_ref = networks[0]
             dvs_port_connection = vim.dvs.PortConnection(
@@ -9833,7 +9791,7 @@ def _get_device_by_key(devices, key):
         return device_keys[0]
     else:
         raise salt.exceptions.VMwareObjectNotFoundError(
-            "Virtual machine device with unique key {} does not exist".format(key)
+            f"Virtual machine device with unique key {key} does not exist"
         )
 
 
@@ -9853,7 +9811,7 @@ def _get_device_by_label(devices, label):
         return device_labels[0]
     else:
         raise salt.exceptions.VMwareObjectNotFoundError(
-            "Virtual machine device with label {} does not exist".format(label)
+            f"Virtual machine device with label {label} does not exist"
         )
 
 
@@ -11207,7 +11165,7 @@ def create_vm(
     )[0]
     if not datastore_object:
         raise salt.exceptions.ArgumentValueError(
-            "Specified datastore: '{}' does not exist.".format(datastore)
+            f"Specified datastore: '{datastore}' does not exist."
         )
     try:
         ds_summary = salt.utils.vmware.get_properties_of_managed_object(
@@ -11218,7 +11176,7 @@ def create_vm(
                 "The vmPathName should be the datastore "
                 "name if the datastore type is vsan"
             )
-            config_spec.files.vmPathName = "[{}]".format(datastore)
+            config_spec.files.vmPathName = f"[{datastore}]"
         else:
             config_spec.files.vmPathName = "[{0}] {1}/{1}.vmx".format(
                 datastore, vm_name

--- a/salt/modules/vsphere.py
+++ b/salt/modules/vsphere.py
@@ -308,7 +308,7 @@ def _deprecation_message(function):
     @wraps(function)
     def wrapped(*args, **kwargs):
         salt.utils.versions.warn_until(
-            "Argon",
+            3008,
             "The 'vsphere' functionality in Salt has been deprecated and its "
             "functionality will be removed in version 3008 in favor of the "
             "saltext.vmware Salt Extension. "

--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -188,7 +188,7 @@ def _parse_openssl_req(csr_filename):
     """
     if not salt.utils.path.which("openssl"):
         raise salt.exceptions.SaltInvocationError("openssl binary not found in path")
-    cmd = "openssl req -text -noout -in {}".format(csr_filename)
+    cmd = f"openssl req -text -noout -in {csr_filename}"
 
     output = __salt__["cmd.run_stdout"](cmd)
 
@@ -231,7 +231,7 @@ def _parse_openssl_crl(crl_filename):
     """
     if not salt.utils.path.which("openssl"):
         raise salt.exceptions.SaltInvocationError("openssl binary not found in path")
-    cmd = "openssl crl -text -noout -in {}".format(crl_filename)
+    cmd = f"openssl crl -text -noout -in {crl_filename}"
 
     output = __salt__["cmd.run_stdout"](cmd)
 
@@ -316,7 +316,7 @@ def _dec2hex(decval):
     """
     Converts decimal values to nicely formatted hex strings
     """
-    return _pretty_hex("{:X}".format(decval))
+    return _pretty_hex(f"{decval:X}")
 
 
 def _isfile(path):
@@ -505,7 +505,7 @@ def get_pem_entry(text, pem_type=None):
                     pem_temp = pem_temp[pem_temp.index("-") :]
         text = "\n".join(pem_fixed)
 
-    errmsg = "PEM text not valid:\n{}".format(text)
+    errmsg = f"PEM text not valid:\n{text}"
     if pem_type:
         errmsg = "PEM does not contain a single entry of type {}:\n{}".format(
             pem_type, text
@@ -824,7 +824,7 @@ def write_pem(text, path, overwrite=True, pem_type=None):
             _fp.write(salt.utils.stringutils.to_str(text))
             if pem_type and pem_type == "CERTIFICATE" and _dhparams:
                 _fp.write(salt.utils.stringutils.to_str(_dhparams))
-    return "PEM written to {}".format(path)
+    return f"PEM written to {path}"
 
 
 def create_private_key(
@@ -1130,7 +1130,7 @@ def get_signing_policy(signing_policy_name):
     """
     signing_policy = _get_signing_policy(signing_policy_name)
     if not signing_policy:
-        return "Signing policy {} does not exist.".format(signing_policy_name)
+        return f"Signing policy {signing_policy_name} does not exist."
     if isinstance(signing_policy, list):
         dict_ = {}
         for item in signing_policy:

--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -96,7 +96,7 @@ def __virtual__():
         return (False, "Superseded, using x509_v2")
     if HAS_M2:
         salt.utils.versions.warn_until(
-            "Potassium",
+            3009,
             "The x509 modules are deprecated. Please migrate to the replacement "
             "modules (x509_v2). They are the default from Salt 3008 (Argon) onwards.",
         )

--- a/salt/modules/x509_v2.py
+++ b/salt/modules/x509_v2.py
@@ -458,7 +458,7 @@ def create_certificate(
     # Deprecation checks vs the old x509 module
     if "algorithm" in kwargs:
         salt.utils.versions.warn_until(
-            "Potassium",
+            3009,
             "`algorithm` has been renamed to `digest`. Please update your code.",
         )
         kwargs["digest"] = kwargs.pop("algorithm")
@@ -473,7 +473,7 @@ def create_certificate(
     if "days_valid" not in kwargs and "not_after" not in kwargs:
         try:
             salt.utils.versions.warn_until(
-                "Potassium",
+                3009,
                 "The default value for `days_valid` will change to 30. Please adapt your code accordingly.",
             )
             kwargs["days_valid"] = 365
@@ -910,7 +910,7 @@ def create_crl(
     if days_valid is None:
         try:
             salt.utils.versions.warn_until(
-                "Potassium",
+                3009,
                 "The default value for `days_valid` will change to 7. Please adapt your code accordingly.",
             )
             days_valid = 100
@@ -922,14 +922,14 @@ def create_crl(
         parsed = {}
         if len(rev) == 1 and isinstance(rev[next(iter(rev))], list):
             salt.utils.versions.warn_until(
-                "Potassium",
+                3009,
                 "Revoked certificates should be specified as a simple list of dicts.",
             )
             for val in rev[next(iter(rev))]:
                 parsed.update(val)
         if "reason" in (parsed or rev):
             salt.utils.versions.warn_until(
-                "Potassium",
+                3009,
                 "The `reason` parameter for revoked certificates should be specified in extensions:CRLReason.",
             )
             salt.utils.dictupdate.set_dict_key_value(
@@ -1079,7 +1079,7 @@ def create_csr(
     # Deprecation checks vs the old x509 module
     if "algorithm" in kwargs:
         salt.utils.versions.warn_until(
-            "Potassium",
+            3009,
             "`algorithm` has been renamed to `digest`. Please update your code.",
         )
         digest = kwargs.pop("algorithm")
@@ -1225,7 +1225,7 @@ def create_private_key(
     # Deprecation checks vs the old x509 module
     if "bits" in kwargs:
         salt.utils.versions.warn_until(
-            "Potassium",
+            3009,
             "`bits` has been renamed to `keysize`. Please update your code.",
         )
         keysize = kwargs.pop("bits")
@@ -1601,7 +1601,7 @@ def get_signing_policy(signing_policy, ca_server=None):
         for long_name in long_names:
             if long_name in policy:
                 salt.utils.versions.warn_until(
-                    "Potassium",
+                    3009,
                     f"Found {long_name} in {signing_policy}. Please migrate to the short name: {name}",
                 )
                 policy[name] = policy.pop(long_name)
@@ -1611,7 +1611,7 @@ def get_signing_policy(signing_policy, ca_server=None):
         for long_name in long_names:
             if long_name in policy:
                 salt.utils.versions.warn_until(
-                    "Potassium",
+                    3009,
                     f"Found {long_name} in {signing_policy}. Please migrate to the short name: {extname}",
                 )
                 policy[extname] = policy.pop(long_name)

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -45,8 +45,8 @@ log = logging.getLogger(__name__)
 
 HAS_ZYPP = False
 ZYPP_HOME = "/etc/zypp"
-LOCKS = "{}/locks".format(ZYPP_HOME)
-REPOS = "{}/repos.d".format(ZYPP_HOME)
+LOCKS = f"{ZYPP_HOME}/locks"
+REPOS = f"{ZYPP_HOME}/repos.d"
 DEFAULT_PRIORITY = 99
 PKG_ARCH_SEPARATOR = "."
 
@@ -372,9 +372,7 @@ class _Zypper:
                 self.TAG_RELEASED,
             )
         if self.error_msg and not self.__no_raise and not self.__ignore_repo_failure:
-            raise CommandExecutionError(
-                "Zypper command failure: {}".format(self.error_msg)
-            )
+            raise CommandExecutionError(f"Zypper command failure: {self.error_msg}")
 
         return (
             self._is_xml_mode()
@@ -483,9 +481,7 @@ class Wildcard:
             "se", "-xv", self.name
         ).getElementsByTagName("solvable")
         if not solvables:
-            raise CommandExecutionError(
-                "No packages found matching '{}'".format(self.name)
-            )
+            raise CommandExecutionError(f"No packages found matching '{self.name}'")
 
         return sorted(
             {
@@ -520,7 +516,7 @@ class Wildcard:
         self._op = version.replace(exact_version, "") or None
         if self._op and self._op not in self.Z_OP:
             raise CommandExecutionError(
-                'Zypper do not supports operator "{}".'.format(self._op)
+                f'Zypper do not supports operator "{self._op}".'
             )
         self.version = exact_version
 
@@ -921,7 +917,7 @@ def list_pkgs(versions_as_list=False, root=None, includes=None, **kwargs):
 
     # Results can be different if a different root or a different
     # inclusion types are passed
-    contextkey = "pkg.list_pkgs_{}_{}".format(root, includes)
+    contextkey = f"pkg.list_pkgs_{root}_{includes}"
 
     if contextkey in __context__ and kwargs.get("use_context", True):
         return _list_pkgs_from_context(versions_as_list, contextkey, attr)
@@ -989,7 +985,7 @@ def list_pkgs(versions_as_list=False, root=None, includes=None, **kwargs):
             else:
                 elements = []
             for element in elements:
-                extended_name = "{}:{}".format(include, element)
+                extended_name = f"{include}:{element}"
                 info = info_available(extended_name, refresh=False, root=root)
                 _ret[extended_name] = [
                     {
@@ -1230,7 +1226,7 @@ def del_repo(repo, root=None):
                     "message": msg[0].childNodes[0].nodeValue,
                 }
 
-    raise CommandExecutionError("Repository '{}' not found.".format(repo))
+    raise CommandExecutionError(f"Repository '{repo}' not found.")
 
 
 def mod_repo(repo, **kwargs):
@@ -1317,7 +1313,7 @@ def mod_repo(repo, **kwargs):
 
             if new_url == base_url:
                 raise CommandExecutionError(
-                    "Repository '{}' already exists as '{}'.".format(repo, alias)
+                    f"Repository '{repo}' already exists as '{alias}'."
                 )
 
         # Add new repo
@@ -1473,7 +1469,7 @@ def install(
     ignore_repo_failure=False,
     no_recommends=False,
     root=None,
-    **kwargs
+    **kwargs,
 ):
     """
     .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
@@ -1640,7 +1636,7 @@ def install(
                 prefix, verstr = salt.utils.pkg.split_comparison(version_num)
                 if not prefix:
                     prefix = "="
-                target = "{}{}{}".format(param, prefix, verstr)
+                target = f"{param}{prefix}{verstr}"
                 log.debug("targeting package: %s", target)
                 targets.append(target)
     elif pkg_type == "advisory":
@@ -1648,9 +1644,7 @@ def install(
         cur_patches = list_patches(root=root)
         for advisory_id in pkg_params:
             if advisory_id not in cur_patches:
-                raise CommandExecutionError(
-                    'Advisory id "{}" not found'.format(advisory_id)
-                )
+                raise CommandExecutionError(f'Advisory id "{advisory_id}" not found')
             else:
                 # If we add here the `patch:` prefix, the
                 # `_find_types` helper will take the patches into the
@@ -1703,7 +1697,7 @@ def install(
     # if the name of the package is already prefixed with 'patch:' we
     # can avoid listing them in the `advisory_ids` field.
     if pkg_type == "advisory":
-        targets = ["patch:{}".format(t) for t in targets]
+        targets = [f"patch:{t}" for t in targets]
 
     # Split the targets into batches of 500 packages each, so that
     # the maximal length of the command line is not broken
@@ -1767,7 +1761,7 @@ def upgrade(
     no_recommends=False,
     root=None,
     diff_attr=None,
-    **kwargs
+    **kwargs,
 ):  # pylint: disable=unused-argument
     """
     .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
@@ -2186,7 +2180,7 @@ def list_holds(pattern=None, full=True, root=None, **kwargs):
                         )
                     )
 
-    ptrn_re = re.compile(r"{}-\S+".format(pattern)) if pattern else None
+    ptrn_re = re.compile(rf"{pattern}-\S+") if pattern else None
     for pkg_name, pkg_editions in inst_pkgs.items():
         for pkg_info in pkg_editions:
             pkg_ret = (
@@ -2328,14 +2322,12 @@ def unhold(name=None, pkgs=None, root=None, **kwargs):
                     target
                 )
             else:
-                removed.append(
-                    target if not lock_ver else "{}={}".format(target, lock_ver)
-                )
+                removed.append(target if not lock_ver else f"{target}={lock_ver}")
                 ret[target]["changes"]["new"] = ""
                 ret[target]["changes"]["old"] = "hold"
-                ret[target]["comment"] = "Package {} is no longer held.".format(target)
+                ret[target]["comment"] = f"Package {target} is no longer held."
         else:
-            ret[target]["comment"] = "Package {} was already unheld.".format(target)
+            ret[target]["comment"] = f"Package {target} was already unheld."
 
     if removed:
         __zypper__(root=root).call("rl", *removed)
@@ -2387,10 +2379,10 @@ def hold(name=None, pkgs=None, root=None, **kwargs):
             (target, version) = next(iter(target.items()))
         ret[target] = {"name": target, "changes": {}, "result": True, "comment": ""}
         if not locks.get(target):
-            added.append(target if not version else "{}={}".format(target, version))
+            added.append(target if not version else f"{target}={version}")
             ret[target]["changes"]["new"] = "hold"
             ret[target]["changes"]["old"] = ""
-            ret[target]["comment"] = "Package {} is now being held.".format(target)
+            ret[target]["comment"] = f"Package {target} is now being held."
         else:
             ret[target]["comment"] = "Package {} is already set to be held.".format(
                 target
@@ -2740,7 +2732,7 @@ def search(criteria, refresh=False, **kwargs):
         .getElementsByTagName("solvable")
     )
     if not solvables:
-        raise CommandExecutionError("No packages found matching '{}'".format(criteria))
+        raise CommandExecutionError(f"No packages found matching '{criteria}'")
 
     out = {}
     for solvable in solvables:

--- a/salt/payload.py
+++ b/salt/payload.py
@@ -241,7 +241,7 @@ class Serial:
 
     def __init__(self, *args, **kwargs):
         salt.utils.versions.warn_until(
-            "Chlorine",
+            3007,
             "The `salt.payload.Serial` class has been deprecated, "
             "and is set to be removed in {version}. "
             "Please use `salt.payload.loads` and `salt.payload.dumps`.",

--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -441,7 +441,7 @@ def _decrypt_ciphertext(cipher):
             )
         else:
             salt.utils.versions.warn_until(
-                "Chlorine",
+                3007,
                 "After the Chlorine release of Salt, gpg_decrypt_must_succeed will default to True.",
             )
         return cipher

--- a/salt/states/esxcluster.py
+++ b/salt/states/esxcluster.py
@@ -107,7 +107,7 @@ def _deprecation_message(function):
     @wraps(function)
     def wrapped(*args, **kwargs):
         salt.utils.versions.warn_until(
-            "Argon",
+            3008,
             "The 'esxcluster' functionality in Salt has been deprecated and its "
             "functionality will be removed in version 3008 in favor of the "
             "saltext.vmware Salt Extension. "

--- a/salt/states/esxcluster.py
+++ b/salt/states/esxcluster.py
@@ -140,7 +140,7 @@ def _get_vsan_datastore(si, cluster_name):
 
     if not vsan_datastores:
         raise salt.exceptions.VMwareObjectRetrievalError(
-            "No vSAN datastores where retrieved for cluster '{}'".format(cluster_name)
+            f"No vSAN datastores where retrieved for cluster '{cluster_name}'"
         )
     return vsan_datastores[0]
 
@@ -201,9 +201,7 @@ def cluster_configured(name, cluster_config):
             __salt__["esxcluster.get_details"]()["datacenter"],
         )
     else:
-        raise salt.exceptions.CommandExecutionError(
-            "Unsupported proxy {}".format(proxy_type)
-        )
+        raise salt.exceptions.CommandExecutionError(f"Unsupported proxy {proxy_type}")
     log.info(
         "Running %s for cluster '%s' in datacenter '%s'",
         name,
@@ -288,13 +286,11 @@ def cluster_configured(name, cluster_config):
                 changes_required = True
                 changes_str = ""
                 if diff.diffs:
-                    changes_str = "{}{}".format(changes_str, diff.changes_str)
+                    changes_str = f"{changes_str}{diff.changes_str}"
                 if ldiff and ldiff.diffs:
                     changes_str = "{}\nha:\n  options:\n{}".format(
                         changes_str,
-                        "\n".join(
-                            ["  {}".format(l) for l in ldiff.changes_str2.split("\n")]
-                        ),
+                        "\n".join([f"  {l}" for l in ldiff.changes_str2.split("\n")]),
                     )
                 # Apply the changes
                 if __opts__["test"]:
@@ -355,7 +351,7 @@ def vsan_datastore_configured(name, datastore_name):
         __salt__["esxcluster.get_details"]()["cluster"],
         __salt__["esxcluster.get_details"]()["datacenter"],
     )
-    display_name = "{}/{}".format(datacenter_name, cluster_name)
+    display_name = f"{datacenter_name}/{cluster_name}"
     log.info("Running vsan_datastore_configured for '%s'", display_name)
     ret = {"name": name, "changes": {}, "result": None, "comment": "Default"}
     comments = []
@@ -394,9 +390,7 @@ def vsan_datastore_configured(name, datastore_name):
                     new_datastore_name=datastore_name,
                     service_instance=si,
                 )
-                comments.append(
-                    "Renamed vSAN datastore to '{}'.".format(datastore_name)
-                )
+                comments.append(f"Renamed vSAN datastore to '{datastore_name}'.")
                 changes = {
                     "vsan_datastore": {
                         "new": {"name": datastore_name},
@@ -446,7 +440,7 @@ def licenses_configured(name, licenses=None):
         __salt__["esxcluster.get_details"]()["cluster"],
         __salt__["esxcluster.get_details"]()["datacenter"],
     )
-    display_name = "{}/{}".format(datacenter_name, cluster_name)
+    display_name = f"{datacenter_name}/{cluster_name}"
     log.info("Running licenses configured for '%s'", display_name)
     log.trace("licenses = %s", licenses)
     entity = {"type": "cluster", "datacenter": datacenter_name, "cluster": cluster_name}
@@ -496,7 +490,7 @@ def licenses_configured(name, licenses=None):
                         log.error(comments[-1])
                         has_errors = True
                         continue
-                    comments.append("Added license '{}'.".format(license_name))
+                    comments.append(f"Added license '{license_name}'.")
                     log.info(comments[-1])
             else:
                 # License exists let's check if it's assigned to the cluster

--- a/salt/states/esxdatacenter.py
+++ b/salt/states/esxdatacenter.py
@@ -129,16 +129,16 @@ def datacenter_configured(name):
         )
         if not dcs:
             if __opts__["test"]:
-                comments.append("State will create datacenter '{}'.".format(dc_name))
+                comments.append(f"State will create datacenter '{dc_name}'.")
             else:
                 log.debug("Creating datacenter '%s'", dc_name)
                 __salt__["vsphere.create_datacenter"](dc_name, si)
-                comments.append("Created datacenter '{}'.".format(dc_name))
+                comments.append(f"Created datacenter '{dc_name}'.")
             log.info(comments[-1])
             ret["changes"].update({"new": {"name": dc_name}})
         else:
             comments.append(
-                "Datacenter '{}' already exists. Nothing to be done.".format(dc_name)
+                f"Datacenter '{dc_name}' already exists. Nothing to be done."
             )
             log.info(comments[-1])
         __salt__["vsphere.disconnect"](si)

--- a/salt/states/esxdatacenter.py
+++ b/salt/states/esxdatacenter.py
@@ -81,7 +81,7 @@ def _deprecation_message(function):
     @wraps(function)
     def wrapped(*args, **kwargs):
         salt.utils.versions.warn_until(
-            "Argon",
+            3008,
             "The 'esxdatacenter' functionality in Salt has been deprecated and its "
             "functionality will be removed in version 3008 in favor of the "
             "saltext.vmware Salt Extension. "

--- a/salt/states/esxi.py
+++ b/salt/states/esxi.py
@@ -226,7 +226,7 @@ def coredump_configured(name, enabled, dump_ip, host_vnic="vmk0", dump_port=6500
     current_config = __salt__[esxi_cmd]("get_coredump_network_config").get(host)
     error = current_config.get("Error")
     if error:
-        ret["comment"] = "Error: {}".format(error)
+        ret["comment"] = f"Error: {error}"
         return ret
 
     current_config = current_config.get("Coredump Config")
@@ -242,7 +242,7 @@ def coredump_configured(name, enabled, dump_ip, host_vnic="vmk0", dump_port=6500
             ).get(host)
             error = response.get("Error")
             if error:
-                ret["comment"] = "Error: {}".format(error)
+                ret["comment"] = f"Error: {error}"
                 return ret
 
             # Allow users to disable core dump, but then return since
@@ -295,7 +295,7 @@ def coredump_configured(name, enabled, dump_ip, host_vnic="vmk0", dump_port=6500
             msg = response.get("stderr")
             if not msg:
                 msg = response.get("stdout")
-            ret["comment"] = "Error: {}".format(msg)
+            ret["comment"] = f"Error: {msg}"
             return ret
 
     ret["result"] = True
@@ -354,7 +354,7 @@ def password_present(name, password):
             __salt__[esxi_cmd]("update_host_password", new_password=password)
         except CommandExecutionError as err:
             ret["result"] = False
-            ret["comment"] = "Error: {}".format(err)
+            ret["comment"] = f"Error: {err}"
             return ret
 
     return ret
@@ -427,7 +427,7 @@ def ntp_configured(
     ntp_running = __salt__[esxi_cmd]("get_service_running", service_name=ntpd).get(host)
     error = ntp_running.get("Error")
     if error:
-        ret["comment"] = "Error: {}".format(error)
+        ret["comment"] = f"Error: {error}"
         return ret
     ntp_running = ntp_running.get(ntpd)
 
@@ -440,7 +440,7 @@ def ntp_configured(
             ).get(host)
             error = response.get("Error")
             if error:
-                ret["comment"] = "Error: {}".format(error)
+                ret["comment"] = f"Error: {error}"
                 return ret
         # Set changes dictionary for ntp_servers
         ret["changes"].update({"ntp_servers": {"old": ntp_config, "new": ntp_servers}})
@@ -456,7 +456,7 @@ def ntp_configured(
                 )
                 error = response.get("Error")
                 if error:
-                    ret["comment"] = "Error: {}".format(error)
+                    ret["comment"] = f"Error: {error}"
                     return ret
             # Stop ntpd if service_running=False
             else:
@@ -465,7 +465,7 @@ def ntp_configured(
                 )
                 error = response.get("Error")
                 if error:
-                    ret["comment"] = "Error: {}".format(error)
+                    ret["comment"] = f"Error: {error}"
                     return ret
         ret["changes"].update(
             {"service_running": {"old": ntp_running, "new": service_running}}
@@ -478,7 +478,7 @@ def ntp_configured(
         ).get(host)
         error = current_service_policy.get("Error")
         if error:
-            ret["comment"] = "Error: {}".format(error)
+            ret["comment"] = f"Error: {error}"
             return ret
         current_service_policy = current_service_policy.get(ntpd)
 
@@ -492,7 +492,7 @@ def ntp_configured(
                 ).get(host)
                 error = response.get("Error")
                 if error:
-                    ret["comment"] = "Error: {}".format(error)
+                    ret["comment"] = f"Error: {error}"
                     return ret
             ret["changes"].update(
                 {
@@ -510,7 +510,7 @@ def ntp_configured(
             response = __salt__[esxi_cmd]("update_host_datetime").get(host)
             error = response.get("Error")
             if error:
-                ret["comment"] = "Error: {}".format(error)
+                ret["comment"] = f"Error: {error}"
                 return ret
         ret["changes"].update(
             {"update_datetime": {"old": "", "new": "Host datetime was updated."}}
@@ -525,7 +525,7 @@ def ntp_configured(
             )
             error = response.get("Error")
             if error:
-                ret["comment"] = "Error: {}".format(error)
+                ret["comment"] = f"Error: {error}"
                 return ret
         ret["changes"].update(
             {"service_restart": {"old": "", "new": "NTP Daemon Restarted."}}
@@ -587,14 +587,14 @@ def vmotion_configured(name, enabled, device="vmk0"):
                 response = __salt__[esxi_cmd]("vmotion_enable", device=device).get(host)
                 error = response.get("Error")
                 if error:
-                    ret["comment"] = "Error: {}".format(error)
+                    ret["comment"] = f"Error: {error}"
                     return ret
             # Disable VMotion if enabled=False
             else:
                 response = __salt__[esxi_cmd]("vmotion_disable").get(host)
                 error = response.get("Error")
                 if error:
-                    ret["comment"] = "Error: {}".format(error)
+                    ret["comment"] = f"Error: {error}"
                     return ret
         ret["changes"].update(
             {"enabled": {"old": current_vmotion_enabled, "new": enabled}}
@@ -647,7 +647,7 @@ def vsan_configured(name, enabled, add_disks_to_vsan=False):
     current_vsan_enabled = __salt__[esxi_cmd]("get_vsan_enabled").get(host)
     error = current_vsan_enabled.get("Error")
     if error:
-        ret["comment"] = "Error: {}".format(error)
+        ret["comment"] = f"Error: {error}"
         return ret
     current_vsan_enabled = current_vsan_enabled.get("VSAN Enabled")
 
@@ -660,14 +660,14 @@ def vsan_configured(name, enabled, add_disks_to_vsan=False):
                 response = __salt__[esxi_cmd]("vsan_enable").get(host)
                 error = response.get("Error")
                 if error:
-                    ret["comment"] = "Error: {}".format(error)
+                    ret["comment"] = f"Error: {error}"
                     return ret
             # Disable VSAN if enabled=False
             else:
                 response = __salt__[esxi_cmd]("vsan_disable").get(host)
                 error = response.get("Error")
                 if error:
-                    ret["comment"] = "Error: {}".format(error)
+                    ret["comment"] = f"Error: {error}"
                     return ret
         ret["changes"].update(
             {"enabled": {"old": current_vsan_enabled, "new": enabled}}
@@ -678,7 +678,7 @@ def vsan_configured(name, enabled, add_disks_to_vsan=False):
         current_eligible_disks = __salt__[esxi_cmd]("get_vsan_eligible_disks").get(host)
         error = current_eligible_disks.get("Error")
         if error:
-            ret["comment"] = "Error: {}".format(error)
+            ret["comment"] = f"Error: {error}"
             return ret
 
         disks = current_eligible_disks.get("Eligible")
@@ -688,7 +688,7 @@ def vsan_configured(name, enabled, add_disks_to_vsan=False):
                 response = __salt__[esxi_cmd]("vsan_add_disks").get(host)
                 error = response.get("Error")
                 if error:
-                    ret["comment"] = "Error: {}".format(error)
+                    ret["comment"] = f"Error: {error}"
                     return ret
 
             ret["changes"].update({"add_disks_to_vsan": {"old": "", "new": disks}})
@@ -779,7 +779,7 @@ def ssh_configured(
     ssh_running = __salt__[esxi_cmd]("get_service_running", service_name=ssh).get(host)
     error = ssh_running.get("Error")
     if error:
-        ret["comment"] = "Error: {}".format(error)
+        ret["comment"] = f"Error: {error}"
         return ret
     ssh_running = ssh_running.get(ssh)
 
@@ -792,14 +792,14 @@ def ssh_configured(
                 enable = __salt__[esxi_cmd]("service_start", service_name=ssh).get(host)
                 error = enable.get("Error")
                 if error:
-                    ret["comment"] = "Error: {}".format(error)
+                    ret["comment"] = f"Error: {error}"
                     return ret
             # Disable SSH if service_running=False
             else:
                 disable = __salt__[esxi_cmd]("service_stop", service_name=ssh).get(host)
                 error = disable.get("Error")
                 if error:
-                    ret["comment"] = "Error: {}".format(error)
+                    ret["comment"] = f"Error: {error}"
                     return ret
 
         ret["changes"].update(
@@ -815,7 +815,7 @@ def ssh_configured(
         )
         error = current_ssh_key.get("Error")
         if error:
-            ret["comment"] = "Error: {}".format(error)
+            ret["comment"] = f"Error: {error}"
             return ret
         current_ssh_key = current_ssh_key.get("key")
         if current_ssh_key:
@@ -854,7 +854,7 @@ def ssh_configured(
             )
             error = response.get("Error")
             if error:
-                ret["comment"] = "Error: {}".format(error)
+                ret["comment"] = f"Error: {error}"
                 return ret
         ret["changes"].update(
             {
@@ -872,7 +872,7 @@ def ssh_configured(
         ).get(host)
         error = current_service_policy.get("Error")
         if error:
-            ret["comment"] = "Error: {}".format(error)
+            ret["comment"] = f"Error: {error}"
             return ret
         current_service_policy = current_service_policy.get(ssh)
 
@@ -886,7 +886,7 @@ def ssh_configured(
                 ).get(host)
                 error = response.get("Error")
                 if error:
-                    ret["comment"] = "Error: {}".format(error)
+                    ret["comment"] = f"Error: {error}"
                     return ret
             ret["changes"].update(
                 {
@@ -904,7 +904,7 @@ def ssh_configured(
             response = __salt__[esxi_cmd]("service_restart", service_name=ssh).get(host)
             error = response.get("Error")
             if error:
-                ret["comment"] = "Error: {}".format(error)
+                ret["comment"] = f"Error: {error}"
                 return ret
         ret["changes"].update(
             {"service_restart": {"old": "", "new": "SSH service restarted."}}
@@ -1008,7 +1008,7 @@ def syslog_configured(
                             "There was an error resetting a syslog config '{}'."
                             "Please check debug logs.".format(val)
                         )
-                    ret["comment"] = "Error: {}".format(msg)
+                    ret["comment"] = f"Error: {msg}"
                     return ret
 
         ret["changes"].update(
@@ -1018,7 +1018,7 @@ def syslog_configured(
     current_firewall = __salt__[esxi_cmd]("get_firewall_status").get(host)
     error = current_firewall.get("Error")
     if error:
-        ret["comment"] = "Error: {}".format(error)
+        ret["comment"] = f"Error: {error}"
         return ret
 
     current_firewall = current_firewall.get("rulesets").get("syslog")
@@ -1033,7 +1033,7 @@ def syslog_configured(
             if enabled.get("retcode") != 0:
                 err = enabled.get("stderr")
                 out = enabled.get("stdout")
-                ret["comment"] = "Error: {}".format(err if err else out)
+                ret["comment"] = f"Error: {err if err else out}"
                 return ret
 
         ret["changes"].update({"firewall": {"old": current_firewall, "new": firewall}})
@@ -1045,7 +1045,7 @@ def syslog_configured(
         try:
             lookup_key = _lookup_syslog_config(key)
         except KeyError:
-            ret["comment"] = "'{}' is not a valid config variable.".format(key)
+            ret["comment"] = f"'{key}' is not a valid config variable."
             return ret
 
         current_val = current_syslog_config[lookup_key]
@@ -1158,7 +1158,7 @@ def diskgroups_configured(name, diskgroups, erase_disks=False):
         host_disks = __salt__["vsphere.list_disks"](service_instance=si)
         if not host_disks:
             raise VMwareObjectRetrievalError(
-                "No disks retrieved from host '{}'".format(hostname)
+                f"No disks retrieved from host '{hostname}'"
             )
         scsi_addr_to_disk_map = {d["scsi_address"]: d for d in host_disks}
         log.trace("scsi_addr_to_disk_map = %s", scsi_addr_to_disk_map)
@@ -1199,14 +1199,12 @@ def diskgroups_configured(name, diskgroups, erase_disks=False):
                 bad_scsi_addrs.append(scsi_addr)
                 continue
             capacity_disk_ids.append(scsi_addr_to_disk_map[scsi_addr]["id"])
-            capacity_disk_displays.append(
-                "{} (id:{})".format(scsi_addr, capacity_disk_ids[-1])
-            )
+            capacity_disk_displays.append(f"{scsi_addr} (id:{capacity_disk_ids[-1]})")
         if bad_scsi_addrs:
             comments.append(
                 "Error in diskgroup #{}: capacity disks with scsi addresses {} "
                 "were not found.".format(
-                    idx, ", ".join(["'{}'".format(a) for a in bad_scsi_addrs])
+                    idx, ", ".join([f"'{a}'" for a in bad_scsi_addrs])
                 )
             )
             log.error(comments[-1])
@@ -1227,9 +1225,7 @@ def diskgroups_configured(name, diskgroups, erase_disks=False):
                             name,
                             idx,
                             cache_disk_display,
-                            ", ".join(
-                                ["'{}'".format(a) for a in capacity_disk_displays]
-                            ),
+                            ", ".join([f"'{a}'" for a in capacity_disk_displays]),
                         )
                     )
                 else:
@@ -1244,9 +1240,7 @@ def diskgroups_configured(name, diskgroups, erase_disks=False):
                         "{}".format(
                             idx,
                             cache_disk_display,
-                            ", ".join(
-                                ["'{}'".format(a) for a in capacity_disk_displays]
-                            ),
+                            ", ".join([f"'{a}'" for a in capacity_disk_displays]),
                         )
                     )
                     log.info(comments[-1])
@@ -1259,7 +1253,7 @@ def diskgroups_configured(name, diskgroups, erase_disks=False):
                         name,
                         idx,
                         cache_disk_display,
-                        ", ".join(["'{}'".format(a) for a in capacity_disk_displays]),
+                        ", ".join([f"'{a}'" for a in capacity_disk_displays]),
                     )
                 )
                 log.info(comments[-1])
@@ -1273,12 +1267,12 @@ def diskgroups_configured(name, diskgroups, erase_disks=False):
                     service_instance=si,
                 )
             except VMwareSaltError as err:
-                comments.append("Error creating disk group #{}: {}.".format(idx, err))
+                comments.append(f"Error creating disk group #{idx}: {err}.")
                 log.error(comments[-1])
                 errors = True
                 continue
 
-            comments.append("Created disk group #'{}'.".format(idx))
+            comments.append(f"Created disk group #'{idx}'.")
             log.info(comments[-1])
             diskgroup_changes[str(idx)] = {
                 "new": {"cache": cache_disk_display, "capacity": capacity_disk_displays}
@@ -1311,9 +1305,7 @@ def diskgroups_configured(name, diskgroups, erase_disks=False):
                     d["scsi_address"] for d in host_disks if d["id"] == disk_id
                 ][0]
                 added_capacity_disk_ids.append(disk_id)
-                added_capacity_disk_displays.append(
-                    "{} (id:{})".format(disk_scsi_addr, disk_id)
-                )
+                added_capacity_disk_displays.append(f"{disk_scsi_addr} (id:{disk_id})")
         for disk_id in existing_diskgroup["capacity_disks"]:
             if disk_id not in capacity_disk_ids:
                 disk_scsi_addr = [
@@ -1321,7 +1313,7 @@ def diskgroups_configured(name, diskgroups, erase_disks=False):
                 ][0]
                 removed_capacity_disk_ids.append(disk_id)
                 removed_capacity_disk_displays.append(
-                    "{} (id:{})".format(disk_scsi_addr, disk_id)
+                    f"{disk_scsi_addr} (id:{disk_id})"
                 )
 
         log.debug(
@@ -1339,9 +1331,7 @@ def diskgroups_configured(name, diskgroups, erase_disks=False):
                 "Error removing capacity disk(s) {} from disk group #{}; "
                 "operation is not supported."
                 "".format(
-                    ", ".join(
-                        ["'{}'".format(id) for id in removed_capacity_disk_displays]
-                    ),
+                    ", ".join([f"'{id}'" for id in removed_capacity_disk_displays]),
                     idx,
                 )
             )
@@ -1354,7 +1344,7 @@ def diskgroups_configured(name, diskgroups, erase_disks=False):
 
             # Building a string representation of the capacity disks
             # that need to be added
-            s = ", ".join(["'{}'".format(id) for id in added_capacity_disk_displays])
+            s = ", ".join([f"'{id}'" for id in added_capacity_disk_displays])
             if __opts__["test"]:
                 comments.append(
                     "State {} will add capacity disk(s) {} to disk group #{}.".format(
@@ -1381,7 +1371,7 @@ def diskgroups_configured(name, diskgroups, erase_disks=False):
                 errors = True
                 continue
 
-            com = "Added capacity disk(s) {} to disk group #{}".format(s, idx)
+            com = f"Added capacity disk(s) {s} to disk group #{idx}"
             log.info(com)
             comments.append(com)
             diskgroup_changes[str(idx)] = {
@@ -1398,7 +1388,7 @@ def diskgroups_configured(name, diskgroups, erase_disks=False):
             continue
 
         # No capacity needs to be added
-        s = "Disk group #{} is correctly configured. Nothing to be done.".format(idx)
+        s = f"Disk group #{idx} is correctly configured. Nothing to be done."
         log.info(s)
         comments.append(s)
     __salt__["vsphere.disconnect"](si)
@@ -1662,7 +1652,7 @@ def host_cache_configured(
                         backing_disk["id"],
                         ", ".join(
                             [
-                                "'{}'".format(disk)
+                                f"'{disk}'"
                                 for disk in existing_datastores[0]["backing_disk_ids"]
                             ]
                         ),
@@ -1710,8 +1700,8 @@ def host_cache_configured(
                 changes.update(
                     {
                         "swap_size": {
-                            "old": "{}GiB".format(existing_swap_size_MiB / 1024),
-                            "new": "{}GiB".format(swap_size_MiB / 1024),
+                            "old": f"{existing_swap_size_MiB / 1024}GiB",
+                            "new": f"{swap_size_MiB / 1024}GiB",
                         }
                     }
                 )
@@ -1746,7 +1736,7 @@ def host_cache_configured(
                     swap_size_MiB=swap_size_MiB,
                     service_instance=si,
                 )
-                comments.append("Host cache configured on host '{}'.".format(hostname))
+                comments.append(f"Host cache configured on host '{hostname}'.")
         else:
             comments.append(
                 "Host cache on host '{}' is already correctly "
@@ -1766,7 +1756,7 @@ def host_cache_configured(
         ret.update(
             {
                 "result": False if not __opts__["test"] else None,
-                "comment": "{}.".format(err),
+                "comment": f"{err}.",
             }
         )
         return ret

--- a/salt/states/esxi.py
+++ b/salt/states/esxi.py
@@ -160,7 +160,7 @@ def _deprecation_message(function):
     @wraps(function)
     def wrapped(*args, **kwargs):
         salt.utils.versions.warn_until(
-            "Argon",
+            3008,
             "The 'esxi' functionality in Salt has been deprecated and its "
             "functionality will be removed in version 3008 in favor of the "
             "saltext.vmware Salt Extension. "

--- a/salt/states/esxvm.py
+++ b/salt/states/esxvm.py
@@ -467,7 +467,7 @@ def vm_updated(
             {
                 "result": True,
                 "changes": {},
-                "comment": "Virtual machine {} is already up to date".format(vm_name),
+                "comment": f"Virtual machine {vm_name} is already up to date",
             }
         )
         return result
@@ -532,7 +532,7 @@ def vm_updated(
         "name": name,
         "result": True,
         "changes": changes,
-        "comment": "Virtual machine {} was updated successfully".format(vm_name),
+        "comment": f"Virtual machine {vm_name} was updated successfully",
     }
 
     return result
@@ -565,7 +565,7 @@ def vm_created(
     result = {"name": name, "result": None, "changes": {}, "comment": ""}
 
     if __opts__["test"]:
-        result["comment"] = "Virtual machine {} will be created".format(vm_name)
+        result["comment"] = f"Virtual machine {vm_name} will be created"
         return result
 
     service_instance = __salt__["vsphere.get_service_instance_via_proxy"]()
@@ -615,7 +615,7 @@ def vm_created(
         "name": name,
         "result": True,
         "changes": changes,
-        "comment": "Virtual machine {} created successfully".format(vm_name),
+        "comment": f"Virtual machine {vm_name} created successfully",
     }
 
     return result
@@ -629,7 +629,7 @@ def vm_registered(vm_name, datacenter, placement, vm_file, power_on=False):
     """
     result = {"name": vm_name, "result": None, "changes": {}, "comment": ""}
 
-    vmx_path = "{}{}".format(vm_file.folderPath, vm_file.file[0].path)
+    vmx_path = f"{vm_file.folderPath}{vm_file.file[0].path}"
     log.trace("Registering virtual machine with vmx file: %s", vmx_path)
     service_instance = __salt__["vsphere.get_service_instance_via_proxy"]()
     try:
@@ -665,7 +665,7 @@ def vm_registered(vm_name, datacenter, placement, vm_file, power_on=False):
         {
             "result": True,
             "changes": {"name": vm_name, "power_on": power_on},
-            "comment": "Virtual machine {} registered successfully".format(vm_name),
+            "comment": f"Virtual machine {vm_name} registered successfully",
         }
     )
 

--- a/salt/states/esxvm.py
+++ b/salt/states/esxvm.py
@@ -247,7 +247,7 @@ def _deprecation_message(function):
     @wraps(function)
     def wrapped(*args, **kwargs):
         salt.utils.versions.warn_until(
-            "Argon",
+            3008,
             "The 'esxvm' functionality in Salt has been deprecated and its "
             "functionality will be removed in version 3008 in favor of the "
             "saltext.vmware Salt Extension. "

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -463,7 +463,7 @@ def managed(name, ppa=None, copr=None, aptkey=True, **kwargs):
         pre = __salt__["pkg.get_repo"](repo=repo, **kwargs)
     except CommandExecutionError as exc:
         ret["result"] = False
-        ret["comment"] = "Failed to examine repo '{}': {}".format(name, exc)
+        ret["comment"] = f"Failed to examine repo '{name}': {exc}"
         return ret
 
     # This is because of how apt-sources works. This pushes distro logic
@@ -545,7 +545,7 @@ def managed(name, ppa=None, copr=None, aptkey=True, **kwargs):
                         break
         else:
             ret["result"] = True
-            ret["comment"] = "Package repo '{}' already configured".format(name)
+            ret["comment"] = f"Package repo '{name}' already configured"
             return ret
 
     if __opts__["test"]:
@@ -580,7 +580,7 @@ def managed(name, ppa=None, copr=None, aptkey=True, **kwargs):
         # This is another way to pass information back from the mod_repo
         # function.
         ret["result"] = False
-        ret["comment"] = "Failed to configure repo '{}': {}".format(name, exc)
+        ret["comment"] = f"Failed to configure repo '{name}': {exc}"
         return ret
 
     try:
@@ -596,10 +596,10 @@ def managed(name, ppa=None, copr=None, aptkey=True, **kwargs):
             ret["changes"] = {"repo": repo}
 
         ret["result"] = True
-        ret["comment"] = "Configured package repo '{}'".format(name)
+        ret["comment"] = f"Configured package repo '{name}'"
     except Exception as exc:  # pylint: disable=broad-except
         ret["result"] = False
-        ret["comment"] = "Failed to confirm config of repo '{}': {}".format(name, exc)
+        ret["comment"] = f"Failed to confirm config of repo '{name}': {exc}"
 
     # Clear cache of available packages, if present, since changes to the
     # repositories may change the packages that are available.
@@ -699,11 +699,11 @@ def absent(name, **kwargs):
         repo = __salt__["pkg.get_repo"](stripname, **kwargs)
     except CommandExecutionError as exc:
         ret["result"] = False
-        ret["comment"] = "Failed to configure repo '{}': {}".format(name, exc)
+        ret["comment"] = f"Failed to configure repo '{name}': {exc}"
         return ret
 
     if not repo:
-        ret["comment"] = "Package repo {} is absent".format(name)
+        ret["comment"] = f"Package repo {name} is absent"
         ret["result"] = True
         return ret
 
@@ -726,7 +726,7 @@ def absent(name, **kwargs):
     repos = __salt__["pkg.list_repos"]()
     if stripname not in repos:
         ret["changes"]["repo"] = name
-        ret["comment"] = "Removed repo {}".format(name)
+        ret["comment"] = f"Removed repo {name}"
 
         if not remove_key:
             ret["result"] = True
@@ -735,13 +735,13 @@ def absent(name, **kwargs):
                 removed_keyid = __salt__["pkg.del_repo_key"](stripname, **kwargs)
             except (CommandExecutionError, SaltInvocationError) as exc:
                 ret["result"] = False
-                ret["comment"] += ", but failed to remove key: {}".format(exc)
+                ret["comment"] += f", but failed to remove key: {exc}"
             else:
                 ret["result"] = True
                 ret["changes"]["keyid"] = removed_keyid
-                ret["comment"] += ", and keyid {}".format(removed_keyid)
+                ret["comment"] += f", and keyid {removed_keyid}"
     else:
         ret["result"] = False
-        ret["comment"] = "Failed to remove repo {}".format(name)
+        ret["comment"] = f"Failed to remove repo {name}"
 
     return ret

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -663,7 +663,7 @@ def wait_for_event(name, id_list, event_id="id", timeout=300, node="master"):
     ret = {"name": name, "changes": {}, "comment": "", "result": False}
 
     if __opts__.get("test"):
-        ret["comment"] = "Orchestration would wait for event '{}'".format(name)
+        ret["comment"] = f"Orchestration would wait for event '{name}'"
         ret["result"] = None
         return ret
 
@@ -793,7 +793,7 @@ def runner(name, **kwargs):
             "name": name,
             "result": None,
             "changes": {},
-            "comment": "Runner function '{}' would be executed.".format(name),
+            "comment": f"Runner function '{name}' would be executed.",
         }
         return ret
 
@@ -918,7 +918,7 @@ def parallel_runners(name, runners, **kwargs):  # pylint: disable=unused-argumen
             "result": False,
             "success": False,
             "changes": {},
-            "comment": "One of the runners raised an exception: {}".format(exc),
+            "comment": f"One of the runners raised an exception: {exc}",
         }
     # We bundle the results of the runners with the IDs of the runners so that
     # we can easily identify which output belongs to which runner. At the same
@@ -997,7 +997,7 @@ def parallel_runners(name, runners, **kwargs):  # pylint: disable=unused-argumen
             comment = "All runner functions executed successfully."
         else:
             if len(failed_runners) == 1:
-                comment = "Runner {} failed.".format(failed_runners[0])
+                comment = f"Runner {failed_runners[0]} failed."
             else:
                 comment = "Runners {} failed.".format(", ".join(failed_runners))
         changes = {"ret": {runner_id: out for runner_id, out in outputs.items()}}
@@ -1043,7 +1043,7 @@ def wheel(name, **kwargs):
     if __opts__.get("test", False):
         ret["result"] = (None,)
         ret["changes"] = {}
-        ret["comment"] = "Wheel function '{}' would be executed.".format(name)
+        ret["comment"] = f"Wheel function '{name}' would be executed."
         return ret
 
     out = __salt__["saltutil.wheel"](

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -815,7 +815,7 @@ def runner(name, **kwargs):
     if features.get("enable_deprecated_orchestration_flag", False):
         ret["__orchestration__"] = True
         salt.utils.versions.warn_until(
-            "Argon",
+            3008,
             "The __orchestration__ return flag will be removed in Salt Argon. "
             "For more information see https://github.com/saltstack/salt/pull/59917.",
         )
@@ -1064,7 +1064,7 @@ def wheel(name, **kwargs):
     if features.get("enable_deprecated_orchestration_flag", False):
         ret["__orchestration__"] = True
         salt.utils.versions.warn_until(
-            "Argon",
+            3008,
             "The __orchestration__ return flag will be removed in Salt Argon. "
             "For more information see https://github.com/saltstack/salt/pull/59917.",
         )

--- a/salt/states/x509.py
+++ b/salt/states/x509.py
@@ -287,7 +287,7 @@ def private_key_managed(
     new=False,
     overwrite=False,
     verbose=True,
-    **kwargs
+    **kwargs,
 ):
     """
     Manage a private key's existence.
@@ -391,7 +391,7 @@ def csr_managed(name, **kwargs):
     try:
         old = __salt__["x509.read_csr"](name)
     except salt.exceptions.SaltInvocationError:
-        old = "{} is not a valid csr.".format(name)
+        old = f"{name} is not a valid csr."
 
     file_args, kwargs = _get_file_args(name, **kwargs)
     file_args["contents"] = __salt__["x509.create_csr"](text=True, **kwargs)
@@ -518,7 +518,7 @@ def _certificate_is_valid(name, days_remaining, append_certs, **cert_spec):
     If False, also provide a message explaining why.
     """
     if not os.path.isfile(name):
-        return False, "{} does not exist".format(name), {}
+        return False, f"{name} does not exist", {}
 
     try:
         cert_info = __salt__["x509.read_certificate"](certificate=name)
@@ -570,7 +570,7 @@ def _certificate_is_valid(name, days_remaining, append_certs, **cert_spec):
 
         return True, "", cert_info
     except salt.exceptions.SaltInvocationError as e:
-        return False, "{} is not a valid certificate: {}".format(name, str(e)), {}
+        return False, f"{name} is not a valid certificate: {str(e)}", {}
 
 
 def _certificate_file_managed(ret, file_args):
@@ -699,7 +699,7 @@ def certificate_managed(name, days_remaining=90, append_certs=None, **kwargs):
         ret = _certificate_file_managed(ret, file_args)
 
         ret["result"] = None
-        ret["comment"] = "Certificate {} will be created".format(name)
+        ret["comment"] = f"Certificate {name} will be created"
         ret["changes"]["Status"] = {
             "Old": invalid_reason,
             "New": "Certificate will be valid and up to date",
@@ -764,7 +764,7 @@ def crl_managed(
     digest="",
     days_remaining=30,
     include_expired=False,
-    **kwargs
+    **kwargs,
 ):
     """
     Manage a Certificate Revocation List
@@ -846,9 +846,9 @@ def crl_managed(
             if days_remaining == 0:
                 days_remaining = current_days_remaining - 1
         except salt.exceptions.SaltInvocationError:
-            current = "{} is not a valid CRL.".format(name)
+            current = f"{name} is not a valid CRL."
     else:
-        current = "{} does not exist.".format(name)
+        current = f"{name} does not exist."
 
     new_crl = __salt__["x509.create_crl"](
         text=True,

--- a/salt/states/x509.py
+++ b/salt/states/x509.py
@@ -209,7 +209,7 @@ def __virtual__():
         return (False, "Superseded, using x509_v2")
     if "x509.get_pem_entry" in __salt__:
         salt.utils.versions.warn_until(
-            "Potassium",
+            3009,
             "The x509 modules are deprecated. Please migrate to the replacement "
             "modules (x509_v2). They are the default from Salt 3008 (Argon) onwards.",
         )

--- a/salt/states/x509_v2.py
+++ b/salt/states/x509_v2.py
@@ -390,7 +390,7 @@ def certificate_managed(
     if days_valid is None and not_after is None:
         try:
             salt.utils.versions.warn_until(
-                "Potassium",
+                3009,
                 "The default value for `days_valid` will change to 30. Please adapt your code accordingly.",
             )
             days_valid = 365
@@ -400,7 +400,7 @@ def certificate_managed(
     if days_remaining is None:
         try:
             salt.utils.versions.warn_until(
-                "Potassium",
+                3009,
                 "The default value for `days_remaining` will change to 7. Please adapt your code accordingly.",
             )
             days_remaining = 90
@@ -409,7 +409,7 @@ def certificate_managed(
 
     if "algorithm" in kwargs:
         salt.utils.versions.warn_until(
-            "Potassium",
+            3009,
             "`algorithm` has been renamed to `digest`. Please update your code.",
         )
         digest = kwargs.pop("algorithm")
@@ -782,7 +782,7 @@ def crl_managed(
     if days_valid is None:
         try:
             salt.utils.versions.warn_until(
-                "Potassium",
+                3009,
                 "The default value for `days_valid` will change to 7. Please adapt your code accordingly.",
             )
             days_valid = 100
@@ -792,7 +792,7 @@ def crl_managed(
     if days_remaining is None:
         try:
             salt.utils.versions.warn_until(
-                "Potassium",
+                3009,
                 "The default value for `days_remaining` will change to 3. Please adapt your code accordingly.",
             )
             days_remaining = 30
@@ -804,14 +804,14 @@ def crl_managed(
         parsed = {}
         if len(rev) == 1 and isinstance(rev[next(iter(rev))], list):
             salt.utils.versions.warn_until(
-                "Potassium",
+                3009,
                 "Revoked certificates should be specified as a simple list of dicts.",
             )
             for val in rev[next(iter(rev))]:
                 parsed.update(val)
         if "reason" in (parsed or rev):
             salt.utils.versions.warn_until(
-                "Potassium",
+                3009,
                 "The `reason` parameter for revoked certificates should be specified in extensions:CRLReason.",
             )
             salt.utils.dictupdate.set_dict_key_value(
@@ -1056,7 +1056,7 @@ def csr_managed(
     # Deprecation checks vs the old x509 module
     if "algorithm" in kwargs:
         salt.utils.versions.warn_until(
-            "Potassium",
+            3009,
             "`algorithm` has been renamed to `digest`. Please update your code.",
         )
         digest = kwargs.pop("algorithm")
@@ -1323,7 +1323,7 @@ def private_key_managed(
     # Deprecation checks vs the old x509 module
     if "bits" in kwargs:
         salt.utils.versions.warn_until(
-            "Potassium",
+            3009,
             "`bits` has been renamed to `keysize`. Please update your code.",
         )
         keysize = kwargs.pop("bits")

--- a/salt/transport/client.py
+++ b/salt/transport/client.py
@@ -25,7 +25,7 @@ class ReqChannel:
         import salt.channel.client
 
         warn_until(
-            "Argon",
+            3008,
             "This module is deprecated. Please use salt.channel.client instead.",
         )
         return salt.channel.client.ReqChannel.factory(opts, **kwargs)
@@ -41,7 +41,7 @@ class PushChannel:
         import salt.channel.client
 
         warn_until(
-            "Argon",
+            3008,
             "This module is deprecated. Please use salt.channel.client instead.",
         )
         return salt.channel.client.PushChannel.factory(opts, **kwargs)
@@ -57,7 +57,7 @@ class PullChannel:
         import salt.channel.client
 
         warn_until(
-            "Argon",
+            3008,
             "This module is deprecated. Please use salt.channel.client instead.",
         )
         return salt.channel.client.PullChannel.factory(opts, **kwargs)
@@ -75,7 +75,7 @@ class AsyncReqChannel:
         import salt.channel.client
 
         warn_until(
-            "Argon",
+            3008,
             "This module is deprecated. Please use salt.channel.client instead.",
         )
         return salt.channel.client.AsyncReqChannel.factory(opts, **kwargs)
@@ -91,7 +91,7 @@ class AsyncPubChannel:
         import salt.channel.client
 
         warn_until(
-            "Argon",
+            3008,
             "This module is deprecated. Please use salt.channel.client instead.",
         )
         return salt.channel.client.AsyncPubChannel.factory(opts, **kwargs)
@@ -110,7 +110,7 @@ class AsyncPushChannel:
         import salt.channel.client
 
         warn_until(
-            "Argon",
+            3008,
             "This module is deprecated. Please use salt.channel.client instead.",
         )
         return salt.channel.client.AsyncPushChannel.factory(opts, **kwargs)
@@ -129,7 +129,7 @@ class AsyncPullChannel:
         import salt.channel.client
 
         warn_until(
-            "Argon",
+            3008,
             "This module is deprecated. Please use salt.channel.client instead.",
         )
         return salt.channel.client.AsyncPullChannel.factory(opts, **kwargs)

--- a/salt/transport/server.py
+++ b/salt/transport/server.py
@@ -25,7 +25,7 @@ class ReqServerChannel:
         import salt.channel.server
 
         warn_until(
-            "Argon",
+            3008,
             "This module is deprecated. Please use salt.channel.server instead.",
         )
         return salt.channel.server.ReqServerChannel.factory(opts, **kwargs)
@@ -41,7 +41,7 @@ class PubServerChannel:
         import salt.channel.server
 
         warn_until(
-            "Argon",
+            3008,
             "This module is deprecated. Please use salt.channel.server instead.",
         )
         return salt.channel.server.PubServerChannel.factory(opts, **kwargs)

--- a/salt/utils/etcd_util.py
+++ b/salt/utils/etcd_util.py
@@ -357,7 +357,7 @@ class EtcdClient(EtcdBase):
         index = kwargs.pop("index", None)
         if index is not None:
             salt.utils.versions.warn_until(
-                "Argon",
+                3008,
                 "The index kwarg has been deprecated, and will be removed "
                 "in the Argon release. Please use start_revision instead.",
             )
@@ -447,14 +447,14 @@ class EtcdClient(EtcdBase):
         wait_index = kwargs.pop("waitIndex", None)
         if recursive is not None:
             salt.utils.versions.warn_until(
-                "Argon",
+                3008,
                 "The recursive kwarg has been deprecated, and will be removed "
                 "in the Argon release. Please use recurse instead.",
             )
             recurse = recursive
         if wait_index is not None:
             salt.utils.versions.warn_until(
-                "Argon",
+                3008,
                 "The waitIndex kwarg has been deprecated, and will be removed "
                 "in the Argon release. Please use start_revision instead.",
             )
@@ -611,7 +611,7 @@ class EtcdClient(EtcdBase):
         recursive = kwargs.pop("recursive", None)
         if recursive is not None:
             salt.utils.versions.warn_until(
-                "Argon",
+                3008,
                 "The recursive kwarg has been deprecated, and will be removed "
                 "in the Argon release. Please use recurse instead.",
             )
@@ -740,7 +740,7 @@ class EtcdClientV3(EtcdBase):
         index = kwargs.pop("index", None)
         if index is not None:
             salt.utils.versions.warn_until(
-                "Argon",
+                3008,
                 "The index kwarg has been deprecated, and will be removed "
                 "in the Argon release. Please use start_revision instead.",
             )
@@ -786,14 +786,14 @@ class EtcdClientV3(EtcdBase):
         wait_index = kwargs.pop("waitIndex", None)
         if recursive is not None:
             salt.utils.versions.warn_until(
-                "Argon",
+                3008,
                 "The recursive kwarg has been deprecated, and will be removed "
                 "in the Argon release. Please use recurse instead.",
             )
             recurse = recursive
         if wait_index is not None:
             salt.utils.versions.warn_until(
-                "Argon",
+                3008,
                 "The waitIndex kwarg has been deprecated, and will be removed "
                 "in the Argon release. Please use start_revision instead.",
             )
@@ -890,7 +890,7 @@ class EtcdClientV3(EtcdBase):
         recursive = kwargs.pop("recursive", None)
         if recursive is not None:
             salt.utils.versions.warn_until(
-                "Argon",
+                3008,
                 "The recursive kwarg has been deprecated, and will be removed "
                 "in the Argon release. Please use recurse instead.",
             )
@@ -983,7 +983,7 @@ def get_conn(opts, profile=None, **kwargs):
     use_v2 = conf.get("etcd.require_v2", True)
     if use_v2:
         salt.utils.versions.warn_until(
-            "Potassium",
+            3009,
             "etcd API v2 has been deprecated.  It will be removed in "
             "the Potassium release, and etcd API v3 will be the default.",
         )

--- a/salt/utils/etcd_util.py
+++ b/salt/utils/etcd_util.py
@@ -143,7 +143,7 @@ class EtcdBase:
         ca=None,
         client_key=None,
         client_cert=None,
-        **kwargs
+        **kwargs,
     ):
         if not kwargs.get("has_etcd_opts", False):
             etcd_opts = _get_etcd_opts(opts, profile)
@@ -201,7 +201,7 @@ class EtcdBase:
         wait=False,
         timeout=None,
         start_revision=None,
-        **kwargs
+        **kwargs,
     ):
         """
         Read a value of a key.
@@ -242,9 +242,9 @@ class EtcdBase:
         for k, v in data.items():
             k = k.strip("/")
             if path:
-                p = "/{}/{}".format(path, k)
+                p = f"/{path}/{k}"
             else:
-                p = "/{}".format(k)
+                p = f"/{k}"
             if isinstance(v, dict):
                 ret = self._flatten(v, p)
                 flat.update(ret)
@@ -441,7 +441,7 @@ class EtcdClient(EtcdBase):
         wait=False,
         timeout=None,
         start_revision=None,
-        **kwargs
+        **kwargs,
     ):
         recursive = kwargs.pop("recursive", None)
         wait_index = kwargs.pop("waitIndex", None)
@@ -487,7 +487,7 @@ class EtcdClient(EtcdBase):
             if wait:
                 # Wait timeouts will throw ReadTimeoutError, which isn't bad
                 log.debug("etcd: Timed out while executing a wait")
-                raise EtcdUtilWatchTimeout("Watch on {} timed out".format(key))
+                raise EtcdUtilWatchTimeout(f"Watch on {key} timed out")
             log.error("etcd: Timed out")
             raise etcd.EtcdConnectionFailed("Connection failed")
         except MaxRetryError as err:
@@ -601,7 +601,7 @@ class EtcdClient(EtcdBase):
             if item.dir is True:
                 if item.key == path:
                     continue
-                dir_name = "{}/".format(item.key)
+                dir_name = f"{item.key}/"
                 ret[dir_name] = {}
             else:
                 ret[item.key] = item.value
@@ -677,7 +677,7 @@ class EtcdClientV3(EtcdBase):
         raw_keys=False,
         raw_values=False,
         unicode_errors=None,
-        **kwargs
+        **kwargs,
     ):
         if not HAS_ETCD_V3:
             raise EtcdLibraryNotInstalled("Don't have etcd3-py, need to install it.")
@@ -780,7 +780,7 @@ class EtcdClientV3(EtcdBase):
         wait=False,
         timeout=None,
         start_revision=None,
-        **kwargs
+        **kwargs,
     ):
         recursive = kwargs.pop("recursive", None)
         wait_index = kwargs.pop("waitIndex", None)

--- a/salt/utils/functools.py
+++ b/salt/utils/functools.py
@@ -80,7 +80,7 @@ def alias_function(fun, name, doc=None):
         alias_fun.__doc__ = doc
     else:
         orig_name = fun.__name__
-        alias_msg = "\nThis function is an alias of ``{}``.\n".format(orig_name)
+        alias_msg = f"\nThis function is an alias of ``{orig_name}``.\n"
         alias_fun.__doc__ = alias_msg + (fun.__doc__ or "")
 
     return alias_fun

--- a/salt/utils/job.py
+++ b/salt/utils/job.py
@@ -192,7 +192,7 @@ def get_keep_jobs_seconds(opts):
     keep_jobs = opts.get("keep_jobs", 24)
     if keep_jobs_seconds == 86400 and keep_jobs != 24:
         salt.utils.versions.warn_until(
-            "Argon",
+            3008,
             "The 'keep_jobs' option has been deprecated and replaced with "
             "'keep_jobs_seconds'.",
         )

--- a/salt/utils/job.py
+++ b/salt/utils/job.py
@@ -41,7 +41,7 @@ def store_job(opts, load, event=None, mminion=None):
                 nocache=load.get("nocache", False)
             )
         except KeyError:
-            emsg = "Returner '{}' does not support function prep_jid".format(job_cache)
+            emsg = f"Returner '{job_cache}' does not support function prep_jid"
             log.error(emsg)
             raise KeyError(emsg)
         except Exception:  # pylint: disable=broad-except
@@ -52,11 +52,11 @@ def store_job(opts, load, event=None, mminion=None):
             )
 
         # save the load, since we don't have it
-        saveload_fstr = "{}.save_load".format(job_cache)
+        saveload_fstr = f"{job_cache}.save_load"
         try:
             mminion.returners[saveload_fstr](load["jid"], load)
         except KeyError:
-            emsg = "Returner '{}' does not support function save_load".format(job_cache)
+            emsg = f"Returner '{job_cache}' does not support function save_load"
             log.error(emsg)
             raise KeyError(emsg)
         except Exception:  # pylint: disable=broad-except
@@ -67,11 +67,11 @@ def store_job(opts, load, event=None, mminion=None):
             )
     elif salt.utils.jid.is_jid(load["jid"]):
         # Store the jid
-        jidstore_fstr = "{}.prep_jid".format(job_cache)
+        jidstore_fstr = f"{job_cache}.prep_jid"
         try:
             mminion.returners[jidstore_fstr](False, passed_jid=load["jid"])
         except KeyError:
-            emsg = "Returner '{}' does not support function prep_jid".format(job_cache)
+            emsg = f"Returner '{job_cache}' does not support function prep_jid"
             log.error(emsg)
             raise KeyError(emsg)
         except Exception:  # pylint: disable=broad-except
@@ -104,10 +104,10 @@ def store_job(opts, load, event=None, mminion=None):
         return
 
     # otherwise, write to the master cache
-    savefstr = "{}.save_load".format(job_cache)
-    getfstr = "{}.get_load".format(job_cache)
-    fstr = "{}.returner".format(job_cache)
-    updateetfstr = "{}.update_endtime".format(job_cache)
+    savefstr = f"{job_cache}.save_load"
+    getfstr = f"{job_cache}.get_load"
+    fstr = f"{job_cache}.returner"
+    updateetfstr = f"{job_cache}.update_endtime"
     if "fun" not in load and load.get("return", {}):
         ret_ = load.get("return", {})
         if "fun" in ret_:
@@ -121,7 +121,7 @@ def store_job(opts, load, event=None, mminion=None):
         getfstr_func = mminion.returners[getfstr]
         fstr_func = mminion.returners[fstr]
     except KeyError as error:
-        emsg = "Returner '{}' does not support function {}".format(job_cache, error)
+        emsg = f"Returner '{job_cache}' does not support function {error}"
         log.error(emsg)
         raise KeyError(emsg)
 
@@ -156,14 +156,12 @@ def store_minions(opts, jid, minions, mminion=None, syndic_id=None):
     if mminion is None:
         mminion = salt.minion.MasterMinion(opts, states=False, rend=False)
     job_cache = opts["master_job_cache"]
-    minions_fstr = "{}.save_minions".format(job_cache)
+    minions_fstr = f"{job_cache}.save_minions"
 
     try:
         mminion.returners[minions_fstr](jid, minions, syndic_id=syndic_id)
     except KeyError:
-        raise KeyError(
-            "Returner '{}' does not support function save_minions".format(job_cache)
-        )
+        raise KeyError(f"Returner '{job_cache}' does not support function save_minions")
 
 
 def get_retcode(ret):

--- a/salt/utils/openstack/neutron.py
+++ b/salt/utils/openstack/neutron.py
@@ -94,7 +94,7 @@ class SaltNeutron(NeutronShell):
         Set up neutron credentials
         """
         salt.utils.versions.warn_until(
-            "Argon",
+            3008,
             "The neutron module has been deprecated and will be removed in {version}.\n"
             "This includes\n"
             "* salt.utils.openstack.neutron\n"

--- a/salt/utils/versions.py
+++ b/salt/utils/versions.py
@@ -105,7 +105,7 @@ def _format_warning(message, category, filename, lineno, line=None):
     Replacement for warnings.formatwarning that disables the echoing of
     the 'line' parameter.
     """
-    return "{}:{}: {}: {}\n".format(filename, lineno, category.__name__, message)
+    return f"{filename}:{lineno}: {category.__name__}: {message}\n"
 
 
 def warn_until(
@@ -317,7 +317,7 @@ def kwargs_warn_until(
     _version_ = salt.version.SaltStackVersion(*_version_info_)
 
     if kwargs or _version_.info >= version.info:
-        arg_names = ", ".join("'{}'".format(key) for key in kwargs)
+        arg_names = ", ".join(f"'{key}'" for key in kwargs)
         warn_until(
             version,
             message=(
@@ -433,7 +433,7 @@ def check_boto_reqs(
             boto_ver = "2.0.0"
 
         if not has_boto or version_cmp(boto.__version__, boto_ver) == -1:
-            return False, "A minimum version of boto {} is required.".format(boto_ver)
+            return False, f"A minimum version of boto {boto_ver} is required."
 
     if check_boto3 is True:
         try:
@@ -455,12 +455,12 @@ def check_boto_reqs(
         if not has_boto3 or version_cmp(boto3.__version__, boto3_ver) == -1:
             return (
                 False,
-                "A minimum version of boto3 {} is required.".format(boto3_ver),
+                f"A minimum version of boto3 {boto3_ver} is required.",
             )
         elif version_cmp(botocore.__version__, botocore_ver) == -1:
             return (
                 False,
-                "A minimum version of botocore {} is required".format(botocore_ver),
+                f"A minimum version of botocore {botocore_ver} is required",
             )
 
     return True

--- a/salt/utils/x509.py
+++ b/salt/utils/x509.py
@@ -215,7 +215,7 @@ def ensure_cert_kwargs_compat(kwargs):
         for long_name in long_names:
             if long_name in kwargs:
                 salt.utils.versions.warn_until(
-                    "Potassium",
+                    3009,
                     f"Found {long_name} in keyword args. Please migrate to the short name: {name}",
                 )
                 kwargs[name] = kwargs.pop(long_name)
@@ -224,7 +224,7 @@ def ensure_cert_kwargs_compat(kwargs):
         for long_name in long_names:
             if long_name in kwargs:
                 salt.utils.versions.warn_until(
-                    "Potassium",
+                    3009,
                     f"Found {long_name} in keyword args. Please migrate to the short name: {extname}",
                 )
                 kwargs[extname] = kwargs.pop(long_name)
@@ -581,7 +581,7 @@ def merge_signing_policy(policy, kwargs):
         for long_name in long_names:
             if long_name in kwargs:
                 salt.utils.versions.warn_until(
-                    "Potassium",
+                    3009,
                     f"Found {long_name} in keyword args. Please migrate to the short name: {name}",
                 )
                 kwargs[name] = kwargs.pop(long_name)
@@ -591,7 +591,7 @@ def merge_signing_policy(policy, kwargs):
         for long_name in long_names:
             if long_name in kwargs:
                 salt.utils.versions.warn_until(
-                    "Potassium",
+                    3009,
                     f"Found {long_name} in keyword args. Please migrate to the short name: {extname}",
                 )
                 kwargs[extname] = kwargs.pop(long_name)

--- a/salt/utils/zeromq.py
+++ b/salt/utils/zeromq.py
@@ -51,7 +51,7 @@ def ip_bracket(addr):
     "This function has been moved to salt.utils.network.ip_bracket"
 
     salt.utils.versions.warn_until(
-        "Argon",
+        3008,
         "The 'utils.zeromq.ip_bracket' has been moved to 'utils.network.ip_bracket'. "
         "Please use 'utils.network.ip_bracket' because 'utils.zeromq.ip_bracket' "
         "will be removed in future releases.",


### PR DESCRIPTION
### What does this PR do?

Now that version numbers are predictable, version names no longer make sense,
and, when used, requires previous knowledge of the version name to
number mapping or a lookup.

Just use the version numbers.