### PR TITLE
[3006.x] Allow randomizing the GH Actions cache seed value by setting the `test:random-cache-seed` label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,11 @@ jobs:
         run:
           tools ci print-gh-event
 
+      - name: Set Cache Seed Output
+        id: set-cache-seed
+        run: |
+          tools ci define-cache-seed ${{ env.CACHE_SEED }}
+
       - name: Setup Salt Version
         id: setup-salt-version
         uses: ./.github/actions/setup-salt-version
@@ -232,11 +237,6 @@ jobs:
         with:
           name: testrun-changed-files.txt
           path: testrun-changed-files.txt
-
-      - name: Set Cache Seed Output
-        id: set-cache-seed
-        run: |
-          echo "cache-seed=${{ env.CACHE_SEED }}" >> "$GITHUB_OUTPUT"
   pre-commit:
     name: Pre-Commit
     if: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -186,6 +186,11 @@ jobs:
         run:
           tools ci print-gh-event
 
+      - name: Set Cache Seed Output
+        id: set-cache-seed
+        run: |
+          tools ci define-cache-seed ${{ env.CACHE_SEED }}
+
       - name: Setup Salt Version
         id: setup-salt-version
         uses: ./.github/actions/setup-salt-version
@@ -278,11 +283,6 @@ jobs:
         with:
           name: testrun-changed-files.txt
           path: testrun-changed-files.txt
-
-      - name: Set Cache Seed Output
-        id: set-cache-seed
-        run: |
-          echo "cache-seed=${{ env.CACHE_SEED }}" >> "$GITHUB_OUTPUT"
   pre-commit:
     name: Pre-Commit
     if: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -176,6 +176,11 @@ jobs:
         run:
           tools ci print-gh-event
 
+      - name: Set Cache Seed Output
+        id: set-cache-seed
+        run: |
+          tools ci define-cache-seed ${{ env.CACHE_SEED }}
+
       - name: Setup Salt Version
         id: setup-salt-version
         uses: ./.github/actions/setup-salt-version
@@ -268,11 +273,6 @@ jobs:
         with:
           name: testrun-changed-files.txt
           path: testrun-changed-files.txt
-
-      - name: Set Cache Seed Output
-        id: set-cache-seed
-        run: |
-          echo "cache-seed=${{ env.CACHE_SEED }}" >> "$GITHUB_OUTPUT"
   pre-commit:
     name: Pre-Commit
     if: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -166,6 +166,11 @@ jobs:
         run:
           tools ci print-gh-event
 
+      - name: Set Cache Seed Output
+        id: set-cache-seed
+        run: |
+          tools ci define-cache-seed ${{ env.CACHE_SEED }}
+
       - name: Setup Salt Version
         id: setup-salt-version
         uses: ./.github/actions/setup-salt-version
@@ -264,11 +269,6 @@ jobs:
         with:
           name: testrun-changed-files.txt
           path: testrun-changed-files.txt
-
-      - name: Set Cache Seed Output
-        id: set-cache-seed
-        run: |
-          echo "cache-seed=${{ env.CACHE_SEED }}" >> "$GITHUB_OUTPUT"
   pre-commit:
     name: Pre-Commit
     if: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}

--- a/.github/workflows/templates/layout.yml.jinja
+++ b/.github/workflows/templates/layout.yml.jinja
@@ -185,6 +185,11 @@ jobs:
         run:
           tools ci print-gh-event
 
+      - name: Set Cache Seed Output
+        id: set-cache-seed
+        run: |
+          tools ci define-cache-seed ${{ env.CACHE_SEED }}
+
       - name: Setup Salt Version
         id: setup-salt-version
         uses: ./.github/actions/setup-salt-version
@@ -289,11 +294,6 @@ jobs:
         with:
           name: testrun-changed-files.txt
           path: testrun-changed-files.txt
-
-      - name: Set Cache Seed Output
-        id: set-cache-seed
-        run: |
-          echo "cache-seed=${{ env.CACHE_SEED }}" >> "$GITHUB_OUTPUT"
   <%- endblock prepare_workflow_job %>
   <%- endif %>
 

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import pathlib
+import random
 import sys
 import time
 from typing import TYPE_CHECKING, Any
@@ -954,3 +955,71 @@ def get_testing_releases(
             wfh.write(f"testing-releases={json.dumps(str_releases)}\n")
 
         ctx.exit(0)
+
+
+@ci.command(
+    name="define-cache-seed",
+    arguments={
+        "static_cache_seed": {
+            "help": "The static cache seed value",
+        },
+        "randomize": {
+            "help": "Randomize the cache seed value",
+        },
+    },
+)
+def define_cache_seed(ctx: Context, static_cache_seed: str, randomize: bool = False):
+    """
+    Set `cache-seed` in GH Actions outputs.
+    """
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output is None:
+        ctx.warn("The 'GITHUB_OUTPUT' variable is not set.")
+        ctx.exit(1)
+
+    if TYPE_CHECKING:
+        assert github_output is not None
+
+    github_step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if github_step_summary is None:
+        ctx.warn("The 'GITHUB_STEP_SUMMARY' variable is not set.")
+        ctx.exit(1)
+
+    if TYPE_CHECKING:
+        assert github_step_summary is not None
+
+    labels: list[str] = []
+    gh_event_path = os.environ.get("GITHUB_EVENT_PATH") or None
+    if gh_event_path is not None:
+        try:
+            gh_event = json.loads(open(gh_event_path).read())
+        except Exception as exc:
+            ctx.error(
+                f"Could not load the GH Event payload from {gh_event_path!r}:\n", exc
+            )
+            ctx.exit(1)
+
+        labels.extend(
+            label[0] for label in _get_pr_test_labels_from_event_payload(gh_event)
+        )
+
+    if randomize is True:
+        cache_seed = f"SEED-{random.randint(100, 1000)}"
+        with open(github_step_summary, "a", encoding="utf-8") as wfh:
+            wfh.write(
+                f"The cache seed has been randomized to `{cache_seed}` because "
+                "`--randomize` was passed to `tools ci define-cache-seed`."
+            )
+    elif "test:random-cache-seed" in labels:
+        cache_seed = f"SEED-{random.randint(100, 1000)}"
+        with open(github_step_summary, "a", encoding="utf-8") as wfh:
+            wfh.write(
+                f"The cache seed has been randomized to `{cache_seed}` because "
+                "the label `test:random-cache-seed` was set."
+            )
+    else:
+        cache_seed = static_cache_seed
+
+    ctx.info("Writing 'cache-seed' to the github outputs file")
+    with open(github_output, "a", encoding="utf-8") as wfh:
+        wfh.write(f"cache-seed={cache_seed}\n")


### PR DESCRIPTION
### What does this PR do?
Allow randomizing the GH Actions cache seed value by setting the `test:random-cache-seed` label

This allows us to force a PR to not use any caches at all(since they are all getting build from scratch again) to debug potential GH Actions caching issues.
