### PR TITLE
[3006.x] Remove duplicate links in navbar

### DIFF
--- a/doc/_themes/saltstack2/layout.html
+++ b/doc/_themes/saltstack2/layout.html
@@ -4,13 +4,13 @@
 
 {%- set link_text = [] %}
 {%- for link_tuple in rellinks %}
-{%- do link_text.append(link_tuple[3]) %}
+{%- set _ = link_text.append(link_tuple[3]) %}
 {%- endfor %}
 {%- for rellink_add in  [
     ('glossary', 'Glossary', 'g', 'Glossary'),
     ('contents', 'Table of Contents', 't', 'Table of Contents'),
 ] %}
-{%- if rellink_add[3] not in link_text %}{% do = rellinks.append(rellink_add) %}{% endif %}
+{%- if rellink_add[3] not in link_text %}{% set _ = rellinks.append(rellink_add) %}{% endif %}
 {%- endfor %}
 
 {%- set reldelim1 = reldelim1 is not defined and ' &raquo;' or reldelim1 %}

--- a/doc/_themes/saltstack2/layout.html
+++ b/doc/_themes/saltstack2/layout.html
@@ -2,10 +2,16 @@
 <!DOCTYPE html>
 {%- endblock %}
 
-{% set xxx = rellinks.extend([
+{%- set link_text = [] %}
+{%- for link_tuple in rellinks %}
+{%- set xxx = link_text.append(link_tuple[3]) %}
+{%- endfor %}
+{%- for rellink_add in  [
     ('glossary', 'Glossary', 'g', 'Glossary'),
     ('contents', 'Table of Contents', 't', 'Table of Contents'),
-]) %}
+] %}
+{%- if rellink_add[3] not in link_text %}{% set xxx = rellinks.append(rellink_add) %}{% endif %}
+{%- endfor %}
 
 {%- set reldelim1 = reldelim1 is not defined and ' &raquo;' or reldelim1 %}
 {%- set reldelim2 = reldelim2 is not defined and ' |' or reldelim2 %}

--- a/doc/_themes/saltstack2/layout.html
+++ b/doc/_themes/saltstack2/layout.html
@@ -4,13 +4,13 @@
 
 {%- set link_text = [] %}
 {%- for link_tuple in rellinks %}
-{%- set xxx = link_text.append(link_tuple[3]) %}
+{%- do link_text.append(link_tuple[3]) %}
 {%- endfor %}
 {%- for rellink_add in  [
     ('glossary', 'Glossary', 'g', 'Glossary'),
     ('contents', 'Table of Contents', 't', 'Table of Contents'),
 ] %}
-{%- if rellink_add[3] not in link_text %}{% set xxx = rellinks.append(rellink_add) %}{% endif %}
+{%- if rellink_add[3] not in link_text %}{% do = rellinks.append(rellink_add) %}{% endif %}
 {%- endfor %}
 
 {%- set reldelim1 = reldelim1 is not defined and ' &raquo;' or reldelim1 %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -153,7 +153,6 @@ extensions = [
     "saltrepo",
     "myst_parser",
     "sphinxcontrib.spelling",
-    "jinja2.ext.do",
     #'saltautodoc', # Must be AFTER autodoc
 ]
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -153,6 +153,7 @@ extensions = [
     "saltrepo",
     "myst_parser",
     "sphinxcontrib.spelling",
+    "jinja2.ext.do",
     #'saltautodoc', # Must be AFTER autodoc
 ]
 


### PR DESCRIPTION
### What does this PR do?
Removes duplicate `Table of Contents` and `Glossary` links in the navbar, particularly on the Salt Module Index page (https://docs.saltproject.io/en/latest/py-modindex.html)

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/23794

### Previous Behavior
Duplicate links showing

### New Behavior
Now they don't

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes