### PR TITLE
[3006.x] Move gitfs lock

### DIFF
--- a/changelog/65086.fixed.md
+++ b/changelog/65086.fixed.md
@@ -1,0 +1,1 @@
+Moved gitfs locks to salt working dir to avoid lock wipes

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -565,7 +565,7 @@ class GitProvider:
         return ret
 
     def _get_lock_file(self, lock_type="update"):
-        return salt.utils.path.join(self.gitdir, lock_type + ".lk")
+        return salt.utils.path.join(self._salt_working_dir, lock_type + ".lk")
 
     @classmethod
     def add_conf_overlay(cls, name):
@@ -857,7 +857,6 @@ class GitProvider:
                     self.id,
                     desired_ssl_verify,
                 )
-                self._ssl_verfiy = self.opts.get(f"{self.role}_ssl_verify", None)
                 conf_changed = True
 
             # Write changes, if necessary

--- a/tests/pytests/functional/utils/test_gitfs.py
+++ b/tests/pytests/functional/utils/test_gitfs.py
@@ -238,3 +238,38 @@ def test_gitpython_remote_map(gitpython_gitfs_opts):
 @skipif_no_pygit2
 def test_pygit2_remote_map(pygit2_gitfs_opts):
     _test_remote_map(pygit2_gitfs_opts)
+
+
+def _test_lock(opts):
+    g = _get_gitfs(
+        opts,
+        "https://github.com/saltstack/salt-test-pillar-gitfs.git",
+    )
+    g.fetch_remotes()
+    assert len(g.remotes) == 1
+    repo = g.remotes[0]
+    assert repo.get_salt_working_dir() in repo._get_lock_file()
+    assert repo.lock() == (
+        [
+            "Set update lock for gitfs remote 'https://github.com/saltstack/salt-test-pillar-gitfs.git'"
+        ],
+        [],
+    )
+    assert os.path.isfile(repo._get_lock_file())
+    assert repo.clear_lock() == (
+        [
+            "Removed update lock for gitfs remote 'https://github.com/saltstack/salt-test-pillar-gitfs.git'"
+        ],
+        [],
+    )
+    assert not os.path.isfile(repo._get_lock_file())
+
+
+@skipif_no_gitpython
+def test_gitpython_lock(gitpython_gitfs_opts):
+    _test_lock(gitpython_gitfs_opts)
+
+
+@skipif_no_pygit2
+def test_pygit2_lock(pygit2_gitfs_opts):
+    _test_lock(pygit2_gitfs_opts)

--- a/tests/pytests/functional/utils/test_pillar.py
+++ b/tests/pytests/functional/utils/test_pillar.py
@@ -328,3 +328,38 @@ def test_gitpython_remote_map(gitpython_pillar_opts):
 @skipif_no_pygit2
 def test_pygit2_remote_map(pygit2_pillar_opts):
     _test_remote_map(pygit2_pillar_opts)
+
+
+def _test_lock(opts):
+    p = _get_pillar(
+        opts,
+        "https://github.com/saltstack/salt-test-pillar-gitfs.git",
+    )
+    p.fetch_remotes()
+    assert len(p.remotes) == 1
+    repo = p.remotes[0]
+    assert repo.get_salt_working_dir() in repo._get_lock_file()
+    assert repo.lock() == (
+        [
+            "Set update lock for git_pillar remote 'https://github.com/saltstack/salt-test-pillar-gitfs.git'"
+        ],
+        [],
+    )
+    assert os.path.isfile(repo._get_lock_file())
+    assert repo.clear_lock() == (
+        [
+            "Removed update lock for git_pillar remote 'https://github.com/saltstack/salt-test-pillar-gitfs.git'"
+        ],
+        [],
+    )
+    assert not os.path.isfile(repo._get_lock_file())
+
+
+@skipif_no_gitpython
+def test_gitpython_lock(gitpython_pillar_opts):
+    _test_lock(gitpython_pillar_opts)
+
+
+@skipif_no_pygit2
+def test_pygit2_lock(pygit2_pillar_opts):
+    _test_lock(pygit2_pillar_opts)

--- a/tests/pytests/functional/utils/test_winrepo.py
+++ b/tests/pytests/functional/utils/test_winrepo.py
@@ -127,3 +127,38 @@ def test_gitpython_remote_map(gitpython_winrepo_opts):
 @skipif_no_pygit2
 def test_pygit2_remote_map(pygit2_winrepo_opts):
     _test_remote_map(pygit2_winrepo_opts)
+
+
+def _test_lock(opts):
+    w = _get_winrepo(
+        opts,
+        "https://github.com/saltstack/salt-test-pillar-gitfs.git",
+    )
+    w.fetch_remotes()
+    assert len(w.remotes) == 1
+    repo = w.remotes[0]
+    assert repo.get_salt_working_dir() in repo._get_lock_file()
+    assert repo.lock() == (
+        [
+            "Set update lock for winrepo remote 'https://github.com/saltstack/salt-test-pillar-gitfs.git'"
+        ],
+        [],
+    )
+    assert os.path.isfile(repo._get_lock_file())
+    assert repo.clear_lock() == (
+        [
+            "Removed update lock for winrepo remote 'https://github.com/saltstack/salt-test-pillar-gitfs.git'"
+        ],
+        [],
+    )
+    assert not os.path.isfile(repo._get_lock_file())
+
+
+@skipif_no_gitpython
+def test_gitpython_lock(gitpython_winrepo_opts):
+    _test_lock(gitpython_winrepo_opts)
+
+
+@skipif_no_pygit2
+def test_pygit2_lock(pygit2_winrepo_opts):
+    _test_lock(pygit2_winrepo_opts)


### PR DESCRIPTION
### What does this PR do?
Move gitfs locks out of `cachedir/.git` -> `salt_working_dir` and remove debug code `self._ssl_verfiy` from #65017 

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/65086

### Previous Behavior
Remove this section if not relevant
pygit2 wipes its `cachedir` when performing some operations 

### New Behavior
Remove this section if not relevant
pygit2 wipes it `cachedir` but locks do not get wiped

### Merge requirements satisfied?
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

