### PR TITLE
[master] Add python version condition to base requrements.txt for contextvars

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,4 +11,4 @@ looseversion
 tornado>=6.3.3
 
 # We need contextvars for salt-ssh
-contextvars
+contextvars ; python_version < '3.7'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,6 +9,3 @@ psutil>=5.0.0
 packaging>=21.3
 looseversion
 tornado>=6.3.3
-
-# We need contextvars for salt-ssh
-contextvars ; python_version < '3.7'

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -87,10 +87,6 @@ click==8.1.3
     # via geomet
 clustershell==1.9.1
     # via -r requirements/static/ci/common.in
-contextvars==2.4
-    # via
-    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
-    #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
@@ -156,10 +152,6 @@ idna==3.4
     #   etcd3-py
     #   requests
     #   yarl
-immutables==0.15
-    # via
-    #   -c requirements/static/ci/../pkg/py3.10/darwin.txt
-    #   contextvars
 inflect==6.0.4
     # via
     #   -c requirements/static/ci/../pkg/py3.10/darwin.txt

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -83,10 +83,6 @@ click==8.1.3
     # via geomet
 clustershell==1.9.1
     # via -r requirements/static/ci/common.in
-contextvars==2.4
-    # via
-    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
-    #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
@@ -147,10 +143,6 @@ idna==3.4
     #   etcd3-py
     #   requests
     #   yarl
-immutables==0.15
-    # via
-    #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt
-    #   contextvars
 importlib-metadata==6.6.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/freebsd.txt

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -97,10 +97,6 @@ click==8.1.3
     # via geomet
 clustershell==1.9.1
     # via -r requirements/static/ci/common.in
-contextvars==2.4
-    # via
-    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
-    #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
@@ -171,10 +167,6 @@ idna==3.4
     #   httpx
     #   requests
     #   yarl
-immutables==0.15
-    # via
-    #   -c requirements/static/ci/../pkg/py3.10/linux.txt
-    #   contextvars
 importlib-metadata==6.6.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/linux.txt

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -84,10 +84,6 @@ colorama==0.4.6
     # via
     #   click
     #   pytest
-contextvars==2.4
-    # via
-    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
-    #   -r requirements/base.txt
 cryptography==41.0.4
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt
@@ -146,10 +142,6 @@ idna==3.4
     #   etcd3-py
     #   requests
     #   yarl
-immutables==0.15
-    # via
-    #   -c requirements/static/ci/../pkg/py3.10/windows.txt
-    #   contextvars
 importlib-metadata==6.6.0
     # via
     #   -c requirements/static/ci/../pkg/py3.10/windows.txt

--- a/requirements/static/ci/py3.11/darwin.txt
+++ b/requirements/static/ci/py3.11/darwin.txt
@@ -87,10 +87,6 @@ click==8.1.3
     # via geomet
 clustershell==1.9.1
     # via -r requirements/static/ci/common.in
-contextvars==2.4
-    # via
-    #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
-    #   -r requirements/base.txt
 croniter==1.3.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
@@ -154,10 +150,6 @@ idna==3.4
     #   etcd3-py
     #   requests
     #   yarl
-immutables==0.15
-    # via
-    #   -c requirements/static/ci/../pkg/py3.11/darwin.txt
-    #   contextvars
 inflect==6.0.4
     # via
     #   -c requirements/static/ci/../pkg/py3.11/darwin.txt

--- a/requirements/static/ci/py3.11/freebsd.txt
+++ b/requirements/static/ci/py3.11/freebsd.txt
@@ -83,10 +83,6 @@ click==8.1.3
     # via geomet
 clustershell==1.9.1
     # via -r requirements/static/ci/common.in
-contextvars==2.4
-    # via
-    #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
-    #   -r requirements/base.txt
 croniter==1.3.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
@@ -145,10 +141,6 @@ idna==3.4
     #   etcd3-py
     #   requests
     #   yarl
