### PR TITLE
[3006.x] fire event at job start

### DIFF
--- a/salt/metaproxy/deltaproxy.py
+++ b/salt/metaproxy/deltaproxy.py
@@ -51,6 +51,7 @@ from salt.exceptions import (
     SaltInvocationError,
     SaltSystemExit,
 )
+from salt.utils.decorators.start_event import fire_started_event_job_wrapper
 from salt.minion import ProxyMinion
 from salt.utils.event import tagify
 from salt.utils.process import SignalHandlingProcess, default_signals
@@ -609,6 +610,7 @@ def target(cls, minion_instance, opts, data, connected, creds_map):
             ProxyMinion._thread_return(minion_instance, opts, data)
 
 
+@fire_started_event_job_wrapper
 def thread_return(cls, minion_instance, opts, data):
     """
     This method should be used as a threading target, start the actual
@@ -858,6 +860,7 @@ def thread_return(cls, minion_instance, opts, data):
                 log.exception("The return failed for job %s: %s", data["jid"], exc)
 
 
+@fire_started_event_job_wrapper
 def thread_multi_return(cls, minion_instance, opts, data):
     """
     This method should be used as a threading target, start the actual

--- a/salt/metaproxy/proxy.py
+++ b/salt/metaproxy/proxy.py
@@ -50,6 +50,7 @@ from salt.exceptions import (
     SaltSystemExit,
 )
 from salt.minion import ProxyMinion
+from salt.utils.decorators.start_event import fire_started_event_job_wrapper
 from salt.utils.event import tagify
 from salt.utils.process import SignalHandlingProcess, default_signals
 
@@ -393,6 +394,7 @@ def target(cls, minion_instance, opts, data, connected, creds_map):
             ProxyMinion._thread_return(minion_instance, opts, data)
 
 
+@fire_started_event_job_wrapper
 def thread_return(cls, minion_instance, opts, data):
     """
     This method should be used as a threading target, start the actual
@@ -632,6 +634,7 @@ def thread_return(cls, minion_instance, opts, data):
                 log.exception("The return failed for job %s: %s", data["jid"], exc)
 
 
+@fire_started_event_job_wrapper
 def thread_multi_return(cls, minion_instance, opts, data):
     """
     This method should be used as a threading target, start the actual

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -72,6 +72,7 @@ from salt.exceptions import (
 from salt.template import SLS_ENCODING
 from salt.utils.ctx import RequestContext
 from salt.utils.debug import enable_sigusr1_handler
+from salt.utils.decorators.start_event import fire_started_event_job_wrapper
 from salt.utils.event import tagify
 from salt.utils.network import parse_host_port
 from salt.utils.odict import OrderedDict
@@ -1906,6 +1907,7 @@ class Minion(MinionBase):
         return None
 
     @classmethod
+    @fire_started_event_job_wrapper
     def _thread_return(cls, minion_instance, opts, data):
         """
         This method should be used as a threading target, start the actual
@@ -2107,6 +2109,7 @@ class Minion(MinionBase):
                     log.exception("The return failed for job %s: %s", data["jid"], exc)
 
     @classmethod
+    @fire_started_event_job_wrapper
     def _thread_multi_return(cls, minion_instance, opts, data):
         """
         This method should be used as a threading target, start the actual

--- a/salt/utils/decorators/start_event.py
+++ b/salt/utils/decorators/start_event.py
@@ -1,0 +1,31 @@
+import os
+import logging
+from functools import wraps
+
+log = logging.getLogger(__name__)
+
+
+def fire_started_event_job_wrapper(function):
+    """
+    Fire a custom/job/<jid>/started/<minion_id> event when starting a job
+    """
+
+    @wraps(function)
+    def wrapped(*args, **kwargs):
+        """We wraps for *args and **kwargs, to be safe, but we expect: (cls, minion_instance, opts, data) as args"""
+
+        try:
+            sdata = {"pid": os.getpid()}
+            sdata.update(args[3])
+
+            jid = sdata["jid"]
+            minion_id = args[1].opts.get("id", "undefined")
+
+            args[1]._fire_master(sdata, f"custom/job/{jid}/started/{minion_id}")
+
+        except Exception as exc:
+            log.warning(f"Exception raised during started job event wrapper: {exc}")
+
+        return function(*args, **kwargs)
+
+    return wrapped


### PR DESCRIPTION
### What does this PR do?
We ran into some issues with a large amount of minions in our salt cluster. We wanted an ack from minions that they were starting job. The `salt/job/<jid>/new` wasn't enough, since it doesn't imply that the job will/have ever be started.

This PR make salt-minion fire an even when a minion start a job.

*This code was meant to be deployed in our production, so the patch were made to be as faulty resistent as possible (hence the decorators for `*args` and `**kwargs`, in a non-existent file)*

### What issues does this PR fix or reference?
Unsure if any similar issue was created for this particular wanted behaviour

### New Behavior
The salt-minion now fire an event under `custom/job/<jid>/started/<minion_id>`  when starting a job.

### Merge requirements satisfied?
- [x] Docs
- [X] Changelog => No issue for this?
- [ ] Tests written/updated
  - No tests written, but i'm open to writting them if this is a wanted feature for salt

### Commits signed with GPG?
Yes
