### PR TITLE
[master] FIX #61578  Zabbix Host Fixes for 5.4

### DIFF
--- a/changelog/61578.fixed.md
+++ b/changelog/61578.fixed.md
@@ -1,0 +1,1 @@
+salt/states/zabbix_host.py - added support for new hostinterface object fields introduced in zabbix 5.4

--- a/salt/states/zabbix_host.py
+++ b/salt/states/zabbix_host.py
@@ -85,14 +85,14 @@ def present(host, groups, interfaces, **kwargs):
     ret = {"name": host, "changes": {}, "result": False, "comment": ""}
 
     # Comment and change messages
-    comment_host_created = "Host {} created.".format(host)
-    comment_host_updated = "Host {} updated.".format(host)
-    comment_host_notcreated = "Unable to create host: {}. ".format(host)
-    comment_host_exists = "Host {} already exists.".format(host)
+    comment_host_created = f"Host {host} created."
+    comment_host_updated = f"Host {host} updated."
+    comment_host_notcreated = f"Unable to create host: {host}. "
+    comment_host_exists = f"Host {host} already exists."
     changes_host_created = {
         host: {
-            "old": "Host {} does not exist.".format(host),
-            "new": "Host {} created.".format(host),
+            "old": f"Host {host} does not exist.",
+            "new": f"Host {host} created.",
         }
     }
 
@@ -206,7 +206,7 @@ def present(host, groups, interfaces, **kwargs):
             try:
                 groupids.append(int(groupid[0]["groupid"]))
             except TypeError:
-                ret["comment"] = "Invalid group {}".format(group)
+                ret["comment"] = f"Invalid group {group}"
                 return ret
         else:
             groupids.append(group)
@@ -224,23 +224,23 @@ def present(host, groups, interfaces, **kwargs):
                     {
                         "output": "proxyid",
                         "selectInterface": "extend",
-                        "filter": {"host": "{}".format(proxy_host)},
+                        "filter": {"host": f"{proxy_host}"},
                     },
-                    **connection_args
+                    **connection_args,
                 )[0]["proxyid"]
             except TypeError:
-                ret["comment"] = "Invalid proxy_host {}".format(proxy_host)
+                ret["comment"] = f"Invalid proxy_host {proxy_host}"
                 return ret
         # Otherwise lookup proxy_host as proxyid
         else:
             try:
                 proxy_hostid = __salt__["zabbix.run_query"](
                     "proxy.get",
-                    {"proxyids": "{}".format(proxy_host), "output": "proxyid"},
-                    **connection_args
+                    {"proxyids": f"{proxy_host}", "output": "proxyid"},
+                    **connection_args,
                 )[0]["proxyid"]
             except TypeError:
-                ret["comment"] = "Invalid proxy_host {}".format(proxy_host)
+                ret["comment"] = f"Invalid proxy_host {proxy_host}"
                 return ret
 
     # Selects if the current inventory should be substituted by the new one
@@ -326,9 +326,17 @@ def present(host, groups, interfaces, **kwargs):
         if hostinterfaces:
             hostinterfaces = sorted(hostinterfaces, key=lambda k: k["main"])
             hostinterfaces_copy = deepcopy(hostinterfaces)
+            hostinterface_read_only_fields = [
+                "interfaceid",
+                "hostid",
+                "available",
+                "error",
+                "errors_from",
+                "disable_until",
+            ]
             for hostintf in hostinterfaces_copy:
-                hostintf.pop("interfaceid")
-                hostintf.pop("hostid")
+                for field in hostinterface_read_only_fields:
+                    hostintf.pop(field, None)
                 # "bulk" is present only in snmp interfaces with Zabbix < 5.0
                 if "bulk" in hostintf:
                     hostintf.pop("bulk")
@@ -459,7 +467,7 @@ def present(host, groups, interfaces, **kwargs):
                             useip=interface["useip"],
                             port=interface["port"],
                             details=interface["details"],
-                            **connection_args
+                            **connection_args,
                         )
                     else:
                         interfaceid = interfaceid_by_type[interface["type"]].pop(0)
@@ -472,7 +480,7 @@ def present(host, groups, interfaces, **kwargs):
                             useip=interface["useip"],
                             port=interface["port"],
                             details=interface["details"],
-                            **connection_args
+                            **connection_args,
                         )
                     return ret
 
@@ -516,7 +524,7 @@ def present(host, groups, interfaces, **kwargs):
             proxy_hostid=proxy_hostid,
             inventory=new_inventory,
             visible_name=visible_name,
-            **sum_kwargs
+            **sum_kwargs,
         )
 
         if "error" not in host_create:
@@ -556,13 +564,13 @@ def absent(name, **kwargs):
     ret = {"name": name, "changes": {}, "result": False, "comment": ""}
 
     # Comment and change messages
-    comment_host_deleted = "Host {} deleted.".format(name)
-    comment_host_notdeleted = "Unable to delete host: {}. ".format(name)
-    comment_host_notexists = "Host {} does not exist.".format(name)
+    comment_host_deleted = f"Host {name} deleted."
+    comment_host_notdeleted = f"Unable to delete host: {name}. "
+    comment_host_notexists = f"Host {name} does not exist."
     changes_host_deleted = {
         name: {
-            "old": "Host {} exists.".format(name),
-            "new": "Host {} deleted.".format(name),
+            "old": f"Host {name} exists.",
+            "new": f"Host {name} deleted.",
         }
     }
     connection_args = {}
@@ -670,7 +678,7 @@ def assign_templates(host, templates, **kwargs):
         hostids=hostid,
         output='[{"hostid"}]',
         selectParentTemplates='["templateid"]',
-        **connection_args
+        **connection_args,
     )
     for template_id in host_templates[0]["parentTemplates"]:
         curr_template_ids.append(template_id["templateid"])
@@ -684,7 +692,7 @@ def assign_templates(host, templates, **kwargs):
             requested_template_ids.append(template_id)
         except TypeError:
             ret["result"] = False
-            ret["comment"] = "Unable to find template: {}.".format(template)
+            ret["comment"] = f"Unable to find template: {template}."
             return ret
 
     # remove any duplications


### PR DESCRIPTION
### What does this PR do?

The Salt state zabbix_host manages hosts in Zabbix using the Zabbix API. Changes to the Zabbix API in version 5.4 lead to a bug for the state module. Even though there was no change either to the configuration or the the host in Zabbix Salt updates the host every time.

The state is checking for differences between the current and the desired state of a host. A host in Zabbix also contains information about different interfaces. In Zabbix 5.4 new fields were added to the hostinterface object. These are read-only fields which reflect information about the status of the interface. These information are not relevant for the configuration state of the host.

I added code to ensure that these fields get removed if they exists before the comparison takes place. Otherwise a difference between the current and the desired state will be assumed. I also updated the unit test so that this information is included. This change should be backwards compatible. I also added a test for not updating a host which already is in the desired state which does not have the new fields included.

Further information to the changes on Zabbix side can be found here:

- https://www.zabbix.com/documentation/5.4/en/manual/api/changes_5.2_-_5.4
- https://support.zabbix.com/browse/ZBXNEXT-6311
- https://www.zabbix.com/documentation/5.4/en/manual/api/reference/hostinterface/object

**tl;dr**
Remove new read-only fields from hostinterface objects, which were added in Zabbix version 5.4
These cause Salt to update the host each and every time, even if there is no difference between the desired and actual state of the host.

### What issues does this PR fix or reference?
Fixes: #61578

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs - no new/different behavior, no new features/parameters - only a bug was fixed - so I applied no changes to the documentation
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