-immutables==0.15
-    # via
-    #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt
-    #   contextvars
 importlib-metadata==6.6.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/freebsd.txt

--- a/requirements/static/ci/py3.11/linux.txt
+++ b/requirements/static/ci/py3.11/linux.txt
@@ -97,10 +97,6 @@ click==8.1.3
     # via geomet
 clustershell==1.9.1
     # via -r requirements/static/ci/common.in
-contextvars==2.4
-    # via
-    #   -c requirements/static/ci/../pkg/py3.11/linux.txt
-    #   -r requirements/base.txt
 croniter==1.3.15 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
@@ -167,10 +163,6 @@ idna==3.4
     #   httpx
     #   requests
     #   yarl
-immutables==0.15
-    # via
-    #   -c requirements/static/ci/../pkg/py3.11/linux.txt
-    #   contextvars
 importlib-metadata==6.6.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/linux.txt

--- a/requirements/static/ci/py3.11/windows.txt
+++ b/requirements/static/ci/py3.11/windows.txt
@@ -84,10 +84,6 @@ colorama==0.4.6
     # via
     #   click
     #   pytest
-contextvars==2.4
-    # via
-    #   -c requirements/static/ci/../pkg/py3.11/windows.txt
-    #   -r requirements/base.txt
 cryptography==41.0.4
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt
@@ -144,10 +140,6 @@ idna==3.4
     #   etcd3-py
     #   requests
     #   yarl
-immutables==0.15
-    # via
-    #   -c requirements/static/ci/../pkg/py3.11/windows.txt
-    #   contextvars
 importlib-metadata==6.6.0
     # via
     #   -c requirements/static/ci/../pkg/py3.11/windows.txt

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -83,10 +83,6 @@ click==8.1.3
     # via geomet
 clustershell==1.9.1
     # via -r requirements/static/ci/common.in
-contextvars==2.4
-    # via
-    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
-    #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
@@ -147,10 +143,6 @@ idna==3.4
     #   etcd3-py
     #   requests
     #   yarl
-immutables==0.15
-    # via
-    #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt
-    #   contextvars
 importlib-metadata==6.6.0
     # via
     #   -c requirements/static/ci/../pkg/py3.8/freebsd.txt

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -97,10 +97,6 @@ click==8.1.3
     # via geomet
 clustershell==1.9.1
     # via -r requirements/static/ci/common.in
-contextvars==2.4
-    # via
-    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
-    #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
@@ -171,10 +167,6 @@ idna==3.4
     #   httpx
     #   requests
     #   yarl
-immutables==0.15
-    # via
-    #   -c requirements/static/ci/../pkg/py3.8/linux.txt
-    #   contextvars
 importlib-metadata==6.6.0
     # via
     #   -c requirements/static/ci/../pkg/py3.8/linux.txt

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -84,10 +84,6 @@ colorama==0.4.6
     # via
     #   click
     #   pytest
-contextvars==2.4
-    # via
-    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
-    #   -r requirements/base.txt
 cryptography==41.0.4
     # via
     #   -c requirements/static/ci/../pkg/py3.8/windows.txt
@@ -146,10 +142,6 @@ idna==3.4
     #   etcd3-py
     #   requests
     #   yarl
-immutables==0.15
-    # via
-    #   -c requirements/static/ci/../pkg/py3.8/windows.txt
-    #   contextvars
 importlib-metadata==6.6.0
     # via
     #   -c requirements/static/ci/../pkg/py3.8/windows.txt

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -87,10 +87,6 @@ click==8.1.3
     # via geomet
 clustershell==1.9.1
     # via -r requirements/static/ci/common.in
-contextvars==2.4
-    # via
-    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
-    #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
@@ -156,10 +152,6 @@ idna==3.4
     #   etcd3-py
     #   requests
     #   yarl
-immutables==0.15
-    # via
-    #   -c requirements/static/ci/../pkg/py3.9/darwin.txt
-    #   contextvars
 inflect==6.0.4
     # via
     #   -c requirements/static/ci/../pkg/py3.9/darwin.txt

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -83,10 +83,6 @@ click==8.1.3
     # via geomet
 clustershell==1.9.1
     # via -r requirements/static/ci/common.in
-contextvars==2.4
-    # via
-    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
-    #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
@@ -147,10 +143,6 @@ idna==3.4
     #   etcd3-py
     #   requests
     #   yarl
-immutables==0.15
-    # via
-    #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt
-    #   contextvars
 importlib-metadata==6.6.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/freebsd.txt

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -97,10 +97,6 @@ click==8.1.3
     # via geomet
 clustershell==1.9.1
     # via -r requirements/static/ci/common.in
-contextvars==2.4
-    # via
-    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
-    #   -r requirements/base.txt
 croniter==0.3.29 ; sys_platform != "win32"
     # via -r requirements/static/ci/common.in
 cryptography==41.0.4
@@ -171,10 +167,6 @@ idna==3.4
     #   httpx
     #   requests
     #   yarl
-immutables==0.15
-    # via
-    #   -c requirements/static/ci/../pkg/py3.9/linux.txt
-    #   contextvars
 importlib-metadata==6.6.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/linux.txt

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -84,10 +84,6 @@ colorama==0.4.6
     # via
     #   click
     #   pytest
-contextvars==2.4
-    # via
-    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
-    #   -r requirements/base.txt
 cryptography==41.0.4
     # via
     #   -c requirements/static/ci/../pkg/py3.9/windows.txt
@@ -146,10 +142,6 @@ idna==3.4
     #   etcd3-py
     #   requests
     #   yarl
-immutables==0.15
-    # via
-    #   -c requirements/static/ci/../pkg/py3.9/windows.txt
-    #   contextvars
 importlib-metadata==6.6.0
     # via
     #   -c requirements/static/ci/../pkg/py3.9/windows.txt

--- a/requirements/static/pkg/py3.10/darwin.txt
+++ b/requirements/static/pkg/py3.10/darwin.txt
@@ -18,8 +18,6 @@ cheroot==10.0.0
     # via cherrypy
 cherrypy==18.8.0
     # via -r requirements/darwin.txt
-contextvars==2.4
-    # via -r requirements/base.txt
 cryptography==41.0.4
     # via
     #   -r requirements/crypto.txt
@@ -35,8 +33,6 @@ idna==3.4
     # via
     #   -r requirements/darwin.txt
     #   requests
-immutables==0.15
-    # via contextvars
 inflect==6.0.4
     # via jaraco.text
 jaraco.collections==4.1.0

--- a/requirements/static/pkg/py3.10/freebsd.txt
+++ b/requirements/static/pkg/py3.10/freebsd.txt
@@ -16,8 +16,6 @@ cheroot==10.0.0
     # via cherrypy
 cherrypy==18.8.0
     # via -r requirements/static/pkg/freebsd.in
-contextvars==2.4
-    # via -r requirements/base.txt
 cryptography==41.0.4
     # via
     #   -r requirements/crypto.txt
@@ -29,8 +27,6 @@ distro==1.8.0
     #   -r requirements/static/pkg/freebsd.in
 idna==3.4
     # via requests
-immutables==0.15
-    # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/static/pkg/freebsd.in
 inflect==6.0.4

--- a/requirements/static/pkg/py3.10/linux.txt
+++ b/requirements/static/pkg/py3.10/linux.txt
@@ -16,8 +16,6 @@ cheroot==10.0.0
     # via cherrypy
 cherrypy==18.8.0
     # via -r requirements/static/pkg/linux.in
-contextvars==2.4
-    # via -r requirements/base.txt
 cryptography==41.0.4
     # via
     #   -r requirements/crypto.txt
@@ -27,8 +25,6 @@ distro==1.8.0
     # via -r requirements/base.txt
 idna==3.4
     # via requests
-immutables==0.15
-    # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/static/pkg/linux.in
 inflect==6.0.4

--- a/requirements/static/pkg/py3.10/windows.txt
+++ b/requirements/static/pkg/py3.10/windows.txt
@@ -23,8 +23,6 @@ cherrypy==18.8.0
     # via -r requirements/windows.txt
 clr-loader==0.2.4
     # via pythonnet
-contextvars==2.4
-    # via -r requirements/base.txt
 cryptography==41.0.4
     # via
     #   -r requirements/crypto.txt
@@ -38,8 +36,6 @@ gitpython==3.1.35
     # via -r requirements/windows.txt
 idna==3.4
     # via requests
-immutables==0.15
-    # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/windows.txt
 inflect==6.0.4

--- a/requirements/static/pkg/py3.11/darwin.txt
+++ b/requirements/static/pkg/py3.11/darwin.txt
@@ -18,8 +18,6 @@ cheroot==10.0.0
     # via cherrypy
 cherrypy==18.8.0
     # via -r requirements/darwin.txt
-contextvars==2.4
-    # via -r requirements/base.txt
 cryptography==41.0.4
     # via
     #   -r requirements/crypto.txt
@@ -35,8 +33,6 @@ idna==3.4
     # via
     #   -r requirements/darwin.txt
     #   requests
-immutables==0.15
-    # via contextvars
 inflect==6.0.4
     # via jaraco.text
 jaraco.collections==4.1.0

--- a/requirements/static/pkg/py3.11/freebsd.txt
+++ b/requirements/static/pkg/py3.11/freebsd.txt
@@ -16,8 +16,6 @@ cheroot==10.0.0
     # via cherrypy
 cherrypy==18.8.0
     # via -r requirements/static/pkg/freebsd.in
-contextvars==2.4
-    # via -r requirements/base.txt
 cryptography==41.0.4
     # via
     #   -r requirements/crypto.txt
@@ -29,8 +27,6 @@ distro==1.8.0
     #   -r requirements/static/pkg/freebsd.in
 idna==3.4
     # via requests
-immutables==0.15
-    # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/static/pkg/freebsd.in
 inflect==6.0.4

--- a/requirements/static/pkg/py3.11/linux.txt
+++ b/requirements/static/pkg/py3.11/linux.txt
@@ -16,8 +16,6 @@ cheroot==10.0.0
     # via cherrypy
 cherrypy==18.8.0
     # via -r requirements/static/pkg/linux.in
-contextvars==2.4
-    # via -r requirements/base.txt
 cryptography==41.0.4
     # via
     #   -r requirements/crypto.txt
@@ -27,8 +25,6 @@ distro==1.8.0
     # via -r requirements/base.txt
 idna==3.4
     # via requests
-immutables==0.15
-    # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/static/pkg/linux.in
 inflect==6.0.4

--- a/requirements/static/pkg/py3.11/windows.txt
+++ b/requirements/static/pkg/py3.11/windows.txt
@@ -23,8 +23,6 @@ cherrypy==18.8.0
     # via -r requirements/windows.txt
 clr-loader==0.2.4
     # via pythonnet
-contextvars==2.4
-    # via -r requirements/base.txt
 cryptography==41.0.4
     # via
     #   -r requirements/crypto.txt
@@ -38,8 +36,6 @@ gitpython==3.1.35
     # via -r requirements/windows.txt
 idna==3.4
     # via requests
-immutables==0.15
-    # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/windows.txt
 inflect==6.0.4

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -16,8 +16,6 @@ cheroot==10.0.0
     # via cherrypy
 cherrypy==18.8.0
     # via -r requirements/static/pkg/freebsd.in
-contextvars==2.4
-    # via -r requirements/base.txt
 cryptography==41.0.4
     # via
     #   -r requirements/crypto.txt
@@ -29,8 +27,6 @@ distro==1.8.0
     #   -r requirements/static/pkg/freebsd.in
 idna==3.4
     # via requests
-immutables==0.15
-    # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/static/pkg/freebsd.in
 importlib-resources==5.12.0

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -16,8 +16,6 @@ cheroot==10.0.0
     # via cherrypy
 cherrypy==18.8.0
     # via -r requirements/static/pkg/linux.in
-contextvars==2.4
-    # via -r requirements/base.txt
 cryptography==41.0.4
     # via
     #   -r requirements/crypto.txt
@@ -27,8 +25,6 @@ distro==1.8.0
     # via -r requirements/base.txt
 idna==3.4
     # via requests
-immutables==0.15
-    # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/static/pkg/linux.in
 importlib-resources==5.12.0

--- a/requirements/static/pkg/py3.8/windows.txt
+++ b/requirements/static/pkg/py3.8/windows.txt
@@ -23,8 +23,6 @@ cherrypy==18.8.0
     # via -r requirements/windows.txt
 clr-loader==0.2.4
     # via pythonnet
-contextvars==2.4
-    # via -r requirements/base.txt
 cryptography==41.0.4
     # via
     #   -r requirements/crypto.txt
@@ -38,8 +36,6 @@ gitpython==3.1.35
     # via -r requirements/windows.txt
 idna==3.4
     # via requests
-immutables==0.15
-    # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/windows.txt
 importlib-resources==5.12.0

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -18,8 +18,6 @@ cheroot==10.0.0
     # via cherrypy
 cherrypy==18.8.0
     # via -r requirements/darwin.txt
-contextvars==2.4
-    # via -r requirements/base.txt
 cryptography==41.0.4
     # via
     #   -r requirements/crypto.txt
@@ -35,8 +33,6 @@ idna==3.4
     # via
     #   -r requirements/darwin.txt
     #   requests
-immutables==0.15
-    # via contextvars
 inflect==6.0.4
     # via jaraco.text
 jaraco.collections==4.1.0

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -16,8 +16,6 @@ cheroot==10.0.0
     # via cherrypy
 cherrypy==18.8.0
     # via -r requirements/static/pkg/freebsd.in
-contextvars==2.4
-    # via -r requirements/base.txt
 cryptography==41.0.4
     # via
     #   -r requirements/crypto.txt
@@ -29,8 +27,6 @@ distro==1.8.0
     #   -r requirements/static/pkg/freebsd.in
 idna==3.4
     # via requests
-immutables==0.15
-    # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/static/pkg/freebsd.in
 inflect==6.0.4

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -16,8 +16,6 @@ cheroot==10.0.0
     # via cherrypy
 cherrypy==18.8.0
     # via -r requirements/static/pkg/linux.in
-contextvars==2.4
-    # via -r requirements/base.txt
 cryptography==41.0.4
     # via
     #   -r requirements/crypto.txt
@@ -27,8 +25,6 @@ distro==1.8.0
     # via -r requirements/base.txt
 idna==3.4
     # via requests
-immutables==0.15
-    # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/static/pkg/linux.in
 inflect==6.0.4

--- a/requirements/static/pkg/py3.9/windows.txt
+++ b/requirements/static/pkg/py3.9/windows.txt
@@ -23,8 +23,6 @@ cherrypy==18.8.0
     # via -r requirements/windows.txt
 clr-loader==0.2.4
     # via pythonnet
-contextvars==2.4
-    # via -r requirements/base.txt
 cryptography==41.0.4
     # via
     #   -r requirements/crypto.txt
@@ -38,8 +36,6 @@ gitpython==3.1.35
     # via -r requirements/windows.txt
 idna==3.4
     # via requests
-immutables==0.15
-    # via contextvars
 importlib-metadata==6.6.0
     # via -r requirements/windows.txt
 inflect==6.0.4


### PR DESCRIPTION
### What does this PR do?
Removes the contextvars requirement since it is part of the standard library since python 3.7.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/65394

### Previous Behavior
Salt requires the contextvars pip package.

### New Behavior
Salt uses the standard library contextvars module.

### Merge requirements satisfied?
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated