### PR TITLE
[3006.x][BACKPORT] Fix heading level of "creates" | Update doc/ref/states/requisites.rst

### DIFF
--- a/doc/ref/states/requisites.rst
+++ b/doc/ref/states/requisites.rst
@@ -1053,8 +1053,8 @@ if the gluster commands return a 0 ret value.
 
 .. _creates-requisite:
 
-Creates
--------
+creates
+~~~~~
 
 .. versionadded:: 3001
 

--- a/doc/ref/states/requisites.rst
+++ b/doc/ref/states/requisites.rst
@@ -1054,7 +1054,7 @@ if the gluster commands return a 0 ret value.
 .. _creates-requisite:
 
 creates
-~~~~~
+~~~~~~~
 
 .. versionadded:: 3001
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `3006.x`:
 - [Fix heading level of "creates"](https://github.com/saltstack/salt/pull/65202)
 - [Update doc/ref/states/requisites.rst](https://github.com/saltstack/salt/pull/65202)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)