### PR TITLE
[3006.x] Ensure jid include is used

### DIFF
--- a/changelog/65302.fixed.md
+++ b/changelog/65302.fixed.md
@@ -1,0 +1,1 @@
+Ensure that the correct value of jid_inclue is passed if the argument is included in the passed keyword arguments.

--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -521,8 +521,7 @@ def build_schedule_item(name, **kwargs):
     else:
         schedule[name]["enabled"] = True
 
-    if "jid_include" not in kwargs or kwargs["jid_include"]:
-        schedule[name]["jid_include"] = True
+    schedule[name]["jid_include"] = kwargs.get("jid_include", True)
 
     if "splay" in kwargs:
         if isinstance(kwargs["splay"], dict):

--- a/tests/pytests/unit/modules/test_schedule.py
+++ b/tests/pytests/unit/modules/test_schedule.py
@@ -198,6 +198,38 @@ def test_build_schedule_item_invalid_jobs_args():
         ) == {"comment": comment2, "result": False}
 
 
+def test_build_schedule_item_jid_include():
+    """
+    Test build_schedule_item when jid_include is passed and not passed
+    """
+    ret = schedule.build_schedule_item("job1", function="test.args", jid_include=False)
+    assert ret == {
+        "function": "test.args",
+        "maxrunning": 1,
+        "name": "job1",
+        "enabled": True,
+        "jid_include": False,
+    }
+
+    ret = schedule.build_schedule_item("job1", function="test.args", jid_include=True)
+    assert ret == {
+        "function": "test.args",
+        "maxrunning": 1,
+        "name": "job1",
+        "enabled": True,
+        "jid_include": True,
+    }
+
+    ret = schedule.build_schedule_item("job1", function="test.args")
+    assert ret == {
+        "function": "test.args",
+        "maxrunning": 1,
+        "name": "job1",
+        "enabled": True,
+        "jid_include": True,
+    }
+
+
 # 'add' function tests: 1
 
 


### PR DESCRIPTION
### What does this PR do?
Ensure that when jid_include is passed to build_schedule_item the correct passed value is included in the built schedule item.

### What issues does this PR fix or reference?
Fixes: #65302 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
