### PR TITLE
[master] fix #64637 site not building - add 3007 release notes

### DIFF
--- a/doc/topics/releases/3007.0.md
+++ b/doc/topics/releases/3007.0.md
@@ -1,0 +1,4 @@
+(release-3007.0)=
+# Salt 3007.0 Release Notes - Codename Chlorine
+
+Salt 3007 is currently under development


### PR DESCRIPTION
### What does this PR do?
This fixes the docs site not building and releasing the docs. with the 3007 release notes file missing nox failes to properly build the docs. This leads to the live site not being updated with new content. 

### What issues does this PR fix or reference?
#64637 

### Previous Behavior
The docs site was not updating and still shows 3006 and 3006.1 as upcoming releases

### New Behavior
once this is merged the docs site should start updating again as PRs are merged.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html - N/A
- [ ] Tests written/updated - N/A

### Commits signed with GPG?
No

