### PR TITLE
[master][FEATURE REQUEST] Added support for dnf5 for Fedora

### DIFF
--- a/changelog/64532.added.md
+++ b/changelog/64532.added.md
@@ -1,0 +1,1 @@
+Added support for dnf5 and its new command syntax

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -3044,7 +3044,7 @@ def mod_repo(repo, basedir=None, **kwargs):
         if use_copr:
             # Is copr plugin installed?
             copr_plugin_name = ""
-            if _yum() == "dnf" or _yum() == "dnf5":
+            if _yum() in ("dnf", "dnf5"):
                 copr_plugin_name = "dnf-plugins-core"
             else:
                 copr_plugin_name = "yum-plugin-copr"

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1061,7 +1061,7 @@ def list_upgrades(refresh=True, **kwargs):
     cmd = ["--quiet"]
     cmd.extend(options)
     cmd.extend(
-        ["list", "upgrades" if (_yum() == "dnf" or _yum() == "dnf5") else "updates"]
+        ["list", "upgrades" if _yum() in ("dnf", "dnf5") else "updates"]
     )
     out = _call_yum(cmd, ignore_retcode=True)
     if out["retcode"] != 0 and "Error:" in out:

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2014,7 +2014,7 @@ def upgrade(
 
         salt '*' pkg.upgrade security=True exclude='kernel*'
     """
-    if (_yum() == "dnf" or _yum() == "dnf5") and not obsoletes:
+    if _yum() in ("dnf", "dnf5") and not obsoletes:
         # for dnf we can just disable obsoletes
         _setopt = [
             opt

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -251,7 +251,7 @@ def _versionlock_pkg(grains=None):
     if grains is None:
         grains = __grains__
 
-    if _yum() == "dnf" or _yum() == "dnf5":
+    if _yum() in ("dnf", "dnf5"):
         if grains["os"].lower() == "fedora":
             return (
                 "python3-dnf-plugin-versionlock"

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2052,7 +2052,7 @@ def upgrade(
         cmd.append("upgrade" if not minimal else "upgrade-minimal")
     else:
         # do not force the removal of obsolete packages
-        if _yum() == "dnf" or _yum() == "dnf5":
+        if _yum() in ("dnf", "dnf5"):
             cmd.append("upgrade" if not minimal else "upgrade-minimal")
         else:
             # for yum we have to use update instead of upgrade

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -14,6 +14,8 @@ Support for YUM/DNF
 
 .. versionadded:: 3003
     Support for ``tdnf`` on Photon OS.
+.. versionadded:: 3007.0
+    Support for ``dnf5``` on Fedora 39
 """
 
 
@@ -122,12 +124,12 @@ def _get_hold(line, pattern=__HOLD_PATTERN, full=True):
     dnf ==> vim-enhanced-2:7.4.827-1.fc22.*
     """
     if full:
-        if _yum() == "dnf":
+        if _yum() == "dnf" or _yum() == "dnf5":
             lock_re = rf"({pattern}-\S+)"
         else:
             lock_re = rf"(\d+:{pattern}-\S+)"
     else:
-        if _yum() == "dnf":
+        if _yum() == "dnf" or _yum() == "dnf5":
             lock_re = rf"({pattern}-\S+)"
         else:
             lock_re = rf"\d+:({pattern}-\S+)"
@@ -145,7 +147,7 @@ def _get_hold(line, pattern=__HOLD_PATTERN, full=True):
 
 def _yum():
     """
-    Determine package manager name (yum or dnf),
+    Determine package manager name (yum or dnf[5]),
     depending on the executable existence in $PATH.
     """
 
@@ -168,7 +170,10 @@ def _yum():
     contextkey = "yum_bin"
     if contextkey not in context:
         for dir in os.environ.get("PATH", os.defpath).split(os.pathsep):
-            if _check(os.path.join(dir, "dnf")):
+            if _check(os.path.join(dir, "dnf5")):
+                context[contextkey] = "dnf5"
+                break
+            elif _check(os.path.join(dir, "dnf")):
                 context[contextkey] = "dnf"
                 break
             elif _check(os.path.join(dir, "tdnf")):
@@ -245,7 +250,8 @@ def _versionlock_pkg(grains=None):
     """
     if grains is None:
         grains = __grains__
-    if _yum() == "dnf":
+
+    if _yum() == "dnf" or _yum() == "dnf5":
         if grains["os"].lower() == "fedora":
             return (
                 "python3-dnf-plugin-versionlock"
@@ -272,10 +278,11 @@ def _check_versionlock():
 
 def _get_options(**kwargs):
     """
-    Returns a list of options to be used in the yum/dnf command, based on the
+    Returns a list of options to be used in the yum/dnf[5] command, based on the
     kwargs passed.
     """
     # Get repo options from the kwargs
+    # dnf5 aliases dnf options, so no need to change
     fromrepo = kwargs.pop("fromrepo", "")
     repo = kwargs.pop("repo", "")
     disablerepo = kwargs.pop("disablerepo", "")
@@ -1053,7 +1060,9 @@ def list_upgrades(refresh=True, **kwargs):
 
     cmd = ["--quiet"]
     cmd.extend(options)
-    cmd.extend(["list", "upgrades" if _yum() == "dnf" else "updates"])
+    cmd.extend(
+        ["list", "upgrades" if (_yum() == "dnf" or _yum() == "dnf5") else "updates"]
+    )
     out = _call_yum(cmd, ignore_retcode=True)
     if out["retcode"] != 0 and "Error:" in out:
         return {}
@@ -1708,7 +1717,8 @@ def install(
         if skip_verify:
             cmd.append("--nogpgcheck")
         if downloadonly:
-            cmd.append("--downloadonly")
+            if _yum() != "dnf5":
+                cmd.append("--downloadonly")
 
     try:
         holds = list_holds(full=False)
@@ -1769,6 +1779,8 @@ def install(
                 cmd.extend(["--best", "--allowerasing"])
             _add_common_args(cmd)
             cmd.append("install" if pkg_type != "advisory" else "update")
+            if _yum() == "dnf5":
+                cmd.extend(["--best", "--allowerasing"])
             cmd.extend(targets)
             out = _call_yum(cmd, ignore_retcode=False, redirect_stderr=True)
             if out["retcode"] != 0:
@@ -2002,7 +2014,7 @@ def upgrade(
 
         salt '*' pkg.upgrade security=True exclude='kernel*'
     """
-    if _yum() == "dnf" and not obsoletes:
+    if (_yum() == "dnf" or _yum() == "dnf5") and not obsoletes:
         # for dnf we can just disable obsoletes
         _setopt = [
             opt
@@ -2040,7 +2052,7 @@ def upgrade(
         cmd.append("upgrade" if not minimal else "upgrade-minimal")
     else:
         # do not force the removal of obsolete packages
-        if _yum() == "dnf":
+        if _yum() == "dnf" or _yum() == "dnf5":
             cmd.append("upgrade" if not minimal else "upgrade-minimal")
         else:
             # for yum we have to use update instead of upgrade
@@ -2396,7 +2408,7 @@ def unhold(name=None, pkgs=None, sources=None, **kwargs):  # pylint: disable=W06
 
         ret[target] = {"name": target, "changes": {}, "result": False, "comment": ""}
 
-        if _yum() == "dnf":
+        if _yum() == "dnf" or _yum() == "dnf5":
             search_locks = [x for x in current_locks if x == target]
         else:
             # To accommodate yum versionlock's lack of support for removing
@@ -3032,7 +3044,7 @@ def mod_repo(repo, basedir=None, **kwargs):
         if use_copr:
             # Is copr plugin installed?
             copr_plugin_name = ""
-            if _yum() == "dnf":
+            if _yum() == "dnf" or _yum() == "dnf5":
                 copr_plugin_name = "dnf-plugins-core"
             else:
                 copr_plugin_name = "yum-plugin-copr"
@@ -3493,7 +3505,7 @@ def services_need_restart(**kwargs):
 
         salt '*' pkg.services_need_restart
     """
-    if _yum() != "dnf":
+    if _yum() == "dnf":
         raise CommandExecutionError("dnf is required to list outdated services.")
     if not salt.utils.systemd.booted(__context__):
         raise CommandExecutionError("systemd is required to list outdated services.")

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -124,7 +124,7 @@ def _get_hold(line, pattern=__HOLD_PATTERN, full=True):
     dnf ==> vim-enhanced-2:7.4.827-1.fc22.*
     """
     if full:
-        if _yum() == "dnf" or _yum() == "dnf5":
+        if _yum() in ("dnf", "dnf5"):
             lock_re = rf"({pattern}-\S+)"
         else:
             lock_re = rf"(\d+:{pattern}-\S+)"

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2408,7 +2408,7 @@ def unhold(name=None, pkgs=None, sources=None, **kwargs):  # pylint: disable=W06
 
         ret[target] = {"name": target, "changes": {}, "result": False, "comment": ""}
 
-        if _yum() == "dnf" or _yum() == "dnf5":
+        if _yum() in ("dnf", "dnf5"):
             search_locks = [x for x in current_locks if x == target]
         else:
             # To accommodate yum versionlock's lack of support for removing

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -129,7 +129,7 @@ def _get_hold(line, pattern=__HOLD_PATTERN, full=True):
         else:
             lock_re = rf"(\d+:{pattern}-\S+)"
     else:
-        if _yum() == "dnf" or _yum() == "dnf5":
+        if _yum() in ("dnf", "dnf5"):
             lock_re = rf"({pattern}-\S+)"
         else:
             lock_re = rf"\d+:({pattern}-\S+)"

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1060,9 +1060,7 @@ def list_upgrades(refresh=True, **kwargs):
 
     cmd = ["--quiet"]
     cmd.extend(options)
-    cmd.extend(
-        ["list", "upgrades" if _yum() in ("dnf", "dnf5") else "updates"]
-    )
+    cmd.extend(["list", "upgrades" if _yum() in ("dnf", "dnf5") else "updates"])
     out = _call_yum(cmd, ignore_retcode=True)
     if out["retcode"] != 0 and "Error:" in out:
         return {}
@@ -3505,7 +3503,7 @@ def services_need_restart(**kwargs):
 
         salt '*' pkg.services_need_restart
     """
-    if _yum() == "dnf":
+    if _yum() != "dnf":
         raise CommandExecutionError("dnf is required to list outdated services.")
     if not salt.utils.systemd.booted(__context__):
         raise CommandExecutionError("systemd is required to list outdated services.")

--- a/tests/pytests/unit/modules/test_yumpkg.py
+++ b/tests/pytests/unit/modules/test_yumpkg.py
@@ -72,7 +72,7 @@ def list_repos_var():
 
 
 @pytest.fixture(
-    ids=["yum", "dnf"],
+    ids=["yum", "dnf", "dnf5"],
     params=[
         {
             "context": {"yum_bin": "yum"},
@@ -83,6 +83,11 @@ def list_repos_var():
             "context": {"yum_bin": "dnf"},
             "grains": {"os": "Fedora", "osrelease": 27},
             "cmd": ["dnf", "-y", "--best", "--allowerasing"],
+        },
+        {
+            "context": {"yum_bin": "dnf5"},
+            "grains": {"os": "Fedora", "osrelease": 39},
+            "cmd": ["dnf5", "-y"],
         },
     ],
 )
@@ -692,7 +697,7 @@ def test_list_repo_pkgs_with_options(list_repos_var):
                         except AssertionError:
                             continue
                     else:
-                        pytest.fail("repo '{}' not checked".format(repo))
+                        pytest.fail(f"repo '{repo}' not checked")
 
 
 def test_list_upgrades_dnf():
@@ -2085,7 +2090,10 @@ def test_59705_version_as_accidental_float_should_become_text(
     new, full_pkg_string, yum_and_dnf
 ):
     name = "fnord"
-    expected_cmd = yum_and_dnf + ["install", full_pkg_string]
+    expected_cmd = yum_and_dnf + ["install"]
+    if expected_cmd[0] == "dnf5":
+        expected_cmd += ["--best", "--allowerasing"]
+    expected_cmd += [full_pkg_string]
     cmd_mock = MagicMock(
         return_value={"pid": 12345, "retcode": 0, "stdout": "", "stderr": ""}
     )


### PR DESCRIPTION
### What does this PR do?
Adds support for ```dnf5``` on Fedora. 
```dnf5``` has changed options etc from the current versions of ```dnf```, 
for example: ```--allowerasing``` is no longer a general option but tied to specific commands like ```install```.
```dnf5``` has changed other options too but has provided aliases to allow for backwards comparability, 
for example: ```--disablerepo=REPO_ID,...  Alias for '--disable-repo'```

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/64532

### Previous Behavior
An install would fail since ```--allowerasing``` precedes the ```install``` command

### New Behavior
install now succeeds as options such as ```--allowerasing``` now follow the ```install``` command

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
