### PR TITLE
[3006.x] Adjust break in control file to 3006.4, for updated salt-common commit b3fcdf8

### DIFF
--- a/pkg/debian/control
+++ b/pkg/debian/control
@@ -25,7 +25,7 @@ Description: Salt debug symbols
 Package: salt-common
 Architecture: amd64 arm64
 Depends: ${misc:Depends}
-Breaks: salt-minion (<= 3006.1)
+Breaks: salt-minion (<= 3006.4)
 Suggests: ifupdown
 Recommends: lsb-release
 Description: shared libraries that salt requires for all packages
@@ -51,8 +51,8 @@ Description: shared libraries that salt requires for all packages
 
 Package: salt-master
 Architecture: amd64 arm64
-Replaces: salt-common (<= 3006.1)
-Breaks: salt-common (<= 3006.1)
+Replaces: salt-common (<= 3006.4)
+Breaks: salt-common (<= 3006.4)
 Depends: salt-common (= ${source:Version}),
          ${misc:Depends}
 Description: remote manager to administer servers via salt
@@ -77,8 +77,8 @@ Description: remote manager to administer servers via salt
 
 Package: salt-minion
 Architecture: amd64 arm64
-Replaces: salt-common (<= 3006.1)
-Breaks: salt-common (<= 3006.1)
+Replaces: salt-common (<= 3006.4)
+Breaks: salt-common (<= 3006.4)
 Depends: bsdmainutils,
          dctrl-tools,
          salt-common (= ${source:Version}),
@@ -131,7 +131,7 @@ Description: master-of-masters for salt, the distributed remote execution system
 
 Package: salt-ssh
 Architecture: amd64 arm64
-Breaks: salt-common (<= 3006.3)
+Breaks: salt-common (<= 3006.4)
 Depends: salt-common (= ${source:Version}),
          openssh-client,
          ${misc:Depends}
@@ -160,7 +160,7 @@ Description: remote manager to administer servers via Salt SSH
 
 Package: salt-cloud
 Architecture: amd64 arm64
-Breaks: salt-common (<= 3006.3)
+Breaks: salt-common (<= 3006.4)
 Depends: salt-common (= ${source:Version}),
          ${misc:Depends}
 Description: public cloud VM management system


### PR DESCRIPTION
### What does this PR do?
Allow for the move of /etc/salt/roster and /etc/salt/cloud from salt-common to salt-ssh and salt-cloud.
This was causing failures with the upgrade tests, due to the ownership of the files/directories changed between packages, when installing all packages, that is, salt-common, salt-ssh, salt-cloud with 3006.4 salt-common installed previously.

### What issues does this PR fix or reference?
Fixes: n/a

### Previous Behavior
Upgrade of salt-common, salt-ssh and salt-cloud would fail since 3006.4 salt-common owns these files/directories.

### New Behavior
Upgrade now succeds

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
