### PR TITLE
[3006.x] Use currently pinned centosstream-9 ami for cloud

### DIFF
--- a/cicd/amis.yml
+++ b/cicd/amis.yml
@@ -1,1 +1,1 @@
-centosstream-9-x86_64: ami-0dfa940714a95b497
+centosstream-9-x86_64: ami-091986d83f4c0bdd7


### PR DESCRIPTION
### What does this PR do?

- `salt-cloud` tests require the AMI listed in `cicd/amis.yml`
- The AMI used by `salt-cloud` should match the AMI for `centosstream-9` in `cicd/golden-images.json`
- If the AMI values differ, there is risk that the AMI will be deleted as part of AMI cleanup processes
- The current value used in `cicd/amis.yml` is out-dated, and has since been deleted
- This PR provides a working, available AMI
