### PR TITLE
[3006.x] Do not expect : in cached filename

### DIFF
--- a/tests/pytests/functional/states/test_archive.py
+++ b/tests/pytests/functional/states/test_archive.py
@@ -147,7 +147,7 @@ def test_archive_extracted_web_source_etag_operation(
         minion_opts["cachedir"],
         "extrn_files",
         "base",
-        "localhost:{free_port}".format(free_port=free_port),
+        "localhost{free_port}".format(free_port=free_port),
         "foo.tar.gz",
     )
     cached_etag = cached_file + ".etag"

--- a/tests/pytests/functional/states/test_file.py
+++ b/tests/pytests/functional/states/test_file.py
@@ -139,7 +139,7 @@ def test_file_managed_web_source_etag_operation(
         minion_opts["cachedir"],
         "extrn_files",
         "base",
-        "localhost:{free_port}".format(free_port=free_port),
+        "localhost{free_port}".format(free_port=free_port),
         "foo.txt",
     )
     cached_etag = cached_file + ".etag"


### PR DESCRIPTION
Fixes the nightly builds. After this was merged:https://github.com/saltstack/salt/pull/64945 we do not expect `:` to be in the cached filename. These tests where not run on the PR.