### PR TITLE
[master] Improve salt-ssh error handling

### DIFF
--- a/changelog/52452.fixed.md
+++ b/changelog/52452.fixed.md
@@ -1,0 +1,1 @@
+Fixed salt-ssh continues state/pillar rendering with incorrect data when an exception is raised by a module on the target

--- a/changelog/64531.fixed.md
+++ b/changelog/64531.fixed.md
@@ -1,0 +1,1 @@
+Made salt-ssh more strict when handling unexpected situations and state.* wrappers treat a remote exception as failure, excluded salt-ssh error returns from mine

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -887,7 +887,10 @@ class SSH(MultiprocessingStateMixin):
             if not isinstance(ret[host], dict):
                 p_data = {host: ret[host]}
             elif "return" not in ret[host]:
-                p_data = ret
+                if ret[host].get("_error") == "Permission denied":
+                    p_data = {host: ret[host]["stderr"]}
+                else:
+                    p_data = ret
             else:
                 outputter = ret[host].get("out", self.opts.get("output", "nested"))
                 p_data = {host: ret[host].get("return", {})}

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -583,7 +583,7 @@ class SSH(MultiprocessingStateMixin):
         )
         ret = {"id": single.id}
         stdout = stderr = ""
-        retcode = 0
+        retcode = salt.defaults.exitcodes.EX_OK
         try:
             stdout, stderr, retcode = single.run()
             try:
@@ -677,7 +677,7 @@ class SSH(MultiprocessingStateMixin):
                 running[host] = {"thread": routine}
                 continue
             ret = {}
-            retcode = 0
+            retcode = salt.defaults.exitcodes.EX_OK
             try:
                 ret, retcode = que.get(False)
                 if "id" in ret:
@@ -865,7 +865,7 @@ class SSH(MultiprocessingStateMixin):
             print("")
         sret = {}
         outputter = self.opts.get("output", "nested")
-        final_exit = 0
+        final_exit = salt.defaults.exitcodes.EX_OK
         for ret, retcode in self.handle_ssh():
             host = next(iter(ret))
             if not isinstance(retcode, int):
@@ -877,7 +877,6 @@ class SSH(MultiprocessingStateMixin):
             ret, deploy_retcode = self.key_deploy(host, ret)
             if deploy_retcode is not None:
                 retcode = deploy_retcode
