### PR TITLE
[master] add nightlys minor/latest symlink to minor/{build_version} + add nightly_latest.repo which points to latest build

### DIFF
--- a/tools/pkg/repo/create.py
+++ b/tools/pkg/repo/create.py
@@ -485,10 +485,12 @@ def rpm(
     if salt_repo_user and salt_repo_pass:
         repo_domain = f"{salt_repo_user}:{salt_repo_pass}@{repo_domain}"
 
-    def _create_repo_file(create_repo_path, url_suffix):
+    def _create_repo_file(create_repo_path, url_suffix, nightly_path=None):
         ctx.info(f"Creating '{repo_file_path.relative_to(repo_path)}' file ...")
         if nightly_build_from:
-            base_url = f"salt-dev/{nightly_build_from}/{datetime.utcnow().strftime('%Y-%m-%d')}/"
+            if not nightly_path:
+                nightly_path = datetime.utcnow().strftime("%Y-%m-%d")
+            base_url = f"salt-dev/{nightly_build_from}/{nightly_path}/"
             repo_file_contents = "[salt-nightly-repo]"
         elif "rc" in salt_version:
             base_url = "salt_rc/"
@@ -531,6 +533,9 @@ def rpm(
     _create_repo_file(repo_file_path, f"minor/{salt_version}")
 
     if nightly_build_from:
+        nightly_latest_repo_file_path = create_repo_path.parent / "nightly_latest.repo"
+        _create_repo_file(nightly_latest_repo_file_path, "minor/nightly", "nightly")
+
         nightly_link = create_repo_path.parent / "minor/nightly"
         ctx.info(f"Creating '{nightly_link.relative_to(repo_path)}' symlink ...")
         nightly_link.symlink_to(f"minor/{salt_version}")

--- a/tools/pkg/repo/create.py
+++ b/tools/pkg/repo/create.py
@@ -488,7 +488,7 @@ def rpm(
     def _create_repo_file(create_repo_path, url_suffix, nightly_path=None):
         ctx.info(f"Creating '{repo_file_path.relative_to(repo_path)}' file ...")
         if nightly_build_from:
-            if not nightly_path:
+            if nightly_path is None:
                 nightly_path = datetime.utcnow().strftime("%Y-%m-%d")
             base_url = f"salt-dev/{nightly_build_from}/{nightly_path}/"
             repo_file_contents = "[salt-nightly-repo]"

--- a/tools/pkg/repo/create.py
+++ b/tools/pkg/repo/create.py
@@ -534,9 +534,9 @@ def rpm(
 
     if nightly_build_from:
         nightly_latest_repo_file_path = create_repo_path.parent / "nightly_latest.repo"
-        _create_repo_file(nightly_latest_repo_file_path, "minor/nightly", "latest")
+        _create_repo_file(nightly_latest_repo_file_path, "minor/latest", "latest")
 
-        nightly_link = create_repo_path.parent / "minor/nightly"
+        nightly_link = create_repo_path.parent / "minor/latest"
         ctx.info(f"Creating '{nightly_link.relative_to(repo_path)}' symlink ...")
         nightly_link.symlink_to(f"minor/{salt_version}")
     else:

--- a/tools/pkg/repo/create.py
+++ b/tools/pkg/repo/create.py
@@ -530,7 +530,11 @@ def rpm(
 
     _create_repo_file(repo_file_path, f"minor/{salt_version}")
 
-    if not nightly_build_from:
+    if nightly_build_from:
+        nightly_link = create_repo_path.parent / "nightly"
+        ctx.info(f"Creating '{nightly_link.relative_to(repo_path)}' symlink ...")
+        nightly_link.symlink_to(f"minor/{salt_version}")
+    else:
         remote_versions = _get_remote_versions(
             tools.utils.STAGING_BUCKET_NAME,
             create_repo_path.parent.relative_to(repo_path),

--- a/tools/pkg/repo/create.py
+++ b/tools/pkg/repo/create.py
@@ -292,7 +292,11 @@ def debian(
 
     ctx.info(f"Running '{' '.join(cmdline)}' ...")
     ctx.run(*cmdline, cwd=create_repo_path)
-    if not nightly_build_from:
+    if nightly_build_from:
+        nightly_link = create_repo_path.parent / "minor/latest"
+        ctx.info(f"Creating '{nightly_link.relative_to(repo_path)}' symlink ...")
+        nightly_link.symlink_to(f"minor/{salt_version}")
+    else:
         remote_versions = _get_remote_versions(
             tools.utils.STAGING_BUCKET_NAME,
             create_repo_path.parent.relative_to(repo_path),

--- a/tools/pkg/repo/create.py
+++ b/tools/pkg/repo/create.py
@@ -531,7 +531,7 @@ def rpm(
     _create_repo_file(repo_file_path, f"minor/{salt_version}")
 
     if nightly_build_from:
-        nightly_link = create_repo_path.parent / "nightly"
+        nightly_link = create_repo_path.parent / "minor/nightly"
         ctx.info(f"Creating '{nightly_link.relative_to(repo_path)}' symlink ...")
         nightly_link.symlink_to(f"minor/{salt_version}")
     else:

--- a/tools/pkg/repo/create.py
+++ b/tools/pkg/repo/create.py
@@ -534,7 +534,7 @@ def rpm(
 
     if nightly_build_from:
         nightly_latest_repo_file_path = create_repo_path.parent / "nightly_latest.repo"
-        _create_repo_file(nightly_latest_repo_file_path, "minor/nightly", "nightly")
+        _create_repo_file(nightly_latest_repo_file_path, "minor/nightly", "latest")
 
         nightly_link = create_repo_path.parent / "minor/nightly"
         ctx.info(f"Creating '{nightly_link.relative_to(repo_path)}' symlink ...")


### PR DESCRIPTION
### What does this PR do?
creates a symlink from "minor/latest" to the build version. also creates a nightly_latest.repo file which always points to the most recent nightly build

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/64927
Note this is an alternative PR to https://github.com/saltstack/salt/pull/64928, this PR contains an additional change of adding a nightly_latest.repo file

### Previous Behavior
rhel repo metadata files are pointing to a path that doesnt exist ( https://github.com/saltstack/salt-bootstrap/actions/runs/5637446197/job/15615868594?pr=1951#step:7:134 )

### New Behavior
creates the path that is being pointed to

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No
