### PR TITLE
[3006.x][BACKPORT] Fix salt user login shell path in Debian packages

### DIFF
--- a/changelog/64377.fixed.md
+++ b/changelog/64377.fixed.md
@@ -1,0 +1,1 @@
+Fix salt user login shell path in Debian packages


### PR DESCRIPTION
# Backport

This will backport the following commits from `3006.x` to `3006.x`:
 - [Fix salt user login shell path in Debian packages](https://github.com/saltstack/salt/pull/64378)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)