### PR TITLE
[3006.x] Ensure we raise an error when the name argument is invalid in pkgrepo.managed

### DIFF
--- a/changelog/64451.fixed.md
+++ b/changelog/64451.fixed.md
@@ -1,0 +1,1 @@
+Ensure we raise an error when the name argument is invalid in pkgrepo.managed state for systems using apt.

--- a/tests/pytests/functional/states/pkgrepo/test_debian.py
+++ b/tests/pytests/functional/states/pkgrepo/test_debian.py
@@ -767,6 +767,40 @@ def test_adding_repo_file_signedby(pkgrepo, states, repo, subtests):
         assert ret.changes == {}
 
 
+def test_adding_repo_file_signedby_invalid_name(pkgrepo, states, repo):
+    """
+    Test adding a repo file using pkgrepo.managed
+    and setting signedby and the name is invalid.
+    Ensure we raise an error.
+    """
+
+    def _run(test=False):
+        return states.pkgrepo.managed(
+            name=repo.repo_content.strip("deb"),
+            file=str(repo.repo_file),
+            clean_file=True,
+            signedby=str(repo.key_file),
+            key_url=repo.key_url,
+            aptkey=False,
+            test=test,
+        )
+
+    default_sources = pathlib.Path("/etc", "apt", "sources.list")
+    with salt.utils.files.fopen(default_sources, "r") as fp:
+        pre_file_content = fp.read()
+
+    ret = _run()
+    assert "Failed to configure repo" in ret.comment
+    assert "This must be the complete repo entry" in ret.comment
+    with salt.utils.files.fopen(str(repo.repo_file), "r") as fp:
+        file_content = fp.read()
+        assert not file_content
+
+    with salt.utils.files.fopen(default_sources, "r") as fp:
+        post_file_content = fp.read()
+    assert pre_file_content == post_file_content
+
+
 def test_adding_repo_file_signedby_keyserver(pkgrepo, states, repo):
     """
     Test adding a repo file using pkgrepo.managed

--- a/tests/pytests/functional/states/pkgrepo/test_debian.py
+++ b/tests/pytests/functional/states/pkgrepo/test_debian.py
@@ -774,22 +774,20 @@ def test_adding_repo_file_signedby_invalid_name(pkgrepo, states, repo):
     Ensure we raise an error.
     """
 
-    def _run(test=False):
-        return states.pkgrepo.managed(
-            name=repo.repo_content.strip("deb"),
-            file=str(repo.repo_file),
-            clean_file=True,
-            signedby=str(repo.key_file),
-            key_url=repo.key_url,
-            aptkey=False,
-            test=test,
-        )
-
     default_sources = pathlib.Path("/etc", "apt", "sources.list")
     with salt.utils.files.fopen(default_sources, "r") as fp:
         pre_file_content = fp.read()
 
-    ret = _run()
+    ret = states.pkgrepo.managed(
+        name=repo.repo_content.strip("deb"),
+        file=str(repo.repo_file),
+        clean_file=True,
+        signedby=str(repo.key_file),
+        key_url=repo.key_url,
+        aptkey=False,
+        test=False,
+    )
+
     assert "Failed to configure repo" in ret.comment
     assert "This must be the complete repo entry" in ret.comment
     with salt.utils.files.fopen(str(repo.repo_file), "r") as fp:

--- a/tests/pytests/unit/modules/test_aptpkg.py
+++ b/tests/pytests/unit/modules/test_aptpkg.py
@@ -732,6 +732,12 @@ def test_mod_repo_enabled():
     """
     Checks if a repo is enabled or disabled depending on the passed kwargs.
     """
+    source_type = "deb"
+    source_uri = "http://cdn-aws.deb.debian.org/debian/"
+    source_line = "deb http://cdn-aws.deb.debian.org/debian/ stretch main\n"
+
+    mock_source = MockSourceEntry(source_uri, source_type, source_line, False)
+
     with patch.dict(
         aptpkg.__salt__,
         {"config.option": MagicMock(), "no_proxy": MagicMock(return_value=False)},
@@ -742,7 +748,9 @@ def test_mod_repo_enabled():
             ) as data_is_true:
                 with patch("salt.modules.aptpkg.SourcesList", MagicMock(), create=True):
                     with patch(
-                        "salt.modules.aptpkg.SourceEntry", MagicMock(), create=True
+                        "salt.modules.aptpkg.SourceEntry",
+                        MagicMock(return_value=mock_source),
+                        create=True,
                     ):
                         with patch("pathlib.Path", MagicMock()):
                             repo = aptpkg.mod_repo("foo", enabled=False)


### PR DESCRIPTION
### What does this PR do?
Ensures we raise an error when the name passed to pkgrepo.managed for aptpkg is invalid

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/64451

### Previous Behavior
It would actually copy a line from /etc/apt/sources.list to the file you defined in your state.

### New Behavior
An error is raised letting the user know they need to properly define their repo name. 

