### PR TITLE
[3006.x] Remove pip install warning - setuptools new release fixed

### DIFF
--- a/doc/topics/releases/3006.3.md
+++ b/doc/topics/releases/3006.3.md
@@ -12,11 +12,6 @@ for a given release.
 Add release specific details below
 -->
 
-| **IMPORTANT** |
-| ------------- |
-| Due to a known issue with the newest release of setuptools, users who use pip to install Salt will experience an install failure. This issue also impacts pip installs for older versions of Salt. The core Salt team is currently investigating the issue and has documented a workaround. To follow the issue and get the latest workaround, see: <https://github.com/saltstack/salt/issues/65149> |
-
-
 <!--
 Do not edit the changelog below.
 This is auto generated.


### PR DESCRIPTION
Remove warning from 3006.3 release notes. https://github.com/saltstack/salt/issues/65149 is resolved and setuptools released a new release which resolves old and new salt installs. 