### PR TITLE
[3006.x] Fix user.present state when group is unset

### DIFF
--- a/changelog/64211.fixed.md
+++ b/changelog/64211.fixed.md
@@ -1,0 +1,1 @@
+Fix user.present state when groups is unset to ensure the groups are unchanged, as documented.

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -127,7 +127,7 @@ def _changes(
             if _gid not in dupe_groups:
                 dupe_groups[_gid] = []
             dupe_groups[_gid].append(lusr["groups"][idx])
-    if not remove_groups:
+    if not remove_groups or groups is None and not optional_groups:
         wanted_groups = sorted(set(wanted_groups + lusr["groups"]))
     if uid and lusr["uid"] != uid:
         change["uid"] = uid

--- a/tests/pytests/functional/states/test_user.py
+++ b/tests/pytests/functional/states/test_user.py
@@ -117,7 +117,6 @@ def test_user_present_when_home_dir_does_not_18843(states, existing_account):
     ret = states.user.present(
         name=existing_account.username,
         home=existing_account.info.home,
-        remove_groups=False,
     )
     assert ret.result is True
     assert pathlib.Path(existing_account.info.home).is_dir()
@@ -228,7 +227,6 @@ def test_user_present_unicode(states, username, subtests):
             roomnumber="①②③",
             workphone="١٢٣٤",
             homephone="६७८",
-            remove_groups=False,
         )
         assert ret.result is True
 

--- a/tests/pytests/functional/states/test_user.py
+++ b/tests/pytests/functional/states/test_user.py
@@ -429,3 +429,75 @@ def test_user_present_change_optional_groups(
     user_info = modules.user.info(username)
     assert user_info
     assert user_info["groups"] == [group_1.name]
+
+
+@pytest.mark.skip_unless_on_linux(reason="underlying functionality only runs on Linux")
+def test_user_present_no_groups(modules, states, username):
+    """
+    test user.present when groups arg is not
+    included by the group is created in another
+    state. Re-run the states to ensure there are
+    not changes and it is idempotent.
+    """
+    groups = ["testgroup1", "testgroup2"]
+    try:
+        ret = states.group.present(name=username, gid=61121)
+        assert ret.result is True
+
+        ret = states.user.present(
+            name=username,
+            uid=61121,
+            gid=61121,
+        )
+        assert ret.result is True
+        assert ret.changes["groups"] == [username]
+        assert ret.changes["name"] == username
+
+        ret = states.group.present(
+            name=groups[0],
+            members=[username],
+        )
+        assert ret.changes["members"] == [username]
+
+        ret = states.group.present(
+            name=groups[1],
+            members=[username],
+        )
+        assert ret.changes["members"] == [username]
+
+        user_info = modules.user.info(username)
+        assert user_info
+        assert user_info["groups"] == [username, groups[0], groups[1]]
+
+        # run again, expecting no changes
+        ret = states.group.present(name=username)
+        assert ret.result is True
+        assert ret.changes == {}
+
+        ret = states.user.present(
+            name=username,
+        )
+        assert ret.result is True
+        assert ret.changes == {}
+
+        ret = states.group.present(
+            name=groups[0],
+            members=[username],
+        )
+        assert ret.result is True
+        assert ret.changes == {}
+
+        ret = states.group.present(
+            name=groups[1],
+            members=[username],
+        )
+        assert ret.result is True
+        assert ret.changes == {}
+
+        user_info = modules.user.info(username)
+        assert user_info
+        assert user_info["groups"] == [username, groups[0], groups[1]]
+    finally:
+        for group in groups:
+            ret = states.group.absent(name=group)
+            assert ret.result is True

--- a/tests/pytests/unit/states/test_user.py
+++ b/tests/pytests/unit/states/test_user.py
@@ -189,6 +189,8 @@ def test_present_uid_gid_change():
         "user.chgid": Mock(),
         "file.group_to_gid": mock_group_to_gid,
         "file.gid_to_group": mock_gid_to_group,
+        "group.info": MagicMock(return_value=after),
+        "user.chgroups": MagicMock(return_value=True),
     }
     with patch.dict(user.__grains__, {"kernel": "Linux"}), patch.dict(
         user.__salt__, dunder_salt


### PR DESCRIPTION
### What does this PR do?
If the `group` arg is unset when using `user.present` it should not edit the groups of the user. This is documented behavior. This was changed in this PR https://github.com/saltstack/salt/pull/62503 to ensure optional_groups are fixed. This PR ensures we keep the optional_groups working and ensure the documented behavior when `group` args is unset. 

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/64211

### Previous Behavior
When `group` was unset when using user.present it would edit the group list if it didn't mirror what groups where currently in the system, resulting in salt returning a changes directory each time. 

### New Behavior
When `group is unset when using `user.present` it does not edit the groups the user is a part of.

