### PR TITLE
[3006.x][BACKPORT] fix nightly repofile path

### DIFF
--- a/tools/pkg/repo/create.py
+++ b/tools/pkg/repo/create.py
@@ -488,7 +488,7 @@ def rpm(
     def _create_repo_file(create_repo_path, url_suffix):
         ctx.info(f"Creating '{repo_file_path.relative_to(repo_path)}' file ...")
         if nightly_build_from:
-            base_url = f"salt-dev/{nightly_build_from}/{datetime.utcnow().strftime("%Y-%m-%d") }"
+            base_url = f"salt-dev/{nightly_build_from}/{datetime.utcnow().strftime("%Y-%m-%d")}"
             repo_file_contents = "[salt-nightly-repo]"
         elif "rc" in salt_version:
             base_url = "salt_rc/"

--- a/tools/pkg/repo/create.py
+++ b/tools/pkg/repo/create.py
@@ -488,7 +488,7 @@ def rpm(
     def _create_repo_file(create_repo_path, url_suffix):
         ctx.info(f"Creating '{repo_file_path.relative_to(repo_path)}' file ...")
         if nightly_build_from:
-            base_url = f"salt-dev/{nightly_build_from}/{datetime.utcnow().strftime("%Y-%m-%d")}/"
+            base_url = f"salt-dev/{nightly_build_from}/{datetime.utcnow().strftime('%Y-%m-%d')}/"
             repo_file_contents = "[salt-nightly-repo]"
         elif "rc" in salt_version:
             base_url = "salt_rc/"

--- a/tools/pkg/repo/create.py
+++ b/tools/pkg/repo/create.py
@@ -488,7 +488,7 @@ def rpm(
     def _create_repo_file(create_repo_path, url_suffix):
         ctx.info(f"Creating '{repo_file_path.relative_to(repo_path)}' file ...")
         if nightly_build_from:
-            base_url = f"salt-dev/{nightly_build_from}/latest/{datetime.utcnow().strftime("%Y-%m-%d") }"
+            base_url = f"salt-dev/{nightly_build_from}/{datetime.utcnow().strftime("%Y-%m-%d") }"
             repo_file_contents = "[salt-nightly-repo]"
         elif "rc" in salt_version:
             base_url = "salt_rc/"

--- a/tools/pkg/repo/create.py
+++ b/tools/pkg/repo/create.py
@@ -488,7 +488,7 @@ def rpm(
     def _create_repo_file(create_repo_path, url_suffix):
         ctx.info(f"Creating '{repo_file_path.relative_to(repo_path)}' file ...")
         if nightly_build_from:
-            base_url = f"salt-dev/{nightly_build_from}/{datetime.utcnow().strftime("%Y-%m-%d")}"
+            base_url = f"salt-dev/{nightly_build_from}/{datetime.utcnow().strftime("%Y-%m-%d")}/"
             repo_file_contents = "[salt-nightly-repo]"
         elif "rc" in salt_version:
             base_url = "salt_rc/"

--- a/tools/pkg/repo/create.py
+++ b/tools/pkg/repo/create.py
@@ -12,6 +12,7 @@ import pathlib
 import shutil
 import sys
 import textwrap
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 from ptscripts import Context, command_group
@@ -487,7 +488,7 @@ def rpm(
     def _create_repo_file(create_repo_path, url_suffix):
         ctx.info(f"Creating '{repo_file_path.relative_to(repo_path)}' file ...")
         if nightly_build_from:
-            base_url = f"salt-dev/{nightly_build_from}/"
+            base_url = f"salt-dev/{nightly_build_from}/latest/{datetime.utcnow().strftime("%Y-%m-%d") }"
             repo_file_contents = "[salt-nightly-repo]"
         elif "rc" in salt_version:
             base_url = "salt_rc/"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `3006.x`:
 - [fix nightly repofile path](https://github.com/saltstack/salt/pull/64907)
 - [drop latest](https://github.com/saltstack/salt/pull/64907)
 - [linting](https://github.com/saltstack/salt/pull/64907)
 - [add missing slash](https://github.com/saltstack/salt/pull/64907)
 - [fix quotes in fstring](https://github.com/saltstack/salt/pull/64907)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)