### PR TITLE
[3006.x] fix #58667 by checking for blank comps in both source and request

### DIFF
--- a/changelog/58667.fixed.md
+++ b/changelog/58667.fixed.md
@@ -1,1 +1,1 @@
-fixes 58667 by checking for blank comps.
+fixes aptpkg module by checking for blank comps.

--- a/changelog/58667.fixed.md
+++ b/changelog/58667.fixed.md
@@ -1,0 +1,1 @@
+fixes 58667 by checking for blank comps.

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2072,7 +2072,7 @@ def del_repo(repo, **kwargs):
 
                 s_comps = set(source.comps)
                 r_comps = set(repo_comps)
-                if s_comps.intersection(r_comps):
+                if s_comps.intersection(r_comps) or (not s_comps and not r_comps):
                     deleted_from[source.file] = 0
                     source.comps = list(s_comps.difference(r_comps))
                     if not source.comps:
@@ -2093,7 +2093,7 @@ def del_repo(repo, **kwargs):
 
                 s_comps = set(source.comps)
                 r_comps = set(repo_comps)
-                if s_comps.intersection(r_comps):
+                if s_comps.intersection(r_comps) or (not s_comps and not r_comps):
                     deleted_from[source.file] = 0
                     source.comps = list(s_comps.difference(r_comps))
                     if not source.comps:

--- a/tests/pytests/functional/modules/test_aptpkg.py
+++ b/tests/pytests/functional/modules/test_aptpkg.py
@@ -85,8 +85,6 @@ def configure_loader_modules(minion_opts):
 
 
 @pytest.fixture()
-@pytest.mark.destructive_test
-@pytest.mark.skip_if_not_root
 def revert_repo_file(tmp_path):
     try:
         repo_file = pathlib.Path("/etc") / "apt" / "sources.list"

--- a/tests/pytests/functional/modules/test_aptpkg.py
+++ b/tests/pytests/functional/modules/test_aptpkg.py
@@ -106,7 +106,7 @@ def build_repo_file():
             "deb [signed-by=/etc/apt/keyrings/salt-archive-keyring-2023.gpg arch=amd64] https://repo.saltproject.io/salt/py3/ubuntu/22.04/amd64/latest jammy main",
             "deb http://dist.list stable/all/",
         ]
-        with salt.utils.files.fopen(source_path, "wr+") as fp:
+        with salt.utils.files.fopen(source_path, "w+") as fp:
             fp.write("\n".join(test_repos))
         yield source_path
     finally:

--- a/tests/pytests/functional/modules/test_aptpkg.py
+++ b/tests/pytests/functional/modules/test_aptpkg.py
@@ -99,8 +99,6 @@ def revert_repo_file(tmp_path):
 
 
 @pytest.fixture
-@pytest.mark.destructive_test
-@pytest.mark.skip_if_not_root
 def build_repo_file():
     source_path = "/etc/apt/sources.list.d/source_test_list.list"
     try:

--- a/tests/pytests/functional/modules/test_aptpkg.py
+++ b/tests/pytests/functional/modules/test_aptpkg.py
@@ -85,6 +85,8 @@ def configure_loader_modules(minion_opts):
 
 
 @pytest.fixture()
+@pytest.mark.destructive_test
+@pytest.mark.skip_if_not_root
 def revert_repo_file(tmp_path):
     try:
         repo_file = pathlib.Path("/etc") / "apt" / "sources.list"
@@ -99,6 +101,8 @@ def revert_repo_file(tmp_path):
 
 
 @pytest.fixture
+@pytest.mark.destructive_test
+@pytest.mark.skip_if_not_root
 def build_repo_file():
     source_path = "/etc/apt/sources.list.d/source_test_list.list"
     try:
@@ -227,6 +231,7 @@ def test_get_repos_doesnot_exist():
 
 
 @pytest.mark.destructive_test
+@pytest.mark.skip_if_not_root
 def test_del_repo(build_repo_file):
     """
     Test aptpkg.del_repo when passing repo
@@ -275,6 +280,7 @@ def test__expand_repo_def(grains):
 
 
 @pytest.mark.destructive_test
+@pytest.mark.skip_if_not_root
 def test_mod_repo(revert_repo_file):
     """
     Test aptpkg.mod_repo when the repo exists.
@@ -289,6 +295,7 @@ def test_mod_repo(revert_repo_file):
 
 
 @pytest.mark.destructive_test
+@pytest.mark.skip_if_not_root
 def test_mod_repo_no_file(tmp_path, revert_repo_file):
     """
     Test aptpkg.mod_repo when the file does not exist.
@@ -317,6 +324,7 @@ def add_key(request, get_key_file):
 @pytest.mark.parametrize("get_key_file", KEY_FILES, indirect=True)
 @pytest.mark.parametrize("add_key", [False, True], indirect=True)
 @pytest.mark.destructive_test
+@pytest.mark.skip_if_not_root
 def test_get_repo_keys(get_key_file, add_key):
     """
     Test aptpkg.get_repo_keys when aptkey is False and True
@@ -330,6 +338,7 @@ def test_get_repo_keys(get_key_file, add_key):
 
 @pytest.mark.parametrize("key", [False, True])
 @pytest.mark.destructive_test
+@pytest.mark.skip_if_not_root
 def test_get_repo_keys_keydir_not_exist(key):
     """
     Test aptpkg.get_repo_keys when aptkey is False and True


### PR DESCRIPTION
### What does this PR do?
checks if comps are blank in both source an request, and allow deleting repos without comps. 

### What issues does this PR fix or reference?
Fixes: #58667 

### Previous Behavior
could not delete repos that had blank comps

### New Behavior
able to delete blank comp repos. 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
No
