### PR TITLE
[3006.x] fix utf-8 codec error (it try to decode binary data)

### DIFF
--- a/salt/ext/tornado/curl_httpclient.py
+++ b/salt/ext/tornado/curl_httpclient.py
@@ -493,6 +493,8 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
         headers.parse_line(header_line)
 
     def _curl_debug(self, debug_type, debug_msg):
+        if debug_type not in (0, 1, 2, 4):
+            return
         debug_types = ('I', '<', '>', '<', '>')
         debug_msg = native_str(debug_msg)
         if debug_type == 0:


### PR DESCRIPTION
### What does this PR do?
Fix in function `_curl_debug` for debug types being ignored in logging (binary data)

### What issues does this PR fix or reference?
Fixes:
fix errors in salt-minion log when called `cp.cache_file`

### Previous Behavior
Before fix in salt-minion log was many repeatedly messages like this:
[salt._logging.impl:1069][ERROR   ][17351] An un-handled exception was caught by Salt's global exception handler:
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xfd in position 18: invalid start byte
Traceback (most recent call last):
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/ext/tornado/curl_httpclient.py", line 497, in _curl_debug
    debug_msg = native_str(debug_msg)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/ext/tornado/escape.py", line 219, in to_unicode
    return value.decode("utf-8")
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xfd in position 18: invalid start byte

### New Behavior
Log contains no errors