### PR TITLE
[3006.x] Clarify rejected_retry option docs

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -1197,8 +1197,8 @@ seconds each iteration.
 
 Default: ``False``
 
-If the master rejects the minion's public key, retry instead of exiting.
-Rejected keys will be handled the same as waiting on acceptance.
+If the master denies or rejects the minion's public key, retry instead of
+exiting.  These keys will be handled the same as waiting on acceptance.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
### What does this PR do?

Add clarification about denied keys to rejected_retry option documentation.

Fixes: #64649 