### PR TITLE
[3006.x] Fix salt-ssh `state.*` commands retcode for render fail

### DIFF
--- a/changelog/64514.fixed.md
+++ b/changelog/64514.fixed.md
@@ -1,0 +1,1 @@
+Fixed salt-ssh state.* commands returning retcode 0 when state/pillar rendering fails

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -304,7 +304,7 @@ class SSH(MultiprocessingStateMixin):
         }
         if self.opts.get("rand_thin_dir"):
             self.defaults["thin_dir"] = os.path.join(
-                "/var/tmp", ".{}".format(uuid.uuid4().hex[:6])
+                "/var/tmp", f".{uuid.uuid4().hex[:6]}"
             )
             self.opts["ssh_wipe"] = "True"
         self.returners = salt.loader.returners(self.opts, {})
@@ -454,9 +454,9 @@ class SSH(MultiprocessingStateMixin):
             priv = self.opts.get(
                 "ssh_priv", os.path.join(self.opts["pki_dir"], "ssh", "salt-ssh.rsa")
             )
-        pub = "{}.pub".format(priv)
+        pub = f"{priv}.pub"
         with salt.utils.files.fopen(pub, "r") as fp_:
-            return "{} rsa root@master".format(fp_.read().split()[1])
+            return f"{fp_.read().split()[1]} rsa root@master"
 
     def key_deploy(self, host, ret):
         """
@@ -500,7 +500,7 @@ class SSH(MultiprocessingStateMixin):
             mods=self.mods,
             fsclient=self.fsclient,
             thin=self.thin,
-            **target
+            **target,
         )
         if salt.utils.path.which("ssh-copy-id"):
             # we have ssh-copy-id, use it!
@@ -516,7 +516,7 @@ class SSH(MultiprocessingStateMixin):
                 mods=self.mods,
                 fsclient=self.fsclient,
                 thin=self.thin,
-                **target
+                **target,
             )
             stdout, stderr, retcode = single.cmd_block()
             try:
@@ -543,7 +543,7 @@ class SSH(MultiprocessingStateMixin):
             fsclient=self.fsclient,
             thin=self.thin,
             mine=mine,
-            **target
+            **target,
         )
         ret = {"id": single.id}
         stdout, stderr, retcode = single.run()
@@ -798,7 +798,7 @@ class SSH(MultiprocessingStateMixin):
             )
 
         if self.opts.get("verbose"):
-            msg = "Executing job with jid {}".format(jid)
+            msg = f"Executing job with jid {jid}"
             print(msg)
             print("-" * len(msg) + "\n")
             print("")
@@ -883,7 +883,7 @@ class Single:
         remote_port_forwards=None,
         winrm=False,
         ssh_options=None,
-        **kwargs
+        **kwargs,
     ):
         # Get mine setting and mine_functions if defined in kwargs (from roster)
         self.mine = mine
@@ -1017,9 +1017,7 @@ class Single:
         """
         check if the thindir exists on the remote machine
         """
-        stdout, stderr, retcode = self.shell.exec_cmd(
-            "test -d {}".format(self.thin_dir)
-        )
+        stdout, stderr, retcode = self.shell.exec_cmd(f"test -d {self.thin_dir}")
         if retcode != 0:
             return False
         return True
@@ -1131,7 +1129,7 @@ class Single:
                 self.id,
                 fsclient=self.fsclient,
                 minion_opts=self.minion_opts,
-                **self.target
+                **self.target,
             )
 
             opts_pkg = pre_wrapper["test.opts_pkg"]()  # pylint: disable=E1102
@@ -1217,7 +1215,7 @@ class Single:
             self.id,
             fsclient=self.fsclient,
             minion_opts=self.minion_opts,
-            **self.target
+            **self.target,
         )
         wrapper.fsclient.opts["cachedir"] = opts["cachedir"]
         self.wfuncs = salt.loader.ssh_wrapper(opts, wrapper, self.context)
@@ -1265,7 +1263,7 @@ class Single:
             else:
                 result = self.wfuncs[self.fun](*self.args, **self.kwargs)
         except TypeError as exc:
-            result = "TypeError encountered executing {}: {}".format(self.fun, exc)
+            result = f"TypeError encountered executing {self.fun}: {exc}"
             log.error(result, exc_info_on_loglevel=logging.DEBUG)
             retcode = 1
         except Exception as exc:  # pylint: disable=broad-except
@@ -1292,7 +1290,7 @@ class Single:
         """
         if self.target.get("sudo"):
             sudo = (
-                "sudo -p '{}'".format(salt.client.ssh.shell.SUDO_PROMPT)
+                f"sudo -p '{salt.client.ssh.shell.SUDO_PROMPT}'"
                 if self.target.get("passwd")
                 else "sudo"
             )
@@ -1364,20 +1362,18 @@ ARGS = {arguments}\n'''.format(
                 script_args = shlex.split(str(script_args))
             args = " {}".format(" ".join([shlex.quote(str(el)) for el in script_args]))
         if extension == "ps1":
-            ret = self.shell.exec_cmd('"powershell {}"'.format(script))
+            ret = self.shell.exec_cmd(f'"powershell {script}"')
         else:
             if not self.winrm:
-                ret = self.shell.exec_cmd(
-                    "/bin/sh '{}{}'{}".format(pre_dir, script, args)
-                )
+                ret = self.shell.exec_cmd(f"/bin/sh '{pre_dir}{script}'{args}")
             else:
                 ret = saltwinshell.call_python(self, script)
 
         # Remove file from target system
         if not self.winrm:
-            self.shell.exec_cmd("rm '{}{}'".format(pre_dir, script))
+            self.shell.exec_cmd(f"rm '{pre_dir}{script}'")
         else:
-            self.shell.exec_cmd("del {}".format(script))
+            self.shell.exec_cmd(f"del {script}")
 
         return ret
 
@@ -1465,7 +1461,7 @@ ARGS = {arguments}\n'''.format(
                 while re.search(RSTR_RE, stderr):
                     stderr = re.split(RSTR_RE, stderr, 1)[1].strip()
             else:
-                return "ERROR: {}".format(error), stderr, retcode
+                return f"ERROR: {error}", stderr, retcode
 
         # FIXME: this discards output from ssh_shim if the shim succeeds.  It should
         # always save the shim output regardless of shim success or failure.
@@ -1525,7 +1521,7 @@ ARGS = {arguments}\n'''.format(
                     # If RSTR is not seen in both stdout and stderr then there
                     # was a thin deployment problem.
                     return (
-                        "ERROR: Failure deploying ext_mods: {}".format(stdout),
+                        f"ERROR: Failure deploying ext_mods: {stdout}",
                         stderr,
                         retcode,
                     )
@@ -1693,7 +1689,7 @@ def mod_data(fsclient):
             files = fsclient.file_list(env)
             for ref in sync_refs:
                 mods_data = {}
-                pref = "_{}".format(ref)
+                pref = f"_{ref}"
                 for fn_ in sorted(files):
                     if fn_.startswith(pref):
                         if fn_.endswith((".py", ".so", ".pyx")):
@@ -1715,9 +1711,7 @@ def mod_data(fsclient):
         ver_base = salt.utils.stringutils.to_bytes(ver_base)
 
         ver = hashlib.sha1(ver_base).hexdigest()
-        ext_tar_path = os.path.join(
-            fsclient.opts["cachedir"], "ext_mods.{}.tgz".format(ver)
-        )
+        ext_tar_path = os.path.join(fsclient.opts["cachedir"], f"ext_mods.{ver}.tgz")
         mods = {"version": ver, "file": ext_tar_path}
         if os.path.isfile(ext_tar_path):
             return mods
@@ -1766,7 +1760,7 @@ def _convert_args(args):
             for key in list(arg.keys()):
                 if key == "__kwarg__":
                     continue
-                converted.append("{}={}".format(key, arg[key]))
+                converted.append(f"{key}={arg[key]}")
         else:
             converted.append(arg)
     return converted

--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -55,7 +55,7 @@ def _ssh_state(chunks, st_kwargs, kwargs, test=False):
         cmd,
         fsclient=__context__["fileclient"],
         minion_opts=__salt__.minion_opts,
-        **st_kwargs
+        **st_kwargs,
     )
     single.shell.send(trans_tar, "{}/salt_state.tgz".format(__opts__["thin_dir"]))
     stdout, stderr, _ = single.cmd_block()
@@ -244,7 +244,7 @@ def sls(mods, saltenv="base", test=None, exclude=None, **kwargs):
             cmd,
             fsclient=__context__["fileclient"],
             minion_opts=__salt__.minion_opts,
-            **st_kwargs
+            **st_kwargs,
         )
         single.shell.send(trans_tar, "{}/salt_state.tgz".format(opts["thin_dir"]))
         stdout, stderr, _ = single.cmd_block()
@@ -392,7 +392,7 @@ def low(data, **kwargs):
             cmd,
             fsclient=__context__["fileclient"],
             minion_opts=__salt__.minion_opts,
-            **st_kwargs
+            **st_kwargs,
         )
         single.shell.send(trans_tar, "{}/salt_state.tgz".format(__opts__["thin_dir"]))
         stdout, stderr, _ = single.cmd_block()
@@ -482,7 +482,7 @@ def high(data, **kwargs):
             cmd,
             fsclient=__context__["fileclient"],
             minion_opts=__salt__.minion_opts,
-            **st_kwargs
+            **st_kwargs,
         )
         single.shell.send(trans_tar, "{}/salt_state.tgz".format(opts["thin_dir"]))
         stdout, stderr, _ = single.cmd_block()
@@ -558,7 +558,7 @@ def request(mods=None, **kwargs):
         try:
             if salt.utils.platform.is_windows():
                 # Make sure cache file isn't read-only
-                __salt__["cmd.run"]('attrib -R "{}"'.format(notify_path))
+                __salt__["cmd.run"](f'attrib -R "{notify_path}"')
             with salt.utils.files.fopen(notify_path, "w+b") as fp_:
                 salt.payload.dump(req, fp_)
         except OSError:
@@ -622,7 +622,7 @@ def clear_request(name=None):
             try:
                 if salt.utils.platform.is_windows():
                     # Make sure cache file isn't read-only
-                    __salt__["cmd.run"]('attrib -R "{}"'.format(notify_path))
+                    __salt__["cmd.run"](f'attrib -R "{notify_path}"')
                 with salt.utils.files.fopen(notify_path, "w+b") as fp_:
                     salt.payload.dump(req, fp_)
             except OSError:
@@ -730,7 +730,7 @@ def highstate(test=None, **kwargs):
             cmd,
             fsclient=__context__["fileclient"],
             minion_opts=__salt__.minion_opts,
-            **st_kwargs
+            **st_kwargs,
         )
         single.shell.send(trans_tar, "{}/salt_state.tgz".format(opts["thin_dir"]))
         stdout, stderr, _ = single.cmd_block()
@@ -821,7 +821,7 @@ def top(topfn, test=None, **kwargs):
             cmd,
             fsclient=__context__["fileclient"],
             minion_opts=__salt__.minion_opts,
-            **st_kwargs
+            **st_kwargs,
         )
         single.shell.send(trans_tar, "{}/salt_state.tgz".format(opts["thin_dir"]))
         stdout, stderr, _ = single.cmd_block()
@@ -1227,7 +1227,7 @@ def single(fun, name, test=None, **kwargs):
         cmd,
         fsclient=__context__["fileclient"],
         minion_opts=__salt__.minion_opts,
-        **st_kwargs
+        **st_kwargs,
     )
 
     # Copy the tar down

--- a/tests/pytests/integration/ssh/test_deploy.py
+++ b/tests/pytests/integration/ssh/test_deploy.py
@@ -75,15 +75,13 @@ def test_set_path(salt_ssh_cli, tmp_path, salt_ssh_roster_file):
         roster_data = salt.utils.yaml.safe_load(rfh)
         roster_data["localhost"].update(
             {
-                "set_path": "$PATH:/usr/local/bin/:{}".format(path),
+                "set_path": f"$PATH:/usr/local/bin/:{path}",
             }
         )
     with salt.utils.files.fopen(roster_file, "w") as wfh:
         salt.utils.yaml.safe_dump(roster_data, wfh)
 
-    ret = salt_ssh_cli.run(
-        "--roster-file={}".format(roster_file), "environ.get", "PATH"
-    )
+    ret = salt_ssh_cli.run(f"--roster-file={roster_file}", "environ.get", "PATH")
     assert ret.returncode == 0
     assert path in ret.data
 
@@ -98,7 +96,7 @@ def test_tty(salt_ssh_cli, tmp_path, salt_ssh_roster_file):
         roster_data["localhost"].update({"tty": True})
     with salt.utils.files.fopen(roster_file, "w") as wfh:
         salt.utils.yaml.safe_dump(roster_data, wfh)
-    ret = salt_ssh_cli.run("--roster-file={}".format(roster_file), "test.ping")
+    ret = salt_ssh_cli.run(f"--roster-file={roster_file}", "test.ping")
     assert ret.returncode == 0
     assert ret.data is True
 


### PR DESCRIPTION
### What does this PR do?
Ensures a state/pillar rendering failure is reported with a non-zero exit code by salt-ssh.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/64514

This also adds a test that tried, but failed to reproduce https://github.com/saltstack/salt/issues/50727, and a test for general module failure retcodes.

### Previous Behavior
exit(0)

### New Behavior
exit(20) (the same as all other failures are reported with)

### Merge requirements satisfied?
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes