### PR TITLE
[3006.x] Add support for Chocolatey v2.0.0

### DIFF
--- a/changelog/64622.fixed.md
+++ b/changelog/64622.fixed.md
@@ -1,0 +1,1 @@
+Added support for Chocolatey 2.0.0+

--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -460,7 +460,11 @@ def list_(
         salt '*' chocolatey.list <narrow> all_versions=True
     """
     choc_path = _find_chocolatey()
-    cmd = [choc_path, "list"]
+    # https://docs.chocolatey.org/en-us/guides/upgrading-to-chocolatey-v2-v6
+    if Version(chocolatey_version()) <= Version("2.0.0"):
+        cmd = [choc_path, "list"]
+    else:
+        cmd = [choc_path, "search"]
     if narrow:
         cmd.append(narrow)
     if salt.utils.data.is_true(all_versions):
@@ -518,7 +522,11 @@ def list_webpi():
         salt '*' chocolatey.list_webpi
     """
     choc_path = _find_chocolatey()
-    cmd = [choc_path, "list", "--source", "webpi"]
+    # https://docs.chocolatey.org/en-us/guides/upgrading-to-chocolatey-v2-v6
+    if Version(chocolatey_version()) <= Version("2.0.0"):
+        cmd = [choc_path, "list", "--source", "webpi"]
+    else:
+        cmd = [choc_path, "search", "--source", "webpi"]
     result = __salt__["cmd.run_all"](cmd, python_shell=False)
 
     if result["retcode"] != 0:
@@ -543,7 +551,11 @@ def list_windowsfeatures():
         salt '*' chocolatey.list_windowsfeatures
     """
     choc_path = _find_chocolatey()
-    cmd = [choc_path, "list", "--source", "windowsfeatures"]
+    # https://docs.chocolatey.org/en-us/guides/upgrading-to-chocolatey-v2-v6
+    if Version(chocolatey_version()) <= Version("2.0.0"):
+        cmd = [choc_path, "list", "--source", "windowsfeatures"]
+    else:
+        cmd = [choc_path, "search", "--source", "windowsfeatures"]
     result = __salt__["cmd.run_all"](cmd, python_shell=False)
 
     if result["retcode"] != 0:

--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -461,7 +461,7 @@ def list_(
     """
     choc_path = _find_chocolatey()
     # https://docs.chocolatey.org/en-us/guides/upgrading-to-chocolatey-v2-v6
-    if Version(chocolatey_version()) <= Version("2.0.0"):
+    if Version(chocolatey_version()) < Version("2.0.0"):
         cmd = [choc_path, "list"]
     else:
         cmd = [choc_path, "search"]
@@ -523,7 +523,7 @@ def list_webpi():
     """
     choc_path = _find_chocolatey()
     # https://docs.chocolatey.org/en-us/guides/upgrading-to-chocolatey-v2-v6
-    if Version(chocolatey_version()) <= Version("2.0.0"):
+    if Version(chocolatey_version()) < Version("2.0.0"):
         cmd = [choc_path, "list", "--source", "webpi"]
     else:
         cmd = [choc_path, "search", "--source", "webpi"]
@@ -552,7 +552,7 @@ def list_windowsfeatures():
     """
     choc_path = _find_chocolatey()
     # https://docs.chocolatey.org/en-us/guides/upgrading-to-chocolatey-v2-v6
-    if Version(chocolatey_version()) <= Version("2.0.0"):
+    if Version(chocolatey_version()) < Version("2.0.0"):
         cmd = [choc_path, "list", "--source", "windowsfeatures"]
     else:
         cmd = [choc_path, "search", "--source", "windowsfeatures"]

--- a/tests/pytests/unit/modules/test_chocolatey.py
+++ b/tests/pytests/unit/modules/test_chocolatey.py
@@ -262,3 +262,75 @@ def test_add_source(choco_path):
             "source_name", "source_location", priority="priority"
         )
         cmd_run_all_mock.assert_called_with(expected_call, python_shell=False)
+
+
+def test_list_pre_2_0_0():
+    mock_version = MagicMock(return_value="1.2.1")
+    mock_find = MagicMock(return_value=choco_path)
+    mock_run = MagicMock(return_value={"stdout": "No packages", "retcode": 0})
+    with patch.object(chocolatey, "chocolatey_version", mock_version), patch.object(
+        chocolatey, "_find_chocolatey", mock_find
+    ), patch.dict(chocolatey.__salt__, {"cmd.run_all": mock_run}):
+        chocolatey.list_()
+        expected_call = [choco_path, "list", "--limit-output"]
+        mock_run.assert_called_with(expected_call, python_shell=False)
+
+
+def test_list_post_2_0_0():
+    mock_version = MagicMock(return_value="2.0.1")
+    mock_find = MagicMock(return_value=choco_path)
+    mock_run = MagicMock(return_value={"stdout": "No packages", "retcode": 0})
+    with patch.object(chocolatey, "chocolatey_version", mock_version), patch.object(
+        chocolatey, "_find_chocolatey", mock_find
+    ), patch.dict(chocolatey.__salt__, {"cmd.run_all": mock_run}):
+        chocolatey.list_()
+        expected_call = [choco_path, "search", "--limit-output"]
+        mock_run.assert_called_with(expected_call, python_shell=False)
+
+
+def test_list_webpi_pre_2_0_0():
+    mock_version = MagicMock(return_value="1.2.1")
+    mock_find = MagicMock(return_value=choco_path)
+    mock_run = MagicMock(return_value={"stdout": "No packages", "retcode": 0})
+    with patch.object(chocolatey, "chocolatey_version", mock_version), patch.object(
+        chocolatey, "_find_chocolatey", mock_find
+    ), patch.dict(chocolatey.__salt__, {"cmd.run_all": mock_run}):
+        chocolatey.list_webpi()
+        expected_call = [choco_path, "list", "--source", "webpi"]
+        mock_run.assert_called_with(expected_call, python_shell=False)
+
+
+def test_list_webpi_post_2_0_0():
+    mock_version = MagicMock(return_value="2.0.1")
+    mock_find = MagicMock(return_value=choco_path)
+    mock_run = MagicMock(return_value={"stdout": "No packages", "retcode": 0})
+    with patch.object(chocolatey, "chocolatey_version", mock_version), patch.object(
+        chocolatey, "_find_chocolatey", mock_find
+    ), patch.dict(chocolatey.__salt__, {"cmd.run_all": mock_run}):
+        chocolatey.list_webpi()
+        expected_call = [choco_path, "search", "--source", "webpi"]
+        mock_run.assert_called_with(expected_call, python_shell=False)
+
+
+def test_list_windowsfeatures_pre_2_0_0():
+    mock_version = MagicMock(return_value="1.2.1")
+    mock_find = MagicMock(return_value=choco_path)
+    mock_run = MagicMock(return_value={"stdout": "No packages", "retcode": 0})
+    with patch.object(chocolatey, "chocolatey_version", mock_version), patch.object(
+        chocolatey, "_find_chocolatey", mock_find
+    ), patch.dict(chocolatey.__salt__, {"cmd.run_all": mock_run}):
+        chocolatey.list_windowsfeatures()
+        expected_call = [choco_path, "list", "--source", "windowsfeatures"]
+        mock_run.assert_called_with(expected_call, python_shell=False)
+
+
+def test_list_windowsfeatures_post_2_0_0():
+    mock_version = MagicMock(return_value="2.0.1")
+    mock_find = MagicMock(return_value=choco_path)
+    mock_run = MagicMock(return_value={"stdout": "No packages", "retcode": 0})
+    with patch.object(chocolatey, "chocolatey_version", mock_version), patch.object(
+        chocolatey, "_find_chocolatey", mock_find
+    ), patch.dict(chocolatey.__salt__, {"cmd.run_all": mock_run}):
+        chocolatey.list_windowsfeatures()
+        expected_call = [choco_path, "search", "--source", "windowsfeatures"]
+        mock_run.assert_called_with(expected_call, python_shell=False)


### PR DESCRIPTION
### What does this PR do?
Chocolatey introduced breaking changes with version 2.0.0. There are 2 changes that affect us.

The 1st is renaming the `chocolatey.exe` binary to `choco.exe`. That one has been fixed here: https://github.com/saltstack/salt/pull/64672

The 2nd is deprecating `--source`, `--local-only`, and `--allversions` from the `list` command. This PR addresses the 2nd issue by using `choco search` instead of `choco list` for version 2.0.0. Older versions will continue to use `choco list`.

### What issues does this PR fix or reference?
Fixes: #64622 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes