### PR TITLE
[3006.x] Allow for semange fcontext -l having trailing whitespace in selinux.fcontext_get_policy

### DIFF
--- a/changelog/63336.fixed.md
+++ b/changelog/63336.fixed.md
@@ -1,0 +1,1 @@
+Fix SELinux get policy with trailing whitespace

--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -477,8 +477,10 @@ def fcontext_get_policy(
     if filetype:
         _validate_filetype(filetype)
     re_spacer = "[ ]+"
+    re_optional_spacer = "[ |\t]*"
     cmd_kwargs = {
         "spacer": re_spacer,
+        "ospacer": re_optional_spacer,
         "filespec": re.escape(name),
         "sel_user": sel_user or "[^:]+",
         "sel_role": "[^:]+",  # se_role for file context is always object_r
@@ -490,7 +492,7 @@ def fcontext_get_policy(
     )
     cmd = (
         "semanage fcontext -l | egrep "
-        + "'^{filespec}{spacer}{filetype}{spacer}{sel_user}:{sel_role}:{sel_type}:{sel_level}$'".format(
+        + "'^{filespec}{spacer}{filetype}{spacer}{sel_user}:{sel_role}:{sel_type}:{sel_level}{ospacer}$'".format(
             **cmd_kwargs
         )
     )

--- a/tests/pytests/unit/modules/test_selinux.py
+++ b/tests/pytests/unit/modules/test_selinux.py
@@ -19,7 +19,7 @@ def test_fcontext_get_policy_parsing():
         {
             "semanage_out": (
                 "/var/www(/.*)?     all files         "
-                " system_u:object_r:httpd_sys_content_t:s0"
+                " system_u:object_r:httpd_sys_content_t:s0 "
             ),
             "name": "/var/www(/.*)?",
             "filetype": "all files",
@@ -31,7 +31,7 @@ def test_fcontext_get_policy_parsing():
         {
             "semanage_out": (
                 "/var/www(/.*)? all files         "
-                " system_u:object_r:httpd_sys_content_t:s0"
+                " system_u:object_r:httpd_sys_content_t:s0  "
             ),
             "name": "/var/www(/.*)?",
             "filetype": "all files",
@@ -43,7 +43,7 @@ def test_fcontext_get_policy_parsing():
         {
             "semanage_out": (
                 "/var/lib/dhcp3?                                    directory      "
-                "    system_u:object_r:dhcp_state_t:s0"
+                "    system_u:object_r:dhcp_state_t:s0	"
             ),
             "name": "/var/lib/dhcp3?",
             "filetype": "directory",


### PR DESCRIPTION
### What does this PR do?
Removes any trailing whitespace returned from ```semanage fcontext -l``` on platforms supporting selinux.
This was leading to erroneous returns when checked if a specific file context exists.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/63336

### Previous Behavior
If there were trailing whitespaces in the output of ```semanage fcontext -l```, the function ```selinux.fcontext_get_policy``` would return no result even though there is one.

### New Behavior
Now the function ```selinux.fcontext_get_policy``` will return the result even if there is a trailing whitespace.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
