### PR TITLE
[3006.x] unflip --no-fast

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -605,7 +605,7 @@ def pytest_runtest_setup(item):
                     "Slow tests are disabled, pass '--run-slow' to enable them.",
                     _use_item_location=True,
                 )
-        if test_group_count == 0 and item.config.getoption("--no-fast-tests"):
+        if test_group_count == 0 and not item.config.getoption("--no-fast-tests"):
             raise pytest.skip.Exception(
                 "Fast tests have been disabled by '--no-fast-tests'.",
                 _use_item_location=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,8 +171,8 @@ def pytest_addoption(parser):
         "--no-fast",
         "--no-fast-tests",
         dest="fast",
-        action="store_false",
-        default=True,
+        action="store_true",
+        default=False,
         help="Don't run salt-fast tests. Default: %(default)s",
     )
     test_selection_group.addoption(
@@ -605,7 +605,7 @@ def pytest_runtest_setup(item):
                     "Slow tests are disabled, pass '--run-slow' to enable them.",
                     _use_item_location=True,
                 )
-        if test_group_count == 0 and not item.config.getoption("--no-fast-tests"):
+        if test_group_count == 0 and item.config.getoption("--no-fast-tests"):
             raise pytest.skip.Exception(
                 "Fast tests have been disabled by '--no-fast-tests'.",
                 _use_item_location=True,


### PR DESCRIPTION
### What does this PR do?
`--no-fast` was flip in https://github.com/saltstack/salt/pull/64386. Because https://github.com/saltstack/salt/pull/64386/files/79cd8696df48782ce4103e6b70895207a99d729f

Test need to be written to avoid another flip.

### What issues does this PR fix or reference?
Fixes: `--no-fast`

- [ ] Tests:

### Commits signed with GPG?
Yes
