### PR TITLE
[freeze] Bump to `cryptography==41.0.4` due to https://github.com/advisories/GHSA-v8gr-m533-ghj9

### DIFF
--- a/changelog/65267.security
+++ b/changelog/65267.security
@@ -1,0 +1,1 @@
+Bump to `cryptography==41.0.4` due to https://github.com/advisories/GHSA-v8gr-m533-ghj9

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -383,7 +383,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -386,7 +386,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/darwin.txt
     #   adal

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -390,7 +390,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -382,7 +382,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   adal

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -388,7 +388,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -396,7 +396,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -73,7 +73,7 @@ colorama==0.4.1
     # via pytest
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==39.0.1
+cryptography==41.0.4
     # via
     #   -r requirements/static/pkg/py3.10/windows.txt
     #   moto

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -390,7 +390,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.7/docs.txt
+++ b/requirements/static/ci/py3.7/docs.txt
@@ -399,7 +399,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -389,7 +389,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   adal

--- a/requirements/static/ci/py3.7/lint.txt
+++ b/requirements/static/ci/py3.7/lint.txt
@@ -397,7 +397,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -403,7 +403,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -74,7 +74,7 @@ colorama==0.4.1
     # via pytest
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/windows.txt
     #   etcd3-py

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -388,7 +388,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.8/docs.txt
+++ b/requirements/static/ci/py3.8/docs.txt
@@ -397,7 +397,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -387,7 +387,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   adal

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -395,7 +395,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -401,7 +401,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -72,7 +72,7 @@ colorama==0.4.1
     # via pytest
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/windows.txt
     #   etcd3-py

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -388,7 +388,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -391,7 +391,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/darwin.txt
     #   adal

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -395,7 +395,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -387,7 +387,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   adal

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -393,7 +393,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -403,7 +403,7 @@ contextvars==2.4
     # via -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/linux.in
     #   adal

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -72,7 +72,7 @@ colorama==0.4.1
     # via pytest
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/windows.txt
     #   etcd3-py

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -18,7 +18,7 @@ cherrypy==18.6.1
     # via -r requirements/darwin.txt
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/darwin.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -20,7 +20,7 @@ cherrypy==18.6.1
     # via -r requirements/windows.txt
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==39.0.1
+cryptography==41.0.4
     # via
     #   -r requirements/windows.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.7/freebsd.txt
+++ b/requirements/static/pkg/py3.7/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.7/linux.txt
+++ b/requirements/static/pkg/py3.7/linux.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -20,7 +20,7 @@ cherrypy==18.6.1
     # via -r requirements/windows.txt
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/windows.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -20,7 +20,7 @@ cherrypy==18.6.1
     # via -r requirements/windows.txt
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/windows.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -18,7 +18,7 @@ cherrypy==18.6.1
     # via -r requirements/darwin.txt
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/darwin.txt
     #   pyopenssl

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/freebsd.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/freebsd.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -16,7 +16,7 @@ cherrypy==18.6.1
     # via -r requirements/static/pkg/linux.in
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/static/pkg/linux.in
     #   pyopenssl

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -20,7 +20,7 @@ cherrypy==18.6.1
     # via -r requirements/windows.txt
 contextvars==2.4
     # via -r requirements/base.txt
-cryptography==41.0.3 ; python_version >= "3.7"
+cryptography==41.0.4 ; python_version >= "3.7"
     # via
     #   -r requirements/windows.txt
     #   pyopenssl


### PR DESCRIPTION
### What does this PR do?
Bump to `cryptography==41.0.4` due to https://github.com/advisories/GHSA-v8gr-m533-ghj9