-
             final_exit = max(final_exit, retcode)
 
             if isinstance(ret[host], dict) and (
@@ -1155,7 +1154,7 @@ class Single:
         Returns tuple of (stdout, stderr, retcode)
         """
         stdout = stderr = ""
-        retcode = 0
+        retcode = salt.defaults.exitcodes.EX_OK
 
         if self.ssh_pre_flight:
             if not self.opts.get("ssh_run_pre_flight", False) and self.check_thin_dir():
@@ -1169,7 +1168,7 @@ class Single:
                 )
             else:
                 stdout, stderr, retcode = self.run_ssh_pre_flight()
-                if retcode != 0:
+                if retcode != salt.defaults.exitcodes.EX_OK:
                     log.error(
                         "Error running ssh_pre_flight script %s", self.ssh_pre_file
                     )
@@ -1252,7 +1251,7 @@ class Single:
             # Use the ID defined in the roster file
             opts_pkg["id"] = self.id
 
-            retcode = 0
+            retcode = salt.defaults.exitcodes.EX_OK
 
             # Restore master grains
             for grain in conf_grains:
@@ -1374,7 +1373,9 @@ class Single:
             retcode = 1
 
         # Ensure retcode from wrappers is respected, especially state render exceptions
-        retcode = max(retcode, self.context.get("retcode", 0))
+        retcode = max(
+            retcode, self.context.get("retcode", salt.defaults.exitcodes.EX_OK)
+        )
 
         # Mimic the json data-structure that "salt-call --local" will
         # emit (as seen in ssh_py_shim.py)

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -572,6 +572,7 @@ class SSH(MultiprocessingStateMixin):
             if not self.opts.get("raw_shell"):
                 # We only expect valid JSON output from Salt
                 retcode = max(retcode, err.retcode, 1)
+            else:
                 ret["ret"].pop("_error", None)
         except Exception as err:  # pylint: disable=broad-except
             log.error(

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -761,7 +761,7 @@ class SSH(MultiprocessingStateMixin):
                 jid, job_load
             )
 
-        for ret, _ in self.handle_ssh(mine=mine):
+        for ret, retcode in self.handle_ssh(mine=mine):
             host = next(iter(ret))
             self.cache_job(jid, host, ret[host], fun)
             if self.event:
@@ -772,6 +772,17 @@ class SSH(MultiprocessingStateMixin):
                     data["id"] = id_
                 if "fun" not in data:
                     data["fun"] = fun
+                if "fun_args" not in data:
+                    data["fun_args"] = args
+                if "retcode" not in data:
+                    data["retcode"] = retcode
+                if "success" not in data:
+                    data["success"] = data["retcode"] == salt.defaults.exitcodes.EX_OK
+                if "return" not in data:
+                    if data["success"]:
+                        data["return"] = data.get("stdout")
+                    else:
+                        data["return"] = data.get("stderr", data.get("stdout"))
                 data[
                     "jid"
                 ] = jid  # make the jid in the payload the same as the jid in the tag
@@ -893,6 +904,17 @@ class SSH(MultiprocessingStateMixin):
                     data["id"] = id_
                 if "fun" not in data:
                     data["fun"] = fun
+                if "fun_args" not in data:
+                    data["fun_args"] = args
+                if "retcode" not in data:
+                    data["retcode"] = retcode
+                if "success" not in data:
+                    data["success"] = data["retcode"] == salt.defaults.exitcodes.EX_OK
+                if "return" not in data:
+                    if data["success"]:
+                        data["return"] = data.get("stdout")
+                    else:
+                        data["return"] = data.get("stderr", data.get("stdout"))
                 data[
                     "jid"
                 ] = jid  # make the jid in the payload the same as the jid in the tag

--- a/salt/client/ssh/wrapper/__init__.py
+++ b/salt/client/ssh/wrapper/__init__.py
@@ -114,7 +114,7 @@ class FunctionWrapper:
         cmd_prefix=None,
         aliases=None,
         minion_opts=None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self.cmd_prefix = cmd_prefix
@@ -163,14 +163,14 @@ class FunctionWrapper:
                 cmd_prefix=cmd,
                 aliases=self.aliases,
                 minion_opts=self.minion_opts,
-                **kwargs
+                **kwargs,
             )
 
         if self.cmd_prefix:
             # We're in an inner FunctionWrapper as created by the code block
             # above. Reconstruct the original cmd in the form 'cmd.run' and
             # then evaluate as normal
-            cmd = "{}.{}".format(self.cmd_prefix, cmd)
+            cmd = f"{self.cmd_prefix}.{cmd}"
 
         if cmd in self.wfuncs:
             return self.wfuncs[cmd]
@@ -199,7 +199,7 @@ class FunctionWrapper:
                 disable_wipe=True,
                 fsclient=self.fsclient,
                 minion_opts=self.minion_opts,
-                **self.kwargs
+                **self.kwargs,
             )
             stdout, stderr, retcode = single.cmd_block()
             return parse_ret(stdout, stderr, retcode, result_only=True)
@@ -214,15 +214,13 @@ class FunctionWrapper:
             # Form of salt.cmd.run in Jinja -- it's expecting a subdictionary
             # containing only 'cmd' module calls, in that case. We don't
             # support assigning directly to prefixes in this way
-            raise KeyError(
-                "Cannot assign to module key {} in the FunctionWrapper".format(cmd)
-            )
+            raise KeyError(f"Cannot assign to module key {cmd} in the FunctionWrapper")
 
         if self.cmd_prefix:
             # We're in an inner FunctionWrapper as created by the first code
             # block in __getitem__. Reconstruct the original cmd in the form
             # 'cmd.run' and then evaluate as normal
-            cmd = "{}.{}".format(self.cmd_prefix, cmd)
+            cmd = f"{self.cmd_prefix}.{cmd}"
 
         if cmd in self.wfuncs:
             self.wfuncs[cmd] = value

--- a/salt/client/ssh/wrapper/__init__.py
+++ b/salt/client/ssh/wrapper/__init__.py
@@ -7,11 +7,94 @@ as ZeroMQ salt, but via ssh.
 
 
 import copy
+import logging
 
 import salt.client.ssh
 import salt.loader
 import salt.utils.data
 import salt.utils.json
+from salt.defaults import NOT_SET
+from salt.exceptions import CommandExecutionError, SaltException
+
+log = logging.getLogger(__name__)
+
+
+class SSHException(SaltException):
+    """
+    Indicates general command failure via salt-ssh.
+    """
+
+    _error = ""
+
+    def __init__(
+        self, stdout, stderr, retcode, result=NOT_SET, data=None, *args, **kwargs
+    ):
+        super().__init__(stderr, *args, **kwargs)
+        self.stdout = stdout
+        self.stderr = stderr
+        self.result = result
+        self.data = data
+        self.retcode = retcode
+        if args:
+            self._error = args.pop(0)
+
+    def to_ret(self):
+        ret = {
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+            "retcode": self.retcode,
+            "data": self.data,
+        }
+        if self._error:
+            ret["_error"] = self._error
+        if self.result is not NOT_SET:
+            ret["return"] = self.result
+        return ret
+
+
+class SSHCommandExecutionError(SSHException, CommandExecutionError):
+    """
+    Thrown whenever a non-zero exit code is returned.
+    This was introduced to make the salt-ssh FunctionWrapper behave
+    more like the usual one, in particular to force template rendering
+    to stop when a function call results in an exception.
+    """
+
+    _error = "The command resulted in a non-zero exit code"
+
+    def to_ret(self):
+        if self.data and "local" in self.data:
+            # Wrapped commands that indicate a non-zero retcode
+            return self.data["local"]
+        elif self.stderr:
+            # Remote executions that indicate a non-zero retcode
+            return self.stderr
+        return super().to_ret()
+
+
+class SSHPermissionDeniedError(SSHException):
+    """
+    Thrown when "Permission denied" is found in stderr
+    """
+
+    _error = "Permission Denied"
+
+
+class SSHReturnDecodeError(SSHException):
+    """
+    Thrown when JSON-decoding stdout fails and the retcode is 0 otherwise
+    """
+
+    _error = "Failed to return clean data"
+
+
+class SSHMalformedReturnError(SSHException):
+    """
+    Thrown when a decoded return dict is not formed as
+    {"local": {"return": ...}}
+    """
+
+    _error = "Return dict was malformed"
 
 
 class FunctionWrapper:
@@ -119,26 +202,7 @@ class FunctionWrapper:
                 **self.kwargs
             )
             stdout, stderr, retcode = single.cmd_block()
-            if stderr.count("Permission Denied"):
-                return {
-                    "_error": "Permission Denied",
-                    "stdout": stdout,
-                    "stderr": stderr,
-                    "retcode": retcode,
-                }
-            try:
-                ret = salt.utils.json.loads(stdout)
-                if len(ret) < 2 and "local" in ret:
-                    ret = ret["local"]
-                ret = ret.get("return", {})
-            except ValueError:
-                ret = {
-                    "_error": "Failed to return clean data",
-                    "stderr": stderr,
-                    "stdout": stdout,
-                    "retcode": retcode,
-                }
-            return ret
+            return parse_ret(stdout, stderr, retcode, result_only=True)
 
         return caller
 
@@ -176,3 +240,67 @@ class FunctionWrapper:
             return self[cmd]
         else:
             return default
+
+
+def parse_ret(stdout, stderr, retcode, result_only=False):
+    """
+    Parse the output of a remote or local command and return its
+    result. Raise exceptions if the command has a non-zero exitcode
+    or its output is not valid JSON or is not in the expected format,
+    usually ``{"local": {"return": value}}`` (+ optional keys in the "local" dict).
+    """
+    try:
+        retcode = int(retcode)
+    except (TypeError, ValueError):
+        log.warning(f"Got an invalid retcode for host: '{retcode}'")
+        retcode = 1
+
+    if retcode and stderr.count("Permission Denied"):
+        raise SSHPermissionDeniedError(stdout=stdout, stderr=stderr, retcode=retcode)
+
+    result = NOT_SET
+    error = None
+    data = None
+    local_data = None
+
+    try:
+        data = salt.utils.json.loads(stdout)
+        if len(data) < 2 and "local" in data:
+            try:
+                result = data["local"]
+                try:
+                    # Ensure a reported local retcode is kept (at least)
+                    retcode = max(retcode, result["retcode"])
+                except (KeyError, TypeError):
+                    pass
+                if not isinstance(data["local"], dict):
+                    # When a command has failed, the return is dumped as-is
+                    # without declaring it as a result, usually a string or list.
+                    error = SSHCommandExecutionError
+                elif result_only:
+                    result = result["return"]
+            except KeyError:
+                error = SSHMalformedReturnError
+        else:
+            error = SSHMalformedReturnError
+
+    except ValueError:
+        # No valid JSON output was found
+        error = SSHReturnDecodeError
+    if retcode:
+        raise SSHCommandExecutionError(
+            stdout=stdout,
+            stderr=stderr,
+            retcode=retcode,
+            result=result,
+            data=local_data if local_data is not None else data,
+        )
+    if error is not None:
+        raise error(
+            stdout=stdout,
+            stderr=stderr,
+            retcode=retcode,
+            result=result,
+            data=local_data if local_data is not None else data,
+        )
+    return result

--- a/salt/client/ssh/wrapper/__init__.py
+++ b/salt/client/ssh/wrapper/__init__.py
@@ -90,6 +90,12 @@ class SSHCommandExecutionError(SSHException, CommandExecutionError):
             return self.stderr
         return super().to_ret()
 
+    def __str__(self):
+        ret = self.to_ret()
+        if isinstance(ret, str):
+            return f"{self._error}: {ret}"
+        return self._error
+
 
 class SSHPermissionDeniedError(SSHException):
     """

--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -58,7 +58,7 @@ def _ssh_state(chunks, st_kwargs, kwargs, pillar, test=False):
         **st_kwargs,
     )
     single.shell.send(trans_tar, "{}/salt_state.tgz".format(__opts__["thin_dir"]))
-    stdout, stderr, _ = single.cmd_block()
+    stdout, stderr, retcode = single.cmd_block()
 
     # Clean up our tar
     try:
@@ -66,33 +66,7 @@ def _ssh_state(chunks, st_kwargs, kwargs, pillar, test=False):
     except OSError:
         pass
 
-    # Read in the JSON data and return the data structure
-    try:
-        return salt.utils.data.decode(
-            salt.utils.json.loads(stdout, object_hook=salt.utils.data.encode_dict)
-        )
-    except Exception as e:  # pylint: disable=broad-except
-        log.error("JSON Render failed for: %s\n%s", stdout, stderr)
-        log.error(str(e))
-
-    # If for some reason the json load fails, return the stdout
-    return salt.utils.data.decode(stdout)
-
-
-def _set_retcode(ret, highstate=None):
-    """
-    Set the return code based on the data back from the state system
-    """
-
-    # Set default retcode to 0
-    __context__["retcode"] = salt.defaults.exitcodes.EX_OK
-
-    if isinstance(ret, list):
-        __context__["retcode"] = salt.defaults.exitcodes.EX_STATE_COMPILER_ERROR
-        return
-    if not salt.utils.state.check_result(ret, highstate=highstate):
-
-        __context__["retcode"] = salt.defaults.exitcodes.EX_STATE_FAILURE
+    return {"local": salt.client.ssh.wrapper.parse_ret(stdout, stderr, retcode)}
 
 
 def _check_pillar(kwargs, pillar=None):
@@ -256,7 +230,7 @@ def sls(mods, saltenv="base", test=None, exclude=None, **kwargs):
             **st_kwargs,
         )
         single.shell.send(trans_tar, "{}/salt_state.tgz".format(opts["thin_dir"]))
-        stdout, stderr, _ = single.cmd_block()
+        stdout, stderr, retcode = single.cmd_block()
 
         # Clean up our tar
         try:
@@ -264,15 +238,7 @@ def sls(mods, saltenv="base", test=None, exclude=None, **kwargs):
         except OSError:
             pass
 
-        # Read in the JSON data and return the data structure
-        try:
-            return salt.utils.json.loads(stdout)
-        except Exception as e:  # pylint: disable=broad-except
-            log.error("JSON Render failed for: %s\n%s", stdout, stderr)
-            log.error(str(e))
-
-        # If for some reason the json load fails, return the stdout
-        return stdout
+        return {"local": salt.client.ssh.wrapper.parse_ret(stdout, stderr, retcode)}
 
 
 def running(concurrent=False):
@@ -400,7 +366,7 @@ def low(data, **kwargs):
             **st_kwargs,
         )
         single.shell.send(trans_tar, "{}/salt_state.tgz".format(__opts__["thin_dir"]))
-        stdout, stderr, _ = single.cmd_block()
+        stdout, stderr, retcode = single.cmd_block()
 
         # Clean up our tar
         try:
@@ -408,15 +374,7 @@ def low(data, **kwargs):
         except OSError:
             pass
 
-        # Read in the JSON data and return the data structure
-        try:
-            return salt.utils.json.loads(stdout)
-        except Exception as e:  # pylint: disable=broad-except
-            log.error("JSON Render failed for: %s\n%s", stdout, stderr)
-            log.error(str(e))
-
-        # If for some reason the json load fails, return the stdout
-        return stdout
+        return {"local": salt.client.ssh.wrapper.parse_ret(stdout, stderr, retcode)}
 
 
 def _get_test_value(test=None, **kwargs):
@@ -499,7 +457,7 @@ def high(data, **kwargs):
             **st_kwargs,
         )
         single.shell.send(trans_tar, "{}/salt_state.tgz".format(opts["thin_dir"]))
-        stdout, stderr, _ = single.cmd_block()
+        stdout, stderr, retcode = single.cmd_block()
 
         # Clean up our tar
         try:
@@ -507,15 +465,7 @@ def high(data, **kwargs):
         except OSError:
             pass
 
-        # Read in the JSON data and return the data structure
-        try:
-            return salt.utils.json.loads(stdout)
-        except Exception as e:  # pylint: disable=broad-except
-            log.error("JSON Render failed for: %s\n%s", stdout, stderr)
-            log.error(str(e))
-
-        # If for some reason the json load fails, return the stdout
-        return stdout
+        return {"local": salt.client.ssh.wrapper.parse_ret(stdout, stderr, retcode)}
 
 
 def apply_(mods=None, **kwargs):
@@ -756,7 +706,7 @@ def highstate(test=None, **kwargs):
             **st_kwargs,
         )
         single.shell.send(trans_tar, "{}/salt_state.tgz".format(opts["thin_dir"]))
-        stdout, stderr, _ = single.cmd_block()
+        stdout, stderr, retcode = single.cmd_block()
 
         # Clean up our tar
         try:
@@ -764,15 +714,7 @@ def highstate(test=None, **kwargs):
         except OSError:
             pass
 
-        # Read in the JSON data and return the data structure
-        try:
-            return salt.utils.json.loads(stdout)
-        except Exception as e:  # pylint: disable=broad-except
-            log.error("JSON Render failed for: %s\n%s", stdout, stderr)
-            log.error(str(e))
-
-        # If for some reason the json load fails, return the stdout
-        return stdout
+        return {"local": salt.client.ssh.wrapper.parse_ret(stdout, stderr, retcode)}
 
 
 def top(topfn, test=None, **kwargs):
