### PR TITLE
[3006.x] Allow runas to accept compound commands

### DIFF
--- a/changelog/44736.fixed.md
+++ b/changelog/44736.fixed.md
@@ -1,0 +1,2 @@
+Commands on Windows are now prefixed with ``cmd /c`` so that compound
+commands (commands separated by ``&&``) run properly when using ``runas``

--- a/changelog/59977.fixed.md
+++ b/changelog/59977.fixed.md
@@ -1,0 +1,2 @@
+Fixed an issue on Windows where checking success_retcodes when using the
+runas parameter would fail. Now success_retcodes are checked correctly

--- a/changelog/60884.fixed.md
+++ b/changelog/60884.fixed.md
@@ -1,0 +1,2 @@
+Fix an issue with cmd.script in Windows so that the exit code from a script will
+be passed through to the retcode of the state

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -293,7 +293,7 @@ def _prep_powershell_cmd(win_shell, cmd, encoded_cmd):
 
         # Commands that are a specific keyword behave differently. They fail if
         # you add a "&" to the front. Add those here as we find them:
-        keywords = ["$", "&", ".", "Configuration"]
+        keywords = ["$", "&", ".", "Configuration", "try"]
 
         for keyword in keywords:
             if cmd.startswith(keyword):

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -296,7 +296,7 @@ def _prep_powershell_cmd(win_shell, cmd, encoded_cmd):
         keywords = ["$", "&", ".", "Configuration", "try"]
 
         for keyword in keywords:
-            if cmd.startswith(keyword):
+            if cmd.lower().startswith(keyword.lower()):
                 new_cmd.extend(["-Command", f"{cmd.strip()}"])
                 break
         else:
@@ -4096,16 +4096,16 @@ def powershell(
     # ConvertTo-JSON is only available on PowerShell 3.0 and later
     psversion = shell_info("powershell")["psversion"]
     if salt.utils.versions.version_cmp(psversion, "2.0") == 1:
-        cmd += " | ConvertTo-JSON"
+        cmd += " | ConvertTo-JSON "
         if depth is not None:
-            cmd += f" -Depth {depth}"
+            cmd += f"-Depth {depth} "
 
     # Put the whole command inside a try / catch block
     # Some errors in PowerShell are not "Terminating Errors" and will not be
     # caught in a try/catch block. For example, the `Get-WmiObject` command will
     # often return a "Non Terminating Error". To fix this, make sure
     # `-ErrorAction Stop` is set in the powershell command
-    cmd = "try {" + cmd + '} catch { "{}" }'
+    cmd = "try { " + cmd + ' } catch { "{}" }'
 
     if encode_cmd:
         # Convert the cmd to UTF-16LE without a BOM and base64 encode.
@@ -4117,7 +4117,7 @@ def powershell(
         cmd = salt.utils.stringutils.to_str(cmd)
         encoded_cmd = True
     else:
-        cmd = f"{{{cmd}}}"
+        cmd = f"{{ {cmd} }}"
         encoded_cmd = False
 
     # Retrieve the response, while overriding shell with 'powershell'

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -458,8 +458,6 @@ def _run(
         if isinstance(cmd, (list, tuple)):
             cmd = " ".join(cmd)
 
-        return win_runas(cmd, runas, password, cwd)
-
     if runas and salt.utils.platform.is_darwin():
         # We need to insert the user simulation into the command itself and not
         # just run it from the environment on macOS as that method doesn't work
@@ -492,7 +490,7 @@ def _run(
         # hang.
         runas = None
 
-    if runas:
+    if runas and not salt.utils.platform.is_windows():
         # Save the original command before munging it
         try:
             pwd.getpwnam(runas)
@@ -513,7 +511,7 @@ def _run(
         else:
             use_sudo = True
 
-    if runas or group:
+    if (runas or group) and not salt.utils.platform.is_windows():
         try:
             # Getting the environment for the runas user
             # Use markers to thwart any stdout noise
@@ -752,90 +750,104 @@ def _run(
 
     if not use_vt:
         # This is where the magic happens
-        try:
+
+        if runas and salt.utils.platform.is_windows():
+
+            # We can't use TimedProc with runas on Windows
             if change_windows_codepage:
                 salt.utils.win_chcp.set_codepage_id(windows_codepage)
-            try:
-                proc = salt.utils.timed_subprocess.TimedProc(cmd, **new_kwargs)
-            except OSError as exc:
-                msg = "Unable to run command '{}' with the context '{}', reason: {}".format(
-                    cmd if output_loglevel is not None else "REDACTED",
-                    new_kwargs,
-                    exc,
-                )
-                raise CommandExecutionError(msg)
 
-            try:
-                proc.run()
-            except TimedProcTimeoutError as exc:
-                ret["stdout"] = str(exc)
-                ret["stderr"] = ""
-                ret["retcode"] = None
-                ret["pid"] = proc.process.pid
-                # ok return code for timeouts?
-                ret["retcode"] = 1
-                return ret
-        finally:
+            ret = win_runas(cmd, runas, password, cwd)
+
             if change_windows_codepage:
                 salt.utils.win_chcp.set_codepage_id(previous_windows_codepage)
 
-        if output_loglevel != "quiet" and output_encoding is not None:
-            log.debug(
-                "Decoding output from command %s using %s encoding",
-                cmd,
-                output_encoding,
-            )
+        else:
+            try:
+                if change_windows_codepage:
+                    salt.utils.win_chcp.set_codepage_id(windows_codepage)
+                try:
+                    proc = salt.utils.timed_subprocess.TimedProc(cmd, **new_kwargs)
+                except OSError as exc:
+                    msg = "Unable to run command '{}' with the context '{}', reason: {}".format(
+                        cmd if output_loglevel is not None else "REDACTED",
+                        new_kwargs,
+                        exc,
+                    )
+                    raise CommandExecutionError(msg)
 
-        try:
-            out = salt.utils.stringutils.to_unicode(
-                proc.stdout, encoding=output_encoding
-            )
-        except TypeError:
-            # stdout is None
-            out = ""
-        except UnicodeDecodeError:
-            out = salt.utils.stringutils.to_unicode(
-                proc.stdout, encoding=output_encoding, errors="replace"
-            )
-            if output_loglevel != "quiet":
-                log.error(
-                    "Failed to decode stdout from command %s, non-decodable "
-                    "characters have been replaced",
-                    _log_cmd(cmd),
+                try:
+                    proc.run()
+                except TimedProcTimeoutError as exc:
+                    ret["stdout"] = str(exc)
+                    ret["stderr"] = ""
+                    ret["retcode"] = None
+                    ret["pid"] = proc.process.pid
+                    # ok return code for timeouts?
+                    ret["retcode"] = 1
+                    return ret
+            finally:
+                if change_windows_codepage:
+                    salt.utils.win_chcp.set_codepage_id(previous_windows_codepage)
+
+            if output_loglevel != "quiet" and output_encoding is not None:
+                log.debug(
+                    "Decoding output from command %s using %s encoding",
+                    cmd,
+                    output_encoding,
                 )
 
-        try:
-            err = salt.utils.stringutils.to_unicode(
-                proc.stderr, encoding=output_encoding
-            )
-        except TypeError:
-            # stderr is None
-            err = ""
-        except UnicodeDecodeError:
-            err = salt.utils.stringutils.to_unicode(
-                proc.stderr, encoding=output_encoding, errors="replace"
-            )
-            if output_loglevel != "quiet":
-                log.error(
-                    "Failed to decode stderr from command %s, non-decodable "
-                    "characters have been replaced",
-                    _log_cmd(cmd),
+            try:
+                out = salt.utils.stringutils.to_unicode(
+                    proc.stdout, encoding=output_encoding
                 )
+            except TypeError:
+                # stdout is None
+                out = ""
+            except UnicodeDecodeError:
+                out = salt.utils.stringutils.to_unicode(
+                    proc.stdout, encoding=output_encoding, errors="replace"
+                )
+                if output_loglevel != "quiet":
+                    log.error(
+                        "Failed to decode stdout from command %s, non-decodable "
+                        "characters have been replaced",
+                        _log_cmd(cmd),
+                    )
 
-        # Encoded commands dump CLIXML data in stderr. It's not an actual error
-        if encoded_cmd and "CLIXML" in err:
-            err = ""
-        if rstrip:
-            if out is not None:
-                out = out.rstrip()
-            if err is not None:
-                err = err.rstrip()
-        ret["pid"] = proc.process.pid
-        ret["retcode"] = proc.process.returncode
+            try:
+                err = salt.utils.stringutils.to_unicode(
+                    proc.stderr, encoding=output_encoding
+                )
+            except TypeError:
+                # stderr is None
+                err = ""
+            except UnicodeDecodeError:
+                err = salt.utils.stringutils.to_unicode(
+                    proc.stderr, encoding=output_encoding, errors="replace"
+                )
+                if output_loglevel != "quiet":
+                    log.error(
+                        "Failed to decode stderr from command %s, non-decodable "
+                        "characters have been replaced",
+                        _log_cmd(cmd),
+                    )
+
+            # Encoded commands dump CLIXML data in stderr. It's not an actual error
+            if encoded_cmd and "CLIXML" in err:
+                err = ""
+            if rstrip:
+                if out is not None:
+                    out = out.rstrip()
+                if err is not None:
+                    err = err.rstrip()
+            ret["pid"] = proc.process.pid
+            ret["retcode"] = proc.process.returncode
+            ret["stdout"] = out
+            ret["stderr"] = err
+
         if ret["retcode"] in success_retcodes:
             ret["retcode"] = 0
-        ret["stdout"] = out
-        ret["stderr"] = err
         if any(
             [stdo in ret["stdout"] for stdo in success_stdout]
             + [stde in ret["stderr"] for stde in success_stderr]

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -283,7 +283,10 @@ def _prep_powershell_cmd(win_shell, cmd, encoded_cmd):
         new_cmd.append("-Command")
         if isinstance(cmd, list):
             cmd = " ".join(cmd)
-        new_cmd.append(f"& {cmd.strip()}")
+        # We need to append $LASTEXITCODE here to return the actual exit code
+        # from the script. Otherwise, it will always return 1 on any non-zero
+        # exit code failure. Issue: #60884
+        new_cmd.append(f"& {cmd.strip()}; exit $LASTEXITCODE")
     elif encoded_cmd:
         new_cmd.extend(["-EncodedCommand", f"{cmd}"])
     else:

--- a/salt/platform/win.py
+++ b/salt/platform/win.py
@@ -185,7 +185,12 @@ class HANDLE(wintypes.HANDLE):
 
     def Close(self, CloseHandle=kernel32.CloseHandle):
         if self and not getattr(self, "closed", False):
-            CloseHandle(self.Detach())
+            try:
+                CloseHandle(self.Detach())
+            except Exception:
+                # Suppress the error when there is no handle (WinError 6)
+                if ctypes.get_last_error() == 6:
+                    pass
 
     __del__ = Close
 

--- a/salt/platform/win.py
+++ b/salt/platform/win.py
@@ -187,7 +187,7 @@ class HANDLE(wintypes.HANDLE):
         if self and not getattr(self, "closed", False):
             try:
                 CloseHandle(self.Detach())
-            except Exception:
+            except OSError:
                 # Suppress the error when there is no handle (WinError 6)
                 if ctypes.get_last_error() == 6:
                     pass

--- a/salt/utils/win_runas.py
+++ b/salt/utils/win_runas.py
@@ -187,8 +187,10 @@ def runas(cmdLine, username, password=None, cwd=None):
         | win32process.CREATE_SUSPENDED
     )
 
+    flags = win32con.STARTF_USESTDHANDLES
+    flags |= win32con.STARTF_USESHOWWINDOW
     startup_info = salt.platform.win.STARTUPINFO(
-        dwFlags=win32con.STARTF_USESTDHANDLES,
+        dwFlags=flags,
         hStdInput=stdin_read.handle,
         hStdOutput=stdout_write.handle,
         hStdError=stderr_write.handle,
@@ -204,7 +206,7 @@ def runas(cmdLine, username, password=None, cwd=None):
             int(user_token),
             logonflags=1,
             applicationname=None,
-            commandline=cmdLine,
+            commandline=f'cmd /c "{cmdLine}"',
             currentdirectory=cwd,
             creationflags=creationflags,
             startupinfo=startup_info,
@@ -286,8 +288,10 @@ def runas_unpriv(cmd, username, password, cwd=None):
     dupin = salt.platform.win.DuplicateHandle(srchandle=stdin, inherit=True)
 
     # Get startup info structure
+    flags = win32con.STARTF_USESTDHANDLES
+    flags |= win32con.STARTF_USESHOWWINDOW
     startup_info = salt.platform.win.STARTUPINFO(
-        dwFlags=win32con.STARTF_USESTDHANDLES,
+        dwFlags=flags,
         hStdInput=dupin,
         hStdOutput=c2pwrite,
         hStdError=errwrite,
@@ -300,7 +304,7 @@ def runas_unpriv(cmd, username, password, cwd=None):
             domain=domain,
             password=password,
             logonflags=salt.platform.win.LOGON_WITH_PROFILE,
-            commandline=cmd,
+            commandline=f'cmd /c "{cmd}"',
             startupinfo=startup_info,
             currentdirectory=cwd,
         )

--- a/salt/utils/win_runas.py
+++ b/salt/utils/win_runas.py
@@ -199,6 +199,9 @@ def runas(cmdLine, username, password=None, cwd=None):
     # Create the environment for the user
     env = create_env(user_token, False)
 
+    if "&&" in cmdLine:
+        cmdLine = f'cmd /c "{cmdLine}"'
+
     hProcess = None
     try:
         # Start the process in a suspended state.
@@ -206,7 +209,7 @@ def runas(cmdLine, username, password=None, cwd=None):
             int(user_token),
             logonflags=1,
             applicationname=None,
-            commandline=f'cmd /c "{cmdLine}"',
+            commandline=cmdLine,
             currentdirectory=cwd,
             creationflags=creationflags,
             startupinfo=startup_info,
@@ -297,6 +300,9 @@ def runas_unpriv(cmd, username, password, cwd=None):
         hStdError=errwrite,
     )
 
+    if "&&" in cmd:
+        cmd = f'cmd /c "{cmd}"'
+
     try:
         # Run command and return process info structure
         process_info = salt.platform.win.CreateProcessWithLogonW(
@@ -304,7 +310,7 @@ def runas_unpriv(cmd, username, password, cwd=None):
             domain=domain,
             password=password,
             logonflags=salt.platform.win.LOGON_WITH_PROFILE,
-            commandline=f'cmd /c "{cmd}"',
+            commandline=cmd,
             startupinfo=startup_info,
             currentdirectory=cwd,
         )

--- a/salt/utils/win_runas.py
+++ b/salt/utils/win_runas.py
@@ -209,7 +209,7 @@ def runas(cmdLine, username, password=None, cwd=None):
             int(user_token),
             logonflags=1,
             applicationname=None,
-            commandline=cmdLine,
+            commandline=f'cmd /c "{cmdLine}"',
             currentdirectory=cwd,
             creationflags=creationflags,
             startupinfo=startup_info,
@@ -310,7 +310,7 @@ def runas_unpriv(cmd, username, password, cwd=None):
             domain=domain,
             password=password,
             logonflags=salt.platform.win.LOGON_WITH_PROFILE,
-            commandline=cmd,
+            commandline=f'cmd /c "{cmd}"',
             startupinfo=startup_info,
             currentdirectory=cwd,
         )

--- a/salt/utils/win_runas.py
+++ b/salt/utils/win_runas.py
@@ -209,7 +209,7 @@ def runas(cmdLine, username, password=None, cwd=None):
             int(user_token),
             logonflags=1,
             applicationname=None,
-            commandline=f'cmd /c "{cmdLine}"',
+            commandline=cmdLine,
             currentdirectory=cwd,
             creationflags=creationflags,
             startupinfo=startup_info,
@@ -310,7 +310,7 @@ def runas_unpriv(cmd, username, password, cwd=None):
             domain=domain,
             password=password,
             logonflags=salt.platform.win.LOGON_WITH_PROFILE,
-            commandline=f'cmd /c "{cmd}"',
+            commandline=cmd,
             startupinfo=startup_info,
             currentdirectory=cwd,
         )

--- a/tests/pytests/functional/modules/cmd/test_run_win.py
+++ b/tests/pytests/functional/modules/cmd/test_run_win.py
@@ -1,0 +1,50 @@
+import pytest
+
+pytestmark = [
+    pytest.mark.core_test,
+    pytest.mark.windows_whitelisted,
+]
+
+
+@pytest.fixture(scope="module")
+def account():
+    with pytest.helpers.create_account() as _account:
+        yield _account
+
+
+@pytest.mark.skip_unless_on_windows(reason="Minion is not Windows")
+@pytest.mark.parametrize(
+    "exit_code, return_code, result",
+    [
+        (300, 0, True),
+        (299, 299, False),
+    ],
+)
+def test_windows_script_exitcode(modules, state_tree, exit_code, return_code, result):
+    ret = modules.state.single(
+        "cmd.run", name=f"cmd.exe /c exit {exit_code}", success_retcodes=[2, 44, 300]
+    )
+    assert ret.result is result
+    assert ret.filtered["changes"]["retcode"] == return_code
+
+
+@pytest.mark.skip_unless_on_windows(reason="Minion is not Windows")
+@pytest.mark.parametrize(
+    "exit_code, return_code, result",
+    [
+        (300, 0, True),
+        (299, 299, False),
+    ],
+)
+def test_windows_script_exitcode_runas(
+    modules, state_tree, exit_code, return_code, result, account
+):
+    ret = modules.state.single(
+        "cmd.run",
+        name=f"cmd.exe /c exit {exit_code}",
+        success_retcodes=[2, 44, 300],
+        runas=account.username,
+        password=account.password,
+    )
+    assert ret.result is result
+    assert ret.filtered["changes"]["retcode"] == return_code

--- a/tests/pytests/functional/utils/test_win_runas.py
+++ b/tests/pytests/functional/utils/test_win_runas.py
@@ -18,21 +18,22 @@ def user():
         yield account
 
 
-def test_runas(user):
-    cmd = "hostname && echo foo"
+def test_compound_runas(user):
+    cmd = "hostname && whoami"
     result = win_runas.runas(
         cmdLine=cmd,
         username=user.username,
         password=user.password,
     )
-    assert "foo" in result["stdout"]
+    assert user.username in result["stdout"]
 
 
-def test_runas_unpriv(user):
-    cmd = "hostname && echo foo"
+def test_compound_runas_unpriv(user):
+    cmd = "hostname && whoami"
+    print(user.username)
     result = win_runas.runas_unpriv(
         cmd=cmd,
         username=user.username,
         password=user.password,
     )
-    assert "foo" in result["stdout"]
+    assert user.username in result["stdout"]

--- a/tests/pytests/functional/utils/test_win_runas.py
+++ b/tests/pytests/functional/utils/test_win_runas.py
@@ -4,8 +4,6 @@ Test the win_runas util
 
 import pytest
 
-import salt.modules.win_useradd as win_user
-import salt.utils.win_functions as win_functions
 import salt.utils.win_runas as win_runas
 
 pytestmark = [
@@ -32,8 +30,6 @@ def test_compound_runas(user):
 
 def test_compound_runas_unpriv(user):
     cmd = "hostname && whoami"
-    is_admin = win_functions.is_admin(user.username)
-    user_info = win_user.info(user.username)
     result = win_runas.runas_unpriv(
         cmd=cmd,
         username=user.username,

--- a/tests/pytests/functional/utils/test_win_runas.py
+++ b/tests/pytests/functional/utils/test_win_runas.py
@@ -1,0 +1,38 @@
+"""
+Test the win_runas util
+"""
+
+import pytest
+
+import salt.utils.win_runas as win_runas
+
+pytestmark = [
+    pytest.mark.windows_whitelisted,
+    pytest.mark.skip_unless_on_windows,
+]
+
+
+@pytest.fixture
+def user():
+    with pytest.helpers.create_account() as account:
+        yield account
+
+
+def test_runas(user):
+    cmd = "hostname && echo foo"
+    result = win_runas.runas(
+        cmdLine=cmd,
+        username=user.username,
+        password=user.password,
+    )
+    assert "foo" in result["stdout"]
+
+
+def test_runas_unpriv(user):
+    cmd = "hostname && echo foo"
+    result = win_runas.runas_unpriv(
+        cmd=cmd,
+        username=user.username,
+        password=user.password,
+    )
+    assert "foo" in result["stdout"]

--- a/tests/pytests/functional/utils/test_win_runas.py
+++ b/tests/pytests/functional/utils/test_win_runas.py
@@ -4,6 +4,8 @@ Test the win_runas util
 
 import pytest
 
+import salt.modules.win_useradd as win_user
+import salt.utils.win_functions as win_functions
 import salt.utils.win_runas as win_runas
 
 pytestmark = [
@@ -30,7 +32,8 @@ def test_compound_runas(user):
 
 def test_compound_runas_unpriv(user):
     cmd = "hostname && whoami"
-    print(user.username)
+    is_admin = win_functions.is_admin(user.username)
+    user_info = win_user.info(user.username)
     result = win_runas.runas_unpriv(
         cmd=cmd,
         username=user.username,

--- a/tests/pytests/functional/utils/test_win_runas.py
+++ b/tests/pytests/functional/utils/test_win_runas.py
@@ -4,8 +4,6 @@ Test the win_runas util
 
 import pytest
 
-import salt.modules.win_useradd as win_user
-import salt.utils.win_functions as win_functions
 import salt.utils.win_runas as win_runas
 
 pytestmark = [

--- a/tests/pytests/functional/utils/test_win_runas.py
+++ b/tests/pytests/functional/utils/test_win_runas.py
@@ -18,21 +18,39 @@ def user():
         yield account
 
 
-def test_compound_runas(user):
-    cmd = "hostname && whoami"
+@pytest.mark.parametrize(
+    "cmd, expected",
+    [
+        ("hostname && whoami", "username"),
+        ("hostname && echo foo", "foo"),
+        ("hostname && python --version", "Python"),
+    ],
+)
+def test_compound_runas(user, cmd, expected):
+    if expected == "username":
+        expected = user.username
     result = win_runas.runas(
         cmdLine=cmd,
         username=user.username,
         password=user.password,
     )
-    assert user.username in result["stdout"]
+    assert expected in result["stdout"]
 
 
-def test_compound_runas_unpriv(user):
-    cmd = "hostname && whoami"
+@pytest.mark.parametrize(
+    "cmd, expected",
+    [
+        ("hostname && whoami", "username"),
+        ("hostname && echo foo", "foo"),
+        ("hostname && python --version", "Python"),
+    ],
+)
+def test_compound_runas_unpriv(user, cmd, expected):
+    if expected == "username":
+        expected = user.username
     result = win_runas.runas_unpriv(
         cmd=cmd,
         username=user.username,
         password=user.password,
     )
-    assert user.username in result["stdout"]
+    assert expected in result["stdout"]

--- a/tests/pytests/functional/utils/test_win_runas.py
+++ b/tests/pytests/functional/utils/test_win_runas.py
@@ -4,6 +4,8 @@ Test the win_runas util
 
 import pytest
 
+import salt.modules.win_useradd as win_user
+import salt.utils.win_functions as win_functions
 import salt.utils.win_runas as win_runas
 
 pytestmark = [

--- a/tests/pytests/unit/modules/test_cmdmod.py
+++ b/tests/pytests/unit/modules/test_cmdmod.py
@@ -1064,6 +1064,7 @@ def test_prep_powershell_cmd_no_powershell():
     [
         ("Write-Host foo", "& Write-Host foo"),
         ("$PSVersionTable", "$PSVersionTable"),
+        ("try {this} catch {that}", "try {this} catch {that}"),
     ],
 )
 def test_prep_powershell_cmd(cmd, parsed):

--- a/tests/pytests/unit/modules/test_cmdmod.py
+++ b/tests/pytests/unit/modules/test_cmdmod.py
@@ -24,6 +24,11 @@ from salt.exceptions import CommandExecutionError
 from tests.support.mock import MagicMock, Mock, MockTimedProc, mock_open, patch
 from tests.support.runtests import RUNTIME_VARS
 
+pytestmark = [
+    pytest.mark.core_test,
+    pytest.mark.windows_whitelisted,
+]
+
 DEFAULT_SHELL = "foo/bar"
 MOCK_SHELL_FILE = "# List of acceptable shells\n\n/bin/bash\n"
 
@@ -1134,7 +1139,7 @@ def test_prep_powershell_cmd_script():
             "-ExecutionPolicy",
             "Bypass",
             "-Command",
-            f"& {script}",
+            f"& {script}; exit $LASTEXITCODE",
         ]
         assert ret == expected
 

--- a/tests/pytests/unit/modules/test_cmdmod.py
+++ b/tests/pytests/unit/modules/test_cmdmod.py
@@ -1057,6 +1057,7 @@ def test_runas_env_sudo_group(bundled):
                                         )
 
 
+@pytest.mark.skip_unless_on_windows
 def test_prep_powershell_cmd_no_powershell():
     with pytest.raises(CommandExecutionError):
         cmdmod._prep_powershell_cmd(
@@ -1072,6 +1073,7 @@ def test_prep_powershell_cmd_no_powershell():
         ("try {this} catch {that}", "try {this} catch {that}"),
     ],
 )
+@pytest.mark.skip_unless_on_windows
 def test_prep_powershell_cmd(cmd, parsed):
     """
     Tests _prep_powershell_cmd returns correct cmd
@@ -1095,6 +1097,7 @@ def test_prep_powershell_cmd(cmd, parsed):
         assert ret == expected
 
 
+@pytest.mark.skip_unless_on_windows
 def test_prep_powershell_cmd_encoded():
     """
     Tests _prep_powershell_cmd returns correct cmd when encoded_cmd=True
@@ -1120,6 +1123,7 @@ def test_prep_powershell_cmd_encoded():
         assert ret == expected
 
 
+@pytest.mark.skip_unless_on_windows
 def test_prep_powershell_cmd_script():
     """
     Tests _prep_powershell_cmd returns correct cmd when called from cmd.script
@@ -1153,6 +1157,7 @@ def test_prep_powershell_cmd_script():
         ('{"foo": "bar"}', '{"foo": "bar"}'),  # Should leave unchanged
     ],
 )
+@pytest.mark.skip_unless_on_windows
 def test_prep_powershell_json(text, expected):
     """
     Make sure the output is valid json

--- a/tests/support/pytest/helpers.py
+++ b/tests/support/pytest/helpers.py
@@ -332,8 +332,9 @@ class TestAccount:
         if salt.utils.platform.is_windows():
             log.debug("Configuring system account: %s", self)
             ret = self.sminion.functions.user.update(
-                self.username, password_never_expires=True
+                self.username, expired=False, password_never_expires=True
             )
+            assert ret is True
         if salt.utils.platform.is_darwin() or salt.utils.platform.is_windows():
             password = self.password
         else:


### PR DESCRIPTION
### What does this PR do?
This PR fixes a few issues with `cmd.run` "RunAs" functionality on Windows.

- Fixes an issue when running compound commands (commands joined by `&&`) with runas (#44736)
- Fixes an issue with success_retcodes and `cmd.run` with RunAs on Windows. The retcodes weren't being evaluated when using RunAs (#59977)
- Fixes and issue with `cmd.script` where exit codes from the script weren't being passed through (#60884)

### What issues does this PR fix or reference?
Fixes: #44736 #59977 #60884 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes