### PR TITLE
[3006.x] Preserve master credentials on spawning platforms

### DIFF
--- a/changelog/64914.fixed.md
+++ b/changelog/64914.fixed.md
@@ -1,0 +1,2 @@
+Preserve credentials on spawning platforms, minions no longer re-authenticate
+with every job when using `multiprocessing=True`.

--- a/tests/pytests/integration/cli/test_matcher.py
+++ b/tests/pytests/integration/cli/test_matcher.py
@@ -401,7 +401,7 @@ def test_grains_targeting_minion_id_disconnected(salt_master, salt_minion, salt_
             "-G",
             "test.ping",
             minion_tgt="id:{}".format(disconnected_minion_id),
-            _timeout=15,
+            _timeout=30,
         )
         assert ret.returncode == 1
         assert disconnected_minion_id in ret.data

--- a/tests/pytests/integration/minion/test_reauth.py
+++ b/tests/pytests/integration/minion/test_reauth.py
@@ -13,7 +13,7 @@ def test_reauth(salt_master_factory, event_listener):
         - name: example
         - changes: True
         - result: True
-        - comment: "Nothing has acutally been changed"
+        - comment: "Nothing has actually been changed"
     """
     events = []
 

--- a/tests/pytests/integration/minion/test_reauth.py
+++ b/tests/pytests/integration/minion/test_reauth.py
@@ -1,0 +1,49 @@
+import time
+
+
+def test_reauth(salt_master_factory, event_listener):
+    """
+    Validate non of our platform need to re-authenticate when runing a job with
+    multiprocessing=True.
+    """
+    sls_name = "issue-64941"
+    sls_contents = """
+    custom_test_state:
+      test.configurable_test_state:
+        - name: example
+        - changes: True
+        - result: True
+        - comment: "Nothing has acutally been changed"
+    """
+    events = []
+
+    def handler(data):
+        events.append(data)
+
+    event_listener.register_auth_event_handler("test_reauth-master", handler)
+    master = salt_master_factory.salt_master_daemon(
+        "test_reauth-master",
+        overrides={"log_level": "info"},
+    )
+    sls_tempfile = master.state_tree.base.temp_file(
+        "{}.sls".format(sls_name), sls_contents
+    )
+    minion = master.salt_minion_daemon(
+        "test_reauth-minion",
+        overrides={"log_level": "info"},
+    )
+    cli = master.salt_cli()
+    start_time = time.time()
+    with master.started(), minion.started():
+        events = event_listener.get_events(
+            [(master.id, "salt/auth")],
+            after_time=start_time,
+        )
+        num_auth = len(events)
+        proc = cli.run("state.sls", sls_name, minion_tgt="*")
+        assert proc.returncode == 1
+        events = event_listener.get_events(
+            [(master.id, "salt/auth")],
+            after_time=start_time,
+        )
+        assert num_auth == len(events)


### PR DESCRIPTION
### What does this PR do?

Prevent spawning platform minions from having to re-authenticate on every job when using `multiprocessing=True`

### What issues does this PR fix or reference?

Fixes: #64914

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

