### PR TITLE
[3006.x] Fix vt.Terminal failing test: test_log_sanitize

### DIFF
--- a/tests/pytests/unit/utils/test_vt.py
+++ b/tests/pytests/unit/utils/test_vt.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import signal
 
@@ -43,10 +44,13 @@ def test_log_sanitize(test_cmd, caplog):
         cmd,
         log_stdout=True,
         log_stderr=True,
+        log_stdout_level="debug",
+        log_stderr_level="debug",
         log_sanitize=password,
         stream_stdout=False,
         stream_stderr=False,
     )
-    ret = term.recv()
+    with caplog.at_level(logging.DEBUG):
+        ret = term.recv()
     assert password not in caplog.text
     assert "******" in caplog.text


### PR DESCRIPTION
Fixes failing test added in a09b4f445052be66f0ac53fd01fa02bfa5b82ea6

We can't assume tests are run at debug level, so this ensures the test passes regardless of what logging level is currently set by capturing the output in caplog at DEBUG which stream_stdout/stream_stderr uses by default.

Cherry-pick of #62813 as per https://github.com/saltstack/salt/pull/62813#issuecomment-1707229099