### PR TITLE
[3006.x] bump pygit2

### DIFF
--- a/requirements/static/ci/darwin.in
+++ b/requirements/static/ci/darwin.in
@@ -3,7 +3,7 @@
 # pylxd(or likely ws4py) will cause the test suite to hang at the finish line under runtests.py
 # pylxd>=2.2.5
 yamlordereddictloader
-pygit2>=1.2.0
+pygit2>=1.10.1
 yamllint
 mercurial
 hglib

--- a/requirements/static/ci/freebsd.in
+++ b/requirements/static/ci/freebsd.in
@@ -1,5 +1,5 @@
 # FreeBSD static CI requirements
-pygit2==1.8.0
+pygit2>=1.10.1
 yamllint
 mercurial
 hglib

--- a/requirements/static/ci/linux.in
+++ b/requirements/static/ci/linux.in
@@ -1,8 +1,6 @@
 # Linux static CI requirements
 pyiface
-pygit2<1.1.0; python_version <= '3.8'
-pygit2>=1.4.0; python_version > '3.8'
-pygit2==1.9.1; python_version >= '3.10'
+pygit2>=1.10.1
 pymysql>=1.0.2
 ansible>=4.4.0; python_version < '3.9'
 ansible>=7.0.0; python_version >= '3.9'

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -663,7 +663,7 @@ pycparser==2.21 ; python_version >= "3.9"
     #   cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pygit2==1.9.1
+pygit2==1.13.1
     # via -r requirements/static/ci/darwin.in
 pyjwt==2.4.0
     # via adal

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -661,7 +661,7 @@ pycparser==2.21 ; python_version >= "3.9"
     #   cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pygit2==1.8.0
+pygit2==1.13.1
     # via -r requirements/static/ci/freebsd.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.10/lint.txt
+++ b/requirements/static/ci/py3.10/lint.txt
@@ -658,7 +658,7 @@ pycparser==2.21 ; python_version >= "3.9"
     #   cffi
 pycryptodomex==3.10.1
     # via -r requirements/crypto.txt
-pygit2==1.9.1 ; python_version >= "3.10"
+pygit2==1.13.1
     # via -r requirements/static/ci/linux.in
 pyiface==0.0.11
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -674,7 +674,7 @@ pycparser==2.21 ; python_version >= "3.9"
     #   cffi
 pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
-pygit2==1.9.1 ; python_version >= "3.10"
+pygit2==1.13.1
     # via -r requirements/static/ci/linux.in
 pyiface==0.0.11
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -231,7 +231,7 @@ pycparser==2.21 ; python_version >= "3.9"
     #   cffi
 pycryptodomex==3.10.1
     # via -r requirements/crypto.txt
-pygit2==1.9.1
+pygit2==1.13.1
     # via -r requirements/static/ci/windows.in
 pymssql==2.2.7
     # via -r requirements/windows.txt

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -346,6 +346,8 @@ botocore==1.24.46
     #   boto3
     #   moto
     #   s3transfer
+cached-property==1.5.2
+    # via pygit2
 cachetools==3.1.0
     # via google-auth
 cassandra-driver==3.24.0
@@ -698,7 +700,7 @@ pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
-pygit2==1.8.0
+pygit2==1.10.1
     # via -r requirements/static/ci/freebsd.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.7/lint.txt
+++ b/requirements/static/ci/py3.7/lint.txt
@@ -351,6 +351,8 @@ botocore==1.24.46
     #   boto3
     #   moto
     #   s3transfer
+cached-property==1.5.2
+    # via pygit2
 cachetools==4.2.2
     # via
     #   google-auth
@@ -701,7 +703,7 @@ pycryptodomex==3.10.1
     # via -r requirements/crypto.txt
 pyeapi==0.8.4
     # via napalm
-pygit2==1.0.3 ; python_version <= "3.8"
+pygit2==1.10.1
     # via -r requirements/static/ci/linux.in
 pyiface==0.0.11
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -357,6 +357,8 @@ botocore==1.24.46
     #   boto3
     #   moto
     #   s3transfer
+cached-property==1.5.2
+    # via pygit2
 cachetools==4.2.2
     # via
     #   google-auth
@@ -711,7 +713,7 @@ pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
-pygit2==1.0.3 ; python_version <= "3.8"
+pygit2==1.10.1
     # via -r requirements/static/ci/linux.in
 pyiface==0.0.11
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -245,7 +245,7 @@ pycparser==2.21
     #   cffi
 pycryptodomex==3.10.1
     # via -r requirements/crypto.txt
-pygit2==1.9.1
+pygit2==1.10.1
     # via -r requirements/static/ci/windows.in
 pymssql==2.2.1
     # via -r requirements/windows.txt

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -687,7 +687,7 @@ pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
-pygit2==1.8.0
+pygit2==1.13.1
     # via -r requirements/static/ci/freebsd.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.8/lint.txt
+++ b/requirements/static/ci/py3.8/lint.txt
@@ -692,7 +692,7 @@ pycryptodomex==3.10.1
     # via -r requirements/crypto.txt
 pyeapi==0.8.4
     # via napalm
-pygit2==1.0.3 ; python_version <= "3.8"
+pygit2==1.13.1
     # via -r requirements/static/ci/linux.in
 pyiface==0.0.11
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -700,7 +700,7 @@ pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
-pygit2==1.0.3 ; python_version <= "3.8"
+pygit2==1.13.1
     # via -r requirements/static/ci/linux.in
 pyiface==0.0.11
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -232,7 +232,7 @@ pycparser==2.21
     #   cffi
 pycryptodomex==3.10.1
     # via -r requirements/crypto.txt
-pygit2==1.9.1
+pygit2==1.13.1
     # via -r requirements/static/ci/windows.in
 pymssql==2.2.1
     # via -r requirements/windows.txt

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -692,7 +692,7 @@ pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
-pygit2==1.9.1
+pygit2==1.13.1
     # via -r requirements/static/ci/darwin.in
 pyjwt==2.4.0
     # via adal

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -690,7 +690,7 @@ pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
-pygit2==1.8.0
+pygit2==1.13.1
     # via -r requirements/static/ci/freebsd.in
 pyinotify==0.9.6 ; sys_platform != "win32" and sys_platform != "darwin" and platform_system != "openbsd"
     # via -r requirements/static/ci/common.in

--- a/requirements/static/ci/py3.9/lint.txt
+++ b/requirements/static/ci/py3.9/lint.txt
@@ -693,7 +693,7 @@ pycryptodomex==3.10.1
     # via -r requirements/crypto.txt
 pyeapi==0.8.4
     # via napalm
-pygit2==1.6.1 ; python_version > "3.8"
+pygit2==1.13.1
     # via -r requirements/static/ci/linux.in
 pyiface==0.0.11
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -355,8 +355,6 @@ botocore==1.24.46
     #   boto3
     #   moto
     #   s3transfer
-cached-property==1.5.2
-    # via pygit2
 cachetools==4.2.2
     # via
     #   google-auth
@@ -705,7 +703,7 @@ pycryptodomex==3.9.8
     # via -r requirements/crypto.txt
 pyeapi==0.8.3
     # via napalm
-pygit2==1.5.0 ; python_version > "3.8"
+pygit2==1.13.1
     # via -r requirements/static/ci/linux.in
 pyiface==0.0.11
     # via -r requirements/static/ci/linux.in

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -233,7 +233,7 @@ pycparser==2.21 ; python_version >= "3.9"
     #   cffi
 pycryptodomex==3.10.1
     # via -r requirements/crypto.txt
-pygit2==1.9.1
+pygit2==1.13.1
     # via -r requirements/static/ci/windows.in
 pymssql==2.2.1
     # via -r requirements/windows.txt

--- a/requirements/static/ci/windows.in
+++ b/requirements/static/ci/windows.in
@@ -1,7 +1,7 @@
 # This is a compilation of requirements installed on salt-jenkins git.salt state run
 dmidecode
 patch
-pygit2>=1.2.0
+pygit2>=1.10.1
 sed
 pywinrm>=0.4.1
 yamllint


### PR DESCRIPTION
### What does this PR do?
bump pygit2 dependence in ci
 
### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/65085

### Previous Behavior
py37 has unsupported version

### New Behavior
pygit2 will have less crashes and leaks and py 37 wont have problems 

### Merge requirements satisfied?
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html

### Commits signed with GPG?
Yes