### PR TITLE
[master] Fix optimization_order opt to prevent test fails

### DIFF
--- a/changelog/65266.fixed.md
+++ b/changelog/65266.fixed.md
@@ -1,0 +1,1 @@
+Put default `optimization_order` to LazyLoader to prevent possible fails on testing

--- a/salt/loader/lazy.py
+++ b/salt/loader/lazy.py
@@ -303,6 +303,8 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                 opts[i], salt.loader.context.NamedLoaderContext
             ):
                 opts[i] = opts[i].value()
+        if "optimization_order" not in opts:
+            opts["optimization_order"] = [0, 1, 2]
         threadsafety = not opts.get("multiprocessing")
         self.opts = self.__prep_mod_opts(opts)
         self.pack_self = pack_self

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -158,7 +158,7 @@ def test_network_grains_secondary_ip(tmp_path):
     opts = {
         "cachedir": str(cache_dir),
         "extension_modules": str(extmods),
-        "optimization_order": [0],
+        "optimization_order": [0, 1, 2],
     }
     with patch("salt.utils.network.interfaces", side_effect=[data]):
         grains = salt.loader.grain_funcs(opts)
@@ -254,7 +254,7 @@ def test_network_grains_cache(tmp_path):
     opts = {
         "cachedir": str(cache_dir),
         "extension_modules": str(extmods),
-        "optimization_order": [0],
+        "optimization_order": [0, 1, 2],
     }
     with patch(
         "salt.utils.network.interfaces", side_effect=[call_1, call_2]

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -158,7 +158,6 @@ def test_network_grains_secondary_ip(tmp_path):
     opts = {
         "cachedir": str(cache_dir),
         "extension_modules": str(extmods),
-        "optimization_order": [0, 1, 2],
     }
     with patch("salt.utils.network.interfaces", side_effect=[data]):
         grains = salt.loader.grain_funcs(opts)
@@ -254,7 +253,6 @@ def test_network_grains_cache(tmp_path):
     opts = {
         "cachedir": str(cache_dir),
         "extension_modules": str(extmods),
-        "optimization_order": [0, 1, 2],
     }
     with patch(
         "salt.utils.network.interfaces", side_effect=[call_1, call_2]

--- a/tests/pytests/unit/loader/test_loader.py
+++ b/tests/pytests/unit/loader/test_loader.py
@@ -59,7 +59,7 @@ def test_raw_mod_functions():
     "Ensure functions loaded by raw_mod are LoaderFunc instances"
     opts = {
         "extension_modules": "",
-        "optimization_order": [0],
+        "optimization_order": [0, 1, 2],
     }
     ret = salt.loader.raw_mod(opts, "grains", "get")
     for k, v in ret.items():

--- a/tests/pytests/unit/loader/test_loader.py
+++ b/tests/pytests/unit/loader/test_loader.py
@@ -59,7 +59,6 @@ def test_raw_mod_functions():
     "Ensure functions loaded by raw_mod are LoaderFunc instances"
     opts = {
         "extension_modules": "",
-        "optimization_order": [0, 1, 2],
     }
     ret = salt.loader.raw_mod(opts, "grains", "get")
     for k, v in ret.items():
@@ -67,9 +66,7 @@ def test_raw_mod_functions():
 
 
 def test_named_loader_context_name_not_packed(tmp_path):
-    opts = {
-        "optimization_order": [0],
-    }
+    opts = {}
     contents = """
     from salt.loader.dunder import loader_context
     __not_packed__ = loader_context.named_context("__not_packed__")

--- a/tests/pytests/unit/test_config.py
+++ b/tests/pytests/unit/test_config.py
@@ -20,7 +20,7 @@ def test_call_id_function(tmp_path):
         "cachedir": str(cache_dir),
         "extension_modules": str(extmods),
         "grains": {"osfinger": "meh"},
-        "optimization_order": [0],
+        "optimization_order": [0, 1, 2],
     }
     ret = salt.config.call_id_function(opts)
     assert ret == "meh"

--- a/tests/pytests/unit/test_config.py
+++ b/tests/pytests/unit/test_config.py
@@ -20,7 +20,6 @@ def test_call_id_function(tmp_path):
         "cachedir": str(cache_dir),
         "extension_modules": str(extmods),
         "grains": {"osfinger": "meh"},
-        "optimization_order": [0, 1, 2],
     }
     ret = salt.config.call_id_function(opts)
     assert ret == "meh"


### PR DESCRIPTION
### What does this PR do?

Some tests contains incomplete list of `optimization_order` opt what can cause fails on running these tests when having optimized compiled `pyc` files for the modules.

### Previous Behavior
Possible test fails if there are `pyc` files in place.

### New Behavior
Normal test runs

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
