### PR TITLE
[3006.x][BACKPORT] Update `py` renderer documentation with information on user-provided context | Formatting fix

### DIFF
--- a/salt/renderers/py.py
+++ b/salt/renderers/py.py
@@ -46,8 +46,23 @@ execution functions, grains, pillar, etc. They are:
   ``/srv/salt/foo/bar/baz.sls``, then ``__sls__`` in that file will be
   ``foo.bar.baz``.
 
-When writing a reactor SLS file the global context ``data`` (same as context ``{{ data }}``
-for states written with Jinja + YAML) is available. The following YAML + Jinja state declaration:
+When used in a scenario where additional user-provided context data is supplied
+(such as with :mod:`file.managed <salt.states.file.managed>`), the additional
+data will typically be injected into the script as one or more global
+variables:
+
+.. code-block:: jinja
+    /etc/http/conf/http.conf:
+      file.managed:
+        - source: salt://apache/generate_http_conf.py
+        - template: py
+        - context:
+            # Will be injected as the global variable "site_name".
+            site_name: {{ site_name }}
+
+When writing a reactor SLS file the global context ``data`` (same as context
+``{{ data }}`` for states written with Jinja + YAML) is available. The
+following YAML + Jinja state declaration:
 
 .. code-block:: jinja
 

--- a/salt/renderers/py.py
+++ b/salt/renderers/py.py
@@ -52,6 +52,7 @@ data will typically be injected into the script as one or more global
 variables:
 
 .. code-block:: jinja
+
     /etc/http/conf/http.conf:
       file.managed:
         - source: salt://apache/generate_http_conf.py


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `3006.x`:
 - [Update `py` renderer documentation with information on user-provided context](https://github.com/saltstack/salt/pull/63876)
 - [Formatting fix](https://github.com/saltstack/salt/pull/63876)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)