### PR TITLE
[3006.x] Bump to `cryptography==41.0.2`  to address GHSA-cf7p-gm2m-833m

### DIFF
--- a/requirements/darwin.txt
+++ b/requirements/darwin.txt
@@ -5,7 +5,7 @@
 apache-libcloud>=2.4.0
 backports.ssl_match_hostname>=3.7.0.1; python_version < '3.7'
 cherrypy>=17.4.1
-cryptography>=41.0.1
+cryptography>=41.0.2
 gitpython>=3.1.30; python_version >= '3.7'
 idna>=2.8
 linode-python>=1.1.1

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -385,7 +385,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -386,7 +386,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/darwin.txt
     #   adal

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -384,7 +384,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.0
+cryptography==41.0.2
     # via
     #   adal
     #   azure-cosmosdb-table

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -390,7 +390,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -398,7 +398,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -71,7 +71,7 @@ colorama==0.4.1
     # via pytest
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/windows.txt
     #   etcd3-py

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -392,7 +392,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -391,7 +391,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.0
+cryptography==41.0.2
     # via
     #   adal
     #   azure-cosmosdb-table

--- a/requirements/static/ci/py3.7/lint.txt
+++ b/requirements/static/ci/py3.7/lint.txt
@@ -399,7 +399,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -405,7 +405,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -77,7 +77,7 @@ colorama==0.4.1
     # via pytest
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/windows.txt
     #   etcd3-py

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -390,7 +390,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -389,7 +389,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.0
+cryptography==41.0.2
     # via
     #   adal
     #   azure-cosmosdb-table

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -397,7 +397,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -403,7 +403,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -73,7 +73,7 @@ colorama==0.4.1
     # via pytest
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/windows.txt
     #   etcd3-py

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -390,7 +390,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -391,7 +391,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/darwin.txt
     #   adal

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -389,7 +389,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.0
+cryptography==41.0.2
     # via
     #   adal
     #   azure-cosmosdb-table

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -395,7 +395,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -405,7 +405,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -73,7 +73,7 @@ colorama==0.4.1
     # via pytest
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/windows.txt
     #   etcd3-py

--- a/requirements/static/pkg/linux.in
+++ b/requirements/static/pkg/linux.in
@@ -10,4 +10,4 @@ rpm-vercmp
 setproctitle>=1.2.3
 timelib>=0.2.5
 importlib-metadata>=3.3.0
-cryptography>=41.0.1
+cryptography>=41.0.2

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -18,7 +18,7 @@ cherrypy==18.6.1
     # via -r requirements/darwin.txt
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/darwin.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==39.0.2
+cryptography==41.0.2
     # via pyopenssl
 distro==1.5.0
     # via

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -23,7 +23,7 @@ clr-loader==0.2.4
     # via pythonnet
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/windows.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.7/freebsd.txt
+++ b/requirements/static/pkg/py3.7/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==39.0.2
+cryptography==41.0.2
     # via pyopenssl
 distro==1.5.0
     # via

--- a/requirements/static/pkg/py3.7/linux.txt
+++ b/requirements/static/pkg/py3.7/linux.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -23,7 +23,7 @@ clr-loader==0.2.4
     # via pythonnet
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/windows.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==39.0.2
+cryptography==41.0.2
     # via pyopenssl
 distro==1.5.0
     # via

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -23,7 +23,7 @@ clr-loader==0.2.4
     # via pythonnet
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/windows.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -18,7 +18,7 @@ cherrypy==18.6.1
     # via -r requirements/darwin.txt
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/darwin.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==39.0.2
+cryptography==41.0.2
     # via pyopenssl
 distro==1.5.0
     # via

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -23,7 +23,7 @@ clr-loader==0.2.4
     # via pythonnet
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.1
+cryptography==41.0.2
     # via
     #   -r requirements/windows.txt
     #   pyopenssl

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -10,7 +10,7 @@ backports.ssl-match-hostname>=3.7.0.1; python_version < '3.7'
 certifi>=2022.12.07
 cffi>=1.14.5
 cherrypy>=18.6.1
-cryptography>=41.0.1
+cryptography>=41.0.2
 gitpython>=3.1.30; python_version >= '3.7'
 ioloop>=0.1a0
 lxml>=4.6.3


### PR DESCRIPTION
### What does this PR do?
See title (GHSA-cf7p-gm2m-833m)

The cryptography package before 41.0.2 for Python mishandles SSH certificates that have critical options.
References:

https://nvd.nist.gov/vuln/detail/CVE-2023-38325
[https://github.com/pyca/cryptography/issues/9207](pyca/cryptography#9207)
[https://github.com/pyca/cryptography/issues/9208](pyca/cryptography#9208)
[https://github.com/pyca/cryptography/compare/41.0.1...41.0.2](pyca/cryptography@41.0.1...41.0.2)
https://pypi.org/project/cryptography/#history
[https://github.com/pyca/cryptography/commit/1ca7adc97b76a9dfbd3d850628b613eb93b78fc3](pyca/cryptography@1ca7adc)