### PR TITLE
[3006.x][BACKPORT] Update chocolatey.py / Search for choco.exe | Update chocolatey.py | Update test_chocolatey.py | Update chocolatey.py | Add changelog | Fix pre-commit | Fix failing tests

### DIFF
--- a/changelog/64427.fixed.md
+++ b/changelog/64427.fixed.md
@@ -1,0 +1,1 @@
+Add search for %ProgramData%\Chocolatey\choco.exe to determine if Chocolatey is installed or not

--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -112,7 +112,7 @@ def _find_chocolatey():
             os.environ.get("ProgramData"), "Chocolatey", "bin", "chocolatey.exe"
         ),
         os.path.join(
-            os.environ.get("ProgramData"), "Chocolatey", "bin", "choco.exe"
+            os.environ.get("ProgramDataChoco"), "Chocolatey", "bin", "choco.exe"
         ),
         os.path.join(
             os.environ.get("SystemDrive"), "Chocolatey", "bin", "chocolatey.bat"

--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -111,9 +111,7 @@ def _find_chocolatey():
         os.path.join(
             os.environ.get("ProgramData"), "Chocolatey", "bin", "chocolatey.exe"
         ),
-        os.path.join(
-            os.environ.get("ProgramData"), "Chocolatey", "bin", "choco.exe"
-        ),
+        os.path.join(os.environ.get("ProgramData"), "Chocolatey", "bin", "choco.exe"),
         os.path.join(
             os.environ.get("SystemDrive"), "Chocolatey", "bin", "chocolatey.bat"
         ),
@@ -210,7 +208,7 @@ def bootstrap(force=False, source=None):
     except CommandExecutionError:
         choc_path = None
     if choc_path and not force:
-        return "Chocolatey found at {}".format(choc_path)
+        return f"Chocolatey found at {choc_path}"
 
     temp_dir = tempfile.gettempdir()
 
@@ -338,7 +336,7 @@ def bootstrap(force=False, source=None):
 
     if not os.path.exists(script):
         raise CommandExecutionError(
-            "Failed to find Chocolatey installation script: {}".format(script)
+            f"Failed to find Chocolatey installation script: {script}"
         )
 
     # Run the Chocolatey bootstrap
@@ -380,7 +378,7 @@ def unbootstrap():
         if os.path.exists(choco_dir):
             log.debug("Removing Chocolatey directory: %s", choco_dir)
             __salt__["file.remove"](path=choco_dir, force=True)
-            removed.append("Removed Directory: {}".format(choco_dir))
+            removed.append(f"Removed Directory: {choco_dir}")
     else:
         known_paths = [
             os.path.join(os.environ.get("ProgramData"), "Chocolatey"),
@@ -390,7 +388,7 @@ def unbootstrap():
             if os.path.exists(path):
                 log.debug("Removing Chocolatey directory: %s", path)
                 __salt__["file.remove"](path=path, force=True)
-                removed.append("Removed Directory: {}".format(path))
+                removed.append(f"Removed Directory: {path}")
 
     # Delete all Chocolatey environment variables
     for env_var in __salt__["environ.items"]():
@@ -402,14 +400,14 @@ def unbootstrap():
             __salt__["environ.setval"](
                 key=env_var, val=False, false_unsets=True, permanent="HKCU"
             )
-            removed.append("Removed Environment Var: {}".format(env_var))
+            removed.append(f"Removed Environment Var: {env_var}")
 
     # Remove Chocolatey from the path:
     for path in __salt__["win_path.get_path"]():
         if "chocolatey" in path.lower():
             log.debug("Removing Chocolatey path item: %s", path)
             __salt__["win_path.remove"](path=path, rehash=True)
-            removed.append("Removed Path Item: {}".format(path))
+            removed.append(f"Removed Path Item: {path}")
 
     return removed
 

--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -112,7 +112,7 @@ def _find_chocolatey():
             os.environ.get("ProgramData"), "Chocolatey", "bin", "chocolatey.exe"
         ),
         os.path.join(
-            os.environ.get("ProgramDataChoco"), "Chocolatey", "bin", "choco.exe"
+            os.environ.get("ProgramData"), "Chocolatey", "bin", "choco.exe"
         ),
         os.path.join(
             os.environ.get("SystemDrive"), "Chocolatey", "bin", "chocolatey.bat"

--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -112,6 +112,9 @@ def _find_chocolatey():
             os.environ.get("ProgramData"), "Chocolatey", "bin", "chocolatey.exe"
         ),
         os.path.join(
+            os.environ.get("ProgramData"), "Chocolatey", "bin", "choco.exe"
+        ),
+        os.path.join(
             os.environ.get("SystemDrive"), "Chocolatey", "bin", "chocolatey.bat"
         ),
     ]

--- a/tests/pytests/unit/modules/test_chocolatey.py
+++ b/tests/pytests/unit/modules/test_chocolatey.py
@@ -33,9 +33,7 @@ def chocolatey_path_pd():
 
 @pytest.fixture(scope="module")
 def choco_path_pd():
-    return os.path.join(
-        os.environ.get("ProgramData"), "Chocolatey", "bin", "choco.exe"
-    )
+    return os.path.join(os.environ.get("ProgramData"), "Chocolatey", "bin", "choco.exe")
 
 
 @pytest.fixture(scope="module")

--- a/tests/pytests/unit/modules/test_chocolatey.py
+++ b/tests/pytests/unit/modules/test_chocolatey.py
@@ -146,19 +146,20 @@ def test__find_chocolatey_programdata(mock_false, mock_true, chocolatey_path_pd)
         "os.path.isfile", mock_true
     ):
         result = chocolatey._find_chocolatey()
-        expected = choco_path_pd
+        expected = chocolatey_path_pd
         # Does it return the correct path
         assert result == expected
         # Does it populate __context__
         assert chocolatey.__context__["chocolatey._path"] == expected
 
 
-def test__find_choco_programdata(mock_false, mock_true, choco_path_pd):
+def test__find_choco_programdata(mock_false, choco_path_pd):
     """
     Test _find_chocolatey when found in ProgramData and named choco.exe
     """
+    mock_is_file = MagicMock(side_effect=[False, True])
     with patch.dict(chocolatey.__salt__, {"cmd.which": mock_false}), patch(
-        "os.path.isfile", mock_true
+        "os.path.isfile", mock_is_file
     ):
         result = chocolatey._find_chocolatey()
         expected = choco_path_pd
@@ -173,7 +174,7 @@ def test__find_chocolatey_systemdrive(mock_false, choco_path_sd):
     Test _find_chocolatey when found on SystemDrive (older versions)
     """
     with patch.dict(chocolatey.__salt__, {"cmd.which": mock_false}), patch(
-        "os.path.isfile", MagicMock(side_effect=[False, True])
+        "os.path.isfile", MagicMock(side_effect=[False, False, True])
     ):
         result = chocolatey._find_chocolatey()
         expected = choco_path_sd

--- a/tests/pytests/unit/modules/test_chocolatey.py
+++ b/tests/pytests/unit/modules/test_chocolatey.py
@@ -25,9 +25,16 @@ def choco_path():
 
 
 @pytest.fixture(scope="module")
-def choco_path_pd():
+def chocolatey_path_pd():
     return os.path.join(
         os.environ.get("ProgramData"), "Chocolatey", "bin", "chocolatey.exe"
+    )
+
+
+@pytest.fixture(scope="module")
+def choco_path_pd():
+    return os.path.join(
+        os.environ.get("ProgramData"), "Chocolatey", "bin", "choco.exe"
     )
 
 
@@ -133,9 +140,24 @@ def test__find_chocolatey_which(choco_path):
         assert chocolatey.__context__["chocolatey._path"] == expected
 
 
-def test__find_chocolatey_programdata(mock_false, mock_true, choco_path_pd):
+def test__find_chocolatey_programdata(mock_false, mock_true, chocolatey_path_pd):
     """
-    Test _find_chocolatey when found in ProgramData
+    Test _find_chocolatey when found in ProgramData and named chocolatey.exe
+    """
+    with patch.dict(chocolatey.__salt__, {"cmd.which": mock_false}), patch(
+        "os.path.isfile", mock_true
+    ):
+        result = chocolatey._find_chocolatey()
+        expected = choco_path_pd
+        # Does it return the correct path
+        assert result == expected
+        # Does it populate __context__
+        assert chocolatey.__context__["chocolatey._path"] == expected
+
+
+def test__find_choco_programdata(mock_false, mock_true, choco_path_pd):
+    """
+    Test _find_chocolatey when found in ProgramData and named choco.exe
     """
     with patch.dict(chocolatey.__salt__, {"cmd.which": mock_false}), patch(
         "os.path.isfile", mock_true


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `3006.x`:
 - [Update chocolatey.py / Search for choco.exe](https://github.com/saltstack/salt/pull/64428)
 - [Update chocolatey.py](https://github.com/saltstack/salt/pull/64428)
 - [Update test_chocolatey.py](https://github.com/saltstack/salt/pull/64428)
 - [Update chocolatey.py](https://github.com/saltstack/salt/pull/64428)
 - [Add changelog](https://github.com/saltstack/salt/pull/64428)
 - [Fix pre-commit](https://github.com/saltstack/salt/pull/64428)
 - [Fix failing tests](https://github.com/saltstack/salt/pull/64428)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)