@@ -853,7 +795,7 @@ def top(topfn, test=None, **kwargs):
             **st_kwargs,
         )
         single.shell.send(trans_tar, "{}/salt_state.tgz".format(opts["thin_dir"]))
-        stdout, stderr, _ = single.cmd_block()
+        stdout, stderr, retcode = single.cmd_block()
 
         # Clean up our tar
         try:
@@ -861,15 +803,7 @@ def top(topfn, test=None, **kwargs):
         except OSError:
             pass
 
-        # Read in the JSON data and return the data structure
-        try:
-            return salt.utils.json.loads(stdout)
-        except Exception as e:  # pylint: disable=broad-except
-            log.error("JSON Render failed for: %s\n%s", stdout, stderr)
-            log.error(str(e))
-
-        # If for some reason the json load fails, return the stdout
-        return stdout
+        return {"local": salt.client.ssh.wrapper.parse_ret(stdout, stderr, retcode)}
 
 
 def show_highstate(**kwargs):
@@ -1042,7 +976,6 @@ def sls_id(id_, mods, test=None, queue=False, **kwargs):
             )
 
         ret = _ssh_state(chunk, st_kwargs, kwargs, pillar, test=test)
-        _set_retcode(ret, highstate=highstate)
         # Work around Windows multiprocessing bug, set __opts__['test'] back to
         # value from before this function was run.
         __opts__["test"] = orig_test
@@ -1300,7 +1233,7 @@ def single(fun, name, test=None, **kwargs):
     single.shell.send(trans_tar, "{}/salt_state.tgz".format(opts["thin_dir"]))
 
     # Run the state.pkg command on the target
-    stdout, stderr, _ = single.cmd_block()
+    stdout, stderr, retcode = single.cmd_block()
 
     # Clean up our tar
     try:
@@ -1308,12 +1241,4 @@ def single(fun, name, test=None, **kwargs):
     except OSError:
         pass
 
-    # Read in the JSON data and return the data structure
-    try:
-        return salt.utils.json.loads(stdout)
-    except Exception as e:  # pylint: disable=broad-except
-        log.error("JSON Render failed for: %s\n%s", stdout, stderr)
-        log.error(str(e))
-
-    # If for some reason the json load fails, return the stdout
-    return stdout
+    return {"local": salt.client.ssh.wrapper.parse_ret(stdout, stderr, retcode)}

--- a/tests/pytests/integration/ssh/state/test_retcode_render_module_exception.py
+++ b/tests/pytests/integration/ssh/state/test_retcode_render_module_exception.py
@@ -1,0 +1,67 @@
+"""
+Verify salt-ssh stops state execution and fails with a retcode > 0
+when a state rendering fails because an execution module throws an exception.
+"""
+
+import pytest
+
+from salt.defaults.exitcodes import EX_AGGREGATE
+
+pytestmark = [
+    pytest.mark.skip_on_windows(reason="salt-ssh not available on Windows"),
+    pytest.mark.slow_test,
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def state_tree_render_module_exception(base_env_state_tree_root_dir):
+    top_file = """
+    base:
+      'localhost':
+        - fail_module_exception
+      '127.0.0.1':
+        - fail_module_exception
+    """
+    state_file = r"""
+    This should fail being rendered:
+      test.show_notification:
+        - text: {{ salt["disk.usage"]("c") | yaml_dquote }}
+    """
+    top_tempfile = pytest.helpers.temp_file(
+        "top.sls", top_file, base_env_state_tree_root_dir
+    )
+    state_tempfile = pytest.helpers.temp_file(
+        "fail_module_exception.sls", state_file, base_env_state_tree_root_dir
+    )
+    with top_tempfile, state_tempfile:
+        yield
+
+
+@pytest.mark.parametrize(
+    "args,retcode",
+    (
+        (("state.sls", "fail_module_exception"), EX_AGGREGATE),
+        (("state.highstate",), EX_AGGREGATE),
+        (("state.sls_id", "foo", "fail_module_exception"), EX_AGGREGATE),
+        (("state.show_sls", "fail_module_exception"), EX_AGGREGATE),
+        (("state.show_low_sls", "fail_module_exception"), EX_AGGREGATE),
+        (("state.show_highstate",), EX_AGGREGATE),
+        # state.show_lowstate exits with 0 for non-ssh as well
+        (("state.show_lowstate",), 0),
+        (("state.top", "top.sls"), EX_AGGREGATE),
+    ),
+)
+def test_it(salt_ssh_cli, args, retcode):
+    ret = salt_ssh_cli.run(*args)
+
+    assert ret.returncode == retcode
+    assert isinstance(ret.data, list)
+    assert ret.data
+    assert isinstance(ret.data[0], str)
+    # While these three should usually follow each other, there
+    # can be warnings in between that would break such a logic.
+    assert "Rendering SLS 'base:fail_module_exception' failed:" in ret.data[0]
+    assert "Problem running salt function in Jinja template:" in ret.data[0]
+    assert (
+        "Error running 'disk.usage': Invalid flag passed to disk.usage" in ret.data[0]
+    )

--- a/tests/pytests/integration/ssh/state/test_retcode_run_fail.py
+++ b/tests/pytests/integration/ssh/state/test_retcode_run_fail.py
@@ -50,3 +50,8 @@ def state_tree_run_fail(base_env_state_tree_root_dir):
 def test_it(salt_ssh_cli, args):
     ret = salt_ssh_cli.run(*args)
     assert ret.returncode == EX_AGGREGATE
+    assert isinstance(ret.data, dict)
+    state = next(iter(ret.data))
+    assert isinstance(ret.data[state], dict)
+    assert "result" in ret.data[state]
+    assert ret.data[state]["result"] is False

--- a/tests/pytests/integration/ssh/state/test_retcode_state_run_remote_exception.py
+++ b/tests/pytests/integration/ssh/state/test_retcode_state_run_remote_exception.py
@@ -1,0 +1,91 @@
+"""
+Verify salt-ssh does not report success when it cannot parse
+the return value.
+"""
+
+import pytest
+
+from salt.defaults.exitcodes import EX_AGGREGATE
+
+pytestmark = [
+    pytest.mark.skip_on_windows(reason="salt-ssh not available on Windows"),
+    pytest.mark.slow_test,
+]
+
+
+@pytest.fixture(scope="module")
+def state_tree_remote_exception_mod(salt_run_cli, base_env_state_tree_root_dir):
+    module_contents = r"""
+import os
+import sys
+
+
+def __virtual__():
+    return "whoops"
+
+
+def do_stuff(name):
+    print("Hi there, nice that you're trying to make me do stuff.", file=sys.stderr)
+    print("Traceback (most recent call last):", file=sys.stderr)
+    print('  File "/dont/treat/me/like/that.py" in buzz_off', file=sys.stderr)
+    print("ComplianceError: 'Outlaw detected'", file=sys.stderr)
+    sys.stderr.flush()
+    os._exit(1)
+"""
+    module_dir = base_env_state_tree_root_dir / "_states"
+    module_tempfile = pytest.helpers.temp_file("whoops.py", module_contents, module_dir)
+    try:
+        with module_tempfile:
+            ret = salt_run_cli.run("saltutil.sync_states")
+            assert ret.returncode == 0
+            assert "states.whoops" in ret.data
+            yield
+    finally:
+        ret = salt_run_cli.run("saltutil.sync_states")
+        assert ret.returncode == 0
+
+
+@pytest.fixture(scope="module", autouse=True)
+def state_tree_remote_exception(
+    base_env_state_tree_root_dir, state_tree_remote_exception_mod
+):
+    top_file = """
+    base:
+      'localhost':
+        - remote_stacktrace
+      '127.0.0.1':
+        - remote_stacktrace
+    """
+    state_file = r"""
+    This should be detected as failure:
+      whoops.do_stuff
+    """
+    top_tempfile = pytest.helpers.temp_file(
+        "top.sls", top_file, base_env_state_tree_root_dir
+    )
+    state_tempfile = pytest.helpers.temp_file(
+        "remote_stacktrace.sls", state_file, base_env_state_tree_root_dir
+    )
+    with top_tempfile, state_tempfile:
+        yield
+
+
+@pytest.mark.slow_test
+@pytest.mark.usefixtures("state_tree_remote_exception")
+@pytest.mark.parametrize(
+    "args",
+    (
+        ("state.sls", "remote_stacktrace"),
+        ("state.highstate",),
+        ("state.sls_id", "This should be detected as failure", "remote_stacktrace"),
+        ("state.top", "top.sls"),
+        ("state.single", "whoops.do_stuff", "now"),
+    ),
+)
+def test_it(salt_ssh_cli, args):
+    ret = salt_ssh_cli.run(*args)
+
+    assert ret.returncode == EX_AGGREGATE
+    assert ret.data
+    assert isinstance(ret.data, str)
+    assert "ComplianceError: 'Outlaw detected'" in ret.data

--- a/tests/pytests/integration/ssh/test_deploy.py
+++ b/tests/pytests/integration/ssh/test_deploy.py
@@ -220,7 +220,6 @@ def test_retcode_exe_run_fail(salt_ssh_cli):
     """
     ret = salt_ssh_cli.run("file.touch", "/tmp/non/ex/is/tent")
     assert ret.returncode == EX_AGGREGATE
-    assert ret.data["retcode"] == 1
     assert isinstance(ret.data, str)
     # This should be the exact output, but some other warnings
     # might be printed to stderr.

--- a/tests/pytests/integration/ssh/test_deploy.py
+++ b/tests/pytests/integration/ssh/test_deploy.py
@@ -232,9 +232,8 @@ def test_retcode_exe_run_exception(salt_ssh_cli):
     """
     ret = salt_ssh_cli.run("salttest.jinja_error")
     assert ret.returncode == EX_AGGREGATE
-    assert isinstance(ret.data, dict)
-    assert ret.data["stderr"].endswith("Exception: hehehe")
-    assert ret.data["retcode"] == 1
+    assert isinstance(ret.data, str)
+    assert ret.data.endswith("Exception: hehehe")
 
 
 @pytest.mark.usefixtures("invalid_json_exe_mod")

--- a/tests/pytests/integration/ssh/test_deploy.py
+++ b/tests/pytests/integration/ssh/test_deploy.py
@@ -28,6 +28,119 @@ def thin_dir(salt_ssh_cli):
         shutil.rmtree(thin_dir_path, ignore_errors=True)
 
 
+@pytest.fixture(scope="module")
+def invalid_json_exe_mod(salt_run_cli, base_env_state_tree_root_dir):
+    module_contents = r"""
+import os
+import sys
+
+
+def __virtual__():
+    return "whoops"
+
+
+def test():
+    data = '{\n  "local": {\n    "whoops": "hrhrhr"\n  }\n}'
+    ctr = 0
+    for line in data.splitlines():
+        sys.stdout.write(line)
+        if ctr == 3:
+            print("Warning: Chaos is not a letter")
+        ctr += 1
+    sys.stdout.flush()
+    os._exit(0)
+"""
+    module_dir = base_env_state_tree_root_dir / "_modules"
+    module_tempfile = pytest.helpers.temp_file("whoops.py", module_contents, module_dir)
+    try:
+        with module_tempfile:
+            ret = salt_run_cli.run("saltutil.sync_modules")
+            assert ret.returncode == 0
+            assert "modules.whoops" in ret.data
+            yield
+    finally:
+        ret = salt_run_cli.run("saltutil.sync_modules")
+        assert ret.returncode == 0
+
+
+@pytest.fixture(scope="module")
+def invalid_return_exe_mod(salt_run_cli, base_env_state_tree_root_dir):
+    module_contents = r"""
+import json
+import os
+import sys
+
+
+def __virtual__():
+    return "whoopsiedoodle"
+
+
+def test(wrapped=True):
+    data = "Chaos is a ladder though"
+    if wrapped:
+        data = {"local": {"no_return_key_present": data}}
+    else:
+        data = {"no_local_key_present": data}
+
+    print(json.dumps(data))
+    sys.stdout.flush()
+    os._exit(0)
+"""
+    module_dir = base_env_state_tree_root_dir / "_modules"
+    module_tempfile = pytest.helpers.temp_file(
+        "whoopsiedoodle.py", module_contents, module_dir
+    )
+    try:
+        with module_tempfile:
+            ret = salt_run_cli.run("saltutil.sync_modules")
+            assert ret.returncode == 0
+            assert "modules.whoopsiedoodle" in ret.data
+            yield
+    finally:
+        ret = salt_run_cli.run("saltutil.sync_modules")
+        assert ret.returncode == 0
+
+
+@pytest.fixture(scope="module")
+def remote_exception_wrap_mod(salt_master):
+    module_contents = r"""
+def __virtual__():
+    return "check_exception"
+
+
+def failure():
+    # This should raise an exception
+    ret = __salt__["disk.usage"]("c")
+    return f"Probably got garbage: {ret}"
+"""
+    module_dir = pathlib.Path(salt_master.config["extension_modules"]) / "wrapper"
+    module_tempfile = pytest.helpers.temp_file(
+        "check_exception.py", module_contents, module_dir
+    )
+    with module_tempfile:
+        yield
+
+
+@pytest.fixture(scope="module")
+def remote_parsing_failure_wrap_mod(salt_master, invalid_json_exe_mod):
+    module_contents = r"""
+def __virtual__():
+    return "check_parsing"
+
+
+def failure(mod):
+    # This should raise an exception
+    ret = __salt__[f"{mod}.test"]()
+    return f"Probably got garbage: {ret}"
+"""
+    module_dir = pathlib.Path(salt_master.config["extension_modules"]) / "wrapper"
+    module_tempfile = pytest.helpers.temp_file(
+        "check_parsing.py", module_contents, module_dir
+    )
+    with module_tempfile:
+        yield
+
+
 def test_ping(salt_ssh_cli):
     """
     Test a simple ping
@@ -122,3 +235,65 @@ def test_retcode_exe_run_exception(salt_ssh_cli):
     assert isinstance(ret.data, dict)
     assert ret.data["stderr"].endswith("Exception: hehehe")
     assert ret.data["retcode"] == 1
+
+
+@pytest.mark.usefixtures("invalid_json_exe_mod")
+def test_retcode_json_decode_error(salt_ssh_cli):
+    """
+    Verify salt-ssh exits with a non-zero exit code when
+    it cannot decode the output of a command.
+    """
+    ret = salt_ssh_cli.run("whoops.test")
+    assert ret.returncode == EX_AGGREGATE
+    assert isinstance(ret.data, dict)
+    assert (
+        ret.data["stdout"]
+        == '{  "local": {    "whoops": "hrhrhr"  }Warning: Chaos is not a letter\n}'
+    )
+    assert ret.data["retcode"] == 0
+
+
+@pytest.mark.usefixtures("invalid_return_exe_mod")
+def test_retcode_invalid_return(salt_ssh_cli):
+    """
+    Verify salt-ssh exits with a non-zero exit code when
+    the decoded command output is invalid.
+    """
+    ret = salt_ssh_cli.run("whoopsiedoodle.test", "false")
+    assert ret.returncode == EX_AGGREGATE
+    assert isinstance(ret.data, dict)
+    assert ret.data["stdout"] == '{"no_local_key_present": "Chaos is a ladder though"}'
+    assert ret.data["retcode"] == 0
+
+
+@pytest.mark.usefixtures("remote_exception_wrap_mod")
+def test_wrapper_unwrapped_command_exception(salt_ssh_cli):
+    """
+    Verify salt-ssh does not return unexpected exception output to wrapper modules.
+    """
+    ret = salt_ssh_cli.run("check_exception.failure")
+    assert ret.data
+    assert "Probably got garbage" not in ret.data
+    assert ret.returncode == EX_AGGREGATE
+
+
+@pytest.mark.usefixtures("remote_parsing_failure_wrap_mod", "invalid_json_exe_mod")
+def test_wrapper_unwrapped_command_parsing_failure(salt_ssh_cli):
+    """
+    Verify salt-ssh does not return unexpected unparsable output to wrapper modules.
+    """
+    ret = salt_ssh_cli.run("check_parsing.failure", "whoops")
+    assert ret.data
+    assert "Probably got garbage" not in ret.data
+    assert ret.returncode == EX_AGGREGATE
+
+
+@pytest.mark.usefixtures("remote_parsing_failure_wrap_mod", "invalid_return_exe_mod")
+def test_wrapper_unwrapped_command_invalid_return(salt_ssh_cli):
+    """
+    Verify salt-ssh does not return unexpected unparsable output to wrapper modules.
+    """
+    ret = salt_ssh_cli.run("check_parsing.failure", "whoopsiedoodle")
+    assert ret.data
+    assert "Probably got garbage" not in ret.data
+    assert ret.returncode == EX_AGGREGATE

--- a/tests/pytests/integration/ssh/test_deploy.py
+++ b/tests/pytests/integration/ssh/test_deploy.py
@@ -220,9 +220,11 @@ def test_retcode_exe_run_fail(salt_ssh_cli):
     """
     ret = salt_ssh_cli.run("file.touch", "/tmp/non/ex/is/tent")
     assert ret.returncode == EX_AGGREGATE
-    assert isinstance(ret.data, dict)
-    assert "Error running 'file.touch': No such file or directory" in ret.data["stderr"]
     assert ret.data["retcode"] == 1
+    assert isinstance(ret.data, str)
+    # This should be the exact output, but some other warnings
+    # might be printed to stderr.
+    assert "Error running 'file.touch': No such file or directory" in ret.data
 
 
 def test_retcode_exe_run_exception(salt_ssh_cli):

--- a/tests/pytests/integration/ssh/test_mine.py
+++ b/tests/pytests/integration/ssh/test_mine.py
@@ -81,7 +81,7 @@ def test_mine_get(salt_ssh_cli, salt_minion, tgts):
         assert ret.data[id_] is True
 
 
-def test_ssh_mine_get_error(salt_ssh_cli):
+def test_ssh_mine_get_error(salt_ssh_cli, caplog):
     """
     Test that a mine function returning an error is not
     included in the output.
@@ -89,3 +89,4 @@ def test_ssh_mine_get_error(salt_ssh_cli):
     ret = salt_ssh_cli.run("mine.get", "localhost", "disk.usage")
     assert ret.returncode == 0
     assert not ret.data
+    assert "Error executing mine func disk.usage" in caplog.text

--- a/tests/pytests/integration/ssh/test_mine.py
+++ b/tests/pytests/integration/ssh/test_mine.py
@@ -8,6 +8,31 @@ pytestmark = [
 ]
 
 
+@pytest.fixture(scope="module", autouse=True)
+def pillar_tree(base_env_pillar_tree_root_dir):
+    top_file = """
+    base:
+      'localhost':
+        - mine
+      '127.0.0.1':
+        - mine
+    """
+    mine_pillar_file = """
+    mine_functions:
+      disk.usage:
+        - c
+    """
+    top_tempfile = pytest.helpers.temp_file(
+        "top.sls", top_file, base_env_pillar_tree_root_dir
+    )
+    mine_tempfile = pytest.helpers.temp_file(
+        "mine.sls", mine_pillar_file, base_env_pillar_tree_root_dir
+    )
+
+    with top_tempfile, mine_tempfile:
+        yield
+
+
 @pytest.fixture(autouse=True)
 def thin_dir(salt_ssh_cli):
     try:
@@ -54,3 +79,13 @@ def test_mine_get(salt_ssh_cli, salt_minion, tgts):
     assert set(ret.data) == exp
     for id_ in exp:
         assert ret.data[id_] is True
+
+
+def test_ssh_mine_get_error(salt_ssh_cli):
+    """
+    Test that a mine function returning an error is not
+    included in the output.
+    """
+    ret = salt_ssh_cli.run("mine.get", "localhost", "disk.usage")
+    assert ret.returncode == 0
+    assert not ret.data

--- a/tests/pytests/unit/client/ssh/test_password.py
+++ b/tests/pytests/unit/client/ssh/test_password.py
@@ -36,16 +36,30 @@ def test_password_failure(temp_salt_master, tmp_path):
                     "retcode": 255,
                     "stderr": "Permission denied (publickey).\r\n",
                     "stdout": "",
+                    "_error": "Permission denied",
                 }
             },
             1,
         )
     ]
+    key_deploy_ret = (
+        {
+            "localhost": {
+                "retcode": 255,
+                "stderr": "Permission denied (publickey)",
+                "stdout": "",
+                "_error": "Permission denied",
+            }
+        },
+        1,
+    )
     expected = {"localhost": "Permission denied (publickey)"}
     display_output = MagicMock()
     with patch("salt.roster.get_roster_file", MagicMock(return_value=roster)), patch(
         "salt.client.ssh.SSH.handle_ssh", MagicMock(return_value=handle_ssh_ret)
-    ), patch("salt.client.ssh.SSH.key_deploy", MagicMock(return_value=expected)), patch(
+    ), patch(
+        "salt.client.ssh.SSH.key_deploy", MagicMock(return_value=key_deploy_ret)
+    ), patch(
         "salt.output.display_output", display_output
     ):
         client = ssh.SSH(opts)

--- a/tests/pytests/unit/client/ssh/test_return_events.py
+++ b/tests/pytests/unit/client/ssh/test_return_events.py
@@ -28,7 +28,7 @@ def test_not_missing_fun_calling_wfuncs(temp_salt_master, tmp_path):
     roster = str(tmp_path / "roster")
     handle_ssh_ret = [({"localhost": {}}, 0)]
 
-    expected = {"localhost": {}}
+    expected = ({"localhost": {}}, 0)
     display_output = MagicMock()
     with patch("salt.roster.get_roster_file", MagicMock(return_value=roster)), patch(
         "salt.client.ssh.SSH.handle_ssh", MagicMock(return_value=handle_ssh_ret)
@@ -41,7 +41,7 @@ def test_not_missing_fun_calling_wfuncs(temp_salt_master, tmp_path):
         assert "localhost" in ret
         assert "fun" in ret["localhost"]
         client.run()
-    display_output.assert_called_once_with(expected, "nested", opts)
+    display_output.assert_called_once_with(expected[0], "nested", opts)
     assert ret is handle_ssh_ret[0][0]
     assert len(client.event.fire_event.call_args_list) == 2
     assert "fun" in client.event.fire_event.call_args_list[0][0][0]

--- a/tests/pytests/unit/client/ssh/test_ssh.py
+++ b/tests/pytests/unit/client/ssh/test_ssh.py
@@ -356,6 +356,7 @@ def test_key_deploy_permission_denied_scp(tmp_path, opts):
 
     ssh_ret = {
         host: {
+            "_error": "Permission denied",
             "stdout": "\rroot@192.168.1.187's password: \n\rroot@192.168.1.187's password: \n\rroot@192.168.1.187's password: \n",
             "stderr": "Permission denied, please try again.\nPermission denied, please try again.\nroot@192.168.1.187: Permission denied (publickey,gssapi-keyex,gssapi-with-micimport pudb; pu.dbassword).\nscp: Connection closed\n",
             "retcode": 255,
@@ -370,7 +371,7 @@ def test_key_deploy_permission_denied_scp(tmp_path, opts):
             "fun": "cmd.run",
             "fun_args": ["echo test"],
         }
-    }
+    }, 0
     patch_roster_file = patch("salt.roster.get_roster_file", MagicMock(return_value=""))
     with patch_roster_file:
         client = ssh.SSH(opts)
@@ -415,7 +416,7 @@ def test_key_deploy_permission_denied_file_scp(tmp_path, opts):
     patch_roster_file = patch("salt.roster.get_roster_file", MagicMock(return_value=""))
     with patch_roster_file:
         client = ssh.SSH(opts)
-    ret = client.key_deploy(host, ssh_ret)
+    ret, retcode = client.key_deploy(host, ssh_ret)
     assert ret == ssh_ret
     assert mock_key_run.call_count == 0
 
@@ -446,7 +447,7 @@ def test_key_deploy_no_permission_denied(tmp_path, opts):
     patch_roster_file = patch("salt.roster.get_roster_file", MagicMock(return_value=""))
     with patch_roster_file:
         client = ssh.SSH(opts)
-    ret = client.key_deploy(host, ssh_ret)
+    ret, retcode = client.key_deploy(host, ssh_ret)
     assert ret == ssh_ret
     assert mock_key_run.call_count == 0
 
@@ -472,7 +473,7 @@ def test_handle_routine_remote_invalid_retcode(opts, target, retcode, expected, 
     que.put.assert_called_once_with(
         ({"id": "localhost", "ret": {"retcode": expected, "return": "foo"}}, 1)
     )
-    assert f"Host 'localhost' reported an invalid retcode: '{expected}'" in caplog.text
+    assert f"Host reported an invalid retcode: '{expected}'" in caplog.text
 
 
 def test_handle_routine_single_run_invalid_retcode(opts, target, caplog):
@@ -496,11 +497,7 @@ def test_handle_routine_single_run_invalid_retcode(opts, target, caplog):
         (
             {
                 "id": "localhost",
-                "ret": {
-                    "stdout": "",
-                    "stderr": "Something went seriously wrong",
-                    "retcode": 1,
-                },
+                "ret": "Something went seriously wrong",
             },
             1,
         )

--- a/tests/pytests/unit/client/ssh/test_ssh.py
+++ b/tests/pytests/unit/client/ssh/test_ssh.py
@@ -408,6 +408,7 @@ def test_key_deploy_permission_denied_file_scp(tmp_path, opts):
 
     ssh_ret = {
         "localhost": {
+            "_error": "The command resulted in a non-zero exit code",
             "stdout": "",
             "stderr": 'scp: dest open "/tmp/preflight.sh": Permission denied\nscp: failed to upload file /etc/salt/preflight.sh to /tmp/preflight.sh\n',
             "retcode": 1,
@@ -418,6 +419,7 @@ def test_key_deploy_permission_denied_file_scp(tmp_path, opts):
         client = ssh.SSH(opts)
     ret, retcode = client.key_deploy(host, ssh_ret)
     assert ret == ssh_ret
+    assert retcode is None
     assert mock_key_run.call_count == 0
 
 
@@ -449,6 +451,7 @@ def test_key_deploy_no_permission_denied(tmp_path, opts):
         client = ssh.SSH(opts)
     ret, retcode = client.key_deploy(host, ssh_ret)
     assert ret == ssh_ret
+    assert retcode is None
     assert mock_key_run.call_count == 0
 
 

--- a/tests/pytests/unit/client/ssh/wrapper/test_parse_ret.py
+++ b/tests/pytests/unit/client/ssh/wrapper/test_parse_ret.py
@@ -1,0 +1,46 @@
+import salt.client.ssh.wrapper as wrap
+
+
+def test_parse_ret_permission_denied_scp():
+    """
+    Ensure that permission denied errors are raised when scp fails to copy
+    a file to a target because of an authentication failure.
+    """
+    stdout = "\rroot@192.168.1.187's password: \n\rroot@192.168.1.187's password: \n\rroot@192.168.1.187's password: \n"
+    stderr = "Permission denied, please try again.\nPermission denied, please try again.\nroot@192.168.1.187: Permission denied (publickey,gssapi-keyex,gssapi-with-micimport pudb; pu.dbassword).\nscp: Connection closed\n"
+    retcode = 255
+
+    try:
+        wrap.parse_ret(stdout, stderr, retcode)
+    except wrap.SSHPermissionDeniedError as err:
+        # need access to the exception instance, which pytest.raises
+        # does not provide
+        ret = err.to_ret()
+    else:
+        assert False, "Did not raise SSHPermissionDeniedError"
+    assert "_error" in ret
+    assert ret["_error"] == "Permission denied"
+    assert "stdout" in ret
+    assert "stderr" in ret
+    assert "Permission denied (publickey" in ret["stderr"]
+    assert "retcode" in ret
+    assert ret["retcode"] == 255
+
+
+def test_parse_ret_permission_denied_because_of_permissions():
+    """
+    Ensure that permission denied errors are NOT raised when scp fails
+    to copy a file to a target due to missing permissions of the user account.
+    The PermissionDeniedError should be exclusive to authentication failures and
+    not apply to authorization ones.
+    """
+    stdout = ""
+    stderr = 'scp: dest open "/tmp/preflight.sh": Permission denied\nscp: failed to upload file /etc/salt/preflight.sh to /tmp/preflight.sh\n'
+    retcode = 1
+
+    try:
+        wrap.parse_ret(stdout, stderr, retcode)
+    except wrap.SSHPermissionDeniedError:
+        assert False, "This should not have resulted in an SSHPermissionDeniedError"
+    except wrap.SSHCommandExecutionError:
+        pass

--- a/tests/pytests/unit/client/ssh/wrapper/test_parse_ret.py
+++ b/tests/pytests/unit/client/ssh/wrapper/test_parse_ret.py
@@ -1,3 +1,5 @@
+import pytest
+
 import salt.client.ssh.wrapper as wrap
 
 
@@ -10,14 +12,9 @@ def test_parse_ret_permission_denied_scp():
     stderr = "Permission denied, please try again.\nPermission denied, please try again.\nroot@192.168.1.187: Permission denied (publickey,gssapi-keyex,gssapi-with-micimport pudb; pu.dbassword).\nscp: Connection closed\n"
     retcode = 255
 
-    try:
+    with pytest.raises(wrap.SSHPermissionDeniedError) as exc:
         wrap.parse_ret(stdout, stderr, retcode)
-    except wrap.SSHPermissionDeniedError as err:
-        # need access to the exception instance, which pytest.raises
-        # does not provide
-        ret = err.to_ret()
-    else:
-        assert False, "Did not raise SSHPermissionDeniedError"
+    ret = exc.value.to_ret()
     assert "_error" in ret
     assert ret["_error"] == "Permission denied"
     assert "stdout" in ret
@@ -41,6 +38,6 @@ def test_parse_ret_permission_denied_because_of_permissions():
     try:
         wrap.parse_ret(stdout, stderr, retcode)
     except wrap.SSHPermissionDeniedError:
-        assert False, "This should not have resulted in an SSHPermissionDeniedError"
+        pytest.fail("This should not have resulted in an SSHPermissionDeniedError")
     except wrap.SSHCommandExecutionError:
         pass


### PR DESCRIPTION
~~Note: This will stay a draft until https://github.com/saltstack/salt/pull/64576 finds its way into master (or the regression is fixed otherwise)~~ ~~Since there has been no activity on the referenced PR for months, I went ahead and merged it into this branch to unblock this PR.~~ It's in. :)

### What does this PR do?
* Ensures that state rendering is interrupted when an execution module run on the target exits with a non-zero exit code or returns non-decodable or invalid data. Thereby ensures that templates are not rendered with garbage inputs. Wrapper modules will receive an exception and thus will not mistake error returns for remote function output. See https://github.com/saltstack/salt/issues/52452#issuecomment-1601065486 for details.
* Excludes error returns from mine data, as it is done in usual Salt as well.
* Makes `state.*` wrappers treat non-decodable json output (usually caused by Salt crashing completely and printing a stacktrace only) as an error condition.
* Ensures salt-ssh job ret events contain all usual data (saw it while reading the code and included the minor fix here, hope that's OK)

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/52452
Fixes: https://github.com/saltstack/salt/issues/64531
Fixes: https://github.com/saltstack/salt/issues/42065
Fixes: https://github.com/saltstack/salt/issues/50727 (last-minute addition: after re-reading the report, I think it's relatively clear why it was not working before and that this should fix it, see test in [tests/pytests/integration/ssh/state/test_retcode_state_run_remote_exception.py](https://github.com/saltstack/salt/pull/64542/files#diff-ae71f89f956935339d33b0b39496d0c77d51b532f65075d89b42d7feec716467))

### Previous Behavior
* Executing any non-wrapped module inside a template or wrapper module would imply the possibility that errors are evaluated as truthy or randomly rendered salt-ssh error return dicts would mess up the YAML etc. structure when printing the output.
* Mine function returns could contain the same garbage.
* Fatal errors on the remote during state execution would be treated as OK.

### New Behavior
* Exceptions are raised when a remote run returns with a non-zero exit code, returns data that indicates failure or if JSON output was expected, but deserialization failed. This causes template rendering to abort and wrapper modules to be confronted with an exception.
* Error returns are excluded from the mine.
* Fatal errors on the remote during state execution return a non-zero exit code.

### Merge requirements satisfied?
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes