### PR TITLE
[3006.x] adding usermod, groupadd, useradd to requires for rpm

### DIFF
--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -50,6 +50,9 @@ Requires: dmidecode
 Requires: pciutils
 Requires: which
 Requires: openssl
+Requires: /usr/sbin/usermod
+Requires: /usr/sbin/groupadd
+Requires: /usr/sbin/useradd
 
 BuildRequires: python3
 BuildRequires: python3-pip


### PR DESCRIPTION
### What does this PR do?
add binaries required for package installation to package requires.

### What issues does this PR fix or reference?
Fixes: installation issue on photon4

https://rpm-software-management.github.io/rpm/manual/boolean_dependencies.html