### PR TITLE
[master] Merge alpine networking

### DIFF
--- a/changelog/64676.added.md
+++ b/changelog/64676.added.md
@@ -1,0 +1,7 @@
+Load ``debian_ip`` as the ``ip`` execution module on Alpine Linux (BusyBox
+``ifupdown`` is compatible with Debian's ``/etc/network/interfaces`` format).
+Fix ``_netstat_route_linux`` to work with BusyBox ``netstat`` (which does not
+accept ``-A inet``), and guard against a ``TypeError`` crash when ``netstat``
+is absent from ``PATH``. Stop loading ``states.network`` when the loaded ``ip``
+execution module cannot manage interface configuration (i.e. lacks
+``build_interface``).

--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1,9 +1,10 @@
 """
-The networking module for Debian-based distros
+The networking module for Debian- and BusyBox-based distros
 
 References:
 
 * http://www.debian.org/doc/manuals/debian-reference/ch05.en.html
+* https://www.busybox.net/downloads/BusyBox.html
 """
 
 import functools
@@ -41,7 +42,7 @@ def __virtual__():
     """
     Confine this module to Debian-based distros
     """
-    if __grains__["os_family"] == "Debian":
+    if __grains__["os_family"] in ["Debian", "Alpine"]:
         return __virtualname__
     return (False, "The debian_ip module could not be loaded: unsupported OS family")
 

--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -40,7 +40,7 @@ __virtualname__ = "ip"
 
 def __virtual__():
     """
-    Confine this module to Debian-based distros
+    Confine this module to Debian- and Alpine-based distros
     """
     if __grains__["os_family"] in ["Debian", "Alpine"]:
         return __virtualname__

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -472,8 +472,11 @@ def _netstat_route_linux():
     """
     ret = []
     cmd = "netstat -A inet -rn | tail -n+3"
-    which_netstat = path.which("netstat")
-    if path.islink(which_netstat) and path.readlink(which_netstat).endswith("/busybox"):
+    which_netstat = salt.utils.path.which("netstat")
+    is_busybox = salt.utils.path.islink(which_netstat) and salt.utils.path.readlink(
+        which_netstat
+    ).endswith("/busybox")
+    if is_busybox:
         cmd = "netstat -rn | tail -n+3"
     out = __salt__["cmd.run"](cmd, python_shell=True)
     for line in out.splitlines():
@@ -488,6 +491,9 @@ def _netstat_route_linux():
                 "interface": comps[7],
             }
         )
+    # No IPv6 in BusyBox'es netstat:
+    if is_busybox:
+        return ret
     cmd = "netstat -A inet6 -rn | tail -n+3"
     out = __salt__["cmd.run"](cmd, python_shell=True)
     for line in out.splitlines():

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -15,6 +15,7 @@ import time
 import salt.utils.decorators.path
 import salt.utils.functools
 import salt.utils.network
+import salt.utils.path
 import salt.utils.platform
 import salt.utils.validate.net
 from salt._compat import ipaddress
@@ -471,6 +472,9 @@ def _netstat_route_linux():
     """
     ret = []
     cmd = "netstat -A inet -rn | tail -n+3"
+    which_netstat = path.which("netstat")
+    if path.islink(which_netstat) and path.readlink(which_netstat).endswith("/busybox"):
+        cmd = "netstat -rn | tail -n+3"
     out = __salt__["cmd.run"](cmd, python_shell=True)
     for line in out.splitlines():
         comps = line.split()

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -473,9 +473,11 @@ def _netstat_route_linux():
     ret = []
     cmd = "netstat -A inet -rn | tail -n+3"
     which_netstat = salt.utils.path.which("netstat")
-    is_busybox = salt.utils.path.islink(which_netstat) and salt.utils.path.readlink(
+    is_busybox = bool(
         which_netstat
-    ).endswith("/busybox")
+        and salt.utils.path.islink(which_netstat)
+        and salt.utils.path.readlink(which_netstat).endswith("/busybox")
+    )
     if is_busybox:
         cmd = "netstat -rn | tail -n+3"
     out = __salt__["cmd.run"](cmd, python_shell=True)

--- a/salt/states/network.py
+++ b/salt/states/network.py
@@ -472,9 +472,11 @@ def __virtual__():
     """
     if salt.utils.platform.is_windows():
         return (False, "Only supported on non-Windows OSs")
-    if "ip.get_interface" in __salt__:
+    if "ip.build_interface" in __salt__:
         return True
-    return (False, "ip module could not be loaded")
+    elif "ip.get_interface" in __salt__:
+        return (False, "Loaded ip exec module can't manage interface config")
+    return (False, "ip execution module could not be loaded")
 
 
 def managed(name, enabled=True, **kwargs):

--- a/tests/pytests/unit/modules/test_debian_ip.py
+++ b/tests/pytests/unit/modules/test_debian_ip.py
@@ -1380,3 +1380,28 @@ def test_when_opts_are_in_data_sorted_opt_keys_should_be_added():
         adapters=comprehensive_adapters
     )
     assert actual_adapters == expected_adapters
+
+
+class TestDebianIpVirtual:
+    """
+    Tests for debian_ip.__virtual__ Alpine Linux support (PR #64676).
+    """
+
+    def test_virtual_loads_on_debian(self):
+        """Module loads on Debian as before."""
+        with patch.dict(debian_ip.__grains__, {"os_family": "Debian"}):
+            result = debian_ip.__virtual__()
+            assert result == debian_ip.__virtualname__
+
+    def test_virtual_loads_on_alpine(self):
+        """Module loads on Alpine (BusyBox ifupdown is Debian-compatible)."""
+        with patch.dict(debian_ip.__grains__, {"os_family": "Alpine"}):
+            result = debian_ip.__virtual__()
+            assert result == debian_ip.__virtualname__
+
+    def test_virtual_refuses_on_other_os(self):
+        """Module refuses to load on unrecognised OS families."""
+        with patch.dict(debian_ip.__grains__, {"os_family": "RedHat"}):
+            result = debian_ip.__virtual__()
+            assert isinstance(result, tuple)
+            assert result[0] is False

--- a/tests/pytests/unit/modules/test_network.py
+++ b/tests/pytests/unit/modules/test_network.py
@@ -842,3 +842,47 @@ fe80::825:63ff:fe2d:19be dev eth0 lladdr 0a:25:63:2d:19:be router STALE
     ):
         result = networkmod.ip_neighs6()
         assert result == expected
+
+
+@pytest.mark.skip_on_windows(reason="_netstat_route_linux not used on Windows")
+def test_netstat_route_linux_busybox():
+    """
+    Test that _netstat_route_linux uses 'netstat -rn' (no -A inet) when
+    netstat is a symlink to a BusyBox binary, and returns no IPv6 entries.
+    """
+    # cmd.run returns the shell pipeline output after 'tail -n+3' strips the
+    # two header lines, so the mock only contains the actual route lines.
+    mock_netstat_output = (
+        "0.0.0.0         192.168.1.1     0.0.0.0         UG        0 0          0 eth0\n"
+        "192.168.1.0     0.0.0.0         255.255.255.0   U         0 0          0 eth0\n"
+    )
+
+    with patch("salt.utils.path.which", return_value="/bin/netstat"), patch(
+        "salt.utils.path.islink", return_value=True
+    ), patch("salt.utils.path.readlink", return_value="/bin/busybox"), patch.dict(
+        networkmod.__salt__, {"cmd.run": MagicMock(return_value=mock_netstat_output)}
+    ):
+        result = networkmod._netstat_route_linux()
+
+    # Should have parsed two routes; no IPv6 entries
+    assert len(result) == 2
+    assert all(r["addr_family"] == "inet" for r in result)
+    assert result[0]["destination"] == "0.0.0.0"
+    assert result[0]["gateway"] == "192.168.1.1"
+    assert result[0]["interface"] == "eth0"
+
+
+@pytest.mark.skip_on_windows(reason="_netstat_route_linux not used on Windows")
+def test_netstat_route_linux_no_netstat():
+    """
+    Test that _netstat_route_linux does not crash with TypeError when
+    netstat is absent from PATH (salt.utils.path.which returns None).
+    """
+    with patch("salt.utils.path.which", return_value=None), patch.dict(
+        networkmod.__salt__, {"cmd.run": MagicMock(return_value="")}
+    ):
+        # Must not raise TypeError when which() returns None
+        result = networkmod._netstat_route_linux()
+
+    # Empty output → empty list
+    assert result == []

--- a/tests/pytests/unit/states/test_network.py
+++ b/tests/pytests/unit/states/test_network.py
@@ -265,3 +265,48 @@ def test_system():
                         }
                     )
                     assert network.system("salt") == ret
+
+
+class TestNetworkVirtual:
+    """
+    Tests for states.network.__virtual__ with the build_interface gate added
+    by PR #64676.
+    """
+
+    def test_virtual_loads_when_build_interface_present(self):
+        """State loads when ip.build_interface is available."""
+        with patch("salt.utils.platform.is_windows", return_value=False), patch.dict(
+            network.__salt__,
+            {
+                "ip.build_interface": MagicMock(),
+                "ip.get_interface": MagicMock(),
+            },
+        ):
+            assert network.__virtual__() is True
+
+    def test_virtual_refuses_when_only_get_interface_present(self):
+        """State refuses to load with a clear message when ip can only read, not manage."""
+        with patch("salt.utils.platform.is_windows", return_value=False), patch.dict(
+            network.__salt__,
+            {"ip.get_interface": MagicMock()},
+        ):
+            result = network.__virtual__()
+            assert isinstance(result, tuple)
+            assert result[0] is False
+            assert "can't manage" in result[1]
+
+    def test_virtual_refuses_when_no_ip_module(self):
+        """State refuses to load when no ip execution module is available."""
+        with patch("salt.utils.platform.is_windows", return_value=False), patch.dict(
+            network.__salt__, {}
+        ):
+            result = network.__virtual__()
+            assert isinstance(result, tuple)
+            assert result[0] is False
+
+    def test_virtual_refuses_on_windows(self):
+        """State refuses to load on Windows."""
+        with patch("salt.utils.platform.is_windows", return_value=True):
+            result = network.__virtual__()
+            assert isinstance(result, tuple)
+            assert result[0] is False


### PR DESCRIPTION
### What does this PR do?
The BusyBox applet `ifupdown` used on Alpine Linux is quiet similar to Debian's as is its `/etc/network/interfaces`
so this pull request has the execution module `debian_ip` loaded as `ip` on Alpine.

The arguments of BusyBox'es `netstat` applet (as they're called in [the documentation](https://www.busybox.net/downloads/BusyBox.html) are a bit different though so a check if `netstat` is actually a symlink to an `busybox` binary had to be added.

Along the way I've noticed the state module `network` would be loaded on Alpine even without my changes while the underlying minimal `ip` exec module couldn't change any interface's config at all.

### What issues does this PR fix or reference?
Fixes: (no GitHub issues)

### Previous Behavior
- `_netstat_route_linux()` from `modules/network.py` won't work if `netstat` is actually a symlink to the BusyBox binary like on Alpine
- Only a very minimal `ip` exec module is loaded on Alpine
- The `network` state module would be loaded even if it couldn't change any interface's state

### New Behavior
(See above)

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
~~Yes~~/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
