### PR TITLE
[3006.x] Docs: Update Slack invite link and VMware Aria Automation Config ref

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -13,7 +13,7 @@ newIssueWelcomeComment: >
 
     - [Community Wiki](https://github.com/saltstack/community/wiki)
     - [Salt’s Contributor Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html)
-    - [Join our Community Slack](https://join.slack.com/t/saltstackcommunity/shared_invite/zt-3av8jjyf-oBQ2M0vhXOhJpNpRkPWBvg)
+    - [Join our Community Slack](https://join.slack.com/t/saltstackcommunity/shared_invite/zt-1zlfxffs1-NuEH~G9TzOeuNGdsfZIl3w)
     - [IRC on LiberaChat](https://web.libera.chat/#salt)
     - [Salt Project YouTube channel](https://www.youtube.com/channel/UCpveTIucFx9ljGelW63-BWg)
     - [Salt Project Twitch channel](https://www.twitch.tv/saltprojectoss)
@@ -39,7 +39,7 @@ newPRWelcomeComment: >
 
     - [Community Wiki](https://github.com/saltstack/community/wiki)
     - [Salt’s Contributor Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html)
-    - [Join our Community Slack](https://join.slack.com/t/saltstackcommunity/shared_invite/zt-3av8jjyf-oBQ2M0vhXOhJpNpRkPWBvg)
+    - [Join our Community Slack](https://join.slack.com/t/saltstackcommunity/shared_invite/zt-1zlfxffs1-NuEH~G9TzOeuNGdsfZIl3w)
     - [IRC on LiberaChat](https://web.libera.chat/#salt)
     - [Salt Project YouTube channel](https://www.youtube.com/channel/UCpveTIucFx9ljGelW63-BWg)
     - [Salt Project Twitch channel](https://www.twitch.tv/saltprojectoss)

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -8,7 +8,7 @@ in a number of ways:
 -  Use Salt and open well-written bug reports.
 -  Join a `working group <https://github.com/saltstack/community>`__.
 -  Answer questions on `irc <https://web.libera.chat/#salt>`__,
-   the `community Slack <https://join.slack.com/t/saltstackcommunity/shared_invite/zt-3av8jjyf-oBQ2M0vhXOhJpNpRkPWBvg>`__,
+   the `community Slack <https://join.slack.com/t/saltstackcommunity/shared_invite/zt-1zlfxffs1-NuEH~G9TzOeuNGdsfZIl3w>`__,
    the `salt-users mailing
    list <https://groups.google.com/forum/#!forum/salt-users>`__,
    `Server Fault <https://serverfault.com/questions/tagged/saltstack>`__,

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@
 
 .. image:: https://img.shields.io/badge/slack-@saltstackcommunity-blue.svg?logo=slack
    :alt: Salt Project Slack Community
-   :target: https://join.slack.com/t/saltstackcommunity/shared_invite/zt-3av8jjyf-oBQ2M0vhXOhJpNpRkPWBvg
+   :target: https://join.slack.com/t/saltstackcommunity/shared_invite/zt-1zlfxffs1-NuEH~G9TzOeuNGdsfZIl3w
 
 .. image:: https://img.shields.io/twitch/status/saltprojectoss
    :alt: Salt Project Twitch Channel
@@ -71,7 +71,8 @@ In addition to configuration management Salt can also:
 
 About our sponsors
 ==================
-Salt powers VMware's `vRealize Automation SaltStack Config`_, and can be found
+Salt powers VMware's `VMware Aria Automation Config`_
+(previously vRealize Automation SaltStack Config / SaltStack Enterprise), and can be found
 under the hood of products from Juniper, Cisco, Cloudflare, Nutanix, SUSE, and
 Tieto, to name a few.
 
@@ -179,8 +180,8 @@ used by external modules.
 A complete list of attributions and dependencies can be found here:
 `salt/DEPENDENCIES.md <https://github.com/saltstack/salt/blob/master/DEPENDENCIES.md>`_
 
-.. _Salt Project Community Slack: https://join.slack.com/t/saltstackcommunity/shared_invite/zt-3av8jjyf-oBQ2M0vhXOhJpNpRkPWBvg
-.. _vRealize Automation SaltStack Config: https://www.vmware.com/products/vrealize-automation/saltstack-config.html
+.. _Salt Project Community Slack: https://join.slack.com/t/saltstackcommunity/shared_invite/zt-1zlfxffs1-NuEH~G9TzOeuNGdsfZIl3w
+.. _VMware Aria Automation Config: https://www.vmware.com/products/vrealize-automation/saltstack-config.html
 .. _Latest Salt Documentation: https://docs.saltproject.io/en/latest/
 .. _Open an issue: https://github.com/saltstack/salt/issues/new/choose
 .. _SECURITY.md: https://github.com/saltstack/salt/blob/master/SECURITY.md

--- a/SUPPORT.rst
+++ b/SUPPORT.rst
@@ -11,7 +11,7 @@ it may take a few moments for someone to reply.
 **SaltStack Slack** - Alongside IRC is our SaltStack Community Slack for the
 SaltStack Working groups. Use the following link to request an invitation.
 
-`<https://join.slack.com/t/saltstackcommunity/shared_invite/zt-3av8jjyf-oBQ2M0vhXOhJpNpRkPWBvg>`_
+`<https://join.slack.com/t/saltstackcommunity/shared_invite/zt-1zlfxffs1-NuEH~G9TzOeuNGdsfZIl3w>`_
 
 **Mailing List** - The SaltStack community users mailing list is hosted by
 Google groups. Anyone can post to ask questions about SaltStack products and

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -174,7 +174,7 @@ rst_prolog = """\
 .. _`salt-users`: https://groups.google.com/forum/#!forum/salt-users
 .. _`salt-announce`: https://groups.google.com/forum/#!forum/salt-announce
 .. _`salt-packagers`: https://groups.google.com/forum/#!forum/salt-packagers
-.. _`salt-slack`: https://join.slack.com/t/saltstackcommunity/shared_invite/zt-3av8jjyf-oBQ2M0vhXOhJpNpRkPWBvg
+.. _`salt-slack`: https://join.slack.com/t/saltstackcommunity/shared_invite/zt-1zlfxffs1-NuEH~G9TzOeuNGdsfZIl3w
 .. |windownload| raw:: html
 
      <p>Python3 x86: <a


### PR DESCRIPTION
### What does this PR do?

#### Fix Slack Invite

This is a follow-up fix to a previous fix:

- https://github.com/saltstack/salt/pull/60096

Old invite URL is broken because it maxes out at 400 invites, so we have to regen it.

- 400 invite cap listed here: https://slack.com/help/articles/201330256-Invite-new-members-to-your-workspace#share-an-invitation-link
  - Old (current) invite URL: https://join.slack.com/t/saltstackcommunity/shared_invite/zt-3av8jjyf-oBQ2M0vhXOhJpNpRkPWBvg
  - New invite URL: https://join.slack.com/t/saltstackcommunity/shared_invite/zt-1zlfxffs1-NuEH~G9TzOeuNGdsfZIl3w

You can see that the experience differs for both. Can open them both up in private windows, and you'll see the difference. The current path requires a saltstack email unless it is a gmail or apple account. That, or a user is stuck needing to reach out to a workspace member.

This sounds like this has been one of the community pain points, and can be something we can just fix on the website and in our docs.

#### VMware Aria Automation Config

I noticed in the README a reference to vRealize Automation SaltStack Config, which has since been renamed to VMware Aria Automation Config. I have made a small update to reflect this.