### PR TITLE
[master] fix: Lookup individual group names instead of getting all groups

### DIFF
--- a/salt/utils/user.py
+++ b/salt/utils/user.py
@@ -158,13 +158,13 @@ def get_specific_user():
     user = get_user()
     if salt.utils.platform.is_windows():
         if _win_current_user_is_admin():
-            return "sudo_{}".format(user)
+            return f"sudo_{user}"
     else:
         env_vars = ("SUDO_USER",)
         if user == "root":
             for evar in env_vars:
                 if evar in os.environ:
-                    return "sudo_{}".format(os.environ[evar])
+                    return f"sudo_{os.environ[evar]}"
     return user
 
 
@@ -182,7 +182,7 @@ def chugid(runas, group=None):
             target_pw_gid = grp.getgrnam(group).gr_gid
         except KeyError as err:
             raise CommandExecutionError(
-                "Failed to fetch the GID for {}. Error: {}".format(group, err)
+                f"Failed to fetch the GID for {group}. Error: {err}"
             )
     else:
         target_pw_gid = uinfo.pw_gid
@@ -295,9 +295,7 @@ def get_group_list(user, include_default=True):
         try:
             user_group_list = os.getgrouplist(user, pwd.getpwnam(user).pw_gid)
             group_names = [
-                _group.gr_name
-                for _group in grp.getgrall()
-                if _group.gr_gid in user_group_list
+                grp.getgrgid(group_id).gr_name for group_id in user_group_list
             ]
         except Exception:  # pylint: disable=broad-except
             pass


### PR DESCRIPTION

### What does this PR do?

Changes the behavior of group lookups in salt/utils/user.py. Lookuping each group the user is a member of instead of listing all groups on the system, and comparing GID numbers with the user's GID numbers.

### What issues does this PR fix or reference?
Fixes: 64888

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
