### PR TITLE
[3005.x] Downgrade to sqren/backport-github-action@v8.9.7 at least errors are reported

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,7 +1,7 @@
 {
   "repoOwner": "saltstack",
   "repoName": "salt",
-  "targetBranchChoices": ["master", "3006.x", "3005.x"],
+  "targetBranchChoices": ["master", "3006.x", "3005.x", "freeze"],
   "autoMerge": false,
   "autoMergeMethod": "rebase",
   "branchLabelMapping": {

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -33,7 +33,7 @@ jobs:
       )
     steps:
       - name: Backport Action
-        uses: sqren/backport-github-action@v9.3.0-a
+        uses: sqren/backport-github-action@v8.9.7
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           auto_backport_label_prefix: "backport:"


### PR DESCRIPTION
### What does this PR do?
See title