### PR TITLE
[master] Add autosign_grains to auth events with action 'pend'

### DIFF
--- a/changelog/56200.changed.md
+++ b/changelog/56200.changed.md
@@ -1,0 +1,1 @@
+Make sure every auth event has the 'act' key set

--- a/changelog/65426.added.md
+++ b/changelog/65426.added.md
@@ -1,0 +1,1 @@
+Add option (auth_events_autosign_grains) to add autosign_grains to auth events

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -1228,6 +1228,22 @@ a minion performs an authentication check with the master.
 
     auth_events: True
 
+.. conf_master:: auth_events_autosign_grains
+
+``auth_events_autosign_grains``
+-------------------------------
+
+.. versionadded:: 3008
+
+Default: ``[]``
+
+Determines which actions the master will include autosign_grains for when
+firing authentication events.
+
+.. code-block:: yaml
+
+    auth_events_autosign_grains: ["accept", "pend", "reject", "full", "denied", "error"]
+
 .. conf_master:: minion_data_cache_events
 
 ``minion_data_cache_events``

--- a/doc/topics/event/master_events.rst
+++ b/doc/topics/event/master_events.rst
@@ -18,7 +18,7 @@ Authentication events
 
     :var id: The minion ID.
     :var act: The current status of the minion key: ``accept``, ``pend``,
-        ``reject``.
+        ``reject``, ``full``, ``denied``, ``error``.
     :var pub: The minion public key.
 
 

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -538,7 +538,12 @@ class ReqServerChannel:
                 load["id"],
             )
             if self.opts.get("auth_events") is True:
-                eload = {"result": False, "id": load["id"], "pub": load["pub"]}
+                eload = {
+                    "result": False,
+                    "act": "reject",
+                    "id": load["id"],
+                    "pub": load["pub"],
+                }
                 self.event.fire_event(eload, salt.utils.event.tagify(prefix="auth"))
             if sign_messages:
                 return self._clear_signed(
@@ -715,6 +720,7 @@ class ReqServerChannel:
                     if self.opts.get("auth_events") is True:
                         eload = {
                             "result": False,
+                            "act": "denied",
                             "id": load["id"],
                             "pub": load["pub"],
                         }
@@ -731,7 +737,12 @@ class ReqServerChannel:
             # Something happened that I have not accounted for, FAIL!
             log.warning("Unaccounted for authentication failure")
             if self.opts.get("auth_events") is True:
-                eload = {"result": False, "id": load["id"], "pub": load["pub"]}
+                eload = {
+                    "result": False,
+                    "act": "error",
+                    "id": load["id"],
+                    "pub": load["pub"],
+                }
                 self.event.fire_event(eload, salt.utils.event.tagify(prefix="auth"))
             if sign_messages:
                 return self._clear_signed(

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -499,6 +499,12 @@ class ReqServerChannel:
                             "id": load["id"],
                             "pub": load["pub"],
                         }
+                        autosign_grains = load.get("autosign_grains", None)
+                        if (
+                            "full" in self.opts.get("auth_events_autosign_grains", [])
+                            and autosign_grains
+                        ):
+                            eload["autosign_grains"] = autosign_grains
                         self.event.fire_event(
                             eload, salt.utils.event.tagify(prefix="auth")
                         )
@@ -544,6 +550,12 @@ class ReqServerChannel:
                     "id": load["id"],
                     "pub": load["pub"],
                 }
+                autosign_grains = load.get("autosign_grains", None)
+                if (
+                    "reject" in self.opts.get("auth_events_autosign_grains", [])
+                    and autosign_grains
+                ):
+                    eload["autosign_grains"] = autosign_grains
                 self.event.fire_event(eload, salt.utils.event.tagify(prefix="auth"))
             if sign_messages:
                 return self._clear_signed(
@@ -572,6 +584,12 @@ class ReqServerChannel:
                         "act": "denied",
                         "pub": load["pub"],
                     }
+                    autosign_grains = load.get("autosign_grains", None)
+                    if (
+                        "denied" in self.opts.get("auth_events_autosign_grains", [])
+                        and autosign_grains
+                    ):
+                        eload["autosign_grains"] = autosign_grains
                     self.event.fire_event(eload, salt.utils.event.tagify(prefix="auth"))
                 if sign_messages:
                     return self._clear_signed(
@@ -609,6 +627,12 @@ class ReqServerChannel:
                         "id": load["id"],
                         "pub": load["pub"],
                     }
