### PR TITLE
[3006.x] Syndic's async request channel is actually async

### DIFF
--- a/changelog/64552.fixed.md
+++ b/changelog/64552.fixed.md
@@ -1,0 +1,1 @@
+Syndic's async_req_channel uses the asynchornous version of request channel

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -3387,7 +3387,7 @@ class Syndic(Minion):
         # add handler to subscriber
         self.pub_channel.on_recv(self._process_cmd_socket)
         self.req_channel = salt.channel.client.ReqChannel.factory(self.opts)
-        self.async_req_channel = salt.channel.client.ReqChannel.factory(self.opts)
+        self.async_req_channel = salt.channel.client.AsyncReqChannel.factory(self.opts)
 
     def _process_cmd_socket(self, payload):
         if payload is not None and payload["enc"] == "aes":

--- a/tests/pytests/unit/conftest.py
+++ b/tests/pytests/unit/conftest.py
@@ -35,3 +35,21 @@ def master_opts(tmp_path):
         opts[name] = str(dirpath)
     opts["log_file"] = "logs/master.log"
     return opts
+
+
+@pytest.fixture
+def syndic_opts(tmp_path):
+    """
+    Default master configuration with relative temporary paths to not require root permissions.
+    """
+    root_dir = tmp_path / "syndic"
+    opts = salt.config.DEFAULT_MINION_OPTS.copy()
+    opts["syndic_master"] = "127.0.0.1"
+    opts["__role"] = "minion"
+    opts["root_dir"] = str(root_dir)
+    for name in ("cachedir", "pki_dir", "sock_dir", "conf_dir"):
+        dirpath = root_dir / name
+        dirpath.mkdir(parents=True)
+        opts[name] = str(dirpath)
+    opts["log_file"] = "logs/syndic.log"
+    return opts

--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -1097,3 +1097,12 @@ async def test_master_type_disable(minion_opts):
         assert minion.connected is False
     finally:
         minion.destroy()
+
+
+async def test_syndic_async_req_channel(syndic_opts):
+    syndic_opts["_minion_conf_file"] = ""
+    syndic_opts["master_uri"] = "tcp://127.0.0.1:4506"
+    syndic = salt.minion.Syndic(syndic_opts)
+    syndic.pub_channel = MagicMock()
+    syndic.tune_in_no_block()
+    assert isinstance(syndic.async_req_channel, salt.channel.client.AsyncReqChannel)


### PR DESCRIPTION
### What does this PR do?

Make sure we use AsyncReqChannel for async_req_channel attribute on Syndic objects.

### What issues does this PR fix or reference?
Fixes: #64552


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated
