### PR TITLE
[3006.x] Address timeout tracebacks

### DIFF
--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -586,8 +586,9 @@ class AsyncReqMessageClient:
 
         :raises: SaltReqTimeoutError
         """
-        self._future = None
-        future.set_exception(SaltReqTimeoutError("Message timed out"))
+        if self._future == future:
+            self._future = None
+            future.set_exception(SaltReqTimeoutError("Message timed out"))
 
     @salt.ext.tornado.gen.coroutine
     def send(self, message, timeout=None, callback=None):


### PR DESCRIPTION
### What does this PR do?


We started seeing these tracebacks in the test suite after #65061 was merged. This is a followup PR to address those errors.

```
Traceback (most recent call last):
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/ext/tornado/ioloop.py", line 606, in _run_callback
    ret = callback()
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/ext/tornado/stack_context.py", line 278, in null_wrapper
    return fn(*args, **kwargs)
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/transport/zeromq.py", line 590, in timeout_message
    future.set_exception(SaltReqTimeoutError("Message timed out"))
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/ext/tornado/concurrent.py", line 294, in set_exception
    self.set_exc_info(
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/ext/tornado/concurrent.py", line 319, in set_exc_info
    self._set_done()
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/ext/tornado/concurrent.py", line 333, in _set_done
    for cb in self._callbacks:
TypeError: 'NoneType' object is not iterable

`