### PR TITLE
[3006.x] Pillar timeout

### DIFF
--- a/changelog/63824.fixed.md
+++ b/changelog/63824.fixed.md
@@ -1,0 +1,1 @@
+Allow long running pillar and file client requests to finish using request_channel_timeout and request_channel_tries minion config.

--- a/changelog/64651.fixed.md
+++ b/changelog/64651.fixed.md
@@ -1,0 +1,1 @@
+Show user friendly message when pillars timeout

--- a/changelog/64653.fixed.md
+++ b/changelog/64653.fixed.md
@@ -1,0 +1,1 @@
+File client timeouts durring jobs show user friendly errors instead of tracbacks

--- a/changelog/64729.fixed.md
+++ b/changelog/64729.fixed.md
@@ -1,0 +1,1 @@
+SaltClientError does not log a traceback on minions, we expect these to happen so a user friendly log is shown.

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -1305,6 +1305,36 @@ restart.
 
     auth_safemode: False
 
+.. conf_minion:: request_channel_timeout
+
+``request_channel_timeout``
+---------------------------
+
+.. versionadded:: 3006.2
+
+Default: ``30``
+
+The default timeout timeout for request channel requests. This setting can be used to tune minions to better handle long running pillar and file client requests.
+
+.. code-block:: yaml
+
+    request_channel_timeout: 30
+
+``request_channel_tries``
+-------------------------
+
+.. versionadded:: 3006.2
+
+Default: ``3``
+
+The default number of times the minion will try request channel requests. This
+setting can be used to tune minions to better handle long running pillar and
+file client requests by retrying them after a timeout happens.
+
+.. code-block:: yaml
+
+    request_channel_tries: 3
+
 .. conf_minion:: ping_interval
 
 ``ping_interval``

--- a/salt/channel/client.py
+++ b/salt/channel/client.py
@@ -40,6 +40,9 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
+REQUEST_CHANNEL_TIMEOUT = 60
+REQUEST_CHANNEL_TRIES = 3
+
 
 class ReqChannel:
     """
@@ -121,6 +124,9 @@ class AsyncReqChannel:
         if io_loop is None:
             io_loop = salt.ext.tornado.ioloop.IOLoop.current()
 
+        timeout = opts.get("request_channel_timeout", REQUEST_CHANNEL_TIMEOUT)
+        tries = opts.get("request_channel_tries", REQUEST_CHANNEL_TRIES)
+
         crypt = kwargs.get("crypt", "aes")
         if crypt != "clear":
             # we don't need to worry about auth as a kwarg, since its a singleton
@@ -129,9 +135,17 @@ class AsyncReqChannel:
             auth = None
 
         transport = salt.transport.request_client(opts, io_loop=io_loop)
-        return cls(opts, transport, auth)
+        return cls(opts, transport, auth, tries=tries, timeout=timeout)
 
-    def __init__(self, opts, transport, auth, **kwargs):
+    def __init__(
+        self,
+        opts,
+        transport,
+        auth,
+        timeout=REQUEST_CHANNEL_TIMEOUT,
+        tries=REQUEST_CHANNEL_TRIES,
+        **kwargs
+    ):
         self.opts = dict(opts)
         self.transport = transport
         self.auth = auth
@@ -139,6 +153,8 @@ class AsyncReqChannel:
         if self.auth:
             self.master_pubkey_path = os.path.join(self.opts["pki_dir"], self.auth.mpub)
         self._closing = False
+        self.timeout = timeout
+        self.tries = tries
 
     @property
     def crypt(self):
@@ -158,27 +174,53 @@ class AsyncReqChannel:
         }
 
     @salt.ext.tornado.gen.coroutine
+    def _send_with_retry(self, load, tries, timeout):
+        _try = 1
+        while True:
+            try:
+                ret = yield self.transport.send(
+                    load,
+                    timeout=timeout,
+                )
+                break
+            except Exception as exc:  # pylint: disable=broad-except
+                log.trace("Failed to send msg %r", exc)
+                if _try >= tries:
+                    raise
+                else:
+                    _try += 1
+                    continue
+        raise salt.ext.tornado.gen.Return(ret)
+
+    @salt.ext.tornado.gen.coroutine
     def crypted_transfer_decode_dictentry(
         self,
         load,
         dictkey=None,
-        timeout=60,
+        timeout=None,
+        tries=None,
     ):
+        if timeout is None:
+            timeout = self.timeout
+        if tries is None:
+            tries = self.tries
         nonce = uuid.uuid4().hex
         load["nonce"] = nonce
         if not self.auth.authenticated:
             yield self.auth.authenticate()
-        ret = yield self.transport.send(
+        ret = yield self._send_with_retry(
             self._package_load(self.auth.crypticle.dumps(load)),
-            timeout=timeout,
+            tries,
+            timeout,
         )
         key = self.auth.get_keys()
         if "key" not in ret:
             # Reauth in the case our key is deleted on the master side.
             yield self.auth.authenticate()
-            ret = yield self.transport.send(
+            ret = yield self._send_with_retry(
                 self._package_load(self.auth.crypticle.dumps(load)),
-                timeout=timeout,
+                tries,
+                timeout,
             )
         if HAS_M2:
             aes = key.private_decrypt(ret["key"], RSA.pkcs1_oaep_padding)
@@ -210,7 +252,7 @@ class AsyncReqChannel:
         return salt.crypt.verify_signature(self.master_pubkey_path, data, sig)
 
     @salt.ext.tornado.gen.coroutine
-    def _crypted_transfer(self, load, timeout=60, raw=False):
+    def _crypted_transfer(self, load, timeout, raw=False):
         """
         Send a load across the wire, with encryption
 
@@ -257,7 +299,7 @@ class AsyncReqChannel:
         raise salt.ext.tornado.gen.Return(ret)
 
     @salt.ext.tornado.gen.coroutine
-    def _uncrypted_transfer(self, load, timeout=60):
+    def _uncrypted_transfer(self, load, timeout):
         """
         Send a load across the wire in cleartext
 
@@ -276,7 +318,7 @@ class AsyncReqChannel:
         yield self.transport.connect()
 
     @salt.ext.tornado.gen.coroutine
-    def send(self, load, tries=3, timeout=60, raw=False):
+    def send(self, load, tries=None, timeout=None, raw=False):
         """
         Send a request, return a future which will complete when we send the message
 
@@ -284,6 +326,10 @@ class AsyncReqChannel:
         :param int tries: The number of times to make before failure
         :param int timeout: The number of seconds on a response before failing
         """
+        if timeout is None:
+            timeout = self.timeout
+        if tries is None:
+            tries = self.tries
         _try = 1
         while True:
             try:

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -991,6 +991,8 @@ VALID_OPTS = immutabletypes.freeze(
         "maintenance_interval": int,
         # Fileserver process restart interval
         "fileserver_interval": int,
+        "request_channel_timeout": int,
+        "request_channel_tries": int,
     }
 )
 
@@ -1052,6 +1054,8 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze(
         "pillar_cache": False,
         "pillar_cache_ttl": 3600,
         "pillar_cache_backend": "disk",
+        "request_channel_timeout": 30,
+        "request_channel_tries": 3,
         "gpg_cache": False,
         "gpg_cache_ttl": 86400,
         "gpg_cache_backend": "disk",

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -9,6 +9,7 @@ import logging
 import os
 import shutil
 import string
+import time
 import urllib.error
 import urllib.parse
 
@@ -31,7 +32,7 @@ import salt.utils.templates
 import salt.utils.url
 import salt.utils.verify
 import salt.utils.versions
-from salt.exceptions import CommandExecutionError, MinionError
+from salt.exceptions import CommandExecutionError, MinionError, SaltClientError
 from salt.ext.tornado.httputil import (
     HTTPHeaders,
     HTTPInputError,
@@ -793,7 +794,7 @@ class Client:
                 opts=self.opts,
                 verify_ssl=verify_ssl,
                 header_dict=header_dict,
-                **get_kwargs
+                **get_kwargs,
             )
 
             # 304 Not Modified is returned when If-None-Match header
@@ -822,7 +823,7 @@ class Client:
                 "HTTP error {0} reading {1}: {3}".format(
                     exc.code,
                     url,
-                    *http.server.BaseHTTPRequestHandler.responses[exc.code]
+                    *http.server.BaseHTTPRequestHandler.responses[exc.code],
                 )
             )
         except urllib.error.URLError as exc:
@@ -839,7 +840,7 @@ class Client:
         makedirs=False,
         saltenv="base",
         cachedir=None,
-        **kwargs
+        **kwargs,
     ):
         """
         Cache a file then process it as a template
@@ -1136,6 +1137,18 @@ class RemoteClient(Client):
         self.channel = salt.channel.client.ReqChannel.factory(self.opts)
         return self.channel
 
+    def _channel_send(self, load, raw=False):
+        start = time.monotonic()
+        try:
+            return self.channel.send(
+                load,
+                raw=raw,
+            )
+        except salt.exceptions.SaltReqTimeoutError:
+            raise SaltClientError(
+                f"File client timed out after {int(time.time() - start)}"
+            )
+
     def destroy(self):
         if self._closing:
             return
@@ -1250,7 +1263,10 @@ class RemoteClient(Client):
                 load["loc"] = 0
             else:
                 load["loc"] = fn_.tell()
-            data = self.channel.send(load, raw=True)
+            data = self._channel_send(
+                load,
+                raw=True,
+            )
             # Sometimes the source is local (eg when using
             # 'salt.fileserver.FSChan'), in which case the keys are
             # already strings. Sometimes the source is remote, in which
@@ -1343,28 +1359,36 @@ class RemoteClient(Client):
         List the files on the master
         """
         load = {"saltenv": saltenv, "prefix": prefix, "cmd": "_file_list"}
-        return self.channel.send(load)
+        return self._channel_send(
+            load,
+        )
 
     def file_list_emptydirs(self, saltenv="base", prefix=""):
         """
         List the empty dirs on the master
         """
         load = {"saltenv": saltenv, "prefix": prefix, "cmd": "_file_list_emptydirs"}
-        return self.channel.send(load)
+        return self._channel_send(
+            load,
+        )
 
     def dir_list(self, saltenv="base", prefix=""):
         """
         List the dirs on the master
         """
         load = {"saltenv": saltenv, "prefix": prefix, "cmd": "_dir_list"}
-        return self.channel.send(load)
+        return self._channel_send(
+            load,
+        )
 
     def symlink_list(self, saltenv="base", prefix=""):
         """
         List symlinked files and dirs on the master
         """
         load = {"saltenv": saltenv, "prefix": prefix, "cmd": "_symlink_list"}
-        return self.channel.send(load)
+        return self._channel_send(
+            load,
+        )
 
     def __hash_and_stat_file(self, path, saltenv="base"):
         """
@@ -1385,7 +1409,9 @@ class RemoteClient(Client):
                 ret["hash_type"] = hash_type
                 return ret
         load = {"path": path, "saltenv": saltenv, "cmd": "_file_hash"}
-        return self.channel.send(load)
+        return self._channel_send(
+            load,
+        )
 
     def hash_file(self, path, saltenv="base"):
         """
@@ -1412,7 +1438,9 @@ class RemoteClient(Client):
                 except Exception:  # pylint: disable=broad-except
                     return hash_result, None
         load = {"path": path, "saltenv": saltenv, "cmd": "_file_find"}
-        fnd = self.channel.send(load)
+        fnd = self._channel_send(
+            load,
+        )
         try:
             stat_result = fnd.get("stat")
         except AttributeError:
@@ -1424,21 +1452,27 @@ class RemoteClient(Client):
         Return a list of the files in the file server's specified environment
         """
         load = {"saltenv": saltenv, "cmd": "_file_list"}
-        return self.channel.send(load)
+        return self._channel_send(
+            load,
+        )
 
     def envs(self):
         """
         Return a list of available environments
         """
         load = {"cmd": "_file_envs"}
-        return self.channel.send(load)
+        return self._channel_send(
+            load,
+        )
 
     def master_opts(self):
         """
         Return the master opts data
         """
         load = {"cmd": "_master_opts"}
-        return self.channel.send(load)
+        return self._channel_send(
+            load,
+        )
 
     def master_tops(self):
         """
@@ -1447,7 +1481,9 @@ class RemoteClient(Client):
         load = {"cmd": "_master_tops", "id": self.opts["id"], "opts": self.opts}
         if self.auth:
             load["tok"] = self.auth.gen_token(b"salt")
-        return self.channel.send(load)
+        return self._channel_send(
+            load,
+        )
 
     def __enter__(self):
         return self

--- a/tests/pytests/integration/minion/test_return_retries.py
+++ b/tests/pytests/integration/minion/test_return_retries.py
@@ -3,6 +3,8 @@ import time
 import pytest
 from saltfactories.utils import random_string
 
+from tests.support.helpers import dedent
+
 
 @pytest.fixture(scope="function")
 def salt_minion_retry(salt_master_factory, salt_minion_id):
@@ -50,3 +52,71 @@ def test_publish_retry(salt_master, salt_minion_retry, salt_cli, salt_run_cli):
 
     assert salt_minion_retry.id in data
     assert data[salt_minion_retry.id] is True
+
+
+@pytest.mark.slow_test
+def test_pillar_timeout(salt_master_factory):
+    cmd = """
+    python -c "import time; time.sleep(4.8); print('{\\"foo\\": \\"bar\\"}');\"
+    """.strip()
+    master_overrides = {
+        "ext_pillar": [
+            {"cmd_json": cmd},
+        ],
+        "auto_accept": True,
+        "worker_threads": 3,
+        "peer": True,
+    }
+    minion_overrides = {
+        "auth_timeout": 20,
+        "request_channel_timeout": 5,
+        "request_channel_tries": 1,
+    }
+    sls_name = "issue-50221"
+    sls_contents = dedent(
+        """
+    custom_test_state:
+      test.configurable_test_state:
+        - name: example
+        - changes: True
+        - result: True
+        - comment: "Nothing has acutally been changed"
+    """
+    )
+    master = salt_master_factory.salt_master_daemon(
+        "pillar-timeout-master",
+        overrides=master_overrides,
+    )
+    minion1 = master.salt_minion_daemon(
+        random_string("pillar-timeout-1-"),
+        overrides=minion_overrides,
+    )
+    minion2 = master.salt_minion_daemon(
+        random_string("pillar-timeout-2-"),
+        overrides=minion_overrides,
+    )
+    minion3 = master.salt_minion_daemon(
+        random_string("pillar-timeout-3-"),
+        overrides=minion_overrides,
+    )
+    minion4 = master.salt_minion_daemon(
+        random_string("pillar-timeout-4-"),
+        overrides=minion_overrides,
+    )
+    cli = master.salt_cli()
+    sls_tempfile = master.state_tree.base.temp_file(
+        "{}.sls".format(sls_name), sls_contents
+    )
+    with master.started(), minion1.started(), minion2.started(), minion3.started(), minion4.started(), sls_tempfile:
+        proc = cli.run("state.sls", sls_name, minion_tgt="*")
+        # At least one minion should have a Pillar timeout
+        print(proc)
+        assert proc.returncode == 1
+        minion_timed_out = False
+        # Find the minion that has a Pillar timeout
+        for key in proc.data:
+            if isinstance(proc.data[key], str):
+                if proc.data[key].find("Pillar timed out") != -1:
+                    minion_timed_out = True
+                    break
+        assert minion_timed_out is True

--- a/tests/pytests/integration/minion/test_return_retries.py
+++ b/tests/pytests/integration/minion/test_return_retries.py
@@ -30,7 +30,7 @@ def salt_minion_retry(salt_master_factory, salt_minion_id):
 @pytest.mark.slow_test
 def test_publish_retry(salt_master, salt_minion_retry, salt_cli, salt_run_cli):
     # run job that takes some time for warmup
-    rtn = salt_cli.run("test.sleep", "5", "--async", minion_tgt=salt_minion_retry.id)
+    rtn = salt_cli.run("test.sleep", "4.9", "--async", minion_tgt=salt_minion_retry.id)
     # obtain JID
     jid = rtn.stdout.strip().split(" ")[-1]
 
@@ -110,13 +110,12 @@ def test_pillar_timeout(salt_master_factory):
     with master.started(), minion1.started(), minion2.started(), minion3.started(), minion4.started(), sls_tempfile:
         proc = cli.run("state.sls", sls_name, minion_tgt="*")
         # At least one minion should have a Pillar timeout
-        print(proc)
         assert proc.returncode == 1
         minion_timed_out = False
         # Find the minion that has a Pillar timeout
         for key in proc.data:
             if isinstance(proc.data[key], str):
-                if proc.data[key].find("Pillar timed out") != -1:
+                if "Pillar timed out" in proc.data[key]:
                     minion_timed_out = True
                     break
         assert minion_timed_out is True

--- a/tests/pytests/integration/minion/test_return_retries.py
+++ b/tests/pytests/integration/minion/test_return_retries.py
@@ -3,8 +3,6 @@ import time
 import pytest
 from saltfactories.utils import random_string
 
-from tests.support.helpers import dedent
-
 
 @pytest.fixture(scope="function")
 def salt_minion_retry(salt_master_factory, salt_minion_id):
@@ -30,7 +28,7 @@ def salt_minion_retry(salt_master_factory, salt_minion_id):
 @pytest.mark.slow_test
 def test_publish_retry(salt_master, salt_minion_retry, salt_cli, salt_run_cli):
     # run job that takes some time for warmup
-    rtn = salt_cli.run("test.sleep", "4.9", "--async", minion_tgt=salt_minion_retry.id)
+    rtn = salt_cli.run("test.sleep", "5", "--async", minion_tgt=salt_minion_retry.id)
     # obtain JID
     jid = rtn.stdout.strip().split(" ")[-1]
 
@@ -57,7 +55,7 @@ def test_publish_retry(salt_master, salt_minion_retry, salt_cli, salt_run_cli):
 @pytest.mark.slow_test
 def test_pillar_timeout(salt_master_factory):
     cmd = """
-    python -c "import time; time.sleep(4.8); print('{\\"foo\\": \\"bar\\"}');\"
+    python -c "import time; time.sleep(2.5); print('{\\"foo\\": \\"bar\\"}');\"
     """.strip()
     master_overrides = {
         "ext_pillar": [
@@ -73,8 +71,7 @@ def test_pillar_timeout(salt_master_factory):
         "request_channel_tries": 1,
     }
     sls_name = "issue-50221"
-    sls_contents = dedent(
-        """
+    sls_contents = """
     custom_test_state:
       test.configurable_test_state:
         - name: example
@@ -82,7 +79,6 @@ def test_pillar_timeout(salt_master_factory):
         - result: True
         - comment: "Nothing has acutally been changed"
     """
-    )
     master = salt_master_factory.salt_master_daemon(
         "pillar-timeout-master",
         overrides=master_overrides,

--- a/tests/pytests/unit/test_fileclient.py
+++ b/tests/pytests/unit/test_fileclient.py
@@ -15,36 +15,33 @@ class MockReqChannel:
         return self
 
 
-def test_fileclient_context_manager_closes(temp_salt_minion, temp_salt_master):
+def test_fileclient_context_manager_closes(minion_opts, master_opts):
     """
     ensure fileclient channel closes
     when used with a context manager
     """
-    opts = temp_salt_minion.config.copy()
-    opts.update(
+    minion_opts.update(
         {
             "id": "root",
             "transport": "zeromq",
             "auth_tries": 1,
             "auth_timeout": 5,
             "master_ip": "127.0.0.1",
-            "master_port": temp_salt_master.config["ret_port"],
-            "master_uri": "tcp://127.0.0.1:{}".format(
-                temp_salt_master.config["ret_port"]
-            ),
+            "master_port": master_opts["ret_port"],
+            "master_uri": "tcp://127.0.0.1:{}".format(master_opts["ret_port"]),
             "request_channel_timeout": 1,
             "request_channel_tries": 1,
         }
     )
     master_uri = "tcp://{master_ip}:{master_port}".format(
-        master_ip="localhost", master_port=opts["master_port"]
+        master_ip="localhost", master_port=minion_opts["master_port"]
     )
     mock_reqchannel = MockReqChannel()
     patch_reqchannel = patch.object(
         salt.channel.client, "ReqChannel", return_value=mock_reqchannel
     )
     with patch_reqchannel:
-        with salt.fileclient.get_file_client(opts) as client:
+        with salt.fileclient.get_file_client(minion_opts) as client:
             client.master_opts()
             assert not client._closing
 
@@ -53,29 +50,26 @@ def test_fileclient_context_manager_closes(temp_salt_minion, temp_salt_master):
 
 
 @pytest.mark.slow_test
-def test_fileclient_timeout(temp_salt_minion, temp_salt_master):
+def test_fileclient_timeout(minion_opts, master_opts):
     """
     ensure fileclient channel closes
     when used with a context manager
     """
-    opts = temp_salt_minion.config.copy()
-    opts.update(
+    minion_opts.update(
         {
             "id": "root",
             "transport": "zeromq",
             "auth_tries": 1,
             "auth_timeout": 5,
             "master_ip": "127.0.0.1",
-            "master_port": temp_salt_master.config["ret_port"],
-            "master_uri": "tcp://127.0.0.1:{}".format(
-                temp_salt_master.config["ret_port"]
-            ),
+            "master_port": master_opts["ret_port"],
+            "master_uri": "tcp://127.0.0.1:{}".format(master_opts["ret_port"]),
             "request_channel_timeout": 1,
             "request_channel_tries": 1,
         }
     )
     master_uri = "tcp://{master_ip}:{master_port}".format(
-        master_ip="localhost", master_port=opts["master_port"]
+        master_ip="localhost", master_port=minion_opts["master_port"]
     )
 
     async def mock_auth():
@@ -84,7 +78,7 @@ def test_fileclient_timeout(temp_salt_minion, temp_salt_master):
     def mock_dumps(*args):
         return b"meh"
 
-    with salt.fileclient.get_file_client(opts) as client:
+    with salt.fileclient.get_file_client(minion_opts) as client:
         # Authenticate must return true
         client.auth.authenticate = mock_auth
         # Crypticla must return bytes to pass to transport.RequestClient.send

--- a/tests/pytests/unit/test_fileclient.py
+++ b/tests/pytests/unit/test_fileclient.py
@@ -1,5 +1,7 @@
+import pytest
+
 import salt.fileclient
-from tests.support.mock import patch
+from tests.support.mock import Mock, patch
 
 
 class MockReqChannel:
@@ -30,6 +32,8 @@ def test_fileclient_context_manager_closes(temp_salt_minion, temp_salt_master):
             "master_uri": "tcp://127.0.0.1:{}".format(
                 temp_salt_master.config["ret_port"]
             ),
+            "request_channel_timeout": 1,
+            "request_channel_tries": 1,
         }
     )
     master_uri = "tcp://{master_ip}:{master_port}".format(
@@ -46,3 +50,45 @@ def test_fileclient_context_manager_closes(temp_salt_minion, temp_salt_master):
 
         assert client._closing
         assert client.channel.close.called
+
+
+@pytest.mark.slow_test
+def test_fileclient_timeout(temp_salt_minion, temp_salt_master):
+    """
+    ensure fileclient channel closes
+    when used with a context manager
+    """
+    opts = temp_salt_minion.config.copy()
+    opts.update(
+        {
+            "id": "root",
+            "transport": "zeromq",
+            "auth_tries": 1,
+            "auth_timeout": 5,
+            "master_ip": "127.0.0.1",
+            "master_port": temp_salt_master.config["ret_port"],
+            "master_uri": "tcp://127.0.0.1:{}".format(
+                temp_salt_master.config["ret_port"]
+            ),
+            "request_channel_timeout": 1,
+            "request_channel_tries": 1,
+        }
+    )
+    master_uri = "tcp://{master_ip}:{master_port}".format(
+        master_ip="localhost", master_port=opts["master_port"]
+    )
+
+    async def mock_auth():
+        return True
+
+    def mock_dumps(*args):
+        return b"meh"
+
+    with salt.fileclient.get_file_client(opts) as client:
+        # Authenticate must return true
+        client.auth.authenticate = mock_auth
+        # Crypticla must return bytes to pass to transport.RequestClient.send
+        client.auth._crypticle = Mock()
+        client.auth._crypticle.dumps = mock_dumps
+        with pytest.raises(salt.exceptions.SaltClientError):
+            client.file_list()


### PR DESCRIPTION
### What does this PR do?

Fixes: #63824 #64651 #64653 #64729

- Allow for long running pillars by being able to tune request channel timeouts
- Show user friendly message in job requests when pillars timeout
- Allow for long running file client requests by being able to tune request channel timeouts
- Show user friendly message in file client requests when pillars timeout
- Do not show tracebacks on minions when SaltClientErrors happen because we expect them. Instead provide a useful log.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated
