### PR TITLE
[3006.x] Stop using the deprecated `locale.getdefaultlocale()` function

### DIFF
--- a/changelog/64565.changed.md
+++ b/changelog/64565.changed.md
@@ -1,0 +1,1 @@
+Stop using the deprecated `locale.getdefaultlocale()` function

--- a/changelog/64565.changed.md
+++ b/changelog/64565.changed.md
@@ -2,3 +2,4 @@ Some more deprecated code fixes:
 
 * Stop using the deprecated `locale.getdefaultlocale()` function
 * Stop accessing deprecated attributes
+* `pathlib.Path.__enter__()` usage is deprecated and not required, a no-op

--- a/changelog/64565.changed.md
+++ b/changelog/64565.changed.md
@@ -1,1 +1,4 @@
-Stop using the deprecated `locale.getdefaultlocale()` function
+Some more deprecated code fixes:
+
+* Stop using the deprecated `locale.getdefaultlocale()` function
+* Stop accessing deprecated attributes

--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -93,14 +93,14 @@ def __define_global_system_encoding_variable__():
         import locale
 
         try:
-            encoding = locale.getdefaultlocale()[-1]
-        except ValueError:
-            # A bad locale setting was most likely found:
-            #   https://github.com/saltstack/salt/issues/26063
-            pass
+            encoding = locale.getencoding()
+        except AttributeError:
+            # Python < 3.11
+            encoding = locale.getpreferredencoding(do_setlocale=True)
 
         # This is now garbage collectable
         del locale
+
         if not encoding:
             # This is most likely ascii which is not the best but we were
             # unable to find a better encoding. If this fails, we fall all

--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -67,14 +67,14 @@ def get_system_encoding():
         import locale
 
         try:
-            encoding = locale.getdefaultlocale()[-1]
-        except ValueError:
-            # A bad locale setting was most likely found:
-            #   https://github.com/saltstack/salt/issues/26063
-            pass
+            encoding = locale.getencoding()
+        except AttributeError:
+            # Python < 3.11
+            encoding = locale.getpreferredencoding(do_setlocale=True)
 
         # This is now garbage collectable
         del locale
+
         if not encoding:
             # This is most likely ascii which is not the best but we were
             # unable to find a better encoding. If this fails, we fall all

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2698,10 +2698,8 @@ def locale_info():
         (
             grains["locale_info"]["defaultlanguage"],
             grains["locale_info"]["defaultencoding"],
-        ) = locale.getdefaultlocale()
+        ) = locale.getlocale()
     except Exception:  # pylint: disable=broad-except
-        # locale.getdefaultlocale can ValueError!! Catch anything else it
-        # might do, per #2205
         grains["locale_info"]["defaultlanguage"] = "unknown"
         grains["locale_info"]["defaultencoding"] = "unknown"
     grains["locale_info"]["detectedencoding"] = __salt_system_encoding__

--- a/tests/pytests/integration/modules/state/test_state_pillar_errors.py
+++ b/tests/pytests/integration/modules/state/test_state_pillar_errors.py
@@ -16,8 +16,8 @@ def reset_pillar(salt_call_cli):
     finally:
         # Refresh pillar once all tests are done.
         ret = salt_call_cli.run("saltutil.refresh_pillar", wait=True)
-        assert ret.exitcode == 0
-        assert ret.json is True
+        assert ret.returncode == 0
+        assert ret.data is True
 
 
 @pytest.fixture
@@ -77,8 +77,8 @@ def test_state_apply_aborts_on_pillar_error(
         shell_result = salt_cli.run(
             "state.apply", "sls-id-test", minion_tgt=salt_minion.id
         )
-        assert shell_result.exitcode == 1
-        assert shell_result.json == expected_comment
+        assert shell_result.returncode == 1
+        assert shell_result.data == expected_comment
 
 
 @pytest.mark.usefixtures("testfile_path", "reset_pillar")
@@ -117,7 +117,7 @@ def test_state_apply_continues_after_pillar_error_is_fixed(
         shell_result = salt_cli.run(
             "saltutil.refresh_pillar", minion_tgt=salt_minion.id
         )
-        assert shell_result.exitcode == 0
+        assert shell_result.returncode == 0
 
     # run state.apply with fixed pillar render error
     with pytest.helpers.temp_file(
@@ -128,7 +128,7 @@ def test_state_apply_continues_after_pillar_error_is_fixed(
         shell_result = salt_cli.run(
             "state.apply", "sls-id-test", minion_tgt=salt_minion.id
         )
-        assert shell_result.exitcode == 0
-        state_result = StateResult(shell_result.json)
+        assert shell_result.returncode == 0
+        state_result = StateResult(shell_result.data)
         assert state_result.result is True
         assert state_result.changes == {"diff": "New file", "mode": "0644"}

--- a/tests/pytests/integration/runners/test_saltutil.py
+++ b/tests/pytests/integration/runners/test_saltutil.py
@@ -85,13 +85,13 @@ def world():
     return "world"
 """
 
-    test_moduledir = salt_master.state_tree.base.paths[0] / "_{}".format(module_type)
+    test_moduledir = salt_master.state_tree.base.write_path / "_{}".format(module_type)
     test_moduledir.mkdir(parents=True, exist_ok=True)
     module_tempfile = salt_master.state_tree.base.temp_file(
         "_{}/{}.py".format(module_type, module_name), module_contents
     )
 
-    with module_tempfile, test_moduledir:
+    with module_tempfile:
         salt_cmd = "saltutil.sync_{}".format(module_sync_functions[module_type])
         ret = salt_run_cli.run(salt_cmd)
         assert ret.returncode == 0

--- a/tests/pytests/integration/states/test_file.py
+++ b/tests/pytests/integration/states/test_file.py
@@ -1070,7 +1070,7 @@ def test_recurse(
         "{}.sls".format(sls_name), sls_contents
     )
 
-    with sls_tempfile, test_tempdir:
+    with sls_tempfile:
         for _dir in "test1", "test2", "test3":
             test_tempdir.joinpath(_dir).mkdir(parents=True, exist_ok=True)
 
@@ -1117,7 +1117,7 @@ def test_recurse_keep_symlinks_in_fileserver_root(
         "{}.sls".format(sls_name), sls_contents
     )
 
-    with sls_tempfile, test_tempdir:
+    with sls_tempfile:
         for _dir in "test1", "test2", "test3":
             test_tempdir.joinpath(_dir).mkdir(parents=True, exist_ok=True)
 
@@ -1169,7 +1169,7 @@ def test_recurse_keep_symlinks_outside_fileserver_root(
         "{}.sls".format(sls_name), sls_contents
     )
 
-    with sls_tempfile, test_tempdir:
+    with sls_tempfile:
         for _dir in "test1", "test2", "test3":
             test_tempdir.joinpath(_dir).mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
### What does this PR do?
See title