### PR TITLE
[3006.x] Make salt-ssh more realistic when handling unexpected situations

### DIFF
--- a/changelog/52452.fixed.md
+++ b/changelog/52452.fixed.md
@@ -1,0 +1,1 @@
+Fixed salt-ssh continues state/pillar rendering with incorrect data when an exception is raised by a module on the target

--- a/tests/pytests/integration/ssh/test_state.py
+++ b/tests/pytests/integration/ssh/test_state.py
@@ -633,8 +633,11 @@ class TestRenderModuleException:
         assert isinstance(ret.data, list)
         assert ret.data
         assert isinstance(ret.data[0], str)
-        assert ret.data[0].startswith(
-            "Rendering SLS 'base:fail_module_exception' failed: "
-            "Problem running salt function in Jinja template: "
+        # While these three should usually follow each other, there
+        # can be warnings in between that would break such a logic.
+        assert "Rendering SLS 'base:fail_module_exception' failed:" in ret.data[0]
+        assert "Problem running salt function in Jinja template:" in ret.data[0]
+        assert (
             "Error running 'disk.usage': Invalid flag passed to disk.usage"
+            in ret.data[0]
         )


### PR DESCRIPTION
### What does this PR do?

* Ensures that state rendering is interrupted when an execution module run on the target exits with a non-zero exit code (usually caused by an exception) or returns non-decodable or invalid data. Thereby also ensures that templates are not rendered with garbage inputs. See https://github.com/saltstack/salt/issues/52452#issuecomment-1601065486 for details
* Also ensures mine functions do not return garbage in those situations and are correctly labeled as failed.
* Mostly homogenizes the way errors are propagated between wrapped and remote functions, while trying to keep the output backwards-compatible: If something fails and only stderr is available, will only print stderr as the return.
* Makes `state.*` wrappers treat non-decodable json output (usually caused by Salt crashing completely) as an error condition as well.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/52452
Fixes: https://github.com/saltstack/salt/issues/64531

### Previous Behavior
* Executing any non-wrapped module inside a template or wrapper module would imply the possibility that errors are evaluated as truthy or randomly rendered salt-ssh error return dicts would mess up the YAML etc. structure when printing the output.
* Mine function returns could contain the same garbage.
* Fatal errors on the remote during state execution would be treated as OK.
* In general, there was no consistency between the ways `Single.cmd_block` and `Single.run_wfunc`[/`FunctionWrapper.caller`] reported errors.

#### Schema wfunc/remote

```
Single.cmd_block
    returns: remote output only (no parsing here)
    return value:
        stdout: what the remote returned, examples:
            success: '{"local": {"retcode": 0, "return": true, "jid": "abc", "id": "id", "fun": "fun.fun", "fun_args": [], "success": true}}'
            failure: ''
        stderr:
            success: warnings
            failure: error description (caught exception) or stacktrace (uncaught)
        retcode: remote retcode

Single.run_wfunc
    returns: local (wrapper) AND remote (when called via __salt__) output or error dicts
    return value:
        success:
            stdout: '{"local": {"return": result}}'
            retcode: 0
        failure:
            non-wrapped remote call in wrapper:
-               depends on the module, likely weird behavior or exception (see below)
            non-wrapped remote call for mine:
~               stdout: {"local": {"stdout": "", "stderr": "abc", "retcode": 1}}
~               retcode: 0 or from __context__ (set by wrappers)
            exception caught:
~               stdout: {"local": {"return": "failure description"}}
                retcode: 1 or from __context__ (set by wrappers)

FunctionWrapper
    returns: actual function return only
    wrapper
        success: return value of wfunc directly
        failure: exceptions from wfunc not caught
    remote
        success: ret["return"]
        failure:
~           no "return" in ret dict: {} (ignores value)
~           "permission denied" in stderr: {"stdout": "", "stderr": "...", "retcode": retcode}
~           no valid json: {"stdout": "...", "stderr": "", "retcode": retcode}
```

### New Behavior
* Exceptions are raised when a remote run returns with a non-zero exit code or if JSON output was expected, but deserialization failed. This causes template rendering to abort and mine function returns to be correctly labeled as failed.
* Fatal errors on the remote during state execution return a non-zero exit code.
* Internally, `Single.cmd_block` and `Single.run_wfunc` outputs are treated the same.

#### Schema wfunc/remote

```
Single.cmd_block (no changes)

Single.run_wfunc
    returns: local (wrapper) AND remote (when called via __salt__) output or error dicts
    return value:
        success:
            stdout: '{"local": {"return": result}}'
+           stderr: ""
            retcode: 0
        failure:
            non-wrapped remote call in wrapper/mine:
+/~             stdout: remote stdout
+/+             stderr: remote stderr
+/~             retcode: remote retcode or from __context__ (set by wrappers)
            exception caught:
~               stdout: ""
+               stderr: "failure description"
                retcode: 1 or from __context__ (set by wrappers)

FunctionWrapper
    returns: actual function return only
    wrapper
        success: return value of wfunc directly
        failure: exceptions from wfunc not caught
    remote
        success: ret["return"]
        failure:
~           no "return" in ret dict: raises exception
~           "permission denied" in stderr AND retcode > 0: raises exception
~           no valid json: raises exception
```

### Merge requirements satisfied?
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes