### PR TITLE
[3006.x] Add Amazon Linux 2023; update Amazon Linux 2 AMI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -797,6 +797,40 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
 
+  amazonlinux-2023-ci-deps:
+    name: Amazon Linux 2023 Deps
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['build-deps-ci'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-salt-onedir-linux
+    uses: ./.github/workflows/build-deps-ci-action.yml
+    with:
+      distro-slug: amazonlinux-2023
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: x86_64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+
+  amazonlinux-2023-arm64-ci-deps:
+    name: Amazon Linux 2023 Arm64 Deps
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['build-deps-ci'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-salt-onedir-linux
+    uses: ./.github/workflows/build-deps-ci-action.yml
+    with:
+      distro-slug: amazonlinux-2023-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+
   archlinux-lts-ci-deps:
     name: Arch Linux LTS Deps
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['build-deps-ci'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -1269,6 +1303,72 @@ jobs:
       nox-session: ci-test-onedir
       platform: linux
       arch: x86_64
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      pkg-type: rpm
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
+      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
+      testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
+
+  amazonlinux-2-arm64-pkg-tests:
+    name: Amazon Linux 2 Arm64 Package Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-rpm-pkgs-onedir
+      - amazonlinux-2-arm64-ci-deps
+    uses: ./.github/workflows/test-packages-action.yml
+    with:
+      distro-slug: amazonlinux-2-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      pkg-type: rpm
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
+      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
+      testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
+
+  amazonlinux-2023-pkg-tests:
+    name: Amazon Linux 2023 Package Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-rpm-pkgs-onedir
+      - amazonlinux-2023-ci-deps
+    uses: ./.github/workflows/test-packages-action.yml
+    with:
+      distro-slug: amazonlinux-2023
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: x86_64
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      pkg-type: rpm
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
+      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
+      testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
+
+  amazonlinux-2023-arm64-pkg-tests:
+    name: Amazon Linux 2023 Arm64 Package Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-rpm-pkgs-onedir
+      - amazonlinux-2023-arm64-ci-deps
+    uses: ./.github/workflows/test-packages-action.yml
+    with:
+      distro-slug: amazonlinux-2023-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       pkg-type: rpm
       nox-version: 2022.8.7
@@ -1982,6 +2082,66 @@ jobs:
       workflow-slug: ci
       default-timeout: 180
 
+  amazonlinux-2-arm64:
+    name: Amazon Linux 2 Arm64 Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - amazonlinux-2-arm64-ci-deps
+    uses: ./.github/workflows/test-action.yml
+    with:
+      distro-slug: amazonlinux-2-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
+      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
+
+  amazonlinux-2023:
+    name: Amazon Linux 2023 Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - amazonlinux-2023-ci-deps
+    uses: ./.github/workflows/test-action.yml
+    with:
+      distro-slug: amazonlinux-2023
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: x86_64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
+      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
+
+  amazonlinux-2023-arm64:
+    name: Amazon Linux 2023 Arm64 Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - amazonlinux-2023-arm64-ci-deps
+    uses: ./.github/workflows/test-action.yml
+    with:
+      distro-slug: amazonlinux-2023-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
+      skip-junit-reports: ${{ github.event_name == 'pull_request' }}
+
   archlinux-lts:
     name: Arch Linux LTS Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -2482,6 +2642,8 @@ jobs:
       - almalinux-9-arm64-ci-deps
       - amazonlinux-2-ci-deps
       - amazonlinux-2-arm64-ci-deps
+      - amazonlinux-2023-ci-deps
+      - amazonlinux-2023-arm64-ci-deps
       - archlinux-lts-ci-deps
       - centos-7-ci-deps
       - centos-7-arm64-ci-deps
@@ -2516,6 +2678,9 @@ jobs:
       - almalinux-8
       - almalinux-9
       - amazonlinux-2
+      - amazonlinux-2-arm64
+      - amazonlinux-2023
+      - amazonlinux-2023-arm64
       - archlinux-lts
       - centos-7
       - centosstream-8
@@ -2673,6 +2838,8 @@ jobs:
       - almalinux-9-arm64-ci-deps
       - amazonlinux-2-ci-deps
       - amazonlinux-2-arm64-ci-deps
+      - amazonlinux-2023-ci-deps
+      - amazonlinux-2023-arm64-ci-deps
       - archlinux-lts-ci-deps
       - centos-7-ci-deps
       - centos-7-arm64-ci-deps
@@ -2707,6 +2874,9 @@ jobs:
       - almalinux-8
       - almalinux-9
       - amazonlinux-2
+      - amazonlinux-2-arm64
+      - amazonlinux-2023
+      - amazonlinux-2023-arm64
       - archlinux-lts
       - centos-7
       - centosstream-8
@@ -2730,6 +2900,9 @@ jobs:
       - ubuntu-2204
       - ubuntu-2204-arm64
       - amazonlinux-2-pkg-tests
+      - amazonlinux-2-arm64-pkg-tests
+      - amazonlinux-2023-pkg-tests
+      - amazonlinux-2023-arm64-pkg-tests
       - centos-7-pkg-tests
       - centosstream-8-pkg-tests
       - centosstream-9-pkg-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2101,6 +2101,8 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
       skip-junit-reports: ${{ github.event_name == 'pull_request' }}
+      workflow-slug: ci
+      default-timeout: 180
 
   amazonlinux-2023:
     name: Amazon Linux 2023 Test
@@ -2121,6 +2123,8 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
       skip-junit-reports: ${{ github.event_name == 'pull_request' }}
+      workflow-slug: ci
+      default-timeout: 180
 
   amazonlinux-2023-arm64:
     name: Amazon Linux 2023 Arm64 Test
@@ -2141,6 +2145,8 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: ${{ fromJSON(needs.prepare-workflow.outputs.testrun)['skip_code_coverage'] }}
       skip-junit-reports: ${{ github.event_name == 'pull_request' }}
+      workflow-slug: ci
+      default-timeout: 180
 
   archlinux-lts:
     name: Arch Linux LTS Test

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2162,6 +2162,8 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
       skip-junit-reports: false
+      workflow-slug: nightly
+      default-timeout: 360
 
   amazonlinux-2023:
     name: Amazon Linux 2023 Test
@@ -2182,6 +2184,8 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
       skip-junit-reports: false
+      workflow-slug: nightly
+      default-timeout: 360
 
   amazonlinux-2023-arm64:
     name: Amazon Linux 2023 Arm64 Test
@@ -2202,6 +2206,8 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
       skip-junit-reports: false
+      workflow-slug: nightly
+      default-timeout: 360
 
   archlinux-lts:
     name: Arch Linux LTS Test

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -858,6 +858,40 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
 
+  amazonlinux-2023-ci-deps:
+    name: Amazon Linux 2023 Deps
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['build-deps-ci'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-salt-onedir-linux
+    uses: ./.github/workflows/build-deps-ci-action.yml
+    with:
+      distro-slug: amazonlinux-2023
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: x86_64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+
+  amazonlinux-2023-arm64-ci-deps:
+    name: Amazon Linux 2023 Arm64 Deps
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['build-deps-ci'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-salt-onedir-linux
+    uses: ./.github/workflows/build-deps-ci-action.yml
+    with:
+      distro-slug: amazonlinux-2023-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+
   archlinux-lts-ci-deps:
     name: Arch Linux LTS Deps
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['build-deps-ci'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -1330,6 +1364,72 @@ jobs:
       nox-session: ci-test-onedir
       platform: linux
       arch: x86_64
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      pkg-type: rpm
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: false
+      skip-junit-reports: false
+      testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
+
+  amazonlinux-2-arm64-pkg-tests:
+    name: Amazon Linux 2 Arm64 Package Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-rpm-pkgs-onedir
+      - amazonlinux-2-arm64-ci-deps
+    uses: ./.github/workflows/test-packages-action.yml
+    with:
+      distro-slug: amazonlinux-2-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      pkg-type: rpm
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: false
+      skip-junit-reports: false
+      testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
+
+  amazonlinux-2023-pkg-tests:
+    name: Amazon Linux 2023 Package Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-rpm-pkgs-onedir
+      - amazonlinux-2023-ci-deps
+    uses: ./.github/workflows/test-packages-action.yml
+    with:
+      distro-slug: amazonlinux-2023
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: x86_64
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      pkg-type: rpm
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: false
+      skip-junit-reports: false
+      testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
+
+  amazonlinux-2023-arm64-pkg-tests:
+    name: Amazon Linux 2023 Arm64 Package Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-rpm-pkgs-onedir
+      - amazonlinux-2023-arm64-ci-deps
+    uses: ./.github/workflows/test-packages-action.yml
+    with:
+      distro-slug: amazonlinux-2023-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       pkg-type: rpm
       nox-version: 2022.8.7
@@ -2043,6 +2143,66 @@ jobs:
       workflow-slug: nightly
       default-timeout: 360
 
+  amazonlinux-2-arm64:
+    name: Amazon Linux 2 Arm64 Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - amazonlinux-2-arm64-ci-deps
+    uses: ./.github/workflows/test-action.yml
+    with:
+      distro-slug: amazonlinux-2-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: false
+      skip-junit-reports: false
+
+  amazonlinux-2023:
+    name: Amazon Linux 2023 Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - amazonlinux-2023-ci-deps
+    uses: ./.github/workflows/test-action.yml
+    with:
+      distro-slug: amazonlinux-2023
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: x86_64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: false
+      skip-junit-reports: false
+
+  amazonlinux-2023-arm64:
+    name: Amazon Linux 2023 Arm64 Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - amazonlinux-2023-arm64-ci-deps
+    uses: ./.github/workflows/test-action.yml
+    with:
+      distro-slug: amazonlinux-2023-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: false
+      skip-junit-reports: false
+
   archlinux-lts:
     name: Arch Linux LTS Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -2543,6 +2703,8 @@ jobs:
       - almalinux-9-arm64-ci-deps
       - amazonlinux-2-ci-deps
       - amazonlinux-2-arm64-ci-deps
+      - amazonlinux-2023-ci-deps
+      - amazonlinux-2023-arm64-ci-deps
       - archlinux-lts-ci-deps
       - centos-7-ci-deps
       - centos-7-arm64-ci-deps
@@ -2577,6 +2739,9 @@ jobs:
       - almalinux-8
       - almalinux-9
       - amazonlinux-2
+      - amazonlinux-2-arm64
+      - amazonlinux-2023
+      - amazonlinux-2023-arm64
       - archlinux-lts
       - centos-7
       - centosstream-8
@@ -2948,6 +3113,14 @@ jobs:
           - pkg-type: rpm
             distro: amazon
             version: "2"
+            arch: aarch64
+          - pkg-type: rpm
+            distro: amazon
+            version: "2023"
+            arch: x86_64
+          - pkg-type: rpm
+            distro: amazon
+            version: "2023"
             arch: aarch64
           - pkg-type: rpm
             distro: redhat
@@ -3425,6 +3598,8 @@ jobs:
       - almalinux-9-arm64-ci-deps
       - amazonlinux-2-ci-deps
       - amazonlinux-2-arm64-ci-deps
+      - amazonlinux-2023-ci-deps
+      - amazonlinux-2023-arm64-ci-deps
       - archlinux-lts-ci-deps
       - centos-7-ci-deps
       - centos-7-arm64-ci-deps
@@ -3459,6 +3634,9 @@ jobs:
       - almalinux-8
       - almalinux-9
       - amazonlinux-2
+      - amazonlinux-2-arm64
+      - amazonlinux-2023
+      - amazonlinux-2023-arm64
       - archlinux-lts
       - centos-7
       - centosstream-8
@@ -3543,6 +3721,9 @@ jobs:
       - combine-all-code-coverage
       - publish-repositories
       - amazonlinux-2-pkg-tests
+      - amazonlinux-2-arm64-pkg-tests
+      - amazonlinux-2023-pkg-tests
+      - amazonlinux-2023-arm64-pkg-tests
       - centos-7-pkg-tests
       - centosstream-8-pkg-tests
       - centosstream-9-pkg-tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,6 +321,38 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
 
+  amazonlinux-2023-ci-deps:
+    name: Amazon Linux 2023 Deps
+    needs:
+      - prepare-workflow
+      - download-onedir-artifact
+    uses: ./.github/workflows/build-deps-ci-action.yml
+    with:
+      distro-slug: amazonlinux-2023
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: x86_64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+
+  amazonlinux-2023-arm64-ci-deps:
+    name: Amazon Linux 2023 Arm64 Deps
+    needs:
+      - prepare-workflow
+      - download-onedir-artifact
+    uses: ./.github/workflows/build-deps-ci-action.yml
+    with:
+      distro-slug: amazonlinux-2023-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+
   archlinux-lts-ci-deps:
     name: Arch Linux LTS Deps
     needs:
@@ -826,6 +858,8 @@ jobs:
       - almalinux-9-ci-deps
       - amazonlinux-2-arm64-ci-deps
       - amazonlinux-2-ci-deps
+      - amazonlinux-2023-arm64-ci-deps
+      - amazonlinux-2023-ci-deps
       - centos-7-arm64-ci-deps
       - centos-7-ci-deps
       - centosstream-8-arm64-ci-deps
@@ -1050,6 +1084,8 @@ jobs:
       - almalinux-9-arm64-ci-deps
       - amazonlinux-2-ci-deps
       - amazonlinux-2-arm64-ci-deps
+      - amazonlinux-2023-ci-deps
+      - amazonlinux-2023-arm64-ci-deps
       - archlinux-lts-ci-deps
       - centos-7-ci-deps
       - centos-7-arm64-ci-deps

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -831,6 +831,40 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
 
+  amazonlinux-2023-ci-deps:
+    name: Amazon Linux 2023 Deps
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['build-deps-ci'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-salt-onedir-linux
+    uses: ./.github/workflows/build-deps-ci-action.yml
+    with:
+      distro-slug: amazonlinux-2023
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: x86_64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+
+  amazonlinux-2023-arm64-ci-deps:
+    name: Amazon Linux 2023 Arm64 Deps
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['build-deps-ci'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-salt-onedir-linux
+    uses: ./.github/workflows/build-deps-ci-action.yml
+    with:
+      distro-slug: amazonlinux-2023-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+
   archlinux-lts-ci-deps:
     name: Arch Linux LTS Deps
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['build-deps-ci'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -1303,6 +1337,72 @@ jobs:
       nox-session: ci-test-onedir
       platform: linux
       arch: x86_64
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      pkg-type: rpm
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: false
+      skip-junit-reports: false
+      testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
+
+  amazonlinux-2-arm64-pkg-tests:
+    name: Amazon Linux 2 Arm64 Package Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-rpm-pkgs-onedir
+      - amazonlinux-2-arm64-ci-deps
+    uses: ./.github/workflows/test-packages-action.yml
+    with:
+      distro-slug: amazonlinux-2-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      pkg-type: rpm
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: false
+      skip-junit-reports: false
+      testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
+
+  amazonlinux-2023-pkg-tests:
+    name: Amazon Linux 2023 Package Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-rpm-pkgs-onedir
+      - amazonlinux-2023-ci-deps
+    uses: ./.github/workflows/test-packages-action.yml
+    with:
+      distro-slug: amazonlinux-2023
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: x86_64
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      pkg-type: rpm
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: false
+      skip-junit-reports: false
+      testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
+
+  amazonlinux-2023-arm64-pkg-tests:
+    name: Amazon Linux 2023 Arm64 Package Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-rpm-pkgs-onedir
+      - amazonlinux-2023-arm64-ci-deps
+    uses: ./.github/workflows/test-packages-action.yml
+    with:
+      distro-slug: amazonlinux-2023-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       pkg-type: rpm
       nox-version: 2022.8.7
@@ -2016,6 +2116,66 @@ jobs:
       workflow-slug: scheduled
       default-timeout: 360
 
+  amazonlinux-2-arm64:
+    name: Amazon Linux 2 Arm64 Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - amazonlinux-2-arm64-ci-deps
+    uses: ./.github/workflows/test-action.yml
+    with:
+      distro-slug: amazonlinux-2-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: false
+      skip-junit-reports: false
+
+  amazonlinux-2023:
+    name: Amazon Linux 2023 Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - amazonlinux-2023-ci-deps
+    uses: ./.github/workflows/test-action.yml
+    with:
+      distro-slug: amazonlinux-2023
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: x86_64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: false
+      skip-junit-reports: false
+
+  amazonlinux-2023-arm64:
+    name: Amazon Linux 2023 Arm64 Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - amazonlinux-2023-arm64-ci-deps
+    uses: ./.github/workflows/test-action.yml
+    with:
+      distro-slug: amazonlinux-2023-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: false
+      skip-junit-reports: false
+
   archlinux-lts:
     name: Arch Linux LTS Test
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -2516,6 +2676,8 @@ jobs:
       - almalinux-9-arm64-ci-deps
       - amazonlinux-2-ci-deps
       - amazonlinux-2-arm64-ci-deps
+      - amazonlinux-2023-ci-deps
+      - amazonlinux-2023-arm64-ci-deps
       - archlinux-lts-ci-deps
       - centos-7-ci-deps
       - centos-7-arm64-ci-deps
@@ -2550,6 +2712,9 @@ jobs:
       - almalinux-8
       - almalinux-9
       - amazonlinux-2
+      - amazonlinux-2-arm64
+      - amazonlinux-2023
+      - amazonlinux-2023-arm64
       - archlinux-lts
       - centos-7
       - centosstream-8
@@ -2709,6 +2874,8 @@ jobs:
       - almalinux-9-arm64-ci-deps
       - amazonlinux-2-ci-deps
       - amazonlinux-2-arm64-ci-deps
+      - amazonlinux-2023-ci-deps
+      - amazonlinux-2023-arm64-ci-deps
       - archlinux-lts-ci-deps
       - centos-7-ci-deps
       - centos-7-arm64-ci-deps
@@ -2743,6 +2910,9 @@ jobs:
       - almalinux-8
       - almalinux-9
       - amazonlinux-2
+      - amazonlinux-2-arm64
+      - amazonlinux-2023
+      - amazonlinux-2023-arm64
       - archlinux-lts
       - centos-7
       - centosstream-8
@@ -2766,6 +2936,9 @@ jobs:
       - ubuntu-2204
       - ubuntu-2204-arm64
       - amazonlinux-2-pkg-tests
+      - amazonlinux-2-arm64-pkg-tests
+      - amazonlinux-2023-pkg-tests
+      - amazonlinux-2023-arm64-pkg-tests
       - centos-7-pkg-tests
       - centosstream-8-pkg-tests
       - centosstream-9-pkg-tests

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -2135,6 +2135,8 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
       skip-junit-reports: false
+      workflow-slug: scheduled
+      default-timeout: 360
 
   amazonlinux-2023:
     name: Amazon Linux 2023 Test
@@ -2155,6 +2157,8 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
       skip-junit-reports: false
+      workflow-slug: scheduled
+      default-timeout: 360
 
   amazonlinux-2023-arm64:
     name: Amazon Linux 2023 Arm64 Test
@@ -2175,6 +2179,8 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: false
       skip-junit-reports: false
+      workflow-slug: scheduled
+      default-timeout: 360
 
   archlinux-lts:
     name: Arch Linux LTS Test

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -853,6 +853,40 @@ jobs:
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
 
+  amazonlinux-2023-ci-deps:
+    name: Amazon Linux 2023 Deps
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['build-deps-ci'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-salt-onedir-linux
+    uses: ./.github/workflows/build-deps-ci-action.yml
+    with:
+      distro-slug: amazonlinux-2023
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: x86_64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+
+  amazonlinux-2023-arm64-ci-deps:
+    name: Amazon Linux 2023 Arm64 Deps
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['build-deps-ci'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-salt-onedir-linux
+    uses: ./.github/workflows/build-deps-ci-action.yml
+    with:
+      distro-slug: amazonlinux-2023-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+
   archlinux-lts-ci-deps:
     name: Arch Linux LTS Deps
     if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['build-deps-ci'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
@@ -1325,6 +1359,72 @@ jobs:
       nox-session: ci-test-onedir
       platform: linux
       arch: x86_64
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      pkg-type: rpm
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: true
+      skip-junit-reports: true
+      testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
+
+  amazonlinux-2-arm64-pkg-tests:
+    name: Amazon Linux 2 Arm64 Package Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-rpm-pkgs-onedir
+      - amazonlinux-2-arm64-ci-deps
+    uses: ./.github/workflows/test-packages-action.yml
+    with:
+      distro-slug: amazonlinux-2-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      pkg-type: rpm
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: true
+      skip-junit-reports: true
+      testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
+
+  amazonlinux-2023-pkg-tests:
+    name: Amazon Linux 2023 Package Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-rpm-pkgs-onedir
+      - amazonlinux-2023-ci-deps
+    uses: ./.github/workflows/test-packages-action.yml
+    with:
+      distro-slug: amazonlinux-2023
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: x86_64
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      pkg-type: rpm
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: true
+      skip-junit-reports: true
+      testing-releases: ${{ needs.prepare-workflow.outputs.testing-releases }}
+
+  amazonlinux-2023-arm64-pkg-tests:
+    name: Amazon Linux 2023 Arm64 Package Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test-pkg'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - build-rpm-pkgs-onedir
+      - amazonlinux-2023-arm64-ci-deps
+    uses: ./.github/workflows/test-packages-action.yml
+    with:
+      distro-slug: amazonlinux-2023-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
       salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
       pkg-type: rpm
       nox-version: 2022.8.7
@@ -2037,6 +2137,66 @@ jobs:
       skip-junit-reports: true
       workflow-slug: staging
       default-timeout: 180
+
+  amazonlinux-2-arm64:
+    name: Amazon Linux 2 Arm64 Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - amazonlinux-2-arm64-ci-deps
+    uses: ./.github/workflows/test-action.yml
+    with:
+      distro-slug: amazonlinux-2-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: true
+      skip-junit-reports: true
+
+  amazonlinux-2023:
+    name: Amazon Linux 2023 Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - amazonlinux-2023-ci-deps
+    uses: ./.github/workflows/test-action.yml
+    with:
+      distro-slug: amazonlinux-2023
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: x86_64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: true
+      skip-junit-reports: true
+
+  amazonlinux-2023-arm64:
+    name: Amazon Linux 2023 Arm64 Test
+    if: ${{ fromJSON(needs.prepare-workflow.outputs.jobs)['test'] && fromJSON(needs.prepare-workflow.outputs.runners)['self-hosted'] }}
+    needs:
+      - prepare-workflow
+      - amazonlinux-2023-arm64-ci-deps
+    uses: ./.github/workflows/test-action.yml
+    with:
+      distro-slug: amazonlinux-2023-arm64
+      nox-session: ci-test-onedir
+      platform: linux
+      arch: aarch64
+      nox-version: 2022.8.7
+      python-version: "3.10"
+      testrun: ${{ needs.prepare-workflow.outputs.testrun }}
+      salt-version: "${{ needs.prepare-workflow.outputs.salt-version }}"
+      cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
+      skip-code-coverage: true
+      skip-junit-reports: true
 
   archlinux-lts:
     name: Arch Linux LTS Test
@@ -2770,6 +2930,14 @@ jobs:
             version: "2"
             arch: aarch64
           - pkg-type: rpm
+            distro: amazon
+            version: "2023"
+            arch: x86_64
+          - pkg-type: rpm
+            distro: amazon
+            version: "2023"
+            arch: aarch64
+          - pkg-type: rpm
             distro: redhat
             version: "7"
             arch: x86_64
@@ -3349,6 +3517,8 @@ jobs:
       - almalinux-9-ci-deps
       - amazonlinux-2-arm64-ci-deps
       - amazonlinux-2-ci-deps
+      - amazonlinux-2023-arm64-ci-deps
+      - amazonlinux-2023-ci-deps
       - centos-7-arm64-ci-deps
       - centos-7-ci-deps
       - centosstream-8-arm64-ci-deps
@@ -3407,6 +3577,8 @@ jobs:
       - almalinux-9-arm64-ci-deps
       - amazonlinux-2-ci-deps
       - amazonlinux-2-arm64-ci-deps
+      - amazonlinux-2023-ci-deps
+      - amazonlinux-2023-arm64-ci-deps
       - archlinux-lts-ci-deps
       - centos-7-ci-deps
       - centos-7-arm64-ci-deps
@@ -3441,6 +3613,9 @@ jobs:
       - almalinux-8
       - almalinux-9
       - amazonlinux-2
+      - amazonlinux-2-arm64
+      - amazonlinux-2023
+      - amazonlinux-2023-arm64
       - archlinux-lts
       - centos-7
       - centosstream-8
@@ -3464,6 +3639,9 @@ jobs:
       - ubuntu-2204
       - ubuntu-2204-arm64
       - amazonlinux-2-pkg-tests
+      - amazonlinux-2-arm64-pkg-tests
+      - amazonlinux-2023-pkg-tests
+      - amazonlinux-2023-arm64-pkg-tests
       - centos-7-pkg-tests
       - centosstream-8-pkg-tests
       - centosstream-9-pkg-tests

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -2157,6 +2157,8 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
       skip-junit-reports: true
+      workflow-slug: staging
+      default-timeout: 180
 
   amazonlinux-2023:
     name: Amazon Linux 2023 Test
@@ -2177,6 +2179,8 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
       skip-junit-reports: true
+      workflow-slug: staging
+      default-timeout: 180
 
   amazonlinux-2023-arm64:
     name: Amazon Linux 2023 Arm64 Test
@@ -2197,6 +2201,8 @@ jobs:
       cache-prefix: ${{ needs.prepare-workflow.outputs.cache-seed }}|3.10.13
       skip-code-coverage: true
       skip-junit-reports: true
+      workflow-slug: staging
+      default-timeout: 180
 
   archlinux-lts:
     name: Arch Linux LTS Test

--- a/.github/workflows/templates/build-rpm-repo.yml.jinja
+++ b/.github/workflows/templates/build-rpm-repo.yml.jinja
@@ -6,6 +6,8 @@
         <%- for distro, version, arch in (
                                             ("amazon", "2", "x86_64"),
                                             ("amazon", "2", "aarch64"),
+                                            ("amazon", "2023", "x86_64"),
+                                            ("amazon", "2023", "aarch64"),
                                             ("redhat", "7", "x86_64"),
                                             ("redhat", "7", "aarch64"),
                                             ("redhat", "8", "x86_64"),

--- a/.github/workflows/test-package-downloads-action.yml
+++ b/.github/workflows/test-package-downloads-action.yml
@@ -83,6 +83,12 @@ jobs:
           - distro-slug: amazonlinux-2-arm64
             arch: aarch64
             pkg-type: package
+          - distro-slug: amazonlinux-2023
+            arch: x86_64
+            pkg-type: package
+          - distro-slug: amazonlinux-2023-arm64
+            arch: aarch64
+            pkg-type: package
           - distro-slug: centos-7
             arch: x86_64
             pkg-type: package

--- a/changelog/64455.added.md
+++ b/changelog/64455.added.md
@@ -1,0 +1,1 @@
+Added Salt support for Amazon Linux 2023

--- a/pkg/tests/integration/test_pkg.py
+++ b/pkg/tests/integration/test_pkg.py
@@ -14,7 +14,7 @@ def pkg_name(salt_call_cli, grains):
     elif grains["os_family"] == "RedHat":
         if grains["os"] == "VMware Photon OS":
             return "snoopy"
-        elif grains["os"] == "Amazon":
+        elif grains["osfinger"] == "Amazon Linux-2023":
             return "dnf-utils"
         return "units"
     elif grains["os_family"] == "Debian":

--- a/pkg/tests/integration/test_pkg.py
+++ b/pkg/tests/integration/test_pkg.py
@@ -14,6 +14,8 @@ def pkg_name(salt_call_cli, grains):
     elif grains["os_family"] == "RedHat":
         if grains["os"] == "VMware Photon OS":
             return "snoopy"
+        elif grains["os"] == "Amazon":
+            return "dnf-utils"
         return "units"
     elif grains["os_family"] == "Debian":
         return "ifenslave"

--- a/pkg/tests/integration/test_systemd_config.py
+++ b/pkg/tests/integration/test_systemd_config.py
@@ -25,6 +25,7 @@ def test_system_config(salt_cli, salt_minion):
             "VMware Photon OS-3",
             "VMware Photon OS-4",
             "VMware Photon OS-5",
+            "Amazon Linux-2023",
         ):
             ret = subprocess.call(
                 "systemctl show -p ${config} salt-minion.service", shell=True

--- a/pkg/tests/integration/test_version.py
+++ b/pkg/tests/integration/test_version.py
@@ -1,5 +1,6 @@
 import os.path
 import pathlib
+import re
 import subprocess
 
 import pytest
@@ -117,7 +118,7 @@ def test_compare_pkg_versions_redhat_rc(version, install_salt):
     if not pkg:
         pytest.skip("Not testing rpm packages")
     pkg = pkg[0].split("/")[-1]
-    if "rc" not in pkg:
+    if not re.search(r"rc[0-9]", pkg):
         pytest.skip("Not testing an RC package")
     assert "~" in pkg
     comp_pkg = pkg.split("~")[0]

--- a/pkg/tests/support/helpers.py
+++ b/pkg/tests/support/helpers.py
@@ -516,7 +516,7 @@ class SaltPkgInstall:
                 gpg_key = "SALT-PROJECT-GPG-PUBKEY-2023.pub"
 
             if platform.is_aarch64():
-                arch = "aarch64"
+                arch = "arm64"
             else:
                 arch = "x86_64"
             ret = self.proc.run(

--- a/tests/pytests/functional/modules/test_pkg.py
+++ b/tests/pytests/functional/modules/test_pkg.py
@@ -64,6 +64,8 @@ def test_pkg(grains):
     elif grains["os_family"] == "RedHat":
         if grains["os"] == "VMware Photon OS":
             _pkg = "snoopy"
+        elif grains["osfinger"] == "Amazon Linux-2023":
+            return "dnf-utils"
         else:
             _pkg = "units"
     elif grains["os_family"] == "Debian":

--- a/tests/pytests/functional/states/pkgrepo/test_centos.py
+++ b/tests/pytests/functional/states/pkgrepo/test_centos.py
@@ -237,12 +237,13 @@ def test_pkgrepo_with_comments(pkgrepo, pkgrepo_with_comments_name, subtests):
 
 @pytest.fixture
 def copr_pkgrepo_with_comments_name(pkgrepo, grains):
-    if (
-        grains["osfinger"] in ("CentOS Linux-7", "Amazon Linux-2")
-        or grains["os"] == "VMware Photon OS"
-    ):
+    if grains["osfinger"] in ("CentOS Linux-7") or grains["os"] == "VMware Photon OS":
         pytest.skip("copr plugin not installed on {} CI".format(grains["osfinger"]))
-    if grains["os"] in ("CentOS Stream", "AlmaLinux") and grains["osmajorrelease"] == 9:
+    if (
+        grains["os"] in ("CentOS Stream", "AlmaLinux")
+        and grains["osmajorrelease"] == 9
+        or grains["osfinger"] == "Amazon Linux-2023"
+    ):
         pytest.skip("No repo for {} in test COPR yet".format(grains["osfinger"]))
     pkgrepo_name = "hello-copr"
     try:

--- a/tests/pytests/functional/states/pkgrepo/test_centos.py
+++ b/tests/pytests/functional/states/pkgrepo/test_centos.py
@@ -237,7 +237,11 @@ def test_pkgrepo_with_comments(pkgrepo, pkgrepo_with_comments_name, subtests):
 
 @pytest.fixture
 def copr_pkgrepo_with_comments_name(pkgrepo, grains):
-    if grains["osfinger"] in ("CentOS Linux-7") or grains["os"] == "VMware Photon OS":
+    if (
+        grains["osfinger"] in ("CentOS Linux-7")
+        or grains["os"] == "VMware Photon OS"
+        or grains["osfinger"] == "Amazon Linux-2"
+    ):
         pytest.skip("copr plugin not installed on {} CI".format(grains["osfinger"]))
     if (
         grains["os"] in ("CentOS Stream", "AlmaLinux")

--- a/tests/pytests/functional/states/pkgrepo/test_centos.py
+++ b/tests/pytests/functional/states/pkgrepo/test_centos.py
@@ -238,9 +238,8 @@ def test_pkgrepo_with_comments(pkgrepo, pkgrepo_with_comments_name, subtests):
 @pytest.fixture
 def copr_pkgrepo_with_comments_name(pkgrepo, grains):
     if (
-        grains["osfinger"] in ("CentOS Linux-7")
+        grains["osfinger"] in ("CentOS Linux-7", "Amazon Linux-2")
         or grains["os"] == "VMware Photon OS"
-        or grains["osfinger"] == "Amazon Linux-2"
     ):
         pytest.skip("copr plugin not installed on {} CI".format(grains["osfinger"]))
     if (

--- a/tests/pytests/functional/states/test_pkg.py
+++ b/tests/pytests/functional/states/test_pkg.py
@@ -43,7 +43,10 @@ def PKG_TARGETS(grains):
     if grains["os"] == "Windows":
         _PKG_TARGETS = ["vlc", "putty"]
     elif grains["os"] == "Amazon":
-        _PKG_TARGETS = ["lynx", "gnuplot"]
+        if grains["osfinger"] == "Amazon Linux-2023":
+            _PKG_TARGETS = ["lynx", "gnuplot-minimal"]
+        else:
+            _PKG_TARGETS = ["lynx", "gnuplot"]
     elif grains["os_family"] == "RedHat":
         if grains["os"] == "VMware Photon OS":
             if grains["osmajorrelease"] >= 5:

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -730,6 +730,9 @@ def pkg_matrix(
             # TODO: remove debian 12 once debian 12 pkgs are released
             "debian-12-arm64",
             "debian-12",
+            # TODO: remove amazon 2023 once amazon 2023 pkgs are released
+            "amazonlinux-2023",
+            "amazonlinux-2023-arm64",
             "ubuntu-20.04-arm64",
             "ubuntu-22.04-arm64",
             "photonos-3",
@@ -773,6 +776,8 @@ def pkg_matrix(
             "debian-11-arm64",
             "debian-12-arm64",
             "debian-12",
+            "amazonlinux-2023",
+            "amazonlinux-2023-arm64",
             "ubuntu-22.04",
             "ubuntu-22.04-arm64",
             "photonos-3",

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -721,6 +721,12 @@ def pkg_matrix(
     sessions = [
         "install",
     ]
+    # OSs that where never included in 3005
+    # We cannot test an upgrade for this OS on this version
+    not_3005 = ["amazonlinux-2-arm64", "photonos-5", "photonos-5-arm64"]
+    # OSs that where never included in 3006
+    # We cannot test an upgrade for this OS on this version
+    not_3006 = ["photonos-5", "photonos-5-arm64"]
     if (
         distro_slug
         not in [
@@ -806,10 +812,17 @@ def pkg_matrix(
         for version in versions:
             if (
                 version
-                and distro_slug.startswith("photonos-5")
+                and distro_slug in not_3005
+                and version < tools.utils.Version("3006.0")
+            ):
+                # We never build packages for these OSs in 3005
+                continue
+            elif (
+                version
+                and distro_slug in not_3006
                 and version < tools.utils.Version("3007.0")
             ):
-                # We never build packages for Photon OS 5 prior to 3007.0
+                # We never build packages for these OSs in 3006
                 continue
             _matrix.append(
                 {

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -724,6 +724,8 @@ def pkg_matrix(
     if (
         distro_slug
         not in [
+            "amazon-2023",
+            "amazon-2023-arm64",
             "debian-11-arm64",
             # TODO: remove debian 12 once debian 12 pkgs are released
             "debian-12-arm64",
@@ -765,6 +767,8 @@ def pkg_matrix(
     if (
         distro_slug
         not in [
+            "amazon-2023",
+            "amazon-2023-arm64",
             "centosstream-9",
             "debian-11-arm64",
             "debian-12-arm64",

--- a/tools/pre_commit.py
+++ b/tools/pre_commit.py
@@ -89,6 +89,9 @@ def generate_workflows(ctx: Context):
             ("almalinux-8", "Alma Linux 8", "x86_64"),
             ("almalinux-9", "Alma Linux 9", "x86_64"),
             ("amazonlinux-2", "Amazon Linux 2", "x86_64"),
+            ("amazonlinux-2-arm64", "Amazon Linux 2 Arm64", "aarch64"),
+            ("amazonlinux-2023", "Amazon Linux 2023", "x86_64"),
+            ("amazonlinux-2023-arm64", "Amazon Linux 2023 Arm64", "aarch64"),
             ("archlinux-lts", "Arch Linux LTS", "x86_64"),
             ("centos-7", "CentOS 7", "x86_64"),
             ("centosstream-8", "CentOS Stream 8", "x86_64"),
@@ -122,6 +125,9 @@ def generate_workflows(ctx: Context):
     test_salt_pkg_listing = {
         "linux": (
             ("amazonlinux-2", "Amazon Linux 2", "x86_64", "rpm"),
+            ("amazonlinux-2-arm64", "Amazon Linux 2 Arm64", "aarch64", "rpm"),
+            ("amazonlinux-2023", "Amazon Linux 2023", "x86_64", "rpm"),
+            ("amazonlinux-2023-arm64", "Amazon Linux 2023 Arm64", "aarch64", "rpm"),
             ("centos-7", "CentOS 7", "x86_64", "rpm"),
             ("centosstream-8", "CentOS Stream 8", "x86_64", "rpm"),
             ("centosstream-9", "CentOS Stream 9", "x86_64", "rpm"),
@@ -156,6 +162,8 @@ def generate_workflows(ctx: Context):
             ("almalinux-9-arm64", "Alma Linux 9 Arm64", "aarch64"),
             ("amazonlinux-2", "Amazon Linux 2", "x86_64"),
             ("amazonlinux-2-arm64", "Amazon Linux 2 Arm64", "aarch64"),
+            ("amazonlinux-2023", "Amazon Linux 2023", "x86_64"),
+            ("amazonlinux-2023-arm64", "Amazon Linux 2023 Arm64", "aarch64"),
             ("archlinux-lts", "Arch Linux LTS", "x86_64"),
             ("centos-7", "CentOS 7", "x86_64"),
             ("centos-7-arm64", "CentOS 7 Arm64", "aarch64"),


### PR DESCRIPTION
### What does this PR do?

- Add Amazon Linux 2023 support
- Update Amazon Linux 2 AMIs used in test suite
  - Ensure Amazon Linux 2 ARM64 AMIs are in test suite

### What issues does this PR fix or reference?
Fixes: #64455