### PR TITLE
[master] Add syncing of custom ssh wrappers

### DIFF
--- a/changelog/45450.added.md
+++ b/changelog/45450.added.md
@@ -1,0 +1,1 @@
+Added syncing of custom salt-ssh wrappers

--- a/doc/topics/development/modules/index.rst
+++ b/doc/topics/development/modules/index.rst
@@ -144,7 +144,7 @@ SDB          ``salt.sdb`` (:ref:`index <all-salt.sdb>`)                       ``
 Serializer   ``salt.serializers`` (:ref:`index <all-salt.serializers>`)       ``serializers`` [#no-fs]_ ``serializers_dirs``
 SPM pkgdb    ``salt.spm.pkgdb``                                               ``pkgdb`` [#no-fs]_       ``pkgdb_dirs``
 SPM pkgfiles ``salt.spm.pkgfiles``                                            ``pkgfiles`` [#no-fs]_    ``pkgfiles_dirs``
-SSH Wrapper  ``salt.client.ssh.wrapper``                                      ``wrapper`` [#no-fs]_     ``wrapper_dirs``
+SSH Wrapper  ``salt.client.ssh.wrapper``                                      ``wrapper``               ``wrapper_dirs``
 State        ``salt.states`` (:ref:`index <all-salt.states>`)                 ``states``                ``states_dirs``
 Thorium      ``salt.thorium`` (:ref:`index <all-salt.thorium>`)               ``thorium``               ``thorium_dirs``
 Tokens       ``salt.tokens``                                                  ``tokens``                ``tokens_dirs``

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -86,9 +86,7 @@ def _get_top_file_envs():
                 else:
                     envs = "base"
             except SaltRenderError as exc:
-                raise CommandExecutionError(
-                    "Unable to render top file(s): {}".format(exc)
-                )
+                raise CommandExecutionError(f"Unable to render top file(s): {exc}")
         __context__["saltutil._top_file_envs"] = envs
         return envs
 
@@ -164,7 +162,7 @@ def update(version=None):
         try:
             version = app.find_update()
         except urllib.error.URLError as exc:
-            ret["_error"] = "Could not connect to update_url. Error: {}".format(exc)
+            ret["_error"] = f"Could not connect to update_url. Error: {exc}"
             return ret
     if not version:
         ret["_error"] = "No updates available"
@@ -172,21 +170,21 @@ def update(version=None):
     try:
         app.fetch_version(version)
     except EskyVersionError as exc:
-        ret["_error"] = "Unable to fetch version {}. Error: {}".format(version, exc)
+        ret["_error"] = f"Unable to fetch version {version}. Error: {exc}"
         return ret
     try:
         app.install_version(version)
     except EskyVersionError as exc:
-        ret["_error"] = "Unable to install version {}. Error: {}".format(version, exc)
+        ret["_error"] = f"Unable to install version {version}. Error: {exc}"
         return ret
     try:
         app.cleanup()
     except Exception as exc:  # pylint: disable=broad-except
-        ret["_error"] = "Unable to cleanup. Error: {}".format(exc)
+        ret["_error"] = f"Unable to cleanup. Error: {exc}"
     restarted = {}
     for service in __opts__["update_restart_services"]:
         restarted[service] = __salt__["service.restart"](service)
-    ret["comment"] = "Updated from {} to {}".format(oldversion, version)
+    ret["comment"] = f"Updated from {oldversion} to {version}"
     ret["restarted"] = restarted
     return ret
 
@@ -1154,7 +1152,9 @@ def sync_all(
     ret["matchers"] = sync_matchers(saltenv, False, extmod_whitelist, extmod_blacklist)
     if __opts__["file_client"] == "local":
         ret["pillar"] = sync_pillar(saltenv, False, extmod_whitelist, extmod_blacklist)
-        ret["wrapper"] = sync_wrapper(saltenv, False, extmod_whitelist, extmod_blacklist)
+        ret["wrapper"] = sync_wrapper(
+            saltenv, False, extmod_whitelist, extmod_blacklist
+        )
     if refresh:
         # we don't need to call refresh_modules here because it's done by refresh_pillar
         refresh_pillar(clean_cache=clean_pillar_cache)
@@ -1452,7 +1452,7 @@ def find_cached_job(jid):
                 " enable cache_jobs on this minion"
             )
         else:
-            return "Local jobs cache directory {} not found".format(job_dir)
+            return f"Local jobs cache directory {job_dir} not found"
     path = os.path.join(job_dir, "return.p")
     with salt.utils.files.fopen(path, "rb") as fp_:
         buf = fp_.read()
@@ -1654,7 +1654,7 @@ def _exec(
     kwarg,
     batch=False,
     subset=False,
-    **kwargs
+    **kwargs,
 ):
     fcn_ret = {}
     seen = 0
@@ -1710,7 +1710,7 @@ def cmd(
     ret="",
     kwarg=None,
     ssh=False,
-    **kwargs
+    **kwargs,
 ):
     """
     .. versionchanged:: 2017.7.0
@@ -1731,7 +1731,7 @@ def cmd(
     # if return is empty, we may have not used the right conf,
     # try with the 'minion relative master configuration counter part
     # if available
-    master_cfgfile = "{}master".format(cfgfile[:-6])  # remove 'minion'
+    master_cfgfile = f"{cfgfile[:-6]}master"  # remove 'minion'
     if (
         not fcn_ret
         and cfgfile.endswith("{}{}".format(os.path.sep, "minion"))
@@ -1754,7 +1754,7 @@ def cmd_iter(
     ret="",
     kwarg=None,
     ssh=False,
-    **kwargs
+    **kwargs,
 ):
     """
     .. versionchanged:: 2017.7.0

--- a/salt/runners/saltutil.py
+++ b/salt/runners/saltutil.py
@@ -146,6 +146,11 @@ def sync_all(saltenv="base", extmod_whitelist=None, extmod_blacklist=None):
         extmod_whitelist=extmod_whitelist,
         extmod_blacklist=extmod_blacklist,
     )
+    ret["wrapper"] = sync_wrapper(
+        saltenv=saltenv,
+        extmod_whitelist=extmod_whitelist,
+        extmod_blacklist=extmod_blacklist,
+    )
     ret["roster"] = sync_roster(
         saltenv=saltenv,
         extmod_whitelist=extmod_whitelist,
@@ -831,6 +836,37 @@ def sync_executors(saltenv="base", extmod_whitelist=None, extmod_blacklist=None)
     return salt.utils.extmods.sync(
         __opts__,
         "executors",
+        saltenv=saltenv,
+        extmod_whitelist=extmod_whitelist,
+        extmod_blacklist=extmod_blacklist,
+    )[0]
+
+
+def sync_wrapper(saltenv="base", extmod_whitelist=None, extmod_blacklist=None):
+    """
+    .. versionadded:: 3000
+
+    Sync salt-ssh wrapper modules from ``salt://_wrapper`` to the master.
+
+    saltenv : base
+        The fileserver environment from which to sync. To sync from more than
+        one environment, pass a comma-separated list.
+
+    extmod_whitelist : None
+        comma-seperated list of modules to sync
+
+    extmod_blacklist : None
+        comma-seperated list of modules to blacklist based on type
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run saltutil.sync_wrapper
+    """
+    return salt.utils.extmods.sync(
+        __opts__,
+        "wrapper",
         saltenv=saltenv,
         extmod_whitelist=extmod_whitelist,
         extmod_blacklist=extmod_blacklist,

--- a/salt/runners/saltutil.py
+++ b/salt/runners/saltutil.py
@@ -844,7 +844,7 @@ def sync_executors(saltenv="base", extmod_whitelist=None, extmod_blacklist=None)
 
 def sync_wrapper(saltenv="base", extmod_whitelist=None, extmod_blacklist=None):
     """
-    .. versionadded:: 3000
+    .. versionadded:: 3007.0
 
     Sync salt-ssh wrapper modules from ``salt://_wrapper`` to the master.
 

--- a/salt/states/saltutil.py
+++ b/salt/states/saltutil.py
@@ -349,3 +349,17 @@ def sync_serializers(name, **kwargs):
             - refresh: True
     """
     return _sync_single(name, "serializers", **kwargs)
+
+
+def sync_wrapper(name, **kwargs):
+    """
+    Performs the same task as saltutil.sync_wrapper module
+    See :mod:`saltutil module for full list of options <salt.modules.saltutil>`
+
+    .. code-block:: yaml
+
+        sync_everything:
+          saltutil.sync_wrapper:
+            - refresh: True
+    """
+    return _sync_single(name, "wrapper", **kwargs)

--- a/salt/states/saltutil.py
+++ b/salt/states/saltutil.py
@@ -353,6 +353,8 @@ def sync_serializers(name, **kwargs):
 
 def sync_wrapper(name, **kwargs):
     """
+    .. versionadded:: 3007.0
+
     Performs the same task as saltutil.sync_wrapper module
     See :mod:`saltutil module for full list of options <salt.modules.saltutil>`
 

--- a/salt/states/saltutil.py
+++ b/salt/states/saltutil.py
@@ -29,18 +29,18 @@ def _sync_single(name, module, **kwargs):
 
     if __opts__["test"]:
         ret["result"] = None
-        ret["comment"] = "saltutil.sync_{} would have been run".format(module)
+        ret["comment"] = f"saltutil.sync_{module} would have been run"
         return ret
 
     try:
-        sync_status = __salt__["saltutil.sync_{}".format(module)](**kwargs)
+        sync_status = __salt__[f"saltutil.sync_{module}"](**kwargs)
         if sync_status:
             ret["changes"][module] = sync_status
-            ret["comment"] = "Updated {}.".format(module)
+            ret["comment"] = f"Updated {module}."
     except Exception as e:  # pylint: disable=broad-except
         log.error("Failed to run saltutil.sync_%s: %s", module, e)
         ret["result"] = False
-        ret["comment"] = "Failed to run sync_{}: {}".format(module, e)
+        ret["comment"] = f"Failed to run sync_{module}: {e}"
         return ret
 
     if not ret["changes"]:
@@ -76,7 +76,7 @@ def sync_all(name, **kwargs):
     except Exception as e:  # pylint: disable=broad-except
         log.error("Failed to run saltutil.sync_all: %s", e)
         ret["result"] = False
-        ret["comment"] = "Failed to run sync_all: {}".format(e)
+        ret["comment"] = f"Failed to run sync_all: {e}"
         return ret
 
     if not ret["changes"]:

--- a/tests/pytests/integration/runners/test_saltutil.py
+++ b/tests/pytests/integration/runners/test_saltutil.py
@@ -31,6 +31,7 @@ def get_module_types():
         "tokens",
         "serializers",
         "executors",
+        "wrapper",
         "roster",
     ]
     return module_types
@@ -66,6 +67,7 @@ def module_sync_functions():
         "tokens": "eauth_tokens",
         "serializers": "serializers",
         "executors": "executors",
+        "wrapper": "wrapper",
         "roster": "roster",
     }
 

--- a/tests/pytests/integration/runners/test_saltutil.py
+++ b/tests/pytests/integration/runners/test_saltutil.py
@@ -78,7 +78,7 @@ def test_sync(
     """
     Ensure modules are synced when various sync functions are called
     """
-    module_name = "hello_sync_{}".format(module_type)
+    module_name = f"hello_sync_{module_type}"
     module_contents = """
 def __virtual__():
     return "hello"
@@ -87,17 +87,17 @@ def world():
     return "world"
 """
 
-    test_moduledir = salt_master.state_tree.base.paths[0] / "_{}".format(module_type)
+    test_moduledir = salt_master.state_tree.base.paths[0] / f"_{module_type}"
     test_moduledir.mkdir(parents=True, exist_ok=True)
     module_tempfile = salt_master.state_tree.base.temp_file(
-        "_{}/{}.py".format(module_type, module_name), module_contents
+        f"_{module_type}/{module_name}.py", module_contents
     )
 
     with module_tempfile, test_moduledir:
-        salt_cmd = "saltutil.sync_{}".format(module_sync_functions[module_type])
+        salt_cmd = f"saltutil.sync_{module_sync_functions[module_type]}"
         ret = salt_run_cli.run(salt_cmd)
         assert ret.returncode == 0
-        assert "{}.hello".format(module_type) in ret.stdout
+        assert f"{module_type}.hello" in ret.stdout
 
 
 def _write_module_dir_and_file(module_type, salt_minion, salt_master):
@@ -113,11 +113,11 @@ def world():
     return "world"
 """
 
-    test_moduledir = salt_master.state_tree.base.paths[0] / "_{}".format(module_type)
+    test_moduledir = salt_master.state_tree.base.paths[0] / f"_{module_type}"
     test_moduledir.mkdir(parents=True, exist_ok=True)
 
     module_tempfile = salt_master.state_tree.base.temp_file(
-        "_{}/{}.py".format(module_type, module_name), module_contents
+        f"_{module_type}/{module_name}.py", module_contents
     )
 
     return module_tempfile
@@ -141,4 +141,4 @@ def test_sync_all(salt_run_cli, salt_minion, salt_master):
 
         assert ret.returncode == 0
         for module_type in get_module_types():
-            assert "{}.hello".format(module_type) in ret.stdout
+            assert f"{module_type}.hello" in ret.stdout

--- a/tests/pytests/integration/ssh/test_master.py
+++ b/tests/pytests/integration/ssh/test_master.py
@@ -63,6 +63,30 @@ def _state_tree(salt_master, tmp_path):
         yield
 
 
+@pytest.fixture
+def custom_wrapper(salt_run_cli, base_env_state_tree_root_dir):
+    module_contents = r"""\
+def __virtual__():
+    return "grains_custom"
+
+def items():
+    return __grains__.value()
+    """
+    module_dir = base_env_state_tree_root_dir / "_wrapper"
+    module_tempfile = pytest.helpers.temp_file(
+        "grains_custom.py", module_contents, module_dir
+    )
+    try:
+        with module_tempfile:
+            ret = salt_run_cli.run("saltutil.sync_wrapper")
+            assert ret.returncode == 0
+            assert "wrapper.grains_custom" in ret.data
+            yield
+    finally:
+        ret = salt_run_cli.run("saltutil.sync_wrapper")
+        assert ret.returncode == 0
+
+
 @pytest.mark.usefixtures("_state_tree")
 def test_state_apply(salt_ssh_cli):
     ret = salt_ssh_cli.run("state.apply", "core")
@@ -77,3 +101,14 @@ def test_state_highstate(salt_ssh_cli):
     assert ret.returncode == 0
     state_result = StateResult(ret.data)
     assert state_result.result is True
+
+
+@pytest.mark.usefixtures("custom_wrapper")
+def test_custom_wrapper(salt_ssh_cli):
+    ret = salt_ssh_cli.run(
+        "grains_custom.items",
+    )
+    assert ret.returncode == 0
+    assert ret.data
+    assert "id" in ret.data
+    assert ret.data["id"] in ("localhost", "127.0.0.1")

--- a/tests/pytests/unit/states/test_saltutil.py
+++ b/tests/pytests/unit/states/test_saltutil.py
@@ -36,6 +36,7 @@ def test_saltutil_sync_all_nochange():
         "pillar": [],
         "matchers": [],
         "serializers": [],
+        "wrapper": [],
     }
     state_id = "somename"
     state_result = {
@@ -71,6 +72,7 @@ def test_saltutil_sync_all_test():
         "pillar": [],
         "matchers": [],
         "serializers": [],
+        "wrapper": [],
     }
     state_id = "somename"
     state_result = {
@@ -107,6 +109,7 @@ def test_saltutil_sync_all_change():
         "pillar": [],
         "matchers": [],
         "serializers": [],
+        "wrapper": [],
     }
     state_id = "somename"
     state_result = {

--- a/tests/pytests/unit/states/test_saltutil.py
+++ b/tests/pytests/unit/states/test_saltutil.py
@@ -142,4 +142,4 @@ def test_saltutil_sync_states_should_match_saltutil_module():
     for fn in module_functions:
         assert (
             fn in state_functions
-        ), "modules.saltutil.{} has no matching state in states.saltutil".format(fn)
+        ), f"modules.saltutil.{fn} has no matching state in states.saltutil"


### PR DESCRIPTION
### What does this PR do?
Adds `sync_wrapper` to the `saltutil` runner/execution/state modules.
From what I can tell, the loader is already configured to load them.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/45450
Reference: https://github.com/saltstack/salt/issues/61637

### Previous Behavior
`<cache_dir>/extmods/wrapper` is respected by the loader, but cannot be synced from the fileserver

### New Behavior
`<cache_dir>/extmods/wrapper` can be synced

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes