### PR TITLE
[3006.x] Ensure sync from _grains occurs before attempting pillar compilation in case custom grain used in pillar file

### DIFF
--- a/changelog/65027.fixed.md
+++ b/changelog/65027.fixed.md
@@ -1,0 +1,1 @@
+Ensure sync from _grains occurs before attempting pillar compilation in case custom grain used in pillar file

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -44,18 +44,13 @@ log = logging.getLogger(__name__)
 MAX_FILENAME_LENGTH = 255
 
 
-def get_file_client(opts, pillar=False):
+def get_file_client(opts, pillar=False, force_local=False):
     """
     Read in the ``file_client`` option and return the correct type of file
     server
     """
     ## client = opts.get("file_client", "remote")
-
-    # TBD DGM this is a big hack, if coming up initially, the first sync _grains
-    # doesn't have opts["master_uri"] set, so need to fake local, otherwise will
-    # throws an exception when attempting to retrieve opts["master_uri"] when
-    # retrieving the key for remote communication
-    if not opts.get("master_uri", None):
+    if force_local:
         client = "local"
     else:
         client = opts.get("file_client", "remote")

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -49,7 +49,6 @@ def get_file_client(opts, pillar=False, force_local=False):
     Read in the ``file_client`` option and return the correct type of file
     server
     """
-    ## client = opts.get("file_client", "remote")
     if force_local:
         client = "local"
     else:

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -49,7 +49,17 @@ def get_file_client(opts, pillar=False):
     Read in the ``file_client`` option and return the correct type of file
     server
     """
-    client = opts.get("file_client", "remote")
+    ## client = opts.get("file_client", "remote")
+
+    # TBD DGM this is a big hack, if coming up initially, the first sync _grains
+    # doesn't have opts["master_uri"] set, so need to fake local, otherwise will
+    # throws an exception when attempting to retrieve opts["master_uri"] when
+    # retrieving the key for remote communication
+    if not opts.get("master_uri", None):
+        client = "local"
+    else:
+        client = opts.get("file_client", "remote")
+
     if pillar and client == "local":
         client = "pillar"
     return {"remote": RemoteClient, "local": FSClient, "pillar": PillarClient}.get(

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -922,14 +922,9 @@ class SMinion(MinionBase):
         import salt.loader
 
         # need sync of custom grains as may be used in pillar compilation
-        ret, touched = salt.utils.extmods.sync(opts, "grains")
-        log.warning(f"DGM SMinion dunder init, sync ret '{ret}', touched '{touched}'")
-
+        salt.utils.extmods.sync(opts, "grains")
         opts["grains"] = salt.loader.grains(opts)
         super().__init__(opts)
-
-        dgm_grains = opts["grains"]
-        log.warning(f"DGM SMinion dunder init, post load grains  '{dgm_grains}'")
 
         # Clean out the proc directory (default /var/cache/salt/minion/proc)
         if self.opts.get("file_client", "remote") == "remote" or self.opts.get(

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -922,7 +922,17 @@ class SMinion(MinionBase):
         import salt.loader
 
         # need sync of custom grains as may be used in pillar compilation
-        salt.utils.extmods.sync(opts, "grains")
+        # if coming up initially and remote client, the first sync _grains
+        # doesn't have opts["master_uri"] set yeti during the sync, so need
+        # to force local, otherwise will throw an exception when attempting
+        # to retrieve opts["master_uri"] when retrieving key for remote communication
+
+        if opts.get("file_client", "remote") == "remote" and not opts.get(
+            "master_uri", None
+        ):
+            salt.utils.extmods.sync(opts, "grains", force_local=True)
+        else:
+            salt.utils.extmods.sync(opts, "grains")
         opts["grains"] = salt.loader.grains(opts)
         super().__init__(opts)
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -73,6 +73,7 @@ from salt.template import SLS_ENCODING
 from salt.utils.ctx import RequestContext
 from salt.utils.debug import enable_sigusr1_handler
 from salt.utils.event import tagify
+from salt.utils.extmods import sync as _sync
 from salt.utils.network import parse_host_port
 from salt.utils.odict import OrderedDict
 from salt.utils.process import ProcessManager, SignalHandlingProcess, default_signals
@@ -920,6 +921,8 @@ class SMinion(MinionBase):
         # Late setup of the opts grains, so we can log from the grains module
         import salt.loader
 
+        # need sync of custom grains as may be used in pillar compilation
+        _sync(opts, "grains")
         opts["grains"] = salt.loader.grains(opts)
         super().__init__(opts)
 
@@ -3936,6 +3939,8 @@ class SProxyMinion(SMinion):
 
             salt '*' sys.reload_modules
         """
+        # need sync of custom grains as may be used in pillar compilation
+        _sync(self.opts, "grains")
         self.opts["grains"] = salt.loader.grains(self.opts)
         self.opts["pillar"] = salt.pillar.get_pillar(
             self.opts,

--- a/salt/state.py
+++ b/salt/state.py
@@ -4254,7 +4254,7 @@ class BaseHighState:
         """
         if not self.opts["autoload_dynamic_modules"]:
             return
-        syncd = self.state.functions["saltutil.sync_all"](list(matches), refresh=False)
+        syncd = self.state.functions["saltutil.sync_all"](list(matches), refresh=True)
         if syncd["grains"]:
             self.opts["grains"] = salt.loader.grains(self.opts)
             self.state.opts["pillar"] = self.state._gather_pillar()

--- a/salt/state.py
+++ b/salt/state.py
@@ -4254,7 +4254,7 @@ class BaseHighState:
         """
         if not self.opts["autoload_dynamic_modules"]:
             return
-        syncd = self.state.functions["saltutil.sync_all"](list(matches), refresh=True)
+        syncd = self.state.functions["saltutil.sync_all"](list(matches), refresh=False)
         if syncd["grains"]:
             self.opts["grains"] = salt.loader.grains(self.opts)
             self.state.opts["pillar"] = self.state._gather_pillar()

--- a/salt/utils/extmods.py
+++ b/salt/utils/extmods.py
@@ -32,7 +32,14 @@ def _listdir_recursively(rootdir):
     return file_list
 
 
-def sync(opts, form, saltenv=None, extmod_whitelist=None, extmod_blacklist=None):
+def sync(
+    opts,
+    form,
+    saltenv=None,
+    extmod_whitelist=None,
+    extmod_blacklist=None,
+    force_local=False,
+):
     """
     Sync custom modules into the extension_modules directory
     """
@@ -75,7 +82,9 @@ def sync(opts, form, saltenv=None, extmod_whitelist=None, extmod_blacklist=None)
                         "Cannot create cache module directory %s. Check permissions.",
                         mod_dir,
                     )
-            with salt.fileclient.get_file_client(opts) as fileclient:
+            with salt.fileclient.get_file_client(
+                opts, pillar=False, force_local=force_local
+            ) as fileclient:
                 for sub_env in saltenv:
                     log.info("Syncing %s for environment '%s'", form, sub_env)
                     cache = []

--- a/tests/pytests/integration/cli/test_salt_call.py
+++ b/tests/pytests/integration/cli/test_salt_call.py
@@ -491,10 +491,12 @@ def test_state_highstate_custom_grains(salt_master, salt_minion_factory):
             assert pillar_items["mypillar"] == "test_value"
 
 
-def test_salt_call_versions(salt_call_cli):
+def test_salt_call_versions(salt_call_cli, caplog):
     """
     Call test.versions without '--local' to test grains
     are sync'd without any missing keys in opts
     """
+    caplog.at_level(logging.DEBUG)
     ret = salt_call_cli.run("test.versions")
     assert ret.returncode == 0
+    assert "LazyLoaded test.versions" in caplog.messages

--- a/tests/pytests/integration/cli/test_salt_call.py
+++ b/tests/pytests/integration/cli/test_salt_call.py
@@ -462,7 +462,7 @@ def test_state_highstate_custom_grains(salt_master, salt_minion_factory):
       test.nop: []
     """
 
-    salt_custom_grains_sls = """
+    salt_custom_grains_py = """
     def main():
         return {'custom_grain': 'test_value'}
     """
@@ -479,7 +479,7 @@ def test_state_highstate_custom_grains(salt_master, salt_minion_factory):
         ), salt_minion.state_tree.base.temp_file(
             "test.sls", salt_test_sls
         ), salt_minion.state_tree.base.temp_file(
-            "_grains/custom_grain.py", salt_custom_grains_sls
+            "_grains/custom_grain.py", salt_custom_grains_py
         ):
             ret = salt_call_cli.run("--local", "state.highstate")
             assert ret.returncode == 0
@@ -496,7 +496,7 @@ def test_salt_call_versions(salt_call_cli, caplog):
     Call test.versions without '--local' to test grains
     are sync'd without any missing keys in opts
     """
-    caplog.at_level(logging.DEBUG)
-    ret = salt_call_cli.run("test.versions")
-    assert ret.returncode == 0
-    assert "Failed to sync grains module: 'master_uri'" not in caplog.messages
+    with caplog.at_level(logging.DEBUG):
+        ret = salt_call_cli.run("test.versions")
+        assert ret.returncode == 0
+        assert "Failed to sync grains module: 'master_uri'" not in caplog.messages

--- a/tests/pytests/integration/cli/test_salt_call.py
+++ b/tests/pytests/integration/cli/test_salt_call.py
@@ -498,4 +498,3 @@ def test_salt_call_versions(salt_call_cli):
     """
     ret = salt_call_cli.run("test.versions")
     assert ret.returncode == 0
-    assert ret.data[0] == 2

--- a/tests/pytests/integration/cli/test_salt_call.py
+++ b/tests/pytests/integration/cli/test_salt_call.py
@@ -499,4 +499,4 @@ def test_salt_call_versions(salt_call_cli, caplog):
     caplog.at_level(logging.DEBUG)
     ret = salt_call_cli.run("test.versions")
     assert ret.returncode == 0
-    assert "LazyLoaded test.versions" in caplog.messages
+    assert "Failed to sync grains module: 'master_uri'" not in caplog.messages

--- a/tests/pytests/integration/cli/test_salt_call.py
+++ b/tests/pytests/integration/cli/test_salt_call.py
@@ -489,3 +489,13 @@ def test_state_highstate_custom_grains(salt_master, salt_minion_factory):
             pillar_items = ret.data
             assert "mypillar" in pillar_items
             assert pillar_items["mypillar"] == "test_value"
+
+
+def test_salt_call_versions(salt_call_cli):
+    """
+    Call test.versions without '--local' to test grains
+    are sync'd without any missing keys in opts
+    """
+    ret = salt_call_cli.run("test.versions")
+    assert ret.returncode == 0
+    assert ret.data[0] == 2

--- a/tests/pytests/integration/cli/test_salt_call.py
+++ b/tests/pytests/integration/cli/test_salt_call.py
@@ -6,6 +6,7 @@ import re
 import sys
 
 import pytest
+from saltfactories.utils.tempfiles import temp_directory
 
 import salt.defaults.exitcodes
 import salt.utils.files
@@ -429,3 +430,127 @@ def test_local_salt_call_no_function_no_retcode(salt_call_cli):
     assert "test" in ret.data
     assert ret.data["test"] == "'test' is not available."
     assert "test.echo" in ret.data
+
+
+def salt_minion(salt_master, salt_minion_factory):
+    """
+    A running salt-minion fixture
+    """
+    assert salt_master.is_running()
+    with salt_minion_factory.started():
+        # Sync All
+        salt_call_cli = salt_minion_factory.salt_call_cli()
+        ret = salt_call_cli.run("saltutil.sync_all", _timeout=120)
+        assert ret.returncode == 0, ret
+        yield salt_minion_factory
+
+
+def salt_call_cli(salt_minion):
+    """
+    The ``salt-call`` CLI as a fixture against the running minion
+    """
+    assert salt_minion.is_running()
+    return salt_minion.salt_call_cli(timeout=30)
+
+
+## DGM def test_state_highstate_custom_grains(salt_minion, salt_call_cli):
+def test_state_highstate_custom_grains(salt_master, salt_minion_factory):
+    """
+    This test ensure that custom grains in salt://_grains are loaded before pillar compilation
+    to ensure that any use of custom grains in pillar files are available, this implies that
+    a sync of grains occurs before loading the regular /etc/salt/grains or configuration file
+    grains, as well as the usual grains.
+
+    Problem: cannot use salt_minion and salt_call_cli, since these will be loaded before
+    the pillar and custom_grains files are written.
+    """
+    pillar_top_sls = """
+    base:
+      '*':
+        - defaults
+        """
+
+    pillar_defaults_sls = """
+    mypillar: "{{ grains['custom_grain'] }}"
+    """
+
+    salt_top_sls = """
+    base:
+      '*':
+        - test
+        """
+
+    salt_test_sls = """
+    "donothing":
+      test.nop: []
+    """
+
+    salt_custom_grains_sls = """
+    def main():
+        return {'custom_grain': 'test_value'}
+    """
+    log.warning("DGM test_state_highstate_custom_grains start of tests")
+
+    assert salt_master.is_running()
+
+    log.warning("DGM test_state_highstate_custom_grains salt_master.is_running")
+
+    with salt_minion_factory.started():
+        ## # Sync All
+        ## salt_call_cli = salt_minion_factory.salt_call_cli()
+        ## ret = salt_call_cli.run("saltutil.sync_all", _timeout=120)
+        ## assert ret.returncode == 0, ret
+        ## yield salt_minion_factory
+
+        log.warning(
+            "DGM test_state_highstate_custom_grains salt_minion_factory started"
+        )
+
+        salt_minion = salt_minion_factory
+        salt_call_cli = salt_minion_factory.salt_call_cli()
+
+        log.warning(
+            "DGM test_state_highstate_custom_grains have salt_minion and salt_call_cli"
+        )
+
+        with salt_minion.pillar_tree.base.temp_file(
+            "top.sls", pillar_top_sls
+        ), salt_minion.pillar_tree.base.temp_file(
+            "defaults.sls", pillar_defaults_sls
+        ), salt_minion.state_tree.base.temp_file(
+            "top.sls",
+            salt_top_sls
+            ## ), test_sls_file = salt_minion.state_tree.base.temp_file(
+            ##     "test.sls", salt_test_sls
+            ## ), temp_directory(
+            ##     "_grains"
+            ## ), salt_minion.state_tree.base.temp_file(
+            ##     "custom_grain.py", salt_custom_grains_sls, "_grains"
+        ):
+            test_sls_file = salt_minion.state_tree.base.temp_file(
+                "test.sls", salt_test_sls
+            )
+            log.warning(f"DGM highstate_custom_grains, test_sls_file '{test_sls_file}'")
+
+            dgm_tmp_dir = temp_directory("_grains")
+            dgm_grains_file = salt_minion.state_tree.base.temp_file(
+                "custom_grain.py", salt_custom_grains_sls, "_grains"
+            )
+            log.warning(
+                f"DGM highstate_custom_grains, dgm_tmp_dir '{dgm_tmp_dir}', dgm_grains_file '{dgm_grains_file}'"
+            )
+
+            log.warning("DGM highstate_custom_grains, cmd.run for salt:// etc.")
+            ret = salt_call_cli.run("--local", "cmd.run", "salt://*")
+            ret = salt_call_cli.run("--local", "cmd.run", "salt://_grains/*")
+
+            log.warning("DGM highstate_custom_grains, pre state.highstate call")
+
+            ret = salt_call_cli.run("--local", "state.highstate")
+
+            log.warning(f"DGM highstate_custom_grains, state.highstate ret '{ret}'")
+            assert ret.returncode == 0
+
+            log.warning(f"DGM highstate_custom_grains, pillar.items ret '{ret}'")
+            ret = salt_call_cli.run("pillar.items")
+            assert ret.returncode == 0


### PR DESCRIPTION
### What does this PR do?
Ensures that grains are sync'd before loading grains and then compiling pillar, since there could be custom grains used in pillar files, which will throw rendering errors if not found.

### What issues does this PR fix or reference?
Fixes:https://github.com/saltstack/salt/issues/65027

### Previous Behavior
Would throw rendering errors if custom grains in salt://_grains were used in pillar files.

### New Behavior
No rendering errors thrown if custom grains in salt://_grains were used in pillar files, and custom grains values available in pillar

Test still to be written

A very old PR #13011(https://github.com/saltstack/salt/commit/d83e6634136735a75b29771787ec963cae397694), A change was made to not refresh on sync_all.  I believe this was in error, the previous code did refresh, and the changes was made to save a module load, but what about everything else, like grains.  Also the old code would not refresh if local so as to not fire events, and I am not sure that that reasoning holds almost 10 years later, either.
Welcome close examination and reasoning of that change in salt/state.py.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
