### PR TITLE
[3006.x] Add coverage contexts to show what tests touch which files

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,7 @@ cover_pylib = False
 parallel = True
 concurrency = multiprocessing
 relative_files = True
+dynamic_context = test_function
 omit =
   setup.py
   .nox/*


### PR DESCRIPTION
### What does this PR do?
Adds [contexts](https://coverage.readthedocs.io/en/coverage-5.5/contexts.html#dynamic-contexts) to our coverage html reports.  This will allow us to see which files touched what lines.

> NOTE: We want to publish the json reports for this to GH Actions artifact storage, as they are the best format to parse out the contexts.

 
### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes