### PR TITLE
[3006.x] Upgrade relenv to 0.13.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,7 +442,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       self-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
       github-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
-      relenv-version: "0.13.10"
+      relenv-version: "0.13.11"
       python-version: "3.10.13"
 
   build-salt-onedir:
@@ -458,7 +458,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       self-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
       github-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
-      relenv-version: "0.13.10"
+      relenv-version: "0.13.11"
       python-version: "3.10.13"
 
   build-rpm-pkgs:
@@ -470,7 +470,7 @@ jobs:
     uses: ./.github/workflows/build-rpm-packages.yml
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.13.10"
+      relenv-version: "0.13.11"
       python-version: "3.10.13"
 
   build-deb-pkgs:
@@ -482,7 +482,7 @@ jobs:
     uses: ./.github/workflows/build-deb-packages.yml
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.13.10"
+      relenv-version: "0.13.11"
       python-version: "3.10.13"
 
   build-windows-pkgs:
@@ -494,7 +494,7 @@ jobs:
     uses: ./.github/workflows/build-windows-packages.yml
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.13.10"
+      relenv-version: "0.13.11"
       python-version: "3.10.13"
 
   build-macos-pkgs:
@@ -506,7 +506,7 @@ jobs:
     uses: ./.github/workflows/build-macos-packages.yml
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.13.10"
+      relenv-version: "0.13.11"
       python-version: "3.10.13"
 
   amazonlinux-2-pkg-tests:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -491,7 +491,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       self-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
       github-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
-      relenv-version: "0.13.10"
+      relenv-version: "0.13.11"
       python-version: "3.10.13"
 
   build-salt-onedir:
@@ -507,7 +507,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       self-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
       github-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
-      relenv-version: "0.13.10"
+      relenv-version: "0.13.11"
       python-version: "3.10.13"
 
   build-rpm-pkgs:
@@ -519,7 +519,7 @@ jobs:
     uses: ./.github/workflows/build-rpm-packages.yml
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.13.10"
+      relenv-version: "0.13.11"
       python-version: "3.10.13"
 
   build-deb-pkgs:
@@ -531,7 +531,7 @@ jobs:
     uses: ./.github/workflows/build-deb-packages.yml
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.13.10"
+      relenv-version: "0.13.11"
       python-version: "3.10.13"
 
   build-windows-pkgs:
@@ -543,7 +543,7 @@ jobs:
     uses: ./.github/workflows/build-windows-packages.yml
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.13.10"
+      relenv-version: "0.13.11"
       python-version: "3.10.13"
       environment: nightly
       sign-packages: false
@@ -558,7 +558,7 @@ jobs:
     uses: ./.github/workflows/build-macos-packages.yml
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.13.10"
+      relenv-version: "0.13.11"
       python-version: "3.10.13"
       environment: nightly
       sign-packages: true

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -476,7 +476,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       self-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
       github-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
-      relenv-version: "0.13.10"
+      relenv-version: "0.13.11"
       python-version: "3.10.13"
 
   build-salt-onedir:
@@ -492,7 +492,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       self-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
       github-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
-      relenv-version: "0.13.10"
+      relenv-version: "0.13.11"
       python-version: "3.10.13"
 
   build-rpm-pkgs:
@@ -504,7 +504,7 @@ jobs:
     uses: ./.github/workflows/build-rpm-packages.yml
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.13.10"
+      relenv-version: "0.13.11"
       python-version: "3.10.13"
 
   build-deb-pkgs:
@@ -516,7 +516,7 @@ jobs:
     uses: ./.github/workflows/build-deb-packages.yml
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.13.10"
+      relenv-version: "0.13.11"
       python-version: "3.10.13"
 
   build-windows-pkgs:
@@ -528,7 +528,7 @@ jobs:
     uses: ./.github/workflows/build-windows-packages.yml
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.13.10"
+      relenv-version: "0.13.11"
       python-version: "3.10.13"
 
   build-macos-pkgs:
@@ -540,7 +540,7 @@ jobs:
     uses: ./.github/workflows/build-macos-packages.yml
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.13.10"
+      relenv-version: "0.13.11"
       python-version: "3.10.13"
 
   amazonlinux-2-pkg-tests:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -486,7 +486,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       self-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
       github-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
-      relenv-version: "0.13.10"
+      relenv-version: "0.13.11"
       python-version: "3.10.13"
 
   build-salt-onedir:
@@ -502,7 +502,7 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       self-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
       github-hosted-runners: ${{ fromJSON(needs.prepare-workflow.outputs.runners)['github-hosted'] }}
-      relenv-version: "0.13.10"
+      relenv-version: "0.13.11"
       python-version: "3.10.13"
 
   build-rpm-pkgs:
@@ -514,7 +514,7 @@ jobs:
     uses: ./.github/workflows/build-rpm-packages.yml
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.13.10"
+      relenv-version: "0.13.11"
       python-version: "3.10.13"
 
   build-deb-pkgs:
@@ -526,7 +526,7 @@ jobs:
     uses: ./.github/workflows/build-deb-packages.yml
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.13.10"
+      relenv-version: "0.13.11"
       python-version: "3.10.13"
 
   build-windows-pkgs:
@@ -538,7 +538,7 @@ jobs:
     uses: ./.github/workflows/build-windows-packages.yml
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.13.10"
+      relenv-version: "0.13.11"
       python-version: "3.10.13"
       environment: staging
       sign-packages: ${{ inputs.sign-windows-packages }}
@@ -553,7 +553,7 @@ jobs:
     uses: ./.github/workflows/build-macos-packages.yml
     with:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
-      relenv-version: "0.13.10"
+      relenv-version: "0.13.11"
       python-version: "3.10.13"
       environment: staging
       sign-packages: true

--- a/cicd/shared-gh-workflows-context.yml
+++ b/cicd/shared-gh-workflows-context.yml
@@ -1,3 +1,3 @@
 nox_version: "2022.8.7"
 python_version: "3.10.13"
-relenv_version: "0.13.10"
+relenv_version: "0.13.11"


### PR DESCRIPTION
### What does this PR do?

Upgrade relenv to 0.13.11 which fixes running salt when the system's OpenSSL has a fips provider configured.
