### PR TITLE
Additions to utils.data: get_type(), glob_list(), list_rm_match(), replace_list_element(), updated_dict()

### DIFF
--- a/changelog/64703.added.md
+++ b/changelog/64703.added.md
@@ -1,0 +1,5 @@
+Added ``get_type()``, ``glob_list()``, ``list_rm_match()``,
+``replace_list_element()``, and ``updated_dict()`` utility functions to
+``salt.utils.data`` for querying Python types, filtering lists by glob or
+regex patterns, expanding list elements, and producing shallow-merged dict
+copies without mutating the originals.

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -928,16 +928,12 @@ def replace_list_element(orig, placeholder, updates_list):
 
     if placeholder not in orig:
         return orig
-    indexed_orig = list(enumerate(orig))
-    indexed_orig.reverse()
     updated = []
-    for index, elem in indexed_orig:
+    for elem in orig:
         if elem == placeholder:
-            for update in updates_list:
-                updated.insert(index, update)
+            updated.extend(updates_list)
         else:
             updated.append(elem)
-    updated.reverse()
     return updated
 
 

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -788,28 +788,59 @@ def filter_by(lookup_dict, lookup, traverse, merge=None, default="default", base
 
 def get_type(var):
     """
-    Return Python type of given variable.
+    Return the Python type name of the given variable as a string.
+
+    Useful for debugging Jinja templates.
+
+    .. versionadded:: 3009.0
+
+    CLI Example:
+
+    .. code-block:: jinja
+
+        {{ myvar | get_type }}
     """
-    return str(type(var))
+    return type(var).__name__
 
 
 def glob_list(data, pattern):
     """
-    Uses fnmatch for "globbing" elements of a list:
-    The globbing the list [eth0, eth2, lo] with pattern
-    'eth*' results in [eth0, eth2]
+    Return those elements of *data* whose string representation matches the
+    fnmatch *pattern*.
 
-    Same function as used in Salt's match.glob.
-    https://docs.python.org/3/library/fnmatch.html
+    The list ``['eth0', 'eth2', 'lo']`` filtered with pattern ``'eth*'``
+    returns ``['eth0', 'eth2']``.
+
+    .. versionadded:: 3009.0
+
+    data
+        A list of strings.
+
+    pattern
+        An fnmatch glob pattern.  See :mod:`fnmatch`.
+
+    CLI Example:
+
+    .. code-block:: jinja
+
+        {{ ['eth0', 'eth2', 'lo'] | glob_list('eth*') }}
     """
+    from salt.exceptions import SaltInvocationError
+
     if not isinstance(data, list):
-        error_msg = "1st argument should be a list but is "
-        raise TypeError(error_msg + str(type(data)))
+        raise SaltInvocationError(
+            "glob_list requires a list as its first argument, got {}".format(
+                type(data).__name__
+            )
+        )
     matches = []
     for num, element in enumerate(data):
         if not isinstance(element, str):
-            error_msg = "List element " + str(num) + " isn't a str but "
-            raise TypeError(error_msg + str(element))
+            raise SaltInvocationError(
+                "glob_list: list element {} is not a str (got {!r})".format(
+                    num, element
+                )
+            )
         if fnmatch.fnmatch(element, str(pattern)):
             matches.append(element)
     return matches
@@ -817,23 +848,38 @@ def glob_list(data, pattern):
 
 def list_rm_match(listing, rgx, ignorecase=False, multiline=False):
     """
-    Removes matching elements of a given
-    list based on a regular expression.
+    Return a new list with those elements of *listing* that match the regular
+    expression *rgx* removed.
+
+    .. versionadded:: 3009.0
+
+    listing
+        A list of strings to filter.
+
+    rgx
+        A regular expression pattern string.  The pattern is matched against
+        the full element string (anchored at the start via :func:`re.match`).
+
+    ignorecase
+        When ``True``, perform a case-insensitive match.  Defaults to
+        ``False``.
+
+    multiline
+        When ``True``, enable multi-line matching (``re.M``).  Defaults to
+        ``False``.
     """
-    # Duplicating code from `utils.jinja.py` as using
-    # `__utils__['jinja.test_match']()` causes KeyErrors
     flag = 0
-    not_matching = []
     if ignorecase:
         flag |= re.I
     if multiline:
         flag |= re.M
-    # compiled_rgx = re.compile(rgx, flag)
+    compiled_rgx = re.compile(rgx, flag)
+    not_matching = []
     for elem in listing:
-        if not re.match(rgx, elem):
+        if not compiled_rgx.match(elem):
             not_matching.append(elem)
     log.debug(
-        "list_rm_match(): regex `%s` turned `[%s]` into `[%s]",
+        "list_rm_match(): regex `%s` turned `[%s]` into `[%s]`",
         rgx,
         ", ".join(listing),
         ", ".join(not_matching),
@@ -843,20 +889,42 @@ def list_rm_match(listing, rgx, ignorecase=False, multiline=False):
 
 def replace_list_element(orig, placeholder, updates_list):
     """
-    Takes a list `orig` and inserts the elements of `updates_list`
-    anyplace where an element equal `placeholder` has been.
-    In list ['a', 'bx', 'c'] placeholder 'bx' would be replaced
-    with the elements of ['b1', 'b2', 'b3'] resulting in list
-    ['a', 'b1', 'b2', 'b3', 'c'].
+    Replace every occurrence of *placeholder* in *orig* with the elements of
+    *updates_list*.
+
+    For example, replacing ``'bx'`` in ``['a', 'bx', 'c']`` with
+    ``['b1', 'b2', 'b3']`` produces ``['a', 'b1', 'b2', 'b3', 'c']``.
+
+    .. versionadded:: 3009.0
+
+    orig
+        The source list.
+
+    placeholder
+        The element value to search for and replace.
+
+    updates_list
+        A list of elements that will be substituted in place of each
+        *placeholder* occurrence.
     """
-    if not isinstance(orig, list) or not isinstance(updates_list, list):
-        if not isinstance(orig, list) and not isinstance(updates_list, list):
-            msg = "Neiter arg 0 'orig' nor arg 2 'updates_list' is a list-like!"
-        if not isinstance(orig, list) and isinstance(updates_list, list):
-            msg = "Arg 0 'orig' isn't a list(-like object)!"
-        if isinstance(orig, list) and not isinstance(updates_list, list):
-            msg = "Arg 2 'updates_list' isn't a list(-like object)!"
-        raise TypeError(msg)
+    from salt.exceptions import SaltInvocationError
+
+    if not isinstance(orig, list) and not isinstance(updates_list, list):
+        raise SaltInvocationError(
+            "replace_list_element: 'orig' and 'updates_list' must both be lists"
+        )
+    if not isinstance(orig, list):
+        raise SaltInvocationError(
+            "replace_list_element: 'orig' must be a list, got {}".format(
+                type(orig).__name__
+            )
+        )
+    if not isinstance(updates_list, list):
+        raise SaltInvocationError(
+            "replace_list_element: 'updates_list' must be a list, got {}".format(
+                type(updates_list).__name__
+            )
+        )
 
     if placeholder not in orig:
         return orig
@@ -975,8 +1043,18 @@ def traverse_dict_and_list(data, key, default=None, delimiter=DEFAULT_TARGET_DEL
 
 def updated_dict(data, updates):
     """
-    Returns a new dict with the 1st dict's content updated/overridden
-    with the 2nd one's.
+    Return a shallow-merged copy of *data* with keys from *updates* applied.
+
+    This is equivalent to ``{**data, **updates}`` — keys present in both dicts
+    take their value from *updates*.  Neither *data* nor *updates* is modified.
+
+    .. versionadded:: 3009.0
+
+    data
+        The base dictionary.
+
+    updates
+        A dictionary whose entries override those in *data*.
     """
     return {**data, **updates}
 

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -786,6 +786,13 @@ def filter_by(lookup_dict, lookup, traverse, merge=None, default="default", base
     return ret
 
 
+def get_type(var):
+    """
+    Return Python type of given variable.
+    """
+    return str(type(var))
+
+
 def glob_list(data, pattern):
     """
     Uses fnmatch for "globbing" elements of a list:

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -873,6 +873,14 @@ def replace_list_element(orig, placeholder, updates_list):
     return updated
 
 
+def updated_dict(data, updates):
+    """
+    Returns a new dict with the 1st dict's content updated/overridden
+    with the 2nd one's.
+    """
+    return {**data, **updates}
+
+
 def traverse_dict(data, key, default=None, delimiter=DEFAULT_TARGET_DELIM):
     """
     Traverse a dict using a colon-delimited (or otherwise delimited, using the

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -786,6 +786,38 @@ def filter_by(lookup_dict, lookup, traverse, merge=None, default="default", base
     return ret
 
 
+def replace_list_element(orig, placeholder, updates_list):
+    """
+    Takes a list `orig` and inserts the elements of `updates_list`
+    anyplace where an element equal `placeholder` has been.
+    In list ['a', 'bx', 'c'] placeholder 'bx' would be replaced
+    with the elements of ['b1', 'b2', 'b3'] resulting in list
+    ['a', 'b1', 'b2', 'b3', 'c'].
+    """
+    if not isinstance(orig, list) or not isinstance(updates_list, list):
+        if not isinstance(orig, list) and not isinstance(updates_list, list):
+            msg = "Neiter arg 0 'orig' nor arg 2 'updates_list' is a list-like!"
+        if not isinstance(orig, list) and isinstance(updates_list, list):
+            msg = "Arg 0 'orig' isn't a list(-like object)!"
+        if isinstance(orig, list) and not isinstance(updates_list, list):
+            msg = "Arg 2 'updates_list' isn't a list(-like object)!"
+        raise TypeError(msg)
+
+    if placeholder not in orig:
+        return orig
+    indexed_orig = list(enumerate(orig))
+    indexed_orig.reverse()
+    updated = []
+    for index, elem in indexed_orig:
+        if elem == placeholder:
+            for update in updates_list:
+                updated.insert(index, update)
+        else:
+            updated.append(elem)
+    updated.reverse()
+    return updated
+
+
 def traverse_dict(data, key, default=None, delimiter=DEFAULT_TARGET_DELIM):
     """
     Traverse a dict using a colon-delimited (or otherwise delimited, using the

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -786,6 +786,28 @@ def filter_by(lookup_dict, lookup, traverse, merge=None, default="default", base
     return ret
 
 
+def glob_list(data, pattern):
+    """
+    Uses fnmatch for "globbing" elements of a list:
+    The globbing the list [eth0, eth2, lo] with pattern
+    'eth*' results in [eth0, eth2]
+
+    Same function as used in Salt's match.glob.
+    https://docs.python.org/3/library/fnmatch.html
+    """
+    if not isinstance(data, list):
+        error_msg = "1st argument should be a list but is "
+        raise TypeError(error_msg + str(type(data)))
+    matches = []
+    for num, element in enumerate(data):
+        if not isinstance(element, str):
+            error_msg = "List element " + str(num) + " isn't a str but "
+            raise TypeError(error_msg + str(element))
+        if fnmatch.fnmatch(element, str(pattern)):
+            matches.append(element)
+    return matches
+
+
 def replace_list_element(orig, placeholder, updates_list):
     """
     Takes a list `orig` and inserts the elements of `updates_list`

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -873,14 +873,6 @@ def replace_list_element(orig, placeholder, updates_list):
     return updated
 
 
-def updated_dict(data, updates):
-    """
-    Returns a new dict with the 1st dict's content updated/overridden
-    with the 2nd one's.
-    """
-    return {**data, **updates}
-
-
 def traverse_dict(data, key, default=None, delimiter=DEFAULT_TARGET_DELIM):
     """
     Traverse a dict using a colon-delimited (or otherwise delimited, using the
@@ -979,6 +971,14 @@ def traverse_dict_and_list(data, key, default=None, delimiter=DEFAULT_TARGET_DEL
             except TypeError:
                 return default
     return ptr
+
+
+def updated_dict(data, updates):
+    """
+    Returns a new dict with the 1st dict's content updated/overridden
+    with the 2nd one's.
+    """
+    return {**data, **updates}
 
 
 def subdict_match(

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -808,6 +808,32 @@ def glob_list(data, pattern):
     return matches
 
 
+def list_rm_match(listing, rgx, ignorecase=False, multiline=False):
+    """
+    Removes matching elements of a given
+    list based on a regular expression.
+    """
+    # Duplicating code from `utils.jinja.py` as using
+    # `__utils__['jinja.test_match']()` causes KeyErrors
+    flag = 0
+    not_matching = []
+    if ignorecase:
+        flag |= re.I
+    if multiline:
+        flag |= re.M
+    # compiled_rgx = re.compile(rgx, flag)
+    for elem in listing:
+        if not re.match(rgx, elem):
+            not_matching.append(elem)
+    log.debug(
+        "list_rm_match(): regex `%s` turned `[%s]` into `[%s]",
+        rgx,
+        ", ".join(listing),
+        ", ".join(not_matching),
+    )
+    return not_matching
+
+
 def replace_list_element(orig, placeholder, updates_list):
     """
     Takes a list `orig` and inserts the elements of `updates_list`

--- a/tests/pytests/unit/utils/test_data.py
+++ b/tests/pytests/unit/utils/test_data.py
@@ -1490,3 +1490,186 @@ def test_ignore_missing_keys_recursive():
     assert expected_result == salt.utils.data.recursive_diff(
         dict_one, dict_two, ignore_missing_keys=True
     )
+
+
+# ---------------------------------------------------------------------------
+# Tests for get_type()
+# ---------------------------------------------------------------------------
+
+
+def test_get_type_int():
+    assert salt.utils.data.get_type(42) == "int"
+
+
+def test_get_type_str():
+    assert salt.utils.data.get_type("hello") == "str"
+
+
+def test_get_type_list():
+    assert salt.utils.data.get_type([]) == "list"
+
+
+def test_get_type_dict():
+    assert salt.utils.data.get_type({}) == "dict"
+
+
+def test_get_type_none():
+    assert salt.utils.data.get_type(None) == "NoneType"
+
+
+def test_get_type_bool():
+    assert salt.utils.data.get_type(True) == "bool"
+
+
+# ---------------------------------------------------------------------------
+# Tests for glob_list()
+# ---------------------------------------------------------------------------
+
+
+def test_glob_list_basic():
+    result = salt.utils.data.glob_list(["eth0", "eth2", "lo"], "eth*")
+    assert result == ["eth0", "eth2"]
+
+
+def test_glob_list_no_match():
+    result = salt.utils.data.glob_list(["lo", "dummy0"], "eth*")
+    assert result == []
+
+
+def test_glob_list_all_match():
+    result = salt.utils.data.glob_list(["eth0", "eth1"], "eth*")
+    assert result == ["eth0", "eth1"]
+
+
+def test_glob_list_empty_list():
+    assert salt.utils.data.glob_list([], "eth*") == []
+
+
+def test_glob_list_requires_list():
+    from salt.exceptions import SaltInvocationError
+
+    with pytest.raises(SaltInvocationError):
+        salt.utils.data.glob_list("eth0", "eth*")
+
+
+def test_glob_list_requires_str_elements():
+    from salt.exceptions import SaltInvocationError
+
+    with pytest.raises(SaltInvocationError):
+        salt.utils.data.glob_list([1, 2, 3], "*")
+
+
+# ---------------------------------------------------------------------------
+# Tests for list_rm_match()
+# ---------------------------------------------------------------------------
+
+
+def test_list_rm_match_basic():
+    result = salt.utils.data.list_rm_match(["eth0", "eth1", "lo"], r"eth.*")
+    assert result == ["lo"]
+
+
+def test_list_rm_match_no_removal():
+    result = salt.utils.data.list_rm_match(["lo", "dummy"], r"eth.*")
+    assert result == ["lo", "dummy"]
+
+
+def test_list_rm_match_remove_all():
+    result = salt.utils.data.list_rm_match(["eth0", "eth1"], r"eth.*")
+    assert result == []
+
+
+def test_list_rm_match_empty_list():
+    assert salt.utils.data.list_rm_match([], r".*") == []
+
+
+def test_list_rm_match_ignorecase():
+    result = salt.utils.data.list_rm_match(["ETH0", "lo"], r"eth.*", ignorecase=True)
+    assert result == ["lo"]
+
+
+def test_list_rm_match_case_sensitive_by_default():
+    # Without ignorecase, uppercase ETH0 should NOT match lowercase eth.*
+    result = salt.utils.data.list_rm_match(["ETH0", "lo"], r"eth.*")
+    assert result == ["ETH0", "lo"]
+
+
+# ---------------------------------------------------------------------------
+# Tests for replace_list_element()
+# ---------------------------------------------------------------------------
+
+
+def test_replace_list_element_basic():
+    result = salt.utils.data.replace_list_element(
+        ["a", "bx", "c"], "bx", ["b1", "b2", "b3"]
+    )
+    assert result == ["a", "b1", "b2", "b3", "c"]
+
+
+def test_replace_list_element_not_found():
+    orig = ["a", "b", "c"]
+    result = salt.utils.data.replace_list_element(orig, "z", ["x"])
+    assert result is orig  # same object returned unchanged
+
+
+def test_replace_list_element_multiple_occurrences():
+    result = salt.utils.data.replace_list_element(["x", "y", "x"], "x", ["1", "2"])
+    assert result == ["1", "2", "y", "1", "2"]  # each 'x' expanded to ['1', '2']
+
+
+def test_replace_list_element_empty_updates():
+    result = salt.utils.data.replace_list_element(["a", "bx", "c"], "bx", [])
+    assert result == ["a", "c"]
+
+
+def test_replace_list_element_orig_not_list():
+    from salt.exceptions import SaltInvocationError
+
+    with pytest.raises(SaltInvocationError):
+        salt.utils.data.replace_list_element("not-a-list", "x", ["y"])
+
+
+def test_replace_list_element_updates_not_list():
+    from salt.exceptions import SaltInvocationError
+
+    with pytest.raises(SaltInvocationError):
+        salt.utils.data.replace_list_element(["a"], "a", "not-a-list")
+
+
+def test_replace_list_element_both_not_list():
+    from salt.exceptions import SaltInvocationError
+
+    with pytest.raises(SaltInvocationError):
+        salt.utils.data.replace_list_element("orig", "x", "updates")
+
+
+# ---------------------------------------------------------------------------
+# Tests for updated_dict()
+# ---------------------------------------------------------------------------
+
+
+def test_updated_dict_basic():
+    base = {"a": 1, "b": 2}
+    updates = {"b": 99, "c": 3}
+    result = salt.utils.data.updated_dict(base, updates)
+    assert result == {"a": 1, "b": 99, "c": 3}
+
+
+def test_updated_dict_does_not_mutate_base():
+    base = {"a": 1}
+    salt.utils.data.updated_dict(base, {"a": 2})
+    assert base == {"a": 1}
+
+
+def test_updated_dict_does_not_mutate_updates():
+    updates = {"b": 2}
+    salt.utils.data.updated_dict({"a": 1}, updates)
+    assert updates == {"b": 2}
+
+
+def test_updated_dict_empty_base():
+    assert salt.utils.data.updated_dict({}, {"a": 1}) == {"a": 1}
+
+
+def test_updated_dict_empty_updates():
+    assert salt.utils.data.updated_dict({"a": 1}, {}) == {"a": 1}


### PR DESCRIPTION
### What does this PR do?

Adds some functions to `salt/utils/data.py`
  - `get_type()` to query a Python type inside a Jinja template
  - `glob_list()` to get only the elements of a list matching the glob
  - `list_rm_match()` to get a news list without the elements matching a regex
  - `replace_list_element()` to turn `[a, bx, c]` into `[a, b1, b2 ,b3, c]`
  - `updated_dict()` to get an update of a dict without modifying the original one

I think all five are results of trying to make Jinja do things it's not made for
and at lease some of them may even be suitable for becoming Jinja filters.

Pointers to other modules doing those things are welcome, too, so we don't
have to maintain custom modules until this PR gets merged, even if only
partially ; )

### What issues does this PR fix or reference?
Fixes: `None`

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
~~Yes~~/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
