### PR TITLE
[3006.x] Connect callback closes it's request channel

### DIFF
--- a/changelog/65464.fixed.md
+++ b/changelog/65464.fixed.md
@@ -1,0 +1,1 @@
+Publish channel connect callback method properly closes it's request channel.

--- a/salt/channel/client.py
+++ b/salt/channel/client.py
@@ -552,19 +552,16 @@ class AsyncPubChannel:
                     "data": data,
                     "tag": tag,
                 }
-                req_channel = AsyncReqChannel.factory(self.opts)
-                try:
-                    yield req_channel.send(load, timeout=60)
-                except salt.exceptions.SaltReqTimeoutError:
-                    log.info(
-                        "fire_master failed: master could not be contacted. Request timed"
-                        " out."
-                    )
-                except Exception:  # pylint: disable=broad-except
-                    log.info("fire_master failed", exc_info=True)
-                finally:
-                    # SyncWrapper will call either close() or destroy(), whichever is available
-                    req_channel.close()
+                with AsyncReqChannel.factory(self.opts) as channel:
+                    try:
+                        yield channel.send(load, timeout=60)
+                    except salt.exceptions.SaltReqTimeoutError:
+                        log.info(
+                            "fire_master failed: master could not be contacted. Request timed"
+                            " out."
+                        )
+                    except Exception:  # pylint: disable=broad-except
+                        log.info("fire_master failed", exc_info=True)
             else:
                 self._reconnected = True
         except Exception as exc:  # pylint: disable=broad-except

--- a/salt/channel/client.py
+++ b/salt/channel/client.py
@@ -564,7 +564,7 @@ class AsyncPubChannel:
                     log.info("fire_master failed", exc_info=True)
                 finally:
                     # SyncWrapper will call either close() or destroy(), whichever is available
-                    del req_channel
+                    req_channel.close()
             else:
                 self._reconnected = True
         except Exception as exc:  # pylint: disable=broad-except

--- a/tests/pytests/functional/channel/test_client.py
+++ b/tests/pytests/functional/channel/test_client.py
@@ -17,7 +17,9 @@ async def test_async_pub_channel_connect_cb(minion_opts):
     channel._reconnected = True
 
     mock = MagicMock(salt.channel.client.AsyncReqChannel)
+    mock.__enter__ = lambda self: mock
+
     with patch("salt.channel.client.AsyncReqChannel.factory", return_value=mock):
         await channel.connect_callback(None)
         mock.send.assert_called_once()
-        mock.close.assert_called_once()
+        mock.__exit__.assert_called_once()

--- a/tests/pytests/functional/channel/test_client.py
+++ b/tests/pytests/functional/channel/test_client.py
@@ -8,18 +8,18 @@ async def test_async_pub_channel_connect_cb(minion_opts):
     """
     minion_opts["master_uri"] = "tcp://127.0.0.1:4506"
     minion_opts["master_ip"] = "127.0.0.1"
-    channel = salt.channel.client.AsyncPubChannel.factory(minion_opts)
+    with salt.channel.client.AsyncPubChannel.factory(minion_opts) as channel:
 
-    async def send_id(*args):
-        return
+        async def send_id(*args):
+            return
 
-    channel.send_id = send_id
-    channel._reconnected = True
+        channel.send_id = send_id
+        channel._reconnected = True
 
-    mock = MagicMock(salt.channel.client.AsyncReqChannel)
-    mock.__enter__ = lambda self: mock
+        mock = MagicMock(salt.channel.client.AsyncReqChannel)
+        mock.__enter__ = lambda self: mock
 
-    with patch("salt.channel.client.AsyncReqChannel.factory", return_value=mock):
-        await channel.connect_callback(None)
-        mock.send.assert_called_once()
-        mock.__exit__.assert_called_once()
+        with patch("salt.channel.client.AsyncReqChannel.factory", return_value=mock):
+            await channel.connect_callback(None)
+            mock.send.assert_called_once()
+            mock.__exit__.assert_called_once()

--- a/tests/pytests/functional/channel/test_client.py
+++ b/tests/pytests/functional/channel/test_client.py
@@ -1,0 +1,23 @@
+import salt.channel.client
+from tests.support.mock import MagicMock, patch
+
+
+async def test_async_pub_channel_connect_cb(minion_opts):
+    """
+    Validate connect_callback closes the request channel it creates.
+    """
+    minion_opts["master_uri"] = "tcp://127.0.0.1:4506"
+    minion_opts["master_ip"] = "127.0.0.1"
+    channel = salt.channel.client.AsyncPubChannel.factory(minion_opts)
+
+    async def send_id(*args):
+        return
+
+    channel.send_id = send_id
+    channel._reconnected = True
+
+    mock = MagicMock(salt.channel.client.AsyncReqChannel)
+    with patch("salt.channel.client.AsyncReqChannel.factory", return_value=mock):
+        await channel.connect_callback(None)
+        mock.send.assert_called_once()
+        mock.close.assert_called_once()


### PR DESCRIPTION
### What does this PR do?

Make sure publish channel's connect_callback method closes the request channel it creates.

### What issues does this PR fix or reference?
Fixes: #65464

### Previous Behavior

The connect callback would create a request channel and delete but but never called it's close method

### New Behavior

The newly created request channel is closed after being used.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated
