### PR TITLE
[3006.x] Add Photon OS 3 ARM64 / aarch64 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1067,6 +1067,23 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
 
+  photonos-3-arm64-ci-deps:
+    name: Photon OS 3 Arm64
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-salt-onedir-linux
+    uses: ./.github/workflows/build-deps-ci-action.yml
+    with:
+      distro-slug: photonos-3-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+
   photonos-4-ci-deps:
     name: Photon OS 4
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -1336,6 +1353,28 @@ jobs:
       nox-session: ci-test-onedir
       platform: linux
       arch: x86_64
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      pkg-type: rpm
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
+      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
+      testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
+
+  photonos-3-arm64-pkg-tests:
+    name: Photon OS 3 Arm64
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-rpm-pkgs-onedir
+      - photonos-3-arm64-ci-deps
+    uses: ./.github/workflows/test-packages-action.yml
+    with:
+      distro-slug: photonos-3-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       pkg-type: rpm
       nox-version: 2022.8.7
@@ -1991,6 +2030,26 @@ jobs:
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
       skip-junit-reports: ${{ github.event_name == 'pull_request' }}
 
+  photonos-3-arm64:
+    name: Photon OS 3 Arm64
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - photonos-3-arm64-ci-deps
+    uses: ./.github/workflows/test-action.yml
+    with:
+      distro-slug: photonos-3-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
+      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
+
   photonos-4:
     name: Photon OS 4
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -2143,6 +2202,7 @@ jobs:
       - fedora-38-arm64-ci-deps
       - opensuse-15-ci-deps
       - photonos-3-ci-deps
+      - photonos-3-arm64-ci-deps
       - photonos-4-ci-deps
       - photonos-4-arm64-ci-deps
       - ubuntu-2004-ci-deps
@@ -2167,6 +2227,7 @@ jobs:
       - fedora-38
       - opensuse-15
       - photonos-3
+      - photonos-3-arm64
       - photonos-4
       - photonos-4-arm64
       - ubuntu-2004
@@ -2272,6 +2333,7 @@ jobs:
       - fedora-38-arm64-ci-deps
       - opensuse-15-ci-deps
       - photonos-3-ci-deps
+      - photonos-3-arm64-ci-deps
       - photonos-4-ci-deps
       - photonos-4-arm64-ci-deps
       - ubuntu-2004-ci-deps
@@ -2296,6 +2358,7 @@ jobs:
       - fedora-38
       - opensuse-15
       - photonos-3
+      - photonos-3-arm64
       - photonos-4
       - photonos-4-arm64
       - ubuntu-2004
@@ -2310,6 +2373,7 @@ jobs:
       - debian-11-pkg-tests
       - debian-11-arm64-pkg-tests
       - photonos-3-pkg-tests
+      - photonos-3-arm64-pkg-tests
       - photonos-4-pkg-tests
       - photonos-4-arm64-pkg-tests
       - ubuntu-2004-pkg-tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1128,6 +1128,23 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
 
+  photonos-3-arm64-ci-deps:
+    name: Photon OS 3 Arm64
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-salt-onedir-linux
+    uses: ./.github/workflows/build-deps-ci-action.yml
+    with:
+      distro-slug: photonos-3-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+
   photonos-4-ci-deps:
     name: Photon OS 4
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -1397,6 +1414,28 @@ jobs:
       nox-session: ci-test-onedir
       platform: linux
       arch: x86_64
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      pkg-type: rpm
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: false
+      skip-junit-reports: false
+      testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
+
+  photonos-3-arm64-pkg-tests:
+    name: Photon OS 3 Arm64
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-rpm-pkgs-onedir
+      - photonos-3-arm64-ci-deps
+    uses: ./.github/workflows/test-packages-action.yml
+    with:
+      distro-slug: photonos-3-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       pkg-type: rpm
       nox-version: 2022.8.7
@@ -2052,6 +2091,26 @@ jobs:
       skip-code-coverage: false
       skip-junit-reports: false
 
+  photonos-3-arm64:
+    name: Photon OS 3 Arm64
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - photonos-3-arm64-ci-deps
+    uses: ./.github/workflows/test-action.yml
+    with:
+      distro-slug: photonos-3-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: false
+      skip-junit-reports: false
+
   photonos-4:
     name: Photon OS 4
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -2204,6 +2263,7 @@ jobs:
       - fedora-38-arm64-ci-deps
       - opensuse-15-ci-deps
       - photonos-3-ci-deps
+      - photonos-3-arm64-ci-deps
       - photonos-4-ci-deps
       - photonos-4-arm64-ci-deps
       - ubuntu-2004-ci-deps
@@ -2228,6 +2288,7 @@ jobs:
       - fedora-38
       - opensuse-15
       - photonos-3
+      - photonos-3-arm64
       - photonos-4
       - photonos-4-arm64
       - ubuntu-2004
@@ -2954,6 +3015,7 @@ jobs:
       - fedora-38-arm64-ci-deps
       - opensuse-15-ci-deps
       - photonos-3-ci-deps
+      - photonos-3-arm64-ci-deps
       - photonos-4-ci-deps
       - photonos-4-arm64-ci-deps
       - ubuntu-2004-ci-deps
@@ -2978,6 +3040,7 @@ jobs:
       - fedora-38
       - opensuse-15
       - photonos-3
+      - photonos-3-arm64
       - photonos-4
       - photonos-4-arm64
       - ubuntu-2004
@@ -3053,6 +3116,7 @@ jobs:
       - debian-11-pkg-tests
       - debian-11-arm64-pkg-tests
       - photonos-3-pkg-tests
+      - photonos-3-arm64-pkg-tests
       - photonos-4-pkg-tests
       - photonos-4-arm64-pkg-tests
       - ubuntu-2004-pkg-tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -683,6 +683,29 @@ jobs:
       pkg-type: package
     secrets: inherit
 
+  photonos-3-arm64-package-download-tests:
+    name: Test Photon OS 3 Arm64 package Downloads
+    if: ${{ inputs.skip-salt-pkg-download-test-suite == false }}
+    needs:
+      - prepare-workflow
+      - publish-repositories
+      - download-onedir-artifact
+    uses: ./.github/workflows/test-package-downloads-action-linux.yml
+    with:
+      distro-slug: photonos-3-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      environment: release
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      skip-code-coverage: true
+      latest-release: "${{ needs.prepare-workflow.outputs.latest-release }}"
+      pkg-type: package
+    secrets: inherit
+
   photonos-4-package-download-tests:
     name: Test Photon OS 4 package Downloads
     if: ${{ inputs.skip-salt-pkg-download-test-suite == false }}
@@ -1013,6 +1036,7 @@ jobs:
       - fedora-38-package-download-tests
       - fedora-38-arm64-package-download-tests
       - photonos-3-package-download-tests
+      - photonos-3-arm64-package-download-tests
       - photonos-4-package-download-tests
       - photonos-4-arm64-package-download-tests
       - ubuntu-2004-package-download-tests

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1101,6 +1101,23 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
 
+  photonos-3-arm64-ci-deps:
+    name: Photon OS 3 Arm64
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-salt-onedir-linux
+    uses: ./.github/workflows/build-deps-ci-action.yml
+    with:
+      distro-slug: photonos-3-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+
   photonos-4-ci-deps:
     name: Photon OS 4
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -1370,6 +1387,28 @@ jobs:
       nox-session: ci-test-onedir
       platform: linux
       arch: x86_64
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      pkg-type: rpm
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: false
+      skip-junit-reports: false
+      testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
+
+  photonos-3-arm64-pkg-tests:
+    name: Photon OS 3 Arm64
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-rpm-pkgs-onedir
+      - photonos-3-arm64-ci-deps
+    uses: ./.github/workflows/test-packages-action.yml
+    with:
+      distro-slug: photonos-3-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       pkg-type: rpm
       nox-version: 2022.8.7
@@ -2025,6 +2064,26 @@ jobs:
       skip-code-coverage: false
       skip-junit-reports: false
 
+  photonos-3-arm64:
+    name: Photon OS 3 Arm64
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - photonos-3-arm64-ci-deps
+    uses: ./.github/workflows/test-action.yml
+    with:
+      distro-slug: photonos-3-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: false
+      skip-junit-reports: false
+
   photonos-4:
     name: Photon OS 4
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -2177,6 +2236,7 @@ jobs:
       - fedora-38-arm64-ci-deps
       - opensuse-15-ci-deps
       - photonos-3-ci-deps
+      - photonos-3-arm64-ci-deps
       - photonos-4-ci-deps
       - photonos-4-arm64-ci-deps
       - ubuntu-2004-ci-deps
@@ -2201,6 +2261,7 @@ jobs:
       - fedora-38
       - opensuse-15
       - photonos-3
+      - photonos-3-arm64
       - photonos-4
       - photonos-4-arm64
       - ubuntu-2004
@@ -2308,6 +2369,7 @@ jobs:
       - fedora-38-arm64-ci-deps
       - opensuse-15-ci-deps
       - photonos-3-ci-deps
+      - photonos-3-arm64-ci-deps
       - photonos-4-ci-deps
       - photonos-4-arm64-ci-deps
       - ubuntu-2004-ci-deps
@@ -2332,6 +2394,7 @@ jobs:
       - fedora-38
       - opensuse-15
       - photonos-3
+      - photonos-3-arm64
       - photonos-4
       - photonos-4-arm64
       - ubuntu-2004
@@ -2346,6 +2409,7 @@ jobs:
       - debian-11-pkg-tests
       - debian-11-arm64-pkg-tests
       - photonos-3-pkg-tests
+      - photonos-3-arm64-pkg-tests
       - photonos-4-pkg-tests
       - photonos-4-arm64-pkg-tests
       - ubuntu-2004-pkg-tests

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1123,6 +1123,23 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
 
+  photonos-3-arm64-ci-deps:
+    name: Photon OS 3 Arm64
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-salt-onedir-linux
+    uses: ./.github/workflows/build-deps-ci-action.yml
+    with:
+      distro-slug: photonos-3-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+
   photonos-4-ci-deps:
     name: Photon OS 4
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -1392,6 +1409,28 @@ jobs:
       nox-session: ci-test-onedir
       platform: linux
       arch: x86_64
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      pkg-type: rpm
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: true
+      skip-junit-reports: true
+      testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
+
+  photonos-3-arm64-pkg-tests:
+    name: Photon OS 3 Arm64
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-rpm-pkgs-onedir
+      - photonos-3-arm64-ci-deps
+    uses: ./.github/workflows/test-packages-action.yml
+    with:
+      distro-slug: photonos-3-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       pkg-type: rpm
       nox-version: 2022.8.7
@@ -2039,6 +2078,26 @@ jobs:
       nox-session: ci-test-onedir
       platform: linux
       arch: x86_64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: true
+      skip-junit-reports: true
+
+  photonos-3-arm64:
+    name: Photon OS 3 Arm64
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - photonos-3-arm64-ci-deps
+    uses: ./.github/workflows/test-action.yml
+    with:
+      distro-slug: photonos-3-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
       nox-version: 2022.8.7
       python-version: "3.10"
       testrun: ${{ needs.prepare-workflow.outputs.testrun }}
@@ -3352,6 +3411,28 @@ jobs:
       pkg-type: package
     secrets: inherit
 
+  photonos-3-arm64-package-download-tests:
+    name: Test Photon OS 3 Arm64 package Downloads
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg-download'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - publish-repositories
+    uses: ./.github/workflows/test-package-downloads-action-linux.yml
+    with:
+      distro-slug: photonos-3-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      environment: staging
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      skip-code-coverage: true
+      latest-release: "${{ needs.prepare-workflow.outputs.latest-release }}"
+      pkg-type: package
+    secrets: inherit
+
   photonos-4-package-download-tests:
     name: Test Photon OS 4 package Downloads
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg-download'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -3670,6 +3751,7 @@ jobs:
       - fedora-38-arm64-ci-deps
       - opensuse-15-ci-deps
       - photonos-3-ci-deps
+      - photonos-3-arm64-ci-deps
       - photonos-4-ci-deps
       - photonos-4-arm64-ci-deps
       - ubuntu-2004-ci-deps
@@ -3694,6 +3776,7 @@ jobs:
       - fedora-38
       - opensuse-15
       - photonos-3
+      - photonos-3-arm64
       - photonos-4
       - photonos-4-arm64
       - ubuntu-2004
@@ -3708,6 +3791,7 @@ jobs:
       - debian-11-pkg-tests
       - debian-11-arm64-pkg-tests
       - photonos-3-pkg-tests
+      - photonos-3-arm64-pkg-tests
       - photonos-4-pkg-tests
       - photonos-4-arm64-pkg-tests
       - ubuntu-2004-pkg-tests
@@ -3741,6 +3825,7 @@ jobs:
       - fedora-38-package-download-tests
       - fedora-38-arm64-package-download-tests
       - photonos-3-package-download-tests
+      - photonos-3-arm64-package-download-tests
       - photonos-4-package-download-tests
       - photonos-4-arm64-package-download-tests
       - ubuntu-2004-package-download-tests

--- a/.github/workflows/templates/build-ci-deps.yml.jinja
+++ b/.github/workflows/templates/build-ci-deps.yml.jinja
@@ -67,6 +67,7 @@
                                        ("fedora-38-arm64", "Fedora 38 Arm64", "aarch64"),
                                        ("opensuse-15", "Opensuse 15", "x86_64"),
                                        ("photonos-3", "Photon OS 3", "x86_64"),
+                                       ("photonos-3-arm64", "Photon OS 3 Arm64", "aarch64"),
                                        ("photonos-4", "Photon OS 4", "x86_64"),
                                        ("photonos-4-arm64", "Photon OS 4 Arm64", "aarch64"),
                                        ("ubuntu-20.04", "Ubuntu 20.04", "x86_64"),

--- a/.github/workflows/templates/test-pkg-repo-downloads.yml.jinja
+++ b/.github/workflows/templates/test-pkg-repo-downloads.yml.jinja
@@ -20,6 +20,7 @@
                                ("fedora-38", "Fedora 38", "x86_64", "package"),
                                ("fedora-38-arm64", "Fedora 38 Arm64", "aarch64", "package"),
                                ("photonos-3", "Photon OS 3", "x86_64", "package"),
+                               ("photonos-3-arm64", "Photon OS 3 Arm64", "aarch64", "package"),
                                ("photonos-4", "Photon OS 4", "x86_64", "package"),
                                ("photonos-4-arm64", "Photon OS 4 Arm64", "aarch64", "package"),
                                ("ubuntu-20.04", "Ubuntu 20.04", "x86_64", "package"),

--- a/.github/workflows/templates/test-salt-pkg.yml.jinja
+++ b/.github/workflows/templates/test-salt-pkg.yml.jinja
@@ -26,6 +26,7 @@
                                ("debian-11", "Debian 11", "x86_64", "deb"),
                                ("debian-11-arm64", "Debian 11 Arm64", "aarch64", "deb"),
                                ("photonos-3", "Photon OS 3", "x86_64", "rpm"),
+                               ("photonos-3-arm64", "Photon OS 3 Arm64", "aarch64", "rpm"),
                                ("photonos-4", "Photon OS 4", "x86_64", "rpm"),
                                ("photonos-4-arm64", "Photon OS 4 Arm64", "aarch64", "rpm"),
                                ("ubuntu-20.04", "Ubuntu 20.04", "x86_64", "deb"),

--- a/.github/workflows/templates/test-salt.yml.jinja
+++ b/.github/workflows/templates/test-salt.yml.jinja
@@ -65,6 +65,7 @@
                                        ("fedora-38", "Fedora 38", "x86_64"),
                                        ("opensuse-15", "Opensuse 15", "x86_64"),
                                        ("photonos-3", "Photon OS 3", "x86_64"),
+                                       ("photonos-3-arm64", "Photon OS 3 Arm64", "aarch64"),
                                        ("photonos-4", "Photon OS 4", "x86_64"),
                                        ("photonos-4-arm64", "Photon OS 4 Arm64", "aarch64"),
                                        ("ubuntu-20.04", "Ubuntu 20.04", "x86_64"),

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -707,6 +707,7 @@ def pkg_matrix(
             "ubuntu-20.04-arm64",
             "ubuntu-22.04-arm64",
             "photonos-3",
+            "photonos-3-arm64",
             "photonos-4",
             "photonos-4-arm64",
         ]


### PR DESCRIPTION
### What does this PR do?

We create packages for Photon OS 3 ARM64, but we aren't actively testing that in CI/CD. This adds into CI/CD.

Followed the same format as Photon OS 4 ARM64 PR:
- https://github.com/saltstack/salt/pull/64991