### PR TITLE
[3006.x] bump pygit2 in ci

### DIFF
--- a/changelog/65085.fixed.md
+++ b/changelog/65085.fixed.md
@@ -1,0 +1,1 @@
+fixed/bumped pygit2 ci test dependence

--- a/requirements/static/ci/common.in
+++ b/requirements/static/ci/common.in
@@ -1,13 +1,15 @@
 # Requirements in this file apply to all platforms.
 # We can also exclude platforms from the requirements using markers, but if a requirement only applies
 # to a particular platform, please add it to the corresponding `<platform>.in` file in this directory.
+--constraint=../pkg/py{py_version}/{platform}.txt
+
 azure==4.0.0; sys_platform != 'win32'
 apache-libcloud>=1.5.0; sys_platform != 'win32'
 boto3>=1.17.67
 boto>=2.46.0
 cassandra-driver>=2.0
 certifi>=2022.12.07
-cffi>=1.15.1
+cffi>=1.14.6
 cherrypy>=17.4.1
 clustershell
 croniter>=0.3.0,!=0.3.22"; sys_platform != 'win32'

--- a/requirements/static/ci/darwin.in
+++ b/requirements/static/ci/darwin.in
@@ -3,8 +3,7 @@
 # pylxd(or likely ws4py) will cause the test suite to hang at the finish line under runtests.py
 # pylxd>=2.2.5
 yamlordereddictloader
-pygit2>=1.10.1; python_version >= '3.7'
-pygit2>=1.13.1; python_version >= '3.8'
+pygit2>=1.10.1
 yamllint
 mercurial
 hglib

--- a/requirements/static/ci/darwin.in
+++ b/requirements/static/ci/darwin.in
@@ -2,6 +2,8 @@
 # XXX: Temporarily do not install pylxd.
 # pylxd(or likely ws4py) will cause the test suite to hang at the finish line under runtests.py
 # pylxd>=2.2.5
+--constraint=../pkg/py{py_version}/{platform}.txt
+
 yamlordereddictloader
 pygit2>=1.10.1
 yamllint

--- a/requirements/static/ci/darwin.in
+++ b/requirements/static/ci/darwin.in
@@ -3,7 +3,8 @@
 # pylxd(or likely ws4py) will cause the test suite to hang at the finish line under runtests.py
 # pylxd>=2.2.5
 yamlordereddictloader
-pygit2>=1.2.0
+pygit2>=1.10.1; python_version >= '3.7'
+pygit2>=1.13.1; python_version >= '3.8'
 yamllint
 mercurial
 hglib

--- a/requirements/static/ci/freebsd.in
+++ b/requirements/static/ci/freebsd.in
@@ -1,4 +1,6 @@
 # FreeBSD static CI requirements
+--constraint=../pkg/py{py_version}/{platform}.txt
+
 pygit2>=1.10.1
 yamllint
 mercurial

--- a/requirements/static/ci/freebsd.in
+++ b/requirements/static/ci/freebsd.in
@@ -1,6 +1,5 @@
 # FreeBSD static CI requirements
-pygit2>=1.10.1; python_version >= '3.7'
-pygit2>=1.13.1; python_version >= '3.8'
+pygit2>=1.10.1
 yamllint
 mercurial
 hglib

--- a/requirements/static/ci/freebsd.in
+++ b/requirements/static/ci/freebsd.in
@@ -1,5 +1,6 @@
 # FreeBSD static CI requirements
-pygit2==1.8.0
+pygit2>=1.10.1; python_version >= '3.7'
+pygit2>=1.13.1; python_version >= '3.8'
 yamllint
 mercurial
 hglib

--- a/requirements/static/ci/linux.in
+++ b/requirements/static/ci/linux.in
@@ -1,8 +1,7 @@
 # Linux static CI requirements
 pyiface
-pygit2<1.1.0; python_version <= '3.8'
-pygit2>=1.4.0; python_version > '3.8'
-pygit2==1.9.1; python_version >= '3.10'
+pygit2>=1.10.1; python_version >= '3.7'
+pygit2>=1.13.1; python_version >= '3.8'
 pymysql>=1.0.2
 ansible>=4.4.0; python_version < '3.9'
 ansible>=7.0.0; python_version >= '3.9'

--- a/requirements/static/ci/linux.in
+++ b/requirements/static/ci/linux.in
@@ -1,4 +1,6 @@
 # Linux static CI requirements
+--constraint=../pkg/py{py_version}/{platform}.txt
+
 pyiface
 pygit2>=1.10.1
 pymysql>=1.0.2
@@ -11,4 +13,4 @@ mercurial
 hglib
 redis-py-cluster
 python-consul
-slack_bolt
+slack-bolt

--- a/requirements/static/ci/linux.in
+++ b/requirements/static/ci/linux.in
@@ -1,7 +1,6 @@
 # Linux static CI requirements
 pyiface
-pygit2>=1.10.1; python_version >= '3.7'
-pygit2>=1.13.1; python_version >= '3.8'
+pygit2>=1.10.1
 pymysql>=1.0.2
 ansible>=4.4.0; python_version < '3.9'
 ansible>=7.0.0; python_version >= '3.9'

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -352,29 +352,35 @@ cassandra-driver==3.25.0
     # via -r requirements/static/ci/common.in
 certifi==2023.07.22
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
     #   kubernetes
     #   msrest
     #   requests
 certvalidator==0.11.1
     # via vcert
-cffi==1.15.1
+cffi==1.14.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
     #   azure-datalake-store
     #   bcrypt
     #   cryptography
     #   pynacl
-charset-normalizer==2.0.12
+charset-normalizer==3.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   aiohttp
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.in
 cheroot==8.5.2
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   cherrypy
 cherrypy==18.6.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/linux.in
 click==8.0.1
@@ -382,11 +388,14 @@ click==8.0.1
 clustershell==1.8.3
     # via -r requirements/static/ci/common.in
 contextvars==2.4
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   adal
     #   azure-cosmosdb-table
@@ -402,8 +411,9 @@ cryptography==41.0.4
     #   vcert
 distlib==0.3.2
     # via virtualenv
-distro==1.6.0
+distro==1.5.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   pytest-skip-markers
 dnspython==2.1.0
@@ -436,13 +446,18 @@ google-auth==2.1.0
     # via kubernetes
 idna==2.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   etcd3-py
     #   requests
     #   yarl
-immutables==0.19
-    # via contextvars
+immutables==0.15
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   contextvars
 importlib-metadata==6.0.0
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/static/pkg/linux.in
 iniconfig==1.1.1
     # via pytest
 ipaddress==1.0.23
@@ -450,23 +465,32 @@ ipaddress==1.0.23
 isodate==0.6.0
     # via msrest
 jaraco.classes==3.2.1
-    # via jaraco.collections
-jaraco.collections==3.4.0
-    # via cherrypy
-jaraco.functools==3.3.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   jaraco.collections
+jaraco.collections==3.4.0
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   cherrypy
+jaraco.functools==2.0
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   cheroot
     #   jaraco.text
     #   tempora
 jaraco.text==3.5.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   jaraco.collections
 jinja2==3.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   junos-eznc
     #   moto
-jmespath==0.10.0
+jmespath==1.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   boto3
@@ -486,7 +510,9 @@ kubernetes==3.0.0
 libnacl==1.8.0 ; sys_platform != "win32" and sys_platform != "darwin"
     # via -r requirements/static/ci/common.in
 looseversion==1.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/base.txt
 lxml==4.9.1
     # via
     #   junos-eznc
@@ -495,6 +521,7 @@ mako==1.2.2
     # via -r requirements/static/ci/common.in
 markupsafe==2.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   jinja2
     #   mako
@@ -502,8 +529,9 @@ markupsafe==2.1.2
     #   werkzeug
 mock==4.0.3
     # via -r requirements/pytest.txt
-more-itertools==8.8.0
+more-itertools==5.0.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   cheroot
     #   cherrypy
     #   jaraco.classes
@@ -512,6 +540,7 @@ moto==3.0.1
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
 msrest==0.6.21
@@ -622,8 +651,9 @@ oauthlib==3.2.2
     # via requests-oauthlib
 oscrypto==1.2.1
     # via certvalidator
-packaging==21.3
+packaging==22.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   docker
     #   pytest
@@ -639,12 +669,15 @@ platformdirs==2.3.0
     # via virtualenv
 pluggy==1.0.0
     # via pytest
-portend==2.7.1
-    # via cherrypy
+portend==2.4
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   cherrypy
 profitbricks==4.1.3
     # via -r requirements/static/ci/cloud.in
 psutil==5.8.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
@@ -657,11 +690,14 @@ pyasn1==0.4.8
     #   rsa
 pycparser==2.21 ; python_version >= "3.9"
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/linux.in
     #   cffi
-pycryptodomex==3.10.1
-    # via -r requirements/crypto.txt
+pycryptodomex==3.9.8
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/crypto.txt
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in
 pyjwt==2.4.0
@@ -672,12 +708,11 @@ pynacl==1.5.0
     #   paramiko
 pyopenssl==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
 pyparsing==3.0.9
-    # via
-    #   junos-eznc
-    #   packaging
+    # via junos-eznc
 pypsexec==0.1.0
     # via -r requirements/static/ci/cloud.in
 pyrsistent==0.18.0
@@ -723,8 +758,9 @@ pytest==7.2.0
     #   pytest-subtests
     #   pytest-system-statistics
     #   pytest-timeout
-python-dateutil==2.8.2
+python-dateutil==2.8.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   adal
     #   azure-cosmosdb-table
@@ -737,9 +773,12 @@ python-dateutil==2.8.2
 python-etcd==0.4.5
     # via -r requirements/static/ci/common.in
 python-gnupg==0.4.8
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/static/pkg/linux.in
 pytz==2022.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   moto
     #   tempora
 pyvmomi==7.0.2
@@ -748,6 +787,7 @@ pywinrm==0.3.0
     # via -r requirements/static/ci/cloud.in
 pyyaml==6.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   clustershell
     #   junos-eznc
@@ -756,6 +796,7 @@ pyyaml==6.0.1
     #   yamlordereddictloader
 pyzmq==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
 requests-ntlm==1.1.0
@@ -764,6 +805,7 @@ requests-oauthlib==1.3.0
     # via msrest
 requests==2.31.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   adal
@@ -791,7 +833,9 @@ responses==0.14.0
 rfc3987==1.3.8
     # via -r requirements/static/ci/common.in
 rpm-vercmp==0.1.2
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/static/pkg/linux.in
 rsa==4.7.2
     # via google-auth
 s3transfer==0.5.0
@@ -801,9 +845,12 @@ scp==0.14.1
 semantic-version==2.9.0
     # via etcd3-py
 setproctitle==1.3.2
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/static/pkg/linux.in
 six==1.16.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   bcrypt
     #   cassandra-driver
     #   cheroot
@@ -815,6 +862,7 @@ six==1.16.0
     #   junos-eznc
     #   kazoo
     #   kubernetes
+    #   more-itertools
     #   msrestazure
     #   ncclient
     #   paramiko
@@ -839,9 +887,13 @@ sqlparse==0.4.4
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in
 tempora==4.1.1
-    # via portend
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   portend
 timelib==0.2.5
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/static/pkg/linux.in
 toml==0.10.2
     # via -r requirements/static/ci/common.in
 tomli==2.0.1
@@ -854,6 +906,7 @@ typing-extensions==4.2.0
     #   pytest-system-statistics
 urllib3==1.26.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   botocore
     #   docker
     #   kubernetes
@@ -886,10 +939,14 @@ yamlordereddictloader==0.4.0
     # via junos-eznc
 yarl==1.7.2
     # via aiohttp
-zc.lockfile==2.0
-    # via cherrypy
+zc.lockfile==1.4
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   cherrypy
 zipp==3.6.0
-    # via importlib-metadata
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -663,7 +663,7 @@ pycparser==2.21 ; python_version >= "3.9"
     #   cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pygit2==1.9.1
+pygit2==1.13.1 ; python_version >= "3.8"
     # via -r requirements/static/ci/darwin.in
 pyjwt==2.4.0
     # via adal

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -663,7 +663,7 @@ pycparser==2.21 ; python_version >= "3.9"
     #   cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pygit2==1.13.1 ; python_version >= "3.8"
+pygit2==1.13.1
     # via -r requirements/static/ci/darwin.in
 pyjwt==2.4.0
     # via adal

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -14,6 +14,7 @@ aiosignal==1.2.0
     # via aiohttp
 apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/darwin.txt
     #   -r requirements/static/ci/common.in
 asn1crypto==1.3.0
@@ -352,30 +353,36 @@ cassandra-driver==3.23.0
     # via -r requirements/static/ci/common.in
 certifi==2023.07.22
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/static/ci/common.in
     #   kubernetes
     #   msrest
     #   requests
 certvalidator==0.11.1
     # via vcert
-cffi==1.15.1
+cffi==1.14.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/static/ci/common.in
     #   azure-datalake-store
     #   bcrypt
     #   cryptography
     #   pygit2
     #   pynacl
-charset-normalizer==2.0.12
+charset-normalizer==3.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   aiohttp
     #   requests
 cheetah3==3.2.6.post2
     # via -r requirements/static/ci/common.in
 cheroot==8.5.2
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   cherrypy
 cherrypy==18.6.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/darwin.txt
     #   -r requirements/static/ci/common.in
 click==7.0
@@ -383,11 +390,14 @@ click==7.0
 clustershell==1.8.1
     # via -r requirements/static/ci/common.in
 contextvars==2.4
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/darwin.txt
     #   adal
     #   azure-cosmosdb-table
@@ -402,6 +412,7 @@ distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/base.txt
     #   pytest-skip-markers
 dnspython==1.16.0
@@ -427,9 +438,12 @@ genshi==0.7.5
 geomet==0.1.2
     # via cassandra-driver
 gitdb==4.0.5
-    # via gitpython
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   gitpython
 gitpython==3.1.35
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/darwin.txt
     #   -r requirements/static/ci/common.in
 google-auth==1.6.3
@@ -438,14 +452,19 @@ hglib==2.6.1
     # via -r requirements/static/ci/darwin.in
 idna==2.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/darwin.txt
     #   etcd3-py
     #   requests
     #   yarl
 immutables==0.15
-    # via contextvars
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   contextvars
 importlib-metadata==6.0.0
-    # via -r requirements/darwin.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   -r requirements/darwin.txt
 iniconfig==1.0.1
     # via pytest
 ipaddress==1.0.22
@@ -453,23 +472,32 @@ ipaddress==1.0.22
 isodate==0.6.0
     # via msrest
 jaraco.classes==3.2.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   jaraco.collections
 jaraco.collections==3.4.0
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   cherrypy
 jaraco.functools==2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   cheroot
     #   jaraco.text
     #   tempora
 jaraco.text==3.5.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   jaraco.collections
 jinja2==3.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/base.txt
     #   junos-eznc
     #   moto
 jmespath==1.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   boto3
@@ -485,9 +513,13 @@ keyring==5.7.1
 kubernetes==3.0.0
     # via -r requirements/static/ci/common.in
 linode-python==1.1.1
-    # via -r requirements/darwin.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   -r requirements/darwin.txt
 looseversion==1.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   -r requirements/base.txt
 lxml==4.9.1
     # via
     #   junos-eznc
@@ -496,6 +528,7 @@ mako==1.2.2
     # via -r requirements/static/ci/common.in
 markupsafe==2.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/base.txt
     #   jinja2
     #   mako
@@ -507,6 +540,7 @@ mock==3.0.5
     # via -r requirements/pytest.txt
 more-itertools==8.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   cheroot
     #   cherrypy
     #   jaraco.classes
@@ -515,6 +549,7 @@ moto==3.0.1
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
 msrest==0.6.19
@@ -621,8 +656,9 @@ oauthlib==3.2.2
     # via requests-oauthlib
 oscrypto==1.2.0
     # via certvalidator
-packaging==21.3
+packaging==22.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/base.txt
     #   docker
     #   pytest
@@ -642,9 +678,12 @@ platformdirs==2.2.0
 pluggy==0.13.1
     # via pytest
 portend==2.6
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   cherrypy
 psutil==5.8.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
@@ -653,16 +692,20 @@ pyasn1-modules==0.2.4
     # via google-auth
 pyasn1==0.4.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/darwin.txt
     #   pyasn1-modules
     #   rsa
 pycparser==2.21 ; python_version >= "3.9"
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/darwin.txt
     #   -r requirements/static/ci/common.in
     #   cffi
 pycryptodomex==3.9.8
-    # via -r requirements/crypto.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   -r requirements/crypto.txt
 pygit2==1.13.1
     # via -r requirements/static/ci/darwin.in
 pyjwt==2.4.0
@@ -673,12 +716,11 @@ pynacl==1.5.0
     #   paramiko
 pyopenssl==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/darwin.txt
     #   etcd3-py
 pyparsing==3.0.9
-    # via
-    #   junos-eznc
-    #   packaging
+    # via junos-eznc
 pyrsistent==0.17.3
     # via jsonschema
 pyserial==3.4
@@ -720,6 +762,7 @@ pytest==7.2.0
     #   pytest-timeout
 python-dateutil==2.8.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/darwin.txt
     #   adal
     #   azure-cosmosdb-table
@@ -732,15 +775,19 @@ python-dateutil==2.8.0
 python-etcd==0.4.5
     # via -r requirements/static/ci/common.in
 python-gnupg==0.4.8
-    # via -r requirements/darwin.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   -r requirements/darwin.txt
 pytz==2022.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   moto
     #   tempora
 pyvmomi==6.7.1.2018.12
     # via -r requirements/static/ci/common.in
 pyyaml==6.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/base.txt
     #   clustershell
     #   junos-eznc
@@ -750,12 +797,14 @@ pyyaml==6.0.1
     #   yamlordereddictloader
 pyzmq==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
 requests-oauthlib==1.3.0
     # via msrest
 requests==2.31.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   adal
@@ -789,9 +838,12 @@ scp==0.13.2
 semantic-version==2.9.0
     # via etcd3-py
 setproctitle==1.3.2
-    # via -r requirements/darwin.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   -r requirements/darwin.txt
 six==1.16.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   bcrypt
     #   cassandra-driver
     #   cheroot
@@ -815,15 +867,21 @@ six==1.16.0
     #   virtualenv
     #   websocket-client
 smmap==3.0.2
-    # via gitdb
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   gitdb
 sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in
 tempora==4.1.1
-    # via portend
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   portend
 timelib==0.2.5
-    # via -r requirements/darwin.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   -r requirements/darwin.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.in
 tomli==2.0.1
@@ -836,6 +894,7 @@ typing-extensions==4.2.0
     #   pytest-system-statistics
 urllib3==1.26.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
     #   botocore
     #   docker
     #   kubernetes
@@ -848,7 +907,9 @@ virtualenv==20.7.2
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 vultr==1.0.1
-    # via -r requirements/darwin.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   -r requirements/darwin.txt
 watchdog==0.10.3
     # via -r requirements/static/ci/common.in
 websocket-client==0.40.0
@@ -872,9 +933,13 @@ yamlordereddictloader==0.4.0
 yarl==1.7.2
     # via aiohttp
 zc.lockfile==2.0
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   cherrypy
 zipp==3.12.0
-    # via importlib-metadata
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.10/docs.txt
+++ b/requirements/static/ci/py3.10/docs.txt
@@ -12,7 +12,7 @@ certifi==2023.07.22
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   requests
-charset-normalizer==2.0.12
+charset-normalizer==3.2.0
     # via
     #   -c requirements/static/ci/py3.10/linux.txt
     #   requests

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -661,7 +661,7 @@ pycparser==2.21 ; python_version >= "3.9"
     #   cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pygit2==1.8.0
+pygit2==1.13.1 ; python_version >= "3.8"
     # via -r requirements/static/ci/freebsd.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -350,30 +350,36 @@ cassandra-driver==3.24.0
     # via -r requirements/static/ci/common.in
 certifi==2023.07.22
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   -r requirements/static/ci/common.in
     #   kubernetes
     #   msrest
     #   requests
 certvalidator==0.11.1
     # via vcert
-cffi==1.15.1
+cffi==1.14.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   -r requirements/static/ci/common.in
     #   azure-datalake-store
     #   bcrypt
     #   cryptography
     #   pygit2
     #   pynacl
-charset-normalizer==2.0.12
+charset-normalizer==3.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   aiohttp
     #   requests
 cheetah3==3.2.6.post2
     # via -r requirements/static/ci/common.in
 cheroot==8.5.2
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
+    #   cherrypy
 cherrypy==18.6.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/freebsd.in
 click==7.1.2
@@ -381,11 +387,14 @@ click==7.1.2
 clustershell==1.8.3
     # via -r requirements/static/ci/common.in
 contextvars==2.4
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
+    #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   -r requirements/static/pkg/freebsd.in
     #   adal
     #   azure-cosmosdb-table
@@ -400,6 +409,7 @@ distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
     #   pytest-skip-markers
@@ -435,13 +445,18 @@ hglib==2.6.1
     # via -r requirements/static/ci/freebsd.in
 idna==2.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   etcd3-py
     #   requests
     #   yarl
 immutables==0.15
-    # via contextvars
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
+    #   contextvars
 importlib-metadata==6.0.0
-    # via -r requirements/static/pkg/freebsd.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
+    #   -r requirements/static/pkg/freebsd.in
 iniconfig==1.0.1
     # via pytest
 ipaddress==1.0.22
@@ -449,23 +464,32 @@ ipaddress==1.0.22
 isodate==0.6.0
     # via msrest
 jaraco.classes==3.2.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
+    #   jaraco.collections
 jaraco.collections==3.4.0
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
+    #   cherrypy
 jaraco.functools==2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   cheroot
     #   jaraco.text
     #   tempora
 jaraco.text==3.5.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
+    #   jaraco.collections
 jinja2==3.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   -r requirements/base.txt
     #   junos-eznc
     #   moto
 jmespath==1.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   boto3
@@ -485,7 +509,9 @@ kubernetes==3.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
     # via -r requirements/static/ci/common.in
 looseversion==1.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
+    #   -r requirements/base.txt
 lxml==4.9.1
     # via
     #   junos-eznc
@@ -494,6 +520,7 @@ mako==1.2.2
     # via -r requirements/static/ci/common.in
 markupsafe==2.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   -r requirements/base.txt
     #   jinja2
     #   mako
@@ -505,6 +532,7 @@ mock==3.0.5
     # via -r requirements/pytest.txt
 more-itertools==5.0.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   cheroot
     #   cherrypy
     #   jaraco.classes
@@ -513,6 +541,7 @@ moto==3.0.1
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
 msrest==0.6.19
@@ -619,8 +648,9 @@ oauthlib==3.2.2
     # via requests-oauthlib
 oscrypto==1.2.0
     # via certvalidator
-packaging==21.3
+packaging==22.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   -r requirements/base.txt
     #   docker
     #   pytest
@@ -641,9 +671,12 @@ platformdirs==2.2.0
 pluggy==0.13.0
     # via pytest
 portend==2.4
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
+    #   cherrypy
 psutil==5.8.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
@@ -656,11 +689,14 @@ pyasn1==0.4.8
     #   rsa
 pycparser==2.21 ; python_version >= "3.9"
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/freebsd.in
     #   cffi
 pycryptodomex==3.9.8
-    # via -r requirements/crypto.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
+    #   -r requirements/crypto.txt
 pygit2==1.13.1
     # via -r requirements/static/ci/freebsd.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
@@ -673,12 +709,11 @@ pynacl==1.5.0
     #   paramiko
 pyopenssl==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   -r requirements/static/pkg/freebsd.in
     #   etcd3-py
 pyparsing==3.0.9
-    # via
-    #   junos-eznc
-    #   packaging
+    # via junos-eznc
 pyrsistent==0.17.3
     # via jsonschema
 pyserial==3.4
@@ -720,6 +755,7 @@ pytest==7.2.0
     #   pytest-timeout
 python-dateutil==2.8.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   -r requirements/static/pkg/freebsd.in
     #   adal
     #   azure-cosmosdb-table
@@ -732,15 +768,19 @@ python-dateutil==2.8.1
 python-etcd==0.4.5
     # via -r requirements/static/ci/common.in
 python-gnupg==0.4.8
-    # via -r requirements/static/pkg/freebsd.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
+    #   -r requirements/static/pkg/freebsd.in
 pytz==2022.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   moto
     #   tempora
 pyvmomi==6.7.1.2018.12
     # via -r requirements/static/ci/common.in
 pyyaml==6.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   -r requirements/base.txt
     #   clustershell
     #   junos-eznc
@@ -750,12 +790,14 @@ pyyaml==6.0.1
     #   yamlordereddictloader
 pyzmq==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
 requests-oauthlib==1.3.0
     # via msrest
 requests==2.31.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   adal
@@ -788,9 +830,12 @@ scp==0.13.2
 semantic-version==2.9.0
     # via etcd3-py
 setproctitle==1.3.2
-    # via -r requirements/static/pkg/freebsd.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
+    #   -r requirements/static/pkg/freebsd.in
 six==1.16.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   bcrypt
     #   cassandra-driver
     #   cheroot
@@ -822,9 +867,13 @@ sqlparse==0.4.4
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in
 tempora==4.1.1
-    # via portend
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
+    #   portend
 timelib==0.2.5
-    # via -r requirements/static/pkg/freebsd.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
+    #   -r requirements/static/pkg/freebsd.in
 toml==0.10.2
     # via -r requirements/static/ci/common.in
 tomli==2.0.1
@@ -837,6 +886,7 @@ typing-extensions==4.2.0
     #   pytest-system-statistics
 urllib3==1.26.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
     #   botocore
     #   docker
     #   kubernetes
@@ -869,9 +919,13 @@ yamlordereddictloader==0.4.0
 yarl==1.7.2
     # via aiohttp
 zc.lockfile==1.4
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
+    #   cherrypy
 zipp==3.12.0
-    # via importlib-metadata
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -661,7 +661,7 @@ pycparser==2.21 ; python_version >= "3.9"
     #   cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pygit2==1.13.1 ; python_version >= "3.8"
+pygit2==1.13.1
     # via -r requirements/static/ci/freebsd.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -658,7 +658,7 @@ pycparser==2.21 ; python_version >= "3.9"
     #   cffi
 pycryptodomex==3.10.1
     # via -r requirements/crypto.txt
-pygit2==1.9.1 ; python_version >= "3.10"
+pygit2==1.13.1 ; python_version >= "3.8"
     # via -r requirements/static/ci/linux.in
 pyiface==0.0.11
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -658,7 +658,7 @@ pycparser==2.21 ; python_version >= "3.9"
     #   cffi
 pycryptodomex==3.10.1
     # via -r requirements/crypto.txt
-pygit2==1.13.1 ; python_version >= "3.8"
+pygit2==1.13.1
     # via -r requirements/static/ci/linux.in
 pyiface==0.0.11
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -355,6 +355,7 @@ cassandra-driver==3.25.0
     # via -r requirements/static/ci/common.in
 certifi==2023.07.22
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
     #   kubernetes
     #   msrest
@@ -362,24 +363,29 @@ certifi==2023.07.22
     #   requests
 certvalidator==0.11.1
     # via vcert
-cffi==1.15.1
+cffi==1.14.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
     #   azure-datalake-store
     #   bcrypt
     #   cryptography
     #   pygit2
     #   pynacl
-charset-normalizer==2.0.4
+charset-normalizer==3.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   aiohttp
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.in
 cheroot==8.5.2
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   cherrypy
 cherrypy==18.6.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/linux.in
 click==8.0.1
@@ -387,11 +393,14 @@ click==8.0.1
 clustershell==1.8.3
     # via -r requirements/static/ci/common.in
 contextvars==2.4
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   adal
     #   ansible-core
@@ -405,8 +414,10 @@ cryptography==41.0.4
     #   vcert
 distlib==0.3.2
     # via virtualenv
-distro==1.6.0
-    # via -r requirements/base.txt
+distro==1.5.0
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/base.txt
 dnspython==2.1.0
     # via
     #   -r requirements/static/ci/common.in
@@ -433,15 +444,20 @@ google-auth==2.0.1
     # via kubernetes
 hglib==2.6.1
     # via -r requirements/static/ci/linux.in
-idna==3.2
+idna==2.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   etcd3-py
     #   requests
     #   yarl
-immutables==0.19
-    # via contextvars
+immutables==0.15
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   contextvars
 importlib-metadata==6.0.0
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/static/pkg/linux.in
 ipaddress==1.0.23
     # via kubernetes
 isodate==0.6.0
@@ -449,24 +465,33 @@ isodate==0.6.0
 isort==4.3.21
     # via pylint
 jaraco.classes==3.2.1
-    # via jaraco.collections
-jaraco.collections==3.4.0
-    # via cherrypy
-jaraco.functools==3.3.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   jaraco.collections
+jaraco.collections==3.4.0
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   cherrypy
+jaraco.functools==2.0
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   cheroot
     #   jaraco.text
     #   tempora
 jaraco.text==3.5.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   jaraco.collections
 jinja2==3.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   ansible-core
     #   junos-eznc
     #   moto
-jmespath==0.10.0
+jmespath==1.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   boto3
@@ -488,7 +513,9 @@ lazy-object-proxy==1.4.3
 libnacl==1.8.0 ; sys_platform != "win32" and sys_platform != "darwin"
     # via -r requirements/static/ci/common.in
 looseversion==1.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/base.txt
 lxml==4.9.1
     # via
     #   junos-eznc
@@ -497,6 +524,7 @@ mako==1.2.2
     # via -r requirements/static/ci/common.in
 markupsafe==2.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   jinja2
     #   mako
@@ -508,8 +536,9 @@ mercurial==6.0.1
     # via -r requirements/static/ci/linux.in
 modernize==0.5
     # via saltpylint
-more-itertools==8.8.0
+more-itertools==5.0.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   cheroot
     #   cherrypy
     #   jaraco.classes
@@ -517,7 +546,9 @@ more-itertools==8.8.0
 moto==3.0.1
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/base.txt
 msrest==0.6.21
     # via
     #   azure-applicationinsights
@@ -622,8 +653,9 @@ oauthlib==3.2.2
     # via requests-oauthlib
 oscrypto==1.2.1
     # via certvalidator
-packaging==21.3
+packaging==22.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   ansible-core
     #   docker
@@ -639,10 +671,14 @@ pathspec==0.9.0
     # via yamllint
 platformdirs==2.2.0
     # via virtualenv
-portend==2.7.1
-    # via cherrypy
+portend==2.4
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   cherrypy
 psutil==5.8.0
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/base.txt
 pyasn1-modules==0.2.8
     # via google-auth
 pyasn1==0.4.8
@@ -653,11 +689,14 @@ pycodestyle==2.5.0
     # via saltpylint
 pycparser==2.21 ; python_version >= "3.9"
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/linux.in
     #   cffi
-pycryptodomex==3.10.1
-    # via -r requirements/crypto.txt
+pycryptodomex==3.9.8
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/crypto.txt
 pygit2==1.13.1
     # via -r requirements/static/ci/linux.in
 pyiface==0.0.11
@@ -680,20 +719,20 @@ pynacl==1.5.0
     #   paramiko
 pyopenssl==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
 pyparsing==3.0.9
-    # via
-    #   junos-eznc
-    #   packaging
+    # via junos-eznc
 pyrsistent==0.18.0
     # via jsonschema
 pyserial==3.5
     # via junos-eznc
 python-consul==1.1.0
     # via -r requirements/static/ci/linux.in
-python-dateutil==2.8.2
+python-dateutil==2.8.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   adal
     #   azure-cosmosdb-table
@@ -706,11 +745,14 @@ python-dateutil==2.8.2
 python-etcd==0.4.5
     # via -r requirements/static/ci/common.in
 python-gnupg==0.4.8
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/static/pkg/linux.in
 python-telegram-bot==13.7
     # via -r requirements/static/ci/linux.in
 pytz==2022.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   apscheduler
     #   moto
     #   python-telegram-bot
@@ -720,6 +762,7 @@ pyvmomi==7.0.2
     # via -r requirements/static/ci/common.in
 pyyaml==6.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   ansible-core
     #   clustershell
@@ -728,7 +771,9 @@ pyyaml==6.0.1
     #   yamllint
     #   yamlordereddictloader
 pyzmq==23.2.0
-    # via -r requirements/zeromq.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/zeromq.txt
 redis-py-cluster==2.1.3
     # via -r requirements/static/ci/linux.in
 redis==3.5.3
@@ -737,6 +782,7 @@ requests-oauthlib==1.3.0
     # via msrest
 requests==2.31.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   adal
@@ -765,7 +811,9 @@ responses==0.13.4
 rfc3987==1.3.8
     # via -r requirements/static/ci/common.in
 rpm-vercmp==0.1.2
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/static/pkg/linux.in
 rsa==4.7.2
     # via google-auth
 s3transfer==0.5.0
@@ -777,9 +825,12 @@ scp==0.13.6
 semantic-version==2.9.0
     # via etcd3-py
 setproctitle==1.3.2
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/static/pkg/linux.in
 six==1.16.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   apscheduler
     #   astroid
     #   bcrypt
@@ -793,6 +844,7 @@ six==1.16.0
     #   junos-eznc
     #   kazoo
     #   kubernetes
+    #   more-itertools
     #   msrestazure
     #   ncclient
     #   paramiko
@@ -815,9 +867,13 @@ sqlparse==0.4.4
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in
 tempora==4.1.1
-    # via portend
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   portend
 timelib==0.2.5
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/static/pkg/linux.in
 toml==0.10.2
     # via
     #   -r requirements/static/ci/common.in
@@ -832,6 +888,7 @@ tzlocal==3.0
     # via apscheduler
 urllib3==1.26.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   botocore
     #   docker
     #   kubernetes
@@ -862,10 +919,14 @@ yamlordereddictloader==0.4.0
     # via junos-eznc
 yarl==1.7.2
     # via aiohttp
-zc.lockfile==2.0
-    # via cherrypy
-zipp==3.5.0
-    # via importlib-metadata
+zc.lockfile==1.4
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   cherrypy
+zipp==3.6.0
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -674,7 +674,7 @@ pycparser==2.21 ; python_version >= "3.9"
     #   cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pygit2==1.9.1 ; python_version >= "3.10"
+pygit2==1.13.1 ; python_version >= "3.8"
     # via -r requirements/static/ci/linux.in
 pyiface==0.0.11
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -363,6 +363,7 @@ cassandra-driver==3.23.0
     # via -r requirements/static/ci/common.in
 certifi==2023.07.22
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
     #   kubernetes
     #   msrest
@@ -370,24 +371,29 @@ certifi==2023.07.22
     #   requests
 certvalidator==0.11.1
     # via vcert
-cffi==1.15.1
+cffi==1.14.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
     #   azure-datalake-store
     #   bcrypt
     #   cryptography
     #   pygit2
     #   pynacl
-charset-normalizer==2.0.12
+charset-normalizer==3.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   aiohttp
     #   requests
 cheetah3==3.2.6.post2
     # via -r requirements/static/ci/common.in
 cheroot==8.5.2
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   cherrypy
 cherrypy==18.6.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/linux.in
 click==7.1.1
@@ -395,11 +401,14 @@ click==7.1.1
 clustershell==1.8.3
     # via -r requirements/static/ci/common.in
 contextvars==2.4
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   adal
     #   ansible-core
@@ -415,6 +424,7 @@ distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   pytest-skip-markers
 dnspython==1.16.0
@@ -449,13 +459,18 @@ hglib==2.6.1
     # via -r requirements/static/ci/linux.in
 idna==2.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   etcd3-py
     #   requests
     #   yarl
 immutables==0.15
-    # via contextvars
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   contextvars
 importlib-metadata==6.0.0
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/static/pkg/linux.in
 iniconfig==1.0.1
     # via pytest
 ipaddress==1.0.22
@@ -463,24 +478,33 @@ ipaddress==1.0.22
 isodate==0.6.0
     # via msrest
 jaraco.classes==3.2.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   jaraco.collections
 jaraco.collections==3.4.0
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   cherrypy
 jaraco.functools==2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   cheroot
     #   jaraco.text
     #   tempora
 jaraco.text==3.5.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   jaraco.collections
 jinja2==3.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   ansible-core
     #   junos-eznc
     #   moto
 jmespath==1.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   boto3
@@ -500,7 +524,9 @@ kubernetes==3.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
     # via -r requirements/static/ci/common.in
 looseversion==1.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/base.txt
 lxml==4.9.1
     # via
     #   junos-eznc
@@ -509,6 +535,7 @@ mako==1.2.2
     # via -r requirements/static/ci/common.in
 markupsafe==2.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   jinja2
     #   mako
@@ -520,6 +547,7 @@ mock==3.0.5
     # via -r requirements/pytest.txt
 more-itertools==5.0.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   cheroot
     #   cherrypy
     #   jaraco.classes
@@ -528,6 +556,7 @@ moto==3.0.1
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
 msrest==0.6.14
@@ -633,6 +662,7 @@ oscrypto==1.2.0
     # via certvalidator
 packaging==22.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   ansible-core
     #   docker
@@ -654,9 +684,12 @@ platformdirs==2.2.0
 pluggy==0.13.0
     # via pytest
 portend==2.4
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   cherrypy
 psutil==5.8.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
@@ -669,11 +702,14 @@ pyasn1==0.4.8
     #   rsa
 pycparser==2.21 ; python_version >= "3.9"
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/linux.in
     #   cffi
 pycryptodomex==3.9.8
-    # via -r requirements/crypto.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/crypto.txt
 pygit2==1.13.1
     # via -r requirements/static/ci/linux.in
 pyiface==0.0.11
@@ -692,6 +728,7 @@ pynacl==1.5.0
     #   paramiko
 pyopenssl==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
 pyparsing==3.0.9
@@ -739,6 +776,7 @@ python-consul==1.1.0
     # via -r requirements/static/ci/linux.in
 python-dateutil==2.8.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   adal
     #   azure-cosmosdb-table
@@ -751,11 +789,14 @@ python-dateutil==2.8.1
 python-etcd==0.4.5
     # via -r requirements/static/ci/common.in
 python-gnupg==0.4.8
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/static/pkg/linux.in
 python-telegram-bot==13.7
     # via -r requirements/static/ci/linux.in
 pytz==2022.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   apscheduler
     #   moto
     #   python-telegram-bot
@@ -766,6 +807,7 @@ pyvmomi==6.7.1.2018.12
     # via -r requirements/static/ci/common.in
 pyyaml==6.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   ansible-core
     #   clustershell
@@ -776,6 +818,7 @@ pyyaml==6.0.1
     #   yamlordereddictloader
 pyzmq==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
 redis-py-cluster==2.1.3
@@ -786,6 +829,7 @@ requests-oauthlib==1.3.0
     # via msrest
 requests==2.31.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   adal
@@ -814,7 +858,9 @@ responses==0.10.6
 rfc3987==1.3.8
     # via -r requirements/static/ci/common.in
 rpm-vercmp==0.1.2
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/static/pkg/linux.in
 rsa==4.7.2
     # via google-auth
 s3transfer==0.5.2
@@ -824,9 +870,12 @@ scp==0.13.2
 semantic-version==2.9.0
     # via etcd3-py
 setproctitle==1.3.2
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/static/pkg/linux.in
 six==1.16.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   apscheduler
     #   bcrypt
     #   cassandra-driver
@@ -863,9 +912,13 @@ sqlparse==0.4.4
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in
 tempora==4.1.1
-    # via portend
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   portend
 timelib==0.2.5
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   -r requirements/static/pkg/linux.in
 toml==0.10.2
     # via -r requirements/static/ci/common.in
 tomli==2.0.1
@@ -884,6 +937,7 @@ tzlocal==2.1
     # via apscheduler
 urllib3==1.26.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
     #   botocore
     #   docker
     #   kubernetes
@@ -916,9 +970,13 @@ yamlordereddictloader==0.4.0
 yarl==1.7.2
     # via aiohttp
 zc.lockfile==1.4
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   cherrypy
 zipp==3.6.0
-    # via importlib-metadata
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -674,7 +674,7 @@ pycparser==2.21 ; python_version >= "3.9"
     #   cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pygit2==1.13.1 ; python_version >= "3.8"
+pygit2==1.13.1
     # via -r requirements/static/ci/linux.in
 pyiface==0.0.11
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -38,42 +38,53 @@ cassandra-driver==3.23.0
     # via -r requirements/static/ci/common.in
 certifi==2023.07.22
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt
     #   kubernetes
     #   requests
-cffi==1.15.1
+cffi==1.14.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt
     #   clr-loader
     #   cryptography
     #   pygit2
     #   pynacl
-charset-normalizer==2.1.1
+charset-normalizer==3.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   aiohttp
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.in
 cheroot==8.5.2
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   cherrypy
 cherrypy==18.6.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt
 click==7.1.2
     # via geomet
 clr-loader==0.2.4
-    # via pythonnet
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   pythonnet
 clustershell==1.8.3
     # via -r requirements/static/ci/common.in
 colorama==0.4.1
     # via pytest
 contextvars==2.4
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   -r requirements/base.txt
 cryptography==41.0.4
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/windows.txt
     #   etcd3-py
     #   moto
@@ -83,6 +94,7 @@ distlib==0.3.6
     # via virtualenv
 distro==1.5.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/base.txt
     #   pytest-skip-markers
 dmidecode==0.9.0
@@ -110,45 +122,64 @@ genshi==0.7.5
 geomet==0.1.2
     # via cassandra-driver
 gitdb==4.0.7
-    # via gitpython
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   gitpython
 gitpython==3.1.35
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt
 google-auth==1.6.3
     # via kubernetes
 idna==2.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   etcd3-py
     #   requests
     #   yarl
 immutables==0.15
-    # via contextvars
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   contextvars
 importlib-metadata==6.0.0
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   -r requirements/windows.txt
 iniconfig==1.0.1
     # via pytest
 ioloop==0.1a0
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   -r requirements/windows.txt
 ipaddress==1.0.22
     # via kubernetes
 jaraco.classes==3.2.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   jaraco.collections
 jaraco.collections==3.3.0
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   cherrypy
 jaraco.functools==2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   cheroot
     #   jaraco.text
     #   tempora
 jaraco.text==3.5.0
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   jaraco.collections
 jinja2==3.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/base.txt
     #   moto
 jmespath==1.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   boto3
@@ -160,13 +191,18 @@ keyring==5.7.1
 kubernetes==3.0.0
     # via -r requirements/static/ci/common.in
 looseversion==1.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   -r requirements/base.txt
 lxml==4.9.1
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   -r requirements/windows.txt
 mako==1.2.2
     # via -r requirements/static/ci/common.in
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/base.txt
     #   jinja2
     #   mako
@@ -176,6 +212,7 @@ mock==3.0.5
     # via -r requirements/pytest.txt
 more-itertools==8.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   cheroot
     #   cherrypy
     #   jaraco.classes
@@ -184,6 +221,7 @@ moto==3.0.1
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
 multidict==6.0.2
@@ -192,8 +230,9 @@ multidict==6.0.2
     #   yarl
 ntlm-auth==1.5.0
     # via requests-ntlm
-packaging==21.3
+packaging==22.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/base.txt
     #   docker
     #   pytest
@@ -210,9 +249,12 @@ platformdirs==2.5.4
 pluggy==0.13.0
     # via pytest
 portend==2.6
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   cherrypy
 psutil==5.8.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
@@ -221,30 +263,37 @@ pyasn1-modules==0.2.4
     # via google-auth
 pyasn1==0.4.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/windows.txt
     #   pyasn1-modules
     #   rsa
 pycparser==2.21 ; python_version >= "3.9"
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt
     #   cffi
 pycryptodomex==3.10.1
-    # via -r requirements/crypto.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   -r requirements/crypto.txt
 pygit2==1.13.1
     # via -r requirements/static/ci/windows.in
 pymssql==2.2.7
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   -r requirements/windows.txt
 pymysql==1.0.2
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   -r requirements/windows.txt
 pynacl==1.5.0
     # via -r requirements/static/ci/common.in
 pyopenssl==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/windows.txt
     #   etcd3-py
-pyparsing==3.0.9
-    # via packaging
 pyrsistent==0.17.3
     # via jsonschema
 pytest-custom-exit-code==0.3.0
@@ -284,6 +333,7 @@ pytest==7.2.0
     #   pytest-timeout
 python-dateutil==2.8.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/windows.txt
     #   botocore
     #   kubernetes
@@ -291,17 +341,23 @@ python-dateutil==2.8.1
 python-etcd==0.4.5
     # via -r requirements/static/ci/common.in
 python-gnupg==0.4.8
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   -r requirements/windows.txt
 pythonnet==3.0.1
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   -r requirements/windows.txt
 pytz==2022.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   moto
     #   tempora
 pyvmomi==6.7.1.2018.12
     # via -r requirements/static/ci/common.in
 pywin32==305
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/windows.txt
     #   docker
     #   pytest-skip-markers
@@ -310,6 +366,7 @@ pywinrm==0.4.1
     # via -r requirements/static/ci/windows.in
 pyyaml==6.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/base.txt
     #   clustershell
     #   kubernetes
@@ -317,12 +374,14 @@ pyyaml==6.0.1
     #   yamllint
 pyzmq==25.0.2 ; sys_platform == "win32"
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
 requests-ntlm==1.1.0
     # via pywinrm
 requests==2.31.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt
@@ -347,9 +406,12 @@ sed==0.3.1
 semantic-version==2.10.0
     # via etcd3-py
 setproctitle==1.3.2
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   -r requirements/windows.txt
 six==1.15.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   cassandra-driver
     #   cheroot
     #   etcd3-py
@@ -365,15 +427,21 @@ six==1.15.0
     #   responses
     #   websocket-client
 smmap==4.0.0
-    # via gitdb
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   gitdb
 sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in
 tempora==4.1.1
-    # via portend
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   portend
 timelib==0.2.5
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   -r requirements/windows.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.in
 tomli==2.0.1
@@ -384,6 +452,7 @@ typing-extensions==4.4.0
     #   pytest-system-statistics
 urllib3==1.26.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
     #   -r requirements/windows.txt
     #   botocore
     #   docker
@@ -407,9 +476,13 @@ werkzeug==2.2.3
     #   moto
     #   pytest-httpserver
 wheel==0.38.4
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   -r requirements/windows.txt
 wmi==1.5.1
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   -r requirements/windows.txt
 xmltodict==0.12.0
     # via
     #   moto
@@ -419,9 +492,13 @@ yamllint==1.28.0
 yarl==1.8.1
     # via aiohttp
 zc.lockfile==2.0
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   cherrypy
 zipp==3.12.0
-    # via importlib-metadata
+    # via
+    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -231,7 +231,7 @@ pycparser==2.21 ; python_version >= "3.9"
     #   cffi
 pycryptodomex==3.10.1
     # via -r requirements/crypto.txt
-pygit2==1.13.1 ; python_version >= "3.8"
+pygit2==1.13.1
     # via -r requirements/static/ci/windows.in
 pymssql==2.2.7
     # via -r requirements/windows.txt

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -231,7 +231,7 @@ pycparser==2.21 ; python_version >= "3.9"
     #   cffi
 pycryptodomex==3.10.1
     # via -r requirements/crypto.txt
-pygit2==1.9.1
+pygit2==1.13.1 ; python_version >= "3.8"
     # via -r requirements/static/ci/windows.in
 pymssql==2.2.7
     # via -r requirements/windows.txt

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -354,30 +354,36 @@ cassandra-driver==3.25.0
     # via -r requirements/static/ci/common.in
 certifi==2023.07.22
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/static/ci/common.in
     #   kubernetes
     #   msrest
     #   requests
 certvalidator==0.11.1
     # via vcert
-cffi==1.15.1
+cffi==1.14.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/static/ci/common.in
     #   azure-datalake-store
     #   bcrypt
     #   cryptography
     #   napalm
     #   pynacl
-charset-normalizer==2.0.12
+charset-normalizer==3.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   aiohttp
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.in
 cheroot==8.5.2
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   cherrypy
 cherrypy==18.6.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/linux.in
 ciscoconfparse==1.5.46
@@ -389,11 +395,14 @@ clustershell==1.8.3
 colorama==0.4.4
     # via ciscoconfparse
 contextvars==2.4
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   adal
     #   azure-cosmosdb-table
@@ -409,8 +418,9 @@ cryptography==41.0.4
     #   vcert
 distlib==0.3.3
     # via virtualenv
-distro==1.6.0
+distro==1.5.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/base.txt
     #   pytest-skip-markers
 dnspython==2.1.0
@@ -448,13 +458,17 @@ google-auth==2.1.0
     # via kubernetes
 idna==2.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   etcd3-py
     #   requests
     #   yarl
-immutables==0.19
-    # via contextvars
-importlib-metadata==4.8.1
+immutables==0.15
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   contextvars
+importlib-metadata==4.6.4
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   attrs
     #   backports.entry-points-selectable
@@ -472,24 +486,33 @@ ipaddress==1.0.23
 isodate==0.6.0
     # via msrest
 jaraco.classes==3.2.1
-    # via jaraco.collections
-jaraco.collections==3.4.0
-    # via cherrypy
-jaraco.functools==3.3.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   jaraco.collections
+jaraco.collections==3.4.0
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   cherrypy
+jaraco.functools==2.0
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   cheroot
     #   jaraco.text
     #   tempora
 jaraco.text==3.5.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   jaraco.collections
 jinja2==3.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/base.txt
     #   junos-eznc
     #   moto
     #   napalm
-jmespath==0.10.0
+jmespath==1.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   boto3
@@ -513,7 +536,9 @@ libnacl==1.8.0 ; sys_platform != "win32" and sys_platform != "darwin"
 loguru==0.6.0
     # via ciscoconfparse
 looseversion==1.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   -r requirements/base.txt
 lxml==4.9.1
     # via
     #   junos-eznc
@@ -523,6 +548,7 @@ mako==1.2.2
     # via -r requirements/static/ci/common.in
 markupsafe==2.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/base.txt
     #   jinja2
     #   mako
@@ -530,8 +556,9 @@ markupsafe==2.1.2
     #   werkzeug
 mock==4.0.3
     # via -r requirements/pytest.txt
-more-itertools==8.8.0
+more-itertools==5.0.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   cheroot
     #   cherrypy
     #   jaraco.classes
@@ -540,6 +567,7 @@ moto==3.0.1
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
 msrest==0.6.21
@@ -662,8 +690,9 @@ oauthlib==3.2.2
     # via requests-oauthlib
 oscrypto==1.2.1
     # via certvalidator
-packaging==21.3
+packaging==22.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/base.txt
     #   docker
     #   pytest
@@ -683,12 +712,15 @@ platformdirs==2.3.0
     # via virtualenv
 pluggy==1.0.0
     # via pytest
-portend==2.7.1
-    # via cherrypy
+portend==2.4
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   cherrypy
 profitbricks==4.1.3
     # via -r requirements/static/ci/cloud.in
 psutil==5.8.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
@@ -699,10 +731,14 @@ pyasn1==0.4.8
     # via
     #   pyasn1-modules
     #   rsa
-pycparser==2.19
-    # via cffi
-pycryptodomex==3.10.1
-    # via -r requirements/crypto.txt
+pycparser==2.17
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   cffi
+pycryptodomex==3.9.8
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   -r requirements/crypto.txt
 pyeapi==0.8.4
     # via napalm
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
@@ -715,12 +751,11 @@ pynacl==1.5.0
     #   paramiko
 pyopenssl==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
 pyparsing==3.0.9
-    # via
-    #   junos-eznc
-    #   packaging
+    # via junos-eznc
 pypsexec==0.1.0
     # via -r requirements/static/ci/cloud.in
 pyrsistent==0.18.0
@@ -768,8 +803,9 @@ pytest==7.2.0
     #   pytest-subtests
     #   pytest-system-statistics
     #   pytest-timeout
-python-dateutil==2.8.2
+python-dateutil==2.8.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   adal
     #   azure-cosmosdb-table
@@ -782,9 +818,12 @@ python-dateutil==2.8.2
 python-etcd==0.4.5
     # via -r requirements/static/ci/common.in
 python-gnupg==0.4.8
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   -r requirements/static/pkg/linux.in
 pytz==2022.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   moto
     #   tempora
 pyvmomi==7.0.2
@@ -793,6 +832,7 @@ pywinrm==0.3.0
     # via -r requirements/static/ci/cloud.in
 pyyaml==6.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/base.txt
     #   clustershell
     #   junos-eznc
@@ -802,6 +842,7 @@ pyyaml==6.0.1
     #   yamlordereddictloader
 pyzmq==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
 requests-ntlm==1.1.0
@@ -810,6 +851,7 @@ requests-oauthlib==1.3.0
     # via msrest
 requests==2.31.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   adal
@@ -838,7 +880,9 @@ responses==0.14.0
 rfc3987==1.3.8
     # via -r requirements/static/ci/common.in
 rpm-vercmp==0.1.2
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   -r requirements/static/pkg/linux.in
 rsa==4.7.2
     # via google-auth
 s3transfer==0.5.0
@@ -851,9 +895,12 @@ scp==0.14.1
 semantic-version==2.9.0
     # via etcd3-py
 setproctitle==1.3.2
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   -r requirements/static/pkg/linux.in
 six==1.16.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   bcrypt
     #   cassandra-driver
     #   cheroot
@@ -865,6 +912,7 @@ six==1.16.0
     #   junos-eznc
     #   kazoo
     #   kubernetes
+    #   more-itertools
     #   msrestazure
     #   ncclient
     #   paramiko
@@ -890,7 +938,9 @@ sqlparse==0.4.4
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in
 tempora==4.1.1
-    # via portend
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   portend
 tenacity==8.0.1
     # via netmiko
 textfsm==1.1.2
@@ -898,7 +948,9 @@ textfsm==1.1.2
     #   napalm
     #   ntc-templates
 timelib==0.2.5
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   -r requirements/static/pkg/linux.in
 toml==0.10.2
     # via -r requirements/static/ci/common.in
 tomli==2.0.1
@@ -907,16 +959,17 @@ transitions==0.8.9
     # via junos-eznc
 typing-extensions==3.10.0.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   aiohttp
     #   async-timeout
     #   gitpython
-    #   immutables
     #   importlib-metadata
     #   pytest-shell-utilities
     #   pytest-system-statistics
     #   yarl
 urllib3==1.26.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   botocore
     #   docker
     #   kubernetes
@@ -949,10 +1002,14 @@ yamlordereddictloader==0.4.0
     # via junos-eznc
 yarl==1.7.2
     # via aiohttp
-zc.lockfile==2.0
-    # via cherrypy
+zc.lockfile==1.4
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   cherrypy
 zipp==3.5.0
-    # via importlib-metadata
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.7/docs.txt
+++ b/requirements/static/ci/py3.7/docs.txt
@@ -12,7 +12,7 @@ certifi==2023.07.22
     # via
     #   -c requirements/static/ci/py3.7/linux.txt
     #   requests
-charset-normalizer==2.0.12
+charset-normalizer==3.2.0
     # via
     #   -c requirements/static/ci/py3.7/linux.txt
     #   requests
@@ -108,7 +108,7 @@ msgpack==1.0.2
     #   -r requirements/base.txt
 myst-docutils[linkify]==0.18.1
     # via -r requirements/static/ci/docs.in
-packaging==21.3
+packaging==22.0
     # via
     #   -c requirements/static/ci/py3.7/linux.txt
     #   -r requirements/base.txt
@@ -129,10 +129,6 @@ pyenchant==3.2.2
     # via sphinxcontrib-spelling
 pygments==2.8.1
     # via sphinx
-pyparsing==3.0.9
-    # via
-    #   -c requirements/static/ci/py3.7/linux.txt
-    #   packaging
 pytz==2022.1
     # via
     #   -c requirements/static/ci/py3.7/linux.txt

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -346,6 +346,8 @@ botocore==1.24.46
     #   boto3
     #   moto
     #   s3transfer
+cached-property==1.5.2
+    # via pygit2
 cachetools==3.1.0
     # via google-auth
 cassandra-driver==3.24.0
@@ -698,7 +700,7 @@ pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
-pygit2==1.8.0
+pygit2==1.10.1 ; python_version >= "3.7"
     # via -r requirements/static/ci/freebsd.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -354,14 +354,16 @@ cassandra-driver==3.24.0
     # via -r requirements/static/ci/common.in
 certifi==2023.07.22
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   -r requirements/static/ci/common.in
     #   kubernetes
     #   msrest
     #   requests
 certvalidator==0.11.1
     # via vcert
-cffi==1.15.1
+cffi==1.14.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   -r requirements/static/ci/common.in
     #   azure-datalake-store
     #   bcrypt
@@ -369,16 +371,20 @@ cffi==1.15.1
     #   napalm
     #   pygit2
     #   pynacl
-charset-normalizer==2.0.12
+charset-normalizer==3.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   aiohttp
     #   requests
 cheetah3==3.2.6.post2
     # via -r requirements/static/ci/common.in
 cheroot==8.5.2
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
+    #   cherrypy
 cherrypy==18.6.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/freebsd.in
 ciscoconfparse==1.5.19
@@ -390,11 +396,14 @@ clustershell==1.8.3
 colorama==0.4.3
     # via ciscoconfparse
 contextvars==2.4
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
+    #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   -r requirements/static/pkg/freebsd.in
     #   adal
     #   azure-cosmosdb-table
@@ -409,6 +418,7 @@ distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
     #   pytest-skip-markers
@@ -449,13 +459,17 @@ hglib==2.6.1
     # via -r requirements/static/ci/freebsd.in
 idna==2.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   etcd3-py
     #   requests
     #   yarl
 immutables==0.15
-    # via contextvars
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
+    #   contextvars
 importlib-metadata==4.6.4
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   -r requirements/static/pkg/freebsd.in
     #   attrs
     #   backports.entry-points-selectable
@@ -472,24 +486,33 @@ ipaddress==1.0.22
 isodate==0.6.0
     # via msrest
 jaraco.classes==3.2.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
+    #   jaraco.collections
 jaraco.collections==3.4.0
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
+    #   cherrypy
 jaraco.functools==2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   cheroot
     #   jaraco.text
     #   tempora
 jaraco.text==3.5.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
+    #   jaraco.collections
 jinja2==3.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   -r requirements/base.txt
     #   junos-eznc
     #   moto
     #   napalm
 jmespath==1.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   boto3
@@ -511,7 +534,9 @@ kubernetes==3.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
     # via -r requirements/static/ci/common.in
 looseversion==1.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
+    #   -r requirements/base.txt
 lxml==4.9.1
     # via
     #   junos-eznc
@@ -521,6 +546,7 @@ mako==1.2.2
     # via -r requirements/static/ci/common.in
 markupsafe==2.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   -r requirements/base.txt
     #   jinja2
     #   mako
@@ -532,6 +558,7 @@ mock==3.0.5
     # via -r requirements/pytest.txt
 more-itertools==5.0.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   cheroot
     #   cherrypy
     #   jaraco.classes
@@ -540,6 +567,7 @@ moto==3.0.1
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
 msrest==0.6.19
@@ -655,8 +683,9 @@ oauthlib==3.2.2
     # via requests-oauthlib
 oscrypto==1.2.0
     # via certvalidator
-packaging==21.3
+packaging==22.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   -r requirements/base.txt
     #   docker
     #   pytest
@@ -681,9 +710,12 @@ platformdirs==2.2.0
 pluggy==0.13.0
     # via pytest
 portend==2.4
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
+    #   cherrypy
 psutil==5.8.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
@@ -695,9 +727,13 @@ pyasn1==0.4.8
     #   pyasn1-modules
     #   rsa
 pycparser==2.17
-    # via cffi
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
+    #   cffi
 pycryptodomex==3.9.8
-    # via -r requirements/crypto.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
+    #   -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
 pygit2==1.10.1
@@ -712,12 +748,11 @@ pynacl==1.5.0
     #   paramiko
 pyopenssl==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   -r requirements/static/pkg/freebsd.in
     #   etcd3-py
 pyparsing==3.0.9
-    # via
-    #   junos-eznc
-    #   packaging
+    # via junos-eznc
 pyrsistent==0.17.3
     # via jsonschema
 pyserial==3.4
@@ -761,6 +796,7 @@ pytest==7.2.0
     #   pytest-timeout
 python-dateutil==2.8.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   -r requirements/static/pkg/freebsd.in
     #   adal
     #   azure-cosmosdb-table
@@ -773,15 +809,19 @@ python-dateutil==2.8.1
 python-etcd==0.4.5
     # via -r requirements/static/ci/common.in
 python-gnupg==0.4.8
-    # via -r requirements/static/pkg/freebsd.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
+    #   -r requirements/static/pkg/freebsd.in
 pytz==2022.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   moto
     #   tempora
 pyvmomi==6.7.1.2018.12
     # via -r requirements/static/ci/common.in
 pyyaml==6.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   -r requirements/base.txt
     #   clustershell
     #   junos-eznc
@@ -792,12 +832,14 @@ pyyaml==6.0.1
     #   yamlordereddictloader
 pyzmq==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
 requests-oauthlib==1.3.0
     # via msrest
 requests==2.31.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   adal
@@ -834,9 +876,12 @@ scp==0.13.2
 semantic-version==2.9.0
     # via etcd3-py
 setproctitle==1.3.2
-    # via -r requirements/static/pkg/freebsd.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
+    #   -r requirements/static/pkg/freebsd.in
 six==1.16.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   bcrypt
     #   cassandra-driver
     #   cheroot
@@ -869,7 +914,9 @@ sqlparse==0.4.4
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in
 tempora==4.1.1
-    # via portend
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
+    #   portend
 terminal==0.4.0
     # via ntc-templates
 textfsm==1.1.0
@@ -878,7 +925,9 @@ textfsm==1.1.0
     #   netmiko
     #   ntc-templates
 timelib==0.2.5
-    # via -r requirements/static/pkg/freebsd.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
+    #   -r requirements/static/pkg/freebsd.in
 toml==0.10.2
     # via -r requirements/static/ci/common.in
 tomli==2.0.1
@@ -887,6 +936,7 @@ transitions==0.8.1
     # via junos-eznc
 typing-extensions==3.10.0.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   aiohttp
     #   async-timeout
     #   gitpython
@@ -896,6 +946,7 @@ typing-extensions==3.10.0.0
     #   yarl
 urllib3==1.26.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
     #   botocore
     #   docker
     #   kubernetes
@@ -928,9 +979,13 @@ yamlordereddictloader==0.4.0
 yarl==1.7.2
     # via aiohttp
 zc.lockfile==1.4
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
+    #   cherrypy
 zipp==3.5.0
-    # via importlib-metadata
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/freebsd.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -700,7 +700,7 @@ pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
-pygit2==1.10.1 ; python_version >= "3.7"
+pygit2==1.10.1
     # via -r requirements/static/ci/freebsd.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.7/lint.txt
+++ b/requirements/static/ci/py3.7/lint.txt
@@ -351,6 +351,8 @@ botocore==1.24.46
     #   boto3
     #   moto
     #   s3transfer
+cached-property==1.5.2
+    # via pygit2
 cachetools==4.2.2
     # via
     #   google-auth
@@ -701,7 +703,7 @@ pycryptodomex==3.10.1
     # via -r requirements/crypto.txt
 pyeapi==0.8.4
     # via napalm
-pygit2==1.0.3 ; python_version <= "3.8"
+pygit2==1.10.1 ; python_version >= "3.7"
     # via -r requirements/static/ci/linux.in
 pyiface==0.0.11
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.7/lint.txt
+++ b/requirements/static/ci/py3.7/lint.txt
@@ -703,7 +703,7 @@ pycryptodomex==3.10.1
     # via -r requirements/crypto.txt
 pyeapi==0.8.4
     # via napalm
-pygit2==1.10.1 ; python_version >= "3.7"
+pygit2==1.10.1
     # via -r requirements/static/ci/linux.in
 pyiface==0.0.11
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.7/lint.txt
+++ b/requirements/static/ci/py3.7/lint.txt
@@ -361,6 +361,7 @@ cassandra-driver==3.25.0
     # via -r requirements/static/ci/common.in
 certifi==2023.07.22
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/static/ci/common.in
     #   kubernetes
     #   msrest
@@ -368,8 +369,9 @@ certifi==2023.07.22
     #   requests
 certvalidator==0.11.1
     # via vcert
-cffi==1.15.1
+cffi==1.14.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/static/ci/common.in
     #   azure-datalake-store
     #   bcrypt
@@ -377,16 +379,20 @@ cffi==1.15.1
     #   napalm
     #   pygit2
     #   pynacl
-charset-normalizer==2.0.4
+charset-normalizer==3.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   aiohttp
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.in
 cheroot==8.5.2
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   cherrypy
 cherrypy==18.6.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/linux.in
 ciscoconfparse==1.5.46
@@ -398,11 +404,14 @@ clustershell==1.8.3
 colorama==0.4.4
     # via ciscoconfparse
 contextvars==2.4
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   adal
     #   ansible-core
@@ -416,8 +425,10 @@ cryptography==41.0.4
     #   vcert
 distlib==0.3.2
     # via virtualenv
-distro==1.6.0
-    # via -r requirements/base.txt
+distro==1.5.0
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   -r requirements/base.txt
 dnspython==2.1.0
     # via
     #   -r requirements/static/ci/common.in
@@ -449,15 +460,19 @@ google-auth==2.0.1
     # via kubernetes
 hglib==2.6.1
     # via -r requirements/static/ci/linux.in
-idna==3.2
+idna==2.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   etcd3-py
     #   requests
     #   yarl
-immutables==0.19
-    # via contextvars
+immutables==0.15
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   contextvars
 importlib-metadata==4.6.4
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   backports.entry-points-selectable
     #   click
@@ -472,25 +487,34 @@ isodate==0.6.0
 isort==4.3.21
     # via pylint
 jaraco.classes==3.2.1
-    # via jaraco.collections
-jaraco.collections==3.4.0
-    # via cherrypy
-jaraco.functools==3.3.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   jaraco.collections
+jaraco.collections==3.4.0
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   cherrypy
+jaraco.functools==2.0
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   cheroot
     #   jaraco.text
     #   tempora
 jaraco.text==3.5.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   jaraco.collections
 jinja2==3.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/base.txt
     #   ansible-core
     #   junos-eznc
     #   moto
     #   napalm
-jmespath==0.10.0
+jmespath==1.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   boto3
@@ -516,7 +540,9 @@ libnacl==1.8.0 ; sys_platform != "win32" and sys_platform != "darwin"
 loguru==0.6.0
     # via ciscoconfparse
 looseversion==1.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   -r requirements/base.txt
 lxml==4.9.1
     # via
     #   junos-eznc
@@ -526,6 +552,7 @@ mako==1.2.2
     # via -r requirements/static/ci/common.in
 markupsafe==2.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/base.txt
     #   jinja2
     #   mako
@@ -537,8 +564,9 @@ mercurial==6.0.1
     # via -r requirements/static/ci/linux.in
 modernize==0.5
     # via saltpylint
-more-itertools==8.8.0
+more-itertools==5.0.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   cheroot
     #   cherrypy
     #   jaraco.classes
@@ -546,7 +574,9 @@ more-itertools==8.8.0
 moto==3.0.1
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   -r requirements/base.txt
 msrest==0.6.21
     # via
     #   azure-applicationinsights
@@ -664,8 +694,9 @@ oauthlib==3.2.2
     # via requests-oauthlib
 oscrypto==1.2.1
     # via certvalidator
-packaging==21.3
+packaging==22.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/base.txt
     #   ansible-core
     #   docker
@@ -685,10 +716,14 @@ pathspec==0.9.0
     # via yamllint
 platformdirs==2.2.0
     # via virtualenv
-portend==2.7.1
-    # via cherrypy
+portend==2.4
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   cherrypy
 psutil==5.8.0
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   -r requirements/base.txt
 pyasn1-modules==0.2.8
     # via google-auth
 pyasn1==0.4.8
@@ -697,10 +732,14 @@ pyasn1==0.4.8
     #   rsa
 pycodestyle==2.5.0
     # via saltpylint
-pycparser==2.20
-    # via cffi
-pycryptodomex==3.10.1
-    # via -r requirements/crypto.txt
+pycparser==2.17
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   cffi
+pycryptodomex==3.9.8
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   -r requirements/crypto.txt
 pyeapi==0.8.4
     # via napalm
 pygit2==1.10.1
@@ -725,12 +764,11 @@ pynacl==1.5.0
     #   paramiko
 pyopenssl==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
 pyparsing==3.0.9
-    # via
-    #   junos-eznc
-    #   packaging
+    # via junos-eznc
 pyrsistent==0.18.0
     # via jsonschema
 pyserial==3.5
@@ -739,8 +777,9 @@ pyserial==3.5
     #   netmiko
 python-consul==1.1.0
     # via -r requirements/static/ci/linux.in
-python-dateutil==2.8.2
+python-dateutil==2.8.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   adal
     #   azure-cosmosdb-table
@@ -753,11 +792,14 @@ python-dateutil==2.8.2
 python-etcd==0.4.5
     # via -r requirements/static/ci/common.in
 python-gnupg==0.4.8
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   -r requirements/static/pkg/linux.in
 python-telegram-bot==13.7
     # via -r requirements/static/ci/linux.in
 pytz==2022.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   apscheduler
     #   moto
     #   python-telegram-bot
@@ -767,6 +809,7 @@ pyvmomi==7.0.2
     # via -r requirements/static/ci/common.in
 pyyaml==6.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/base.txt
     #   ansible-core
     #   clustershell
@@ -776,7 +819,9 @@ pyyaml==6.0.1
     #   yamllint
     #   yamlordereddictloader
 pyzmq==23.2.0
-    # via -r requirements/zeromq.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   -r requirements/zeromq.txt
 redis-py-cluster==2.1.3
     # via -r requirements/static/ci/linux.in
 redis==3.5.3
@@ -785,6 +830,7 @@ requests-oauthlib==1.3.0
     # via msrest
 requests==2.31.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   adal
@@ -814,7 +860,9 @@ responses==0.13.4
 rfc3987==1.3.8
     # via -r requirements/static/ci/common.in
 rpm-vercmp==0.1.2
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   -r requirements/static/pkg/linux.in
 rsa==4.7.2
     # via google-auth
 s3transfer==0.5.0
@@ -829,9 +877,12 @@ scp==0.13.6
 semantic-version==2.9.0
     # via etcd3-py
 setproctitle==1.3.2
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   -r requirements/static/pkg/linux.in
 six==1.16.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   apscheduler
     #   astroid
     #   bcrypt
@@ -845,6 +896,7 @@ six==1.16.0
     #   junos-eznc
     #   kazoo
     #   kubernetes
+    #   more-itertools
     #   msrestazure
     #   ncclient
     #   paramiko
@@ -868,7 +920,9 @@ sqlparse==0.4.4
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in
 tempora==4.1.1
-    # via portend
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   portend
 tenacity==8.0.1
     # via netmiko
 textfsm==1.1.2
@@ -876,7 +930,9 @@ textfsm==1.1.2
     #   napalm
     #   ntc-templates
 timelib==0.2.5
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   -r requirements/static/pkg/linux.in
 toml==0.10.2
     # via
     #   -r requirements/static/ci/common.in
@@ -889,18 +945,19 @@ twilio==7.9.2
     # via -r requirements/static/ci/linux.in
 typed-ast==1.4.1
     # via astroid
-typing-extensions==4.6.3
+typing-extensions==3.10.0.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   aiohttp
     #   async-timeout
     #   gitpython
-    #   immutables
     #   importlib-metadata
     #   yarl
 tzlocal==3.0
     # via apscheduler
 urllib3==1.26.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   botocore
     #   docker
     #   kubernetes
@@ -931,10 +988,14 @@ yamlordereddictloader==0.4.0
     # via junos-eznc
 yarl==1.7.2
     # via aiohttp
-zc.lockfile==2.0
-    # via cherrypy
+zc.lockfile==1.4
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   cherrypy
 zipp==3.5.0
-    # via importlib-metadata
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -367,6 +367,7 @@ cassandra-driver==3.23.0
     # via -r requirements/static/ci/common.in
 certifi==2023.07.22
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/static/ci/common.in
     #   kubernetes
     #   msrest
@@ -374,8 +375,9 @@ certifi==2023.07.22
     #   requests
 certvalidator==0.11.1
     # via vcert
-cffi==1.15.1
+cffi==1.14.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/static/ci/common.in
     #   azure-datalake-store
     #   bcrypt
@@ -383,16 +385,20 @@ cffi==1.15.1
     #   napalm
     #   pygit2
     #   pynacl
-charset-normalizer==2.0.12
+charset-normalizer==3.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   aiohttp
     #   requests
 cheetah3==3.2.6.post2
     # via -r requirements/static/ci/common.in
 cheroot==8.5.2
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   cherrypy
 cherrypy==18.6.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/linux.in
 ciscoconfparse==1.5.19
@@ -404,11 +410,14 @@ clustershell==1.8.3
 colorama==0.4.3
     # via ciscoconfparse
 contextvars==2.4
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   adal
     #   ansible-core
@@ -424,6 +433,7 @@ distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/base.txt
     #   pytest-skip-markers
 dnspython==1.16.0
@@ -463,13 +473,17 @@ hglib==2.6.1
     # via -r requirements/static/ci/linux.in
 idna==2.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   etcd3-py
     #   requests
     #   yarl
 immutables==0.15
-    # via contextvars
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   contextvars
 importlib-metadata==4.6.4
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   attrs
     #   backports.entry-points-selectable
@@ -486,18 +500,26 @@ ipaddress==1.0.22
 isodate==0.6.0
     # via msrest
 jaraco.classes==3.2.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   jaraco.collections
 jaraco.collections==3.4.0
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   cherrypy
 jaraco.functools==2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   cheroot
     #   jaraco.text
     #   tempora
 jaraco.text==3.5.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   jaraco.collections
 jinja2==3.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/base.txt
     #   ansible-core
     #   junos-eznc
@@ -505,6 +527,7 @@ jinja2==3.1.2
     #   napalm
 jmespath==1.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   boto3
@@ -526,7 +549,9 @@ kubernetes==3.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
     # via -r requirements/static/ci/common.in
 looseversion==1.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   -r requirements/base.txt
 lxml==4.9.1
     # via
     #   junos-eznc
@@ -536,6 +561,7 @@ mako==1.2.2
     # via -r requirements/static/ci/common.in
 markupsafe==2.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/base.txt
     #   jinja2
     #   mako
@@ -547,6 +573,7 @@ mock==3.0.5
     # via -r requirements/pytest.txt
 more-itertools==5.0.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   cheroot
     #   cherrypy
     #   jaraco.classes
@@ -555,6 +582,7 @@ moto==3.0.1
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
 msrest==0.6.14
@@ -667,8 +695,9 @@ oauthlib==3.2.2
     # via requests-oauthlib
 oscrypto==1.2.0
     # via certvalidator
-packaging==21.3
+packaging==22.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/base.txt
     #   ansible-core
     #   docker
@@ -694,9 +723,12 @@ platformdirs==2.2.0
 pluggy==0.13.0
     # via pytest
 portend==2.4
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   cherrypy
 psutil==5.8.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
@@ -708,9 +740,13 @@ pyasn1==0.4.8
     #   pyasn1-modules
     #   rsa
 pycparser==2.17
-    # via cffi
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   cffi
 pycryptodomex==3.9.8
-    # via -r requirements/crypto.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
 pygit2==1.10.1
@@ -731,12 +767,11 @@ pynacl==1.5.0
     #   paramiko
 pyopenssl==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
 pyparsing==3.0.9
-    # via
-    #   junos-eznc
-    #   packaging
+    # via junos-eznc
 pyrsistent==0.17.3
     # via jsonschema
 pyserial==3.4
@@ -782,6 +817,7 @@ python-consul==1.1.0
     # via -r requirements/static/ci/linux.in
 python-dateutil==2.8.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   adal
     #   azure-cosmosdb-table
@@ -794,11 +830,14 @@ python-dateutil==2.8.1
 python-etcd==0.4.5
     # via -r requirements/static/ci/common.in
 python-gnupg==0.4.8
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   -r requirements/static/pkg/linux.in
 python-telegram-bot==13.7
     # via -r requirements/static/ci/linux.in
 pytz==2022.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   apscheduler
     #   moto
     #   python-telegram-bot
@@ -809,6 +848,7 @@ pyvmomi==6.7.1.2018.12
     # via -r requirements/static/ci/common.in
 pyyaml==6.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/base.txt
     #   ansible-core
     #   clustershell
@@ -820,6 +860,7 @@ pyyaml==6.0.1
     #   yamlordereddictloader
 pyzmq==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
 redis-py-cluster==2.1.3
@@ -830,6 +871,7 @@ requests-oauthlib==1.3.0
     # via msrest
 requests==2.31.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   adal
@@ -859,7 +901,9 @@ responses==0.10.6
 rfc3987==1.3.8
     # via -r requirements/static/ci/common.in
 rpm-vercmp==0.1.2
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   -r requirements/static/pkg/linux.in
 rsa==4.7.2
     # via google-auth
 s3transfer==0.5.2
@@ -872,9 +916,12 @@ scp==0.13.2
 semantic-version==2.9.0
     # via etcd3-py
 setproctitle==1.3.2
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   -r requirements/static/pkg/linux.in
 six==1.16.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   apscheduler
     #   bcrypt
     #   cassandra-driver
@@ -912,7 +959,9 @@ sqlparse==0.4.4
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in
 tempora==4.1.1
-    # via portend
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   portend
 terminal==0.4.0
     # via ntc-templates
 textfsm==1.1.0
@@ -921,7 +970,9 @@ textfsm==1.1.0
     #   netmiko
     #   ntc-templates
 timelib==0.2.5
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   -r requirements/static/pkg/linux.in
 toml==0.10.2
     # via -r requirements/static/ci/common.in
 tomli==2.0.1
@@ -934,6 +985,7 @@ twilio==7.9.2
     # via -r requirements/static/ci/linux.in
 typing-extensions==3.10.0.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   aiohttp
     #   async-timeout
     #   gitpython
@@ -945,6 +997,7 @@ tzlocal==2.1
     # via apscheduler
 urllib3==1.26.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
     #   botocore
     #   docker
     #   kubernetes
@@ -977,9 +1030,13 @@ yamlordereddictloader==0.4.0
 yarl==1.7.2
     # via aiohttp
 zc.lockfile==1.4
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   cherrypy
 zipp==3.5.0
-    # via importlib-metadata
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/linux.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -713,7 +713,7 @@ pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
-pygit2==1.10.1 ; python_version >= "3.7"
+pygit2==1.10.1
     # via -r requirements/static/ci/linux.in
 pyiface==0.0.11
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -357,6 +357,8 @@ botocore==1.24.46
     #   boto3
     #   moto
     #   s3transfer
+cached-property==1.5.2
+    # via pygit2
 cachetools==4.2.2
     # via
     #   google-auth
@@ -711,7 +713,7 @@ pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
-pygit2==1.0.3 ; python_version <= "3.8"
+pygit2==1.10.1 ; python_version >= "3.7"
     # via -r requirements/static/ci/linux.in
 pyiface==0.0.11
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -44,42 +44,53 @@ cassandra-driver==3.23.0
     # via -r requirements/static/ci/common.in
 certifi==2023.07.22
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt
     #   kubernetes
     #   requests
-cffi==1.15.1
+cffi==1.14.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt
     #   clr-loader
     #   cryptography
     #   pygit2
     #   pynacl
-charset-normalizer==2.0.12
+charset-normalizer==3.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   aiohttp
     #   requests
 cheetah3==3.2.6.post2
     # via -r requirements/static/ci/common.in
 cheroot==8.5.2
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
+    #   cherrypy
 cherrypy==18.6.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt
 click==7.1.2
     # via geomet
 clr-loader==0.2.4
-    # via pythonnet
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
+    #   pythonnet
 clustershell==1.8.3
     # via -r requirements/static/ci/common.in
 colorama==0.4.1
     # via pytest
 contextvars==2.4
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
+    #   -r requirements/base.txt
 cryptography==41.0.4
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/windows.txt
     #   etcd3-py
     #   moto
@@ -89,6 +100,7 @@ distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/base.txt
     #   pytest-skip-markers
 dmidecode==0.9.0
@@ -116,22 +128,29 @@ genshi==0.7.5
 geomet==0.1.2
     # via cassandra-driver
 gitdb==4.0.7
-    # via gitpython
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
+    #   gitpython
 gitpython==3.1.35
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt
 google-auth==1.6.3
     # via kubernetes
 idna==2.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   etcd3-py
     #   requests
     #   yarl
 immutables==0.15
-    # via contextvars
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
+    #   contextvars
 importlib-metadata==4.6.4
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/windows.txt
     #   attrs
     #   backports.entry-points-selectable
@@ -144,26 +163,37 @@ importlib-metadata==4.6.4
 iniconfig==1.0.1
     # via pytest
 ioloop==0.1a0
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
+    #   -r requirements/windows.txt
 ipaddress==1.0.22
     # via kubernetes
 jaraco.classes==3.2.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
+    #   jaraco.collections
 jaraco.collections==3.3.0
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
+    #   cherrypy
 jaraco.functools==2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   cheroot
     #   jaraco.text
     #   tempora
 jaraco.text==3.5.0
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
+    #   jaraco.collections
 jinja2==3.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/base.txt
     #   moto
 jmespath==1.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   boto3
@@ -175,13 +205,18 @@ keyring==5.7.1
 kubernetes==3.0.0
     # via -r requirements/static/ci/common.in
 looseversion==1.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
+    #   -r requirements/base.txt
 lxml==4.9.1
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
+    #   -r requirements/windows.txt
 mako==1.2.2
     # via -r requirements/static/ci/common.in
 markupsafe==2.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/base.txt
     #   jinja2
     #   mako
@@ -191,6 +226,7 @@ mock==3.0.5
     # via -r requirements/pytest.txt
 more-itertools==8.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   cheroot
     #   cherrypy
     #   jaraco.classes
@@ -199,6 +235,7 @@ moto==3.0.1
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
 multidict==6.0.2
@@ -207,8 +244,9 @@ multidict==6.0.2
     #   yarl
 ntlm-auth==1.5.0
     # via requests-ntlm
-packaging==21.3
+packaging==22.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/base.txt
     #   docker
     #   pytest
@@ -225,9 +263,12 @@ platformdirs==2.2.0
 pluggy==0.13.0
     # via pytest
 portend==2.6
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
+    #   cherrypy
 psutil==5.8.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
@@ -236,29 +277,36 @@ pyasn1-modules==0.2.4
     # via google-auth
 pyasn1==0.4.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/windows.txt
     #   pyasn1-modules
     #   rsa
 pycparser==2.21
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/windows.txt
     #   cffi
 pycryptodomex==3.10.1
-    # via -r requirements/crypto.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
+    #   -r requirements/crypto.txt
 pygit2==1.10.1
     # via -r requirements/static/ci/windows.in
 pymssql==2.2.1
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
+    #   -r requirements/windows.txt
 pymysql==1.0.2
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
+    #   -r requirements/windows.txt
 pynacl==1.5.0
     # via -r requirements/static/ci/common.in
 pyopenssl==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/windows.txt
     #   etcd3-py
-pyparsing==3.0.9
-    # via packaging
 pyrsistent==0.17.3
     # via jsonschema
 pytest-custom-exit-code==0.3.0
@@ -298,6 +346,7 @@ pytest==7.2.0
     #   pytest-timeout
 python-dateutil==2.8.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/windows.txt
     #   botocore
     #   kubernetes
@@ -305,17 +354,23 @@ python-dateutil==2.8.1
 python-etcd==0.4.5
     # via -r requirements/static/ci/common.in
 python-gnupg==0.4.8
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
+    #   -r requirements/windows.txt
 pythonnet==3.0.1
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
+    #   -r requirements/windows.txt
 pytz==2022.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   moto
     #   tempora
 pyvmomi==6.7.1.2018.12
     # via -r requirements/static/ci/common.in
 pywin32==305
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/windows.txt
     #   cherrypy
     #   docker
@@ -325,6 +380,7 @@ pywinrm==0.4.1
     # via -r requirements/static/ci/windows.in
 pyyaml==6.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/base.txt
     #   clustershell
     #   kubernetes
@@ -332,12 +388,14 @@ pyyaml==6.0.1
     #   yamllint
 pyzmq==25.0.2 ; sys_platform == "win32"
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
 requests-ntlm==1.1.0
     # via pywinrm
 requests==2.31.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt
@@ -362,9 +420,12 @@ sed==0.3.1
 semantic-version==2.9.0
     # via etcd3-py
 setproctitle==1.3.2
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
+    #   -r requirements/windows.txt
 six==1.15.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   cassandra-driver
     #   cheroot
     #   etcd3-py
@@ -381,21 +442,28 @@ six==1.15.0
     #   virtualenv
     #   websocket-client
 smmap==4.0.0
-    # via gitdb
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
+    #   gitdb
 sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in
 tempora==4.1.1
-    # via portend
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
+    #   portend
 timelib==0.2.5
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
+    #   -r requirements/windows.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.in
 tomli==2.0.1
     # via pytest
-typing-extensions==4.2.0
+typing-extensions==4.4.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   aiohttp
     #   async-timeout
     #   gitpython
@@ -405,6 +473,7 @@ typing-extensions==4.2.0
     #   yarl
 urllib3==1.26.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
     #   -r requirements/windows.txt
     #   botocore
     #   docker
@@ -428,9 +497,13 @@ werkzeug==2.2.3
     #   moto
     #   pytest-httpserver
 wheel==0.38.4
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
+    #   -r requirements/windows.txt
 wmi==1.5.1
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
+    #   -r requirements/windows.txt
 xmltodict==0.12.0
     # via
     #   moto
@@ -440,9 +513,13 @@ yamllint==1.26.3
 yarl==1.7.2
     # via aiohttp
 zc.lockfile==2.0
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
+    #   cherrypy
 zipp==3.5.0
-    # via importlib-metadata
+    # via
+    #   -c requirements/static/ci/../pkg/py3.7/windows.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -245,7 +245,7 @@ pycparser==2.21
     #   cffi
 pycryptodomex==3.10.1
     # via -r requirements/crypto.txt
-pygit2==1.9.1
+pygit2==1.10.1 ; python_version >= "3.7"
     # via -r requirements/static/ci/windows.in
 pymssql==2.2.1
     # via -r requirements/windows.txt

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -245,7 +245,7 @@ pycparser==2.21
     #   cffi
 pycryptodomex==3.10.1
     # via -r requirements/crypto.txt
-pygit2==1.10.1 ; python_version >= "3.7"
+pygit2==1.10.1
     # via -r requirements/static/ci/windows.in
 pymssql==2.2.1
     # via -r requirements/windows.txt

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -352,30 +352,36 @@ cassandra-driver==3.25.0
     # via -r requirements/static/ci/common.in
 certifi==2023.07.22
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/static/ci/common.in
     #   kubernetes
     #   msrest
     #   requests
 certvalidator==0.11.1
     # via vcert
-cffi==1.15.1
+cffi==1.14.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/static/ci/common.in
     #   azure-datalake-store
     #   bcrypt
     #   cryptography
     #   napalm
     #   pynacl
-charset-normalizer==2.0.12
+charset-normalizer==3.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   aiohttp
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.in
 cheroot==8.5.2
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   cherrypy
 cherrypy==18.6.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/linux.in
 ciscoconfparse==1.5.46
@@ -387,11 +393,14 @@ clustershell==1.8.3
 colorama==0.4.4
     # via ciscoconfparse
 contextvars==2.4
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   adal
     #   azure-cosmosdb-table
@@ -407,8 +416,9 @@ cryptography==41.0.4
     #   vcert
 distlib==0.3.3
     # via virtualenv
-distro==1.6.0
+distro==1.5.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt
     #   pytest-skip-markers
 dnspython==2.1.0
@@ -446,13 +456,18 @@ google-auth==2.1.0
     # via kubernetes
 idna==2.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   etcd3-py
     #   requests
     #   yarl
-immutables==0.19
-    # via contextvars
-importlib-metadata==4.8.1
-    # via -r requirements/static/pkg/linux.in
+immutables==0.15
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   contextvars
+importlib-metadata==4.6.4
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/static/pkg/linux.in
 iniconfig==1.1.1
     # via pytest
 ipaddress==1.0.23
@@ -460,24 +475,33 @@ ipaddress==1.0.23
 isodate==0.6.0
     # via msrest
 jaraco.classes==3.2.1
-    # via jaraco.collections
-jaraco.collections==3.4.0
-    # via cherrypy
-jaraco.functools==3.3.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   jaraco.collections
+jaraco.collections==3.4.0
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   cherrypy
+jaraco.functools==2.0
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   cheroot
     #   jaraco.text
     #   tempora
 jaraco.text==3.5.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   jaraco.collections
 jinja2==3.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt
     #   junos-eznc
     #   moto
     #   napalm
-jmespath==0.10.0
+jmespath==1.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   boto3
@@ -501,7 +525,9 @@ libnacl==1.8.0 ; sys_platform != "win32" and sys_platform != "darwin"
 loguru==0.6.0
     # via ciscoconfparse
 looseversion==1.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/base.txt
 lxml==4.9.1
     # via
     #   junos-eznc
@@ -511,6 +537,7 @@ mako==1.2.2
     # via -r requirements/static/ci/common.in
 markupsafe==2.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt
     #   jinja2
     #   mako
@@ -518,8 +545,9 @@ markupsafe==2.1.2
     #   werkzeug
 mock==4.0.3
     # via -r requirements/pytest.txt
-more-itertools==8.8.0
+more-itertools==5.0.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   cheroot
     #   cherrypy
     #   jaraco.classes
@@ -528,6 +556,7 @@ moto==3.0.1
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
 msrest==0.6.21
@@ -650,8 +679,9 @@ oauthlib==3.2.2
     # via requests-oauthlib
 oscrypto==1.2.1
     # via certvalidator
-packaging==21.3
+packaging==22.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt
     #   docker
     #   pytest
@@ -671,12 +701,15 @@ platformdirs==2.3.0
     # via virtualenv
 pluggy==1.0.0
     # via pytest
-portend==2.7.1
-    # via cherrypy
+portend==2.4
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   cherrypy
 profitbricks==4.1.3
     # via -r requirements/static/ci/cloud.in
 psutil==5.8.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
@@ -687,10 +720,14 @@ pyasn1==0.4.8
     # via
     #   pyasn1-modules
     #   rsa
-pycparser==2.19
-    # via cffi
-pycryptodomex==3.10.1
-    # via -r requirements/crypto.txt
+pycparser==2.17
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   cffi
+pycryptodomex==3.9.8
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/crypto.txt
 pyeapi==0.8.4
     # via napalm
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
@@ -703,12 +740,11 @@ pynacl==1.5.0
     #   paramiko
 pyopenssl==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
 pyparsing==3.0.9
-    # via
-    #   junos-eznc
-    #   packaging
+    # via junos-eznc
 pypsexec==0.1.0
     # via -r requirements/static/ci/cloud.in
 pyrsistent==0.18.0
@@ -756,8 +792,9 @@ pytest==7.2.0
     #   pytest-subtests
     #   pytest-system-statistics
     #   pytest-timeout
-python-dateutil==2.8.2
+python-dateutil==2.8.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   adal
     #   azure-cosmosdb-table
@@ -770,9 +807,12 @@ python-dateutil==2.8.2
 python-etcd==0.4.5
     # via -r requirements/static/ci/common.in
 python-gnupg==0.4.8
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/static/pkg/linux.in
 pytz==2022.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   moto
     #   tempora
 pyvmomi==7.0.2
@@ -781,6 +821,7 @@ pywinrm==0.3.0
     # via -r requirements/static/ci/cloud.in
 pyyaml==6.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt
     #   clustershell
     #   junos-eznc
@@ -790,6 +831,7 @@ pyyaml==6.0.1
     #   yamlordereddictloader
 pyzmq==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
 requests-ntlm==1.1.0
@@ -798,6 +840,7 @@ requests-oauthlib==1.3.0
     # via msrest
 requests==2.31.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   adal
@@ -826,7 +869,9 @@ responses==0.14.0
 rfc3987==1.3.8
     # via -r requirements/static/ci/common.in
 rpm-vercmp==0.1.2
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/static/pkg/linux.in
 rsa==4.7.2
     # via google-auth
 s3transfer==0.5.0
@@ -839,9 +884,12 @@ scp==0.14.1
 semantic-version==2.9.0
     # via etcd3-py
 setproctitle==1.3.2
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/static/pkg/linux.in
 six==1.16.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   bcrypt
     #   cassandra-driver
     #   cheroot
@@ -853,6 +901,7 @@ six==1.16.0
     #   junos-eznc
     #   kazoo
     #   kubernetes
+    #   more-itertools
     #   msrestazure
     #   ncclient
     #   paramiko
@@ -878,7 +927,9 @@ sqlparse==0.4.4
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in
 tempora==4.1.1
-    # via portend
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   portend
 tenacity==8.0.1
     # via netmiko
 textfsm==1.1.2
@@ -886,7 +937,9 @@ textfsm==1.1.2
     #   napalm
     #   ntc-templates
 timelib==0.2.5
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/static/pkg/linux.in
 toml==0.10.2
     # via -r requirements/static/ci/common.in
 tomli==2.0.1
@@ -899,6 +952,7 @@ typing-extensions==3.10.0.2
     #   pytest-system-statistics
 urllib3==1.26.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   botocore
     #   docker
     #   kubernetes
@@ -931,10 +985,14 @@ yamlordereddictloader==0.4.0
     # via junos-eznc
 yarl==1.7.2
     # via aiohttp
-zc.lockfile==2.0
-    # via cherrypy
+zc.lockfile==1.4
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   cherrypy
 zipp==3.5.0
-    # via importlib-metadata
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.8/docs.txt
+++ b/requirements/static/ci/py3.8/docs.txt
@@ -12,7 +12,7 @@ certifi==2023.07.22
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   requests
-charset-normalizer==2.0.12
+charset-normalizer==3.2.0
     # via
     #   -c requirements/static/ci/py3.8/linux.txt
     #   requests

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -687,7 +687,7 @@ pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
-pygit2==1.8.0
+pygit2==1.13.1 ; python_version >= "3.8"
     # via -r requirements/static/ci/freebsd.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -687,7 +687,7 @@ pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
-pygit2==1.13.1 ; python_version >= "3.8"
+pygit2==1.13.1
     # via -r requirements/static/ci/freebsd.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -350,14 +350,16 @@ cassandra-driver==3.24.0
     # via -r requirements/static/ci/common.in
 certifi==2023.07.22
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   -r requirements/static/ci/common.in
     #   kubernetes
     #   msrest
     #   requests
 certvalidator==0.11.1
     # via vcert
-cffi==1.15.1
+cffi==1.14.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   -r requirements/static/ci/common.in
     #   azure-datalake-store
     #   bcrypt
@@ -365,16 +367,20 @@ cffi==1.15.1
     #   napalm
     #   pygit2
     #   pynacl
-charset-normalizer==2.0.12
+charset-normalizer==3.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   aiohttp
     #   requests
 cheetah3==3.2.6.post2
     # via -r requirements/static/ci/common.in
 cheroot==8.5.2
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
+    #   cherrypy
 cherrypy==18.6.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/freebsd.in
 ciscoconfparse==1.5.19
@@ -386,11 +392,14 @@ clustershell==1.8.3
 colorama==0.4.3
     # via ciscoconfparse
 contextvars==2.4
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
+    #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   -r requirements/static/pkg/freebsd.in
     #   adal
     #   azure-cosmosdb-table
@@ -405,6 +414,7 @@ distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
     #   pytest-skip-markers
@@ -445,13 +455,18 @@ hglib==2.6.1
     # via -r requirements/static/ci/freebsd.in
 idna==2.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   etcd3-py
     #   requests
     #   yarl
 immutables==0.15
-    # via contextvars
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
+    #   contextvars
 importlib-metadata==4.6.4
-    # via -r requirements/static/pkg/freebsd.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
+    #   -r requirements/static/pkg/freebsd.in
 iniconfig==1.0.1
     # via pytest
 ipaddress==1.0.22
@@ -459,24 +474,33 @@ ipaddress==1.0.22
 isodate==0.6.0
     # via msrest
 jaraco.classes==3.2.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
+    #   jaraco.collections
 jaraco.collections==3.4.0
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
+    #   cherrypy
 jaraco.functools==2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   cheroot
     #   jaraco.text
     #   tempora
 jaraco.text==3.5.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
+    #   jaraco.collections
 jinja2==3.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   -r requirements/base.txt
     #   junos-eznc
     #   moto
     #   napalm
 jmespath==1.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   boto3
@@ -498,7 +522,9 @@ kubernetes==3.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
     # via -r requirements/static/ci/common.in
 looseversion==1.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
+    #   -r requirements/base.txt
 lxml==4.9.1
     # via
     #   junos-eznc
@@ -508,6 +534,7 @@ mako==1.2.2
     # via -r requirements/static/ci/common.in
 markupsafe==2.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   -r requirements/base.txt
     #   jinja2
     #   mako
@@ -519,6 +546,7 @@ mock==3.0.5
     # via -r requirements/pytest.txt
 more-itertools==5.0.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   cheroot
     #   cherrypy
     #   jaraco.classes
@@ -527,6 +555,7 @@ moto==3.0.1
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
 msrest==0.6.19
@@ -642,8 +671,9 @@ oauthlib==3.2.2
     # via requests-oauthlib
 oscrypto==1.2.0
     # via certvalidator
-packaging==21.3
+packaging==22.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   -r requirements/base.txt
     #   docker
     #   pytest
@@ -668,9 +698,12 @@ platformdirs==2.2.0
 pluggy==0.13.0
     # via pytest
 portend==2.4
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
+    #   cherrypy
 psutil==5.8.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
@@ -682,9 +715,13 @@ pyasn1==0.4.8
     #   pyasn1-modules
     #   rsa
 pycparser==2.17
-    # via cffi
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
+    #   cffi
 pycryptodomex==3.9.8
-    # via -r requirements/crypto.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
+    #   -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
 pygit2==1.13.1
@@ -699,12 +736,11 @@ pynacl==1.5.0
     #   paramiko
 pyopenssl==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   -r requirements/static/pkg/freebsd.in
     #   etcd3-py
 pyparsing==3.0.9
-    # via
-    #   junos-eznc
-    #   packaging
+    # via junos-eznc
 pyrsistent==0.17.3
     # via jsonschema
 pyserial==3.4
@@ -748,6 +784,7 @@ pytest==7.2.0
     #   pytest-timeout
 python-dateutil==2.8.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   -r requirements/static/pkg/freebsd.in
     #   adal
     #   azure-cosmosdb-table
@@ -760,15 +797,19 @@ python-dateutil==2.8.1
 python-etcd==0.4.5
     # via -r requirements/static/ci/common.in
 python-gnupg==0.4.8
-    # via -r requirements/static/pkg/freebsd.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
+    #   -r requirements/static/pkg/freebsd.in
 pytz==2022.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   moto
     #   tempora
 pyvmomi==6.7.1.2018.12
     # via -r requirements/static/ci/common.in
 pyyaml==6.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   -r requirements/base.txt
     #   clustershell
     #   junos-eznc
@@ -779,12 +820,14 @@ pyyaml==6.0.1
     #   yamlordereddictloader
 pyzmq==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
 requests-oauthlib==1.3.0
     # via msrest
 requests==2.31.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   adal
@@ -821,9 +864,12 @@ scp==0.13.2
 semantic-version==2.9.0
     # via etcd3-py
 setproctitle==1.3.2
-    # via -r requirements/static/pkg/freebsd.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
+    #   -r requirements/static/pkg/freebsd.in
 six==1.16.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   bcrypt
     #   cassandra-driver
     #   cheroot
@@ -856,7 +902,9 @@ sqlparse==0.4.4
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in
 tempora==4.1.1
-    # via portend
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
+    #   portend
 terminal==0.4.0
     # via ntc-templates
 textfsm==1.1.0
@@ -865,7 +913,9 @@ textfsm==1.1.0
     #   netmiko
     #   ntc-templates
 timelib==0.2.5
-    # via -r requirements/static/pkg/freebsd.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
+    #   -r requirements/static/pkg/freebsd.in
 toml==0.10.2
     # via -r requirements/static/ci/common.in
 tomli==2.0.1
@@ -878,6 +928,7 @@ typing-extensions==4.2.0
     #   pytest-system-statistics
 urllib3==1.26.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
     #   botocore
     #   docker
     #   kubernetes
@@ -910,9 +961,13 @@ yamlordereddictloader==0.4.0
 yarl==1.7.2
     # via aiohttp
 zc.lockfile==1.4
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
+    #   cherrypy
 zipp==3.5.0
-    # via importlib-metadata
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -692,7 +692,7 @@ pycryptodomex==3.10.1
     # via -r requirements/crypto.txt
 pyeapi==0.8.4
     # via napalm
-pygit2==1.0.3 ; python_version <= "3.8"
+pygit2==1.13.1 ; python_version >= "3.8"
     # via -r requirements/static/ci/linux.in
 pyiface==0.0.11
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -692,7 +692,7 @@ pycryptodomex==3.10.1
     # via -r requirements/crypto.txt
 pyeapi==0.8.4
     # via napalm
-pygit2==1.13.1 ; python_version >= "3.8"
+pygit2==1.13.1
     # via -r requirements/static/ci/linux.in
 pyiface==0.0.11
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -357,6 +357,7 @@ cassandra-driver==3.25.0
     # via -r requirements/static/ci/common.in
 certifi==2023.07.22
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/static/ci/common.in
     #   kubernetes
     #   msrest
@@ -364,8 +365,9 @@ certifi==2023.07.22
     #   requests
 certvalidator==0.11.1
     # via vcert
-cffi==1.15.1
+cffi==1.14.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/static/ci/common.in
     #   azure-datalake-store
     #   bcrypt
@@ -373,16 +375,20 @@ cffi==1.15.1
     #   napalm
     #   pygit2
     #   pynacl
-charset-normalizer==2.0.4
+charset-normalizer==3.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   aiohttp
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.in
 cheroot==8.5.2
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   cherrypy
 cherrypy==18.6.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/linux.in
 ciscoconfparse==1.5.46
@@ -394,11 +400,14 @@ clustershell==1.8.3
 colorama==0.4.4
     # via ciscoconfparse
 contextvars==2.4
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   adal
     #   ansible-core
@@ -412,8 +421,10 @@ cryptography==41.0.4
     #   vcert
 distlib==0.3.2
     # via virtualenv
-distro==1.6.0
-    # via -r requirements/base.txt
+distro==1.5.0
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/base.txt
 dnspython==2.1.0
     # via
     #   -r requirements/static/ci/common.in
@@ -445,15 +456,20 @@ google-auth==2.0.1
     # via kubernetes
 hglib==2.6.1
     # via -r requirements/static/ci/linux.in
-idna==3.2
+idna==2.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   etcd3-py
     #   requests
     #   yarl
-immutables==0.19
-    # via contextvars
+immutables==0.15
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   contextvars
 importlib-metadata==4.6.4
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/static/pkg/linux.in
 ipaddress==1.0.23
     # via kubernetes
 isodate==0.6.0
@@ -461,25 +477,34 @@ isodate==0.6.0
 isort==4.3.21
     # via pylint
 jaraco.classes==3.2.1
-    # via jaraco.collections
-jaraco.collections==3.4.0
-    # via cherrypy
-jaraco.functools==3.3.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   jaraco.collections
+jaraco.collections==3.4.0
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   cherrypy
+jaraco.functools==2.0
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   cheroot
     #   jaraco.text
     #   tempora
 jaraco.text==3.5.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   jaraco.collections
 jinja2==3.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt
     #   ansible-core
     #   junos-eznc
     #   moto
     #   napalm
-jmespath==0.10.0
+jmespath==1.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   boto3
@@ -505,7 +530,9 @@ libnacl==1.8.0 ; sys_platform != "win32" and sys_platform != "darwin"
 loguru==0.6.0
     # via ciscoconfparse
 looseversion==1.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/base.txt
 lxml==4.9.1
     # via
     #   junos-eznc
@@ -515,6 +542,7 @@ mako==1.2.2
     # via -r requirements/static/ci/common.in
 markupsafe==2.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt
     #   jinja2
     #   mako
@@ -526,8 +554,9 @@ mercurial==6.0.1
     # via -r requirements/static/ci/linux.in
 modernize==0.5
     # via saltpylint
-more-itertools==8.8.0
+more-itertools==5.0.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   cheroot
     #   cherrypy
     #   jaraco.classes
@@ -535,7 +564,9 @@ more-itertools==8.8.0
 moto==3.0.1
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/base.txt
 msrest==0.6.21
     # via
     #   azure-applicationinsights
@@ -653,8 +684,9 @@ oauthlib==3.2.2
     # via requests-oauthlib
 oscrypto==1.2.1
     # via certvalidator
-packaging==21.3
+packaging==22.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt
     #   ansible-core
     #   docker
@@ -674,10 +706,14 @@ pathspec==0.9.0
     # via yamllint
 platformdirs==2.2.0
     # via virtualenv
-portend==2.7.1
-    # via cherrypy
+portend==2.4
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   cherrypy
 psutil==5.8.0
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/base.txt
 pyasn1-modules==0.2.8
     # via google-auth
 pyasn1==0.4.8
@@ -686,10 +722,14 @@ pyasn1==0.4.8
     #   rsa
 pycodestyle==2.5.0
     # via saltpylint
-pycparser==2.20
-    # via cffi
-pycryptodomex==3.10.1
-    # via -r requirements/crypto.txt
+pycparser==2.17
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   cffi
+pycryptodomex==3.9.8
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/crypto.txt
 pyeapi==0.8.4
     # via napalm
 pygit2==1.13.1
@@ -714,12 +754,11 @@ pynacl==1.5.0
     #   paramiko
 pyopenssl==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
 pyparsing==3.0.9
-    # via
-    #   junos-eznc
-    #   packaging
+    # via junos-eznc
 pyrsistent==0.18.0
     # via jsonschema
 pyserial==3.5
@@ -728,8 +767,9 @@ pyserial==3.5
     #   netmiko
 python-consul==1.1.0
     # via -r requirements/static/ci/linux.in
-python-dateutil==2.8.2
+python-dateutil==2.8.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   adal
     #   azure-cosmosdb-table
@@ -742,11 +782,14 @@ python-dateutil==2.8.2
 python-etcd==0.4.5
     # via -r requirements/static/ci/common.in
 python-gnupg==0.4.8
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/static/pkg/linux.in
 python-telegram-bot==13.7
     # via -r requirements/static/ci/linux.in
 pytz==2022.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   apscheduler
     #   moto
     #   python-telegram-bot
@@ -756,6 +799,7 @@ pyvmomi==7.0.2
     # via -r requirements/static/ci/common.in
 pyyaml==6.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt
     #   ansible-core
     #   clustershell
@@ -765,7 +809,9 @@ pyyaml==6.0.1
     #   yamllint
     #   yamlordereddictloader
 pyzmq==23.2.0
-    # via -r requirements/zeromq.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/zeromq.txt
 redis-py-cluster==2.1.3
     # via -r requirements/static/ci/linux.in
 redis==3.5.3
@@ -774,6 +820,7 @@ requests-oauthlib==1.3.0
     # via msrest
 requests==2.31.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   adal
@@ -803,7 +850,9 @@ responses==0.13.4
 rfc3987==1.3.8
     # via -r requirements/static/ci/common.in
 rpm-vercmp==0.1.2
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/static/pkg/linux.in
 rsa==4.7.2
     # via google-auth
 s3transfer==0.5.0
@@ -818,9 +867,12 @@ scp==0.13.6
 semantic-version==2.9.0
     # via etcd3-py
 setproctitle==1.3.2
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/static/pkg/linux.in
 six==1.16.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   apscheduler
     #   astroid
     #   bcrypt
@@ -834,6 +886,7 @@ six==1.16.0
     #   junos-eznc
     #   kazoo
     #   kubernetes
+    #   more-itertools
     #   msrestazure
     #   ncclient
     #   paramiko
@@ -857,7 +910,9 @@ sqlparse==0.4.4
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in
 tempora==4.1.1
-    # via portend
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   portend
 tenacity==8.0.1
     # via netmiko
 textfsm==1.1.2
@@ -865,7 +920,9 @@ textfsm==1.1.2
     #   napalm
     #   ntc-templates
 timelib==0.2.5
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/static/pkg/linux.in
 toml==0.10.2
     # via
     #   -r requirements/static/ci/common.in
@@ -880,6 +937,7 @@ tzlocal==3.0
     # via apscheduler
 urllib3==1.26.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   botocore
     #   docker
     #   kubernetes
@@ -910,10 +968,14 @@ yamlordereddictloader==0.4.0
     # via junos-eznc
 yarl==1.7.2
     # via aiohttp
-zc.lockfile==2.0
-    # via cherrypy
+zc.lockfile==1.4
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   cherrypy
 zipp==3.5.0
-    # via importlib-metadata
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -700,7 +700,7 @@ pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
-pygit2==1.0.3 ; python_version <= "3.8"
+pygit2==1.13.1 ; python_version >= "3.8"
     # via -r requirements/static/ci/linux.in
 pyiface==0.0.11
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -363,6 +363,7 @@ cassandra-driver==3.23.0
     # via -r requirements/static/ci/common.in
 certifi==2023.07.22
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/static/ci/common.in
     #   kubernetes
     #   msrest
@@ -370,8 +371,9 @@ certifi==2023.07.22
     #   requests
 certvalidator==0.11.1
     # via vcert
-cffi==1.15.1
+cffi==1.14.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/static/ci/common.in
     #   azure-datalake-store
     #   bcrypt
@@ -379,16 +381,20 @@ cffi==1.15.1
     #   napalm
     #   pygit2
     #   pynacl
-charset-normalizer==2.0.12
+charset-normalizer==3.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   aiohttp
     #   requests
 cheetah3==3.2.6.post2
     # via -r requirements/static/ci/common.in
 cheroot==8.5.2
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   cherrypy
 cherrypy==18.6.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/linux.in
 ciscoconfparse==1.5.19
@@ -400,11 +406,14 @@ clustershell==1.8.3
 colorama==0.4.3
     # via ciscoconfparse
 contextvars==2.4
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   adal
     #   ansible-core
@@ -420,6 +429,7 @@ distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt
     #   pytest-skip-markers
 dnspython==1.16.0
@@ -459,13 +469,18 @@ hglib==2.6.1
     # via -r requirements/static/ci/linux.in
 idna==2.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   etcd3-py
     #   requests
     #   yarl
 immutables==0.15
-    # via contextvars
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   contextvars
 importlib-metadata==4.6.4
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/static/pkg/linux.in
 iniconfig==1.0.1
     # via pytest
 ipaddress==1.0.22
@@ -473,18 +488,26 @@ ipaddress==1.0.22
 isodate==0.6.0
     # via msrest
 jaraco.classes==3.2.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   jaraco.collections
 jaraco.collections==3.4.0
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   cherrypy
 jaraco.functools==2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   cheroot
     #   jaraco.text
     #   tempora
 jaraco.text==3.5.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   jaraco.collections
 jinja2==3.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt
     #   ansible-core
     #   junos-eznc
@@ -492,6 +515,7 @@ jinja2==3.1.2
     #   napalm
 jmespath==1.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   boto3
@@ -513,7 +537,9 @@ kubernetes==3.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
     # via -r requirements/static/ci/common.in
 looseversion==1.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/base.txt
 lxml==4.9.1
     # via
     #   junos-eznc
@@ -523,6 +549,7 @@ mako==1.2.2
     # via -r requirements/static/ci/common.in
 markupsafe==2.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt
     #   jinja2
     #   mako
@@ -534,6 +561,7 @@ mock==3.0.5
     # via -r requirements/pytest.txt
 more-itertools==5.0.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   cheroot
     #   cherrypy
     #   jaraco.classes
@@ -542,6 +570,7 @@ moto==3.0.1
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
 msrest==0.6.14
@@ -656,6 +685,7 @@ oscrypto==1.2.0
     # via certvalidator
 packaging==22.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt
     #   ansible-core
     #   docker
@@ -681,9 +711,12 @@ platformdirs==2.2.0
 pluggy==0.13.0
     # via pytest
 portend==2.4
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   cherrypy
 psutil==5.8.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
@@ -695,9 +728,13 @@ pyasn1==0.4.8
     #   pyasn1-modules
     #   rsa
 pycparser==2.17
-    # via cffi
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   cffi
 pycryptodomex==3.9.8
-    # via -r requirements/crypto.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
 pygit2==1.13.1
@@ -718,6 +755,7 @@ pynacl==1.5.0
     #   paramiko
 pyopenssl==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
 pyparsing==3.0.9
@@ -767,6 +805,7 @@ python-consul==1.1.0
     # via -r requirements/static/ci/linux.in
 python-dateutil==2.8.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   adal
     #   azure-cosmosdb-table
@@ -779,11 +818,14 @@ python-dateutil==2.8.1
 python-etcd==0.4.5
     # via -r requirements/static/ci/common.in
 python-gnupg==0.4.8
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/static/pkg/linux.in
 python-telegram-bot==13.7
     # via -r requirements/static/ci/linux.in
 pytz==2022.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   apscheduler
     #   moto
     #   python-telegram-bot
@@ -794,6 +836,7 @@ pyvmomi==6.7.1.2018.12
     # via -r requirements/static/ci/common.in
 pyyaml==6.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt
     #   ansible-core
     #   clustershell
@@ -805,6 +848,7 @@ pyyaml==6.0.1
     #   yamlordereddictloader
 pyzmq==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
 redis-py-cluster==2.1.3
@@ -815,6 +859,7 @@ requests-oauthlib==1.3.0
     # via msrest
 requests==2.31.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   adal
@@ -844,7 +889,9 @@ responses==0.10.6
 rfc3987==1.3.8
     # via -r requirements/static/ci/common.in
 rpm-vercmp==0.1.2
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/static/pkg/linux.in
 rsa==4.7.2
     # via google-auth
 s3transfer==0.5.2
@@ -857,9 +904,12 @@ scp==0.13.2
 semantic-version==2.9.0
     # via etcd3-py
 setproctitle==1.3.2
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/static/pkg/linux.in
 six==1.16.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   apscheduler
     #   bcrypt
     #   cassandra-driver
@@ -897,7 +947,9 @@ sqlparse==0.4.4
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in
 tempora==4.1.1
-    # via portend
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   portend
 terminal==0.4.0
     # via ntc-templates
 textfsm==1.1.0
@@ -906,7 +958,9 @@ textfsm==1.1.0
     #   netmiko
     #   ntc-templates
 timelib==0.2.5
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   -r requirements/static/pkg/linux.in
 toml==0.10.2
     # via -r requirements/static/ci/common.in
 tomli==2.0.1
@@ -925,6 +979,7 @@ tzlocal==2.1
     # via apscheduler
 urllib3==1.26.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
     #   botocore
     #   docker
     #   kubernetes
@@ -957,9 +1012,13 @@ yamlordereddictloader==0.4.0
 yarl==1.7.2
     # via aiohttp
 zc.lockfile==1.4
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   cherrypy
 zipp==3.5.0
-    # via importlib-metadata
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -700,7 +700,7 @@ pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
-pygit2==1.13.1 ; python_version >= "3.8"
+pygit2==1.13.1
     # via -r requirements/static/ci/linux.in
 pyiface==0.0.11
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -40,42 +40,53 @@ cassandra-driver==3.23.0
     # via -r requirements/static/ci/common.in
 certifi==2023.07.22
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt
     #   kubernetes
     #   requests
-cffi==1.15.1
+cffi==1.14.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt
     #   clr-loader
     #   cryptography
     #   pygit2
     #   pynacl
-charset-normalizer==2.0.12
+charset-normalizer==3.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   aiohttp
     #   requests
 cheetah3==3.2.6.post2
     # via -r requirements/static/ci/common.in
 cheroot==8.5.2
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   cherrypy
 cherrypy==18.6.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt
 click==7.1.2
     # via geomet
 clr-loader==0.2.4
-    # via pythonnet
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   pythonnet
 clustershell==1.8.3
     # via -r requirements/static/ci/common.in
 colorama==0.4.1
     # via pytest
 contextvars==2.4
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   -r requirements/base.txt
 cryptography==41.0.4
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/windows.txt
     #   etcd3-py
     #   moto
@@ -85,6 +96,7 @@ distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/base.txt
     #   pytest-skip-markers
 dmidecode==0.9.0
@@ -112,45 +124,64 @@ genshi==0.7.5
 geomet==0.1.2
     # via cassandra-driver
 gitdb==4.0.7
-    # via gitpython
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   gitpython
 gitpython==3.1.35
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt
 google-auth==1.6.3
     # via kubernetes
 idna==2.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   etcd3-py
     #   requests
     #   yarl
 immutables==0.15
-    # via contextvars
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   contextvars
 importlib-metadata==4.6.4
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   -r requirements/windows.txt
 iniconfig==1.0.1
     # via pytest
 ioloop==0.1a0
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   -r requirements/windows.txt
 ipaddress==1.0.22
     # via kubernetes
 jaraco.classes==3.2.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   jaraco.collections
 jaraco.collections==3.3.0
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   cherrypy
 jaraco.functools==2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   cheroot
     #   jaraco.text
     #   tempora
 jaraco.text==3.5.0
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   jaraco.collections
 jinja2==3.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/base.txt
     #   moto
 jmespath==1.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   boto3
@@ -162,13 +193,18 @@ keyring==5.7.1
 kubernetes==3.0.0
     # via -r requirements/static/ci/common.in
 looseversion==1.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   -r requirements/base.txt
 lxml==4.9.1
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   -r requirements/windows.txt
 mako==1.2.2
     # via -r requirements/static/ci/common.in
 markupsafe==2.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/base.txt
     #   jinja2
     #   mako
@@ -178,6 +214,7 @@ mock==3.0.5
     # via -r requirements/pytest.txt
 more-itertools==8.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   cheroot
     #   cherrypy
     #   jaraco.classes
@@ -186,6 +223,7 @@ moto==3.0.1
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
 multidict==6.0.2
@@ -194,8 +232,9 @@ multidict==6.0.2
     #   yarl
 ntlm-auth==1.5.0
     # via requests-ntlm
-packaging==21.3
+packaging==22.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/base.txt
     #   docker
     #   pytest
@@ -212,9 +251,12 @@ platformdirs==2.2.0
 pluggy==0.13.0
     # via pytest
 portend==2.6
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   cherrypy
 psutil==5.8.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
@@ -223,29 +265,36 @@ pyasn1-modules==0.2.4
     # via google-auth
 pyasn1==0.4.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/windows.txt
     #   pyasn1-modules
     #   rsa
 pycparser==2.21
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/windows.txt
     #   cffi
 pycryptodomex==3.10.1
-    # via -r requirements/crypto.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   -r requirements/crypto.txt
 pygit2==1.13.1
     # via -r requirements/static/ci/windows.in
 pymssql==2.2.1
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   -r requirements/windows.txt
 pymysql==1.0.2
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   -r requirements/windows.txt
 pynacl==1.5.0
     # via -r requirements/static/ci/common.in
 pyopenssl==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/windows.txt
     #   etcd3-py
-pyparsing==3.0.9
-    # via packaging
 pyrsistent==0.17.3
     # via jsonschema
 pytest-custom-exit-code==0.3.0
@@ -285,6 +334,7 @@ pytest==7.2.0
     #   pytest-timeout
 python-dateutil==2.8.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/windows.txt
     #   botocore
     #   kubernetes
@@ -292,17 +342,23 @@ python-dateutil==2.8.1
 python-etcd==0.4.5
     # via -r requirements/static/ci/common.in
 python-gnupg==0.4.8
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   -r requirements/windows.txt
 pythonnet==3.0.1
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   -r requirements/windows.txt
 pytz==2022.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   moto
     #   tempora
 pyvmomi==6.7.1.2018.12
     # via -r requirements/static/ci/common.in
 pywin32==305
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/windows.txt
     #   cherrypy
     #   docker
@@ -312,6 +368,7 @@ pywinrm==0.4.1
     # via -r requirements/static/ci/windows.in
 pyyaml==6.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/base.txt
     #   clustershell
     #   kubernetes
@@ -319,12 +376,14 @@ pyyaml==6.0.1
     #   yamllint
 pyzmq==25.0.2 ; sys_platform == "win32"
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
 requests-ntlm==1.1.0
     # via pywinrm
 requests==2.31.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt
@@ -349,9 +408,12 @@ sed==0.3.1
 semantic-version==2.9.0
     # via etcd3-py
 setproctitle==1.3.2
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   -r requirements/windows.txt
 six==1.15.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   cassandra-driver
     #   cheroot
     #   etcd3-py
@@ -368,15 +430,21 @@ six==1.15.0
     #   virtualenv
     #   websocket-client
 smmap==4.0.0
-    # via gitdb
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   gitdb
 sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in
 tempora==4.1.1
-    # via portend
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   portend
 timelib==0.2.5
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   -r requirements/windows.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.in
 tomli==2.0.1
@@ -387,6 +455,7 @@ typing-extensions==4.2.0
     #   pytest-system-statistics
 urllib3==1.26.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
     #   -r requirements/windows.txt
     #   botocore
     #   docker
@@ -410,9 +479,13 @@ werkzeug==2.2.3
     #   moto
     #   pytest-httpserver
 wheel==0.38.4
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   -r requirements/windows.txt
 wmi==1.5.1
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   -r requirements/windows.txt
 xmltodict==0.12.0
     # via
     #   moto
@@ -422,9 +495,13 @@ yamllint==1.26.3
 yarl==1.7.2
     # via aiohttp
 zc.lockfile==2.0
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   cherrypy
 zipp==3.5.0
-    # via importlib-metadata
+    # via
+    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -232,7 +232,7 @@ pycparser==2.21
     #   cffi
 pycryptodomex==3.10.1
     # via -r requirements/crypto.txt
-pygit2==1.9.1
+pygit2==1.13.1 ; python_version >= "3.8"
     # via -r requirements/static/ci/windows.in
 pymssql==2.2.1
     # via -r requirements/windows.txt

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -232,7 +232,7 @@ pycparser==2.21
     #   cffi
 pycryptodomex==3.10.1
     # via -r requirements/crypto.txt
-pygit2==1.13.1 ; python_version >= "3.8"
+pygit2==1.13.1
     # via -r requirements/static/ci/windows.in
 pymssql==2.2.1
     # via -r requirements/windows.txt

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -352,30 +352,36 @@ cassandra-driver==3.25.0
     # via -r requirements/static/ci/common.in
 certifi==2023.07.22
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
     #   kubernetes
     #   msrest
     #   requests
 certvalidator==0.11.1
     # via vcert
-cffi==1.15.1
+cffi==1.14.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
     #   azure-datalake-store
     #   bcrypt
     #   cryptography
     #   napalm
     #   pynacl
-charset-normalizer==2.0.12
+charset-normalizer==3.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   aiohttp
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.in
 cheroot==8.5.2
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   cherrypy
 cherrypy==18.6.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/linux.in
 ciscoconfparse==1.5.46
@@ -387,11 +393,14 @@ clustershell==1.8.3
 colorama==0.4.4
     # via ciscoconfparse
 contextvars==2.4
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   adal
     #   azure-cosmosdb-table
@@ -407,8 +416,9 @@ cryptography==41.0.4
     #   vcert
 distlib==0.3.3
     # via virtualenv
-distro==1.6.0
+distro==1.5.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt
     #   pytest-skip-markers
 dnspython==2.1.0
@@ -446,13 +456,18 @@ google-auth==2.1.0
     # via kubernetes
 idna==2.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   etcd3-py
     #   requests
     #   yarl
-immutables==0.19
-    # via contextvars
+immutables==0.15
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   contextvars
 importlib-metadata==6.0.0
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/static/pkg/linux.in
 iniconfig==1.1.1
     # via pytest
 ipaddress==1.0.23
@@ -460,24 +475,33 @@ ipaddress==1.0.23
 isodate==0.6.0
     # via msrest
 jaraco.classes==3.2.1
-    # via jaraco.collections
-jaraco.collections==3.4.0
-    # via cherrypy
-jaraco.functools==3.3.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   jaraco.collections
+jaraco.collections==3.4.0
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   cherrypy
+jaraco.functools==2.0
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   cheroot
     #   jaraco.text
     #   tempora
 jaraco.text==3.5.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   jaraco.collections
 jinja2==3.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt
     #   junos-eznc
     #   moto
     #   napalm
-jmespath==0.10.0
+jmespath==1.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   boto3
@@ -501,7 +525,9 @@ libnacl==1.8.0 ; sys_platform != "win32" and sys_platform != "darwin"
 loguru==0.6.0
     # via ciscoconfparse
 looseversion==1.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/base.txt
 lxml==4.9.1
     # via
     #   junos-eznc
@@ -511,6 +537,7 @@ mako==1.2.2
     # via -r requirements/static/ci/common.in
 markupsafe==2.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt
     #   jinja2
     #   mako
@@ -518,8 +545,9 @@ markupsafe==2.1.2
     #   werkzeug
 mock==4.0.3
     # via -r requirements/pytest.txt
-more-itertools==8.8.0
+more-itertools==5.0.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   cheroot
     #   cherrypy
     #   jaraco.classes
@@ -528,6 +556,7 @@ moto==3.0.1
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
 msrest==0.6.21
@@ -650,8 +679,9 @@ oauthlib==3.2.2
     # via requests-oauthlib
 oscrypto==1.2.1
     # via certvalidator
-packaging==21.3
+packaging==22.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt
     #   docker
     #   pytest
@@ -671,12 +701,15 @@ platformdirs==2.3.0
     # via virtualenv
 pluggy==1.0.0
     # via pytest
-portend==2.7.1
-    # via cherrypy
+portend==2.4
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   cherrypy
 profitbricks==4.1.3
     # via -r requirements/static/ci/cloud.in
 psutil==5.8.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
@@ -689,11 +722,14 @@ pyasn1==0.4.8
     #   rsa
 pycparser==2.21 ; python_version >= "3.9"
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/linux.in
     #   cffi
-pycryptodomex==3.10.1
-    # via -r requirements/crypto.txt
+pycryptodomex==3.9.8
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/crypto.txt
 pyeapi==0.8.4
     # via napalm
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
@@ -706,12 +742,11 @@ pynacl==1.5.0
     #   paramiko
 pyopenssl==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
 pyparsing==3.0.9
-    # via
-    #   junos-eznc
-    #   packaging
+    # via junos-eznc
 pypsexec==0.1.0
     # via -r requirements/static/ci/cloud.in
 pyrsistent==0.18.0
@@ -759,8 +794,9 @@ pytest==7.2.0
     #   pytest-subtests
     #   pytest-system-statistics
     #   pytest-timeout
-python-dateutil==2.8.2
+python-dateutil==2.8.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   adal
     #   azure-cosmosdb-table
@@ -773,9 +809,12 @@ python-dateutil==2.8.2
 python-etcd==0.4.5
     # via -r requirements/static/ci/common.in
 python-gnupg==0.4.8
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/static/pkg/linux.in
 pytz==2022.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   moto
     #   tempora
 pyvmomi==7.0.2
@@ -784,6 +823,7 @@ pywinrm==0.3.0
     # via -r requirements/static/ci/cloud.in
 pyyaml==6.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt
     #   clustershell
     #   junos-eznc
@@ -793,6 +833,7 @@ pyyaml==6.0.1
     #   yamlordereddictloader
 pyzmq==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
 requests-ntlm==1.1.0
@@ -801,6 +842,7 @@ requests-oauthlib==1.3.0
     # via msrest
 requests==2.31.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   adal
@@ -829,7 +871,9 @@ responses==0.14.0
 rfc3987==1.3.8
     # via -r requirements/static/ci/common.in
 rpm-vercmp==0.1.2
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/static/pkg/linux.in
 rsa==4.7.2
     # via google-auth
 s3transfer==0.5.0
@@ -842,9 +886,12 @@ scp==0.14.1
 semantic-version==2.9.0
     # via etcd3-py
 setproctitle==1.3.2
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/static/pkg/linux.in
 six==1.16.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   bcrypt
     #   cassandra-driver
     #   cheroot
@@ -856,6 +903,7 @@ six==1.16.0
     #   junos-eznc
     #   kazoo
     #   kubernetes
+    #   more-itertools
     #   msrestazure
     #   ncclient
     #   paramiko
@@ -881,7 +929,9 @@ sqlparse==0.4.4
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in
 tempora==4.1.1
-    # via portend
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   portend
 tenacity==8.0.1
     # via netmiko
 textfsm==1.1.2
@@ -889,7 +939,9 @@ textfsm==1.1.2
     #   napalm
     #   ntc-templates
 timelib==0.2.5
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/static/pkg/linux.in
 toml==0.10.2
     # via -r requirements/static/ci/common.in
 tomli==2.0.1
@@ -902,6 +954,7 @@ typing-extensions==3.10.0.2
     #   pytest-system-statistics
 urllib3==1.26.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   botocore
     #   docker
     #   kubernetes
@@ -934,10 +987,14 @@ yamlordereddictloader==0.4.0
     # via junos-eznc
 yarl==1.7.2
     # via aiohttp
-zc.lockfile==2.0
-    # via cherrypy
+zc.lockfile==1.4
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   cherrypy
 zipp==3.5.0
-    # via importlib-metadata
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -14,6 +14,7 @@ aiosignal==1.2.0
     # via aiohttp
 apache-libcloud==2.5.0 ; sys_platform != "win32"
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/darwin.txt
     #   -r requirements/static/ci/common.in
 asn1crypto==1.3.0
@@ -352,14 +353,16 @@ cassandra-driver==3.23.0
     # via -r requirements/static/ci/common.in
 certifi==2023.07.22
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/static/ci/common.in
     #   kubernetes
     #   msrest
     #   requests
 certvalidator==0.11.1
     # via vcert
-cffi==1.15.1
+cffi==1.14.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/static/ci/common.in
     #   azure-datalake-store
     #   bcrypt
@@ -367,16 +370,20 @@ cffi==1.15.1
     #   napalm
     #   pygit2
     #   pynacl
-charset-normalizer==2.0.12
+charset-normalizer==3.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   aiohttp
     #   requests
 cheetah3==3.2.6.post2
     # via -r requirements/static/ci/common.in
 cheroot==8.5.2
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   cherrypy
 cherrypy==18.6.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/darwin.txt
     #   -r requirements/static/ci/common.in
 ciscoconfparse==1.5.19
@@ -388,11 +395,14 @@ clustershell==1.8.1
 colorama==0.4.3
     # via ciscoconfparse
 contextvars==2.4
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/darwin.txt
     #   adal
     #   azure-cosmosdb-table
@@ -407,6 +417,7 @@ distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/base.txt
     #   pytest-skip-markers
 dnspython==1.16.0
@@ -437,9 +448,12 @@ genshi==0.7.5
 geomet==0.1.2
     # via cassandra-driver
 gitdb==4.0.5
-    # via gitpython
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   gitpython
 gitpython==3.1.35
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/darwin.txt
     #   -r requirements/static/ci/common.in
 google-auth==1.6.3
@@ -448,14 +462,19 @@ hglib==2.6.1
     # via -r requirements/static/ci/darwin.in
 idna==2.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/darwin.txt
     #   etcd3-py
     #   requests
     #   yarl
 immutables==0.15
-    # via contextvars
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   contextvars
 importlib-metadata==6.0.0
-    # via -r requirements/darwin.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   -r requirements/darwin.txt
 iniconfig==1.0.1
     # via pytest
 ipaddress==1.0.22
@@ -463,24 +482,33 @@ ipaddress==1.0.22
 isodate==0.6.0
     # via msrest
 jaraco.classes==3.2.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   jaraco.collections
 jaraco.collections==3.4.0
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   cherrypy
 jaraco.functools==2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   cheroot
     #   jaraco.text
     #   tempora
 jaraco.text==3.5.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   jaraco.collections
 jinja2==3.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/base.txt
     #   junos-eznc
     #   moto
     #   napalm
 jmespath==1.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   boto3
@@ -498,9 +526,13 @@ keyring==5.7.1
 kubernetes==3.0.0
     # via -r requirements/static/ci/common.in
 linode-python==1.1.1
-    # via -r requirements/darwin.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   -r requirements/darwin.txt
 looseversion==1.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   -r requirements/base.txt
 lxml==4.9.1
     # via
     #   junos-eznc
@@ -510,6 +542,7 @@ mako==1.2.2
     # via -r requirements/static/ci/common.in
 markupsafe==2.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/base.txt
     #   jinja2
     #   mako
@@ -521,6 +554,7 @@ mock==3.0.5
     # via -r requirements/pytest.txt
 more-itertools==8.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   cheroot
     #   cherrypy
     #   jaraco.classes
@@ -529,6 +563,7 @@ moto==3.0.1
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
 msrest==0.6.19
@@ -644,8 +679,9 @@ oauthlib==3.2.2
     # via requests-oauthlib
 oscrypto==1.2.0
     # via certvalidator
-packaging==21.3
+packaging==22.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/base.txt
     #   docker
     #   pytest
@@ -669,9 +705,12 @@ platformdirs==2.2.0
 pluggy==0.13.1
     # via pytest
 portend==2.6
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   cherrypy
 psutil==5.8.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
@@ -680,16 +719,20 @@ pyasn1-modules==0.2.4
     # via google-auth
 pyasn1==0.4.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/darwin.txt
     #   pyasn1-modules
     #   rsa
 pycparser==2.21 ; python_version >= "3.9"
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/darwin.txt
     #   -r requirements/static/ci/common.in
     #   cffi
 pycryptodomex==3.9.8
-    # via -r requirements/crypto.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
 pygit2==1.13.1
@@ -702,12 +745,11 @@ pynacl==1.5.0
     #   paramiko
 pyopenssl==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/darwin.txt
     #   etcd3-py
 pyparsing==3.0.9
-    # via
-    #   junos-eznc
-    #   packaging
+    # via junos-eznc
 pyrsistent==0.17.3
     # via jsonschema
 pyserial==3.4
@@ -751,6 +793,7 @@ pytest==7.2.0
     #   pytest-timeout
 python-dateutil==2.8.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/darwin.txt
     #   adal
     #   azure-cosmosdb-table
@@ -763,15 +806,19 @@ python-dateutil==2.8.0
 python-etcd==0.4.5
     # via -r requirements/static/ci/common.in
 python-gnupg==0.4.8
-    # via -r requirements/darwin.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   -r requirements/darwin.txt
 pytz==2022.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   moto
     #   tempora
 pyvmomi==6.7.1.2018.12
     # via -r requirements/static/ci/common.in
 pyyaml==6.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/base.txt
     #   clustershell
     #   junos-eznc
@@ -782,12 +829,14 @@ pyyaml==6.0.1
     #   yamlordereddictloader
 pyzmq==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
 requests-oauthlib==1.3.0
     # via msrest
 requests==2.31.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   adal
@@ -825,9 +874,12 @@ scp==0.13.2
 semantic-version==2.9.0
     # via etcd3-py
 setproctitle==1.3.2
-    # via -r requirements/darwin.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   -r requirements/darwin.txt
 six==1.16.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   bcrypt
     #   cassandra-driver
     #   cheroot
@@ -852,13 +904,17 @@ six==1.16.0
     #   virtualenv
     #   websocket-client
 smmap==3.0.2
-    # via gitdb
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   gitdb
 sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in
 tempora==4.1.1
-    # via portend
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   portend
 terminal==0.4.0
     # via ntc-templates
 textfsm==1.1.0
@@ -867,7 +923,9 @@ textfsm==1.1.0
     #   netmiko
     #   ntc-templates
 timelib==0.2.5
-    # via -r requirements/darwin.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   -r requirements/darwin.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.in
 tomli==2.0.1
@@ -880,6 +938,7 @@ typing-extensions==4.2.0
     #   pytest-system-statistics
 urllib3==1.26.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
     #   botocore
     #   docker
     #   kubernetes
@@ -892,7 +951,9 @@ virtualenv==20.7.2
     #   -r requirements/static/ci/common.in
     #   pytest-salt-factories
 vultr==1.0.1
-    # via -r requirements/darwin.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   -r requirements/darwin.txt
 watchdog==0.10.3
     # via -r requirements/static/ci/common.in
 websocket-client==0.40.0
@@ -916,9 +977,13 @@ yamlordereddictloader==0.4.0
 yarl==1.7.2
     # via aiohttp
 zc.lockfile==2.0
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   cherrypy
 zipp==3.5.0
-    # via importlib-metadata
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -692,7 +692,7 @@ pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
-pygit2==1.13.1 ; python_version >= "3.8"
+pygit2==1.13.1
     # via -r requirements/static/ci/darwin.in
 pyjwt==2.4.0
     # via adal

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -692,7 +692,7 @@ pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
-pygit2==1.9.1
+pygit2==1.13.1 ; python_version >= "3.8"
     # via -r requirements/static/ci/darwin.in
 pyjwt==2.4.0
     # via adal

--- a/requirements/static/ci/py3.9/docs.txt
+++ b/requirements/static/ci/py3.9/docs.txt
@@ -12,7 +12,7 @@ certifi==2023.07.22
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   requests
-charset-normalizer==2.0.12
+charset-normalizer==3.2.0
     # via
     #   -c requirements/static/ci/py3.9/linux.txt
     #   requests

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -690,7 +690,7 @@ pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
-pygit2==1.8.0
+pygit2==1.13.1 ; python_version >= "3.8"
     # via -r requirements/static/ci/freebsd.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -350,14 +350,16 @@ cassandra-driver==3.24.0
     # via -r requirements/static/ci/common.in
 certifi==2023.07.22
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   -r requirements/static/ci/common.in
     #   kubernetes
     #   msrest
     #   requests
 certvalidator==0.11.1
     # via vcert
-cffi==1.15.1
+cffi==1.14.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   -r requirements/static/ci/common.in
     #   azure-datalake-store
     #   bcrypt
@@ -365,16 +367,20 @@ cffi==1.15.1
     #   napalm
     #   pygit2
     #   pynacl
-charset-normalizer==2.0.12
+charset-normalizer==3.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   aiohttp
     #   requests
 cheetah3==3.2.6.post2
     # via -r requirements/static/ci/common.in
 cheroot==8.5.2
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
+    #   cherrypy
 cherrypy==18.6.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/freebsd.in
 ciscoconfparse==1.5.19
@@ -386,11 +392,14 @@ clustershell==1.8.3
 colorama==0.4.3
     # via ciscoconfparse
 contextvars==2.4
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
+    #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   -r requirements/static/pkg/freebsd.in
     #   adal
     #   azure-cosmosdb-table
@@ -405,6 +414,7 @@ distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   -r requirements/base.txt
     #   -r requirements/static/pkg/freebsd.in
     #   pytest-skip-markers
@@ -445,13 +455,18 @@ hglib==2.6.1
     # via -r requirements/static/ci/freebsd.in
 idna==2.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   etcd3-py
     #   requests
     #   yarl
 immutables==0.15
-    # via contextvars
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
+    #   contextvars
 importlib-metadata==6.0.0
-    # via -r requirements/static/pkg/freebsd.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
+    #   -r requirements/static/pkg/freebsd.in
 iniconfig==1.0.1
     # via pytest
 ipaddress==1.0.22
@@ -459,24 +474,33 @@ ipaddress==1.0.22
 isodate==0.6.0
     # via msrest
 jaraco.classes==3.2.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
+    #   jaraco.collections
 jaraco.collections==3.4.0
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
+    #   cherrypy
 jaraco.functools==2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   cheroot
     #   jaraco.text
     #   tempora
 jaraco.text==3.5.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
+    #   jaraco.collections
 jinja2==3.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   -r requirements/base.txt
     #   junos-eznc
     #   moto
     #   napalm
 jmespath==1.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   boto3
@@ -498,7 +522,9 @@ kubernetes==3.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
     # via -r requirements/static/ci/common.in
 looseversion==1.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
+    #   -r requirements/base.txt
 lxml==4.9.1
     # via
     #   junos-eznc
@@ -508,6 +534,7 @@ mako==1.2.2
     # via -r requirements/static/ci/common.in
 markupsafe==2.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   -r requirements/base.txt
     #   jinja2
     #   mako
@@ -519,6 +546,7 @@ mock==3.0.5
     # via -r requirements/pytest.txt
 more-itertools==5.0.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   cheroot
     #   cherrypy
     #   jaraco.classes
@@ -527,6 +555,7 @@ moto==3.0.1
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
 msrest==0.6.19
@@ -642,8 +671,9 @@ oauthlib==3.2.2
     # via requests-oauthlib
 oscrypto==1.2.0
     # via certvalidator
-packaging==21.3
+packaging==22.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   -r requirements/base.txt
     #   docker
     #   pytest
@@ -668,9 +698,12 @@ platformdirs==2.2.0
 pluggy==0.13.0
     # via pytest
 portend==2.4
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
+    #   cherrypy
 psutil==5.8.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
@@ -683,11 +716,14 @@ pyasn1==0.4.8
     #   rsa
 pycparser==2.21 ; python_version >= "3.9"
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/freebsd.in
     #   cffi
 pycryptodomex==3.9.8
-    # via -r requirements/crypto.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
+    #   -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
 pygit2==1.13.1
@@ -702,12 +738,11 @@ pynacl==1.5.0
     #   paramiko
 pyopenssl==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   -r requirements/static/pkg/freebsd.in
     #   etcd3-py
 pyparsing==3.0.9
-    # via
-    #   junos-eznc
-    #   packaging
+    # via junos-eznc
 pyrsistent==0.17.3
     # via jsonschema
 pyserial==3.4
@@ -751,6 +786,7 @@ pytest==7.2.0
     #   pytest-timeout
 python-dateutil==2.8.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   -r requirements/static/pkg/freebsd.in
     #   adal
     #   azure-cosmosdb-table
@@ -763,15 +799,19 @@ python-dateutil==2.8.1
 python-etcd==0.4.5
     # via -r requirements/static/ci/common.in
 python-gnupg==0.4.8
-    # via -r requirements/static/pkg/freebsd.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
+    #   -r requirements/static/pkg/freebsd.in
 pytz==2022.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   moto
     #   tempora
 pyvmomi==6.7.1.2018.12
     # via -r requirements/static/ci/common.in
 pyyaml==6.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   -r requirements/base.txt
     #   clustershell
     #   junos-eznc
@@ -782,12 +822,14 @@ pyyaml==6.0.1
     #   yamlordereddictloader
 pyzmq==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
 requests-oauthlib==1.3.0
     # via msrest
 requests==2.31.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   adal
@@ -824,9 +866,12 @@ scp==0.13.2
 semantic-version==2.9.0
     # via etcd3-py
 setproctitle==1.3.2
-    # via -r requirements/static/pkg/freebsd.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
+    #   -r requirements/static/pkg/freebsd.in
 six==1.16.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   bcrypt
     #   cassandra-driver
     #   cheroot
@@ -859,7 +904,9 @@ sqlparse==0.4.4
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in
 tempora==4.1.1
-    # via portend
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
+    #   portend
 terminal==0.4.0
     # via ntc-templates
 textfsm==1.1.0
@@ -868,7 +915,9 @@ textfsm==1.1.0
     #   netmiko
     #   ntc-templates
 timelib==0.2.5
-    # via -r requirements/static/pkg/freebsd.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
+    #   -r requirements/static/pkg/freebsd.in
 toml==0.10.2
     # via -r requirements/static/ci/common.in
 tomli==2.0.1
@@ -881,6 +930,7 @@ typing-extensions==4.2.0
     #   pytest-system-statistics
 urllib3==1.26.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
     #   botocore
     #   docker
     #   kubernetes
@@ -913,9 +963,13 @@ yamlordereddictloader==0.4.0
 yarl==1.7.2
     # via aiohttp
 zc.lockfile==1.4
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
+    #   cherrypy
 zipp==3.5.0
-    # via importlib-metadata
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -690,7 +690,7 @@ pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
-pygit2==1.13.1 ; python_version >= "3.8"
+pygit2==1.13.1
     # via -r requirements/static/ci/freebsd.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -693,7 +693,7 @@ pycryptodomex==3.10.1
     # via -r requirements/crypto.txt
 pyeapi==0.8.4
     # via napalm
-pygit2==1.13.1 ; python_version >= "3.8"
+pygit2==1.13.1
     # via -r requirements/static/ci/linux.in
 pyiface==0.0.11
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -693,7 +693,7 @@ pycryptodomex==3.10.1
     # via -r requirements/crypto.txt
 pyeapi==0.8.4
     # via napalm
-pygit2==1.6.1 ; python_version > "3.8"
+pygit2==1.13.1 ; python_version >= "3.8"
     # via -r requirements/static/ci/linux.in
 pyiface==0.0.11
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -355,6 +355,7 @@ cassandra-driver==3.25.0
     # via -r requirements/static/ci/common.in
 certifi==2023.07.22
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
     #   kubernetes
     #   msrest
@@ -362,8 +363,9 @@ certifi==2023.07.22
     #   requests
 certvalidator==0.11.1
     # via vcert
-cffi==1.15.1
+cffi==1.14.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
     #   azure-datalake-store
     #   bcrypt
@@ -371,16 +373,20 @@ cffi==1.15.1
     #   napalm
     #   pygit2
     #   pynacl
-charset-normalizer==2.0.4
+charset-normalizer==3.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   aiohttp
     #   requests
 cheetah3==3.2.6.post1
     # via -r requirements/static/ci/common.in
 cheroot==8.5.2
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   cherrypy
 cherrypy==18.6.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/linux.in
 ciscoconfparse==1.5.46
@@ -392,11 +398,14 @@ clustershell==1.8.3
 colorama==0.4.4
     # via ciscoconfparse
 contextvars==2.4
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/base.txt
 croniter==1.0.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   adal
     #   ansible-core
@@ -410,8 +419,10 @@ cryptography==41.0.4
     #   vcert
 distlib==0.3.2
     # via virtualenv
-distro==1.6.0
-    # via -r requirements/base.txt
+distro==1.5.0
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/base.txt
 dnspython==2.1.0
     # via
     #   -r requirements/static/ci/common.in
@@ -443,15 +454,20 @@ google-auth==2.0.1
     # via kubernetes
 hglib==2.6.1
     # via -r requirements/static/ci/linux.in
-idna==3.2
+idna==2.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   etcd3-py
     #   requests
     #   yarl
-immutables==0.19
-    # via contextvars
+immutables==0.15
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   contextvars
 importlib-metadata==6.0.0
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/static/pkg/linux.in
 ipaddress==1.0.23
     # via kubernetes
 isodate==0.6.0
@@ -459,25 +475,34 @@ isodate==0.6.0
 isort==4.3.21
     # via pylint
 jaraco.classes==3.2.1
-    # via jaraco.collections
-jaraco.collections==3.4.0
-    # via cherrypy
-jaraco.functools==3.3.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   jaraco.collections
+jaraco.collections==3.4.0
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   cherrypy
+jaraco.functools==2.0
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   cheroot
     #   jaraco.text
     #   tempora
 jaraco.text==3.5.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   jaraco.collections
 jinja2==3.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt
     #   ansible-core
     #   junos-eznc
     #   moto
     #   napalm
-jmespath==0.10.0
+jmespath==1.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   boto3
@@ -503,7 +528,9 @@ libnacl==1.8.0 ; sys_platform != "win32" and sys_platform != "darwin"
 loguru==0.6.0
     # via ciscoconfparse
 looseversion==1.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/base.txt
 lxml==4.9.1
     # via
     #   junos-eznc
@@ -513,6 +540,7 @@ mako==1.2.2
     # via -r requirements/static/ci/common.in
 markupsafe==2.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt
     #   jinja2
     #   mako
@@ -524,8 +552,9 @@ mercurial==6.0.1
     # via -r requirements/static/ci/linux.in
 modernize==0.5
     # via saltpylint
-more-itertools==8.8.0
+more-itertools==5.0.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   cheroot
     #   cherrypy
     #   jaraco.classes
@@ -533,7 +562,9 @@ more-itertools==8.8.0
 moto==3.0.1
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/base.txt
 msrest==0.6.21
     # via
     #   azure-applicationinsights
@@ -651,8 +682,9 @@ oauthlib==3.2.2
     # via requests-oauthlib
 oscrypto==1.2.1
     # via certvalidator
-packaging==21.3
+packaging==22.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt
     #   ansible-core
     #   docker
@@ -672,10 +704,14 @@ pathspec==0.9.0
     # via yamllint
 platformdirs==2.2.0
     # via virtualenv
-portend==2.7.1
-    # via cherrypy
+portend==2.4
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   cherrypy
 psutil==5.8.0
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/base.txt
 pyasn1-modules==0.2.8
     # via google-auth
 pyasn1==0.4.8
@@ -686,11 +722,14 @@ pycodestyle==2.5.0
     # via saltpylint
 pycparser==2.21 ; python_version >= "3.9"
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/linux.in
     #   cffi
-pycryptodomex==3.10.1
-    # via -r requirements/crypto.txt
+pycryptodomex==3.9.8
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/crypto.txt
 pyeapi==0.8.4
     # via napalm
 pygit2==1.13.1
@@ -715,12 +754,11 @@ pynacl==1.5.0
     #   paramiko
 pyopenssl==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
 pyparsing==3.0.9
-    # via
-    #   junos-eznc
-    #   packaging
+    # via junos-eznc
 pyrsistent==0.18.0
     # via jsonschema
 pyserial==3.5
@@ -729,8 +767,9 @@ pyserial==3.5
     #   netmiko
 python-consul==1.1.0
     # via -r requirements/static/ci/linux.in
-python-dateutil==2.8.2
+python-dateutil==2.8.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   adal
     #   azure-cosmosdb-table
@@ -743,11 +782,14 @@ python-dateutil==2.8.2
 python-etcd==0.4.5
     # via -r requirements/static/ci/common.in
 python-gnupg==0.4.8
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/static/pkg/linux.in
 python-telegram-bot==13.7
     # via -r requirements/static/ci/linux.in
 pytz==2022.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   apscheduler
     #   moto
     #   python-telegram-bot
@@ -757,6 +799,7 @@ pyvmomi==7.0.2
     # via -r requirements/static/ci/common.in
 pyyaml==6.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt
     #   ansible-core
     #   clustershell
@@ -766,7 +809,9 @@ pyyaml==6.0.1
     #   yamllint
     #   yamlordereddictloader
 pyzmq==23.2.0
-    # via -r requirements/zeromq.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/zeromq.txt
 redis-py-cluster==2.1.3
     # via -r requirements/static/ci/linux.in
 redis==3.5.3
@@ -775,6 +820,7 @@ requests-oauthlib==1.3.0
     # via msrest
 requests==2.31.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   adal
@@ -804,7 +850,9 @@ responses==0.13.4
 rfc3987==1.3.8
     # via -r requirements/static/ci/common.in
 rpm-vercmp==0.1.2
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/static/pkg/linux.in
 rsa==4.7.2
     # via google-auth
 s3transfer==0.5.0
@@ -819,9 +867,12 @@ scp==0.13.6
 semantic-version==2.9.0
     # via etcd3-py
 setproctitle==1.3.2
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/static/pkg/linux.in
 six==1.16.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   apscheduler
     #   astroid
     #   bcrypt
@@ -835,6 +886,7 @@ six==1.16.0
     #   junos-eznc
     #   kazoo
     #   kubernetes
+    #   more-itertools
     #   msrestazure
     #   ncclient
     #   paramiko
@@ -858,7 +910,9 @@ sqlparse==0.4.4
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in
 tempora==4.1.1
-    # via portend
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   portend
 tenacity==8.0.1
     # via netmiko
 textfsm==1.1.2
@@ -866,7 +920,9 @@ textfsm==1.1.2
     #   napalm
     #   ntc-templates
 timelib==0.2.5
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/static/pkg/linux.in
 toml==0.10.2
     # via
     #   -r requirements/static/ci/common.in
@@ -881,6 +937,7 @@ tzlocal==3.0
     # via apscheduler
 urllib3==1.26.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   botocore
     #   docker
     #   kubernetes
@@ -911,10 +968,14 @@ yamlordereddictloader==0.4.0
     # via junos-eznc
 yarl==1.7.2
     # via aiohttp
-zc.lockfile==2.0
-    # via cherrypy
+zc.lockfile==1.4
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   cherrypy
 zipp==3.5.0
-    # via importlib-metadata
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -363,6 +363,7 @@ cassandra-driver==3.23.0
     # via -r requirements/static/ci/common.in
 certifi==2023.07.22
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
     #   kubernetes
     #   msrest
@@ -370,8 +371,9 @@ certifi==2023.07.22
     #   requests
 certvalidator==0.11.1
     # via vcert
-cffi==1.15.1
+cffi==1.14.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
     #   azure-datalake-store
     #   bcrypt
@@ -379,16 +381,20 @@ cffi==1.15.1
     #   napalm
     #   pygit2
     #   pynacl
-charset-normalizer==2.0.12
+charset-normalizer==3.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   aiohttp
     #   requests
 cheetah3==3.2.6.post2
     # via -r requirements/static/ci/common.in
 cheroot==8.5.2
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   cherrypy
 cherrypy==18.6.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/linux.in
 ciscoconfparse==1.5.19
@@ -400,11 +406,14 @@ clustershell==1.8.3
 colorama==0.4.3
     # via ciscoconfparse
 contextvars==2.4
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   adal
     #   ansible-core
@@ -420,6 +429,7 @@ distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt
     #   pytest-skip-markers
 dnspython==1.16.0
@@ -459,13 +469,18 @@ hglib==2.6.1
     # via -r requirements/static/ci/linux.in
 idna==2.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   etcd3-py
     #   requests
     #   yarl
 immutables==0.15
-    # via contextvars
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   contextvars
 importlib-metadata==6.0.0
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/static/pkg/linux.in
 iniconfig==1.0.1
     # via pytest
 ipaddress==1.0.22
@@ -473,18 +488,26 @@ ipaddress==1.0.22
 isodate==0.6.0
     # via msrest
 jaraco.classes==3.2.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   jaraco.collections
 jaraco.collections==3.4.0
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   cherrypy
 jaraco.functools==2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   cheroot
     #   jaraco.text
     #   tempora
 jaraco.text==3.5.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   jaraco.collections
 jinja2==3.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt
     #   ansible-core
     #   junos-eznc
@@ -492,6 +515,7 @@ jinja2==3.1.2
     #   napalm
 jmespath==1.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   boto3
@@ -513,7 +537,9 @@ kubernetes==3.0.0
 libnacl==1.7.1 ; sys_platform != "win32" and sys_platform != "darwin"
     # via -r requirements/static/ci/common.in
 looseversion==1.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/base.txt
 lxml==4.9.1
     # via
     #   junos-eznc
@@ -523,6 +549,7 @@ mako==1.2.2
     # via -r requirements/static/ci/common.in
 markupsafe==2.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt
     #   jinja2
     #   mako
@@ -534,6 +561,7 @@ mock==3.0.5
     # via -r requirements/pytest.txt
 more-itertools==5.0.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   cheroot
     #   cherrypy
     #   jaraco.classes
@@ -542,6 +570,7 @@ moto==3.0.1
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
 msrest==0.6.14
@@ -656,6 +685,7 @@ oscrypto==1.2.0
     # via certvalidator
 packaging==22.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt
     #   ansible-core
     #   docker
@@ -681,9 +711,12 @@ platformdirs==2.2.0
 pluggy==0.13.0
     # via pytest
 portend==2.4
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   cherrypy
 psutil==5.8.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
@@ -696,11 +729,14 @@ pyasn1==0.4.8
     #   rsa
 pycparser==2.21 ; python_version >= "3.9"
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/static/pkg/linux.in
     #   cffi
 pycryptodomex==3.9.8
-    # via -r requirements/crypto.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
 pygit2==1.13.1
@@ -721,6 +757,7 @@ pynacl==1.5.0
     #   paramiko
 pyopenssl==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   etcd3-py
 pyparsing==3.0.9
@@ -770,6 +807,7 @@ python-consul==1.1.0
     # via -r requirements/static/ci/linux.in
 python-dateutil==2.8.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/static/pkg/linux.in
     #   adal
     #   azure-cosmosdb-table
@@ -782,11 +820,14 @@ python-dateutil==2.8.1
 python-etcd==0.4.5
     # via -r requirements/static/ci/common.in
 python-gnupg==0.4.8
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/static/pkg/linux.in
 python-telegram-bot==13.7
     # via -r requirements/static/ci/linux.in
 pytz==2022.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   apscheduler
     #   moto
     #   python-telegram-bot
@@ -797,6 +838,7 @@ pyvmomi==6.7.1.2018.12
     # via -r requirements/static/ci/common.in
 pyyaml==6.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt
     #   ansible-core
     #   clustershell
@@ -808,6 +850,7 @@ pyyaml==6.0.1
     #   yamlordereddictloader
 pyzmq==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
 redis-py-cluster==2.1.3
@@ -818,6 +861,7 @@ requests-oauthlib==1.3.0
     # via msrest
 requests==2.31.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   adal
@@ -847,7 +891,9 @@ responses==0.10.6
 rfc3987==1.3.8
     # via -r requirements/static/ci/common.in
 rpm-vercmp==0.1.2
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/static/pkg/linux.in
 rsa==4.7.2
     # via google-auth
 s3transfer==0.5.2
@@ -860,9 +906,12 @@ scp==0.13.2
 semantic-version==2.9.0
     # via etcd3-py
 setproctitle==1.3.2
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/static/pkg/linux.in
 six==1.16.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   apscheduler
     #   bcrypt
     #   cassandra-driver
@@ -900,7 +949,9 @@ sqlparse==0.4.4
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in
 tempora==4.1.1
-    # via portend
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   portend
 terminal==0.4.0
     # via ntc-templates
 textfsm==1.1.0
@@ -909,7 +960,9 @@ textfsm==1.1.0
     #   netmiko
     #   ntc-templates
 timelib==0.2.5
-    # via -r requirements/static/pkg/linux.in
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   -r requirements/static/pkg/linux.in
 toml==0.10.2
     # via -r requirements/static/ci/common.in
 tomli==2.0.1
@@ -928,6 +981,7 @@ tzlocal==2.1
     # via apscheduler
 urllib3==1.26.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
     #   botocore
     #   docker
     #   kubernetes
@@ -960,9 +1014,13 @@ yamlordereddictloader==0.4.0
 yarl==1.7.2
     # via aiohttp
 zc.lockfile==1.4
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   cherrypy
 zipp==3.5.0
-    # via importlib-metadata
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -703,7 +703,7 @@ pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
-pygit2==1.13.1 ; python_version >= "3.8"
+pygit2==1.13.1
     # via -r requirements/static/ci/linux.in
 pyiface==0.0.11
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -355,8 +355,6 @@ botocore==1.24.46
     #   boto3
     #   moto
     #   s3transfer
-cached-property==1.5.2
-    # via pygit2
 cachetools==4.2.2
     # via
     #   google-auth
@@ -705,7 +703,7 @@ pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
-pygit2==1.5.0 ; python_version > "3.8"
+pygit2==1.13.1 ; python_version >= "3.8"
     # via -r requirements/static/ci/linux.in
 pyiface==0.0.11
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -233,7 +233,7 @@ pycparser==2.21 ; python_version >= "3.9"
     #   cffi
 pycryptodomex==3.10.1
     # via -r requirements/crypto.txt
-pygit2==1.13.1 ; python_version >= "3.8"
+pygit2==1.13.1
     # via -r requirements/static/ci/windows.in
 pymssql==2.2.1
     # via -r requirements/windows.txt

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -233,7 +233,7 @@ pycparser==2.21 ; python_version >= "3.9"
     #   cffi
 pycryptodomex==3.10.1
     # via -r requirements/crypto.txt
-pygit2==1.9.1
+pygit2==1.13.1 ; python_version >= "3.8"
     # via -r requirements/static/ci/windows.in
 pymssql==2.2.1
     # via -r requirements/windows.txt

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -40,42 +40,53 @@ cassandra-driver==3.23.0
     # via -r requirements/static/ci/common.in
 certifi==2023.07.22
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt
     #   kubernetes
     #   requests
-cffi==1.15.1
+cffi==1.14.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt
     #   clr-loader
     #   cryptography
     #   pygit2
     #   pynacl
-charset-normalizer==2.0.12
+charset-normalizer==3.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   aiohttp
     #   requests
 cheetah3==3.2.6.post2
     # via -r requirements/static/ci/common.in
 cheroot==8.5.2
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   cherrypy
 cherrypy==18.6.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt
 click==7.1.2
     # via geomet
 clr-loader==0.2.4
-    # via pythonnet
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   pythonnet
 clustershell==1.8.3
     # via -r requirements/static/ci/common.in
 colorama==0.4.1
     # via pytest
 contextvars==2.4
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   -r requirements/base.txt
 cryptography==41.0.4
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/windows.txt
     #   etcd3-py
     #   moto
@@ -85,6 +96,7 @@ distlib==0.3.2
     # via virtualenv
 distro==1.5.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/base.txt
     #   pytest-skip-markers
 dmidecode==0.9.0
@@ -112,45 +124,64 @@ genshi==0.7.5
 geomet==0.1.2
     # via cassandra-driver
 gitdb==4.0.7
-    # via gitpython
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   gitpython
 gitpython==3.1.35
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt
 google-auth==1.6.3
     # via kubernetes
 idna==2.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   etcd3-py
     #   requests
     #   yarl
 immutables==0.15
-    # via contextvars
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   contextvars
 importlib-metadata==6.0.0
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   -r requirements/windows.txt
 iniconfig==1.0.1
     # via pytest
 ioloop==0.1a0
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   -r requirements/windows.txt
 ipaddress==1.0.22
     # via kubernetes
 jaraco.classes==3.2.1
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   jaraco.collections
 jaraco.collections==3.3.0
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   cherrypy
 jaraco.functools==2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   cheroot
     #   jaraco.text
     #   tempora
 jaraco.text==3.5.0
-    # via jaraco.collections
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   jaraco.collections
 jinja2==3.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/base.txt
     #   moto
 jmespath==1.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   boto3
@@ -162,13 +193,18 @@ keyring==5.7.1
 kubernetes==3.0.0
     # via -r requirements/static/ci/common.in
 looseversion==1.0.2
-    # via -r requirements/base.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   -r requirements/base.txt
 lxml==4.9.1
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   -r requirements/windows.txt
 mako==1.2.2
     # via -r requirements/static/ci/common.in
 markupsafe==2.1.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/base.txt
     #   jinja2
     #   mako
@@ -178,6 +214,7 @@ mock==3.0.5
     # via -r requirements/pytest.txt
 more-itertools==8.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   cheroot
     #   cherrypy
     #   jaraco.classes
@@ -186,6 +223,7 @@ moto==3.0.1
     # via -r requirements/static/ci/common.in
 msgpack==1.0.2
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
 multidict==6.0.2
@@ -194,8 +232,9 @@ multidict==6.0.2
     #   yarl
 ntlm-auth==1.5.0
     # via requests-ntlm
-packaging==21.3
+packaging==22.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/base.txt
     #   docker
     #   pytest
@@ -212,9 +251,12 @@ platformdirs==2.2.0
 pluggy==0.13.0
     # via pytest
 portend==2.6
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   cherrypy
 psutil==5.8.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/base.txt
     #   pytest-salt-factories
     #   pytest-shell-utilities
@@ -223,30 +265,37 @@ pyasn1-modules==0.2.4
     # via google-auth
 pyasn1==0.4.8
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/windows.txt
     #   pyasn1-modules
     #   rsa
 pycparser==2.21 ; python_version >= "3.9"
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt
     #   cffi
 pycryptodomex==3.10.1
-    # via -r requirements/crypto.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   -r requirements/crypto.txt
 pygit2==1.13.1
     # via -r requirements/static/ci/windows.in
 pymssql==2.2.1
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   -r requirements/windows.txt
 pymysql==1.0.2
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   -r requirements/windows.txt
 pynacl==1.5.0
     # via -r requirements/static/ci/common.in
 pyopenssl==23.2.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/windows.txt
     #   etcd3-py
-pyparsing==3.0.9
-    # via packaging
 pyrsistent==0.17.3
     # via jsonschema
 pytest-custom-exit-code==0.3.0
@@ -286,6 +335,7 @@ pytest==7.2.0
     #   pytest-timeout
 python-dateutil==2.8.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/windows.txt
     #   botocore
     #   kubernetes
@@ -293,17 +343,23 @@ python-dateutil==2.8.1
 python-etcd==0.4.5
     # via -r requirements/static/ci/common.in
 python-gnupg==0.4.8
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   -r requirements/windows.txt
 pythonnet==3.0.1
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   -r requirements/windows.txt
 pytz==2022.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   moto
     #   tempora
 pyvmomi==6.7.1.2018.12
     # via -r requirements/static/ci/common.in
 pywin32==305
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/windows.txt
     #   cherrypy
     #   docker
@@ -313,6 +369,7 @@ pywinrm==0.4.1
     # via -r requirements/static/ci/windows.in
 pyyaml==6.0.1
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/base.txt
     #   clustershell
     #   kubernetes
@@ -320,12 +377,14 @@ pyyaml==6.0.1
     #   yamllint
 pyzmq==25.0.2 ; sys_platform == "win32"
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/zeromq.txt
     #   pytest-salt-factories
 requests-ntlm==1.1.0
     # via pywinrm
 requests==2.31.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/base.txt
     #   -r requirements/static/ci/common.in
     #   -r requirements/windows.txt
@@ -350,9 +409,12 @@ sed==0.3.1
 semantic-version==2.9.0
     # via etcd3-py
 setproctitle==1.3.2
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   -r requirements/windows.txt
 six==1.15.0
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   cassandra-driver
     #   cheroot
     #   etcd3-py
@@ -369,15 +431,21 @@ six==1.15.0
     #   virtualenv
     #   websocket-client
 smmap==4.0.0
-    # via gitdb
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   gitdb
 sqlparse==0.4.4
     # via -r requirements/static/ci/common.in
 strict-rfc3339==0.7
     # via -r requirements/static/ci/common.in
 tempora==4.1.1
-    # via portend
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   portend
 timelib==0.2.5
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   -r requirements/windows.txt
 toml==0.10.2
     # via -r requirements/static/ci/common.in
 tomli==2.0.1
@@ -388,6 +456,7 @@ typing-extensions==4.2.0
     #   pytest-system-statistics
 urllib3==1.26.6
     # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
     #   -r requirements/windows.txt
     #   botocore
     #   docker
@@ -411,9 +480,13 @@ werkzeug==2.2.3
     #   moto
     #   pytest-httpserver
 wheel==0.38.4
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   -r requirements/windows.txt
 wmi==1.5.1
-    # via -r requirements/windows.txt
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   -r requirements/windows.txt
 xmltodict==0.12.0
     # via
     #   moto
@@ -423,9 +496,13 @@ yamllint==1.26.3
 yarl==1.7.2
     # via aiohttp
 zc.lockfile==2.0
-    # via cherrypy
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   cherrypy
 zipp==3.5.0
-    # via importlib-metadata
+    # via
+    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
+    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/static/ci/windows.in
+++ b/requirements/static/ci/windows.in
@@ -1,4 +1,6 @@
 # This is a compilation of requirements installed on salt-jenkins git.salt state run
+--constraint=../pkg/py{py_version}/{platform}.txt
+
 dmidecode
 patch
 pygit2>=1.10.1

--- a/requirements/static/ci/windows.in
+++ b/requirements/static/ci/windows.in
@@ -1,8 +1,7 @@
 # This is a compilation of requirements installed on salt-jenkins git.salt state run
 dmidecode
 patch
-pygit2>=1.10.1; python_version >= '3.7'
-pygit2>=1.13.1; python_version >= '3.8'
+pygit2>=1.10.1
 sed
 pywinrm>=0.4.1
 yamllint

--- a/requirements/static/ci/windows.in
+++ b/requirements/static/ci/windows.in
@@ -1,7 +1,8 @@
 # This is a compilation of requirements installed on salt-jenkins git.salt state run
 dmidecode
 patch
-pygit2>=1.2.0
+pygit2>=1.10.1; python_version >= '3.7'
+pygit2>=1.13.1; python_version >= '3.8'
 sed
 pywinrm>=0.4.1
 yamllint

--- a/tests/pytests/functional/auth/auth.py
+++ b/tests/pytests/functional/auth/auth.py
@@ -1,0 +1,17 @@
+import salt.utils.user
+from salt import auth
+
+
+def test_user_is_sudo():
+    assert auth.AuthUser("bob").is_sudo() is False
+    assert auth.AuthUser("sudo_bob").is_sudo() is True
+
+
+def test_user_is_running_user():
+    current_user = salt.utils.user.get_user()
+    assert auth.AuthUser(salt.utils.user.get_user() + "1").is_running_user() is False
+    assert auth.AuthUser(current_user).is_running_user() is True
+
+
+def test_user_sudo_name():
+    assert auth.AuthUser("sudo_bob").sudo_name() == "bob"


### PR DESCRIPTION
### What does this PR do?
bump pygit2 dependence in ci
 
### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/65085

### Previous Behavior
py37 has unsupported version

### New Behavior
pygit2 will have less crashes and leaks and py 37 wont have problems 

### Merge requirements satisfied?
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html

### Commits signed with GPG?
Yes
