### PR TITLE
[3006.x] fix #64973 by adding header that microsoft started enforcing.

### DIFF
--- a/changelog/64973.fixed.md
+++ b/changelog/64973.fixed.md
@@ -1,0 +1,1 @@
+fix msteams by adding the missing header that Microsoft is now enforcing.

--- a/salt/modules/msteams.py
+++ b/salt/modules/msteams.py
@@ -70,8 +70,16 @@ def post_card(message, hook_url=None, title=None, theme_color=None):
 
     payload = {"text": message, "title": title, "themeColor": theme_color}
 
+    headers = {
+        "Content-Type": "application/json",
+    }
+
     result = salt.utils.http.query(
-        hook_url, method="POST", data=salt.utils.json.dumps(payload), status=True
+        hook_url,
+        method="POST",
+        header_dict=headers,
+        data=salt.utils.json.dumps(payload),
+        status=True,
     )
 
     if result["status"] <= 201:

--- a/tests/pytests/unit/modules/test_msteams.py
+++ b/tests/pytests/unit/modules/test_msteams.py
@@ -1,0 +1,31 @@
+import pytest
+
+import salt.modules.config as config
+import salt.modules.msteams as msteams
+from tests.support.mock import MagicMock, patch
+
+
+@pytest.fixture
+def configure_loader_modules(minion_opts):
+    minion_opts.update({"msteams": {"hook_url": "https://example.com/web_hook"}})
+    msteams_obj = {
+        msteams: {"__opts__": minion_opts, "__salt__": {"config.get": config.get}},
+        config: {
+            "__opts__": minion_opts,
+            "__grains__": {},
+        },
+    }
+    return msteams_obj
+
+
+def test_post_card():
+    http_ret = {"status": 200}
+    http_mock = MagicMock(return_value=http_ret)
+    with patch("salt.utils.http.query", http_mock):
+        ret = msteams.post_card("test")
+        assert ret
+        assert http_mock.called_once_with(
+            method="POST",
+            header_dict={"Content-Type": "application/json"},
+            data='{"text": "test", "title": Null, "themeColor": Null}',
+        )


### PR DESCRIPTION
### What does this PR do?
adds content header to the http.query for msteams.


### What issues does this PR fix or reference?
Fixes: #64973 

### Previous Behavior
microsoft started enforcing the use of a Content header.

### New Behavior
respect the Content header

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated
