### PR TITLE
[3006.x] Exclude some un-executed lines in `salt/__init__.py` from coverage

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -7,7 +7,7 @@ import os
 import sys
 import warnings
 
-if sys.version_info < (3,):
+if sys.version_info < (3,):  # pragma: no cover
     sys.stderr.write(
         "\n\nAfter the Sodium release, 3001, Salt no longer supports Python 2. Exiting.\n\n"
     )
@@ -22,7 +22,7 @@ class TornadoImporter:
         if USE_VENDORED_TORNADO:
             if module_name.startswith("tornado"):
                 return self
-        else:
+        else:  # pragma: no cover
             if module_name.startswith("salt.ext.tornado"):
                 return self
         return None
@@ -30,7 +30,7 @@ class TornadoImporter:
     def create_module(self, spec):
         if USE_VENDORED_TORNADO:
             mod = importlib.import_module("salt.ext.{}".format(spec.name))
-        else:
+        else:  # pragma: no cover
             # Remove 'salt.ext.' from the module
             mod = importlib.import_module(spec.name[9:])
         sys.modules[spec.name] = mod


### PR DESCRIPTION
### What does this PR do?
See title, we might just want to remove these lines... USE_VENDORED_TORNADO isn't used anywhere but the 3 times in this file, and the Python 2 warning is very out of date.

### What issues does this PR fix or reference?
Fixes: One file for https://github.com/saltstack/salt/issues/64739

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes