### PR TITLE
[master] Re-use the matchers loader object

### DIFF
--- a/salt/matchers/confirm_top.py
+++ b/salt/matchers/confirm_top.py
@@ -10,7 +10,7 @@ import salt.loader
 log = logging.getLogger(__file__)
 
 
-def confirm_top(match, data, nodegroups=None):
+def confirm_top(match, data, nodegroups=None, matchers=None):
     """
     Takes the data passed to a top file environment and determines if the
     data matches this minion
@@ -21,7 +21,8 @@ def confirm_top(match, data, nodegroups=None):
             if "match" in item:
                 matcher = item["match"]
 
-    matchers = salt.loader.matchers(__opts__)
+    if matchers is None:
+        matchers = salt.loader.matchers(__opts__)
     funcname = matcher + "_match.match"
     if matcher == "nodegroup":
         return matchers[funcname](match, nodegroups)

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -858,6 +858,7 @@ class Pillar:
                     match,
                     data,
                     self.opts.get("nodegroups", {}),
+                    self.matchers,
                 ):
                     if saltenv not in matches:
                         matches[saltenv] = env_matches = []

--- a/salt/state.py
+++ b/salt/state.py
@@ -4188,7 +4188,9 @@ class BaseHighState:
                 def _filter_matches(_match, _data, _opts):
                     if isinstance(_data, str):
                         _data = [_data]
-                    if self.matchers["confirm_top.confirm_top"](_match, _data, _opts):
+                    if self.matchers["confirm_top.confirm_top"](
+                        _match, _data, _opts, self.matchers
+                    ):
                         if saltenv not in matches:
                             matches[saltenv] = []
                         for item in _data:


### PR DESCRIPTION
Avoid recreating it repeatedly for every match. This cuts our pillar top matching time from ~5s down to <0.2s

### What does this PR do?

### What issues does this PR fix or reference?
Fixes: #61950

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
