### PR TITLE
[master] fix(mac_brew_pkg): Improve search for Homebrew's prefix

### DIFF
--- a/changelog/64924.fixed.md
+++ b/changelog/64924.fixed.md
@@ -1,0 +1,7 @@
+Fix the way Salt tries to get the Homebrew's prefix
+
+The first attempt to get the Homebrew's prefix is to look for
+the `HOMEBREW_PREFIX` environment variable. If it's not set, then
+Salt tries to get the prefix from the `brew` command. However, the
+`brew` command can failed. So a last attempt is made to get the
+prefix by guessing the installation path.

--- a/changelog/64924.fixed.md
+++ b/changelog/64924.fixed.md
@@ -3,5 +3,5 @@ Fix the way Salt tries to get the Homebrew's prefix
 The first attempt to get the Homebrew's prefix is to look for
 the `HOMEBREW_PREFIX` environment variable. If it's not set, then
 Salt tries to get the prefix from the `brew` command. However, the
-`brew` command can failed. So a last attempt is made to get the
+`brew` command can fail. So a last attempt is made to get the
 prefix by guessing the installation path.

--- a/salt/modules/mac_brew_pkg.py
+++ b/salt/modules/mac_brew_pkg.py
@@ -137,9 +137,11 @@ def _homebrew_bin(quiet=False):
     quiet
         When ``True``, does not log warnings when the homebrew prefix cannot be found.
     """
-    ret = homebrew_prefix(quiet=quiet)
+    ret = homebrew_prefix()
     if ret is not None:
         ret += "/bin/brew"
+    else:
+        log.warning("Failed to find homebrew prefix")
 
     return ret
 
@@ -182,12 +184,9 @@ def _list_pkgs_from_context(versions_as_list):
         return ret
 
 
-def homebrew_prefix(quiet=False):
+def homebrew_prefix():
     """
     Returns the full path to the homebrew prefix.
-
-    quiet
-        When ``True``, does not log warnings when the homebrew prefix cannot be found.
 
     CLI Example:
 
@@ -201,8 +200,6 @@ def homebrew_prefix(quiet=False):
     if env_homebrew_prefix in os.environ:
         log.debug(f"{env_homebrew_prefix} is set. Using it for homebrew prefix.")
         return os.environ[env_homebrew_prefix]
-    elif not quiet:
-        log.warning(f"{env_homebrew_prefix} is not set. Please, consider adding it.")
 
     # Try brew --prefix
     try:
@@ -221,15 +218,8 @@ def homebrew_prefix(quiet=False):
 
             return ret
     except CommandExecutionError as e:
-        if not quiet:
-            log.warning(
-                f"Unable to find homebrew prefix by running 'brew --prefix'. Error: {str(e)}"
-            )
-
-    # Unable to find brew prefix
-    if not quiet:
-        log.warning(
-            f"Failed to find homebrew prefix. Please, set {env_homebrew_prefix} env variable"
+        log.debug(
+            f"Unable to find homebrew prefix by running 'brew --prefix'. Error: {str(e)}"
         )
 
     return None

--- a/salt/modules/mac_brew_pkg.py
+++ b/salt/modules/mac_brew_pkg.py
@@ -1,6 +1,14 @@
 """
 Homebrew for macOS
 
+It is recommended for the ``salt-minion`` to have the ``HOMEBREW_PREFIX``
+environment variable set.
+
+This will ensure that Salt uses the correct path for the ``brew`` binary.
+
+Typically, this is set to ``/usr/local`` for Intel Macs and ``/opt/homebrew``
+for Apple Silicon Macs.
+
 .. important::
     If you feel that Salt should be using this module to manage packages on a
     minion, and it is using a different module (or gives an error similar to
@@ -10,6 +18,7 @@ Homebrew for macOS
 
 import copy
 import logging
+import os
 
 import salt.utils.data
 import salt.utils.functools
@@ -31,7 +40,7 @@ def __virtual__():
     """
     if __grains__["os"] != "MacOS":
         return False, "brew module is macos specific"
-    if not _homebrew_os_bin():
+    if not _homebrew_bin(quiet=False):
         return False, "The 'brew' binary was not found"
     return __virtualname__
 
@@ -97,31 +106,56 @@ def _homebrew_os_bin():
     """
     Fetch PATH binary brew full path eg: /usr/local/bin/brew (symbolic link)
     """
-    return salt.utils.path.which("brew")
+
+    # Add "/opt/homebrew" temporary to the PATH for Apple Silicon if
+    # the PATH does not include "/opt/homebrew"
+    original_path = None
+    current_path = os.environ.get("PATH", "")
+    homebrew_path = "/opt/homebrew/bin"
+    if homebrew_path not in current_path.split(os.path.pathsep):
+        original_path = current_path
+        extended_path = os.path.pathsep.join([original_path, homebrew_path])
+        os.environ["PATH"] = extended_path.lstrip(os.path.pathsep)
+
+    # Search for the brew executable in the current PATH
+    brew = salt.utils.path.which("brew")
+
+    # Restore the original PATH if needed
+    if original_path is not None:
+        if original_path == "":
+            del os.environ["PATH"]
+        else:
+            os.environ["PATH"] = original_path
+
+    return brew
 
 
-def _homebrew_bin():
+def _homebrew_bin(quiet=False):
     """
     Returns the full path to the homebrew binary in the homebrew installation folder
+
+    quiet
+        When ``True``, does not log warnings when the homebrew prefix cannot be found.
     """
-    brew = _homebrew_os_bin()
-    if brew:
-        # Fetch and ret brew installation folder full path eg: /opt/homebrew/bin/brew
-        brew = __salt__["cmd.run"](f"{brew} --prefix", output_loglevel="trace")
-        brew += "/bin/brew"
-    return brew
+    ret = homebrew_prefix(quiet=quiet)
+    if ret is not None:
+        ret += "/bin/brew"
+
+    return ret
 
 
 def _call_brew(*cmd, failhard=True):
     """
     Calls the brew command with the user account of brew
     """
-    user = __salt__["file.get_user"](_homebrew_bin())
+    brew_exec = _homebrew_bin(quiet=True)
+
+    user = __salt__["file.get_user"](brew_exec)
     runas = user if user != __opts__["user"] else None
     _cmd = []
     if runas:
         _cmd = [f"sudo -i -n -H -u {runas} -- "]
-    _cmd = _cmd + [_homebrew_bin()] + list(cmd)
+    _cmd = _cmd + [brew_exec] + list(cmd)
     _cmd = " ".join(_cmd)
 
     runas = None
@@ -146,6 +180,59 @@ def _list_pkgs_from_context(versions_as_list):
         ret = copy.deepcopy(__context__["pkg.list_pkgs"])
         __salt__["pkg_resource.stringify"](ret)
         return ret
+
+
+def homebrew_prefix(quiet=False):
+    """
+    Returns the full path to the homebrew prefix.
+
+    quiet
+        When ``True``, does not log warnings when the homebrew prefix cannot be found.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.homebrew_prefix
+    """
+
+    # Try HOMEBREW_PREFIX env variable
+    env_homebrew_prefix = "HOMEBREW_PREFIX"
+    if env_homebrew_prefix in os.environ:
+        log.debug(f"{env_homebrew_prefix} is set. Using it for homebrew prefix.")
+        return os.environ[env_homebrew_prefix]
+    elif not quiet:
+        log.warning(f"{env_homebrew_prefix} is not set. Please, consider adding it.")
+
+    # Try brew --prefix
+    try:
+        log.debug("Trying to find homebrew prefix by running 'brew --prefix'")
+
+        brew = _homebrew_os_bin()
+        if brew is not None:
+            # Check if the found brew command is the right one
+            import salt.modules.cmdmod
+            import salt.modules.file
+
+            runas = salt.modules.file.get_user(brew)
+            ret = salt.modules.cmdmod.run(
+                "brew --prefix", runas=runas, output_loglevel="trace", raise_err=True
+            )
+
+            return ret
+    except CommandExecutionError as e:
+        if not quiet:
+            log.warning(
+                f"Unable to find homebrew prefix by running 'brew --prefix'. Error: {str(e)}"
+            )
+
+    # Unable to find brew prefix
+    if not quiet:
+        log.warning(
+            f"Failed to find homebrew prefix. Please, set {env_homebrew_prefix} env variable"
+        )
+
+    return None
 
 
 def list_pkgs(versions_as_list=False, **kwargs):
@@ -657,17 +744,13 @@ def hold(name=None, pkgs=None, sources=None, **kwargs):  # pylint: disable=W0613
                 if result:
                     changes = {"old": "install", "new": "hold"}
                     ret[target].update(changes=changes, result=True)
-                    ret[target]["comment"] = "Package {} is now being held.".format(
-                        target
-                    )
+                    ret[target]["comment"] = f"Package {target} is now being held."
                 else:
                     ret[target].update(result=False)
                     ret[target]["comment"] = f"Unable to hold package {target}."
         else:
             ret[target].update(result=True)
-            ret[target]["comment"] = "Package {} is already set to be held.".format(
-                target
-            )
+            ret[target]["comment"] = f"Package {target} is already set to be held."
     return ret
 
 
@@ -727,9 +810,7 @@ def unhold(name=None, pkgs=None, sources=None, **kwargs):  # pylint: disable=W06
         elif target in pinned:
             if "test" in __opts__ and __opts__["test"]:
                 ret[target].update(result=None)
-                ret[target]["comment"] = "Package {} is set to be unheld.".format(
-                    target
-                )
+                ret[target]["comment"] = f"Package {target} is set to be unheld."
             else:
                 result = _unpin(target)
                 if result:
@@ -740,14 +821,10 @@ def unhold(name=None, pkgs=None, sources=None, **kwargs):  # pylint: disable=W06
                     ] = f"Package {target} is no longer being held."
                 else:
                     ret[target].update(result=False)
-                    ret[target]["comment"] = "Unable to unhold package {}.".format(
-                        target
-                    )
+                    ret[target]["comment"] = f"Unable to unhold package {target}."
         else:
             ret[target].update(result=True)
-            ret[target]["comment"] = "Package {} is already set not to be held.".format(
-                target
-            )
+            ret[target]["comment"] = f"Package {target} is already set not to be held."
     return ret
 
 

--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -46,7 +46,7 @@ def _find_libcrypto():
         # Find library symlinks in Homebrew locations.
         import salt.modules.mac_brew_pkg as mac_brew
 
-        brew_prefix = mac_brew.homebrew_prefix(quiet=True)
+        brew_prefix = mac_brew.homebrew_prefix()
         if brew_prefix is not None:
             lib = lib or glob.glob(
                 os.path.join(brew_prefix, "opt/openssl/lib/libcrypto.dylib")

--- a/salt/utils/rsax931.py
+++ b/salt/utils/rsax931.py
@@ -44,13 +44,17 @@ def _find_libcrypto():
         lib = lib or glob.glob("lib/libcrypto.dylib")
 
         # Find library symlinks in Homebrew locations.
-        brew_prefix = os.getenv("HOMEBREW_PREFIX", "/usr/local")
-        lib = lib or glob.glob(
-            os.path.join(brew_prefix, "opt/openssl/lib/libcrypto.dylib")
-        )
-        lib = lib or glob.glob(
-            os.path.join(brew_prefix, "opt/openssl@*/lib/libcrypto.dylib")
-        )
+        import salt.modules.mac_brew_pkg as mac_brew
+
+        brew_prefix = mac_brew.homebrew_prefix(quiet=True)
+        if brew_prefix is not None:
+            lib = lib or glob.glob(
+                os.path.join(brew_prefix, "opt/openssl/lib/libcrypto.dylib")
+            )
+            lib = lib or glob.glob(
+                os.path.join(brew_prefix, "opt/openssl@*/lib/libcrypto.dylib")
+            )
+
         # look in macports.
         lib = lib or glob.glob("/opt/local/lib/libcrypto.dylib")
         # check if 10.15, regular libcrypto.dylib is just a false pointer.

--- a/tests/pytests/unit/modules/test_mac_brew_pkg.py
+++ b/tests/pytests/unit/modules/test_mac_brew_pkg.py
@@ -481,7 +481,7 @@ def test_homebrew_prefix_command(HOMEBREW_PREFIX, HOMEBREW_BIN):
 
 def test_homebrew_prefix_returns_none():
     """
-    Tets that homebrew_prefix returns None when
+    Tests that homebrew_prefix returns None when
     all attempts fail.
     """
 
@@ -489,7 +489,7 @@ def test_homebrew_prefix_returns_none():
     if "HOMEBREW_PREFIX" in mock_env:
         del mock_env["HOMEBREW_PREFIX"]
 
-    with patch.dict(os.environ, mock_env):
+    with patch.dict(os.environ, mock_env, clear=True):
         with patch(
             "salt.modules.mac_brew_pkg._homebrew_os_bin", MagicMock(return_value=None)
         ):
@@ -498,7 +498,7 @@ def test_homebrew_prefix_returns_none():
 
 def test_homebrew_prefix_returns_none_even_with_execution_errors():
     """
-    Tets that homebrew_prefix returns None when
+    Tests that homebrew_prefix returns None when
     all attempts fail even with command execution errors.
     """
 
@@ -506,7 +506,7 @@ def test_homebrew_prefix_returns_none_even_with_execution_errors():
     if "HOMEBREW_PREFIX" in mock_env:
         del mock_env["HOMEBREW_PREFIX"]
 
-    with patch.dict(os.environ, mock_env):
+    with patch.dict(os.environ, mock_env, clear=True):
         with patch(
             "salt.modules.cmdmod.run", MagicMock(side_effect=CommandExecutionError)
         ), patch(
@@ -523,7 +523,7 @@ def test_homebrew_os_bin_fallback_apple_silicon():
     """
     Test the path to the homebrew executable for Apple Silicon.
 
-    This test checks that even if the PATH does not contains
+    This test checks that even if the PATH does not contain
     the default Homebrew's prefix for the Apple Silicon
     architecture, it is appended.
     """

--- a/tests/pytests/unit/modules/test_mac_brew_pkg.py
+++ b/tests/pytests/unit/modules/test_mac_brew_pkg.py
@@ -1,6 +1,7 @@
 """
     :codeauthor: Nicole Thomas <nicole@saltstack.com>
 """
+import os
 import textwrap
 
 import pytest
@@ -22,8 +23,13 @@ def TAPS_LIST():
 
 
 @pytest.fixture
-def HOMEBREW_BIN():
-    return "/usr/local/bin/brew"
+def HOMEBREW_PREFIX():
+    return "/opt/homebrew"
+
+
+@pytest.fixture
+def HOMEBREW_BIN(HOMEBREW_PREFIX):
+    return HOMEBREW_PREFIX + "/bin/brew"
 
 
 @pytest.fixture
@@ -371,7 +377,9 @@ def test_list_taps(TAPS_STRING, TAPS_LIST, HOMEBREW_BIN):
     mock_taps = MagicMock(return_value={"stdout": TAPS_STRING, "retcode": 0})
     mock_user = MagicMock(return_value="foo")
     mock_cmd = MagicMock(return_value="")
-    with patch("salt.utils.path.which", MagicMock(return_value=HOMEBREW_BIN)):
+    with patch(
+        "salt.modules.mac_brew_pkg._homebrew_bin", MagicMock(return_value=HOMEBREW_BIN)
+    ):
         with patch.dict(
             mac_brew.__salt__,
             {"file.get_user": mock_user, "cmd.run_all": mock_taps, "cmd.run": mock_cmd},
@@ -399,7 +407,9 @@ def test_tap_failure(HOMEBREW_BIN):
     mock_failure = MagicMock(return_value={"stdout": "", "stderr": "", "retcode": 1})
     mock_user = MagicMock(return_value="foo")
     mock_cmd = MagicMock(return_value="")
-    with patch("salt.utils.path.which", MagicMock(return_value=HOMEBREW_BIN)):
+    with patch(
+        "salt.modules.mac_brew_pkg._homebrew_bin", MagicMock(return_value=HOMEBREW_BIN)
+    ):
         with patch.dict(
             mac_brew.__salt__,
             {
@@ -418,7 +428,9 @@ def test_tap(TAPS_LIST, HOMEBREW_BIN):
     mock_failure = MagicMock(return_value={"retcode": 0})
     mock_user = MagicMock(return_value="foo")
     mock_cmd = MagicMock(return_value="")
-    with patch("salt.utils.path.which", MagicMock(return_value=HOMEBREW_BIN)):
+    with patch(
+        "salt.modules.mac_brew_pkg._homebrew_bin", MagicMock(return_value=HOMEBREW_BIN)
+    ):
         with patch.dict(
             mac_brew.__salt__,
             {
@@ -432,17 +444,118 @@ def test_tap(TAPS_LIST, HOMEBREW_BIN):
             assert mac_brew._tap("homebrew/test")
 
 
+# 'homebrew_prefix' function tests: 4
+
+
+def test_homebrew_prefix_env(HOMEBREW_PREFIX):
+    """
+    Test the path to the homebrew prefix by looking
+    at the HOMEBREW_PREFIX environment variable.
+    """
+    mock_env = os.environ.copy()
+    mock_env["HOMEBREW_PREFIX"] = HOMEBREW_PREFIX
+
+    with patch.dict(os.environ, mock_env):
+        assert mac_brew.homebrew_prefix() == HOMEBREW_PREFIX
+
+
+def test_homebrew_prefix_command(HOMEBREW_PREFIX, HOMEBREW_BIN):
+    """
+    Test the path to the homebrew prefix by running
+    the brew --prefix command when the HOMEBREW_PREFIX
+    environment variable is not set.
+    """
+    mock_env = os.environ.copy()
+    if "HOMEBREW_PREFIX" in mock_env:
+        del mock_env["HOMEBREW_PREFIX"]
+
+    with patch.dict(os.environ, mock_env):
+        with patch(
+            "salt.modules.cmdmod.run", MagicMock(return_value=HOMEBREW_PREFIX)
+        ), patch("salt.modules.file.get_user", MagicMock(return_value="foo")), patch(
+            "salt.modules.mac_brew_pkg._homebrew_os_bin",
+            MagicMock(return_value=HOMEBREW_BIN),
+        ):
+            assert mac_brew.homebrew_prefix() == HOMEBREW_PREFIX
+
+
+def test_homebrew_prefix_returns_none():
+    """
+    Tets that homebrew_prefix returns None when
+    all attempts fail.
+    """
+
+    mock_env = os.environ.copy()
+    if "HOMEBREW_PREFIX" in mock_env:
+        del mock_env["HOMEBREW_PREFIX"]
+
+    with patch.dict(os.environ, mock_env):
+        with patch(
+            "salt.modules.mac_brew_pkg._homebrew_os_bin", MagicMock(return_value=None)
+        ):
+            assert mac_brew.homebrew_prefix() is None
+
+
+def test_homebrew_prefix_returns_none_even_with_execution_errors():
+    """
+    Tets that homebrew_prefix returns None when
+    all attempts fail even with command execution errors.
+    """
+
+    mock_env = os.environ.copy()
+    if "HOMEBREW_PREFIX" in mock_env:
+        del mock_env["HOMEBREW_PREFIX"]
+
+    with patch.dict(os.environ, mock_env):
+        with patch(
+            "salt.modules.cmdmod.run", MagicMock(side_effect=CommandExecutionError)
+        ), patch(
+            "salt.modules.mac_brew_pkg._homebrew_os_bin",
+            MagicMock(return_value=None),
+        ):
+            assert mac_brew.homebrew_prefix() is None
+
+
+# '_homebrew_os_bin' function tests: 1
+
+
+def test_homebrew_os_bin_fallback_apple_silicon():
+    """
+    Test the path to the homebrew executable for Apple Silicon.
+
+    This test checks that even if the PATH does not contains
+    the default Homebrew's prefix for the Apple Silicon
+    architecture, it is appended.
+    """
+
+    # Ensure Homebrew's prefix for Apple Silicon is not present in the PATH
+    mock_env = os.environ.copy()
+    mock_env["PATH"] = "/usr/local/bin:/usr/bin"
+
+    apple_silicon_homebrew_path = "/opt/homebrew/bin"
+    apple_silicon_homebrew_bin = f"{apple_silicon_homebrew_path}/brew"
+
+    def mock_utils_path_which(*args):
+        if apple_silicon_homebrew_path in os.environ.get("PATH", "").split(
+            os.path.pathsep
+        ):
+            return apple_silicon_homebrew_bin
+        return None
+
+    with patch("salt.utils.path.which", mock_utils_path_which):
+        assert mac_brew._homebrew_os_bin() == apple_silicon_homebrew_bin
+
+
 # '_homebrew_bin' function tests: 1
 
 
-def test_homebrew_bin(HOMEBREW_BIN):
+def test_homebrew_bin(HOMEBREW_PREFIX, HOMEBREW_BIN):
     """
     Tests the path to the homebrew binary
     """
-    mock_path = MagicMock(return_value="/usr/local")
-    with patch("salt.utils.path.which", MagicMock(return_value=HOMEBREW_BIN)):
-        with patch.dict(mac_brew.__salt__, {"cmd.run": mock_path}):
-            assert mac_brew._homebrew_bin() == HOMEBREW_BIN
+    mock_path = MagicMock(return_value=HOMEBREW_PREFIX)
+    with patch("salt.modules.mac_brew_pkg.homebrew_prefix", mock_path):
+        assert mac_brew._homebrew_bin() == HOMEBREW_BIN
 
 
 # 'list_pkgs' function tests: 2
@@ -624,7 +737,9 @@ def test_hold(HOMEBREW_BIN):
     }
 
     mock_params = MagicMock(return_value=({"foo": None}, "repository"))
-    with patch("salt.utils.path.which", MagicMock(return_value=HOMEBREW_BIN)):
+    with patch(
+        "salt.modules.mac_brew_pkg._homebrew_bin", MagicMock(return_value=HOMEBREW_BIN)
+    ):
         with patch(
             "salt.modules.mac_brew_pkg.list_pkgs", return_value={"foo": "0.1.5"}
         ), patch.dict(
@@ -658,7 +773,9 @@ def test_hold_not_installed(HOMEBREW_BIN):
     }
 
     mock_params = MagicMock(return_value=({"foo": None}, "repository"))
-    with patch("salt.utils.path.which", MagicMock(return_value=HOMEBREW_BIN)):
+    with patch(
+        "salt.modules.mac_brew_pkg._homebrew_bin", MagicMock(return_value=HOMEBREW_BIN)
+    ):
         with patch("salt.modules.mac_brew_pkg.list_pkgs", return_value={}), patch.dict(
             mac_brew.__salt__,
             {
@@ -728,7 +845,9 @@ def test_unhold(HOMEBREW_BIN):
     }
 
     mock_params = MagicMock(return_value=({"foo": None}, "repository"))
-    with patch("salt.utils.path.which", MagicMock(return_value=HOMEBREW_BIN)):
+    with patch(
+        "salt.modules.mac_brew_pkg._homebrew_bin", MagicMock(return_value=HOMEBREW_BIN)
+    ):
         with patch(
             "salt.modules.mac_brew_pkg.list_pkgs", return_value={"foo": "0.1.5"}
         ), patch(
@@ -876,7 +995,9 @@ def test_info_installed(HOMEBREW_BIN):
         },
     }
 
-    with patch("salt.utils.path.which", MagicMock(return_value=HOMEBREW_BIN)):
+    with patch(
+        "salt.modules.mac_brew_pkg._homebrew_bin", MagicMock(return_value=HOMEBREW_BIN)
+    ):
         with patch("salt.modules.mac_brew_pkg.list_pkgs", return_value={}), patch(
             "salt.modules.mac_brew_pkg._list_pinned", return_value=["foo"]
         ), patch.dict(
@@ -943,7 +1064,9 @@ def test_list_upgrades(HOMEBREW_BIN):
         "ksdiff": "2.3.6,123-jan-18-2021",
     }
 
-    with patch("salt.utils.path.which", MagicMock(return_value=HOMEBREW_BIN)):
+    with patch(
+        "salt.modules.mac_brew_pkg._homebrew_bin", MagicMock(return_value=HOMEBREW_BIN)
+    ):
         with patch("salt.modules.mac_brew_pkg.list_pkgs", return_value={}), patch(
             "salt.modules.mac_brew_pkg._list_pinned", return_value=["foo"]
         ), patch.dict(

--- a/tests/pytests/unit/utils/test_rsax931.py
+++ b/tests/pytests/unit/utils/test_rsax931.py
@@ -247,11 +247,12 @@ def test_find_libcrypto_darwin_bigsur_packaged():
         platform, "mac_ver", lambda: ("11.2.2", (), "")
     ), patch.object(sys, "platform", "macosx"):
         for package_manager, expected_lib in managed_paths.items():
+            mock_env = os.environ.copy()
             if package_manager == "brew":
-                env = {"HOMEBREW_PREFIX": "/test/homebrew/prefix"}
-            else:
-                env = {"HOMEBREW_PREFIX": ""}
-            with patch.object(os, "getenv", mock_getenv(env)):
+                mock_env["HOMEBREW_PREFIX"] = "/test/homebrew/prefix"
+            elif "HOMEBREW_PREFIX" in mock_env:
+                del mock_env["HOMEBREW_PREFIX"]
+            with patch.dict(os.environ, mock_env):
                 with patch.object(glob, "glob", mock_glob(expected_lib)):
                     lib_path = _find_libcrypto()
 


### PR DESCRIPTION
### What does this PR do?

This PR improves the way salt tries to figure out the `brew` macOS command.

### What issues does this PR fix or reference?

After latest changes in brew command: https://github.com/Homebrew/brew/pull/15787, https://github.com/Homebrew/brew/pull/15818 and finally https://github.com/Homebrew/brew/pull/15827, `salt` fails executing `brew` commands when no `HOME` env variable is set with the following error:

```
[salt.state       :325 ][ERROR   ][9799] An error was encountered while removing package(s): Path not found: Error: $HOME must be set to run brew./bin/brew
[salt.loaded.int.module.cmdmod:920 ][ERROR   ][13361] Command 'brew' failed with return code: 1
```

This is due because `salt-minion` is launched as a Launch Daemon in macOS with a very reduced environment:

```sh
LC_PAPER=C
LC_ADDRESS=C
LC_MONETARY=C
LC_NUMERIC=C
LC_TELEPHONE=C
PATH=/opt/homebrew/bin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
LC_MESSAGES=C
LC_IDENTIFICATION=C
LC_COLLATE=C
PWD=/private/var/root
LC_MEASUREMENT=C
XPC_FLAGS=0x0
XPC_SERVICE_NAME=0
SHLVL=1
LANGUAGE=C
HOMEBREW_PREFIX=/opt/homebrew
LC_CTYPE=C
LC_TIME=C
LC_NAME=C
_=/usr/bin/env
```

(I have added `PATH` and `HOMEBREW_PREFIX` manually to my daemon's plist file)

When `salt` tries to recover the `brew --prefix` with the following code:

https://github.com/saltstack/salt/blob/4e8b77df671fd756970fe4fb08122fba9b47c50b/salt/modules/mac_brew_pkg.py#L96-L102

There is no `$HOME`, neither `$USER`, neither `$LOGNAME` in the environment.

This PR tries to figure out the Homebrew's prefix, by using the `HOMEBREW_PREFIX` env variable. As it is already used in other salt modules, like in `rsax931.py`:

https://github.com/saltstack/salt/blob/4e8b77df671fd756970fe4fb08122fba9b47c50b/salt/utils/rsax931.py#L41

If the environment variable is not set, then it tries the most common paths for `brew` regarding the system architecture. `/opt/homebrew` for Apple Silicon (a.k.a.: _arm64_), `/usr/local` for Intel Macs (a.k.a.: _x86_64_).

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?

Yes

Closes #61340