### PR TITLE
[master] Fix arguments to getaddrinfo

### DIFF
--- a/salt/utils/dns.py
+++ b/salt/utils/dns.py
@@ -396,7 +396,7 @@ def _lookup_gai(name, rdtype, timeout=None):
     try:
         addresses = [
             sock[4][0]
-            for sock in socket.getaddrinfo(name, None, sock_t, 0, socket.SOCK_RAW)
+            for sock in socket.getaddrinfo(name, None, sock_t, socket.SOCK_RAW, 0)
         ]
         return addresses
     except socket.gaierror:


### PR DESCRIPTION
SOCK_RAW is not a IPPROTO. It is a type and should be the fourth argument. The glibc resolver handles this gracefully, but the FreeBSD resolver raises an error.

See https://docs.python.org/3/library/socket.html#socket.getaddrinfo

On Linux:
```
>>> socket.getaddrinfo('example.com', None, socket.AF_INET, 0, socket.SOCK_RAW)
[(<AddressFamily.AF_INET: 2>, <SocketKind.SOCK_RAW: 3>, 3, '', ('93.184.216.34', 0))]
```

```
>>> socket.getaddrinfo('example.com', None, socket.AF_INET, socket.SOCK_RAW, 0)
[(<AddressFamily.AF_INET: 2>, <SocketKind.SOCK_RAW: 3>, 0, '', ('93.184.216.34', 0))]
```

On FreeBSD:
```
>>> socket.getaddrinfo('example.com', None, socket.AF_INET, 0, socket.SOCK_RAW)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.9/socket.py", line 954, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno 4] Non-recoverable failure in name resolution
```

```
>>> socket.getaddrinfo('example.com', None, socket.AF_INET, socket.SOCK_RAW, 0)
[(<AddressFamily.AF_INET: 2>, <SocketKind.SOCK_RAW: 3>, 0, '', ('142.251.208.142', 0))]
```