### PR TITLE
[3006.x][BACKPORT] fixes saltstack/salt#64122 state_queue type checking does not allow int values | Write some tests | Fix test description

### DIFF
--- a/changelog/64122.fixed.md
+++ b/changelog/64122.fixed.md
@@ -1,0 +1,1 @@
+Fix state_queue type checking to allow int values

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -373,7 +373,7 @@ VALID_OPTS = immutabletypes.freeze(
         # applications that depend on the original format.
         "unique_jid": bool,
         # Governs whether state runs will queue or fail to run when a state is already running
-        "state_queue": bool,
+        "state_queue": (bool, int),
         # Tells the highstate outputter to show successful states. False will omit successes.
         "state_verbose": bool,
         # Specify the format for state outputs. See highstate outputter for additional details.

--- a/tests/pytests/unit/config/test__validate_opts.py
+++ b/tests/pytests/unit/config/test__validate_opts.py
@@ -418,9 +418,9 @@ def test_dict_bool_none_types(option_value, expected):
 )
 def test_bool_int_types(option_value, expected):
     """
-    Some config settings have three types, dict, bool, and None which should
-    evaluate as True. All others should return False.
-    ssl is a dict, bool type config option
+    Some config settings have two types, bool and int. In that case, bool and
+    int should evaluate as True. All others should return False.
+    state_queue is a bool/int config option
     """
     result = salt.config._validate_opts({"state_queue": option_value})
     assert result is expected

--- a/tests/pytests/unit/config/test__validate_opts.py
+++ b/tests/pytests/unit/config/test__validate_opts.py
@@ -401,3 +401,26 @@ def test_dict_bool_none_types(option_value, expected):
     """
     result = salt.config._validate_opts({"ssl": option_value})
     assert result is expected
+
+
+@pytest.mark.parametrize(
+    "option_value,expected",
+    [
+        ([1, 2, 3], False),  # list
+        ((1, 2, 3), False),  # tuple
+        ({"key": "value"}, False),  # dict
+        ("str", False),  # str
+        (True, True),  # bool
+        (1, True),  # int
+        (0.123, False),  # float
+        (None, False),  # None
+    ],
+)
+def test_bool_int_types(option_value, expected):
+    """
+    Some config settings have three types, dict, bool, and None which should
+    evaluate as True. All others should return False.
+    ssl is a dict, bool type config option
+    """
+    result = salt.config._validate_opts({"state_queue": option_value})
+    assert result is expected


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `3006.x`:
 - [fixes saltstack/salt#64122 state_queue type checking does not allow int values](https://github.com/saltstack/salt/pull/64123)
 - [Write some tests](https://github.com/saltstack/salt/pull/64123)
 - [Fix test description](https://github.com/saltstack/salt/pull/64123)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)