### PR TITLE
[master] Write hardcoded salt version before building when running "setup.py --with-salt-version=xxxx"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -595,6 +595,10 @@ HOME_DIR = {home_dir!r}
 
 class Build(build):
     def run(self):
+        if getattr(self.distribution, "with_salt_version", False):
+            self.distribution.salt_version_hardcoded_path = SALT_VERSION_HARDCODED
+            self.run_command("write_salt_version")
+
         # Run build.run function
         build.run(self)
         salt_build_ver_file = os.path.join(self.build_lib, "salt", "_version.txt")


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue we detected when building Salt with `setup.py` script and making use of `--with-salt-version` parameter to hardcode an specific Salt version:

```console
# python3 setup.py --with-salt-version=9999 build
# python3 setup.py --with-salt-version=9999 install
```

After running the above commands, the generated "egg-info" metadata for the built package is not reflecting the specified version but instead it is calculating it without respecting what it was provided via `--with-salt-version` parameter:

```console
# cat salt.egg-info/PKG-INFO | grep ^Version
Version: 3006.2+1103.g2cc6113338
```

### Previous Behavior

As mentioned, I got a different version than the specified:

```console
# python3 setup.py --with-salt-version=9999 build
...
# python3 setup.py --with-salt-version=9999 install
...
Finished processing dependencies for salt==3006.2+1103.g2cc6113338
# cat salt.egg-info/PKG-INFO | grep ^Version
Version: 3006.2+1103.g2cc6113338
``` 

### New Behavior

After this PR, I get the expected version in the generated egg-info:

```console
# python3 setup.py --with-salt-version=9999 build
...
# python3 setup.py --with-salt-version=9999 install
...
Finished processing dependencies for salt==9999.0
# cat salt.egg-info/PKG-INFO | grep ^Version
Version: 9999.0
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes