### PR TITLE
[3006.x] Update Slack Community invite link to a shortlink

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -13,7 +13,7 @@ newIssueWelcomeComment: >
 
     - [Community Wiki](https://github.com/saltstack/community/wiki)
     - [Salt’s Contributor Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html)
-    - [Join our Community Slack](https://join.slack.com/t/saltstackcommunity/shared_invite/zt-1zlfxffs1-NuEH~G9TzOeuNGdsfZIl3w)
+    - [Join our Community Slack](https://via.vmw.com/salt-slack)
     - [IRC on LiberaChat](https://web.libera.chat/#salt)
     - [Salt Project YouTube channel](https://www.youtube.com/channel/UCpveTIucFx9ljGelW63-BWg)
     - [Salt Project Twitch channel](https://www.twitch.tv/saltprojectoss)
@@ -39,7 +39,7 @@ newPRWelcomeComment: >
 
     - [Community Wiki](https://github.com/saltstack/community/wiki)
     - [Salt’s Contributor Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html)
-    - [Join our Community Slack](https://join.slack.com/t/saltstackcommunity/shared_invite/zt-1zlfxffs1-NuEH~G9TzOeuNGdsfZIl3w)
+    - [Join our Community Slack](https://via.vmw.com/salt-slack)
     - [IRC on LiberaChat](https://web.libera.chat/#salt)
     - [Salt Project YouTube channel](https://www.youtube.com/channel/UCpveTIucFx9ljGelW63-BWg)
     - [Salt Project Twitch channel](https://www.twitch.tv/saltprojectoss)

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -8,7 +8,7 @@ in a number of ways:
 -  Use Salt and open well-written bug reports.
 -  Join a `working group <https://github.com/saltstack/community>`__.
 -  Answer questions on `irc <https://web.libera.chat/#salt>`__,
-   the `community Slack <https://join.slack.com/t/saltstackcommunity/shared_invite/zt-1zlfxffs1-NuEH~G9TzOeuNGdsfZIl3w>`__,
+   the `community Slack <https://via.vmw.com/salt-slack>`__,
    the `salt-users mailing
    list <https://groups.google.com/forum/#!forum/salt-users>`__,
    `Server Fault <https://serverfault.com/questions/tagged/saltstack>`__,

--- a/README.rst
+++ b/README.rst
@@ -10,9 +10,9 @@
    :alt: PyPi Package Downloads
    :target: https://lgtm.com/projects/g/saltstack/salt/context:python
 
-.. image:: https://img.shields.io/badge/slack-@saltstackcommunity-blue.svg?logo=slack
+.. image:: https://img.shields.io/badge/slack-SaltProject-blue.svg?logo=slack
    :alt: Salt Project Slack Community
-   :target: https://join.slack.com/t/saltstackcommunity/shared_invite/zt-1zlfxffs1-NuEH~G9TzOeuNGdsfZIl3w
+   :target: https://via.vmw.com/salt-slack
 
 .. image:: https://img.shields.io/twitch/status/saltprojectoss
    :alt: Salt Project Twitch Channel
@@ -180,7 +180,7 @@ used by external modules.
 A complete list of attributions and dependencies can be found here:
 `salt/DEPENDENCIES.md <https://github.com/saltstack/salt/blob/master/DEPENDENCIES.md>`_
 
-.. _Salt Project Community Slack: https://join.slack.com/t/saltstackcommunity/shared_invite/zt-1zlfxffs1-NuEH~G9TzOeuNGdsfZIl3w
+.. _Salt Project Community Slack: https://via.vmw.com/salt-slack
 .. _VMware Aria Automation Config: https://www.vmware.com/products/vrealize-automation/saltstack-config.html
 .. _Latest Salt Documentation: https://docs.saltproject.io/en/latest/
 .. _Open an issue: https://github.com/saltstack/salt/issues/new/choose

--- a/SUPPORT.rst
+++ b/SUPPORT.rst
@@ -11,7 +11,7 @@ it may take a few moments for someone to reply.
 **SaltStack Slack** - Alongside IRC is our SaltStack Community Slack for the
 SaltStack Working groups. Use the following link to request an invitation.
 
-`<https://join.slack.com/t/saltstackcommunity/shared_invite/zt-1zlfxffs1-NuEH~G9TzOeuNGdsfZIl3w>`_
+`<https://via.vmw.com/salt-slack>`_
 
 **Mailing List** - The SaltStack community users mailing list is hosted by
 Google groups. Anyone can post to ask questions about SaltStack products and

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -174,7 +174,7 @@ rst_prolog = """\
 .. _`salt-users`: https://groups.google.com/forum/#!forum/salt-users
 .. _`salt-announce`: https://groups.google.com/forum/#!forum/salt-announce
 .. _`salt-packagers`: https://groups.google.com/forum/#!forum/salt-packagers
-.. _`salt-slack`: https://join.slack.com/t/saltstackcommunity/shared_invite/zt-1zlfxffs1-NuEH~G9TzOeuNGdsfZIl3w
+.. _`salt-slack`: https://via.vmw.com/salt-slack
 .. |windownload| raw:: html
 
      <p>Python3 x86: <a


### PR DESCRIPTION
### What does this PR do?

Uses a shortlink for the Salt Project Slack Community invite link:

- https://via.vmw.com/salt-slack

### What issues does this PR fix or reference?

More permanent solution to the temporary Slack invite link issues addressed in:

- https://github.com/saltstack/salt/pull/64664
- https://github.com/saltstack/salt/pull/60096

### Previous Behavior

- Using a slack invite link that would need to be regenerated as an entirely new link annually
  - Due to 400 invite cap listed here: https://slack.com/help/articles/201330256-Invite-new-members-to-your-workspace#share-an-invitation-link

### New Behavior

- Only need to update the link the shortlink is pointing to, as opposed to needing to update the link in several repos (`salt`, `salt-install-guide`, `salt-user-guide`, etc.)