### PR TITLE
[3006.x] fix nightlies by unbreaking runner.run.

### DIFF
--- a/salt/cli/run.py
+++ b/salt/cli/run.py
@@ -31,7 +31,7 @@ class SaltRun(salt.utils.parsers.SaltRunOptionParser):
             if check_user(self.config["user"]):
                 pr = salt.utils.profile.activate_profile(profiling_enabled)
                 try:
-                    ret = runner.run()
+                    ret = runner.run(full_return=True)
                     # In older versions ret['data']['retcode'] was used
                     # for signaling the return code. This has been
                     # changed for the orchestrate runner, but external

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -207,7 +207,7 @@ class Runner(RunnerClient):
             print(docs[fun])
 
     # TODO: move to mixin whenever we want a salt-wheel cli
-    def run(self):
+    def run(self, full_return=False):
         """
         Execute the runner sequence
         """
@@ -306,7 +306,7 @@ class Runner(RunnerClient):
                         tag=async_pub["tag"],
                         jid=async_pub["jid"],
                         daemonize=False,
-                        full_return=True,
+                        full_return=full_return,
                     )
             except salt.exceptions.SaltException as exc:
                 with salt.utils.event.get_event("master", opts=self.opts) as evt:

--- a/tests/support/case.py
+++ b/tests/support/case.py
@@ -191,12 +191,6 @@ class ShellCase(TestCase, AdaptedConfigurationTestCaseMixin, ScriptPathMixin):
         with RedirectStdStreams():
             runner = salt.runner.Runner(opts)
             ret["return"] = runner.run()
-            if (
-                isinstance(ret["return"], dict)
-                and "return" in ret["return"]
-                and "retcode" not in ret["return"]
-            ):
-                ret["return"] = ret["return"]["return"]
             try:
                 ret["jid"] = runner.jid
             except AttributeError:


### PR DESCRIPTION
### What does this PR do?
fix 3006.x nighties by putting a full_return=False into the runner.run so that anywhere runner.run was working before is now going to work like it was. even though these places should have been using runner.cmd. 


### What issues does this PR fix or reference?
Fixes: 
reverts https://github.com/saltstack/salt/pull/64540
and adds full_return=False to `runner.run` allowing the run.cli to call `runner.run(full_return=True)` but still work like runner.run was before the changes. 

so that it can get the exit codes as it needs. 

### Previous Behavior
runner.run was changed to allow calling with full_return=True to change the behavior of the return. 

### New Behavior
this changes it so that it has to be called with full_return=True to get the full_return. 