### PR TITLE
[master][WIP] github.get_releases() & github.check_releases

### DIFF
--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -779,6 +779,28 @@ def filter_by(lookup_dict, lookup, traverse, merge=None, default="default", base
     return ret
 
 
+def glob_list(data, pattern):
+    """
+    Uses fnmatch for "globbing" elements of a list:
+    The globbing the list [eth0, eth2, lo] with pattern
+    'eth*' results in [eth0, eth2]
+
+    Same function as used in Salt's match.glob.
+    https://docs.python.org/3/library/fnmatch.html
+    """
+    if not isinstance(data, list):
+        error_msg = "1st argument should be a list but is "
+        raise TypeError(error_msg + str(type(data)))
+    matches = []
+    for num, element in enumerate(data):
+        if not isinstance(element, str):
+            error_msg = "List element " + str(num) + " isn't a str but "
+            raise TypeError(error_msg + str(element))
+        if fnmatch.fnmatch(element, str(pattern)):
+            matches.append(element)
+    return matches
+
+
 def replace_list_element(orig, placeholder, updates_list):
     """
     Takes a list `orig` and inserts the elements of `updates_list`

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -779,6 +779,38 @@ def filter_by(lookup_dict, lookup, traverse, merge=None, default="default", base
     return ret
 
 
+def replace_list_element(orig, placeholder, updates_list):
+    """
+    Takes a list `orig` and inserts the elements of `updates_list`
+    anyplace where an element equal `placeholder` has been.
+    In list ['a', 'bx', 'c'] placeholder 'bx' would be replaced
+    with the elements of ['b1', 'b2', 'b3'] resulting in list
+    ['a', 'b1', 'b2', 'b3', 'c'].
+    """
+    if not isinstance(orig, list) or not isinstance(updates_list, list):
+        if not isinstance(orig, list) and not isinstance(updates_list, list):
+            msg = "Neiter arg 0 'orig' nor arg 2 'updates_list' is a list-like!"
+        if not isinstance(orig, list) and isinstance(updates_list, list):
+            msg = "Arg 0 'orig' isn't a list(-like object)!"
+        if isinstance(orig, list) and not isinstance(updates_list, list):
+            msg = "Arg 2 'updates_list' isn't a list(-like object)!"
+        raise TypeError(msg)
+
+    if placeholder not in orig:
+        return orig
+    indexed_orig = list(enumerate(orig))
+    indexed_orig.reverse()
+    updated = []
+    for index, elem in indexed_orig:
+        if elem == placeholder:
+            for update in updates_list:
+                updated.insert(index, update)
+        else:
+            updated.append(elem)
+    updated.reverse()
+    return updated
+
+
 def traverse_dict(data, key, default=None, delimiter=DEFAULT_TARGET_DELIM):
     """
     Traverse a dict using a colon-delimited (or otherwise delimited, using the


### PR DESCRIPTION
### What does this PR do?
Big W.I.P., quite some clean-up needed besides docs missing.

Adds functions to get a list of a Github project's releases and to check for a specific project's release. Globbing of the version number (querying for version 1.2 and accepting 1.2.1, too) in the later one depends on `salt.utils.data.glob_list()`, see [PR #64703](https://github.com/saltstack/salt/pull/64703/commits/0ebb736ed9233267407d8a007ea1be1918689dfb).[^1]

[^1]: No idea why idea why the changes from [`f664e6e` which added `replace_list_element()`](https://github.com/saltstack/salt/pull/64703/commits/f664e6ec2c458c20a25a2c27d2edae914a272927) were applied when I cherry-picked the one for `salt.utils.data.glob_list()` but cherry-picking both resulted in a cleaner commit history.

Doesn't actually use PyGithub just the pure JSON API so it would work despite PyGithub missing on the minion.
Would be nice to have a reduced `github` exec module is PyGithub is missing, wouldn't it?

### What issues does this PR fix or reference?
Fixes: `None`

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
~~Yes~~/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
