### PR TITLE
[3006.x] Only run` __create_keys_dir` if we have a `--gen-keys` argument

### DIFF
--- a/changelog/65093.fixed.md
+++ b/changelog/65093.fixed.md
@@ -1,0 +1,1 @@
+Only attempt to create a keys directory when `--gen-keys` is passed to the `salt-key` CLI

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2649,7 +2649,7 @@ class SaltKeyOptionParser(
             default=".",
             help=(
                 "Set the directory to save the generated keypair, only "
-                "works with \"gen_keys_dir\" option. Default: '%default'."
+                "works with \"--gen-keys\" option. Default: '%default'."
             ),
         )
 
@@ -2767,10 +2767,11 @@ class SaltKeyOptionParser(
 
     def process_gen_keys_dir(self):
         # Schedule __create_keys_dir() to run if there's a value for
-        # --create-keys-dir
-        self._mixin_after_parsed_funcs.append(
-            self.__create_keys_dir
-        )  # pylint: disable=no-member
+        # --gen-keys-dir
+        if self.options.gen_keys:
+            self._mixin_after_parsed_funcs.append(
+                self.__create_keys_dir
+            )  # pylint: disable=no-member
 
     def __create_keys_dir(self):
         if not os.path.isdir(self.config["gen_keys_dir"]):

--- a/tests/pytests/integration/cli/test_salt_key.py
+++ b/tests/pytests/integration/cli/test_salt_key.py
@@ -292,6 +292,13 @@ def test_keys_generation(salt_key_cli, tmp_path):
             filename.chmod(0o700)
 
 
+def test_gen_keys_dir_without_gen_keys(salt_key_cli, tmp_path):
+    gen_keys_path = tmp_path / "temp-gen-keys-path"
+    ret = salt_key_cli.run("--gen-keys-dir", str(gen_keys_path))
+    assert ret.returncode == 0
+    assert not gen_keys_path.exists()
+
+
 def test_keys_generation_keysize_min(salt_key_cli, tmp_path):
     ret = salt_key_cli.run(
         "--gen-keys", "minibar", "--gen-keys-dir", str(tmp_path), "--keysize", "1024"


### PR DESCRIPTION
### What does this PR do?
See title

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/65093

### Previous Behavior
We would try to run `__create_keys_dir` whether or not `--gen-keys` was passed.

### New Behavior
Only run `__create_keys_dir` if both `--gen-keys` is passed

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes