### PR TITLE
[3006.x] Updated semanage fcontext to use --modify if context already exists when adding context

### DIFF
--- a/changelog/64625.fixed.md
+++ b/changelog/64625.fixed.md
@@ -1,0 +1,1 @@
+Updated semanage fcontext to use --modify if context already exists when adding context

--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -611,20 +611,29 @@ def _fcontext_add_or_delete_policy(
     """
     if action not in ["add", "delete"]:
         raise SaltInvocationError(
-            'Actions supported are "add" and "delete", not "{}".'.format(action)
+            f'Actions supported are "add" and "delete", not "{action}".'
         )
-    cmd = "semanage fcontext --{}".format(action)
+
+    if "add" == action:
+        # need to use --modify if context for name file exists, otherwise ValueError
+        filespec = re.escape(name)
+        cmd = f"semanage fcontext -l | egrep {filespec}"
+        current_entry_text = __salt__["cmd.shell"](cmd, ignore_retcode=True)
+        if current_entry_text != "":
+            action = "modify"
+
+    cmd = f"semanage fcontext --{action}"
     # "semanage --ftype a" isn't valid on Centos 6,
     # don't pass --ftype since "a" is the default filetype.
     if filetype is not None and filetype != "a":
         _validate_filetype(filetype)
-        cmd += " --ftype {}".format(filetype)
+        cmd += f" --ftype {filetype}"
     if sel_type is not None:
-        cmd += " --type {}".format(sel_type)
+        cmd += f" --type {sel_type}"
     if sel_user is not None:
-        cmd += " --seuser {}".format(sel_user)
+        cmd += f" --seuser {sel_user}"
     if sel_level is not None:
-        cmd += " --range {}".format(sel_level)
+        cmd += f" --range {sel_level}"
     cmd += " " + re.escape(name)
     return __salt__["cmd.run_all"](cmd)
 

--- a/tests/pytests/unit/modules/file/test_file_selinux.py
+++ b/tests/pytests/unit/modules/file/test_file_selinux.py
@@ -101,6 +101,20 @@ def test_selinux_setcontext_persist(tfile2):
     assert result == "system_u:object_r:user_tmp_t:s0"
 
 
+def test_selinux_setcontext_persist_change(tfile2):
+    """
+    Test set selinux context with persist=True
+    Assumes default selinux attributes on temporary files
+    """
+    result = filemod.set_selinux_context(tfile2, user="system_u", persist=True)
+    assert result == "system_u:object_r:user_tmp_t:s0"
+
+    result = filemod.set_selinux_context(
+        tfile2, user="unconfined_u", type="net_conf_t", persist=True
+    )
+    assert result == "unconfined_u:object_r:net_conf_t:s0"
+
+
 def test_file_check_perms(tfile3):
     expected_result = (
         {


### PR DESCRIPTION
### What does this PR do?
If a semanage fcontext already exists for a file, then the command ```semanage fcontext --modify``` is used rather than ```semanage fcontext --add```

### What issues does this PR fix or reference?
Fixes:https://github.com/saltstack/salt/issues/64625

### Previous Behavior
If the file already had a fcontext, a ValueError would be thrown, similar to the following
```
Unable to manage file: Problem setting fcontext: {'pid': 43053, 'retcode': 1, 'stdout': '', 'stderr': 'ValueError: File context for /root/test-one.txt already defined'}
```

### New Behavior
The code checks to see if If the file already has a fcontext, and uses ```--modify``` rather than ```--add``` which will throw a ValueError if used in this case.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
