### PR TITLE
[master] Allow all primitive grain types for autosign_grains

### DIFF
--- a/changelog/61416.fixed.md
+++ b/changelog/61416.fixed.md
@@ -1,0 +1,1 @@
+Allow all primitive grain types for autosign_grains

--- a/changelog/63708.fixed.md
+++ b/changelog/63708.fixed.md
@@ -1,0 +1,1 @@
+Allow all primitive grain types for autosign_grains

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -88,7 +88,7 @@ def clean_fsbackend(opts):
     # Clear remote fileserver backend caches so they get recreated
     for backend in ("git", "hg", "svn"):
         if backend in opts["fileserver_backend"]:
-            env_cache = os.path.join(opts["cachedir"], "{}fs".format(backend), "envs.p")
+            env_cache = os.path.join(opts["cachedir"], f"{backend}fs", "envs.p")
             if os.path.isfile(env_cache):
                 log.debug("Clearing %sfs env cache", backend)
                 try:
@@ -99,7 +99,7 @@ def clean_fsbackend(opts):
                     )
 
             file_lists_dir = os.path.join(
-                opts["cachedir"], "file_lists", "{}fs".format(backend)
+                opts["cachedir"], "file_lists", f"{backend}fs"
             )
             try:
                 file_lists_caches = os.listdir(file_lists_dir)
@@ -177,7 +177,7 @@ def mk_key(opts, user):
             opts["cachedir"], ".{}_key".format(user.replace("\\", "_"))
         )
     else:
-        keyfile = os.path.join(opts["cachedir"], ".{}_key".format(user))
+        keyfile = os.path.join(opts["cachedir"], f".{user}_key")
 
     if os.path.exists(keyfile):
         log.debug("Removing stale keyfile: %s", keyfile)
@@ -220,7 +220,7 @@ def access_keys(opts):
     for user in acl_users:
         log.info("Preparing the %s key for local communication", user)
 
-        keyfile = os.path.join(opts["cachedir"], ".{}_key".format(user))
+        keyfile = os.path.join(opts["cachedir"], f".{user}_key")
         if os.path.exists(keyfile):
             with salt.utils.files.fopen(keyfile, "r") as fp:
                 key = salt.utils.stringutils.to_unicode(fp.read())
@@ -603,7 +603,7 @@ class RemoteFuncs:
         minions = _res["minions"]
         minion_side_acl = {}  # Cache minion-side ACL
         for minion in minions:
-            mine_data = self.cache.fetch("minions/{}".format(minion), "mine")
+            mine_data = self.cache.fetch(f"minions/{minion}", "mine")
             if not isinstance(mine_data, dict):
                 continue
             for function in functions_allowed:
@@ -630,7 +630,7 @@ class RemoteFuncs:
                                 continue
                             salt.utils.dictupdate.set_dict_key_value(
                                 minion_side_acl,
-                                "{}:{}".format(minion, function),
+                                f"{minion}:{function}",
                                 get_minion,
                             )
                 if salt.utils.mine.minion_side_acl_denied(
@@ -1190,7 +1190,7 @@ class LocalFuncs:
         fun = load.pop("fun")
         tag = salt.utils.event.tagify(jid, prefix="wheel")
         data = {
-            "fun": "wheel.{}".format(fun),
+            "fun": f"wheel.{fun}",
             "jid": jid,
             "tag": tag,
             "user": username,
@@ -1274,7 +1274,7 @@ class LocalFuncs:
         # Setup authorization list variable and error information
         auth_list = auth_check.get("auth_list", [])
         error = auth_check.get("error")
-        err_msg = 'Authentication failure of type "{}" occurred.'.format(auth_type)
+        err_msg = f'Authentication failure of type "{auth_type}" occurred.'
 
         if error:
             # Authentication error occurred: do not continue.

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -380,7 +380,7 @@ class AutoKey:
                             line = salt.utils.stringutils.to_unicode(line).strip()
                             if line.startswith("#"):
                                 continue
-                            if autosign_grains[grain] == line:
+                            if str(autosign_grains[grain]) == line:
                                 return True
         return False
 

--- a/tests/pytests/unit/daemons/masterapi/test_auto_key.py
+++ b/tests/pytests/unit/daemons/masterapi/test_auto_key.py
@@ -256,16 +256,17 @@ def test_check_autosign_grains_no_autosign_grains_dir(auto_key):
     _test_check_autosign_grains(test_func, auto_key, autosign_grains_dir=None)
 
 
-def test_check_autosign_grains_accept(auto_key):
+@pytest.mark.parametrize("grain_value", ["test_value", 123, True])
+def test_check_autosign_grains_accept(grain_value, auto_key):
     """
     Asserts that autosigning from grains passes when a matching grain value is in an
     autosign_grain file.
     """
 
     def test_func(*args):
-        assert auto_key.check_autosign_grains({"test_grain": "test_value"}) is True
+        assert auto_key.check_autosign_grains({"test_grain": grain_value}) is True
 
-    file_content = "#test_ignore\ntest_value"
+    file_content = f"#test_ignore\n{grain_value}"
     _test_check_autosign_grains(test_func, auto_key, file_content=file_content)
 
 

--- a/tests/pytests/unit/daemons/masterapi/test_auto_key.py
+++ b/tests/pytests/unit/daemons/masterapi/test_auto_key.py
@@ -17,11 +17,11 @@ def gen_permissions(owner="", group="", others=""):
     """
     ret = 0
     for c in owner:
-        ret |= getattr(stat, "S_I{}USR".format(c.upper()), 0)
+        ret |= getattr(stat, f"S_I{c.upper()}USR", 0)
     for c in group:
-        ret |= getattr(stat, "S_I{}GRP".format(c.upper()), 0)
+        ret |= getattr(stat, f"S_I{c.upper()}GRP", 0)
     for c in others:
-        ret |= getattr(stat, "S_I{}OTH".format(c.upper()), 0)
+        ret |= getattr(stat, f"S_I{c.upper()}OTH", 0)
     return ret
 
 


### PR DESCRIPTION
### What does this PR do?
Allow non-str grain types for autosign grains. Currently the code is very naive and only compares `grain == line`, where `grain` can be any type a grain can be and `line` is a string. The change casts `grain` to a str, which makes it easy to use with e.g. numeric grains. More complex autosign_grains, such as nested dicts, are not really covered (str() is not stable across Python versions afaik). 


### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/61436
Fixes: https://github.com/saltstack/salt/issues/63708

### Previous Behavior
Autosign_grain with a non-str (e.g. numeric/boolean) grain does not work (never matches the contents of a file in /etc/autosign_grains/).

### New Behavior
Autosign_grain with a non-str (e.g. numeric/boolean) grain works.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
