### PR TITLE
[3006.x] Ensure quoted filespec when using egrep to allow for regex with selinux

### DIFF
--- a/changelog/65340.fixed.md
+++ b/changelog/65340.fixed.md
@@ -1,0 +1,1 @@
+Fix regex for filespec adding/deleting fcontext policy in selinux

--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -617,7 +617,7 @@ def _fcontext_add_or_delete_policy(
     if "add" == action:
         # need to use --modify if context for name file exists, otherwise ValueError
         filespec = re.escape(name)
-        cmd = f"semanage fcontext -l | egrep {filespec}"
+        cmd = f"semanage fcontext -l | egrep '{filespec}'"
         current_entry_text = __salt__["cmd.shell"](cmd, ignore_retcode=True)
         if current_entry_text != "":
             action = "modify"

--- a/tests/pytests/unit/modules/test_selinux.py
+++ b/tests/pytests/unit/modules/test_selinux.py
@@ -399,15 +399,14 @@ def test_selinux_add_policy_regex(name, sel_type):
     ):
         selinux.fcontext_add_policy(name, sel_type=sel_type)
         filespec = re.escape(name)
-        filespec_test = f"'{filespec}'"
-        expected_cmd_shell = f"semanage fcontext -l | egrep {filespec_test}"
+        expected_cmd_shell = f"semanage fcontext -l | egrep '{filespec}'"
         mock_cmd_shell.assert_called_once_with(
-            f"{expected_cmd_shell}",
+            expected_cmd_shell,
             ignore_retcode=True,
         )
         expected_cmd_run_all = (
             f"semanage fcontext --modify --type {sel_type} {filespec}"
         )
         mock_cmd_run_all.assert_called_once_with(
-            f"{expected_cmd_run_all}",
+            expected_cmd_run_all,
         )

--- a/tests/pytests/unit/modules/test_selinux.py
+++ b/tests/pytests/unit/modules/test_selinux.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 import salt.modules.selinux as selinux
@@ -376,3 +378,36 @@ SELINUXTYPE=targeted
         for line in writes:
             if line.startswith("SELINUX="):
                 assert line == "SELINUX=disabled"
+
+
+@pytest.mark.parametrize(
+    "name,sel_type",
+    (
+        ("/srv/ssl/ldap/.*[.]key", "slapd_cert_t"),
+        ("/srv/ssl/ldap(/.*[.](pem|crt))?", "cert_t"),
+    ),
+)
+def test_selinux_add_policy_regex(name, sel_type):
+    """
+    Test adding policy with regex components parsing the stdout response of restorecon used in fcontext_policy_applied, new style.
+    """
+    mock_cmd_shell = MagicMock(return_value={"retcode": 0})
+    mock_cmd_run_all = MagicMock(return_value={"retcode": 0})
+
+    with patch.dict(selinux.__salt__, {"cmd.shell": mock_cmd_shell}), patch.dict(
+        selinux.__salt__, {"cmd.run_all": mock_cmd_run_all}
+    ):
+        selinux.fcontext_add_policy(name, sel_type=sel_type)
+        filespec = re.escape(name)
+        filespec_test = f"'{filespec}'"
+        expected_cmd_shell = f"semanage fcontext -l | egrep {filespec_test}"
+        mock_cmd_shell.assert_called_once_with(
+            f"{expected_cmd_shell}",
+            ignore_retcode=True,
+        )
+        expected_cmd_run_all = (
+            f"semanage fcontext --modify --type {sel_type} {filespec}"
+        )
+        mock_cmd_run_all.assert_called_once_with(
+            f"{expected_cmd_run_all}",
+        )


### PR DESCRIPTION
### What does this PR do?
Ensure that a quoted named filespec is used when searching the output of 'semanage fcontext -l' with egrep so ensure that regex named values are interpreted correctly.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/65340

### Previous Behavior
Various regex names were confused with each other, preventing subsequent regex name values from being added.

### New Behavior
Various regex names are no longer confused with each other, allowing subsequent regex name values to be added.


Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
