### PR TITLE
[3006.x][WIP] 3006 debian12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1121,6 +1121,44 @@ jobs:
       skip-code-coverage: ${{ github.event_name == 'pull_request' }}
       skip-junit-reports: ${{ github.event_name == 'pull_request' }}
 
+  debian-12:
+    name: Debian 12
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-salt-onedir
+    uses: ./.github/workflows/test-action.yml
+    with:
+      distro-slug: debian-12
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: x86_64
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.11
+      pull-labels: ${{ needs.prepare-workflow.outputs.pull-labels }}
+      skip-code-coverage: ${{ github.event_name == 'pull_request' }}
+      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
+
+  debian-12-arm64:
+    name: Debian 12 Arm64
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-salt-onedir
+    uses: ./.github/workflows/test-action.yml
+    with:
+      distro-slug: debian-12-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.11
+      pull-labels: ${{ needs.prepare-workflow.outputs.pull-labels }}
+      skip-code-coverage: ${{ github.event_name == 'pull_request' }}
+      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
+
   fedora-37:
     name: Fedora 37
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -1319,6 +1357,8 @@ jobs:
       - debian-10
       - debian-11
       - debian-11-arm64
+      - debian-12
+      - debian-12-arm64
       - fedora-37
       - fedora-38
       - opensuse-15

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1185,6 +1185,44 @@ jobs:
       skip-code-coverage: false
       skip-junit-reports: false
 
+  debian-12:
+    name: Debian 12
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-salt-onedir
+    uses: ./.github/workflows/test-action.yml
+    with:
+      distro-slug: debian-12
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: x86_64
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.11
+      pull-labels: ${{ needs.prepare-workflow.outputs.pull-labels }}
+      skip-code-coverage: false
+      skip-junit-reports: false
+
+  debian-12-arm64:
+    name: Debian 12 Arm64
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-salt-onedir
+    uses: ./.github/workflows/test-action.yml
+    with:
+      distro-slug: debian-12-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.11
+      pull-labels: ${{ needs.prepare-workflow.outputs.pull-labels }}
+      skip-code-coverage: false
+      skip-junit-reports: false
+
   fedora-37:
     name: Fedora 37
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -1473,6 +1511,12 @@ jobs:
             arch: x86_64
           - distro: debian
             version: "11"
+            arch: aarch64
+          - distro: debian
+            version: "12"
+            arch: x86_64
+          - distro: debian
+            version: "12"
             arch: aarch64
           - distro: ubuntu
             version: "20.04"
@@ -2015,6 +2059,8 @@ jobs:
       - debian-10
       - debian-11
       - debian-11-arm64
+      - debian-12
+      - debian-12-arm64
       - fedora-37
       - fedora-38
       - opensuse-15

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -520,6 +520,46 @@ jobs:
       pkg-type: package
     secrets: inherit
 
+  debian-12-package-download-tests:
+    name: Test Debian 12 package Downloads
+    if: ${{ inputs.skip-salt-pkg-download-test-suite == false }}
+    needs:
+      - prepare-workflow
+      - publish-repositories
+      - download-onedir-artifact
+    uses: ./.github/workflows/test-package-downloads-action-linux.yml
+    with:
+      distro-slug: debian-12
+      platform: linux
+      arch: x86_64
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.11
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      environment: release
+      skip-code-coverage: true
+      latest-release: "${{ needs.prepare-workflow.outputs.latest-release }}"
+      pkg-type: package
+    secrets: inherit
+
+  debian-12-arm64-package-download-tests:
+    name: Test Debian 12 Arm64 package Downloads
+    if: ${{ inputs.skip-salt-pkg-download-test-suite == false }}
+    needs:
+      - prepare-workflow
+      - publish-repositories
+      - download-onedir-artifact
+    uses: ./.github/workflows/test-package-downloads-action-linux.yml
+    with:
+      distro-slug: debian-12-arm64
+      platform: linux
+      arch: aarch64
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.11
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      environment: release
+      skip-code-coverage: true
+      latest-release: "${{ needs.prepare-workflow.outputs.latest-release }}"
+      pkg-type: package
+    secrets: inherit
+
   fedora-37-package-download-tests:
     name: Test Fedora 37 package Downloads
     if: ${{ inputs.skip-salt-pkg-download-test-suite == false }}
@@ -886,6 +926,8 @@ jobs:
       - debian-10-package-download-tests
       - debian-11-package-download-tests
       - debian-11-arm64-package-download-tests
+      - debian-12-package-download-tests
+      - debian-12-arm64-package-download-tests
       - fedora-37-package-download-tests
       - fedora-37-arm64-package-download-tests
       - fedora-38-package-download-tests

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1164,6 +1164,44 @@ jobs:
       skip-code-coverage: false
       skip-junit-reports: false
 
+  debian-12:
+    name: Debian 12
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-salt-onedir
+    uses: ./.github/workflows/test-action.yml
+    with:
+      distro-slug: debian-12
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: x86_64
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.11
+      pull-labels: ${{ needs.prepare-workflow.outputs.pull-labels }}
+      skip-code-coverage: false
+      skip-junit-reports: false
+
+  debian-12-arm64:
+    name: Debian 12 Arm64
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-salt-onedir
+    uses: ./.github/workflows/test-action.yml
+    with:
+      distro-slug: debian-12-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.11
+      pull-labels: ${{ needs.prepare-workflow.outputs.pull-labels }}
+      skip-code-coverage: false
+      skip-junit-reports: false
+
   fedora-37:
     name: Fedora 37
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -1364,6 +1402,8 @@ jobs:
       - debian-10
       - debian-11
       - debian-11-arm64
+      - debian-12
+      - debian-12-arm64
       - fedora-37
       - fedora-38
       - opensuse-15

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1170,6 +1170,44 @@ jobs:
       skip-code-coverage: true
       skip-junit-reports: true
 
+  debian-12:
+    name: Debian 12
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-salt-onedir
+    uses: ./.github/workflows/test-action.yml
+    with:
+      distro-slug: debian-12
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: x86_64
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.11
+      pull-labels: ${{ needs.prepare-workflow.outputs.pull-labels }}
+      skip-code-coverage: true
+      skip-junit-reports: true
+
+  debian-12-arm64:
+    name: Debian 12 Arm64
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-salt-onedir
+    uses: ./.github/workflows/test-action.yml
+    with:
+      distro-slug: debian-12-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.11
+      pull-labels: ${{ needs.prepare-workflow.outputs.pull-labels }}
+      skip-code-coverage: true
+      skip-junit-reports: true
+
   fedora-37:
     name: Fedora 37
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -1458,6 +1496,12 @@ jobs:
             arch: x86_64
           - distro: debian
             version: "11"
+            arch: aarch64
+          - distro: debian
+            version: "12"
+            arch: x86_64
+          - distro: debian
+            version: "12"
             arch: aarch64
           - distro: ubuntu
             version: "20.04"
@@ -2373,6 +2417,44 @@ jobs:
       pkg-type: package
     secrets: inherit
 
+  debian-12-package-download-tests:
+    name: Test Debian 12 package Downloads
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg-download'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - publish-repositories
+    uses: ./.github/workflows/test-package-downloads-action-linux.yml
+    with:
+      distro-slug: debian-12
+      platform: linux
+      arch: x86_64
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.11
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      environment: staging
+      skip-code-coverage: true
+      latest-release: "${{ needs.prepare-workflow.outputs.latest-release }}"
+      pkg-type: package
+    secrets: inherit
+
+  debian-12-arm64-package-download-tests:
+    name: Test Debian 12 Arm64 package Downloads
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg-download'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - publish-repositories
+    uses: ./.github/workflows/test-package-downloads-action-linux.yml
+    with:
+      distro-slug: debian-12-arm64
+      platform: linux
+      arch: aarch64
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.11
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      environment: staging
+      skip-code-coverage: true
+      latest-release: "${{ needs.prepare-workflow.outputs.latest-release }}"
+      pkg-type: package
+    secrets: inherit
+
   fedora-37-package-download-tests:
     name: Test Fedora 37 package Downloads
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg-download'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -2716,6 +2798,8 @@ jobs:
       - debian-10
       - debian-11
       - debian-11-arm64
+      - debian-12
+      - debian-12-arm64
       - fedora-37
       - fedora-38
       - opensuse-15
@@ -2760,6 +2844,8 @@ jobs:
       - debian-10-package-download-tests
       - debian-11-package-download-tests
       - debian-11-arm64-package-download-tests
+      - debian-12-package-download-tests
+      - debian-12-arm64-package-download-tests
       - fedora-37-package-download-tests
       - fedora-37-arm64-package-download-tests
       - fedora-38-package-download-tests

--- a/.github/workflows/templates/build-deb-repo.yml.jinja
+++ b/.github/workflows/templates/build-deb-repo.yml.jinja
@@ -8,6 +8,8 @@
                                             ("debian", "10", "aarch64"),
                                             ("debian", "11", "x86_64"),
                                             ("debian", "11", "aarch64"),
+                                            ("debian", "12", "x86_64"),
+                                            ("debian", "12", "aarch64"),
                                             ("ubuntu", "20.04", "x86_64"),
                                             ("ubuntu", "20.04", "aarch64"),
                                             ("ubuntu", "22.04", "x86_64"),

--- a/.github/workflows/templates/test-pkg-repo-downloads.yml.jinja
+++ b/.github/workflows/templates/test-pkg-repo-downloads.yml.jinja
@@ -15,6 +15,8 @@
                                ("debian-10", "Debian 10", "x86_64", "package"),
                                ("debian-11", "Debian 11", "x86_64", "package"),
                                ("debian-11-arm64", "Debian 11 Arm64", "aarch64", "package"),
+                               ("debian-12", "Debian 12", "x86_64", "package"),
+                               ("debian-12-arm64", "Debian 12 Arm64", "aarch64", "package"),
                                ("fedora-37", "Fedora 37", "x86_64", "package"),
                                ("fedora-37-arm64", "Fedora 37 Arm64", "aarch64", "package"),
                                ("fedora-38", "Fedora 38", "x86_64", "package"),

--- a/.github/workflows/templates/test-salt-pkg.yml.jinja
+++ b/.github/workflows/templates/test-salt-pkg.yml.jinja
@@ -9,6 +9,8 @@
                                ("debian-10", "Debian 10", "x86_64", "deb"),
                                ("debian-11", "Debian 11", "x86_64", "deb"),
                                ("debian-11-arm64", "Debian 11 Arm64", "aarch64", "deb"),
+                               ("debian-12", "Debian 12", "x86_64", "deb"),
+                               ("debian-12-arm64", "Debian 12 Arm64", "aarch64", "deb"),
                                ("fedora-37", "Fedora 37", "x86_64", "rpm"),
                                ("fedora-38", "Fedora 38", "x86_64", "rpm"),
                                ("ubuntu-20.04", "Ubuntu 20.04", "x86_64", "deb"),

--- a/.github/workflows/templates/test-salt.yml.jinja
+++ b/.github/workflows/templates/test-salt.yml.jinja
@@ -59,6 +59,8 @@
                                        ("debian-10", "Debian 10", "x86_64"),
                                        ("debian-11", "Debian 11", "x86_64"),
                                        ("debian-11-arm64", "Debian 11 Arm64", "aarch64"),
+                                       ("debian-12", "Debian 12", "x86_64"),
+                                       ("debian-12-arm64", "Debian 12 Arm64", "aarch64"),
                                        ("fedora-37", "Fedora 37", "x86_64"),
                                        ("fedora-38", "Fedora 38", "x86_64"),
                                        ("opensuse-15", "Opensuse 15", "x86_64"),

--- a/cicd/golden-images.json
+++ b/cicd/golden-images.json
@@ -169,6 +169,26 @@
     "is_windows": "false",
     "ssh_username": "admin"
   },
+ "debian-12-arm64": {
+    "ami": "ami-0ba0301d072f27d3d",
+    "ami_description": "CI Image of Debian 12 arm64",
+    "ami_name": "salt-project/ci/debian/12/arm64/20230626.2228",
+    "arch": "arm64",
+    "cloudwatch-agent-available": "false",
+    "instance_type": "m6g.large",
+    "is_windows": "false",
+    "ssh_username": "admin"
+  },
+  "debian-12": {
+    "ami": "ami-04034625f26cdb36e",
+    "ami_description": "CI Image of Debian 12 x86_64",
+    "ami_name": "salt-project/ci/debian/12/x86_64/20230626.2228",
+    "arch": "x86_64",
+    "cloudwatch-agent-available": "true",
+    "instance_type": "t3a.large",
+    "is_windows": "false",
+    "ssh_username": "admin"
+  },
   "fedora-37-arm64": {
     "ami": "ami-0d71d6f2b0869842f",
     "ami_description": "CI Image of Fedora 37 arm64",

--- a/salt/cloud/deploy/bootstrap-salt.sh
+++ b/salt/cloud/deploy/bootstrap-salt.sh
@@ -991,6 +991,8 @@ __derive_debian_numeric_version() {
             NUMERIC_VERSION=$(__parse_version_string "10.0")
         elif [ "$INPUT_VERSION" = "bullseye/sid" ]; then
             NUMERIC_VERSION=$(__parse_version_string "11.0")
+        elif [ "$INPUT_VERSION" = "bookworm/sid" ]; then
+            NUMERIC_VERSION=$(__parse_version_string "12.0")
         else
             echowarn "Unable to parse the Debian Version (codename: '$INPUT_VERSION')"
         fi

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -891,6 +891,36 @@ def test_debian_11_os_grains():
 
 
 @pytest.mark.skip_unless_on_linux
+def test_debian_12_os_grains():
+    """
+    Test if OS grains are parsed correctly in Debian 12 "bookworm"
+    """
+    # /etc/os-release data taken from base-files 12.4
+    _os_release_data = {
+        "PRETTY_NAME": "Debian GNU/Linux 12 (bookworm)",
+        "NAME": "Debian GNU/Linux",
+        "VERSION_ID": "12",
+        "VERSION": "12 (bookworm)",
+        "VERSION_CODENAME": "bookworm",
+        "ID": "debian",
+        "HOME_URL": "https://www.debian.org/",
+        "SUPPORT_URL": "https://www.debian.org/support",
+        "BUG_REPORT_URL": "https://bugs.debian.org/",
+    }
+    expectation = {
+        "os": "Debian",
+        "os_family": "Debian",
+        "oscodename": "bookworm",
+        "osfullname": "Debian GNU/Linux",
+        "osrelease": "12",
+        "osrelease_info": (12,),
+        "osmajorrelease": 12,
+        "osfinger": "Debian-12",
+    }
+    _run_os_grains_tests(_os_release_data, {}, expectation)
+
+
+@pytest.mark.skip_unless_on_linux
 def test_centos_8_os_grains():
     """
     Test if OS grains are parsed correctly in Centos 8

--- a/tools/pkg/repo/create.py
+++ b/tools/pkg/repo/create.py
@@ -51,11 +51,16 @@ _deb_distro_info = {
         "10": {
             "label": "deb10ary",
             "codename": "buster",
-            "suitename": "oldstable",
+            "suitename": "oldoldstable",
         },
         "11": {
             "label": "deb11ary",
             "codename": "bullseye",
+            "suitename": "oldstable",
+        },
+        "12": {
+            "label": "deb12ary",
+            "codename": "bookworm",
             "suitename": "stable",
         },
     },


### PR DESCRIPTION
### What does this PR do?

This work in progress PR tries to add package building for Debian 12, as, while official support for Debian 12 won't happen until 3007, some of us would still like to use onedir Salt packages for that target.

### What issues does this PR fix or reference?
References: https://github.com/saltstack/salt/issues/64223 (doesn't fix)

### Previous Behavior
No Salt packages delivered for Debian 12

### New Behavior
Salt packages delivered for Debian 12

### Merge requirements satisfied?
Work in progress PR that I need to submit in order to make the CI run (I don't have access to the selfhosted github action CI nodes)
- [:no_entry_sign:] Docs
- [:no_entry_sign:] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [:no_entry_sign:] Tests written/updated

### Commits signed with GPG?
Yes
