### PR TITLE
[master] Add PYTHONWARNINGS=ignore option to silence deprecation warnings

### DIFF
--- a/changelog/64660.added.md
+++ b/changelog/64660.added.md
@@ -1,0 +1,1 @@
+Added ability to use PYTHONWARNINGS=ignore to silence deprecation warnings.

--- a/doc/topics/development/deprecations.rst
+++ b/doc/topics/development/deprecations.rst
@@ -55,3 +55,10 @@ Development begins on ``Aluminium``, or ``v3003``, after the ``v3002`` tag is
 applied to the ``master`` branch.  Once this occurs, all uses of the
 ``warn_until`` function targeting ``Aluminium``, along with the code they are
 warning about should be removed from the code.
+
+
+Silence Deprecation Warnings
+----------------------------
+
+If you set the `PYTHONWARNINGS` environment variable to `ignore` Salt will
+not print the deprecation warnings.

--- a/salt/utils/versions.py
+++ b/salt/utils/versions.py
@@ -12,6 +12,7 @@ import datetime
 import inspect
 import logging
 import numbers
+import os
 import sys
 import warnings
 
@@ -183,7 +184,7 @@ def warn_until(
             ),
         )
 
-    if _dont_call_warnings is False:
+    if _dont_call_warnings is False and os.environ.get("PYTHONWARNINGS") != "ignore":
         warnings.warn(
             message.format(version=version.formatted_version),
             category,
@@ -252,7 +253,7 @@ def warn_until_date(
             ),
         )
 
-    if _dont_call_warnings is False:
+    if _dont_call_warnings is False and os.environ.get("PYTHONWARNINGS") != "ignore":
         warnings.warn(
             message.format(date=date.isoformat(), today=today.isoformat()),
             category,

--- a/tests/pytests/functional/modules/test_test.py
+++ b/tests/pytests/functional/modules/test_test.py
@@ -1,0 +1,9 @@
+def test_deprecation_warnings_ignore(salt_call_cli):
+    """
+    Test to ensure when env variable PYTHONWARNINGS=ignore
+    is set that we do not add warning to output.
+    """
+    ret = salt_call_cli.run(
+        "--local", "test.deprecation_warning", env={"PYTHONWARNINGS": "ignore"}
+    )
+    assert "DeprecationWarning" not in ret.stderr

--- a/tests/pytests/functional/modules/test_test.py
+++ b/tests/pytests/functional/modules/test_test.py
@@ -1,9 +1,24 @@
-def test_deprecation_warnings_ignore(salt_call_cli):
+import pytest
+
+
+@pytest.mark.parametrize(
+    "env,warn_expected",
+    [
+        ({"PYTHONWARNINGS": "ignore"}, False),
+        ({"PYTHONWARNINGS": "test"}, True),
+        ({}, True),
+    ],
+)
+def test_deprecation_warnings(salt_call_cli, env, warn_expected):
     """
     Test to ensure when env variable PYTHONWARNINGS=ignore
     is set that we do not add warning to output.
+    And when it's not set to ignore the warning will show.
     """
-    ret = salt_call_cli.run(
-        "--local", "test.deprecation_warning", env={"PYTHONWARNINGS": "ignore"}
-    )
-    assert "DeprecationWarning" not in ret.stderr
+    ret = salt_call_cli.run("--local", "test.deprecation_warning", env=env)
+    if warn_expected:
+        assert "DeprecationWarning" in ret.stderr
+        assert ret.stderr.count("DeprecationWarning") >= 2
+    else:
+        assert "DeprecationWarning" not in ret.stderr
+        assert ret.data


### PR DESCRIPTION
### What does this PR do?
Allows a user to set `PYTHONWARNINGS=ignore` to silence the Salt deprecation warnings. 
This environment variable is an environment variable used by Python, so my other thought is to name this something else like `SALT_DEPRECATION_WARNINGS` instead, if there is an issue with using the same environment variable that python uses.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/64660
 
### Previous Behavior
No option to silence deprecation warnings.

### New Behavior
Can now silence deprecation warnings with environment variable.
