### PR TITLE
[master] Allow salt-call arguments --file-root, --pillar-root and --states-dir to be specified multiple times

### DIFF
--- a/changelog/64486.added.md
+++ b/changelog/64486.added.md
@@ -1,0 +1,1 @@
+Allow salt-call arguments --file-root, --pillar-root and --states-dir to be specified multiple times

--- a/doc/ref/cli/salt-call.rst
+++ b/doc/ref/cli/salt-call.rst
@@ -77,6 +77,11 @@ Options
     Set this directory as the base pillar root. Can be specified more than
     once to include multiple base pillar roots.
 
+.. option:: --states-dir=STATES_DIR
+
+    Set this directory to search for additional states. Can be specified more
+    than once to include multiple states directories.
+
 .. option:: --retcode-passthrough
 
     Exit with the salt call retcode and not the salt binary retcode

--- a/doc/ref/cli/salt-call.rst
+++ b/doc/ref/cli/salt-call.rst
@@ -69,11 +69,13 @@ Options
 
 .. option:: --file-root=FILE_ROOT
 
-    Set this directory as the base file root.
+    Set this directory as the base file root. Can be specified more than once
+    to include multiple base file roots.
 
 .. option:: --pillar-root=PILLAR_ROOT
 
-    Set this directory as the base pillar root.
+    Set this directory as the base pillar root. Can be specified more than
+    once to include multiple base pillar roots.
 
 .. option:: --retcode-passthrough
 

--- a/salt/cli/call.py
+++ b/salt/cli/call.py
@@ -32,8 +32,8 @@ class SaltCall(salt.utils.parsers.SaltCallOptionParser):
             self.config["pillar_roots"] = {"base": _expand_glob_path(pillar_roots)}
 
         if self.options.states_dir:
-            state_dirs = []
-            for state_dir in self.options.states_dir:
+            states_dirs = []
+            for states_dir in self.options.states_dir:
                 # check if the argument is pointing to a file on disk
                 states_dirs.append(os.path.abspath(states_dir))
             self.config["states_dirs"] = states_dirs

--- a/salt/cli/call.py
+++ b/salt/cli/call.py
@@ -18,19 +18,25 @@ class SaltCall(salt.utils.parsers.SaltCallOptionParser):
         self.parse_args()
 
         if self.options.file_root:
-            # check if the argument is pointing to a file on disk
-            file_root = os.path.abspath(self.options.file_root)
-            self.config["file_roots"] = {"base": _expand_glob_path([file_root])}
+            file_roots = []
+            for file_root in self.options.file_root:
+                # check if the argument is pointing to a file on disk
+                file_roots.append(os.path.abspath(file_root))
+            self.config["file_roots"] = {"base": _expand_glob_path(file_roots)}
 
         if self.options.pillar_root:
-            # check if the argument is pointing to a file on disk
-            pillar_root = os.path.abspath(self.options.pillar_root)
-            self.config["pillar_roots"] = {"base": _expand_glob_path([pillar_root])}
+            pillar_roots = []
+            for pillar_root in self.options.pillar_root:
+                # check if the argument is pointing to a file on disk
+                pillar_roots.append(os.path.abspath(pillar_root))
+            self.config["pillar_roots"] = {"base": _expand_glob_path(pillar_roots)}
 
         if self.options.states_dir:
-            # check if the argument is pointing to a file on disk
-            states_dir = os.path.abspath(self.options.states_dir)
-            self.config["states_dirs"] = [states_dir]
+            state_dirs = []
+            for state_dir in self.options.states_dir:
+                # check if the argument is pointing to a file on disk
+                states_dirs.append(os.path.abspath(states_dir))
+            self.config["states_dirs"] = states_dirs
 
         if self.options.local:
             self.config["file_client"] = "local"

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2867,16 +2867,19 @@ class SaltCallOptionParser(
         self.add_option(
             "--file-root",
             default=None,
+            action="append",
             help="Set this directory as the base file root.",
         )
         self.add_option(
             "--pillar-root",
             default=None,
+            action="append",
             help="Set this directory as the base pillar root.",
         )
         self.add_option(
             "--states-dir",
             default=None,
+            action="append",
             help="Set this directory to search for additional states.",
         )
         self.add_option(

--- a/tests/pytests/integration/cli/test_salt_call.py
+++ b/tests/pytests/integration/cli/test_salt_call.py
@@ -99,9 +99,7 @@ def test_local_sls_call_multiple_file_roots(salt_master, salt_call_cli):
     """
     with salt_master.state_tree.base.temp_file(
         "saltcalllocal1.sls", sls_contents1
-    ), salt_master.state_tree.prod.temp_file(
-        "saltcalllocal2.sls", sls_contents2
-    ):
+    ), salt_master.state_tree.prod.temp_file("saltcalllocal2.sls", sls_contents2):
         ret = salt_call_cli.run(
             "--local",
             "--file-root",
@@ -236,7 +234,7 @@ def configured(name, setting="default2"):
     (states_dir1 / "teststate1.py").write_text(teststate1_content)
     (states_dir2 / "teststate2.py").write_text(teststate2_content)
 
-    sls_contents = '''
+    sls_contents = """
 test_from_states_dir1:
   teststate1.managed:
     - name: /tmp/test1
@@ -246,16 +244,19 @@ test_from_states_dir2:
   teststate2.configured:
     - name: /tmp/test2
     - setting: hello from dir2
-'''
+"""
 
     with salt_master.state_tree.base.temp_file("teststates.sls", sls_contents):
         # First test: verify both state modules are available
         ret = salt_call_cli.run(
             "--local",
-            "--states-dir", str(states_dir1),
-            "--states-dir", str(states_dir2),
-            "--file-root", str(salt_master.state_tree.base.paths[0]),
-            "sys.list_state_modules"
+            "--states-dir",
+            str(states_dir1),
+            "--states-dir",
+            str(states_dir2),
+            "--file-root",
+            str(salt_master.state_tree.base.paths[0]),
+            "sys.list_state_modules",
         )
         assert ret.returncode == 0
         assert "teststate1" in ret.data
@@ -264,11 +265,14 @@ test_from_states_dir2:
         # Second test: run the SLS that uses both custom states
         ret = salt_call_cli.run(
             "--local",
-            "--states-dir", str(states_dir1),
-            "--states-dir", str(states_dir2),
-            "--file-root", str(salt_master.state_tree.base.paths[0]),
+            "--states-dir",
+            str(states_dir1),
+            "--states-dir",
+            str(states_dir2),
+            "--file-root",
+            str(salt_master.state_tree.base.paths[0]),
             "state.sls",
-            "teststates"
+            "teststates",
         )
         assert ret.returncode == 0
 

--- a/tests/pytests/integration/cli/test_salt_call.py
+++ b/tests/pytests/integration/cli/test_salt_call.py
@@ -82,6 +82,9 @@ def test_local_sls_call(salt_master, salt_call_cli):
 
 
 def test_local_sls_call_multiple_file_roots(salt_master, salt_call_cli):
+    """
+    Test that multiple file-root arguments work correctly
+    """
     sls_contents1 = """
     regular-module1:
       module.run:
@@ -131,6 +134,9 @@ def test_local_sls_call_multiple_file_roots(salt_master, salt_call_cli):
 
 
 def test_local_sls_call_multiple_pillar_roots(salt_master, salt_call_cli):
+    """
+    Test that multiple pillar-root arguments work correctly
+    """
     top_file = """
     base:
       '*':
@@ -166,6 +172,123 @@ def test_local_sls_call_multiple_pillar_roots(salt_master, salt_call_cli):
         assert "some_key2" in ret.data
         assert ret.data["some_key1"] is True
         assert ret.data["some_key2"] is False
+
+
+def test_local_sls_call_multiple_states_dirs(salt_master, salt_call_cli, tmp_path):
+    """
+    Test that multiple states-dir arguments work correctly
+    """
+    states_dir1 = tmp_path / "states1"
+    states_dir2 = tmp_path / "states2"
+    states_dir1.mkdir()
+    states_dir2.mkdir()
+
+    teststate1_content = '''
+"""
+Test state module 1
+"""
+
+__virtualname__ = "teststate1"
+
+
+def __virtual__():
+    return __virtualname__
+
+
+def managed(name, content="default1"):
+    """
+    Test state function from states dir 1
+    """
+    ret = {
+        "name": name,
+        "result": True,
+        "comment": f"teststate1.managed: {content}",
+        "changes": {"content": content}
+    }
+    return ret
+'''
+
+    teststate2_content = '''
+"""
+Test state module 2
+"""
+
+__virtualname__ = "teststate2"
+
+
+def __virtual__():
+    return __virtualname__
+
+
+def configured(name, setting="default2"):
+    """
+    Test state function from states dir 2
+    """
+    ret = {
+        "name": name,
+        "result": True,
+        "comment": f"teststate2.configured: {setting}",
+        "changes": {"setting": setting}
+    }
+    return ret
+'''
+
+    (states_dir1 / "teststate1.py").write_text(teststate1_content)
+    (states_dir2 / "teststate2.py").write_text(teststate2_content)
+
+    sls_contents = '''
+test_from_states_dir1:
+  teststate1.managed:
+    - name: /tmp/test1
+    - content: hello from dir1
+
+test_from_states_dir2:
+  teststate2.configured:
+    - name: /tmp/test2
+    - setting: hello from dir2
+'''
+
+    with salt_master.state_tree.base.temp_file("teststates.sls", sls_contents):
+        # First test: verify both state modules are available
+        ret = salt_call_cli.run(
+            "--local",
+            "--states-dir", str(states_dir1),
+            "--states-dir", str(states_dir2),
+            "--file-root", str(salt_master.state_tree.base.paths[0]),
+            "sys.list_state_modules"
+        )
+        assert ret.returncode == 0
+        assert "teststate1" in ret.data
+        assert "teststate2" in ret.data
+
+        # Second test: run the SLS that uses both custom states
+        ret = salt_call_cli.run(
+            "--local",
+            "--states-dir", str(states_dir1),
+            "--states-dir", str(states_dir2),
+            "--file-root", str(salt_master.state_tree.base.paths[0]),
+            "state.sls",
+            "teststates"
+        )
+        assert ret.returncode == 0
+
+        # Verify results from both states
+        states_results = list(ret.data.values())
+        assert len(states_results) == 2
+
+        # Find the results by name
+        state1_result = next(s for s in states_results if s["name"] == "/tmp/test1")
+        state2_result = next(s for s in states_results if s["name"] == "/tmp/test2")
+
+        # Verify teststate1 result
+        assert state1_result["result"] is True
+        assert "teststate1.managed: hello from dir1" in state1_result["comment"]
+        assert state1_result["changes"]["content"] == "hello from dir1"
+
+        # Verify teststate2 result
+        assert state2_result["result"] is True
+        assert "teststate2.configured: hello from dir2" in state2_result["comment"]
+        assert state2_result["changes"]["setting"] == "hello from dir2"
 
 
 def test_local_salt_call(salt_call_cli):


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes: #64486

### Previous Behavior
The `salt-call` arguments `--file-root`, `--pillar-root` and `--states-dir` can each be specified only once.

### New Behavior
The `salt-call` arguments `--file-root`, `--pillar-root` and `--states-dir` can each be specified multiple times.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
