### PR TITLE
[3006.x][BACKPORT] Comply with pre-commit and lint

### DIFF
--- a/salt/modules/ipset.py
+++ b/salt/modules/ipset.py
@@ -315,7 +315,7 @@ def new_set(name=None, set_type=None, family="ipv4", comment=False, **kwargs):
     # Check for required arguments
     for item in _CREATE_OPTIONS_REQUIRED[set_type]:
         if item not in kwargs:
-            return "Error: {} is a required argument".format(item)
+            return f"Error: {item} is a required argument"
 
     cmd = [_ipset_cmd(), "create", name, set_type]
 
@@ -478,7 +478,7 @@ def add(name=None, entry=None, family="ipv4", **kwargs):
 
     setinfo = _find_set_info(name)
     if not setinfo:
-        return "Error: Set {} does not exist".format(name)
+        return f"Error: Set {name} does not exist"
 
     settype = setinfo["Type"]
 
@@ -486,21 +486,21 @@ def add(name=None, entry=None, family="ipv4", **kwargs):
 
     if "timeout" in kwargs:
         if "timeout" not in setinfo["Header"]:
-            return "Error: Set {} not created with timeout support".format(name)
+            return f"Error: Set {name} not created with timeout support"
 
     if "packets" in kwargs or "bytes" in kwargs:
         if "counters" not in setinfo["Header"]:
-            return "Error: Set {} not created with counters support".format(name)
+            return f"Error: Set {name} not created with counters support"
 
     if "comment" in kwargs:
         if "comment" not in setinfo["Header"]:
-            return "Error: Set {} not created with comment support".format(name)
+            return f"Error: Set {name} not created with comment support"
         if "comment" not in entry:
             cmd = cmd + ["comment", f"{kwargs['comment']}"]
 
     if {"skbmark", "skbprio", "skbqueue"} & set(kwargs.keys()):
         if "skbinfo" not in setinfo["Header"]:
-            return "Error: Set {} not created with skbinfo support".format(name)
+            return f"Error: Set {name} not created with skbinfo support"
 
     for item in _ADD_OPTIONS[settype]:
         if item in kwargs:
@@ -508,14 +508,14 @@ def add(name=None, entry=None, family="ipv4", **kwargs):
 
     current_members = _find_set_members(name)
     if entry in current_members:
-        return "Warn: Entry {} already exists in set {}".format(entry, name)
+        return f"Warn: Entry {entry} already exists in set {name}"
 
     # Using -exist to ensure entries are updated if the comment changes
     out = __salt__["cmd.run"](cmd, python_shell=False)
 
     if not out:
         return "Success"
-    return "Error: {}".format(out)
+    return f"Error: {out}"
 
 
 def delete(name=None, entry=None, family="ipv4", **kwargs):
@@ -537,14 +537,14 @@ def delete(name=None, entry=None, family="ipv4", **kwargs):
     settype = _find_set_type(name)
 
     if not settype:
-        return "Error: Set {} does not exist".format(name)
+        return f"Error: Set {name} does not exist"
 
     cmd = [_ipset_cmd(), "del", name, entry]
     out = __salt__["cmd.run"](cmd, python_shell=False)
 
     if not out:
         return "Success"
-    return "Error: {}".format(out)
+    return f"Error: {out}"
 
 
 def check(name=None, entry=None, family="ipv4"):
@@ -581,7 +581,7 @@ def check(name=None, entry=None, family="ipv4"):
 
     settype = _find_set_type(name)
     if not settype:
-        return "Error: Set {} does not exist".format(name)
+        return f"Error: Set {name} does not exist"
 
     current_members = _parse_members(settype, _find_set_members(name))
 
@@ -621,7 +621,7 @@ def test(name=None, entry=None, family="ipv4", **kwargs):
 
     settype = _find_set_type(name)
     if not settype:
-        return "Error: Set {} does not exist".format(name)
+        return f"Error: Set {name} does not exist"
 
     cmd = [_ipset_cmd(), "test", name, entry]
     out = __salt__["cmd.run_all"](cmd, python_shell=False)

--- a/tests/pytests/functional/modules/test_ipset.py
+++ b/tests/pytests/functional/modules/test_ipset.py
@@ -47,3 +47,17 @@ def test_ipset_add_comment_kwarg(ipset, setup_set):
     assert ret == "Success"
     check_set = ipset.list_sets()
     assert any([x for x in check_set if x["Name"] == setup_set])
+
+
+def test_ipset_new_set_with_family(ipset):
+    """
+    test ipset.new_set with set_type that uses family (eg. hash:ip)
+    """
+    set_name = "test_name_haship"
+    ret = ipset.new_set(name=set_name, set_type="hash:ip")
+    assert ret is True
+    check_set = ipset.list_sets()
+    try:
+        assert any([x for x in check_set if x["Name"] == set_name])
+    finally:
+        ipset.delete_set(set_name)


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `3006.x`:
 - [Comply with pre-commit and lint](https://github.com/saltstack/salt/pull/65044)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)