### PR TITLE
[master] Fix the failing package tests on Windows

### DIFF
--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -256,7 +256,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   cherrypy
-psutil==5.9.5
+psutil==5.8.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -47,7 +47,7 @@ certifi==2023.5.7
     #   -r requirements/windows.txt
     #   kubernetes
     #   requests
-cffi==1.15.1
+cffi==1.14.6
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.11/windows.txt
+++ b/requirements/static/ci/py3.11/windows.txt
@@ -47,7 +47,7 @@ certifi==2023.5.7
     #   -r requirements/windows.txt
     #   kubernetes
     #   requests
-cffi==1.15.1
+cffi==1.14.6
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt
     #   -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.11/windows.txt
+++ b/requirements/static/ci/py3.11/windows.txt
@@ -254,7 +254,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt
     #   cherrypy
-psutil==5.9.5
+psutil==5.8.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -47,7 +47,7 @@ certifi==2023.5.7
     #   -r requirements/windows.txt
     #   kubernetes
     #   requests
-cffi==1.15.1
+cffi==1.14.6
     # via
     #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -260,7 +260,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   cherrypy
-psutil==5.9.5
+psutil==5.8.0
     # via
     #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -256,7 +256,7 @@ portend==3.1.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   cherrypy
-psutil==5.9.5
+psutil==5.8.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/base.txt

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -47,7 +47,7 @@ certifi==2023.5.7
     #   -r requirements/windows.txt
     #   kubernetes
     #   requests
-cffi==1.15.1
+cffi==1.14.6
     # via
     #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/static/ci/common.in

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -10,7 +10,7 @@ certifi==2023.5.7
     # via
     #   -r requirements/windows.txt
     #   requests
-cffi==1.15.1
+cffi==1.14.6
     # via
     #   -r requirements/windows.txt
     #   clr-loader

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -78,7 +78,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==5.9.5
+psutil==5.8.0
     # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/windows.txt

--- a/requirements/static/pkg/py3.11/windows.txt
+++ b/requirements/static/pkg/py3.11/windows.txt
@@ -10,7 +10,7 @@ certifi==2023.5.7
     # via
     #   -r requirements/windows.txt
     #   requests
-cffi==1.15.1
+cffi==1.14.6
     # via
     #   -r requirements/windows.txt
     #   clr-loader

--- a/requirements/static/pkg/py3.11/windows.txt
+++ b/requirements/static/pkg/py3.11/windows.txt
@@ -78,7 +78,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==5.9.5
+psutil==5.8.0
     # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/windows.txt

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -10,7 +10,7 @@ certifi==2023.5.7
     # via
     #   -r requirements/windows.txt
     #   requests
-cffi==1.15.1
+cffi==1.14.6
     # via
     #   -r requirements/windows.txt
     #   clr-loader

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -80,7 +80,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==5.9.5
+psutil==5.8.0
     # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/windows.txt

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -10,7 +10,7 @@ certifi==2023.5.7
     # via
     #   -r requirements/windows.txt
     #   requests
-cffi==1.15.1
+cffi==1.14.6
     # via
     #   -r requirements/windows.txt
     #   clr-loader

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -78,7 +78,7 @@ packaging==23.1
     # via -r requirements/base.txt
 portend==3.1.0
     # via cherrypy
-psutil==5.9.5
+psutil==5.8.0
     # via -r requirements/base.txt
 pyasn1==0.4.8
     # via -r requirements/windows.txt


### PR DESCRIPTION
### What does this PR do?
~Attempts to fix the failing package tests on Windows by loading the coreclr before importing clr~
Fixes the windows package upgrade tests by downgrading some dependencies to match those in 3006.1 because the NSIS packages leave some files behind on upgrades when it shouldn't.