### PR TITLE
[master] Add execution and state modules to manage Grafana via `grafana-cli`

### DIFF
--- a/changelog/65249.added.md
+++ b/changelog/65249.added.md
@@ -1,0 +1,1 @@
+Added execution and state modules for managing Grafana via grafana-cli.

--- a/salt/modules/grafana_cli.py
+++ b/salt/modules/grafana_cli.py
@@ -153,3 +153,40 @@ def plugins_get_latest_version(name, repo=None, user=None):
     latest_version = result["stdout"].split("\n")[0]
 
     return {"retcode": 0, "version": latest_version}
+
+
+def plugins_get_status(name, plugins_dir=None, user=None):
+    """
+    Get the status of the plugin.
+
+    :param str name:
+        The ID of the plugin.
+
+    :param str plugins_dir:
+        Overrides the path to where your local Grafana instance stores plugins.
+
+    :param str user:
+        User name under which to run the grafana-cli command. By default, the command is run by the
+        user under which the minion is running.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' grafana_cli.plugins_get_status foo
+    """
+    result = plugins_ls(plugins_dir=plugins_dir, user=user)
+
+    if result["retcode"] != 0:
+        return result
+
+    plugins = result["stdout"].split("\n")[1:]
+
+    for plugin in plugins:
+        plugin_name = plugin.split("@")[0].strip()
+        plugin_version = plugin.split("@")[1].strip()
+
+        if name == plugin_name:
+            return {"retcode": 0, "installed": True, "version": plugin_version}
+
+    return {"retcode": 0, "installed": False, "version": None}

--- a/salt/modules/grafana_cli.py
+++ b/salt/modules/grafana_cli.py
@@ -40,6 +40,8 @@ def _prepare_cmd(binary="grafana-cli", command=None, options=None, arguments=Non
     for option, value in options.items():
         if option == "plugins_dir" and value is not None:
             cmd += ("--pluginsDir", value)
+        if option == "repo" and value is not None:
+            cmd += ("--repo", value)
 
     if command is not None:
         cmd += (command,)
@@ -91,5 +93,32 @@ def plugins_ls(plugins_dir=None, user=None):
     """
     options = {"plugins_dir": plugins_dir}
     arguments = ("ls",)
+
+    return _run_cmd(command="plugins", options=options, arguments=arguments, user=user)
+
+
+def plugins_list_versions(name, repo=None, user=None):
+    """
+    Interface with `grafana-cli plugins list-versions`.
+
+    :param str name:
+        The ID of the plugin.
+
+    :param str repo:
+        Allows you to download and install or update plugins from a repository other than the
+        default Grafana repo.
+
+    :param str user:
+        User name under which to run the grafana-cli command. By default, the command is run by the
+        user under which the minion is running.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' grafana_cli.plugins_list_versions foo
+    """
+    options = {"repo": repo}
+    arguments = ("list-versions", name)
 
     return _run_cmd(command="plugins", options=options, arguments=arguments, user=user)

--- a/salt/modules/grafana_cli.py
+++ b/salt/modules/grafana_cli.py
@@ -1,0 +1,95 @@
+"""
+Interface with `grafana-cli`.
+"""
+
+import logging
+
+import salt
+from salt.exceptions import CommandExecutionError
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    """
+    Only load if grafana-cli exists on the system.
+    """
+    if salt.utils.path.which("grafana-cli") is None:
+        return (
+            False,
+            "The grafana_cli execution module cannot be loaded: grafana-cli unavailable.",
+        )
+    else:
+        return True
+
+
+def _prepare_cmd(binary="grafana-cli", command=None, options=None, arguments=None):
+    """
+    Prepare a command to be run by Salt's cmd.run.
+
+    :param str binary:
+    :param str command:
+    :param dict options:
+    :param tuple arguments:
+    """
+    cmd = (binary,)
+
+    if options is None:
+        options = {}
+
+    for option, value in options.items():
+        if option == "plugins_dir" and value is not None:
+            cmd += ("--pluginsDir", value)
+
+    if command is not None:
+        cmd += (command,)
+
+    if arguments is not None:
+        cmd += arguments
+
+    return cmd
+
+
+def _run_cmd(command=None, options=None, arguments=None, user=None):
+    """
+    Run the grafana-cli command.
+
+    :param str command:
+    :param dict options:
+    :param tuple arguments:
+    :param str user:
+    """
+    cmd = _prepare_cmd(command=command, options=options, arguments=arguments)
+    cmd_string = " ".join(cmd)
+
+    try:
+        result = __salt__["cmd.run_all"](cmd=cmd, runas=user)
+        result.update({"cmd": cmd_string})
+    except CommandExecutionError as err:
+        result = {"retcode": 1, "stdout": err, "cmd": cmd_string}
+        log.error(result)
+
+    return result
+
+
+def plugins_ls(plugins_dir=None, user=None):
+    """
+    Interface with `grafana-cli plugins ls`.
+
+    :param str plugins_dir:
+        Overrides the path to where your local Grafana instance stores plugins.
+
+    :param str user:
+        User name under which to run the grafana-cli command. By default, the command is run by the
+        user under which the minion is running.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' grafana_cli.plugins_ls
+    """
+    options = {"plugins_dir": plugins_dir}
+    arguments = ("ls",)
+
+    return _run_cmd(command="plugins", options=options, arguments=arguments, user=user)

--- a/salt/modules/grafana_cli.py
+++ b/salt/modules/grafana_cli.py
@@ -311,3 +311,42 @@ def plugins_install(name, version=None, plugins_dir=None, repo=None, user=None):
         "old": check_result["old_version"],
         "new": check_result["new_version"],
     }
+
+
+def plugins_remove(name, plugins_dir=None, user=None):
+    """
+    Interface with `grafana-cli plugins remove`.
+
+    :param str name:
+        The ID of the plugin.
+
+    :param str plugins_dir:
+        Overrides the path to where your local Grafana instance stores plugins.
+
+    :param str user:
+        User name under which to run the grafana-cli command. By default, the command is run by the
+        user under which the minion is running.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' grafana_cli.plugins_remove foo
+    """
+    get_status_result = plugins_get_status(name, plugins_dir=plugins_dir, user=user)
+
+    if get_status_result["retcode"] != 0:
+        return result
+
+    if not get_status_result["installed"]:
+        return {"retcode": 0, "result": False, "old": None, "new": None}
+
+    options = {"plugins_dir": plugins_dir}
+    arguments = ("remove", name)
+
+    result = _run_cmd(command="plugins", options=options, arguments=arguments, user=user)
+
+    if result["retcode"] != 0:
+        return result
+
+    return {"retcode": 0, "result": True, "old": get_status_result["version"], "new": None}

--- a/salt/modules/grafana_cli.py
+++ b/salt/modules/grafana_cli.py
@@ -122,3 +122,34 @@ def plugins_list_versions(name, repo=None, user=None):
     arguments = ("list-versions", name)
 
     return _run_cmd(command="plugins", options=options, arguments=arguments, user=user)
+
+
+def plugins_get_latest_version(name, repo=None, user=None):
+    """
+    Get latest version of a plugin.
+
+    :param str name:
+        The ID of the plugin.
+
+    :param str repo:
+        Allows you to download and install or update plugins from a repository other than the
+        default Grafana repo.
+
+    :param str user:
+        User name under which to run the grafana-cli command. By default, the command is run by the
+        user under which the minion is running.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' grafana_cli.plugins_get_latest_version foo
+    """
+    result = plugins_list_versions(name, repo=repo, user=user)
+
+    if result["retcode"] != 0:
+        return result
+
+    latest_version = result["stdout"].split("\n")[0]
+
+    return {"retcode": 0, "version": latest_version}

--- a/salt/states/grafana_cli.py
+++ b/salt/states/grafana_cli.py
@@ -1,0 +1,154 @@
+"""
+Manage Grafana using grafana-cli.
+"""
+
+
+def __virtual__():
+    """
+    Only load if grafana_cli is available.
+    """
+    if "grafana_cli.plugins_ls" not in __salt__:
+        return (False, "grafana_cli module could not be loaded")
+    else:
+        return True
+
+
+def plugin_installed(
+    name, version=None, plugins=None, plugins_dir=None, repo=None, user=None
+):
+    """
+    Ensure that a plugin is installed, and that it is in the correct version (if specified).
+
+    :param str name:
+        The ID of the plugin to be installed. This parameter is ignored if ``plugins`` is used.
+
+    :param str version:
+        Install a specific version of a plugin. This option is ignored if ``plugins`` is used.
+
+        Example:
+
+        ... code-block:: yaml
+
+            myplugin:
+              grafana_cli.plugin_installed:
+                - version: 2.2.0
+
+    :param list plugins:
+        A list of plugins to install. Version numbers can be specified.
+        All plugins listed under ``plugins`` will be installed via a single command.
+
+        Example:
+
+        ... code-block:: yaml
+
+            myplugins:
+              grafana-cli.plugin_installed:
+                - plugins:
+                  - foo
+                  - bar: 1.3.0
+                  - baz
+
+    :param str plugins_dir:
+        Overrides the path to where your local Grafana instance stores plugins.
+
+    :param str repo:
+        Allows you to download and install or update plugins from a repository other than the
+        default Grafana repo.
+
+    :param str user:
+        User name under which to run the grafana-cli command. By default, the command is run by the
+        user under which the minion is running.
+    """
+    if isinstance(plugins, list) and len(plugins) == 0:
+        return {
+            "name": name,
+            "result": True,
+            "changes": {},
+            "comment": "No plugins to install provided",
+        }
+
+    if plugins is None:
+        plugins = [{"name": name, "version": version}]
+
+    ret = {"name": name, "result": True, "changes": {}, "comment": ""}
+
+    changes = {}
+    messages = []
+    newly_installed = []
+    already_installed = []
+
+    for plugin in plugins:
+        if isinstance(plugin, str):
+            plugin = {"name": plugin, "version": None}
+
+        result = __salt__["grafana_cli.plugins_install_check"](
+            plugin["name"], plugins_dir=plugins_dir, repo=repo, user=user, version=plugin["version"]
+        )
+
+        if result["retcode"] != 0:
+            ret["result"] = False
+            messages.append(result["stdout"])
+            break
+
+        if not result["to_install"]:
+            already_installed.append(plugin["name"])
+            continue
+
+        changes[plugin["name"]] = "{0} -> {1}".format(result["old_version"], result["new_version"])
+
+        if __opts__["test"]:
+            ret["result"] = None
+            newly_installed.append(plugin["name"])
+            continue
+
+        result = __salt__["grafana_cli.plugins_install"](
+            plugin["name"], plugins_dir=plugins_dir, repo=repo, user=user, version=plugin["version"]
+        )
+
+        if result["retcode"] != 0:
+            ret["result"] = False
+            messages.append(result["stdout"])
+            break
+
+        result = __salt__["grafana_cli.plugins_install_check"](
+            plugin["name"], plugins_dir=plugins_dir, repo=repo, user=user, version=plugin["version"]
+        )
+
+        if result["retcode"] != 0:
+            ret["result"] = False
+            messages.append(result["stdout"])
+            break
+
+        if not result["to_install"]:
+            newly_installed.append(plugin["name"])
+        else:
+            ret["result"] = False
+            messages.append("{0} failed to install".format(plugin["name"]))
+            break
+
+    ret["changes"] = changes
+
+    if len(newly_installed) > 0:
+        newly_installed.sort()
+
+        if __opts__["test"]:
+            ret["comment"] += "The following plugins would be installed:\n"
+        else:
+            ret["comment"] += "The following plugins have been installed:\n"
+
+        for x in newly_installed:
+            ret["comment"] += "  - {0}\n".format(x)
+
+    if len(already_installed) > 0:
+        already_installed.sort()
+
+        ret["comment"] += "The following plugins are already installed:\n"
+
+        for x in already_installed:
+            ret["comment"] += "  - {0}\n".format(x)
+
+    if len(messages) > 0:
+        ret["comment"] += "Messages:\n"
+        ret["comment"] += "\n".join(messages)
+
+    return ret


### PR DESCRIPTION
### What does this PR do?

Adds execution and state modules for managing Grafana via `grafana-cli`.

The interfacing with `grafana-cli` is not complete. As a start I just added support for a few basic things that allow installing and removing plugins. Support for more stuff can be added in the future when required.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes