### PR TITLE
[master] Bump to `pytest-shell-utilities==1.8.0` which officially support Py3.11

### DIFF
--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -359,7 +359,7 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.0rc21
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.7.0
+pytest-shell-utilities==1.8.0
     # via pytest-salt-factories
 pytest-skip-markers==1.4.0
     # via

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -354,7 +354,7 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.0rc21
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.7.0
+pytest-shell-utilities==1.8.0
     # via pytest-salt-factories
 pytest-skip-markers==1.4.0
     # via

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -387,7 +387,7 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.0rc21
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.7.0
+pytest-shell-utilities==1.8.0
     # via pytest-salt-factories
 pytest-skip-markers==1.4.0
     # via

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -313,7 +313,7 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.0rc21
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.7.0
+pytest-shell-utilities==1.8.0
     # via pytest-salt-factories
 pytest-skip-markers==1.4.0
     # via

--- a/requirements/static/ci/py3.11/darwin.txt
+++ b/requirements/static/ci/py3.11/darwin.txt
@@ -357,7 +357,7 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.0rc21
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.7.0
+pytest-shell-utilities==1.8.0
     # via pytest-salt-factories
 pytest-skip-markers==1.4.0
     # via

--- a/requirements/static/ci/py3.11/freebsd.txt
+++ b/requirements/static/ci/py3.11/freebsd.txt
@@ -352,7 +352,7 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.0rc21
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.7.0
+pytest-shell-utilities==1.8.0
     # via pytest-salt-factories
 pytest-skip-markers==1.4.0
     # via

--- a/requirements/static/ci/py3.11/linux.txt
+++ b/requirements/static/ci/py3.11/linux.txt
@@ -383,7 +383,7 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.0rc21
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.7.0
+pytest-shell-utilities==1.8.0
     # via pytest-salt-factories
 pytest-skip-markers==1.4.0
     # via

--- a/requirements/static/ci/py3.11/windows.txt
+++ b/requirements/static/ci/py3.11/windows.txt
@@ -311,7 +311,7 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.0rc21
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.7.0
+pytest-shell-utilities==1.8.0
     # via pytest-salt-factories
 pytest-skip-markers==1.4.0
     # via

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -357,7 +357,7 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.0rc21
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.7.0
+pytest-shell-utilities==1.8.0
     # via pytest-salt-factories
 pytest-skip-markers==1.4.0
     # via

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -391,7 +391,7 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.0rc21
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.7.0
+pytest-shell-utilities==1.8.0
     # via pytest-salt-factories
 pytest-skip-markers==1.4.0
     # via

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -317,7 +317,7 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.0rc21
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.7.0
+pytest-shell-utilities==1.8.0
     # via pytest-salt-factories
 pytest-skip-markers==1.4.0
     # via

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -359,7 +359,7 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.0rc21
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.7.0
+pytest-shell-utilities==1.8.0
     # via pytest-salt-factories
 pytest-skip-markers==1.4.0
     # via

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -354,7 +354,7 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.0rc21
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.7.0
+pytest-shell-utilities==1.8.0
     # via pytest-salt-factories
 pytest-skip-markers==1.4.0
     # via

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -389,7 +389,7 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.0rc21
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.7.0
+pytest-shell-utilities==1.8.0
     # via pytest-salt-factories
 pytest-skip-markers==1.4.0
     # via

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -313,7 +313,7 @@ pytest-httpserver==1.0.8
     # via -r requirements/pytest.txt
 pytest-salt-factories==1.0.0rc21
     # via -r requirements/pytest.txt
-pytest-shell-utilities==1.7.0
+pytest-shell-utilities==1.8.0
     # via pytest-salt-factories
 pytest-skip-markers==1.4.0
     # via


### PR DESCRIPTION
### What does this PR do?
See title