+                    autosign_grains = load.get("autosign_grains", None)
+                    if (
+                        key_act in self.opts.get("auth_events_autosign_grains", [])
+                        and autosign_grains
+                    ):
+                        eload["autosign_grains"] = autosign_grains
                     self.event.fire_event(eload, salt.utils.event.tagify(prefix="auth"))
                 if sign_messages:
                     return self._clear_signed(
@@ -637,6 +661,12 @@ class ReqServerChannel:
                         "id": load["id"],
                         "pub": load["pub"],
                     }
+                    autosign_grains = load.get("autosign_grains", None)
+                    if (
+                        "reject" in self.opts.get("auth_events_autosign_grains", [])
+                        and autosign_grains
+                    ):
+                        eload["autosign_grains"] = autosign_grains
                     self.event.fire_event(eload, salt.utils.event.tagify(prefix="auth"))
                 if sign_messages:
                     return self._clear_signed(
@@ -668,6 +698,12 @@ class ReqServerChannel:
                             "act": "denied",
                             "pub": load["pub"],
                         }
+                        autosign_grains = load.get("autosign_grains", None)
+                        if (
+                            "denied" in self.opts.get("auth_events_autosign_grains", [])
+                            and autosign_grains
+                        ):
+                            eload["autosign_grains"] = autosign_grains
                         self.event.fire_event(
                             eload, salt.utils.event.tagify(prefix="auth")
                         )
@@ -692,6 +728,12 @@ class ReqServerChannel:
                             "id": load["id"],
                             "pub": load["pub"],
                         }
+                        autosign_grains = load.get("autosign_grains", None)
+                        if (
+                            "pend" in self.opts.get("auth_events_autosign_grains", [])
+                            and autosign_grains
+                        ):
+                            eload["autosign_grains"] = autosign_grains
                         self.event.fire_event(
                             eload, salt.utils.event.tagify(prefix="auth")
                         )
@@ -724,6 +766,12 @@ class ReqServerChannel:
                             "id": load["id"],
                             "pub": load["pub"],
                         }
+                        autosign_grains = load.get("autosign_grains", None)
+                        if (
+                            "denied" in self.opts.get("auth_events_autosign_grains", [])
+                            and autosign_grains
+                        ):
+                            eload["autosign_grains"] = autosign_grains
                         self.event.fire_event(
                             eload, salt.utils.event.tagify(prefix="auth")
                         )
@@ -743,6 +791,12 @@ class ReqServerChannel:
                     "id": load["id"],
                     "pub": load["pub"],
                 }
+                autosign_grains = load.get("autosign_grains", None)
+                if (
+                    "error" in self.opts.get("auth_events_autosign_grains", [])
+                    and autosign_grains
+                ):
+                    eload["autosign_grains"] = autosign_grains
                 self.event.fire_event(eload, salt.utils.event.tagify(prefix="auth"))
             if sign_messages:
                 return self._clear_signed(
@@ -878,6 +932,12 @@ class ReqServerChannel:
                 "id": load["id"],
                 "pub": load["pub"],
             }
+            autosign_grains = load.get("autosign_grains", None)
+            if (
+                "accept" in self.opts.get("auth_events_autosign_grains", [])
+                and autosign_grains
+            ):
+                eload["autosign_grains"] = autosign_grains
             self.event.fire_event(eload, salt.utils.event.tagify(prefix="auth"))
         if sign_messages:
             ret["nonce"] = load["nonce"]

--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -491,14 +491,14 @@ class ReqServerChannel:
                         self.opts["max_minions"],
                         load["id"],
                     )
-                    eload = {
-                        "result": False,
-                        "act": "full",
-                        "id": load["id"],
-                        "pub": load["pub"],
-                    }
 
                     if self.opts.get("auth_events") is True:
+                        eload = {
+                            "result": False,
+                            "act": "full",
+                            "id": load["id"],
+                            "pub": load["pub"],
+                        }
                         self.event.fire_event(
                             eload, salt.utils.event.tagify(prefix="auth")
                         )
@@ -537,8 +537,8 @@ class ReqServerChannel:
                 "Public key rejected for %s. Key is present in rejection key dir.",
                 load["id"],
             )
-            eload = {"result": False, "id": load["id"], "pub": load["pub"]}
             if self.opts.get("auth_events") is True:
+                eload = {"result": False, "id": load["id"], "pub": load["pub"]}
                 self.event.fire_event(eload, salt.utils.event.tagify(prefix="auth"))
             if sign_messages:
                 return self._clear_signed(
@@ -560,13 +560,13 @@ class ReqServerChannel:
                     denied.append(load["pub"])
                     self.cache.store("denied_keys", load["id"], denied)
 
-                eload = {
-                    "result": False,
-                    "id": load["id"],
-                    "act": "denied",
-                    "pub": load["pub"],
-                }
                 if self.opts.get("auth_events") is True:
+                    eload = {
+                        "result": False,
+                        "id": load["id"],
+                        "act": "denied",
+                        "pub": load["pub"],
+                    }
                     self.event.fire_event(eload, salt.utils.event.tagify(prefix="auth"))
                 if sign_messages:
                     return self._clear_signed(
@@ -597,13 +597,13 @@ class ReqServerChannel:
                 key_result = None
 
             if key_result is not None:
-                eload = {
-                    "result": key_result,
-                    "act": key_act,
-                    "id": load["id"],
-                    "pub": load["pub"],
-                }
                 if self.opts.get("auth_events") is True:
+                    eload = {
+                        "result": key_result,
+                        "act": key_act,
+                        "id": load["id"],
+                        "pub": load["pub"],
+                    }
                     self.event.fire_event(eload, salt.utils.event.tagify(prefix="auth"))
                 if sign_messages:
                     return self._clear_signed(
@@ -625,13 +625,13 @@ class ReqServerChannel:
                     "Pending public key for %s rejected via autoreject_file",
                     load["id"],
                 )
-                eload = {
-                    "result": False,
-                    "act": "reject",
-                    "id": load["id"],
-                    "pub": load["pub"],
-                }
                 if self.opts.get("auth_events") is True:
+                    eload = {
+                        "result": False,
+                        "act": "reject",
+                        "id": load["id"],
+                        "pub": load["pub"],
+                    }
                     self.event.fire_event(eload, salt.utils.event.tagify(prefix="auth"))
                 if sign_messages:
                     return self._clear_signed(
@@ -656,13 +656,13 @@ class ReqServerChannel:
                     if load["pub"] not in denied:
                         denied.append(load["pub"])
                         self.cache.store("denied_keys", load["id"], denied)
-                    eload = {
-                        "result": False,
-                        "id": load["id"],
-                        "act": "denied",
-                        "pub": load["pub"],
-                    }
                     if self.opts.get("auth_events") is True:
+                        eload = {
+                            "result": False,
+                            "id": load["id"],
+                            "act": "denied",
+                            "pub": load["pub"],
+                        }
                         self.event.fire_event(
                             eload, salt.utils.event.tagify(prefix="auth")
                         )
@@ -680,13 +680,13 @@ class ReqServerChannel:
                         load["id"],
                         load["id"],
                     )
-                    eload = {
-                        "result": True,
-                        "act": "pend",
-                        "id": load["id"],
-                        "pub": load["pub"],
-                    }
                     if self.opts.get("auth_events") is True:
+                        eload = {
+                            "result": True,
+                            "act": "pend",
+                            "id": load["id"],
+                            "pub": load["pub"],
+                        }
                         self.event.fire_event(
                             eload, salt.utils.event.tagify(prefix="auth")
                         )
@@ -712,8 +712,12 @@ class ReqServerChannel:
                     if load["pub"] not in denied:
                         denied.append(load["pub"])
                         self.cache.store("denied_keys", load["id"], denied)
-                    eload = {"result": False, "id": load["id"], "pub": load["pub"]}
                     if self.opts.get("auth_events") is True:
+                        eload = {
+                            "result": False,
+                            "id": load["id"],
+                            "pub": load["pub"],
+                        }
                         self.event.fire_event(
                             eload, salt.utils.event.tagify(prefix="auth")
                         )
@@ -726,8 +730,8 @@ class ReqServerChannel:
         else:
             # Something happened that I have not accounted for, FAIL!
             log.warning("Unaccounted for authentication failure")
-            eload = {"result": False, "id": load["id"], "pub": load["pub"]}
             if self.opts.get("auth_events") is True:
+                eload = {"result": False, "id": load["id"], "pub": load["pub"]}
                 self.event.fire_event(eload, salt.utils.event.tagify(prefix="auth"))
             if sign_messages:
                 return self._clear_signed(
@@ -856,8 +860,13 @@ class ReqServerChannel:
         # Be aggressive about the signature
         digest = salt.utils.stringutils.to_bytes(hashlib.sha256(aes).hexdigest())
         ret["sig"] = self.master_key.encrypt(digest)
-        eload = {"result": True, "act": "accept", "id": load["id"], "pub": load["pub"]}
         if self.opts.get("auth_events") is True:
+            eload = {
+                "result": True,
+                "act": "accept",
+                "id": load["id"],
+                "pub": load["pub"],
+            }
             self.event.fire_event(eload, salt.utils.event.tagify(prefix="auth"))
         if sign_messages:
             ret["nonce"] = load["nonce"]

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -987,6 +987,8 @@ VALID_OPTS = immutabletypes.freeze(
         "schedule": dict,
         # Whether to fire auth events
         "auth_events": bool,
+        # Specify auth events to add autosign_grains to
+        "auth_events_autosign_grains": list,
         # Whether to fire Minion data cache refresh events
         "minion_data_cache_events": bool,
         # Enable calling ssh minions from the salt master
@@ -1703,6 +1705,7 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze(
         "discovery": False,
         "schedule": {},
         "auth_events": True,
+        "auth_events_pend_autosign_grains": False,
         "minion_data_cache_events": True,
         "enable_ssh_minions": False,
         "netapi_allow_raw_shell": False,

--- a/tests/pytests/integration/events/test_auth_events.py
+++ b/tests/pytests/integration/events/test_auth_events.py
@@ -1,0 +1,193 @@
+import time
+
+from saltfactories.utils import random_string
+
+
+def test_auth_events_autosign_grains_pend_enabled(salt_master_factory, event_listener):
+    """
+    Test auth events when auth_events_autosign_grains contains 'pend',
+    and the minion sends autosign grains.
+    """
+    master_id = random_string("auth_event_master-")
+    minion_id = random_string("auth_event_minion-")
+    start_time = time.time()
+    autosign_grain = random_string("grain-")
+    events = []
+
+    def handler(data):
+        events.append(data)
+
+    event_listener.register_auth_event_handler(master_id, handler)
+    master = salt_master_factory.salt_master_daemon(
+        master_id,
+        overrides={
+            "log_level": "info",
+            "auth_events_autosign_grains": ["pend"],
+        },
+    )
+    minion = master.salt_minion_daemon(
+        minion_id,
+        overrides={
+            "log_level": "info",
+            "grains": {
+                "autosign_key": {
+                    # Add some extra nesting just for the fun of it
+                    "a": {
+                        "b": autosign_grain,
+                    }
+                }
+            },
+            "autosign_grains": ["autosign_key"],
+        },
+    )
+
+    with master.started(), minion.started():
+        events = event_listener.get_events(
+            [(master.id, "salt/auth")],
+            after_time=start_time,
+        )
+
+        for event in events:
+            assert event.data["act"] != "error"
+
+            if event.data["act"] == "pend":
+                grain = event.data["autosign_grains"]
+                assert grain["autosign_key"]["a"]["b"] == autosign_grain
+            else:
+                assert "autosign_grains" not in event.data
+
+    event_listener.unregister_auth_event_handler(master_id)
+
+
+def test_auth_events_autosign_grains_pend_enabled_without_grains(
+    salt_master_factory, event_listener
+):
+    """
+    Test auth events when auth_events_autosign_grains contains 'pend',
+    and the minion does not send autosign grains.
+    """
+    master_id = random_string("auth_event_master-")
+    minion_id = random_string("auth_event_minion-")
+    start_time = time.time()
+    events = []
+
+    def handler(data):
+        events.append(data)
+
+    event_listener.register_auth_event_handler(master_id, handler)
+    master = salt_master_factory.salt_master_daemon(
+        master_id,
+        overrides={
+            "log_level": "info",
+            "auth_events_autosign_grains": ["pend"],
+        },
+    )
+    minion = master.salt_minion_daemon(
+        minion_id,
+        overrides={
+            "log_level": "info",
+        },
+    )
+
+    with master.started(), minion.started():
+        events = event_listener.get_events(
+            [(master.id, "salt/auth")],
+            after_time=start_time,
+        )
+
+        for event in events:
+            assert event.data["act"] != "error"
+            assert "autosign_grains" not in event.data
+
+    event_listener.unregister_auth_event_handler(master_id)
+
+
+def test_auth_events_autosign_grains_pend_disabled(salt_master_factory, event_listener):
+    """
+    Test auth events when auth_events_autosign_grains does not contain
+    'pend', and the minion sends autosign grains.
+    """
+    master_id = random_string("auth_event_master-")
+    minion_id = random_string("auth_event_minion-")
+    start_time = time.time()
+    autosign_grain = random_string("grain-")
+    events = []
+
+    def handler(data):
+        events.append(data)
+
+    event_listener.register_auth_event_handler(master_id, handler)
+    master = salt_master_factory.salt_master_daemon(
+        master_id,
+        overrides={
+            "log_level": "info",
+            "auth_events_autosign_grains": ["reject"],
+        },
+    )
+    minion = master.salt_minion_daemon(
+        minion_id,
+        overrides={
+            "log_level": "info",
+            "grains": {
+                "autosign_key": autosign_grain,
+            },
+            "autosign_grains": ["autosign_key"],
+        },
+    )
+
+    with master.started(), minion.started():
+        events = event_listener.get_events(
+            [(master.id, "salt/auth")],
+            after_time=start_time,
+        )
+
+        for event in events:
+            assert event.data["act"] != "error"
+            assert "autosign_grains" not in event.data
+
+    event_listener.unregister_auth_event_handler(master_id)
+
+
+def test_auth_events_autosign_grains_not_set(salt_master_factory, event_listener):
+    """
+    Test auth events when auth_events_autosign_grains is not set at all,
+    and the minion sends autosign grains.
+    """
+    master_id = random_string("auth_event_master-")
+    minion_id = random_string("auth_event_minion-")
+    start_time = time.time()
+    autosign_grain = random_string("grain-")
+    events = []
+
+    def handler(data):
+        events.append(data)
+
+    event_listener.register_auth_event_handler(master_id, handler)
+    master = salt_master_factory.salt_master_daemon(
+        master_id,
+        overrides={
+            "log_level": "info",
+        },
+    )
+    minion = master.salt_minion_daemon(
+        minion_id,
+        overrides={
+            "log_level": "info",
+            "grains": {
+                "autosign_key": autosign_grain,
+            },
+            "autosign_grains": ["autosign_key"],
+        },
+    )
+
+    with master.started(), minion.started():
+        events = event_listener.get_events(
+            [(master.id, "salt/auth")],
+            after_time=start_time,
+        )
+
+        for event in events:
+            assert event.data["act"] != "error"
+            assert "autosign_grains" not in event.data
+
+    event_listener.unregister_auth_event_handler(master_id)


### PR DESCRIPTION
### What does this PR do?

It adds the "autosign_grains" that the minion sends during auth to the auth event that the master sends. This enables us to create a runner to do more cool autosign stuff (more than just shared secrets, which is already supported by autosign_grains).

To enable it, the option `auth_events_pend_autosign_grains` is added. By default it is false. When enabled, it only passes on the "autosign_grains" when the action is pending. This means that it not added any more when a key is accepted, rejected or denied.

Example auth event (with autosign grains):
```
salt/auth       {
    "_stamp": "2023-10-18T11:57:23.212718",
    "act": "pend",
    "id": "test.example.com",
    "pub": "<REDACTED>",
    "autosign_grains": {
        "autosign_key": "abcdefgh"
    }
}
```
As far as I can see, people has wanted something similar in the past: #37712, #43394, #56189 (all closed issues)

In addition to this, I also fixed so all auth events have the "act" field set (#56200) and moved variables that was only used when auth events were enabled.

### What issues does this PR fix or reference?
Fixes: #56200
(not the main goal of the PR, but I had to touch that part of the code anyway)

### New Behavior
Add "autosign_grains" to auth events when "act" is "pend".

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [X] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
