### PR TITLE
[3006.x]  rpm doenst need to check digest and signing when listing packages

### DIFF
--- a/changelog/65152.fixed.md
+++ b/changelog/65152.fixed.md
@@ -1,0 +1,1 @@
+speed up yumpkg list_pkgs by not requiring digest or signature verification on lookup.

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -746,6 +746,8 @@ def list_pkgs(versions_as_list=False, **kwargs):
     cmd = [
         "rpm",
         "-qa",
+        "--nodigest",
+        "--nosignature",
         "--queryformat",
         salt.utils.pkg.rpm.QUERYFORMAT.replace("%{REPOID}", "(none)") + "\n",
     ]

--- a/tests/pytests/functional/modules/test_yumpkg.py
+++ b/tests/pytests/functional/modules/test_yumpkg.py
@@ -1,0 +1,41 @@
+import pytest
+
+import salt.modules.cmdmod
+import salt.modules.pkg_resource
+import salt.modules.yumpkg
+import salt.utils.pkg.rpm
+
+
+@pytest.fixture
+def configure_loader_modules(minion_opts):
+    return {
+        salt.modules.yumpkg: {
+            "__salt__": {
+                "cmd.run": salt.modules.cmdmod.run,
+                "pkg_resource.add_pkg": salt.modules.pkg_resource.add_pkg,
+                "pkg_resource.format_pkg_list": salt.modules.pkg_resource.format_pkg_list,
+            },
+            "__grains__": {"osarch": salt.utils.pkg.rpm.get_osarch()},
+        },
+    }
+
+
+@pytest.mark.slow_test
+def test_yum_list_pkgs(grains):
+    """
+    compare the output of rpm -qa vs the return of yumpkg.list_pkgs,
+    make sure that any changes to ympkg.list_pkgs still returns.
+    """
+
+    if grains["os_family"] != "RedHat":
+        pytest.skip("Skip if not RedHat")
+    cmd = [
+        "rpm",
+        "-qa",
+        "--queryformat",
+        "%{NAME}\n",
+    ]
+    known_pkgs = salt.modules.cmdmod.run(cmd, python_shell=False)
+    listed_pkgs = salt.modules.yumpkg.list_pkgs()
+    for line in known_pkgs.splitlines():
+        assert any(line in d for d in listed_pkgs)


### PR DESCRIPTION
### What does this PR do?
speeds up pkg.list_pkgs in redhat systems

### What issues does this PR fix or reference?
Fixes: #65152 

### Previous Behavior
yumpkg.list_pkgs was a bit slow

### New Behavior
yumpkg.list_pkgs is faster because not checking digest and signatures to list packages. 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

