### PR TITLE
[master] feat: allow configurable destination for netbox ext_pillar data

### DIFF
--- a/changelog/65531.added.md
+++ b/changelog/65531.added.md
@@ -1,0 +1,1 @@
+Added ability to configure the pillar destination for the `netbox` ext_pillar via `destination_pillar_key`

--- a/salt/pillar/netbox.py
+++ b/salt/pillar/netbox.py
@@ -88,6 +88,15 @@ connected_devices: ``False``
     Whether connected_devices key should be populated with device objects.
     If set to True it will force `interfaces` to also be true as a dependency
 
+destination_pillar_key: ``netbox``
+    .. versionadded:: 3006.0
+
+    A colon-delimited string representing a nested path within the pillar
+    where the data should be placed. This allows flexibility in organizing
+    pillar data. For example, you can store the data under ``netbox:minion``
+    or ``an-arbitrary-location``, which is useful if you already use the
+    ``netbox`` pillar and need to avoid key conflicts within it.
+
 Note that each option you enable can have a detrimental impact on pillar
 performance, so use them with caution.
 
@@ -1072,6 +1081,7 @@ def ext_pillar(minion_id, pillar, *args, **kwargs):
     proxy_username = kwargs.get("proxy_username", None)
     proxy_return = kwargs.get("proxy_return", True)
     connected_devices = kwargs.get("connected_devices", False)
+    destination_pillar_key = kwargs.get("destination_pillar_key", "netbox")
     if connected_devices and not interfaces:
         # connected_devices logic requires interfaces to be populated
         interfaces = True
@@ -1081,6 +1091,7 @@ def ext_pillar(minion_id, pillar, *args, **kwargs):
     api_query_result_limit = kwargs.get("api_query_result_limit")
 
     ret = {}
+    netbox_data = {}
 
     # Check that we have a valid API URL:
     if not salt.utils.url.validate(api_url, ["http", "https"]):
@@ -1123,15 +1134,15 @@ def ext_pillar(minion_id, pillar, *args, **kwargs):
         )
     if len(nodes) == 1:
         # Return the 0th (and only) item in the list
-        ret["netbox"] = nodes[0]
+        netbox_data = nodes[0]
     elif len(nodes) > 1:
         log.error('More than one node found for "%s"', minion_id)
         return ret
     else:
         log.error('Unable to pull NetBox data for "%s"', minion_id)
         return ret
