### PR TITLE
[freeze] Remove testing  3.9 for rabbitmq to fix flaky behavior

### DIFF
--- a/tests/pytests/functional/modules/test_win_dsc.py
+++ b/tests/pytests/functional/modules/test_win_dsc.py
@@ -213,6 +213,7 @@ def test_apply_config(dsc, ps1_file, psd1_file):
     assert result is True
 
 
+@pytest.mark.flaky(max_runs=4)
 def test_get_config_not_configured(dsc):
     dsc.remove_config(reset=False)
     with pytest.raises(salt.exceptions.CommandExecutionError) as exc:

--- a/tests/pytests/functional/states/rabbitmq/conftest.py
+++ b/tests/pytests/functional/states/rabbitmq/conftest.py
@@ -31,10 +31,7 @@ class RabbitMQCombo:
 def get_test_versions():
     test_versions = []
     name = "rabbitmq"
-    for version in (
-        "3.8",
-        "3.9",
-    ):
+    for version in ("3.8",):
         test_versions.append(
             RabbitMQImage(name=name, tag=version),
         )


### PR DESCRIPTION
This should resolve the flaky behavior on freeze branch. The issue with spinning up docker containers and ensuring the previous container was closed is resolved in a Salt factories upgrade, which would not be feasible to upgrade on this branch. So I decided to only test one version. This way we are still testing rabbitmq and resolving flaky behavior. 