### PR TITLE
[master] Fix bug in pip.installed state when user does not exists

### DIFF
--- a/changelog/65458.fixed.md
+++ b/changelog/65458.fixed.md
@@ -1,0 +1,1 @@
+pip.installed state will now properly fail when a specified user does not exists

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -839,6 +839,13 @@ def installed(
             ret["comment"] = "\n".join(comments)
             return ret
 
+    # If the user does not exist, stop here with error:
+    if user and "user.info" in __salt__ and not __salt__["user.info"](user):
+        # The user does not exists, exit with result set to False
+        ret["result"] = False
+        ret["comment"] = f"User {user} does not exist"
+        return ret
+
     # If a requirements file is specified, only install the contents of the
     # requirements file. Similarly, using the --editable flag with pip should
     # also ignore the "name" and "pkgs" parameters.

--- a/tests/unit/states/test_pip_state.py
+++ b/tests/unit/states/test_pip_state.py
@@ -379,6 +379,24 @@ class PipStateTest(TestCase, SaltReturnAssertsMixin, LoaderModuleMockMixin):
             self.assertSaltTrueReturn({"test": ret})
             self.assertInSaltComment("successfully installed", {"test": ret})
 
+    def test_install_with_specified_user(self):
+        """
+        Check that if `user` parameter is set and the user does not exists
+        it will fail with an error, see #65458
+        """
+        user_info = MagicMock(return_value={})
+        pip_version = MagicMock(return_value="10.0.1")
+        with patch.dict(
+            pip_state.__salt__,
+            {
+                "user.info": user_info,
+                "pip.version": pip_version,
+            },
+        ):
+            ret = pip_state.installed("mypkg", user="fred")
+            self.assertSaltFalseReturn({"test": ret})
+            self.assertInSaltComment("User fred does not exist", {"test": ret})
+
 
 class PipStateUtilsTest(TestCase):
     def test_has_internal_exceptions_mod_function(self):

--- a/tests/unit/states/test_pip_state.py
+++ b/tests/unit/states/test_pip_state.py
@@ -432,7 +432,7 @@ class PipStateInstallationErrorTest(TestCase):
         extra_requirements = []
         for name, version in salt.version.dependency_information():
             if name in ["PyYAML", "packaging", "looseversion"]:
-                extra_requirements.append("{}=={}".format(name, version))
+                extra_requirements.append(f"{name}=={version}")
         failures = {}
         pip_version_requirements = [
             # Latest pip 18
@@ -471,7 +471,7 @@ class PipStateInstallationErrorTest(TestCase):
                 with VirtualEnv() as venv:
                     venv.install(*extra_requirements)
                     if requirement:
-                        venv.install("pip{}".format(requirement))
+                        venv.install(f"pip{requirement}")
                     try:
                         subprocess.check_output([venv.venv_python, "-c", code])
                     except subprocess.CalledProcessError as exc:


### PR DESCRIPTION
### What does this PR do?
This will fix that pip will give a stacktrace when the `pip.installed` state is executed with an specified user that does not exists.

### What issues does this PR fix or reference?
Fixes: #65458

### Previous Behavior
Without this fix, pip will throw a stacktrace like this:

```
[ERROR   ] Pre-caching of PIP packages during states.pip.installed failed by exception from pip.list: User 'fred' is not available
Traceback (most recent call last):
  File "/salt/salt/modules/cmdmod.py", line 485, in _run
    pwd.getpwnam(runas)
KeyError: "getpwnam(): name not found: 'fred'"

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/salt/salt/states/pip_state.py", line 852, in installed
    pip_list = __salt__["pip.list"](
  File "/salt/salt/loader/lazy.py", line 159, in __call__
    ret = self.loader.run(run_func, *args, **kwargs)
  File "/salt/salt/loader/lazy.py", line 1245, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/salt/salt/loader/lazy.py", line 1260, in _run_as
    return _func_or_method(*args, **kwargs)
  File "/salt/salt/modules/pip.py", line 1353, in list_
    result = __salt__["cmd.run_all"](cmd, **cmd_kwargs)
  File "/salt/salt/loader/lazy.py", line 159, in __call__
    ret = self.loader.run(run_func, *args, **kwargs)
  File "/salt/salt/loader/lazy.py", line 1245, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/salt/salt/loader/lazy.py", line 1260, in _run_as
    return _func_or_method(*args, **kwargs)
  File "/salt/salt/modules/cmdmod.py", line 2329, in run_all
    ret = _run(
  File "/salt/salt/modules/cmdmod.py", line 487, in _run
    raise CommandExecutionError("User '{}' is not available".format(runas))
salt.exceptions.CommandExecutionError: User 'fred' is not available
[ERROR   ] An exception occurred in this state: Traceback (most recent call last):
  File "/salt/salt/modules/cmdmod.py", line 485, in _run
    pwd.getpwnam(runas)
KeyError: "getpwnam(): name not found: 'fred'"

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/salt/salt/state.py", line 2381, in call
    ret = self.states[cdata["full"]](
  File "/salt/salt/loader/lazy.py", line 159, in __call__
    ret = self.loader.run(run_func, *args, **kwargs)
  File "/salt/salt/loader/lazy.py", line 1245, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/salt/salt/loader/lazy.py", line 1260, in _run_as
    return _func_or_method(*args, **kwargs)
  File "/salt/salt/loader/lazy.py", line 1293, in wrapper
    return f(*args, **kwargs)
  File "/salt/salt/states/pip_state.py", line 865, in installed
    out = _check_if_installed(
  File "/salt/salt/states/pip_state.py", line 276, in _check_if_installed
    or __salt__["pip.list"](
  File "/salt/salt/loader/lazy.py", line 159, in __call__
    ret = self.loader.run(run_func, *args, **kwargs)
  File "/salt/salt/loader/lazy.py", line 1245, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/salt/salt/loader/lazy.py", line 1260, in _run_as
    return _func_or_method(*args, **kwargs)
  File "/salt/salt/modules/pip.py", line 1353, in list_
    result = __salt__["cmd.run_all"](cmd, **cmd_kwargs)
  File "/salt/salt/loader/lazy.py", line 159, in __call__
    ret = self.loader.run(run_func, *args, **kwargs)
  File "/salt/salt/loader/lazy.py", line 1245, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/salt/salt/loader/lazy.py", line 1260, in _run_as
    return _func_or_method(*args, **kwargs)
  File "/salt/salt/modules/cmdmod.py", line 2329, in run_all
    ret = _run(
  File "/salt/salt/modules/cmdmod.py", line 487, in _run
    raise CommandExecutionError("User '{}' is not available".format(runas))
salt.exceptions.CommandExecutionError: User 'fred' is not available
```

### New Behavior
With this fix the output of de state.apply will be this:

```
----------
          ID: Flask
    Function: pip.installed
      Result: False
     Comment: User fred does not exist
     Started: 07:47:15.282932
    Duration: 179.845 ms
     Changes:
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes
