### PR TITLE
[3006.x] nightly fix to the is_leader reactor test.

### DIFF
--- a/tests/pytests/integration/reactor/test_reactor.py
+++ b/tests/pytests/integration/reactor/test_reactor.py
@@ -119,21 +119,21 @@ def test_reactor_is_leader(
     When leader is set to false reactor should timeout/not do anything.
     """
     ret = salt_run_cli.run("reactor.is_leader")
-    assert ret.returncode == 0
+    assert ret.returncode == 1
     assert (
         "salt.exceptions.CommandExecutionError: Reactor system is not running."
         in ret.stdout
     )
 
     ret = salt_run_cli.run("reactor.set_leader", value=True)
-    assert ret.returncode == 0
+    assert ret.returncode == 1
     assert (
         "salt.exceptions.CommandExecutionError: Reactor system is not running."
         in ret.stdout
     )
 
     ret = salt_run_cli.run("reactor.is_leader")
-    assert ret.returncode == 0
+    assert ret.returncode == 1
     assert (
         "salt.exceptions.CommandExecutionError: Reactor system is not running."
         in ret.stdout
@@ -220,7 +220,7 @@ def test_reactor_is_leader(
 
     # Let's just confirm the engine is not running once again(because the config file is deleted by now)
     ret = salt_run_cli.run("reactor.is_leader")
-    assert ret.returncode == 0
+    assert ret.returncode == 1
     assert (
         "salt.exceptions.CommandExecutionError: Reactor system is not running."
         in ret.stdout


### PR DESCRIPTION
### What does this PR do?
changes the test to reflect how the exit code should be when a exception is thrown by the runner module. 

which is the behavior mentioned in https://github.com/saltstack/salt/issues/61173


### What issues does this PR fix or reference?
Fixes: nightly build is_leader reactor test
