### PR TITLE
[3006.x] Ensure __kwarg__ is preserved when checking for kwargs

### DIFF
--- a/changelog/65179.fixed.md
+++ b/changelog/65179.fixed.md
@@ -1,1 +1,1 @@
-Ensure kwarg arguments are sent along correctly.  This change affects proxy minions when used with Deltaproxy, which had kwargs popped when targeting multiple minions id.
+Ensure __kwarg__ is preserved when checking for kwargs.  This change affects proxy minions when used with Deltaproxy, which had kwargs popped when targeting multiple minions id.

--- a/changelog/65179.fixed.md
+++ b/changelog/65179.fixed.md
@@ -1,0 +1,1 @@
+Ensure kwarg arguments are sent along correctly.  This change affects proxy minions when used with Deltaproxy, which had kwargs popped when targeting multiple minions id.

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -327,9 +327,12 @@ def load_args_and_kwargs(func, args, data=None, ignore_invalid=False):
     invalid_kwargs = []
 
     for arg in args:
-        if isinstance(arg, dict) and arg.pop("__kwarg__", False) is True:
+        if isinstance(arg, dict) and arg.get("__kwarg__", False) is True:
             # if the arg is a dict with __kwarg__ == True, then its a kwarg
             for key, val in arg.items():
+                # Skip __kwarg__ when checking kwargs
+                if key == "__kwarg__":
+                    continue
                 if argspec.keywords or key in argspec.args:
                     # Function supports **kwargs or is a positional argument to
                     # the function.
@@ -339,7 +342,6 @@ def load_args_and_kwargs(func, args, data=None, ignore_invalid=False):
                     # list of positional arguments. This keyword argument is
                     # invalid.
                     invalid_kwargs.append("{}={}".format(key, val))
-            arg.update({"__kwarg__": True})
             continue
 
         else:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -339,6 +339,7 @@ def load_args_and_kwargs(func, args, data=None, ignore_invalid=False):
                     # list of positional arguments. This keyword argument is
                     # invalid.
                     invalid_kwargs.append("{}={}".format(key, val))
+            arg.update({"__kwarg__": True})
             continue
 
         else:

--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -8,6 +8,7 @@ import salt.ext.tornado
 import salt.ext.tornado.gen
 import salt.ext.tornado.testing
 import salt.minion
+import salt.modules.test as test_mod
 import salt.syspaths
 import salt.utils.crypt
 import salt.utils.event as event
@@ -1102,3 +1103,19 @@ async def test_syndic_async_req_channel(syndic_opts):
     syndic.pub_channel = MagicMock()
     syndic.tune_in_no_block()
     assert isinstance(syndic.async_req_channel, salt.channel.client.AsyncReqChannel)
+
+
+@pytest.mark.slow_test
+def test_load_args_and_kwargs(minion_opts):
+    """
+    Ensure load_args_and_kwargs performs correctly
+    """
+    _args = [{"max": 40, "__kwarg__": True}]
+    ret = salt.minion.load_args_and_kwargs(test_mod.rand_sleep, _args)
+    assert ret == ([], {"max": 40})
+    assert all([True if "__kwarg__" in item else False for item in _args])
+
+    # Test invalid arguments
+    _args = [{"max_sleep": 40, "__kwarg__": True}]
+    with pytest.raises(salt.exceptions.SaltInvocationError):
+        ret = salt.minion.load_args_and_kwargs(test_mod.rand_sleep, _args)


### PR DESCRIPTION
### What does this PR do?
Ensure __kwarg__ is preserved when checking for kwargs

### What issues does this PR fix or reference?
Fixes: #65179 

### Previous Behavior
Proxy minions missing kwargs

### New Behavior
Ensure kwargs are sent to proxy minions correctly

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
