### PR TITLE
[master] Dereference symlinks to set proper `__cli` opt

### DIFF
--- a/changelog/65435.fixed.md
+++ b/changelog/65435.fixed.md
@@ -1,0 +1,1 @@
+Dereference symlinks to set proper __cli opt

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -3762,7 +3762,9 @@ def apply_minion_config(
             )
             opts["fileserver_backend"][idx] = new_val
 
-    opts["__cli"] = salt.utils.stringutils.to_unicode(os.path.basename(sys.argv[0]))
+    opts["__cli"] = salt.utils.stringutils.to_unicode(
+        os.path.basename(salt.utils.path.expand(sys.argv[0]))
+    )
 
     # No ID provided. Will getfqdn save us?
     using_ip_for_id = False
@@ -3964,7 +3966,9 @@ def apply_master_config(overrides=None, defaults=None):
             )
         opts["keep_acl_in_token"] = True
 
-    opts["__cli"] = salt.utils.stringutils.to_unicode(os.path.basename(sys.argv[0]))
+    opts["__cli"] = salt.utils.stringutils.to_unicode(
+        os.path.basename(salt.utils.path.expand(sys.argv[0]))
+    )
 
     if "environment" in opts:
         if opts["saltenv"] is not None:

--- a/tests/pytests/unit/config/test_master_config.py
+++ b/tests/pytests/unit/config/test_master_config.py
@@ -1,4 +1,5 @@
 import salt.config
+from tests.support.mock import MagicMock, patch
 
 
 def test_apply_no_cluster_id():
@@ -60,3 +61,14 @@ def test_apply_for_cluster():
     assert isinstance(opts["cluster_peers"], list)
     opts["cluster_peers"].sort()
     assert ["127.0.0.1", "127.0.0.3"] == opts["cluster_peers"]
+
+
+def test___cli_path_is_expanded():
+    defaults = salt.config.DEFAULT_MASTER_OPTS.copy()
+    overrides = {}
+    with patch(
+        "salt.utils.path.expand", MagicMock(return_value="/path/to/testcli")
+    ) as expand_mock:
+        opts = salt.config.apply_master_config(overrides, defaults)
+        assert expand_mock.called
+        assert opts["__cli"] == "testcli"

--- a/tests/pytests/unit/config/test_minion_config.py
+++ b/tests/pytests/unit/config/test_minion_config.py
@@ -1,0 +1,13 @@
+import salt.config
+from tests.support.mock import MagicMock, patch
+
+
+def test___cli_path_is_expanded():
+    defaults = salt.config.DEFAULT_MINION_OPTS.copy()
+    overrides = {}
+    with patch(
+        "salt.utils.path.expand", MagicMock(return_value="/path/to/testcli")
+    ) as expand_mock:
+        opts = salt.config.apply_minion_config(overrides, defaults)
+        assert expand_mock.called
+        assert opts["__cli"] == "testcli"


### PR DESCRIPTION
### What does this PR do?

In case of creating symlinks to `salt-call`, the behaviour of some modules could be different than expected as `__cli` contains the name of the symlink instead of `salt-call` itself. This change will dereference the symlinks to set `__cli` opt to the proper value.

### Previous Behavior
Different behaviour on calling modules like `state`, `event` and `git` if the call is performed with symlink to `salt-call` instead of `salt-call` itself.

### New Behavior
The same behaviour for `salt-call` and any name of symlink pointint to it as expected.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
