### PR TITLE
[3006.x] Fix `pkg.latest` failing for winrepo packages that are already up to date

### DIFF
--- a/changelog/65165.fixed.md
+++ b/changelog/65165.fixed.md
@@ -1,0 +1,1 @@
+Fix pkg.latest failing on windows for winrepo packages where the package is already up to date

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -2789,7 +2789,8 @@ def latest(
                 x
                 for x in targets
                 if not changes.get(x)
-                or targets[x] not in changes[x].get("new").split(",")
+                or changes[x].get("new") is not None
+                and targets[x] not in changes[x].get("new").split(",")
                 and targets[x] != "latest"
             ]
             successful = [x for x in targets if x not in failed]

--- a/tests/pytests/unit/states/test_pkg.py
+++ b/tests/pytests/unit/states/test_pkg.py
@@ -1196,3 +1196,24 @@ def test_latest_multiple_versions():
     with patch.dict(pkg.__salt__, salt_dict):
         ret = pkg.latest(pkg_name)
         assert ret.get("result", False) is True
+
+
+def test_latest_no_change_windows():
+    """
+    Test pkg.latest with no change to the package version for winrepo packages
+
+    See: https://github.com/saltstack/salt/issues/65165
+    """
+    pkg_name = "fake_pkg"
+    version = "1.2.2"
+    latest_version_mock = MagicMock(return_value={pkg_name: version})
+    current_version_mock = MagicMock(return_value={pkg_name: version})
+    install_mock = MagicMock(return_value={pkg_name: {"install status": "success"}})
+    salt_dict = {
+        "pkg.latest_version": latest_version_mock,
+        "pkg.version": current_version_mock,
+        "pkg.install": install_mock,
+    }
+    with patch.dict(pkg.__salt__, salt_dict):
+        ret = pkg.latest(pkg_name)
+        assert ret.get("result", False) is True


### PR DESCRIPTION
### What does this PR do?
See title

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/65165

### Previous Behavior
Failed with `NoneType` has no attribute `split`

### New Behavior
No more failures :)

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes