### PR TITLE
[3006.x] Return body when error with tornado backend salt.utils.http

### DIFF
--- a/changelog/63557.fixed.md
+++ b/changelog/63557.fixed.md
@@ -1,0 +1,1 @@
+Ensure body is returned when salt.utils.http returns something other than 200 with tornado backend.

--- a/tests/pytests/conftest.py
+++ b/tests/pytests/conftest.py
@@ -11,7 +11,6 @@ import shutil
 import ssl
 import stat
 import sys
-import tarfile
 import tempfile
 import types
 
@@ -549,13 +548,7 @@ def ssl_webserver(integration_files_dir, this_txt_file):
 
 
 @pytest.fixture(scope="module")
-def website_contents(integration_files_dir):
-    with tarfile.open(integration_files_dir / "test.tar.gz", "w:gz") as tar:
-        tar.add(integration_files_dir / "this.txt")
-
-
-@pytest.fixture(scope="module")
-def webserver(integration_files_dir, this_txt_file, website_contents):
+def webserver(integration_files_dir, this_txt_file):
     """
     spins up an http webserver.
     """

--- a/tests/pytests/conftest.py
+++ b/tests/pytests/conftest.py
@@ -11,6 +11,7 @@ import shutil
 import ssl
 import stat
 import sys
+import tarfile
 import tempfile
 import types
 
@@ -544,6 +545,21 @@ def ssl_webserver(integration_files_dir, this_txt_file):
     )
 
     with Webserver(root=str(integration_files_dir), ssl_opts=context) as webserver:
+        yield webserver
+
+
+@pytest.fixture(scope="module")
+def website_contents(integration_files_dir):
+    with tarfile.open(integration_files_dir / "test.tar.gz", "w:gz") as tar:
+        tar.add(integration_files_dir / "this.txt")
+
+
+@pytest.fixture(scope="module")
+def webserver(integration_files_dir, this_txt_file, website_contents):
+    """
+    spins up an http webserver.
+    """
+    with Webserver(root=str(integration_files_dir)) as webserver:
         yield webserver
 
 

--- a/tests/pytests/functional/modules/test_http.py
+++ b/tests/pytests/functional/modules/test_http.py
@@ -1,0 +1,34 @@
+import pytest
+
+import salt.modules.http as http
+
+
+@pytest.fixture
+def configure_loader_modules(minion_opts):
+    return {http: {}}
+
+
+def test_query_error_tornado(webserver):
+    """
+    Ensure we return expected data when website does not return
+    a 200 with tornado
+    """
+    url = webserver.url("doesnotexist")
+    ret = http.query(url, backend="tornado")
+    assert (
+        ret["body"]
+        == "<html><title>404: Not Found</title><body>404: Not Found</body></html>"
+    )
+    assert ret["error"] == "HTTP 404: Not Found"
+    assert ret["status"] == 404
+
+
+@pytest.mark.parametrize("backend", ["requests", "urllib2", "tornado"])
+def test_query_success(webserver, backend):
+    """
+    Ensure we return a success when querying
+    a website
+    """
+    url = webserver.url("this.txt")
+    ret = http.query(url, backend=backend)
+    assert ret == {"body": "test"}

--- a/tests/pytests/functional/modules/test_http.py
+++ b/tests/pytests/functional/modules/test_http.py
@@ -4,7 +4,7 @@ import salt.modules.http as http
 
 
 @pytest.fixture
-def configure_loader_modules(minion_opts):
+def configure_loader_modules():
     return {http: {}}
 
 

--- a/tests/pytests/functional/utils/test_http.py
+++ b/tests/pytests/functional/utils/test_http.py
@@ -1,0 +1,16 @@
+import tarfile
+
+import pytest
+
+import salt.utils.http
+
+
+@pytest.mark.parametrize("backend", ["requests", "urllib2", "tornado"])
+def test_decode_body(webserver, integration_files_dir, backend):
+    with tarfile.open(integration_files_dir / "test.tar.gz", "w:gz") as tar:
+        tar.add(integration_files_dir / "this.txt")
+
+    ret = salt.utils.http.query(
+        webserver.url("test.tar.gz"), backend=backend, decode_body=False
+    )
+    assert isinstance(ret["body"], bytes)

--- a/tests/pytests/unit/utils/test_http.py
+++ b/tests/pytests/unit/utils/test_http.py
@@ -51,11 +51,3 @@ def test_session_ca_bundle():
     with patch_os:
         ret = salt.utils.http.session(ca_bundle=fpath)
     assert ret.verify == fpath
-
-
-@pytest.mark.parametrize("backend", ["requests", "urllib2", "tornado"])
-def test_decode_body(webserver, backend):
-    ret = salt.utils.http.query(
-        webserver.url("test.tar.gz"), backend=backend, decode_body=False
-    )
-    assert isinstance(ret["body"], bytes)

--- a/tests/pytests/unit/utils/test_http.py
+++ b/tests/pytests/unit/utils/test_http.py
@@ -51,3 +51,11 @@ def test_session_ca_bundle():
     with patch_os:
         ret = salt.utils.http.session(ca_bundle=fpath)
     assert ret.verify == fpath
+
+
+@pytest.mark.parametrize("backend", ["requests", "urllib2", "tornado"])
+def test_decode_body(webserver, backend):
+    ret = salt.utils.http.query(
+        webserver.url("test.tar.gz"), backend=backend, decode_body=False
+    )
+    assert isinstance(ret["body"], bytes)


### PR DESCRIPTION
### What does this PR do?

Ensures we also return the body when there is an error when calling into salt.utils.http and using tornado backend.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/63557

### Previous Behavior

```
(py-3.10)  ch3ll@megan-precision5550  ~/git/salt  ➦ f0743ec9a8  salt-run http.query http://localhost:8000/% backend=tornado decode_body=False
error:
    HTTP 400: Bad Request
status:
    400
```

### New Behavior

```
(py-3.10)  ch3ll@megan-precision5550  ~/git/salt   fix_http  salt-run http.query http://localhost:8000/% backend=tornado decode_body=False
body:
    <html>
    <head><title>400 Bad Request</title></head>
    <body>
    <center><h1>400 Bad Request</h1></center>
    <hr><center>nginx/1.24.0</center>
    </body>
    </html>
error:
    HTTP 400: Bad Request
status:
    400

```
