### PR TITLE
[master] Fix calculation of SLS context vars when trailing dots on targetted sls/state

### DIFF
--- a/changelog/63411.fixed.md
+++ b/changelog/63411.fixed.md
@@ -1,0 +1,1 @@
+Fix calculation of SLS context vars when trailing dots on targetted state

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -105,8 +105,9 @@ def generate_sls_context(tmplpath, sls):
 
     sls_context = {}
 
-    # Normalize SLS as path.
-    slspath = sls.replace(".", "/")
+    # Normalize SLS as path and remove possible trailing slashes
+    # to prevent matching issues and wrong vars calculation
+    slspath = sls.replace(".", "/").rstrip("/")
 
     if tmplpath:
         # Normalize template path

--- a/tests/pytests/unit/utils/templates/test_wrap_tmpl_func.py
+++ b/tests/pytests/unit/utils/templates/test_wrap_tmpl_func.py
@@ -30,7 +30,7 @@ def _test_generated_sls_context(tmplpath, sls, **expected):
         tmplpath = f"C:{tmplpath}"
     expected["tplpath"] = tmplpath
     actual = generate_sls_context(tmplpath, sls)
-    assert {key: actual[key] for key in expected if key in actual} == actual
+    assert {key: actual[key] for key in expected if key in actual} == expected
 
 
 def test_sls_context_call(tmp_path):

--- a/tests/pytests/unit/utils/templates/test_wrap_tmpl_func.py
+++ b/tests/pytests/unit/utils/templates/test_wrap_tmpl_func.py
@@ -91,6 +91,21 @@ def test_generate_sls_context__one_level_init_implicit():
     )
 
 
+def test_generate_sls_context__one_level_init_implicit_with_trailing_dot():
+    """generate_sls_context - Basic one level with implicit init.sls with trailing dot"""
+    _test_generated_sls_context(
+        "/tmp/foo/init.sls",
+        "foo.",
+        tplfile="foo/init.sls",
+        tpldir="foo",
+        tpldot="foo",
+        slsdotpath="foo",
+        slscolonpath="foo",
+        sls_path="foo",
+        slspath="foo",
+    )
+
+
 def test_generate_sls_context__one_level_init_explicit():
     """generate_sls_context - Basic one level with explicit init.sls"""
     _test_generated_sls_context(


### PR DESCRIPTION
### What does this PR do?
This PR fixes a problem on the behavior of SLS context vars, that has been identified when targetting an SLS with trailing dots.

Let say I have the following in my "file_roots":

```
/srv/salt/
/srv/salt/test/
/srv/salt/test/init.sls
```

where `test/init.sls` contains:

```
Show Variables:
  cmd.run:
    - name: echo "sls = {{sls}}\nslspath = {{slspath}}\nsls_path = {{sls_path}}\ntplfile = {{tplfile}}\ntpldir = {{tpldir}}\ntplpath = {{tplpath}}"
```

Now, depending how I trigger the state, I got wrong calculation of SLS context variables (slspath, slsdotpath, slscolonpath, sls_path), where the expected relative paths are actually rendered as absolute paths:

```console
# This works as expected
# salt <minion> state.sls test 
...
                  sls = test
                  slspath = test
                  sls_path = test
                  tplfile = test/init.sls
                  tpldir = test
                  tplpath = /var/cache/salt/minion/files/test_edit/test/init.sls
...
```
```console
# This DOES NOT work as expected
# salt <minion> state.sls test.
...
                  sls = test.
                  slspath = /var/cache/salt/minion/files/test_edit/test
                  sls_path = _var_cache_salt_minion_files_test_edit_test
                  tplfile = /var/cache/salt/minion/files/test_edit/test/init.sls
                  tpldir = /var/cache/salt/minion/files/test_edit/test
                  tplpath = /var/cache/salt/minion/files/test_edit/test/init.sls
```

```console
# This works as expected
# salt <minion> state.sls test.init
...
                  sls = test.init
                  slspath = test
                  sls_path = test
                  tplfile = test/init.sls
                  tpldir = test
                  tplpath = /var/cache/salt/minion/files/test_edit/test/init.sls
...
```

Additionally, this PR fixes a bad logic for test comparison that was making related tests to always pass.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/63411

### Previous Behavior
As mentioned, when targetting as `test.`, I got unexpected absolute paths:

```
                  sls = test.
                  slspath = /var/cache/salt/minion/files/test_edit/test
                  sls_path = _var_cache_salt_minion_files_test_edit_test
                  tplfile = /var/cache/salt/minion/files/test_edit/test/init.sls
                  tpldir = /var/cache/salt/minion/files/test_edit/test
                  tplpath = /var/cache/salt/minion/files/test_edit/test/init.sls
```

### New Behavior
After this PR, I got expected values:

```
                  sls = test.
                  slspath = test
                  sls_path = test
                  tplfile = test/init.sls
                  tpldir = test
                  tplpath = /var/cache/salt/minion/files/test_edit/test/init.sls
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
