### PR TITLE
[3006.x] Handle permissions access error when calling `ls_release` with the salt user

### DIFF
--- a/changelog/65024.fixed.md
+++ b/changelog/65024.fixed.md
@@ -1,0 +1,1 @@
+Handle permissions access error when calling `lsb_release` with the salt user

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2320,14 +2320,9 @@ def _legacy_linux_distribution_data(grains, os_release, lsb_has_error):
     log.trace(
         "Getting OS name, release, and codename from distro id, version, codename"
     )
-    try:
-        (osname, osrelease, oscodename) = (
-            x.strip('"').strip("'") for x in _linux_distribution()
-        )
-    except subprocess.CalledProcessError:
-        # When running under the salt user, a call to `lsb_release` might raise
-        # permissin errors.
-        return grains
+    (osname, osrelease, oscodename) = (
+        x.strip('"').strip("'") for x in _linux_distribution()
+    )
     # Try to assign these three names based on the lsb info, they tend to
     # be more accurate than what python gets from /etc/DISTRO-release.
     # It's worth noting that Ubuntu has patched their Python distribution

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2320,9 +2320,14 @@ def _legacy_linux_distribution_data(grains, os_release, lsb_has_error):
     log.trace(
         "Getting OS name, release, and codename from distro id, version, codename"
     )
-    (osname, osrelease, oscodename) = (
-        x.strip('"').strip("'") for x in _linux_distribution()
-    )
+    try:
+        (osname, osrelease, oscodename) = (
+            x.strip('"').strip("'") for x in _linux_distribution()
+        )
+    except subprocess.CalledProcessError:
+        # When running under the salt user, a call to `lsb_release` might raise
+        # permissin errors.
+        return grains
     # Try to assign these three names based on the lsb info, they tend to
     # be more accurate than what python gets from /etc/DISTRO-release.
     # It's worth noting that Ubuntu has patched their Python distribution

--- a/salt/utils/platform.py
+++ b/salt/utils/platform.py
@@ -1,7 +1,7 @@
 """
 Functions for identifying which platform a machine is
 """
-
+import contextlib
 import multiprocessing
 import os
 import platform
@@ -18,8 +18,16 @@ def linux_distribution(full_distribution_name=True):
     Simple function to return information about the OS distribution (id_name, version, codename).
     """
     if full_distribution_name:
-        return distro.name(), distro.version(best=True), distro.codename()
-    return distro.id(), distro.version(best=True), distro.codename()
+        distro_name = distro.name()
+    else:
+        distro_name = distro.id()
+    # Empty string fallbacks
+    distro_version = distro_codename = ""
+    with contextlib.suppress(subprocess.CalledProcessError):
+        distro_version = distro.version(best=True)
+    with contextlib.suppress(subprocess.CalledProcessError):
+        distro_codename = distro.codename()
+    return distro_name, distro_version, distro_codename
 
 
 @real_memoize

--- a/tests/pytests/unit/utils/test_platform.py
+++ b/tests/pytests/unit/utils/test_platform.py
@@ -1,0 +1,47 @@
+import subprocess
+
+import salt.utils.platform
+from tests.support.mock import patch
+
+
+def test_linux_distribution():
+    """
+    Test that when `distro` fails with a `subprocess.CalledProcessError` salt
+    returns empty strings as default values.
+    """
+    distro_name = "Salt"
+    distro_version = "1"
+    distro_codename = "Awesome"
+    with patch("distro.name", return_value=distro_name):
+        with patch("distro.version", return_value=distro_version), patch(
+            "distro.codename", return_value=distro_codename
+        ):
+            assert salt.utils.platform.linux_distribution() == (
+                distro_name,
+                distro_version,
+                distro_codename,
+            )
+
+        distro_version = ""
+        with patch(
+            "distro.version",
+            side_effect=subprocess.CalledProcessError(returncode=1, cmd=["foo"]),
+        ), patch("distro.codename", return_value=distro_codename):
+            assert salt.utils.platform.linux_distribution() == (
+                distro_name,
+                distro_version,
+                distro_codename,
+            )
+        distro_codename = ""
+        with patch(
+            "distro.version",
+            side_effect=subprocess.CalledProcessError(returncode=1, cmd=["foo"]),
+        ), patch(
+            "distro.codename",
+            side_effect=subprocess.CalledProcessError(returncode=1, cmd=["foo"]),
+        ):
+            assert salt.utils.platform.linux_distribution() == (
+                distro_name,
+                distro_version,
+                distro_codename,
+            )


### PR DESCRIPTION
```
[ERROR   ] [SaltMaster(id='master-NkEYGW')] An un-handled exception was caught by Salt's global exception handler:
CalledProcessError: Command '('lsb_release', '-a')' returned non-zero exit status 126.
Traceback (most recent call last):
  File "/usr/bin/salt-master", line 11, in <module>
    sys.exit(salt_master())
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/scripts.py", line 88, in salt_master
    master.start()
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/cli/daemons.py", line 204, in start
    self.master.start()
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/master.py", line 723, in start
    chan = salt.channel.server.PubServerChannel.factory(opts)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/channel/server.py", line 721, in factory
    return cls(opts, transport, presence_events=presence_events)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/channel/server.py", line 727, in __init__
    self.aes_funcs = salt.master.AESFuncs(self.opts)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/master.py", line 1233, in __init__
    self.mminion = salt.minion.MasterMinion(
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/minion.py", line 974, in __init__
    self.opts = salt.config.mminion_config(
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/config/__init__.py", line 2332, in mminion_config
    opts["grains"] = salt.loader.grains(opts)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/__init__.py", line 1116, in grains
    ret = funcs[key]()
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 159, in __call__
    ret = self.loader.run(run_func, *args, **kwargs)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 1245, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 1260, in _run_as
    return _func_or_method(*args, **kwargs)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/grains/core.py", line 2602, in os_data
    grains.update(_linux_distribution_data())
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/grains/core.py", line 2189, in _linux_distribution_data
    return _legacy_linux_distribution_data(grains, os_release, lsb_has_error)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/grains/core.py", line 2324, in _legacy_linux_distribution_data
    x.strip('"').strip("'") for x in _linux_distribution()
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/utils/platform.py", line 21, in linux_distribution
    return distro.name(), distro.version(best=True), distro.codename()
  File "/opt/saltstack/salt/lib/python3.10/site-packages/distro.py", line 287, in version
    return _distro.version(pretty, best)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/distro.py", line 741, in version
    self.lsb_release_attr('release'),
  File "/opt/saltstack/salt/lib/python3.10/site-packages/distro.py", line 903, in lsb_release_attr
    return self._lsb_release_info.get(attribute, '')
  File "/opt/saltstack/salt/lib/python3.10/site-packages/distro.py", line 556, in __get__
    ret = obj.__dict__[self._fname] = self._f(obj)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/distro.py", line 1014, in _lsb_release_info
    stdout = subprocess.check_output(cmd, stderr=devnull)
  File "/opt/saltstack/salt/lib/python3.10/subprocess.py", line 421, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/opt/saltstack/salt/lib/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '('lsb_release', '-a')' returned non-zero exit status 126.
```
