### PR TITLE
[3006.x] Don't fail on pkg.latest when multiple versions are installed

### DIFF
--- a/changelog/60931.fixed.md
+++ b/changelog/60931.fixed.md
@@ -1,0 +1,1 @@
+pkg.latest no longer fails when multiple versions are reported to be installed (e.g. updating the kernel)

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -2789,7 +2789,7 @@ def latest(
                 x
                 for x in targets
                 if not changes.get(x)
-                or changes[x].get("new") != targets[x]
+                or targets[x] not in changes[x].get("new").split(",")
                 and targets[x] != "latest"
             ]
             successful = [x for x in targets if x not in failed]


### PR DESCRIPTION
### What does this PR do?
See title (a port of [this PR](https://github.com/saltstack/salt/pull/60935) with tests)

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/60931

### Previous Behavior
pkg.latest would fail when multiple versions are installed

### New Behavior
Checks the new versions installed as a comma separated list

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes