### PR TITLE
[3006.x] attempt file.recurse speed up

### DIFF
--- a/changelog/61998.fixed.md
+++ b/changelog/61998.fixed.md
@@ -1,0 +1,1 @@
+speed up file.recurse by using prefix with cp.list_master_dir and remove an un-needed loop.

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -4495,10 +4495,8 @@ def recurse(
     srcpath, senv = salt.utils.url.parse(source)
     if senv is None:
         senv = __env__
-    master_dirs = __salt__["cp.list_master_dirs"](saltenv=senv)
-    if srcpath not in master_dirs and not any(
-        x for x in master_dirs if x.startswith(srcpath + "/")
-    ):
+    master_dirs = __salt__["cp.list_master_dirs"](saltenv=senv, prefix=srcpath + "/")
+    if srcpath not in master_dirs:
         ret["result"] = False
         ret["comment"] = (
             "The directory '{}' does not exist on the salt fileserver "


### PR DESCRIPTION
### What does this PR do?

speed up file.recurse by removing a loop and utilizing prefix with cp.list_master_dirs

### What issues does this PR fix or reference?
Fixes: #61998 


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated
