### PR TITLE
[3006.x] Better error message on inconsistent decoded payload

### DIFF
--- a/changelog/65020.fixed.md
+++ b/changelog/65020.fixed.md
@@ -1,0 +1,1 @@
+Better error message on inconsistent decoded payload

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -22,6 +22,7 @@ import salt.utils.minions
 import salt.utils.platform
 import salt.utils.stringutils
 import salt.utils.verify
+from salt.exceptions import SaltDeserializationError
 from salt.utils.cache import CacheCli
 
 try:
@@ -252,6 +253,15 @@ class ReqServerChannel:
         return False
 
     def _decode_payload(self, payload):
+        # Sometimes msgpack deserialization of random bytes could be successful,
+        # so we need to ensure payload in good shape to process this function.
+        if (
+            not isinstance(payload, dict)
+            or "enc" not in payload
+            or "load" not in payload
+        ):
+            raise SaltDeserializationError("bad load received on socket!")
+
         # we need to decrypt it
         if payload["enc"] == "aes":
             try:

--- a/tests/pytests/unit/transport/test_zeromq.py
+++ b/tests/pytests/unit/transport/test_zeromq.py
@@ -1434,3 +1434,42 @@ async def test_req_server_garbage_request(io_loop):
         pytest.fail("Exception was raised {}".format(exc))
 
     request_server.stream.send.assert_called_once_with(valid_response)
+
+
+async def test_req_chan_bad_payload_to_decode(pki_dir, io_loop):
+    opts = {
+        "master_uri": "tcp://127.0.0.1:4506",
+        "interface": "127.0.0.1",
+        "ret_port": 4506,
+        "ipv6": False,
+        "sock_dir": ".",
+        "pki_dir": str(pki_dir.joinpath("minion")),
+        "id": "minion",
+        "__role": "minion",
+        "keysize": 4096,
+        "max_minions": 0,
+        "auto_accept": False,
+        "open_mode": False,
+        "key_pass": None,
+        "publish_port": 4505,
+        "auth_mode": 1,
+        "acceptance_wait_time": 3,
+        "acceptance_wait_time_max": 3,
+    }
+    SMaster.secrets["aes"] = {
+        "secret": multiprocessing.Array(
+            ctypes.c_char,
+            salt.utils.stringutils.to_bytes(salt.crypt.Crypticle.generate_key_string()),
+        ),
+        "reload": salt.crypt.Crypticle.generate_key_string,
+    }
+    master_opts = dict(opts, pki_dir=str(pki_dir.joinpath("master")))
+    master_opts["master_sign_pubkey"] = False
+    server = salt.channel.server.ReqServerChannel.factory(master_opts)
+
+    with pytest.raises(salt.exceptions.SaltDeserializationError):
+        server._decode_payload(None)
+    with pytest.raises(salt.exceptions.SaltDeserializationError):
+        server._decode_payload({})
+    with pytest.raises(salt.exceptions.SaltDeserializationError):
+        server._decode_payload(12345)


### PR DESCRIPTION
### What does this PR do?

When writting ramdom bytes at port 4506, ReqChannel, it can happen that msgpack successfully decodes these bytes as, for example an `int`, instead of making msgpack to fail the decoding.

When this situation happens, since there is not msgpack deserialization error produced, then the payload is propagated and Salt tries to "decode" the actual load from the payload, producing the following error:

```
2023-08-21 13:24:40,083 [salt.channel.server:117 ][ERROR   ][19858] Bad load from minion: TypeError: 'int' object is not subscriptable
```

Having this generic Python exception shown in the logs doesn't sound really nice, as a user might think something has crashes or that unexpected exception has been produced when seeing `TypeError: 'int' object is not subscriptable`.

This PR simply ensure the msgpack decoded payload is consistent before Salt continues processing it. If not consistent, then it raises an specific message.

NOTE: I'm targetting `3006.x` branch here as this changes goes on top of https://github.com/saltstack/salt/pull/64998 (which is not yet merged)


### Previous Behavior
```
2023-08-21 13:24:38,843 [salt.payload     :117 ][CRITICAL][19858] Could not deserialize msgpack message. This often happens when trying to read a file not in binary mode. To see message payload, enable debug logging and retry. Exception: unpack(b) received extra data.
2023-08-21 13:24:40,083 [salt.channel.server:117 ][ERROR   ][19858] Bad load from minion: TypeError: 'int' object is not subscriptable
2023-08-21 13:24:40,327 [salt.channel.server:117 ][ERROR   ][19844] Bad load from minion: TypeError: 'int' object is not subscriptable
```

### New Behavior
```
2023-08-21 13:37:04,715 [salt.payload     :117 ][CRITICAL][22139] Could not deserialize msgpack message. This often happens when trying to read a file not in binary mode. To see message payload, enable debug logging and retry. Exception: unpack(b) received extra data.
2023-08-21 13:37:04,719 [salt.channel.server:120 ][ERROR   ][22139] Bad load from minion: SaltDeserializationError: bad load received on socket!
2023-08-21 13:44:15,786 [salt.channel.server:120 ][ERROR   ][22141] Bad load from minion: SaltDeserializationError: bad load received on socket!
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
