### PR TITLE
[3006.x] Fix creation of wildcard DNS in SAN in `x509_v2`

### DIFF
--- a/changelog/65072.fixed.md
+++ b/changelog/65072.fixed.md
@@ -1,0 +1,1 @@
+Fixed creation of wildcard DNS in SAN in `x509_v2`

--- a/salt/utils/x509.py
+++ b/salt/utils/x509.py
@@ -1691,7 +1691,10 @@ def _parse_general_names(val):
             if allow_leading_dot:
                 has_dot = val.startswith(".")
                 val = val.lstrip(".")
-            ret = idna.encode(val).decode()
+            ret = ".".join(
+                idna.encode(elem).decode() if elem != "*" else elem
+                for elem in val.split(".")
+            )
             if has_dot:
                 return f".{ret}"
             return ret

--- a/salt/utils/x509.py
+++ b/salt/utils/x509.py
@@ -1683,22 +1683,40 @@ def _deserialize_openssl_confstring(conf, multiple=False):
 
 
 def _parse_general_names(val):
-    def idna_encode(val, allow_leading_dot=False):
-        if HAS_IDNA:
-            # A leading dot is allowed in some values.
-            # idna complains about it not being a valid domain name
-            has_dot = False
-            if allow_leading_dot:
-                has_dot = val.startswith(".")
-                val = val.lstrip(".")
-            ret = ".".join(
-                idna.encode(elem).decode() if elem != "*" else elem
-                for elem in val.split(".")
+    def idna_encode(val, allow_leading_dot=False, allow_wildcard=False):
+        # A leading dot is allowed in some values (nameConstraints).
+        # idna complains about it not being a valid domain name
+        try:
+            has_dot = val.startswith(".")
+        except AttributeError:
+            raise SaltInvocationError(
+                f"Expected string value, got {type(val).__name__}: `{val}`"
             )
+        if has_dot:
+            if not allow_leading_dot:
+                raise CommandExecutionError(
+                    "Leading dots are not allowed in this context"
+                )
+            val = val.lstrip(".")
+        has_wildcard = val.startswith("*.")
+        if has_wildcard:
+            if not allow_wildcard:
+                raise CommandExecutionError("Wildcards are not allowed in this context")
             if has_dot:
-                return f".{ret}"
-            return ret
+                raise CommandExecutionError(
+                    "Wildcards and leading dots cannot be present together"
+                )
+            val = val[2:]
+            if val.startswith("."):
+                raise CommandExecutionError("Empty label")
+        if HAS_IDNA:
+            try:
+                ret = idna.encode(val).decode()
+            except idna.IDNAError as err:
+                raise CommandExecutionError(str(err)) from err
         else:
+            if not val:
+                raise CommandExecutionError("Empty domain")
             try:
                 val.encode(encoding="ascii")
             except UnicodeEncodeError as err:
@@ -1706,6 +1724,20 @@ def _parse_general_names(val):
                     "Cannot encode non-ASCII strings to internationalized domain "
                     "name format, missing library: idna"
                 ) from err
+            for elem in val.split("."):
+                if not elem:
+                    raise CommandExecutionError("Empty Label")
+                invalid = re.search(r"[^A-Za-z\d\-\.]", elem)
+                if invalid is not None:
+                    raise CommandExecutionError(
+                        f"Codepoint U+00{hex(ord(invalid.group()))[2:]} at position {invalid.end()} of '{val}' not allowed"
+                    )
+            ret = val
+        if has_dot:
+            return f".{ret}"
+        if has_wildcard:
+            return f"*.{ret}"
+        return ret
 
     valid_types = {
         "email": cx509.general_name.RFC822Name,
@@ -1741,6 +1773,7 @@ def _parse_general_names(val):
                 domain = idna_encode(domain)
                 v = "@".join((user, domain))
             else:
+                # nameConstraints
                 v = idna_encode(splits[0], allow_leading_dot=True)
         elif typ == "uri":
             url = urlparse(v)
@@ -1750,7 +1783,7 @@ def _parse_general_names(val):
                     (url.scheme, domain, url.path, url.params, url.query, url.fragment)
                 )
         elif typ == "dns":
-            v = idna_encode(v, allow_leading_dot=True)
+            v = idna_encode(v, allow_leading_dot=True, allow_wildcard=True)
         elif typ == "othername":
             raise SaltInvocationError("otherName is currently not implemented")
         if typ in valid_types:

--- a/tests/pytests/functional/modules/test_x509_v2.py
+++ b/tests/pytests/functional/modules/test_x509_v2.py
@@ -1359,6 +1359,14 @@ def test_create_csr_with_extensions(x509, rsa_privkey):
     assert res.startswith("-----BEGIN CERTIFICATE REQUEST-----")
 
 
+def test_create_csr_with_wildcard_san(x509, rsa_privkey):
+    """
+    Test that wildcards in SAN extension are supported. Issue #65072
+    """
+    res = x509.create_csr(private_key=rsa_privkey, subjectAltName="DNS:*.salt.ca")
+    assert res.startswith("-----BEGIN CERTIFICATE REQUEST-----")
+
+
 @pytest.mark.parametrize("encoding", ["pem", "der"])
 def test_create_csr_write_to_path(x509, encoding, rsa_privkey, tmp_path):
     tgt = tmp_path / "csr"

--- a/tests/pytests/unit/utils/test_x509.py
+++ b/tests/pytests/unit/utils/test_x509.py
@@ -1070,6 +1070,7 @@ class TestCreateExtension:
         ),
         (("DNS", "example.com"), cx509.DNSName, "example.com"),
         (("DNS", "überexample.com"), cx509.DNSName, "xn--berexample-8db.com"),
+        (("DNS", "*.überexample.com"), cx509.DNSName, "*.xn--berexample-8db.com"),
         (("RID", "1.2.3.4"), cx509.RegisteredID, cx509.ObjectIdentifier("1.2.3.4")),
         (
             ("IP", "13.37.13.37"),


### PR DESCRIPTION
### What does this PR do?
Ensures wildcards can be used in SAN extension when creating certificates and certificate signing requests.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/65072

### Previous Behavior
Exception

### New Behavior
Works

### Merge requirements satisfied?
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes