### PR TITLE
[3006.x] Set `cgroupns` to `host` to fix the libvirt migration tests.

### DIFF
--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -410,7 +410,7 @@ dnspython==2.1.0
     # via
     #   -r requirements/static/ci/common.in
     #   python-etcd
-docker==6.1.2
+docker==6.1.3
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -410,7 +410,7 @@ dnspython==2.1.0
     # via
     #   -r requirements/static/ci/common.in
     #   python-etcd
-docker==5.0.2
+docker==6.1.2
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in
@@ -625,6 +625,7 @@ oscrypto==1.2.1
 packaging==21.3
     # via
     #   -r requirements/base.txt
+    #   docker
     #   pytest
 paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
     # via
@@ -854,6 +855,7 @@ typing-extensions==4.2.0
 urllib3==1.26.6
     # via
     #   botocore
+    #   docker
     #   kubernetes
     #   python-etcd
     #   requests

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -408,7 +408,7 @@ dnspython==1.16.0
     # via
     #   -r requirements/static/ci/common.in
     #   python-etcd
-docker==6.1.2
+docker==6.1.3
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -408,7 +408,7 @@ dnspython==1.16.0
     # via
     #   -r requirements/static/ci/common.in
     #   python-etcd
-docker==5.0.3
+docker==6.1.2
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -407,7 +407,7 @@ dnspython==1.16.0
     # via
     #   -r requirements/static/ci/common.in
     #   python-etcd
-docker==5.0.3
+docker==6.1.2
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -407,7 +407,7 @@ dnspython==1.16.0
     # via
     #   -r requirements/static/ci/common.in
     #   python-etcd
-docker==6.1.2
+docker==6.1.3
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -411,7 +411,7 @@ dnspython==2.1.0
     # via
     #   -r requirements/static/ci/common.in
     #   python-etcd
-docker==5.0.0
+docker==6.1.2
     # via -r requirements/static/ci/lint.in
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -411,7 +411,7 @@ dnspython==2.1.0
     # via
     #   -r requirements/static/ci/common.in
     #   python-etcd
-docker==6.1.2
+docker==6.1.3
     # via -r requirements/static/ci/lint.in
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in
@@ -626,6 +626,7 @@ packaging==21.3
     # via
     #   -r requirements/base.txt
     #   ansible-core
+    #   docker
 paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
     # via
     #   -r requirements/static/ci/common.in
@@ -832,6 +833,7 @@ tzlocal==3.0
 urllib3==1.26.6
     # via
     #   botocore
+    #   docker
     #   kubernetes
     #   python-etcd
     #   requests

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -421,7 +421,7 @@ dnspython==1.16.0
     # via
     #   -r requirements/static/ci/common.in
     #   python-etcd
-docker==5.0.3
+docker==6.1.2
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -421,7 +421,7 @@ dnspython==1.16.0
     # via
     #   -r requirements/static/ci/common.in
     #   python-etcd
-docker==6.1.2
+docker==6.1.3
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.10/pkgtests.txt
+++ b/requirements/static/ci/py3.10/pkgtests.txt
@@ -29,7 +29,7 @@ distro==1.8.0
     # via
     #   -r requirements/base.txt
     #   pytest-skip-markers
-docker==6.1.2
+docker==6.1.3
     # via -r requirements/static/ci/pkgtests.in
 exceptiongroup==1.1.0
     # via pytest

--- a/requirements/static/ci/py3.10/pkgtests.txt
+++ b/requirements/static/ci/py3.10/pkgtests.txt
@@ -29,7 +29,7 @@ distro==1.8.0
     # via
     #   -r requirements/base.txt
     #   pytest-skip-markers
-docker==5.0.3
+docker==6.1.2
     # via -r requirements/static/ci/pkgtests.in
 exceptiongroup==1.1.0
     # via pytest

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -93,7 +93,7 @@ dnspython==1.16.0
     #   python-etcd
 docker-pycreds==0.4.0
     # via docker
-docker==2.7.0
+docker==6.1.2
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -93,7 +93,7 @@ dnspython==1.16.0
     #   python-etcd
 docker-pycreds==0.4.0
     # via docker
-docker==6.1.2
+docker==6.1.3
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -418,7 +418,7 @@ dnspython==2.1.0
     #   -r requirements/static/ci/common.in
     #   ciscoconfparse
     #   python-etcd
-docker==5.0.2
+docker==6.1.2
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in
@@ -665,6 +665,7 @@ oscrypto==1.2.1
 packaging==21.3
     # via
     #   -r requirements/base.txt
+    #   docker
     #   pytest
 paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
     # via
@@ -917,6 +918,7 @@ typing-extensions==3.10.0.0
 urllib3==1.26.6
     # via
     #   botocore
+    #   docker
     #   kubernetes
     #   python-etcd
     #   requests

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -418,7 +418,7 @@ dnspython==2.1.0
     #   -r requirements/static/ci/common.in
     #   ciscoconfparse
     #   python-etcd
-docker==6.1.2
+docker==6.1.3
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -415,7 +415,7 @@ dnspython==1.16.0
     #   -r requirements/static/ci/common.in
     #   ciscoconfparse
     #   python-etcd
-docker==5.0.3
+docker==6.1.2
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -415,7 +415,7 @@ dnspython==1.16.0
     #   -r requirements/static/ci/common.in
     #   ciscoconfparse
     #   python-etcd
-docker==6.1.2
+docker==6.1.3
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.7/lint.txt
+++ b/requirements/static/ci/py3.7/lint.txt
@@ -421,7 +421,7 @@ dnspython==2.1.0
     #   -r requirements/static/ci/common.in
     #   ciscoconfparse
     #   python-etcd
-docker==5.0.0
+docker==6.1.2
     # via -r requirements/static/ci/lint.in
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.7/lint.txt
+++ b/requirements/static/ci/py3.7/lint.txt
@@ -421,7 +421,7 @@ dnspython==2.1.0
     #   -r requirements/static/ci/common.in
     #   ciscoconfparse
     #   python-etcd
-docker==6.1.2
+docker==6.1.3
     # via -r requirements/static/ci/lint.in
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in
@@ -666,6 +666,7 @@ packaging==21.3
     # via
     #   -r requirements/base.txt
     #   ansible-core
+    #   docker
 paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
     # via
     #   -r requirements/static/ci/common.in
@@ -899,6 +900,7 @@ tzlocal==3.0
 urllib3==1.26.6
     # via
     #   botocore
+    #   docker
     #   kubernetes
     #   python-etcd
     #   requests

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -429,7 +429,7 @@ dnspython==1.16.0
     #   -r requirements/static/ci/common.in
     #   ciscoconfparse
     #   python-etcd
-docker==5.0.3
+docker==6.1.2
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -429,7 +429,7 @@ dnspython==1.16.0
     #   -r requirements/static/ci/common.in
     #   ciscoconfparse
     #   python-etcd
-docker==6.1.2
+docker==6.1.3
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -99,7 +99,7 @@ dnspython==1.16.0
     #   python-etcd
 docker-pycreds==0.4.0
     # via docker
-docker==6.1.2
+docker==6.1.3
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -99,7 +99,7 @@ dnspython==1.16.0
     #   python-etcd
 docker-pycreds==0.4.0
     # via docker
-docker==2.7.0
+docker==6.1.2
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -416,7 +416,7 @@ dnspython==2.1.0
     #   -r requirements/static/ci/common.in
     #   ciscoconfparse
     #   python-etcd
-docker==5.0.2
+docker==6.1.2
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in
@@ -653,6 +653,7 @@ oscrypto==1.2.1
 packaging==21.3
     # via
     #   -r requirements/base.txt
+    #   docker
     #   pytest
 paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
     # via
@@ -899,6 +900,7 @@ typing-extensions==3.10.0.2
 urllib3==1.26.6
     # via
     #   botocore
+    #   docker
     #   kubernetes
     #   python-etcd
     #   requests

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -416,7 +416,7 @@ dnspython==2.1.0
     #   -r requirements/static/ci/common.in
     #   ciscoconfparse
     #   python-etcd
-docker==6.1.2
+docker==6.1.3
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -413,7 +413,7 @@ dnspython==1.16.0
     #   -r requirements/static/ci/common.in
     #   ciscoconfparse
     #   python-etcd
-docker==5.0.3
+docker==6.1.2
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -413,7 +413,7 @@ dnspython==1.16.0
     #   -r requirements/static/ci/common.in
     #   ciscoconfparse
     #   python-etcd
-docker==6.1.2
+docker==6.1.3
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -419,7 +419,7 @@ dnspython==2.1.0
     #   -r requirements/static/ci/common.in
     #   ciscoconfparse
     #   python-etcd
-docker==6.1.2
+docker==6.1.3
     # via -r requirements/static/ci/lint.in
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in
@@ -657,6 +657,7 @@ packaging==21.3
     # via
     #   -r requirements/base.txt
     #   ansible-core
+    #   docker
 paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
     # via
     #   -r requirements/static/ci/common.in
@@ -880,6 +881,7 @@ tzlocal==3.0
 urllib3==1.26.6
     # via
     #   botocore
+    #   docker
     #   kubernetes
     #   python-etcd
     #   requests

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -419,7 +419,7 @@ dnspython==2.1.0
     #   -r requirements/static/ci/common.in
     #   ciscoconfparse
     #   python-etcd
-docker==5.0.0
+docker==6.1.2
     # via -r requirements/static/ci/lint.in
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -427,7 +427,7 @@ dnspython==1.16.0
     #   -r requirements/static/ci/common.in
     #   ciscoconfparse
     #   python-etcd
-docker==6.1.2
+docker==6.1.3
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -427,7 +427,7 @@ dnspython==1.16.0
     #   -r requirements/static/ci/common.in
     #   ciscoconfparse
     #   python-etcd
-docker==5.0.3
+docker==6.1.2
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -95,7 +95,7 @@ dnspython==1.16.0
     #   python-etcd
 docker-pycreds==0.4.0
     # via docker
-docker==2.7.0
+docker==6.1.2
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -95,7 +95,7 @@ dnspython==1.16.0
     #   python-etcd
 docker-pycreds==0.4.0
     # via docker
-docker==6.1.2
+docker==6.1.3
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -416,7 +416,7 @@ dnspython==2.1.0
     #   -r requirements/static/ci/common.in
     #   ciscoconfparse
     #   python-etcd
-docker==5.0.2
+docker==6.1.2
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in
@@ -653,6 +653,7 @@ oscrypto==1.2.1
 packaging==21.3
     # via
     #   -r requirements/base.txt
+    #   docker
     #   pytest
 paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
     # via
@@ -902,6 +903,7 @@ typing-extensions==3.10.0.2
 urllib3==1.26.6
     # via
     #   botocore
+    #   docker
     #   kubernetes
     #   python-etcd
     #   requests

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -416,7 +416,7 @@ dnspython==2.1.0
     #   -r requirements/static/ci/common.in
     #   ciscoconfparse
     #   python-etcd
-docker==6.1.2
+docker==6.1.3
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -414,7 +414,7 @@ dnspython==1.16.0
     #   -r requirements/static/ci/common.in
     #   ciscoconfparse
     #   python-etcd
-docker==5.0.3
+docker==6.1.2
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -414,7 +414,7 @@ dnspython==1.16.0
     #   -r requirements/static/ci/common.in
     #   ciscoconfparse
     #   python-etcd
-docker==6.1.2
+docker==6.1.3
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -413,7 +413,7 @@ dnspython==1.16.0
     #   -r requirements/static/ci/common.in
     #   ciscoconfparse
     #   python-etcd
-docker==5.0.3
+docker==6.1.2
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -413,7 +413,7 @@ dnspython==1.16.0
     #   -r requirements/static/ci/common.in
     #   ciscoconfparse
     #   python-etcd
-docker==6.1.2
+docker==6.1.3
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -417,7 +417,7 @@ dnspython==2.1.0
     #   -r requirements/static/ci/common.in
     #   ciscoconfparse
     #   python-etcd
-docker==6.1.2
+docker==6.1.3
     # via -r requirements/static/ci/lint.in
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in
@@ -655,6 +655,7 @@ packaging==21.3
     # via
     #   -r requirements/base.txt
     #   ansible-core
+    #   docker
 paramiko==2.10.1 ; sys_platform != "win32" and sys_platform != "darwin"
     # via
     #   -r requirements/static/ci/common.in
@@ -881,6 +882,7 @@ tzlocal==3.0
 urllib3==1.26.6
     # via
     #   botocore
+    #   docker
     #   kubernetes
     #   python-etcd
     #   requests

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -417,7 +417,7 @@ dnspython==2.1.0
     #   -r requirements/static/ci/common.in
     #   ciscoconfparse
     #   python-etcd
-docker==5.0.0
+docker==6.1.2
     # via -r requirements/static/ci/lint.in
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -429,7 +429,7 @@ dnspython==1.16.0
     #   -r requirements/static/ci/common.in
     #   ciscoconfparse
     #   python-etcd
-docker==5.0.3
+docker==6.1.2
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -429,7 +429,7 @@ dnspython==1.16.0
     #   -r requirements/static/ci/common.in
     #   ciscoconfparse
     #   python-etcd
-docker==6.1.2
+docker==6.1.3
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -95,7 +95,7 @@ dnspython==1.16.0
     #   python-etcd
 docker-pycreds==0.4.0
     # via docker
-docker==2.7.0
+docker==6.1.2
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -95,7 +95,7 @@ dnspython==1.16.0
     #   python-etcd
 docker-pycreds==0.4.0
     # via docker
-docker==6.1.2
+docker==6.1.3
     # via -r requirements/pytest.txt
 etcd3-py==0.1.6
     # via -r requirements/static/ci/common.in

--- a/tests/filename_map.yml
+++ b/tests/filename_map.yml
@@ -323,6 +323,9 @@ salt/(minion\.py|channel/.+|transport/.+):
 tests/support/mock.py:
   - unit.test_mock
 
+tests/support/virt.py:
+  - pytests.integration.modules.test_virt
+
 tests/support/pytest/mysql.py:
   - pytests.functional.states.test_mysql
   - pytests.functional.modules.test_mysql

--- a/tests/pytests/integration/modules/test_virt.py
+++ b/tests/pytests/integration/modules/test_virt.py
@@ -66,7 +66,8 @@ def virt_minion_0(
             "extra_hosts": {
                 virt_minion_0_id: "127.0.0.1",
                 virt_minion_1_id: "127.0.0.1",
-            }
+            },
+            "cgroupns": "host",
         },
         pull_before_start=True,
         skip_on_pull_failure=True,
@@ -103,7 +104,8 @@ def virt_minion_1(
             "extra_hosts": {
                 virt_minion_0_id: "127.0.0.1",
                 virt_minion_1_id: "127.0.0.1",
-            }
+            },
+            "cgroupns": "host",
         },
         pull_before_start=True,
         skip_on_pull_failure=True,

--- a/tests/pytests/unit/modules/dockermod/test_module.py
+++ b/tests/pytests/unit/modules/dockermod/test_module.py
@@ -9,13 +9,18 @@ import pytest
 import salt.loader
 import salt.modules.dockermod as docker_mod
 import salt.utils.platform
+import salt.utils.versions
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 from tests.support.mock import MagicMock, Mock, call, patch
 
 log = logging.getLogger(__name__)
 
-pytest.importorskip(
+docker = pytest.importorskip(
     "docker", reason="The python 'docker' package must be installed to run these tests"
+)
+docker_older_than_1_5_0_skip_marker = pytest.mark.skipif(
+    salt.utils.versions.Version(docker.__version__) < "1.5.0",
+    reason="docker module must be installed to run this test or is too old. <=1.5.0",
 )
 
 
@@ -354,10 +359,7 @@ def test_update_mine():
         mine_mock.assert_called_once()
 
 
-@pytest.mark.skipif(
-    docker_mod.docker.version_info < (1, 5, 0),
-    reason="docker module must be installed to run this test or is too old. >=1.5.0",
-)
+@docker_older_than_1_5_0_skip_marker
 def test_list_networks():
     """
     test list networks.
@@ -378,10 +380,7 @@ def test_list_networks():
     client.networks.assert_called_once_with(names=["foo"], ids=["01234"])
 
 
-@pytest.mark.skipif(
-    docker_mod.docker.version_info < (1, 5, 0),
-    reason="docker module must be installed to run this test or is too old. >=1.5.0",
-)
+@docker_older_than_1_5_0_skip_marker
 def test_create_network():
     """
     test create network.
@@ -422,10 +421,7 @@ def test_create_network():
     )
 
 
-@pytest.mark.skipif(
-    docker_mod.docker.version_info < (1, 5, 0),
-    reason="docker module must be installed to run this test or is too old. >=1.5.0",
-)
+@docker_older_than_1_5_0_skip_marker
 def test_remove_network():
     """
     test remove network.
@@ -444,10 +440,7 @@ def test_remove_network():
     client.remove_network.assert_called_once_with("foo")
 
 
-@pytest.mark.skipif(
-    docker_mod.docker.version_info < (1, 5, 0),
-    reason="docker module must be installed to run this test or is too old. >=1.5.0",
-)
+@docker_older_than_1_5_0_skip_marker
 def test_inspect_network():
     """
     test inspect network.
@@ -466,10 +459,7 @@ def test_inspect_network():
     client.inspect_network.assert_called_once_with("foo")
 
 
-@pytest.mark.skipif(
-    docker_mod.docker.version_info < (1, 5, 0),
-    reason="docker module must be installed to run this test or is too old. >=1.5.0",
-)
+@docker_older_than_1_5_0_skip_marker
 def test_connect_container_to_network():
     """
     test connect_container_to_network
@@ -491,10 +481,7 @@ def test_connect_container_to_network():
     client.connect_container_to_network.assert_called_once_with("container", "foo")
 
 
-@pytest.mark.skipif(
-    docker_mod.docker.version_info < (1, 5, 0),
-    reason="docker module must be installed to run this test or is too old. >=1.5.0",
-)
+@docker_older_than_1_5_0_skip_marker
 def test_disconnect_container_from_network():
     """
     test disconnect_container_from_network
@@ -513,10 +500,7 @@ def test_disconnect_container_from_network():
     client.disconnect_container_from_network.assert_called_once_with("container", "foo")
 
 
-@pytest.mark.skipif(
-    docker_mod.docker.version_info < (1, 5, 0),
-    reason="docker module must be installed to run this test or is too old. >=1.5.0",
-)
+@docker_older_than_1_5_0_skip_marker
 def test_list_volumes():
     """
     test list volumes.
@@ -539,10 +523,7 @@ def test_list_volumes():
     )
 
 
-@pytest.mark.skipif(
-    docker_mod.docker.version_info < (1, 5, 0),
-    reason="docker module must be installed to run this test or is too old. >=1.5.0",
-)
+@docker_older_than_1_5_0_skip_marker
 def test_create_volume():
     """
     test create volume.
@@ -569,10 +550,7 @@ def test_create_volume():
     )
 
 
-@pytest.mark.skipif(
-    docker_mod.docker.version_info < (1, 5, 0),
-    reason="docker module must be installed to run this test or is too old. >=1.5.0",
-)
+@docker_older_than_1_5_0_skip_marker
 def test_remove_volume():
     """
     test remove volume.
@@ -591,10 +569,7 @@ def test_remove_volume():
     client.remove_volume.assert_called_once_with("foo")
 
 
-@pytest.mark.skipif(
-    docker_mod.docker.version_info < (1, 5, 0),
-    reason="docker module must be installed to run this test or is too old. >=1.5.0",
-)
+@docker_older_than_1_5_0_skip_marker
 def test_inspect_volume():
     """
     test inspect volume.


### PR DESCRIPTION
### What does this PR do?
Set `cgroupns` to `host` to fix the libvirt migration tests.

This needs a newer version of the python docker package.

The breakage was due to updating the docker container used. - https://github.com/saltstack/salt-ci-containers/pull/42