### PR TITLE
[3006.x] Integration tests without splits now take longer then 7 hours. Split it again.

### DIFF
--- a/tools/ci.py
+++ b/tools/ci.py
@@ -640,8 +640,12 @@ def matrix(ctx: Context, distro_slug: str, full: bool = False, workflow: str = "
     }
     # On nightly and scheduled builds we don't want splits at all
     if workflow.lower() in ("nightly", "scheduled"):
-        ctx.info(f"Clearning splits definition since workflow is '{workflow}'")
-        _splits.clear()
+        ctx.info(f"Reducing splits definition since workflow is '{workflow}'")
+        for key in _splits:
+            new_value = _splits[key] - 2
+            if new_value < 1:
+                new_value = 1
+            _splits[key] = new_value
 
     for transport in ("zeromq", "tcp"):
         if transport == "tcp":


### PR DESCRIPTION
### What does this PR do?
See title