### PR TITLE
[master] APPX: Fix issue when there are duplicate packages

### DIFF
--- a/changelog/64450.fixed.md
+++ b/changelog/64450.fixed.md
@@ -1,0 +1,1 @@
+Fixed issue uninstalling duplicate packages in ``win_appx`` execution module

--- a/salt/modules/win_appx.py
+++ b/salt/modules/win_appx.py
@@ -48,6 +48,7 @@ import logging
 import salt.utils.platform
 import salt.utils.win_pwsh
 import salt.utils.win_reg
+from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
 
@@ -261,10 +262,15 @@ def remove(query=None, include_store=False, frameworks=False, deprovision_only=F
                 frameworks=frameworks,
                 bundles=True,
             )
-            if bundle and bundle["IsBundle"]:
-                log.debug(f'Found bundle: {bundle["PackageFullName"]}')
-                remove_name = bundle["PackageFullName"]
-
+            if isinstance(bundle, list):
+                # There may be multiple packages that match the query
+                # Let's remove each one individually
+                for item in bundle:
+                    remove_package(item)
+            else:
+                if bundle and bundle["IsBundle"]:
+                    log.debug(f'Found bundle: {bundle["PackageFullName"]}')
+                    remove_name = bundle["PackageFullName"]
         if deprovision_only:
             log.debug("Deprovisioning package: %s", remove_name)
             remove_cmd = (
@@ -273,7 +279,16 @@ def remove(query=None, include_store=False, frameworks=False, deprovision_only=F
         else:
             log.debug("Removing package: %s", remove_name)
             remove_cmd = f"Remove-AppxPackage -AllUsers -Package {remove_name}"
-        salt.utils.win_pwsh.run_dict(remove_cmd)
+        try:
+            salt.utils.win_pwsh.run_dict(remove_cmd)
+        except CommandExecutionError as exc:
+            # Some packages may be in a partially updated state
+            # In that case, there will be 2 entries with the same name
+            # The old one will not have an installer and will throw an error
+            # We should be safe just logging the message
+            # This is really hard to replicate
+            log.debug(f"There was an error removing package: {remove_name}")
+            log.debug(exc)
 
     if isinstance(packages, list):
         log.debug("Removing %s packages", len(packages))


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where multiple packages match the query for packages to be removed. Some packages can be in a state where they're being updated. In that scenario, two packages with different versions may match the query. One of the packages will be missing the uninstall information as well.

### What issues does this PR fix or reference?
Fixes: #64450 

### Previous Behavior
Stacktrace on duplicate names
Stacktrace when the package is missing AppxManifest.xml

### New Behavior
Don't stack trace on multiple matching packages
Log the error and continue if the package is missing the AppxManifest.xml

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes