### PR TITLE
[3006.x] Bump to `certifi==2023.07.22` due to https://github.com/advisories/GHSA-xqr8-7jwr-rhp7

### DIFF
--- a/changelog/64718.security.md
+++ b/changelog/64718.security.md
@@ -1,0 +1,1 @@
+Bump to `certifi==2023.07.22` due to https://github.com/advisories/GHSA-xqr8-7jwr-rhp7

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -350,7 +350,7 @@ cachetools==4.2.2
     # via google-auth
 cassandra-driver==3.25.0
     # via -r requirements/static/ci/common.in
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -r requirements/static/ci/common.in
     #   kubernetes

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -350,7 +350,7 @@ cachetools==3.1.0
     # via google-auth
 cassandra-driver==3.23.0
     # via -r requirements/static/ci/common.in
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -r requirements/static/ci/common.in
     #   kubernetes

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -8,7 +8,7 @@ alabaster==0.7.12
     # via sphinx
 babel==2.9.1
     # via sphinx
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   requests

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -348,7 +348,7 @@ cachetools==3.1.0
     # via google-auth
 cassandra-driver==3.24.0
     # via -r requirements/static/ci/common.in
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -r requirements/static/ci/common.in
     #   kubernetes

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -353,7 +353,7 @@ cachetools==4.2.2
     #   python-telegram-bot
 cassandra-driver==3.25.0
     # via -r requirements/static/ci/common.in
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -r requirements/static/ci/common.in
     #   kubernetes

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -361,7 +361,7 @@ cachetools==4.2.2
     #   python-telegram-bot
 cassandra-driver==3.23.0
     # via -r requirements/static/ci/common.in
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -r requirements/static/ci/common.in
     #   kubernetes

--- a/requirements/static/ci/py3.10/pkgtests-windows.txt
+++ b/requirements/static/ci/py3.10/pkgtests-windows.txt
@@ -13,7 +13,7 @@ attrs==22.2.0
     #   pytest-system-statistics
 autocommand==2.2.2
     # via jaraco.text
-certifi==2022.12.7
+certifi==2023.07.22
     # via requests
 cffi==1.15.1
     # via clr-loader

--- a/requirements/static/ci/py3.10/pkgtests.txt
+++ b/requirements/static/ci/py3.10/pkgtests.txt
@@ -13,7 +13,7 @@ attrs==22.2.0
     #   pytest-system-statistics
 autocommand==2.2.2
     # via jaraco.text
-certifi==2022.12.7
+certifi==2023.07.22
     # via requests
 charset-normalizer==3.0.1
     # via requests

--- a/requirements/static/ci/py3.10/tools.txt
+++ b/requirements/static/ci/py3.10/tools.txt
@@ -14,7 +14,7 @@ botocore==1.24.46
     # via
     #   boto3
     #   s3transfer
-certifi==2022.12.7
+certifi==2023.07.22
     # via requests
 charset-normalizer==3.0.1
     # via requests

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -36,7 +36,7 @@ cachetools==3.1.0
     # via google-auth
 cassandra-driver==3.23.0
     # via -r requirements/static/ci/common.in
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt

--- a/requirements/static/ci/py3.11/tools.txt
+++ b/requirements/static/ci/py3.11/tools.txt
@@ -14,7 +14,7 @@ botocore==1.24.46
     # via
     #   boto3
     #   s3transfer
-certifi==2022.12.7
+certifi==2023.07.22
     # via requests
 charset-normalizer==3.0.1
     # via requests

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -352,7 +352,7 @@ cachetools==4.2.2
     # via google-auth
 cassandra-driver==3.25.0
     # via -r requirements/static/ci/common.in
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -r requirements/static/ci/common.in
     #   kubernetes

--- a/requirements/static/ci/py3.7/docs.txt
+++ b/requirements/static/ci/py3.7/docs.txt
@@ -8,7 +8,7 @@ alabaster==0.7.12
     # via sphinx
 babel==2.9.1
     # via sphinx
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -c requirements/static/ci/py3.7/linux.txt
     #   requests

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -350,7 +350,7 @@ cachetools==3.1.0
     # via google-auth
 cassandra-driver==3.24.0
     # via -r requirements/static/ci/common.in
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -r requirements/static/ci/common.in
     #   kubernetes

--- a/requirements/static/ci/py3.7/lint.txt
+++ b/requirements/static/ci/py3.7/lint.txt
@@ -357,7 +357,7 @@ cachetools==4.2.2
     #   python-telegram-bot
 cassandra-driver==3.25.0
     # via -r requirements/static/ci/common.in
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -r requirements/static/ci/common.in
     #   kubernetes

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -363,7 +363,7 @@ cachetools==4.2.2
     #   python-telegram-bot
 cassandra-driver==3.23.0
     # via -r requirements/static/ci/common.in
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -r requirements/static/ci/common.in
     #   kubernetes

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -42,7 +42,7 @@ cachetools==3.1.0
     # via google-auth
 cassandra-driver==3.23.0
     # via -r requirements/static/ci/common.in
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -350,7 +350,7 @@ cachetools==4.2.2
     # via google-auth
 cassandra-driver==3.25.0
     # via -r requirements/static/ci/common.in
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -r requirements/static/ci/common.in
     #   kubernetes

--- a/requirements/static/ci/py3.8/docs.txt
+++ b/requirements/static/ci/py3.8/docs.txt
@@ -8,7 +8,7 @@ alabaster==0.7.12
     # via sphinx
 babel==2.9.1
     # via sphinx
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   requests

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -348,7 +348,7 @@ cachetools==3.1.0
     # via google-auth
 cassandra-driver==3.24.0
     # via -r requirements/static/ci/common.in
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -r requirements/static/ci/common.in
     #   kubernetes

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -355,7 +355,7 @@ cachetools==4.2.2
     #   python-telegram-bot
 cassandra-driver==3.25.0
     # via -r requirements/static/ci/common.in
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -r requirements/static/ci/common.in
     #   kubernetes

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -361,7 +361,7 @@ cachetools==4.2.2
     #   python-telegram-bot
 cassandra-driver==3.23.0
     # via -r requirements/static/ci/common.in
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -r requirements/static/ci/common.in
     #   kubernetes

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -38,7 +38,7 @@ cachetools==3.1.0
     # via google-auth
 cassandra-driver==3.23.0
     # via -r requirements/static/ci/common.in
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -350,7 +350,7 @@ cachetools==4.2.2
     # via google-auth
 cassandra-driver==3.25.0
     # via -r requirements/static/ci/common.in
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -r requirements/static/ci/common.in
     #   kubernetes

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -350,7 +350,7 @@ cachetools==3.1.0
     # via google-auth
 cassandra-driver==3.23.0
     # via -r requirements/static/ci/common.in
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -r requirements/static/ci/common.in
     #   kubernetes

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -8,7 +8,7 @@ alabaster==0.7.12
     # via sphinx
 babel==2.9.1
     # via sphinx
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   requests

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -348,7 +348,7 @@ cachetools==3.1.0
     # via google-auth
 cassandra-driver==3.24.0
     # via -r requirements/static/ci/common.in
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -r requirements/static/ci/common.in
     #   kubernetes

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -353,7 +353,7 @@ cachetools==4.2.2
     #   python-telegram-bot
 cassandra-driver==3.25.0
     # via -r requirements/static/ci/common.in
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -r requirements/static/ci/common.in
     #   kubernetes

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -363,7 +363,7 @@ cachetools==4.2.2
     #   python-telegram-bot
 cassandra-driver==3.23.0
     # via -r requirements/static/ci/common.in
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -r requirements/static/ci/common.in
     #   kubernetes

--- a/requirements/static/ci/py3.9/tools.txt
+++ b/requirements/static/ci/py3.9/tools.txt
@@ -14,7 +14,7 @@ botocore==1.24.46
     # via
     #   boto3
     #   s3transfer
-certifi==2022.12.7
+certifi==2023.07.22
     # via requests
 charset-normalizer==3.0.1
     # via requests

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -38,7 +38,7 @@ cachetools==3.1.0
     # via google-auth
 cassandra-driver==3.23.0
     # via -r requirements/static/ci/common.in
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -6,7 +6,7 @@
 #
 apache-libcloud==2.5.0
     # via -r requirements/darwin.txt
-certifi==2022.12.7
+certifi==2023.07.22
     # via requests
 cffi==1.14.6
     # via cryptography

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/static/pkg/py3.10/freebsd.txt requirements/base.txt requirements/static/pkg/freebsd.in requirements/zeromq.txt
 #
-certifi==2022.12.7
+certifi==2023.07.22
     # via requests
 cffi==1.14.6
     # via cryptography

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/static/pkg/py3.10/linux.txt requirements/base.txt requirements/static/pkg/linux.in requirements/zeromq.txt
 #
-certifi==2022.12.7
+certifi==2023.07.22
     # via requests
 cffi==1.14.6
     # via cryptography

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/static/pkg/py3.10/windows.txt requirements/static/pkg/windows.in requirements/windows.txt
 #
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -r requirements/windows.txt
     #   requests

--- a/requirements/static/pkg/py3.7/freebsd.txt
+++ b/requirements/static/pkg/py3.7/freebsd.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/static/pkg/py3.7/freebsd.txt requirements/base.txt requirements/static/pkg/freebsd.in requirements/zeromq.txt
 #
-certifi==2022.12.7
+certifi==2023.07.22
     # via requests
 cffi==1.14.6
     # via cryptography

--- a/requirements/static/pkg/py3.7/linux.txt
+++ b/requirements/static/pkg/py3.7/linux.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/static/pkg/py3.7/linux.txt requirements/base.txt requirements/static/pkg/linux.in requirements/zeromq.txt
 #
-certifi==2022.12.7
+certifi==2023.07.22
     # via requests
 cffi==1.14.6
     # via cryptography

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/static/pkg/py3.7/windows.txt requirements/static/pkg/windows.in requirements/windows.txt
 #
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -r requirements/windows.txt
     #   requests

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/static/pkg/py3.8/freebsd.txt requirements/base.txt requirements/static/pkg/freebsd.in requirements/zeromq.txt
 #
-certifi==2022.12.7
+certifi==2023.07.22
     # via requests
 cffi==1.14.6
     # via cryptography

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/static/pkg/py3.8/linux.txt requirements/base.txt requirements/static/pkg/linux.in requirements/zeromq.txt
 #
-certifi==2022.12.7
+certifi==2023.07.22
     # via requests
 cffi==1.14.6
     # via cryptography

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/static/pkg/py3.8/windows.txt requirements/static/pkg/windows.in requirements/windows.txt
 #
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -r requirements/windows.txt
     #   requests

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -6,7 +6,7 @@
 #
 apache-libcloud==2.5.0
     # via -r requirements/darwin.txt
-certifi==2022.12.7
+certifi==2023.07.22
     # via requests
 cffi==1.14.6
     # via cryptography

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/static/pkg/py3.9/freebsd.txt requirements/base.txt requirements/static/pkg/freebsd.in requirements/zeromq.txt
 #
-certifi==2022.12.7
+certifi==2023.07.22
     # via requests
 cffi==1.14.6
     # via cryptography

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/static/pkg/py3.9/linux.txt requirements/base.txt requirements/static/pkg/linux.in requirements/zeromq.txt
 #
-certifi==2022.12.7
+certifi==2023.07.22
     # via requests
 cffi==1.14.6
     # via cryptography

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/static/pkg/py3.9/windows.txt requirements/static/pkg/windows.in requirements/windows.txt
 #
-certifi==2022.12.7
+certifi==2023.07.22
     # via
     #   -r requirements/windows.txt
     #   requests


### PR DESCRIPTION
### What does this PR do?
Bump to `certifi==2023.07.22` due to https://github.com/advisories/GHSA-xqr8-7jwr-rhp7
