### PR TITLE
[3006.x] Include 24 hour clock time example in at module

### DIFF
--- a/salt/modules/at.py
+++ b/salt/modules/at.py
@@ -245,6 +245,7 @@ def at(*args, **kwargs):  # pylint: disable=C0103
         salt '*' at.at <timespec> <cmd> [tag=<tag>] [runas=<user>]
         salt '*' at.at 12:05am '/sbin/reboot' tag=reboot
         salt '*' at.at '3:05am +3 days' 'bin/myscript' tag=nightly runas=jim
+        salt '*' at.at '"22:02"' 'bin/myscript' tag=nightly runas=jim
     """
 
     if len(args) < 2:


### PR DESCRIPTION
### What does this PR do?
Adds 24 hour clock time example in the `at` module.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/42008

