### PR TITLE
[3006.x] Move salt.ufw to correct location /etc/ufw/applications.d/

### DIFF
--- a/changelog/64572.fixed.md
+++ b/changelog/64572.fixed.md
@@ -1,0 +1,1 @@
+Move salt.ufw to correct location /etc/ufw/applications.d/

--- a/pkg/debian/salt-master.dirs
+++ b/pkg/debian/salt-master.dirs
@@ -1,5 +1,4 @@
 /etc/salt/master.d
-/etc/ufw/applications.d/salt-master
 /etc/salt/pki/master/minions
 /etc/salt/pki/master/minions_autosign
 /etc/salt/pki/master/minions_denied

--- a/pkg/debian/salt-master.install
+++ b/pkg/debian/salt-master.install
@@ -1,2 +1,2 @@
 pkg/common/salt-master.service /lib/systemd/system
-pkg/common/salt.ufw /etc/ufw/applications.d/salt-master
+pkg/common/salt.ufw /etc/ufw/applications.d

--- a/pkg/debian/salt-master.install
+++ b/pkg/debian/salt-master.install
@@ -1,2 +1,2 @@
 pkg/common/salt-master.service /lib/systemd/system
-pkg/common/salt.ufw /etc/ufw/applications.d
+pkg/common/salt.ufw /etc/ufw/applications.d/salt-master

--- a/pkg/tests/integration/test_salt_ufw.py
+++ b/pkg/tests/integration/test_salt_ufw.py
@@ -14,8 +14,6 @@ def test_salt_ufw(salt_master, salt_call_cli, install_salt):
     """
     Test salt.ufw for Debian/Ubuntu salt-master
     """
-    log.warning(f"DGM test_salt_ufw install_salt '{install_salt}'")
-
     if install_salt.distro_id not in ("debian", "ubuntu"):
         pytest.skip("Only tests Debian / Ubuntu packages")
 
@@ -24,10 +22,3 @@ def test_salt_ufw(salt_master, salt_call_cli, install_salt):
 
     ufw_master_path = pathlib.Path("/etc/ufw/applications.d/salt-master")
     assert ufw_master_path.exists()
-
-    etc_ufw_path = pathlib.Path("/etc/ufw/applications.d")
-    str_etc_ufw_path = str(etc_ufw_path)
-    log.warning(f"DGM test_salt_ufw etc ufw contents '{etc_ufw_path}'")
-    ret = salt_call_cli.run("--local", "cmd.run", f"ls -alh {etc_ufw_path}/")
-    log.warning(f"DGM test_salt_ufw etc ufw contents, ls -alh file, returned '{ret}'")
-    assert ret.returncode == 0

--- a/pkg/tests/integration/test_salt_ufw.py
+++ b/pkg/tests/integration/test_salt_ufw.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 
 
 @pytest.mark.skip_on_windows()
-def test_salt_ufw(salt_master, install_salt):
+def test_salt_ufw(salt_master, salt_call_cli, install_salt):
     """
     Test salt.ufw for Debian/Ubuntu salt-master
     """
@@ -19,12 +19,38 @@ def test_salt_ufw(salt_master, install_salt):
     if install_salt.distro_id not in ("debian", "ubuntu"):
         pytest.skip("Only tests Debian / Ubuntu packages")
 
-    pkg = [x for x in install_salt.pkgs if "deb" in x]
+    pkg = [x for x in install_salt.pkgs if "deb" in x and "master" in x]
     if not pkg:
         pytest.skip("Not testing deb packages")
-    pkg = pkg[0].split("/")[-1]
-    if "rc" not in pkg:
-        pytest.skip("Not testing an RC package")
+    pkg_master = pkg[0]
 
-    ufw_master_path = Path("/etc/ufw/applications.d/salt-master")
-    assert ufw_master_path.is_file()
+    pkg = [x for x in install_salt.pkgs if "deb" in x and "common" in x]
+    if not pkg:
+        pytest.skip("Not testing deb packages")
+    pkg_common = pkg[0]
+    log.warning(f"DGM test_salt_ufw pkg_common '{pkg_common}'")
+
+    pkg_mngr = install_salt.pkg_mngr
+    log.warning(
+        f"DGM test_salt_ufw pkg_mngr '{pkg_mngr}', pkg_common '{pkg_common}', pkg_master '{pkg_master}'"
+    )
+
+    install_common_cmd = f"{pkg_mngr} -y install {pkg_common}"
+    install_master_cmd = f"{pkg_mngr} -y install {pkg_master}"
+    ## ret = salt_call_cli.run("--local", "cmd.run", pkg_mngr, "-y", "install", pkg_to_install)
+    ret = salt_call_cli.run("--local", "cmd.run", install_common_cmd)
+    log.warning(f"DGM test_salt_ufw salt_common post install '{ret}'")
+    assert ret.returncode == 0
+
+    ret = salt_call_cli.run("--local", "cmd.run", install_master_cmd)
+    log.warning(f"DGM test_salt_ufw salt_master post install '{ret}'")
+    assert ret.returncode == 0
+
+    ufw_master_path = pathlib.Path("/etc/ufw/applications.d/salt-master")
+    assert ufw_master_path.exists()
+
+    # cleanup
+    remove_cmd = f"{pkg_mngr} -y remove salt-common"
+    ret = salt_call_cli.run("--local", "cmd.run", remove_cmd)
+    log.warning(f"DGM test_salt_ufw salt_master post remove '{ret}'")
+    assert ret.returncode == 0

--- a/pkg/tests/integration/test_salt_ufw.py
+++ b/pkg/tests/integration/test_salt_ufw.py
@@ -20,7 +20,8 @@ def test_salt_ufw(salt_master, salt_call_cli, install_salt):
     # check that the salt_master is running
     assert salt_master.is_running()
 
-    ufw_master_path = pathlib.Path("/etc/ufw/applications.d/salt-master")
+    ## ufw_master_path = pathlib.Path("/etc/ufw/applications.d/salt-master")
+    ufw_master_path = pathlib.Path("/etc/ufw/applications.d/salt.ufw")
     assert ufw_master_path.exists()
     assert ufw_master_path.is_file()
 

--- a/pkg/tests/integration/test_salt_ufw.py
+++ b/pkg/tests/integration/test_salt_ufw.py
@@ -1,9 +1,6 @@
-import os.path
 import pathlib
-import subprocess
 
 import pytest
-from pytestskipmarkers.utils import platform
 
 
 @pytest.mark.skip_on_windows

--- a/pkg/tests/integration/test_salt_ufw.py
+++ b/pkg/tests/integration/test_salt_ufw.py
@@ -33,6 +33,7 @@ def test_salt_ufw(salt_master, salt_call_cli, install_salt):
 Title: salt
 Description: fast and powerful configuration management and remote
 execution
+
 Ports:
   4505,4506/tcp"""
     ufw_info_cmd = "/usr/sbin/ufw app info Salt"

--- a/pkg/tests/integration/test_salt_ufw.py
+++ b/pkg/tests/integration/test_salt_ufw.py
@@ -1,0 +1,30 @@
+import logging
+import os.path
+import pathlib
+import subprocess
+
+import pytest
+from pytestskipmarkers.utils import platform
+
+log = logging.getLogger(__name__)
+
+
+@pytest.mark.skip_on_windows()
+def test_salt_ufw(salt_master, install_salt):
+    """
+    Test salt.ufw for Debian/Ubuntu salt-master
+    """
+    log.warning(f"DGM test_salt_ufw install_salt '{install_salt}'")
+
+    if install_salt.distro_id not in ("debian", "ubuntu"):
+        pytest.skip("Only tests Debian / Ubuntu packages")
+
+    pkg = [x for x in install_salt.pkgs if "deb" in x]
+    if not pkg:
+        pytest.skip("Not testing deb packages")
+    pkg = pkg[0].split("/")[-1]
+    if "rc" not in pkg:
+        pytest.skip("Not testing an RC package")
+
+    ufw_master_path = Path("/etc/ufw/applications.d/salt-master")
+    assert ufw_master_path.is_file()

--- a/pkg/tests/integration/test_salt_ufw.py
+++ b/pkg/tests/integration/test_salt_ufw.py
@@ -43,4 +43,4 @@ Ports:
 
         ufw_info_cmd = "/usr/sbin/ufw app info Salt"
         ret = salt_call_cli.run("--local", "cmd.run", ufw_info_cmd)
-        assert ret.data == expected_info
+        assert expected_info in ret.data

--- a/pkg/tests/integration/test_salt_ufw.py
+++ b/pkg/tests/integration/test_salt_ufw.py
@@ -19,38 +19,15 @@ def test_salt_ufw(salt_master, salt_call_cli, install_salt):
     if install_salt.distro_id not in ("debian", "ubuntu"):
         pytest.skip("Only tests Debian / Ubuntu packages")
 
-    pkg = [x for x in install_salt.pkgs if "deb" in x and "master" in x]
-    if not pkg:
-        pytest.skip("Not testing deb packages")
-    pkg_master = pkg[0]
-
-    pkg = [x for x in install_salt.pkgs if "deb" in x and "common" in x]
-    if not pkg:
-        pytest.skip("Not testing deb packages")
-    pkg_common = pkg[0]
-    log.warning(f"DGM test_salt_ufw pkg_common '{pkg_common}'")
-
-    pkg_mngr = install_salt.pkg_mngr
-    log.warning(
-        f"DGM test_salt_ufw pkg_mngr '{pkg_mngr}', pkg_common '{pkg_common}', pkg_master '{pkg_master}'"
-    )
-
-    install_common_cmd = f"{pkg_mngr} -y install {pkg_common}"
-    install_master_cmd = f"{pkg_mngr} -y install {pkg_master}"
-    ## ret = salt_call_cli.run("--local", "cmd.run", pkg_mngr, "-y", "install", pkg_to_install)
-    ret = salt_call_cli.run("--local", "cmd.run", install_common_cmd)
-    log.warning(f"DGM test_salt_ufw salt_common post install '{ret}'")
-    assert ret.returncode == 0
-
-    ret = salt_call_cli.run("--local", "cmd.run", install_master_cmd)
-    log.warning(f"DGM test_salt_ufw salt_master post install '{ret}'")
-    assert ret.returncode == 0
+    # check that the salt_master is running
+    assert salt_master.is_running()
 
     ufw_master_path = pathlib.Path("/etc/ufw/applications.d/salt-master")
     assert ufw_master_path.exists()
 
-    # cleanup
-    remove_cmd = f"{pkg_mngr} -y remove salt-common"
-    ret = salt_call_cli.run("--local", "cmd.run", remove_cmd)
-    log.warning(f"DGM test_salt_ufw salt_master post remove '{ret}'")
+    etc_ufw_path = pathlib.Path("/etc/ufw/applications.d")
+    str_etc_ufw_path = str(etc_ufw_path)
+    log.warning(f"DGM test_salt_ufw etc ufw contents '{etc_ufw_path}'")
+    ret = salt_call_cli.run("--local", "cmd.run", f"ls -alh {etc_ufw_path}/")
+    log.warning(f"DGM test_salt_ufw etc ufw contents, ls -alh file, returned '{ret}'")
     assert ret.returncode == 0

--- a/pkg/tests/integration/test_salt_ufw.py
+++ b/pkg/tests/integration/test_salt_ufw.py
@@ -22,16 +22,18 @@ def test_salt_ufw(salt_master, salt_call_cli, install_salt):
     assert ufw_master_path.exists()
     assert ufw_master_path.is_file()
 
-    ufw_list_cmd = "/usr/sbin/ufw app list"
-    ret = salt_call_cli.run("--local", "cmd.run", ufw_list_cmd)
-    assert "Available applications" in ret.stdout
-    assert "Salt" in ret.stdout
+    ufw_cmd_path = pathlib.Path("/usr/sbin/ufw")
+    if ufw_cmd_path.exists():
+        ufw_list_cmd = "/usr/sbin/ufw app list"
+        ret = salt_call_cli.run("--local", "cmd.run", ufw_list_cmd)
+        assert "Available applications" in ret.stdout
+        assert "Salt" in ret.stdout
 
-    ufw_upd_cmd = "/usr/sbin/ufw app update Salt"
-    ret = salt_call_cli.run("--local", "cmd.run", ufw_upd_cmd)
-    assert ret.returncode == 0
+        ufw_upd_cmd = "/usr/sbin/ufw app update Salt"
+        ret = salt_call_cli.run("--local", "cmd.run", ufw_upd_cmd)
+        assert ret.returncode == 0
 
-    expected_info = """Profile: Salt
+        expected_info = """Profile: Salt
 Title: salt
 Description: fast and powerful configuration management and remote
 execution
@@ -39,6 +41,6 @@ execution
 Ports:
   4505,4506/tcp"""
 
-    ufw_info_cmd = "/usr/sbin/ufw app info Salt"
-    ret = salt_call_cli.run("--local", "cmd.run", ufw_info_cmd)
-    assert ret.data == expected_info
+        ufw_info_cmd = "/usr/sbin/ufw app info Salt"
+        ret = salt_call_cli.run("--local", "cmd.run", ufw_info_cmd)
+        assert ret.data == expected_info

--- a/pkg/tests/integration/test_salt_ufw.py
+++ b/pkg/tests/integration/test_salt_ufw.py
@@ -1,12 +1,9 @@
-import logging
 import os.path
 import pathlib
 import subprocess
 
 import pytest
 from pytestskipmarkers.utils import platform
-
-log = logging.getLogger(__name__)
 
 
 @pytest.mark.skip_on_windows()
@@ -25,21 +22,23 @@ def test_salt_ufw(salt_master, salt_call_cli, install_salt):
     assert ufw_master_path.exists()
     assert ufw_master_path.is_file()
 
-    ls_cmd = "ls -alhrt /etc/ufw/applications.d/"
-    ret = salt_call_cli.run("--local", "cmd.run", ls_cmd)
-    log.warning(f"DGM test_salt_ufw  ls cmd ret '{ret}'")
-
-    cat_cmd = "cat /etc/ufw/applications.d/salt-master"
-    ret = salt_call_cli.run("--local", "cmd.run", cat_cmd)
-    log.warning(f"DGM test_salt_ufw  cat cmd ret '{ret}'")
-
     ufw_list_cmd = "/usr/sbin/ufw app list"
     ret = salt_call_cli.run("--local", "cmd.run", ufw_list_cmd)
-    log.warning(f"DGM test_salt_ufw  list ret '{ret}'")
+    assert "Available applications" in ret.stdout
+    assert "Salt" in ret.stdout
 
     ufw_upd_cmd = "/usr/sbin/ufw app update Salt"
     ret = salt_call_cli.run("--local", "cmd.run", ufw_upd_cmd)
-    log.warning(f"DGM test_salt_ufw  update ret '{ret}'")
+    assert ret.returncode == 0
+
+    expected_info = """Profile: Salt
+Title: salt
+Description: fast and powerful configuration management and remote
+execution
+
+Ports:
+  4505,4506/tcp"""
 
     ufw_info_cmd = "/usr/sbin/ufw app info Salt"
     ret = salt_call_cli.run("--local", "cmd.run", ufw_info_cmd)
+    assert ret.data == expected_info

--- a/pkg/tests/integration/test_salt_ufw.py
+++ b/pkg/tests/integration/test_salt_ufw.py
@@ -22,3 +22,23 @@ def test_salt_ufw(salt_master, salt_call_cli, install_salt):
 
     ufw_master_path = pathlib.Path("/etc/ufw/applications.d/salt-master")
     assert ufw_master_path.exists()
+    assert ufw_master_path.is_file()
+
+    ls_cmd = "ls -alhrt /etc/ufw/applications.d/"
+    ret = salt_call_cli.run("--local", "cmd.run", ls_cmd)
+    log.warning(f"DGM test_salt_ufw  ls cmd ret '{ret}'")
+
+    cat_cmd = "cat /etc/ufw/applications.d/salt-master"
+    ret = salt_call_cli.run("--local", "cmd.run", cat_cmd)
+    log.warning(f"DGM test_salt_ufw  cat cmd ret '{ret}'")
+
+    ufw_list_cmd = "/usr/sbin/ufw app list"
+    ret = salt_call_cli.run("--local", "cmd.run", ufw_list_cmd)
+    log.warning(f"DGM test_salt_ufw  list ret '{ret}'")
+
+    ufw_upd_cmd = "/usr/sbin/ufw app update Salt"
+    ret = salt_call_cli.run("--local", "cmd.run", ufw_upd_cmd)
+    log.warning(f"DGM test_salt_ufw  update ret '{ret}'")
+
+    ufw_info_cmd = "/usr/sbin/ufw app info Salt"
+    ret = salt_call_cli.run("--local", "cmd.run", ufw_info_cmd)


### PR DESCRIPTION
### What does this PR do?
Move salt.ufw to correct location ```/etc/ufw/applications.d/``` and not ```/etc/ufw/applications.d/salt-master``` which has been done for almost a decade, as stated in salt.ufw 
```
# Install into /etc/ufw/applications.d/ and run 'ufw app update' to add salt
# firewall rules to systems with UFW.  Activate with 'ufw allow salt'
```

### What issues does this PR fix or reference?
Fixes:https://github.com/saltstack/salt/issues/64572

### Previous Behavior
Placed salt.ufw in directory  ```/etc/ufw/applications.d/salt-master```

### New Behavior
Correctly places salt.ufw in directory  ```/etc/ufw/applications.d```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
