### PR TITLE
fix: erroneous "new" minion presence events on process startup

### DIFF
--- a/changelog/64505.fixed.md
+++ b/changelog/64505.fixed.md
@@ -1,0 +1,1 @@
+Fixed incorrect minion presence events being sent out on hourly ``Maintenance`` process restarts

--- a/salt/master.py
+++ b/salt/master.py
@@ -38,6 +38,7 @@ import salt.serializers.msgpack
 import salt.state
 import salt.utils.args
 import salt.utils.atomicfile
+import salt.utils.cache
 import salt.utils.event
 import salt.utils.files
 import salt.utils.gitfs
@@ -269,7 +270,18 @@ class Maintenance(salt.utils.process.SignalHandlingProcess):
         now = int(time.time())
 
         git_pillar_update_interval = self.opts.get("git_pillar_update_interval", 0)
-        old_present = set()
+        # Load the presence data from the cache on disk so a Maintenance process
+        # restart does not cause spurious "new" presence events for already-connected
+        # minions.
+        presence_cache = salt.utils.cache.CacheFactory.factory(
+            "disk",
+            3600,
+            minion_cache_path=os.path.join(self.opts["cachedir"], "presence-data"),
+        )
+        try:
+            old_present = set(presence_cache["present"])
+        except KeyError:
+            old_present = set()
         while time.time() - start < self.restart_interval:
             log.trace("Running maintenance routines")
             if not last or (now - last) >= self.loop_interval:
@@ -385,6 +397,14 @@ class Maintenance(salt.utils.process.SignalHandlingProcess):
             self.event.fire_event(data, tagify("present", "presence"))
             old_present.clear()
             old_present.update(present)
+            # Persist the presence list so a Maintenance restart can seed
+            # old_present without triggering spurious "new" events.
+            presence_cache = salt.utils.cache.CacheFactory.factory(
+                "disk",
+                3600,
+                minion_cache_path=os.path.join(self.opts["cachedir"], "presence-data"),
+            )
+            presence_cache["present"] = list(present)
 
 
 class FileserverUpdate(salt.utils.process.SignalHandlingProcess):

--- a/tests/pytests/unit/test_master.py
+++ b/tests/pytests/unit/test_master.py
@@ -1,4 +1,5 @@
 import collections
+import os
 import pathlib
 import time
 
@@ -10,6 +11,7 @@ import salt.crypt
 import salt.exceptions
 import salt.master
 import salt.serializers.msgpack
+import salt.utils.cache
 import salt.utils.files
 import salt.utils.platform
 from tests.support.mock import MagicMock, patch
@@ -24,6 +26,30 @@ except ImportError:
 
 
 skipif_no_pygit2 = pytest.mark.skipif(not HAS_PYGIT2, reason="Missing pygit2")
+
+
+@pytest.fixture
+def maintenance_opts(master_opts, tmp_path):
+    """
+    Options needed for the master's Maintenance class.
+    """
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    opts = master_opts.copy()
+    opts.update(
+        cachedir=str(cache_dir),
+        git_pillar_update_interval=180,
+        maintenance_interval=181,
+    )
+    return opts
+
+
+@pytest.fixture
+def maintenance(maintenance_opts):
+    """
+    An instance of the master's Maintenance class.
+    """
+    return salt.master.Maintenance(maintenance_opts)
 
 
 @pytest.fixture
@@ -470,3 +496,94 @@ def test_handle_clear_missing_cmd_returns_empty_reply(caplog):
         ret = salt.master.MWorker._handle_clear(worker, {})
     assert ret == ({}, {"fun": "send_clear"})
     assert "Received malformed clear command (missing 'cmd')" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "cached_present,connected_ids,change_expected",
+    [
+        (
+            # No change: same minions in cache and currently connected.
+            ["minion1", "minion2"],
+            {"minion1", "minion2"},
+            False,
+        ),
+        (
+            # A new minion appeared since last cache write.
+            ["minion1"],
+            {"minion1", "minion2"},
+            True,
+        ),
+        (
+            # A minion disappeared since last cache write.
+            ["minion1", "minion2"],
+            {"minion1"},
+            True,
+        ),
+    ],
+)
+def test_handle_presence(
+    maintenance, cached_present, connected_ids, change_expected, tmp_path
+):
+    """
+    handle_presence fires a /present event every cycle and a /change event only
+    when the set of connected minions differs from the cached presence list.
+    After each call the cache on disk must reflect the current connected set.
+    """
+    fire_event = MagicMock()
+
+    # Seed the presence cache with old (possibly stale) data.
+    presence_cache = salt.utils.cache.CacheFactory.factory(
+        "disk",
+        3600,
+        minion_cache_path=os.path.join(maintenance.opts["cachedir"], "presence-data"),
+    )
+    presence_cache.clear()
+    presence_cache["present"] = cached_present
+
+    with patch("salt.master.Maintenance.run", MagicMock()), patch(
+        "salt.master.Maintenance.presence_events", True, create=True
+    ), patch(
+        "salt.master.Maintenance.event",
+        MagicMock(
+            connect_pull=MagicMock(return_value=True),
+            fire_event=fire_event,
+        ),
+        create=True,
+    ), patch(
+        "salt.master.Maintenance.ckminions",
+        MagicMock(connected_ids=MagicMock(return_value=connected_ids)),
+        create=True,
+    ):
+        maintenance.handle_presence(set(presence_cache["present"]))
+
+        # A /present event is always fired.
+        assert fire_event.called
+
+        if change_expected:
+            # A /change event must be fired in addition to /present.
+            assert fire_event.call_count == 2
+            change_events = [
+                c[0][0] for c in fire_event.call_args_list if "/change" in c[0][1]
+            ]
+            assert change_events, "Expected a /change event but none was fired"
+        else:
+            assert fire_event.call_count == 1
+
+        present_event = [
+            c[0][0] for c in fire_event.call_args_list if "/present" in c[0][1]
+        ][0]
+        assert (
+            set(present_event["present"]) == connected_ids
+        ), "The /present event does not contain the expected minion set"
+
+        # The cache on disk must now reflect the current connected set.
+        new_presence_cache = salt.utils.cache.CacheFactory.factory(
+            "disk",
+            3600,
+            minion_cache_path=os.path.join(
+                maintenance.opts["cachedir"], "presence-data"
+            ),
+        )
+        assert (
+            set(new_presence_cache["present"]) == connected_ids
+        ), "The presence cache on disk does not reflect the current connected set"


### PR DESCRIPTION
### What does this PR do?
This fixes the issue of the master processes sending incorrect presence events on either the restart of the salt-master process or any of the `Maintenance` process restart events (default is every hour). This issue began in 3006.0.

Although this was intended to fix the hourly incorrect presence update this also fixes the spammy presence updates between  salt-master process restarts. 

### What issues does this PR fix or reference?
Fixes: #64505

### Previous Behavior
The salt-master process sends incorrect presence events at every `restart_interval` of the `Maintenance` process, signalling that every node connected to the master is "new".

### New Behavior
Only actual presence events are sent.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
  - I don't see any references to the `Maintenance` process in the current documentation so I think this does not need a specific mention since we are fixing a bug
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

I will update all of these once this is commented on and direction is approved.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
