### PR TITLE
[3006.x] Update centos9 ami

### DIFF
--- a/cicd/amis.yml
+++ b/cicd/amis.yml
@@ -1,1 +1,1 @@
-centosstream-9-x86_64: ami-09b72b340acb62c73
+centosstream-9-x86_64: ami-0a47f4f785cb7a81c


### PR DESCRIPTION
### What does this PR do?

Updates the centosstream-9 AMI, used for salt-cloud tests, to be using the current centosstream-9 AMI in `golden-images.json`:

https://github.com/saltstack/salt/blob/b213670518b94a4d41714c1185424638d363414d/cicd/golden-images.json#L142-L143