### PR TITLE
[3006.x] Fixed KeyError in logs when running a state that fails.

### DIFF
--- a/changelog/64231.fixed.md
+++ b/changelog/64231.fixed.md
@@ -1,0 +1,1 @@
+Fixed KeyError in logs when running a state that fails.

--- a/salt/master.py
+++ b/salt/master.py
@@ -1782,7 +1782,7 @@ class AESFuncs(TransportMethods):
     def pub_ret(self, load):
         """
         Request the return data from a specific jid, only allowed
-        if the requesting minion also initialted the execution.
+        if the requesting minion also initiated the execution.
 
         :param dict load: The minion payload
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2057,6 +2057,8 @@ class Minion(MinionBase):
         ret["jid"] = data["jid"]
         ret["fun"] = data["fun"]
         ret["fun_args"] = data["arg"]
+        if "user" in data:
+            ret["user"] = data["user"]
         if "master_id" in data:
             ret["master_id"] = data["master_id"]
         if "metadata" in data:
@@ -2176,6 +2178,8 @@ class Minion(MinionBase):
             ret["jid"] = data["jid"]
             ret["fun"] = data["fun"]
             ret["fun_args"] = data["arg"]
+            if "user" in data:
+                ret["user"] = data["user"]
         if "metadata" in data:
             ret["metadata"] = data["metadata"]
         if minion_instance.connected:

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -902,7 +902,8 @@ class SaltEvent:
                     data["success"] = False
                     data["return"] = "Error: {}.{}".format(tags[0], tags[-1])
                     data["fun"] = fun
-                    data["user"] = load["user"]
+                    if "user" in load:
+                        data["user"] = load["user"]
                     self.fire_event(
                         data,
                         tagify([load["jid"], "sub", load["id"], "error", fun], "job"),

--- a/tests/pytests/integration/states/test_state_test.py
+++ b/tests/pytests/integration/states/test_state_test.py
@@ -1,3 +1,8 @@
+import logging
+
+log = logging.getLogger(__name__)
+
+
 def test_issue_62590(salt_master, salt_minion, salt_cli):
 
     statepy = """
@@ -32,3 +37,43 @@ def test_issue_62590(salt_master, salt_minion, salt_cli):
         ret = salt_cli.run("state.apply", "test_62590", minion_tgt=salt_minion.id)
         assert ret.returncode == 0
         assert "Success!" == ret.data["test_|-nop_|-nop_|-nop"]["comment"]
+
+
+def test_failing_sls(salt_master, salt_minion, salt_cli, caplog):
+    """
+    Test when running state.sls and the state fails.
+    When the master stores the job and attempts to send
+    an event a KeyError was previously being logged.
+    This test ensures we do not log an error when
+    attempting to send an event about a failing state.
+    """
+    statesls = """
+    test_state:
+      test.fail_without_changes:
+        - name: "bla"
+    """
+    with salt_master.state_tree.base.temp_file("test_failure.sls", statesls):
+        ret = salt_cli.run("state.sls", "test_failure", minion_tgt=salt_minion.id)
+        for message in caplog.messages:
+            assert "Event iteration failed with" not in message
+
+
+def test_failing_sls_compound(salt_master, salt_minion, salt_cli, caplog):
+    """
+    Test when running state.sls in a compound command and the state fails.
+    When the master stores the job and attempts to send
+    an event a KeyError was previously being logged.
+    This test ensures we do not log an error when
+    attempting to send an event about a failing state.
+    """
+    statesls = """
+    test_state:
+      test.fail_without_changes:
+        - name: "bla"
+    """
+    with salt_master.state_tree.base.temp_file("test_failure.sls", statesls):
+        ret = salt_cli.run(
+            "state.sls,cmd.run", "test_failure,ls", minion_tgt=salt_minion.id
+        )
+        for message in caplog.messages:
+            assert "Event iteration failed with" not in message


### PR DESCRIPTION
### What does this PR do?

When running `state.sls` against a state that fails would result in a KeyError in the logs:

```
[ERROR   ] Event iteration failed with exception: 'user'
Traceback (most recent call last):
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/utils/event.py", line 905, in _fire_ret_load_specific_fun
    data["user"] = load["user"]
KeyError: 'user'
```

This is because `user` was never in the returned payload back to the master. This PR adds the user who originally submitted the job to the minion to be added to the return payload. 

For example:

```
salt/job/20230818161008007954/ret/poc-minion    {                                                                                                                                                                                                                                                                             
    "_stamp": "2023-08-18T16:10:08.265648",                                                                                                                                                                                                                                                                                   
    "cmd": "_return",                                                                                                                                                                                                                                                                                                         
    "fun": "state.sls",                                                                                                                                                                                                                                                                                                       
    "fun_args": [                                                                                                                                                                                                                                                                                                             
        "issues.64231",                                                                                                                                                                                                                                                                                                       
        {                                                                                                                                                                                                                                                                                                                     
            "saltenv": "base"                                                                                                                                                                                                                                                                                                 
        }                                                                                                                                                                                                                                                                                                                     
    ],                                                                                                                                                                                                                                                                                                                        
    "id": "poc-minion",                                                                                                                                                                                                                                                                                                       
    "jid": "20230818161008007954",                                                                                                                                                                                                                                                                                            
    "out": "highstate",                                                                                                                                                                                                                                                                                                       
    "retcode": 2,                                                                                                                                                                                                                                                                                                             
    "return": {                                                                                                                                                                                                                                                                                                               
        "test_|-test_state_|-bla_|-fail_without_changes": {                                                                                                                                                                                                                                                                   
            "__id__": "test_state",                                                                                                                                                                                                                                                                                           
            "__run_num__": 0,                                                                                                                                                                                                                                                                                                 
            "__sls__": "issues.64231",                                                                                                                                                                                                                                                                                        
            "changes": {},                                                                                                                                                                                                                                                                                                    
            "comment": "Failure!",                                                                                                                                                                                                                                                                                            
            "duration": 0.686,                                                                                                                                                                                                                                                                                                
            "name": "bla",                                                                                                                                                                                                                                                                                                    
            "result": false,                                                                                                                                                                                                                                                                                                  
            "start_time": "10:10:08.257480"                                                                                                                                                                                                                                                                                   
        }                                                                                                                                                                                                                                                                                                                     
    },                                                                                                                                                                                                                                                                                                                        
    "success": false,                                                                                                                                                                                                                                                                                                         
    "user": "sudo_ch3ll"                                                                                                                                                                                                                                                                                                      
}
```

This will also add the `user` to a return job that passes:

```
salt/job/20230818161650076852/ret/poc-minion    {
    "_stamp": "2023-08-18T16:16:50.163082",
    "cmd": "_return",
    "fun": "test.ping",
    "fun_args": [],
    "id": "poc-minion",
    "jid": "20230818161650076852",
    "retcode": 0,
    "return": true,
    "success": true,
    "user": "sudo_ch3ll"
}
```

My only concern is this might be confusing to a user and they might think that was the user who ran the job on the minion. I could also easily just remove or add a `.get` call in salt/utils/event.py when trying to get user from the dictionary. 


### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/64231

### Previous Behavior
KeyError in logs and failing state event would not properly fire off

### New Behavior
No KeyError in log and the event properly fires off.

