### PR TITLE
[3006.x] Keep extras directory when upgrading Salt on macOS

### DIFF
--- a/changelog/65073.fixed.md
+++ b/changelog/65073.fixed.md
@@ -1,0 +1,1 @@
+The macOS installer no longer removes the extras directory

--- a/pkg/macos/build.sh
+++ b/pkg/macos/build.sh
@@ -119,11 +119,32 @@ _usage() {
      echo "usage: ${0}"
      echo "             [-h|--help] [-v|--version]"
      echo ""
-     echo "  -h, --help      this message"
-     echo "  -v, --version   version of Salt display in the package"
+     echo "  -h, --help             Display this message"
+     echo "  -v, --version          Version of Salt to display in the package"
+     echo "  -p, --python-version   Version of python to install using relenv."
+     echo "                         The python version is tied to the relenv"
+     echo "                         version"
+     echo "  -r, --relenv-version   Version of relenv to install"
      echo ""
      echo "  Build a Salt package:"
      echo "      example: $0 3006.1-1"
+}
+
+function _parse_yaml {
+   local prefix=$2
+   local s='[[:space:]]*' w='[a-zA-Z0-9_]*' fs=$(echo @|tr @ '\034')
+   sed -ne "s|^\($s\):|\1|" \
+        -e "s|^\($s\)\($w\)$s:$s[\"']\(.*\)[\"']$s\$|\1$fs\2$fs\3|p" \
+        -e "s|^\($s\)\($w\)$s:$s\(.*\)$s\$|\1$fs\2$fs\3|p"  $1 |
+   awk -F$fs '{
+      indent = length($1)/2;
+      vname[indent] = $2;
+      for (i in vname) {if (i > indent) {delete vname[i]}}
+      if (length($3) > 0) {
+         vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
+         printf("%s%s%s=\"%s\"\n", "'$prefix'",vn, $2, $3);
+      }
+   }'
 }
 
 #-------------------------------------------------------------------------------
@@ -139,6 +160,16 @@ while true; do
         -v | --version )
             shift
             VERSION="$*"
+            shift
+            ;;
+        -p | --python-version )
+            shift
+            PY_VERSION="$1"
+            shift
+            ;;
+        -r | --relenv-version )
+            shift
+            RELENV_VERSION="$1"
             shift
             ;;
         -*)
@@ -158,6 +189,17 @@ if [ -z "$VERSION" ]; then
     VERSION=$(git describe)
 fi
 VERSION=${VERSION#"v"}
+
+# Get defaults from workflows. This defines $python_version and $relenv_version
+eval "$(_parse_yaml "$SRC_DIR/cicd/shared-gh-workflows-context.yml")"
+
+if [ -z "$PY_VERSION" ]; then
+    PY_VERSION=$python_version
+fi
+
+if [ -z "$RELENV_VERSION" ]; then
+    RELENV_VERSION=$relenv_version
+fi
 
 #-------------------------------------------------------------------------------
 # Quit on error
@@ -184,12 +226,14 @@ fi
 #-------------------------------------------------------------------------------
 printf "#%.0s" {1..80}; printf "\n"
 echo "Build Salt Package for macOS"
+echo "- Python Version: $PY_VERSION"
+echo "- Relenv Version: $RELENV_VERSION"
 printf "v%.0s" {1..80}; printf "\n"
 
 #-------------------------------------------------------------------------------
 # Build Python
 #-------------------------------------------------------------------------------
-"$SCRIPT_DIR/build_python.sh" -v 3.10.12 -r 0.13.4
+"$SCRIPT_DIR/build_python.sh" -v $PY_VERSION -r $RELENV_VERSION
 
 #-------------------------------------------------------------------------------
 # Install Salt

--- a/pkg/macos/build.sh
+++ b/pkg/macos/build.sh
@@ -189,7 +189,7 @@ printf "v%.0s" {1..80}; printf "\n"
 #-------------------------------------------------------------------------------
 # Build Python
 #-------------------------------------------------------------------------------
-"$SCRIPT_DIR/build_python.sh"
+"$SCRIPT_DIR/build_python.sh" -v 3.10.12 -r 0.13.4
 
 #-------------------------------------------------------------------------------
 # Install Salt
@@ -210,15 +210,15 @@ printf "v%.0s" {1..80}; printf "\n"
 # Build and Sign Package
 #-------------------------------------------------------------------------------
 if [ "$(id -un)" != "root" ]; then
-    sudo "$SCRIPT_DIR/package.sh" "$VERSION"
+    sudo "$SCRIPT_DIR/package.sh" "$VERSION" -s
 else
-    "$SCRIPT_DIR/package.sh" "$VERSION"
+    "$SCRIPT_DIR/package.sh" "$VERSION" -s
 fi
 
 #-------------------------------------------------------------------------------
 # Notarize Package
 #-------------------------------------------------------------------------------
-"$SCRIPT_DIR/notarize.sh" "salt-$VERSION-py3-$CPU_ARCH-signed.pkg"
+"$SCRIPT_DIR/notarize.sh" "salt-$VERSION-py3-$CPU_ARCH.pkg"
 
 #-------------------------------------------------------------------------------
 # Script Completed

--- a/pkg/macos/build_python.sh
+++ b/pkg/macos/build_python.sh
@@ -23,6 +23,7 @@
 # TODO: is building
 
 # Locations
+SRC_DIR="$(git rev-parse --show-toplevel)"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SYS_PY_BIN="$(which python3)"
 BUILD_DIR="$SCRIPT_DIR/build"
@@ -43,13 +44,14 @@ _usage() {
      echo "usage: ${0}"
      echo "             [-h|--help] [-v|--version]"
      echo ""
-     echo "  -h, --help      this message"
-     echo "  -b, --build     build python instead of fetching"
-     echo "  -v, --version   version of python to install, must be available with relenv"
-     echo "  -r, --relenv-version   version of python to install, must be available with relenv"
+     echo "  -h, --help             this message"
+     echo "  -b, --build            build python instead of fetching"
+     echo "  -v, --version          version of python to install, must be a"
+     echo "                         version available in relenv"
+     echo "  -r, --relenv-version   version of relenv to install"
      echo ""
-     echo "  To build python 3.10.12:"
-     echo "      example: $0 --version 3.10.12"
+     echo "  To build python 3.10.13 you need to use relenv 0.13.5:"
+     echo "      example: $0 --relenv-version 0.13.5 --version 3.10.13"
 }
 
 # _msg
@@ -72,6 +74,23 @@ _success() {
 _failure() {
     printf '\e[31m%s\e[0m\n' "Failure"
     exit 1
+}
+
+function _parse_yaml {
+   local prefix=$2
+   local s='[[:space:]]*' w='[a-zA-Z0-9_]*' fs=$(echo @|tr @ '\034')
+   sed -ne "s|^\($s\):|\1|" \
+        -e "s|^\($s\)\($w\)$s:$s[\"']\(.*\)[\"']$s\$|\1$fs\2$fs\3|p" \
+        -e "s|^\($s\)\($w\)$s:$s\(.*\)$s\$|\1$fs\2$fs\3|p"  $1 |
+   awk -F$fs '{
+      indent = length($1)/2;
+      vname[indent] = $2;
+      for (i in vname) {if (i > indent) {delete vname[i]}}
+      if (length($3) > 0) {
+         vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
+         printf("%s%s%s=\"%s\"\n", "'$prefix'",vn, $2, $3);
+      }
+   }'
 }
 
 #-------------------------------------------------------------------------------
@@ -112,6 +131,17 @@ while true; do
     esac
 done
 
+# Get defaults from workflows. This defines $python_version and $relenv_version
+eval "$(_parse_yaml "$SRC_DIR/cicd/shared-gh-workflows-context.yml")"
+
+if [ -z "$PY_VERSION" ]; then
+    PY_VERSION=$python_version
+fi
+
+if [ -z "$RELENV_VERSION" ]; then
+    RELENV_VERSION=$relenv_version
+fi
+
 #-------------------------------------------------------------------------------
 # Script Start
 #-------------------------------------------------------------------------------
@@ -122,6 +152,7 @@ else
     echo "Fetch Python with Relenv"
 fi
 echo "- Python Version: $PY_VERSION"
+echo "- Relenv Version: $RELENV_VERSION"
 printf -- "-%.0s" {1..80}; printf "\n"
 
 #-------------------------------------------------------------------------------
@@ -207,7 +238,7 @@ export RELENV_FETCH_VERSION=$(relenv --version)
 #-------------------------------------------------------------------------------
 if [ $BUILD -gt 0 ]; then
     echo "- Building python (relenv):"
-    relenv build --clean
+    relenv build --clean --python=$PY_VERSION
 else
     # We want to suppress the output here so it looks nice
     # To see the output, remove the output redirection

--- a/pkg/macos/package.sh
+++ b/pkg/macos/package.sh
@@ -246,7 +246,7 @@ if [ -d "$SCRIPTS_DIR" ]; then
 fi
 
 _msg "Creating scripts directory"
-cp "$SCRIPT_DIR/pkg-scripts" "$SCRIPTS_DIR"
+cp -r "$SCRIPT_DIR/pkg-scripts" "$SCRIPTS_DIR"
 if [ -d "$SCRIPTS_DIR" ]; then
     _success
 else

--- a/pkg/macos/package.sh
+++ b/pkg/macos/package.sh
@@ -55,6 +55,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DIST_XML="$SCRIPT_DIR/distribution.xml"
 BUILD_DIR="$SCRIPT_DIR/build"
 CMD_OUTPUT=$(mktemp -t cmd_log.XXX)
+SCRIPTS_DIR="$SCRIPT_DIR/scripts"
+# Get the python version from the relenv python
+BLD_PY_BIN="$BUILD_DIR/opt/salt/bin/python3"
+PY_VER=$($BLD_PY_BIN -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
 
 #-------------------------------------------------------------------------------
 # Functions
@@ -231,6 +235,35 @@ else
     _failure
 fi
 
+if [ -d "$SCRIPTS_DIR" ]; then
+    _msg "Removing existing scripts directory"
+    rm -f "$SCRIPTS_DIR"
+    if ! [ -d "$SCRIPTS_DIR" ]; then
+        _success
+    else
+        _failure
+    fi
+fi
+
+_msg "Creating scripts directory"
+cp "$SCRIPT_DIR/pkg-scripts" "$SCRIPTS_DIR"
+if [ -d "$SCRIPTS_DIR" ]; then
+    _success
+else
+    CMD_OUTPUT="Failed to copy: $SCRIPTS_DIR"
+    _failure
+fi
+
+_msg "Setting python version for preinstall"
+SED_STR="s/@PY_VER@/$PY_VER/g"
+sed -i "" "$SED_STR" "$SCRIPTS_DIR/preinstall"
+if grep -q "$PY_VER" "$SCRIPTS_DIR/preinstall"; then
+    _success
+else
+    CMD_OUTPUT="Failed to set: $PY_VER"
+    _failure
+fi
+
 #-------------------------------------------------------------------------------
 # Build and Sign the Package
 #-------------------------------------------------------------------------------
@@ -239,7 +272,7 @@ _msg "Building the source package"
 # Build the src package
 FILE="$SCRIPT_DIR/salt-src-$VERSION-py3-$CPU_ARCH.pkg"
 if pkgbuild --root="$BUILD_DIR" \
-            --scripts="$SCRIPT_DIR/pkg-scripts" \
+            --scripts="$SCRIPTS_DIR" \
             --identifier=com.saltstack.salt \
             --version="$VERSION" \
             --ownership=recommended \

--- a/pkg/macos/package.sh
+++ b/pkg/macos/package.sh
@@ -55,7 +55,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DIST_XML="$SCRIPT_DIR/distribution.xml"
 BUILD_DIR="$SCRIPT_DIR/build"
 CMD_OUTPUT=$(mktemp -t cmd_log.XXX)
-SCRIPTS_DIR="$SCRIPT_DIR/scripts"
+SCRIPTS_DIR="$SCRIPT_DIR/dist_scripts"
 # Get the python version from the relenv python
 BLD_PY_BIN="$BUILD_DIR/opt/salt/bin/python3"
 PY_VER=$($BLD_PY_BIN -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')

--- a/pkg/macos/pkg-scripts/preinstall
+++ b/pkg/macos/pkg-scripts/preinstall
@@ -97,10 +97,12 @@ fi
 
 #-------------------------------------------------------------------------------
 # Remove folders and files from the INSTALL_DIR
-# Don't remove extras-3.10
+# Don't remove extras-3.##
+# The part wrapped in `@` will be replaced by the correct version of python
+# during packaging using SED
 #-------------------------------------------------------------------------------
 for dir in "$INSTALL_DIR"/*/; do
-    if [[ "$dir" != *"extras-3."* ]]; then
+    if [[ "$dir" != *"extras-@PY_VER@"* ]]; then
         log "Cleanup: Removing $dir"
         rm -rf "$dir"
     fi

--- a/pkg/macos/pkg-scripts/preinstall
+++ b/pkg/macos/pkg-scripts/preinstall
@@ -96,12 +96,20 @@ if [ -L "$SBIN_DIR/salt-config" ]; then
 fi
 
 #-------------------------------------------------------------------------------
-# Remove the $INSTALL_DIR directory
+# Remove folders and files from the INSTALL_DIR
+# Don't remove extras-3.10
 #-------------------------------------------------------------------------------
-if [ -d "$INSTALL_DIR" ]; then
-    log "Cleanup: Removing $INSTALL_DIR"
-    rm -rf "$INSTALL_DIR"
-    log "Cleanup: Removed Successfully"
+for dir in "$INSTALL_DIR"/*/; do
+    if [[ "$dir" != *"extras-3."* ]]; then
+        log "Cleanup: Removing $dir"
+        rm -rf "$dir"
+    fi
+done
+log "Cleanup: Removed Directories Successfully"
+
+if [ -f "$INSTALL_DIR/salt-minion" ]; then
+    find $INSTALL_DIR -maxdepth 1 -type f -delete
+    log "Cleanup: Removed Files Successfully"
 fi
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with the macOS installer so that the ``extras-3.10`` directory isn't removed during an upgrade.

### What issues does this PR fix or reference?
Fixes: #65073 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes