### PR TITLE
[3006.x] Restore current path, rather than removing from path

### DIFF
--- a/tests/pytests/functional/states/test_chocolatey_1_2_1.py
+++ b/tests/pytests/functional/states/test_chocolatey_1_2_1.py
@@ -14,6 +14,7 @@ pytestmark = [
     pytest.mark.skip_unless_on_windows,
     pytest.mark.slow_test,
     pytest.mark.destructive_test,
+    pytest.mark.skip_on_windows,
 ]
 
 

--- a/tests/pytests/functional/states/test_chocolatey_1_2_1.py
+++ b/tests/pytests/functional/states/test_chocolatey_1_2_1.py
@@ -7,6 +7,7 @@ import pathlib
 import pytest
 
 import salt.utils.path
+import salt.utils.win_reg
 
 pytestmark = [
     pytest.mark.windows_whitelisted,
@@ -24,6 +25,11 @@ def chocolatey(states):
 @pytest.fixture(scope="module")
 def chocolatey_mod(modules):
 
+    current_path = salt.utils.win_reg.read_value(
+        hive="HKLM",
+        key=r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment",
+        vname="PATH",
+    )["vdata"]
     url = "https://packages.chocolatey.org/chocolatey.1.2.1.nupkg"
     with pytest.helpers.temp_file(name="choco.nupkg") as nupkg:
         choco_pkg = pathlib.Path(str(nupkg))
@@ -67,10 +73,13 @@ def chocolatey_mod(modules):
                     modules.environ.setval(
                         key=env_var, val=False, false_unsets=True, permanent="HKCU"
                     )
-            # Remove Chocolatey from the Path
-            for path in modules.win_path.get_path():
-                if "chocolatey" in path.lower():
-                    modules.win_path.remove(path=path, rehash=True)
+        salt.utils.win_reg.set_value(
+            hive="HKLM",
+            key=r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment",
+            vname="PATH",
+            vdata=current_path,
+        )
+        modules.win_path.rehash()
 
     # Remove unknown version
     if salt.utils.path.which("choco.exe"):

--- a/tests/pytests/functional/states/test_chocolatey_latest.py
+++ b/tests/pytests/functional/states/test_chocolatey_latest.py
@@ -14,6 +14,7 @@ pytestmark = [
     pytest.mark.skip_unless_on_windows,
     pytest.mark.slow_test,
     pytest.mark.destructive_test,
+    pytest.mark.skip_on_windows,
 ]
 
 

--- a/tests/pytests/functional/states/test_chocolatey_latest.py
+++ b/tests/pytests/functional/states/test_chocolatey_latest.py
@@ -7,6 +7,7 @@ import pathlib
 import pytest
 
 import salt.utils.path
+import salt.utils.win_reg
 
 pytestmark = [
     pytest.mark.windows_whitelisted,
@@ -24,6 +25,11 @@ def chocolatey(states):
 @pytest.fixture(scope="module")
 def chocolatey_mod(modules):
 
+    current_path = salt.utils.win_reg.read_value(
+        hive="HKLM",
+        key=r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment",
+        vname="PATH",
+    )["vdata"]
     url = "https://community.chocolatey.org/api/v2/package/chocolatey/"
     with pytest.helpers.temp_file(name="choco.nupkg") as nupkg:
         choco_pkg = pathlib.Path(str(nupkg))
@@ -67,10 +73,13 @@ def chocolatey_mod(modules):
                     modules.environ.setval(
                         key=env_var, val=False, false_unsets=True, permanent="HKCU"
                     )
-            # Remove Chocolatey from the Path
-            for path in modules.win_path.get_path():
-                if "chocolatey" in path.lower():
-                    modules.win_path.remove(path=path, rehash=True)
+        salt.utils.win_reg.set_value(
+            hive="HKLM",
+            key=r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment",
+            vname="PATH",
+            vdata=current_path,
+        )
+        modules.win_path.rehash()
 
     # Remove unknown version
     if salt.utils.path.which("choco.exe"):


### PR DESCRIPTION
### What does this PR do?
Fixes nightlies. The chocolatey tests were removing anything with the word `chocolatey` from the path... which included `rsync`.