-    node_id = ret["netbox"]["id"]
-    node_type = ret["netbox"]["node_type"]
+    node_id = netbox_data["id"]
+    node_type = netbox_data["node_type"]
     if interfaces:
         interfaces_list = _get_interfaces(
             api_url, minion_id, node_id, node_type, headers, api_query_result_limit
@@ -1140,34 +1151,42 @@ def ext_pillar(minion_id, pillar, *args, **kwargs):
             interface_ips_list = _get_interface_ips(
                 api_url, minion_id, node_id, node_type, headers, api_query_result_limit
             )
-            ret["netbox"]["interfaces"] = _associate_ips_to_interfaces(
+            netbox_data["interfaces"] = _associate_ips_to_interfaces(
                 interfaces_list, interface_ips_list
             )
-    site_id = ret["netbox"]["site"]["id"]
-    site_name = ret["netbox"]["site"]["name"]
+    site_id = netbox_data["site"]["id"]
+    site_name = netbox_data["site"]["name"]
     if site_details:
-        ret["netbox"]["site"] = _get_site_details(
+        netbox_data["site"] = _get_site_details(
             api_url, minion_id, site_name, site_id, headers
         )
     if site_prefixes:
-        ret["netbox"]["site"]["prefixes"] = _get_site_prefixes(
+        netbox_data["site"]["prefixes"] = _get_site_prefixes(
             api_url, minion_id, site_name, site_id, headers, api_query_result_limit
         )
     if connected_devices:
-        ret["netbox"]["connected_devices"] = _get_connected_devices(
-            api_url, minion_id, ret["netbox"]["interfaces"], headers
+        netbox_data["connected_devices"] = _get_connected_devices(
+            api_url, minion_id, netbox_data["interfaces"], headers
         )
+
+    # Add netbox_data to ret at the configured destination
+    destination_keys = destination_pillar_key.split(":")
+    nested = netbox_data
+    for key in reversed(destination_keys[1:]):
+        nested = {key: nested}
+    ret[destination_keys[0]] = nested
+
     if proxy_return:
-        if ret["netbox"]["platform"]:
-            platform_id = ret["netbox"]["platform"]["id"]
+        if netbox_data["platform"]:
+            platform_id = netbox_data["platform"]["id"]
         else:
             log.error(
                 'You have set "proxy_return" to "True" but you have not set the platform in NetBox for "%s"',
                 minion_id,
             )
             return
-        if ret["netbox"]["primary_ip"]:
-            primary_ip = ret["netbox"]["primary_ip"]["address"]
+        if netbox_data["primary_ip"]:
+            primary_ip = netbox_data["primary_ip"]["address"]
         else:
             log.error(
                 'You have set "proxy_return" to "True" but you have not set the primary IPv4 or IPv6 address in NetBox for "%s"',

--- a/tests/pytests/unit/pillar/test_netbox.py
+++ b/tests/pytests/unit/pillar/test_netbox.py
@@ -2473,6 +2473,44 @@ def test_when_we_retrieve_everything_successfully_then_return_dict(
         assert actual_result == expected_result
 
 
+@pytest.mark.parametrize(
+    "destination_pillar_key,expected_keys",
+    [
+        ("netbox", ["netbox"]),
+        ("netbox:minion", ["netbox", "minion"]),
+        ("custom:nested:key", ["custom", "nested", "key"]),
+    ],
+)
+def test_destination_pillar_key_routes_data_to_correct_location(
+    default_kwargs,
+    device_results,
+    no_results,
+    destination_pillar_key,
+    expected_keys,
+):
+    """Test that destination_pillar_key correctly nests the netbox data."""
+    default_kwargs["virtual_machines"] = False
+    default_kwargs["proxy_return"] = False
+    default_kwargs["site_details"] = False
+    default_kwargs["site_prefixes"] = False
+    default_kwargs["destination_pillar_key"] = destination_pillar_key
+
+    with patch("salt.pillar.netbox._get_devices", autospec=True) as get_devices, patch(
+        "salt.pillar.netbox._get_virtual_machines", autospec=True
+    ) as get_virtual_machines:
+        get_devices.return_value = device_results["dict"]["results"]
+        get_virtual_machines.return_value = no_results["dict"]["results"]
+
+        actual_result = netbox.ext_pillar(**default_kwargs)
+
+        # Walk the expected nesting path and verify data is present
+        node = actual_result
+        for key in expected_keys:
+            assert key in node, f"Key '{key}' not found in {list(node.keys())}"
+            node = node[key]
+        assert node["id"] == 511
+
+
 def test_when_we_set_proxy_return_but_get_no_value_for_platform_then_error_message_should_be_logged(
     default_kwargs, headers, device_results
 ):


### PR DESCRIPTION
### What does this PR do?
This adds support to allow the user to configure in what pillar key the netbox ext_pillar data gets populated in. For example I already use the `netbox` pillar for server and client configuration and there are a few overlapping keys there. Personally I would prefer to leave the existing config as-is and then move the minion data in to the pillar location `netbox:minion`.


### What issues does this PR fix or reference?
I didn't open an issue for this since it seemed like a trivial addition for me to just add and ask for opinions on afterwards.

### Previous Behavior
The netbox minion data would always be populated in the `netbox` pillar.

### New Behavior
The netbox minion data will be populated in the `netbox` pillar by default but the user can now specify the pillar location they would like it placed in to, optionally.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
