### PR TITLE
[master] Added deprecation warning for Salt's backport of OrderedDict class removal in 3009

### DIFF
--- a/changelog/65542.deprecated.md
+++ b/changelog/65542.deprecated.md
@@ -1,1 +1,1 @@
-Deprecation warning for Salt's backport of OrderedDict class which wil be removed in 3009
+Deprecation warning for Salt's backport of ``OrderedDict`` class which will be removed in 3009

--- a/changelog/65542.deprecated.md
+++ b/changelog/65542.deprecated.md
@@ -1,0 +1,1 @@
+Deprecation warning for Salt's backport of OrderedDict class which wil be removed in 3009

--- a/salt/utils/odict.py
+++ b/salt/utils/odict.py
@@ -24,6 +24,8 @@
 
 from collections.abc import Callable
 
+import salt.utils.versions
+
 try:
     # pylint: disable=E0611,minimum-python-version
     import collections
@@ -72,6 +74,14 @@ except (ImportError, AttributeError):
                 because their insertion order is arbitrary.
 
                 """
+                salt.utils.versions.warn_until(
+                    3009,
+                    "The Salt backport `OrderedDict` class introduced for Python 2 "
+                    "has been deprecated, and is set to be removed in {version}. "
+                    "Please use Python 3 `OrderedDict`.",
+                    category=FutureWarning,
+                )
+
                 super().__init__()
                 if len(args) > 1:
                     raise TypeError(f"expected at most 1 arguments, got {len(args)}")

--- a/salt/utils/odict.py
+++ b/salt/utils/odict.py
@@ -78,7 +78,7 @@ except (ImportError, AttributeError):
                     3009,
                     "The Salt backport `OrderedDict` class introduced for Python 2 "
                     "has been deprecated, and is set to be removed in {version}. "
-                    "Please use Python 3 `OrderedDict`.",
+                    "Please import `OrderedDict` from `collections`.",
                     category=FutureWarning,
                 )
 

--- a/salt/utils/odict.py
+++ b/salt/utils/odict.py
@@ -79,7 +79,7 @@ except (ImportError, AttributeError):
                     "The Salt backport `OrderedDict` class introduced for Python 2 "
                     "has been deprecated, and is set to be removed in {version}. "
                     "Please import `OrderedDict` from `collections`.",
-                    category=FutureWarning,
+                    category=DeprecationWarning
                 )
 
                 super().__init__()

--- a/salt/utils/odict.py
+++ b/salt/utils/odict.py
@@ -79,7 +79,7 @@ except (ImportError, AttributeError):
                     "The Salt backport `OrderedDict` class introduced for Python 2 "
                     "has been deprecated, and is set to be removed in {version}. "
                     "Please import `OrderedDict` from `collections`.",
-                    category=DeprecationWarning
+                    category=DeprecationWarning,
                 )
 
                 super().__init__()


### PR DESCRIPTION
### What does this PR do?
Added deprecation warning for Salt's backport of OrderedDict class removal in 3009

### What issues does this PR fix or reference?
Fixes: 

### New Behavior
Deprecation warning issued about removal of Salt's backport of OrderedDict added in Python 2 days, recommending use of Python 3 OrderedDict.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
