### PR TITLE
Don't try to connect to a master if `file_client` is local and `use_master_when_local` is False

### DIFF
--- a/changelog/65013.fixed.md
+++ b/changelog/65013.fixed.md
@@ -1,0 +1,1 @@
+Fix MinionManager not skipping master connection when `file_client` is `local` and `use_master_when_local` is `False`

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1338,7 +1338,10 @@ class MinionManager(MinionBase):
                 if minion.opts.get("scheduler_before_connect", False):
                     minion.setup_scheduler(before_connect=True)
                 if minion.opts.get("master_type", "str") != "disable":
-                    await minion.connect_master(failed=failed)
+                    if minion.opts.get(
+                        "file_client", "remote"
+                    ) == "remote" or minion.opts.get("use_master_when_local", False):
+                        await minion.connect_master(failed=failed)
                 minion.tune_in(start=False)
                 self.minions.append(minion)
                 break

--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -1615,6 +1615,76 @@ async def test_master_type_disable(minion_opts):
         minion.destroy()
 
 
+async def test_masterless_minion_does_not_connect_to_master(minion_opts):
+    """
+    When file_client is local and use_master_when_local is False (the default),
+    MinionManager._connect_minion must not call connect_master.
+    Regression test for https://github.com/saltstack/salt/issues/57866 and
+    https://github.com/saltstack/salt/issues/64952.
+    """
+    minion_opts.update(
+        {
+            "file_client": "local",
+            "use_master_when_local": False,
+            "__role": "",
+            "pub_ret": False,
+        }
+    )
+
+    minion = salt.minion.Minion(minion_opts)
+    try:
+        connect_master_called = False
+
+        async def mock_connect_master(failed=False):
+            nonlocal connect_master_called
+            connect_master_called = True
+
+        minion.connect_master = mock_connect_master
+        minion_man = salt.minion.MinionManager(minion_opts)
+        await minion_man._connect_minion(minion)
+        assert not connect_master_called, (
+            "connect_master should not be called when file_client=local and"
+            " use_master_when_local=False"
+        )
+    finally:
+        minion.io_loop = MagicMock()
+        minion.destroy()
+
+
+async def test_masterless_minion_connects_when_use_master_when_local(minion_opts):
+    """
+    When file_client is local and use_master_when_local is True,
+    MinionManager._connect_minion must still call connect_master.
+    """
+    minion_opts.update(
+        {
+            "file_client": "local",
+            "use_master_when_local": True,
+            "__role": "",
+            "pub_ret": False,
+        }
+    )
+
+    minion = salt.minion.Minion(minion_opts)
+    try:
+        connect_master_called = False
+
+        async def mock_connect_master(failed=False):
+            nonlocal connect_master_called
+            connect_master_called = True
+
+        minion.connect_master = mock_connect_master
+        minion_man = salt.minion.MinionManager(minion_opts)
+        await minion_man._connect_minion(minion)
+        assert connect_master_called, (
+            "connect_master should be called when file_client=local and"
+            " use_master_when_local=True"
+        )
+    finally:
+        minion.io_loop = MagicMock()
+        minion.destroy()
+
+
 async def test_syndic_async_req_channel(syndic_opts):
     syndic_opts["_minion_conf_file"] = ""
     syndic_opts["master_uri"] = "tcp://127.0.0.1:4506"


### PR DESCRIPTION
### What does this PR do?
See title and the following...
- https://docs.saltproject.io/en/latest/ref/configuration/minion.html#use-master-when-local
- https://docs.saltproject.io/en/latest/topics/tutorials/quickstart.html#telling-salt-to-run-masterless

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/64952 https://github.com/saltstack/salt/issues/57866

### Previous Behavior
The minion would try to connect to the master

### New Behavior
Now it doesn't

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes