### PR TITLE
[master] Add support for show_jid to salt-run

### DIFF
--- a/changelog/65008.added.md
+++ b/changelog/65008.added.md
@@ -1,0 +1,3 @@
+Add support for show_jid to salt-run
+
+Adds support for show_jid master config option to salt-run, so its behaviour matches the salt cli command.

--- a/salt/cli/run.py
+++ b/salt/cli/run.py
@@ -30,8 +30,9 @@ class SaltRun(salt.utils.parsers.SaltRunOptionParser):
         try:
             if check_user(self.config["user"]):
                 pr = salt.utils.profile.activate_profile(profiling_enabled)
+                show_jid = self.config.get("show_jid", False)
                 try:
-                    ret = runner.run(full_return=True)
+                    ret = runner.run(full_return=True, show_jid=show_jid)
                     # In older versions ret['data']['retcode'] was used
                     # for signaling the return code. This has been
                     # changed for the orchestrate runner, but external

--- a/salt/cli/run.py
+++ b/salt/cli/run.py
@@ -30,9 +30,8 @@ class SaltRun(salt.utils.parsers.SaltRunOptionParser):
         try:
             if check_user(self.config["user"]):
                 pr = salt.utils.profile.activate_profile(profiling_enabled)
-                show_jid = self.config.get("show_jid", False)
                 try:
-                    ret = runner.run(full_return=True, show_jid=show_jid)
+                    ret = runner.run(full_return=True)
                     # In older versions ret['data']['retcode'] was used
                     # for signaling the return code. This has been
                     # changed for the orchestrate runner, but external

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -207,7 +207,7 @@ class Runner(RunnerClient):
             print(docs[fun])
 
     # TODO: move to mixin whenever we want a salt-wheel cli
-    def run(self, full_return=False, show_jid=False):
+    def run(self, full_return=False):
         """
         Execute the runner sequence
         """
@@ -288,7 +288,7 @@ class Runner(RunnerClient):
                     return async_pub["jid"]  # return the jid
 
                 # otherwise run it in the main process
-                if show_jid:
+                if self.opts.get("show_jid"):
                     print(f"jid: {self.jid}")
 
                 if self.opts.get("eauth"):

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -207,7 +207,7 @@ class Runner(RunnerClient):
             print(docs[fun])
 
     # TODO: move to mixin whenever we want a salt-wheel cli
-    def run(self, full_return=False):
+    def run(self, full_return=False, show_jid=False):
         """
         Execute the runner sequence
         """
@@ -288,6 +288,9 @@ class Runner(RunnerClient):
                     return async_pub["jid"]  # return the jid
 
                 # otherwise run it in the main process
+                if show_jid:
+                    print(f"jid: {self.jid}")
+
                 if self.opts.get("eauth"):
                     ret = self.cmd_sync(low)
                     if isinstance(ret, dict) and set(ret) == {"data", "outputter"}:

--- a/tests/pytests/functional/cli/test_salt_run_show_jid.py
+++ b/tests/pytests/functional/cli/test_salt_run_show_jid.py
@@ -1,0 +1,42 @@
+"""
+Tests for salt-run with show_jid
+"""
+
+import logging
+import re
+
+import pytest
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def salt_master(salt_factories):
+    """
+    Salt master with `show_jid: True`
+    """
+    config_defaults = {
+        "show_jid": True,
+    }
+    salt_master = salt_factories.salt_master_daemon(
+        "salt-run-show-jid-master", defaults=config_defaults
+    )
+    with salt_master.started():
+        yield salt_master
+
+
+@pytest.fixture(scope="module")
+def salt_run_cli(salt_master):
+    """
+    The ``salt-run`` CLI as a fixture against the running master
+    """
+    assert salt_master.is_running()
+    return salt_master.salt_run_cli(timeout=30)
+
+
+def test_salt_run_show_jid(salt_run_cli):
+    """
+    Test that jid is output
+    """
+    ret = salt_run_cli.run("test.stdout_print")
+    assert re.match(r"jid: \d+", ret.stdout)


### PR DESCRIPTION
### What does this PR do?

Adds support for show_jid to the salt-run cli command to match the behaviour of the salt cli command.

Could have implemented this entirely within `salt/runner.py`, but I think it makes sense to not output the JID when Runner is called from other places - happy to get any feedback or alternative suggests on that.

### Previous Behavior
If `show_jid: True` was set in master config, running `salt-run` would not show a JID.

### New Behavior

`salt-run` now prints `jid: <jid>`

### Merge requirements satisfied?

- [X] Changelog
- [X] Tests written/updated

### Commits signed with GPG?
No
